### PR TITLE
chore(docs): add Jordan McQueen to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -125,6 +125,7 @@ John Pena
 John Schaeffer
 Jon M
 Jonny Summers-Muir
+Jordan McQueen
 Jordi Enric
 José Luis Ledesma
 Joshen Lim


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to `humans.txt` to add `Jordan McQueen`
 
## What is the current behavior?

`Jordan McQueen` does not yet exist in `humans.txt`

## What is the new behavior?

`Jordan McQueen` exists in `humans.txt`