### PR TITLE
feat(www): add optional expiration date support for /go pages

### DIFF
--- a/apps/www/_go/events/accenture-reinvention-2026/contest.tsx
+++ b/apps/www/_go/events/accenture-reinvention-2026/contest.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'accenture-reinvention-2026/contest',
+  expiresAt: '2026-05-31',
   metadata: {
     title:
       'Win an iPhone 17 Pro Max | Supabase at Accenture AI & Data Conference (ReinventionX) 2026',

--- a/apps/www/_go/events/postgresconf-sjc-2026/contest-thank-you.tsx
+++ b/apps/www/_go/events/postgresconf-sjc-2026/contest-thank-you.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'thank-you',
   slug: 'postgresconf-sjc-2026/contest/thank-you',
+  expiresAt: '2026-05-31',
   metadata: {
     title: "You're entered | Supabase at PostgresConf San Jose 2026",
     description:

--- a/apps/www/_go/events/postgresconf-sjc-2026/contest.tsx
+++ b/apps/www/_go/events/postgresconf-sjc-2026/contest.tsx
@@ -11,6 +11,7 @@ const speaker2 = authors.find((a) => a.author_id === 'sugu_sougoumarane')
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'postgresconf-sjc-2026/contest',
+  expiresAt: '2026-05-31',
   metadata: {
     title: 'Win a Mac Mini | Supabase at PostgresConf San Jose 2026',
     description:

--- a/apps/www/_go/events/startup-grind-2026/contest.tsx
+++ b/apps/www/_go/events/startup-grind-2026/contest.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'startup-grind-2026/contest',
+  expiresAt: '2026-05-31',
   metadata: {
     title: 'Win an iPhone 17 Pro Max | Supabase at Startup Grind 2026',
     description:

--- a/apps/www/_go/events/stripe-sessions-2026/contest.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/contest.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'stripe/contest',
+  expiresAt: '2026-05-31',
   metadata: {
     title: 'Win an iPhone 17 Pro Max | Supabase at Stripe Sessions',
     description:

--- a/apps/www/_go/events/stripe-sessions-2026/exec-dinner-thank-you.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/exec-dinner-thank-you.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'thank-you',
   slug: 'exec-dinner-april-2026/thank-you',
+  expiresAt: '2026-05-31',
   metadata: {
     title: "You're confirmed | Supabase Executive Dinner",
     description:

--- a/apps/www/_go/events/stripe-sessions-2026/exec-dinner.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/exec-dinner.tsx
@@ -10,6 +10,7 @@ const joe = authors.find((a) => a.author_id === 'joe_sciarrino')
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'exec-dinner-april-2026',
+  expiresAt: '2026-05-31',
   metadata: {
     title: 'Executive Dinner: The Future of Scalable Databases | Supabase',
     description:

--- a/apps/www/_go/events/stripe-sessions-2026/meeting-scheduler.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/meeting-scheduler.tsx
@@ -3,6 +3,7 @@ import type { GoPageInput } from 'marketing'
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'stripe/schedule',
+  expiresAt: '2026-05-31',
   metadata: {
     title: 'Schedule a Meeting at Stripe Sessions 2026 | Supabase',
     description:

--- a/apps/www/_go/events/stripe-sessions-2026/party.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/party.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'sf-rooftop-party',
+  expiresAt: '2026-05-31',
   metadata: {
     title: 'Win a MacBook Neo | Supabase, Stigg & Dreambase Rooftop Party',
     description:

--- a/apps/www/_go/events/sxsw-2026/contest.tsx
+++ b/apps/www/_go/events/sxsw-2026/contest.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'sxsw-2026/contest',
+  expiresAt: '2026-04-30',
   metadata: {
     title: 'Win a MacBook Neo | Supabase x Dreambase at SXSW 2026',
     description: 'Sign up for Supabase and Dreambase for a chance to win a MacBook Neo. SXSW 2026.',

--- a/apps/www/_go/index.tsx
+++ b/apps/www/_go/index.tsx
@@ -35,24 +35,24 @@ const pages: GoPageInput[] = [
   contestRules,
   figmaWebinarMay2026,
   figmaWebinarMay2026ThankYou,
-  boltWebinar, // remove after March 31, 2026
-  boltWebinarThankYou, // remove after March 31, 2026
-  stripeExecDinner, // remove after May 31, 2026
-  stripeExecDinnerThankYou, // remove after May 31, 2026
-  stripeMeetingScheduler, // remove after May 31, 2026
-  stripeSessionsContest, // remove after May 31, 2026
-  stripeParty, // remove after May 31, 2026
-  sxswContest, // remove after April 30, 2026
-  accentureContest, // remove after May 31, 2026
-  postgresconfContest, // remove after May 31, 2026
-  postgresconfContestThankYou, // remove after May 31, 2026
+  boltWebinar,
+  boltWebinarThankYou,
+  stripeExecDinner,
+  stripeExecDinnerThankYou,
+  stripeMeetingScheduler,
+  stripeSessionsContest,
+  stripeParty,
+  sxswContest,
+  accentureContest,
+  postgresconfContest,
+  postgresconfContestThankYou,
   mcpDevSummitContest,
   mcpDevSummitContestThankYou,
   pgconfDevContest,
   pgconfDevContestThankYou,
   aiEngineerEuropeContest,
   aiEngineerEuropeContestThankYou,
-  startupGrindContest, // remove after May 31, 2026
+  startupGrindContest,
   supabaseStripeProjects,
 ]
 

--- a/apps/www/_go/webinar/bolt-webinar-thank-you.tsx
+++ b/apps/www/_go/webinar/bolt-webinar-thank-you.tsx
@@ -5,6 +5,7 @@ import { Button } from 'ui'
 const page: GoPageInput = {
   template: 'thank-you',
   slug: 'vibe-coding-done-right-webinar/thank-you',
+  expiresAt: '2026-03-31',
   metadata: {
     title: 'Thank you',
     description: 'Thanks for getting in touch. We’ll be in touch with resources and next steps.',

--- a/apps/www/_go/webinar/bolt-webinar.tsx
+++ b/apps/www/_go/webinar/bolt-webinar.tsx
@@ -4,6 +4,7 @@ import { MediaBlock } from 'marketing'
 const page: GoPageInput = {
   template: 'lead-gen',
   slug: 'vibe-coding-done-right-webinar',
+  expiresAt: '2026-03-31',
   metadata: {
     title: 'Vibe Coding, Done Right: Learn More | Supabase + Bolt.new',
     description:

--- a/apps/www/lib/go.ts
+++ b/apps/www/lib/go.ts
@@ -1,11 +1,18 @@
 import rawPages from '@/_go'
 import { goPageSchema, type GoPage } from '@/types/go'
 
+function isExpired(page: { expiresAt?: string }): boolean {
+  if (!page.expiresAt) return false
+  return new Date(page.expiresAt) < new Date()
+}
+
 export function getAllGoPages(): GoPage[] {
   const pages: GoPage[] = []
   const seenSlugs = new Set<string>()
 
   for (const raw of rawPages) {
+    if (isExpired(raw)) continue
+
     const result = goPageSchema.safeParse(raw)
 
     if (!result.success) {

--- a/apps/www/lib/go.ts
+++ b/apps/www/lib/go.ts
@@ -3,7 +3,12 @@ import { goPageSchema, type GoPage } from '@/types/go'
 
 function isExpired(page: { expiresAt?: string }): boolean {
   if (!page.expiresAt) return false
-  return new Date(page.expiresAt) < new Date()
+  const [year, month, day] = page.expiresAt.split('-').map(Number)
+  if (![year, month, day].every(Number.isInteger)) {
+    throw new Error(`Invalid expiresAt value: "${page.expiresAt}"`)
+  }
+  const expiresAtEndOfDayUtc = Date.UTC(year, month - 1, day, 23, 59, 59, 999)
+  return Date.now() > expiresAtEndOfDayUtc
 }
 
 export function getAllGoPages(): GoPage[] {

--- a/packages/marketing/src/go/schemas.ts
+++ b/packages/marketing/src/go/schemas.ts
@@ -332,6 +332,8 @@ const goPageBaseSchema = z.object({
   hero: heroSectionSchema,
   sections: z.array(goSectionSchema).optional(),
   publishedAt: z.string().optional(),
+  /** ISO 8601 date (YYYY-MM-DD) after which the page should return a 404. */
+  expiresAt: z.string().optional(),
 })
 
 export const leadGenPageSchema = goPageBaseSchema.extend({

--- a/packages/marketing/src/go/schemas.ts
+++ b/packages/marketing/src/go/schemas.ts
@@ -333,7 +333,10 @@ const goPageBaseSchema = z.object({
   sections: z.array(goSectionSchema).optional(),
   publishedAt: z.string().optional(),
   /** ISO 8601 date (YYYY-MM-DD) after which the page should return a 404. */
-  expiresAt: z.string().optional(),
+  expiresAt: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, 'expiresAt must be YYYY-MM-DD')
+    .optional(),
 })
 
 export const leadGenPageSchema = goPageBaseSchema.extend({


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

/go page expiration dates are tracked via code comments (e.g. `// remove after March 31, 2026`) in the page registry, requiring manual cleanup.

Resolves [DEBR-218](https://linear.app/supabase/issue/DEBR-218/add-optional-expiration-date-support-for-go-pages)

## What is the new behavior?

- Adds an optional `expiresAt` (ISO date string) field to the `GoPageInput` schema in the marketing package
- Expired pages are automatically filtered out at build time in `getAllGoPages()`, excluding them from static generation
- All 12 pages that had expiration comments now use the `expiresAt` field instead

## Additional context

No runtime overhead — expiration is checked once during the Next.js build. Expired pages simply won't be generated as static pages, resulting in a 404.


```js
const message = "This is javascript example."
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic page expiration capability. Event pages are now automatically hidden after their expiration date.

* **Chores**
  * Set expiration dates for event pages and webinars scheduled through mid-2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->