### PR TITLE
fix(studio): parameterize database queue SQL queries

### DIFF
--- a/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
@@ -27,7 +27,8 @@ export async function archiveDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `SELECT * FROM pgmq.archive('${queueName}', ${messageId})`,
+    sql: `SELECT * FROM pgmq.archive($1::text, $2::bigint)`,
+    parameters: [queueName, messageId],
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
@@ -28,7 +28,8 @@ export async function deleteDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `SELECT * FROM pgmq.delete('${queueName}', ${messageId})`,
+    sql: `SELECT * FROM pgmq.delete($1::text, $2::bigint)`,
+    parameters: [queueName, messageId],
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
@@ -67,13 +67,14 @@ export async function getDatabaseQueue({
         ${[queueQuery, archivedQuery].filter(Boolean).join(' UNION ALL ')}
       ) AS combined`
   if (afterTimestamp) {
-    query += ` WHERE enqueued_at > '${afterTimestamp}'`
+    query += ` WHERE enqueued_at > $1::timestamptz`
   }
 
   const { result } = await executeSql({
     projectRef,
     connectionString,
     sql: `${query} order by enqueued_at LIMIT ${QUEUE_MESSAGES_PAGE_SIZE}`,
+    ...(afterTimestamp ? { parameters: [afterTimestamp] } : {}),
   })
   return result as DatabaseQueueData
 }

--- a/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
@@ -30,7 +30,8 @@ export async function readDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from pgmq.set_vt('${queueName}', ${messageId}, ${duration})`,
+    sql: `select * from pgmq.set_vt($1::text, $2::bigint, $3::integer)`,
+    parameters: [queueName, messageId, duration],
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
@@ -30,7 +30,8 @@ export async function sendDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from pgmq.send( '${queueName}', '${payload}', ${delay})`,
+    sql: `select * from pgmq.send($1::text, $2::jsonb, $3::integer)`,
+    parameters: [queueName, payload, delay],
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -25,6 +25,10 @@ export type ExecuteSqlVariables = {
   projectRef?: string
   connectionString?: string | null
   sql: string
+  /**
+   * Bound to PostgreSQL placeholders ($1, $2, …) in `sql`. Sent to pg-meta as `parameters`.
+   */
+  parameters?: unknown[]
   queryKey?: QueryKey
   handleError?: (error: ResponseError) => { result: any }
   isRoleImpersonationEnabled?: boolean
@@ -49,6 +53,7 @@ export async function executeSql<T = any>(
     projectRef,
     connectionString,
     sql,
+    parameters,
     queryKey,
     handleError,
     isRoleImpersonationEnabled = false,
@@ -59,6 +64,7 @@ export async function executeSql<T = any>(
   headersInit?: HeadersInit,
   fetcherOverride?: (options: {
     query: string
+    parameters?: unknown[]
     headers?: HeadersInit
   }) => Promise<{ data: T } | { error: ResponseError }>
 ): Promise<{ result: T }> {
@@ -77,7 +83,11 @@ export async function executeSql<T = any>(
   let error
 
   if (fetcherOverride) {
-    const result = await fetcherOverride({ query: sql, headers })
+    const result = await fetcherOverride({
+      query: sql,
+      ...(parameters !== undefined ? { parameters } : {}),
+      headers,
+    })
     if ('data' in result) {
       data = result.data
     } else {
@@ -109,6 +119,7 @@ export async function executeSql<T = any>(
         body: {
           query: `explain ${sql}`,
           disable_statement_timeout: isStatementTimeoutDisabled,
+          ...(parameters !== undefined ? { parameters } : {}),
         },
         params: {
           ...options.params,
@@ -133,7 +144,11 @@ export async function executeSql<T = any>(
       queryKey?.filter((seg) => typeof seg === 'string' || typeof seg === 'number').join('-') ?? ''
     const result = await post('/platform/pg-meta/{ref}/query', {
       ...options,
-      body: { query: sql, disable_statement_timeout: isStatementTimeoutDisabled },
+      body: {
+        query: sql,
+        disable_statement_timeout: isStatementTimeoutDisabled,
+        ...(parameters !== undefined ? { parameters } : {}),
+      },
       params: {
         ...options.params,
         // @ts-expect-error: This is just a client side thing to identify queries better
@@ -201,6 +216,7 @@ export const useExecuteSqlQuery = <TData = ExecuteSqlData>(
     projectRef,
     connectionString,
     sql,
+    parameters,
     queryKey,
     handleError,
     isRoleImpersonationEnabled,
@@ -214,7 +230,15 @@ export const useExecuteSqlQuery = <TData = ExecuteSqlData>(
     queryKey: sqlKeys.query(projectRef, queryKey ?? [btoa(sql)]),
     queryFn: ({ signal }) =>
       executeSql(
-        { projectRef, connectionString, sql, queryKey, handleError, isRoleImpersonationEnabled },
+        {
+          projectRef,
+          connectionString,
+          sql,
+          parameters,
+          queryKey,
+          handleError,
+          isRoleImpersonationEnabled,
+        },
         signal
       ),
     enabled: enabled && typeof projectRef !== 'undefined' && isActive,


### PR DESCRIPTION
## Summary
Extends `executeSql` with optional `parameters` (forwarded to pg-meta `RunQueryBody`) and uses PostgreSQL placeholders for Studio database queue operations instead of string interpolation.

## Changes
- **execute-sql-query**: optional `parameters` on requests (including preflight EXPLAIN); `fetcherOverride` and deprecated `useExecuteSqlQuery` updated accordingly.
- **Queue messages**: parameterized `pgmq.send`, `delete`, `archive`, `set_vt`, and pagination `enqueued_at` filter.

## Context
Fixes defense-in-depth concerns from user-controlled `payload` and timestamps (GH-44375).

Closes #44375

Made with [Cursor](https://cursor.com)