### PR TITLE
add routes for saml sso to self-hosted proxy configs

### DIFF
--- a/docker/volumes/proxy/caddy/Caddyfile
+++ b/docker/volumes/proxy/caddy/Caddyfile
@@ -1,5 +1,5 @@
 {$PROXY_DOMAIN} {
-    @supabase_api path /auth/v1/* /rest/v1/* /graphql/v1 /realtime/v1/* /storage/v1/* /functions/v1/* /mcp
+    @supabase_api path /auth/v1/* /rest/v1/* /graphql/v1 /realtime/v1/* /storage/v1/* /functions/v1/* /mcp /sso/*
 
     handle @supabase_api {
         reverse_proxy kong:8000

--- a/docker/volumes/proxy/nginx/supabase-nginx.conf.tpl
+++ b/docker/volumes/proxy/nginx/supabase-nginx.conf.tpl
@@ -88,4 +88,8 @@ server {
     location /mcp {
         proxy_pass http://kong_upstream;
     }
+
+    location /sso {
+        proxy_pass http://kong_upstream;
+    }
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Following the changes in PR #43386 and PR #43385 - add the SAML SSO routes to both nginx and Caddy configs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Single Sign-On (SSO) endpoints are now available and fully integrated into the application infrastructure. SSO authentication routes have been configured and updated across the routing layer, enabling users to authenticate using single sign-on methods when accessing the platform. The application now supports SSO-based authentication through its proxy infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->