### PR TITLE
fix(studio): use hook for org in NoProjectsOnPaidOrgInfo

### DIFF
--- a/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
+++ b/apps/studio/components/interfaces/Billing/NoProjectsOnPaidOrgInfo.tsx
@@ -2,15 +2,12 @@ import Link from 'next/link'
 import { Admonition } from 'ui-patterns'
 
 import { useOrgProjectsInfiniteQuery } from '@/data/projects/org-projects-infinite-query'
-import type { Organization } from '@/types'
-
-interface NoProjectsOnPaidOrgInfoProps {
-  organization?: Organization
-}
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
 const EXCLUDED_PLANS = ['free', 'platform', 'enterprise']
 
-export const NoProjectsOnPaidOrgInfo = ({ organization }: NoProjectsOnPaidOrgInfoProps) => {
+export const NoProjectsOnPaidOrgInfo = () => {
+  const { data: organization } = useSelectedOrganizationQuery()
   const isEligible = organization != null && !EXCLUDED_PLANS.includes(organization.plan.id ?? '')
 
   const { data } = useOrgProjectsInfiniteQuery(


### PR DESCRIPTION
Follow-up to #44562 – the org prop wasn't actually being passed in, so `NoProjectsOnPaidOrgInfo` was always returning null. Switched to `useSelectedOrganizationQuery` hook instead.

## To test

- Go to an org on a paid plan with no projects
- Verify the admonition banner appears on the general settings page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified component architecture by replacing prop-based organization retrieval with hook-based approach, reducing component coupling and improving maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->