### PR TITLE
[FE-2913] feat(studio): restrict cloud provider to AWS (Revamped) for HA projects

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn, useWatch as useWatch_Shadcn_ } from 'react-hook-form'
+import { UseFormReturn } from 'react-hook-form'
 import {
   FormControl_Shadcn_,
   FormField_Shadcn_,
@@ -8,6 +8,7 @@ import {
   SelectItem_Shadcn_,
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
+  useWatch_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 

--- a/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
@@ -1,4 +1,4 @@
-import { UseFormReturn } from 'react-hook-form'
+import { UseFormReturn, useWatch as useWatch_Shadcn_ } from 'react-hook-form'
 import {
   FormControl_Shadcn_,
   FormField_Shadcn_,
@@ -16,12 +16,15 @@ import Panel from '@/components/ui/Panel'
 import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
 import { PROVIDERS } from '@/lib/constants'
 
+const HA_SUPPORTED_PROVIDERS = ['AWS_K8S']
+
 interface CloudProviderSelectorProps {
   form: UseFormReturn<CreateProjectForm>
 }
 
 export const CloudProviderSelector = ({ form }: CloudProviderSelectorProps) => {
   const { infraCloudProviders: validCloudProviders } = useCustomContent(['infra:cloud_providers'])
+  const highAvailability = useWatch_Shadcn_({ control: form.control, name: 'highAvailability' })
 
   return (
     <Panel.Content>
@@ -29,10 +32,21 @@ export const CloudProviderSelector = ({ form }: CloudProviderSelectorProps) => {
         control={form.control}
         name="cloudProvider"
         render={({ field }) => (
-          <FormItemLayout label="Cloud provider" layout="horizontal">
+          <FormItemLayout
+            label="Cloud provider"
+            layout="horizontal"
+            description={
+              highAvailability ? (
+                <p className="text-warning">
+                  High availability is only supported on AWS (Revamped)
+                </p>
+              ) : undefined
+            }
+          >
             <Select_Shadcn_
               onValueChange={(value) => field.onChange(value)}
               defaultValue={field.value}
+              value={field.value}
             >
               <FormControl_Shadcn_>
                 <SelectTrigger_Shadcn_>
@@ -46,8 +60,9 @@ export const CloudProviderSelector = ({ form }: CloudProviderSelectorProps) => {
                     .map((providerObj) => {
                       const label = providerObj['name']
                       const value = providerObj['id']
+                      const isDisabled = highAvailability && !HA_SUPPORTED_PROVIDERS.includes(value)
                       return (
-                        <SelectItem_Shadcn_ key={value} value={value}>
+                        <SelectItem_Shadcn_ key={value} value={value} disabled={isDisabled}>
                           {label}
                         </SelectItem_Shadcn_>
                       )

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.schema.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.schema.ts
@@ -38,14 +38,23 @@ export const FormSchema = z
     postgresVersionSelection: z.string(),
     useOrioleDb: z.boolean(),
   })
-  .superRefine(({ dbPassStrength, dbPassStrengthWarning }, ctx) => {
-    if (dbPassStrength < DEFAULT_MINIMUM_PASSWORD_STRENGTH) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        path: ['dbPass'],
-        message: dbPassStrengthWarning || 'Password not secure enough',
-      })
+  .superRefine(
+    ({ dbPassStrength, dbPassStrengthWarning, highAvailability, cloudProvider }, ctx) => {
+      if (dbPassStrength < DEFAULT_MINIMUM_PASSWORD_STRENGTH) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['dbPass'],
+          message: dbPassStrengthWarning || 'Password not secure enough',
+        })
+      }
+      if (highAvailability && cloudProvider !== 'AWS_K8S') {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['cloudProvider'],
+          message: 'High availability is only supported on AWS (Revamped)',
+        })
+      }
     }
-  })
+  )
 
 export type CreateProjectForm = z.infer<typeof FormSchema>

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -403,6 +403,12 @@ const Wizard: NextPageWithLayout = () => {
   }, [recommendedSmartRegion])
 
   useEffect(() => {
+    if (highAvailability && cloudProvider !== 'AWS_K8S') {
+      form.setValue('cloudProvider', 'AWS_K8S')
+    }
+  }, [highAvailability, cloudProvider, form])
+
+  useEffect(() => {
     if (watchedInstanceSize !== instanceSize) {
       form.setValue('instanceSize', instanceSize, {
         shouldDirty: false,


### PR DESCRIPTION
When high availability is enabled during project creation, automatically switch to AWS (Revamped) and disable other cloud providers – multigres/HA is only supported on v3.

<img width="778" height="390" alt="Screenshot 2026-04-06 at 5 09 55 PM" src="https://github.com/user-attachments/assets/c458f345-497e-4963-9c2f-b4b1eafd030b" />

**Changed:**
- Cloud provider selector now watches `highAvailability` form state
- Non-`AWS_K8S` providers (Fly.io, AWS, AWS Nimbus) are disabled when HA is on
- Warning description shown in orange when HA restricts the provider choice

**Added:**
- `useEffect` in project creation form to auto-switch cloud provider to `AWS_K8S` when HA is toggled on

## To test

- Enable the HA toggle on the new project page (requires `instances.high_availability` entitlement)
- Verify cloud provider auto-switches to AWS (Revamped)
- Verify other providers are greyed out in the dropdown
- Verify orange warning text appears below the cloud provider label
- Toggle HA off and confirm all providers become selectable again
- Ensure project creation still works for both HA and non-HA projects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * When high availability is enabled, cloud provider selection is restricted to AWS.
  * A warning appears when high availability is enabled, noting AWS-only support.
  * The cloud provider selection automatically switches to AWS if high availability is toggled on.

* **Bug Fixes**
  * Improved form validation to prevent incompatible high-availability and provider combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->