### PR TITLE
refactor: start migrating pgmeta functions to return SafeSqlFragment

### DIFF
--- a/packages/pg-meta/src/helpers.ts
+++ b/packages/pg-meta/src/helpers.ts
@@ -1,16 +1,16 @@
-import { literal } from './pg-format'
+import { ident, joinSqlFragments, literal, safeSql, type SafeSqlFragment } from './pg-format'
 
-export const coalesceRowsToArray = (source: string, filter: string) => {
-  return `
+export const coalesceRowsToArray = (source: string, filter: SafeSqlFragment) => {
+  return safeSql`
 COALESCE(
   (
     SELECT
-      array_agg(row_to_json(${source})) FILTER (WHERE ${filter})
+      array_agg(row_to_json(${ident(source)})) FILTER (WHERE ${filter})
     FROM
-      ${source}
+      ${ident(source)}
   ),
   '{}'
-) AS ${source}`
+) AS ${ident(source)}`
 }
 
 export function filterByList(include?: string[], exclude?: string[], defaultExclude?: string[]) {
@@ -18,13 +18,13 @@ export function filterByList(include?: string[], exclude?: string[], defaultExcl
     exclude = defaultExclude.concat(exclude ?? [])
   }
   if (include?.length) {
-    return `IN (${include.map(literal).join(',')})`
+    return safeSql`IN (${joinSqlFragments(include.map(literal), ',')})`
   } else if (exclude?.length) {
-    return `NOT IN (${exclude.map(literal).join(',')})`
+    return safeSql`NOT IN (${joinSqlFragments(exclude.map(literal), ',')})`
   }
-  return ''
+  return safeSql``
 }
 
 export function exceptionIdentifierNotFound(entityName: string, whereClause: string) {
-  return `raise exception 'Cannot find ${entityName} with: %', ${literal(whereClause)};`
+  return safeSql`raise exception 'Cannot find ${ident(entityName)} with: %', ${literal(whereClause)};`
 }

--- a/packages/pg-meta/src/pg-meta-column-privileges.ts
+++ b/packages/pg-meta/src/pg-meta-column-privileges.ts
@@ -2,7 +2,14 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { filterByList } from './helpers'
-import { ident, literal } from './pg-format'
+import {
+  ident,
+  joinSqlFragments,
+  keyword,
+  literal,
+  safeSql,
+  type SafeSqlFragment,
+} from './pg-format'
 import { COLUMN_PRIVILEGES_SQL } from './sql/column-privileges'
 
 const pgColumnPrivilegeGrant = z.object({
@@ -53,16 +60,16 @@ function list({
   limit?: number
   offset?: number
 } = {}): {
-  sql: string
+  sql: SafeSqlFragment
   zod: typeof pgColumnPrivilegesArrayZod
 } {
-  let sql = `
+  let sql = safeSql`
   with column_privileges as (${COLUMN_PRIVILEGES_SQL})
   select *
   from column_privileges
   `
 
-  const conditions: string[] = []
+  const conditions: SafeSqlFragment[] = []
 
   const filter = filterByList(
     includedSchemas,
@@ -70,22 +77,22 @@ function list({
     !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
   )
   if (filter) {
-    conditions.push(`relation_schema ${filter}`)
+    conditions.push(safeSql`relation_schema ${filter}`)
   }
 
   if (columnIds?.length) {
-    conditions.push(`column_id in (${columnIds.map(literal).join(',')})`)
+    conditions.push(safeSql`column_id in (${joinSqlFragments(columnIds.map(literal), ',')})`)
   }
 
   if (conditions.length > 0) {
-    sql += ` where ${conditions.join(' and ')}`
+    sql = safeSql`${sql} where ${joinSqlFragments(conditions, ' and ')}`
   }
 
   if (limit) {
-    sql += ` limit ${limit}`
+    sql = safeSql`${sql} limit ${literal(limit)}`
   }
   if (offset) {
-    sql += ` offset ${offset}`
+    sql = safeSql`${sql} offset ${literal(offset)}`
   }
   return {
     sql,
@@ -94,60 +101,62 @@ function list({
 }
 
 type ColumnPrivilegesGrant = z.infer<typeof privilegeGrant>
-function grant(grants: ColumnPrivilegesGrant[]): { sql: string } {
-  const sql = `
+function grant(grants: ColumnPrivilegesGrant[]): { sql: SafeSqlFragment } {
+  const sql = safeSql`
 do $$
 declare
   col record;
 begin
-${grants
-  .map(({ privilegeType, columnId, grantee, isGrantable }) => {
+${joinSqlFragments(
+  grants.map(({ privilegeType, columnId, grantee, isGrantable }) => {
     const [relationId, columnNumber] = columnId.split('.')
-    return `
+    return safeSql`
 select *
 from pg_attribute a
 where a.attrelid = ${literal(relationId)}
   and a.attnum = ${literal(columnNumber)}
 into col;
 execute format(
-  'grant ${privilegeType} (%I) on %s to ${
-    grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
-  } ${isGrantable ? 'with grant option' : ''}',
+  'grant ${keyword(privilegeType)} (%I) on %s to ${
+    grantee.toLowerCase() === 'public' ? safeSql`public` : ident(grantee)
+  } ${isGrantable ? safeSql`with grant option` : safeSql``}',
   col.attname,
   col.attrelid::regclass
 );`
-  })
-  .join('\n')}
+  }),
+  '\n'
+)}
 end $$;
 `
   return { sql }
 }
 
 type ColumnPrivilegesRevoke = Omit<ColumnPrivilegesGrant, 'isGrantable'>
-function revoke(revokes: ColumnPrivilegesRevoke[]): { sql: string } {
-  const sql = `
+function revoke(revokes: ColumnPrivilegesRevoke[]): { sql: SafeSqlFragment } {
+  const sql = safeSql`
 do $$
 declare
   col record;
 begin
-${revokes
-  .map(({ privilegeType, columnId, grantee }) => {
+${joinSqlFragments(
+  revokes.map(({ privilegeType, columnId, grantee }) => {
     const [relationId, columnNumber] = columnId.split('.')
-    return `
+    return safeSql`
 select *
 from pg_attribute a
 where a.attrelid = ${literal(relationId)}
   and a.attnum = ${literal(columnNumber)}
 into col;
 execute format(
-  'revoke ${privilegeType} (%I) on %s from ${
-    grantee.toLowerCase() === 'public' ? 'public' : ident(grantee)
+  'revoke ${keyword(privilegeType)} (%I) on %s from ${
+    grantee.toLowerCase() === 'public' ? safeSql`public` : ident(grantee)
   }',
   col.attname,
   col.attrelid::regclass
 );`
-  })
-  .join('\n')}
+  }),
+  '\n'
+)}
 end $$;
 `
   return { sql }

--- a/packages/pg-meta/src/pg-meta-foreign-tables.ts
+++ b/packages/pg-meta/src/pg-meta-foreign-tables.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { coalesceRowsToArray, filterByList } from './helpers'
-import { ident, literal } from './pg-format'
+import { ident, literal, safeSql, type SafeSqlFragment } from './pg-format'
 import { pgColumnArrayZod } from './pg-meta-columns'
 import { COLUMNS_SQL } from './sql/columns'
 import { FOREIGN_TABLES_SQL } from './sql/foreign-tables'
@@ -47,7 +47,7 @@ export function list<T extends boolean | undefined = true>(
     includeColumns?: T
   } = {} as any
 ): {
-  sql: string
+  sql: SafeSqlFragment
   zod: z.ZodType<ForeignTableBasedOnIncludeColumns<T>[]>
 } {
   let sql = generateEnrichedForeignTablesSql({ includeColumns })
@@ -57,13 +57,13 @@ export function list<T extends boolean | undefined = true>(
     !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
   )
   if (filter) {
-    sql += ` where schema ${filter}`
+    sql = safeSql`${sql} where schema ${filter}`
   }
   if (limit) {
-    sql += ` limit ${limit}`
+    sql = safeSql`${sql} limit ${literal(limit)}`
   }
   if (offset) {
-    sql += ` offset ${offset}`
+    sql = safeSql`${sql} offset ${literal(offset)}`
   }
   return {
     sql,
@@ -73,33 +73,37 @@ export function list<T extends boolean | undefined = true>(
 
 type ForeignTableIdentifier = Pick<PGForeignTable, 'id'> | Pick<PGForeignTable, 'name' | 'schema'>
 
-function getIdentifierWhereClause(identifier: ForeignTableIdentifier): string {
+function getIdentifierWhereClause(identifier: ForeignTableIdentifier): SafeSqlFragment {
   if ('id' in identifier && identifier.id) {
-    return `${ident('id')} = ${literal(identifier.id)}`
+    return safeSql`${ident('id')} = ${literal(identifier.id)}`
   }
   if ('name' in identifier && identifier.name && identifier.schema) {
-    return `${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
+    return safeSql`${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
   }
   throw new Error('Must provide either id or name and schema')
 }
 
 export function retrieve(identifier: ForeignTableIdentifier): {
-  sql: string
+  sql: SafeSqlFragment
   zod: typeof pgForeignTableOptionalZod
 } {
-  const sql = `${generateEnrichedForeignTablesSql({ includeColumns: true })} where ${getIdentifierWhereClause(identifier)};`
+  const sql = safeSql`${generateEnrichedForeignTablesSql({ includeColumns: true })} where ${getIdentifierWhereClause(identifier)};`
   return {
     sql,
     zod: pgForeignTableOptionalZod,
   }
 }
 
-const generateEnrichedForeignTablesSql = ({ includeColumns }: { includeColumns?: boolean }) => `
+const generateEnrichedForeignTablesSql = ({
+  includeColumns,
+}: {
+  includeColumns?: boolean
+}) => safeSql`
 with foreign_tables as (${FOREIGN_TABLES_SQL})
-  ${includeColumns ? `, columns as (${COLUMNS_SQL})` : ''}
+  ${includeColumns ? safeSql`, columns as (${COLUMNS_SQL})` : safeSql``}
 select
   *
-  ${includeColumns ? `, ${coalesceRowsToArray('columns', 'columns.table_id = foreign_tables.id')}` : ''}
+  ${includeColumns ? safeSql`, ${coalesceRowsToArray('columns', safeSql`columns.table_id = foreign_tables.id`)}` : safeSql``}
 from foreign_tables`
 
 export default {

--- a/packages/pg-meta/src/pg-meta-materialized-views.ts
+++ b/packages/pg-meta/src/pg-meta-materialized-views.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { coalesceRowsToArray, filterByList } from './helpers'
-import { ident, literal } from './pg-format'
+import { ident, literal, safeSql, type SafeSqlFragment } from './pg-format'
 import { pgColumnArrayZod } from './pg-meta-columns'
 import { COLUMNS_SQL } from './sql/columns'
 import { MATERIALIZED_VIEWS_SQL } from './sql/materialized-views'
@@ -45,7 +45,7 @@ export function list<T extends boolean | undefined = true>(
     includeColumns?: T
   } = {} as any
 ): {
-  sql: string
+  sql: SafeSqlFragment
   zod: z.ZodType<MaterializedViewBasedOnIncludeColumns<T>[]>
 } {
   let sql = generateEnrichedMaterializedViewsSql({ includeColumns })
@@ -55,13 +55,13 @@ export function list<T extends boolean | undefined = true>(
     !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
   )
   if (filter) {
-    sql += ` where schema ${filter}`
+    sql = safeSql`${sql} where schema ${filter}`
   }
   if (limit) {
-    sql += ` limit ${limit}`
+    sql = safeSql`${sql} limit ${literal(limit)}`
   }
   if (offset) {
-    sql += ` offset ${offset}`
+    sql = safeSql`${sql} offset ${literal(offset)}`
   }
   return {
     sql,
@@ -73,35 +73,39 @@ type MaterializedViewIdentifier =
   | Pick<PGMaterializedView, 'id'>
   | Pick<PGMaterializedView, 'name' | 'schema'>
 
-function getIdentifierWhereClause(identifier: MaterializedViewIdentifier): string {
+function getIdentifierWhereClause(identifier: MaterializedViewIdentifier): SafeSqlFragment {
   if ('id' in identifier && identifier.id) {
-    return `${ident('id')} = ${literal(identifier.id)}`
+    return safeSql`${ident('id')} = ${literal(identifier.id)}`
   }
   if ('name' in identifier && identifier.name && identifier.schema) {
-    return `${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
+    return safeSql`${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
   }
   throw new Error('Must provide either id or name and schema')
 }
 
 export function retrieve(identifier: MaterializedViewIdentifier): {
-  sql: string
+  sql: SafeSqlFragment
   zod: typeof pgMaterializedViewOptionalZod
 } {
   let whereClause = getIdentifierWhereClause(identifier)
 
-  const sql = `${generateEnrichedMaterializedViewsSql({ includeColumns: true })} where ${whereClause};`
+  const sql = safeSql`${generateEnrichedMaterializedViewsSql({ includeColumns: true })} where ${whereClause};`
   return {
     sql,
     zod: pgMaterializedViewOptionalZod,
   }
 }
 
-const generateEnrichedMaterializedViewsSql = ({ includeColumns }: { includeColumns?: boolean }) => `
+const generateEnrichedMaterializedViewsSql = ({
+  includeColumns,
+}: {
+  includeColumns?: boolean
+}) => safeSql`
 with materialized_views as (${MATERIALIZED_VIEWS_SQL})
-  ${includeColumns ? `, columns as (${COLUMNS_SQL})` : ''}
+  ${includeColumns ? safeSql`, columns as (${COLUMNS_SQL})` : safeSql``}
 select
   *
-  ${includeColumns ? `, ${coalesceRowsToArray('columns', 'columns.table_id = materialized_views.id')}` : ''}
+  ${includeColumns ? safeSql`, ${coalesceRowsToArray('columns', safeSql`columns.table_id = materialized_views.id`)}` : safeSql``}
 from materialized_views`
 
 export default {

--- a/packages/pg-meta/src/pg-meta-tables.ts
+++ b/packages/pg-meta/src/pg-meta-tables.ts
@@ -2,7 +2,14 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { coalesceRowsToArray, filterByList } from './helpers'
-import { ident, literal } from './pg-format'
+import {
+  ident,
+  joinSqlFragments,
+  keyword,
+  literal,
+  safeSql,
+  type SafeSqlFragment,
+} from './pg-format'
 import { pgColumnArrayZod } from './pg-meta-columns'
 import { COLUMNS_SQL } from './sql/columns'
 import { TABLES_SQL } from './sql/tables'
@@ -55,12 +62,12 @@ type TableBasedOnIncludeColumns<T extends boolean | undefined> = T extends true
 
 type TableIdentifier = Pick<PGTable, 'id'> | Pick<PGTable, 'name' | 'schema'>
 
-function getIdentifierWhereClause(identifier: TableIdentifier): string {
+function getIdentifierWhereClause(identifier: TableIdentifier): SafeSqlFragment {
   if ('id' in identifier && identifier.id) {
-    return `${ident('id')} = ${literal(identifier.id)}`
+    return safeSql`${ident('id')} = ${literal(identifier.id)}`
   }
   if ('name' in identifier && identifier.name && identifier.schema) {
-    return `${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
+    return safeSql`${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
   }
   throw new Error('Must provide either id or name and schema')
 }
@@ -82,7 +89,7 @@ function list<T extends boolean | undefined = true>(
     includeColumns?: T
   } = {} as any
 ): {
-  sql: string
+  sql: SafeSqlFragment
   zod: z.ZodType<TableBasedOnIncludeColumns<T>[]>
 } {
   let sql = generateEnrichedTablesSql({ includeColumns })
@@ -92,13 +99,13 @@ function list<T extends boolean | undefined = true>(
     !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
   )
   if (filter) {
-    sql += ` where schema ${filter}`
+    sql = safeSql`${sql} where schema ${filter}`
   }
   if (limit) {
-    sql += ` limit ${limit}`
+    sql = safeSql`${sql} limit ${literal(limit)}`
   }
   if (offset) {
-    sql += ` offset ${offset}`
+    sql = safeSql`${sql} offset ${literal(offset)}`
   }
   return {
     sql,
@@ -107,12 +114,12 @@ function list<T extends boolean | undefined = true>(
 }
 
 function retrieve(identifier: TableIdentifier): {
-  sql: string
+  sql: SafeSqlFragment
   zod: z.ZodType<TableWithColumns>
 } {
   let whereClause = getIdentifierWhereClause(identifier)
 
-  const sql = `${generateEnrichedTablesSql({ includeColumns: true })} where ${whereClause};`
+  const sql = safeSql`${generateEnrichedTablesSql({ includeColumns: true })} where ${whereClause};`
   return {
     sql,
     zod: pgTableZod,
@@ -122,19 +129,19 @@ function retrieve(identifier: TableIdentifier): {
 function remove(
   table: Pick<PGTable, 'name' | 'schema'>,
   { cascade = false } = {}
-): { sql: string } {
-  const sql = `DROP TABLE ${ident(table.schema)}.${ident(table.name)} ${
-    cascade ? 'CASCADE' : 'RESTRICT'
+): { sql: SafeSqlFragment } {
+  const sql = safeSql`DROP TABLE ${ident(table.schema)}.${ident(table.name)} ${
+    cascade ? safeSql`CASCADE` : safeSql`RESTRICT`
   };`
   return { sql }
 }
 
-const generateEnrichedTablesSql = ({ includeColumns }: { includeColumns?: boolean }) => `
+const generateEnrichedTablesSql = ({ includeColumns }: { includeColumns?: boolean }) => safeSql`
   with tables as (${TABLES_SQL})
-  ${includeColumns ? `, columns as (${COLUMNS_SQL})` : ''}
+  ${includeColumns ? safeSql`, columns as (${COLUMNS_SQL})` : safeSql``}
   select
     *
-    ${includeColumns ? `, ${coalesceRowsToArray('columns', 'columns.table_id = tables.id')}` : ''}
+    ${includeColumns ? safeSql`, ${coalesceRowsToArray('columns', safeSql`columns.table_id = tables.id`)}` : safeSql``}
   from tables`
 
 type TableCreateParams = {
@@ -145,19 +152,19 @@ type TableCreateParams = {
 }
 
 function create({ name, schema = 'public', comment, no_transaction = false }: TableCreateParams): {
-  sql: string
+  sql: SafeSqlFragment
 } {
-  const tableSql = `CREATE TABLE ${ident(schema)}.${ident(name)} ();`
+  const tableSql = safeSql`CREATE TABLE ${ident(schema)}.${ident(name)} ();`
   const commentSql =
     comment != undefined
-      ? `COMMENT ON TABLE ${ident(schema)}.${ident(name)} IS ${literal(comment)};`
-      : ''
+      ? safeSql`COMMENT ON TABLE ${ident(schema)}.${ident(name)} IS ${literal(comment)};`
+      : safeSql``
 
   if (no_transaction) {
-    const sql = `${tableSql} ${commentSql}`
+    const sql = safeSql`${tableSql} ${commentSql}`
     return { sql }
   }
-  const sql = `BEGIN; ${tableSql} ${commentSql} COMMIT;`
+  const sql = safeSql`BEGIN; ${tableSql} ${commentSql} COMMIT;`
   return { sql }
 }
 
@@ -184,39 +191,40 @@ function update(
     primary_keys,
     comment,
   }: TableUpdateParams
-): { sql: string } {
-  const alter = `ALTER TABLE ${ident(old.schema)}.${ident(old.name)}`
-  const schemaSql = schema === undefined ? '' : `${alter} SET SCHEMA ${ident(schema)};`
-  let nameSql = ''
+): { sql: SafeSqlFragment } {
+  const alter = safeSql`ALTER TABLE ${ident(old.schema)}.${ident(old.name)}`
+  const schemaSql =
+    schema === undefined ? safeSql`` : safeSql`${alter} SET SCHEMA ${ident(schema)};`
+  let nameSql = safeSql``
   if (name !== undefined && name !== old.name) {
     const currentSchema = schema === undefined ? old.schema : schema
-    nameSql = `ALTER TABLE ${ident(currentSchema)}.${ident(old.name)} RENAME TO ${ident(name)};`
+    nameSql = safeSql`ALTER TABLE ${ident(currentSchema)}.${ident(old.name)} RENAME TO ${ident(name)};`
   }
-  let enableRls = ''
+  let enableRls = safeSql``
   if (rls_enabled !== undefined) {
-    const enable = `${alter} ENABLE ROW LEVEL SECURITY;`
-    const disable = `${alter} DISABLE ROW LEVEL SECURITY;`
+    const enable = safeSql`${alter} ENABLE ROW LEVEL SECURITY;`
+    const disable = safeSql`${alter} DISABLE ROW LEVEL SECURITY;`
     enableRls = rls_enabled ? enable : disable
   }
-  let forceRls = ''
+  let forceRls = safeSql``
   if (rls_forced !== undefined) {
-    const enable = `${alter} FORCE ROW LEVEL SECURITY;`
-    const disable = `${alter} NO FORCE ROW LEVEL SECURITY;`
+    const enable = safeSql`${alter} FORCE ROW LEVEL SECURITY;`
+    const disable = safeSql`${alter} NO FORCE ROW LEVEL SECURITY;`
     forceRls = rls_forced ? enable : disable
   }
-  let replicaSql = ''
+  let replicaSql = safeSql``
   if (replica_identity === undefined) {
     // skip
   } else if (replica_identity === 'INDEX') {
-    replicaSql = `${alter} REPLICA IDENTITY USING INDEX ${replica_identity_index};`
+    replicaSql = safeSql`${alter} REPLICA IDENTITY USING INDEX ${ident(replica_identity_index)};`
   } else {
-    replicaSql = `${alter} REPLICA IDENTITY ${replica_identity};`
+    replicaSql = safeSql`${alter} REPLICA IDENTITY ${keyword(replica_identity)};`
   }
-  let primaryKeysSql = ''
+  let primaryKeysSql = safeSql``
   if (primary_keys === undefined) {
     // skip
   } else {
-    primaryKeysSql += `
+    primaryKeysSql = safeSql`${primaryKeysSql}
 DO $$
 DECLARE
   r record;
@@ -235,18 +243,19 @@ $$;
     if (primary_keys.length === 0) {
       // skip
     } else {
-      primaryKeysSql += `${alter} ADD PRIMARY KEY (${primary_keys
-        .map((x) => ident(x.name))
-        .join(',')});`
+      primaryKeysSql = safeSql`${primaryKeysSql} ${alter} ADD PRIMARY KEY (${joinSqlFragments(
+        primary_keys.map((x) => ident(x.name)),
+        ','
+      )});`
     }
   }
   const commentSql =
     comment == undefined
-      ? ''
-      : `COMMENT ON TABLE ${ident(old.schema)}.${ident(old.name)} IS ${literal(comment)};`
+      ? safeSql``
+      : safeSql`COMMENT ON TABLE ${ident(old.schema)}.${ident(old.name)} IS ${literal(comment)};`
 
   // nameSql must be last, right below schemaSql
-  const sql = `
+  const sql = safeSql`
 BEGIN;
   ${enableRls}
   ${forceRls}

--- a/packages/pg-meta/src/pg-meta-views.ts
+++ b/packages/pg-meta/src/pg-meta-views.ts
@@ -2,7 +2,7 @@ import { z } from 'zod'
 
 import { DEFAULT_SYSTEM_SCHEMAS } from './constants'
 import { coalesceRowsToArray, filterByList } from './helpers'
-import { ident, literal } from './pg-format'
+import { ident, literal, safeSql, type SafeSqlFragment } from './pg-format'
 import { pgColumnArrayZod } from './pg-meta-columns'
 import { COLUMNS_SQL } from './sql/columns'
 import { VIEWS_SQL } from './sql/views'
@@ -45,7 +45,7 @@ export function list<T extends boolean | undefined = true>(
     includeColumns?: T
   } = {} as any
 ): {
-  sql: string
+  sql: SafeSqlFragment
   zod: z.ZodType<ViewBasedOnIncludeColumns<T>[]>
 } {
   let sql = generateEnrichedViewsSql({ includeColumns })
@@ -55,13 +55,13 @@ export function list<T extends boolean | undefined = true>(
     !includeSystemSchemas ? DEFAULT_SYSTEM_SCHEMAS : undefined
   )
   if (filter) {
-    sql += ` where schema ${filter}`
+    sql = safeSql`${sql} where schema ${filter}`
   }
   if (limit) {
-    sql += ` limit ${limit}`
+    sql = safeSql`${sql} limit ${literal(limit)}`
   }
   if (offset) {
-    sql += ` offset ${offset}`
+    sql = safeSql`${sql} offset ${literal(offset)}`
   }
   return {
     sql,
@@ -71,35 +71,35 @@ export function list<T extends boolean | undefined = true>(
 
 type ViewIdentifier = Pick<PGView, 'id'> | Pick<PGView, 'name' | 'schema'>
 
-function getIdentifierWhereClause(identifier: ViewIdentifier): string {
+function getIdentifierWhereClause(identifier: ViewIdentifier): SafeSqlFragment {
   if ('id' in identifier && identifier.id) {
-    return `${ident('id')} = ${literal(identifier.id)}`
+    return safeSql`${ident('id')} = ${literal(identifier.id)}`
   }
   if ('name' in identifier && identifier.name && identifier.schema) {
-    return `${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
+    return safeSql`${ident('name')} = ${literal(identifier.name)} and ${ident('schema')} = ${literal(identifier.schema)}`
   }
   throw new Error('Must provide either id or name and schema')
 }
 
 export function retrieve(identifier: ViewIdentifier): {
-  sql: string
+  sql: SafeSqlFragment
   zod: typeof pgViewOptionalZod
 } {
   let whereClause = getIdentifierWhereClause(identifier)
 
-  const sql = `${generateEnrichedViewsSql({ includeColumns: true })} where ${whereClause};`
+  const sql = safeSql`${generateEnrichedViewsSql({ includeColumns: true })} where ${whereClause};`
   return {
     sql,
     zod: pgViewOptionalZod,
   }
 }
 
-const generateEnrichedViewsSql = ({ includeColumns }: { includeColumns?: boolean }) => `
+const generateEnrichedViewsSql = ({ includeColumns }: { includeColumns?: boolean }) => safeSql`
 with views as (${VIEWS_SQL})
-  ${includeColumns ? `, columns as (${COLUMNS_SQL})` : ''}
+  ${includeColumns ? safeSql`, columns as (${COLUMNS_SQL})` : safeSql``}
 select
   *
-  ${includeColumns ? `, ${coalesceRowsToArray('columns', 'columns.table_id = views.id')}` : ''}
+  ${includeColumns ? safeSql`, ${coalesceRowsToArray('columns', safeSql`columns.table_id = views.id`)}` : safeSql``}
 from views`
 
 export default {

--- a/packages/pg-meta/src/sql/column-privileges.ts
+++ b/packages/pg-meta/src/sql/column-privileges.ts
@@ -1,4 +1,6 @@
-export const COLUMN_PRIVILEGES_SQL = /* SQL */ `
+import { safeSql } from '../pg-format'
+
+export const COLUMN_PRIVILEGES_SQL = /* SQL */ safeSql`
 -- Lists each column's privileges in the form of:
 --
 -- [

--- a/packages/pg-meta/src/sql/columns.ts
+++ b/packages/pg-meta/src/sql/columns.ts
@@ -1,4 +1,6 @@
-export const COLUMNS_SQL = /* SQL */ `
+import { safeSql } from '../pg-format'
+
+export const COLUMNS_SQL = /* SQL */ safeSql`
 -- Adapted from information_schema.columns
 
 SELECT

--- a/packages/pg-meta/src/sql/foreign-tables.ts
+++ b/packages/pg-meta/src/sql/foreign-tables.ts
@@ -1,4 +1,6 @@
-export const FOREIGN_TABLES_SQL = /* SQL */ `
+import { safeSql } from '../pg-format'
+
+export const FOREIGN_TABLES_SQL = /* SQL */ safeSql`
 select
   c.oid::int8 as id,
   n.nspname as schema,

--- a/packages/pg-meta/src/sql/materialized-views.ts
+++ b/packages/pg-meta/src/sql/materialized-views.ts
@@ -1,4 +1,6 @@
-export const MATERIALIZED_VIEWS_SQL = /* SQL */ `
+import { safeSql } from '../pg-format'
+
+export const MATERIALIZED_VIEWS_SQL = /* SQL */ safeSql`
 select
   c.oid::int8 as id,
   n.nspname as schema,

--- a/packages/pg-meta/src/sql/tables.ts
+++ b/packages/pg-meta/src/sql/tables.ts
@@ -1,4 +1,6 @@
-export const TABLES_SQL = /* SQL */ `
+import { safeSql } from '../pg-format'
+
+export const TABLES_SQL = /* SQL */ safeSql`
 SELECT
   c.oid :: int8 AS id,
   nc.nspname AS schema,

--- a/packages/pg-meta/src/sql/views.ts
+++ b/packages/pg-meta/src/sql/views.ts
@@ -1,4 +1,6 @@
-export const VIEWS_SQL = /* SQL */ `
+import { safeSql } from '../pg-format'
+
+export const VIEWS_SQL = /* SQL */ safeSql`
 SELECT
   c.oid :: int8 AS id,
   n.nspname AS schema,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated SQL handling across the pg-meta package to use a new type-safe SQL construction approach throughout helper functions and query builders.
  * Modified return types for query methods in column privileges, foreign tables, materialized views, tables, and views modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->