### PR TITLE
fix: show API error message when an error occurs during branch creation

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -254,8 +254,9 @@ export const CreateBranchModal = () => {
             if (form.getValues('gitBranchName') !== branchName) return
             setIsGitBranchValid(false)
             form.setError('gitBranchName', {
-              ...error,
-              message: `Unable to find branch "${branchName}" in ${repoOwner}/${repoName}`,
+              message:
+                error?.message ??
+                `Unable to find branch "${branchName}" in ${repoOwner}/${repoName}`,
             })
           },
         }


### PR DESCRIPTION
## Problem

When a user creates a branch but their GitHub account does not have access to the repo, the UI shows a generic branch not found message.

## Solution

The API actually returns a more detailed message. Show it instead of the generic one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error message handling when creating branches from invalid Git references. Users will now receive appropriate error messages when attempting to use a non-existent branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->