### PR TITLE
fix: invalid react-hook-form usage

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -111,7 +111,7 @@ export const ConnectionPooling = () => {
     resolver: zodResolver(PoolingConfigurationFormSchema),
     defaultValues: {
       default_pool_size: undefined,
-      max_client_conn: null,
+      max_client_conn: undefined,
     },
   })
   const { default_pool_size } = form.watch()

--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -273,7 +273,7 @@ export const ConnectionPooling = () => {
                                 {...field}
                                 type="number"
                                 className="w-full"
-                                value={field.value || ''}
+                                value={field.value ?? ''}
                                 placeholder={defaultPoolSize.toString()}
                                 onChange={(event) =>
                                   field.onChange(
@@ -337,7 +337,7 @@ export const ConnectionPooling = () => {
                                 {...field}
                                 type="number"
                                 className="w-full"
-                                value={pgbouncerConfig?.max_client_conn || ''}
+                                value={pgbouncerConfig?.max_client_conn ?? ''}
                                 placeholder={defaultMaxClientConn.toString()}
                                 onChange={(event) =>
                                   field.onChange(

--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -53,8 +53,14 @@ import { POOLING_OPTIMIZATIONS } from './ConnectionPooling.constants'
 const formId = 'pooling-configuration-form'
 
 const PoolingConfigurationFormSchema = z.object({
-  default_pool_size: z.number().nullable(),
-  max_client_conn: z.number().nullable(),
+  default_pool_size: z.preprocess(
+    (val) => (val === '' || val === null || val === undefined ? undefined : val),
+    z.coerce.number().optional()
+  ),
+  max_client_conn: z.preprocess(
+    (val) => (val === '' || val === null || val === undefined ? undefined : val),
+    z.coerce.number().optional()
+  ),
 })
 
 /**
@@ -269,9 +275,13 @@ export const ConnectionPooling = () => {
                                 className="w-full"
                                 value={field.value || ''}
                                 placeholder={defaultPoolSize.toString()}
-                                {...form.register('default_pool_size', {
-                                  setValueAs: setValueAsNullableNumber,
-                                })}
+                                onChange={(event) =>
+                                  field.onChange(
+                                    isNaN(event.target.valueAsNumber)
+                                      ? null
+                                      : event.target.valueAsNumber
+                                  )
+                                }
                               />
                             </InputGroup>
                           </FormControl_Shadcn_>
@@ -296,6 +306,7 @@ export const ConnectionPooling = () => {
 
                     <FormField_Shadcn_
                       control={form.control}
+                      disabled
                       name="max_client_conn"
                       render={({ field }) => (
                         <FormItemLayout
@@ -327,11 +338,14 @@ export const ConnectionPooling = () => {
                                 type="number"
                                 className="w-full"
                                 value={pgbouncerConfig?.max_client_conn || ''}
-                                disabled={true}
                                 placeholder={defaultMaxClientConn.toString()}
-                                {...form.register('max_client_conn', {
-                                  setValueAs: setValueAsNullableNumber,
-                                })}
+                                onChange={(event) =>
+                                  field.onChange(
+                                    isNaN(event.target.valueAsNumber)
+                                      ? null
+                                      : event.target.valueAsNumber
+                                  )
+                                }
                               />
                             </InputGroup>
                           </FormControl_Shadcn_>

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.schema.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+
 import { NEW_NAMESPACE_MARKER } from './CreateTableSheet.constants'
 
 const getValidRegex = (type: 'namespace' | 'table') =>
@@ -68,6 +69,38 @@ export const createFormSchema = () =>
           })
         }
       }
+
+      data.columns.forEach((column, index) => {
+        if (column.type === 'decimal') {
+          if (column.precision == null) {
+            console.log(`columns.${index}.precision`)
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Required',
+              path: [`columns.${index}.precision`],
+            })
+          }
+          if (column.scale == null) {
+            console.log(`columns.${index}.scale`)
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Required',
+              path: [`columns.${index}.scale`],
+            })
+          }
+        }
+
+        if (column.type === 'fixed') {
+          if (column.length == null) {
+            console.log(`columns.${index}.length`)
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Required',
+              path: [`columns.${index}.length`],
+            })
+          }
+        }
+      })
 
       if (data.name) {
         const newTableError = validateName({ name: data.name, type: 'table' })

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.schema.ts
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.schema.ts
@@ -73,7 +73,6 @@ export const createFormSchema = () =>
       data.columns.forEach((column, index) => {
         if (column.type === 'decimal') {
           if (column.precision == null) {
-            console.log(`columns.${index}.precision`)
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message: 'Required',
@@ -81,7 +80,6 @@ export const createFormSchema = () =>
             })
           }
           if (column.scale == null) {
-            console.log(`columns.${index}.scale`)
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message: 'Required',
@@ -92,7 +90,6 @@ export const createFormSchema = () =>
 
         if (column.type === 'fixed') {
           if (column.length == null) {
-            console.log(`columns.${index}.length`)
             ctx.addIssue({
               code: z.ZodIssueCode.custom,
               message: 'Required',

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableSheet.tsx
@@ -18,6 +18,9 @@ import {
   FormControl_Shadcn_,
   FormField_Shadcn_,
   Input_Shadcn_,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectItem_Shadcn_,
@@ -298,42 +301,35 @@ export const CreateTableSheet = ({ open, onOpenChange }: CreateTableSheetProps) 
 
                                 {additionalFields.length > 0 && (
                                   <div className="col-span-full flex items-center mt-2">
-                                    <div className="grid grid-cols-2 gap-x-1 w-[85%]">
-                                      {additionalFields.map((x, index) => (
-                                        <div
-                                          key={x.name}
-                                          className="flex items-center"
-                                          style={
-                                            additionalFields.length % 2 === 1 && index % 2 === 0
-                                              ? { gridColumnStart: 2 }
-                                              : undefined
-                                          }
-                                        >
-                                          <div className="font-mono text-xs px-2 border border-r-0 rounded-l h-full flex items-center justify-center">
-                                            {x.name}
-                                          </div>
-                                          <FormField_Shadcn_
-                                            control={form.control}
-                                            key={`columns.${idx}.${x.name}`}
-                                            name={`columns.${idx}.${x.name}` as any}
-                                            render={({ field }) => (
+                                    <div className="flex items-center justify-end gap-1 w-[85%] ">
+                                      {additionalFields.map((x) => (
+                                        <FormField_Shadcn_
+                                          control={form.control}
+                                          key={`columns.${idx}.${x.name}`}
+                                          name={`columns.${idx}.${x.name}` as any}
+                                          render={({ field }) => (
+                                            <InputGroup>
+                                              <InputGroupAddon align="inline-start">
+                                                {x.name}
+                                              </InputGroupAddon>
                                               <FormControl_Shadcn_>
-                                                <Input_Shadcn_
+                                                <InputGroupInput
                                                   {...field}
                                                   type={x.type === 'number' ? 'number' : 'text'}
                                                   disabled={isCreating}
                                                   className="h-[34px] rounded-l-none"
-                                                  {...form.register(
-                                                    `columns.${idx}.${x.name}` as any,
-                                                    {
-                                                      valueAsNumber: true, // Ensure the value is handled as a number
-                                                    }
-                                                  )}
+                                                  onChange={(event) =>
+                                                    field.onChange(
+                                                      isNaN(event.target.valueAsNumber)
+                                                        ? null
+                                                        : event.target.valueAsNumber
+                                                    )
+                                                  }
                                                 />
                                               </FormControl_Shadcn_>
-                                            )}
-                                          />
-                                        </div>
+                                            </InputGroup>
+                                          )}
+                                        />
                                       ))}
                                     </div>
                                     <div className="w-4 h-[1.6rem] border-r border-b rounded-br mr-3 border-control -translate-y-3" />


### PR DESCRIPTION
## Problem

Some forms register their inputs incorrectly by calling `control.register` and spreading the `field`.
This makes the form unusable.

## Screenshots

Design of the new analytics buckets table

Before:
<img width="554" height="564" alt="image" src="https://github.com/user-attachments/assets/6ddf7ead-f576-44c4-b184-8102a52a22e2" />

After:
<img width="395" height="791" alt="image" src="https://github.com/user-attachments/assets/ee85fcdd-b2a5-410d-9296-8bd6f1aa0b2f" />
