### PR TITLE
ci: add release notes on update js libs pr

### DIFF
--- a/.github/workflows/update-js-libs.yml
+++ b/.github/workflows/update-js-libs.yml
@@ -59,6 +59,33 @@ jobs:
       - name: Install dependencies
         run: pnpm install --no-frozen-lockfile
 
+      - name: Fetch release notes
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          CURRENT_FULL=$(git show HEAD:pnpm-workspace.yaml | grep -oP "(?<='@supabase/supabase-js': )[\d]+\.[\d]+\.[\d]+(-[\w.]+)?")
+          CURRENT_BASE=$(echo "$CURRENT_FULL" | grep -oP '[\d]+\.[\d]+\.[\d]+')
+          [[ "$CURRENT_FULL" == *"-"* ]] && INCLUDE_CURRENT=true || INCLUDE_CURRENT=false
+          [[ "$VERSION" == *"-"* ]] && STABLE_ONLY=false || STABLE_ONLY=true
+          RELEASES=$(gh api "repos/supabase/supabase-js/releases?per_page=100")
+          RELEASE_NOTES=$(echo "$RELEASES" | jq -r \
+            --arg current "v${CURRENT_BASE}" \
+            --arg new "v${VERSION}" \
+            --argjson stable_only "$STABLE_ONLY" \
+            --argjson include_current "$INCLUDE_CURRENT" \
+            '[.[] | select(.draft == false) | select(if $stable_only then .prerelease == false else true end)] |
+             (map(.tag_name) | index($new)) as $start |
+             (map(.tag_name) | index($current)) as $end |
+             ($end | if . != null and $include_current then . + 1 else . end) as $end_adj |
+             if $start == null then ["Target version not found in last 100 releases."]
+             elif $end_adj != null and $start >= $end_adj then ["Downgrade — no release notes available."]
+             else [.[$start:$end_adj][] | "## " + .tag_name + "\n\n" + (.body // "No release notes.")]
+             end | .[]')
+          echo "RELEASE_NOTES<<EOF" >> "$GITHUB_ENV"
+          echo "$RELEASE_NOTES" >> "$GITHUB_ENV"
+          echo "EOF" >> "$GITHUB_ENV"
+
       - name: Generate token
         id: app-token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
@@ -83,6 +110,12 @@ jobs:
             - Updated @supabase/realtime-js to ${{ github.event.inputs.version }}
             - Updated @supabase/postgest-js to ${{ github.event.inputs.version }}
             - Refreshed pnpm-lock.yaml
+
+            ---
+
+            ## Release Notes
+
+            ${{ env.RELEASE_NOTES }}
 
             This PR was created automatically.
           branch: 'gha/auto-update-js-libs-v${{ github.event.inputs.version }}'


### PR DESCRIPTION
Include release notes in the automated PR that updates supabase-js across the repo.

* Looks at what version is installed
* It includes all changelogs between installed version and to-be-installed version