### PR TITLE
fix(studio): fix and filter Sentry issues

### DIFF
--- a/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
@@ -59,7 +59,10 @@ function filterGroupToFilters(group: FilterGroup): Filter[] {
 
 // Custom date picker component for the FilterBar
 function DatePickerOption({ onChange, onCancel, search }: CustomOptionProps) {
-  const [date, setDate] = useState<Date | undefined>(search ? new Date(search) : undefined)
+  const parsed = search ? new Date(search) : undefined
+  const [date, setDate] = useState<Date | undefined>(
+    parsed && !isNaN(parsed.getTime()) ? parsed : undefined
+  )
 
   return (
     <div className="w-[300px] space-y-4">

--- a/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
@@ -28,7 +28,7 @@ export const ReadReplicasWarning = ({ latestPgVersion }: { latestPgVersion: stri
 const getValidationErrorTitle = (error: ProjectUpgradeEligibilityValidationError): string => {
   switch (error.type) {
     case 'objects_depending_on_pg_cron':
-      return error.dependents.join(', ')
+      return (error.dependents ?? []).join(', ')
     case 'indexes_referencing_ll_to_earth':
       return `${error.schema_name}.${error.index_name}`
     case 'function_using_obsolete_lang':

--- a/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/UpgradeWarnings.tsx
@@ -28,7 +28,7 @@ export const ReadReplicasWarning = ({ latestPgVersion }: { latestPgVersion: stri
 const getValidationErrorTitle = (error: ProjectUpgradeEligibilityValidationError): string => {
   switch (error.type) {
     case 'objects_depending_on_pg_cron':
-      return (error.dependents ?? []).join(', ')
+      return (error.dependents ?? []).join(', ') || 'Objects depending on pg_cron'
     case 'indexes_referencing_ll_to_earth':
       return `${error.schema_name}.${error.index_name}`
     case 'function_using_obsolete_lang':

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
@@ -108,7 +108,7 @@ export const JsonEditor = ({
 
   useEffect(() => {
     if (visible) {
-      const temp = prettifyJSON(jsonString)
+      const temp = prettifyJSON(jsonString ?? '')
       setJsonStr(temp)
     }
   }, [visible])
@@ -174,7 +174,7 @@ export const JsonEditor = ({
               key={jsonString}
               readOnly={readOnly}
               onInputChange={(val) => setJsonStr(val ?? '')}
-              value={jsonStr.toString()}
+              value={(jsonStr ?? '').toString()}
             />
           </div>
         ) : (

--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -298,6 +298,7 @@ Sentry.init({
     // === Third-party library race conditions ===
     // cmdk: useSyncExternalStore subscribe called before store context is available
     "Cannot read properties of undefined (reading 'subscribe')",
+    "undefined is not an object (evaluating 't.subscribe')",
 
     // === Misc known noise ===
     'r.default.setDefaultLevel is not a function',

--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -65,27 +65,6 @@ export function isCancellationRejection(event: Sentry.Event): boolean {
   return serialized?.type === 'cancelation'
 }
 
-// Filter cmdk useSyncExternalStore race condition
-// The subscribe call fails when the store context is not yet available
-// Examples: SUPABASE-APP-B1N, SUPABASE-APP-BMF, SUPABASE-APP-E4Q, SUPABASE-APP-E5M
-export function isCmdkSubscribeError(error: unknown, event: Sentry.Event): boolean {
-  const errorMessage = error instanceof Error ? error.message : ''
-  const eventMessage = event.message || ''
-  const exceptionMessages = event.exception?.values?.map((ex) => ex.value ?? '') ?? []
-  const messages = [errorMessage, eventMessage, ...exceptionMessages].filter(Boolean)
-
-  const isSubscribeError = messages.some(
-    (msg) => msg.includes("reading 'subscribe'") || msg.includes("evaluating 't.subscribe'")
-  )
-  if (!isSubscribeError) return false
-
-  const frames = event.exception?.values?.flatMap((e) => e.stacktrace?.frames || []) || []
-  return frames.some((frame) => {
-    const filename = frame.filename || frame.abs_path || ''
-    return filename.includes('cmdk')
-  })
-}
-
 // Filter challenge/captcha expired errors (user timeout)
 // These happen when users don't complete captcha in time - expected behavior
 // Example: SUPABASE-APP-ACC
@@ -231,9 +210,6 @@ Sentry.init({
     if (isBrowserWalletExtensionError(event)) {
       return null
     }
-    if (isCmdkSubscribeError(hint.originalException, event)) {
-      return null
-    }
     if (isUserAbortedOperation(hint.originalException, event)) {
       return null
     }
@@ -318,6 +294,11 @@ Sentry.init({
 
     // === Web crawler / bot errors ===
     'instantSearchSDKJSBridgeClearHighlight',
+
+    // === Third-party library race conditions ===
+    // cmdk: useSyncExternalStore subscribe called before store context is available
+    "Cannot read properties of undefined (reading 'subscribe')",
+    "undefined is not an object (evaluating 't.subscribe')",
 
     // === Misc known noise ===
     'r.default.setDefaultLevel is not a function',

--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -280,6 +280,7 @@ Sentry.init({
     // === Non-Error throws (extensions, third-party libs throwing strings/objects) ===
     'Non-Error exception captured',
     'Non-Error promise rejection captured',
+    /^Object captured as exception with keys:/,
 
     // === Cross-origin script errors (no useful info) ===
     'Script error.',

--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -268,6 +268,7 @@ Sentry.init({
 
     // === Browser extensions & Google Translate DOM manipulation ===
     'Node.insertBefore: Child to insert before is not a child of this node',
+    'Node.removeChild: The node to be removed is not a child of this node',
     "NotFoundError: Failed to execute 'removeChild' on 'Node'",
     "NotFoundError: Failed to execute 'insertBefore' on 'Node'",
     'NotFoundError: The object can not be found here.',
@@ -292,6 +293,10 @@ Sentry.init({
 
     // === Web crawler / bot errors ===
     'instantSearchSDKJSBridgeClearHighlight',
+
+    // === Third-party library race conditions ===
+    // cmdk: useSyncExternalStore subscribe called before store context is available
+    "Cannot read properties of undefined (reading 'subscribe')",
 
     // === Misc known noise ===
     'r.default.setDefaultLevel is not a function',

--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -65,6 +65,27 @@ export function isCancellationRejection(event: Sentry.Event): boolean {
   return serialized?.type === 'cancelation'
 }
 
+// Filter cmdk useSyncExternalStore race condition
+// The subscribe call fails when the store context is not yet available
+// Examples: SUPABASE-APP-B1N, SUPABASE-APP-BMF, SUPABASE-APP-E4Q, SUPABASE-APP-E5M
+export function isCmdkSubscribeError(error: unknown, event: Sentry.Event): boolean {
+  const errorMessage = error instanceof Error ? error.message : ''
+  const eventMessage = event.message || ''
+  const exceptionMessages = event.exception?.values?.map((ex) => ex.value ?? '') ?? []
+  const messages = [errorMessage, eventMessage, ...exceptionMessages].filter(Boolean)
+
+  const isSubscribeError = messages.some(
+    (msg) => msg.includes("reading 'subscribe'") || msg.includes("evaluating 't.subscribe'")
+  )
+  if (!isSubscribeError) return false
+
+  const frames = event.exception?.values?.flatMap((e) => e.stacktrace?.frames || []) || []
+  return frames.some((frame) => {
+    const filename = frame.filename || frame.abs_path || ''
+    return filename.includes('cmdk')
+  })
+}
+
 // Filter challenge/captcha expired errors (user timeout)
 // These happen when users don't complete captcha in time - expected behavior
 // Example: SUPABASE-APP-ACC
@@ -210,6 +231,9 @@ Sentry.init({
     if (isBrowserWalletExtensionError(event)) {
       return null
     }
+    if (isCmdkSubscribeError(hint.originalException, event)) {
+      return null
+    }
     if (isUserAbortedOperation(hint.originalException, event)) {
       return null
     }
@@ -294,11 +318,6 @@ Sentry.init({
 
     // === Web crawler / bot errors ===
     'instantSearchSDKJSBridgeClearHighlight',
-
-    // === Third-party library race conditions ===
-    // cmdk: useSyncExternalStore subscribe called before store context is available
-    "Cannot read properties of undefined (reading 'subscribe')",
-    "undefined is not an object (evaluating 't.subscribe')",
 
     // === Misc known noise ===
     'r.default.setDefaultLevel is not a function',


### PR DESCRIPTION
## Summary

Fixes and filters several noisy Sentry issues affecting Studio.

### Code fixes
- **SUPABASE-APP-BG0** — `TypeError: Cannot read properties of undefined (reading 'toString')` in JsonEditor. Guarded against `undefined` `jsonStr` when `prettifyJSON` receives an undefined value.
- **SUPABASE-APP-BKM** — `TypeError: Cannot read properties of undefined (reading 'join')` in UpgradeWarnings. Added fallback for `error.dependents` being undefined from the API.
- **SUPABASE-APP-BVE** — `RangeError: Invalid time value` in filter date picker. Validated date before passing to `Calendar` component.

### Sentry `ignoreErrors` filters
- **SUPABASE-APP-B1N / SUPABASE-APP-BMF / SUPABASE-APP-E4Q** — `cmdk` `useSyncExternalStore` subscribe race condition (Chrome variant).
- **SUPABASE-APP-E5M** — Same `cmdk` subscribe error (Safari variant).
- **SUPABASE-APP-ASG** — Firefox `Node.removeChild` DOM manipulation error (Chrome variant was already filtered).
- **SUPABASE-APP-AWE** — Non-Error object exceptions (`Object captured as exception with keys:`).

### Ignored in Sentry (no code change)
- **SUPABASE-APP-ASG** — Resolved (now filtered in code).
- **SUPABASE-APP-FK9** — `SyntaxError: Invalid or unexpected token` from `react-markdown` parser. Single user, one-off.
- **SUPABASE-APP-EV3** — React fiber error from DOM manipulation. Single user, already archived.

## Test plan
- [ ] Verify JsonEditor opens correctly with valid and missing JSON values
- [ ] Verify UpgradeWarnings renders when `dependents` is undefined
- [ ] Verify filter date picker handles invalid date strings gracefully