### PR TITLE
fix: add tooltip to settings icon in dashboard

### DIFF
--- a/apps/studio/components/interfaces/LocalDropdown.tsx
+++ b/apps/studio/components/interfaces/LocalDropdown.tsx
@@ -12,6 +12,9 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   singleThemes,
   Theme,
 } from 'ui'
@@ -33,14 +36,22 @@ export const LocalDropdown = ({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger className={cn('border flex-shrink-0 px-3', triggerClassName)} asChild>
-        <Button
-          type="default"
-          className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
-        >
-          <ProfileImage className="w-8 h-8 rounded-md" />
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger className={cn('border flex-shrink-0 px-3', triggerClassName)} asChild>
+            <Button
+              type="default"
+              aria-label="Open account menu"
+              className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
+            >
+              <ProfileImage className="w-8 h-8 rounded-md" />
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Settings</p>
+        </TooltipContent>
+      </Tooltip>
       <DropdownMenuContent side="bottom" align="end" className={cn('w-44', contentClassName)}>
         <DropdownMenuItem
           className="flex gap-2 cursor-pointer"

--- a/apps/studio/components/interfaces/LocalDropdown.tsx
+++ b/apps/studio/components/interfaces/LocalDropdown.tsx
@@ -12,11 +12,11 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  singleThemes,
+  Theme,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-  singleThemes,
-  Theme,
 } from 'ui'
 import { useSetCommandMenuOpen } from 'ui-patterns'
 
@@ -38,7 +38,10 @@ export const LocalDropdown = ({
     <DropdownMenu>
       <Tooltip>
         <TooltipTrigger asChild>
-          <DropdownMenuTrigger className={cn('border flex-shrink-0 px-3', triggerClassName)} asChild>
+          <DropdownMenuTrigger
+            className={cn('border flex-shrink-0 px-3', triggerClassName)}
+            asChild
+          >
             <Button
               type="default"
               aria-label="Open account menu"

--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -14,11 +14,11 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  singleThemes,
+  Theme,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
-  singleThemes,
-  Theme,
 } from 'ui'
 
 import { useFeaturePreviewModal } from './App/FeaturePreview/FeaturePreviewContext'
@@ -47,7 +47,10 @@ export function UserDropdown({
     <DropdownMenu>
       <Tooltip>
         <TooltipTrigger asChild>
-          <DropdownMenuTrigger asChild className={cn('border flex-shrink-0 px-3', triggerClassName)}>
+          <DropdownMenuTrigger
+            asChild
+            className={cn('border flex-shrink-0 px-3', triggerClassName)}
+          >
             <Button
               type="default"
               aria-label="Open account menu"

--- a/apps/studio/components/interfaces/UserDropdown.tsx
+++ b/apps/studio/components/interfaces/UserDropdown.tsx
@@ -14,6 +14,9 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   singleThemes,
   Theme,
 } from 'ui'
@@ -42,20 +45,28 @@ export function UserDropdown({
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild className={cn('border flex-shrink-0 px-3', triggerClassName)}>
-        <Button
-          type="default"
-          className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
-        >
-          {isLoading ? (
-            <div className="w-full h-full flex items-center justify-center">
-              <Loader2 className="animate-spin text-foreground-lighter" size={16} />
-            </div>
-          ) : (
-            <ProfileImage alt={username} src={avatarUrl} className="w-8 h-8 rounded-md" />
-          )}
-        </Button>
-      </DropdownMenuTrigger>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger asChild className={cn('border flex-shrink-0 px-3', triggerClassName)}>
+            <Button
+              type="default"
+              aria-label="Open account menu"
+              className="[&>span]:flex px-0 py-0 rounded-full overflow-hidden h-8 w-8"
+            >
+              {isLoading ? (
+                <div className="w-full h-full flex items-center justify-center">
+                  <Loader2 className="animate-spin text-foreground-lighter" size={16} />
+                </div>
+              ) : (
+                <ProfileImage alt={username} src={avatarUrl} className="w-8 h-8 rounded-md" />
+              )}
+            </Button>
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          <p>Account</p>
+        </TooltipContent>
+      </Tooltip>
 
       <DropdownMenuContent side="bottom" align="end" className={contentClassName}>
         {IS_PLATFORM && (


### PR DESCRIPTION
## I have read the [[CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md)](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (UI/UX improvement)

## What is the current behavior?

The settings icon button in the dashboard does not display a tooltip on hover.
This makes it less accessible and unclear for users, as the button has no accompanying text or description.

Related issue: #44524

## What is the new behavior?

A tooltip is now displayed when hovering over the settings icon, improving accessibility and user experience by providing context about the button's functionality.

## Additional context

* This change enhances usability, especially for new users.
* No breaking changes introduced.
* UI remains consistent with existing tooltip patterns in the dashboard.

<img width="1470" height="956" alt="Screenshot 2026-04-05 at 11 30 00 AM" src="https://github.com/user-attachments/assets/de393e9c-9ae0-4356-bac7-35ac7cff4270" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account and settings menu controls now show contextual tooltips on hover, labeled "Account" and "Settings" to clarify available actions.

* **Accessibility**
  * Account menu buttons gained aria-labels ("Open account menu") to improve screen reader support and keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->