### PR TITLE
fix: restore consent from ucData when GTM overwrites SDK storage

### DIFF
--- a/packages/common/consent-state.ts
+++ b/packages/common/consent-state.ts
@@ -4,6 +4,35 @@ import { proxy, snapshot, useSnapshot } from 'valtio'
 
 import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from './constants'
 
+/**
+ * Check if the user previously accepted all consent services by reading
+ * the compressed ucData format that the GTM/Usercentrics integration writes.
+ *
+ * Context (FE-2648): After acceptAllServices(), the GTM script's Usercentrics
+ * integration replaces uc_settings with ucString/ucData. On the next page load,
+ * UC.init() can't read that format and treats the user as new. This function
+ * detects that prior consent so we can silently re-accept.
+ */
+function hasPreviousConsentInUcData(): boolean {
+  try {
+    const ucData = localStorage?.getItem('ucData')
+    if (!ucData) return false
+
+    const data = JSON.parse(ucData)
+    const services = data?.consent?.services
+    if (!services || typeof services !== 'object') return false
+
+    const serviceValues = Object.values(services)
+    if (serviceValues.length === 0) return false
+
+    return serviceValues.every(
+      (s) => typeof s === 'object' && s !== null && (s as { consent: boolean }).consent === true
+    )
+  } catch {
+    return false
+  }
+}
+
 export const consentState = proxy({
   // Usercentrics state
   UC: null as Usercentrics | null,
@@ -73,27 +102,59 @@ async function initUserCentrics() {
     return
   }
 
-  const { default: Usercentrics } = await import('@usercentrics/cmp-browser-sdk')
+  // Check for prior consent BEFORE UC.init(), which can't read the compressed
+  // ucData format written by the GTM/Usercentrics integration (FE-2648).
+  const previouslyAccepted = hasPreviousConsentInUcData()
 
-  const UC = new Usercentrics(process.env.NEXT_PUBLIC_USERCENTRICS_RULESET_ID!, {
-    rulesetId: process.env.NEXT_PUBLIC_USERCENTRICS_RULESET_ID,
-    useRulesetId: true,
-  })
+  try {
+    const { default: Usercentrics } = await import('@usercentrics/cmp-browser-sdk')
 
-  const initialUIValues = await UC.init()
+    const UC = new Usercentrics(process.env.NEXT_PUBLIC_USERCENTRICS_RULESET_ID!, {
+      rulesetId: process.env.NEXT_PUBLIC_USERCENTRICS_RULESET_ID,
+      useRulesetId: true,
+    })
 
-  consentState.UC = UC
-  const hasConsented = UC.areAllConsentsAccepted()
+    const initialUIValues = await UC.init()
 
-  // 0 = first layer, aka show consent toast
-  consentState.showConsentToast = initialUIValues.initialLayer === 0
-  consentState.hasConsented = hasConsented
-  consentState.categories = UC.getCategoriesBaseInfo()
+    consentState.UC = UC
+    const hasConsented = UC.areAllConsentsAccepted()
 
-  // If the user has previously consented (before usercentrics), accept all services
-  if (!hasConsented && localStorage?.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT) === 'true') {
-    consentState.acceptAll()
-    localStorage.removeItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
+    // If the SDK wants to show the banner but the user previously accepted
+    // (ucData exists from a prior GTM-mediated accept), silently re-accept
+    // instead of showing the banner again.
+    if (initialUIValues.initialLayer === 0 && !hasConsented && previouslyAccepted) {
+      consentState.hasConsented = true
+      consentState.showConsentToast = false
+      consentState.categories = UC.getCategoriesBaseInfo()
+      localStorage?.removeItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
+      UC.acceptAllServices()
+        .then(() => {
+          consentState.categories = UC.getCategoriesBaseInfo()
+        })
+        .catch(() => {
+          // If re-accept fails, fall back to showing the banner
+          consentState.hasConsented = false
+          consentState.showConsentToast = true
+        })
+      return
+    }
+
+    // 0 = first layer, aka show consent toast
+    consentState.showConsentToast = initialUIValues.initialLayer === 0
+    consentState.hasConsented = hasConsented
+    consentState.categories = UC.getCategoriesBaseInfo()
+
+    // If the user has previously consented (before usercentrics), accept all services
+    if (!hasConsented && localStorage?.getItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT) === 'true') {
+      consentState.acceptAll()
+      localStorage.removeItem(LOCAL_STORAGE_KEYS.TELEMETRY_CONSENT)
+    }
+  } catch (error) {
+    console.error('Failed to initialize Usercentrics:', error)
+    // If SDK fails but user previously accepted, honor that
+    if (previouslyAccepted) {
+      consentState.hasConsented = true
+    }
   }
 }
 


### PR DESCRIPTION
## Problem

After PR #43221 gated `TelemetryTagManager` behind consent, the EU cookie consent banner started reappearing on every page load and when navigating between apps (www, studio, docs).

Back in late February we changed `TelemetryTagManager` to only load when the user has accepted consent. This was the right call for GDPR — don't load tracking scripts before consent. But it created a chicken-and-egg problem with how the Usercentrics SDK stores consent.

## What happened

When a user clicks Accept, the SDK writes `uc_settings` + `uc_user_interaction: true` to localStorage. Then the GTM script loads (now that consent is granted), and its Usercentrics integration immediately replaces those keys with a compressed `ucString` + `ucData` format — deleting the originals.

On the next page load, `UC.init()` only knows how to read `uc_settings`. It can't find it (GTM deleted it), so it treats the user as brand new and shows the banner again. Before #43221, GTM loaded on every page unconditionally, so its integration was already present during `UC.init()` and could interpret the compressed format.

Confirmed via production console monitoring — the exact sequence after clicking Accept:

```
setItem("uc_settings", ...)           // SDK writes consent
setItem("uc_user_interaction", "true") // SDK marks interaction
removeItem("uc_settings")             // GTM deletes SDK format
removeItem("uc_user_interaction")     // GTM deletes SDK format
setItem("ucString", ...)              // GTM writes compressed format
setItem("ucData", ...)                // GTM writes compressed format
```

## Changes

- Read `ucData` from localStorage **before** `UC.init()` to detect prior consent in the compressed format
- If the SDK wants to show the banner but `ucData` shows all services were previously accepted, silently re-accept instead of re-prompting
- Added try/catch around the SDK initialization (was fire-and-forget with no error handling, any failure was completely silent)
- Error fallback also honors prior `ucData` consent if the SDK fails to initialize

## Testing

Can't fully reproduce on staging previews because CSP blocks the GTM script there (so the storage migration never fires). Verified the root cause via production console monitoring with localStorage monkey-patching, and confirmed the `ucData` format persists across page loads on production.

Closes FE-2648