### PR TITLE
fix(studio): handle undefined connectionStringPooler in connect sheet

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -14,7 +14,10 @@ import {
   type ConnectionStringMethod,
   type DatabaseConnectionType,
 } from '@/components/interfaces/ConnectSheet/Connect.constants'
-import type { StepContentProps } from '@/components/interfaces/ConnectSheet/Connect.types'
+import type {
+  ConnectionStringPooler,
+  StepContentProps,
+} from '@/components/interfaces/ConnectSheet/Connect.types'
 import { ConnectionParameters } from '@/components/interfaces/ConnectSheet/ConnectionParameters'
 import {
   buildConnectionParameters,
@@ -134,9 +137,9 @@ function DirectConnectionContent({ state }: StepContentProps) {
   const useSharedPooler = Boolean(state.useSharedPooler)
 
   const connectionStrings = useConnectionStringDatabases()
-  const connectionStringPooler =
+  const connectionStringPooler: ConnectionStringPooler | undefined =
     connectionStrings[connectionSource as keyof typeof connectionStrings]
-  const hasIPv4Addon = connectionStringPooler.ipv4SupportedForDedicatedPooler
+  const hasIPv4Addon = connectionStringPooler?.ipv4SupportedForDedicatedPooler ?? false
 
   // Determine which connection string to use
   const resolvedConnectionString = useMemo(


### PR DESCRIPTION
Follow-up to #44471. Fixes Sentry error: `can't access property "ipv4SupportedForDedicatedPooler", g is undefined`.

`connectionStringPooler` can be `undefined` when the databases query hasn't resolved yet (returns `[]` by default, so the lookup object is empty). Added optional chaining + explicit typing.

## To test

- Open the connect sheet on any project — should render without errors
- Check that IPv4 status panel still displays correctly once loaded

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and robustness in connection pooler configuration handling for more reliable IPv4 capability detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->