### PR TITLE
fix: Set the default branch if it's not already set on Github integration

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -316,7 +316,15 @@ export const GitHubIntegrationConnectionForm = ({
       },
     })
 
-    if (prodBranch) {
+    // if for some reason, the project doesn't have a default branch yet, create it.
+    if (existingBranches && existingBranches.length === 0) {
+      createBranch({
+        projectRef: selectedProject.ref,
+        gitBranch: data.enableProductionSync ? data.branchName : '',
+        branchName: data.branchName || 'main',
+        is_default: true,
+      })
+    } else if (prodBranch) {
       updateBranch({
         branchRef: prodBranch.project_ref,
         projectRef: selectedProject.ref,

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -779,7 +779,7 @@ export const GitHubIntegrationConnectionForm = ({
                         </Button>
                       )}
                       <Button
-                        type="default"
+                        type="primary"
                         htmlType="submit"
                         disabled={
                           !hasAccessToGitHubIntegration ||

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -316,20 +316,20 @@ export const GitHubIntegrationConnectionForm = ({
       },
     })
 
-    // if for some reason, the project doesn't have a default branch yet, create it.
-    if (existingBranches && existingBranches.length === 0) {
-      createBranch({
-        projectRef: selectedProject.ref,
-        gitBranch: data.enableProductionSync ? data.branchName : '',
-        branchName: data.branchName || 'main',
-        is_default: true,
-      })
-    } else if (prodBranch) {
+    if (prodBranch) {
       updateBranch({
         branchRef: prodBranch.project_ref,
         projectRef: selectedProject.ref,
         gitBranch: data.enableProductionSync ? data.branchName : '',
         branchName: data.branchName || 'main',
+      })
+    } else {
+      // if for some reason, the project doesn't have a default branch yet, create it.
+      createBranch({
+        projectRef: selectedProject.ref,
+        gitBranch: data.enableProductionSync ? data.branchName : '',
+        branchName: data.branchName || 'main',
+        is_default: true,
       })
     }
 


### PR DESCRIPTION
Previously, the POST to `/v1/projects/{ref}/branches` didn't work on free projects, which left some Supabase projects setup without a default branch. Easy fix for those projects would be to disable/enable the whole integration. 

This PR fixes that so that when the user wants to setup a production sync, the code checks if there's branches already setup and if not, sets the selected branch as default.