### PR TITLE
feat(www): show confirmation message after newsletter signup

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -162,7 +162,12 @@ const Footer = (props: Props) => {
             </div>
             <div className="mt-8">
               {newsletterStatus === 'success' ? (
-                <p className="text-brand-link text-sm">Thanks for subscribing!</p>
+                <div className="flex flex-col gap-1">
+                  <p className="text-brand-link text-sm">Thanks for subscribing!</p>
+                  <p className="text-foreground-lighter text-xs">
+                    You'll hear from us when we publish our next newsletter issue.
+                  </p>
+                </div>
               ) : (
                 <form onSubmit={handleNewsletterSubmit} className="flex flex-col gap-2">
                   <p className="text-foreground-lighter text-sm">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

After subscribing to the newsletter in the footer, users only see "Thanks for subscribing!" with no indication of what to expect next.

## What is the new behavior?

After a successful newsletter signup, a secondary message is shown: "You'll hear from us when we publish our next newsletter issue." This sets expectations that they will receive emails when new issues are published.

## Additional context

Small UX improvement to the footer newsletter form success state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced newsletter subscription confirmation message with additional details about when the next issue will be published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->