### PR TITLE
fix(studio): fix mouse wheel scrolling in auth policy editor dropdowns

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyDetailsV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyDetailsV2.tsx
@@ -22,6 +22,7 @@ import {
   PopoverTrigger_Shadcn_,
   RadioGroup_Shadcn_,
   RadioGroupLargeItem_Shadcn_,
+  ScrollArea,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectGroup_Shadcn_,
@@ -162,37 +163,37 @@ export const PolicyDetailsV2 = ({
                       </PopoverTrigger_Shadcn_>
 
                       <PopoverContent_Shadcn_
-                        className="p-0"
+                        className="p-0 pointer-events-auto"
                         side="bottom"
                         align="start"
                         sameWidthAsTrigger
                       >
                         <Command_Shadcn_>
                           <CommandInput_Shadcn_ placeholder="Find a table..." />
-                          <CommandList_Shadcn_
-                            className={(tables ?? []).length > 7 ? 'max-h-[200px]' : ''}
-                          >
+                          <CommandList_Shadcn_>
                             <CommandEmpty_Shadcn_>No tables found</CommandEmpty_Shadcn_>
                             <CommandGroup_Shadcn_>
-                              {(tables ?? []).map((table) => (
-                                <CommandItem_Shadcn_
-                                  key={table.id}
-                                  className="cursor-pointer flex items-center justify-between space-x-2 w-full"
-                                  onSelect={() => {
-                                    form.setValue('table', table.name)
-                                    setOpen(false)
-                                  }}
-                                  onClick={() => {
-                                    form.setValue('table', table.name)
-                                    setOpen(false)
-                                  }}
-                                >
-                                  <span className="flex items-center gap-1.5">
-                                    {field.value === table.name ? <Check size={13} /> : ''}
-                                    {table.name}
-                                  </span>
-                                </CommandItem_Shadcn_>
-                              ))}
+                              <ScrollArea className={(tables ?? []).length > 7 ? 'h-[200px]' : ''}>
+                                {(tables ?? []).map((table) => (
+                                  <CommandItem_Shadcn_
+                                    key={table.id}
+                                    className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                                    onSelect={() => {
+                                      form.setValue('table', table.name)
+                                      setOpen(false)
+                                    }}
+                                    onClick={() => {
+                                      form.setValue('table', table.name)
+                                      setOpen(false)
+                                    }}
+                                  >
+                                    <span className="flex items-center gap-1.5">
+                                      {field.value === table.name ? <Check size={13} /> : ''}
+                                      {table.name}
+                                    </span>
+                                  </CommandItem_Shadcn_>
+                                ))}
+                              </ScrollArea>
                             </CommandGroup_Shadcn_>
                           </CommandList_Shadcn_>
                         </Command_Shadcn_>

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyDetailsV2.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyDetailsV2.tsx
@@ -22,7 +22,6 @@ import {
   PopoverTrigger_Shadcn_,
   RadioGroup_Shadcn_,
   RadioGroupLargeItem_Shadcn_,
-  ScrollArea,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectGroup_Shadcn_,
@@ -170,30 +169,30 @@ export const PolicyDetailsV2 = ({
                       >
                         <Command_Shadcn_>
                           <CommandInput_Shadcn_ placeholder="Find a table..." />
-                          <CommandList_Shadcn_>
+                          <CommandList_Shadcn_
+                            className={(tables ?? []).length > 7 ? 'max-h-[200px]' : ''}
+                          >
                             <CommandEmpty_Shadcn_>No tables found</CommandEmpty_Shadcn_>
                             <CommandGroup_Shadcn_>
-                              <ScrollArea className={(tables ?? []).length > 7 ? 'h-[200px]' : ''}>
-                                {(tables ?? []).map((table) => (
-                                  <CommandItem_Shadcn_
-                                    key={table.id}
-                                    className="cursor-pointer flex items-center justify-between space-x-2 w-full"
-                                    onSelect={() => {
-                                      form.setValue('table', table.name)
-                                      setOpen(false)
-                                    }}
-                                    onClick={() => {
-                                      form.setValue('table', table.name)
-                                      setOpen(false)
-                                    }}
-                                  >
-                                    <span className="flex items-center gap-1.5">
-                                      {field.value === table.name ? <Check size={13} /> : ''}
-                                      {table.name}
-                                    </span>
-                                  </CommandItem_Shadcn_>
-                                ))}
-                              </ScrollArea>
+                              {(tables ?? []).map((table) => (
+                                <CommandItem_Shadcn_
+                                  key={table.id}
+                                  className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                                  onSelect={() => {
+                                    form.setValue('table', table.name)
+                                    setOpen(false)
+                                  }}
+                                  onClick={() => {
+                                    form.setValue('table', table.name)
+                                    setOpen(false)
+                                  }}
+                                >
+                                  <span className="flex items-center gap-1.5">
+                                    {field.value === table.name ? <Check size={13} /> : ''}
+                                    {table.name}
+                                  </span>
+                                </CommandItem_Shadcn_>
+                              ))}
                             </CommandGroup_Shadcn_>
                           </CommandList_Shadcn_>
                         </Command_Shadcn_>

--- a/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
+++ b/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
@@ -120,34 +120,32 @@ export const MultiSelectV2 = ({
         <PopoverContent_Shadcn_ className="p-0 w-96 border-strong" side="bottom" align="start">
           <Command_Shadcn_>
             <CommandInput_Shadcn_ placeholder={searchPlaceholder} />
-            <CommandList_Shadcn_
-              className={formattedOptions.length > 7 ? 'max-h-[210px]' : ''}
-            >
+            <CommandList_Shadcn_ className={formattedOptions.length > 7 ? 'max-h-[210px]' : ''}>
               <CommandEmpty_Shadcn_>No options found</CommandEmpty_Shadcn_>
               <CommandGroup_Shadcn_>
-                  {formattedOptions?.map((option) => {
-                    const active =
-                      selectedOptions &&
-                      selectedOptions.find((selected) => {
-                        return selected === option.value
-                      })
-                        ? true
-                        : false
-                    return (
-                      <CommandItem_Shadcn_
-                        key={option.id}
-                        value={option.value}
-                        className="cursor-pointer w-full"
-                        onClick={() => handleChange(option)}
-                        onSelect={() => handleChange(option)}
-                      >
-                        <div className="w-full flex items-center justify-between">
-                          {option.name}
-                          {active && <Check size={14} />}
-                        </div>
-                      </CommandItem_Shadcn_>
-                    )
-                  })}
+                {formattedOptions?.map((option) => {
+                  const active =
+                    selectedOptions &&
+                    selectedOptions.find((selected) => {
+                      return selected === option.value
+                    })
+                      ? true
+                      : false
+                  return (
+                    <CommandItem_Shadcn_
+                      key={option.id}
+                      value={option.value}
+                      className="cursor-pointer w-full"
+                      onClick={() => handleChange(option)}
+                      onSelect={() => handleChange(option)}
+                    >
+                      <div className="w-full flex items-center justify-between">
+                        {option.name}
+                        {active && <Check size={14} />}
+                      </div>
+                    </CommandItem_Shadcn_>
+                  )
+                })}
               </CommandGroup_Shadcn_>
             </CommandList_Shadcn_>
           </Command_Shadcn_>

--- a/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
+++ b/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
@@ -12,6 +12,7 @@ import {
   Popover_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
+  ScrollArea,
 } from 'ui'
 
 import { BadgeDisabled, BadgeSelected } from './Badges'
@@ -117,13 +118,18 @@ export const MultiSelectV2 = ({
             </div>
           </div>
         </PopoverTrigger_Shadcn_>
-        <PopoverContent_Shadcn_ className="p-0 w-96 border-strong" side="bottom" align="start">
+        <PopoverContent_Shadcn_
+          className="p-0 w-96 border-strong pointer-events-auto"
+          side="bottom"
+          align="start"
+        >
           <Command_Shadcn_>
             <CommandInput_Shadcn_ placeholder={searchPlaceholder} />
-            <CommandList_Shadcn_ className={formattedOptions.length > 7 ? 'max-h-[210px]' : ''}>
+            <CommandList_Shadcn_>
               <CommandEmpty_Shadcn_>No options found</CommandEmpty_Shadcn_>
               <CommandGroup_Shadcn_>
-                {formattedOptions?.map((option) => {
+                <ScrollArea className={cn(formattedOptions.length > 7 ? 'h-[210px]' : '')}>
+                  {formattedOptions?.map((option) => {
                   const active =
                     selectedOptions &&
                     selectedOptions.find((selected) => {
@@ -146,6 +152,7 @@ export const MultiSelectV2 = ({
                     </CommandItem_Shadcn_>
                   )
                 })}
+                </ScrollArea>
               </CommandGroup_Shadcn_>
             </CommandList_Shadcn_>
           </Command_Shadcn_>

--- a/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
+++ b/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
@@ -130,28 +130,28 @@ export const MultiSelectV2 = ({
               <CommandGroup_Shadcn_>
                 <ScrollArea className={cn(formattedOptions.length > 7 ? 'h-[210px]' : '')}>
                   {formattedOptions?.map((option) => {
-                  const active =
-                    selectedOptions &&
-                    selectedOptions.find((selected) => {
-                      return selected === option.value
-                    })
-                      ? true
-                      : false
-                  return (
-                    <CommandItem_Shadcn_
-                      key={option.id}
-                      value={option.value}
-                      className="cursor-pointer w-full"
-                      onClick={() => handleChange(option)}
-                      onSelect={() => handleChange(option)}
-                    >
-                      <div className="w-full flex items-center justify-between">
-                        {option.name}
-                        {active && <Check size={14} />}
-                      </div>
-                    </CommandItem_Shadcn_>
-                  )
-                })}
+                    const active =
+                      selectedOptions &&
+                      selectedOptions.find((selected) => {
+                        return selected === option.value
+                      })
+                        ? true
+                        : false
+                    return (
+                      <CommandItem_Shadcn_
+                        key={option.id}
+                        value={option.value}
+                        className="cursor-pointer w-full"
+                        onClick={() => handleChange(option)}
+                        onSelect={() => handleChange(option)}
+                      >
+                        <div className="w-full flex items-center justify-between">
+                          {option.name}
+                          {active && <Check size={14} />}
+                        </div>
+                      </CommandItem_Shadcn_>
+                    )
+                  })}
                 </ScrollArea>
               </CommandGroup_Shadcn_>
             </CommandList_Shadcn_>

--- a/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
+++ b/packages/ui-patterns/src/MultiSelectDeprecated/MultiSelectV2.tsx
@@ -12,7 +12,6 @@ import {
   Popover_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
-  ScrollArea,
 } from 'ui'
 
 import { BadgeDisabled, BadgeSelected } from './Badges'
@@ -121,10 +120,11 @@ export const MultiSelectV2 = ({
         <PopoverContent_Shadcn_ className="p-0 w-96 border-strong" side="bottom" align="start">
           <Command_Shadcn_>
             <CommandInput_Shadcn_ placeholder={searchPlaceholder} />
-            <CommandList_Shadcn_>
+            <CommandList_Shadcn_
+              className={formattedOptions.length > 7 ? 'max-h-[210px]' : ''}
+            >
               <CommandEmpty_Shadcn_>No options found</CommandEmpty_Shadcn_>
               <CommandGroup_Shadcn_>
-                <ScrollArea className={cn(formattedOptions.length > 7 ? 'h-[210px]' : '')}>
                   {formattedOptions?.map((option) => {
                     const active =
                       selectedOptions &&
@@ -148,7 +148,6 @@ export const MultiSelectV2 = ({
                       </CommandItem_Shadcn_>
                     )
                   })}
-                </ScrollArea>
               </CommandGroup_Shadcn_>
             </CommandList_Shadcn_>
           </Command_Shadcn_>


### PR DESCRIPTION
## Summary
- Remove redundant `ScrollArea` wrappers nested inside `CommandList` in the auth policy editor's "Table on" and "Target Roles to" dropdowns
- `CommandList` already provides `overflow-y-auto` scrolling — nesting `ScrollArea` inside it created two competing scroll containers, causing wheel events to be captured by the outer container instead of scrolling the dropdown content
- Move the height constraints (`max-h-[200px]`/`max-h-[210px]`) to `CommandList` where they belong

## Test plan
- [ ] Open Authentication → Policies in Studio
- [ ] Create or edit a policy
- [ ] Open the "Table on" dropdown and verify mouse wheel scrolling works
- [ ] Open the "Target Roles to" dropdown and verify mouse wheel scrolling works
- [ ] Verify keyboard navigation still works in both dropdowns

Fixes FE-2948