### PR TITLE
fix: audit logs project filtering hide all projects logs

### DIFF
--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -135,7 +135,7 @@ export const AuditLogs = () => {
     })
     ?.filter((log) => {
       if (filters.projects.length > 0) {
-        return filters.projects.includes(log.target.metadata.project_ref || '')
+        return filters.projects.includes(log.target.metadata.ref || '')
       } else {
         return log
       }


### PR DESCRIPTION
## Problem

The Audit Logs filtering by project doesn't work. Filtering by one or several projects hides all logs

## Solution

It appears the API returns a `ref` property and not a `project_ref`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed project filtering in audit logs to correctly match against the appropriate metadata field, ensuring accurate results when selecting specific projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->