### PR TITLE
Remove realtime EU metrics callout

### DIFF
--- a/apps/studio/pages/project/[ref]/observability/realtime.tsx
+++ b/apps/studio/pages/project/[ref]/observability/realtime.tsx
@@ -1,30 +1,26 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useFlag, useParams } from 'common'
-import dayjs from 'dayjs'
-import { ArrowRight, RefreshCw } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
-
 import ReportFilterBar from 'components/interfaces/Reports/ReportFilterBar'
 import ReportHeader from 'components/interfaces/Reports/ReportHeader'
 import ReportPadding from 'components/interfaces/Reports/ReportPadding'
+import { REPORT_DATERANGE_HELPER_LABELS } from 'components/interfaces/Reports/Reports.constants'
+import ReportStickyNav from 'components/interfaces/Reports/ReportStickyNav'
+import { SharedAPIReport } from 'components/interfaces/Reports/SharedAPIReport/SharedAPIReport'
+import { useSharedAPIReport } from 'components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants'
 import { ReportChartV2 } from 'components/interfaces/Reports/v2/ReportChartV2'
 import { LogsDatePicker } from 'components/interfaces/Settings/Logs/Logs.DatePickers'
+import UpgradePrompt from 'components/interfaces/Settings/Logs/UpgradePrompt'
 import DefaultLayout from 'components/layouts/DefaultLayout'
 import ObservabilityLayout from 'components/layouts/ObservabilityLayout/ObservabilityLayout'
 import { ButtonTooltip } from 'components/ui/ButtonTooltip'
-import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
-
-import { REPORT_DATERANGE_HELPER_LABELS } from 'components/interfaces/Reports/Reports.constants'
-import ReportStickyNav from 'components/interfaces/Reports/ReportStickyNav'
-import UpgradePrompt from 'components/interfaces/Settings/Logs/UpgradePrompt'
-import { useRefreshHandler, useReportDateRange } from 'hooks/misc/useReportDateRange'
-
-import { SharedAPIReport } from 'components/interfaces/Reports/SharedAPIReport/SharedAPIReport'
-import { useSharedAPIReport } from 'components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants'
-import { realtimeReports } from 'data/reports/v2/realtime.config'
-import type { NextPageWithLayout } from 'types'
-import { Admonition } from 'ui-patterns'
 import { ObservabilityLink } from 'components/ui/ObservabilityLink'
+import { realtimeReports } from 'data/reports/v2/realtime.config'
+import dayjs from 'dayjs'
+import { useRefreshHandler, useReportDateRange } from 'hooks/misc/useReportDateRange'
+import { ArrowRight, RefreshCw } from 'lucide-react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+import { useDatabaseSelectorStateSnapshot } from 'state/database-selector'
+import type { NextPageWithLayout } from 'types'
 
 const RealtimeReport: NextPageWithLayout = () => {
   return (
@@ -46,7 +42,6 @@ export default RealtimeReport
 const RealtimeUsage = () => {
   const [isRefreshing, setIsRefreshing] = useState(false)
   const { db, chart, ref } = useParams()
-  const showEUAlert = useFlag('realtimeReportEUAlert')
 
   const {
     selectedDateRange,
@@ -134,13 +129,6 @@ const RealtimeUsage = () => {
   return (
     <>
       <ReportHeader showDatabaseSelector={false} title="Realtime" />
-      {showEUAlert ? (
-        <Admonition
-          type="warning"
-          title="EU projects metrics limitation"
-          description="For EU projects, Realtime metrics may not be accurate at this time. Please do not rely on these numbers for the time being."
-        />
-      ) : null}
       <ReportStickyNav
         content={
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
Resolves FE-2931

Just removes this callout here as the issue is resolved
<img width="2574" height="298" alt="image" src="https://github.com/user-attachments/assets/e5e45640-9b16-43c1-9a14-b8ad4594540e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed EU projects metrics limitation warning from observability views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->