### PR TITLE
Joshen/fe 2899 migrate wrappers integration to new UI

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet.tsx
@@ -108,7 +108,7 @@ export const InstallIntegrationSheet = ({ integration }: InstallIntegrationSheet
   const { mutateAsync: enableExtension } = useDatabaseExtensionEnableMutation({ onError: () => {} })
 
   const enableExtensionsSQL = getEnableExtensionsSQL({
-    extensions: requiredExtensions,
+    extensions: requiredExtensions.filter((ext) => !ext.installed_version),
     extensionsSchema,
   })
   const installationSQLContent = installationSql ?? enableExtensionsSQL
@@ -156,26 +156,28 @@ export const InstallIntegrationSheet = ({ integration }: InstallIntegrationSheet
 
     const { ref: projectRef, connectionString } = project
     const results = await Promise.allSettled(
-      requiredExtensions.map((ext) => {
-        const { name, default_version: version } = ext
-        const createSchema = extensionsSchema[name].schema === 'custom'
-        const schema =
-          name === 'pg_cron'
-            ? 'pg_catalog'
-            : createSchema
-              ? (extensionsSchema[name].value as string)
-              : extensionsSchema[name].schema
+      requiredExtensions
+        .filter((ext) => !ext.installed_version)
+        .map((ext) => {
+          const { name, default_version: version } = ext
+          const createSchema = extensionsSchema[name].schema === 'custom'
+          const schema =
+            name === 'pg_cron'
+              ? 'pg_catalog'
+              : createSchema
+                ? (extensionsSchema[name].value as string)
+                : extensionsSchema[name].schema
 
-        return enableExtension({
-          projectRef,
-          connectionString,
-          schema,
-          name,
-          version,
-          cascade: true,
-          createSchema,
+          return enableExtension({
+            projectRef,
+            connectionString,
+            schema,
+            name,
+            version,
+            cascade: true,
+            createSchema,
+          })
         })
-      })
     )
 
     const failure = results.find((r) => r.status === 'rejected')
@@ -240,11 +242,11 @@ export const InstallIntegrationSheet = ({ integration }: InstallIntegrationSheet
                     )}
                   </TabsList_Shadcn_>
 
-                  <TabsContent_Shadcn_ value="extensions" className="mt-0 px-4">
+                  <TabsContent_Shadcn_ value="extensions" className="mt-0 divide-y">
                     {requiredExtensionNames.map((extName) => {
                       const ext = extensions.find((x) => x.name === extName)
                       return (
-                        <div key={extName} className="py-3 flex items-center justify-between">
+                        <div key={extName} className="py-3 px-4 flex items-center justify-between">
                           <code className="text-xs">{extName}</code>
                           {!ext ? (
                             <Badge>Unavailable</Badge>
@@ -290,6 +292,7 @@ export const InstallIntegrationSheet = ({ integration }: InstallIntegrationSheet
                         Select which schemas to install the database extensions under
                       </p>
                       {requiredExtensionNames.map((extName) => {
+                        const ext = extensions.find((x) => x.name === extName)
                         const extMeta = extensionsSchema[extName as keyof typeof extensionsSchema]
                         const { schema, value } = extMeta
                         const recommendedSchema = extensionsWithRecommendedSchemas[extName]
@@ -300,8 +303,23 @@ export const InstallIntegrationSheet = ({ integration }: InstallIntegrationSheet
                             isReactForm={false}
                             layout="horizontal"
                             label={extName}
+                            description={
+                              !!recommendedSchema ? (
+                                <>
+                                  Use the{' '}
+                                  <code className="text-code-inline">{recommendedSchema}</code>{' '}
+                                  schema for full compatibility with related features
+                                </>
+                              ) : !!ext?.installed_version ? (
+                                <>
+                                  Installed in{' '}
+                                  <code className="text-code-inline">{ext.schema}</code> schema
+                                </>
+                              ) : undefined
+                            }
                           >
                             <Select_Shadcn_
+                              disabled={!!ext?.installed_version}
                               value={schema}
                               onValueChange={(schema) =>
                                 setExtensionsSchema((prev) => ({

--- a/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
@@ -192,7 +192,7 @@ const SUPABASE_INTEGRATIONS: Array<IntegrationDefinition> = [
       <Vault className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
     ),
     description: 'Application level encryption for your project',
-    docsUrl: DOCS_URL,
+    docsUrl: `${DOCS_URL}/guides/database/vault`,
     author: authorSupabase,
     navigation: [
       {
@@ -236,7 +236,7 @@ const SUPABASE_INTEGRATIONS: Array<IntegrationDefinition> = [
     ),
     description:
       'Send real-time data from your database to another system when a table event occurs',
-    docsUrl: DOCS_URL,
+    docsUrl: `${DOCS_URL}/guides/database/webhooks`,
     author: authorSupabase,
     requiredExtensions: ['pg_net'],
     navigation: [
@@ -357,7 +357,7 @@ const SUPABASE_INTEGRATIONS: Array<IntegrationDefinition> = [
       />
     ),
     description: 'Run GraphQL queries through our interactive in-browser IDE',
-    docsUrl: DOCS_URL,
+    docsUrl: `${DOCS_URL}/guides/database/extensions/pg_graphql`,
     author: authorSupabase,
     navigation: [
       {

--- a/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
@@ -15,7 +15,6 @@ import {
   AlertDescription_Shadcn_,
   AlertTitle_Shadcn_,
   Button,
-  Separator,
   Sheet,
   SheetContent,
   WarningIcon,
@@ -24,7 +23,6 @@ import {
 import { IntegrationOverviewTab } from '../Integration/IntegrationOverviewTab'
 import { IntegrationOverviewTabV2 } from '../Integration/IntegrationOverviewTabV2'
 import { useAvailableIntegrations } from '../Landing/useAvailableIntegrations'
-import { useInstalledIntegrations } from '../Landing/useInstalledIntegrations'
 import { CreateIcebergWrapperSheet } from './CreateIcebergWrapperSheet'
 import { CreateWrapperSheet } from './CreateWrapperSheet'
 import { WRAPPERS } from './Wrappers.constants'
@@ -60,8 +58,8 @@ const WrapperOverviewContent = () => {
 
   return (
     <>
-      <div className="flex flex-col gap-5">
-        Recent wrappers
+      <div className="flex flex-col gap-y-5">
+        <p>Recent wrappers</p>
         <WrapperTable />
       </div>
 
@@ -70,10 +68,8 @@ const WrapperOverviewContent = () => {
           <SheetContent size="lg" tabIndex={undefined}>
             <CreateWrapperSheetComponent
               wrapperMeta={wrapperMeta}
-              onDirty={(dirty) => setIsDirty(dirty)}
-              onClose={() => {
-                setCreateWrapperShown(false)
-              }}
+              onDirty={setIsDirty}
+              onClose={() => setCreateWrapperShown(false)}
               onCloseWithConfirmation={confirmOnClose}
             />
           </SheetContent>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
@@ -8,17 +8,10 @@ import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useConfirmOnClose } from 'hooks/ui/useConfirmOnClose'
 import Link from 'next/link'
+import { Admonition } from 'node_modules/ui-patterns'
 import { parseAsBoolean, useQueryState } from 'nuqs'
 import { useState } from 'react'
-import {
-  Alert_Shadcn_,
-  AlertDescription_Shadcn_,
-  AlertTitle_Shadcn_,
-  Button,
-  Sheet,
-  SheetContent,
-  WarningIcon,
-} from 'ui'
+import { Button, Sheet, SheetContent } from 'ui'
 
 import { IntegrationOverviewTab } from '../Integration/IntegrationOverviewTab'
 import { IntegrationOverviewTabV2 } from '../Integration/IntegrationOverviewTabV2'
@@ -109,14 +102,10 @@ const AddNewWrapperCTA = () => {
   const databaseNeedsUpgrading =
     wrappersExtension?.installed_version === wrappersExtension?.default_version
 
-  return !!wrapperMeta && isWrappersExtensionInstalled && !hasRequiredVersion ? (
-    <div className="">
-      <Alert_Shadcn_ variant="warning">
-        <WarningIcon />
-        <AlertTitle_Shadcn_>
-          Your extension version is outdated for this wrapper.
-        </AlertTitle_Shadcn_>
-        <AlertDescription_Shadcn_ className="flex flex-col gap-y-2">
+  if (!!wrapperMeta && isWrappersExtensionInstalled && !hasRequiredVersion) {
+    return (
+      <Admonition type="warning" title="Your extension version is outdated for this wrapper">
+        <div className="flex flex-col gap-y-2 [&>p]:!mb-0">
           <p>
             The {wrapperMeta.label} wrapper requires a minimum extension version of{' '}
             {wrapperMeta.minimumExtensionVersion}. You have version{' '}
@@ -129,23 +118,23 @@ const AddNewWrapperCTA = () => {
             Warning: Before reinstalling the wrapper extension, you must first remove all existing
             wrappers. Afterward, you can recreate the wrappers.
           </p>
-        </AlertDescription_Shadcn_>
-        <AlertDescription_Shadcn_ className="mt-3">
-          <Button asChild type="default">
-            <Link
-              href={
-                databaseNeedsUpgrading
-                  ? `/project/${project?.ref}/settings/infrastructure`
-                  : `/project/${project?.ref}/database/extensions?filter=wrappers`
-              }
-            >
-              {databaseNeedsUpgrading ? 'Upgrade database' : 'View wrappers extension'}
-            </Link>
-          </Button>
-        </AlertDescription_Shadcn_>
-      </Alert_Shadcn_>
-    </div>
-  ) : (
+        </div>
+        <Button asChild type="default" className="w-min mt-3">
+          <Link
+            href={
+              databaseNeedsUpgrading
+                ? `/project/${project?.ref}/settings/infrastructure`
+                : `/project/${project?.ref}/database/extensions?filter=wrappers`
+            }
+          >
+            {databaseNeedsUpgrading ? 'Upgrade database' : 'View wrappers extension'}
+          </Link>
+        </Button>
+      </Admonition>
+    )
+  }
+
+  return (
     <div className="py-3 px-5 border rounded-md">
       <ButtonTooltip
         type="default"

--- a/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
@@ -1,15 +1,15 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import Link from 'next/link'
-import { useState } from 'react'
-import { parseAsBoolean, useQueryState } from 'nuqs'
-
-import { useParams } from 'common'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
+import { useFlag, useParams } from 'common'
+import { ScaffoldContainer, ScaffoldSection } from 'components/layouts/Scaffold'
 import { DiscardChangesConfirmationDialog } from 'components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
+import { ButtonTooltip } from 'components/ui/ButtonTooltip'
 import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
 import { useAsyncCheckPermissions } from 'hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { useConfirmOnClose } from 'hooks/ui/useConfirmOnClose'
+import Link from 'next/link'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useState } from 'react'
 import {
   Alert_Shadcn_,
   AlertDescription_Shadcn_,
@@ -20,16 +20,75 @@ import {
   SheetContent,
   WarningIcon,
 } from 'ui'
+
 import { IntegrationOverviewTab } from '../Integration/IntegrationOverviewTab'
+import { IntegrationOverviewTabV2 } from '../Integration/IntegrationOverviewTabV2'
+import { useAvailableIntegrations } from '../Landing/useAvailableIntegrations'
+import { useInstalledIntegrations } from '../Landing/useInstalledIntegrations'
 import { CreateIcebergWrapperSheet } from './CreateIcebergWrapperSheet'
 import { CreateWrapperSheet } from './CreateWrapperSheet'
 import { WRAPPERS } from './Wrappers.constants'
 import { WrapperTable } from './WrapperTable'
 
-export const WrapperOverviewTab = () => {
+const WrapperOverviewContent = () => {
+  const { id } = useParams()
+  const wrapperMeta = WRAPPERS.find((w) => w.name === id)
+
+  const [isDirty, setIsDirty] = useState(false)
+  const [createWrapperShown, setCreateWrapperShown] = useQueryState(
+    'new',
+    parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
+  )
+
+  const { confirmOnClose, handleOpenChange, modalProps } = useConfirmOnClose({
+    checkIsDirty: () => isDirty,
+    onClose: () => {
+      setCreateWrapperShown(false)
+      setIsDirty(false)
+    },
+  })
+
+  // [Joshen] Opting to declare custom wrapper sheets here instead of within Wrappers.constants.ts
+  // as we'll easily run into circular dependencies doing so unfortunately
+  const CreateWrapperSheetComponent = !!wrapperMeta
+    ? wrapperMeta.customComponent
+      ? wrapperMeta.name === 'iceberg_wrapper'
+        ? CreateIcebergWrapperSheet
+        : ({}) => null
+      : CreateWrapperSheet
+    : null
+
+  return (
+    <>
+      <div className="flex flex-col gap-5">
+        Recent wrappers
+        <WrapperTable />
+      </div>
+
+      {!!CreateWrapperSheetComponent && !!wrapperMeta && (
+        <Sheet open={!!createWrapperShown} onOpenChange={handleOpenChange}>
+          <SheetContent size="lg" tabIndex={undefined}>
+            <CreateWrapperSheetComponent
+              wrapperMeta={wrapperMeta}
+              onDirty={(dirty) => setIsDirty(dirty)}
+              onClose={() => {
+                setCreateWrapperShown(false)
+              }}
+              onCloseWithConfirmation={confirmOnClose}
+            />
+          </SheetContent>
+        </Sheet>
+      )}
+
+      <DiscardChangesConfirmationDialog {...modalProps} />
+    </>
+  )
+}
+
+const AddNewWrapperCTA = () => {
   const { id } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const [createWrapperShown, setCreateWrapperShown] = useQueryState(
+  const [, setCreateWrapperShown] = useQueryState(
     'new',
     parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
   )
@@ -44,21 +103,7 @@ export const WrapperOverviewTab = () => {
     connectionString: project?.connectionString,
   })
 
-  const [isDirty, setIsDirty] = useState(false)
-  const { confirmOnClose, handleOpenChange, modalProps } = useConfirmOnClose({
-    checkIsDirty: () => isDirty,
-    onClose: () => {
-      setCreateWrapperShown(false)
-      setIsDirty(false)
-    },
-  })
-
   const wrapperMeta = WRAPPERS.find((w) => w.name === id)
-
-  if (!wrapperMeta) {
-    return <p className="text-sm text-foreground-light">Unsupported integration type</p>
-  }
-
   const wrappersExtension = data?.find((ext) => ext.name === 'wrappers')
   const isWrappersExtensionInstalled = !!wrappersExtension?.installed_version
   const hasRequiredVersion =
@@ -68,92 +113,108 @@ export const WrapperOverviewTab = () => {
   const databaseNeedsUpgrading =
     wrappersExtension?.installed_version === wrappersExtension?.default_version
 
-  // [Joshen] Opting to declare custom wrapper sheets here instead of within Wrappers.constants.ts
-  // as we'll easily run into circular dependencies doing so unfortunately
-  const CreateWrapperSheetComponent = wrapperMeta.customComponent
-    ? wrapperMeta.name === 'iceberg_wrapper'
-      ? CreateIcebergWrapperSheet
-      : ({}) => null
-    : CreateWrapperSheet
-
-  return (
-    <IntegrationOverviewTab
-      actions={
-        isWrappersExtensionInstalled && !hasRequiredVersion ? (
-          <div className="">
-            <Alert_Shadcn_ variant="warning">
-              <WarningIcon />
-              <AlertTitle_Shadcn_>
-                Your extension version is outdated for this wrapper.
-              </AlertTitle_Shadcn_>
-              <AlertDescription_Shadcn_ className="flex flex-col gap-y-2">
-                <p>
-                  The {wrapperMeta.label} wrapper requires a minimum extension version of{' '}
-                  {wrapperMeta.minimumExtensionVersion}. You have version{' '}
-                  {wrappersExtension?.installed_version} installed. Please{' '}
-                  {databaseNeedsUpgrading && 'upgrade your database then '}update the extension by
-                  disabling and enabling the <code className="text-code-inline">wrappers</code>{' '}
-                  extension to create this wrapper.
-                </p>
-                <p className="text-warning">
-                  Warning: Before reinstalling the wrapper extension, you must first remove all
-                  existing wrappers. Afterward, you can recreate the wrappers.
-                </p>
-              </AlertDescription_Shadcn_>
-              <AlertDescription_Shadcn_ className="mt-3">
-                <Button asChild type="default">
-                  <Link
-                    href={
-                      databaseNeedsUpgrading
-                        ? `/project/${project?.ref}/settings/infrastructure`
-                        : `/project/${project?.ref}/database/extensions?filter=wrappers`
-                    }
-                  >
-                    {databaseNeedsUpgrading ? 'Upgrade database' : 'View wrappers extension'}
-                  </Link>
-                </Button>
-              </AlertDescription_Shadcn_>
-            </Alert_Shadcn_>
-          </div>
-        ) : (
-          <div className="py-3 px-5 border rounded-md">
-            <ButtonTooltip
-              type="default"
-              onClick={() => setCreateWrapperShown(true)}
-              disabled={!canCreateWrapper}
-              tooltip={{
-                content: {
-                  text: !canCreateWrapper
-                    ? 'You need additional permissions to create a foreign data wrapper'
-                    : undefined,
-                },
-              }}
+  return !!wrapperMeta && isWrappersExtensionInstalled && !hasRequiredVersion ? (
+    <div className="">
+      <Alert_Shadcn_ variant="warning">
+        <WarningIcon />
+        <AlertTitle_Shadcn_>
+          Your extension version is outdated for this wrapper.
+        </AlertTitle_Shadcn_>
+        <AlertDescription_Shadcn_ className="flex flex-col gap-y-2">
+          <p>
+            The {wrapperMeta.label} wrapper requires a minimum extension version of{' '}
+            {wrapperMeta.minimumExtensionVersion}. You have version{' '}
+            {wrappersExtension?.installed_version} installed. Please{' '}
+            {databaseNeedsUpgrading && 'upgrade your database then '}update the extension by
+            disabling and enabling the <code className="text-code-inline">wrappers</code> extension
+            to create this wrapper.
+          </p>
+          <p className="text-warning">
+            Warning: Before reinstalling the wrapper extension, you must first remove all existing
+            wrappers. Afterward, you can recreate the wrappers.
+          </p>
+        </AlertDescription_Shadcn_>
+        <AlertDescription_Shadcn_ className="mt-3">
+          <Button asChild type="default">
+            <Link
+              href={
+                databaseNeedsUpgrading
+                  ? `/project/${project?.ref}/settings/infrastructure`
+                  : `/project/${project?.ref}/database/extensions?filter=wrappers`
+              }
             >
-              Add new wrapper
-            </ButtonTooltip>
-          </div>
-        )
-      }
-    >
-      <div className="mx-10 flex flex-col gap-5">
-        Recent wrappers
-        <WrapperTable />
-      </div>
-      <Separator />
-
-      <Sheet open={!!createWrapperShown} onOpenChange={handleOpenChange}>
-        <SheetContent size="lg" tabIndex={undefined}>
-          <CreateWrapperSheetComponent
-            wrapperMeta={wrapperMeta}
-            onDirty={(dirty) => setIsDirty(dirty)}
-            onClose={() => {
-              setCreateWrapperShown(false)
-            }}
-            onCloseWithConfirmation={confirmOnClose}
-          />
-        </SheetContent>
-      </Sheet>
-      <DiscardChangesConfirmationDialog {...modalProps} />
-    </IntegrationOverviewTab>
+              {databaseNeedsUpgrading ? 'Upgrade database' : 'View wrappers extension'}
+            </Link>
+          </Button>
+        </AlertDescription_Shadcn_>
+      </Alert_Shadcn_>
+    </div>
+  ) : (
+    <div className="py-3 px-5 border rounded-md">
+      <ButtonTooltip
+        type="default"
+        onClick={() => setCreateWrapperShown(true)}
+        disabled={!canCreateWrapper}
+        tooltip={{
+          content: {
+            text: !canCreateWrapper
+              ? 'You need additional permissions to create a foreign data wrapper'
+              : undefined,
+          },
+        }}
+      >
+        Add new wrapper
+      </ButtonTooltip>
+    </div>
   )
+}
+
+export const WrapperOverviewTab = () => {
+  const { id } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+  const isMarketplaceEnabled = useFlag('marketplaceIntegrations')
+
+  const { data: integrations = [] } = useAvailableIntegrations()
+  const integration = integrations.find((i) => i.id === id)
+  const wrapperMeta = WRAPPERS.find((w) => w.name === id)
+
+  const { data: extensions } = useDatabaseExtensionsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+  const installableExtensions = (extensions ?? []).filter((ext) =>
+    (integration?.requiredExtensions ?? []).includes(ext.name)
+  )
+  const isInstalled = installableExtensions.every((x) => x.installed_version)
+
+  if (!wrapperMeta) {
+    return (
+      <ScaffoldContainer>
+        <ScaffoldSection isFullWidth>
+          <p className="text-sm text-foreground-light">Unsupported integration type</p>
+        </ScaffoldSection>
+      </ScaffoldContainer>
+    )
+  }
+
+  if (isMarketplaceEnabled) {
+    return (
+      <IntegrationOverviewTabV2>
+        {isInstalled && (
+          <>
+            <AddNewWrapperCTA />
+            <WrapperOverviewContent />
+          </>
+        )}
+      </IntegrationOverviewTabV2>
+    )
+  } else {
+    return (
+      <IntegrationOverviewTab actions={<AddNewWrapperCTA />}>
+        <div className="mx-10">
+          <WrapperOverviewContent />
+        </div>
+      </IntegrationOverviewTab>
+    )
+  }
 }

--- a/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/OverviewTab.tsx
@@ -48,13 +48,13 @@ const WrapperOverviewContent = () => {
 
   // [Joshen] Opting to declare custom wrapper sheets here instead of within Wrappers.constants.ts
   // as we'll easily run into circular dependencies doing so unfortunately
-  const CreateWrapperSheetComponent = !!wrapperMeta
-    ? wrapperMeta.customComponent
+  const CreateWrapperSheetComponent = !wrapperMeta
+    ? null
+    : wrapperMeta.customComponent
       ? wrapperMeta.name === 'iceberg_wrapper'
         ? CreateIcebergWrapperSheet
-        : ({}) => null
+        : null
       : CreateWrapperSheet
-    : null
 
   return (
     <>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTable.tsx
@@ -94,7 +94,7 @@ export const WrapperTable = ({ isLatest = false }: WrapperTableProps) => {
               wrappers.length === 0 ? 'border-t-0' : ''
             )}
           >
-            <TableRow>
+            <TableRow className="border-b-0">
               <TableCell colSpan={4}>
                 {wrappers.length} {integration?.name}
                 {wrappers.length === 0 || wrappers.length > 1 ? 's' : ''} created

--- a/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
+++ b/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
@@ -3,7 +3,9 @@ import { INTEGRATIONS } from 'components/interfaces/Integrations/Landing/Integra
 import { useInstalledIntegrations } from 'components/interfaces/Integrations/Landing/useInstalledIntegrations'
 import { DefaultLayout } from 'components/layouts/DefaultLayout'
 import { UnknownInterface } from 'components/ui/UnknownInterface'
+import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
+import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { IS_PLATFORM } from 'lib/constants'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -43,9 +45,15 @@ type NavigationItem = { label: string; href: string; active?: boolean }
 
 const IntegrationPage: NextPageWithLayout = () => {
   const router = useRouter()
+  const { data: project } = useSelectedProjectQuery()
   const { ref, id, pageId, childId } = useParams()
   const { integrationsWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
   const isMarketplaceEnabled = useFlag('marketplaceIntegrations')
+
+  const { data: extensions } = useDatabaseExtensionsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
 
   const { data: allIntegrations, isPending: isAvailableIntegrationsLoading } =
     useAvailableIntegrations()
@@ -59,6 +67,14 @@ const IntegrationPage: NextPageWithLayout = () => {
     () => installedIntegrations.find((inst) => inst.id === id),
     [installedIntegrations, id]
   )
+
+  const installableExtensions = (extensions ?? []).filter((ext) =>
+    (integration?.requiredExtensions ?? []).includes(ext.name)
+  )
+  const extensionsInstalled = installableExtensions.every((x) => x.installed_version)
+
+  const isInstalled =
+    !!integration && (!!installation || (integration.type === 'wrapper' && extensionsInstalled))
 
   // Get the corresponding component dynamically
   const Component = useMemo(
@@ -197,9 +213,9 @@ const IntegrationPage: NextPageWithLayout = () => {
                   Install integration
                 </a>
               </Button>
-            ) : isMarketplaceEnabled && !!integration && !installation ? (
+            ) : isMarketplaceEnabled && !!integration && !isInstalled ? (
               <InstallIntegrationSheet integration={integration} />
-            ) : isMarketplaceEnabled && !!integration && !!installation ? (
+            ) : isMarketplaceEnabled && isInstalled ? (
               <Button disabled type="outline">
                 Installed
               </Button>

--- a/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
+++ b/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
@@ -49,10 +49,8 @@ const IntegrationPage: NextPageWithLayout = () => {
 
   const { data: allIntegrations, isPending: isAvailableIntegrationsLoading } =
     useAvailableIntegrations()
-  const {
-    installedIntegrations: installedIntegrations,
-    isLoading: isInstalledIntegrationsLoading,
-  } = useInstalledIntegrations()
+  const { installedIntegrations, isLoading: isInstalledIntegrationsLoading } =
+    useInstalledIntegrations()
 
   // everything is wrapped in useMemo to avoid UI resets when installing additional extensions like pg_net
   const integration = useMemo(() => allIntegrations.find((i) => i.id === id), [allIntegrations, id])
@@ -201,6 +199,10 @@ const IntegrationPage: NextPageWithLayout = () => {
               </Button>
             ) : isMarketplaceEnabled && !!integration && !installation ? (
               <InstallIntegrationSheet integration={integration} />
+            ) : isMarketplaceEnabled && !!integration && !!installation ? (
+              <Button disabled type="outline">
+                Installed
+              </Button>
             ) : null}
           </PageHeaderMeta>
         )}

--- a/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
+++ b/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
@@ -1,12 +1,10 @@
 import { useFlag, useParams } from 'common'
-import { INTEGRATIONS } from 'components/interfaces/Integrations/Landing/Integrations.constants'
 import { useInstalledIntegrations } from 'components/interfaces/Integrations/Landing/useInstalledIntegrations'
 import { DefaultLayout } from 'components/layouts/DefaultLayout'
 import { UnknownInterface } from 'components/ui/UnknownInterface'
 import { useDatabaseExtensionsQuery } from 'data/database-extensions/database-extensions-query'
 import { useIsFeatureEnabled } from 'hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { IS_PLATFORM } from 'lib/constants'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
@@ -47,6 +45,7 @@ const IntegrationPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { data: project } = useSelectedProjectQuery()
   const { ref, id, pageId, childId } = useParams()
+
   const { integrationsWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
   const isMarketplaceEnabled = useFlag('marketplaceIntegrations')
 
@@ -88,10 +87,10 @@ const IntegrationPage: NextPageWithLayout = () => {
     if (!integration?.navigation) return []
 
     // Only show navigation if the integration is installed, or if we're on the overview page
-    const showNavigation = installation || pageId === 'overview'
+    const showNavigation = isInstalled || pageId === 'overview'
     if (!showNavigation) return []
 
-    const availableTabs = installation
+    const availableTabs = isInstalled
       ? integration.navigation
       : integration.navigation.filter((tab) => tab.route === 'overview')
 
@@ -100,7 +99,7 @@ const IntegrationPage: NextPageWithLayout = () => {
       href: `/project/${ref}/integrations/${id}/${nav.route}`,
       active: pageId === nav.route,
     }))
-  }, [integration, ref, id, pageId, installation])
+  }, [integration, pageId, isInstalled, ref, id])
 
   useEffect(() => {
     // if the integration is not installed, redirect to the overview page
@@ -108,12 +107,12 @@ const IntegrationPage: NextPageWithLayout = () => {
       router &&
       router?.isReady &&
       !isInstalledIntegrationsLoading &&
-      !installation &&
+      !isInstalled &&
       pageId !== 'overview'
     ) {
       router.replace(`/project/${ref}/integrations/${id}/overview`)
     }
-  }, [installation, isInstalledIntegrationsLoading, pageId, router, ref, id])
+  }, [isInstalled, isInstalledIntegrationsLoading, pageId, router, ref, id])
 
   // Determine page title, icon, and subtitle based on state
   const pageTitle = integration?.name || 'Integration not found'

--- a/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
+++ b/apps/studio/pages/project/[ref]/integrations/[id]/[pageId]/index.tsx
@@ -73,6 +73,7 @@ const IntegrationPage: NextPageWithLayout = () => {
   )
   const extensionsInstalled = installableExtensions.every((x) => x.installed_version)
 
+  // [Joshen] installedIntegrations doesn't return wrappers unless there's a wrapper created
   const isInstalled =
     !!integration && (!!installation || (integration.type === 'wrapper' && extensionsInstalled))
 


### PR DESCRIPTION
## Context
Related to marketplace integrations, now shifting wrappers over to the new UI (feature flagged)

## Changes involved
- Added a "Installed" indicator if the integration is installed
  <img width="1155" height="171" alt="image" src="https://github.com/user-attachments/assets/6de2ea49-64bb-46af-ba04-db6629ec7546" />
- New UI will only show the "Add new wrapper" + "Recent wrappers" table only if the required extensions have been installed (Current UI shows them both irregardless)
  <img width="1147" height="518" alt="image" src="https://github.com/user-attachments/assets/c428ff70-4a52-401e-a369-6948100d1cef" />
- Once required extensions are installed, the wrappers tab will also show up
  - Currently the wrappers tab only shows up after a wrapper is created
  - This change will affect the existing behaviour too (reckon it makes more sense this UX)
  <img width="1143" height="611" alt="image" src="https://github.com/user-attachments/assets/b05f5196-854e-41c1-8a01-7a5e5cca9d4e" />
- In the install integration sheet, only extensions that have yet to be installed will users be allowed to adjust schema selection for
  <img width="553" height="583" alt="image" src="https://github.com/user-attachments/assets/045e185a-6235-4dc5-a984-b039b64cd7fd" />
- Likewise, if the extension has already been installed, it will be omitted from the SQL code output
  <img width="575" height="267" alt="image" src="https://github.com/user-attachments/assets/5e6c0a75-5738-4a0d-9e33-ff19aed074d3" />
- Updated docs URL for some of the integrations (vault, database webhooks, graphql)
- Nit: This one's bugged me for the longest time but remove extra border bottom in "Recent wrappers" table
  <img width="1068" height="177" alt="image" src="https://github.com/user-attachments/assets/1d6e24cf-072a-4605-8eca-ee0f37406d74" />

FWIW i think the integrations UI for wrappers is due for an update, but we'll leave things as they are for now - at least until we're bit more clearer on the requirements for marketplace integrations (less we make changes now which then have to be redone again later)

## To test
- [ ] Verify that you can install + create wrappers still with the new UI
- [ ] Verify that behaviour is status quo with flag off (except the ones mentioned explicitly)