### PR TITLE
fix mgmt api examples for ipv4 addon

### DIFF
--- a/apps/docs/content/guides/platform/ipv4-address.mdx
+++ b/apps/docs/content/guides/platform/ipv4-address.mdx
@@ -44,11 +44,12 @@ curl -X POST "https://api.supabase.com/v1/projects/$PROJECT_REF/addons" \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
+    "addon_variant": "ipv4_default", 
     "addon_type": "ipv4"
   }'
 
 # Disable IPv4 add-on
-curl -X DELETE "https://api.supabase.com/v1/projects/$PROJECT_REF/billing/addons/ipv4" \
+curl -X DELETE "https://api.supabase.com/v1/projects/$PROJECT_REF/billing/addons/ipv4_default" \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
 ```
 

--- a/apps/docs/content/guides/platform/ipv4-address.mdx
+++ b/apps/docs/content/guides/platform/ipv4-address.mdx
@@ -40,7 +40,7 @@ curl -X GET "https://api.supabase.com/v1/projects/$PROJECT_REF/billing/addons" \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN"
 
 # Enable IPv4 add-on
-curl -X POST "https://api.supabase.com/v1/projects/$PROJECT_REF/addons" \
+curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/billing/addons" \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{

--- a/apps/docs/content/guides/platform/ipv4-address.mdx
+++ b/apps/docs/content/guides/platform/ipv4-address.mdx
@@ -44,7 +44,7 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/billing/addons"
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "addon_variant": "ipv4_default", 
+    "addon_variant": "ipv4_default",
     "addon_type": "ipv4"
   }'
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Incorrect examples that don't work

## What is the new behavior?

Added correct attributes 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Management API guide for the Dedicated IPv4 add-on: examples now include the add-on variant when enabling.
  * Clarified example API paths for enabling and disabling the IPv4 add-on to reflect variant-specific endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->