### PR TITLE
docs(self-hosting): fix SSO endpoint path in SAML login flow example

### DIFF
--- a/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
@@ -34,7 +34,7 @@ SAML SSO is configured in two layers:
 
 The login flow works as follows:
 
-1. Your app calls `POST /sso` with a domain or provider_id
+1. Your app calls `POST /auth/v1/sso` with a domain or provider_id
 2. Auth generates a SAML `AuthnRequest` and returns a redirect URL to the IdP
 3. The user authenticates at the IdP
 4. The IdP POSTs a SAML Response to `POST /sso/saml/acs`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SAML single sign-on self-hosting guide with corrected API endpoint references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->