### PR TITLE
fix(studio): only redirect after project deletion if still on project page

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -83,8 +83,14 @@ export const DeleteProjectModal = ({
 
       toast.success(`Successfully deleted ${project?.name}`)
 
-      if (lastVisitedOrganization) router.push(`/org/${lastVisitedOrganization}`)
-      else router.push('/organizations')
+      // Only redirect if still viewing the deleted project
+      if (router.asPath.startsWith(`/project/${projectRef}`)) {
+        if (lastVisitedOrganization) {
+          router.push(`/org/${lastVisitedOrganization}`)
+        } else {
+          router.push('/organizations')
+        }
+      }
     },
   })
   const { mutateAsync: sendExitSurvey, isPending: isSending } = useSendDowngradeFeedbackMutation()


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

After clicking delete on a project, the `onSuccess` callback unconditionally redirects to `/org/{slug}` or `/organizations`. If the user has already navigated away from the project page before the deletion completes, this causes an unwanted redirect back to the organizations page.

## What is the new behavior?

The redirect now only happens if the user is still viewing the deleted project's page (`router.asPath.startsWith(/project/${projectRef})`). If they've already navigated away, only the success toast is shown.

## Additional context

The Next.js pages router object is mutable, so `router.asPath` reflects the current URL at callback execution time, not at closure creation time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed navigation behavior after project deletion to avoid unnecessary redirects when you've already navigated away from the deleted project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->