### PR TITLE
fix auth providers string fields are all considered sensitive

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -166,16 +166,20 @@ const FormField = ({
                         }
                         className="w-full"
                       >
-                        <DataInput
-                          {...field}
-                          type={properties.isSecret ? 'password' : 'text'}
-                          id={name}
-                          size="small"
-                          copy
-                          reveal
-                        />
+                        {properties.isSecret ? (
+                          <DataInput
+                            {...field}
+                            type={properties.isSecret ? 'password' : 'text'}
+                            id={name}
+                            size="small"
+                            copy
+                            reveal
+                          />
+                        ) : (
+                          <Input_Shadcn_ {...field} id={name} />
+                        )}
                       </PrePostTab>
-                    ) : (
+                    ) : properties.isSecret ? (
                       <DataInput
                         {...field}
                         type={properties.isSecret ? 'password' : 'text'}
@@ -184,6 +188,8 @@ const FormField = ({
                         copy
                         reveal
                       />
+                    ) : (
+                      <Input_Shadcn_ {...field} id={name} />
                     )}
                   </FormControl_Shadcn_>
                 </FormItemLayout>


### PR DESCRIPTION
## Problem

All Auth Providers string fields are considered sensitive

## Solution

Restore check of the `sensitive` property that was mistakenly removed in #44095

## Screenshots

<img width="815" height="949" alt="image" src="https://github.com/user-attachments/assets/5eab2db9-7023-4351-ab64-f09f5b54d1b8" />
