### PR TITLE
feat(auth): allow newlines in SMS OTP template

### DIFF
--- a/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
@@ -15,7 +15,6 @@ import {
   FormControl_Shadcn_,
   FormField_Shadcn_,
   FormInputGroupInput,
-  Input_Shadcn_,
   InputGroup,
   InputGroupAddon,
   InputGroupText,
@@ -25,6 +24,7 @@ import {
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
   Switch,
+  Textarea,
   WarningIcon,
 } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
@@ -541,9 +541,9 @@ export const MfaAuthSettingsForm = () => {
                         description="To format the OTP code use `{{ .Code }}`"
                       >
                         <FormControl_Shadcn_>
-                          <Input_Shadcn_
-                            type="text"
+                          <Textarea
                             {...field}
+                            rows={3}
                             disabled={!canUpdateConfig || !hasAccessToMFA}
                             data-1p-ignore // 1Password
                             data-lpignore="true" // LastPass


### PR DESCRIPTION
The MFA phone OTP template used a single-line input that stripped newlines. Changed it to a textarea so you can format the SMS for WebOTP API compatibility (which needs the code on its own line).

The main SMS template already supported multiline — this just brings the MFA phone template in line.

Fixes #6435