### PR TITLE
fix(studio): include view options (security_invoker) in view definition display

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/TableDefinition.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableDefinition.tsx
@@ -53,17 +53,26 @@ export const TableDefinition = ({ entity }: TableDefinitionProps) => {
     }
   )
 
-  const { data: definition, isLoading } = isViewLike(entity) ? viewResult : tableResult
+  const { data: viewData, isLoading: isViewLoading } = viewResult
+  const { data: tableData, isLoading: isTableLoading } = tableResult
+
+  const isLoading = isViewLike(entity) ? isViewLoading : isTableLoading
+  const definition = isViewLike(entity) ? viewData?.definition : tableData
+
+  const viewOptions =
+    isViewLike(entity) && viewData?.viewOptions
+      ? ` with (${viewData.viewOptions})`
+      : ''
 
   const prepend = isView(entity)
-    ? `create view ${entity.schema}.${entity.name} as\n`
+    ? `create view ${entity.schema}.${entity.name}${viewOptions} as\n`
     : isMaterializedView(entity)
-      ? `create materialized view ${entity.schema}.${entity.name} as\n`
+      ? `create materialized view ${entity.schema}.${entity.name}${viewOptions} as\n`
       : ''
 
   const formattedDefinition = useMemo(
     () => (definition ? formatSql(prepend + definition) : undefined),
-    [definition]
+    [definition, prepend]
   )
 
   const handleEditorOnMount = async (editor: any, monaco: any) => {

--- a/apps/studio/components/interfaces/TableGridEditor/TableDefinition.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/TableDefinition.tsx
@@ -60,9 +60,7 @@ export const TableDefinition = ({ entity }: TableDefinitionProps) => {
   const definition = isViewLike(entity) ? viewData?.definition : tableData
 
   const viewOptions =
-    isViewLike(entity) && viewData?.viewOptions
-      ? ` with (${viewData.viewOptions})`
-      : ''
+    isViewLike(entity) && viewData?.viewOptions ? ` with (${viewData.viewOptions})` : ''
 
   const prepend = isView(entity)
     ? `create view ${entity.schema}.${entity.name}${viewOptions} as\n`

--- a/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
@@ -85,7 +85,7 @@ export default function ViewEntityAutofixSecurityModal({
             {isLoading && <GenericSkeletonLoader />}
             {isSuccess && (
               <SimpleCodeBlock>
-                {`create view ${table.schema}.${table.name} as\n ${data}`}
+                {`create view ${table.schema}.${table.name}${data?.viewOptions ? ` with (${data.viewOptions})` : ''} as\n ${data?.definition}`}
               </SimpleCodeBlock>
             )}
           </ScrollArea>
@@ -97,7 +97,7 @@ export default function ViewEntityAutofixSecurityModal({
             {isLoading && <GenericSkeletonLoader />}
             {isSuccess && (
               <SimpleCodeBlock>
-                {`create view ${table.schema}.${table.name} with (security_invoker = on) as\n ${data}`}
+                {`create view ${table.schema}.${table.name} with (security_invoker = on) as\n ${data?.definition}`}
               </SimpleCodeBlock>
             )}
           </ScrollArea>

--- a/apps/studio/data/database/view-definition-query.ts
+++ b/apps/studio/data/database/view-definition-query.ts
@@ -31,10 +31,13 @@ export async function getViewDefinition(
     signal
   )
 
-  return result[0].definition.trim()
+  return {
+    definition: result[0].definition.trim(),
+    viewOptions: result[0].view_options ?? null,
+  }
 }
 
-export type ViewDefinitionData = string
+export type ViewDefinitionData = { definition: string; viewOptions: string | null }
 export type ViewDefinitionError = ExecuteSqlError
 
 export const useViewDefinitionQuery = <TData = ViewDefinitionData>(

--- a/packages/pg-meta/src/sql/studio/database/table-definition.ts
+++ b/packages/pg-meta/src/sql/studio/database/table-definition.ts
@@ -751,11 +751,23 @@ with records as (
         'NO_TRIGGERS'
       )
       when 'v' then concat(
-        'create view ', concat(nc.nspname, '.', c.relname), ' as',
+        'create view ', concat(nc.nspname, '.', c.relname),
+        case
+          when c.reloptions is not null and array_length(c.reloptions, 1) > 0
+          then concat(' with (', array_to_string(c.reloptions, ', '), ')')
+          else ''
+        end,
+        ' as',
         pg_get_viewdef(concat(nc.nspname, '.', c.relname), true)
       )
       when 'm' then concat(
-        'create materialized view ', concat(nc.nspname, '.', c.relname), ' as',
+        'create materialized view ', concat(nc.nspname, '.', c.relname),
+        case
+          when c.reloptions is not null and array_length(c.reloptions, 1) > 0
+          then concat(' with (', array_to_string(c.reloptions, ', '), ')')
+          else ''
+        end,
+        ' as',
         pg_get_viewdef(concat(nc.nspname, '.', c.relname), true)
       )
       when 'f' then concat('create foreign table ', nc.nspname, '.', c.relname, ' ( ... )')

--- a/packages/pg-meta/src/sql/studio/database/views.ts
+++ b/packages/pg-meta/src/sql/studio/database/views.ts
@@ -5,15 +5,22 @@ export const getViewDefinitionSql = ({ id }: { id: number }) => {
 
   const sql = /* SQL */ `
     with table_info as (
-      select 
+      select
         n.nspname::text as schema,
         c.relname::text as name,
+        c.reloptions,
         to_regclass(concat('"', n.nspname, '"."', c.relname, '"')) as regclass
       from pg_class c
       join pg_namespace n on n.oid = c.relnamespace
       where c.oid = ${id}
     )
-    select pg_get_viewdef(t.regclass, true) as definition
+    select
+      pg_get_viewdef(t.regclass, true) as definition,
+      case
+        when t.reloptions is not null and array_length(t.reloptions, 1) > 0
+        then array_to_string(t.reloptions, ', ')
+        else null
+      end as view_options
     from table_info t
   `.trim()
 


### PR DESCRIPTION
## Summary

Fixes #35823.

Views created with `WITH (security_invoker = TRUE)` had this clause stripped from the definition shown in the Dashboard. Copying and re-running the definition would silently remove RLS protection — a security footgun.

### Changes

1. **`packages/pg-meta/src/sql/studio/database/views.ts`** — Added `c.reloptions` to the SQL query and return `view_options` as a comma-separated string (null when no options)

2. **`apps/studio/data/database/view-definition-query.ts`** — Changed return type from `string` to `{ definition: string; viewOptions: string | null }`

3. **`apps/studio/components/interfaces/TableGridEditor/TableDefinition.tsx`** — Builds `WITH (...)` clause from `viewOptions` for both regular and materialized views

4. **`apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx`** — Updated to use new `data.definition` / `data.viewOptions` shape

5. **`packages/pg-meta/src/sql/studio/database/table-definition.ts`** — Added `reloptions` handling in entity definitions SQL for `'v'` and `'m'` CASE branches

### How it works

`pg_class.reloptions` is a `text[]` column containing entries like `security_invoker=true`. The SQL query now returns this as a comma-separated string via `array_to_string()`. The UI prepends `WITH (...)` to the `CREATE VIEW` statement only when options exist — views without options are unaffected.

## Test plan

- [x] Views with `security_invoker = true` → DDL shows `WITH (security_invoker=true)`
- [x] Views without options → no `WITH ()` clause (unchanged behavior)
- [x] Materialized views with storage options → `WITH (...)` included
- [x] `ViewEntityAutofixSecurityModal` correctly shows existing vs updated query

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CREATE VIEW / CREATE MATERIALIZED VIEW output now includes view configuration options (WITH (...)) so displayed SQL accurately reflects view settings.
  * View definition UI shows the view body and its options separately and updates the displayed SQL header when options change.
  * View-definition retrieval now returns both the definition and its options to ensure consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->