### PR TITLE
feat: link repo in supabase.sh post

### DIFF
--- a/apps/www/_blog/2026-04-01-supabase-docs-over-ssh.mdx
+++ b/apps/www/_blog/2026-04-01-supabase-docs-over-ssh.mdx
@@ -13,7 +13,7 @@ date: '2026-04-01'
 toc_depth: 2
 ---
 
-Today, we're launching [supabase.sh](https://supabase.sh), a public SSH server that gives AI coding agents direct bash access to Supabase documentation. It's free and available now as a public experiment:
+We're launching [supabase.sh](https://supabase.sh), a public SSH server that gives AI coding agents direct bash access to Supabase documentation. It's free and available now as a public experiment:
 
 ```bash
 ssh supabase.sh
@@ -69,4 +69,6 @@ To add Supabase context to your project:
 ssh supabase.sh agents >> AGENTS.md
 ```
 
-This is an early experiment - let us know what you think. If you run into something interesting or something's missing, share it in our [GitHub discussions](https://github.com/supabase/supabase/discussions) or find us on [X](https://x.com/supabase).
+It's open source - find the code at [github.com/supabase-community/supabase-ssh](https://github.com/supabase-community/supabase-ssh).
+
+This is an early experiment - let us know what you think. If you run into something or something's missing, [open an issue on GitHub](https://github.com/supabase-community/supabase-ssh/issues/new/choose) or find us on [X](https://x.com/supabase).


### PR DESCRIPTION
Adds a link to the [OSS repo](https://github.com/supabase-community/supabase-ssh) in the supabase.sh blog post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated blog post with refined introductory messaging
  * Redirected community feedback links to the open-source repository for issue reporting
  * Added repository information to facilitate user access and contributions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->