### PR TITLE
chore: remove outdated GitHub discussion link

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/DashboardSettingsToggles.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/DashboardSettingsToggles.tsx
@@ -75,7 +75,6 @@ export const DashboardSettingsToggles = () => {
           name="queueOperationsEnabled"
           label="Queue table operations"
           description="Review and batch table edits in Table Editor before saving them to your database."
-          discussionsUrl="https://github.com/orgs/supabase/discussions/42460"
           onToggle={handleQueueOperationsToggle}
           isLast
         />

--- a/apps/studio/components/interfaces/Account/Preferences/DashboardToggle.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/DashboardToggle.tsx
@@ -1,5 +1,3 @@
-import { ExternalLink } from 'lucide-react'
-import Link from 'next/link'
 import type { ReactNode } from 'react'
 import type { FieldValues, Path, UseFormReturn } from 'react-hook-form'
 import { CardContent, FormControl_Shadcn_, FormField_Shadcn_, Switch } from 'ui'
@@ -11,7 +9,6 @@ interface DashboardToggleProps<T extends FieldValues> {
   label: string
   description: ReactNode
   onToggle: (value: boolean) => void
-  discussionsUrl?: string
   isLast?: boolean
 }
 
@@ -21,7 +18,6 @@ export function DashboardToggle<T extends FieldValues>({
   label,
   description,
   onToggle,
-  discussionsUrl,
   isLast,
 }: DashboardToggleProps<T>) {
   return (
@@ -30,29 +26,7 @@ export function DashboardToggle<T extends FieldValues>({
         control={form.control}
         name={name}
         render={({ field }) => (
-          <FormItemLayout
-            layout="flex-row-reverse"
-            label={label}
-            description={
-              <p className="text-balance">
-                {description}
-                {discussionsUrl && (
-                  <>
-                    {' '}
-                    <Link
-                      href={discussionsUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="inline-flex items-center gap-x-1 text-foreground-light hover:text-foreground transition"
-                    >
-                      Give feedback
-                      <ExternalLink size={12} strokeWidth={1.5} />
-                    </Link>
-                  </>
-                )}
-              </p>
-            }
-          >
+          <FormItemLayout layout="flex-row-reverse" label={label} description={description}>
             <FormControl_Shadcn_>
               <Switch
                 checked={field.value}


### PR DESCRIPTION
## Summary
- Remove the outdated GitHub discussion feedback link from the "Queue table operations" dashboard setting
- Clean up the unused `discussionsUrl` prop and related rendering logic from `DashboardToggle`

Closes FE-2973
## Test plan
- [ ] Verify the "Queue table operations" toggle in Account > Preferences no longer shows a "Give feedback" link
- [ ] Verify the "Edit entities in SQL" toggle still renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed the feedback link from dashboard settings toggles. The "Give feedback" option is no longer available in the preferences interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->