### PR TITLE
Add fallback for SNIPPETS_MANAGEMENT_FOLDER env variable

### DIFF
--- a/apps/studio/lib/api/snippets.constants.ts
+++ b/apps/studio/lib/api/snippets.constants.ts
@@ -1,1 +1,1 @@
-export const SNIPPETS_DIR = process.env.SNIPPETS_MANAGEMENT_FOLDER ?? ''
+export const SNIPPETS_DIR = process.env.SNIPPETS_MANAGEMENT_FOLDER || 'snippets'


### PR DESCRIPTION

## Problem

When `SNIPPETS_MANAGEMENT_FOLDER` environment variable is not set, the application falls back to an empty string (`''`).  
This can lead to invalid paths and unexpected behavior in snippets management.

## Fix

- Added a proper fallback to a default folder (`'snippets'`) when the env variable is not defined
- Ensured the application continues to work without requiring explicit configuration

## Before

- Missing env → empty string used as path ❌
- Potential runtime issues / invalid directory usage

## After

- Missing env → defaults to `'snippets'` ✅
- More robust and predictable behavior

## Impact

- Improves developer experience
- Prevents potential runtime issues
- Makes configuration optional instead of required

---

If this approach looks good, I can also extend it to show a warning or UI hint when the env variable is not set.
fixes #44220 