### PR TITLE
fix: remove SMS validation of fields for Twilio Verify

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -194,9 +194,25 @@ export const getPhoneProviderValidationSchema = (config: ProjectAuthConfigData) 
     }),
 
     // Phone SMS
-    SMS_OTP_EXP: number().min(0, 'Must be more than 0').required('This is required'),
-    SMS_OTP_LENGTH: number().min(6, 'Must be 6 or more in length').required('This is required'),
-    SMS_TEMPLATE: string().required('SMS template is required.'),
+    SMS_OTP_EXP: number()
+      .min(0, 'Must be more than 0')
+      .when('SMS_PROVIDER', {
+        is: (val: string) => val !== 'twilio_verify',
+        then: (schema) => schema.required('This is required'),
+        otherwise: (schema) => schema,
+      }),
+    SMS_OTP_LENGTH: number()
+      .min(6, 'Must be 6 or more in length')
+      .when('SMS_PROVIDER', {
+        is: (val: string) => val !== 'twilio_verify',
+        then: (schema) => schema.required('This is required'),
+        otherwise: (schema) => schema,
+      }),
+    SMS_TEMPLATE: string().when('SMS_PROVIDER', {
+      is: (val: string) => val !== 'twilio_verify',
+      then: (schema) => schema.required('SMS template is required.'),
+      otherwise: (schema) => schema,
+    }),
     SMS_TEST_OTP: string()
       .matches(
         /^\s*([0-9]{1,15}=[0-9]+)(\s*,\s*[0-9]{1,15}=[0-9]+)*\s*$/g,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Investigation by claude, validated! 

- Before (Formik): The old form used `<Form initialValues={INITIAL_VALUES} validationSchema={...}>` Formik does not unregister hidden fields — all fields from initialValues stay in form state with their initial values, so hidden required  fields still pass validation because they retain their default values (e.g., the OTP expiry/length numbers from the config).

- After (react-hook-form): The new form uses useForm({ shouldUnregister: true }). This explicitly removes fields from form state when their components unmount. When Twilio Verify is selected, the three hidden fields are unmounted, their values become undefined, and yup's unconditional .required() fails silently.

this bug was introduced today by PR #44095, the Formik-to-react-hook-form migration.