### PR TITLE
fix(studio): escape SQL identifiers in view security invoker autofix

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/ViewEntityAutofixSecurityModal.tsx
@@ -1,3 +1,4 @@
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 import { ScrollArea } from 'ui'
@@ -52,7 +53,7 @@ export default function ViewEntityAutofixSecurityModal({
 
   function handleConfirm() {
     const sql = `
-	ALTER VIEW "${table.schema}"."${table.name}" SET (security_invoker = on);
+	ALTER VIEW ${ident(table.schema)}.${ident(table.name)} SET (security_invoker = on);
 	`
     execute({
       projectRef: project?.ref,


### PR DESCRIPTION
## Summary

The `ViewEntityAutofixSecurityModal` builds its ALTER VIEW statement using raw string interpolation:

```sql
ALTER VIEW "${table.schema}"."${table.name}" SET (security_invoker = on);
```

A schema or view name containing a double quote would break out of the identifier quoting and allow arbitrary SQL in the executed statement.

This replaces the raw interpolation with `ident()` from `@supabase/pg-meta/src/pg-format`, matching the pattern used throughout the rest of Studio (including the recent fix in #44589).

## Test plan

- [ ] Open a view in the Table Editor that has `security_invoker = off`
- [ ] Confirm the autofix modal still works and the ALTER VIEW executes correctly
- [ ] Verify `ident()` is imported and used for both schema and table name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL identifier formatting for table and schema names to ensure proper handling of special characters and reserved keywords in security configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->