### PR TITLE
feat(studio): add connection_string_copied tracking to ConnectSheet

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/ConnectionParameters.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectionParameters.tsx
@@ -9,9 +9,10 @@ interface Parameter {
 
 interface ConnectionParametersProps {
   parameters: Parameter[]
+  onCopy?: (paramKey: string) => void
 }
 
-export const ConnectionParameters = ({ parameters }: ConnectionParametersProps) => {
+export const ConnectionParameters = ({ parameters, onCopy }: ConnectionParametersProps) => {
   const [copiedMap, setCopiedMap] = useState<Record<string, boolean>>({})
 
   return (
@@ -25,6 +26,7 @@ export const ConnectionParameters = ({ parameters }: ConnectionParametersProps) 
               onClick={() => {
                 copyToClipboard(param.value, () => {
                   setCopiedMap((prev) => ({ ...prev, [param.key]: true }))
+                  onCopy?.(param.key)
                   setTimeout(() => {
                     setCopiedMap((prev) => ({ ...prev, [param.key]: false }))
                   }, 1000)

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import { useCallback, useMemo } from 'react'
+import { useMemo } from 'react'
 import { CodeBlock } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -165,7 +165,7 @@ function DirectConnectionContent({ state }: StepContentProps) {
     }
   }, [connectionType, connectionParams, safeConnectionString])
 
-  const trackCopy = useCallback(() => {
+  const trackCopy = () => {
     const typeConfig = DATABASE_CONNECTION_TYPES.find((t) => t.id === connectionType)
     track('connection_string_copied', {
       connectionType: typeConfig?.label ?? connectionType,
@@ -174,7 +174,7 @@ function DirectConnectionContent({ state }: StepContentProps) {
       connectionTab: 'Connection String',
       source: 'studio',
     })
-  }, [connectionType, connectionMethod, track])
+  }
 
   if (!resolvedConnectionString) {
     return (

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -1,16 +1,18 @@
 import { useParams } from 'common'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import { CodeBlock } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { getConnectionStrings } from '../../../DatabaseSettings.utils'
 import { getAddons } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
 import {
+  DATABASE_CONNECTION_TYPES,
   type ConnectionStringMethod,
   type DatabaseConnectionType,
 } from '@/components/interfaces/ConnectSheet/Connect.constants'
 import type { StepContentProps } from '@/components/interfaces/ConnectSheet/Connect.types'
 import { ConnectionParameters } from '@/components/interfaces/ConnectSheet/ConnectionParameters'
+import { useTrack } from 'lib/telemetry/track'
 import {
   buildConnectionParameters,
   buildSafeConnectionString,
@@ -104,11 +106,21 @@ const useConnectionStringDatabases = () => {
   )
 }
 
+const CONNECTION_METHOD_TO_TELEMETRY: Record<
+  ConnectionStringMethod,
+  'direct' | 'transaction_pooler' | 'session_pooler'
+> = {
+  direct: 'direct',
+  transaction: 'transaction_pooler',
+  session: 'session_pooler',
+}
+
 /**
  * Step component for direct database connections.
  * Uses state to determine which connection string to show.
  */
 function DirectConnectionContent({ state }: StepContentProps) {
+  const track = useTrack()
   const connectionSource = state.connectionSource
   const connectionType = (state.connectionType as DatabaseConnectionType) ?? 'uri'
   const connectionMethod = (state.connectionMethod as ConnectionStringMethod) ?? 'direct'
@@ -153,6 +165,17 @@ function DirectConnectionContent({ state }: StepContentProps) {
     }
   }, [connectionType, connectionParams, safeConnectionString])
 
+  const trackCopy = useCallback(() => {
+    const typeConfig = DATABASE_CONNECTION_TYPES.find((t) => t.id === connectionType)
+    track('connection_string_copied', {
+      connectionType: typeConfig?.label ?? connectionType,
+      lang: typeConfig?.lang ?? 'bash',
+      connectionMethod: CONNECTION_METHOD_TO_TELEMETRY[connectionMethod],
+      connectionTab: 'Connection String',
+      source: 'studio',
+    })
+  }, [connectionType, connectionMethod, track])
+
   if (!resolvedConnectionString) {
     return (
       <div className="p-4">
@@ -169,10 +192,14 @@ function DirectConnectionContent({ state }: StepContentProps) {
         value={connectionString}
         hideLineNumbers
         language="bash"
+        onCopyCallback={trackCopy}
       >
         {connectionString}
       </CodeBlock>
-      <ConnectionParameters parameters={buildConnectionParameters(connectionParams)} />
+      <ConnectionParameters
+        parameters={buildConnectionParameters(connectionParams)}
+        onCopy={trackCopy}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary

The new ConnectSheet is missing `connection_string_copied` event tracking, making it harder to analyze ConnectSheet experiments. This adds instrumentation to the direct connection step so copy actions on the connection string CodeBlock and individual connection parameters fire the existing `connection_string_copied` event.

## Changes

- **ConnectionParameters.tsx**: added optional `onCopy` callback prop, invoked when any individual parameter is copied
- **direct-connection/content.tsx**: wired `useTrack` to fire `connection_string_copied` on both CodeBlock copy and individual parameter copy, with `connectionType`, `lang`, `connectionMethod`, `connectionTab`, and `source` properties. Added `CONNECTION_METHOD_TO_TELEMETRY` mapping to translate ConnectSheet's `ConnectionStringMethod` (`transaction`/`session`) to the telemetry schema's `transaction_pooler`/`session_pooler`

Uses the existing `ConnectionStringCopiedEvent` schema and `useTrack` hook (not deprecated `useSendEventMutation`).

## Testing

Tested on Vercel preview:
- [x] Open ConnectSheet, select direct connection mode, copy the connection string via CodeBlock, verify `connection_string_copied` event fires in PostHog with correct properties
- [x] Copy an individual parameter (e.g. host), verify same event fires
- [x] Switch connection type (URI/PSQL/JDBC/PHP) and connection method (direct/transaction/session), verify properties update accordingly

## Linear

- fixes GROWTH-729