### PR TITLE
fix(studio): fix wrong 'API disabled' label on RLS tables in local dev

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx
@@ -66,18 +66,24 @@ const PolicyTableRowComponent = ({
     [exposedSchemas, table.schema]
   )
 
-  const { data: tablesWithAnonAuthAccess = new Set(), isLoading: isLoadingRolesAccess } =
-    useTablesRolesAccessQuery({
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-      schema: table.schema,
-    })
+  const {
+    data: tablesWithAnonAuthAccess = new Set(),
+    isLoading: isLoadingRolesAccess,
+    isError: isErrorRolesAccess,
+  } = useTablesRolesAccessQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    schema: table.schema,
+  })
 
   const hasAnonAuthenticatedRolesAccess = tablesWithAnonAuthAccess.has(table.name)
   const hasApiAccess = isTableExposedThroughAPI && hasAnonAuthenticatedRolesAccess
   const isPubliclyReadableWritable = !isRLSEnabled && hasApiAccess
   const rlsEnabledNoPolicies = isRLSEnabled && hasApiAccess && policies.length === 0
-  const isApiDisabledDueToRoles = isTableExposedThroughAPI && !hasAnonAuthenticatedRolesAccess
+  // Only flag API as disabled when the query succeeded — an errored query should not
+  // produce a false "API disabled" warning (common in local dev environments)
+  const isApiDisabledDueToRoles =
+    !isErrorRolesAccess && isTableExposedThroughAPI && !hasAnonAuthenticatedRolesAccess
   const isRealtimeSchema = table.schema === 'realtime'
   const isRealtimeMessagesTable = isRealtimeSchema && table.name === 'messages'
   const isTableLocked = isRealtimeSchema ? !isRealtimeMessagesTable : isLocked

--- a/packages/pg-meta/src/sql/studio/database/check-tables-anon-authenticated-access.ts
+++ b/packages/pg-meta/src/sql/studio/database/check-tables-anon-authenticated-access.ts
@@ -1,6 +1,13 @@
 /**
  * Given a schema name, list all the tables in that schema which have access
- * granted to either the "anon" or "authenticated" role
+ * granted to either the "anon" or "authenticated" role.
+ *
+ * Checks two sources:
+ * 1. Explicit grants on the table (pg_class.relacl) — used by cloud Supabase and any
+ *    table created after an explicit GRANT was issued.
+ * 2. Schema-level default privileges (pg_default_acl) — used by local Supabase CLI which
+ *    bootstraps via ALTER DEFAULT PRIVILEGES. Tables created before those defaults were set
+ *    may have a NULL relacl but the schema-level defaults still represent the intended access.
  */
 export const getTablesWithAnonAuthenticatedAccessSQL = ({ schema }: { schema: string }) =>
   /* SQL */ `
@@ -9,11 +16,28 @@ FROM pg_catalog.pg_class AS c
 JOIN pg_catalog.pg_namespace AS n ON n.oid = c.relnamespace
 WHERE n.nspname = '${schema}'
   AND c.relkind IN ('r','p')  -- table, partitioned table
-  AND EXISTS (
-    SELECT 1
-    FROM pg_catalog.aclexplode(COALESCE(c.relacl, '{}'::aclitem[])) AS a
-    JOIN pg_catalog.pg_roles r ON r.oid = a.grantee
-    WHERE r.rolname IN ('anon','authenticated')
+  AND (
+    -- Explicit table-level grant to anon or authenticated
+    EXISTS (
+      SELECT 1
+      FROM pg_catalog.aclexplode(COALESCE(c.relacl, '{}'::aclitem[])) AS a
+      LEFT JOIN pg_catalog.pg_roles r ON r.oid = a.grantee
+      WHERE r.rolname IN ('anon','authenticated')
+         OR a.grantee = 0  -- PUBLIC pseudo-role (inherited by all roles)
+    )
+    OR
+    -- Schema-level default privileges grant anon or authenticated access to tables
+    -- (covers local Supabase CLI which uses ALTER DEFAULT PRIVILEGES)
+    EXISTS (
+      SELECT 1
+      FROM pg_catalog.pg_default_acl da
+      JOIN pg_catalog.pg_namespace dn ON dn.oid = da.defaclnamespace
+      CROSS JOIN pg_catalog.aclexplode(da.defaclacl) AS a
+      LEFT JOIN pg_catalog.pg_roles r ON r.oid = a.grantee
+      WHERE dn.nspname = n.nspname
+        AND da.defaclobjtype = 'r'  -- 'r' = tables
+        AND (r.rolname IN ('anon','authenticated') OR a.grantee = 0)
+    )
   )
 ;
 `.trim()


### PR DESCRIPTION
## What

Fixes the false **"This table cannot be accessed via the Data API as no permissions exist for the anon or authenticated roles"** warning shown on RLS tables in local Supabase environments.

## Root causes

### 1. SQL query misses `pg_default_acl` grants

`getTablesWithAnonAuthenticatedAccessSQL` only checked `pg_class.relacl` for explicit table-level grants. Local Supabase CLI bootstraps access via `ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO anon, authenticated`, which stores grants in `pg_default_acl` — **not** in `relacl` for tables that existed before that command ran.

**Fix:** The query now also checks `pg_catalog.pg_default_acl` for schema-level default privileges covering `anon`, `authenticated`, or the `PUBLIC` pseudo-role (inherited by both).

### 2. Query error state not handled in component

If `useTablesRolesAccessQuery` errored (e.g. connection differences in local environments), `data` fell back to the default empty `Set`, making `isApiDisabledDueToRoles = true` for every table in the schema — a false positive.

**Fix:** The component now destructures `isError` and guards `isApiDisabledDueToRoles` so it's only `true` when the query **succeeded** and genuinely found no access.

## Changes

| File | Change |
|------|--------|
| `packages/pg-meta/src/sql/studio/database/check-tables-anon-authenticated-access.ts` | Extend SQL to also check `pg_default_acl` and PUBLIC (grantee = 0) grants |
| `apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx` | Handle `isError` from `useTablesRolesAccessQuery` to suppress false warning |

Fixes #42553

## Test plan

- [ ] Create a table locally via `supabase start` → RLS policies page should show correct API access state
- [ ] Tables with `authenticated` policies should not show "API disabled" warning locally
- [ ] Cloud behaviour is unchanged (explicit relacl grants still detected as before)
- [x] All existing unit tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed incorrect "API disabled" warning appearing after failed role access queries
* Improved database table access detection by checking both table-level and schema-level permissions for more accurate access control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->