### PR TITLE
refactor: switch to @ imports and enforce sorting for studio/state

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -5,8 +5,6 @@ import useLogsQuery from 'hooks/analytics/useLogsQuery'
 import { ExternalLink } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { Fragment, useMemo } from 'react'
-import { useAiAssistantStateSnapshot } from 'state/ai-assistant-state'
-import { useSidebarManagerSnapshot } from 'state/sidebar-manager-state'
 import {
   Badge,
   Button,
@@ -43,6 +41,8 @@ import {
   toAlertError,
   type RecentErrorGroup,
 } from './EdgeFunctionRecentErrors.utils'
+import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 interface EdgeFunctionRecentErrorsProps {
   functionId?: string

--- a/apps/studio/state/addons-page.ts
+++ b/apps/studio/state/addons-page.ts
@@ -1,4 +1,4 @@
-import { useUrlState } from 'hooks/ui/useUrlState'
+import { useUrlState } from '@/hooks/ui/useUrlState'
 
 export const ADDONS_PANEL_KEYS_ARRAY = ['pitr', 'customDomain', 'ipv4'] as const
 

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -1,19 +1,18 @@
 import { Chat, type UIMessage as MessageType } from '@ai-sdk/react'
 import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { DBSchema, IDBPDatabase, openDB } from 'idb'
 import { debounce } from 'lodash'
 import { createContext, PropsWithChildren, useContext, useEffect, useState } from 'react'
 import { v4 as uuidv4 } from 'uuid'
 import { proxy, ref, snapshot, subscribe, useSnapshot } from 'valtio'
 
-import { constructHeaders } from 'data/fetchers'
-import { prepareMessagesForAPI } from 'lib/ai/message-utils'
-import { isKnownAssistantModelId } from 'lib/ai/model.utils'
-import type { AssistantModelId } from 'lib/ai/model.utils'
-import { BASE_PATH, IS_PLATFORM } from 'lib/constants'
-
-import { LOCAL_STORAGE_KEYS } from 'common'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
+import { constructHeaders } from '@/data/fetchers'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { prepareMessagesForAPI } from '@/lib/ai/message-utils'
+import { isKnownAssistantModelId } from '@/lib/ai/model.utils'
+import type { AssistantModelId } from '@/lib/ai/model.utils'
+import { BASE_PATH, IS_PLATFORM } from '@/lib/constants'
 
 type SuggestionsType = {
   title: string

--- a/apps/studio/state/database-selector.tsx
+++ b/apps/studio/state/database-selector.tsx
@@ -1,7 +1,6 @@
-import { PropsWithChildren, createContext, useCallback, useContext } from 'react'
-import { proxy, snapshot, useSnapshot } from 'valtio'
-
 import { useConstant } from 'common'
+import { createContext, PropsWithChildren, useCallback, useContext } from 'react'
+import { proxy, snapshot, useSnapshot } from 'valtio'
 
 export function createDatabaseSelectorState() {
   const state = proxy({

--- a/apps/studio/state/database-settings.tsx
+++ b/apps/studio/state/database-settings.tsx
@@ -1,7 +1,6 @@
-import { PropsWithChildren, createContext, useContext } from 'react'
-import { proxy, useSnapshot } from 'valtio'
-
 import { useConstant } from 'common'
+import { createContext, PropsWithChildren, useContext } from 'react'
+import { proxy, useSnapshot } from 'valtio'
 
 export function createDatabaseSettingsState() {
   const state = proxy({

--- a/apps/studio/state/role-impersonation-state.tsx
+++ b/apps/studio/state/role-impersonation-state.tsx
@@ -1,12 +1,12 @@
+import { useConstant } from 'common'
 import { createContext, PropsWithChildren, useCallback, useContext, useEffect } from 'react'
 import { proxy, snapshot, subscribe, useSnapshot } from 'valtio'
 
-import { useConstant } from 'common'
-import { executeSql } from 'data/sql/execute-sql-query'
-import useLatest from 'hooks/misc/useLatest'
-import { useSelectedProjectQuery } from 'hooks/misc/useSelectedProject'
-import { getPostgrestClaims, ImpersonationRole } from 'lib/role-impersonation'
 import { CustomAccessTokenHookDetails } from '../hooks/misc/useCustomAccessTokenHookDetails'
+import { executeSql } from '@/data/sql/execute-sql-query'
+import useLatest from '@/hooks/misc/useLatest'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { getPostgrestClaims, ImpersonationRole } from '@/lib/role-impersonation'
 
 export function createRoleImpersonationState(
   projectRef: string,

--- a/apps/studio/state/sidebar-manager-state.tsx
+++ b/apps/studio/state/sidebar-manager-state.tsx
@@ -1,8 +1,9 @@
 import { LOCAL_STORAGE_KEYS } from 'common/constants'
-import useLatest from 'hooks/misc/useLatest'
-import { useLocalStorageQuery } from 'hooks/misc/useLocalStorage'
 import { ReactNode, useEffect } from 'react'
 import { proxy, snapshot, useSnapshot } from 'valtio'
+
+import useLatest from '@/hooks/misc/useLatest'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 type SidebarHandlers = {
   onOpen?: () => void

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -1,17 +1,18 @@
-import type { QueryPlanRow } from 'components/interfaces/ExplainVisualizer/ExplainVisualizer.types'
-import { DiffType } from 'components/interfaces/SQLEditor/SQLEditor.types'
-import { UpsertContentPayload, upsertContent } from 'data/content/content-upsert-mutation'
-import { contentKeys } from 'data/content/keys'
-import { createSQLSnippetFolder } from 'data/content/sql-folder-create-mutation'
-import { updateSQLSnippetFolder } from 'data/content/sql-folder-update-mutation'
-import { Snippet, SnippetFolder } from 'data/content/sql-folders-query'
-import { getQueryClient } from 'data/query-client'
 import { debounce, memoize } from 'lodash'
 import { useMemo } from 'react'
 import { toast } from 'sonner'
 import type { SqlSnippets } from 'types'
 import { proxy, ref, snapshot, subscribe, useSnapshot } from 'valtio'
 import { devtools, proxyMap } from 'valtio/utils'
+
+import type { QueryPlanRow } from '@/components/interfaces/ExplainVisualizer/ExplainVisualizer.types'
+import { DiffType } from '@/components/interfaces/SQLEditor/SQLEditor.types'
+import { upsertContent, UpsertContentPayload } from '@/data/content/content-upsert-mutation'
+import { contentKeys } from '@/data/content/keys'
+import { createSQLSnippetFolder } from '@/data/content/sql-folder-create-mutation'
+import { updateSQLSnippetFolder } from '@/data/content/sql-folder-update-mutation'
+import { Snippet, SnippetFolder } from '@/data/content/sql-folders-query'
+import { getQueryClient } from '@/data/query-client'
 
 type StateSnippetFolder = {
   projectRef: string

--- a/apps/studio/state/table-editor-operation-queue.types.ts
+++ b/apps/studio/state/table-editor-operation-queue.types.ts
@@ -1,7 +1,7 @@
-import type { Entity } from 'data/table-editor/table-editor-types'
 import type { Dictionary } from 'types'
 
 import { PendingAddRow, SupaRow } from '@/components/grid/types'
+import type { Entity } from '@/data/table-editor/table-editor-types'
 
 export enum QueuedOperationType {
   EDIT_CELL_CONTENT = 'edit_cell_content',

--- a/apps/studio/state/table-editor-table.tsx
+++ b/apps/studio/state/table-editor-table.tsx
@@ -1,19 +1,19 @@
-import { TableIndexAdvisorProvider } from 'components/grid/context/TableIndexAdvisorContext'
-import {
-  loadTableEditorStateFromLocalStorage,
-  parseSupaTable,
-  saveTableEditorStateToLocalStorageDebounced,
-} from 'components/grid/SupabaseGrid.utils'
-import { Filter, SupaRow } from 'components/grid/types'
-import { getInitialGridColumns } from 'components/grid/utils/column'
-import { getGridColumns } from 'components/grid/utils/gridColumns'
-import { Entity } from 'data/table-editor/table-editor-types'
 import { createContext, PropsWithChildren, useContext, useEffect, useRef } from 'react'
 import { CalculatedColumn } from 'react-data-grid'
 import { proxy, ref, subscribe, useSnapshot } from 'valtio'
 import { proxySet } from 'valtio/utils'
 
 import { useTableEditorStateSnapshot } from './table-editor'
+import { TableIndexAdvisorProvider } from '@/components/grid/context/TableIndexAdvisorContext'
+import {
+  loadTableEditorStateFromLocalStorage,
+  parseSupaTable,
+  saveTableEditorStateToLocalStorageDebounced,
+} from '@/components/grid/SupabaseGrid.utils'
+import { Filter, SupaRow } from '@/components/grid/types'
+import { getInitialGridColumns } from '@/components/grid/utils/column'
+import { getGridColumns } from '@/components/grid/utils/gridColumns'
+import { Entity } from '@/data/table-editor/table-editor-types'
 
 export const createTableEditorTableState = ({
   projectRef,

--- a/apps/studio/state/table-editor.tsx
+++ b/apps/studio/state/table-editor.tsx
@@ -1,16 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
 import type { PostgresColumn } from '@supabase/postgres-meta'
 import { useConstant } from 'common'
-import type { SupaRow } from 'components/grid/types'
-import {
-  resolveDeleteRowConflicts,
-  resolveEditCellConflicts,
-  upsertOperation,
-} from 'components/grid/utils/queueConflictResolution'
-import { generateTableChangeKey } from 'components/grid/utils/queueOperationUtils'
-import { ForeignKey } from 'components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types'
-import type { EditValue } from 'components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
-import type { TableField } from 'components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types'
 import { createContext, PropsWithChildren, useContext } from 'react'
 import type { Dictionary } from 'types'
 import { proxy, useSnapshot } from 'valtio'
@@ -21,6 +11,16 @@ import {
   type OperationQueueState,
   type QueueStatus,
 } from './table-editor-operation-queue.types'
+import type { SupaRow } from '@/components/grid/types'
+import {
+  resolveDeleteRowConflicts,
+  resolveEditCellConflicts,
+  upsertOperation,
+} from '@/components/grid/utils/queueConflictResolution'
+import { generateTableChangeKey } from '@/components/grid/utils/queueOperationUtils'
+import { ForeignKey } from '@/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.types'
+import type { EditValue } from '@/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.types'
+import type { TableField } from '@/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.types'
 
 export const TABLE_EDITOR_DEFAULT_ROWS_PER_PAGE = 100
 

--- a/prettier.config.mjs
+++ b/prettier.config.mjs
@@ -28,7 +28,7 @@ if (process.env.SORT_IMPORTS !== 'false') {
   options = { ...options, ...sortImportsOptions }
 } else {
   options.overrides.push({
-    files: 'apps/studio/{components,data,hooks}/**/*.{js,jsx,ts,tsx}',
+    files: 'apps/studio/{components,data,hooks,state}/**/*.{js,jsx,ts,tsx}',
     options: sortImportsOptions,
   })
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized internal import paths to use unified alias conventions across the studio codebase.
  * Reorganized import ordering for improved consistency and readability.
  * Expanded import-sorting scope in formatting config to cover additional studio code areas when import-sorting is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->