### PR TITLE
Added deadlines for contest entries

### DIFF
--- a/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
+++ b/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
@@ -79,7 +79,7 @@ const page: GoPageInput = {
             <li>Create a Supabase account and note the email address you used</li>
             <li>Load data into a Supabase database</li>
             <li>Fill out the entry form below</li>
-            <li>Complete these steps by the contest deadline</li>
+            <li>Complete these steps by the contest deadline, Monday Aprul 13, 2026 at 12:00 PM PST</li>
           </ol>
           <Button asChild type="default" size="medium">
             <Link href="https://supabase.com/dashboard">Create your account</Link>

--- a/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
+++ b/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
@@ -79,7 +79,7 @@ const page: GoPageInput = {
             <li>Create a Supabase account and note the email address you used</li>
             <li>Load data into a Supabase database</li>
             <li>Fill out the entry form below</li>
-            <li>Complete these steps by the contest deadline, Monday Aprul 13, 2026 at 12:00 PM PST</li>
+            <li>Complete these steps by the contest deadline, Monday April 13, 2026 at 12:00 PM PST</li>
           </ol>
           <Button asChild type="default" size="medium">
             <Link href="https://supabase.com/dashboard">Create your account</Link>

--- a/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
+++ b/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
@@ -79,7 +79,7 @@ const page: GoPageInput = {
             <li>Create a Supabase account and note the email address you used</li>
             <li>Load data into a Supabase database</li>
             <li>Fill out the entry form below</li>
-            <li>Complete these steps by the contest deadline, Monday April 13, 2026 at 12:00 PM PST</li>
+            <li>Complete these steps by the contest deadline, Monday April 13, 2026 at 12:00 PM PDT</li>
           </ol>
           <Button asChild type="default" size="medium">
             <Link href="https://supabase.com/dashboard">Create your account</Link>

--- a/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
+++ b/apps/www/_go/events/mcp-dev-nyc-2026/contest.tsx
@@ -79,7 +79,9 @@ const page: GoPageInput = {
             <li>Create a Supabase account and note the email address you used</li>
             <li>Load data into a Supabase database</li>
             <li>Fill out the entry form below</li>
-            <li>Complete these steps by the contest deadline, Monday April 13, 2026 at 12:00 PM PDT</li>
+            <li>
+              Complete these steps by the contest deadline, Monday April 13, 2026 at 12:00 PM PDT
+            </li>
           </ol>
           <Button asChild type="default" size="medium">
             <Link href="https://supabase.com/dashboard">Create your account</Link>

--- a/apps/www/_go/events/pgconf-dev-2026/contest.tsx
+++ b/apps/www/_go/events/pgconf-dev-2026/contest.tsx
@@ -79,7 +79,9 @@ const page: GoPageInput = {
             <li>Create a Supabase account and note the email address you used</li>
             <li>Load data into a Supabase database</li>
             <li>Fill out the entry form below</li>
-            <li>Complete these steps by the contest deadline, Monday June 1, 2026 at 12:00 PM PDT</li>
+            <li>
+              Complete these steps by the contest deadline, Monday June 1, 2026 at 12:00 PM PDT
+            </li>
           </ol>
           <Button asChild type="default" size="medium">
             <Link href="https://supabase.com/dashboard">Create your account</Link>

--- a/apps/www/_go/events/pgconf-dev-2026/contest.tsx
+++ b/apps/www/_go/events/pgconf-dev-2026/contest.tsx
@@ -79,7 +79,7 @@ const page: GoPageInput = {
             <li>Create a Supabase account and note the email address you used</li>
             <li>Load data into a Supabase database</li>
             <li>Fill out the entry form below</li>
-            <li>Complete these steps by the contest deadline</li>
+            <li>Complete these steps by the contest deadline, Monday June 1, 2026 at 12:00 PM PDT</li>
           </ol>
           <Button asChild type="default" size="medium">
             <Link href="https://supabase.com/dashboard">Create your account</Link>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Added contest deadlines to two conference landing pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contest entry deadlines in the “How to enter” checklist: MCP Dev NYC 2026 — Monday April 13, 2026 at 12:00 PM PDT; PgConf Dev 2026 — Monday June 1, 2026 at 12:00 PM PDT.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->