### PR TITLE
docs(database): clarify local psql import connection mode and fallback

### DIFF
--- a/apps/docs/content/guides/database/import-data.mdx
+++ b/apps/docs/content/guides/database/import-data.mdx
@@ -67,7 +67,35 @@ For databases using the Postgres engine, we recommend using the [pg_dump](https:
 
 ### Option 3: Using Postgres copy command
 
-Read more about [Bulk data loading.](/docs/guides/database/tables#bulk-data-loading)
+For local `psql` imports, choose a connection mode first:
+
+1. Start with the **Direct connection** string from
+   [Connect](/dashboard/project/_?showConnect=true). This is the preferred path for
+   Postgres-native commands such as `psql`, `pg_dump`, and restore/import workflows.
+2. If direct connection fails (for example, your environment does not support IPv6), switch to
+   the **Session pooler** connection string (`:5432`) from
+   [Connect](/dashboard/project/_?showConnect=true&method=session).
+3. Avoid using **Transaction pooler** (`:6543`) for bulk imports.
+
+```bash
+# Preferred: direct connection (IPv6-capable environments)
+export SUPABASE_DB_URL="postgresql://postgres:[YOUR-PASSWORD]@db.[PROJECT-REF].supabase.co:5432/postgres"
+
+# Fallback: session pooler (works for IPv4 and IPv6)
+# Note: session pooler username includes your project ref.
+# export SUPABASE_DB_URL="postgresql://postgres.[PROJECT-REF]:[YOUR-PASSWORD]@aws-0-[REGION].pooler.supabase.com:5432/postgres"
+
+# Verify the connection before importing
+psql "$SUPABASE_DB_URL" -c '\conninfo'
+
+# Import a local CSV file
+psql "$SUPABASE_DB_URL" -c "\COPY public.movies FROM './movies.csv' WITH (FORMAT csv, HEADER true)"
+```
+
+Read more about:
+
+- [Bulk data loading](/docs/guides/database/tables#bulk-data-loading)
+- [Choosing the right connection method](/docs/guides/database/connecting-to-postgres#how-to-choose-the-right-connection-method)
 
 ### Option 4: Using the Supabase API
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update

## What is the current behavior?

Issue #43614 reports that local `psql` import guidance is split across pages, making it easy to choose the wrong connection mode.

## What is the new behavior?

This update adds a clear connection decision flow directly in the import guide:

- Start local `psql` imports with **Direct connection**
- If direct fails (for example, no IPv6), fall back to **Session pooler** on `:5432`
- Avoid **Transaction pooler** for bulk imports
- Include a minimal copy-paste `psql` flow to verify connectivity and run `\COPY`

Changes:
- `apps/docs/content/guides/database/import-data.mdx`

Closes #43614

## Validation

- `pnpm --filter docs lint -- content/guides/database/import-data.mdx` (passes, with unrelated repo-wide warnings)
- `pnpm exec prettier --check apps/docs/content/guides/database/import-data.mdx` (passes)
- `pnpm --filter docs lint:mdx` could not run in this environment due missing `node-pty` native module (`../build/Debug/pty.node`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Improved the PostgreSQL data import guide with detailed step-by-step instructions for using the copy command
* Added guidance on selecting between direct connections and session pooler connections
* Included examples for verifying connectivity and importing CSV files
* Updated reference links for additional resources

<!-- end of auto-generated comment: release notes by coderabbit.ai -->