### PR TITLE
chore: @supabase/ssr version management

### DIFF
--- a/.github/workflows/docs-js-libs-update.yml
+++ b/.github/workflows/docs-js-libs-update.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   update-docs:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/update-js-libs.yml
+++ b/.github/workflows/update-js-libs.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   update-js-libs:
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0

--- a/.github/workflows/update-ssr.yml
+++ b/.github/workflows/update-ssr.yml
@@ -1,0 +1,76 @@
+name: Update @supabase/ssr
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to update to'
+        required: true
+        type: string
+      source:
+        description: 'Source of the update'
+        required: false
+        type: string
+        default: 'manual'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  update-ssr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: master
+
+      - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
+        name: Install pnpm
+        with:
+          run_install: false
+
+      - name: Use Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Update @supabase/ssr in pnpm-workspace.yaml
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+        run: |
+          sed -i "s|'@supabase/ssr': .*|'@supabase/ssr': ${VERSION}|" pnpm-workspace.yaml
+
+          echo "Updated pnpm-workspace.yaml:"
+          cat pnpm-workspace.yaml
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          commit-message: 'feat: update @supabase/ssr to v${{ github.event.inputs.version }}'
+          title: 'feat: update @supabase/ssr to v${{ github.event.inputs.version }}'
+          body: |
+            This PR updates @supabase/ssr to version ${{ github.event.inputs.version }}.
+
+            **Source**: ${{ github.event.inputs.source }}
+
+            **Changes**:
+            - Updated @supabase/ssr to ${{ github.event.inputs.version }}
+            - Refreshed pnpm-lock.yaml
+
+            This PR was created automatically.
+          branch: 'gha/auto-update-ssr-v${{ github.event.inputs.version }}'
+          base: 'master'

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -96,7 +96,7 @@
     "@babel/core": "*",
     "@react-router/dev": "^7.9.0",
     "@shikijs/compat": "^1.1.7",
-    "@supabase/ssr": "^0.7.0",
+    "@supabase/ssr": "catalog:",
     "@supabase/supabase-js": "catalog:",
     "@tanstack/react-router": "^1.150.0",
     "@tanstack/react-start": "^1.150.0",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -34,7 +34,7 @@
     "@octokit/rest": "^21.0.0",
     "@radix-ui/react-dialog": "^1.0.5",
     "@sentry/nextjs": "catalog:",
-    "@supabase/ssr": "^0.9.0",
+    "@supabase/ssr": "catalog:",
     "@supabase/supabase-js": "catalog:",
     "@vercel/og": "^0.6.2",
     "ai-commands": "workspace:*",

--- a/blocks/vue/package.json
+++ b/blocks/vue/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@supabase/ssr": "^0.7.0",
+    "@supabase/ssr": "catalog:",
     "@supabase/supabase-js": "catalog:",
     "@vueuse/core": "^14.1.0",
     "class-variance-authority": "^0.7.1",
@@ -23,7 +23,6 @@
     "vue-router": "^4.5.1"
   },
   "devDependencies": {
-    "@supabase/ssr": "workspace:*",
     "shadcn": "^3.3.1",
     "tsconfig": "workspace:*",
     "vite": "catalog:"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@supabase/realtime-js':
       specifier: 2.103.0
       version: 2.103.0
+    '@supabase/ssr':
+      specifier: 0.10.2
+      version: 0.10.2
     '@supabase/supabase-js':
       specifier: 2.103.0
       version: 2.103.0
@@ -1591,8 +1594,8 @@ importers:
         specifier: ^1.1.7
         version: 1.6.0
       '@supabase/ssr':
-        specifier: ^0.7.0
-        version: 0.7.0(@supabase/supabase-js@2.103.0)
+        specifier: 'catalog:'
+        version: 0.10.2(@supabase/supabase-js@2.103.0)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.103.0
@@ -1705,8 +1708,8 @@ importers:
         specifier: 'catalog:'
         version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@15.5.14(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4)
       '@supabase/ssr':
-        specifier: ^0.9.0
-        version: 0.9.0(@supabase/supabase-js@2.103.0)
+        specifier: 'catalog:'
+        version: 0.10.2(@supabase/supabase-js@2.103.0)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.103.0
@@ -1958,8 +1961,8 @@ importers:
   blocks/vue:
     dependencies:
       '@supabase/ssr':
-        specifier: ^0.7.0
-        version: 0.7.0(@supabase/supabase-js@2.103.0)
+        specifier: 'catalog:'
+        version: 0.10.2(@supabase/supabase-js@2.103.0)
       '@supabase/supabase-js':
         specifier: 'catalog:'
         version: 2.103.0
@@ -8668,15 +8671,10 @@ packages:
   '@supabase/sql-to-rest@0.1.6':
     resolution: {integrity: sha512-06KgjeINtc6405XQvfnchBE1azEsU8G2NElfadmvVHKmHa5l2bFzjbtFbpaYgpgTzccHlcDmBaCgedVf2Gyl8Q==}
 
-  '@supabase/ssr@0.7.0':
-    resolution: {integrity: sha512-G65t5EhLSJ5c8hTCcXifSL9Q/ZRXvqgXeNo+d3P56f4U1IxwTqjB64UfmfixvmMcjuxnq2yGqEWVJqUcO+AzAg==}
+  '@supabase/ssr@0.10.2':
+    resolution: {integrity: sha512-JFbchN63CXLFHJRNT7udec4/RoD9PmXkSGko3QSO6vUuqGBtSzdmxR7FPfQNr7SuFd65I7Xv46q66ALjEN1cgQ==}
     peerDependencies:
-      '@supabase/supabase-js': ^2.43.4
-
-  '@supabase/ssr@0.9.0':
-    resolution: {integrity: sha512-UFY6otYV3yqCgV+AyHj80vNkTvbf1Gas2LW4dpbQ4ap6p6v3eB2oaDfcI99jsuJzwVBCFU4BJI+oDYyhNk1z0Q==}
-    peerDependencies:
-      '@supabase/supabase-js': ^2.97.0
+      '@supabase/supabase-js': ^2.102.1
 
   '@supabase/storage-js@2.103.0':
     resolution: {integrity: sha512-DHmlvdAXwtOmZNbkIZi4lkobPR3XjIzoOgzoz5duMf6G+sDeY015YrzMJCnqdccuYr7X5x4yYuSwF//RoN2dvQ==}
@@ -26230,12 +26228,7 @@ snapshots:
       - encoding
       - supports-color
 
-  '@supabase/ssr@0.7.0(@supabase/supabase-js@2.103.0)':
-    dependencies:
-      '@supabase/supabase-js': 2.103.0
-      cookie: 1.0.2
-
-  '@supabase/ssr@0.9.0(@supabase/supabase-js@2.103.0)':
+  '@supabase/ssr@0.10.2(@supabase/supabase-js@2.103.0)':
     dependencies:
       '@supabase/supabase-js': 2.103.0
       cookie: 1.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,6 +6,7 @@ packages:
 
 catalog:
   '@sentry/nextjs': ^10.26.0
+  '@supabase/ssr': 0.10.2
   '@supabase/auth-js': 2.103.0
   '@supabase/postgrest-js': 2.103.0
   '@supabase/realtime-js': 2.103.0


### PR DESCRIPTION
* Add `@supabase/ssr` to catalog
* Use `catalog:` version of `@supabase/ssr` across repo
* Add workflow to update `@supabase/ssr`
* Switch runners for package and docs updates to `ubuntu-latest` (free, lighter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Centralized `@supabase/ssr` versioning across the workspace via the package catalog.
  * Updated CI workflow runners to a more consistent execution environment.
  * Added an automated workflow to streamline updating the `@supabase/ssr` package and refreshing dependency lockfiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->