### PR TITLE
fix(self-hosted): add compose healthcheck start_periods

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       timeout: 10s
       interval: 5s
       retries: 3
+      start_period: 60s
     depends_on:
       analytics:
         condition: service_healthy
@@ -81,6 +82,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+      start_period: 10s
     depends_on:
       studio:
         condition: service_healthy
@@ -132,6 +134,7 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
+      start_period: 10s
     depends_on:
       db:
         # Disable this if you are using an external Postgres database
@@ -528,6 +531,7 @@ services:
       interval: 5s
       timeout: 5s
       retries: 10
+      start_period: 30s
     environment:
       POSTGRES_HOST: /var/run/postgresql
       PGPORT: ${POSTGRES_PORT}
@@ -567,6 +571,7 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
+      start_period: 10s
     environment:
       LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
     command:


### PR DESCRIPTION
## What changed
- add `start_period` to `studio`, `kong`, `auth`, `db`, and `vector` healthchecks in `docker/docker-compose.yml`
- align self-hosted compose defaults with startup timing expectations from issue #44376

## Why
Without `start_period`, early health checks can mark services unhealthy during normal startup on slower hosts.

## Validation
- `docker compose --env-file docker/.env.example -f docker/docker-compose.yml config`

Closes #44376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated health check configurations for multiple services in the deployment setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->