### PR TITLE
fix(webhooks): allow enabling webhooks when using installationCommand

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet.tsx
@@ -398,7 +398,7 @@ export const InstallIntegrationSheet = ({ integration }: InstallIntegrationSheet
           </SheetClose>
           <Button
             type="primary"
-            disabled={hasMissingExtensions}
+            disabled={hasMissingExtensions && !installationCommand}
             loading={isInstalling}
             onClick={onInstallIntegration}
           >


### PR DESCRIPTION
## Summary
- The "Install integration" button in `InstallIntegrationSheet` was unconditionally disabled when required extensions were missing from the DB image (`hasMissingExtensions`)
- For webhooks, the installation goes through `installationCommand` (platform API `/database/{ref}/hook-enable`) which handles `pg_net` setup server-side — the client-side extension check is unnecessary
- Now only disables the button for missing extensions when there is no custom `installationCommand`

## How this happened
PR #44277 migrated Database Webhooks to the new marketplace integrations UI. The `InstallIntegrationSheet` already had a `disabled={hasMissingExtensions}` guard from its original implementation (for extension-only integrations like queues). When webhooks was added with its `installationCommand` + `requiredExtensions: ['pg_net']`, the guard wasn't updated to account for the command-based install path.

## Test plan
- [ ] With marketplace flag enabled, verify the "Install integration" button is clickable for webhooks even if `pg_net` is not pre-installed
- [ ] Verify clicking it successfully enables webhooks via the platform API
- [ ] Verify that extension-only integrations (e.g. queues) still correctly disable the button when extensions are unavailable

Fixes FE-2928