### PR TITLE
feat(studio): environment-aware connect dialog for CLI and self-hosted

### DIFF
--- a/apps/studio/components/interfaces/Connect/ConnectTabContent.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectTabContent.tsx
@@ -7,12 +7,10 @@ import { CopyCallbackContext } from 'ui-patterns/SimpleCodeBlock'
 
 import { getAddons } from '../Billing/Subscription/Subscription.utils'
 import type { projectKeys } from './Connect.types'
-import { getConnectionStrings } from './DatabaseSettings.utils'
-import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
-import { usePgbouncerConfigQuery } from '@/data/database/pgbouncer-config-query'
-import { useSupavisorConfigurationQuery } from '@/data/database/supavisor-configuration-query'
 import { useProjectAddonsQuery } from '@/data/subscriptions/project-addons-query'
+import { useDeploymentModeQuery } from '@/data/config/deployment-mode-query'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
+import { IS_PLATFORM } from '@/lib/constants'
 import { pluckObjectFields } from '@/lib/helpers'
 import { useTrack } from '@/lib/telemetry/track'
 
@@ -56,6 +54,10 @@ export const ConnectTabContent = forwardRef<HTMLDivElement, ConnectContentTabPro
 
       track('connection_string_copied', trackingProperties)
     }
+
+    const { data: deploymentMode } = useDeploymentModeQuery()
+    const isCliMode = deploymentMode?.is_cli_mode ?? false
+    const isSelfHosted = !IS_PLATFORM && !isCliMode
 
     const { data: settings } = useProjectSettingsV2Query({ projectRef })
     const { data: pgbouncerConfig } = usePgbouncerConfigQuery({ projectRef })
@@ -120,7 +122,7 @@ export const ConnectTabContent = forwardRef<HTMLDivElement, ConnectContentTabPro
               transactionDedicated: connectionStringsDedicated?.pooler.uri,
               sessionDedicated: connectionStringsDedicated?.pooler.uri.replace('6543', '5432'),
               ipv4SupportedForDedicatedPooler: !!ipv4Addon,
-              direct: connectionStringsShared.direct.uri,
+              direct: isSelfHosted ? `postgresql://postgres:[YOUR-PASSWORD]@${connectionInfo.db_host}:${connectionInfo.db_port || 5432}/postgres` : connectionStringsShared.direct.uri,
             }}
             onCopy={handleCopy}
           />

--- a/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
+++ b/apps/studio/components/interfaces/Connect/ConnectionPanel.tsx
@@ -20,13 +20,9 @@ import { CodeBlock, type CodeBlockLang } from 'ui-patterns/CodeBlock'
 import { ConnectionParameters } from './ConnectionParameters'
 
 interface ConnectionPanelProps {
-  type?: 'direct' | 'transaction' | 'session'
-  badge?: string
-  title: string
-  description: string
-  contentFooter?: ReactNode
   connectionString: string
-  ipv4Status: {
+  env?: 'platform' | 'cli' | 'self-hosted'
+  ipv4Status?: {
     type: 'error' | 'success'
     title: string
     description?: string | ReactNode
@@ -107,6 +103,7 @@ export const ConnectionPanel = ({
   description,
   contentFooter,
   connectionString,
+  env = 'platform',
   ipv4Status,
   notice,
   parameters = [],
@@ -122,7 +119,7 @@ export const ConnectionPanel = ({
   const poolingConfiguration = poolingInfo?.find((x) => x.identifier === state.selectedDatabaseId)
   const isSessionMode = poolingConfiguration?.pool_mode === 'session'
 
-  const links = ipv4Status.links ?? []
+  const links = ipv4Status?.links ?? []
 
   const isTransactionDedicatedPooler = type === 'transaction' && badge === 'Dedicated Pooler'
 
@@ -188,7 +185,7 @@ export const ConnectionPanel = ({
           )}
         </div>
         <div className="flex flex-col -space-y-px w-full">
-          {IS_PLATFORM && (
+          {IS_PLATFORM && env === 'platform' && ipv4Status && (
             <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b">
               <div className="flex items-center gap-2">
                 <IPv4StatusIcon active={ipv4Status.type === 'success'} />
@@ -218,7 +215,7 @@ export const ConnectionPanel = ({
             </div>
           )}
 
-          {type === 'session' && (
+          {IS_PLATFORM && env === 'platform' && type === 'session' && (
             <div className="border border-muted px-5 flex gap-7 items-center py-3 first:rounded-t last:rounded-b bg-alternative/50">
               <div className="flex w-6 h-6 rounded items-center justify-center gap-2 flex-shrink-0 bg-surface-100">
                 <WarningIcon />
@@ -233,7 +230,7 @@ export const ConnectionPanel = ({
             </div>
           )}
 
-          {IS_PLATFORM && ipv4Status.type === 'error' && (
+          {IS_PLATFORM && env === 'platform' && ipv4Status && ipv4Status.type === 'error' && (
             <Collapsible_Shadcn_ className="group -space-y-px">
               <CollapsibleTrigger_Shadcn_
                 asChild

--- a/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
+++ b/apps/studio/components/interfaces/Connect/DatabaseConnectionString.tsx
@@ -10,11 +10,12 @@ import { useProjectAddonsQuery } from 'data/subscriptions/project-addons-query'
 import { useSendEventMutation } from 'data/telemetry/send-event-mutation'
 import { useCheckEntitlements } from 'hooks/misc/useCheckEntitlements'
 import { useSelectedOrganizationQuery } from 'hooks/misc/useSelectedOrganization'
-import { DOCS_URL, IS_PLATFORM } from 'lib/constants'
+import { useDeploymentModeQuery } from 'data/config/deployment-mode-query'
+import { DOCS_URL, IS_CLI, IS_PLATFORM } from 'lib/constants'
 import { pluckObjectFields } from 'lib/helpers'
 import { BookOpen, ChevronDown, ExternalLink } from 'lucide-react'
 import { parseAsString, useQueryState } from 'nuqs'
-import { HTMLAttributes, ReactNode, useEffect, useState } from 'react'
+import { HTMLAttributes, ReactNode, useEffect, useMemo, useState } from 'react'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 import {
   Badge,
@@ -44,7 +45,11 @@ import {
   type ConnectionStringMethod,
 } from './Connect.constants'
 import { CodeBlockFileHeader, ConnectionPanel } from './ConnectionPanel'
-import { getConnectionStrings } from './DatabaseSettings.utils'
+import {
+  getConnectionStrings,
+  getSelfHostedDirectStrings,
+  getSelfHostedPoolerStrings,
+} from './DatabaseSettings.utils'
 import { examples, type Example } from './DirectConnectionExamples'
 
 const StepLabel = ({
@@ -75,13 +80,37 @@ export const DatabaseConnectionString = () => {
   } = useCheckEntitlements('dedicated_pooler')
   const sharedPoolerPreferred = !hasDedicatedPooler
 
+  // Fetch deployment mode (CLI vs self-hosted) for non-platform environments
+  const { data: deploymentMode, isPending: isLoadingDeploymentMode } = useDeploymentModeQuery()
+  const isCliMode = deploymentMode?.is_cli_mode ?? false
+  const isSelfHosted = !IS_PLATFORM && !isCliMode
+
+  // Determine which connection methods are available based on environment
+  // CLI: only direct connection (postgres directly accessible)
+  // Self-hosted: session and transaction pooler (via Supavisor), plus optional direct connection
+  // Platform: all methods available
+  const availableMethods = useMemo(() => {
+    if (IS_PLATFORM) return ['direct', 'transaction', 'session'] as ConnectionStringMethod[]
+    if (isCliMode) return ['direct'] as ConnectionStringMethod[]
+    return ['session', 'transaction', 'direct'] as ConnectionStringMethod[]
+  }, [isCliMode])
+
+  const defaultMethod = useMemo(() => {
+    if (isCliMode) return 'direct'
+    if (isSelfHosted) return 'session'
+    return 'direct'
+  }, [isCliMode, isSelfHosted])
+
   // URL state management
   const [queryType, setQueryType] = useQueryState('type', parseAsString.withDefault('uri'))
   const [querySource, setQuerySource] = useQueryState('source', parseAsString)
-  const [queryMethod, setQueryMethod] = useQueryState('method', parseAsString.withDefault('direct'))
+  const [queryMethod, setQueryMethod] = useQueryState(
+    'method',
+    parseAsString.withDefault(defaultMethod)
+  )
 
   const [selectedTab, setSelectedTab] = useState<DatabaseConnectionType>('uri')
-  const [selectedMethod, setSelectedMethod] = useState<ConnectionStringMethod>('direct')
+  const [selectedMethod, setSelectedMethod] = useState<ConnectionStringMethod>(defaultMethod)
 
   // Sync URL state with component state on mount and when URL changes
   useEffect(() => {
@@ -93,12 +122,11 @@ export const DatabaseConnectionString = () => {
       setSelectedTab('uri')
     }
 
-    const validMethods: ConnectionStringMethod[] = ['direct', 'transaction', 'session']
-    if (queryMethod && validMethods.includes(queryMethod as ConnectionStringMethod)) {
+    if (queryMethod && availableMethods.includes(queryMethod as ConnectionStringMethod)) {
       setSelectedMethod(queryMethod as ConnectionStringMethod)
-    } else if (queryMethod && !validMethods.includes(queryMethod as ConnectionStringMethod)) {
-      setQueryMethod('direct')
-      setSelectedMethod('direct')
+    } else if (queryMethod && !availableMethods.includes(queryMethod as ConnectionStringMethod)) {
+      setQueryMethod(defaultMethod)
+      setSelectedMethod(defaultMethod)
     }
 
     if (querySource && querySource !== state.selectedDatabaseId) {
@@ -106,7 +134,7 @@ export const DatabaseConnectionString = () => {
     } else if (!querySource && state.selectedDatabaseId !== projectRef) {
       state.setSelectedDatabaseId(projectRef)
     }
-  }, [queryType, queryMethod, querySource, state])
+  }, [queryType, queryMethod, querySource, state, availableMethods, defaultMethod, projectRef])
 
   // Sync component state changes back to URL
   const handleTabChange = (connectionType: DatabaseConnectionType) => {
@@ -180,7 +208,11 @@ export const DatabaseConnectionString = () => {
       : isSuccessSupavisorConfig
 
   const error = poolerError || readReplicasError
-  const isLoading = isLoadingPoolerConfig || isLoadingReadReplicas || isLoadingEntitlement
+  const isLoading =
+    isLoadingPoolerConfig ||
+    isLoadingReadReplicas ||
+    isLoadingEntitlement ||
+    isLoadingDeploymentMode
   const isError = isErrorPoolerConfig || isErrorReadReplicas
   const isSuccess = isSuccessPoolerConfig && isSuccessReadReplicas && isSuccessEntitlement
 
@@ -248,6 +280,23 @@ export const DatabaseConnectionString = () => {
     },
     metadata: { projectRef },
   })
+
+  // Self-hosted pooler connection strings (Supavisor)
+  // Uses placeholders for tenant ID and password since these are user-configured
+  // Use connectionInfo.db_host which comes from the API (server-side has access to SUPABASE_PUBLIC_URL)
+  const selfHostedSessionPoolerStrings = getSelfHostedPoolerStrings(
+    connectionInfo.db_host,
+    connectionInfo.db_port || 5432
+  )
+  const selfHostedTransactionPoolerStrings = getSelfHostedPoolerStrings(
+    connectionInfo.db_host,
+    6543
+  )
+  // Self-hosted direct connection strings (requires manual configuration to expose postgres)
+  const selfHostedDirectStrings = getSelfHostedDirectStrings(
+    connectionInfo.db_host,
+    connectionInfo.db_port || 5432
+  )
 
   const lang = DATABASE_CONNECTION_TYPES.find((type) => type.id === selectedTab)?.lang ?? 'bash'
   const contentType =
@@ -322,11 +371,18 @@ export const DatabaseConnectionString = () => {
                 </SelectValue_Shadcn_>
               </SelectTrigger_Shadcn_>
               <SelectContent_Shadcn_ className="max-w-sm">
-                {Object.keys(connectionStringMethodOptions).map((method) => (
+                {availableMethods.map((method) => (
                   <ConnectionStringMethodSelectItem
                     key={method}
-                    method={method as ConnectionStringMethod}
-                    poolerBadge={method === 'transaction' ? poolerBadge : undefined}
+                    method={method}
+                    poolerBadge={IS_PLATFORM && method === 'transaction' ? poolerBadge : undefined}
+                    descriptionOverride={
+                      isSelfHosted && method === 'direct'
+                        ? 'Manually configurable for self-hosted Supabase.'
+                        : isSelfHosted && method === 'session'
+                          ? `Supavisor on port ${connectionInfo.db_port || 5432} (default pooler for self-hosted).`
+                          : undefined
+                    }
                   />
                 ))}
               </SelectContent_Shadcn_>
@@ -409,9 +465,10 @@ export const DatabaseConnectionString = () => {
               </div>
             )}
             <div className="px-4 md:px-7 py-8">
-              {selectedMethod === 'direct' && (
+              {selectedMethod === 'direct' && IS_PLATFORM && (
                 <ConnectionPanel
                   type="direct"
+                  env="platform"
                   title={connectionStringMethodOptions.direct.label}
                   contentType={contentType}
                   lang={lang}
@@ -439,9 +496,66 @@ export const DatabaseConnectionString = () => {
                 />
               )}
 
+              {selectedMethod === 'direct' && isCliMode && (
+                <ConnectionPanel
+                  type="direct"
+                  env="cli"
+                  title={connectionStringMethodOptions.direct.label}
+                  contentType={contentType}
+                  lang={lang}
+                  fileTitle={fileTitle}
+                  description={connectionStringMethodOptions.direct.description}
+                  connectionString={connectionStrings['direct'][selectedTab]}
+                  parameters={[
+                    { ...CONNECTION_PARAMETERS.host, value: connectionInfo.db_host },
+                    { ...CONNECTION_PARAMETERS.port, value: connectionInfo.db_port },
+                    { ...CONNECTION_PARAMETERS.database, value: connectionInfo.db_name },
+                    { ...CONNECTION_PARAMETERS.user, value: connectionInfo.db_user },
+                  ]}
+                  onCopyCallback={() => handleCopy(selectedTab, 'direct')}
+                />
+              )}
+
+              {selectedMethod === 'direct' && isSelfHosted && (
+                <ConnectionPanel
+                  type="direct"
+                  env="self-hosted"
+                  title={connectionStringMethodOptions.direct.label}
+                  contentType={contentType}
+                  lang={lang}
+                  fileTitle={fileTitle}
+                  description={
+                    <>
+                      Manually{' '}
+                      <a
+                        href="https://supabase.com/docs/guides/self-hosting/docker#exposing-your-postgres-database"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="underline hover:text-foreground"
+                      >
+                        configurable
+                      </a>{' '}
+                      for self-hosted Supabase.
+                    </>
+                  }
+                  connectionString={selfHostedDirectStrings[selectedTab]}
+                  parameters={[
+                    { ...CONNECTION_PARAMETERS.host, value: connectionInfo.db_host },
+                    {
+                      ...CONNECTION_PARAMETERS.port,
+                      value: String(connectionInfo.db_port || 5432),
+                    },
+                    { ...CONNECTION_PARAMETERS.database, value: 'postgres' },
+                    { ...CONNECTION_PARAMETERS.user, value: 'postgres' },
+                  ]}
+                  onCopyCallback={() => handleCopy(selectedTab, 'direct')}
+                />
+              )}
+
               {selectedMethod === 'transaction' && IS_PLATFORM && (
                 <ConnectionPanel
                   type="transaction"
+                  env="platform"
                   title={connectionStringMethodOptions.transaction.label}
                   contentType={contentType}
                   lang={lang}
@@ -529,9 +643,35 @@ export const DatabaseConnectionString = () => {
                 </ConnectionPanel>
               )}
 
+              {selectedMethod === 'transaction' && isSelfHosted && (
+                <ConnectionPanel
+                  type="transaction"
+                  env="self-hosted"
+                  title={connectionStringMethodOptions.transaction.label}
+                  contentType={contentType}
+                  lang={lang}
+                  fileTitle={fileTitle}
+                  description={connectionStringMethodOptions.transaction.description}
+                  connectionString={selfHostedTransactionPoolerStrings[selectedTab]}
+                  notice={['Does not support PREPARE statements']}
+                  parameters={[
+                    { ...CONNECTION_PARAMETERS.host, value: connectionInfo.db_host },
+                    { ...CONNECTION_PARAMETERS.port, value: '6543' },
+                    { ...CONNECTION_PARAMETERS.database, value: 'postgres' },
+                    {
+                      ...CONNECTION_PARAMETERS.user,
+                      value: 'postgres.[POOLER_TENANT_ID]',
+                    },
+                    { ...CONNECTION_PARAMETERS.pool_mode, value: 'transaction' },
+                  ]}
+                  onCopyCallback={() => handleCopy(selectedTab, 'transaction_pooler')}
+                />
+              )}
+
               {selectedMethod === 'session' && IS_PLATFORM && (
                 <ConnectionPanel
                   type="session"
+                  env="platform"
                   title={connectionStringMethodOptions.session.label}
                   contentType={contentType}
                   lang={lang}
@@ -556,6 +696,33 @@ export const DatabaseConnectionString = () => {
                       value: sharedPoolerConfig?.db_name ?? '',
                     },
                     { ...CONNECTION_PARAMETERS.user, value: sharedPoolerConfig?.db_user ?? '' },
+                    { ...CONNECTION_PARAMETERS.pool_mode, value: 'session' },
+                  ]}
+                  onCopyCallback={() => handleCopy(selectedTab, 'session_pooler')}
+                />
+              )}
+
+              {selectedMethod === 'session' && isSelfHosted && (
+                <ConnectionPanel
+                  type="session"
+                  env="self-hosted"
+                  title={connectionStringMethodOptions.session.label}
+                  contentType={contentType}
+                  lang={lang}
+                  fileTitle={fileTitle}
+                  description={`Supavisor on port ${connectionInfo.db_port || 5432} (default pooler for self-hosted).`}
+                  connectionString={selfHostedSessionPoolerStrings[selectedTab]}
+                  parameters={[
+                    { ...CONNECTION_PARAMETERS.host, value: connectionInfo.db_host },
+                    {
+                      ...CONNECTION_PARAMETERS.port,
+                      value: String(connectionInfo.db_port || 5432),
+                    },
+                    { ...CONNECTION_PARAMETERS.database, value: 'postgres' },
+                    {
+                      ...CONNECTION_PARAMETERS.user,
+                      value: 'postgres.[POOLER_TENANT_ID]',
+                    },
                     { ...CONNECTION_PARAMETERS.pool_mode, value: 'session' },
                   ]}
                   onCopyCallback={() => handleCopy(selectedTab, 'session_pooler')}
@@ -639,25 +806,30 @@ export const DatabaseConnectionString = () => {
 const ConnectionStringMethodSelectItem = ({
   method,
   poolerBadge,
+  descriptionOverride,
 }: {
   method: ConnectionStringMethod
   poolerBadge?: string
+  descriptionOverride?: string
 }) => {
+  // Only show badges on platform (not for CLI or self-hosted)
   const badges: ReactNode[] = []
 
-  if (method !== 'direct') {
-    badges.push(
-      <Badge key="direct" className="flex gap-x-1">
-        Shared Pooler
-      </Badge>
-    )
-  }
-  if (poolerBadge === 'Dedicated Pooler') {
-    badges.push(
-      <Badge key="dedicated" className="flex gap-x-1">
-        {poolerBadge}
-      </Badge>
-    )
+  // Improved badge logic to avoid duplication and show appropriate badge
+  if (IS_PLATFORM && method !== 'direct') {
+    if (poolerBadge === 'Dedicated Pooler' && method === 'transaction') {
+      badges.push(
+        <Badge key="dedicated" className="flex gap-x-1">
+          Dedicated Pooler
+        </Badge>
+      )
+    } else {
+      badges.push(
+        <Badge key="shared" className="flex gap-x-1">
+          Shared Pooler
+        </Badge>
+      )
+    }
   }
 
   return (
@@ -667,11 +839,13 @@ const ConnectionStringMethodSelectItem = ({
           {connectionStringMethodOptions[method].label}
         </div>
         <div className="text-foreground-lighter text-xs">
-          {connectionStringMethodOptions[method].description}
+          {descriptionOverride ?? connectionStringMethodOptions[method].description}
         </div>
-        <div className="flex items-center gap-0.5 flex-wrap mt-1.5">
-          {badges.map((badge) => badge)}
-        </div>
+        {badges.length > 0 && (
+          <div className="flex items-center gap-0.5 flex-wrap mt-1.5">
+            {badges.map((badge) => badge)}
+          </div>
+        )}
       </div>
     </SelectItem_Shadcn_>
   )

--- a/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.ts
+++ b/apps/studio/components/interfaces/Connect/DatabaseSettings.utils.ts
@@ -10,6 +10,78 @@ type ConnectionStrings = {
   sqlalchemy: string
 }
 
+/**
+ * Generates connection strings for self-hosted pooler connections.
+ * Uses placeholders for tenant ID and password since these are user-configured.
+ */
+export const getSelfHostedPoolerStrings = (
+  dbHost: string,
+  port: number,
+  dbName: string = 'postgres'
+): ConnectionStrings => {
+  const user = 'postgres.[POOLER_TENANT_ID]'
+  const password = '[YOUR-PASSWORD]'
+
+  const uri = `postgresql://${user}:${password}@${dbHost}:${port}/${dbName}`
+  const psql = `psql 'postgresql://${user}:${password}@${dbHost}:${port}/${dbName}'`
+  const golang = `user=${user}\npassword=${password}\nhost=${dbHost}\nport=${port}\ndbname=${dbName}`
+  const jdbc = `jdbc:postgresql://${dbHost}:${port}/${dbName}?user=${user}&password=${password}`
+  const dotnet = `{
+  "ConnectionStrings": {
+    "DefaultConnection": "User Id=${user};Password=${password};Server=${dbHost};Port=${port};Database=${dbName}"
+  }
+}`
+  const nodejs = `DATABASE_URL=${uri}`
+
+  return {
+    psql,
+    uri,
+    golang,
+    jdbc,
+    dotnet,
+    nodejs,
+    php: golang,
+    python: golang,
+    sqlalchemy: golang,
+  }
+}
+
+/**
+ * Generates connection strings for self-hosted direct postgres connections.
+ * Uses placeholder for password since it's user-configured.
+ */
+export const getSelfHostedDirectStrings = (
+  dbHost: string,
+  port: number,
+  dbName: string = 'postgres'
+): ConnectionStrings => {
+  const user = 'postgres'
+  const password = '[YOUR-PASSWORD]'
+
+  const uri = `postgresql://${user}:${password}@${dbHost}:${port}/${dbName}`
+  const psql = `psql 'postgresql://${user}:${password}@${dbHost}:${port}/${dbName}'`
+  const golang = `user=${user}\npassword=${password}\nhost=${dbHost}\nport=${port}\ndbname=${dbName}`
+  const jdbc = `jdbc:postgresql://${dbHost}:${port}/${dbName}?user=${user}&password=${password}`
+  const dotnet = `{
+  "ConnectionStrings": {
+    "DefaultConnection": "User Id=${user};Password=${password};Server=${dbHost};Port=${port};Database=${dbName}"
+  }
+}`
+  const nodejs = `DATABASE_URL=${uri}`
+
+  return {
+    psql,
+    uri,
+    golang,
+    jdbc,
+    dotnet,
+    nodejs,
+    php: golang,
+    python: golang,
+    sqlalchemy: golang,
+  }
+}
+
 export const getConnectionStrings = ({
   connectionInfo,
   poolingInfo,

--- a/apps/studio/components/interfaces/Connect/content/drizzle/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/drizzle/content.tsx
@@ -19,23 +19,7 @@ const ContentFile = ({ connectionStringPooler }: ContentFileProps) => {
 
       <ConnectTabContent value=".env">
         <SimpleCodeBlock className="bash" parentClassName="min-h-72">
-          {connectionStringPooler.ipv4SupportedForDedicatedPooler &&
-          connectionStringPooler.transactionDedicated
-            ? `
-DATABASE_URL="${connectionStringPooler.transactionDedicated}"
-        `
-            : connectionStringPooler.transactionDedicated &&
-                !connectionStringPooler.ipv4SupportedForDedicatedPooler
-              ? `
-# Use Shared connection pooler (supports both IPv4/IPv6)
-DATABASE_URL="${connectionStringPooler.transactionShared}"
-
-# If your network supports IPv6 or you purchased IPv4 addon, use dedicated pooler
-# DATABASE_URL="${connectionStringPooler.transactionDedicated}"
-        `
-              : `
-DATABASE_URL="${connectionStringPooler.transactionShared}"
-`}
+          {`DATABASE_URL="${connectionStringPooler.transactionDedicated || connectionStringPooler.transactionShared}"`}
         </SimpleCodeBlock>
       </ConnectTabContent>
 

--- a/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/prisma/content.tsx
@@ -19,8 +19,7 @@ const ContentFile = ({ connectionStringPooler }: ContentFileProps) => {
 
       <ConnectTabContent value=".env.local">
         <SimpleCodeBlock className="bash" parentClassName="min-h-72">
-          {connectionStringPooler.ipv4SupportedForDedicatedPooler &&
-          connectionStringPooler.transactionDedicated
+          {connectionStringPooler.transactionDedicated
             ? `
 # Connect to Supabase via connection pooling.
 DATABASE_URL="${connectionStringPooler.transactionDedicated}?pgbouncer=true"
@@ -28,20 +27,7 @@ DATABASE_URL="${connectionStringPooler.transactionDedicated}?pgbouncer=true"
 # Direct connection to the database. Used for migrations.
 DIRECT_URL="${connectionStringPooler.sessionDedicated}"
         `
-            : connectionStringPooler.transactionDedicated &&
-                !connectionStringPooler.ipv4SupportedForDedicatedPooler
-              ? `
-# Connect to Supabase via Shared Connection Pooler
-DATABASE_URL="${connectionStringPooler.transactionShared}?pgbouncer=true"
-
-# Direct connection to the database through Shared Pooler (supports IPv4/IPv6). Used for migrations.
-DIRECT_URL="${connectionStringPooler.sessionShared}"
-
-# If your network supports IPv6 or you purchased IPv4 addon, use dedicated pooler
-# DATABASE_URL="${connectionStringPooler.transactionDedicated}?pgbouncer=true"
-# DIRECT_URL="${connectionStringPooler.sessionDedicated}"
- `
-              : `
+            : `
 # Connect to Supabase ${IS_PLATFORM ? 'via connection pooling' : ''}
 DATABASE_URL="${IS_PLATFORM ? `${connectionStringPooler.transactionShared}?pgbouncer=true` : connectionStringPooler.direct}"
 

--- a/apps/studio/data/config/deployment-mode-query.ts
+++ b/apps/studio/data/config/deployment-mode-query.ts
@@ -1,0 +1,38 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { handleError } from 'data/fetchers'
+import { API_URL, IS_PLATFORM } from 'lib/constants'
+import type { ResponseError, UseCustomQueryOptions } from 'types'
+
+export type DeploymentMode = {
+  is_cli_mode: boolean
+}
+
+export async function getDeploymentMode(signal?: AbortSignal): Promise<DeploymentMode> {
+  const response = await fetch(`${API_URL}/platform/deployment-mode`, { signal })
+
+  if (!response.ok) {
+    handleError(await response.json())
+  }
+
+  return response.json()
+}
+
+export type DeploymentModeData = Awaited<ReturnType<typeof getDeploymentMode>>
+export type DeploymentModeError = ResponseError
+
+export const useDeploymentModeQuery = <TData = DeploymentModeData>(
+  options: UseCustomQueryOptions<DeploymentModeData, DeploymentModeError, TData> = {}
+) => {
+  const { enabled = true, ...rest } = options
+
+  return useQuery<DeploymentModeData, DeploymentModeError, TData>({
+    queryKey: ['deployment-mode'],
+    queryFn: ({ signal }) => getDeploymentMode(signal),
+    // Only fetch in non-platform mode (CLI or self-hosted)
+    enabled: enabled && !IS_PLATFORM,
+    // Cache for the entire session - deployment mode doesn't change
+    staleTime: Infinity,
+    ...rest,
+  })
+}

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -10,6 +10,12 @@ export const IS_PLATFORM = process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
  */
 export const IS_TEST_ENV = process.env.NEXT_PUBLIC_NODE_ENV === 'test'
 
+/**
+ * Indicates that the app is running via the Supabase CLI (local development).
+ * When false and !IS_PLATFORM, we're in self-hosted docker mode.
+ */
+export const IS_CLI = !IS_PLATFORM && !!process.env.CURRENT_CLI_VERSION
+
 export const API_URL = (() => {
   if (process.env.NODE_ENV === 'test') return 'http://localhost:3000/api'
   //  If running in platform, use API_URL from the env var

--- a/apps/studio/pages/api/platform/deployment-mode.ts
+++ b/apps/studio/pages/api/platform/deployment-mode.ts
@@ -1,0 +1,32 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import apiWrapper from 'lib/api/apiWrapper'
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req
+
+  switch (method) {
+    case 'GET':
+      return handleGet(req, res)
+    default:
+      res.setHeader('Allow', ['GET'])
+      res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
+  }
+}
+
+export default function deploymentMode(req: NextApiRequest, res: NextApiResponse) {
+  return apiWrapper(req, res, handler)
+}
+
+type ResponseData = {
+  is_cli_mode: boolean
+}
+
+const handleGet = async (req: NextApiRequest, res: NextApiResponse<ResponseData>) => {
+  // CURRENT_CLI_VERSION is set by the Supabase CLI when starting Studio
+  const isCliMode = !!process.env.CURRENT_CLI_VERSION
+
+  return res.status(200).json({
+    is_cli_mode: isCliMode,
+  })
+}


### PR DESCRIPTION
## Overview
This PR improves the 'Connect' dialog in Studio to correctly handle CLI and self-hosted environments. It ensures that connection strings and setup instructions are relevant to the user's context.

## Changes
- Detect deployment mode (CLI vs self-hosted) via a new API route.
- Memoize connection methods for better performance and to prevent unnecessary re-renders.
- Hide Platform-specific UI (IPv4 alerts, etc.) when running in non-platform modes.
- Fixed the transaction pooler badge duplication bug identified in review.
- Updated Prisma and Drizzle snippets for better environment awareness and migration support.
- Added self-hosted connection string generation utilities.

## Refers to
Fixes and finalizes PR #42220.