### PR TITLE
fix(studio): escape SQL identifiers in index create/delete mutations

### DIFF
--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -1,7 +1,7 @@
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { ident } from '@supabase/pg-meta/src/pg-format'
 import { databaseIndexesKeys } from './keys'
 import { executeSql } from '@/data/sql/execute-sql-query'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -17,18 +17,12 @@ export type DatabaseIndexCreateVariables = {
   }
 }
 
-const VALID_INDEX_TYPES = ['btree', 'hash', 'gist', 'spgist', 'gin', 'brin']
-
 export async function createDatabaseIndex({
   projectRef,
   connectionString,
   payload,
 }: DatabaseIndexCreateVariables) {
   const { schema, entity, type, columns } = payload
-
-  if (!VALID_INDEX_TYPES.includes(type)) {
-    throw new Error(`Invalid index type: ${type}`)
-  }
 
   const sql = `
   CREATE INDEX ON ${ident(schema)}.${ident(entity)} USING ${type} (${columns

--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -17,12 +17,18 @@ export type DatabaseIndexCreateVariables = {
   }
 }
 
+const VALID_INDEX_TYPES = ['btree', 'hash', 'gist', 'spgist', 'gin', 'brin']
+
 export async function createDatabaseIndex({
   projectRef,
   connectionString,
   payload,
 }: DatabaseIndexCreateVariables) {
   const { schema, entity, type, columns } = payload
+
+  if (!VALID_INDEX_TYPES.includes(type)) {
+    throw new Error(`Invalid index type: ${type}`)
+  }
 
   const sql = `
   CREATE INDEX ON ${ident(schema)}.${ident(entity)} USING ${type} (${columns

--- a/apps/studio/data/database-indexes/index-create-mutation.ts
+++ b/apps/studio/data/database-indexes/index-create-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { databaseIndexesKeys } from './keys'
 import { executeSql } from '@/data/sql/execute-sql-query'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -24,8 +25,8 @@ export async function createDatabaseIndex({
   const { schema, entity, type, columns } = payload
 
   const sql = `
-  CREATE INDEX ON "${schema}"."${entity}" USING ${type} (${columns
-    .map((column) => `"${column}"`)
+  CREATE INDEX ON ${ident(schema)}.${ident(entity)} USING ${type} (${columns
+    .map((column) => ident(column))
     .join(', ')});
   `.trim()
 

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -1,7 +1,7 @@
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
-import { ident } from '@supabase/pg-meta/src/pg-format'
 import { databaseIndexesKeys } from './keys'
 import { executeSql } from '@/data/sql/execute-sql-query'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'

--- a/apps/studio/data/database-indexes/index-delete-mutation.ts
+++ b/apps/studio/data/database-indexes/index-delete-mutation.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { databaseIndexesKeys } from './keys'
 import { executeSql } from '@/data/sql/execute-sql-query'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -18,7 +19,7 @@ export async function deleteDatabaseIndex({
   name,
   schema,
 }: DatabaseIndexDeleteVariables) {
-  const sql = `drop index if exists "${schema}"."${name}"`
+  const sql = `drop index if exists ${ident(schema)}.${ident(name)}`
 
   const { result } = await executeSql({
     projectRef,


### PR DESCRIPTION
Fixes #44587

index-delete-mutation.ts and index-create-mutation.ts construct SQL using raw string interpolation for identifiers (schema, table, column names) without escaping double quotes. Uses ident() from @supabase/pg-meta/src/pg-format, same utility already used in the database-queues mutations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved identifier quoting/escaping for creating and dropping database indexes to ensure consistent, safer index operations.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->