### PR TITLE
fix: redirect unauthenticated pricing CTA to sign-up instead of dashboard

### DIFF
--- a/apps/www/components/Pricing/PricingComparisonTable.tsx
+++ b/apps/www/components/Pricing/PricingComparisonTable.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { useState } from 'react'
+import { useIsLoggedIn } from 'common'
 
 import { plans } from 'shared-data/plans'
 import { pricing } from 'shared-data/pricing'
@@ -32,9 +33,16 @@ const MobileHeader = ({
   hasExistingOrganizations?: boolean
 }) => {
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const isLoggedIn = useIsLoggedIn()
 
   const selectedPlan = plans.find((p) => p.name === plan)!
   const isUpgradablePlan = selectedPlan.name === 'Pro' || selectedPlan.name === 'Team'
+
+  const isDashboardNew = selectedPlan.href.startsWith('https://supabase.com/dashboard/new')
+  const planHref =
+    !isLoggedIn && isDashboardNew
+      ? `https://supabase.com/dashboard/sign-up?plan=${selectedPlan.planId}&returnTo=%2Fdashboard%2Fnew`
+      : selectedPlan.href
 
   return (
     <div className="mt-8 px-4 mobile-header">
@@ -73,7 +81,7 @@ const MobileHeader = ({
       ) : (
         <Button asChild size="medium" type={plan === 'Enterprise' ? 'default' : 'primary'} block>
           <Link
-            href={selectedPlan.href}
+            href={planHref}
             onClick={() =>
               sendTelemetryEvent({
                 action: 'www_pricing_plan_cta_clicked',
@@ -106,6 +114,7 @@ const PricingComparisonTable = ({
   const [activeMobilePlan, setActiveMobilePlan] = useState('Free')
 
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const isLoggedIn = useIsLoggedIn()
 
   return (
     <div
@@ -373,6 +382,12 @@ const PricingComparisonTable = ({
               {plans.map((plan) => {
                 const isUpgradablePlan = plan.name === 'Pro' || plan.name === 'Team'
 
+                const isDashboardNew = plan.href.startsWith('https://supabase.com/dashboard/new')
+                const planHref =
+                  !isLoggedIn && isDashboardNew
+                    ? `https://supabase.com/dashboard/sign-up?plan=${plan.planId}&returnTo=%2Fdashboard%2Fnew`
+                    : plan.href
+
                 return (
                   <th
                     className="text-foreground w-1/4 px-0 text-left text-sm font-normal"
@@ -428,7 +443,7 @@ const PricingComparisonTable = ({
                             block
                           >
                             <Link
-                              href={plan.href}
+                              href={planHref}
                               onClick={() =>
                                 sendTelemetryEvent({
                                   action: 'www_pricing_plan_cta_clicked',

--- a/apps/www/components/Pricing/PricingPlans.tsx
+++ b/apps/www/components/Pricing/PricingPlans.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { Check } from 'lucide-react'
 import { plans } from 'shared-data/plans'
 import { Button, cn } from 'ui'
+import { useIsLoggedIn } from 'common'
 import { Organization } from '~/data/organizations'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
 import UpgradePlan from './UpgradePlan'
@@ -16,6 +17,7 @@ interface PricingPlansProps {
 
 const PricingPlans = ({ organizations, hasExistingOrganizations }: PricingPlansProps) => {
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const isLoggedIn = useIsLoggedIn()
 
   return (
     <div className="mx-auto lg:container lg:px-16 xl:px-12 flex flex-col">
@@ -27,6 +29,12 @@ const PricingPlans = ({ organizations, hasExistingOrganizations }: PricingPlansP
             const isUpgradablePlan = isProPlan || isTeamPlan
             const features = plan.features
             const footer = plan.footer
+
+            const isDashboardNew = plan.href.startsWith('https://supabase.com/dashboard/new')
+            const planHref =
+              !isLoggedIn && isDashboardNew
+                ? `https://supabase.com/dashboard/sign-up?plan=${plan.planId}&returnTo=%2Fdashboard%2Fnew`
+                : plan.href
 
             const sendPricingEvent = () => {
               sendTelemetryEvent({
@@ -87,7 +95,7 @@ const PricingPlans = ({ organizations, hasExistingOrganizations }: PricingPlansP
                       type={plan.name === 'Enterprise' ? 'default' : 'primary'}
                       asChild
                     >
-                      <Link href={plan.href} onClick={sendPricingEvent}>
+                      <Link href={planHref} onClick={sendPricingEvent}>
                         {plan.cta}
                       </Link>
                     </Button>


### PR DESCRIPTION
## Problem

Clicking "Start for free" on the pricing page redirects unauthenticated users to `/dashboard/new`, which requires authentication and causes a redirect to sign-in, creating a confusing onboarding flow.

## Solution

Added conditional routing based on authentication state:
- Authenticated users → `/dashboard/new?plan=<plan>`
- Unauthenticated users → `/dashboard/sign-up?plan=<plan>&returnTo=/dashboard/new`

This ensures new users are guided through the correct sign-up flow before accessing the dashboard.

## Testing

- Verified logged-out users are redirected to sign-up with correct parameters
- Verified users are redirected to `/dashboard/new` after sign-up
- Verified logged-in users directly access `/dashboard/new`
- Tested for free, pro, and team plans

Fixes #44280