### PR TITLE
refactor(studio): extract storage preferences into useStoragePreference hook

### DIFF
--- a/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
@@ -22,6 +22,7 @@ import { CreateBucketModal } from '../CreateBucketModal'
 import { EmptyBucketState } from '../EmptyBucketState'
 import { CreateBucketButton } from '../NewBucketButton'
 import { STORAGE_BUCKET_SORT } from '../Storage.constants'
+import { useStoragePreference } from '../StorageExplorer/useStoragePreference'
 import { BucketsTable } from './BucketsTable'
 import AlertError from '@/components/ui/AlertError'
 import { InlineLink } from '@/components/ui/InlineLink'
@@ -30,7 +31,6 @@ import { usePaginatedBucketsQuery } from '@/data/storage/buckets-query'
 import { IS_PLATFORM } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
-import { useStoragePreference } from '../StorageExplorer/useStoragePreference'
 
 export const FilesBuckets = () => {
   const { ref } = useParams()
@@ -126,9 +126,7 @@ export const FilesBuckets = () => {
                           <DropdownMenuContent align="start" className="w-40">
                             <DropdownMenuRadioGroup
                               value={sortBucket}
-                              onValueChange={(value) =>
-                                setSortBucket(value as STORAGE_BUCKET_SORT)
-                              }
+                              onValueChange={(value) => setSortBucket(value as STORAGE_BUCKET_SORT)}
                             >
                               <DropdownMenuRadioItem value="alphabetical">
                                 Sort by name

--- a/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
+++ b/apps/studio/components/interfaces/Storage/FilesBuckets/index.tsx
@@ -30,17 +30,19 @@ import { usePaginatedBucketsQuery } from '@/data/storage/buckets-query'
 import { IS_PLATFORM } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+import { useStoragePreference } from '../StorageExplorer/useStoragePreference'
 
 export const FilesBuckets = () => {
   const { ref } = useParams()
   const snap = useStorageExplorerStateSnapshot()
+  const { sortBucket, setSortBucket } = useStoragePreference(snap.projectRef)
 
   const [filterString, setFilterString] = useState('')
   const debouncedFilterString = useDebounce(filterString, 250)
   const normalizedSearch = debouncedFilterString.trim()
 
-  const sortColumn = snap.sortBucket === STORAGE_BUCKET_SORT.ALPHABETICAL ? 'name' : 'created_at'
-  const sortOrder = snap.sortBucket === STORAGE_BUCKET_SORT.ALPHABETICAL ? 'asc' : 'desc'
+  const sortColumn = sortBucket === STORAGE_BUCKET_SORT.ALPHABETICAL ? 'name' : 'created_at'
+  const sortOrder = sortBucket === STORAGE_BUCKET_SORT.ALPHABETICAL ? 'asc' : 'desc'
 
   const [visible, setVisible] = useQueryState(
     'new',
@@ -118,14 +120,14 @@ export const FilesBuckets = () => {
                         <DropdownMenu>
                           <DropdownMenuTrigger asChild>
                             <Button type="default" icon={<ArrowDownNarrowWide />}>
-                              Sorted by {snap.sortBucket === 'alphabetical' ? 'name' : 'created at'}
+                              Sorted by {sortBucket === 'alphabetical' ? 'name' : 'created at'}
                             </Button>
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="start" className="w-40">
                             <DropdownMenuRadioGroup
-                              value={snap.sortBucket}
+                              value={sortBucket}
                               onValueChange={(value) =>
-                                snap.setSortBucket(value as STORAGE_BUCKET_SORT)
+                                setSortBucket(value as STORAGE_BUCKET_SORT)
                               }
                             >
                               <DropdownMenuRadioItem value="alphabetical">

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/ColumnContextMenu.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/ColumnContextMenu.tsx
@@ -12,6 +12,7 @@ import {
   STORAGE_SORT_BY_ORDER,
   STORAGE_VIEWS,
 } from '../Storage.constants'
+import { useStoragePreference } from './useStoragePreference'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
 
@@ -21,14 +22,31 @@ interface ColumnContextMenuProps {
 
 export const ColumnContextMenu = ({ id = '' }: ColumnContextMenuProps) => {
   const {
+    projectRef,
     columns,
     selectedItems,
     setSelectedItems,
-    setView,
-    setSortBy,
-    setSortByOrder,
+    setSelectedFilePreview,
+    refetchAllOpenedFolders,
     addNewFolderPlaceholder,
   } = useStorageExplorerStateSnapshot()
+  const {
+    setView,
+    setSortBy: setPreferenceSortBy,
+    setSortByOrder: setPreferenceSortByOrder,
+  } = useStoragePreference(projectRef)
+
+  const setSortBy = async (value: STORAGE_SORT_BY) => {
+    setPreferenceSortBy(value)
+    setSelectedFilePreview(undefined)
+    await refetchAllOpenedFolders()
+  }
+
+  const setSortByOrder = async (value: STORAGE_SORT_BY_ORDER) => {
+    setPreferenceSortByOrder(value)
+    setSelectedFilePreview(undefined)
+    await refetchAllOpenedFolders()
+  }
 
   const { can: canUpdateFiles } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
@@ -8,8 +8,8 @@ import { ColumnContextMenu } from './ColumnContextMenu'
 import { FileExplorerColumn } from './FileExplorerColumn'
 import { FolderContextMenu } from './FolderContextMenu'
 import { ItemContextMenu } from './ItemContextMenu'
-import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
 import { useStoragePreference } from './useStoragePreference'
+import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
 
 export interface FileExplorerProps {
   columns: StorageColumn[]

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorer.tsx
@@ -9,6 +9,7 @@ import { FileExplorerColumn } from './FileExplorerColumn'
 import { FolderContextMenu } from './FolderContextMenu'
 import { ItemContextMenu } from './ItemContextMenu'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+import { useStoragePreference } from './useStoragePreference'
 
 export interface FileExplorerProps {
   columns: StorageColumn[]
@@ -33,6 +34,7 @@ export const FileExplorer = ({
 }: FileExplorerProps) => {
   const fileExplorerRef = useRef<any>(null)
   const snap = useStorageExplorerStateSnapshot()
+  const { view } = useStoragePreference(snap.projectRef)
 
   useEffect(() => {
     if (fileExplorerRef) {
@@ -48,7 +50,7 @@ export const FileExplorer = ({
       ref={fileExplorerRef}
       className={cn(
         'file-explorer flex flex-grow overflow-x-auto justify-between h-full w-full relative',
-        snap.view === STORAGE_VIEWS.LIST && 'flex-col'
+        view === STORAGE_VIEWS.LIST && 'flex-col'
       )}
     >
       <ColumnContextMenu id={CONTEXT_MENU_KEYS.STORAGE_COLUMN} />
@@ -59,7 +61,7 @@ export const FileExplorer = ({
         <FileExplorerColumn
           column={{ id: '', name: '', path: '', items: [], status: STORAGE_ROW_STATUS.LOADING }}
         />
-      ) : snap.view === STORAGE_VIEWS.COLUMNS ? (
+      ) : view === STORAGE_VIEWS.COLUMNS ? (
         <div className="flex">
           {columns.map((column, index) => (
             <FileExplorerColumn
@@ -75,7 +77,7 @@ export const FileExplorer = ({
             />
           ))}
         </div>
-      ) : snap.view === STORAGE_VIEWS.LIST ? (
+      ) : view === STORAGE_VIEWS.LIST ? (
         <>
           {columns.length > 0 && (
             <FileExplorerColumn
@@ -92,7 +94,7 @@ export const FileExplorer = ({
           )}
         </>
       ) : (
-        <div>Unknown view: {snap.view}</div>
+        <div>Unknown view: {view}</div>
       )}
     </div>
   )

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -16,12 +16,12 @@ import {
 } from '../Storage.constants'
 import type { StorageColumn, StorageItemWithColumn } from '../Storage.types'
 import { FileExplorerRow } from './FileExplorerRow'
+import { useStoragePreference } from './useStoragePreference'
 import { InfiniteListDefault, LoaderForIconMenuItems } from '@/components/ui/InfiniteList'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { BASE_PATH } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
-import { useStoragePreference } from './useStoragePreference'
 
 const DragOverOverlay = ({ isOpen, onDragLeave, onDrop, folderIsEmpty }: any) => {
   return (

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerColumn.tsx
@@ -21,6 +21,7 @@ import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { BASE_PATH } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+import { useStoragePreference } from './useStoragePreference'
 
 const DragOverOverlay = ({ isOpen, onDragLeave, onDrop, folderIsEmpty }: any) => {
   return (
@@ -83,6 +84,7 @@ export const FileExplorerColumn = ({
   const fileExplorerColumnRef = useRef<any>(null)
 
   const snap = useStorageExplorerStateSnapshot()
+  const { view } = useStoragePreference(snap.projectRef)
   const { can: canUpdateStorage } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
 
   useEffect(() => {
@@ -156,11 +158,11 @@ export const FileExplorerColumn = ({
 
   const itemProps = useMemo(
     () => ({
-      view: snap.view,
+      view: view,
       columnIndex: index,
       selectedItems,
     }),
-    [snap.view, index, selectedItems]
+    [view, index, selectedItems]
   )
 
   return (
@@ -168,7 +170,7 @@ export const FileExplorerColumn = ({
       ref={fileExplorerColumnRef}
       className={cn(
         fullWidth ? 'w-full' : 'w-64 border-r border-overlay',
-        snap.view === STORAGE_VIEWS.LIST && 'h-full',
+        view === STORAGE_VIEWS.LIST && 'h-full',
         'hide-scrollbar relative flex flex-shrink-0 flex-col overflow-auto'
       )}
       onContextMenu={displayMenu}
@@ -181,7 +183,7 @@ export const FileExplorerColumn = ({
       }}
     >
       {/* Checkbox selection for select all */}
-      {snap.view === STORAGE_VIEWS.COLUMNS && (
+      {view === STORAGE_VIEWS.COLUMNS && (
         <div
           className={cn(
             'sticky top-0 z-10 mb-0 flex items-center bg-table-header-light px-2.5 [[data-theme*=dark]_&]:bg-table-header-dark',
@@ -202,7 +204,7 @@ export const FileExplorerColumn = ({
       )}
 
       {/* List Interface Header */}
-      {snap.view === STORAGE_VIEWS.LIST && (
+      {view === STORAGE_VIEWS.LIST && (
         <div className="sticky top-0 py-2 z-10 flex min-w-min items-center border-b border-overlay bg-surface-100 px-2.5">
           <div className="flex w-[40%] min-w-[250px] items-center">
             <SelectAllCheckbox />
@@ -283,7 +285,7 @@ export const FileExplorerColumn = ({
       />
 
       {/* List interface footer */}
-      {snap.view === STORAGE_VIEWS.LIST && (
+      {view === STORAGE_VIEWS.LIST && (
         <div className="shrink-0 rounded-b-md z-10 flex min-w-min items-center bg-panel-footer-light px-2.5 py-2 [[data-theme*=dark]_&]:bg-panel-footer-dark w-full">
           <p className="text-sm">
             {formatBytes(columnItemsSize)} for {columnItems.length} items

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.test.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.test.tsx
@@ -11,11 +11,13 @@ const {
   mockUseStorageExplorerStateSnapshot,
   mockUseAsyncCheckPermissions,
   mockIsAPIDocsSidePanelEnabled,
+  mockUseStoragePreference,
 } = vi.hoisted(() => ({
   mockTrack: vi.fn(),
   mockUseStorageExplorerStateSnapshot: vi.fn(),
   mockUseAsyncCheckPermissions: vi.fn(),
   mockIsAPIDocsSidePanelEnabled: vi.fn(),
+  mockUseStoragePreference: vi.fn(),
 }))
 
 vi.mock('lib/telemetry/track', () => ({ useTrack: () => mockTrack }))
@@ -31,6 +33,9 @@ vi.mock('components/interfaces/App/FeaturePreview/FeaturePreviewContext', () => 
 vi.mock('components/ui/APIDocsButton', () => ({
   APIDocsButton: () => null,
 }))
+vi.mock('./useStoragePreference', () => ({
+  useStoragePreference: (...args: any[]) => mockUseStoragePreference(...args),
+}))
 
 function makeColumn(name: string) {
   return {
@@ -41,13 +46,10 @@ function makeColumn(name: string) {
   }
 }
 
-function createSnapshot(view: STORAGE_VIEWS = STORAGE_VIEWS.COLUMNS) {
+function createSnapshot() {
   return {
+    projectRef: 'test-ref',
     columns: [makeColumn('my-bucket'), makeColumn('images'), makeColumn('2024')],
-    sortBy: STORAGE_SORT_BY.NAME,
-    setSortBy: vi.fn(),
-    sortByOrder: STORAGE_SORT_BY_ORDER.ASC,
-    setSortByOrder: vi.fn(),
     popColumn: vi.fn(),
     popColumnAtIndex: vi.fn(),
     popOpenedFolders: vi.fn(),
@@ -60,8 +62,19 @@ function createSnapshot(view: STORAGE_VIEWS = STORAGE_VIEWS.COLUMNS) {
     selectedBucket: { id: 'bucket-id', name: 'my-bucket' },
     isSearching: false,
     setIsSearching: vi.fn(),
+  }
+}
+
+function createPreference(view: STORAGE_VIEWS = STORAGE_VIEWS.COLUMNS) {
+  return {
     view,
     setView: vi.fn(),
+    sortBy: STORAGE_SORT_BY.NAME,
+    setSortBy: vi.fn(),
+    sortByOrder: STORAGE_SORT_BY_ORDER.ASC,
+    setSortByOrder: vi.fn(),
+    sortBucket: 'created_at',
+    setSortBucket: vi.fn(),
   }
 }
 
@@ -71,8 +84,10 @@ describe('FileExplorerHeader', () => {
     mockUseStorageExplorerStateSnapshot.mockReset()
     mockUseAsyncCheckPermissions.mockReset()
     mockIsAPIDocsSidePanelEnabled.mockReset()
+    mockUseStoragePreference.mockReset()
 
     mockUseStorageExplorerStateSnapshot.mockReturnValue(createSnapshot())
+    mockUseStoragePreference.mockReturnValue(createPreference())
     mockUseAsyncCheckPermissions.mockReturnValue({ can: true })
     mockIsAPIDocsSidePanelEnabled.mockReturnValue(false)
   })
@@ -202,7 +217,7 @@ describe('FileExplorerHeader', () => {
   })
 
   it('does not render Navigate in list view', () => {
-    mockUseStorageExplorerStateSnapshot.mockReturnValue(createSnapshot(STORAGE_VIEWS.LIST))
+    mockUseStoragePreference.mockReturnValue(createPreference(STORAGE_VIEWS.LIST))
 
     render(
       <FileExplorerHeader

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
@@ -46,6 +46,7 @@ import {
 import { Input } from 'ui-patterns/DataInputs/Input'
 
 import { STORAGE_SORT_BY, STORAGE_SORT_BY_ORDER, STORAGE_VIEWS } from '../Storage.constants'
+import { useStoragePreference } from './useStoragePreference'
 import { useIsAPIDocsSidePanelEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { APIDocsButton } from '@/components/ui/APIDocsButton'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -220,11 +221,8 @@ export const FileExplorerHeader = ({
   const previousBreadcrumbs = useRef<string[] | null>(null)
 
   const {
+    projectRef,
     columns,
-    sortBy,
-    setSortBy,
-    sortByOrder,
-    setSortByOrder,
     popColumn,
     popColumnAtIndex,
     popOpenedFolders,
@@ -236,10 +234,30 @@ export const FileExplorerHeader = ({
     setSelectedFilePreview,
     selectedBucket,
   } = useStorageExplorerStateSnapshot()
+  const {
+    view,
+    setView,
+    sortBy,
+    setSortBy: setPreferenceSortBy,
+    sortByOrder,
+    setSortByOrder: setPreferenceSortByOrder,
+  } = useStoragePreference(projectRef)
 
   const breadcrumbs = columns.map((column) => column.name)
   const backDisabled = columns.length <= 1
   const { can: canUpdateStorage } = useAsyncCheckPermissions(PermissionAction.STORAGE_WRITE, '*')
+
+  const setSortBy = async (value: STORAGE_SORT_BY) => {
+    setPreferenceSortBy(value)
+    setSelectedFilePreview(undefined)
+    await refetchAllOpenedFolders()
+  }
+
+  const setSortByOrder = async (value: STORAGE_SORT_BY_ORDER) => {
+    setPreferenceSortByOrder(value)
+    setSelectedFilePreview(undefined)
+    await refetchAllOpenedFolders()
+  }
 
   useEffect(() => {
     // [Joshen] Somehow toggle search triggers this despite breadcrumbs
@@ -370,7 +388,7 @@ export const FileExplorerHeader = ({
           {/* Actions */}
           <div className="flex shrink-0 items-center whitespace-nowrap py-[7px]">
             <div className="flex shrink-0 items-center space-x-1 px-2">
-              {snap.view === STORAGE_VIEWS.COLUMNS && (
+              {view === STORAGE_VIEWS.COLUMNS && (
                 <Button
                   size="tiny"
                   icon={<Edit2 />}
@@ -396,7 +414,7 @@ export const FileExplorerHeader = ({
                   <Button
                     type="text"
                     icon={
-                      snap.view === 'LIST' ? (
+                      view === 'LIST' ? (
                         <List size={16} strokeWidth={2} />
                       ) : (
                         <Columns size={16} strokeWidth={2} />
@@ -408,10 +426,10 @@ export const FileExplorerHeader = ({
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-40 min-w-0">
                   {VIEW_OPTIONS.map((option) => (
-                    <DropdownMenuItem key={option.key} onClick={() => snap.setView(option.key)}>
+                    <DropdownMenuItem key={option.key} onClick={() => setView(option.key)}>
                       <div className="flex items-center justify-between w-full">
                         <p>{option.name}</p>
-                        {snap.view === option.key && (
+                        {view === option.key && (
                           <Check size={16} className="text-brand" strokeWidth={2} />
                         )}
                       </div>

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -17,13 +17,13 @@ import type { Bucket } from '@/data/storage/buckets-query'
 import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
+import { useStoragePreference } from './useStoragePreference'
 
 export const StorageExplorer = () => {
   const { ref, bucketId } = useParams()
   const storageExplorerRef = useRef(null)
   const {
     projectRef,
-    view,
     columns,
     selectedItems,
     openedFolders,
@@ -41,6 +41,7 @@ export const StorageExplorer = () => {
     setSelectedFilePreview,
     setSelectedItemsToMove,
   } = useStorageExplorerStateSnapshot()
+  const { view } = useStoragePreference(projectRef)
 
   useProjectStorageConfigQuery({ projectRef: ref }, { enabled: IS_PLATFORM })
   const { data: bucket, isLoading: isBucketQueryLoading } = useSelectedBucket()

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.tsx
@@ -12,12 +12,12 @@ import { FileExplorerHeader } from './FileExplorerHeader'
 import { FileExplorerHeaderSelection } from './FileExplorerHeaderSelection'
 import { MoveItemsModal } from './MoveItemsModal'
 import { PreviewPane } from './PreviewPane'
+import { useStoragePreference } from './useStoragePreference'
 import { useProjectStorageConfigQuery } from '@/data/config/project-storage-config-query'
 import type { Bucket } from '@/data/storage/buckets-query'
 import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useStorageExplorerStateSnapshot } from '@/state/storage-explorer'
-import { useStoragePreference } from './useStoragePreference'
 
 export const StorageExplorer = () => {
   const { ref, bucketId } = useParams()

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/useStoragePreference.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/useStoragePreference.ts
@@ -7,7 +7,7 @@ import {
   STORAGE_SORT_BY_ORDER,
   STORAGE_VIEWS,
 } from '../Storage.constants'
-import { useLocalStorage } from '@/hooks/misc/useLocalStorage'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 interface StoragePreference {
   view: STORAGE_VIEWS
@@ -39,7 +39,7 @@ export function getStoragePreference(projectRef: string): StoragePreference {
 }
 
 export function useStoragePreference(projectRef: string) {
-  const [preference, setPreference] = useLocalStorage<StoragePreference>(
+  const [preference, setPreference] = useLocalStorageQuery<StoragePreference>(
     LOCAL_STORAGE_KEYS.STORAGE_PREFERENCE(projectRef),
     DEFAULT_PREFERENCES
   )

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/useStoragePreference.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/useStoragePreference.ts
@@ -1,0 +1,85 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { useCallback } from 'react'
+
+import {
+  STORAGE_BUCKET_SORT,
+  STORAGE_SORT_BY,
+  STORAGE_SORT_BY_ORDER,
+  STORAGE_VIEWS,
+} from '../Storage.constants'
+import { useLocalStorage } from '@/hooks/misc/useLocalStorage'
+
+interface StoragePreference {
+  view: STORAGE_VIEWS
+  sortBy: STORAGE_SORT_BY
+  sortByOrder: STORAGE_SORT_BY_ORDER
+  sortBucket: STORAGE_BUCKET_SORT
+}
+
+const DEFAULT_PREFERENCES: StoragePreference = {
+  view: STORAGE_VIEWS.COLUMNS,
+  sortBy: STORAGE_SORT_BY.NAME,
+  sortByOrder: STORAGE_SORT_BY_ORDER.ASC,
+  sortBucket: STORAGE_BUCKET_SORT.CREATED_AT,
+}
+
+/**
+ * Read the current storage preference directly from localStorage.
+ * Use this outside of React (e.g. inside Valtio state methods).
+ */
+export function getStoragePreference(projectRef: string): StoragePreference {
+  if (typeof window === 'undefined') return DEFAULT_PREFERENCES
+  try {
+    const raw = window.localStorage.getItem(LOCAL_STORAGE_KEYS.STORAGE_PREFERENCE(projectRef))
+    if (raw) {
+      return { ...DEFAULT_PREFERENCES, ...JSON.parse(raw) }
+    }
+  } catch {}
+  return DEFAULT_PREFERENCES
+}
+
+export function useStoragePreference(projectRef: string) {
+  const [preference, setPreference] = useLocalStorage<StoragePreference>(
+    LOCAL_STORAGE_KEYS.STORAGE_PREFERENCE(projectRef),
+    DEFAULT_PREFERENCES
+  )
+
+  const setView = useCallback(
+    (view: STORAGE_VIEWS) => {
+      setPreference((prev) => ({ ...prev, view }))
+    },
+    [setPreference]
+  )
+
+  const setSortBy = useCallback(
+    (sortBy: STORAGE_SORT_BY) => {
+      setPreference((prev) => ({ ...prev, sortBy }))
+    },
+    [setPreference]
+  )
+
+  const setSortByOrder = useCallback(
+    (sortByOrder: STORAGE_SORT_BY_ORDER) => {
+      setPreference((prev) => ({ ...prev, sortByOrder }))
+    },
+    [setPreference]
+  )
+
+  const setSortBucket = useCallback(
+    (sortBucket: STORAGE_BUCKET_SORT) => {
+      setPreference((prev) => ({ ...prev, sortBucket }))
+    },
+    [setPreference]
+  )
+
+  return {
+    view: preference.view,
+    sortBy: preference.sortBy,
+    sortByOrder: preference.sortByOrder,
+    sortBucket: preference.sortBucket,
+    setView,
+    setSortBy,
+    setSortByOrder,
+    setSortBucket,
+  }
+}

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1,5 +1,5 @@
 import { BlobReader, BlobWriter, ZipWriter } from '@zip.js/zip.js'
-import { IS_PLATFORM, LOCAL_STORAGE_KEYS } from 'common'
+import { IS_PLATFORM } from 'common'
 import { capitalize, chunk, compact, find, findIndex, has, isObject, uniq, uniqBy } from 'lodash'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 import { useLatest } from 'react-use'
@@ -10,12 +10,8 @@ import { proxy, useSnapshot } from 'valtio'
 
 import { useSelectedBucket } from '@/components/interfaces/Storage/FilesBuckets/useSelectedBucket'
 import {
-  STORAGE_BUCKET_SORT,
   STORAGE_ROW_STATUS,
   STORAGE_ROW_TYPES,
-  STORAGE_SORT_BY,
-  STORAGE_SORT_BY_ORDER,
-  STORAGE_VIEWS,
 } from '@/components/interfaces/Storage/Storage.constants'
 import {
   StorageColumn,
@@ -34,6 +30,7 @@ import {
   validateFolderName,
 } from '@/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils'
 import { fetchFileUrl } from '@/components/interfaces/Storage/StorageExplorer/useFetchFileUrlQuery'
+import { getStoragePreference } from '@/components/interfaces/Storage/StorageExplorer/useStoragePreference'
 import { convertFromBytes } from '@/components/interfaces/Storage/StorageSettings/StorageSettings.utils'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { getOrRefreshTemporaryApiKey } from '@/data/api-keys/temp-api-keys-utils'
@@ -49,7 +46,6 @@ import type { Bucket } from '@/data/storage/buckets-query'
 import { moveStorageObject } from '@/data/storage/object-move-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from '@/lib/constants'
-import { tryParseJson } from '@/lib/helpers'
 import { lookupMime } from '@/lib/mime'
 import { createProjectSupabaseClient } from '@/lib/project-supabase-client'
 import { ResponseError } from '@/types'
@@ -67,12 +63,6 @@ const OFFSET = 0
 const DEFAULT_RETRY_SECONDS = 5
 const RATE_LIMIT_RETRY_SECONDS = 60
 
-const DEFAULT_PREFERENCES = {
-  view: STORAGE_VIEWS.COLUMNS,
-  sortBy: STORAGE_SORT_BY.NAME,
-  sortByOrder: STORAGE_SORT_BY_ORDER.ASC,
-  sortBucket: STORAGE_BUCKET_SORT.CREATED_AT,
-}
 const STORAGE_PROGRESS_INFO_TEXT = "Do not close the browser until it's completed"
 
 let abortController: AbortController
@@ -93,10 +83,10 @@ function createStorageExplorerState({
   resumableUploadUrl: string
   clientEndpoint: string
 }) {
-  const localStorageKey = LOCAL_STORAGE_KEYS.STORAGE_PREFERENCE(projectRef)
-  const { view, sortBy, sortByOrder, sortBucket } =
-    (typeof window !== 'undefined' && tryParseJson(localStorage?.getItem(localStorageKey))) ||
-    DEFAULT_PREFERENCES
+  const getSortOptions = () => {
+    const { sortBy, sortByOrder } = getStoragePreference(projectRef)
+    return { column: sortBy, order: sortByOrder }
+  }
 
   const state = proxy({
     projectRef,
@@ -172,34 +162,6 @@ function createStorageExplorerState({
       })
     },
 
-    view,
-    setView: (value: STORAGE_VIEWS) => {
-      state.view = value
-      state.updateExplorerPreference()
-    },
-
-    sortBucket,
-    setSortBucket: async (value: STORAGE_BUCKET_SORT) => {
-      state.sortBucket = value
-      state.updateExplorerPreference()
-    },
-
-    sortBy,
-    setSortBy: async (value: STORAGE_SORT_BY) => {
-      state.sortBy = value
-      state.updateExplorerPreference()
-      state.setSelectedFilePreview(undefined)
-      await state.refetchAllOpenedFolders()
-    },
-
-    sortByOrder,
-    setSortByOrder: async (value: STORAGE_SORT_BY_ORDER) => {
-      state.sortByOrder = value
-      state.updateExplorerPreference()
-      state.setSelectedFilePreview(undefined)
-      await state.refetchAllOpenedFolders()
-    },
-
     isSearching: false,
     setIsSearching: (value: boolean) => (state.isSearching = value),
 
@@ -208,15 +170,6 @@ function createStorageExplorerState({
 
     selectedFileCustomExpiry: undefined as StorageItem | undefined,
     setSelectedFileCustomExpiry: (item?: StorageItem) => (state.selectedFileCustomExpiry = item),
-
-    updateExplorerPreference: () => {
-      const localStorageKey = LOCAL_STORAGE_KEYS.STORAGE_PREFERENCE(projectRef)
-      const { view, sortBy, sortByOrder, sortBucket } = state
-      localStorage.setItem(
-        localStorageKey,
-        JSON.stringify({ view, sortBy, sortByOrder, sortBucket })
-      )
-    },
 
     // Functions that manage the UI of the Storage Explorer
 
@@ -346,7 +299,7 @@ function createStorageExplorerState({
         limit: LIMIT,
         offset: OFFSET,
         search: searchString,
-        sortBy: { column: state.sortBy, order: state.sortByOrder },
+        sortBy: getSortOptions(),
       }
 
       try {
@@ -406,7 +359,7 @@ function createStorageExplorerState({
         limit: LIMIT,
         offset: column.items.length,
         search: searchString,
-        sortBy: { column: state.sortBy, order: state.sortByOrder },
+        sortBy: getSortOptions(),
       }
 
       try {
@@ -471,7 +424,7 @@ function createStorageExplorerState({
             limit: LIMIT,
             offset: OFFSET,
             search: searchString,
-            sortBy: { column: state.sortBy, order: state.sortByOrder },
+            sortBy: getSortOptions(),
           }
 
           try {
@@ -540,7 +493,7 @@ function createStorageExplorerState({
           options: {
             limit: LIMIT,
             offset: OFFSET,
-            sortBy: { column: state.sortBy, order: state.sortByOrder },
+            sortBy: getSortOptions(),
           },
         })
 
@@ -960,7 +913,7 @@ function createStorageExplorerState({
       const options = {
         limit: 10000,
         offset: OFFSET,
-        sortBy: { column: state.sortBy, order: state.sortByOrder },
+        sortBy: getSortOptions(),
       }
       let folderContents: StorageObject[] = []
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

Storage explorer preferences (`view`, `sortBy`, `sortByOrder`, `sortBucket`) are managed inline within the Valtio proxy state in `storage-explorer.tsx`, which reads/writes localStorage directly.

## What is the new behavior?

Preferences are extracted into a dedicated `useStoragePreference` hook backed by `useLocalStorage`. A companion `getStoragePreference` function allows the Valtio state to read sort options imperatively for API calls without holding preference data itself. Consumers import the hook directly instead of reading preferences from the snapshot.

## Additional context

No behavioral or visual changes — localStorage key and data shape are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Storage view and sorting preferences now persist per project and drive the explorer UI.
  * Changing view or sort preferences refreshes folder contents and clears the open file preview.

* **Chores**
  * Centralized preference handling for consistent behavior across the storage explorer.

* **Tests**
  * Updated tests to exercise the new preference-backed behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->