### PR TITLE
docs: Remove Vercel from project transfer requirements in documentation

### DIFF
--- a/apps/docs/content/guides/platform/project-transfer.mdx
+++ b/apps/docs/content/guides/platform/project-transfer.mdx
@@ -40,7 +40,6 @@ Target organization - the organization you want to move the project to
 - No active GitHub integration connection
 - No project-scoped roles pointing to the project (Team/Enterprise plan)
 - No log drains configured
-- Target organization is not managed by Vercel Marketplace (currently unsupported)
 
 ## Usage-billing and project add-ons
 


### PR DESCRIPTION
Removed note about target organization not being managed by Vercel Marketplace.
Not true anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed pre-requirement restriction from project transfer guide, allowing transfers to organizations managed by Vercel Marketplace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->