### PR TITLE
feat(tracking): add compute_badge_upgrade_clicked event

### DIFF
--- a/apps/studio/components/ui/ComputeBadgeWrapper.tsx
+++ b/apps/studio/components/ui/ComputeBadgeWrapper.tsx
@@ -6,6 +6,7 @@ import { ProjectAddonVariantMeta } from 'data/subscriptions/types'
 import { ResourceWarning } from 'data/usage/resource-warnings-query'
 import { getCloudProviderArchitecture } from 'lib/cloudprovider-utils'
 import { INSTANCE_MICRO_SPECS } from 'lib/constants'
+import { useTrack } from 'lib/telemetry/track'
 import Link from 'next/link'
 import { useState } from 'react'
 import { Button, cn, HoverCard, HoverCardContent, HoverCardTrigger, Separator } from 'ui'
@@ -106,6 +107,8 @@ export const ComputeBadgeWrapper = ({
     !!resourceWarnings?.disk_io_exhaustion
   const showUpgradeGlow = isEligibleForFreeUpgrade && isComputeNearExhaustion
 
+  const track = useTrack()
+
   const isLoading = isLoadingAddons || isLoadingSubscriptions
 
   if (!computeSize) return null
@@ -194,7 +197,19 @@ export const ComputeBadgeWrapper = ({
                 </p>
               </div>
               <div>
-                <Button asChild type="default" htmlType="button" role="button">
+                <Button
+                  asChild
+                  type="default"
+                  htmlType="button"
+                  role="button"
+                  onClick={() => {
+                    track('compute_badge_upgrade_clicked', {
+                      computeSize: computeSize ?? 'unknown',
+                      planId: data?.plan.id ?? 'unknown',
+                      upgradeType: isEligibleForFreeUpgrade ? 'free_micro_upgrade' : 'compute_upgrade',
+                    })
+                  }}
+                >
                   <Link href={`/project/${projectRef}/settings/compute-and-disk`}>
                     Upgrade compute
                   </Link>

--- a/apps/studio/components/ui/ComputeBadgeWrapper.tsx
+++ b/apps/studio/components/ui/ComputeBadgeWrapper.tsx
@@ -206,7 +206,9 @@ export const ComputeBadgeWrapper = ({
                     track('compute_badge_upgrade_clicked', {
                       computeSize: computeSize ?? 'unknown',
                       planId: data?.plan.id ?? 'unknown',
-                      upgradeType: isEligibleForFreeUpgrade ? 'free_micro_upgrade' : 'compute_upgrade',
+                      upgradeType: isEligibleForFreeUpgrade
+                        ? 'free_micro_upgrade'
+                        : 'compute_upgrade',
                     })
                   }}
                 >


### PR DESCRIPTION
## Summary

The `compute_badge_upgrade_clicked` event had zero fires since Apr 1 because the PostHog tracking call was never wired up on the "Upgrade compute" button in the compute badge hover card. This adds the missing `useTrack` call using the existing event definition in `telemetry-constants.ts`.

## Changes
- Add `useTrack` hook and `onClick` handler to the upgrade button in `ComputeBadgeWrapper.tsx`
- Fires `compute_badge_upgrade_clicked` with `computeSize`, `planId`, and `upgradeType` properties
- Preserves existing `asChild` + `<Link>` navigation pattern

## Testing

Tested on Vercel preview:
- [x] Hover compute badge on a project with non-max compute, click "Upgrade compute", verify `compute_badge_upgrade_clicked` event appears in PostHog live events with correct properties
- [x] Verify navigation to compute settings page still works (client-side, no full reload)
- [x] Test with paid-plan nano project: `upgradeType` should be `free_micro_upgrade`
- [x] Test with paid-plan non-nano project: `upgradeType` should be `compute_upgrade`

## Linear
- fixes GROWTH-751

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added analytics tracking for compute upgrade button clicks to record upgrade type (free micro vs. paid), selected compute size (with fallback), and plan identifier. This ensures upgrade interactions are captured for product insights without changing visible UI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->