### PR TITLE
chore: use `react-hook-form` in logs query modals

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
@@ -1,15 +1,15 @@
-import { useRouter } from 'next/router'
-import { useState } from 'react'
-import { toast } from 'sonner'
-
 import { useParams } from 'common'
 import { useContentDeleteMutation } from 'data/content/content-delete-mutation'
 import { useContentUpsertMutation } from 'data/content/content-upsert-mutation'
+import { SqlEditor } from 'icons'
+import { Edit, Trash } from 'lucide-react'
+import { useRouter } from 'next/router'
+import { useState } from 'react'
+import { toast } from 'sonner'
 import { DropdownMenuItem, DropdownMenuSeparator } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
 import { UpdateSavedQueryModal } from './Logs.UpdateSavedQueryModal'
-import { Edit, Trash } from 'lucide-react'
-import { SqlEditor } from 'icons'
 import { LogsSidebarItem } from './SidebarV2/SidebarItem'
 
 interface SavedQueriesItemProps {
@@ -110,6 +110,7 @@ const SavedQueriesItem = ({ item }: SavedQueriesItemProps) => {
         </p>
       </ConfirmationModal>
       <UpdateSavedQueryModal
+        header="Update saved query"
         visible={showUpdateModal}
         initialValues={{ name: item.name, description: item.description }}
         onCancel={() => {

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.SavedQueriesItem.tsx
@@ -39,7 +39,7 @@ const SavedQueriesItem = ({ item }: SavedQueriesItemProps) => {
       toast.error(`Failed to delete saved query: ${error.message}`)
     },
   })
-  const { mutate: updateContent } = useContentUpsertMutation({
+  const { mutateAsync: updateContent } = useContentUpsertMutation({
     onSuccess: () => {
       setShowUpdateModal(false)
       toast.success('Successfully updated query')
@@ -56,7 +56,7 @@ const SavedQueriesItem = ({ item }: SavedQueriesItemProps) => {
 
   const onConfirmUpdate = async ({ name, description }: { name: string; description?: string }) => {
     if (!ref || typeof ref !== 'string') return console.error('Invalid project reference')
-    updateContent({
+    await updateContent({
       projectRef: ref,
       payload: {
         ...item,
@@ -116,9 +116,7 @@ const SavedQueriesItem = ({ item }: SavedQueriesItemProps) => {
         onCancel={() => {
           setShowUpdateModal(false)
         }}
-        onSubmit={(newValues) => {
-          onConfirmUpdate(newValues)
-        }}
+        onSubmit={onConfirmUpdate}
       />
     </>
   )

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
@@ -1,11 +1,29 @@
-import { Button, Form, Input, Modal } from 'ui'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useEffect } from 'react'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import {
+  Button,
+  Form_Shadcn_,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  Input_Shadcn_,
+  Modal,
+  Textarea,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import * as z from 'zod'
 
-type SavedQuery = { name: string; description?: string }
+const formSchema = z.object({
+  name: z.string().min(1, 'Required'),
+  description: z.string().optional(),
+})
+
+type SavedQuery = z.infer<typeof formSchema>
 
 export interface UpdateSavedQueryProps {
   visible: boolean
   onCancel: () => void
-  onSubmit: (newValues: SavedQuery) => void
+  onSubmit: SubmitHandler<SavedQuery>
   initialValues: SavedQuery
 }
 
@@ -15,57 +33,70 @@ export const UpdateSavedQueryModal = ({
   onSubmit,
   initialValues,
 }: UpdateSavedQueryProps) => {
-  function validate(values: SavedQuery) {
-    const errors: Partial<SavedQuery> = {}
+  const form = useForm<SavedQuery>({
+    resolver: zodResolver(formSchema),
+    defaultValues: initialValues,
+  })
+  const { reset, formState } = form
+  const { isDirty, isSubmitting } = formState
 
-    if (!values.name) {
-      errors.name = 'Required'
-    }
+  useEffect(() => {
+    if (isDirty) return
+    reset(initialValues)
+  }, [isDirty, initialValues, reset])
 
-    return errors
+  const handleCancel = () => {
+    form.reset()
+    onCancel()
   }
 
   return (
     <Modal
       visible={visible}
-      onCancel={onCancel}
+      onCancel={handleCancel}
       hideFooter
       header="Update saved query"
       size="medium"
     >
-      <Form
-        onReset={onCancel}
-        validateOnBlur
-        initialValues={initialValues}
-        validate={validate}
-        onSubmit={onSubmit}
-      >
-        {({ isSubmitting }: { isSubmitting: boolean }) => (
-          <>
-            <Modal.Content>
-              <Input label="Name" id="name" name="name" />
-            </Modal.Content>
-            <Modal.Content>
-              <Input.TextArea
-                label="Description"
-                id="description"
-                placeholder="Describe query"
-                size="medium"
-                textAreaClassName="resize-none"
-              />
-            </Modal.Content>
-            <Modal.Separator />
-            <Modal.Content className="flex items-center justify-end gap-2">
-              <Button htmlType="reset" type="default" onClick={onCancel} disabled={isSubmitting}>
-                Cancel
-              </Button>
-              <Button htmlType="submit" loading={isSubmitting} disabled={isSubmitting}>
-                Save query
-              </Button>
-            </Modal.Content>
-          </>
-        )}
-      </Form>
+      <Form_Shadcn_ {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
+          <Modal.Content>
+            <FormField_Shadcn_
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItemLayout layout="vertical" label="Name">
+                  <FormControl_Shadcn_>
+                    <Input_Shadcn_ {...field} placeholder="Enter text" />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+          </Modal.Content>
+          <Modal.Content>
+            <FormField_Shadcn_
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItemLayout layout="vertical" label="Description">
+                  <FormControl_Shadcn_>
+                    <Textarea {...field} placeholder="Describe query" className="resize-none" />
+                  </FormControl_Shadcn_>
+                </FormItemLayout>
+              )}
+            />
+          </Modal.Content>
+          <Modal.Separator />
+          <Modal.Content className="flex items-center justify-end gap-2">
+            <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button htmlType="submit" loading={isSubmitting} disabled={isSubmitting || !isDirty}>
+              Save query
+            </Button>
+          </Modal.Content>
+        </form>
+      </Form_Shadcn_>
     </Modal>
   )
 }

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
@@ -37,14 +37,14 @@ export const UpdateSavedQueryModal = ({
 }: UpdateSavedQueryProps) => {
   const form = useForm<SavedQuery>({
     resolver: zodResolver(formSchema),
-    defaultValues: initialValues,
+    defaultValues: { ...initialValues, description: initialValues.description ?? '' },
   })
   const { reset, formState } = form
   const { isDirty, isSubmitting } = formState
 
   useEffect(() => {
     if (isDirty) return
-    reset(initialValues)
+    reset({ ...initialValues, description: initialValues.description ?? '' })
   }, [isDirty, initialValues, reset])
 
   const handleCancel = () => {

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal.tsx
@@ -21,6 +21,7 @@ const formSchema = z.object({
 type SavedQuery = z.infer<typeof formSchema>
 
 export interface UpdateSavedQueryProps {
+  header: string
   visible: boolean
   onCancel: () => void
   onSubmit: SubmitHandler<SavedQuery>
@@ -28,6 +29,7 @@ export interface UpdateSavedQueryProps {
 }
 
 export const UpdateSavedQueryModal = ({
+  header,
   visible,
   onCancel,
   onSubmit,
@@ -51,13 +53,7 @@ export const UpdateSavedQueryModal = ({
   }
 
   return (
-    <Modal
-      visible={visible}
-      onCancel={handleCancel}
-      hideFooter
-      header="Update saved query"
-      size="medium"
-    >
+    <Modal visible={visible} onCancel={handleCancel} hideFooter header={header} size="medium">
       <Form_Shadcn_ {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
           <Modal.Content>

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -142,7 +142,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   const results = logData
   const isLoading = logsLoading
 
-  const { mutate: upsertContent, isPending: isUpsertingContent } = useContentUpsertMutation({
+  const { mutateAsync: upsertContent, isPending: isUpsertingContent } = useContentUpsertMutation({
     onError: (e) => {
       const error = e as { message: string }
       console.error(error)
@@ -267,7 +267,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
       owner_id: profile.id,
       visibility: 'user' as const,
     }
-    upsertContent(
+    await upsertContent(
       { projectRef, payload },
       {
         onSuccess: () => router.push(`/project/${projectRef}/logs/explorer?queryId=${id}`),
@@ -275,12 +275,12 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
     )
   }
 
-  function handleOnSave() {
+  async function handleOnSave() {
     if (!projectRef) return console.error('Project ref is required')
 
     // if we have a queryId, we are editing a saved query
     if (queryId && query) {
-      upsertContent({
+      await upsertContent({
         projectRef: projectRef!,
         payload: {
           ...query,

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -45,15 +45,9 @@ import { useRouter } from 'next/router'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { LogSqlSnippets, NextPageWithLayout } from 'types'
-import {
-  Button,
-  Form,
-  Input,
-  Modal,
-  ResizableHandle,
-  ResizablePanel,
-  ResizablePanelGroup,
-} from 'ui'
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from 'ui'
+
+import { UpdateSavedQueryModal } from '@/components/interfaces/Settings/Logs/Logs.UpdateSavedQueryModal'
 
 const LOCAL_PLACEHOLDER_QUERY =
   'select\n  timestamp, event_message, metadata\n  from edge_logs limit 5'
@@ -254,13 +248,9 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
 
   type SaveQueryFormValues = { name: string; description?: string }
 
-  const handleCreateQuery = async (
-    values: SaveQueryFormValues,
-    { setSubmitting }: { setSubmitting: (value: boolean) => void }
-  ) => {
+  const handleCreateQuery = async (values: SaveQueryFormValues) => {
     if (!projectRef) return console.error('Project ref is required')
     if (!profile) return console.error('Profile is required')
-    setSubmitting(true)
 
     const id = uuidv4()
     const payload: UpsertContentPayload = {
@@ -424,52 +414,15 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
         </ResizablePanel>
       </ResizablePanelGroup>
 
-      <Modal
-        size="medium"
-        onCancel={() => setSaveModalOpen(!saveModalOpen)}
+      <UpdateSavedQueryModal
         header="Save log query"
         visible={saveModalOpen}
-        hideFooter
-      >
-        <Form
-          initialValues={{
-            name: '',
-            description: '',
-          }}
-          onSubmit={handleCreateQuery}
-        >
-          {() => (
-            <>
-              <Modal.Content className="space-y-6">
-                <Input layout="horizontal" label="Name" id="name" />
-                <div className="text-area-text-sm">
-                  <Input.TextArea
-                    layout="horizontal"
-                    labelOptional="Optional"
-                    label="Description"
-                    id="description"
-                    rows={2}
-                  />
-                </div>
-              </Modal.Content>
-              <Modal.Separator />
-              <Modal.Content className="flex items-center justify-end gap-2">
-                <Button size="tiny" type="default" onClick={() => setSaveModalOpen(!saveModalOpen)}>
-                  Cancel
-                </Button>
-                <Button
-                  size="tiny"
-                  loading={isUpsertingContent}
-                  disabled={isUpsertingContent}
-                  htmlType="submit"
-                >
-                  Save
-                </Button>
-              </Modal.Content>
-            </>
-          )}
-        </Form>
-      </Modal>
+        initialValues={{ name: '', description: '' }}
+        onCancel={() => {
+          setSaveModalOpen(false)
+        }}
+        onSubmit={handleCreateQuery}
+      />
     </div>
   )
 }

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -382,6 +382,8 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
           />
           <ShimmerLine active={isLoading} />
           <CodeEditor
+            // Ensure we reset the editor to the query content whenever the selected query changes
+            key={queryId}
             id={editorId}
             editorRef={editorRef}
             language="pgsql"


### PR DESCRIPTION
## Problem

- Logs query modals still use `formik` and we want to remove it in favour of `react-hook-form` to keep only one form library

## Solution

- Migrate to `react-hook-form`

## Screenshots

New query:
<img width="566" height="387" alt="image" src="https://github.com/user-attachments/assets/f300a292-88f6-454e-8f86-84a27a8c4892" />

Existing query:
<img width="554" height="378" alt="image" src="https://github.com/user-attachments/assets/2333f041-7185-47f6-8fb0-5176b5a0c77b" />
