### PR TITLE
feat(docs): Allow opening search links in new tab

### DIFF
--- a/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
+++ b/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
@@ -100,33 +100,57 @@ const DocsSearchPage = () => {
   )
 
   async function openLink(pageType: PageType, link: string) {
+    // A simple way to achieve opening links in new tab but room for improvement including support for middle clicks
+    const openInNewTab = window.event?.metaKey || window.event?.ctrlKey;
+
     switch (pageType) {
       case PageType.Markdown:
       case PageType.Reference:
       case PageType.Troubleshooting:
         if (BASE_PATH === '/docs') {
-          router.push(link)
-          setIsOpen(false)
+          if(openInNewTab){
+            window.open(`/docs${link}`, '_blank', 'noreferrer,noopener')
+          }
+          else{
+            router.push(link)
+            setIsOpen(false)
+          }
         } else if (!BASE_PATH) {
-          router.push(`/docs${link}`)
-          setIsOpen(false)
+          if(openInNewTab){
+            window.open(`/docs${link}`, '_blank', 'noreferrer,noopener')
+          }
+          else{
+            router.push(`/docs${link}`)
+            setIsOpen(false)
+          }
         } else {
           window.open(`https://supabase.com/docs${link}`, '_blank', 'noreferrer,noopener')
-          setIsOpen(false)
+          if(!openInNewTab){
+            setIsOpen(false)
+          }
         }
         break
       case PageType.Integration:
         if (!BASE_PATH) {
-          router.push(link)
-          setIsOpen(false)
+          if(openInNewTab){
+            window.open(link, '_blank', 'noreferrer,noopener')
+          }
+          else{
+            router.push(link)
+            setIsOpen(false)
+          }
         } else {
           window.open(`https://supabase.com${link}`, '_blank', 'noreferrer,noopener')
-          setIsOpen(false)
+          if(!openInNewTab){
+            setIsOpen(false)
+          }
         }
         break
       case PageType.GithubDiscussion:
         window.open(link, '_blank', 'noreferrer,noopener')
-        setIsOpen(false)
+          if(!openInNewTab){
+            setIsOpen(false)
+          }
         break
       default:
         throw new Error(`Unknown page type '${pageType}'`)

--- a/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
+++ b/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
@@ -1,14 +1,14 @@
 'use client'
 
 import {
-  type DocsSearchResult as Page,
-  type DocsSearchResultSection as PageSection,
   DocsSearchResultType as PageType,
   useDocsSearch,
+  type DocsSearchResult as Page,
+  type DocsSearchResultSection as PageSection,
 } from 'common'
 import { Book, ChevronRight, Github, Hash, Loader2, MessageSquare, Search } from 'lucide-react'
 import { useCallback, useEffect, useRef } from 'react'
-import { Button, CommandGroup_Shadcn_, CommandItem_Shadcn_, CommandList_Shadcn_, cn } from 'ui'
+import { Button, cn, CommandGroup_Shadcn_, CommandItem_Shadcn_, CommandList_Shadcn_ } from 'ui'
 import { StatusIcon } from 'ui/src/components/StatusIcon'
 
 import {
@@ -19,8 +19,8 @@ import {
   escapeAttributeSelector,
   generateCommandClassNames,
   TextHighlighter,
-  useCrossCompatRouter,
   useCommandMenuTelemetryContext,
+  useCrossCompatRouter,
   useQuery,
   useSetCommandMenuOpen,
   useSetQuery,
@@ -101,56 +101,53 @@ const DocsSearchPage = () => {
 
   async function openLink(pageType: PageType, link: string) {
     // A simple way to achieve opening links in new tab but room for improvement including support for middle clicks
-    const openInNewTab = window.event?.metaKey || window.event?.ctrlKey;
+    const openInNewTab = window.event?.metaKey || window.event?.ctrlKey
 
     switch (pageType) {
       case PageType.Markdown:
       case PageType.Reference:
       case PageType.Troubleshooting:
         if (BASE_PATH === '/docs') {
-          if(openInNewTab){
+          if (openInNewTab) {
             window.open(`/docs${link}`, '_blank', 'noreferrer,noopener')
-          }
-          else{
+          } else {
             router.push(link)
             setIsOpen(false)
           }
         } else if (!BASE_PATH) {
-          if(openInNewTab){
+          if (openInNewTab) {
             window.open(`/docs${link}`, '_blank', 'noreferrer,noopener')
-          }
-          else{
+          } else {
             router.push(`/docs${link}`)
             setIsOpen(false)
           }
         } else {
           window.open(`https://supabase.com/docs${link}`, '_blank', 'noreferrer,noopener')
-          if(!openInNewTab){
+          if (!openInNewTab) {
             setIsOpen(false)
           }
         }
         break
       case PageType.Integration:
         if (!BASE_PATH) {
-          if(openInNewTab){
+          if (openInNewTab) {
             window.open(link, '_blank', 'noreferrer,noopener')
-          }
-          else{
+          } else {
             router.push(link)
             setIsOpen(false)
           }
         } else {
           window.open(`https://supabase.com${link}`, '_blank', 'noreferrer,noopener')
-          if(!openInNewTab){
+          if (!openInNewTab) {
             setIsOpen(false)
           }
         }
         break
       case PageType.GithubDiscussion:
         window.open(link, '_blank', 'noreferrer,noopener')
-          if(!openInNewTab){
-            setIsOpen(false)
-          }
+        if (!openInNewTab) {
+          setIsOpen(false)
+        }
         break
       default:
         throw new Error(`Unknown page type '${pageType}'`)

--- a/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
+++ b/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
@@ -101,7 +101,7 @@ const DocsSearchPage = () => {
 
   async function openLink(pageType: PageType, link: string) {
     // A simple way to achieve opening links in new tab but room for improvement including support for middle clicks
-    const openInNewTab = window.event?.metaKey || window.event?.ctrlKey
+    const openInNewTab = (window.event as KeyboardEvent)?.metaKey || (window.event as KeyboardEvent)?.ctrlKey
 
     switch (pageType) {
       case PageType.Markdown:

--- a/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
+++ b/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
@@ -101,7 +101,8 @@ const DocsSearchPage = () => {
 
   async function openLink(pageType: PageType, link: string) {
     // A simple way to achieve opening links in new tab but room for improvement including support for middle clicks
-    const openInNewTab = (window.event as KeyboardEvent)?.metaKey || (window.event as KeyboardEvent)?.ctrlKey
+    const openInNewTab =
+      (window.event as KeyboardEvent)?.metaKey || (window.event as KeyboardEvent)?.ctrlKey
 
     switch (pageType) {
       case PageType.Markdown:

--- a/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
+++ b/packages/ui-patterns/src/CommandMenu/prepackaged/DocsSearch/DocsSearchPage.tsx
@@ -101,57 +101,41 @@ const DocsSearchPage = () => {
 
   async function openLink(pageType: PageType, link: string) {
     // A simple way to achieve opening links in new tab but room for improvement including support for middle clicks
-    const openInNewTab =
+    let openInNewTab =
       (window.event as KeyboardEvent)?.metaKey || (window.event as KeyboardEvent)?.ctrlKey
-
+    let finalLink: string = link
     switch (pageType) {
       case PageType.Markdown:
       case PageType.Reference:
       case PageType.Troubleshooting:
         if (BASE_PATH === '/docs') {
           if (openInNewTab) {
-            window.open(`/docs${link}`, '_blank', 'noreferrer,noopener')
-          } else {
-            router.push(link)
-            setIsOpen(false)
+            finalLink = `/docs${link}`
           }
         } else if (!BASE_PATH) {
-          if (openInNewTab) {
-            window.open(`/docs${link}`, '_blank', 'noreferrer,noopener')
-          } else {
-            router.push(`/docs${link}`)
-            setIsOpen(false)
-          }
+          finalLink = `/docs${link}`
         } else {
-          window.open(`https://supabase.com/docs${link}`, '_blank', 'noreferrer,noopener')
-          if (!openInNewTab) {
-            setIsOpen(false)
-          }
+          finalLink = `https://supabase.com/docs${link}`
+          openInNewTab = true
         }
         break
       case PageType.Integration:
-        if (!BASE_PATH) {
-          if (openInNewTab) {
-            window.open(link, '_blank', 'noreferrer,noopener')
-          } else {
-            router.push(link)
-            setIsOpen(false)
-          }
-        } else {
-          window.open(`https://supabase.com${link}`, '_blank', 'noreferrer,noopener')
-          if (!openInNewTab) {
-            setIsOpen(false)
-          }
+        if (BASE_PATH) {
+          openInNewTab = true
+          finalLink = `https://supabase.com${link}`
         }
         break
       case PageType.GithubDiscussion:
-        window.open(link, '_blank', 'noreferrer,noopener')
-        if (!openInNewTab) {
-          setIsOpen(false)
-        }
+        openInNewTab = true
         break
       default:
         throw new Error(`Unknown page type '${pageType}'`)
+    }
+    if (openInNewTab) {
+      window.open(finalLink, '_blank', 'noreferrer,noopener')
+    } else {
+      router.push(finalLink)
+      setIsOpen(false)
     }
   }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

A simple way to allow for opening doc search results in a new tab

<img width="530" height="542" alt="image" src="https://github.com/user-attachments/assets/d2a3b420-ec61-4b94-a94b-b3f2bc160f7b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Documentation search now respects Ctrl/Cmd-click to open links in a new tab.
  * Documentation, reference, and troubleshooting pages open in-app or in a new tab depending on modifier key; same-tab navigation closes the search menu, new-tab does not.
  * Integration and external discussion links follow the same modifier-key behavior; the search menu only closes for same-tab navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->