### PR TITLE
fix(studio): guard against non-array sources response in POST log-dra…

### DIFF
--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/log-drains.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/log-drains.ts
@@ -74,14 +74,25 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
       const sourcesGetUrl = new URL(baseUrl)
       sourcesGetUrl.pathname = '/api/sources'
-      const sources = await fetch(sourcesGetUrl, {
-        method: 'GET',
-        headers: {
-          Authorization: `Bearer ${process.env.LOGFLARE_PRIVATE_ACCESS_TOKEN}`,
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
-      }).then((r) => r.json())
+      let sources: unknown
+      try {
+        sources = await fetch(sourcesGetUrl, {
+          method: 'GET',
+          headers: {
+            Authorization: `Bearer ${process.env.LOGFLARE_PRIVATE_ACCESS_TOKEN}`,
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+        }).then((r) => r.json())
+      } catch {
+        return res.status(500).json({ error: { message: 'Failed to fetch sources from upstream' } })
+      }
+
+      if (!Array.isArray(sources)) {
+        return res
+          .status(500)
+          .json({ error: { message: 'Unexpected response format from upstream' } })
+      }
 
       const params = sources
         .filter((source: { name: string; metadata: { type: string } }) =>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On self-hosted Supabase instances, creating a log drain via the Studio UI crashes with a 500 Internal Server Error. The POST handler in `log-drains.ts` calls `.filter()` directly on the result of a fetch to `/api/sources` without validating the response shape first. When Logflare is unavailable or returns a non-array response, this throws `TypeError: .filter is not a function`.

Fixes #44200
Related to #41585

## What is the new behavior?

The POST handler now mirrors the defensive pattern already used in the GET handler:
- A `try-catch` wraps the sources fetch to handle network errors when Logflare is unreachable
- An `Array.isArray(sources)` guard prevents the TypeError when upstream returns a non-array response

`.filter()` is only called once the response is confirmed to be a valid array.

## Additional context

No visual changes. The fix is confined to a single file:
`apps/studio/pages/api/platform/projects/[ref]/analytics/log-drains.ts`