### PR TITLE
fix(www): bust social-media cache for dynamic OG images

### DIFF
--- a/apps/www/lib/blog-images.test.ts
+++ b/apps/www/lib/blog-images.test.ts
@@ -53,6 +53,25 @@ describe('blog image helpers', () => {
     ).toBe('https://supabase.com/images/blog/example/og.png')
   })
 
+  it('appends a cache-busting param to dynamic OG function URLs', () => {
+    const url = getAbsoluteBlogSocialImage(
+      {
+        imgSocial:
+          'https://zhfonblqamxferhoguzj.supabase.co/functions/v1/generate-og?template=announcement',
+      },
+      'https://supabase.com'
+    )
+    expect(url).toMatch(
+      /^https:\/\/zhfonblqamxferhoguzj\.supabase\.co\/functions\/v1\/generate-og\?template=announcement&v=.+$/
+    )
+  })
+
+  it('does not append a cache-busting param to static image URLs', () => {
+    expect(
+      getAbsoluteBlogSocialImage({ imgSocial: 'example/og.png' }, 'https://supabase.com')
+    ).toBe('https://supabase.com/images/blog/example/og.png')
+  })
+
   it('uses the placeholder when neither image is present', () => {
     expect(getBlogThumbnailImage({})).toBe(BLOG_PLACEHOLDER_IMAGE)
     expect(getBlogThumbnailImage({}, { fallbackToPlaceholder: false })).toBeUndefined()

--- a/apps/www/lib/blog-images.ts
+++ b/apps/www/lib/blog-images.ts
@@ -61,12 +61,29 @@ export function getBlogSocialImage({ imgThumb, imgSocial }: BlogImageFields) {
   return image ? resolveBlogImagePath(image) : undefined
 }
 
+/**
+ * Build-time ID appended to OG image URLs that point to the dynamic
+ * `generate-og` Edge Function. A fresh value on every deploy forces
+ * social-media crawlers (X, LinkedIn, etc.) to bypass their image cache.
+ */
+const buildId = Date.now()
+
 export function getAbsoluteBlogSocialImage(
   { imgThumb, imgSocial }: BlogImageFields,
   siteOrigin: string = SITE_ORIGIN
 ) {
   const image = imgSocial || imgThumb
-  return image ? toAbsoluteBlogImageUrl(image, siteOrigin) : undefined
+  if (!image) return undefined
+
+  const url = toAbsoluteBlogImageUrl(image, siteOrigin)
+
+  // Only bust cache for the dynamic OG function, not static images
+  if (url.includes('/functions/v1/generate-og')) {
+    const separator = url.includes('?') ? '&' : '?'
+    return `${url}${separator}v=${buildId}`
+  }
+
+  return url
 }
 
 export function validateBlogFrontmatterImages(


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Social-media crawlers (X, LinkedIn, etc.) cache the dynamic OG images generated by the `generate-og` Edge Function. When an OG image is updated or a crawler caches the wrong image, the stale version persists indefinitely because the URL doesn't change between deploys.

## What is the new behavior?

`getAbsoluteBlogSocialImage` now appends a `&v={timestamp}` parameter to OG image URLs that point to the `generate-og` Edge Function. The timestamp is evaluated once at build time (`Date.now()`), so each deploy produces unique meta tag URLs that bypass crawler caches. Static image URLs are left untouched.

## Additional context

Only affects the `og:image` and `twitter:image` meta tags — on-site thumbnails and other image references are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed cache refresh behavior for dynamically generated OG images to ensure updated content is served with each deployment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->