### PR TITLE
fix(Docs): Migrate the rest of the raw.githubcontent calls to new util

### DIFF
--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -35,10 +35,10 @@ type TagQueryResponse = {
   repository: {
     refs: {
       nodes:
-      | {
-        name: string
-      }[]
-      | null
+        | {
+            name: string
+          }[]
+        | null
       pageInfo: {
         hasNextPage: boolean
         endCursor: string | null
@@ -270,16 +270,16 @@ const WrappersDocs = async (props: { params: Promise<Params> }) => {
 
   const options = isExternal
     ? ({
-      mdxOptions: {
-        remarkPlugins: [
-          remarkMkDocsAdmonition,
-          emoji,
-          remarkPyMdownTabs,
-          [removeTitle, meta.title],
-        ],
-        rehypePlugins: [[linkTransform, combinedUrlTransformer], rehypeSlug],
-      },
-    } as SerializeOptions)
+        mdxOptions: {
+          remarkPlugins: [
+            remarkMkDocsAdmonition,
+            emoji,
+            remarkPyMdownTabs,
+            [removeTitle, meta.title],
+          ],
+          rehypePlugins: [[linkTransform, combinedUrlTransformer], rehypeSlug],
+        },
+      } as SerializeOptions)
     : undefined
 
   const dashboardIntegrationURL = getDashboardIntegrationURL(meta.dashboardIntegrationPath)
@@ -335,14 +335,14 @@ const getContent = async (params: Params) => {
       ),
       'utf-8'
     )
-      ; ({ data: meta, content } = matter(rawContent))
+    ;({ data: meta, content } = matter(rawContent))
     if (!isValidGuideFrontmatter(meta)) {
       throw Error(`Expected valid frontmatter, got ${JSON.stringify(meta, null, 2)}`)
     }
   } else {
     isExternal = true
     let remoteFile: string
-      ; ({ remoteFile, meta } = federatedPage)
+    ;({ remoteFile, meta } = federatedPage)
 
     const tag = await getLatestRelease()
     if (!tag) {
@@ -350,12 +350,7 @@ const getContent = async (params: Params) => {
     }
 
     editLink = `${org}/${repo}/blob/${tag}/${docsDir}/${remoteFile}`
-    console.log('WRAPPERS PAGE', {
-      org,
-      repo,
-      path: `${docsDir}/${remoteFile}`,
-      branch: tag,
-    })
+
     let rawContent = await getGitHubFileContents({
       org,
       repo,

--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -16,14 +16,13 @@ import {
   removeRedundantH1,
 } from '~/features/docs/GuidesMdx.utils'
 import { newEditLink } from '~/features/helpers.edit-link'
-import { REVALIDATION_TAGS } from '~/features/helpers.fetch'
 import { Guide, GuideArticle, GuideFooter, GuideHeader, GuideMdxContent } from '~/features/ui/guide'
 import { GUIDES_DIRECTORY, isValidGuideFrontmatter } from '~/lib/docs'
 import { linkTransform, type UrlTransformFunction } from '~/lib/mdx/plugins/rehypeLinkTransform'
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
 import { removeTitle } from '~/lib/mdx/plugins/remarkRemoveTitle'
 import remarkPyMdownTabs from '~/lib/mdx/plugins/remarkTabs'
-import { octokit } from '~/lib/octokit'
+import { getGitHubFileContents, octokit } from '~/lib/octokit'
 import type { SerializeOptions } from '~/types/next-mdx-remote-serialize'
 
 // We fetch these docs at build time from an external repo
@@ -36,10 +35,10 @@ type TagQueryResponse = {
   repository: {
     refs: {
       nodes:
-        | {
-            name: string
-          }[]
-        | null
+      | {
+        name: string
+      }[]
+      | null
       pageInfo: {
         hasNextPage: boolean
         endCursor: string | null
@@ -85,13 +84,6 @@ async function getLatestRelease(after: string | null = null) {
       owner: org,
       name: repo,
       after,
-      request: {
-        fetch: (url: RequestInfo | URL, options?: RequestInit) =>
-          fetch(url, {
-            ...options,
-            next: { tags: [REVALIDATION_TAGS.WRAPPERS] },
-          }),
-      },
     })
 
     return (
@@ -278,16 +270,16 @@ const WrappersDocs = async (props: { params: Promise<Params> }) => {
 
   const options = isExternal
     ? ({
-        mdxOptions: {
-          remarkPlugins: [
-            remarkMkDocsAdmonition,
-            emoji,
-            remarkPyMdownTabs,
-            [removeTitle, meta.title],
-          ],
-          rehypePlugins: [[linkTransform, combinedUrlTransformer], rehypeSlug],
-        },
-      } as SerializeOptions)
+      mdxOptions: {
+        remarkPlugins: [
+          remarkMkDocsAdmonition,
+          emoji,
+          remarkPyMdownTabs,
+          [removeTitle, meta.title],
+        ],
+        rehypePlugins: [[linkTransform, combinedUrlTransformer], rehypeSlug],
+      },
+    } as SerializeOptions)
     : undefined
 
   const dashboardIntegrationURL = getDashboardIntegrationURL(meta.dashboardIntegrationPath)
@@ -343,40 +335,33 @@ const getContent = async (params: Params) => {
       ),
       'utf-8'
     )
-    ;({ data: meta, content } = matter(rawContent))
+      ; ({ data: meta, content } = matter(rawContent))
     if (!isValidGuideFrontmatter(meta)) {
       throw Error(`Expected valid frontmatter, got ${JSON.stringify(meta, null, 2)}`)
     }
   } else {
     isExternal = true
     let remoteFile: string
-    ;({ remoteFile, meta } = federatedPage)
+      ; ({ remoteFile, meta } = federatedPage)
 
     const tag = await getLatestRelease()
     if (!tag) {
       throw new Error('No latest release found for federated wrappers pages')
     }
 
-    const repoPath = `${org}/${repo}/${tag}/${docsDir}/${remoteFile}`
     editLink = `${org}/${repo}/blob/${tag}/${docsDir}/${remoteFile}`
-
-    let response: Response
-    try {
-      response = await fetch(`https://raw.githubusercontent.com/${repoPath}`, {
-        cache: 'force-cache',
-        next: { tags: [REVALIDATION_TAGS.WRAPPERS] },
-      })
-    } catch (err) {
-      throw new Error(`Failed to fetch wrappers docs from GitHub (network error): ${err}`)
-    }
-
-    if (!response.ok) {
-      throw new Error(
-        `Failed to fetch wrappers docs from GitHub: ${response.status} ${response.statusText}`
-      )
-    }
-
-    const rawContent = await response.text()
+    console.log('WRAPPERS PAGE', {
+      org,
+      repo,
+      path: `${docsDir}/${remoteFile}`,
+      branch: tag,
+    })
+    let rawContent = await getGitHubFileContents({
+      org,
+      repo,
+      path: `${docsDir}/${remoteFile}`,
+      branch: tag,
+    })
 
     assetsBaseUrl = `https://raw.githubusercontent.com/${org}/${repo}/${tag}/docs/assets/`
 

--- a/apps/docs/lib/octokit.constants.ts
+++ b/apps/docs/lib/octokit.constants.ts
@@ -1,0 +1,4 @@
+export const OCTOKIT_RETRY_OPTIONS = {
+  retries: 5,
+  retryAfter: 1,
+} as const

--- a/apps/docs/lib/octokit.ts
+++ b/apps/docs/lib/octokit.ts
@@ -6,13 +6,11 @@ import { retry } from '@octokit/plugin-retry'
 import crypto from 'node:crypto'
 
 import { fetchRevalidatePerDay } from '~/features/helpers.fetch'
+import { OCTOKIT_RETRY_OPTIONS } from './octokit.constants'
+
+export { OCTOKIT_RETRY_OPTIONS }
 
 const RetryOctokit = Octokit.plugin(retry)
-
-export const OCTOKIT_RETRY_OPTIONS = {
-  retries: 5,
-  retryAfter: 1,
-} as const
 
 let octokitInstance: InstanceType<typeof RetryOctokit>
 

--- a/apps/docs/scripts/search/sources/lint-warnings-guide.ts
+++ b/apps/docs/scripts/search/sources/lint-warnings-guide.ts
@@ -1,7 +1,11 @@
 import { createAppAuth } from '@octokit/auth-app'
 import { Octokit } from '@octokit/core'
+import { retry } from '@octokit/plugin-retry'
 import crypto, { createHash } from 'node:crypto'
+import { OCTOKIT_RETRY_OPTIONS } from '../../../lib/octokit.constants.js'
 import { BaseLoader, BaseSource } from './base.js'
+
+const RetryOctokit = Octokit.plugin(retry)
 
 const appId = process.env.DOCS_GITHUB_APP_ID
 const installationId = process.env.DOCS_GITHUB_APP_INSTALLATION_ID
@@ -28,7 +32,7 @@ export class LintWarningsGuideLoader extends BaseLoader {
       throw new Error('Missing DOCS_GITHUB_APP_* environment variables')
     }
 
-    const octokit = new Octokit({
+    const octokit = new RetryOctokit({
       authStrategy: createAppAuth,
       auth: {
         appId,
@@ -42,6 +46,7 @@ export class LintWarningsGuideLoader extends BaseLoader {
       repo: this.repo,
       path: this.docsDir,
       ref: this.branch,
+      request: OCTOKIT_RETRY_OPTIONS,
       headers: {
         'X-GitHub-Api-Version': '2022-11-28',
       },
@@ -62,15 +67,19 @@ export class LintWarningsGuideLoader extends BaseLoader {
     // Fetch all lint files and combine them into a single guide
     const lints = await Promise.all(
       lintsList.map(async ({ path }) => {
-        const fileResponse = await fetch(
-          `https://raw.githubusercontent.com/${this.org}/${this.repo}/${this.branch}/${path}`
-        )
+        const fileResponse = await octokit.request('GET /repos/{owner}/{repo}/contents/{path}', {
+          owner: this.org,
+          repo: this.repo,
+          path,
+          ref: this.branch,
+          request: OCTOKIT_RETRY_OPTIONS,
+        })
 
-        if (fileResponse.status >= 400) {
+        if (!('content' in fileResponse.data) || fileResponse.data.type !== 'file') {
           throw Error(`Could not get contents of file ${this.org}/${this.repo}/${path}`)
         }
 
-        const content = await fileResponse.text()
+        const content = Buffer.from(fileResponse.data.content, 'base64').toString('utf-8')
         const basename = getBasename(path)
 
         return {


### PR DESCRIPTION
## What kind of change does this PR introduce?

This migrates the rest of the GitHub content calls to our new util and methodology. We didn't migrate them because they weren't reported on the last two months, though we detected this particular pages failing during a preview.

## What is the current behavior?

Now all network calls for external content coming from GitHub are done using our authenticated Octokit client.