### PR TITLE
feat: modify public bucket tooltip copy

### DIFF
--- a/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/BucketTable.tsx
@@ -12,6 +12,7 @@ import {
   TooltipTrigger,
 } from 'ui'
 
+import { PUBLIC_BUCKET_TOOLTIP } from '@/components/interfaces/Storage/Storage.constants'
 import { useBucketPolicyCount } from '@/components/interfaces/Storage/useBucketPolicyCount'
 import {
   VirtualizedTableCell,
@@ -125,10 +126,7 @@ export const BucketTableRow = ({
                   Public
                 </Badge>
               </TooltipTrigger>
-              <TooltipContent side="top">
-                This bucket is publicly readable. Anyone can list and access all objects stored in
-                it.
-              </TooltipContent>
+              <TooltipContent side="top">{PUBLIC_BUCKET_TOOLTIP}</TooltipContent>
             </Tooltip>
           )}
         </div>

--- a/apps/studio/components/interfaces/Storage/Storage.constants.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.constants.ts
@@ -89,5 +89,4 @@ export const BUCKET_TYPES = {
 export const BUCKET_TYPE_KEYS = Object.keys(BUCKET_TYPES) as Array<keyof typeof BUCKET_TYPES>
 export const DEFAULT_BUCKET_TYPE: keyof typeof BUCKET_TYPES = 'files'
 
-export const PUBLIC_BUCKET_TOOLTIP =
-  'This bucket is publicly readable. Anyone with the object URL can access files stored in it.'
+export const PUBLIC_BUCKET_TOOLTIP = 'Objects in this bucket are readable by anyone with the URL.'

--- a/apps/studio/components/interfaces/Storage/Storage.constants.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.constants.ts
@@ -88,3 +88,6 @@ export const BUCKET_TYPES = {
 }
 export const BUCKET_TYPE_KEYS = Object.keys(BUCKET_TYPES) as Array<keyof typeof BUCKET_TYPES>
 export const DEFAULT_BUCKET_TYPE: keyof typeof BUCKET_TYPES = 'files'
+
+export const PUBLIC_BUCKET_TOOLTIP =
+  'This bucket is publicly readable. Anyone with the object URL can access files stored in it.'

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesBucketRow.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesBucketRow.tsx
@@ -20,6 +20,7 @@ import {
 } from 'ui'
 
 import { PolicyRow } from '@/components/interfaces/Auth/Policies/PolicyTableRow/PolicyRow'
+import { PUBLIC_BUCKET_TOOLTIP } from '@/components/interfaces/Storage/Storage.constants'
 import { Bucket } from '@/data/storage/buckets-query'
 
 interface StoragePoliciesBucketRowProps {
@@ -61,10 +62,7 @@ export const StoragePoliciesBucketRow = forwardRef<HTMLDivElement, StoragePolici
                       Public
                     </Badge>
                   </TooltipTrigger>
-                  <TooltipContent side="top">
-                    This bucket is publicly readable. Anyone can list and access all objects stored
-                    in it.
-                  </TooltipContent>
+                  <TooltipContent side="top">{PUBLIC_BUCKET_TOOLTIP}</TooltipContent>
                 </Tooltip>
               )}
             </div>

--- a/apps/studio/pages/project/[ref]/storage/files/buckets/[bucketId].tsx
+++ b/apps/studio/pages/project/[ref]/storage/files/buckets/[bucketId].tsx
@@ -3,6 +3,7 @@ import { DeleteBucketModal } from 'components/interfaces/Storage/DeleteBucketMod
 import { EditBucketModal } from 'components/interfaces/Storage/EditBucketModal'
 import { EmptyBucketModal } from 'components/interfaces/Storage/EmptyBucketModal'
 import { useSelectedBucket } from 'components/interfaces/Storage/FilesBuckets/useSelectedBucket'
+import { PUBLIC_BUCKET_TOOLTIP } from 'components/interfaces/Storage/Storage.constants'
 import StorageBucketsError from 'components/interfaces/Storage/StorageBucketsError'
 import { StorageExplorer } from 'components/interfaces/Storage/StorageExplorer/StorageExplorer'
 import { useBucketPolicyCount } from 'components/interfaces/Storage/useBucketPolicyCount'
@@ -80,10 +81,7 @@ const BucketPage: NextPageWithLayout = () => {
                     Public
                   </Badge>
                 </TooltipTrigger>
-                <TooltipContent side="bottom">
-                  This bucket is publicly readable. Anyone can list and access all objects stored in
-                  it.
-                </TooltipContent>
+                <TooltipContent side="bottom">{PUBLIC_BUCKET_TOOLTIP}</TooltipContent>
               </Tooltip>
             )}
           </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates the tooltip copy for `public` pills in Storage. More accurate description.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified the tooltip text for "Public" buckets across the storage interface so the same explanatory message appears consistently on bucket listings, badges, and bucket pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->