### PR TITLE
fix(studio): guard OrganizationSelector against transient state

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/OrganizationSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/OrganizationSelector.tsx
@@ -35,7 +35,10 @@ export const OrganizationSelector = ({ form }: OrganizationSelectorProps) => {
   const { slug } = useParams()
   const queryClient = useQueryClient()
   const { data: currentOrg } = useSelectedOrganizationQuery()
-  const { can: isAdmin } = useAsyncCheckPermissions(PermissionAction.CREATE, 'projects')
+  const { can: isAdmin, isLoading: isPermissionsLoading } = useAsyncCheckPermissions(
+    PermissionAction.CREATE,
+    'projects'
+  )
 
   // Permissions may be stale for newly created accounts due to replication lag between
   // org setup and the permissions endpoint. Invalidate in the background on mount so the
@@ -45,7 +48,7 @@ export const OrganizationSelector = ({ form }: OrganizationSelectorProps) => {
   }, [queryClient])
 
   const { data: organizations, isSuccess: isOrganizationsSuccess } = useOrganizationsQuery()
-  const isInvalidSlug = isOrganizationsSuccess && currentOrg === undefined
+  const isInvalidSlug = isOrganizationsSuccess && !!slug && currentOrg === undefined
   const orgNotFound = (organizations?.length ?? 0) > 0 && isInvalidSlug
 
   return (
@@ -87,7 +90,7 @@ export const OrganizationSelector = ({ form }: OrganizationSelectorProps) => {
         )}
       />
 
-      {isOrganizationsSuccess && !isAdmin && !orgNotFound && (
+      {isOrganizationsSuccess && !isPermissionsLoading && !isAdmin && !orgNotFound && (
         <NoPermission resourceText="create a project" />
       )}
       {orgNotFound && <OrgNotFound slug={slug} />}


### PR DESCRIPTION
During a GitHub SSO signup (Personal Org, Free Plan, ~2025-03-30), I encountered an error screen on the project creation page (`/new/[slug]`) immediately after creating an organization. Refreshing resolved it and showed the expected "Create a new project" form.

It looks like `useParams()` can return `slug` as `undefined` on the first render during client-side navigation (there is an existing comment in `[slug].tsx` acknowledging this). When that happens:

- `useSelectedOrganizationQuery` cannot find the org, so `currentOrg` is `undefined`, and `isInvalidSlug` fires, showing `OrgNotFound`.
- `useAsyncCheckPermissions` also cannot resolve without an org slug, so `can` (`isAdmin`) defaults to `false` while loading, which could show `NoPermission` instead if `OrgNotFound` doesn't render first.

This change:
- Adds `!!slug` to the `isInvalidSlug` check, so we don't declare the org invalid before we have a slug to look up.
- Uses `isLoading` from `useAsyncCheckPermissions` to avoid showing `NoPermission` while permissions are still resolving.

Why?

This appears to be a bug in the new-user onboarding wizard. If it gets encountered often, it could hurt conversion -- new users would see a dead-end error page ("Organization not found" or "You need additional permissions") at the moment they are trying to create their first project.