### PR TITLE
chore(studio): wire public bucket listing advisor lint

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -320,6 +320,21 @@ export const lintInfoMap: LintInfo[] = [
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0024_permissive_rls_policy`,
     category: 'security',
   },
+  {
+    name: 'public_bucket_allows_listing',
+    title: 'Public Bucket Allows Listing',
+    icon: <Box className="text-foreground-muted" size={15} strokeWidth={1.5} />,
+    link: ({ projectRef, metadata }) => {
+      const bucketId = (metadata as Record<string, string | undefined> | undefined)?.bucket_id
+
+      return `/project/${projectRef}/storage/files/buckets/${encodeURIComponent(
+        bucketId ?? metadata?.name ?? ''
+      )}`
+    },
+    linkText: 'View bucket',
+    docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0025_public_bucket_allows_listing`,
+    category: 'security',
+  },
 ]
 
 export const LintCTA = ({

--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -1408,4 +1408,126 @@ where
 order by
     schema_name,
     table_name,
-    policy_name)`.trim()
+    policy_name)
+union all
+(
+with storage_bucket_table as (
+    select
+        1
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        n.nspname = 'storage'
+        and c.relname = 'buckets'
+        and c.relkind in ('r', 'p')
+),
+public_buckets as (
+    select
+        bucket_id,
+        bucket_name,
+        replace(
+            replace(
+                replace(
+                    replace(
+                        replace(
+                            replace(
+                                replace(pg_catalog.quote_literal(bucket_id), '.', E'\\.'),
+                                '*',
+                                E'\\*'
+                            ),
+                            '(',
+                            E'\\('
+                        ),
+                        ')',
+                        E'\\)'
+                    ),
+                    '$',
+                    E'\\$'
+                ),
+                '+',
+                E'\\+'
+            ),
+            '?',
+            E'\\?'
+        ) as quoted_bucket_pattern
+    from
+        (
+            select
+                (xpath('/row/id/text()', bucket_xml))[1]::text as bucket_id,
+                (xpath('/row/name/text()', bucket_xml))[1]::text as bucket_name
+            from
+                storage_bucket_table
+        cross join lateral unnest(
+            xpath(
+                '/table/row',
+                pg_catalog.query_to_xml(
+                    'select id, name from storage.buckets where public = true order by id',
+                    false,
+                    false,
+                    ''
+                )
+            )
+        ) as bucket_rows(bucket_xml)
+        ) public_bucket_rows
+),
+matching_policies as (
+    select
+        b.bucket_id,
+        b.bucket_name,
+        p.policyname
+    from
+        public_buckets b
+        join pg_catalog.pg_policies p
+            on p.schemaname = 'storage'
+            and p.tablename = 'objects'
+            and p.cmd = 'SELECT'
+    where
+        p.qual ~* (E'bucket_id\\s*=\\s*' || b.quoted_bucket_pattern)
+),
+affected_buckets as (
+    select
+        bucket_id,
+        bucket_name,
+        array_agg(policyname order by policyname) as policy_names,
+        count(*)::int as policy_count
+    from
+        matching_policies
+    group by
+        bucket_id,
+        bucket_name
+)
+select
+    'public_bucket_allows_listing' as name,
+    'Public Bucket Allows Listing' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects public storage buckets that also have bucket-specific SELECT policies on storage.objects. Public buckets do not require SELECT policies for object URL access, and adding them can unintentionally make bucket contents listable.' as description,
+    format(
+        'Public storage bucket \`%s\` (\`%s\`) has %s matching SELECT %s on \`storage.objects\`: %s. This allows clients to list the bucket contents. Public buckets do not require SELECT policies for object URL access, and this is often unintentional.',
+        bucket_name,
+        bucket_id,
+        policy_count,
+        case
+            when policy_count = 1 then 'policy'
+            else 'policies'
+        end,
+        array_to_string(policy_names, ', ')
+    ) as detail,
+    '${docsUrl}/guides/database/database-linter?lint=0025_public_bucket_allows_listing' as remediation,
+    jsonb_build_object(
+        'schema', 'storage',
+        'name', bucket_name,
+        'type', 'bucket',
+        'bucket_id', bucket_id,
+        'bucket_name', bucket_name,
+        'policy_names', policy_names,
+        'policy_count', policy_count
+    ) as metadata,
+    format('public_bucket_allows_listing_%s', bucket_id) as cache_key
+from
+    affected_buckets
+order by
+    bucket_id)`.trim()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore.

## What is the current behavior?

The new `public_bucket_allows_listing` warning exists in Splinter, but Studio's embedded advisor SQL does not surface it in the `supabase/supabase` flow yet. That means local and self-hosted paths can miss the warning even though the underlying lint now exists, and Studio also lacks the lint metadata needed to label it cleanly and link to the affected bucket.

## What is the new behavior?

This wires the new `public_bucket_allows_listing` advisor query into the embedded pg-meta lint SQL and adds the Studio lint metadata entry so the warning renders with a storage bucket CTA.

This keeps the global/project-wide Advisor behaviour aligned with the new Splinter source of truth while preserving the existing inline bucket-page admonition.

## How has this been tested?

- Applied the same SQL logic that now ships in `supabase/splinter`.
- Smoke-tested the Studio integration patch in a throwaway local worktree.
- Confirmed the new lint metadata entry resolves cleanly after fixing the `bucket_id` metadata access in the CTA link.
- Manual product test to run on local or staging:

```sql
insert into storage.buckets (id, name, public)
values ('listable.bucket+1', 'listable.bucket+1', true);

create policy "listable_bucket_select"
on storage.objects
for select
to authenticated
using (bucket_id = 'listable.bucket+1');
```

Expected result:
- Security Advisor shows one warning for that bucket.
- The bucket page continues to show the existing inline admonition.

Cleanup:

```sql
drop policy "listable_bucket_select" on storage.objects;
```

Expected result:
- The Advisor warning disappears.
- The bucket remains public, but no longer counts as listable.
