### PR TITLE
fix: make Apple OAuth client secret optional for native sign-in

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -471,69 +471,59 @@ const EXTERNAL_PROVIDER_APPLE = {
   },
   validationSchema: object().shape({
     EXTERNAL_APPLE_ENABLED: boolean().required(),
-    EXTERNAL_APPLE_SECRET: string()
-      .when(['EXTERNAL_APPLE_ENABLED', 'EXTERNAL_APPLE_CLIENT_ID'], {
-        is: (EXTERNAL_APPLE_ENABLED: boolean, EXTERNAL_APPLE_CLIENT_ID: string) => {
-          return EXTERNAL_APPLE_ENABLED && !!EXTERNAL_APPLE_CLIENT_ID
-        },
-        then: (schema) =>
-          schema
-            .matches(/^[a-z0-9_-]+([.][a-z0-9_-]+){2}$/i, 'Secret key should be a JWT.')
-            .test({
-              message: 'Secret key is not a correctly generated JWT.',
-              test: (value?: string): boolean => {
-                if (!value) {
-                  return true
-                }
-                try {
-                  const parts = value.split('.').map((value) => parseBase64URL(value))
-                  const header = JSON.parse(parts[0])
-                  const body = JSON.parse(parts[1])
-                  return (
-                    typeof header === 'object' &&
-                    typeof body === 'object' &&
-                    header &&
-                    body &&
-                    header.alg === 'ES256' &&
-                    body.aud === 'https://appleid.apple.com'
-                  )
-                } catch (e: any) {
-                  console.log(e)
-                  return false
-                }
-
+    EXTERNAL_APPLE_SECRET: string().when('EXTERNAL_APPLE_ENABLED', {
+      is: true,
+      then: (schema) =>
+        schema
+          .matches(
+            /^([a-z0-9_-]+([.][a-z0-9_-]+){2})?$/i,
+            'Secret key should be a JWT.'
+          )
+          .test({
+            message: 'Secret key is not a correctly generated JWT.',
+            test: (value?: string): boolean => {
+              if (!value) {
                 return true
-              },
-            })
-            .test({
-              message: 'Secret key expires in less than 7 days!',
-              test: (value?: string) => {
-                if (!value) {
-                  return true
-                }
-                try {
-                  const parts = value.split('.').map((value) => parseBase64URL(value))
-                  const body = JSON.parse(parts[1])
-                  return Date.now() > body.exp - 7 * 24 * 60 * 60 * 1000
-                } catch (e: any) {
-                  console.log(e)
-                  return false
-                }
+              }
+              try {
+                const parts = value.split('.').map((value) => parseBase64URL(value))
+                const header = JSON.parse(parts[0])
+                const body = JSON.parse(parts[1])
+                return (
+                  typeof header === 'object' &&
+                  typeof body === 'object' &&
+                  header &&
+                  body &&
+                  header.alg === 'ES256' &&
+                  body.aud === 'https://appleid.apple.com'
+                )
+              } catch (e: any) {
+                console.log(e)
+                return false
+              }
 
+              return true
+            },
+          })
+          .test({
+            message: 'Secret key expires in less than 7 days!',
+            test: (value?: string) => {
+              if (!value) {
                 return true
-              },
-            }),
-      })
-      .when(['EXTERNAL_APPLE_ENABLED', 'EXTERNAL_APPLE_CLIENT_ID'], {
-        is: (EXTERNAL_APPLE_ENABLED: boolean, EXTERNAL_APPLE_CLIENT_ID: string) => {
-          return EXTERNAL_APPLE_ENABLED && !EXTERNAL_APPLE_CLIENT_ID
-        },
-        then: (schema) =>
-          schema.matches(
-            /^$/,
-            'Secret Key should only be set if Service ID for OAuth is provided.'
-          ),
-      }),
+              }
+              try {
+                const parts = value.split('.').map((value) => parseBase64URL(value))
+                const body = JSON.parse(parts[1])
+                return Date.now() > body.exp - 7 * 24 * 60 * 60 * 1000
+              } catch (e: any) {
+                console.log(e)
+                return false
+              }
+
+              return true
+            },
+          }),
+    }),
     EXTERNAL_APPLE_CLIENT_ID: string()
       .matches(/^\S+$/, 'Client IDs should not contain spaces.')
       .matches(

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -475,10 +475,7 @@ const EXTERNAL_PROVIDER_APPLE = {
       is: true,
       then: (schema) =>
         schema
-          .matches(
-            /^([a-z0-9_-]+([.][a-z0-9_-]+){2})?$/i,
-            'Secret key should be a JWT.'
-          )
+          .matches(/^([a-z0-9_-]+([.][a-z0-9_-]+){2})?$/i, 'Secret key should be a JWT.')
           .test({
             message: 'Secret key is not a correctly generated JWT.',
             test: (value?: string): boolean => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

 When enabling Apple Sign-in in Studio, the form requires a valid JWT secret key whenever a client ID is provided. This blocks users who only use Apple native sign-in (iOS, macOS, watchOS, tvOS), where only the client ID (bundle ID) is needed and no secret is required.

Resolves AUTH-1138

## What is the new behavior?

The secret key field is now optional, matching Google's provider behavior. JWT format validation still applies when a secret is provided, but leaving it empty is allowed. This supports native-only Apple sign-in configurations.

## Additional context

  The validation was simplified from two `.when` clauses (dependent on both `ENABLED` and `CLIENT_ID`) to a single `.when` (dependent only on `ENABLED`), matching the pattern used by the Google provider.