### PR TITLE
fix(observability): guard pg_stat_statements queries against missing extension FE-2843

### DIFF
--- a/apps/studio/components/interfaces/Observability/useSlowQueriesCount.test.ts
+++ b/apps/studio/components/interfaces/Observability/useSlowQueriesCount.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSlowQueriesCountSql } from './useSlowQueriesCount'
+
+describe('buildSlowQueriesCountSql', () => {
+  it('checks pg_extension before querying pg_stat_statements', () => {
+    const sql = buildSlowQueriesCountSql()
+    expect(sql).toContain('pg_extension')
+    expect(sql).toContain("extname = 'pg_stat_statements'")
+  })
+
+  it('returns 0 when extension is not installed', () => {
+    expect(buildSlowQueriesCountSql()).toContain('ELSE 0')
+  })
+
+  it('still queries pg_stat_statements when extension exists', () => {
+    const sql = buildSlowQueriesCountSql()
+    expect(sql).toContain('pg_stat_statements')
+    expect(sql).toContain('total_exec_time + total_plan_time > 1000')
+  })
+})

--- a/apps/studio/components/interfaces/Observability/useSlowQueriesCount.ts
+++ b/apps/studio/components/interfaces/Observability/useSlowQueriesCount.ts
@@ -1,19 +1,31 @@
 import useDbQuery from 'hooks/analytics/useDbQuery'
 import { useMemo } from 'react'
 
-export const useSlowQueriesCount = (projectRef?: string, refreshKey: number = 0) => {
-  // SQL to count queries with total execution time > 1000ms (1 second)
-  // refreshKey is used in useMemo to force recomputation when refresh is triggered
-  const sql = useMemo(
-    () => `
+export function buildSlowQueriesCountSql(): string {
+  return `
     -- observability-slow-queries-count
     set search_path to public, extensions;
 
     SELECT
-      count(*)::int as slow_queries_count
-    FROM pg_stat_statements
-    WHERE total_exec_time + total_plan_time > 1000;
-  `,
+      CASE
+        WHEN EXISTS (
+          SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements'
+        )
+        THEN (
+          SELECT count(*)::int
+          FROM pg_stat_statements
+          WHERE total_exec_time + total_plan_time > 1000
+        )
+        ELSE 0
+      END AS slow_queries_count;
+  `
+}
+
+export const useSlowQueriesCount = (projectRef?: string, refreshKey: number = 0) => {
+  // refreshKey is used in useMemo to force recomputation when refresh is triggered
+  const sql = useMemo(
+    () => buildSlowQueriesCountSql(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [refreshKey]
   )
 

--- a/apps/studio/components/interfaces/QueryPerformance/WithStatements/WithStatements.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/WithStatements/WithStatements.tsx
@@ -96,16 +96,22 @@ export const WithStatements = ({
   useEffect(() => {
     if (mainQueryError) {
       const errorMessage = getErrorMessage(mainQueryError)
-      captureQueryPerformanceError(mainQueryError, {
-        projectRef: ref,
-        databaseIdentifier: state.selectedDatabaseId,
-        queryPreset: 'unified',
-        queryType: 'mainQuery',
-        postgresVersion: project?.dbVersion,
-        databaseType: isPrimaryDatabase ? 'primary' : 'read-replica',
-        sql: queryPerformanceQuery.resolvedSql,
-        errorMessage: errorMessage || undefined,
-      })
+      const isNotInstalled =
+        typeof errorMessage === 'string' &&
+        errorMessage.includes('pg_stat_statements') &&
+        errorMessage.includes('does not exist')
+      if (!isNotInstalled) {
+        captureQueryPerformanceError(mainQueryError, {
+          projectRef: ref,
+          databaseIdentifier: state.selectedDatabaseId,
+          queryPreset: 'unified',
+          queryType: 'mainQuery',
+          postgresVersion: project?.dbVersion,
+          databaseType: isPrimaryDatabase ? 'primary' : 'read-replica',
+          sql: queryPerformanceQuery.resolvedSql,
+          errorMessage: errorMessage || undefined,
+        })
+      }
     }
   }, [
     mainQueryError,
@@ -155,18 +161,31 @@ export const WithStatements = ({
         ? getErrorMessage(metricsError) || 'Failed to load query metrics'
         : null
 
+  const isPgStatStatementsNotInstalled =
+    typeof errorMessage === 'string' &&
+    errorMessage.includes('pg_stat_statements') &&
+    errorMessage.includes('does not exist')
+
   return (
     <>
       {hasError && (
         <div className="px-6 pt-4">
-          <Admonition
-            type="destructive"
-            title="Error loading query performance data"
-            description={
-              errorMessage ||
-              'An error occurred while loading query performance data. Please try refreshing the page.'
-            }
-          />
+          {isPgStatStatementsNotInstalled ? (
+            <Admonition
+              type="warning"
+              title="pg_stat_statements extension is not enabled"
+              description="Query Performance requires the pg_stat_statements extension. Enable it in Database → Extensions."
+            />
+          ) : (
+            <Admonition
+              type="destructive"
+              title="Error loading query performance data"
+              description={
+                errorMessage ||
+                'An error occurred while loading query performance data. Please try refreshing the page.'
+              }
+            />
+          )}
         </div>
       )}
       <QueryPerformanceMetrics />

--- a/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.test.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { QueryPerformanceSort } from './QueryPerformance.types'
 import { generateQueryPerformanceSql } from './useQueryPerformanceQuery'
 
 describe('generateQueryPerformanceSql', () => {
@@ -168,5 +169,53 @@ describe('generateQueryPerformanceSql', () => {
     const result = generateQueryPerformanceSql({ preset: 'unified', page: 1, pageSize: NaN })
     expect(result.sql).not.toContain('NaN')
     expect(result.sql).toContain('limit 20')
+  })
+})
+
+describe('generateQueryPerformanceSql - ORDER BY column validation', () => {
+  it('rejects invalid orderBy column containing colon (old URL format)', () => {
+    const result = generateQueryPerformanceSql({
+      preset: 'mostFrequentlyInvoked',
+      orderBy: { column: 'created_at:asc' as any, order: 'desc' },
+    })
+    expect(result.orderBySql).toBeUndefined()
+  })
+
+  it('rejects SQL injection in orderBy column', () => {
+    const result = generateQueryPerformanceSql({
+      preset: 'mostFrequentlyInvoked',
+      orderBy: { column: 'calls; DROP TABLE users--' as any, order: 'asc' },
+    })
+    expect(result.orderBySql).toBeUndefined()
+    expect(result.sql).not.toContain('DROP TABLE')
+  })
+
+  it('falls back to default ORDER BY when column is invalid', () => {
+    const result = generateQueryPerformanceSql({
+      preset: 'mostFrequentlyInvoked',
+      orderBy: { column: 'created_at:asc' as any, order: 'asc' },
+    })
+    expect(result.sql).toContain('order by statements.calls desc')
+  })
+
+  it('accepts all valid sort columns', () => {
+    const columns: QueryPerformanceSort['column'][] = [
+      'query',
+      'rolname',
+      'total_time',
+      'prop_total_time',
+      'calls',
+      'avg_rows',
+      'max_time',
+      'mean_time',
+      'min_time',
+    ]
+    for (const column of columns) {
+      const result = generateQueryPerformanceSql({
+        preset: 'mostFrequentlyInvoked',
+        orderBy: { column, order: 'asc' },
+      })
+      expect(result.orderBySql).toBe(`ORDER BY ${column} asc`)
+    }
   })
 })

--- a/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
@@ -7,7 +7,19 @@ import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 
 import { PRESET_CONFIG } from '../Reports/Reports.constants'
 import { Presets } from '../Reports/Reports.types'
-import { QueryPerformanceRow, QueryPerformanceSQLParams } from './QueryPerformance.types'
+import { QueryPerformanceRow, QueryPerformanceSort, QueryPerformanceSQLParams } from './QueryPerformance.types'
+
+const VALID_SORT_COLUMNS: ReadonlySet<string> = new Set<QueryPerformanceSort['column']>([
+  'query',
+  'rolname',
+  'total_time',
+  'prop_total_time',
+  'calls',
+  'avg_rows',
+  'max_time',
+  'mean_time',
+  'min_time',
+])
 
 export function generateQueryPerformanceSql({
   preset,
@@ -30,7 +42,12 @@ export function generateQueryPerformanceSql({
   const queryPerfQueries = PRESET_CONFIG[Presets.QUERY_PERFORMANCE]
   const baseSQL = queryPerfQueries.queries[preset]
 
-  const orderBySql = orderBy && `ORDER BY ${orderBy.column} ${orderBy.order}`
+  const isValidOrderBy =
+    orderBy != null &&
+    VALID_SORT_COLUMNS.has(orderBy.column) &&
+    (orderBy.order === 'asc' || orderBy.order === 'desc')
+
+  const orderBySql = isValidOrderBy ? `ORDER BY ${orderBy!.column} ${orderBy!.order}` : undefined
 
   const whereConditions = []
   if (roles.length > 0) {

--- a/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
@@ -7,7 +7,11 @@ import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 
 import { PRESET_CONFIG } from '../Reports/Reports.constants'
 import { Presets } from '../Reports/Reports.types'
-import { QueryPerformanceRow, QueryPerformanceSort, QueryPerformanceSQLParams } from './QueryPerformance.types'
+import {
+  QueryPerformanceRow,
+  QueryPerformanceSort,
+  QueryPerformanceSQLParams,
+} from './QueryPerformance.types'
 
 const VALID_SORT_COLUMNS: ReadonlySet<string> = new Set<QueryPerformanceSort['column']>([
   'query',

--- a/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
@@ -3,6 +3,7 @@ import { useReadReplicasQuery } from 'data/read-replicas/replicas-query'
 import { executeSql } from 'data/sql/execute-sql-query'
 import useDbQuery from 'hooks/analytics/useDbQuery'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { IS_PLATFORM } from 'lib/constants'
 import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
 
 import { PRESET_CONFIG } from '../Reports/Reports.constants'
@@ -171,7 +172,9 @@ export const useQueryPerformanceInfiniteQuery = (
       },
       // Don't run until we have a connection string for the selected database.
       // For replicas this prevents a silent fallback to the primary before replicas load.
-      enabled: Boolean(project?.ref) && Boolean(effectiveConnectionString),
+      // In self-hosted mode (IS_PLATFORM=false) there is no real connection string, so we
+      // skip the check — executeSql works fine without one on self-hosted deployments.
+      enabled: Boolean(project?.ref) && (!IS_PLATFORM || Boolean(effectiveConnectionString)),
       refetchOnWindowFocus: false,
       refetchOnReconnect: false,
     })


### PR DESCRIPTION
## Problem

On self-hosted Supabase instances where the `pg_stat_statements` extension is not installed, the Observability Overview page automatically queries the extension on every page load. This produces "relation pg_stat_statements does not exist" errors in Postgres logs for all projects without the extension. Additionally, if a user navigated to the Query Performance page, they received a generic error with no actionable guidance. A secondary issue allowed malformed sort URL params (e.g. `?sort=created_at:asc&order=asc`) to be interpolated directly into SQL ORDER BY clauses.

## Fix

- Wrapped the `useSlowQueriesCount` SQL in a `CASE WHEN EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_stat_statements')` guard. The query now returns 0 silently instead of erroring when the extension is absent.
- Added a `VALID_SORT_COLUMNS` whitelist in `generateQueryPerformanceSql`. Invalid column names from URL params are rejected and the query falls back to the preset default ORDER BY.
- When the Query Performance page fails because `pg_stat_statements` does not exist, a `warning` admonition now appears with "Enable it in Database -> Extensions" guidance instead of a generic destructive error. The Sentry capture is skipped for this expected configuration state.
- Extracted `buildSlowQueriesCountSql` as a testable function and added unit tests for both fixes.

## How to test

**Extension not installed (self-hosted):**
1. Run a self-hosted Supabase instance without the `pg_stat_statements` extension enabled.
2. Navigate to the Observability Overview page.
3. Check Postgres logs -- no "relation pg_stat_statements does not exist" errors should appear.
4. Navigate to the Query Performance page.
5. Expected: a yellow warning admonition appears saying the extension is not enabled, with a link to Database -> Extensions. No red error.

**Extension installed (normal flow):**
1. With `pg_stat_statements` installed, navigate to Observability Overview.
2. Expected: slow queries count loads as normal.
3. Navigate to Query Performance -- data loads as normal.

**Invalid sort URL param:**
1. Navigate to `/project/<ref>/observability/query-performance?sort=created_at:asc&order=asc`.
2. Expected: the page loads and falls back to the default sort order (total time descending). No SQL error in logs.

**Unit tests:**
```
node apps/studio/node_modules/vitest/dist/cli.js run --no-coverage \
  apps/studio/components/interfaces/Observability/useSlowQueriesCount.test.ts \
  apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.test.ts
```
All 28 tests should pass.