### PR TITLE
docs: update SDK reference docs and guides from recent SDK changes

### DIFF
--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -1,7 +1,7 @@
 ---
 id: automatic-retries-in-supabase-js
 title: 'How to do automatic retries with `supabase-js`'
-subtitle: 'Learn how to add automatic retries to your Supabase API requests using `fetch-retry`.'
+subtitle: 'Learn how to configure automatic retries for your Supabase API requests.'
 ---
 
 <Admonition type="danger" title="Important">
@@ -10,9 +10,35 @@ You should only enable retries if your requests fail with network errors (e.g. 5
 
 </Admonition>
 
-The `fetch-retry` package allows you to add retry logic to `fetch` requests, making it a useful tool for enhancing the resilience of API calls in your Supabase applications. Here's a step-by-step guide on how to integrate `fetch-retry` with the `supabase-js` library.
+## Built-in retries for PostgREST queries
 
-## 1. Install dependencies
+Starting with `supabase-js` v2.102.0, PostgREST queries (`.from()`, `.rpc()`) include built-in automatic retries for transient errors. Retries are **enabled by default** and use exponential backoff with jitter.
+
+Retryable errors include HTTP status codes 408 (Request Timeout), 409 (Conflict), 503 (Service Unavailable), and 504 (Gateway Timeout), as well as network failures. Only idempotent HTTP methods (GET, HEAD, OPTIONS) and POST requests (used by PostgREST) are retried.
+
+### Disable built-in retries
+
+If you prefer to handle retries yourself, you can disable the built-in retry behavior:
+
+```javascript
+import { createClient } from '@supabase/supabase-js'
+
+const supabase = createClient(
+  'https://your-supabase-url.supabase.co',
+  'your-anon-key',
+  {
+    db: {
+      retry: false,
+    },
+  }
+)
+```
+
+## Custom retries with `fetch-retry`
+
+For more control over retry behavior, or to add retries to non-PostgREST requests (auth, storage, functions), you can use the `fetch-retry` package. This approach wraps the native `fetch` function and applies to all requests made by the client.
+
+### 1. Install dependencies
 
 To get started, ensure you have both `supabase-js` and `fetch-retry` installed in your project:
 
@@ -20,7 +46,7 @@ To get started, ensure you have both `supabase-js` and `fetch-retry` installed i
 npm install @supabase/supabase-js fetch-retry
 ```
 
-## 2. Wrap the fetch function
+### 2. Wrap the fetch function
 
 The `fetch-retry` package works by wrapping the native `fetch` function. You can create a custom fetch instance with retry logic and pass it to the `supabase-js` client.
 
@@ -43,7 +69,7 @@ const supabase = createClient(
 )
 ```
 
-## 3. Configure retry options
+### 3. Configure retry options
 
 You can configure `fetch-retry` options to control retry behavior, such as the number of retries, retry delay, and which errors should trigger a retry.
 
@@ -59,7 +85,7 @@ const fetchWithRetry = fetchRetry(fetch, {
 
 In this example, the `retryDelay` function implements an exponential backoff strategy, and retries are triggered only for specific HTTP status codes.
 
-## 4. Using the Supabase client
+### 4. Using the Supabase client
 
 With `fetch-retry` integrated, you can use the Supabase client as usual. The retry logic will automatically apply to all network requests made by `supabase-js`.
 
@@ -77,7 +103,7 @@ async function fetchData() {
 fetchData()
 ```
 
-## 5. Fine-Tuning retries for specific requests
+### 5. Fine-tuning retries for specific requests
 
 If you need different retry logic for certain requests, you can use the `retryOn` with a custom function to inspect the URL or response and decide whether to retry the request.
 
@@ -119,4 +145,4 @@ By using `retryOn` with a custom function, you can define specific conditions fo
 
 ## Conclusion
 
-Integrating `fetch-retry` with `supabase-js` is a straightforward way to add robustness to your Supabase API requests. By handling transient errors and implementing retry strategies, you can improve the reliability of your application while maintaining a seamless user experience.
+For most use cases, the built-in PostgREST retry mechanism is sufficient. Use `fetch-retry` when you need retries on non-PostgREST requests or need fine-grained control over retry behavior.

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -23,15 +23,11 @@ If you prefer to handle retries yourself, you can disable the built-in retry beh
 ```javascript
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient(
-  'https://your-supabase-url.supabase.co',
-  'your-anon-key',
-  {
-    db: {
-      retry: false,
-    },
-  }
-)
+const supabase = createClient('https://your-supabase-url.supabase.co', 'your-anon-key', {
+  db: {
+    retry: false,
+  },
+})
 ```
 
 ## Custom retries with `fetch-retry`

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -1028,6 +1028,41 @@ final UserResponse res = await supabase.auth.updateUser(
 </$Show>
 </Tabs>
 
+#### Verifying the current password
+
+If your app requires users to confirm their current password before setting a new one, you can pass `currentPassword` (available in `supabase-js` v2.102.0+ and `supabase-kt` 3.5.0+):
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+```js
+await supabase.auth.updateUser({
+  password: 'new_password',
+  currentPassword: 'old_password',
+})
+```
+
+</TabPanel>
+<$Show if="sdk:kotlin">
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+supabase.auth.updateUser {
+    password = "new_password"
+    currentPassword = "old_password"
+}
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
+
 ### Email sending
 
 The signup confirmation and password reset flows require an SMTP server to send emails.

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -82,6 +82,10 @@ functions:
             isOptional: true
             type: int
             description: The number of times to retry a failed upload request. Defaults to `0`.
+          - name: useNewHostname
+            isOptional: true
+            type: bool
+            description: Whether to rewrite legacy storage URLs to use the dedicated storage host (`<ref>.storage.supabase.co`). Set to `true` only if your project has the dedicated storage host enabled. Defaults to `false`.
     examples:
       - id: flutter-initialize
         name: For Flutter
@@ -788,6 +792,18 @@ functions:
             redirectTo: kIsWeb ? null : 'my.scheme://my-host', // Optionally set the redirect link to bring back the user via deeplink.
             authScreenLaunchMode:
                 kIsWeb ? LaunchMode.platformDefault : LaunchMode.externalApplication, // Launch the auth screen in a new webview on mobile.
+          );
+          ```
+      - id: sign-in-with-custom-provider
+        name: Sign in with a custom OIDC provider
+        description: |
+          `OAuthProvider` is now a class instead of an enum, allowing you to use custom OIDC providers by passing a custom provider string.
+        isSpotlight: false
+        code: |
+          ```dart
+          await supabase.auth.signInWithOAuth(
+            OAuthProvider('custom:my-oidc-provider'),
+            redirectTo: kIsWeb ? null : 'my.scheme://my-host',
           );
           ```
       - id: sign-in-using-a-third-party-provider-with-redirect
@@ -1579,6 +1595,10 @@ functions:
         isOptional: false
         type: String
         description: Refresh token to use to get a new session.
+      - name: accessToken
+        isOptional: true
+        type: String
+        description: Optional access token to set along with the refresh token.
     examples:
       - id: refresh-the-session
         name: Refresh the session
@@ -1590,6 +1610,17 @@ functions:
           final AuthResponse response = await supabase.auth.setSession(refreshToken);
 
           final session = res.session;
+          ```
+      - id: set-session-with-access-token
+        name: Set session with access token
+        description: You can optionally provide an access token along with the refresh token.
+        isSpotlight: false
+        code: |
+          ```dart
+          final AuthResponse response = await supabase.auth.setSession(
+            refreshToken,
+            accessToken: accessToken,
+          );
           ```
         response: |
           ```json

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -169,6 +169,22 @@ functions:
     $ref: '@supabase/auth-js.GoTrueAdminMFAApi.listFactors'
   - id: mfa-delete-factor
     $ref: '@supabase/auth-js.GoTrueAdminMFAApi.deleteFactor'
+  - id: admin-custom-providers-api
+    title: Custom OIDC/OAuth Provider Admin API
+    notes: |
+      - These methods allow you to manage custom OIDC/OAuth providers programmatically.
+      - Requires `service_role` key.
+      - Custom providers use the `custom:` prefix when signing in (e.g., `custom:my-oidc-provider`).
+  - id: admin-custom-providers-create
+    $ref: '@supabase/auth-js.GoTrueAdminCustomProvidersApi.createProvider'
+  - id: admin-custom-providers-list
+    $ref: '@supabase/auth-js.GoTrueAdminCustomProvidersApi.listProviders'
+  - id: admin-custom-providers-get
+    $ref: '@supabase/auth-js.GoTrueAdminCustomProvidersApi.getProvider'
+  - id: admin-custom-providers-update
+    $ref: '@supabase/auth-js.GoTrueAdminCustomProvidersApi.updateProvider'
+  - id: admin-custom-providers-delete
+    $ref: '@supabase/auth-js.GoTrueAdminCustomProvidersApi.deleteProvider'
   - id: select
     $ref: '@supabase/postgrest-js.PostgrestQueryBuilder.select'
   - id: insert

--- a/apps/docs/spec/supabase_kt_v3.yml
+++ b/apps/docs/spec/supabase_kt_v3.yml
@@ -213,6 +213,10 @@ functions:
           `customUrl` - Custom url for the PostgREST API. Can be safely ignored when using Supabase. Default: `null`
 
           `jwtToken` - Plugin specific JWT Token. Can be ignored when using the Auth plugin. Default: `null`
+
+          `urlLengthLimit` - The maximum URL length for requests. When exceeded, the request is automatically sent as POST with query parameters in the body. Default: `null` (unlimited)
+
+          `timeout` - The timeout for PostgREST requests. Default: `30.seconds`
       - id: configure-storage
         name: Configure Storage module
         code: |
@@ -3561,6 +3565,10 @@ functions:
             isOptional: true
             type: JsonObject
             description: The new user data.
+          - name: currentPassword
+            isOptional: true
+            type: String?
+            description: The current password. Required when reauthentication is needed to change the password.
     examples:
       - id: update-the-email-for-an-authenticated-user
         name: Update the email for an authenticated user
@@ -4604,6 +4612,27 @@ functions:
           ```
         description: |
           The return type of the invoking methods is an `HttpResponse`. You can access the response body via `response.body<T>()`, where `T` can be any serializable type.
+      - id: invoke-with-streaming
+        name: Invoke with streaming (SSE)
+        description: |
+          You can invoke edge functions that return Server-Sent Events (SSE) and consume them as a Kotlin Flow.
+        isSpotlight: true
+        code: |
+          ```kotlin
+          val function = supabase.functions.buildEdgeFunction("streaming-function")
+
+          // Collect SSE events as a Flow
+          function.collectAsFlow(
+              body = buildJsonObject {
+                  put("prompt", "Hello!")
+              }
+          ).collect { event ->
+              println("Event: ${event.event}")
+              println("Data: ${event.data}")
+              // Decode typed data
+              val response = event.decodeAs<MyResponse>()
+          }
+          ```
       - id: reuse-function
         name: Reuse function by saving it to a variable
         isSpotlight: true

--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -53,6 +53,25 @@ functions:
             )
           )
           ```
+      - id: initialize-client-with-retries
+        name: Initialize Client with automatic retries
+        description: |
+          PostgREST requests automatically retry on transient errors (HTTP 408, 409, 503, 504 and network failures) with exponential backoff. Retries are enabled by default and can be disabled per client.
+        code: |
+          ```swift
+          import Supabase
+
+          let supabase = SupabaseClient(
+            supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
+            supabaseKey: "publishable-or-anon-key",
+            options: SupabaseClientOptions(
+              db: .init(
+                // Disable automatic retries for this client
+                retryEnabled: false
+              )
+            )
+          )
+          ```
       - id: initialize-client-with-logging
         name: Initialize Client with Logging
         code: |
@@ -4393,6 +4412,7 @@ functions:
       - You can receive the "previous" data for updates and deletes by setting the table's `REPLICA IDENTITY` to `FULL` (e.g., `ALTER TABLE your_table REPLICA IDENTITY FULL;`).
       - Row level security is not applied to delete statements. When RLS is enabled and replica identity is set to full, only the primary key is sent to clients.
       - Use AsyncStream or callbacks for listening to changes.
+      - Presence and Postgres change callbacks must be registered **before** calling `subscribe()`. Attempting to add them after the channel is subscribing or subscribed will trigger a warning and the callback will be rejected.
     examples:
       - id: listen-to-broadcast
         name: Listen to broadcast messages

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -317,6 +317,7 @@ allow_list = [
     "Redis",
     "RedwoodJS",
     "Refine",
+    "[Rr]etryable",
     "Roboflow",
     "Rollup",
     "SaaS",


### PR DESCRIPTION
## Summary

Updates documentation based on SDK changes from 2026-02-16 to 2026-04-07 across all Supabase client SDKs.

### SDK changes analyzed

| SDK | Repository | Commits | Latest Tag |
|-----|-----------|---------|------------|
| JS | supabase/supabase-js | 78 | v2.104.0-canary.0 |
| Dart | supabase/supabase-flutter | 17 | - |
| Python | supabase/supabase-py | 11 | v2.28.3 |
| Swift | supabase/supabase-swift | 13 | v2.43.0 |
| Kotlin | supabase-community/supabase-kt | ~40 | 3.5.0 |
| C# | supabase-community/supabase-csharp | 0 (no changes) | v1.1.2 |

### Documentation updates

**Spec files:**
- **JS** (`supabase_js_v2.yml`): Added custom OIDC/OAuth provider admin CRUD method refs (`createProvider`, `listProviders`, `getProvider`, `updateProvider`, `deleteProvider`)
- **Dart** (`supabase_dart_v2.yml`): Added custom OAuthProvider class example, `accessToken` param for `setSession()`, `useNewHostname` storage option
- **Swift** (`supabase_swift_v2.yml`): Added PostgREST automatic retries initialization example, realtime callback registration timing note
- **Kotlin** (`supabase_kt_v3.yml`): Added streaming edge functions (SSE) example via `collectAsFlow`, `currentPassword` param for `updateUser`, `urlLengthLimit`/`timeout` PostgREST config options

**Guides:**
- `api/automatic-retries-in-supabase-js.mdx`: Added built-in PostgREST retry documentation (enabled by default since v2.102.0), restructured guide to show native retries first, `fetch-retry` as advanced option
- `auth/passwords.mdx`: Added `currentPassword` verification section with JS and Kotlin examples

## Test plan

- [ ] Verify YAML spec files parse correctly (validated locally with Python yaml parser)
- [ ] Check that `$ref` entries for JS custom provider admin methods resolve correctly against tsdoc
- [ ] Review rendered documentation for all updated spec sections
- [ ] Verify MDX guide pages render correctly with new Tabs/TabPanel sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Documented built-in automatic retries for PostgREST (enabled by default, exponential backoff, retryable status codes) and option to disable per client
  * Retained prior fetch-retry guidance as a “Custom retries” alternative
  * Added “Verifying the current password” guidance with version notes
  * Added admin APIs for custom OAuth providers and examples
  * Added PostgREST config options, streaming edge-function docs, and clarified realtime subscription callback ordering
  * Allowed “retryable” in spelling rules
<!-- end of auto-generated comment: release notes by coderabbit.ai -->