### PR TITLE
chore: migrate observability report modals to use `react-hook-form`

### DIFF
--- a/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
+++ b/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
@@ -1,19 +1,36 @@
-import { useRouter } from 'next/router'
-import { useMemo } from 'react'
-import { toast } from 'sonner'
-
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useContentUpsertMutation } from 'data/content/content-upsert-mutation'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { uuidv4 } from 'lib/helpers'
 import { useProfile } from 'lib/profile'
-import { Button, Form, Input, Modal } from 'ui'
+import { useRouter } from 'next/router'
+import { useMemo } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import {
+  Button,
+  Form_Shadcn_,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Input_Shadcn_,
+  Modal,
+  Textarea,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import * as z from 'zod'
 
-type CustomReport = { name: string; description?: string }
 export interface CreateReportModal {
   visible: boolean
   onCancel: () => void
   afterSubmit: () => void
 }
+
+const formSchema = z.object({
+  name: z.string().min(1, 'Required'),
+  description: z.string().optional(),
+})
+
+type CustomReport = z.infer<typeof formSchema>
 
 export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateReportModal) => {
   const router = useRouter()
@@ -47,7 +64,7 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
     },
   })
 
-  async function createCustomReport({ name, description }: { name: string; description?: string }) {
+  const createCustomReport: SubmitHandler<CustomReport> = async ({ name, description }) => {
     if (!ref) return console.error('Project ref is required')
     if (!profile) return console.error('Profile is required')
 
@@ -77,6 +94,12 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
     })
   }
 
+  const form = useForm<CustomReport>({
+    resolver: zodResolver(formSchema),
+    defaultValues: { name: '', description: '' },
+  })
+  const { isDirty } = form.formState
+
   return (
     <Modal
       visible={visible}
@@ -85,45 +108,50 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
       header="Create a custom report"
       size="small"
     >
-      <Form
-        onReset={onCancel}
-        validateOnBlur
-        initialValues={{ name: '', description: '' }}
-        validate={(vals) => {
-          const errors: Partial<CustomReport> = {}
-
-          if (!vals.name) {
-            errors.name = 'Required'
-          }
-
-          return errors
-        }}
-        onSubmit={(newVals) => createCustomReport(newVals)}
-      >
-        {() => (
-          <>
-            <Modal.Content className="space-y-4">
-              <Input label="Name" id="name" name="name" />
-              <Input.TextArea
-                label="Description"
-                id="description"
-                placeholder="Describe your custom report"
-                size="medium"
-                textAreaClassName="resize-none"
-              />
-            </Modal.Content>
-            <Modal.Separator />
-            <Modal.Content className="flex items-center justify-end gap-2">
-              <Button htmlType="reset" type="default" onClick={onCancel} disabled={isCreating}>
-                Cancel
-              </Button>
-              <Button htmlType="submit" loading={isCreating} disabled={isCreating}>
-                Create report
-              </Button>
-            </Modal.Content>
-          </>
-        )}
-      </Form>
+      <Form_Shadcn_ {...form}>
+        <form onSubmit={form.handleSubmit(createCustomReport)} noValidate>
+          <Modal.Content>
+            <FormField_Shadcn_
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItemLayout layout="vertical" label="Name">
+                  <FormControl_Shadcn_>
+                    <Input_Shadcn_ {...field} />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+          </Modal.Content>
+          <Modal.Content>
+            <FormField_Shadcn_
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItemLayout layout="vertical" label="Description">
+                  <FormControl_Shadcn_>
+                    <Textarea
+                      {...field}
+                      rows={4}
+                      placeholder="Describe your custom report"
+                      className="resize-none"
+                    />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+          </Modal.Content>
+          <Modal.Separator />
+          <Modal.Content className="flex items-center justify-end gap-2">
+            <Button htmlType="reset" type="default" onClick={onCancel} disabled={isCreating}>
+              Cancel
+            </Button>
+            <Button htmlType="submit" loading={isCreating} disabled={isCreating || !isDirty}>
+              Create report
+            </Button>
+          </Modal.Content>
+        </form>
+      </Form_Shadcn_>
     </Modal>
   )
 }

--- a/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
+++ b/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
@@ -94,6 +94,11 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
     })
   }
 
+  const handleCancel = () => {
+    onCancel()
+    form.reset()
+  }
+
   const form = useForm<CustomReport>({
     resolver: zodResolver(formSchema),
     defaultValues: { name: '', description: '' },
@@ -103,7 +108,7 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
   return (
     <Modal
       visible={visible}
-      onCancel={onCancel}
+      onCancel={handleCancel}
       hideFooter
       header="Create a custom report"
       size="small"
@@ -115,9 +120,9 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
               control={form.control}
               name="name"
               render={({ field }) => (
-                <FormItemLayout layout="vertical" label="Name">
+                <FormItemLayout name="name" layout="vertical" label="Name">
                   <FormControl_Shadcn_>
-                    <Input_Shadcn_ {...field} />
+                    <Input_Shadcn_ {...field} id="name" />
                   </FormControl_Shadcn_>
                 </FormItemLayout>
               )}
@@ -128,10 +133,11 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
               control={form.control}
               name="description"
               render={({ field }) => (
-                <FormItemLayout layout="vertical" label="Description">
+                <FormItemLayout name="description" layout="vertical" label="Description">
                   <FormControl_Shadcn_>
                     <Textarea
                       {...field}
+                      id="description"
                       rows={4}
                       placeholder="Describe your custom report"
                       className="resize-none"
@@ -143,7 +149,7 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
           </Modal.Content>
           <Modal.Separator />
           <Modal.Content className="flex items-center justify-end gap-2">
-            <Button htmlType="reset" type="default" onClick={onCancel} disabled={isCreating}>
+            <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isCreating}>
               Cancel
             </Button>
             <Button htmlType="submit" loading={isCreating} disabled={isCreating || !isDirty}>

--- a/apps/studio/components/interfaces/Reports/UpdateModal.tsx
+++ b/apps/studio/components/interfaces/Reports/UpdateModal.tsx
@@ -1,11 +1,27 @@
-import { toast } from 'sonner'
-
+import { zodResolver } from '@hookform/resolvers/zod'
 import { useParams } from 'common'
 import { Content } from 'data/content/content-query'
 import { useContentUpsertMutation } from 'data/content/content-upsert-mutation'
-import { Button, Form, Input, Modal } from 'ui'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { toast } from 'sonner'
+import {
+  Button,
+  Form_Shadcn_,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Input_Shadcn_,
+  Modal,
+  Textarea,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import * as z from 'zod'
 
-type CustomReport = { name: string; description?: string }
+const formSchema = z.object({
+  name: z.string().min(1, 'Required'),
+  description: z.string().optional(),
+})
+
+type CustomReport = z.infer<typeof formSchema>
 
 export interface UpdateCustomReportProps {
   selectedReport?: Content
@@ -29,7 +45,7 @@ export const UpdateCustomReportModal = ({
     },
   })
 
-  const onConfirmUpdateReport = (newVals: { name: string; description?: string }) => {
+  const onConfirmUpdateReport: SubmitHandler<CustomReport> = (newVals) => {
     if (!ref) return console.error('Project ref is required')
     if (!selectedReport) return
     if (!selectedReport.id) return
@@ -48,53 +64,69 @@ export const UpdateCustomReportModal = ({
     })
   }
 
-  function validate(values: CustomReport) {
-    const errors: Partial<CustomReport> = {}
-    if (!values.name) errors.name = 'This field is required'
-    return errors
+  const handleCancel = () => {
+    onCancel()
+    form.reset()
   }
+
+  const form = useForm<CustomReport>({
+    resolver: zodResolver(formSchema),
+    defaultValues: initialValues,
+  })
+  const { isDirty } = form.formState
 
   return (
     <Modal
       visible={selectedReport !== undefined}
-      onCancel={onCancel}
+      onCancel={handleCancel}
       hideFooter
       header="Update custom report"
       size="small"
     >
-      <Form
-        onReset={onCancel}
-        validateOnBlur
-        initialValues={initialValues}
-        validate={validate}
-        onSubmit={onConfirmUpdateReport}
-      >
-        {() => (
-          <>
-            <Modal.Content>
-              <Input label="Name" id="name" name="name" />
-            </Modal.Content>
-            <Modal.Content>
-              <Input.TextArea
-                label="Description"
-                id="description"
-                placeholder="Describe your custom report"
-                size="medium"
-                textAreaClassName="resize-none"
-              />
-            </Modal.Content>
-            <Modal.Separator />
-            <Modal.Content className="flex items-center justify-end gap-2">
-              <Button htmlType="reset" type="default" onClick={onCancel} disabled={isUpdating}>
-                Cancel
-              </Button>
-              <Button htmlType="submit" loading={isUpdating} disabled={isUpdating}>
-                Save custom report
-              </Button>
-            </Modal.Content>
-          </>
-        )}
-      </Form>
+      <Form_Shadcn_ {...form}>
+        <form onSubmit={form.handleSubmit(onConfirmUpdateReport)} noValidate>
+          <Modal.Content>
+            <FormField_Shadcn_
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItemLayout layout="vertical" label="Name">
+                  <FormControl_Shadcn_>
+                    <Input_Shadcn_ {...field} />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+          </Modal.Content>
+          <Modal.Content>
+            <FormField_Shadcn_
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItemLayout layout="vertical" label="Description">
+                  <FormControl_Shadcn_>
+                    <Textarea
+                      {...field}
+                      rows={4}
+                      placeholder="Describe your custom report"
+                      className="resize-none"
+                    />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+          </Modal.Content>
+          <Modal.Separator />
+          <Modal.Content className="flex items-center justify-end gap-2">
+            <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isUpdating}>
+              Cancel
+            </Button>
+            <Button htmlType="submit" loading={isUpdating} disabled={isUpdating || !isDirty}>
+              Save custom report
+            </Button>
+          </Modal.Content>
+        </form>
+      </Form_Shadcn_>
     </Modal>
   )
 }

--- a/apps/studio/components/interfaces/Reports/UpdateModal.tsx
+++ b/apps/studio/components/interfaces/Reports/UpdateModal.tsx
@@ -2,6 +2,7 @@ import { zodResolver } from '@hookform/resolvers/zod'
 import { useParams } from 'common'
 import { Content } from 'data/content/content-query'
 import { useContentUpsertMutation } from 'data/content/content-upsert-mutation'
+import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -73,7 +74,13 @@ export const UpdateCustomReportModal = ({
     resolver: zodResolver(formSchema),
     defaultValues: initialValues,
   })
-  const { isDirty } = form.formState
+  const { formState, reset } = form
+  const { isDirty } = formState
+
+  useEffect(() => {
+    if (isDirty) return
+    reset(initialValues)
+  }, [initialValues, isDirty, reset])
 
   return (
     <Modal
@@ -90,9 +97,9 @@ export const UpdateCustomReportModal = ({
               control={form.control}
               name="name"
               render={({ field }) => (
-                <FormItemLayout layout="vertical" label="Name">
+                <FormItemLayout name="name" layout="vertical" label="Name">
                   <FormControl_Shadcn_>
-                    <Input_Shadcn_ {...field} />
+                    <Input_Shadcn_ {...field} id="name" />
                   </FormControl_Shadcn_>
                 </FormItemLayout>
               )}
@@ -103,10 +110,11 @@ export const UpdateCustomReportModal = ({
               control={form.control}
               name="description"
               render={({ field }) => (
-                <FormItemLayout layout="vertical" label="Description">
+                <FormItemLayout name="description" layout="vertical" label="Description">
                   <FormControl_Shadcn_>
                     <Textarea
                       {...field}
+                      id="description"
                       rows={4}
                       placeholder="Describe your custom report"
                       className="resize-none"


### PR DESCRIPTION
## Problem

- observability report modals still uses `formik` and we want to remove it in favour of `react-hook-form` to keep only one form library

## Solution

- Migrate to `react-hook-form`