### PR TITLE
chandana-postgrest-multiple-schema-objects

### DIFF
--- a/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
+++ b/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
@@ -16,7 +16,7 @@ Could not find the table 'X' in the schema cache
 
 ## Why this happens
 
-This happens because when multiple schemas are exposed, the first entry in the list is treated as the default, so PostgREST resolves unqualified object names only against that schema. 
+When multiple schemas are exposed, the first entry in the list is treated as the default, so PostgREST resolves unqualified object names only against that schema. 
 
 This behavior is intentional, as it prevents conflicts when different schemas contain objects with the same name.
 

--- a/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
+++ b/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
@@ -1,0 +1,23 @@
+---
+title = "PostgREST not recognizing the objects(tables/functions/views) in a schema even after adding it to the exposed schemas"
+topics = [
+  "database",
+  "rest-api",
+  "platform"
+]
+keywords = []
+---
+
+PostgREST is returning errors by not recognizing the objects(tables/tables/views) in a schema and logging errors similar to:
+
+```console
+Could not find the table 'X' in the schema cache
+```
+
+## Why this happens
+
+This happens because, when you have multiple schemas, the default schema will be the first in the list of exposed schemas.
+
+## How to fix this
+
+If you want to use the objects without specifying a schema you'd need to put it first. Else, you should initialise the Supabase client with the schema([”With custom schemas”](https://supabase.com/docs/reference/javascript/initializing)) or specify the schema on each request using ".schema('your_schema')" (["Switching schemas per query"](https://supabase.com/docs/reference/javascript/select))

--- a/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
+++ b/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
@@ -10,7 +10,7 @@ keywords = []
 
 PostgREST is returning errors by not recognizing the objects(tables/functions/views) in a schema and logging errors similar to:
 
-```console
+```
 Could not find the table 'X' in the schema cache
 ```
 

--- a/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
+++ b/apps/docs/content/troubleshooting/postgrest-not-recognizing-objects-in-schema
@@ -8,7 +8,7 @@ topics = [
 keywords = []
 ---
 
-PostgREST is returning errors by not recognizing the objects(tables/tables/views) in a schema and logging errors similar to:
+PostgREST is returning errors by not recognizing the objects(tables/functions/views) in a schema and logging errors similar to:
 
 ```console
 Could not find the table 'X' in the schema cache
@@ -16,8 +16,10 @@ Could not find the table 'X' in the schema cache
 
 ## Why this happens
 
-This happens because, when you have multiple schemas, the default schema will be the first in the list of exposed schemas.
+This happens because when multiple schemas are exposed, the first entry in the list is treated as the default, so PostgREST resolves unqualified object names only against that schema. 
+
+This behavior is intentional, as it prevents conflicts when different schemas contain objects with the same name.
 
 ## How to fix this
 
-If you want to use the objects without specifying a schema you'd need to put it first. Else, you should initialise the Supabase client with the schema([”With custom schemas”](https://supabase.com/docs/reference/javascript/initializing)) or specify the schema on each request using ".schema('your_schema')" (["Switching schemas per query"](https://supabase.com/docs/reference/javascript/select))
+If you want to use the objects without specifying a schema, you'd need to put it first. Else, you should initialise the Supabase client with the schema([”With custom schemas”](https://supabase.com/docs/reference/javascript/initializing)) or specify the schema on each request using ".schema('your_schema')" (["Switching schemas per query"](https://supabase.com/docs/reference/javascript/select))

--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
@@ -1,5 +1,5 @@
 ---
-title = "schema "pg_pgrst_no_exposed_schemas" does not exist"
+title = "schema \"pg_pgrst_no_exposed_schemas\" does not exist"
 topics = [
   "database",
   "rest-api",

--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
@@ -5,7 +5,6 @@ topics = [
   "rest-api",
   "platform"
 ]
-
 [[errors]]
 message = "schema pg_pgrst_no_exposed_schemas does not exist"
 ---
@@ -13,7 +12,6 @@ message = "schema pg_pgrst_no_exposed_schemas does not exist"
 PostgREST logs showing the error:
 
 - `schema "pg_pgrst_no_exposed_schemas" does not exist`
-
 
 ## Why this happens
 

--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
@@ -15,6 +15,7 @@ PostgREST logs showing the error:
 
 ## Why this happens
 
-- This error means that the Data API is disabled on the Supabase project.
-- We don’t really shutdown postgrest when data api is disabled. You will see a schema called `pg_pgrst_no_exposed_schemas` added in the exposed schemas.
-- This should not adversely affect the project, although it may result in additional entries in your logs. We're aware of the noise caused by these logs and are working on it.
+- This error is seen when the Data API is disabled on the Supabase project.
+- Currently, we don’t really shutdown postgrest when data api is disabled. You will see a schema called `pg_pgrst_no_exposed_schemas` added in the exposed schemas.
+- This should not adversely affect the project, although it may result in additional entries in your logs.
+- We're aware of this issue and are working on it.

--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
@@ -17,4 +17,4 @@ PostgREST logs showing the error:
 
 - This error means that the Data API is disabled on the Supabase project.
 - We don’t really shutdown postgrest when data api is disabled. You will see a schema called `pg_pgrst_no_exposed_schemas` added in the exposed schemas.
-- This should not adversely affect the project, although it may result in additional entries in your logs.
+- This should not adversely affect the project, although it may result in additional entries in your logs. We're aware of the noise caused by these logs and are working on it.

--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist
@@ -1,0 +1,22 @@
+---
+title = "schema "pg_pgrst_no_exposed_schemas" does not exist"
+topics = [
+  "database",
+  "rest-api",
+  "platform"
+]
+
+[[errors]]
+message = "schema pg_pgrst_no_exposed_schemas does not exist"
+---
+
+PostgREST logs showing the error:
+
+- `schema "pg_pgrst_no_exposed_schemas" does not exist`
+
+
+## Why this happens
+
+- This error means that the Data API is disabled on the Supabase project.
+- We don’t really shutdown postgrest when data api is disabled. You will see a schema called `pg_pgrst_no_exposed_schemas` added in the exposed schemas.
+- This should not adversely affect the project, although it may result in additional entries in your logs.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

New troubleshooting guide for PostgREST


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a troubleshooting guide explaining why unqualified object names can fail when multiple schemas are exposed and how to resolve it (reorder schemas, initialize the client with a schema, or set schema per request).
  * Added a troubleshooting entry for the "schema pg_pgrst_no_exposed_schemas does not exist" PostgREST error, describing typical logs, causes, and when it appears if the Data API is disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->