### PR TITLE
Update SvelteKit Connect File to use Svelte 5 props

### DIFF
--- a/apps/studio/components/interfaces/Connect/content/sveltekit/supabasejs/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/sveltekit/supabasejs/content.tsx
@@ -64,7 +64,7 @@ export async function load() {
         <SimpleCodeBlock className="html" parentClassName="min-h-72">
           {`
 <script>
-  export let data;
+  let { data } = $props();
 </script>
 
 <ul>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Uses old Svelte 4 props behavior.

## What is the new behavior?

Updates prop behavior to Svelte 5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SvelteKit code examples in the Supabase integration guide to reflect current best practices for component prop handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->