### PR TITLE
chore(studio): remove privacy policy update notification banner

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AnalyticsSettings.tsx
@@ -1,15 +1,9 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useConsentState } from 'common'
-import { LOCAL_STORAGE_KEYS } from 'common/constants/local-storage'
-import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { InlineLink } from 'components/ui/InlineLink'
 import { useSendResetMutation } from 'data/telemetry/send-reset-mutation'
-import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
-import { X } from 'lucide-react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { Card, CardContent, Form_Shadcn_, FormControl_Shadcn_, FormField_Shadcn_, Switch } from 'ui'
-import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import {
   PageSection,
@@ -20,40 +14,6 @@ import {
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
 import * as z from 'zod'
-
-export const PrivacyUpdateBanner = () => {
-  const [privacyUpdateAcknowledged, setPrivacyUpdateAcknowledged] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.PRIVACY_NOTICE_ACKNOWLEDGED,
-    false
-  )
-
-  if (privacyUpdateAcknowledged) return null
-
-  return (
-    <Admonition
-      type="note"
-      title="Updates to our privacy policy"
-      description={
-        <>
-          We’ve clarified how we use analytics, cookies, and advertising tools in our{' '}
-          <InlineLink href="https://supabase.com/privacy">privacy policy</InlineLink>, effective
-          March 16, 2026. By continuing to use Supabase, you agree to the updated terms.{' '}
-          <InlineLink href="mailto:privacy@supabase.com">Contact us</InlineLink> with any
-          questions.{' '}
-        </>
-      }
-      className="mb-10 relative"
-    >
-      <ButtonTooltip
-        type="text"
-        icon={<X />}
-        className="absolute top-2 right-2 px-1"
-        onClick={() => setPrivacyUpdateAcknowledged(true)}
-        tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
-      />
-    </Admonition>
-  )
-}
 
 const AnalyticsSchema = z.object({
   telemetryEnabled: z.boolean(),

--- a/apps/studio/pages/org/[slug]/index.tsx
+++ b/apps/studio/pages/org/[slug]/index.tsx
@@ -1,5 +1,4 @@
 import { useIsMFAEnabled } from 'common'
-import { PrivacyUpdateBanner } from 'components/interfaces/Account/Preferences/AnalyticsSettings'
 import { ProjectList } from 'components/interfaces/Home/ProjectList/ProjectList'
 import { HomePageActions } from 'components/interfaces/HomePageActions'
 import DefaultLayout from 'components/layouts/DefaultLayout'
@@ -21,7 +20,6 @@ const ProjectsPage: NextPageWithLayout = () => {
   return (
     <ScaffoldContainer className="flex-grow flex">
       <ScaffoldSection isFullWidth className="pb-0">
-        <PrivacyUpdateBanner />
         {disableAccessMfa ? (
           <Admonition
             type="note"

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -1,5 +1,4 @@
 import { useParams } from 'common'
-import { PrivacyUpdateBanner } from 'components/interfaces/Account/Preferences/AnalyticsSettings'
 import { NoOrganizationsState } from 'components/interfaces/Home/ProjectList/EmptyStates'
 import { OrganizationCard } from 'components/interfaces/Organization/OrganizationCard'
 import { AppLayout } from 'components/layouts/AppLayout/AppLayout'
@@ -66,7 +65,6 @@ const OrganizationsPage: NextPageWithLayout = () => {
       </Head>
       <ScaffoldContainer>
         <ScaffoldSection isFullWidth className="flex flex-col gap-y-4">
-          <PrivacyUpdateBanner />
           {orgNotFound && (
             <Admonition
               type="destructive"

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -116,7 +116,6 @@ export const LOCAL_STORAGE_KEYS = {
 
   TABLE_EDITOR_QUEUE_OPERATIONS_BANNER_DISMISSED: (ref: string) =>
     `table-editor-queue-operations-banner-dismissed-${ref}`,
-  PRIVACY_NOTICE_ACKNOWLEDGED: 'privacy-notice-acknowledged-2026-03',
 
   /**
    * COMMON


### PR DESCRIPTION
## Summary

Remove the privacy policy update notification banner that was added for the March 2026 policy update. The effective date has passed and users have had sufficient notice.

## Changes

- Remove `PrivacyUpdateBanner` component from `AnalyticsSettings.tsx` and its unused imports
- Remove banner usage from the organizations list page and org projects page
- Remove `PRIVACY_NOTICE_ACKNOWLEDGED` localStorage key

## Testing

No setup needed - this is a removal of UI elements.

Tested on Vercel preview:
- [x] Organizations page loads without the banner
- [x] Org projects page loads without the banner
- [ ] No console errors on either page
- [x] Analytics settings page still renders correctly

## Linear

- fixes GROWTH-692