### PR TITLE
feat: Allow branch selection in support request form project picker

### DIFF
--- a/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
+++ b/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
@@ -13,6 +13,11 @@ import {
   CommandItem_Shadcn_,
   FormControl_Shadcn_,
   FormField_Shadcn_,
+  Select_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -23,6 +28,7 @@ import type { SupportFormValues } from './SupportForm.schema'
 import { NO_ORG_MARKER, NO_PROJECT_MARKER } from './SupportForm.utils'
 import CopyButton from '@/components/ui/CopyButton'
 import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
+import { useBranchesQuery } from '@/data/branches/branches-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
 interface ProjectAndPlanProps {
@@ -43,11 +49,14 @@ export function ProjectAndPlanInfo({
   showPlanExpectationInfo = true,
 }: ProjectAndPlanProps) {
   const hasProjectSelected = projectRef && projectRef !== NO_PROJECT_MARKER
+  const branchRef = form.watch('branchRef')
+  const displayedRef = branchRef || projectRef
 
   return (
     <div className="flex flex-col gap-y-2">
       <ProjectSelector form={form} orgSlug={orgSlug} projectRef={projectRef} />
-      <ProjectRefHighlighted projectRef={projectRef} />
+      <BranchSelector form={form} projectRef={projectRef} />
+      <ProjectRefHighlighted projectRef={displayedRef} />
 
       {!hasProjectSelected && <Admonition type="default" title="No project has been selected" />}
 
@@ -89,7 +98,10 @@ function ProjectSelector({ form, orgSlug, projectRef }: ProjectSelectorProps) {
                 if (!urlProjectRef && (!projectRef || projectRef === NO_PROJECT_MARKER))
                   field.onChange(projects[0]?.ref ?? NO_PROJECT_MARKER)
               }}
-              onSelect={(project) => field.onChange(project.ref)}
+              onSelect={(project) => {
+                field.onChange(project.ref)
+                form.setValue('branchRef', undefined)
+              }}
               renderTrigger={({ isLoading, project, listboxId, open }) => {
                 return (
                   <Button
@@ -130,6 +142,60 @@ function ProjectSelector({ form, orgSlug, projectRef }: ProjectSelectorProps) {
                 </CommandGroup_Shadcn_>
               )}
             />
+          </FormControl_Shadcn_>
+        </FormItemLayout>
+      )}
+    />
+  )
+}
+
+interface BranchSelectorProps {
+  form: UseFormReturn<SupportFormValues>
+  projectRef: string | null
+}
+
+function BranchSelector({ form, projectRef }: BranchSelectorProps) {
+  const { data: branches, isLoading } = useBranchesQuery(
+    { projectRef: projectRef ?? undefined },
+    { enabled: !!projectRef && projectRef !== NO_PROJECT_MARKER }
+  )
+
+  const nonDefaultBranches = (branches ?? []).filter((b) => !b.is_default)
+
+  if (
+    !projectRef ||
+    projectRef === NO_PROJECT_MARKER ||
+    (!isLoading && nonDefaultBranches.length === 0)
+  ) {
+    return null
+  }
+
+  return (
+    <FormField_Shadcn_
+      name="branchRef"
+      control={form.control}
+      render={({ field }) => (
+        <FormItemLayout hideMessage layout="vertical" label="Is this a branch project issue?">
+          <FormControl_Shadcn_>
+            <Select_Shadcn_
+              value={field.value ?? 'no-branch'}
+              onValueChange={(val) => field.onChange(val === 'no-branch' ? undefined : val)}
+            >
+              <SelectTrigger_Shadcn_ size="small">
+                <SelectValue_Shadcn_ placeholder="No, the issue is with the main project" />
+              </SelectTrigger_Shadcn_>
+              <SelectContent_Shadcn_>
+                <SelectItem_Shadcn_ value="no-branch">
+                  No, the issue is with the main project
+                </SelectItem_Shadcn_>
+                {nonDefaultBranches.map((branch) => (
+                  <SelectItem_Shadcn_ key={branch.id} value={branch.project_ref}>
+                    {branch.name}
+                    {branch.git_branch ? ` (${branch.git_branch})` : ''}
+                  </SelectItem_Shadcn_>
+                ))}
+              </SelectContent_Shadcn_>
+            </Select_Shadcn_>
           </FormControl_Shadcn_>
         </FormItemLayout>
       )}

--- a/apps/studio/components/interfaces/Support/SupportForm.schema.ts
+++ b/apps/studio/components/interfaces/Support/SupportForm.schema.ts
@@ -21,6 +21,7 @@ export const SupportFormSchema = z
     allowSupportAccess: z.boolean(),
     attachDashboardLogs: z.boolean(),
     dashboardSentryIssueId: z.string().optional(),
+    branchRef: z.string().optional(),
   })
   .refine(
     (data) => {

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -124,7 +124,8 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
 
     dispatch({ type: 'SUBMIT' })
 
-    const { attachDashboardLogs: formAttachDashboardLogs, ...values } = formValues
+    const { attachDashboardLogs: formAttachDashboardLogs, branchRef, ...values } = formValues
+    const effectiveProjectRef = branchRef || values.projectRef
     const attachDashboardLogs =
       formAttachDashboardLogs && DASHBOARD_LOG_CATEGORIES.includes(values.category)
 
@@ -146,7 +147,7 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
     const payload = {
       ...values,
       organizationSlug: values.organizationSlug ?? NO_ORG_MARKER,
-      projectRef: values.projectRef ?? NO_PROJECT_MARKER,
+      projectRef: effectiveProjectRef ?? NO_PROJECT_MARKER,
       allowSupportAccess:
         values.category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(values.category)
           ? values.allowSupportAccess
@@ -175,10 +176,10 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
       dashboardStudioVersion: commit ? formatStudioVersion(commit) : undefined,
     }
 
-    if (values.projectRef !== NO_PROJECT_MARKER) {
+    if (effectiveProjectRef !== NO_PROJECT_MARKER) {
       try {
         const authConfig = await getProjectAuthConfig({
-          projectRef: values.projectRef,
+          projectRef: effectiveProjectRef,
         })
         payload.siteUrl = authConfig.SITE_URL
         payload.additionalRedirectUrls = authConfig.URI_ALLOW_LIST


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

feature to the support form. It will need more discussion but this is just a placeholder PR. I have not fully tested submission so we need discuss how this would look on our side in support

## What is the current behavior?

We can only select a main project and never any of the branches beneath the main project.

## What is the new behavior?

You can select a branch if the issue stems from that:
<img width="611" height="146" alt="image" src="https://github.com/user-attachments/assets/50f333c4-0185-4ca0-9a78-c82fdaaec01b" />

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Branch selection now available in the support form
  * Branch selector dynamically appears based on project selection
  * Support requests submitted with branch information when available

<!-- end of auto-generated comment: release notes by coderabbit.ai -->