### PR TITLE
fix(ci): fix spam detection env var passing in auto-label-issues

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -58,7 +58,7 @@ jobs:
             -H "Authorization: Bearer $BEARER_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{"issue_id": $NUMBER}')
-          echo "spam_response=$RESPONSE" >> $GITHUB_OUTPUT
+          echo "SPAM_RESPONSE=$RESPONSE" >> $GITHUB_ENV
       - name: Use spam detector output to label issue
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .next
 node_modules
 pnpm-lock.yaml
+package-lock.json
 docker*
 apps/**/out
 # prettier-plugin-sql-cst only supports sqlite syntax


### PR DESCRIPTION
## Summary

- Fix the `spam-detection` job in `auto-label-issues.yml` so it actually labels spam issues.

## Problem

The spam detection job has never worked. Step 1 calls the spam detection API and writes the result to `$GITHUB_OUTPUT`:

```yaml
echo "spam_response=$RESPONSE" >> $GITHUB_OUTPUT
```

Step 2 tries to read it as an environment variable `$SPAM_RESPONSE`:

```yaml
IS_SPAM=$(echo "$SPAM_RESPONSE" | jq -r '.spam')
```

`$GITHUB_OUTPUT` values are only accessible via `steps.<id>.outputs.<name>`, not as env vars. Since `$SPAM_RESPONSE` is always empty, `jq -r '.spam'` returns `null`, the condition never matches, and no issue ever gets the `flagged` label.

## Fix

Changed step 1 to write to `$GITHUB_ENV` instead of `$GITHUB_OUTPUT`, and use the uppercase `SPAM_RESPONSE` key to match what step 2 reads:

```diff
-          echo "spam_response=$RESPONSE" >> $GITHUB_OUTPUT
+          echo "SPAM_RESPONSE=$RESPONSE" >> $GITHUB_ENV
```

`$GITHUB_ENV` makes variables available as environment variables in all subsequent steps, which is what the existing step 2 code expects.

## Verification

1. After merge, create a test issue (or wait for a new one) and check the `spam-detection` job logs.
2. The `SPAM_RESPONSE` variable should now contain the API response in step 2.
3. If the API returns `{"spam": true}`, the issue should get the `flagged` label.

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.