### PR TITLE
docs: cacheNonce

### DIFF
--- a/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
+++ b/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
@@ -33,6 +33,6 @@ If you anticipate that your asset might be deleted, it's advisable to set a shor
 
 ## Bypassing cache
 
-If you need to ensure assets refresh directly from the origin server and bypass the cache, you can achieve this by adding a unique query string to the URL.
+If you need to ensure assets refresh directly from the origin server and bypass the cache, you can achieve this by adding a unique query string such as `cacheNonce` to the URL.
 
-For instance, you can use a URL like `/storage/v1/object/sign/profile-pictures/cat.jpg?version=1` with a long browser cache (e.g., 1 year). To update the picture, increment the version query parameter in the URL, like `/storage/v1/object/sign/profile-pictures/cat.jpg?version=2`. The CDN will recognize it as a new object and fetch the updated version from the origin.
+For instance, you can use a URL like `/storage/v1/object/sign/profile-pictures/cat.jpg?cacheNonce=1` with a long browser cache (e.g., 1 year). To update the picture, increment the `cacheNonce` query parameter in the URL, like `/storage/v1/object/sign/profile-pictures/cat.jpg?cacheNonce=2`. The CDN will recognize it as a new object and fetch the updated version from the origin.


### PR DESCRIPTION
smol follow up to: 
- https://github.com/supabase/supabase-js/pull/2234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


## Summary by CodeRabbit

* **Documentation**
  * Improved Smart CDN documentation with updated cache-bypass instructions. The guidance now uses the `cacheNonce` query parameter to clarify how to force the CDN to fetch fresh content from origin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->