### PR TITLE
fix: improve oauth apps callback urls UX

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -353,7 +353,7 @@ export const PublishAppSidePanel = ({
                                 {...field}
                                 placeholder="e.g https://my-website.com"
                               />
-                              {callbackUrlsFields.length > 0 ? (
+                              {callbackUrlsFields.length > 1 ? (
                                 <InputGroupAddon align="inline-end">
                                   <InputGroupButton
                                     type="default"


### PR DESCRIPTION
## Problem

#44677 modified the previous behaviour on callback URLs. It used to prevent users to remove the URL if only one was provided.

## Solution

Restore the previous behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Remove button behavior for OAuth callback URLs. The button now only appears when multiple callback URLs are configured, preventing accidental deletion of the only redirect URI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->