### PR TITLE
docs: fix undefined host variable in Drizzle connection snippet

### DIFF
--- a/apps/docs/content/guides/database/drizzle.mdx
+++ b/apps/docs/content/guides/database/drizzle.mdx
@@ -81,8 +81,8 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
     import postgres from 'postgres'
 
     let connectionString = process.env.DATABASE_URL
-    if (host.includes('postgres:postgres@supabase_db_')) {
-      const url = URL.parse(host)!
+    if (connectionString.includes('postgres:postgres@supabase_db_')) {
+      const url = URL.parse(connectionString)!
       url.hostname = url.hostname.split('_')[1]
       connectionString = url.href
     }


### PR DESCRIPTION
Fixes #43920

The Drizzle connection code snippet references an undefined variable `host`. It should be `connectionString` which is defined on the previous line. Bug was introduced in #40288.

**Before:**
```ts
if (host.includes('postgres:postgres@supabase_db_')) {
  const url = URL.parse(host)!
```

**After:**
```ts
if (connectionString.includes('postgres:postgres@supabase_db_')) {
  const url = URL.parse(connectionString)!
```