### PR TITLE
fix: tsconfig auto-import resolution

### DIFF
--- a/apps/studio/data/database-extensions/database-extensions-query.ts
+++ b/apps/studio/data/database-extensions/database-extensions-query.ts
@@ -1,9 +1,9 @@
+import { getDatabaseExtensionsSQL } from '@supabase/pg-meta/src'
 import { useQuery } from '@tanstack/react-query'
 import { components } from 'api-types'
 import { executeSql } from 'data/sql/execute-sql-query'
 import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from 'lib/constants'
-import { getDatabaseExtensionsSQL } from 'node_modules/@supabase/pg-meta/src'
 import type { ResponseError, UseCustomQueryOptions } from 'types'
 
 import { databaseExtensionsKeys } from './keys'

--- a/apps/studio/tsconfig.json
+++ b/apps/studio/tsconfig.json
@@ -5,10 +5,36 @@
     "allowJs": false,
     "lib": ["dom", "dom.iterable", "esnext"],
     "paths": {
-      // @deprecated: Don't import directly without suffix. Use @/ always.
-      "*": ["./*"],
       "@/*": ["./*"],
-      "@ui/*": ["./../../packages/ui/src/*"] // handle ui package paths
+      "@ui/*": ["./../../packages/ui/src/*"], // handle ui package paths
+      // @deprecated: use @/ prefix instead
+      "components/*": ["./components/*"],
+      // @deprecated: use @/ prefix instead
+      "data/*": ["./data/*"],
+      // @deprecated: use @/ prefix instead
+      "evals/*": ["./evals/*"],
+      // @deprecated: use @/ prefix instead
+      "fonts/*": ["./fonts/*"],
+      // @deprecated: use @/ prefix instead
+      "hooks/*": ["./hooks/*"],
+      // @deprecated: use @/ prefix instead
+      "lib/*": ["./lib/*"],
+      // @deprecated: use @/ prefix instead
+      "pages/*": ["./pages/*"],
+      // @deprecated: use @/ prefix instead
+      "public/*": ["./public/*"],
+      // @deprecated: use @/ prefix instead
+      "state/*": ["./state/*"],
+      // @deprecated: use @/ prefix instead
+      "static-data/*": ["./static-data/*"],
+      // @deprecated: use @/ prefix instead
+      "styles/*": ["./styles/*"],
+      // @deprecated: use @/ prefix instead
+      "tests/*": ["./tests/*"],
+      // @deprecated: use @/ prefix instead
+      "types": ["./types"],
+      // @deprecated: use @/ prefix instead
+      "types/*": ["./types/*"]
     },
     "plugins": [{ "name": "next" }]
   },

--- a/apps/www/components/Nav/DevelopersDropdown.tsx
+++ b/apps/www/components/Nav/DevelopersDropdown.tsx
@@ -1,8 +1,7 @@
+import staticContent from '.generated/staticContent/_index.json'
+import { data as DevelopersData } from 'data/Developers'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
-
-import { data as DevelopersData } from 'data/Developers'
-import staticContent from '.generated/staticContent/_index.json'
 
 type LinkProps = {
   text: string
@@ -58,7 +57,7 @@ export const DevelopersDropdown = () => {
             <ChevronRight className="h-3 w-3 transition-transform will-change-transform -translate-x-1 group-hover:translate-x-0" />
           </Link>
           <ul className="flex flex-col gap-5">
-            {latestBlogPosts?.slice(0, 2).map((post) => (
+            {latestBlogPosts?.slice(0, 2).map((post: any) => (
               <li key={post.title}>
                 <Link
                   href={post.url}

--- a/apps/www/tsconfig.json
+++ b/apps/www/tsconfig.json
@@ -5,12 +5,38 @@
     "allowJs": true,
     "lib": ["dom", "dom.iterable", "esnext"],
     "paths": {
-      // @deprecated: Don't import directly without suffix. Use @/ always.
-      "*": ["./*"],
       // @deprecated: use @/ instead of importing from root
       "~/*": ["./*"],
       "@/*": ["./*"],
-      "contentlayer/generated": ["./.contentlayer/generated"]
+      "contentlayer/generated": ["./.contentlayer/generated"],
+      // @deprecated: use @/ prefix instead
+      ".generated/*": ["./.generated/*"],
+      // @deprecated: use @/ prefix instead
+      "app/*": ["./app/*"],
+      // @deprecated: use @/ prefix instead
+      "components/*": ["./components/*"],
+      // @deprecated: use @/ prefix instead
+      "data/*": ["./data/*"],
+      // @deprecated: use @/ prefix instead
+      "hooks/*": ["./hooks/*"],
+      // @deprecated: use @/ prefix instead
+      "internals/*": ["./internals/*"],
+      // @deprecated: use @/ prefix instead
+      "layouts/*": ["./layouts/*"],
+      // @deprecated: use @/ prefix instead
+      "lib/*": ["./lib/*"],
+      // @deprecated: use @/ prefix instead
+      "pages/*": ["./pages/*"],
+      // @deprecated: use @/ prefix instead
+      "public/*": ["./public/*"],
+      // @deprecated: use @/ prefix instead
+      "scripts/*": ["./scripts/*"],
+      // @deprecated: use @/ prefix instead
+      "styles/*": ["./styles/*"],
+      // @deprecated: use @/ prefix instead
+      "types": ["./types"],
+      // @deprecated: use @/ prefix instead
+      "types/*": ["./types/*"]
     },
     "plugins": [{ "name": "next" }]
   },


### PR DESCRIPTION
Ever since the update to TypeScript 6, IDE auto-imports are suggesting "node_modules/package_name/...." rather than the correct "package_name". This is due to our deprecated bare specifier wildcard in paths, replacing this with a listing of all bare specifiers we currently support (while migrating away) to restore auto-import suggestions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Internal import path and module reference updates.
  * Adjusted TypeScript path alias configuration across projects (removed deprecated wildcard, added/expanded explicit aliases and types mappings).
  * Minor import reordering and a local type annotation to clarify type-checking.

No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->