### PR TITLE
fix: do not query backups for project in unknown state

### DIFF
--- a/apps/studio/data/database/backups-query.ts
+++ b/apps/studio/data/database/backups-query.ts
@@ -43,7 +43,8 @@ export const useBackupsQuery = <TData = BackupsData>(
       enabled &&
       !isOrioleDbInAws &&
       typeof projectRef !== 'undefined' &&
-      projectStatus !== PROJECT_STATUS.COMING_UP,
+      projectStatus !== PROJECT_STATUS.COMING_UP &&
+      projectStatus !== PROJECT_STATUS.UNKNOWN,
     ...options,
   })
 }


### PR DESCRIPTION
Unknown state is explicitly set before a project is coming up, leading to a bunch of invalid backups list requests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the backups feature to properly handle cases where the project status is unknown. The system now avoids executing backup-related queries when the project state is indeterminate, resulting in more stable and predictable behavior while preventing potential issues that could arise from executing operations during uncertain project states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->