### PR TITLE
Laurence/data api docs functions

### DIFF
--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -108,7 +108,7 @@ const fetchWithRetry = fetchRetry(fetch, {
         attempt < 3
           && response
           && response.status == 520 // Cloudflare errors
-          && response.url.includes('rpc/your_stored_procedure')
+          && response.url.includes('rpc/your_database_function')
 
     if (shouldRetry(attempt, error, response)) {
       console.log(`Retrying request... Attempt #${attempt}`, response)
@@ -119,9 +119,9 @@ const fetchWithRetry = fetchRetry(fetch, {
   }
 })
 
-async function yourStoredProcedure() {
+async function yourDatabaseFunction() {
   const { data, error } = await supabase
-    .rpc('your_stored_procedure', { param1: 'value1' });
+    .rpc('your_database_function', { param1: 'value1' });
 
   if (error) {
     console.log('Error executing RPC:', error);
@@ -130,10 +130,10 @@ async function yourStoredProcedure() {
   }
 }
 
-yourStoredProcedure();
+yourDatabaseFunction();
 ```
 
-By using `retryOn` with a custom function, you can define specific conditions for retrying requests. In this example, the retry logic is applied only to requests targeting a specific stored procedure.
+By using `retryOn` with a custom function, you can define specific conditions for retrying requests. In this example, the retry logic is applied only to requests targeting a specific database function.
 
 ## Conclusion
 

--- a/apps/docs/content/guides/database/full-text-search.mdx
+++ b/apps/docs/content/guides/database/full-text-search.mdx
@@ -665,7 +665,7 @@ select title from books where to_tsvector(title) @@ to_tsquery('Lit:*');
 
 ### Extending functionality with RPC
 
-To make the partial search functionality accessible through the API, you can wrap the search logic in a stored procedure.
+To make the partial search functionality accessible through the API, you can wrap the search logic in a database function.
 
 After creating this function, you can invoke it from your application using the SDK for your platform. Here's an example:
 

--- a/apps/docs/content/troubleshooting/certain-operations-are-too-complex-to-perform-directly-using-the-client-libraries-8JaphH.mdx
+++ b/apps/docs/content/troubleshooting/certain-operations-are-too-complex-to-perform-directly-using-the-client-libraries-8JaphH.mdx
@@ -53,4 +53,4 @@ supabase.rpc("get_my_complex_query", { parameter: 1 })
 **Further Resources:**
 
 For more information on Postgres database functions, refer to the following resource:
-[Supabase Stored Procedures](/docs/guides/database/functions#quick-demo)
+[Supabase Functions](/docs/guides/database/functions#quick-demo)

--- a/apps/docs/spec/cli_v1_commands.yaml
+++ b/apps/docs/spec/cli_v1_commands.yaml
@@ -2391,7 +2391,7 @@ commands:
 
       Automatically generates type definitions based on your Postgres database schema.
 
-      This command connects to your database (local or remote) and generates typed definitions that match your database tables, views, and stored procedures. By default, it generates TypeScript definitions, but also supports Go and Swift.
+      This command connects to your database (local or remote) and generates typed definitions that match your database tables, views, and functions. By default, it generates TypeScript definitions, but also supports Go and Swift.
 
       Generated types give you type safety and autocompletion when working with your database in code, helping prevent runtime errors and improving developer experience.
 

--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -116,7 +116,7 @@ parameters:
     required: false
     default: '1000'
     description: |
-      The maximum number of rows returned from a view, table, or stored procedure. Limits payload size for accidental or malicious requests.
+      The maximum number of rows returned from a view, table, or function. Limits payload size for accidental or malicious requests.
     links:
       - name: 'PostgREST configuration'
         link: 'https://postgrest.org/en/stable/configuration.html'

--- a/apps/docs/spec/supabase_csharp_v0.yml
+++ b/apps/docs/spec/supabase_csharp_v0.yml
@@ -667,17 +667,17 @@ functions:
           ```
 
   - id: rpc
-    title: 'Stored Procedures: Rpc()'
+    title: 'Database Functions: Rpc()'
     description: |
-      You can call stored procedures as a "Remote Procedure Call".
+      You can call functions as a "Remote Procedure Call".
 
       That's a fancy way of saying that you can put some logic into your database then call it from anywhere.
       It's especially useful when the logic rarely changes - like password resets and updates.
     examples:
-      - id: call-a-stored-procedure
-        name: Call a stored procedure
+      - id: call-a-database-function
+        name: Call a database function
         isSpotlight: true
-        description: This is an example invoking a stored procedure.
+        description: This is an example invoking a database function.
         code: |
           ```c#
           await supabase.Rpc("hello_world", null);

--- a/apps/docs/spec/supabase_csharp_v1.yml
+++ b/apps/docs/spec/supabase_csharp_v1.yml
@@ -667,17 +667,17 @@ functions:
           ```
 
   - id: rpc
-    title: 'Stored Procedures: Rpc()'
+    title: 'Database Functions: Rpc()'
     description: |
-      You can call stored procedures as a "Remote Procedure Call".
+      You can call functions as a "Remote Procedure Call".
 
       That's a fancy way of saying that you can put some logic into your database then call it from anywhere.
       It's especially useful when the logic rarely changes - like password resets and updates.
     examples:
-      - id: call-a-stored-procedure
-        name: Call a stored procedure
+      - id: call-a-database-function
+        name: Call a database function
         isSpotlight: true
-        description: This is an example invoking a stored procedure.
+        description: This is an example invoking a database function.
         code: |
           ```c#
           await supabase.Rpc("hello_world", null);

--- a/apps/docs/spec/supabase_dart_v1.yml
+++ b/apps/docs/spec/supabase_dart_v1.yml
@@ -1049,17 +1049,17 @@ functions:
           ```
 
   - id: rpc
-    title: 'Stored Procedures: rpc()'
+    title: 'Database Functions: rpc()'
     description: |
-      You can call stored procedures as a "Remote Procedure Call".
+      You can call functions as a "Remote Procedure Call".
 
       That's a fancy way of saying that you can put some logic into your database then call it from anywhere.
       It's especially useful when the logic rarely changes - like password resets and updates.
     examples:
-      - id: call-a-stored-procedure
-        name: Call a stored procedure
+      - id: call-a-database-function
+        name: Call a database function
         isSpotlight: true
-        description: This is an example invoking a stored procedure.
+        description: This is an example invoking a database function.
         code: |
           ```dart
           final data = await supabase
@@ -1994,9 +1994,9 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
-            .rpc('echo_all_instruments)
+            .rpc('echo_all_instruments')
             .not('name', 'eq', 'violin');
           ```
 
@@ -2037,7 +2037,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_instruments')
             .match({'name': 'violin', 'country_id': 3});
@@ -2080,7 +2080,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_instruments')
             .eq('name', 'guqin');
@@ -2123,7 +2123,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_instruments')
             .neq('name', 'violin');
@@ -2166,7 +2166,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .gt('country_id', 250);
@@ -2209,7 +2209,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .gte('country_id', 250);
@@ -2252,7 +2252,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .lt('country_id', 250);
@@ -2296,7 +2296,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .lte('country_id', 250);
@@ -2340,7 +2340,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .like('name', '%la%');
@@ -2383,7 +2383,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .ilike('name', '%la%');
@@ -2428,7 +2428,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .is_('name', null);
@@ -2473,7 +2473,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .in_('name', ['Minas Tirith', 'Minas Morgul']);
@@ -2514,7 +2514,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .contains('main_exports', ['oil']);
@@ -2555,7 +2555,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .containedBy('main_exports', ['cars', 'food', 'machine']);
@@ -2596,7 +2596,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .rangeLt('population_range_millions', '[150, 250]');
@@ -2637,7 +2637,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .rangeGt('population_range_millions', '[150, 250]');
@@ -2678,7 +2678,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .rangeGte('population_range_millions', '[150, 250]');
@@ -2720,7 +2720,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .rangeLte('population_range_millions', [150, 250]);
@@ -2761,7 +2761,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .rangeAdjacent('population_range_millions', '[70, 185]');
@@ -2802,7 +2802,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .overlaps('main_exports', ['computers', 'minerals']);
@@ -2918,7 +2918,7 @@ functions:
         name: With `rpc()`
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .filter('name', 'in', '("Minas Tirith","Minas Morgul")');

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -3532,7 +3532,7 @@ functions:
           ```
 
   - id: rpc
-    title: 'Stored Procedures: rpc()'
+    title: 'Database Functions: rpc()'
     description: |
       Perform a function call.
 
@@ -5680,7 +5680,7 @@ functions:
         name: With rpc()
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_cities')
             .not('name', 'eq', 'Mordor');
@@ -7047,7 +7047,7 @@ functions:
         name: With rpc()
         code: |
           ```dart
-          // Only valid if the Stored Procedure returns a table type.
+          // Only valid if the database function returns a table type.
           final data = await supabase
             .rpc('echo_all_countries')
             .filter('name', 'in', '("Rohan","Mordor")');

--- a/apps/docs/spec/supabase_kt_v1.yml
+++ b/apps/docs/spec/supabase_kt_v1.yml
@@ -553,19 +553,19 @@ functions:
           }.decodeSingle<City>()
           ```
   - id: rpc
-    title: 'Stored Procedures: rpc()'
+    title: 'Database Functions: rpc()'
     description: |
-      You can call stored procedures as a "Remote Procedure Call".
+      You can call functions as a "Remote Procedure Call".
 
       That's a fancy way of saying that you can put some logic into your database then call it from anywhere.
       It's especially useful when the logic rarely changes - like password resets and updates.
 
       - When calling `rpc` with parameters, you have to provide a [serializable value](/docs/reference/kotlin/installing#serialization) in the function parameter.
     examples:
-      - id: call-a-stored-procedure
-        name: Call a stored procedure
+      - id: call-a-database-function
+        name: Call a database function
         isSpotlight: true
-        description: This is an example invoking a stored procedure.
+        description: This is an example invoking a database function.
         code: |
           ```kotlin
           supabase.postgrest.rpc("hello_world")

--- a/apps/docs/spec/supabase_kt_v2.yml
+++ b/apps/docs/spec/supabase_kt_v2.yml
@@ -684,9 +684,9 @@ functions:
           }.decodeSingle<City>()
           ```
   - id: rpc
-    title: 'Stored Procedures: rpc()'
+    title: 'Database Functions: rpc()'
     description: |
-      You can call stored procedures as a "Remote Procedure Call".
+      You can call functions as a "Remote Procedure Call".
 
       That's a fancy way of saying that you can put some logic into your database then call it from anywhere.
       It's especially useful when the logic rarely changes - like password resets and updates.
@@ -710,10 +710,10 @@ functions:
         type: PostgrestRequestBuilder.() -> Unit
         description: Additional configuration & filtering for the request.
     examples:
-      - id: call-a-stored-procedure
-        name: Call a stored procedure
+      - id: call-a-database-function
+        name: Call a database function
         isSpotlight: true
-        description: This is an example invoking a stored procedure.
+        description: This is an example invoking a database function.
         code: |
           ```kotlin
           supabase.postgrest.rpc("hello_world")

--- a/apps/docs/spec/supabase_kt_v3.yml
+++ b/apps/docs/spec/supabase_kt_v3.yml
@@ -697,9 +697,9 @@ functions:
           }.decodeSingle<City>()
           ```
   - id: rpc
-    title: 'Stored Procedures: rpc()'
+    title: 'Database Functions: rpc()'
     description: |
-      You can call stored procedures as a "Remote Procedure Call".
+      You can call functions as a "Remote Procedure Call".
 
       That's a fancy way of saying that you can put some logic into your database then call it from anywhere.
       It's especially useful when the logic rarely changes - like password resets and updates.
@@ -728,10 +728,10 @@ functions:
             type: String
             description: The schema to use for the function. Defaults to `public`
     examples:
-      - id: call-a-stored-procedure
-        name: Call a stored procedure
+      - id: call-a-database-function
+        name: Call a database function
         isSpotlight: true
-        description: This is an example invoking a stored procedure.
+        description: This is an example invoking a database function.
         code: |
           ```kotlin
           supabase.postgrest.rpc("hello_world")

--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -4154,11 +4154,11 @@ functions:
       - name: fn
         isOptional: false
         type: callable
-        description: The stored procedure call to be executed.
+        description: The database function call to be executed.
       - name: params
         isOptional: true
         type: dict of any
-        description: Parameters passed into the stored procedure call.
+        description: Parameters passed into the database function call.
       - name: get
         isOptional: true
         type: dict of any

--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -4052,7 +4052,7 @@ functions:
             .execute()
           ```
         description: |
-          Ensure that the RPC call affects at most 10 rows. Useful for limiting the impact of stored procedures.
+          Ensure that the RPC call affects at most 10 rows. Useful for limiting the impact of functions.
 
   - id: single
     title: single()

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -224,7 +224,7 @@ export const FunctionsList = () => {
             disabledMessage="You need additional permissions to create functions"
           >
             <p className="text-sm text-foreground-light">
-              PostgreSQL functions, also known as stored procedures, is a set of SQL and procedural
+              PostgreSQL functions are a set of SQL and procedural
               commands such as declarations, assignments, loops, flow-of-control, etc.
             </p>
             <p className="text-sm text-foreground-light">

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -224,8 +224,8 @@ export const FunctionsList = () => {
             disabledMessage="You need additional permissions to create functions"
           >
             <p className="text-sm text-foreground-light">
-              PostgreSQL functions are a set of SQL and procedural
-              commands such as declarations, assignments, loops, flow-of-control, etc.
+              PostgreSQL functions are a set of SQL and procedural commands such as declarations,
+              assignments, loops, flow-of-control, etc.
             </p>
             <p className="text-sm text-foreground-light">
               It's stored on the database server and can be invoked using the SQL interface.

--- a/apps/studio/components/interfaces/Docs/Pages/Rpc/Introduction.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/Rpc/Introduction.tsx
@@ -7,7 +7,7 @@ const Introduction = () => {
       content={
         <>
           <p>
-            All of your database stored procedures are available on your API. This means you can
+            All of your database functions are available on your API. This means you can
             build your logic directly into the database (if you're brave enough)!
           </p>
           <p>The API endpoint supports POST (and in some cases GET) to execute the function.</p>

--- a/apps/studio/components/interfaces/Docs/Pages/Rpc/Introduction.tsx
+++ b/apps/studio/components/interfaces/Docs/Pages/Rpc/Introduction.tsx
@@ -7,8 +7,8 @@ const Introduction = () => {
       content={
         <>
           <p>
-            All of your database functions are available on your API. This means you can
-            build your logic directly into the database (if you're brave enough)!
+            All of your database functions are available on your API. This means you can build your
+            logic directly into the database (if you're brave enough)!
           </p>
           <p>The API endpoint supports POST (and in some cases GET) to execute the function.</p>
         </>

--- a/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/ProjectAPIDocs.constants.ts
@@ -14,7 +14,7 @@ export const DOCS_MENU = [
   { name: 'Connect', key: API_DOCS_CATEGORIES.INTRODUCTION },
   { name: 'User Management', key: API_DOCS_CATEGORIES.USER_MANAGEMENT },
   { name: 'Tables & Views', key: API_DOCS_CATEGORIES.ENTITIES },
-  { name: 'Stored Procedures', key: API_DOCS_CATEGORIES.STORED_PROCEDURES },
+  { name: 'Database Functions', key: API_DOCS_CATEGORIES.STORED_PROCEDURES },
   { name: 'Storage', key: API_DOCS_CATEGORIES.STORAGE },
   { name: 'Edge Functions', key: API_DOCS_CATEGORIES.EDGE_FUNCTIONS },
   { name: 'Realtime', key: API_DOCS_CATEGORIES.REALTIME },
@@ -471,13 +471,13 @@ const { data, error } = await supabase
   \`)
     `,
   },
-  // Stored Procedures
+  // Database Functions
   storedProceduresIntroduction: {
     key: 'stored-procedures-introduction',
     category: API_DOCS_CATEGORIES.STORED_PROCEDURES,
     title: 'Introduction',
     description: `
-All of your database stored procedures are available on your API. This means you can build your logic directly into the database (if you're brave enough)!
+All of your database functions are available on your API. This means you can build your logic directly into the database (if you're brave enough)!
 
 The API endpoint supports POST (and in some cases GET) to execute the function.
 `,

--- a/apps/studio/components/interfaces/ProjectAPIDocs/SecondLevelNav.tsx
+++ b/apps/studio/components/interfaces/ProjectAPIDocs/SecondLevelNav.tsx
@@ -40,13 +40,13 @@ const StoredProceduresSecondLevelNav = () => {
   return (
     <SecondLevelNavLayout
       category={API_DOCS_CATEGORIES.STORED_PROCEDURES}
-      title="Stored Procedures"
+      title="Database Functions"
       docsUrl={`${DOCS_URL}/reference/javascript/rpc`}
       renderResourceList={(props) => (
         <ResourcePickerList
           {...props}
           items={functions}
-          emptyMessage="No stored procedures available"
+          emptyMessage="No database functions available"
         />
       )}
     />

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
@@ -92,7 +92,7 @@ for each row execute
     id: 9,
     type: 'template',
     title: 'Increment field value',
-    description: 'Update a field with incrementing value using stored procedure.',
+    description: 'Update a field with incrementing value using a function.',
     sql: `
 create function increment(row_id int)
 returns void as

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -469,7 +469,7 @@ export const PostgrestConfig = () => {
                           <FormItem_Shadcn_>
                             <FormItemLayout
                               label="Exposed schemas"
-                              description="The schemas to expose in your API. Tables, views and stored procedures in
+                              description="The schemas to expose in your API. Tables, views and functions in
                           these schemas will get API endpoints."
                               layout="flex-row-reverse"
                             >
@@ -607,7 +607,7 @@ export const PostgrestConfig = () => {
                           <FormItemLayout
                             layout="flex-row-reverse"
                             label="Max rows"
-                            description="The maximum number of rows returned from a view, table, or stored procedure. Limits payload size for accidental or malicious requests."
+                            description="The maximum number of rows returned from a view, table, or function. Limits payload size for accidental or malicious requests."
                           >
                             <FormControl_Shadcn_>
                               <InputGroup>

--- a/apps/studio/components/layouts/DocsLayout/DocsLayout.utils.tsx
+++ b/apps/studio/components/layouts/DocsLayout/DocsLayout.utils.tsx
@@ -66,7 +66,7 @@ export const generateDocsMenu = (
       ],
     },
     {
-      title: 'Stored Procedures',
+      title: 'Functions',
       items: [
         {
           name: 'Introduction',

--- a/apps/ui-library/supabase/config.toml
+++ b/apps/ui-library/supabase/config.toml
@@ -8,12 +8,12 @@ project_id = "ui-library"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/apps/www/supabase/config.toml
+++ b/apps/www/supabase/config.toml
@@ -5,12 +5,12 @@ project_id = "obuldanrptloktxcffvn"
 [api]
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = []
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/e2e/studio/supabase/config.toml
+++ b/e2e/studio/supabase/config.toml
@@ -8,12 +8,12 @@ project_id = "studio"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/ai/edge-functions/supabase/config.toml
+++ b/examples/ai/edge-functions/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "ai-in-edge-functions"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` is always included.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request. `public` is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/auth/hono-full/supabase/config.toml
+++ b/examples/auth/hono-full/supabase/config.toml
@@ -8,12 +8,12 @@ project_id = "hono"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/auth/nextjs-full/supabase/config.toml
+++ b/examples/auth/nextjs-full/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "nextjs"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/caching/with-nextjs-13/supabase/config.toml
+++ b/examples/caching/with-nextjs-13/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "with-nextjs-13"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` is always included.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request. `public` is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/caching/with-react-query-nextjs-14/supabase/config.toml
+++ b/examples/caching/with-react-query-nextjs-14/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "supa-react-query"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` is always included.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request. `public` is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/clerk/supabase/config.toml
+++ b/examples/clerk/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "clerk"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/edge-functions/supabase/config.toml
+++ b/examples/edge-functions/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "edge-functions"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` is always included.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request. `public` is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/realtime/flutter-figma-clone/supabase/config.toml
+++ b/examples/realtime/flutter-figma-clone/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "design"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` and `graphql_public` schemas are included by default.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/slack-clone/nextjs-slack-clone-dotenvx/supabase/config.toml
+++ b/examples/slack-clone/nextjs-slack-clone-dotenvx/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "slack-clone"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/slack-clone/nextjs-slack-clone/supabase/config.toml
+++ b/examples/slack-clone/nextjs-slack-clone/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "slack-clone"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/todo-list/nextjs-todo-list/supabase/config.toml
+++ b/examples/todo-list/nextjs-todo-list/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "nextjs-todo-list"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` and `graphql_public` are included by default.
 schemas = ["public", "graphql_public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/user-management/expo-push-notifications/supabase/config.toml
+++ b/examples/user-management/expo-push-notifications/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "expo-user-management"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/user-management/expo-user-management/supabase/config.toml
+++ b/examples/user-management/expo-user-management/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "expo-user-management"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/user-management/flutter-user-management/supabase/config.toml
+++ b/examples/user-management/flutter-user-management/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "flutter-user-management"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/user-management/nextjs-user-management/supabase/config.toml
+++ b/examples/user-management/nextjs-user-management/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "nextjs-user-management"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. `public` and `graphql_public` are included by default.
 schemas = ["public"]
 # Extra schemas to add to the search_path of every request.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/examples/user-management/swift-user-management/supabase/config.toml
+++ b/examples/user-management/swift-user-management/supabase/config.toml
@@ -6,12 +6,12 @@ project_id = "swift-user-management"
 enabled = true
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 

--- a/packages/ui-patterns/src/SqlToRest/sql-to-rest.tsx
+++ b/packages/ui-patterns/src/SqlToRest/sql-to-rest.tsx
@@ -315,7 +315,7 @@ export default function SqlToRest({
             </div>
             <div className="prose text-sm mt-2">
               PostgREST doesn't support this query. If you're sure the syntax is correct and are
-              unable to modify it, wrap it in a stored procedure and call it using the{' '}
+              unable to modify it, wrap it in a database function and call it using the{' '}
               <a href="https://postgrest.org/en/v12/references/api/stored_procedures.html#stored-procedures">
                 RPC
               </a>{' '}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -8,12 +8,12 @@ project_id = "xguihxuzqibwxjnimxev"
 [api]
 # Port to use for the API URL.
 port = 54321
-# Schemas to expose in your API. Tables, views and stored procedures in this schema will get API
+# Schemas to expose in your API. Tables, views and functions in this schema will get API
 # endpoints. public and storage are always included.
 schemas = ["public", "content", "storage", "graphql_public"]
 # Extra schemas to add to the search_path of every request. public is always included.
 extra_search_path = ["public", "extensions"]
-# The maximum number of rows returns from a view, table, or stored procedure. Limits payload size
+# The maximum number of rows returned from a view, table, or function. Limits payload size
 # for accidental or malicious requests.
 max_rows = 1000
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Replaces "stored procedures" with "functions" for everything related to the Data API.

## Additional context

It's not accurate to call database functions "stored procedures". It may have been that way before Postgres 11, but now it causes  confusion because PostgREST allows functions and not stored procedures. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized terminology across docs, SDK guides, CLI/config specs, examples, UI, and config comments to use "database functions" (or "functions") instead of "stored procedures".
  * Updated API docs, CLI/config descriptions, Studio UI labels, help text, empty-state and navigation copy, RPC documentation, examples, and error/help messages for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->