### PR TITLE
fix: update import paths for Supabase client to use the new package name

### DIFF
--- a/examples/edge-functions/supabase/functions/background-upload-storage/index.ts
+++ b/examples/edge-functions/supabase/functions/background-upload-storage/index.ts
@@ -1,4 +1,4 @@
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 import OpenAI from 'https://deno.land/x/openai@v4.68.2/mod.ts'
 
 const client = new OpenAI({ apiKey: Deno.env.get('OPENAI_API_KEY')! })

--- a/examples/edge-functions/supabase/functions/elevenlabs-speech-to-text/index.ts
+++ b/examples/edge-functions/supabase/functions/elevenlabs-speech-to-text/index.ts
@@ -4,7 +4,7 @@
 
 // Setup type definitions for built-in Supabase Runtime APIs
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 
 console.log(`Function "elevenlabs-scribe-bot" up and running!`)
 

--- a/examples/edge-functions/supabase/functions/elevenlabs-text-to-speech/index.ts
+++ b/examples/edge-functions/supabase/functions/elevenlabs-text-to-speech/index.ts
@@ -1,6 +1,6 @@
 // Setup type definitions for built-in Supabase Runtime APIs
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 import { ElevenLabsClient } from 'npm:elevenlabs@1.52.0'
 import * as hash from 'npm:object-hash'
 

--- a/examples/edge-functions/supabase/functions/file-upload-storage/index.ts
+++ b/examples/edge-functions/supabase/functions/file-upload-storage/index.ts
@@ -2,7 +2,7 @@
 // and write files to Supabase Storage and other fields to a database table.
 
 import { Application } from 'https://deno.land/x/oak@v11.1.0/mod.ts'
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 
 const MB = 1024 * 1024
 

--- a/examples/edge-functions/supabase/functions/get-tshirt-competition/index.ts
+++ b/examples/edge-functions/supabase/functions/get-tshirt-competition/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 // New approach (v2.95.0+)
 import { corsHeaders } from 'jsr:@supabase/supabase-js@2/cors'
 // For older versions:

--- a/examples/edge-functions/supabase/functions/huggingface-image-captioning/index.ts
+++ b/examples/edge-functions/supabase/functions/huggingface-image-captioning/index.ts
@@ -1,5 +1,5 @@
 import { HfInference } from 'https://esm.sh/@huggingface/inference@2.3.2'
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 import { Database } from './types.ts'
 
 console.log('Hello from `huggingface-image-captioning` function!')

--- a/examples/edge-functions/supabase/functions/openai-image-generation/index.ts
+++ b/examples/edge-functions/supabase/functions/openai-image-generation/index.ts
@@ -2,7 +2,7 @@
 // - `generated-images` bucket already created.
 // - `OPENAI_API_KEY` environment variable set.
 
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 import OpenAI, { toFile } from 'jsr:@openai/openai@4.96.2'
 
 // Configure COS headers for the function

--- a/examples/edge-functions/supabase/functions/read-storage/index.ts
+++ b/examples/edge-functions/supabase/functions/read-storage/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 // New approach (v2.95.0+)
 import { corsHeaders } from 'jsr:@supabase/supabase-js@2/cors'
 // For older versions, use hardcoded headers:

--- a/examples/edge-functions/supabase/functions/restful-tasks/index.ts
+++ b/examples/edge-functions/supabase/functions/restful-tasks/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient, SupabaseClient } from 'npm:supabase-js@2'
+import { createClient, SupabaseClient } from 'npm:@supabase/supabase-js'
 // New approach (v2.95.0+)
 import { corsHeaders } from 'jsr:@supabase/supabase-js@2/cors'
 // For older versions, use hardcoded headers:

--- a/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
+++ b/examples/edge-functions/supabase/functions/select-from-table-with-auth-rls/index.ts
@@ -2,7 +2,7 @@
 // https://deno.land/manual/getting_started/setup_your_environment
 // This enables autocomplete, go to definition, etc.
 
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 // New approach (v2.95.0+)
 import { corsHeaders } from 'jsr:@supabase/supabase-js@2/cors'
 // For older versions:

--- a/examples/edge-functions/supabase/functions/sentry/index.ts
+++ b/examples/edge-functions/supabase/functions/sentry/index.ts
@@ -4,7 +4,7 @@
 
 console.log('Hello from the Sentry Functions Challenge!')
 
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 import * as Sentry from 'https://deno.land/x/sentry@7.102.0/index.mjs'
 
 const supabase = createClient(

--- a/examples/edge-functions/supabase/functions/upstash-redis-ratelimit/index.ts
+++ b/examples/edge-functions/supabase/functions/upstash-redis-ratelimit/index.ts
@@ -1,6 +1,6 @@
 import { Redis } from 'https://deno.land/x/upstash_redis@v1.19.3/mod.ts'
 import { Ratelimit } from 'https://cdn.skypack.dev/@upstash/ratelimit@0.4.4'
-import { createClient } from 'npm:supabase-js@2'
+import { createClient } from 'npm:@supabase/supabase-js'
 
 console.log(`Function "upstash-redis-counter" up and running!`)
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / examples maintenance.

## What is the current behavior?

Several Edge Function examples still import the Supabase client from `npm:supabase-js@2`, which uses the old npm package name.

## What is the new behavior?

These examples now import the client from `npm:@supabase/supabase-js` instead. This keeps the examples aligned with the current package name without changing their runtime logic.

Updated examples include:
- background-upload-storage
- elevenlabs-speech-to-text
- elevenlabs-text-to-speech
- file-upload-storage
- get-tshirt-competition
- huggingface-image-captioning
- openai-image-generation
- read-storage
- restful-tasks
- select-from-table-with-auth-rls
- sentry
- upstash-redis-ratelimit

## Additional context

This PR only updates import paths in example Edge Functions.

Validation:
- reviewed the branch diff against `master`
- confirmed there are no remaining `npm:supabase-js@2` imports in the repository


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Supabase client library imports across example edge functions to align with the current package distribution standards, ensuring consistency and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->