### PR TITLE
fix(studio): escape SQL literals in queue message queries

### DIFF
--- a/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-archive-mutation.ts
@@ -1,9 +1,10 @@
+import { literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-
 import { isQueueNameValid } from 'components/interfaces/Integrations/Queues/Queues.utils'
 import { executeSql } from 'data/sql/execute-sql-query'
+import { toast } from 'sonner'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
+
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueMessageArchiveVariables = {
@@ -27,7 +28,7 @@ export async function archiveDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `SELECT * FROM pgmq.archive('${queueName}', ${messageId})`,
+    sql: `SELECT * FROM pgmq.archive(${literal(queueName)}, ${literal(messageId)})`,
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-delete-mutation.ts
@@ -1,9 +1,10 @@
+import { literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-
 import { isQueueNameValid } from 'components/interfaces/Integrations/Queues/Queues.utils'
 import { executeSql } from 'data/sql/execute-sql-query'
+import { toast } from 'sonner'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
+
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueMessageDeleteVariables = {
@@ -28,7 +29,7 @@ export async function deleteDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `SELECT * FROM pgmq.delete('${queueName}', ${messageId})`,
+    sql: `SELECT * FROM pgmq.delete(${literal(queueName)}, ${literal(messageId)})`,
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-infinite-query.ts
@@ -1,12 +1,13 @@
+import { literal } from '@supabase/pg-meta/src/pg-format'
 import { InfiniteData, useInfiniteQuery } from '@tanstack/react-query'
-import dayjs from 'dayjs'
-import { last } from 'lodash'
-
 import { isQueueNameValid } from 'components/interfaces/Integrations/Queues/Queues.utils'
 import { QUEUE_MESSAGE_TYPE } from 'components/interfaces/Integrations/Queues/SingleQueue/Queue.utils'
 import { executeSql } from 'data/sql/execute-sql-query'
+import dayjs from 'dayjs'
 import { DATE_FORMAT } from 'lib/constants'
+import { last } from 'lodash'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from 'types'
+
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueVariables = {
@@ -67,7 +68,7 @@ export async function getDatabaseQueue({
         ${[queueQuery, archivedQuery].filter(Boolean).join(' UNION ALL ')}
       ) AS combined`
   if (afterTimestamp) {
-    query += ` WHERE enqueued_at > '${afterTimestamp}'`
+    query += ` WHERE enqueued_at > ${literal(afterTimestamp)}`
   }
 
   const { result } = await executeSql({

--- a/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-send-mutation.ts
@@ -1,9 +1,10 @@
+import { literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
-
 import { isQueueNameValid } from 'components/interfaces/Integrations/Queues/Queues.utils'
 import { executeSql } from 'data/sql/execute-sql-query'
+import { toast } from 'sonner'
 import type { ResponseError, UseCustomMutationOptions } from 'types'
+
 import { databaseQueuesKeys } from './keys'
 
 export type DatabaseQueueMessageSendVariables = {
@@ -30,7 +31,7 @@ export async function sendDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from pgmq.send( '${queueName}', '${payload}', ${delay})`,
+    sql: `select * from pgmq.send(${literal(queueName)}, ${literal(payload)}, ${literal(delay)})`,
     queryKey: databaseQueuesKeys.create(),
   })
 


### PR DESCRIPTION
## What

Escapes user-controlled string values before interpolating them into SQL in `apps/studio/data/database-queues/`.

## Why

Several queue message queries were constructing SQL via direct string interpolation without sanitization:

| File | Value | Risk |
|------|-------|------|
| `database-queue-messages-send-mutation.ts` | `payload` | **High** — arbitrary user-provided JSON; a single quote breaks the query and a crafted payload could execute arbitrary SQL |
| `database-queue-messages-infinite-query.ts` | `afterTimestamp` | Medium — sourced from a previous DB result, but still unsafe to interpolate |
| `database-queue-messages-delete-mutation.ts` | `messageId` | Low — typed `number`, but truncated for safety |
| `database-queue-messages-archive-mutation.ts` | `messageId` | Low — same as above |

## Fix

- Escape string literals with the standard PostgreSQL approach (doubling single quotes `'` → `''`) before interpolation
- Wrap numeric `messageId` values with `Math.trunc()` to prevent floating-point edge cases
- `queueName` was already validated via `isQueueNameValid` regex (alphanumeric/underscore/hyphen only) — no change needed

Fixes #44375

## Test plan

- [x] Open Queue Messages panel in Studio
- [x] Send a message with a payload containing single quotes (e.g. `{"key": "it's a value"}`) — verify it sends without error
- [x] Verify pagination still works correctly after fix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved safety of queue operations by ensuring message IDs, payloads, timestamps, and queue names are handled securely to prevent injection and formatting issues.
  * Normalized numeric message fields (IDs/delays) for consistent processing.
  * Increased stability and correctness of archive, delete, query, and send operations; no public APIs were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->