### PR TITLE
fix(oauth-custom-providers): use host endpoint for listing providers

### DIFF
--- a/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
@@ -114,7 +114,7 @@ export const CreateOrUpdateCustomProviderSheet = ({
 }: CreateOrUpdateCustomProviderSheetProps) => {
   const isEditMode = !!providerToEdit
   const { ref: projectRef } = useParams()
-  const { data: endpointData } = useProjectApiUrl({ projectRef })
+  const { hostEndpoint: endpointData } = useProjectApiUrl({ projectRef })
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: initialValues,

--- a/apps/studio/data/oauth-custom-providers/oauth-custom-providers-query.ts
+++ b/apps/studio/data/oauth-custom-providers/oauth-custom-providers-query.ts
@@ -48,7 +48,7 @@ export const useOAuthCustomProvidersQuery = <TData = OAuthCustomProvidersData>(
     ...options
   }: UseCustomQueryOptions<OAuthCustomProvidersData, OAuthCustomProvidersError, TData> = {}
 ) => {
-  const { data: clientEndpoint } = useProjectApiUrl({ projectRef })
+  const { hostEndpoint: clientEndpoint } = useProjectApiUrl({ projectRef })
   const { data: authConfig, isSuccess: isSuccessConfig } = useAuthConfigQuery({ projectRef })
   const isOAuthCustomProvidersEnabled = !!authConfig?.CUSTOM_OAUTH_ENABLED
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## Summary

Use supabase project url for CRUD custom oauth providers

