### PR TITLE
fix(webhooks): unblock enable button in old integrations UI

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTab.tsx
@@ -105,10 +105,12 @@ export const IntegrationOverviewTab = ({
 
       {!!actions && (
         <div
-          aria-disabled={hasToInstallExtensions}
+          aria-disabled={hasToInstallExtensions && !hideRequiredExtensionsSection}
           className={cn(
             'px-10 max-w-4xl',
-            hasToInstallExtensions && 'opacity-25 [&_button]:pointer-events-none'
+            hasToInstallExtensions &&
+              !hideRequiredExtensionsSection &&
+              'opacity-25 [&_button]:pointer-events-none'
           )}
         >
           {actions}


### PR DESCRIPTION
## Summary
- Fixes the "Enable webhooks" button being greyed out in the non-marketplace UI
- PR #44277 added `requiredExtensions: ['pg_net']` for the new UI, which inadvertently caused the old UI's actions area to get disabled via `hasToInstallExtensions`
- Skips the disabled styling when `hideRequiredExtensionsSection` is set, since webhooks handles `pg_net` installation server-side

Companion to #44402 which fixed the same issue in the new (V2) UI.