### PR TITLE
feat: show disk throughput for all tiers DEBUG-53

### DIFF
--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -202,8 +202,6 @@ export const getReportAttributesV2: (
       label: 'Disk throughput',
       docsUrl: `${DOCS_URL}/guides/platform/compute-add-ons#disk-throughput`,
       syncId: 'database-reports',
-      entitlement: 'disk_throughput',
-      requiredPlan: 'Team',
       hide: false,
       showTooltip: true,
       format: 'bytes-per-second',


### PR DESCRIPTION
## Problem

The disk throughput chart on the database observability report was gated to Team plan and above. This prevented Free and Pro tier users from seeing disk throughput data, which is a useful self-debugging aid when hitting DiskIO-related resource exhaustion, especially on smaller instances where baseline throughput limits are a major constraint.

The gate was originally introduced to reduce load on the metrics infrastructure while observability queries were being scaled. That constraint no longer applies.

## Fix

Remove the `entitlement` and `requiredPlan` fields from the `disk-throughput` chart config in `apps/studio/data/reports/database-charts.ts`. The rendering logic in the database observability page only shows the upsell prompt when `chart.entitlement` is set, so removing it makes the chart render unconditionally for all tiers.

## How to test

- Open the database observability report at `/project/<ref>/observability/database` on a Free or Pro project
- Confirm the Disk Throughput chart is visible and showing data (not an upsell card)
- Confirm the chart still works correctly on a Team or Enterprise project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed plan-based access restrictions from disk-throughput metrics, making them available to all users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->