### PR TITLE
fix(studio): escape SQL identifiers in auth hook permission statements

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import { useParams } from 'common'
 import randomBytes from 'randombytes'
 import { useEffect, useMemo } from 'react'
@@ -187,9 +188,9 @@ export const CreateHookSheet = ({
     if (values.postgresValues.functionName !== '') {
       permissionChanges = [
         ...permissionChanges,
-        `-- Grant access to function to supabase_auth_admin\ngrant execute on function ${values.postgresValues.schema}.${values.postgresValues.functionName} to supabase_auth_admin;`,
-        `-- Grant access to schema to supabase_auth_admin\ngrant usage on schema ${values.postgresValues.schema} to supabase_auth_admin;`,
-        `-- Revoke function permissions from authenticated, anon and public\nrevoke execute on function ${values.postgresValues.schema}.${values.postgresValues.functionName} from authenticated, anon, public;`,
+        `-- Grant access to function to supabase_auth_admin\ngrant execute on function ${ident(values.postgresValues.schema)}.${ident(values.postgresValues.functionName)} to supabase_auth_admin;`,
+        `-- Grant access to schema to supabase_auth_admin\ngrant usage on schema ${ident(values.postgresValues.schema)} to supabase_auth_admin;`,
+        `-- Revoke function permissions from authenticated, anon and public\nrevoke execute on function ${ident(values.postgresValues.schema)}.${ident(values.postgresValues.functionName)} from authenticated, anon, public;`,
       ]
     }
     return permissionChanges

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
@@ -1,3 +1,5 @@
+import { ident } from '@supabase/pg-meta/src/pg-format'
+
 import { Hook } from './hooks.constants'
 
 export const extractMethod = (
@@ -36,8 +38,8 @@ export const isValidHook = (h: Hook) => {
  */
 export const getRevokePermissionStatements = (schema: string, functionName: string): string[] => {
   return [
-    `-- Revoke access to function from supabase_auth_admin\nrevoke execute on function ${schema}.${functionName} from supabase_auth_admin;`,
-    `-- Revoke access to schema from supabase_auth_admin\nrevoke usage on schema ${schema} from supabase_auth_admin;`,
-    `-- Restore function permissions to authenticated, anon and public\ngrant execute on function ${schema}.${functionName} to authenticated, anon, public;`,
+    `-- Revoke access to function from supabase_auth_admin\nrevoke execute on function ${ident(schema)}.${ident(functionName)} from supabase_auth_admin;`,
+    `-- Revoke access to schema from supabase_auth_admin\nrevoke usage on schema ${ident(schema)} from supabase_auth_admin;`,
+    `-- Restore function permissions to authenticated, anon and public\ngrant execute on function ${ident(schema)}.${ident(functionName)} to authenticated, anon, public;`,
   ]
 }


### PR DESCRIPTION
## Summary

The auth hook management flows construct GRANT/REVOKE statements using raw template literal interpolation for schema and function names:

```sql
grant execute on function ${schema}.${functionName} to supabase_auth_admin;
```

A schema or function name containing a double quote would break out of the identifier quoting in the executed statement.

This applies `ident()` from `@supabase/pg-meta/src/pg-format` to all six SQL interpolation sites across two files:

- `hooks.utils.ts` -- `getRevokePermissionStatements()` (3 statements)
- `CreateHookSheet.tsx` -- permission grant `useMemo` (3 statements)

`HooksListing.tsx` calls `getRevokePermissionStatements()` and is covered by the utility fix.

Same pattern as the recent fixes in #44555 (queue mutations), #44589 (index mutations), and #44721 (view autofix modal).

## Test plan

- [ ] Create an auth hook pointing to a Postgres function -- verify GRANT/REVOKE statements execute correctly
- [ ] Delete an auth hook -- verify revoke statements execute correctly
- [ ] Verify `ident()` is imported and applied to both schema and function name in all statements

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL identifier formatting for authentication hook permission statements to ensure proper handling of schema and function names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->