### PR TITLE
Stripe party go page

### DIFF
--- a/apps/www/_go/events/stripe-sessions-2026/party.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/party.tsx
@@ -15,6 +15,10 @@ const page: GoPageInput = {
     subtitle: 'Supabase, Stigg & Dreambase at Stripe Sessions 2026',
     description:
       "Great hanging out with you at Stripe Sessions. We're giving away a MacBook Neo to one lucky attendee. Complete the steps below to enter.",
+    image: {
+      src: '/images/landing-pages/sxsw-2026/macbook-neo.png',
+      alt: 'MacBook Neo in four colors',
+    },
     ctas: [
       {
         label: 'Get started',

--- a/apps/www/_go/events/stripe-sessions-2026/party.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/party.tsx
@@ -45,7 +45,7 @@ const page: GoPageInput = {
             </li>
             <li>
               Create a{' '}
-              <Link href="https://dreambase.io" className="underline">
+              <Link href="https://dreambase.ai" className="underline">
                 Dreambase
               </Link>{' '}
               account using the same email

--- a/apps/www/_go/events/stripe-sessions-2026/party.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/party.tsx
@@ -1,0 +1,71 @@
+import type { GoPageInput } from 'marketing'
+import Link from 'next/link'
+import { Button } from 'ui'
+
+const page: GoPageInput = {
+  template: 'lead-gen',
+  slug: 'stripe/party',
+  metadata: {
+    title: 'Win a MacBook Neo | Supabase, Stigg & Dreambase at Stripe Sessions',
+    description:
+      'Join the Supabase, Stigg, and Dreambase party at Stripe Sessions 2026. Complete the steps for a chance to win a MacBook Neo.',
+  },
+  hero: {
+    title: 'Thanks for partying with us',
+    subtitle: 'Supabase, Stigg & Dreambase at Stripe Sessions 2026',
+    description:
+      "Great hanging out with you at Stripe Sessions. We're giving away a MacBook Neo to one lucky attendee. Complete the steps below to enter.",
+    ctas: [
+      {
+        label: 'Get started',
+        href: '#how-to-enter',
+        variant: 'primary',
+      },
+    ],
+  },
+  sections: [
+    {
+      type: 'single-column',
+      id: 'how-to-enter',
+      title: 'How to enter',
+      children: (
+        <div className="flex flex-col items-center gap-6">
+          <ol className="flex flex-col gap-4 text-foreground-light text-lg list-decimal list-inside">
+            <li>
+              Create a Supabase account with the same email address where you got our post-event
+              note
+            </li>
+            <li>Load data into a Supabase database</li>
+            <li>
+              Create a{' '}
+              <Link href="https://stigg.io" className="underline">
+                Stigg
+              </Link>{' '}
+              account using the same email
+            </li>
+            <li>
+              Create a{' '}
+              <Link href="https://dreambase.io" className="underline">
+                Dreambase
+              </Link>{' '}
+              account using the same email
+            </li>
+            <li>Complete these steps by Monday, May 11, 2026 at 12:00 PM PST</li>
+          </ol>
+          <Button asChild type="default" size="medium">
+            <Link href="https://supabase.com/dashboard">Create your Supabase account</Link>
+          </Button>
+          <p className="text-xs text-foreground-lighter mt-4">
+            No purchase necessary. Void where prohibited.{' '}
+            <Link href="/go/contest-rules" className="underline">
+              Official rules
+            </Link>
+            .
+          </p>
+        </div>
+      ),
+    },
+  ],
+}
+
+export default page

--- a/apps/www/_go/index.tsx
+++ b/apps/www/_go/index.tsx
@@ -14,6 +14,7 @@ import stripeSessionsContest from './events/stripe-sessions-2026/contest'
 import stripeExecDinner from './events/stripe-sessions-2026/exec-dinner'
 import stripeExecDinnerThankYou from './events/stripe-sessions-2026/exec-dinner-thank-you'
 import stripeMeetingScheduler from './events/stripe-sessions-2026/meeting-scheduler'
+import stripeParty from './events/stripe-sessions-2026/party'
 import sxswContest from './events/sxsw-2026/contest'
 import exampleLeadGen from './lead-gen/example-lead-gen'
 import amoe from './legal/amoe'
@@ -40,6 +41,7 @@ const pages: GoPageInput[] = [
   stripeExecDinnerThankYou, // remove after May 31, 2026
   stripeMeetingScheduler, // remove after May 31, 2026
   stripeSessionsContest, // remove after May 31, 2026
+  stripeParty, // remove after May 31, 2026
   sxswContest, // remove after April 30, 2026
   accentureContest, // remove after May 31, 2026
   postgresconfContest, // remove after May 31, 2026


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Post-party landing page for the sweepstakes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an event page for the Stripe Sessions 2026 party with a hero (headline, subtitle, image, primary CTA to “How to enter”), a single-column “How to enter” section with ordered participation steps and external resource links (including account creation), and a disclaimer linking to contest rules. Page is scheduled for removal after May 31, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->