### PR TITLE
fix(studio): show legacy API keys toggle for project-level admins

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/ToggleLegacyApiKeys.tsx
+++ b/apps/studio/components/ui/ProjectSettings/ToggleLegacyApiKeys.tsx
@@ -44,13 +44,46 @@ export const ToggleLegacyApiKeysPanel = () => {
     { enabled: canReadAPIKeys }
   )
 
-  const { data: authorizedApps = [], isSuccess: isAuthorizedAppsSuccess } = useAuthorizedAppsQuery({
+  const { data: authorizedApps = [], isError: isAuthorizedAppsError } = useAuthorizedAppsQuery({
     slug: org?.slug,
   })
 
   const { enabled: isLegacyKeysEnabled } = legacyAPIKeysStatusData || {}
 
-  if (!(isLegacyAPIKeysStatusSuccess && isPermissionsSuccess && isAuthorizedAppsSuccess)) {
+  const oauthAppsLink = (
+    <a
+      href={`/dashboard/org/${org?.slug}/apps`}
+      target="_blank"
+      rel="noreferrer"
+      className="underline"
+    >
+      OAuth apps
+    </a>
+  )
+
+  const appsWarning = isAuthorizedAppsError
+    ? {
+        title: 'Check your OAuth apps before continuing',
+        description: (
+          <>
+            Disabling legacy API keys can break apps that integrate with Supabase. Before
+            continuing, check your organization's {oauthAppsLink} to ensure none of them depend on
+            the legacy API keys.
+          </>
+        ),
+      }
+    : {
+        title: 'Apps using Supabase may break',
+        description: (
+          <>
+            Your project uses apps that integrate with Supabase. Disabling the legacy API keys is a
+            brand new feature and the apps you're using may not have added support for this yet. It
+            can cause them to stop functioning. Check your {oauthAppsLink} before continuing.
+          </>
+        ),
+      }
+
+  if (!(isLegacyAPIKeysStatusSuccess && isPermissionsSuccess)) {
     return null
   }
 
@@ -73,7 +106,7 @@ export const ToggleLegacyApiKeysPanel = () => {
               <ButtonTooltip
                 type="default"
                 onClick={
-                  authorizedApps?.length
+                  authorizedApps?.length || isAuthorizedAppsError
                     ? () => setIsAppsWarningOpen(true)
                     : () => setIsConfirmOpen(true)
                 }
@@ -110,12 +143,8 @@ export const ToggleLegacyApiKeysPanel = () => {
       <AlertDialog open={isAppsWarningOpen} onOpenChange={(value) => setIsAppsWarningOpen(value)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Apps using Supabase may break</AlertDialogTitle>
-            <AlertDialogDescription>
-              Your project uses apps that integrate with Supabase. Disabling the legacy API keys is
-              a brand new feature and the apps you’re using may not have added support for this yet.
-              It can cause them to stop functioning. Check before continuing.
-            </AlertDialogDescription>
+            <AlertDialogTitle>{appsWarning.title}</AlertDialogTitle>
+            <AlertDialogDescription>{appsWarning.description}</AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>

--- a/apps/studio/components/ui/ProjectSettings/ToggleLegacyApiKeys.tsx
+++ b/apps/studio/components/ui/ProjectSettings/ToggleLegacyApiKeys.tsx
@@ -106,7 +106,7 @@ export const ToggleLegacyApiKeysPanel = () => {
               <ButtonTooltip
                 type="default"
                 onClick={
-                  authorizedApps?.length || isAuthorizedAppsError
+                  isLegacyKeysEnabled && (authorizedApps?.length || isAuthorizedAppsError)
                     ? () => setIsAppsWarningOpen(true)
                     : () => setIsConfirmOpen(true)
                 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Summary

  - Fix `ToggleLegacyApiKeysPanel` being permanently hidden for users with project-level admin access but no org-level access
  - The `useAuthorizedAppsQuery` calls an org-level endpoint (`/platform/organizations/{slug}/oauth/apps`) which returns 403 for project-only admins, causing `isAuthorizedAppsSuccess` to never become `true` and
  the entire panel to never render
  - When the authorized apps query fails, show a fallback warning directing users to verify their org's OAuth apps before disabling legacy keys

  ## What changed

  - Removed `isAuthorizedAppsSuccess` from the rendering guard, the panel now renders once legacy keys status and permissions resolve
  - When the authorized apps query errors (e.g. 403), the button still opens a warning dialog with appropriate copy before proceeding to the confirmation modal

  ## Behavior

  | User type | Authorized apps query | Button click |
  |---|---|---|
  | Org-level access, has apps | Success, apps > 0 | Warning → confirm modal |
  | Org-level access, no apps | Success, apps = 0 | Confirm modal directly |
  | Project-only admin | 403 error | Fallback warning → confirm modal |

## Current behavior


<img width="1461" height="707" alt="image-IcxHfCX0" src="https://github.com/user-attachments/assets/2fd124cd-02eb-46c0-816e-178fe3ce99b0" />

Project admins can't view the button

## Changed behaaviour

<img width="1455" height="704" alt="image-YW1k6GQe" src="https://github.com/user-attachments/assets/8c428c63-f1de-4b84-a1f2-6af7ff064e50" />


Projects admins can view the disable button and when clicked views a warning about oauth apps:

<img width="451" height="250" alt="image-yu4bux3l" src="https://github.com/user-attachments/assets/5a314329-350b-4207-b8e4-311d0c827e6f" />

and when they visit oauth apps, there is warning to contact with project owner

<img width="1453" height="578" alt="image-pppzfksn" src="https://github.com/user-attachments/assets/489ba3ba-c94e-4efb-923b-a989eebb2fc4" />


