### PR TITLE
fix(self-hosted): studio container shouldn't depend on host's ipv6 stack

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,8 +28,8 @@ services:
       analytics:
         condition: service_healthy
     environment:
-      # Binds nestjs listener to both IPv4 and IPv6 network interfaces
-      HOSTNAME: "::"
+      #  Listen on all IPv4 interfaces
+      HOSTNAME: "0.0.0.0"
 
       STUDIO_PG_META_URL: http://meta:8080
       POSTGRES_PORT: ${POSTGRES_PORT}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix `HOSTNAME` env var for Studio container to use "0.0.0.0" - bind to all IPv4 interfaces only, not IPv4/IPv6.

## What is the current behavior?

 The `HOSTNAME=::` introduced in PR #39383 doesn't do much, but prevents Studio to start on systems without IPv6 in the kernel (e.g. with `ipv6.disable=1` in grub settings).

[Self-hosted Supabase](https://supabase.com/docs/guides/self-hosting) configuration doesn't include IPv6, and no containers have IPv6 enabled.

[CLI](https://supabase.com/docs/guides/local-development) sets `HOSTNAME` to `0.0.0.0` as well (see [here](https://github.com/supabase/cli/blob/2faacf12b4a55196defd1c4b566a23f948bf199e/internal/start/start.go#L1214)).