### PR TITLE
feat(studio): improve database column list scanning

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -352,9 +352,7 @@ export const ColumnList = ({
                       <TableCell className="w-0 !pl-5 !pr-1">
                         <Tooltip>
                           <TooltipTrigger className="cursor-default" aria-label={typeLabel}>
-                            <div className="flex w-4 justify-center">
-                              {TypeIcon}
-                            </div>
+                            <div className="flex w-4 justify-center">{TypeIcon}</div>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">
                             <div className="flex flex-col">

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -1,11 +1,11 @@
 import { PostgresColumn } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
+import { POSTGRES_DATA_TYPE_OPTIONS } from 'components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { NoSearchResults } from 'components/ui/NoSearchResults'
 import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
-import { POSTGRES_DATA_TYPE_OPTIONS } from 'components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants'
+import { NoSearchResults } from 'components/ui/NoSearchResults'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -29,6 +29,7 @@ import {
   Badge,
   Button,
   Card,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
@@ -42,7 +43,6 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-  cn,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
@@ -51,7 +51,9 @@ import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
 
 const getColumnTypeAffordance = (column: PostgresColumn) => {
   const normalizedFormat = column.format.replaceAll('"', '').replace(/\[\]$/, '')
-  const optionType = POSTGRES_DATA_TYPE_OPTIONS.find((option) => option.name === normalizedFormat)?.type
+  const optionType = POSTGRES_DATA_TYPE_OPTIONS.find(
+    (option) => option.name === normalizedFormat
+  )?.type
 
   const iconClassName = 'text-foreground-muted'
 
@@ -74,7 +76,9 @@ const getColumnTypeAffordance = (column: PostgresColumn) => {
     case 'json':
       return {
         icon: (
-          <div className={cn(iconClassName, 'px-px text-[11px] leading-none font-mono')}>{'{ }'}</div>
+          <div className={cn(iconClassName, 'px-px text-[11px] leading-none font-mono')}>
+            {'{ }'}
+          </div>
         ),
         label: 'JSON',
       }
@@ -254,7 +258,7 @@ export const ColumnList = ({
 
                   return (
                     <TableRow key={column.name}>
-                      <TableCell className="w-0 !pl-5 !pr-0">
+                      <TableCell className="w-0 !pl-5 !pr-1">
                         <Tooltip>
                           <TooltipTrigger className="cursor-default">
                             <div aria-label={typeLabel} className="flex w-4 justify-center">
@@ -287,7 +291,7 @@ export const ColumnList = ({
                         </div>
                       </TableCell>
                       <TableCell>
-                        <code className="text-code-inline">{column.format}</code>
+                        <p className="text-foreground-light">{column.format}</p>
                       </TableCell>
                       <TableCell>
                         <div className="flex flex-wrap gap-1">

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -12,6 +12,7 @@ import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import { noop } from 'lodash'
 import {
+  Braces,
   Calendar,
   DiamondIcon,
   Fingerprint,
@@ -55,45 +56,7 @@ import {
   getPrimaryKeyColumnNames,
   getUniqueIndexColumnNames,
 } from './ColumnList.utils'
-
-interface ConstraintTokenProps {
-  icon?: ReactNode
-  label: string
-  variant?: 'default' | 'secondary' | 'primary'
-}
-
-const constraintTokenClassName =
-  'inline-flex items-center justify-center rounded-md text-center font-mono uppercase whitespace-nowrap font-medium tracking-[0.06em] text-[11px] leading-[1.1] px-[5.5px] py-[3px] transition-all border'
-
-const ConstraintToken = ({ icon, label, variant = 'default' }: ConstraintTokenProps) => {
-  const tokenToneClassName =
-    variant === 'primary'
-      ? 'bg-brand bg-opacity-10 text-brand-600 border-brand-500'
-      : variant === 'default'
-        ? 'bg-surface-75 text-foreground-light border-strong'
-        : 'bg-surface-75 bg-opacity-50 text-foreground-light border-strong'
-
-  return (
-    <div className="inline-flex items-center whitespace-nowrap">
-      {icon && (
-        <span
-          className={cn(constraintTokenClassName, tokenToneClassName, 'rounded-r-none border-r-0')}
-        >
-          {icon}
-        </span>
-      )}
-      <span
-        className={cn(
-          constraintTokenClassName,
-          tokenToneClassName,
-          icon ? 'rounded-l-none' : 'rounded-md'
-        )}
-      >
-        {label}
-      </span>
-    </div>
-  )
-}
+import { ConstraintToken } from './ConstraintToken'
 
 const getColumnTypeAffordancePresentation = (column: PostgresColumn) => {
   const { kind, label } = getColumnTypeAffordance(column.format)
@@ -117,11 +80,7 @@ const getColumnTypeAffordancePresentation = (column: PostgresColumn) => {
       }
     case 'json':
       return {
-        icon: (
-          <div className={cn(iconClassName, 'px-px text-[11px] leading-none font-mono')}>
-            {'{ }'}
-          </div>
-        ),
+        icon: <Braces size={14} className={iconClassName} strokeWidth={1.5} />,
         label,
       }
     case 'bool':
@@ -232,7 +191,10 @@ export const ColumnList = ({
             <TableHeader>
               <TableRow>
                 <TableHead className="w-0 !px-0" />
-                <TableHead className={columns.length === 0 ? 'text-foreground-muted' : undefined}>
+
+                <TableHead
+                  className={cn(columns.length === 0 ? 'text-foreground-muted' : undefined)}
+                >
                   Name
                 </TableHead>
                 <TableHead className={columns.length === 0 ? 'text-foreground-muted' : undefined}>
@@ -244,6 +206,7 @@ export const ColumnList = ({
                 <TableHead />
               </TableRow>
             </TableHeader>
+
             <TableBody>
               {isError && (
                 <TableRow className="[&>td]:hover:bg-inherit">
@@ -280,10 +243,10 @@ export const ColumnList = ({
               )}
 
               {isSuccess &&
-                columns.length > 0 &&
                 columns.map((column) => {
                   const { icon: TypeIcon, label: typeLabel } =
                     getColumnTypeAffordancePresentation(column)
+
                   const constraintTokens = [
                     primaryKeyColumns.has(column.name) ? (
                       <ConstraintToken
@@ -351,7 +314,7 @@ export const ColumnList = ({
                     <TableRow key={column.name}>
                       <TableCell className="w-0 !pl-5 !pr-1">
                         <Tooltip>
-                          <TooltipTrigger className="cursor-default" aria-label={typeLabel}>
+                          <TooltipTrigger asChild className="cursor-default" aria-label={typeLabel}>
                             <div className="flex w-4 justify-center">{TypeIcon}</div>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">
@@ -366,7 +329,7 @@ export const ColumnList = ({
                           </TooltipContent>
                         </Tooltip>
                       </TableCell>
-                      <TableCell>
+                      <TableCell className="max-w-[160px] sm:max-w-[280px]">
                         <div className="flex min-w-0 flex-col">
                           <p>{column.name}</p>
                           {column.comment !== null ? (

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -5,6 +5,7 @@ import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { NoSearchResults } from 'components/ui/NoSearchResults'
 import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
+import { POSTGRES_DATA_TYPE_OPTIONS } from 'components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -12,14 +13,10 @@ import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import { noop } from 'lodash'
 import {
-  Binary,
-  Braces,
-  CalendarClock,
-  Database,
+  Calendar,
   Edit,
-  Fingerprint,
   Hash,
-  List,
+  ListPlus,
   MoreVertical,
   Plus,
   Search,
@@ -45,6 +42,7 @@ import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
+  cn,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
@@ -52,47 +50,45 @@ import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
 
 const getColumnTypeAffordance = (column: PostgresColumn) => {
-  const value = `${column.format} ${column.data_type}`.toLowerCase()
+  const normalizedFormat = column.format.replaceAll('"', '').replace(/\[\]$/, '')
+  const optionType = POSTGRES_DATA_TYPE_OPTIONS.find((option) => option.name === normalizedFormat)?.type
 
-  if (value.includes('uuid')) return { icon: Fingerprint, label: 'UUID' }
-  if (value.includes('json')) return { icon: Braces, label: 'JSON' }
-  if (value.includes('bool')) return { icon: ToggleRight, label: 'Boolean' }
-  if (
-    value.includes('timestamp') ||
-    value.includes('timestamptz') ||
-    value.includes('date') ||
-    value.includes('time') ||
-    value.includes('interval')
-  ) {
-    return { icon: CalendarClock, label: 'Date / time' }
-  }
-  if (
-    value.includes('int') ||
-    value.includes('numeric') ||
-    value.includes('decimal') ||
-    value.includes('float') ||
-    value.includes('double') ||
-    value.includes('real') ||
-    value.includes('serial')
-  ) {
-    return { icon: Hash, label: 'Numeric' }
-  }
-  if (value.includes('array') || column.format.endsWith('[]') || value.includes('enum')) {
-    return { icon: List, label: 'List / enum' }
-  }
-  if (value.includes('bytea') || value.includes('binary')) {
-    return { icon: Binary, label: 'Binary' }
-  }
-  if (
-    value.includes('char') ||
-    value.includes('text') ||
-    value.includes('varchar') ||
-    value.includes('citext')
-  ) {
-    return { icon: Type, label: 'Text' }
-  }
+  const iconClassName = 'text-foreground-muted'
 
-  return { icon: Database, label: 'Other' }
+  switch (optionType) {
+    case 'number':
+      return {
+        icon: <Hash size={14} className={iconClassName} strokeWidth={1.5} />,
+        label: 'Numeric',
+      }
+    case 'time':
+      return {
+        icon: <Calendar size={14} className={iconClassName} strokeWidth={1.5} />,
+        label: 'Date / time',
+      }
+    case 'text':
+      return {
+        icon: <Type size={14} className={iconClassName} strokeWidth={1.5} />,
+        label: 'Text',
+      }
+    case 'json':
+      return {
+        icon: (
+          <div className={cn(iconClassName, 'px-px text-[11px] leading-none font-mono')}>{'{ }'}</div>
+        ),
+        label: 'JSON',
+      }
+    case 'bool':
+      return {
+        icon: <ToggleRight size={14} className={iconClassName} strokeWidth={1.5} />,
+        label: 'Boolean',
+      }
+    default:
+      return {
+        icon: <ListPlus size={16} className={iconClassName} strokeWidth={1.5} />,
+        label: 'Other',
+      }
+  }
 }
 
 interface ColumnListProps {
@@ -203,7 +199,7 @@ export const ColumnList = ({
           <Table>
             <TableHeader>
               <TableRow>
-                <TableHead className="!px-0" />
+                <TableHead className="w-0 !px-0" />
                 <TableHead className={columns.length === 0 ? 'text-foreground-muted' : undefined}>
                   Name
                 </TableHead>
@@ -258,15 +254,12 @@ export const ColumnList = ({
 
                   return (
                     <TableRow key={column.name}>
-                      <TableCell className="!pl-5 !pr-1">
+                      <TableCell className="w-0 !pl-5 !pr-0">
                         <Tooltip>
                           <TooltipTrigger className="cursor-default">
-                            <TypeIcon
-                              aria-label={typeLabel}
-                              size={14}
-                              strokeWidth={1.75}
-                              className="text-foreground-light"
-                            />
+                            <div aria-label={typeLabel} className="flex w-4 justify-center">
+                              {TypeIcon}
+                            </div>
                           </TooltipTrigger>
                           <TooltipContent side="bottom">
                             <div className="flex flex-col">

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -14,6 +14,7 @@ import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import { noop } from 'lodash'
 import {
   Calendar,
+  DiamondIcon,
   Edit,
   Fingerprint,
   Hash,
@@ -346,6 +347,14 @@ export const ColumnList = ({
                     ) : null,
                     <ConstraintToken
                       key="nullability"
+                      icon={
+                        <DiamondIcon
+                          size={12}
+                          strokeWidth={1.7}
+                          className="shrink-0"
+                          fill={column.is_nullable ? 'none' : 'currentColor'}
+                        />
+                      }
                       label={column.is_nullable ? 'Nullable' : 'Required'}
                       variant="secondary"
                     />,

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -1,7 +1,6 @@
 import { PostgresColumn } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import { POSTGRES_DATA_TYPE_OPTIONS } from 'components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
@@ -15,7 +14,6 @@ import { noop } from 'lodash'
 import {
   Calendar,
   DiamondIcon,
-  Edit,
   Fingerprint,
   Hash,
   Key,
@@ -51,6 +49,12 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
+import {
+  getColumnTypeAffordance,
+  getForeignKeyColumnNames,
+  getPrimaryKeyColumnNames,
+  getUniqueIndexColumnNames,
+} from './ColumnList.utils'
 
 interface ConstraintTokenProps {
   icon?: ReactNode
@@ -91,29 +95,25 @@ const ConstraintToken = ({ icon, label, variant = 'default' }: ConstraintTokenPr
   )
 }
 
-const getColumnTypeAffordance = (column: PostgresColumn) => {
-  const normalizedFormat = column.format.replaceAll('"', '').replace(/\[\]$/, '')
-  const optionType = POSTGRES_DATA_TYPE_OPTIONS.find(
-    (option) => option.name === normalizedFormat
-  )?.type
-
+const getColumnTypeAffordancePresentation = (column: PostgresColumn) => {
+  const { kind, label } = getColumnTypeAffordance(column.format)
   const iconClassName = 'text-foreground-muted'
 
-  switch (optionType) {
+  switch (kind) {
     case 'number':
       return {
         icon: <Hash size={14} className={iconClassName} strokeWidth={1.5} />,
-        label: 'Numeric',
+        label,
       }
     case 'time':
       return {
         icon: <Calendar size={14} className={iconClassName} strokeWidth={1.5} />,
-        label: 'Date / time',
+        label,
       }
     case 'text':
       return {
         icon: <Type size={14} className={iconClassName} strokeWidth={1.5} />,
-        label: 'Text',
+        label,
       }
     case 'json':
       return {
@@ -122,17 +122,17 @@ const getColumnTypeAffordance = (column: PostgresColumn) => {
             {'{ }'}
           </div>
         ),
-        label: 'JSON',
+        label,
       }
     case 'bool':
       return {
         icon: <ToggleRight size={14} className={iconClassName} strokeWidth={1.5} />,
-        label: 'Boolean',
+        label,
       }
     default:
       return {
         icon: <ListPlus size={16} className={iconClassName} strokeWidth={1.5} />,
-        label: 'Other',
+        label,
       }
   }
 }
@@ -166,27 +166,10 @@ export const ColumnList = ({
 
   const [filterString, setFilterString] = useState<string>('')
   const isTableEntity = isTableLike(selectedTable)
-  const primaryKeyColumns = new Set(
-    isTableEntity ? selectedTable.primary_keys.map((primaryKey) => primaryKey.name) : []
-  )
-  const foreignKeyColumns = new Set(
-    isTableEntity
-      ? selectedTable.relationships
-          .filter(
-            (relationship) =>
-              relationship.source_schema === selectedTable.schema &&
-              relationship.source_table_name === selectedTable.name
-          )
-          .map((relationship) => relationship.source_column_name)
-      : []
-  )
-  const uniqueIndexColumns = new Set(
-    isTableEntity
-      ? (selectedTable.unique_indexes ?? [])
-          .filter((uniqueIndex) => uniqueIndex.columns.length === 1)
-          .flatMap((uniqueIndex) => uniqueIndex.columns)
-      : []
-  )
+  const tableConstraintSource = isTableEntity ? selectedTable : undefined
+  const primaryKeyColumns = getPrimaryKeyColumnNames(tableConstraintSource)
+  const foreignKeyColumns = getForeignKeyColumnNames(tableConstraintSource)
+  const uniqueIndexColumns = getUniqueIndexColumnNames(tableConstraintSource)
 
   const columns =
     (filterString.length === 0
@@ -200,6 +183,9 @@ export const ColumnList = ({
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'columns'
   )
+  const deleteColumnTooltipText = !canUpdateColumns
+    ? 'Additional permissions required to delete column'
+    : undefined
 
   return (
     <div className="space-y-4">
@@ -296,7 +282,8 @@ export const ColumnList = ({
               {isSuccess &&
                 columns.length > 0 &&
                 columns.map((column) => {
-                  const { icon: TypeIcon, label: typeLabel } = getColumnTypeAffordance(column)
+                  const { icon: TypeIcon, label: typeLabel } =
+                    getColumnTypeAffordancePresentation(column)
                   const constraintTokens = [
                     primaryKeyColumns.has(column.name) ? (
                       <ConstraintToken
@@ -424,13 +411,13 @@ export const ColumnList = ({
                               </DropdownMenuTrigger>
                               <DropdownMenuContent side="bottom" align="end" className="w-32">
                                 <DropdownMenuItemTooltip
-                                  disabled={!canUpdateColumns || isSchemaLocked}
+                                  disabled={!canUpdateColumns}
                                   onClick={() => onDeleteColumn(column)}
                                   className="gap-x-2"
                                   tooltip={{
                                     content: {
                                       side: 'left',
-                                      text: 'Additional permissions required to delete column',
+                                      text: deleteColumnTooltipText,
                                     },
                                   }}
                                 >

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -4,6 +4,7 @@ import { useParams } from 'common'
 import AlertError from 'components/ui/AlertError'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { NoSearchResults } from 'components/ui/NoSearchResults'
+import { DropdownMenuItemTooltip } from 'components/ui/DropdownMenuItemTooltip'
 import { useTableEditorQuery } from 'data/table-editor/table-editor-query'
 import { isTableLike } from 'data/table-editor/table-editor-types'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
@@ -33,7 +34,6 @@ import {
   Card,
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
   DropdownMenuTrigger,
   Table,
   TableBody,
@@ -332,23 +332,20 @@ export const ColumnList = ({
                                 <Button type="default" className="px-1" icon={<MoreVertical />} />
                               </DropdownMenuTrigger>
                               <DropdownMenuContent side="bottom" align="end" className="w-32">
-                                <Tooltip>
-                                  <TooltipTrigger>
-                                    <DropdownMenuItem
-                                      disabled={!canUpdateColumns || isSchemaLocked}
-                                      onClick={() => onDeleteColumn(column)}
-                                      className="space-x-2"
-                                    >
-                                      <Trash size={12} />
-                                      <p>Delete column</p>
-                                    </DropdownMenuItem>
-                                  </TooltipTrigger>
-                                  {!canUpdateColumns && (
-                                    <TooltipContent side="bottom">
-                                      Additional permissions required to delete column
-                                    </TooltipContent>
-                                  )}
-                                </Tooltip>
+                                <DropdownMenuItemTooltip
+                                  disabled={!canUpdateColumns || isSchemaLocked}
+                                  onClick={() => onDeleteColumn(column)}
+                                  className="gap-x-2"
+                                  tooltip={{
+                                    content: {
+                                      side: 'left',
+                                      text: 'Additional permissions required to delete column',
+                                    },
+                                  }}
+                                >
+                                  <Trash size={12} />
+                                  <p>Delete column</p>
+                                </DropdownMenuItemTooltip>
                               </DropdownMenuContent>
                             </DropdownMenu>
                           </div>

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -342,7 +342,7 @@ export const ColumnList = ({
                           fill={column.is_nullable ? 'none' : 'currentColor'}
                         />
                       }
-                      label={column.is_nullable ? 'Nullable' : 'Required'}
+                      label={column.is_nullable ? 'Nullable' : 'Non-nullable'}
                       variant="secondary"
                     />,
                   ].filter(Boolean)
@@ -351,8 +351,8 @@ export const ColumnList = ({
                     <TableRow key={column.name}>
                       <TableCell className="w-0 !pl-5 !pr-1">
                         <Tooltip>
-                          <TooltipTrigger className="cursor-default">
-                            <div aria-label={typeLabel} className="flex w-4 justify-center">
+                          <TooltipTrigger className="cursor-default" aria-label={typeLabel}>
+                            <div className="flex w-4 justify-center">
                               {TypeIcon}
                             </div>
                           </TooltipTrigger>

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -196,7 +196,7 @@ export const ColumnList = ({
                     <TableCell>
                       <code className="text-code-inline">{column.data_type}</code>
                     </TableCell>
-                    <TableCell className="font-mono text-xs">
+                    <TableCell>
                       <code className="text-code-inline">{column.format}</code>
                     </TableCell>
                     <TableCell className="text-right">

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -10,9 +10,25 @@ import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from 'hooks/useProtectedSchemas'
 import { noop } from 'lodash'
-import { Check, Edit, MoreVertical, Plus, Search, Trash, X } from 'lucide-react'
+import {
+  Binary,
+  Braces,
+  CalendarClock,
+  Database,
+  Edit,
+  Fingerprint,
+  Hash,
+  List,
+  MoreVertical,
+  Plus,
+  Search,
+  ToggleRight,
+  Trash,
+  Type,
+} from 'lucide-react'
 import { useState } from 'react'
 import {
+  Badge,
   Button,
   Card,
   DropdownMenu,
@@ -34,6 +50,50 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
+
+const getColumnTypeAffordance = (column: PostgresColumn) => {
+  const value = `${column.format} ${column.data_type}`.toLowerCase()
+
+  if (value.includes('uuid')) return { icon: Fingerprint, label: 'UUID' }
+  if (value.includes('json')) return { icon: Braces, label: 'JSON' }
+  if (value.includes('bool')) return { icon: ToggleRight, label: 'Boolean' }
+  if (
+    value.includes('timestamp') ||
+    value.includes('timestamptz') ||
+    value.includes('date') ||
+    value.includes('time') ||
+    value.includes('interval')
+  ) {
+    return { icon: CalendarClock, label: 'Date / time' }
+  }
+  if (
+    value.includes('int') ||
+    value.includes('numeric') ||
+    value.includes('decimal') ||
+    value.includes('float') ||
+    value.includes('double') ||
+    value.includes('real') ||
+    value.includes('serial')
+  ) {
+    return { icon: Hash, label: 'Numeric' }
+  }
+  if (value.includes('array') || column.format.endsWith('[]') || value.includes('enum')) {
+    return { icon: List, label: 'List / enum' }
+  }
+  if (value.includes('bytea') || value.includes('binary')) {
+    return { icon: Binary, label: 'Binary' }
+  }
+  if (
+    value.includes('char') ||
+    value.includes('text') ||
+    value.includes('varchar') ||
+    value.includes('citext')
+  ) {
+    return { icon: Type, label: 'Text' }
+  }
+
+  return { icon: Database, label: 'Other' }
+}
 
 interface ColumnListProps {
   onAddColumn: () => void
@@ -64,6 +124,27 @@ export const ColumnList = ({
 
   const [filterString, setFilterString] = useState<string>('')
   const isTableEntity = isTableLike(selectedTable)
+  const primaryKeyColumns = new Set(
+    isTableEntity ? selectedTable.primary_keys.map((primaryKey) => primaryKey.name) : []
+  )
+  const foreignKeyColumns = new Set(
+    isTableEntity
+      ? selectedTable.relationships
+          .filter(
+            (relationship) =>
+              relationship.source_schema === selectedTable.schema &&
+              relationship.source_table_name === selectedTable.name
+          )
+          .map((relationship) => relationship.source_column_name)
+      : []
+  )
+  const uniqueIndexColumns = new Set(
+    isTableEntity
+      ? (selectedTable.unique_indexes ?? [])
+          .filter((uniqueIndex) => uniqueIndex.columns.length === 1)
+          .flatMap((uniqueIndex) => uniqueIndex.columns)
+      : []
+  )
 
   const columns =
     (filterString.length === 0
@@ -122,21 +203,15 @@ export const ColumnList = ({
           <Table>
             <TableHeader>
               <TableRow>
+                <TableHead className="!px-0" />
                 <TableHead className={columns.length === 0 ? 'text-foreground-muted' : undefined}>
                   Name
                 </TableHead>
                 <TableHead className={columns.length === 0 ? 'text-foreground-muted' : undefined}>
-                  Data Type
+                  Type
                 </TableHead>
                 <TableHead className={columns.length === 0 ? 'text-foreground-muted' : undefined}>
-                  Format
-                </TableHead>
-                <TableHead
-                  className={
-                    columns.length === 0 ? 'text-right text-foreground-muted' : 'text-right'
-                  }
-                >
-                  Nullable
+                  Constraints
                 </TableHead>
                 <TableHead />
               </TableRow>
@@ -178,85 +253,110 @@ export const ColumnList = ({
 
               {isSuccess &&
                 columns.length > 0 &&
-                columns.map((column) => (
-                  <TableRow key={column.name}>
-                    <TableCell>
-                      <div className="flex min-w-0 flex-col">
-                        <p>{column.name}</p>
-                        {column.comment !== null ? (
-                          <span
-                            className="max-w-md truncate text-foreground-lighter"
-                            title={column.comment}
-                          >
-                            {column.comment}
-                          </span>
-                        ) : null}
-                      </div>
-                    </TableCell>
-                    <TableCell>
-                      <code className="text-code-inline">{column.data_type}</code>
-                    </TableCell>
-                    <TableCell>
-                      <code className="text-code-inline">{column.format}</code>
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {column.is_nullable ? (
-                        <div className="flex justify-end">
-                          <Check size={16} strokeWidth={2} className="text-brand" />
+                columns.map((column) => {
+                  const { icon: TypeIcon, label: typeLabel } = getColumnTypeAffordance(column)
+
+                  return (
+                    <TableRow key={column.name}>
+                      <TableCell className="!pl-5 !pr-1">
+                        <Tooltip>
+                          <TooltipTrigger className="cursor-default">
+                            <TypeIcon
+                              aria-label={typeLabel}
+                              size={14}
+                              strokeWidth={1.75}
+                              className="text-foreground-light"
+                            />
+                          </TooltipTrigger>
+                          <TooltipContent side="bottom">
+                            <div className="flex flex-col">
+                              <span>{column.data_type}</span>
+                              {column.format !== column.data_type && (
+                                <span className="text-xs text-foreground-light">
+                                  {column.format}
+                                </span>
+                              )}
+                            </div>
+                          </TooltipContent>
+                        </Tooltip>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex min-w-0 flex-col">
+                          <p>{column.name}</p>
+                          {column.comment !== null ? (
+                            <span
+                              className="max-w-md truncate text-foreground-lighter"
+                              title={column.comment}
+                            >
+                              {column.comment}
+                            </span>
+                          ) : null}
                         </div>
-                      ) : (
-                        <div className="flex justify-end">
-                          <X size={16} strokeWidth={2} className="text-foreground-lighter" />
+                      </TableCell>
+                      <TableCell>
+                        <code className="text-code-inline">{column.format}</code>
+                      </TableCell>
+                      <TableCell>
+                        <div className="flex flex-wrap gap-1">
+                          {primaryKeyColumns.has(column.name) && <Badge>PK</Badge>}
+                          {foreignKeyColumns.has(column.name) && <Badge>FK</Badge>}
+                          {(column.is_unique || uniqueIndexColumns.has(column.name)) && (
+                            <Badge>UQ</Badge>
+                          )}
+                          {column.is_identity && <Badge>ID</Badge>}
+                          <Badge variant="secondary">
+                            {column.is_nullable ? 'NULL' : 'NOT NULL'}
+                          </Badge>
                         </div>
-                      )}
-                    </TableCell>
-                    <TableCell className="text-right">
-                      {!isSchemaLocked && isTableEntity && (
-                        <div className="flex justify-end gap-2">
-                          <ButtonTooltip
-                            type="default"
-                            disabled={!canUpdateColumns}
-                            onClick={() => onEditColumn(column)}
-                            tooltip={{
-                              content: {
-                                side: 'bottom',
-                                text: !canUpdateColumns
-                                  ? 'Additional permissions required to edit column'
-                                  : undefined,
-                              },
-                            }}
-                          >
-                            Edit
-                          </ButtonTooltip>
-                          <DropdownMenu>
-                            <DropdownMenuTrigger asChild>
-                              <Button type="default" className="px-1" icon={<MoreVertical />} />
-                            </DropdownMenuTrigger>
-                            <DropdownMenuContent side="bottom" align="end" className="w-32">
-                              <Tooltip>
-                                <TooltipTrigger>
-                                  <DropdownMenuItem
-                                    disabled={!canUpdateColumns || isSchemaLocked}
-                                    onClick={() => onDeleteColumn(column)}
-                                    className="space-x-2"
-                                  >
-                                    <Trash size={12} />
-                                    <p>Delete column</p>
-                                  </DropdownMenuItem>
-                                </TooltipTrigger>
-                                {!canUpdateColumns && (
-                                  <TooltipContent side="bottom">
-                                    Additional permissions required to delete column
-                                  </TooltipContent>
-                                )}
-                              </Tooltip>
-                            </DropdownMenuContent>
-                          </DropdownMenu>
-                        </div>
-                      )}
-                    </TableCell>
-                  </TableRow>
-                ))}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        {!isSchemaLocked && isTableEntity && (
+                          <div className="flex justify-end gap-2">
+                            <ButtonTooltip
+                              type="default"
+                              disabled={!canUpdateColumns}
+                              onClick={() => onEditColumn(column)}
+                              tooltip={{
+                                content: {
+                                  side: 'bottom',
+                                  text: !canUpdateColumns
+                                    ? 'Additional permissions required to edit column'
+                                    : undefined,
+                                },
+                              }}
+                            >
+                              Edit
+                            </ButtonTooltip>
+                            <DropdownMenu>
+                              <DropdownMenuTrigger asChild>
+                                <Button type="default" className="px-1" icon={<MoreVertical />} />
+                              </DropdownMenuTrigger>
+                              <DropdownMenuContent side="bottom" align="end" className="w-32">
+                                <Tooltip>
+                                  <TooltipTrigger>
+                                    <DropdownMenuItem
+                                      disabled={!canUpdateColumns || isSchemaLocked}
+                                      onClick={() => onDeleteColumn(column)}
+                                      className="space-x-2"
+                                    >
+                                      <Trash size={12} />
+                                      <p>Delete column</p>
+                                    </DropdownMenuItem>
+                                  </TooltipTrigger>
+                                  {!canUpdateColumns && (
+                                    <TooltipContent side="bottom">
+                                      Additional permissions required to delete column
+                                    </TooltipContent>
+                                  )}
+                                </Tooltip>
+                              </DropdownMenuContent>
+                            </DropdownMenu>
+                          </div>
+                        )}
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
             </TableBody>
             {isSuccess && (
               <TableFooter className="font-normal">

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.tsx
@@ -15,7 +15,10 @@ import { noop } from 'lodash'
 import {
   Calendar,
   Edit,
+  Fingerprint,
   Hash,
+  Key,
+  Link as LinkIcon,
   ListPlus,
   MoreVertical,
   Plus,
@@ -24,9 +27,8 @@ import {
   Trash,
   Type,
 } from 'lucide-react'
-import { useState } from 'react'
+import { useState, type ReactNode } from 'react'
 import {
-  Badge,
   Button,
   Card,
   cn,
@@ -48,6 +50,45 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
+
+interface ConstraintTokenProps {
+  icon?: ReactNode
+  label: string
+  variant?: 'default' | 'secondary' | 'primary'
+}
+
+const constraintTokenClassName =
+  'inline-flex items-center justify-center rounded-md text-center font-mono uppercase whitespace-nowrap font-medium tracking-[0.06em] text-[11px] leading-[1.1] px-[5.5px] py-[3px] transition-all border'
+
+const ConstraintToken = ({ icon, label, variant = 'default' }: ConstraintTokenProps) => {
+  const tokenToneClassName =
+    variant === 'primary'
+      ? 'bg-brand bg-opacity-10 text-brand-600 border-brand-500'
+      : variant === 'default'
+        ? 'bg-surface-75 text-foreground-light border-strong'
+        : 'bg-surface-75 bg-opacity-50 text-foreground-light border-strong'
+
+  return (
+    <div className="inline-flex items-center whitespace-nowrap">
+      {icon && (
+        <span
+          className={cn(constraintTokenClassName, tokenToneClassName, 'rounded-r-none border-r-0')}
+        >
+          {icon}
+        </span>
+      )}
+      <span
+        className={cn(
+          constraintTokenClassName,
+          tokenToneClassName,
+          icon ? 'rounded-l-none' : 'rounded-md'
+        )}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}
 
 const getColumnTypeAffordance = (column: PostgresColumn) => {
   const normalizedFormat = column.format.replaceAll('"', '').replace(/\[\]$/, '')
@@ -255,6 +296,60 @@ export const ColumnList = ({
                 columns.length > 0 &&
                 columns.map((column) => {
                   const { icon: TypeIcon, label: typeLabel } = getColumnTypeAffordance(column)
+                  const constraintTokens = [
+                    primaryKeyColumns.has(column.name) ? (
+                      <ConstraintToken
+                        key="primary"
+                        icon={<Key size={12} strokeWidth={1.7} className="shrink-0" />}
+                        label="Primary"
+                        variant="primary"
+                      />
+                    ) : null,
+                    foreignKeyColumns.has(column.name) ? (
+                      <ConstraintToken
+                        key="foreign-key"
+                        icon={
+                          <LinkIcon
+                            size={12}
+                            strokeWidth={1.7}
+                            className="shrink-0 text-foreground-muted"
+                          />
+                        }
+                        label="Foreign key"
+                      />
+                    ) : null,
+                    column.is_unique || uniqueIndexColumns.has(column.name) ? (
+                      <ConstraintToken
+                        key="unique"
+                        icon={
+                          <Fingerprint
+                            size={12}
+                            strokeWidth={1.7}
+                            className="shrink-0 text-foreground-light"
+                          />
+                        }
+                        label="Unique"
+                      />
+                    ) : null,
+                    column.is_identity ? (
+                      <ConstraintToken
+                        key="identity"
+                        icon={
+                          <Hash
+                            size={12}
+                            strokeWidth={1.7}
+                            className="shrink-0 text-foreground-lighter"
+                          />
+                        }
+                        label="Identity"
+                      />
+                    ) : null,
+                    <ConstraintToken
+                      key="nullability"
+                      label={column.is_nullable ? 'Nullable' : 'Required'}
+                      variant="secondary"
+                    />,
+                  ].filter(Boolean)
 
                   return (
                     <TableRow key={column.name}>
@@ -291,20 +386,10 @@ export const ColumnList = ({
                         </div>
                       </TableCell>
                       <TableCell>
-                        <p className="text-foreground-light">{column.format}</p>
+                        <p className="text-foreground-lighter">{column.format}</p>
                       </TableCell>
                       <TableCell>
-                        <div className="flex flex-wrap gap-1">
-                          {primaryKeyColumns.has(column.name) && <Badge>PK</Badge>}
-                          {foreignKeyColumns.has(column.name) && <Badge>FK</Badge>}
-                          {(column.is_unique || uniqueIndexColumns.has(column.name)) && (
-                            <Badge>UQ</Badge>
-                          )}
-                          {column.is_identity && <Badge>ID</Badge>}
-                          <Badge variant="secondary">
-                            {column.is_nullable ? 'NULL' : 'NOT NULL'}
-                          </Badge>
-                        </div>
+                        <div className="flex flex-wrap gap-1.5">{constraintTokens}</div>
                       </TableCell>
                       <TableCell className="text-right">
                         {!isSchemaLocked && isTableEntity && (

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.test.ts
@@ -54,10 +54,7 @@ describe('ColumnList.utils', () => {
           target_column_name: 'id',
         },
       ],
-      unique_indexes: [
-        { columns: ['reference'] },
-        { columns: ['customer_id', 'reference'] },
-      ],
+      unique_indexes: [{ columns: ['reference'] }, { columns: ['customer_id', 'reference'] }],
     } as const
 
     expect([...getPrimaryKeyColumnNames(table)]).toEqual(['id'])

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.test.ts
@@ -1,3 +1,5 @@
+import { describe, expect, it } from 'vitest'
+
 import {
   getColumnTypeAffordance,
   getForeignKeyColumnNames,

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.test.ts
@@ -1,0 +1,67 @@
+import {
+  getColumnTypeAffordance,
+  getForeignKeyColumnNames,
+  getPrimaryKeyColumnNames,
+  getUniqueIndexColumnNames,
+} from './ColumnList.utils'
+
+describe('ColumnList.utils', () => {
+  it('normalises quoted array formats before resolving the affordance kind', () => {
+    expect(getColumnTypeAffordance('"uuid"[]')).toEqual({
+      kind: 'text',
+      label: 'Text',
+    })
+  })
+
+  it('maps recognised Postgres formats to their affordance labels', () => {
+    expect(getColumnTypeAffordance('timestamptz')).toEqual({
+      kind: 'time',
+      label: 'Date / time',
+    })
+    expect(getColumnTypeAffordance('jsonb')).toEqual({
+      kind: 'json',
+      label: 'JSON',
+    })
+  })
+
+  it('falls back to the other affordance for unrecognised formats', () => {
+    expect(getColumnTypeAffordance('citext')).toEqual({
+      kind: 'other',
+      label: 'Other',
+    })
+  })
+
+  it('derives only source-table foreign key column names', () => {
+    const table = {
+      schema: 'public',
+      name: 'orders',
+      primary_keys: [{ name: 'id' }],
+      relationships: [
+        {
+          source_schema: 'public',
+          source_table_name: 'orders',
+          source_column_name: 'customer_id',
+          target_table_schema: 'public',
+          target_table_name: 'customers',
+          target_column_name: 'id',
+        },
+        {
+          source_schema: 'public',
+          source_table_name: 'customers',
+          source_column_name: 'account_id',
+          target_table_schema: 'public',
+          target_table_name: 'accounts',
+          target_column_name: 'id',
+        },
+      ],
+      unique_indexes: [
+        { columns: ['reference'] },
+        { columns: ['customer_id', 'reference'] },
+      ],
+    } as const
+
+    expect([...getPrimaryKeyColumnNames(table)]).toEqual(['id'])
+    expect([...getForeignKeyColumnNames(table)]).toEqual(['customer_id'])
+    expect([...getUniqueIndexColumnNames(table)]).toEqual(['reference'])
+  })
+})

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.ts
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.ts
@@ -1,0 +1,73 @@
+import { POSTGRES_DATA_TYPE_OPTIONS } from 'components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.constants'
+
+type TableConstraintSource = {
+  schema: string
+  name: string
+  primary_keys: Array<{ name: string }>
+  relationships: Array<{
+    source_schema: string
+    source_table_name: string
+    source_column_name: string
+  }>
+  unique_indexes?: Array<{ columns: string[] }>
+}
+
+export type ColumnAffordanceKind = 'number' | 'time' | 'text' | 'json' | 'bool' | 'other'
+
+export interface ColumnTypeAffordance {
+  kind: ColumnAffordanceKind
+  label: string
+}
+
+const COLUMN_AFFORDANCE_LABELS: Record<ColumnAffordanceKind, string> = {
+  number: 'Numeric',
+  time: 'Date / time',
+  text: 'Text',
+  json: 'JSON',
+  bool: 'Boolean',
+  other: 'Other',
+}
+
+const normalizeColumnFormat = (format: string) => format.replaceAll('"', '').replace(/\[\]$/, '')
+
+export function getColumnTypeAffordance(format: string): ColumnTypeAffordance {
+  const normalizedFormat = normalizeColumnFormat(format)
+  const optionType = POSTGRES_DATA_TYPE_OPTIONS.find(
+    (option) => option.name === normalizedFormat
+  )?.type
+
+  switch (optionType) {
+    case 'number':
+    case 'time':
+    case 'text':
+    case 'json':
+    case 'bool':
+      return { kind: optionType, label: COLUMN_AFFORDANCE_LABELS[optionType] }
+    default:
+      return { kind: 'other', label: COLUMN_AFFORDANCE_LABELS.other }
+  }
+}
+
+export function getPrimaryKeyColumnNames(table?: TableConstraintSource) {
+  return new Set(table?.primary_keys.map((primaryKey) => primaryKey.name) ?? [])
+}
+
+export function getForeignKeyColumnNames(table?: TableConstraintSource) {
+  return new Set(
+    table?.relationships
+      .filter(
+        (relationship) =>
+          relationship.source_schema === table.schema &&
+          relationship.source_table_name === table.name
+      )
+      .map((relationship) => relationship.source_column_name) ?? []
+  )
+}
+
+export function getUniqueIndexColumnNames(table?: TableConstraintSource) {
+  return new Set(
+    table?.unique_indexes
+      ?.filter((uniqueIndex) => uniqueIndex.columns.length === 1)
+      .flatMap((uniqueIndex) => uniqueIndex.columns) ?? []
+  )
+}

--- a/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.ts
+++ b/apps/studio/components/interfaces/Database/Tables/ColumnList.utils.ts
@@ -3,13 +3,13 @@ import { POSTGRES_DATA_TYPE_OPTIONS } from 'components/interfaces/TableGridEdito
 type TableConstraintSource = {
   schema: string
   name: string
-  primary_keys: Array<{ name: string }>
-  relationships: Array<{
+  primary_keys: ReadonlyArray<{ name: string }>
+  relationships: ReadonlyArray<{
     source_schema: string
     source_table_name: string
     source_column_name: string
   }>
-  unique_indexes?: Array<{ columns: string[] }>
+  unique_indexes?: ReadonlyArray<{ columns: ReadonlyArray<string> }>
 }
 
 export type ColumnAffordanceKind = 'number' | 'time' | 'text' | 'json' | 'bool' | 'other'
@@ -53,14 +53,19 @@ export function getPrimaryKeyColumnNames(table?: TableConstraintSource) {
 }
 
 export function getForeignKeyColumnNames(table?: TableConstraintSource) {
+  if (!table) {
+    return new Set<string>()
+  }
+
+  const { schema, name, relationships } = table
+
   return new Set(
-    table?.relationships
+    relationships
       .filter(
         (relationship) =>
-          relationship.source_schema === table.schema &&
-          relationship.source_table_name === table.name
+          relationship.source_schema === schema && relationship.source_table_name === name
       )
-      .map((relationship) => relationship.source_column_name) ?? []
+      .map((relationship) => relationship.source_column_name)
   )
 }
 

--- a/apps/studio/components/interfaces/Database/Tables/ConstraintToken.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/ConstraintToken.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from 'react'
+import { cn } from 'ui'
+
+interface ConstraintTokenProps {
+  icon?: ReactNode
+  label: string
+  variant?: 'default' | 'secondary' | 'primary'
+}
+
+const constraintTokenClassName = cn(
+  'inline-flex items-center justify-center rounded-md text-center font-mono uppercase whitespace-nowrap font-medium',
+  'tracking-[0.06em] text-[11px] leading-[1.1] px-[5.5px] h-[21px]',
+  'transition-all border'
+)
+
+export const ConstraintToken = ({ icon, label, variant = 'default' }: ConstraintTokenProps) => {
+  const tokenToneClassName =
+    variant === 'primary'
+      ? 'bg-brand bg-opacity-10 text-brand-600 border-brand-500'
+      : variant === 'default'
+        ? 'bg-surface-75 text-foreground-light border-strong'
+        : 'bg-surface-75 bg-opacity-50 text-foreground-light border-strong'
+
+  return (
+    <div className="inline-flex items-center whitespace-nowrap">
+      {icon && (
+        <span
+          className={cn(constraintTokenClassName, tokenToneClassName, 'rounded-r-none border-r-0')}
+        >
+          {icon}
+        </span>
+      )}
+      <span
+        className={cn(
+          constraintTokenClassName,
+          tokenToneClassName,
+          icon ? 'rounded-l-none' : 'rounded-md'
+        )}
+      >
+        {label}
+      </span>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -310,18 +310,10 @@ export const TableList = ({
                   <TableHead key="name" className="max-w-[160px] sm:max-w-[280px]">
                     Name
                   </TableHead>
-                  <TableHead key="columns" className="text-right">
-                    Columns
-                  </TableHead>
-                  <TableHead key="rows" className="text-right">
-                    Rows (Estimated)
-                  </TableHead>
-                  <TableHead key="size" className="text-right">
-                    Size (Estimated)
-                  </TableHead>
-                  <TableHead key="realtime" className="text-right">
-                    Realtime Enabled
-                  </TableHead>
+                  <TableHead key="columns">Columns</TableHead>
+                  <TableHead key="rows">Rows (Estimated)</TableHead>
+                  <TableHead key="size">Size (Estimated)</TableHead>
+                  <TableHead key="realtime">Realtime</TableHead>
                   <TableHead key="buttons"></TableHead>
                 </TableRow>
               </TableHeader>
@@ -414,35 +406,37 @@ export const TableList = ({
                             ) : null}
                           </div>
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell>
                           <p className="text-foreground-light">
                             {x.columns.length.toLocaleString()}
                           </p>
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell>
                           {x.rows !== undefined ? (
                             <p className="text-foreground-light">{x.rows.toLocaleString()}</p>
                           ) : (
                             <p className="text-foreground-muted">–</p>
                           )}
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell>
                           {x.size !== undefined ? (
                             <p className="text-foreground-light">{x.size}</p>
                           ) : (
                             <p className="text-foreground-muted">–</p>
                           )}
                         </TableCell>
-                        <TableCell className="text-right">
+                        <TableCell>
                           {(realtimePublication?.tables ?? []).find(
                             (table) => table.id === x.id
                           ) ? (
-                            <div className="flex justify-end">
-                              <Check size={16} strokeWidth={2} className="text-brand" />
+                            <div className="flex items-center gap-x-2">
+                              <Check size={16} strokeWidth={2} className="text-brand-link" />
+                              <p className="text-foreground-light">Enabled</p>
                             </div>
                           ) : (
-                            <div className="flex justify-end">
-                              <X size={16} strokeWidth={2} className="text-foreground-lighter" />
+                            <div className="flex items-center gap-x-2">
+                              <X size={16} strokeWidth={2} className="text-foreground-muted" />
+                              <p className="text-foreground-lighter">Disabled</p>
                             </div>
                           )}
                         </TableCell>

--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -369,7 +369,7 @@ export const TableList = ({
                       <TableRow key={x.id}>
                         <TableCell className="w-0 !pl-5 !pr-1">
                           <Tooltip>
-                            <TooltipTrigger className="cursor-default">
+                            <TooltipTrigger asChild className="cursor-default">
                               <div className="flex w-4 justify-center">
                                 <EntityTypeIcon type={x.type} />
                               </div>

--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -306,7 +306,7 @@ export const TableList = ({
             <Table>
               <TableHeader>
                 <TableRow>
-                  <TableHead key="icon" className="!px-0" />
+                  <TableHead key="icon" className="w-0 !px-0" />
                   <TableHead key="name" className="max-w-[160px] sm:max-w-[280px]">
                     Name
                   </TableHead>
@@ -375,10 +375,12 @@ export const TableList = ({
                   {entities.length > 0 &&
                     entities.map((x) => (
                       <TableRow key={x.id}>
-                        <TableCell className="!pl-5 !pr-1">
+                        <TableCell className="w-0 !pl-5 !pr-1">
                           <Tooltip>
                             <TooltipTrigger className="cursor-default">
-                              <EntityTypeIcon type={x.type} />
+                              <div className="flex w-4 justify-center">
+                                <EntityTypeIcon type={x.type} />
+                              </div>
                             </TooltipTrigger>
                             <TooltipContent side="bottom">
                               {formatTooltipText(x.type)}


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI improvements. Resolves DEPR-419.

## What is the current behavior?

- `ColumnList` splits type information across separate `Data Type` and `Format` columns, which makes scanning less efficient
- The list only surfaces a limited subset of column metadata up front, so key structural information like primary keys, foreign keys, uniqueness, and identity is not easy to scan
- Constraint and nullability affordances are not aligned with the visual language already used in the Table Editor and Schema Visualiser

## What is the new behavior?

- `ColumnList` now shows a leading type affordance icon, while keeping the exact Postgres type visible in the `Type` column
- The standalone `Data Type` column is removed, and `format` is now the primary textual type shown in the table
- The `Constraints` column now surfaces explicit icon-plus-label tokens for:
  - `Primary`
  - `Foreign key`
  - `Unique`
  - `Identity`
  - `Nullable` / `Non-nullable`
- Constraint tokens use a purpose-built segmented style based on `ComputeBadge`, including a green primary variant for primary keys
- Nullability now matches Schema Visualiser semantics exactly: outlined diamond for nullable, filled diamond for non-nullable
- Existing search, descriptions, row actions, and permission gating are preserved