### PR TITLE
fix(studio): respect enabled prop in index advisor query hook

### DIFF
--- a/apps/studio/data/database/retrieve-index-advisor-result-query.ts
+++ b/apps/studio/data/database/retrieve-index-advisor-result-query.ts
@@ -77,16 +77,20 @@ export const useGetIndexAdvisorResult = <TData = GetIndexAdvisorResultData>(
     enabled = true,
     ...options
   }: UseCustomQueryOptions<GetIndexAdvisorResultData, GetIndexAdvisorResultError, TData> = {}
-) =>
-  useQuery<GetIndexAdvisorResultData, GetIndexAdvisorResultError, TData>({
+) => {
+  const formattedQuery = (query ?? '').trim().toLowerCase()
+  const isValidQueryForIndexing =
+    formattedQuery.startsWith('select') || formattedQuery.startsWith('with pgrst_source')
+
+  return useQuery<GetIndexAdvisorResultData, GetIndexAdvisorResultError, TData>({
     queryKey: databaseKeys.indexAdvisorFromQuery(projectRef, query),
     queryFn: () => getIndexAdvisorResult({ projectRef, connectionString, query }),
     retry: false,
     enabled:
-      (enabled &&
-        typeof projectRef !== 'undefined' &&
-        typeof query !== 'undefined' &&
-        (query.startsWith('select') || query.startsWith('SELECT'))) ||
-      (typeof query === 'string' && query.trim().toLowerCase().startsWith('with pgrst_source')),
+      enabled &&
+      typeof projectRef !== 'undefined' &&
+      typeof query !== 'undefined' &&
+      isValidQueryForIndexing,
     ...options,
   })
+}


### PR DESCRIPTION
Fixes #44586

The `enabled` field in `useGetIndexAdvisorResult` had an OR branch that bypassed the `enabled` prop for queries starting with `with pgrst_source`. This meant the query could fire even when `enabled: false` was passed (e.g. when the index_advisor extension isn't installed or the result is already prefetched).

Restructures the logic to match the sibling hook in `retrieve-index-from-select-query.ts`, which correctly ANDs `enabled` with all conditions using an extracted `isValidQueryForIndexing` variable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query validation in index advisor to more reliably handle SQL query normalization and ensure consistent query processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->