### PR TITLE
fix: add tooltip, replace button with Tooltip one

### DIFF
--- a/apps/studio/components/interfaces/LocalDropdown.tsx
+++ b/apps/studio/components/interfaces/LocalDropdown.tsx
@@ -17,9 +17,9 @@ import {
 } from 'ui'
 import { useSetCommandMenuOpen } from 'ui-patterns'
 
+import { ButtonTooltip } from '../ui/ButtonTooltip'
 import { useFeaturePreviewModal } from './App/FeaturePreview/FeaturePreviewContext'
 import { ProfileImage } from '@/components/ui/ProfileImage'
-import { ButtonTooltip } from '../ui/ButtonTooltip'
 
 export const LocalDropdown = ({
   triggerClassName,
@@ -37,8 +37,8 @@ export const LocalDropdown = ({
       <DropdownMenuTrigger className={cn('border flex-shrink-0 px-3', triggerClassName)} asChild>
         <ButtonTooltip
           type="default"
-          className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8" 
-          tooltip={{ content: { text: 'Settings' } }}            
+          className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
+          tooltip={{ content: { text: 'Settings' } }}
         >
           <ProfileImage className="w-8 h-8 rounded-md" />
         </ButtonTooltip>

--- a/apps/studio/components/interfaces/LocalDropdown.tsx
+++ b/apps/studio/components/interfaces/LocalDropdown.tsx
@@ -19,6 +19,7 @@ import { useSetCommandMenuOpen } from 'ui-patterns'
 
 import { useFeaturePreviewModal } from './App/FeaturePreview/FeaturePreviewContext'
 import { ProfileImage } from '@/components/ui/ProfileImage'
+import { ButtonTooltip } from '../ui/ButtonTooltip'
 
 export const LocalDropdown = ({
   triggerClassName,
@@ -34,12 +35,13 @@ export const LocalDropdown = ({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger className={cn('border flex-shrink-0 px-3', triggerClassName)} asChild>
-        <Button
+        <ButtonTooltip
           type="default"
-          className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
+          className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8" 
+          tooltip={{ content: { text: 'Settings' } }}            
         >
           <ProfileImage className="w-8 h-8 rounded-md" />
-        </Button>
+        </ButtonTooltip>
       </DropdownMenuTrigger>
       <DropdownMenuContent side="bottom" align="end" className={cn('w-44', contentClassName)}>
         <DropdownMenuItem

--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -24,6 +24,7 @@ import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useProfileNameAndPicture } from '@/lib/profile'
 import { useAppStateSnapshot } from '@/state/app-state'
+import { ButtonTooltip } from '../ui/ButtonTooltip'
 
 export function UserDropdown({
   triggerClassName,
@@ -43,9 +44,10 @@ export function UserDropdown({
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild className={cn('border flex-shrink-0 px-3', triggerClassName)}>
-        <Button
+        <ButtonTooltip
           type="default"
           className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
+          tooltip={{ content: { text: 'Account settings' } }}    
         >
           {isLoading ? (
             <div className="w-full h-full flex items-center justify-center">
@@ -54,7 +56,7 @@ export function UserDropdown({
           ) : (
             <ProfileImage alt={username} src={avatarUrl} className="w-8 h-8 rounded-md" />
           )}
-        </Button>
+        </ButtonTooltip>
       </DropdownMenuTrigger>
 
       <DropdownMenuContent side="bottom" align="end" className={contentClassName}>

--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -18,13 +18,13 @@ import {
   Theme,
 } from 'ui'
 
+import { ButtonTooltip } from '../ui/ButtonTooltip'
 import { useFeaturePreviewModal } from './App/FeaturePreview/FeaturePreviewContext'
 import { ProfileImage } from '@/components/ui/ProfileImage'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useProfileNameAndPicture } from '@/lib/profile'
 import { useAppStateSnapshot } from '@/state/app-state'
-import { ButtonTooltip } from '../ui/ButtonTooltip'
 
 export function UserDropdown({
   triggerClassName,
@@ -47,7 +47,7 @@ export function UserDropdown({
         <ButtonTooltip
           type="default"
           className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
-          tooltip={{ content: { text: 'Account settings' } }}    
+          tooltip={{ content: { text: 'Account settings' } }}
         >
           {isLoading ? (
             <div className="w-full h-full flex items-center justify-center">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a tooltip for the account settings button

## What is the current behavior?

It has no tooltip

Closes #44524

## What is the new behavior?

Has Tooltip

## Additional context

<img width="552" height="167" alt="Screenshot 2026-04-03 at 22 21 35" src="https://github.com/user-attachments/assets/e41caee7-e688-4bd9-8823-0c47133c5470" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added descriptive tooltips to studio dropdown triggers: the settings dropdown now shows "Settings".
  * The user account dropdown trigger now shows "Account settings" to improve discoverability and guidance for key interface controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->