### PR TITLE
fix: docs mfa totp default values

### DIFF
--- a/apps/docs/spec/cli_v1_config.yaml
+++ b/apps/docs/spec/cli_v1_config.yaml
@@ -1331,7 +1331,7 @@ parameters:
     title: 'auth.mfa.totp.enroll_enabled'
     tags: ['auth']
     required: false
-    default: 'true'
+    default: 'false'
     description: |
       Enable TOTP enrollment for multi-factor authentication.
     links:
@@ -1342,7 +1342,7 @@ parameters:
     title: 'auth.mfa.totp.verify_enabled'
     tags: ['auth']
     required: false
-    default: 'true'
+    default: 'false'
     description: |
       Enable TOTP verification for multi-factor authentication.
     links:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs - [CLI Config Reference](https://supabase.com/docs/guides/local-development/cli/config#auth.mfa.totp.enroll_enabled)

## What is the current behavior?

Default values in the cli config reference for mfa totp are set as `true` which is not correct.

## What is the new behavior?

Changed to use `false` and match the default `config.toml`.
<img width="868" height="723" alt="Screenshot 2026-04-01 at 15 53 54" src="https://github.com/user-attachments/assets/5e3e33a0-5edb-44d6-a013-4327aef537b4" />

## Additional context

Fixes: https://github.com/supabase/cli/issues/3737


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CLI configuration defaults for TOTP multi-factor authentication. TOTP enrollment and verification are now disabled by default. Users relying on these features may need to manually enable them in their configuration if required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->