### PR TITLE
chore(docs): add David Alvarez to list of contributors

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -59,6 +59,7 @@ Danny White
 Darren Cunningham
 Dave Wilson
 David A. Ventimiglia
+David Alvarez
 David Birdsong
 David Camacho Cateura
 David Weitzman


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update to add David Alvarez to humans.txt

## What is the current behavior?

David Alvarez is not currently in the humans.txt file

## What is the new behavior?

David Alvarez is now in the humans.txt file!
