### PR TITLE
Clarification on signed urls caching

### DIFF
--- a/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
+++ b/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
@@ -36,3 +36,18 @@ If you anticipate that your asset might be deleted, it's advisable to set a shor
 If you need to ensure assets refresh directly from the origin server and bypass the cache, you can achieve this by adding a unique query string such as `cacheNonce` to the URL.
 
 For instance, you can use a URL like `/storage/v1/object/sign/profile-pictures/cat.jpg?cacheNonce=1` with a long browser cache (e.g., 1 year). To update the picture, increment the `cacheNonce` query parameter in the URL, like `/storage/v1/object/sign/profile-pictures/cat.jpg?cacheNonce=2`. The CDN will recognize it as a new object and fetch the updated version from the origin.
+
+## Signed URLs and CDN caching
+
+Signed URLs are the primary way to serve assets from private buckets to end users. With Smart CDN enabled, signed URL responses are cached at the CDN edge, just like any other storage request.
+
+Unlike public bucket URLs, each signed URL contains a unique token query parameter (`?token=...`). Smart CDN treats each unique token as a separate cache key, meaning the first request with any given signed URL results in a cache miss, and only subsequent requests using that exact same URL will receive a cache hit. Two different signed URLs for the same object even if generated seconds apart each maintain their own independent cache entry.
+
+This affects how you should think about serving private assets:
+
+- If you generate a new signed URL on every request, the cache will never be warm and every request hits the origin.
+- If you re-use the same signed URL across multiple requests, subsequent requests are served from cache. If the asset has no meaningful per-user access restriction, a public bucket is worth considering. It results in higher cache hit rates and removes the need to manage signed URL generation entirely.
+- Revoking or expiring a token does not purge its CDN cache entry. The cached response persists at the edge until the cache duration expires.
+- Deleting the object invalidates all cached entries for that file across all tokens. This propagates within 60 seconds.
+
+Token expiry (`expiresIn`) and CDN cache duration (`cacheControl`) are independent. Once a response is cached at the edge, it can still be served to requests that arrive with a valid token for the same object, even after the original token expires. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.

--- a/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
+++ b/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
@@ -50,4 +50,4 @@ This affects how you should think about serving private assets:
 - Revoking or expiring a token does not purge its CDN cache entry. The cached response persists at the edge until the cache duration expires.
 - Deleting the object invalidates all cached entries for that file across all tokens. This propagates within 60 seconds.
 
-Token expiry (`expiresIn`) and CDN cache duration (`cacheControl`) are independent. Once a response is cached at the edge, it can still be served to requests that arrive with the same token URL, even after the original token expires. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.
+Token expiry (`expiresIn`) and CDN cache duration (`cacheControl`) are independent. Once a response is cached at the edge, that cached response can continue to be served for the exact same signed URL until the CDN cache duration expires, even if the token in that URL has already expired. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.

--- a/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
+++ b/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
@@ -50,4 +50,4 @@ This affects how you should think about serving private assets:
 - Revoking or expiring a token does not purge its CDN cache entry. The cached response persists at the edge until the cache duration expires.
 - Deleting the object invalidates all cached entries for that file across all tokens. This propagates within 60 seconds.
 
-Token expiry (`expiresIn`) and CDN cache duration (`cacheControl`) are independent. Once a response is cached at the edge, it can still be served to requests that arrive with a valid token for the same object, even after the original token expires. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.
+Token expiry (`expiresIn`) and CDN cache duration (`cacheControl`) are independent. Once a response is cached at the edge, it can still be served to requests that arrive with the same token URL, even after the original token expires. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.

--- a/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
+++ b/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
@@ -41,13 +41,13 @@ For instance, you can use a URL like `/storage/v1/object/sign/profile-pictures/c
 
 Signed URLs are the primary way to serve assets from private buckets to end users. With Smart CDN enabled, signed URL responses are cached at the CDN edge, just like any other storage request.
 
-Unlike public bucket URLs, each signed URL contains a unique token query parameter (`?token=...`). Smart CDN treats each unique token as a separate cache key, meaning the first request with any given signed URL results in a cache miss, and only subsequent requests using that exact same URL will receive a cache hit. Two different signed URLs for the same object even if generated seconds apart each maintain their own independent cache entry.
+Unlike public bucket URLs, each signed URL contains a unique token query parameter (`?token=...`). Smart CDN treats each unique token as a separate cache key, meaning the first request with any given signed URL results in a cache miss, and only subsequent requests using that exact same URL will receive a cache hit. Two different signed URLs for the same object even if generated seconds apart, each maintain their own independent cache entry.
 
 This affects how you should think about serving private assets:
 
 - If you generate a new signed URL on every request, the cache will never be warm and every request hits the origin.
-- If you re-use the same signed URL across multiple requests, subsequent requests are served from cache. If the asset has no meaningful per-user access restriction, a public bucket is worth considering. It results in higher cache hit rates and removes the need to manage signed URL generation entirely.
+- If you re-use the same signed URL across multiple requests, subsequent requests are served from cache. If the asset has no meaningful per-user access restriction, prefer a public bucket. It results in higher cache hit rates and removes the need to manage signed URL generation entirely.
 - Revoking or expiring a token does not purge its CDN cache entry. The cached response persists at the edge until the cache duration expires.
-- Deleting the object invalidates all cached entries for that file across all tokens. This propagates within 60 seconds.
+- Deleting the object invalidates all cached entries for that object across all tokens. This can take up to a minute to propagate.
 
-Token expiry (`expiresIn`) and CDN cache duration (`cacheControl`) are independent. Once a response is cached at the edge, that cached response can continue to be served for the exact same signed URL until the CDN cache duration expires, even if the token in that URL has already expired. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.
+Token expiry (`expiresIn`) and the object's response cache TTL (`cacheControl`) are independent. Once a response is cached at the edge, that cached response can continue to be served for the same signed URL until the CDN cache duration expires, even if the token in that URL has already expired. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.

--- a/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
+++ b/apps/docs/content/guides/storage/cdn/smart-cdn.mdx
@@ -41,7 +41,7 @@ For instance, you can use a URL like `/storage/v1/object/sign/profile-pictures/c
 
 Signed URLs are the primary way to serve assets from private buckets to end users. With Smart CDN enabled, signed URL responses are cached at the CDN edge, just like any other storage request.
 
-Unlike public bucket URLs, each signed URL contains a unique token query parameter (`?token=...`). Smart CDN treats each unique token as a separate cache key, meaning the first request with any given signed URL results in a cache miss, and only subsequent requests using that exact same URL will receive a cache hit. Two different signed URLs for the same object even if generated seconds apart, each maintain their own independent cache entry.
+Unlike public bucket URLs, each signed URL contains a unique token query parameter (`?token=...`). Smart CDN treats each unique token as a separate cache key, meaning the first request with any given signed URL results in a cache miss, and only subsequent requests using that exact same URL will receive a cache hit. Two different signed URLs for the same object, even if generated seconds apart, each maintain their own independent cache entry.
 
 This affects how you should think about serving private assets:
 
@@ -50,4 +50,4 @@ This affects how you should think about serving private assets:
 - Revoking or expiring a token does not purge its CDN cache entry. The cached response persists at the edge until the cache duration expires.
 - Deleting the object invalidates all cached entries for that object across all tokens. This can take up to a minute to propagate.
 
-Token expiry (`expiresIn`) and the object's response cache TTL (`cacheControl`) are independent. Once a response is cached at the edge, that cached response can continue to be served for the same signed URL until the CDN cache duration expires, even if the token in that URL has already expired. If you need to cut off access to an asset immediately, delete the object from the bucket rather than relying on token expiry alone.
+Token expiry (`expiresIn`) and the object's response cache TTL (`cacheControl`) are independent. Once a response is cached at the edge, that cached response can continue to be served for the same signed URL until the CDN cache duration expires, even if the token in that URL has already expired. If you need to cut off access to an asset, delete the object from the bucket rather than relying on token expiry alone.


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update

## Additional context

The Smart CDN documentation lacked clarity around caching behavior for signed URLs used with private bucket assets. This update adds that missing detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Smart CDN guide section on signed URL caching at the CDN edge: each unique signed URL is a separate cache key.
  * Explained cache behavior: first request for a specific signed URL is a miss; subsequent identical requests are cache hits; cached responses remain until CDN cache expiry.
  * Clarified access-control interactions: revoking/expiring a token does not purge cached content; deleting the object invalidates cached entries (propagates within ~60s).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->