### PR TITLE
docs: add AWS SES setup note to SMTP guide

### DIFF
--- a/apps/docs/content/guides/auth/auth-smtp.mdx
+++ b/apps/docs/content/guides/auth/auth-smtp.mdx
@@ -48,6 +48,16 @@ A non-exhaustive list of services that work with Supabase Auth is:
 - [ZeptoMail](https://www.zoho.com/zeptomail/help/smtp-home.html)
 - [Brevo](https://help.brevo.com/hc/en-us/articles/7924908994450-Send-transactional-emails-using-Brevo-SMTP)
 
+<Admonition type="note" label="Using AWS SES">
+
+If you use AWS SES, check these AWS requirements before configuring Supabase:
+
+- New Amazon SES accounts start in the [sandbox](https://docs.aws.amazon.com/ses/latest/dg/request-production-access.html). While your account is in the sandbox, you can send only to verified email addresses and domains.
+- Verify the identity that you want to send from, ideally a [domain identity](https://docs.aws.amazon.com/ses/latest/dg/creating-identities.html) for production use.
+- Generate [SMTP credentials](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html) for the same AWS Region as your SES SMTP endpoint. These credentials are different from your standard AWS access keys.
+
+</Admonition>
+
 Once you've set up your account with an email sending service, head to the [Authentication settings page](/dashboard/project/_/auth/smtp) to enable and configure custom SMTP.
 
 You can also configure custom SMTP using the Management API:


### PR DESCRIPTION
This adds a short AWS SES note to the SMTP guide.

It tells people about:
- SES sandbox restrictions
- verifying the sender identity
- using SES SMTP credentials in the right AWS region

Closes #22054

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive AWS SES-specific guidance to the SMTP authentication documentation, including instructions for managing sandbox restrictions with verified recipients only, properly verifying sender identity (with domain identity recommended for production use), and generating SMTP credentials aligned with the same AWS Region as the SES SMTP endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->