### PR TITLE
chore: add ssl modes table for reference

### DIFF
--- a/apps/docs/content/guides/platform/ssl-enforcement.mdx
+++ b/apps/docs/content/guides/platform/ssl-enforcement.mdx
@@ -103,6 +103,15 @@ supabase ssl-enforcement --project-ref {ref} update --disable-db-ssl-enforcement
 
 Postgres supports [multiple SSL modes](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) on the client side. These modes provide different levels of protection. Depending on your needs, it is important to verify that the SSL mode in use is performing the required level of enforcement and verification of SSL connections.
 
+| SSL Mode | Encryption | Verifies CA | Verifies Hostname | Description |
+| --- | --- | --- | --- | --- |
+| `disable` | No | No | No | SSL is not used. All data is transmitted in plaintext. |
+| `allow` | Optional | No | No | Tries a non-SSL connection first; falls back to SSL if the server requires it. |
+| `prefer` | Optional | No | No | Tries an SSL connection first; falls back to non-SSL if the server doesn't support it. This is the default. |
+| `require` | Yes | No | No | Always uses SSL, but does not verify the server certificate or hostname. |
+| `verify-ca` | Yes | Yes | No | Uses SSL and verifies that the server certificate is signed by a trusted CA. |
+| `verify-full` | Yes | Yes | Yes | Uses SSL, verifies the CA certificate, and confirms the hostname matches the certificate. Recommended when SSL enforcement is enabled. |
+
 The strongest mode offered by Postgres is `verify-full` and this is the mode you most likely want to use when SSL enforcement is enabled. To use `verify-full` you will need to download the Supabase CA certificate for your database. The certificate is available through the dashboard under the SSL Configuration section in the [Database Settings page](/dashboard/project/_/database/settings).
 
 Once the CA certificate has been downloaded, add it to the certificate authority list used by Postgres.

--- a/apps/docs/content/guides/platform/ssl-enforcement.mdx
+++ b/apps/docs/content/guides/platform/ssl-enforcement.mdx
@@ -103,14 +103,14 @@ supabase ssl-enforcement --project-ref {ref} update --disable-db-ssl-enforcement
 
 Postgres supports [multiple SSL modes](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBPQ-SSL-PROTECTION) on the client side. These modes provide different levels of protection. Depending on your needs, it is important to verify that the SSL mode in use is performing the required level of enforcement and verification of SSL connections.
 
-| SSL Mode | Encryption | Verifies CA | Verifies Hostname | Description |
-| --- | --- | --- | --- | --- |
-| `disable` | No | No | No | SSL is not used. All data is transmitted in plaintext. |
-| `allow` | Optional | No | No | Tries a non-SSL connection first; falls back to SSL if the server requires it. |
-| `prefer` | Optional | No | No | Tries an SSL connection first; falls back to non-SSL if the server doesn't support it. This is the default. |
-| `require` | Yes | No | No | Always uses SSL, but does not verify the server certificate or hostname. |
-| `verify-ca` | Yes | Yes | No | Uses SSL and verifies that the server certificate is signed by a trusted CA. |
-| `verify-full` | Yes | Yes | Yes | Uses SSL, verifies the CA certificate, and confirms the hostname matches the certificate. Recommended when SSL enforcement is enabled. |
+| SSL Mode      | Encryption | Verifies CA | Verifies Hostname | Description                                                                                                                            |
+| ------------- | ---------- | ----------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `disable`     | No         | No          | No                | SSL is not used. All data is transmitted in plaintext.                                                                                 |
+| `allow`       | Optional   | No          | No                | Tries a non-SSL connection first; falls back to SSL if the server requires it.                                                         |
+| `prefer`      | Optional   | No          | No                | Tries an SSL connection first; falls back to non-SSL if the server doesn't support it. This is the default.                            |
+| `require`     | Yes        | No          | No                | Always uses SSL, but does not verify the server certificate or hostname.                                                               |
+| `verify-ca`   | Yes        | Yes         | No                | Uses SSL and verifies that the server certificate is signed by a trusted CA.                                                           |
+| `verify-full` | Yes        | Yes         | Yes               | Uses SSL, verifies the CA certificate, and confirms the hostname matches the certificate. Recommended when SSL enforcement is enabled. |
 
 The strongest mode offered by Postgres is `verify-full` and this is the mode you most likely want to use when SSL enforcement is enabled. To use `verify-full` you will need to download the Supabase CA certificate for your database. The certificate is available through the dashboard under the SSL Configuration section in the [Database Settings page](/dashboard/project/_/database/settings).
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the new behavior?

SSL modes table reference
<img width="1000" height="567" alt="CleanShot 2026-04-05 at 15 39 27" src="https://github.com/user-attachments/assets/ed05d05b-b559-4554-aef1-d70038f520b9" />

## Additional context
While there is a table available in postgres docs, other providers do include simplified versions of that table. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a clear reference table for Postgres client-side SSL modes (disable, allow, prefer, require, verify-ca, verify-full), summarizing encryption, certificate authority validation, hostname verification, and connection behavior for each mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->