### PR TITLE
chore: do not preload plan change data on page load

### DIFF
--- a/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
+++ b/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
@@ -19,14 +19,7 @@ export const NoProjectsOnPaidOrgInfo = ({ organization }: NoProjectsOnPaidOrgInf
   )
   const projectCount = data?.pages[0].pagination.count ?? 0
 
-  if (
-    projectCount > 0 ||
-    organization?.plan === undefined ||
-    organization.plan.id === 'free' ||
-    organization.plan.id === 'enterprise' ||
-    organization.plan.id === 'platform'
-  )
-    return null
+  if (projectCount > 0 || !organization) return null
 
   return (
     <Admonition

--- a/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
+++ b/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
@@ -9,17 +9,17 @@ interface NoProjectsOnPaidOrgInfoProps {
 }
 
 export const NoProjectsOnPaidOrgInfo = ({ organization }: NoProjectsOnPaidOrgInfoProps) => {
-  const { data } = useOrgProjectsInfiniteQuery({ slug: organization?.slug })
+  const { data } = useOrgProjectsInfiniteQuery(
+    { slug: organization?.slug },
+    {
+      enabled:
+        organization != null &&
+        !['free', 'platform', 'enterprise'].includes(organization.plan.id ?? ''),
+    }
+  )
   const projectCount = data?.pages[0].pagination.count ?? 0
 
-  if (
-    projectCount > 0 ||
-    organization?.plan === undefined ||
-    organization.plan.id === 'free' ||
-    organization.plan.id === 'enterprise' ||
-    organization.plan.id === 'platform'
-  )
-    return null
+  if (projectCount > 0 || !organization) return null
 
   return (
     <Admonition

--- a/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
+++ b/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
@@ -8,18 +8,18 @@ interface NoProjectsOnPaidOrgInfoProps {
   organization?: Organization
 }
 
+const EXCLUDED_PLANS = ['free', 'platform', 'enterprise']
+
 export const NoProjectsOnPaidOrgInfo = ({ organization }: NoProjectsOnPaidOrgInfoProps) => {
+  const isEligible = organization != null && !EXCLUDED_PLANS.includes(organization.plan.id ?? '')
+
   const { data } = useOrgProjectsInfiniteQuery(
     { slug: organization?.slug },
-    {
-      enabled:
-        organization != null &&
-        !['free', 'platform', 'enterprise'].includes(organization.plan.id ?? ''),
-    }
+    { enabled: isEligible }
   )
   const projectCount = data?.pages[0].pagination.count ?? 0
 
-  if (projectCount > 0 || !organization) return null
+  if (!isEligible || projectCount > 0) return null
 
   return (
     <Admonition

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -67,7 +67,10 @@ export const PlanUpdateSidePanel = () => {
     'stripe.subscriptions'
   )
 
-  const { data: orgProjectsData } = useOrgProjectsInfiniteQuery({ slug })
+  const snap = useOrgSettingsPageStateSnapshot()
+  const visible = snap.panelKey === 'subscriptionPlan'
+
+  const { data: orgProjectsData } = useOrgProjectsInfiniteQuery({ slug }, { enabled: visible })
   const orgProjects =
     useMemo(
       () => orgProjectsData?.pages.flatMap((page) => page.projects),
@@ -77,8 +80,6 @@ export const PlanUpdateSidePanel = () => {
   const { data } = useOrganizationQuery({ slug })
   const hasOrioleProjects = !!data?.has_oriole_project
 
-  const snap = useOrgSettingsPageStateSnapshot()
-  const visible = snap.panelKey === 'subscriptionPlan'
   const onClose = () => {
     const { panel, ...queryWithoutPanel } = router.query
     router.push({ pathname: router.pathname, query: queryWithoutPanel }, undefined, {
@@ -90,8 +91,14 @@ export const PlanUpdateSidePanel = () => {
   const { data: subscription, isSuccess: isSuccessSubscription } = useOrgSubscriptionQuery({
     orgSlug: slug,
   })
-  const { data: plans, isPending: isLoadingPlans } = useOrgPlansQuery({ orgSlug: slug })
-  const { data: membersExceededLimit } = useFreeProjectLimitCheckQuery({ slug })
+  const { data: plans, isPending: isLoadingPlans } = useOrgPlansQuery(
+    { orgSlug: slug },
+    { enabled: visible }
+  )
+  const { data: membersExceededLimit } = useFreeProjectLimitCheckQuery(
+    { slug },
+    { enabled: visible }
+  )
 
   const {
     data: subscriptionPreview,


### PR DESCRIPTION
The data is preloaded even though the modal is never visible

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized billing UI to conditionally load project and plan data only when relevant (based on organization state and panel visibility), reducing unnecessary network requests.
  * Simplified visibility and eligibility checks in billing interfaces, streamlining rendering logic and improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->