### PR TITLE
docs(billing-faq): add paused/deleted project usage note

### DIFF
--- a/apps/docs/content/guides/platform/billing-faq.mdx
+++ b/apps/docs/content/guides/platform/billing-faq.mdx
@@ -142,6 +142,10 @@ To remove restrictions, you will need to address the issue that caused the restr
 
 Restrictions due to usage limits are lifted once your quota refills at the start of the next billing cycle. Note that there may be a short delay after your billing period resets before restrictions are fully lifted. You can see when your current billing cycle ends on the [billing page](/dashboard/org/_/billing) under "Upcoming Invoice". You can also lift restrictions immediately by [upgrading](/dashboard/org/_/billing?panel=subscriptionPlan) to Pro (if on Free Plan) or by [disabling spend cap](/dashboard/org/_/billing?panel=costControl) (if on Pro Plan with spend cap enabled).
 
+<Admonition type="note">
+Pausing or deleting a project stops new usage from accumulating, but does not remove usage that already occurred during the current billing cycle. For quota-based limits, that usage still counts until the billing period resets.
+</Admonition>
+
 ## Reports and invoices
 
 #### Where do I find my invoices?

--- a/apps/docs/content/guides/platform/billing-faq.mdx
+++ b/apps/docs/content/guides/platform/billing-faq.mdx
@@ -143,7 +143,9 @@ To remove restrictions, you will need to address the issue that caused the restr
 Restrictions due to usage limits are lifted once your quota refills at the start of the next billing cycle. Note that there may be a short delay after your billing period resets before restrictions are fully lifted. You can see when your current billing cycle ends on the [billing page](/dashboard/org/_/billing) under "Upcoming Invoice". You can also lift restrictions immediately by [upgrading](/dashboard/org/_/billing?panel=subscriptionPlan) to Pro (if on Free Plan) or by [disabling spend cap](/dashboard/org/_/billing?panel=costControl) (if on Pro Plan with spend cap enabled).
 
 <Admonition type="note">
+
 Pausing or deleting a project stops new usage from accumulating, but does not remove usage that already occurred during the current billing cycle. For quota-based limits, that usage still counts until the billing period resets.
+
 </Admonition>
 
 ## Reports and invoices


### PR DESCRIPTION
## Summary
- Add an Admonition note to the Fair Use Policy section clarifying that pausing or deleting a project does not remove accumulated usage from the current billing cycle
- Addresses a common source of confusion identified in #team-support thread (2026-04-02)

## Test plan
- [ ] Preview the MDX locally to confirm Admonition renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated billing FAQ to clarify that pausing or deleting a project stops new usage from accruing but does not remove usage already incurred in the current billing cycle; quota-based usage remains counted until the billing period resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->