### PR TITLE
fix: detect prior consent via uc_user_interaction for fast cross-app navigation

### DIFF
--- a/packages/common/consent-state.test.ts
+++ b/packages/common/consent-state.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { detectPriorConsent } from './consent-state'
+
+// jsdom's localStorage can be flaky in vitest, so ensure it's available
+const storage = new Map<string, string>()
+const mockLocalStorage = {
+  getItem: (key: string) => storage.get(key) ?? null,
+  setItem: (key: string, value: string) => storage.set(key, value),
+  removeItem: (key: string) => storage.delete(key),
+  clear: () => storage.clear(),
+  get length() {
+    return storage.size
+  },
+  key: (index: number) => Array.from(storage.keys())[index] ?? null,
+}
+
+beforeEach(() => {
+  storage.clear()
+  Object.defineProperty(globalThis, 'localStorage', {
+    value: mockLocalStorage,
+    writable: true,
+    configurable: true,
+  })
+})
+
+afterEach(() => {
+  storage.clear()
+})
+
+describe('detectPriorConsent', () => {
+  describe('scenario 1: GTM compressed format (ucData)', () => {
+    it('returns true when ucData has all services consented', () => {
+      storage.set(
+        'ucData',
+        JSON.stringify({
+          gcm: { adStorage: 'granted', analyticsStorage: 'granted' },
+          consent: {
+            services: {
+              svc1: { name: 'Google Analytics', consent: true },
+              svc2: { name: 'Stripe', consent: true },
+              svc3: { name: 'Sentry', consent: true },
+            },
+          },
+        })
+      )
+
+      expect(detectPriorConsent()).toBe(true)
+    })
+
+    it('returns false when any service has consent: false', () => {
+      storage.set(
+        'ucData',
+        JSON.stringify({
+          consent: {
+            services: {
+              svc1: { name: 'Google Analytics', consent: true },
+              svc2: { name: 'Stripe', consent: false },
+            },
+          },
+        })
+      )
+
+      expect(detectPriorConsent()).toBe(false)
+    })
+
+    it('returns false when services object is empty', () => {
+      storage.set('ucData', JSON.stringify({ consent: { services: {} } }))
+      expect(detectPriorConsent()).toBe(false)
+    })
+
+    it('returns false when ucData is malformed JSON', () => {
+      storage.set('ucData', 'not-json')
+      expect(detectPriorConsent()).toBe(false)
+    })
+
+    it('returns false when ucData has no consent.services', () => {
+      storage.set('ucData', JSON.stringify({ gcm: {} }))
+      expect(detectPriorConsent()).toBe(false)
+    })
+
+    it('returns false when services contains non-object values', () => {
+      storage.set('ucData', JSON.stringify({ consent: { services: { svc1: 'not-an-object' } } }))
+      expect(detectPriorConsent()).toBe(false)
+    })
+  })
+
+  describe('scenario 2: fast cross-app navigation (uc_user_interaction)', () => {
+    it('returns true when uc_user_interaction is "true"', () => {
+      storage.set('uc_user_interaction', 'true')
+      expect(detectPriorConsent()).toBe(true)
+    })
+
+    it('returns false when uc_user_interaction is "false"', () => {
+      storage.set('uc_user_interaction', 'false')
+      expect(detectPriorConsent()).toBe(false)
+    })
+
+    it('returns false when uc_user_interaction is absent', () => {
+      expect(detectPriorConsent()).toBe(false)
+    })
+  })
+
+  describe('combined scenarios', () => {
+    it('returns true when both ucData and uc_user_interaction indicate consent', () => {
+      storage.set(
+        'ucData',
+        JSON.stringify({
+          consent: { services: { svc1: { name: 'GA', consent: true } } },
+        })
+      )
+      storage.set('uc_user_interaction', 'true')
+      expect(detectPriorConsent()).toBe(true)
+    })
+
+    it('returns true when ucData has consent but uc_user_interaction is false', () => {
+      storage.set(
+        'ucData',
+        JSON.stringify({
+          consent: { services: { svc1: { name: 'GA', consent: true } } },
+        })
+      )
+      storage.set('uc_user_interaction', 'false')
+      expect(detectPriorConsent()).toBe(true)
+    })
+
+    it('returns true when ucData is absent but uc_user_interaction is true', () => {
+      storage.set('uc_user_interaction', 'true')
+      expect(detectPriorConsent()).toBe(true)
+    })
+
+    it('returns false when localStorage is completely empty', () => {
+      expect(detectPriorConsent()).toBe(false)
+    })
+  })
+})

--- a/packages/common/consent-state.ts
+++ b/packages/common/consent-state.ts
@@ -6,28 +6,48 @@ import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from './constants'
 
 /**
  * Check if the user previously accepted all consent services by reading
- * the compressed ucData format that the GTM/Usercentrics integration writes.
+ * localStorage state that was written before UC.init() overwrites it.
  *
- * Context (FE-2648): After acceptAllServices(), the GTM script's Usercentrics
- * integration replaces uc_settings with ucString/ucData. On the next page load,
- * UC.init() can't read that format and treats the user as new. This function
- * detects that prior consent so we can silently re-accept.
+ * Handles two scenarios (FE-2648):
+ *
+ * 1. Slow navigation: GTM's Usercentrics integration replaced uc_settings with
+ *    compressed ucString/ucData after acceptAllServices(). On the next page load,
+ *    UC.init() can't read that format and treats the user as new.
+ *
+ * 2. Fast navigation: User accepted on app A and navigated to app B before GTM
+ *    finished writing ucData. App B's UC.init() overwrites uc_settings with a
+ *    fresh controllerId and resets uc_user_interaction to false. We detect the
+ *    prior uc_user_interaction: "true" before init stomps it.
+ *
+ * Must be called BEFORE UC.init() since init overwrites these keys.
  */
-function hasPreviousConsentInUcData(): boolean {
+export function detectPriorConsent(): boolean {
   try {
+    // Scenario 1: GTM wrote compressed format (slow navigation / same-app refresh)
     const ucData = localStorage?.getItem('ucData')
-    if (!ucData) return false
+    if (ucData) {
+      const data = JSON.parse(ucData)
+      const services = data?.consent?.services
+      if (services && typeof services === 'object') {
+        const serviceValues = Object.values(services)
+        if (
+          serviceValues.length > 0 &&
+          serviceValues.every(
+            (s) =>
+              typeof s === 'object' && s !== null && (s as { consent: boolean }).consent === true
+          )
+        ) {
+          return true
+        }
+      }
+    }
 
-    const data = JSON.parse(ucData)
-    const services = data?.consent?.services
-    if (!services || typeof services !== 'object') return false
+    // Scenario 2: SDK wrote uc_user_interaction: "true" (fast cross-app navigation)
+    if (localStorage?.getItem('uc_user_interaction') === 'true') {
+      return true
+    }
 
-    const serviceValues = Object.values(services)
-    if (serviceValues.length === 0) return false
-
-    return serviceValues.every(
-      (s) => typeof s === 'object' && s !== null && (s as { consent: boolean }).consent === true
-    )
+    return false
   } catch {
     return false
   }
@@ -104,7 +124,7 @@ async function initUserCentrics() {
 
   // Check for prior consent BEFORE UC.init(), which can't read the compressed
   // ucData format written by the GTM/Usercentrics integration (FE-2648).
-  const previouslyAccepted = hasPreviousConsentInUcData()
+  const previouslyAccepted = detectPriorConsent()
 
   try {
     const { default: Usercentrics } = await import('@usercentrics/cmp-browser-sdk')
@@ -120,8 +140,8 @@ async function initUserCentrics() {
     const hasConsented = UC.areAllConsentsAccepted()
 
     // If the SDK wants to show the banner but the user previously accepted
-    // (ucData exists from a prior GTM-mediated accept), silently re-accept
-    // instead of showing the banner again.
+    // (detected via ucData or uc_user_interaction before init overwrote them),
+    // silently re-accept instead of showing the banner again (FE-2648).
     if (initialUIValues.initialLayer === 0 && !hasConsented && previouslyAccepted) {
       consentState.hasConsented = true
       consentState.showConsentToast = false


### PR DESCRIPTION
## Problem

Follow-up to #44252. The previous fix handled the case where the user waits on the page after accepting (GTM writes `ucData`), but there's a second scenario: if the user accepts and navigates to another app quickly (before GTM finishes), `ucData` hasn't been written yet. The SDK on the new app overwrites `uc_user_interaction: "true"` with `"false"` and shows the banner again.

## What changed

`hasPreviousConsentInUcData` is now `detectPriorConsent` and checks two signals before `UC.init()` overwrites them:

1. **Slow navigation** (existing): `ucData` contains all services with `consent: true`
2. **Fast navigation** (new): `uc_user_interaction` is `"true"` — the SDK on the previous app wrote this but GTM hasn't had time to replace it yet

Also adds unit tests covering both scenarios, edge cases (empty services, malformed JSON, mixed signals), and the combined behavior.

## Testing

- 13 unit tests for `detectPriorConsent()` covering all localStorage state combinations
- Can't fully reproduce on staging previews (CSP blocks GTM), verified root cause via production console monitoring

Closes FE-2648