### PR TITLE
fix(ci): exclude package-lock.json from Prettier checks

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,6 +2,7 @@
 .next
 node_modules
 pnpm-lock.yaml
+package-lock.json
 docker*
 apps/**/out
 # prettier-plugin-sql-cst only supports sqlite syntax


### PR DESCRIPTION
## Summary

- Add `package-lock.json` to `.prettierignore` to stop Prettier from failing on lockfiles from npm-based examples.

## Problem

The `Check Code with Prettier` workflow fails on ~30% of recent CI runs because `examples/user-management/nuxt3-user-management/package-lock.json` isn't formatted to Prettier's config.

The error is deterministic and hits every PR branch since the file is on master:

```
[warn] examples/user-management/nuxt3-user-management/package-lock.json
[warn] Code style issues found in the above file. Run Prettier with --write to fix.
ELIFECYCLE  Command failed with exit code 1.
```

9 of the last 30 failed runs were caused by this single file (run IDs: 24053618859, 24049997476, 24048918588, 24047037795, 24046832876, 24046576136, 24045873777, 24039178183, 24038505594).

## Fix

`.prettierignore` already excludes `pnpm-lock.yaml` (the monorepo lockfile) but not `package-lock.json`. The nuxt3 example uses npm, not pnpm, so it has its own `package-lock.json` that doesn't conform.

Added `package-lock.json` to `.prettierignore`, right after the existing `pnpm-lock.yaml` entry. This matches the existing pattern of excluding lockfiles from formatting checks.

## Verification

After merge, the `Check Code with Prettier` workflow should pass on PRs that were previously failing due to this file. The next Dependabot PRs should no longer hit this error.

---

> [!NOTE]
> Created by [Mendral](https://mendral.com). Tag @mendral-agent with feedback or questions.