### PR TITLE
fix(support-form): defer org/project initial selection until org data loaded

### DIFF
--- a/apps/studio/components/interfaces/Support/useSupportForm.ts
+++ b/apps/studio/components/interfaces/Support/useSupportForm.ts
@@ -77,8 +77,7 @@ export function useSupportForm(dispatch: Dispatch<SupportFormActions>): UseSuppo
     if (hasAppliedOrgProjectRef.current) return
     if (!urlParamsRef.current) return
     if (organizationsLoading) return
-
-    hasAppliedOrgProjectRef.current = true
+    if (organizations === undefined) return
 
     const orgSlugFromUrl =
       urlParamsRef.current.orgSlug && urlParamsRef.current.orgSlug !== NO_ORG_MARKER
@@ -107,6 +106,7 @@ export function useSupportForm(dispatch: Dispatch<SupportFormActions>): UseSuppo
         // Ignored: fall back to defaults when lookup fails
       })
       .finally(() => {
+        hasAppliedOrgProjectRef.current = true
         dispatch({ type: 'INITIALIZE', debugSource: 'useSupportForm' })
       })
   }, [organizations, organizationsLoading, form, dispatch])


### PR DESCRIPTION
## Summary
Fix support form initialization race condition by waiting for organizations data to load before pre-selecting organization/project values.

This prevents transient UI states like **"No specific organization"** and makes the form state stable in tests and real usage.

## Checklist
- [x] I have read the `CONTRIBUTING.md`

## Type of Change
- Bug fix

## Current Behavior

`useSupportForm` applied initial org/project selection too early:

- `selectInitialOrgAndProject` could run before `organizations` was defined
- `hasAppliedOrgProjectRef` was toggled too soon
- Support form could briefly show fallback **"No specific organization"**
- Tests intermittently failed:

```ts
expect(organization).toHaveTextContent('Organization 1')
```

## New Behavior

`useSupportForm` now waits for organizations data before applying the initial selection.

Returns early when data is not ready:

```ts
if (organizations === undefined) return
```

Marks initialization complete only after execution finishes:

```ts
hasAppliedOrgProjectRef.current = true
```

inside:

```ts
.finally(...)
```

This ensures:

- Organization/project selection happens once with valid data
- Deterministic support form behavior
- Existing support form tests remain stable

## Additional Context

Changed file:

- `useSupportForm.ts`

No new behavior outside this initialization path.

## Testing

```bash
pnpm --filter studio test -- --run
```

Target tests:

- SupportFormPage reliably shows **Organization 1**
- No TS/ES errors on modified file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed support form initialization to reliably pre-populate organization and project information when accessed via direct URL links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->