### PR TITLE
docs: fix incorrect JSON key in Network Restrictions API example

### DIFF
--- a/apps/docs/content/guides/platform/network-restrictions.mdx
+++ b/apps/docs/content/guides/platform/network-restrictions.mdx
@@ -36,7 +36,7 @@ curl -X POST "https://api.supabase.com/v1/projects/$PROJECT_REF/network-restrict
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "db_allowed_cidrs": [
+    "dbAllowedCidrs": [
       "192.168.0.1/24",
     ]
   }'


### PR DESCRIPTION
Fixes #44164

The curl example for updating network restrictions used `db_allowed_cidrs` but the Management API expects `dbAllowedCidrs`. Updated to match the [API reference](https://supabase.com/docs/reference/api/v1-update-network-restrictions).

**Before:** `"db_allowed_cidrs": [...]`  
**After:** `"dbAllowedCidrs": [...]`