### PR TITLE
docs(tutorials): add getClaims guidance to SvelteKit tutorial

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -76,7 +76,13 @@ meta="name=src/hooks.server.ts"
 
 </$CodeTabs>
 
-<$Partial path="get_session_warning.mdx" />
+<Admonition type="danger">
+
+When protecting pages or server routes, use `event.locals.supabase.auth.getClaims()` instead of `getSession()` or `getUser()`.
+
+`getClaims()` validates the auth token and is safer and faster than `getUser()`, which makes an extra database call. Only use `getUser()` when you need the full user object.
+
+
 {/* TODO: Change when adding JS autoconversion */}
 As this tutorial uses TypeScript the compiler complains about `event.locals.supabase` and `event.locals.safeGetSession`, you can fix this by updating the `src/app.d.ts` with the content below:
 


### PR DESCRIPTION
## Problem

The SvelteKit tutorial was missing guidance on using `getClaims()` instead of `getSession()`/`getUser()` for server-side auth protection.

The NextJS tutorial already recommends `getClaims()`. Other framework tutorials should too.

## Fix

Added an admonition to the SvelteKit tutorial recommending `getClaims()` for safer and faster auth token validation.

## Changes

- apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx

Fixes #40985

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SvelteKit authentication guidance to clarify the recommended method for protecting pages and server routes, with guidance on alternative approaches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->