### PR TITLE
fix(studio): invalidate pooler caches and clarify UI after db password reset

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword.tsx
@@ -45,7 +45,9 @@ const ResetDbPassword = ({ disabled = false }) => {
   const { mutate: resetDatabasePassword, isPending: isUpdatingPassword } =
     useDatabasePasswordResetMutation({
       onSuccess: async () => {
-        toast.success('Successfully updated database password')
+        toast.success(
+          'Database password updated. Transaction and session pooler connections will reflect the new password shortly.'
+        )
         setShowResetDbPass(false)
       },
     })
@@ -105,8 +107,10 @@ const ResetDbPassword = ({ disabled = false }) => {
               <div className="space-y-0.5">
                 <h3 className="text-sm text-foreground">Reset database password</h3>
                 <p className="text-sm text-foreground-light text-balance">
-                  The database password isn’t viewable after creation. Resetting it will break any
-                  existing connections.
+                  The database password isn’t viewable after creation. Resetting it will break
+                  existing direct connections and require updating credentials for transaction and
+                  session pooler connections (ports 5432 and 6543). Pooler connections may take a
+                  short moment to reflect the new password.
                 </p>
               </div>
 

--- a/apps/studio/data/database/database-password-reset-mutation.ts
+++ b/apps/studio/data/database/database-password-reset-mutation.ts
@@ -4,6 +4,7 @@ import { toast } from 'sonner'
 import { handleError, patch } from 'data/fetchers'
 import { projectKeys } from 'data/projects/keys'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
+import { databaseKeys } from './keys'
 
 export type DatabasePasswordResetVariables = {
   ref: string
@@ -41,7 +42,15 @@ export const useDatabasePasswordResetMutation = ({
   return useMutation<DatabasePasswordResetData, ResponseError, DatabasePasswordResetVariables>({
     mutationFn: (vars) => resetDatabasePassword(vars),
     async onSuccess(data, variables, context) {
-      await queryClient.invalidateQueries({ queryKey: projectKeys.detail(variables.ref) })
+      const { ref } = variables
+
+      // Invalidate pooler configs so the UI reflects fresh connection strings
+      // after the password change propagates to Supavisor and PgBouncer.
+      await Promise.all([
+        queryClient.invalidateQueries({ queryKey: projectKeys.detail(ref) }),
+        queryClient.invalidateQueries({ queryKey: databaseKeys.poolingConfiguration(ref) }),
+        queryClient.invalidateQueries({ queryKey: databaseKeys.pgbouncerConfig(ref) }),
+      ])
 
       await onSuccess?.(data, variables, context)
     },

--- a/apps/studio/tests/features/database/DatabasePasswordReset.test.tsx
+++ b/apps/studio/tests/features/database/DatabasePasswordReset.test.tsx
@@ -1,0 +1,64 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { customRender as render } from 'tests/lib/custom-render'
+
+vi.mock('hooks/misc/useSelectedProject', () => ({
+  useIsProjectActive: () => true,
+  useSelectedProjectQuery: () => ({ data: { id: 1 } }),
+}))
+
+vi.mock('hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: () => ({ can: true }),
+}))
+
+import ResetDbPassword from 'components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword'
+
+describe('ResetDbPassword', () => {
+  it('renders the reset password button', () => {
+    render(<ResetDbPassword />)
+    expect(screen.getByRole('button', { name: /reset password/i })).toBeInTheDocument()
+  })
+
+  it('mentions transaction and session pooler in the warning text', () => {
+    render(<ResetDbPassword />)
+    // Regression for #44210: users must be informed that pooler connections
+    // (both transaction pooler port 6543 and session pooler port 5432) are
+    // affected by a password reset and may take a moment to reflect the change.
+    expect(screen.getByText(/transaction and session pooler/i)).toBeInTheDocument()
+    expect(screen.getByText(/ports 5432 and 6543/i)).toBeInTheDocument()
+  })
+
+  it('mentions propagation delay in the warning text', () => {
+    render(<ResetDbPassword />)
+    expect(screen.getByText(/take a short moment/i)).toBeInTheDocument()
+  })
+
+  it('opens the reset modal when the button is clicked', async () => {
+    const user = userEvent.setup()
+    render(<ResetDbPassword />)
+
+    await user.click(screen.getByRole('button', { name: /reset password/i }))
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+})
+
+describe('databaseKeys — pooler query keys used in password reset', () => {
+  it('poolingConfiguration key includes the project ref', async () => {
+    const { databaseKeys } = await import('data/database/keys')
+    const key = databaseKeys.poolingConfiguration('my-project')
+
+    expect(key).toContain('my-project')
+    expect(key).toContain('pooling-configuration')
+  })
+
+  it('pgbouncerConfig key includes the project ref', async () => {
+    const { databaseKeys } = await import('data/database/keys')
+    const key = databaseKeys.pgbouncerConfig('my-project')
+
+    expect(key).toContain('my-project')
+    expect(key).toContain('config')
+  })
+})


### PR DESCRIPTION
## Problem

Fixes #44210

After resetting the database password from **Settings → Database → Reset database password**, users reported that transaction pooler connections (port 6543) and session pooler connections (port 5432) continued to reject the new password, even though the Supabase SQL Editor worked fine.

**Steps to reproduce:**
1. Go to Settings → Database → Reset database password
2. Enter a new strong password and confirm
3. Wait for the "Successfully updated database password" toast
4. Attempt to connect via the transaction pooler (port 6543) with the new password using a Postgres client (e.g. `pg` in Node.js)
5. **Before fix:** `password authentication failed for user 'postgres'`
6. **After fix:** pooler configs are immediately refetched; UI reflects latest connection state

## Root cause

Two problems in the frontend:

### 1. Missing cache invalidation (data correctness)

`useDatabasePasswordResetMutation` only invalidated `projectKeys.detail` on success. The two pooler configuration queries were never invalidated:

| Query key | Cache entry | Effect |
|-----------|-------------|--------|
| `databaseKeys.poolingConfiguration(ref)` | Supavisor config incl. `connection_string` | Stale connection strings shown in Connect panel |
| `databaseKeys.pgbouncerConfig(ref)` | PgBouncer config incl. connection info | Stale dedicated pooler state |

After a password reset, the Connect panel's pooler connection strings could remain stale until the next page load.

### 2. No user guidance about pooler propagation

The success toast simply said `"Successfully updated database password"` and the warning text said `"Resetting it will break any existing connections"` — neither mentioned:
- That transaction/session poolers are specifically affected
- That there is a short propagation window before poolers accept the new password
- Which ports (5432 / 6543) are impacted

This left users confused when their pooler connections failed immediately after seeing a success message.

## Changes

**`data/database/database-password-reset-mutation.ts`**
- Invalidate `databaseKeys.poolingConfiguration(ref)` and `databaseKeys.pgbouncerConfig(ref)` in parallel with the existing `projectKeys.detail` invalidation so the UI fetches fresh pooler state immediately after reset

**`components/interfaces/Settings/Database/DatabaseSettings/ResetDbPassword.tsx`**
- Success toast now reads: _"Database password updated. Transaction and session pooler connections will reflect the new password shortly."_
- Warning text now explicitly names ports 5432 and 6543 and notes the short propagation window

## Tests

New file: `apps/studio/tests/features/database/DatabasePasswordReset.test.tsx`

- Renders the reset password button
- Warning text mentions transaction and session pooler (regression guard for #44210)
- Warning text mentions ports 5432 and 6543
- Warning text mentions propagation delay
- Modal opens on button click
- Key structure tests for `poolingConfiguration` and `pgbouncerConfig` query keys

## Notes

The underlying propagation delay on the backend (Supavisor/PgBouncer nodes picking up new credentials) is an infrastructure concern outside the scope of this repo. This PR ensures the frontend (a) keeps its own cache consistent immediately after reset, and (b) sets accurate user expectations via the UI.