### PR TITLE
fix(studio): lazy-render MobileNavigationBar and skip project count for platform orgs

### DIFF
--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -1,4 +1,4 @@
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useBreakpoint, useParams } from 'common'
 import { useRouter } from 'next/router'
 import { PropsWithChildren, useEffect, useState } from 'react'
 import { ResizablePanel, ResizablePanelGroup, SidebarProvider } from 'ui'
@@ -57,6 +57,8 @@ export const DefaultLayout = ({
 
   useCheckLatestDeploy()
 
+  const isMobile = useBreakpoint('md')
+
   const contentMinSizePercentage = 50
   const contentMaxSizePercentage = 70
 
@@ -82,10 +84,12 @@ export const DefaultLayout = ({
                 {/* Top Banner */}
                 <AppBannerWrapper />
                 <div className="flex-shrink-0">
-                  <MobileNavigationBar
-                    hideMobileMenu={hideMobileMenu}
-                    backToDashboardURL={backToDashboardURL}
-                  />
+                  {isMobile && (
+                    <MobileNavigationBar
+                      hideMobileMenu={hideMobileMenu}
+                      backToDashboardURL={backToDashboardURL}
+                    />
+                  )}
                   <LayoutHeader headerTitle={headerTitle} backToDashboardURL={backToDashboardURL} />
                 </div>
                 {/* Main Content Area */}

--- a/apps/studio/components/layouts/Navigation/NavigationBar/OrgSelector.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/OrgSelector.tsx
@@ -38,15 +38,17 @@ export function OrgSelector() {
   const [open, setOpen] = useState(false)
 
   const slug = selectedOrganization?.slug
+  const isPlatformOrg = selectedOrganization?.plan?.id === 'platform'
   const selectedOrgInitial = selectedOrganization?.name?.trim().charAt(0).toUpperCase() || 'O'
   const { data: projects } = useOrgProjectsInfiniteQuery(
     { slug, limit: 1 },
-    { enabled: Boolean(slug) }
+    { enabled: Boolean(slug) && !isPlatformOrg }
   )
 
   const numProjects = projects?.pages[0]?.pagination.count
-  const projectsLabel =
-    typeof numProjects === 'number'
+  const projectsLabel = isPlatformOrg
+    ? 'Platform'
+    : typeof numProjects === 'number'
       ? `${numProjects} project${numProjects === 1 ? '' : 's'}`
       : 'No projects'
 


### PR DESCRIPTION
MobileNavigationBar was always mounted – even on desktop – triggering org/project queries that desktop users never see. Platform orgs (e.g. Lovable with >1M projects) also had an expensive project-count fetch on every page load.

**Changed:**
- Only render `MobileNavigationBar` when the viewport is mobile (`useBreakpoint('md')`)
- Disable `useOrgProjectsInfiniteQuery` for platform orgs and show "Platform" label instead of a project count

## To test

- Open Studio on a desktop viewport – verify the mobile nav bar is not in the DOM and no `/organizations/{slug}/projects` request fires
- Resize to a mobile viewport – verify the mobile nav bar appears and works normally
- If you have access to a platform org, verify the OrgSelector shows "Platform" instead of a project count and no projects query fires

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile navigation now conditionally renders on mobile devices only for improved layout optimization.

* **Bug Fixes**
  * Platform organizations now display with proper "Platform" label instead of project count.
  * Projects query no longer executes unnecessarily for platform organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->