### PR TITLE
fix(logs): filter edge function logs by pathname instead of function_id FUNC-476

### DIFF
--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/invocations.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/invocations.tsx
@@ -20,7 +20,7 @@ export const LogPage: NextPageWithLayout = () => {
         condensedLayout
         projectRef={ref as string}
         queryType="fn_edge"
-        filterOverride={{ function_id: selectedFunction.id }}
+        filterOverride={{ 'request.pathname': `/functions/v1/${selectedFunction.slug}` }}
       />
     </div>
   )

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
@@ -21,7 +21,7 @@ export const LogPage: NextPageWithLayout = () => {
         condensedLayout
         projectRef={ref as string}
         queryType="functions"
-        filterOverride={{ 'metadata.function_id': selectedFunction.id }}
+        filterOverride={{ 'metadata.request.pathname': `/functions/v1/${selectedFunction.slug}` }}
       />
     </div>
   )

--- a/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
+++ b/apps/studio/pages/project/[ref]/functions/[functionSlug]/logs.tsx
@@ -21,7 +21,7 @@ export const LogPage: NextPageWithLayout = () => {
         condensedLayout
         projectRef={ref as string}
         queryType="functions"
-        filterOverride={{ 'metadata.request.pathname': `/functions/v1/${selectedFunction.slug}` }}
+        filterOverride={{ 'metadata.function_id': selectedFunction.id }}
       />
     </div>
   )


### PR DESCRIPTION
## Problem

429 rate-limited responses from edge-functions-ingress do not appear in the edge function logs dashboard. The cause is that rate-limited requests are rejected before a function ID is resolved, so their log events have no `metadata.function_id`. The dashboard filters logs by `metadata.function_id`, silently dropping these events. Cloudflare errors (502, 503, 525) are excluded for the same reason.

## Fix

Changed the filter in the edge function logs page from `metadata.function_id` to `metadata.request.pathname`. The pathname (`/functions/v1/{slug}`) is present on all requests, including rate-limited ones, so 429s and Cloudflare errors are now visible alongside normal invocation logs.

## Before 
- Not seeing 429s
<img width="2408" height="1608" alt="CleanShot 2026-04-08 at 13 13 24@2x" src="https://github.com/user-attachments/assets/ee369506-dbf0-4f67-b996-3bb9c0f66796" />


## After
- seeing 429s
<img width="2404" height="1606" alt="CleanShot 2026-04-08 at 13 12 27@2x" src="https://github.com/user-attachments/assets/e5fa4a63-04b5-4a9e-b691-6315c118b09f" />


## How to test

- Navigate to an edge function's Logs tab in the dashboard
- Confirm that normal invocation logs still load and are scoped to the correct function
- Trigger a rate-limited request (>100 req/s to a function) and confirm the 429 now appears in the logs tab
- Expected result: 429 events appear in the function logs dashboard

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of edge function invocation log filtering by refining the matching criteria used to display relevant logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->