### PR TITLE
fix: round currency value to 2 decimal places in subscription upgrade preview

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -529,11 +529,9 @@ export const SubscriptionPlanUpdateDialog = ({
                                         translate="no"
                                       >
                                         {formatCurrency(
-                                          Math.round(
-                                            subscriptionPreview?.breakdown?.reduce(
-                                              (prev, cur) => prev + cur.total_price,
-                                              0
-                                            ) ?? 0
+                                          subscriptionPreview?.breakdown?.reduce(
+                                            (prev, cur) => prev + cur.total_price,
+                                            0
                                           ) ?? 0
                                         )}
                                       </TableCell>
@@ -547,12 +545,10 @@ export const SubscriptionPlanUpdateDialog = ({
                       </div>
                       <div className="py-2 pr-0 text-right" translate="no">
                         {formatCurrency(
-                          Math.round(
-                            subscriptionPreview?.breakdown.reduce(
-                              (prev: number, cur) => prev + cur.total_price,
-                              0
-                            ) ?? 0
-                          )
+                          subscriptionPreview?.breakdown.reduce(
+                            (prev: number, cur) => prev + cur.total_price,
+                            0
+                          ) ?? 0
                         )}
                       </div>
                     </div>


### PR DESCRIPTION
This PR removes the `Math.round` from the `Totals` in the subscription upgrade preview.

| Before | After |
|--------|-------|
| <img width="388" height="397" alt="image" src="https://github.com/user-attachments/assets/f0f63ad5-c7c0-44b2-9ebc-59c9e4ad66c0" /> | <img width="422" height="457" alt="image" src="https://github.com/user-attachments/assets/98a7f69f-429a-42eb-98ce-20de4974c29e" /> |
| <img width="563" height="401" alt="image" src="https://github.com/user-attachments/assets/083942f5-90b2-4c91-b195-4526694e365d" /> | <img width="766" height="467" alt="image" src="https://github.com/user-attachments/assets/854e127d-db45-48d4-b3a9-fdb010748f71" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision of billing calculations in subscription plans, with monthly invoice estimates and plan totals now displaying more accurate currency amounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->