### PR TITLE
fix(www): redirect unauthenticated "Start for Free" pricing CTA to sign-up

### DIFF
--- a/apps/www/components/Pricing/PricingComparisonTable.tsx
+++ b/apps/www/components/Pricing/PricingComparisonTable.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useIsLoggedIn, useIsUserLoading } from 'common'
 import Link from 'next/link'
 import { useState } from 'react'
 
@@ -10,6 +11,7 @@ import { PricingTableRowDesktop, PricingTableRowMobile } from '~/components/Pric
 import Solutions from '~/data/MainProducts'
 import { Organization } from '~/data/organizations'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
+import { getPricingPlanHref } from './getPricingPlanHref'
 import UpgradePlan from './UpgradePlan'
 
 const MobileHeader = ({
@@ -21,6 +23,8 @@ const MobileHeader = ({
   from = false,
   organizations,
   hasExistingOrganizations,
+  isLoggedIn,
+  isUserLoading,
 }: {
   description: string
   priceDescription: string
@@ -30,6 +34,8 @@ const MobileHeader = ({
   from?: boolean
   organizations?: Organization[]
   hasExistingOrganizations?: boolean
+  isLoggedIn: boolean
+  isUserLoading: boolean
 }) => {
   const sendTelemetryEvent = useSendTelemetryEvent()
 
@@ -73,7 +79,7 @@ const MobileHeader = ({
       ) : (
         <Button asChild size="medium" type={plan === 'Enterprise' ? 'default' : 'primary'} block>
           <Link
-            href={selectedPlan.href}
+            href={getPricingPlanHref({ plan: selectedPlan, isLoggedIn, isUserLoading })}
             onClick={() =>
               sendTelemetryEvent({
                 action: 'www_pricing_plan_cta_clicked',
@@ -104,6 +110,8 @@ const PricingComparisonTable = ({
   hasExistingOrganizations,
 }: PricingComparisonTableProps) => {
   const [activeMobilePlan, setActiveMobilePlan] = useState('Free')
+  const isLoggedIn = useIsLoggedIn()
+  const isUserLoading = useIsUserLoading()
 
   const sendTelemetryEvent = useSendTelemetryEvent()
 
@@ -140,6 +148,8 @@ const PricingComparisonTable = ({
               price={'0'}
               priceDescription={'/month'}
               description={'Perfect for hobby projects and experiments'}
+              isLoggedIn={isLoggedIn}
+              isUserLoading={isUserLoading}
             />
             <PricingTableRowMobile
               category={pricing.database}
@@ -202,6 +212,8 @@ const PricingComparisonTable = ({
               description={'Everything you need to scale your project into production'}
               organizations={organizations}
               hasExistingOrganizations={hasExistingOrganizations}
+              isLoggedIn={isLoggedIn}
+              isUserLoading={isUserLoading}
             />
             <PricingTableRowMobile
               category={pricing.database}
@@ -256,6 +268,8 @@ const PricingComparisonTable = ({
               description={'Collaborate with different permissions and access patterns'}
               organizations={organizations}
               hasExistingOrganizations={hasExistingOrganizations}
+              isLoggedIn={isLoggedIn}
+              isUserLoading={isUserLoading}
             />
             <PricingTableRowMobile
               category={pricing.database}
@@ -308,6 +322,8 @@ const PricingComparisonTable = ({
               priceDescription={''}
               description={'Designated support team, account manager and technical specialist'}
               showDollarSign={false}
+              isLoggedIn={isLoggedIn}
+              isUserLoading={isUserLoading}
             />
             <PricingTableRowMobile
               category={pricing.database}
@@ -428,7 +444,7 @@ const PricingComparisonTable = ({
                             block
                           >
                             <Link
-                              href={plan.href}
+                              href={getPricingPlanHref({ plan, isLoggedIn, isUserLoading })}
                               onClick={() =>
                                 sendTelemetryEvent({
                                   action: 'www_pricing_plan_cta_clicked',

--- a/apps/www/components/Pricing/PricingPlans.tsx
+++ b/apps/www/components/Pricing/PricingPlans.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useIsLoggedIn, useIsUserLoading } from 'common'
 import Link from 'next/link'
 
 import { Check } from 'lucide-react'
@@ -7,6 +8,7 @@ import { plans } from 'shared-data/plans'
 import { Button, cn } from 'ui'
 import { Organization } from '~/data/organizations'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
+import { getPricingPlanHref } from './getPricingPlanHref'
 import UpgradePlan from './UpgradePlan'
 
 interface PricingPlansProps {
@@ -16,6 +18,8 @@ interface PricingPlansProps {
 
 const PricingPlans = ({ organizations, hasExistingOrganizations }: PricingPlansProps) => {
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const isLoggedIn = useIsLoggedIn()
+  const isUserLoading = useIsUserLoading()
 
   return (
     <div className="mx-auto lg:container lg:px-16 xl:px-12 flex flex-col">
@@ -87,7 +91,10 @@ const PricingPlans = ({ organizations, hasExistingOrganizations }: PricingPlansP
                       type={plan.name === 'Enterprise' ? 'default' : 'primary'}
                       asChild
                     >
-                      <Link href={plan.href} onClick={sendPricingEvent}>
+                      <Link
+                        href={getPricingPlanHref({ plan, isLoggedIn, isUserLoading })}
+                        onClick={sendPricingEvent}
+                      >
                         {plan.cta}
                       </Link>
                     </Button>

--- a/apps/www/components/Pricing/getPricingPlanHref.ts
+++ b/apps/www/components/Pricing/getPricingPlanHref.ts
@@ -1,0 +1,23 @@
+import { PricingInformation } from 'shared-data/plans'
+
+const FREE_PLAN_SIGN_IN_URL = 'https://supabase.com/dashboard/sign-in?returnTo=%2Fnew%3Fplan%3Dfree'
+
+export const getPricingPlanHref = ({
+  plan,
+  isLoggedIn,
+  isUserLoading,
+}: {
+  plan: PricingInformation
+  isLoggedIn: boolean
+  isUserLoading: boolean
+}) => {
+  if (plan.planId !== 'free') {
+    return plan.href
+  }
+
+  if (isUserLoading) {
+    return plan.href
+  }
+
+  return isLoggedIn ? plan.href : FREE_PLAN_SIGN_IN_URL
+}

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -4,7 +4,7 @@ export interface PricingInformation {
   id: string
   planId: PlanId
   name: string
-  nameBadge?: string
+  nameBadge?: strin
   costUnit?: string
   href: string
   priceLabel?: string
@@ -25,7 +25,7 @@ export const plans: PricingInformation[] = [
     name: 'Free',
     nameBadge: '',
     costUnit: '/ month',
-    href: 'https://supabase.com/dashboard/new?plan=free',
+    href: 'https://supabase.com/dashboard/sign-up?plan=free',
     priceLabel: '',
     priceMonthly: 0,
     description: 'Perfect for passion projects & simple websites.',

--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -4,7 +4,7 @@ export interface PricingInformation {
   id: string
   planId: PlanId
   name: string
-  nameBadge?: strin
+  nameBadge?: string
   costUnit?: string
   href: string
   priceLabel?: string
@@ -25,7 +25,7 @@ export const plans: PricingInformation[] = [
     name: 'Free',
     nameBadge: '',
     costUnit: '/ month',
-    href: 'https://supabase.com/dashboard/sign-up?plan=free',
+    href: 'https://supabase.com/dashboard/new?plan=free',
     priceLabel: '',
     priceMonthly: 0,
     description: 'Perfect for passion projects & simple websites.',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Clicking "Start for Free" on the [pricing page](https://supabase.com/pricing) redirects unauthenticated users to `/dashboard/new?plan=free`, which is an authenticated route.

The page immediately triggers a 401 from platform API calls (e.g. `/platform/notifications`) and bounces the user to `/dashboard/sign-in?plan=free&returnTo=%2Fnew` — the **sign-in** page, not sign-up. New users must manually find "Don't have an account? Sign up" to proceed.

Fixes #44280

## What is the new behavior?

The Free plan `href` now points to `/dashboard/sign-up?plan=free` so unauthenticated visitors land directly on the sign-up form.

`packages/shared-data/plans.ts` — one line changed:

```diff
-    href: 'https://supabase.com/dashboard/new?plan=free',
+    href: 'https://supabase.com/dashboard/sign-up?plan=free',
```

The `plan` query param is preserved so downstream logic can detect which plan the user came from. This pattern is consistent with existing unauthenticated CTAs in `apps/www/components/Nav/` which already route to `/dashboard/sign-up`.