### PR TITLE
fix(studio): apply literal() escaping to remaining queue mutation files

### DIFF
--- a/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
+++ b/apps/studio/data/database-queues/database-queue-messages-read-mutation.ts
@@ -1,3 +1,4 @@
+import { literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -30,7 +31,7 @@ export async function readDatabaseQueueMessage({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from pgmq.set_vt('${queueName}', ${messageId}, ${duration})`,
+    sql: `select * from pgmq.set_vt(${literal(queueName)}, ${literal(messageId)}, ${literal(duration)})`,
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/database-queues/database-queues-create-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-create-mutation.ts
@@ -1,7 +1,9 @@
+import { ident, literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import { databaseQueuesKeys } from './keys'
+import { isQueueNameValid } from '@/components/interfaces/Integrations/Queues/Queues.utils'
 import { executeSql } from '@/data/sql/execute-sql-query'
 import { tableKeys } from '@/data/tables/keys'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -26,19 +28,25 @@ export async function createDatabaseQueue({
   enableRls,
   configuration,
 }: DatabaseQueueCreateVariables) {
+  if (!isQueueNameValid(name)) {
+    throw new Error(
+      'Invalid queue name: must contain only alphanumeric characters, underscores, and hyphens'
+    )
+  }
+
   const { partitionInterval, retentionInterval } = configuration ?? {}
 
   const query =
     type === 'partitioned'
-      ? `select from pgmq.create_partitioned('${name}', '${partitionInterval}', '${retentionInterval}');`
+      ? `select from pgmq.create_partitioned(${literal(name)}, ${literal(partitionInterval)}, ${literal(retentionInterval)});`
       : type === 'unlogged'
-        ? `SELECT pgmq.create_unlogged('${name}');`
-        : `SELECT pgmq.create('${name}');`
+        ? `SELECT pgmq.create_unlogged(${literal(name)});`
+        : `SELECT pgmq.create(${literal(name)});`
 
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `${query} ${enableRls ? `alter table pgmq."q_${name}" enable row level security;` : ''}`.trim(),
+    sql: `${query} ${enableRls ? `alter table pgmq.${ident('q_' + name)} enable row level security;` : ''}`.trim(),
     queryKey: databaseQueuesKeys.create(),
   })
 

--- a/apps/studio/data/database-queues/database-queues-delete-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-delete-mutation.ts
@@ -1,3 +1,4 @@
+import { literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -26,7 +27,7 @@ export async function deleteDatabaseQueue({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from pgmq.drop_queue('${queueName}');`,
+    sql: `select * from pgmq.drop_queue(${literal(queueName)});`,
     queryKey: databaseQueuesKeys.delete(queueName),
   })
 

--- a/apps/studio/data/database-queues/database-queues-metrics-query.ts
+++ b/apps/studio/data/database-queues/database-queues-metrics-query.ts
@@ -1,3 +1,4 @@
+import { ident, literal } from '@supabase/pg-meta/src/pg-format'
 import { useQuery } from '@tanstack/react-query'
 
 import { databaseQueuesKeys } from './keys'
@@ -23,7 +24,7 @@ const preciseMetricsSqlQuery = (queueName: string) => {
   SELECT
     COUNT(*) AS row_count
   FROM
-    "pgmq"."q_${queueName}";
+    "pgmq".${ident('q_' + queueName)};
 `
 }
 
@@ -34,7 +35,7 @@ const estimateMetricsSqlQuery = (queueName: string) => {
     from
   pg_class
     where
-  relname = 'q_${queueName}'
+  relname = ${literal('q_' + queueName)}
   and relnamespace = 'pgmq'::regnamespace;
 `
 }

--- a/apps/studio/data/database-queues/database-queues-purge-mutation.ts
+++ b/apps/studio/data/database-queues/database-queues-purge-mutation.ts
@@ -1,3 +1,4 @@
+import { literal } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
@@ -26,7 +27,7 @@ export async function purgeDatabaseQueue({
   const { result } = await executeSql({
     projectRef,
     connectionString,
-    sql: `select * from pgmq.purge_queue('${queueName}');`,
+    sql: `select * from pgmq.purge_queue(${literal(queueName)});`,
     queryKey: databaseQueuesKeys.purge(queueName),
   })
 


### PR DESCRIPTION
Fixes #44554

Follow-up to #44451 which added `literal()` escaping to 4 queue message files. The remaining 5 files in the same directory still use raw string interpolation.

The create mutation was the biggest gap -- no `literal()` and no `isQueueNameValid` at all. It could also interpolate `undefined` into SQL when partition config is missing.

Applied the same pattern from #44451 to all 5 files: import `literal`, wrap interpolated values. For the metrics query and create mutation, also used `ident()` for table name references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal SQL query construction for database queue operations to enhance code reliability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->