### PR TITLE
fix(studio): allow native Apple sign-in without OAuth secret

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -478,7 +478,10 @@ const EXTERNAL_PROVIDER_APPLE = {
         },
         then: (schema) =>
           schema
-            .matches(/^[a-z0-9_-]+([.][a-z0-9_-]+){2}$/i, 'Secret key should be a JWT.')
+            .matches(/^[a-z0-9_-]+([.][a-z0-9_-]+){2}$/i, {
+              message: 'Secret key should be a JWT.',
+              excludeEmptyString: true,
+            })
             .test({
               message: 'Secret key is not a correctly generated JWT.',
               test: (value?: string): boolean => {

--- a/apps/studio/tests/unit/auth-providers-form-validation.test.ts
+++ b/apps/studio/tests/unit/auth-providers-form-validation.test.ts
@@ -1,0 +1,39 @@
+import { PROVIDERS_SCHEMAS } from 'components/interfaces/Auth/AuthProvidersFormValidation'
+import { describe, expect, test, vi } from 'vitest'
+
+const appleProvider = PROVIDERS_SCHEMAS.find((provider) => provider.title === 'Apple')
+
+if (!appleProvider?.validationSchema) {
+  throw new Error('Apple auth provider schema not found')
+}
+
+const appleValidationSchema = appleProvider.validationSchema
+const malformedAppleSecret =
+  'eyJhbGciOiJIUzI1NiJ9.eyJhdWQiOiJodHRwczovL2V4YW1wbGUuY29tIn0.signature'
+
+describe('AuthProvidersFormValidation: Apple', () => {
+  test('allows native Apple client IDs without a secret key', async () => {
+    const isValid = await appleValidationSchema.isValid({
+      EXTERNAL_APPLE_ENABLED: true,
+      EXTERNAL_APPLE_CLIENT_ID: 'com.example.app',
+      EXTERNAL_APPLE_SECRET: '',
+      EXTERNAL_APPLE_EMAIL_OPTIONAL: false,
+    })
+
+    expect(isValid).toBe(true)
+  })
+
+  test('rejects malformed non-empty secret keys', async () => {
+    const consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => undefined)
+
+    const isValid = await appleValidationSchema.isValid({
+      EXTERNAL_APPLE_ENABLED: true,
+      EXTERNAL_APPLE_CLIENT_ID: 'com.example.app',
+      EXTERNAL_APPLE_SECRET: malformedAppleSecret,
+      EXTERNAL_APPLE_EMAIL_OPTIONAL: false,
+    })
+
+    expect(isValid).toBe(false)
+    consoleLogSpy.mockRestore()
+  })
+})


### PR DESCRIPTION
## What changed
- Updated Apple auth validation in `AuthProvidersFormValidation.tsx` to allow an empty `EXTERNAL_APPLE_SECRET` when a client ID is provided by using `excludeEmptyString: true` on the JWT format check.
- Added a unit regression test for Apple provider validation.

## Why
Issue #44315 reports that native Apple sign-in (bundle ID only) incorrectly requires a secret key in Studio. The schema already intends to allow empty values, but the JWT regex rejected empty strings before downstream tests could allow that path.

## Validation
- `pnpm exec vitest run tests/unit/auth-providers-form-validation.test.ts`
- `pnpm exec eslint components/interfaces/Auth/AuthProvidersFormValidation.tsx tests/unit/auth-providers-form-validation.test.ts`

Closes #44315
