### PR TITLE
fix: remove plan checks from SSO Config Query

### DIFF
--- a/apps/studio/data/sso/sso-config-query.ts
+++ b/apps/studio/data/sso/sso-config-query.ts
@@ -42,14 +42,10 @@ export const useOrgSSOConfigQuery = <TData = OrgSSOConfigData>(
     ...options
   }: UseCustomQueryOptions<OrgSSOConfigData, OrgSSOConfigError, TData> = {}
 ) => {
-  const { data: organization } = useSelectedOrganizationQuery()
-  const plan = organization?.plan.id
-  const canSetupSSOConfig = ['team', 'enterprise', 'platform'].includes(plan ?? '')
-
   return useQuery<OrgSSOConfigData, OrgSSOConfigError, TData>({
     queryKey: orgSSOKeys.orgSSOConfig(orgSlug),
     queryFn: ({ signal }) => getOrgSSOConfig({ orgSlug }, signal),
-    enabled: enabled && IS_PLATFORM && typeof orgSlug !== 'undefined' && canSetupSSOConfig,
+    enabled: enabled && IS_PLATFORM && typeof orgSlug !== 'undefined',
     ...options,
   })
 }


### PR DESCRIPTION
`useOrgSSOConfigQuery` had an internal plan-based gate (`canSetupSSOConfig`) that permanently disabled the query for non-team/enterprise orgs. 

The fix removes the redundant plan gate from the query hook, plan-based access is already controlled upstream via the entitlement check in the component.