### PR TITLE
fix(studio): use router.replace for observability auto-redirects to fix back-navigation loop

### DIFF
--- a/apps/studio/pages/project/[ref]/observability/index.tsx
+++ b/apps/studio/pages/project/[ref]/observability/index.tsx
@@ -43,8 +43,8 @@ export const UserReportPage: NextPageWithLayout = () => {
     const reports = data.content
       .filter((x) => x.type === 'report')
       .sort((a, b) => a.name.localeCompare(b.name))
-    if (reports.length >= 1) router.push(`/project/${ref}/observability/${reports[0].id}`)
-    if (reports.length === 0) router.push(`/project/${ref}/observability/api-overview`)
+    if (reports.length >= 1) router.replace(`/project/${ref}/observability/${reports[0].id}`)
+    if (reports.length === 0) router.replace(`/project/${ref}/observability/api-overview`)
   }, [isSuccess, data, router, ref, showOverview, flagsLoaded])
 
   const { can: canCreateReport } = useAsyncCheckPermissions(


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.
Yes

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The /observability index page auto-redirects using router.push(), which adds entries to the browser history. Pressing back returns to /observability, which immediately redirects forward again — creating an infinite back-navigation loop making it impossible to leave the page.

Fixes #43807

## What is the new behavior?
Changed both router.push() calls to router.replace() so the intermediate /observability URL is replaced in history rather than pushed. The back button now correctly navigates away.

## Additional context
Same pattern as commit f8419ef which applied the identical fix elsewhere in the codebase. One-line change, no UI impact.