### PR TITLE
[FE-2946] fix(studio): skip available-versions request when dbRegion is empty

### DIFF
--- a/apps/studio/data/config/project-creation-postgres-versions-query.ts
+++ b/apps/studio/data/config/project-creation-postgres-versions-query.ts
@@ -48,10 +48,7 @@ export const useProjectCreationPostgresVersionsQuery = <TData = ProjectCreationP
     queryFn: ({ signal }) =>
       getPostgresCreationVersions({ organizationSlug, cloudProvider, dbRegion }, signal),
     enabled:
-      enabled &&
-      typeof organizationSlug !== 'undefined' &&
-      organizationSlug !== '_' &&
-      typeof dbRegion !== 'undefined',
+      enabled && typeof organizationSlug !== 'undefined' && organizationSlug !== '_' && !!dbRegion,
     ...options,
   })
 }


### PR DESCRIPTION
Don't fire the `available-versions` request when `dbRegion` is falsy (undefined or empty string). Fixes race condition where the request fires before a region is selected.

## To test

- Confirm no invalid `available-versions` request in the network tab
- Confirm create new project still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database region validation during project creation to consistently handle empty or undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->