### PR TITLE
fix(studio): spacing on pricing table header

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -194,7 +194,7 @@ export const PlanUpdateSidePanel = () => {
         visible={visible}
         onCancel={() => onClose()}
         header={
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between w-full">
             <h4>Change subscription plan for {selectedOrganization?.name}</h4>
             <Button asChild type="default" icon={<ExternalLink />}>
               <a href="https://supabase.com/pricing" target="_blank" rel="noreferrer">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Missing a `w-full` to apply `justify-between`. 

| Before | After |
|--------|--------|
| <img width="894" height="98" alt="Screenshot 2026-04-08 at 17 05 26" src="https://github.com/user-attachments/assets/c3c2cfe3-0280-4772-bbad-9570b5595981" /> | <img width="897" height="101" alt="Screenshot 2026-04-08 at 17 05 18" src="https://github.com/user-attachments/assets/36b65fc0-bb9c-43c4-a6da-670c753f846a" /> | 






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Style
  * Adjusted the subscription plan panel header to span the full available width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->