### PR TITLE
fix(assistant): skip DPA signed check when tracing is disabled

### DIFF
--- a/apps/studio/lib/ai/ai-details.test.ts
+++ b/apps/studio/lib/ai/ai-details.test.ts
@@ -34,6 +34,10 @@ vi.mock('@/data/fetchers', () => ({
   get: vi.fn(),
 }))
 
+vi.mock('@/lib/ai/braintrust-logger', () => ({
+  IS_TRACING_ENABLED: true,
+}))
+
 const AUTH = 'Bearer token'
 const HEADERS = { 'Content-Type': 'application/json', Authorization: AUTH }
 
@@ -170,6 +174,23 @@ describe('getOrgAIDetails', () => {
 
     expect(result.orgId).toBe(2)
     expect(result.planId).toBe('pro')
+  })
+
+  it('skips dpa-signed call when tracing is disabled', async () => {
+    const braintrustLogger = await import('@/lib/ai/braintrust-logger')
+    vi.mocked(braintrustLogger).IS_TRACING_ENABLED = false as any
+
+    mockGetOrganizations.mockResolvedValue([
+      { id: 1, slug: 'test-org', plan: { id: 'pro' }, opt_in_tags: [] },
+    ])
+    mockGetAiOptInLevel.mockReturnValue('schema')
+
+    const result = await getOrgAIDetails({ orgSlug: 'test-org', authorization: AUTH })
+
+    expect(mockGet).not.toHaveBeenCalled()
+    expect(result.isDpaSigned).toBeUndefined()
+
+    vi.mocked(braintrustLogger).IS_TRACING_ENABLED = true as any
   })
 })
 

--- a/apps/studio/lib/ai/ai-details.ts
+++ b/apps/studio/lib/ai/ai-details.ts
@@ -6,6 +6,7 @@ import { getOrganizations } from '@/data/organizations/organizations-query'
 import { getProjectDetail } from '@/data/projects/project-detail-query'
 import { getOrgSubscription } from '@/data/subscriptions/org-subscription-query'
 import { getAiOptInLevel } from '@/hooks/misc/useOrgOptedIntoAi'
+import { IS_TRACING_ENABLED } from '@/lib/ai/braintrust-logger'
 
 export const getOrgAIDetails = async ({
   orgSlug,
@@ -19,14 +20,18 @@ export const getOrgAIDetails = async ({
     ...(authorization && { Authorization: authorization }),
   }
 
+  const dpaPromise = IS_TRACING_ENABLED
+    ? get('/platform/organizations/{slug}/documents/dpa-signed', {
+        params: { path: { slug: orgSlug } },
+        headers,
+      })
+    : undefined
+
   const [organizations, subscription, advanceModelAccess, dpaSignedStatus] = await Promise.all([
     getOrganizations({ headers }),
     getOrgSubscription({ orgSlug }, undefined, headers),
     checkEntitlement(orgSlug, 'assistant.advance_model', undefined, headers),
-    get('/platform/organizations/{slug}/documents/dpa-signed', {
-      params: { path: { slug: orgSlug } },
-      headers,
-    }),
+    dpaPromise,
   ])
 
   const selectedOrg = organizations.find((org) => org.slug === orgSlug)
@@ -35,7 +40,7 @@ export const getOrgAIDetails = async ({
     aiOptInLevel: getAiOptInLevel(selectedOrg?.opt_in_tags),
     hasAccessToAdvanceModel: advanceModelAccess.hasAccess,
     hasHipaaAddon: subscriptionHasHipaaAddon(subscription),
-    isDpaSigned: dpaSignedStatus.data?.signed,
+    isDpaSigned: dpaSignedStatus?.data?.signed,
     orgId: selectedOrg?.id,
     planId: selectedOrg?.plan.id,
   }


### PR DESCRIPTION
## Summary
- Skip the `GET /dpa-signed` API call in `getOrgAIDetails()` when `IS_TRACING_ENABLED` is false
- The endpoint requires org-level permissions, but gets called for every user on every AI assistant request, generating ~43 403 errors/day (80% of all DPA errors)
- Since `isDpaSigned` is only consumed by `isTracingAllowed()`, and tracing is currently disabled in production, the call is unnecessary
- When skipped, `isDpaSigned` defaults to `undefined`, which `isTracingAllowed()` already treats as "tracing not allowed" (privacy-protective default)

## Context
- Investigation: https://app.hex.tech/supabase/thread/019d6b95-4af6-777d-a37e-242204bcb0f8
- Linear: GROWTH-755
- The 403s come from project-scoped users (org role `None`) hitting the `ProjectPermissionsDisabledFeatureGuard`

## Test plan
- [x] Existing tests pass with `IS_TRACING_ENABLED` mocked as `true` (no behavior change when tracing enabled)
- [x] New test verifies DPA call is skipped when `IS_TRACING_ENABLED` is `false`
- [x] `isDpaSigned` returns `undefined` when call is skipped (correct for tracing-disabled path)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for conditional DPA retrieval, including a test that simulates tracing being disabled to verify no DPA fetch occurs and resulting state remains unset.

* **Bug Fixes**
  * DPA status fetch now respects tracing settings and safely handles the no-fetch case, preventing unnecessary network calls and avoiding undefined access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->