### PR TITLE
Docs: add cyberduck link as example for s3 client setup

### DIFF
--- a/apps/docs/content/guides/storage/s3/compatibility.mdx
+++ b/apps/docs/content/guides/storage/s3/compatibility.mdx
@@ -6,7 +6,7 @@ subtitle: 'Learn about the compatibility of Supabase Storage with S3.'
 sidebar_label: 'S3'
 ---
 
-Supabase Storage is compatible with the S3 protocol. You can use any S3 client to interact with your Storage objects.
+Supabase Storage is compatible with the S3 protocol. You can use almost any S3 client to interact with your Storage objects (such as [Cyberduck](https://supabase.com/partners/integrations/cyberduck)).
 
 Storage supports [standard](/docs/guides/storage/uploads/standard-uploads), [resumable](/docs/guides/storage/uploads/resumable-uploads) and [S3 uploads](/docs/guides/storage/uploads/s3-uploads) and all these protocols are interoperable. You can upload a file with the S3 protocol and list it with the REST API or upload with Resumable uploads and list with S3.
 

--- a/apps/docs/content/guides/storage/s3/compatibility.mdx
+++ b/apps/docs/content/guides/storage/s3/compatibility.mdx
@@ -6,7 +6,7 @@ subtitle: 'Learn about the compatibility of Supabase Storage with S3.'
 sidebar_label: 'S3'
 ---
 
-Supabase Storage is compatible with the S3 protocol. You can use almost any S3 client to interact with your Storage objects (such as [Cyberduck](https://supabase.com/partners/integrations/cyberduck)).
+Supabase Storage is compatible with the S3 protocol. You can use almost any S3 client to interact with your Storage objects (such as [Cyberduck](/partners/integrations/cyberduck)).
 
 Storage supports [standard](/docs/guides/storage/uploads/standard-uploads), [resumable](/docs/guides/storage/uploads/resumable-uploads) and [S3 uploads](/docs/guides/storage/uploads/s3-uploads) and all these protocols are interoperable. You can upload a file with the S3 protocol and list it with the REST API or upload with Resumable uploads and list with S3.
 

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -182,6 +182,7 @@ allow_list = [
     "Codium",
     "Cognito",
     "Colab",
+    "Cyberduck",
     "DBeaver",
     "Database Functions?",
     "Datadog",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

No link

## What is the new behavior?

1. Mention not all S3 clients are expected to work
2. Add link to Cyberduck integration as an example

## Additional context




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated S3 compatibility guide to clarify support scope for S3 clients and included a reference example for validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->