### PR TITLE
fix(Docs): Remove legacy option for service key rotation

### DIFF
--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -148,10 +148,7 @@ Rotating a secret key (`sb_secret_...`) is easy and painless. Use the [API Keys]
 
 **Deleting a secret key is irreversible and once done it will be gone forever.**
 
-If you are still using the JWT-based `service_role` key, there are two options.
-
-1. **Strongly recommended:** Replace the `service_role` key with a new secret key instead. Follow the guide from above as if you are rotating an existing secret key.
-2. [Rotate your project's JWT secret.](/dashboard/project/_/settings/jwt) This operation is only recommended if you suspect that the JWT secret has leaked itself. Consider switching your `anon` JWT-based key to the publishable key, and all `service_role` JWT-based keys to secret keys. Only then rotate the JWT secret. Check the FAQ below if you use the JWT-based keys in mobile, desktop or CLI applications!
+If you are still using the JWT-based `service_role` key, replace the `service_role` key with a new secret key instead. Follow the guide from above as if you are rotating an existing secret key.
 
 ## Known limitations and compatibility differences
 

--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -150,6 +150,8 @@ Rotating a secret key (`sb_secret_...`) is easy and painless. Use the [API Keys]
 
 If you are still using the JWT-based `service_role` key, replace the `service_role` key with a new secret key instead. Follow the guide from above as if you are rotating an existing secret key.
 
+If you believe this is not possible for your implementation, please [contact Support](https://supabase.com/dashboard/support/new).
+
 ## Known limitations and compatibility differences
 
 As the publishable and secret keys are no longer JWT-based, there are some known limitations and compatibility differences that you may need to plan for:

--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -150,7 +150,7 @@ Rotating a secret key (`sb_secret_...`) is easy and painless. Use the [API Keys]
 
 If you are still using the JWT-based `service_role` key, replace the `service_role` key with a new secret key instead. Follow the guide from above as if you are rotating an existing secret key.
 
-If you believe this is not possible for your implementation, please [contact Support](https://supabase.com/dashboard/support/new).
+If you believe this is not possible for your implementation, please [contact Support](/dashboard/support/new).
 
 ## Known limitations and compatibility differences
 

--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -150,7 +150,7 @@ Rotating a secret key (`sb_secret_...`) is easy and painless. Use the [API Keys]
 
 If you are still using the JWT-based `service_role` key, replace the `service_role` key with a new secret key instead. Follow the guide from above as if you are rotating an existing secret key.
 
-If you believe this is not possible for your implementation, please [contact Support](/dashboard/support/new).
+If you believe this is not possible for your implementation, [contact Support](/dashboard/support/new).
 
 ## Known limitations and compatibility differences
 

--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -162,6 +162,12 @@ As the publishable and secret keys are no longer JWT-based, there are some known
 
 {/* supa-mdx-lint-disable Rule004ExcludeWords */}
 
+### I am using JWT-based `anon` key in a mobile, desktop, or CLI application and need to rotate my `service_role` JWT secret?
+
+If you know or suspect that the JWT secret itself is leaked, refer to the section on [rotating the JWT](#what-to-do-if-a-secret-key-or-servicerole-has-been-leaked-or-compromised).
+
+If the JWT secret is secure, prefer substituting the `service_role` JWT-based key with a new secret key which you can create in the [API Keys](/dashboard/project/_/settings/api-keys) dashboard. This will prevent downtime for your application.
+
 ### Can I still use my old `anon` and `service-role` API keys after enabling the publishable and secret keys?
 
 Yes. This allows you to transition between the API keys with zero downtime by gradually swapping your clients while both sets of keys are active. See the next question for how to deactivate your keys once all your clients are switched over.

--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -162,12 +162,6 @@ As the publishable and secret keys are no longer JWT-based, there are some known
 
 {/* supa-mdx-lint-disable Rule004ExcludeWords */}
 
-### I am using JWT-based `anon` key in a mobile, desktop, or CLI application and need to rotate my `service_role` JWT secret?
-
-If you know or suspect that the JWT secret itself is leaked, refer to the section on [rotating the JWT](#what-to-do-if-a-secret-key-or-servicerole-has-been-leaked-or-compromised).
-
-If the JWT secret is secure, prefer substituting the `service_role` JWT-based key with a new secret key which you can create in the [API Keys](/dashboard/project/_/settings/api-keys) dashboard. This will prevent downtime for your application.
-
 ### Can I still use my old `anon` and `service-role` API keys after enabling the publishable and secret keys?
 
 Yes. This allows you to transition between the API keys with zero downtime by gradually swapping your clients while both sets of keys are active. See the next question for how to deactivate your keys once all your clients are switched over.

--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -164,9 +164,7 @@ As the publishable and secret keys are no longer JWT-based, there are some known
 
 ### I am using JWT-based `anon` key in a mobile, desktop, or CLI application and need to rotate my `service_role` JWT secret?
 
-If you know or suspect that the JWT secret itself is leaked, refer to the section on [rotating the JWT](#what-to-do-if-a-secret-key-or-servicerole-has-been-leaked-or-compromised).
-
-If the JWT secret is secure, prefer substituting the `service_role` JWT-based key with a new secret key which you can create in the [API Keys](/dashboard/project/_/settings/api-keys) dashboard. This will prevent downtime for your application.
+If the JWT secret is secure, substitute the `service_role` JWT-based key with a new secret key which you can create in the [API Keys](/dashboard/project/_/settings/api-keys) dashboard. This will prevent downtime for your application.
 
 ### Can I still use my old `anon` and `service-role` API keys after enabling the publishable and secret keys?
 

--- a/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
+++ b/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
@@ -46,6 +46,5 @@ If you have migrated to new symmetric JWT signing keys:
 
 ## Further readings
 
-- [How to rotate the service role key](/docs/guides/api/api-keys#i-am-using-jwt-based-anon-key-in-a-mobile-desktop-or-cli-application-and-need-to-rotate-my-servicerole-jwt-secret)
 - [What to do if a secret key or service_role has been leaked or compromised?](/docs/guides/api/api-keys#what-to-do-if-a-secret-key-or-servicerole-has-been-leaked-or-compromised)
 - [JWT Signing Keys](/docs/guides/auth/signing-keys)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Consolidated guidance for leaked/compromised service_role (JWT) keys: now instructs replacing the service_role key via the standard secret rotation process and adds a fallback to contact Support if replacement isn’t feasible.
  * Simplified FAQ paths for anon users: removed the alternate branch that redirected to rotating the JWT secret.
  * Removed an obsolete "rotate service role key" further-reading link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->