### PR TITLE
chore(docs): add Dimitrios Liappis to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -66,6 +66,7 @@ David Weitzman
 Deepthi Sigireddi
 Deji I
 Dennis Senn
+Dimitrios Liappis
 Div Arora
 Divit D
 Douglas Hunley


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to `humans.txt` to add `Dimitrios Liappis`

## What is the current behavior?

`Dimitrios Liappis` does not exist in `humans.txt`

## What is the new behavior?

`Dimitrios Liappis` exists in `humans.txt`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated contributor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->