### PR TITLE
docs: fix SSR cookie header omission in OAuth PKCE flow (fixes #30900)

### DIFF
--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -1,5 +1,3 @@
----
-
 For a PKCE flow, for example in Server-Side Auth, you need an extra step to handle the code exchange. When calling `signInWithOAuth`, provide a `redirectTo` URL which points to a callback route. This redirect URL should be added to your [redirect allow list](/docs/guides/auth/redirect-urls).
 
 <Tabs

--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -1,3 +1,5 @@
+---
+
 For a PKCE flow, for example in Server-Side Auth, you need an extra step to handle the code exchange. When calling `signInWithOAuth`, provide a `redirectTo` URL which points to a callback route. This redirect URL should be added to your [redirect allow list](/docs/guides/auth/redirect-urls).
 
 <Tabs
@@ -29,15 +31,31 @@ await supabase.auth.signInWithOAuth({
 
 <TabPanel id="server" label="Server">
 
-In the server, you need to handle the redirect to the OAuth provider's authentication endpoint. The `signInWithOAuth` method returns the endpoint URL, which you can redirect to.
+In the server, you need to handle the redirect to the OAuth provider's authentication endpoint. When using Server-Side Auth, you must use `@supabase/ssr` to ensure the PKCE flow's session cookies are preserved before redirecting.
 
 ```js
-import { createClient, type Provider } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+import { createServerClient, serializeCookieHeader } from '@supabase/ssr'
+import { type Provider } from '@supabase/supabase-js'
+
 const provider = 'provider' as Provider
-const redirect = (url: string) => {}
+const redirect = (url: string, options?: { headers: Headers }) => {}
 
 // ---cut---
+const headers = new Headers()
+const supabase = createServerClient('url', 'anonKey', {
+  cookies: {
+    getAll() {
+      // return cookies from the request
+      return []
+    },
+    setAll(cookiesToSet) {
+      cookiesToSet.forEach(({ name, value, options }) =>
+        headers.append('Set-Cookie', serializeCookieHeader(name, value, options))
+      )
+    },
+  },
+})
+
 const { data, error } = await supabase.auth.signInWithOAuth({
   provider,
   options: {
@@ -46,7 +64,7 @@ const { data, error } = await supabase.auth.signInWithOAuth({
 })
 
 if (data.url) {
-  redirect(data.url) // use the redirect API for your server framework
+  redirect(data.url, { headers }) // use the redirect API for your server framework
 }
 ```
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs fix.

## What is the current behavior?

The shared server-side OAuth snippet in the PKCE flow docs redirects using `data.url` but does not forward `Set-Cookie` HTTP headers that are captured by `@supabase/ssr`.

In frameworks such as Remix, this drops the PKCE `code_verifier` cookie, resulting in an uncatchable authentication failure during the callback endpoint exchange flow.

## What is the new behavior?

- Updates the shared server snippet in `oauth_pkce_flow.mdx` to use `createServerClient` and demonstrate capturing the `Set-Cookie` in a `Headers` instance.
- Explicitly passes `{ headers }` into the `redirect(data.url)` to show the PKCE cookie preservation requirement.
- Simplifies guidance for Server-Side authentication.

## Additional context

Closes #30900

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Server-Side Auth example in OAuth PKCE flow: now demonstrates SSR-oriented client usage, explicit cookie serialization/handling, and performing redirects that include constructed headers for correct cookie propagation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->