### PR TITLE
fix: clean up grouped input border rendering

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.tsx
@@ -1,11 +1,11 @@
 import { UseFormReturn } from 'react-hook-form'
-import { FormControl_Shadcn_, FormField_Shadcn_ } from 'ui'
-import { Input } from 'ui-patterns/DataInputs/Input'
+import { FormControl_Shadcn_, FormField_Shadcn_, Input_Shadcn_ } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { DATABASE_PASSWORD_REGEX } from './ProjectCreation.constants'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import { SpecialSymbolsCallout } from './SpecialSymbolsCallout'
+import CopyButton from '@/components/ui/CopyButton'
 import Panel from '@/components/ui/Panel'
 import { PasswordStrengthBar } from '@/components/ui/PasswordStrengthBar'
 import { passwordStrength } from '@/lib/password-strength'
@@ -68,21 +68,34 @@ export const DatabasePasswordInput = ({ form }: DatabasePasswordInputProps) => {
                 </>
               }
             >
-              <FormControl_Shadcn_>
-                <Input
-                  copy={field.value.length > 0}
-                  type="password"
-                  placeholder="Type in a strong password"
-                  {...field}
-                  autoComplete="off"
-                  onChange={async (event) => {
-                    const newValue = event.target.value
-                    field.onChange(event)
+              <div className="relative">
+                <FormControl_Shadcn_>
+                  <Input_Shadcn_
+                    type="password"
+                    placeholder="Type in a strong password"
+                    {...field}
+                    autoComplete="off"
+                    className={field.value.length > 0 ? 'pr-10' : undefined}
+                    onChange={async (event) => {
+                      const newValue = event.target.value
+                      field.onChange(event)
 
-                    updatePasswordStrength(form, newValue)
-                  }}
-                />
-              </FormControl_Shadcn_>
+                      updatePasswordStrength(form, newValue)
+                    }}
+                  />
+                </FormControl_Shadcn_>
+                {field.value.length > 0 && (
+                  <CopyButton
+                    iconOnly
+                    size="tiny"
+                    type="default"
+                    title="Copy password"
+                    aria-label="Copy password"
+                    text={field.value}
+                    className="absolute right-1 top-1/2 -translate-y-1/2"
+                  />
+                )}
+              </div>
             </FormItemLayout>
           )
         }}

--- a/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.tsx
@@ -1,11 +1,11 @@
 import { UseFormReturn } from 'react-hook-form'
-import { FormControl_Shadcn_, FormField_Shadcn_, Input_Shadcn_ } from 'ui'
+import { FormControl_Shadcn_, FormField_Shadcn_ } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { DATABASE_PASSWORD_REGEX } from './ProjectCreation.constants'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import { SpecialSymbolsCallout } from './SpecialSymbolsCallout'
-import CopyButton from '@/components/ui/CopyButton'
 import Panel from '@/components/ui/Panel'
 import { PasswordStrengthBar } from '@/components/ui/PasswordStrengthBar'
 import { passwordStrength } from '@/lib/password-strength'
@@ -68,34 +68,21 @@ export const DatabasePasswordInput = ({ form }: DatabasePasswordInputProps) => {
                 </>
               }
             >
-              <div className="relative">
-                <FormControl_Shadcn_>
-                  <Input_Shadcn_
-                    type="password"
-                    placeholder="Type in a strong password"
-                    {...field}
-                    autoComplete="off"
-                    className={field.value.length > 0 ? 'pr-10' : undefined}
-                    onChange={async (event) => {
-                      const newValue = event.target.value
-                      field.onChange(event)
+              <FormControl_Shadcn_>
+                <Input
+                  copy={field.value.length > 0}
+                  type="password"
+                  placeholder="Type in a strong password"
+                  {...field}
+                  autoComplete="off"
+                  onChange={async (event) => {
+                    const newValue = event.target.value
+                    field.onChange(event)
 
-                      updatePasswordStrength(form, newValue)
-                    }}
-                  />
-                </FormControl_Shadcn_>
-                {field.value.length > 0 && (
-                  <CopyButton
-                    iconOnly
-                    size="tiny"
-                    type="default"
-                    title="Copy password"
-                    aria-label="Copy password"
-                    text={field.value}
-                    className="absolute right-1 top-1/2 -translate-y-1/2"
-                  />
-                )}
-              </div>
+                    updatePasswordStrength(form, newValue)
+                  }}
+                />
+              </FormControl_Shadcn_>
             </FormItemLayout>
           )
         }}

--- a/packages/ui-patterns/src/DataInputs/Input.tsx
+++ b/packages/ui-patterns/src/DataInputs/Input.tsx
@@ -88,7 +88,11 @@ const Input = forwardRef<
         />
         {icon && <InputGroupAddon align="inline-start">{icon}</InputGroupAddon>}
         {copy || actions ? (
-          <InputGroupAddon align="inline-end">
+          <InputGroupAddon
+            align="inline-end"
+            // Override defaults
+            className="pr-1 has-[>button]:mr-0 has-[>kbd]:mr-0"
+          >
             {copy && !(reveal && hidden) ? (
               <InputGroupButton
                 size="tiny"

--- a/packages/ui/src/components/shadcn/ui/input-group.tsx
+++ b/packages/ui/src/components/shadcn/ui/input-group.tsx
@@ -27,7 +27,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
         'has-[[data-slot=input-group-control]:focus-visible]:outline-none has-[[data-slot=input-group-control]:focus-visible]:ring-2 has-[[data-slot=input-group-control]:focus-visible]:ring-background-control has-[[data-slot=input-group-control]:focus-visible]:ring-offset-2 has-[[data-slot=input-group-control]:focus-visible]:ring-offset-foreground-muted',
 
         // Error state.
-        'has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
+        'has-[[data-slot][aria-invalid=true]]:bg-destructive-200 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive-400 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
 
         // Disabled state.
         'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed has-[[data-slot=input-group-control]:disabled]:text-foreground-muted',

--- a/packages/ui/src/components/shadcn/ui/input-group.tsx
+++ b/packages/ui/src/components/shadcn/ui/input-group.tsx
@@ -28,6 +28,7 @@ function InputGroup({ className, ...props }: React.ComponentProps<'div'>) {
 
         // Error state.
         'has-[[data-slot][aria-invalid=true]]:bg-destructive-200 has-[[data-slot][aria-invalid=true]]:ring-destructive/20 has-[[data-slot][aria-invalid=true]]:border-destructive-400 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40',
+        'has-[[data-slot][aria-invalid=true]]:has-[[data-slot=input-group-control]:focus-visible]:border-destructive',
 
         // Disabled state.
         'has-[[data-slot=input-group-control]:disabled]:cursor-not-allowed has-[[data-slot=input-group-control]:disabled]:text-foreground-muted',
@@ -128,7 +129,11 @@ function InputGroupInput({ className, ...props }: InputProps) {
     <Input
       data-slot="input-group-control"
       className={cn(
-        'flex-1 rounded-none border-0 -m-px bg-transparent shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent',
+        'flex-1 rounded-none border border-transparent -m-px bg-transparent shadow-none',
+        'focus:border-transparent focus-visible:border-transparent focus-visible:ring-0 focus-visible:ring-offset-0',
+        'read-only:border-transparent',
+        'aria-[invalid=true]:border-transparent aria-[invalid=true]:bg-transparent',
+        'aria-[invalid=true]:focus:border-transparent aria-[invalid=true]:focus-visible:border-transparent',
         className
       )}
       {...props}
@@ -141,7 +146,8 @@ function InputGroupTextarea({ className, ...props }: TextareaProps) {
     <Textarea
       data-slot="input-group-control"
       className={cn(
-        'flex-1 resize-none rounded-none border-0 bg-transparent py-0 shadow-none focus-visible:ring-0 focus-visible:ring-offset-0 dark:bg-transparent',
+        'flex-1 resize-none rounded-none border border-transparent bg-transparent py-0 shadow-none',
+        'focus:border-transparent focus-visible:border-transparent focus-visible:ring-0 focus-visible:ring-offset-0',
         className
       )}
       {...props}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Resolves FE-2959.

## What is the current behaviour?

Grouped inputs strip the inner control border with `border-0`, while the outer `InputGroup` is responsible for the visible outline. After #44703, grouped form inputs now receive the correct validation attributes, but the primitive still removes the inner border dimensions entirely. That keeps the visual layer brittle and can lead to inconsistent error rendering, especially in light mode where the grouped password field does not match the Project name input.

The shared `ui-patterns` input wrapper also inherits the generic `inline-end` button spacing from `InputGroupAddon`, which pushes the password copy button slightly too far to the right.

## What is the new behaviour?

The shared grouped-input primitive now keeps a transparent inner border instead of removing border widths entirely. The outer `InputGroup` continues to own the visible border, focus ring and error treatment, but the inner control now has stable border metrics and no redundant dark-mode background override.

The grouped invalid state now also matches the plain input treatment more closely:

- unfocused error border uses `destructive-400`
- focused error border uses `destructive`
- error background uses `destructive-200`

The `ui-patterns` input wrapper now overrides the inherited `inline-end` negative margin for its own copy/reveal button addon, so the password copy button sits in the right place without changing spacing for other direct `InputGroup` consumers.

| Before | After |
| --- | --- |
| <img width="1338" height="284" alt="CleanShot 2026-04-09 at 13 43 50@2x-91489355-5EEA-4884-BAA2-B93B28F1D7CB" src="https://github.com/user-attachments/assets/ed40683b-8a87-4deb-8a0f-f892d00894f0" />| <img width="1334" height="278" alt="CleanShot 2026-04-09 at 13 41 36@2x-5D7E930B-EDB2-4002-9367-34ACE2DF4DB4" src="https://github.com/user-attachments/assets/7d9594a4-9988-480e-a809-9f5ed29e8e24" /> |
| <img width="1336" height="210" alt="CleanShot 2026-04-09 at 14 06 15@2x-05379F74-4CA5-4E6E-9250-CBA2764C1318" src="https://github.com/user-attachments/assets/25e48cd4-de0a-47f3-9022-d7a3829a0626" /> | <img width="1334" height="210" alt="CleanShot 2026-04-09 at 14 12 11@2x-11FBC519-D398-4A59-971A-97FBFEF610DE" src="https://github.com/user-attachments/assets/91c3710c-7773-4286-854d-7b7144db85ab" /> |

An easy place to test this is the Database password field in the New Project creation flow. See also the Minimum password length field in Email (Sign In / Providers).

## Summary

- update `packages/ui/src/components/shadcn/ui/input-group.tsx`
- replace `border-0` on grouped inputs/textareas with transparent borders
- remove the redundant `dark:bg-transparent`
- keep the inner grouped controls visually neutral so the outer group owns the rendered border state
- align grouped invalid border and background styling with the plain input treatment
- update `packages/ui-patterns/src/DataInputs/Input.tsx` so copy/reveal buttons do not inherit the extra right pull intended for other `inline-end` addons
