### PR TITLE
fix(studio): skip project count query for platform orgs

### DIFF
--- a/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
+++ b/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
@@ -9,7 +9,11 @@ interface NoProjectsOnPaidOrgInfoProps {
 }
 
 export const NoProjectsOnPaidOrgInfo = ({ organization }: NoProjectsOnPaidOrgInfoProps) => {
-  const { data } = useOrgProjectsInfiniteQuery({ slug: organization?.slug })
+  const isPlatformOrg = organization?.plan?.id === 'platform'
+  const { data } = useOrgProjectsInfiniteQuery(
+    { slug: organization?.slug },
+    { enabled: !isPlatformOrg }
+  )
   const projectCount = data?.pages[0].pagination.count ?? 0
 
   if (
@@ -17,7 +21,7 @@ export const NoProjectsOnPaidOrgInfo = ({ organization }: NoProjectsOnPaidOrgInf
     organization?.plan === undefined ||
     organization.plan.id === 'free' ||
     organization.plan.id === 'enterprise' ||
-    organization.plan.id === 'platform'
+    isPlatformOrg
   )
     return null
 

--- a/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
+++ b/apps/studio/components/interfaces/Organization/OrganizationCard.tsx
@@ -23,7 +23,11 @@ export const OrganizationCard = ({
   onClick?: () => void
 }) => {
   const isUserMFAEnabled = useIsMFAEnabled()
-  const { data } = useOrgProjectsInfiniteQuery({ slug: organization.slug })
+  const isPlatformOrg = organization.plan?.id === 'platform'
+  const { data } = useOrgProjectsInfiniteQuery(
+    { slug: organization.slug },
+    { enabled: !isPlatformOrg }
+  )
   const numProjects = data?.pages[0].pagination.count ?? 0
   const isMfaRequired = organization.organization_requires_mfa
 

--- a/apps/studio/components/layouts/Navigation/NavigationBar/OrgSelector.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/OrgSelector.tsx
@@ -38,15 +38,17 @@ export function OrgSelector() {
   const [open, setOpen] = useState(false)
 
   const slug = selectedOrganization?.slug
+  const isPlatformOrg = selectedOrganization?.plan?.id === 'platform'
   const selectedOrgInitial = selectedOrganization?.name?.trim().charAt(0).toUpperCase() || 'O'
   const { data: projects } = useOrgProjectsInfiniteQuery(
     { slug, limit: 1 },
-    { enabled: Boolean(slug) }
+    { enabled: Boolean(slug) && !isPlatformOrg }
   )
 
   const numProjects = projects?.pages[0]?.pagination.count
-  const projectsLabel =
-    typeof numProjects === 'number'
+  const projectsLabel = isPlatformOrg
+    ? 'Platform'
+    : typeof numProjects === 'number'
       ? `${numProjects} project${numProjects === 1 ? '' : 's'}`
       : 'No projects'
 


### PR DESCRIPTION
Platform orgs can have very high project cardinality (>1M projects), making the project count query expensive. This disables the query across all count-only usages for platform plan orgs.

**Changed:**
- `OrgSelector` — disable query, show "Platform" label instead of count
- `OrganizationCard` — disable query, hide project count for platform orgs
- `NoProjectsOnPaidOrgInfo` — disable query (component already returned null for platform orgs)

**Not changed:**
- `TeamSettings` — also uses the count, but the warning it powers is specifically relevant for orgs with a lot of projects, and it's tucked away on the team settings page rather than on every page load.

## To test

- On a platform org, verify no `/organizations/{slug}/projects` requests fire from the org selector, org cards, or billing info
- For regular orgs, verify the project count still displays normally everywhere

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Organization selector now shows a dedicated "Platform" label for platform organizations instead of a project count.
  * Reduced unnecessary network activity by skipping project fetching when a platform organization is selected, improving load performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->