### PR TITLE
fix(docs): highlight supabase skills on the agent skills docs page

### DIFF
--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -24,7 +24,7 @@ You can also install the skills as Claude Code plugins:
 
 ```bash
 /plugin marketplace add supabase/agent-skills
-/plugin install postgres-best-practices@supabase-agent-skills
+/plugin install supabase@supabase-agent-skills
 ```
 
 Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The documentation references the specific postgres best practices plugin:
```bash
/plugin install postgres-best-practices@supabase-agent-skills
```

## What is the new behavior?

Updated the plugin installation command to highlight the Supabase agent skill:
```bash
/plugin install supabase@supabase-agent-skills
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Claude Code plugin installation command in the AI Skills guide to reflect the latest plugin identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->