### PR TITLE
chore: use dndkit for enumerated types sorting

### DIFF
--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
@@ -83,6 +83,7 @@ const CreateEnumeratedTypeSidePanel = ({
     defaultValues: initialValues,
   })
   const { reset } = form
+  const { isDirty } = form.formState
 
   useEffect(() => {
     reset(initialValues)
@@ -133,6 +134,7 @@ const CreateEnumeratedTypeSidePanel = ({
   return (
     <SidePanel
       loading={isCreating}
+      disabled={!isDirty}
       visible={visible}
       onCancel={closePanel}
       header="Create a new enumerated type"

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
@@ -1,8 +1,21 @@
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { AlertCircle, ExternalLink, Plus } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useRef } from 'react'
-import { DragDropContext, Droppable, DroppableProvided } from 'react-beautiful-dnd'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -34,12 +47,13 @@ interface CreateEnumeratedTypeSidePanelProps {
   schema: string
 }
 
+const initialValues = { name: '', description: '', values: [{ value: '' }] }
+
 const CreateEnumeratedTypeSidePanel = ({
   visible,
   onClose,
   schema,
 }: CreateEnumeratedTypeSidePanelProps) => {
-  const initialValues = { name: '', description: '', values: [{ value: '' }] }
   const submitRef = useRef<HTMLButtonElement>(null)
   const { data: project } = useSelectedProjectQuery()
   const { mutate: createEnumeratedType, isPending: isCreating } = useEnumeratedTypeCreateMutation({
@@ -48,10 +62,6 @@ const CreateEnumeratedTypeSidePanel = ({
       closePanel()
     },
   })
-
-  useEffect(() => {
-    form.reset(initialValues)
-  }, [visible])
 
   const FormSchema = z.object({
     name: z
@@ -72,16 +82,25 @@ const CreateEnumeratedTypeSidePanel = ({
     resolver: zodResolver(FormSchema),
     defaultValues: initialValues,
   })
+  const { reset } = form
 
-  const { fields, append, remove, move } = useFieldArray({
+  useEffect(() => {
+    reset(initialValues)
+  }, [reset, visible])
+
+  const { fields, append, remove, swap } = useFieldArray({
     name: 'values',
     control: form.control,
   })
 
-  const updateOrder = (result: any) => {
-    // Dropped outside of the list
-    if (!result.destination) return
-    move(result.source.index, result.destination.index)
+  const handleDragEnd = (event: DragEndEvent) => {
+    if (event.over == null) return
+    const overIndex = fields.findIndex((item) => item.id === event.over?.id)
+    if (overIndex < 0) return
+    const activeIndex = fields.findIndex((item) => item.id === event.active.id)
+    if (activeIndex < 0) return
+
+    swap(activeIndex, overIndex)
   }
 
   const onSubmit = (data: z.infer<typeof FormSchema>) => {
@@ -103,6 +122,13 @@ const CreateEnumeratedTypeSidePanel = ({
     form.reset(initialValues)
     onClose()
   }
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  )
 
   return (
     <SidePanel
@@ -145,67 +171,62 @@ const CreateEnumeratedTypeSidePanel = ({
               )}
             />
 
-            <DragDropContext onDragEnd={(result: any) => updateOrder(result)}>
-              <Droppable droppableId="enum_type_values_droppable">
-                {(droppableProvided: DroppableProvided) => (
-                  <div ref={droppableProvided.innerRef}>
-                    {fields.map((field, index) => (
-                      <FormField_Shadcn_
-                        control={form.control}
-                        key={field.id}
-                        name={`values.${index}.value`}
-                        render={({ field: inputField }) => (
-                          <FormItem_Shadcn_>
-                            <FormLabel_Shadcn_ className={cn(index !== 0 && 'sr-only')}>
-                              Values
-                            </FormLabel_Shadcn_>
-                            {index === 0 && (
-                              <Alert_Shadcn_>
-                                <AlertCircle strokeWidth={1.5} />
-                                <AlertTitle_Shadcn_>
-                                  After creation, values cannot be deleted or sorted
-                                </AlertTitle_Shadcn_>
-                                <AlertDescription_Shadcn_>
-                                  <p className="!leading-normal track">
-                                    You will need to delete and recreate the enumerated type with
-                                    the updated values instead.
-                                  </p>
-                                  <Button
-                                    asChild
-                                    type="default"
-                                    icon={<ExternalLink strokeWidth={1.5} />}
-                                    className="mt-2"
-                                  >
-                                    <Link
-                                      href="https://www.postgresql.org/message-id/21012.1459434338%40sss.pgh.pa.us"
-                                      target="_blank"
-                                      rel="noreferrer"
-                                    >
-                                      Learn more
-                                    </Link>
-                                  </Button>
-                                </AlertDescription_Shadcn_>
-                              </Alert_Shadcn_>
-                            )}
-                            <FormControl_Shadcn_>
-                              <EnumeratedTypeValueRow
-                                index={index}
-                                id={field.id}
-                                field={inputField}
-                                isDisabled={fields.length < 2}
-                                onRemoveValue={() => remove(index)}
-                              />
-                            </FormControl_Shadcn_>
-                            <FormMessage_Shadcn_ className="ml-6" />
-                          </FormItem_Shadcn_>
-                        )}
-                      />
-                    ))}
-                    {droppableProvided.placeholder}
-                  </div>
+            <div>
+              <span
+                className={cn(
+                  'text-foreground-light text-sm',
+                  'transition-colors',
+                  'leading-normal'
                 )}
-              </Droppable>
-            </DragDropContext>
+              >
+                Values
+              </span>
+              <Alert_Shadcn_>
+                <AlertCircle strokeWidth={1.5} />
+                <AlertTitle_Shadcn_>
+                  After creation, values cannot be deleted or sorted
+                </AlertTitle_Shadcn_>
+                <AlertDescription_Shadcn_>
+                  <p className="!leading-normal track">
+                    You will need to delete and recreate the enumerated type with the updated values
+                    instead.
+                  </p>
+                  <Button
+                    asChild
+                    type="default"
+                    icon={<ExternalLink strokeWidth={1.5} />}
+                    className="mt-2"
+                  >
+                    <Link
+                      href="https://www.postgresql.org/message-id/21012.1459434338%40sss.pgh.pa.us"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more
+                    </Link>
+                  </Button>
+                </AlertDescription_Shadcn_>
+              </Alert_Shadcn_>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext items={fields} strategy={verticalListSortingStrategy}>
+                  {fields.map((field, index) => (
+                    <EnumeratedTypeValueRow
+                      key={field.id}
+                      id={field.id}
+                      name={`values.${index}.value`}
+                      index={index}
+                      control={form.control}
+                      isDisabled={fields.length < 2}
+                      onRemoveValue={() => remove(index)}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
+            </div>
 
             <Button
               type="default"

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/CreateEnumeratedTypeSidePanel.tsx
@@ -88,7 +88,7 @@ const CreateEnumeratedTypeSidePanel = ({
     reset(initialValues)
   }, [reset, visible])
 
-  const { fields, append, remove, swap } = useFieldArray({
+  const { fields, append, remove, move } = useFieldArray({
     name: 'values',
     control: form.control,
   })
@@ -100,7 +100,7 @@ const CreateEnumeratedTypeSidePanel = ({
     const activeIndex = fields.findIndex((item) => item.id === event.active.id)
     if (activeIndex < 0) return
 
-    swap(activeIndex, overIndex)
+    move(activeIndex, overIndex)
   }
 
   const onSubmit = (data: z.infer<typeof FormSchema>) => {

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
@@ -15,7 +15,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod'
 import { AlertCircle, ExternalLink, Plus } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -79,11 +79,15 @@ const EditEnumeratedTypeSidePanel = ({
     defaultValues: {
       name: '',
       description: '',
-      values: [{ isNew: true, originalValue: '', updatedValue: '' }],
+      values: (selectedEnumeratedType?.enums ?? []).map((x) => ({
+        isNew: false,
+        originalValue: x,
+        updatedValue: x,
+      })),
     },
   })
   const { reset } = form
-
+  const { isDirty } = form.formState
   const { fields, append, remove, move } = useFieldArray({
     name: 'values',
     control: form.control,
@@ -98,16 +102,6 @@ const EditEnumeratedTypeSidePanel = ({
 
     move(activeIndex, overIndex)
   }
-
-  const originalEnumeratedTypes = useMemo(
-    () =>
-      (selectedEnumeratedType?.enums ?? []).map((x) => ({
-        isNew: false,
-        originalValue: x,
-        updatedValue: x,
-      })),
-    [selectedEnumeratedType]
-  )
 
   const onSubmit = (data: z.infer<typeof FormSchema>) => {
     if (project?.ref === undefined) return console.error('Project ref required')
@@ -144,6 +138,12 @@ const EditEnumeratedTypeSidePanel = ({
   }
 
   useEffect(() => {
+    const originalEnumeratedTypes = (selectedEnumeratedType?.enums ?? []).map((x) => ({
+      isNew: false,
+      originalValue: x,
+      updatedValue: x,
+    }))
+
     if (selectedEnumeratedType !== undefined) {
       reset({
         name: selectedEnumeratedType.name,
@@ -157,7 +157,7 @@ const EditEnumeratedTypeSidePanel = ({
         values: originalEnumeratedTypes,
       })
     }
-  }, [reset, originalEnumeratedTypes, selectedEnumeratedType])
+  }, [reset, selectedEnumeratedType, visible])
 
   const sensors = useSensors(
     useSensor(PointerSensor),
@@ -169,6 +169,7 @@ const EditEnumeratedTypeSidePanel = ({
   return (
     <SidePanel
       loading={isCreating}
+      disabled={!isDirty}
       visible={visible}
       onCancel={onClose}
       header={`Update type "${selectedEnumeratedType?.name}"`}

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
@@ -1,8 +1,21 @@
+import {
+  closestCenter,
+  DndContext,
+  DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+} from '@dnd-kit/core'
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { AlertCircle, ExternalLink, Plus } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useRef } from 'react'
-import { DragDropContext, Droppable, DroppableProvided } from 'react-beautiful-dnd'
+import { useEffect, useMemo, useRef } from 'react'
 import { useFieldArray, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -69,23 +82,32 @@ const EditEnumeratedTypeSidePanel = ({
       values: [{ isNew: true, originalValue: '', updatedValue: '' }],
     },
   })
+  const { reset } = form
 
-  const { fields, append, remove, move } = useFieldArray({
+  const { fields, append, remove, swap } = useFieldArray({
     name: 'values',
     control: form.control,
   })
 
-  const updateOrder = (result: any) => {
-    // Dropped outside of the list
-    if (!result.destination) return
-    move(result.source.index, result.destination.index)
+  const handleDragEnd = (event: DragEndEvent) => {
+    if (event.over == null) return
+    const overIndex = fields.findIndex((item) => item.id === event.over?.id)
+    if (overIndex < 0) return
+    const activeIndex = fields.findIndex((item) => item.id === event.active.id)
+    if (activeIndex < 0) return
+
+    swap(activeIndex, overIndex)
   }
 
-  const originalEnumeratedTypes = (selectedEnumeratedType?.enums ?? []).map((x) => ({
-    isNew: false,
-    originalValue: x,
-    updatedValue: x,
-  }))
+  const originalEnumeratedTypes = useMemo(
+    () =>
+      (selectedEnumeratedType?.enums ?? []).map((x) => ({
+        isNew: false,
+        originalValue: x,
+        updatedValue: x,
+      })),
+    [selectedEnumeratedType]
+  )
 
   const onSubmit = (data: z.infer<typeof FormSchema>) => {
     if (project?.ref === undefined) return console.error('Project ref required')
@@ -123,7 +145,7 @@ const EditEnumeratedTypeSidePanel = ({
 
   useEffect(() => {
     if (selectedEnumeratedType !== undefined) {
-      form.reset({
+      reset({
         name: selectedEnumeratedType.name,
         description: selectedEnumeratedType.comment ?? '',
         values: originalEnumeratedTypes,
@@ -131,12 +153,18 @@ const EditEnumeratedTypeSidePanel = ({
     }
 
     if (selectedEnumeratedType == undefined) {
-      form.reset({
+      reset({
         values: originalEnumeratedTypes,
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedEnumeratedType])
+  }, [reset, originalEnumeratedTypes, selectedEnumeratedType])
+
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
+    })
+  )
 
   return (
     <SidePanel
@@ -179,67 +207,60 @@ const EditEnumeratedTypeSidePanel = ({
               )}
             />
 
-            <DragDropContext onDragEnd={(result: any) => updateOrder(result)}>
-              <Droppable droppableId="enum_type_values_droppable">
-                {(droppableProvided: DroppableProvided) => (
-                  <div ref={droppableProvided.innerRef}>
-                    {fields.map((field, index) => (
-                      <FormField_Shadcn_
-                        control={form.control}
-                        key={field.id}
-                        name={`values.${index}.updatedValue`}
-                        render={({ field: inputField }) => (
-                          <FormItem_Shadcn_>
-                            <FormLabel_Shadcn_ className={cn(index !== 0 && 'sr-only')}>
-                              Values
-                            </FormLabel_Shadcn_>
-                            {index === 0 && (
-                              <Alert_Shadcn_>
-                                <AlertCircle strokeWidth={1.5} />
-                                <AlertTitle_Shadcn_>
-                                  Existing values cannot be deleted or sorted
-                                </AlertTitle_Shadcn_>
-                                <AlertDescription_Shadcn_>
-                                  <p className="!leading-normal track">
-                                    You will need to delete and recreate the enumerated type with
-                                    the updated values instead.
-                                  </p>
-                                  <Button
-                                    asChild
-                                    type="default"
-                                    icon={<ExternalLink strokeWidth={1.5} />}
-                                    className="mt-2"
-                                  >
-                                    <Link
-                                      href="https://www.postgresql.org/message-id/21012.1459434338%40sss.pgh.pa.us"
-                                      target="_blank"
-                                      rel="noreferrer"
-                                    >
-                                      Learn more
-                                    </Link>
-                                  </Button>
-                                </AlertDescription_Shadcn_>
-                              </Alert_Shadcn_>
-                            )}
-                            <FormControl_Shadcn_>
-                              <EnumeratedTypeValueRow
-                                index={index}
-                                id={field.id}
-                                field={inputField}
-                                isDisabled={!field.isNew}
-                                onRemoveValue={() => remove(index)}
-                              />
-                            </FormControl_Shadcn_>
-                            <FormMessage_Shadcn_ className="ml-6" />
-                          </FormItem_Shadcn_>
-                        )}
-                      />
-                    ))}
-                    {droppableProvided.placeholder}
-                  </div>
+            <div>
+              <span
+                className={cn(
+                  'text-foreground-light text-sm',
+                  'transition-colors',
+                  'leading-normal'
                 )}
-              </Droppable>
-            </DragDropContext>
+              >
+                Values
+              </span>
+              <Alert_Shadcn_>
+                <AlertCircle strokeWidth={1.5} />
+                <AlertTitle_Shadcn_>Existing values cannot be deleted or sorted</AlertTitle_Shadcn_>
+                <AlertDescription_Shadcn_>
+                  <p className="!leading-normal track">
+                    You will need to delete and recreate the enumerated type with the updated values
+                    instead.
+                  </p>
+                  <Button
+                    asChild
+                    type="default"
+                    icon={<ExternalLink strokeWidth={1.5} />}
+                    className="mt-2"
+                  >
+                    <Link
+                      href="https://www.postgresql.org/message-id/21012.1459434338%40sss.pgh.pa.us"
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      Learn more
+                    </Link>
+                  </Button>
+                </AlertDescription_Shadcn_>
+              </Alert_Shadcn_>
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext items={fields} strategy={verticalListSortingStrategy}>
+                  {fields.map((field, index) => (
+                    <EnumeratedTypeValueRow
+                      key={field.id}
+                      id={field.id}
+                      name={`values.${index}.updatedValue`}
+                      index={index}
+                      control={form.control}
+                      isDisabled={!field.isNew}
+                      onRemoveValue={() => remove(index)}
+                    />
+                  ))}
+                </SortableContext>
+              </DndContext>
+            </div>
 
             <Button
               type="default"

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EditEnumeratedTypeSidePanel.tsx
@@ -84,7 +84,7 @@ const EditEnumeratedTypeSidePanel = ({
   })
   const { reset } = form
 
-  const { fields, append, remove, swap } = useFieldArray({
+  const { fields, append, remove, move } = useFieldArray({
     name: 'values',
     control: form.control,
   })
@@ -96,7 +96,7 @@ const EditEnumeratedTypeSidePanel = ({
     const activeIndex = fields.findIndex((item) => item.id === event.active.id)
     if (activeIndex < 0) return
 
-    swap(activeIndex, overIndex)
+    move(activeIndex, overIndex)
   }
 
   const originalEnumeratedTypes = useMemo(

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypeValueRow.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypeValueRow.tsx
@@ -1,50 +1,81 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
 import { GripVertical, Trash } from 'lucide-react'
-import { Draggable, DraggableProvided } from 'react-beautiful-dnd'
-import { Button, Input_Shadcn_ } from 'ui'
+import { Control } from 'react-hook-form'
+import {
+  Button,
+  FormControl_Shadcn_,
+  FormField_Shadcn_,
+  FormItem_Shadcn_,
+  FormLabel_Shadcn_,
+  FormMessage_Shadcn_,
+  Input_Shadcn_,
+} from 'ui'
 
 interface EnumeratedTypeValueRowProps {
+  control: Control<any>
   index: number
   id: string
-  field: any
+  name: string
   isDisabled?: boolean
   onRemoveValue: () => void
 }
 
 const EnumeratedTypeValueRow = ({
+  control,
   index,
   id,
-  field,
+  name,
   isDisabled = false,
   onRemoveValue,
 }: EnumeratedTypeValueRowProps) => {
+  const { attributes, listeners, setNodeRef, setActivatorNodeRef, transform, transition } =
+    useSortable({
+      disabled: isDisabled,
+      id,
+    })
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  }
+
   return (
-    <Draggable draggableId={id} index={index} isDragDisabled={isDisabled}>
-      {(draggableProvided: DraggableProvided) => (
-        <div
-          ref={draggableProvided.innerRef}
-          {...draggableProvided.draggableProps}
-          className="flex items-center space-x-2 space-y-2"
-        >
-          <div
-            {...draggableProvided.dragHandleProps}
-            className={`opacity-50 hover:opacity-100 transition ${
-              isDisabled ? 'text-foreground-lighter !cursor-default' : 'text-foreground'
-            }`}
-          >
-            <GripVertical size={16} strokeWidth={1.5} />
-          </div>
-          <Input_Shadcn_ {...field} className="w-full" />
-          <Button
-            type="default"
-            size="small"
-            disabled={isDisabled}
-            icon={<Trash strokeWidth={1.5} size={16} />}
-            className="px-2"
-            onClick={() => onRemoveValue()}
-          />
-        </div>
+    <FormField_Shadcn_
+      control={control}
+      name={name}
+      render={({ field: inputField }) => (
+        <FormItem_Shadcn_ ref={setNodeRef} style={style}>
+          <FormLabel_Shadcn_ className="sr-only">Value {index}</FormLabel_Shadcn_>
+          <FormControl_Shadcn_>
+            <div className="flex items-center space-x-2 space-y-2">
+              <button
+                ref={setActivatorNodeRef}
+                {...attributes}
+                {...listeners}
+                className={`opacity-50 hover:opacity-100 disabled:hover:opacity-50 transition cursor-grab ${
+                  isDisabled ? 'text-foreground-lighter !cursor-default' : 'text-foreground'
+                }`}
+                disabled={isDisabled}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <GripVertical size={16} strokeWidth={1.5} />
+              </button>
+              <Input_Shadcn_ {...inputField} className="w-full" />
+              <Button
+                type="default"
+                size="small"
+                disabled={isDisabled}
+                icon={<Trash strokeWidth={1.5} size={16} />}
+                className="px-2"
+                onClick={() => onRemoveValue()}
+              />
+            </div>
+          </FormControl_Shadcn_>
+          <FormMessage_Shadcn_ className="ml-6" />
+        </FormItem_Shadcn_>
       )}
-    </Draggable>
+    />
   )
 }
 

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypeValueRow.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypeValueRow.tsx
@@ -58,7 +58,6 @@ const EnumeratedTypeValueRow = ({
                 }`}
                 type="button"
                 disabled={isDisabled}
-                onClick={(e) => e.stopPropagation()}
               >
                 <GripVertical size={16} strokeWidth={1.5} />
               </button>

--- a/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypeValueRow.tsx
+++ b/apps/studio/components/interfaces/Database/EnumeratedTypes/EnumeratedTypeValueRow.tsx
@@ -56,6 +56,7 @@ const EnumeratedTypeValueRow = ({
                 className={`opacity-50 hover:opacity-100 disabled:hover:opacity-50 transition cursor-grab ${
                   isDisabled ? 'text-foreground-lighter !cursor-default' : 'text-foreground'
                 }`}
+                type="button"
                 disabled={isDisabled}
                 onClick={(e) => e.stopPropagation()}
               >


### PR DESCRIPTION
## Problem

We currently have 3 different libraries for drag & drop, two of which are not actively maintained anymore.

## Solution

Migrate all usage of the two unmaintained libraries to DndKit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced drag-and-drop with a newer library offering pointer and keyboard sensors, improved accessibility, and more reliable reordering.
  * Simplified list markup by removing legacy wrappers and placeholders; rows render directly and use a dedicated drag handle.
  * Updated row editing to use form controls with inline validation.
  * Improved form initialization/reset behavior and disable the side panel when the form is not dirty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->