### PR TITLE
allow empty string in saml metadata url

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -1568,7 +1568,9 @@ const PROVIDER_SAML = {
   },
   validationSchema: object().shape({
     SAML_ENABLED: boolean().required(),
-    SAML_EXTERNAL_URL: string().matches(urlRegex(), 'Must be a valid URL').optional(),
+    SAML_EXTERNAL_URL: string()
+      .matches(urlRegex(), { message: 'Must be a valid URL', excludeEmptyString: true })
+      .optional(),
     SAML_ALLOW_ENCRYPTED_ASSERTIONS: boolean().optional(),
   }),
   misc: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

SAML metadata URL cannot be saved with an empty string; it works through the management API

<img width="781" height="412" alt="image" src="https://github.com/user-attachments/assets/586d3de2-30bc-4e8a-9d4b-b039685cb455" />

## What is the new behavior?

Allow saving SAML 2.0 config with an empty SAML metadata URL 
