### PR TITLE
fix: regenerate pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37118,7 +37118,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
-      next: 15.5.14(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
+      next: 15.5.14(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
 
   unified@10.1.2:
     dependencies:


### PR DESCRIPTION
## Summary
- Regenerates pnpm-lock.yaml to fix broken lockfile entry for `next@15.5.14` after merge
- Resolves CI `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY` failure

## Test plan
- [ ] CI passes with the updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)