### PR TITLE
fix(studio): return 503 for logs.all and improve error messages

### DIFF
--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
@@ -5,6 +5,19 @@ import assert from 'node:assert'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 
+function formatLocalLogsUnavailableMessage(error: Error): string {
+  const msg = error.message.toLowerCase()
+  if (
+    msg.includes('fetch failed') ||
+    msg.includes('econnrefused') ||
+    msg.includes('enotfound') ||
+    msg.includes('etimedout')
+  ) {
+    return 'Logs are unavailable: the analytics service could not be reached. Check that Logflare is running and accessible.'
+  }
+  return 'Logs are unavailable: the analytics service is not configured. Ensure PROJECT_ANALYTICS_URL and LOGFLARE_PRIVATE_ACCESS_TOKEN are set.'
+}
+
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { method } = req
 
@@ -17,16 +30,30 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
       assert(typeof ref === 'string', 'Invalid or missing ref parameter')
       assert(typeof name === 'string', 'Invalid or missing name parameter')
 
-      const { data, error } = await retrieveAnalyticsData({
-        name,
-        params,
-        projectRef: ref,
-      })
+      try {
+        const { data, error } = await retrieveAnalyticsData({
+          name,
+          params,
+          projectRef: ref,
+        })
 
-      if (data) {
-        return res.status(200).json(data)
-      } else {
-        return res.status(500).json({ error: { message: error.message } })
+        if (data) {
+          return res.status(200).json(data)
+        } else {
+          if (name === 'logs.all') {
+            return res
+              .status(503)
+              .json({ error: { message: formatLocalLogsUnavailableMessage(error) } })
+          }
+          return res.status(500).json({ error: { message: error.message } })
+        }
+      } catch (err) {
+        if (name === 'logs.all' && err instanceof Error) {
+          return res
+            .status(503)
+            .json({ error: { message: formatLocalLogsUnavailableMessage(err) } })
+        }
+        throw err
       }
     default:
       res.setHeader('Allow', ['GET', 'POST'])


### PR DESCRIPTION
## Changes

- Added `formatLocalLogsUnavailableMessage()` function to differentiate between connection errors (fetch failed, ECONNREFUSED, ENOTFOUND, ETIMEDOUT) and configuration errors
- Return HTTP 503 (Service Unavailable) instead of 500 for `logs.all` endpoint failures
- Wrap analytics data retrieval in try-catch to handle thrown errors and provide meaningful error messages for the logs.all endpoint
- Preserve original error handling behavior for other endpoints