### PR TITLE
Fix startup report indexing metadata

### DIFF
--- a/apps/www/app/state-of-startups/page.tsx
+++ b/apps/www/app/state-of-startups/page.tsx
@@ -11,6 +11,9 @@ export const metadata: Metadata = SHOW_RESULTS
       title: 'State of Startups 2026 | Supabase',
       description:
         'The latest trends among builders in tech stacks, AI usage, problem domains, and more.',
+      alternates: {
+        canonical: 'https://supabase.com/state-of-startups',
+      },
       openGraph: {
         title: 'State of Startups 2026 | Supabase',
         description:
@@ -26,6 +29,14 @@ export const metadata: Metadata = SHOW_RESULTS
   : {
       title: 'State of Startups 2026 — Survey | Supabase',
       description: 'Be the first to access the State of Startups 2026 report.',
+      alternates: {
+        canonical: 'https://supabase.com/state-of-startups',
+      },
+      openGraph: {
+        title: 'State of Startups 2026 — Survey | Supabase',
+        description: 'Be the first to access the State of Startups 2026 report.',
+        url: 'https://supabase.com/state-of-startups',
+      },
     }
 
 export default function StateOfStartupsPage() {

--- a/apps/www/app/state-of-startups/register/RegisterContent.tsx
+++ b/apps/www/app/state-of-startups/register/RegisterContent.tsx
@@ -134,6 +134,12 @@ export function RegisterContent() {
         <SurveySectionBreak />
       </section>
 
+      <section className="px-4 py-16 md:px-8 md:py-32">
+        <div className="max-w-[60rem] mx-auto">
+          <PreviousResultsCta />
+        </div>
+      </section>
+
       <Footer />
     </main>
   )
@@ -171,5 +177,40 @@ function ShirtImage() {
         </motion.div>
       </motion.div>
     </div>
+  )
+}
+
+function PreviousResultsCta() {
+  return (
+    <Link
+      href="/state-of-startups-2025"
+      className="group grid gap-8 transition-colors md:grid-cols-[auto_1fr_auto] md:items-end md:gap-12"
+    >
+      <div className="flex w-fit flex-col gap-2" aria-hidden="true">
+        <div className="w-fit bg-brand-300 px-5 py-3 text-[1.75rem] leading-8 tracking-tight text-brand md:text-[2.25rem] md:leading-10">
+          State
+        </div>
+        <div className="w-fit bg-brand-300 px-5 py-3 text-[1.75rem] leading-8 tracking-tight text-brand md:text-[2.25rem] md:leading-10">
+          of
+        </div>
+        <div className="w-fit bg-brand px-5 py-3 text-[1.75rem] leading-8 tracking-tight text-background dark:text-brand-200 md:text-[2.25rem] md:leading-10">
+          Startups
+        </div>
+        <div className="w-fit bg-brand-500 px-5 py-3 text-[1.75rem] leading-8 tracking-tight text-brand-300 md:text-[2.25rem] md:leading-10">
+          2025
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-2 self-end">
+        <p className="font-mono text-xs uppercase tracking-[0.18em] text-foreground-light">
+          Previous Report
+        </p>
+        <p className="text-2xl tracking-tight text-foreground">See last year&apos;s report.</p>
+      </div>
+
+      <div className="flex items-center self-end text-foreground-light transition-transform duration-200 group-hover:translate-x-1 group-hover:text-foreground md:justify-self-end">
+        <ArrowRight size={18} />
+      </div>
+    </Link>
   )
 }

--- a/apps/www/pages/state-of-startups-2025.tsx
+++ b/apps/www/pages/state-of-startups-2025.tsx
@@ -174,10 +174,11 @@ function StateOfStartupsPage() {
       <NextSeo
         title={meta_title}
         description={meta_description}
+        canonical="https://supabase.com/state-of-startups-2025"
         openGraph={{
           title: meta_title,
           description: meta_description,
-          url: `https://supabase.com/state-of-startups`,
+          url: `https://supabase.com/state-of-startups-2025`,
           images: [
             {
               url: `https://supabase.com/images/state-of-startups/state-of-startups-og.png`,

--- a/apps/www/public/rss.xml
+++ b/apps/www/public/rss.xml
@@ -4,16 +4,9 @@
       <link>https://supabase.com</link>
       <description>Latest news from Supabase</description>
       <language>en</language>
-      <lastBuildDate>Wed, 08 Apr 2026 00:00:00 -0700</lastBuildDate>
+      <lastBuildDate>Thu, 02 Apr 2026 00:00:00 -0700</lastBuildDate>
       <atom:link href="https://supabase.com/rss.xml" rel="self" type="application/rss+xml"/>
       <item>
-  <guid>https://supabase.com/blog/custom-oauth-oidc-providers</guid>
-  <title>Custom OIDC Providers for Supabase Auth</title>
-  <link>https://supabase.com/blog/custom-oauth-oidc-providers</link>
-  <description>Connect any OpenID Connect identity provider to your Supabase project: GitHub Enterprise, regional providers, and more.</description>
-  <pubDate>Wed, 08 Apr 2026 00:00:00 -0700</pubDate>
-</item>
-<item>
   <guid>https://supabase.com/blog/100000-github-stars</guid>
   <title>100,000 GitHub stars</title>
   <link>https://supabase.com/blog/100000-github-stars</link>

--- a/apps/www/public/rss.xml
+++ b/apps/www/public/rss.xml
@@ -4,9 +4,16 @@
       <link>https://supabase.com</link>
       <description>Latest news from Supabase</description>
       <language>en</language>
-      <lastBuildDate>Thu, 02 Apr 2026 00:00:00 -0700</lastBuildDate>
+      <lastBuildDate>Wed, 08 Apr 2026 00:00:00 -0700</lastBuildDate>
       <atom:link href="https://supabase.com/rss.xml" rel="self" type="application/rss+xml"/>
       <item>
+  <guid>https://supabase.com/blog/custom-oauth-oidc-providers</guid>
+  <title>Custom OIDC Providers for Supabase Auth</title>
+  <link>https://supabase.com/blog/custom-oauth-oidc-providers</link>
+  <description>Connect any OpenID Connect identity provider to your Supabase project: GitHub Enterprise, regional providers, and more.</description>
+  <pubDate>Wed, 08 Apr 2026 00:00:00 -0700</pubDate>
+</item>
+<item>
   <guid>https://supabase.com/blog/100000-github-stars</guid>
   <title>100,000 GitHub stars</title>
   <link>https://supabase.com/blog/100000-github-stars</link>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix and small marketing UI update.

## What is the current behavior?

The 2025 State of Startups page advertises `/state-of-startups` in its metadata, which can cause Google to prefer the 2026 page for 2025 queries. The 2026 registration page also does not link users or crawlers back to the 2025 report, and the workspace diff includes an RSS feed refresh.

## What is the new behavior?

The 2025 page now self-canonicalizes to `/state-of-startups-2025`, the 2026 page has explicit canonical/Open Graph metadata for `/state-of-startups`, and the registration page now includes a prominent CTA linking to the 2025 report. This PR also includes the current `rss.xml` update present in the workspace diff.

## Additional context

No local build or preview was run in this workspace.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a call-to-action section on the registration page linking to the State of Startups 2025 report.

- **Chores**
  - Improved SEO metadata for State of Startups pages to enhance search visibility and social media sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->