### PR TITLE
feat(assistant): enable Braintrust tracing in production

### DIFF
--- a/apps/studio/lib/ai/braintrust-logger.ts
+++ b/apps/studio/lib/ai/braintrust-logger.ts
@@ -3,11 +3,8 @@ import { initLogger } from 'braintrust'
 const BRAINTRUST_API_KEY = process.env.BRAINTRUST_API_KEY
 const BRAINTRUST_PROJECT_ID = process.env.BRAINTRUST_PROJECT_ID
 
-const IS_PRODUCTION = process.env.NEXT_PUBLIC_ENVIRONMENT === 'prod'
-
-// NOTE(mattrossman): Temporary killswitch to disable tracing in production
 export const IS_TRACING_ENABLED =
-  BRAINTRUST_API_KEY !== undefined && BRAINTRUST_PROJECT_ID !== undefined && !IS_PRODUCTION
+  BRAINTRUST_API_KEY !== undefined && BRAINTRUST_PROJECT_ID !== undefined
 
 if (IS_TRACING_ENABLED) {
   initLogger({


### PR DESCRIPTION
Removes the temporary killswitch that was blocking tracing in production environments.

Note this still excludes from tracing projects that are any of the following:
- HIPAA sensitive
- Hosted in EU regions
- Within orgs where some owner previously signed our DPA

See [approval message](https://supabase.slack.com/archives/C051L8U2EJF/p1775526578561789?thread_ts=1775144006.270549&cid=C051L8U2EJF) for context.

Closes AI-450

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tracing enablement now depends solely on the presence of required API credentials instead of environment-based restrictions, enabling diagnostic tracing functionality across all environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->