### PR TITLE
feat(studio): hide overlay on test edge function sheet

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -291,6 +291,7 @@ export const EdgeFunctionTesterSheet = ({ visible, onClose }: EdgeFunctionTester
     <Sheet open={visible} onOpenChange={onClose}>
       <SheetContent
         size="default"
+        hasOverlay={false}
         className="flex flex-col gap-0 p-0"
         onPointerDownOutside={(e) => {
           // react-resizable-panels v4 registers document-level capture-phase pointer


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Ability to view things beneath the sheet, such as edge function logs while testing.

| Before | After |
|--------|--------|
| <img width="1203" height="842" alt="Screenshot 2026-04-07 at 13 33 57" src="https://github.com/user-attachments/assets/90423650-fcf0-4a88-aadd-dbbb373e2a33" /> | <img width="1206" height="838" alt="Screenshot 2026-04-07 at 13 30 53" src="https://github.com/user-attachments/assets/103a05a6-eaed-4985-a83d-4aa4b945ee9f" /> | 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual appearance of the edge function tester sheet by removing the overlay effect, providing a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->