### PR TITLE
fix(reports): fix report block styling issues FE-2844

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -176,6 +176,15 @@ export const ChartBlock = ({
 
   const effectiveLogScale = logScale && !hasNonPositiveValues
 
+  const maxDataValue = data.length > 0
+    ? Math.max(...data.map((d: any) => Number(d[metricLabel]) || 0))
+    : 0
+  const yAxisWidth = effectiveLogScale
+    ? 52
+    : isPercentage
+      ? 36
+      : Math.max(36, (String(Math.round(maxDataValue)).length + 1) * 7)
+
   const getInitialHighlightedValue = useCallback(() => {
     if (!chartData?.data?.length) return undefined
     const lastDataPoint = chartData.data[chartData.data.length - 1]
@@ -301,13 +310,12 @@ export const ChartBlock = ({
                   scale={effectiveLogScale ? 'log' : 'auto'}
                   domain={effectiveLogScale ? [1, 'auto'] : isPercentage ? [0, 100] : undefined}
                   allowDataOverflow={effectiveLogScale}
-                  width={effectiveLogScale ? 52 : undefined}
+                  width={yAxisWidth}
                   tickFormatter={effectiveLogScale ? formatLogTick : undefined}
                 />
                 <ChartTooltip
                   content={
                     <ChartTooltipContent
-                      className="w-[200px]"
                       labelSuffix={isPercentage ? '%' : ''}
                       labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
                     />
@@ -329,13 +337,12 @@ export const ChartBlock = ({
                   scale={effectiveLogScale ? 'log' : 'auto'}
                   domain={effectiveLogScale ? [1, 'auto'] : isPercentage ? [0, 100] : undefined}
                   allowDataOverflow={effectiveLogScale}
-                  width={effectiveLogScale ? 52 : undefined}
+                  width={yAxisWidth}
                   tickFormatter={effectiveLogScale ? formatLogTick : undefined}
                 />
                 <ChartTooltip
                   content={
                     <ChartTooltipContent
-                      className="w-[200px]"
                       labelSuffix={chartData?.format === '%' ? '%' : ''}
                       labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
                     />

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -12,6 +12,7 @@ import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import {
   checkHasNonPositiveValues,
+  computeYAxisWidth,
   formatLogTick,
   formatYAxisTick,
 } from '@/components/ui/QueryBlock/QueryBlock.utils'
@@ -177,11 +178,10 @@ export const ChartBlock = ({
 
   const effectiveLogScale = logScale && !hasNonPositiveValues
 
-  // Use max absolute magnitude so the width accommodates negative tick labels too
-  const maxMagnitude =
-    data.length > 0 ? Math.max(...data.map((d: any) => Math.abs(Number(d[metricLabel]) || 0))) : 0
-  const maxFormattedLength = isPercentage ? 3 : formatYAxisTick(maxMagnitude).length
-  const yAxisWidth = effectiveLogScale ? 52 : Math.max(36, (maxFormattedLength + 1) * 8)
+  const yAxisWidth = computeYAxisWidth(data, metricLabel, {
+    isLogScale: effectiveLogScale,
+    isPercentage,
+  })
 
   const getInitialHighlightedValue = useCallback(() => {
     if (!chartData?.data?.length) return undefined

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -330,6 +330,7 @@ export const ChartBlock = ({
                 <ChartTooltip
                   content={
                     <ChartTooltipContent
+                      className="min-w-[200px]"
                       labelSuffix={isPercentage ? '%' : ''}
                       labelFormatter={(x) => dayjs(x).format('DD MMM YYYY')}
                     />

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -28,6 +28,24 @@ import { METRICS } from '@/lib/constants/metrics'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import type { Dashboards } from '@/types'
 
+function formatYAxisTick(value: number): string {
+  if (Math.abs(value) >= 1_000_000) {
+    const n = value / 1_000_000
+    return `${Number.isInteger(n) ? n : n.toFixed(1)}M`
+  }
+  if (Math.abs(value) >= 1_000) {
+    const n = value / 1_000
+    return `${Number.isInteger(n) ? n : n.toFixed(1)}K`
+  }
+  if (value !== 0 && Math.abs(value) < 1) {
+    return parseFloat(value.toFixed(2)).toString()
+  }
+  if (!Number.isInteger(value)) {
+    return parseFloat(value.toFixed(1)).toString()
+  }
+  return String(value)
+}
+
 interface ChartBlockProps {
   label: string
   attribute: string
@@ -178,11 +196,8 @@ export const ChartBlock = ({
 
   const maxDataValue =
     data.length > 0 ? Math.max(...data.map((d: any) => Number(d[metricLabel]) || 0)) : 0
-  const yAxisWidth = effectiveLogScale
-    ? 52
-    : isPercentage
-      ? 36
-      : Math.max(36, (String(Math.round(maxDataValue)).length + 1) * 7)
+  const maxFormattedLength = isPercentage ? 3 : formatYAxisTick(maxDataValue).length
+  const yAxisWidth = effectiveLogScale ? 52 : Math.max(36, (maxFormattedLength + 1) * 8)
 
   const getInitialHighlightedValue = useCallback(() => {
     if (!chartData?.data?.length) return undefined
@@ -310,7 +325,7 @@ export const ChartBlock = ({
                   domain={effectiveLogScale ? [1, 'auto'] : isPercentage ? [0, 100] : undefined}
                   allowDataOverflow={effectiveLogScale}
                   width={yAxisWidth}
-                  tickFormatter={effectiveLogScale ? formatLogTick : undefined}
+                  tickFormatter={effectiveLogScale ? formatLogTick : formatYAxisTick}
                 />
                 <ChartTooltip
                   content={
@@ -337,7 +352,7 @@ export const ChartBlock = ({
                   domain={effectiveLogScale ? [1, 'auto'] : isPercentage ? [0, 100] : undefined}
                   allowDataOverflow={effectiveLogScale}
                   width={yAxisWidth}
-                  tickFormatter={effectiveLogScale ? formatLogTick : undefined}
+                  tickFormatter={effectiveLogScale ? formatLogTick : formatYAxisTick}
                 />
                 <ChartTooltip
                   content={

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -13,6 +13,7 @@ import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import {
   checkHasNonPositiveValues,
   formatLogTick,
+  formatYAxisTick,
 } from '@/components/ui/QueryBlock/QueryBlock.utils'
 import { AnalyticsInterval } from '@/data/analytics/constants'
 import { mapMultiResponseToAnalyticsData } from '@/data/analytics/infra-monitoring-queries'
@@ -27,24 +28,6 @@ import {
 import { METRICS } from '@/lib/constants/metrics'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import type { Dashboards } from '@/types'
-
-function formatYAxisTick(value: number): string {
-  if (Math.abs(value) >= 1_000_000) {
-    const n = value / 1_000_000
-    return `${Number.isInteger(n) ? n : n.toFixed(1)}M`
-  }
-  if (Math.abs(value) >= 1_000) {
-    const n = value / 1_000
-    return `${Number.isInteger(n) ? n : n.toFixed(1)}K`
-  }
-  if (value !== 0 && Math.abs(value) < 1) {
-    return parseFloat(value.toFixed(2)).toString()
-  }
-  if (!Number.isInteger(value)) {
-    return parseFloat(value.toFixed(1)).toString()
-  }
-  return String(value)
-}
 
 interface ChartBlockProps {
   label: string

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -177,9 +177,10 @@ export const ChartBlock = ({
 
   const effectiveLogScale = logScale && !hasNonPositiveValues
 
-  const maxDataValue =
-    data.length > 0 ? Math.max(...data.map((d: any) => Number(d[metricLabel]) || 0)) : 0
-  const maxFormattedLength = isPercentage ? 3 : formatYAxisTick(maxDataValue).length
+  // Use max absolute magnitude so the width accommodates negative tick labels too
+  const maxMagnitude =
+    data.length > 0 ? Math.max(...data.map((d: any) => Math.abs(Number(d[metricLabel]) || 0))) : 0
+  const maxFormattedLength = isPercentage ? 3 : formatYAxisTick(maxMagnitude).length
   const yAxisWidth = effectiveLogScale ? 52 : Math.max(36, (maxFormattedLength + 1) * 8)
 
   const getInitialHighlightedValue = useCallback(() => {

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -176,9 +176,8 @@ export const ChartBlock = ({
 
   const effectiveLogScale = logScale && !hasNonPositiveValues
 
-  const maxDataValue = data.length > 0
-    ? Math.max(...data.map((d: any) => Number(d[metricLabel]) || 0))
-    : 0
+  const maxDataValue =
+    data.length > 0 ? Math.max(...data.map((d: any) => Number(d[metricLabel]) || 0)) : 0
   const yAxisWidth = effectiveLogScale
     ? 52
     : isPercentage

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlockContainer.tsx
@@ -56,7 +56,7 @@ export const ReportBlockContainer = ({
               <h3 className="heading-meta truncate">{label}</h3>
               {badge && <div className="flex items-center shrink-0">{badge}</div>}
             </div>
-            <div className="flex items-center">{actions}</div>
+            <div className="flex items-center shrink-0">{actions}</div>
           </div>
         </TooltipTrigger>
         {tooltip && (

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -13,6 +13,7 @@ import { BlockViewConfiguration } from './BlockViewConfiguration'
 import { EditQueryButton } from './EditQueryButton'
 import {
   checkHasNonPositiveValues,
+  computeYAxisWidth,
   formatLogTick,
   formatYAxisTick,
   getCumulativeResults,
@@ -118,12 +119,9 @@ export const QueryBlock = ({
 
   const effectiveLogScale = logScale && !hasNonPositiveValues
 
-  // Use max absolute magnitude so the width accommodates negative tick labels too
-  const maxYMagnitude =
-    chartData && yKey ? Math.max(...chartData.map((d: any) => Math.abs(Number(d[yKey]) || 0))) : 0
-  const yAxisWidth = effectiveLogScale
-    ? 52
-    : Math.max(36, (formatYAxisTick(maxYMagnitude).length + 1) * 8)
+  const yAxisWidth = computeYAxisWidth(chartData ?? [], yKey ?? '', {
+    isLogScale: effectiveLogScale,
+  })
 
   const getDateFormat = (key: any) => {
     const value = chartData?.[0]?.[key] || ''

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -226,7 +226,7 @@ export const QueryBlock = ({
 
       {showSql && (
         <div
-          className={cn('shrink-0 grow-1 w-full h-full overflow-y-auto max-h-[min(300px, 100%)]', {
+          className={cn('shrink-0 grow-1 w-full h-full overflow-y-auto overscroll-contain max-h-[min(300px, 100%)]', {
             'border-b': results !== undefined,
           })}
         >
@@ -342,7 +342,7 @@ export const QueryBlock = ({
             </div>
           ) : (
             results && (
-              <div className={cn('flex flex-col flex-1 w-full relative max-h-64')}>
+              <div className={cn('flex flex-col flex-1 w-full overflow-auto overscroll-contain relative max-h-64')}>
                 <Results rows={results} />
               </div>
             )

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -118,11 +118,12 @@ export const QueryBlock = ({
 
   const effectiveLogScale = logScale && !hasNonPositiveValues
 
-  const maxYValue =
-    chartData && yKey ? Math.max(...chartData.map((d: any) => Number(d[yKey]) || 0)) : 0
+  // Use max absolute magnitude so the width accommodates negative tick labels too
+  const maxYMagnitude =
+    chartData && yKey ? Math.max(...chartData.map((d: any) => Math.abs(Number(d[yKey]) || 0))) : 0
   const yAxisWidth = effectiveLogScale
     ? 52
-    : Math.max(36, (formatYAxisTick(maxYValue).length + 1) * 8)
+    : Math.max(36, (formatYAxisTick(maxYMagnitude).length + 1) * 8)
 
   const getDateFormat = (key: any) => {
     const value = chartData?.[0]?.[key] || ''

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -226,9 +226,12 @@ export const QueryBlock = ({
 
       {showSql && (
         <div
-          className={cn('shrink-0 grow-1 w-full h-full overflow-y-auto overscroll-contain max-h-[min(300px, 100%)]', {
-            'border-b': results !== undefined,
-          })}
+          className={cn(
+            'shrink-0 grow-1 w-full h-full overflow-y-auto overscroll-contain max-h-[min(300px, 100%)]',
+            {
+              'border-b': results !== undefined,
+            }
+          )}
         >
           <CodeBlock
             hideLineNumbers
@@ -342,7 +345,11 @@ export const QueryBlock = ({
             </div>
           ) : (
             results && (
-              <div className={cn('flex flex-col flex-1 w-full overflow-auto overscroll-contain relative max-h-64')}>
+              <div
+                className={cn(
+                  'flex flex-col flex-1 w-full overflow-auto overscroll-contain relative max-h-64'
+                )}
+              >
                 <Results rows={results} />
               </div>
             )

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -329,7 +329,7 @@ export const QueryBlock = ({
                       />
                     }
                   />
-                  <Bar radius={1} dataKey={yKey}>
+                  <Bar radius={1} dataKey={yKey} fill="hsl(var(--chart-1))">
                     {chartData?.map((_: any, index: number) => (
                       <Cell
                         key={`cell-${index}`}

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.tsx
@@ -11,7 +11,12 @@ import { CHART_COLORS } from '../Charts/Charts.constants'
 import { SqlWarningAdmonition } from '../SqlWarningAdmonition'
 import { BlockViewConfiguration } from './BlockViewConfiguration'
 import { EditQueryButton } from './EditQueryButton'
-import { checkHasNonPositiveValues, formatLogTick, getCumulativeResults } from './QueryBlock.utils'
+import {
+  checkHasNonPositiveValues,
+  formatLogTick,
+  formatYAxisTick,
+  getCumulativeResults,
+} from './QueryBlock.utils'
 import { ReportBlockContainer } from '@/components/interfaces/Reports/ReportBlock/ReportBlockContainer'
 import { ChartConfig } from '@/components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import Results from '@/components/interfaces/SQLEditor/UtilityPanel/Results'
@@ -112,6 +117,12 @@ export const QueryBlock = ({
   }, [logScale, yKey, chartData])
 
   const effectiveLogScale = logScale && !hasNonPositiveValues
+
+  const maxYValue =
+    chartData && yKey ? Math.max(...chartData.map((d: any) => Number(d[yKey]) || 0)) : 0
+  const yAxisWidth = effectiveLogScale
+    ? 52
+    : Math.max(36, (formatYAxisTick(maxYValue).length + 1) * 8)
 
   const getDateFormat = (key: any) => {
     const value = chartData?.[0]?.[key] || ''
@@ -275,7 +286,7 @@ export const QueryBlock = ({
               >
                 <BarChart
                   accessibilityLayer
-                  margin={{ left: -20, right: 0, top: 10 }}
+                  margin={{ left: 0, right: 0, top: 10 }}
                   data={chartData}
                   onMouseMove={(e: any) => {
                     if (e.activeTooltipIndex !== focusDataIndex) {
@@ -303,10 +314,21 @@ export const QueryBlock = ({
                     scale={effectiveLogScale ? 'log' : 'auto'}
                     domain={effectiveLogScale ? [1, 'auto'] : undefined}
                     allowDataOverflow={effectiveLogScale}
-                    width={effectiveLogScale ? 52 : undefined}
-                    tickFormatter={effectiveLogScale ? formatLogTick : undefined}
+                    width={yAxisWidth}
+                    tickFormatter={effectiveLogScale ? formatLogTick : formatYAxisTick}
                   />
-                  <Tooltip content={<ChartTooltipContent className="w-[150px]" />} />
+                  <Tooltip
+                    content={
+                      <ChartTooltipContent
+                        className="min-w-[200px]"
+                        labelFormatter={(value) =>
+                          xKeyDateFormat === 'date'
+                            ? dayjs(value).format('MMM D YYYY HH:mm')
+                            : String(value)
+                        }
+                      />
+                    }
+                  />
                   <Bar radius={1} dataKey={yKey}>
                     {chartData?.map((_: any, index: number) => (
                       <Cell

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.utils.test.ts
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.utils.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+
 import { formatYAxisTick } from './QueryBlock.utils'
 
 describe('formatYAxisTick', () => {

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.utils.test.ts
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.utils.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import { formatYAxisTick } from './QueryBlock.utils'
+
+describe('formatYAxisTick', () => {
+  it('returns integers as-is when below 1000', () => {
+    expect(formatYAxisTick(0)).toBe('0')
+    expect(formatYAxisTick(1)).toBe('1')
+    expect(formatYAxisTick(999)).toBe('999')
+  })
+
+  it('abbreviates thousands with K', () => {
+    expect(formatYAxisTick(1_000)).toBe('1K')
+    expect(formatYAxisTick(5_000)).toBe('5K')
+    expect(formatYAxisTick(999_000)).toBe('999K')
+  })
+
+  it('rounds thousands to one decimal place', () => {
+    expect(formatYAxisTick(1_500)).toBe('1.5K')
+    expect(formatYAxisTick(55_300)).toBe('55.3K')
+    expect(formatYAxisTick(1_234)).toBe('1.2K')
+  })
+
+  it('abbreviates millions with M', () => {
+    expect(formatYAxisTick(1_000_000)).toBe('1M')
+    expect(formatYAxisTick(2_000_000)).toBe('2M')
+  })
+
+  it('rounds millions to one decimal place', () => {
+    expect(formatYAxisTick(1_500_000)).toBe('1.5M')
+    expect(formatYAxisTick(3_208_914)).toBe('3.2M')
+  })
+
+  it('handles values just below the million threshold', () => {
+    expect(formatYAxisTick(999_900)).toBe('999.9K')
+  })
+
+  it('handles negative values', () => {
+    expect(formatYAxisTick(-1_000)).toBe('-1K')
+    expect(formatYAxisTick(-1_500)).toBe('-1.5K')
+    expect(formatYAxisTick(-1_000_000)).toBe('-1M')
+    expect(formatYAxisTick(-999)).toBe('-999')
+  })
+
+  it('rounds small decimals to 2 places', () => {
+    expect(formatYAxisTick(0.456)).toBe('0.46')
+    expect(formatYAxisTick(0.1)).toBe('0.1')
+    expect(formatYAxisTick(-0.123)).toBe('-0.12')
+  })
+
+  it('rounds non-integer values between 1 and 1000 to 1 decimal place', () => {
+    expect(formatYAxisTick(1.25)).toBe('1.3')
+    expect(formatYAxisTick(99.9)).toBe('99.9')
+    expect(formatYAxisTick(5.0)).toBe('5')
+  })
+})

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.utils.test.ts
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatYAxisTick } from './QueryBlock.utils'
+import { computeYAxisWidth, formatYAxisTick } from './QueryBlock.utils'
 
 describe('formatYAxisTick', () => {
   it('returns integers as-is when below 1000', () => {
@@ -52,5 +52,41 @@ describe('formatYAxisTick', () => {
     expect(formatYAxisTick(1.25)).toBe('1.3')
     expect(formatYAxisTick(99.9)).toBe('99.9')
     expect(formatYAxisTick(5.0)).toBe('5')
+  })
+})
+
+describe('computeYAxisWidth', () => {
+  const row = (v: number) => ({ val: v })
+
+  it('returns 52 for log scale regardless of data', () => {
+    expect(computeYAxisWidth([row(1_000_000)], 'val', { isLogScale: true })).toBe(52)
+  })
+
+  it('returns a fixed width for percentage data', () => {
+    const width = computeYAxisWidth([row(99)], 'val', { isPercentage: true })
+    // "100" is the longest tick → (3+1)*8 = 32, floor at 36
+    expect(width).toBe(36)
+  })
+
+  it('returns minimum 36 for small values', () => {
+    expect(computeYAxisWidth([row(5)], 'val')).toBe(36)
+    expect(computeYAxisWidth([], 'val')).toBe(36)
+  })
+
+  it('widens for large values', () => {
+    // formatYAxisTick(55_300) = "55.3K" (5 chars) → (5+1)*8 = 48
+    expect(computeYAxisWidth([row(55_300)], 'val')).toBe(48)
+  })
+
+  it('uses absolute magnitude so negative data is handled correctly', () => {
+    const negWidth = computeYAxisWidth([row(-55_300)], 'val')
+    const posWidth = computeYAxisWidth([row(55_300)], 'val')
+    expect(negWidth).toBe(posWidth)
+  })
+
+  it('picks the largest magnitude across all rows', () => {
+    const data = [row(100), row(5_000), row(200)]
+    // max is 5000 → "5K" (2 chars) → (2+1)*8 = 24, floor at 36
+    expect(computeYAxisWidth(data, 'val')).toBe(36)
   })
 })

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.utils.ts
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.utils.ts
@@ -29,7 +29,6 @@ export const formatLogTick = (value: number): string => {
   return value.toLocaleString()
 }
 
-// Add helper function for cumulative results
 export const getCumulativeResults = (results: { rows: any[] }, config: ChartConfig) => {
   if (!results?.rows?.length) {
     return []

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.utils.ts
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.utils.ts
@@ -21,6 +21,21 @@ export const formatYAxisTick = (value: number): string => {
   return String(value)
 }
 
+export const computeYAxisWidth = (
+  data: Record<string, unknown>[],
+  key: string,
+  {
+    isLogScale = false,
+    isPercentage = false,
+  }: { isLogScale?: boolean; isPercentage?: boolean } = {}
+): number => {
+  if (isLogScale) return 52
+  if (isPercentage) return Math.max(36, (3 + 1) * 8) // max tick is "100"
+  const maxMagnitude =
+    data.length > 0 ? Math.max(...data.map((d) => Math.abs(Number(d[key]) || 0))) : 0
+  return Math.max(36, (formatYAxisTick(maxMagnitude).length + 1) * 8)
+}
+
 export const formatLogTick = (value: number): string => {
   if (value >= 1_000_000)
     return `${(value / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 1 })}M`

--- a/apps/studio/components/ui/QueryBlock/QueryBlock.utils.ts
+++ b/apps/studio/components/ui/QueryBlock/QueryBlock.utils.ts
@@ -3,6 +3,24 @@ import { ChartConfig } from '@/components/interfaces/SQLEditor/UtilityPanel/Char
 export const checkHasNonPositiveValues = (data: Record<string, unknown>[], key: string): boolean =>
   data.some((row) => (row[key] as number) <= 0)
 
+export const formatYAxisTick = (value: number): string => {
+  if (Math.abs(value) >= 1_000_000) {
+    const n = value / 1_000_000
+    return `${Number.isInteger(n) ? n : n.toFixed(1)}M`
+  }
+  if (Math.abs(value) >= 1_000) {
+    const n = value / 1_000
+    return `${Number.isInteger(n) ? n : n.toFixed(1)}K`
+  }
+  if (value !== 0 && Math.abs(value) < 1) {
+    return parseFloat(value.toFixed(2)).toString()
+  }
+  if (!Number.isInteger(value)) {
+    return parseFloat(value.toFixed(1)).toString()
+  }
+  return String(value)
+}
+
 export const formatLogTick = (value: number): string => {
   if (value >= 1_000_000)
     return `${(value / 1_000_000).toLocaleString(undefined, { maximumFractionDigits: 1 })}M`


### PR DESCRIPTION
## Problem

The Report Blocks section (custom dashboards) has four visual and UX bugs: tooltip content overflows its container, Y-axis labels with 5+ digits get clipped (e.g. `10000` renders as `0000`), action buttons become unreachable when a block title is long, and scrolling inside a scrollable block also scrolls the parent page.

## Fix

- Remove the fixed `w-[200px]` class from `ChartTooltipContent` in `ChartBlock` so tooltips auto-size to their content instead of overflowing.
- Compute a dynamic Y-axis width in `ChartBlock` based on the string length of the maximum data value, replacing the `undefined` default that caused clipping.
- Add `min-w-0` to the label container and `shrink-0` to the actions container in `ReportBlockContainer` so the truncation works correctly and action buttons are never pushed off-screen.
- Add `overscroll-contain` to the scrollable SQL code and results table divs in `QueryBlock` to stop scroll events from propagating to the page.

## How to test

- Navigate to a custom Report with multiple blocks
- Hover over a chart bar on a block with a long metric name. The tooltip should be fully visible with no text overflow.
- Find or create a block whose Y-axis values exceed 9999 (e.g. disk IOPS). The full number should appear on the Y-axis without any leading digits being clipped.
- Use a block on a read replica so the label appends "of replica", making it long. The chart-type toggle, log scale toggle, and remove buttons should all remain visible and clickable.
- Add a SQL snippet block that returns a large table of results. Scroll within the results table. The page should not scroll while the inner table is scrolling.

## Before
<img width="1166" height="680" alt="CleanShot 2026-04-07 at 15 36 45@2x" src="https://github.com/user-attachments/assets/8e7bd3c9-8319-47c9-b2d9-b194d2803809" />


## After
<img width="1166" height="680" alt="CleanShot 2026-04-07 at 15 36 15@2x" src="https://github.com/user-attachments/assets/6ca5873a-cd09-4001-9cd0-932c12b6536e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * More consistent Y-axis sizing with dynamic widths for better label fit.
  * Improved Y-axis number formatting (K/M suffixes, sensible decimals) for clearer tick labels.
  * Simplified, more flexible chart tooltips (min-width applied; removed fixed widths).
  * Tighter report header layout so labels truncate predictably and actions keep their size.
  * Added overscroll containment to query results and SQL view to reduce unwanted scrolling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->