### PR TITLE
fix(self-hosted): local AI assistant unable to read schemas and interpret/execute SQL

### DIFF
--- a/apps/studio/lib/ai/tools/fallback-tools.ts
+++ b/apps/studio/lib/ai/tools/fallback-tools.ts
@@ -37,7 +37,7 @@ export const getFallbackTools = ({
       }),
       execute: async ({ schemas }) => {
         try {
-          const result = includeSchemaMetadata
+          const { result } = includeSchemaMetadata
             ? await executeSql(
                 {
                   projectRef,

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -35,6 +35,7 @@ export const getStudioTools = () => ({
         .describe('Chart configuration for rendering the results'),
       isWriteQuery: z
         .boolean()
+        .default(false)
         .describe(
           'Whether the SQL statement performs a write operation of any kind instead of a read operation'
         ),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix for #42574 

## What is the current behavior?

If you setup a self-hosted Supabase environment and ask local AI assistant it is unable to interpret the results for executed SQL queries.

## What is the new behavior?

Local AI assistant can now read schemas and interpret the results for executed SQL queries.

## Additional context

I tested it using ollama with a smaller model which does not support reasoning mode so It would be useful if someone can test it using an actual OpenAI API KEY.

The main issue was that `executeSql` returns a wrapped `{ result: {...} }` on `fallback-tools.ts` making the model think there's no result. 
The solution is just to unwrap it like it's done at: `apps/studio/data/database-functions/database-functions-query.ts`: 

```
export async function getDatabaseFunctions(...) {
...
  const { result } = await executeSql(...)
...
  return result as DatabaseFunction[]
}
```

Also added a `false` default value in `execute_sql` tool schema so zod validation does not reject a valid LLM tool call if the model omits the field (which happened with the smaller model)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal schema metadata query handling in AI tools.

* **Chores**
  * Enhanced SQL execution tool robustness by providing a sensible default for query type specification when not explicitly provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->