### PR TITLE
fix: stop tax id from being cleared out by changes in address form

### DIFF
--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -269,7 +269,7 @@ export const NewPaymentMethodElement = forwardRef(
         form.setValue('tax_id_value', '')
         form.setValue('tax_id_name', taxIdOption.name)
       }
-    }, [availableTaxIds, addressCountry])
+    }, [availableTaxIds, addressCountry, currentTaxId])
 
     return (
       <div className="space-y-2">

--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -13,7 +13,7 @@ import {
 } from '@stripe/stripe-js'
 import { Form } from '@ui/components/shadcn/ui/form'
 import { Check, ChevronsUpDown } from 'lucide-react'
-import { forwardRef, useEffect, useId, useImperativeHandle, useMemo, useState } from 'react'
+import { forwardRef, useEffect, useId, useImperativeHandle, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -147,13 +147,14 @@ export const NewPaymentMethodElement = forwardRef(
       }
     }, [purchasingAsBusiness, selectedTaxId, tax_id_value, onTaxIdChange])
 
+    const addressCountry = stripeAddress?.address.country
     const availableTaxIds = useMemo(() => {
-      const country = stripeAddress?.address.country || null
+      const country = addressCountry || null
 
       return TAX_IDS.filter((taxId) => country == null || taxId.countryIso2 === country).sort(
         (a, b) => a.country.localeCompare(b.country)
       )
-    }, [stripeAddress])
+    }, [addressCountry])
 
     const createPaymentMethod = async (): ReturnType<
       PaymentMethodElementRef['createPaymentMethod']
@@ -247,15 +248,24 @@ export const NewPaymentMethodElement = forwardRef(
       [purchasingAsBusiness]
     )
 
-    // Preselect tax id if there is no more than 2 available tax ids (even if there are two options, first one in the list is likely to be it)
+    // Preselect tax id when the country changes (if there are available tax ids for that country)
+    const prevCountryRef = useRef(addressCountry)
     useEffect(() => {
-      if (availableTaxIds.length && stripeAddress?.address.country && !currentTaxId) {
+      if (!availableTaxIds.length || !addressCountry) return
+
+      const isCountryChange =
+        prevCountryRef.current !== undefined && prevCountryRef.current !== addressCountry
+      prevCountryRef.current = addressCountry
+
+      // On country change: always reset to the new country's default
+      // On initial load: only preselect if there's no existing tax id
+      if (isCountryChange || !currentTaxId) {
         const taxIdOption = availableTaxIds[0]
         form.setValue('tax_id_type', taxIdOption.type)
         form.setValue('tax_id_value', '')
         form.setValue('tax_id_name', taxIdOption.name)
       }
-    }, [availableTaxIds, stripeAddress])
+    }, [availableTaxIds, addressCountry])
 
     return (
       <div className="space-y-2">

--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -240,9 +240,13 @@ export const NewPaymentMethodElement = forwardRef(
           mode: 'google_maps_api',
         },
         display: { name: purchasingAsBusiness ? 'organization' : 'full' },
+        // Use live form state (stripeAddress) so the address survives remounts triggered
+        // by the purchasingAsBusiness toggle (which changes the key prop). Without this,
+        // the element resets to the original currentAddress prop, causing the country to
+        // revert and the tax ID selector to fall out of sync.
         defaultValues: {
-          address: currentAddress ?? undefined,
-          name: customerName,
+          address: stripeAddress?.address ?? currentAddress ?? undefined,
+          name: stripeAddress?.name ?? customerName,
         },
       }),
       [purchasingAsBusiness]


### PR DESCRIPTION
## Summary

- The `availableTaxIds` memo and preselect `useEffect` in `NewPaymentMethodElement` depended on the full `stripeAddress` object. Since the Stripe `AddressElement` fires `onChange` on every keystroke (org name, street, city, etc.), this created a new object reference each time, causing the memo to recompute and the effect to re-fire, which cleared `tax_id_value` to `''`.
- Narrowed both dependencies to `addressCountry`, so the tax ID is only reset when the billing country actually changes.
- Used a `prevCountryRef` to distinguish initial mount from country changes: on mount we preserve any existing `currentTaxId`, on country change we always reset to the new country's default.

## Test plan

- [ ]  New org flow: select paid plan, check "purchasing as a business", fill in tax ID value, type in org name / address fields - tax ID should persist
- [ ]  New org flow: change country - tax ID selector should update to the new country's default
- [ ]  Plan upgrade flow: open upgrade dialog with existing tax ID, type in address fields - tax ID should persist
- [ ]  Plan upgrade flow: change country - tax ID should reset to new country's default

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tax ID handling is now country-aware and updates correctly when the billing country changes.
  * Address name and country persist across form remounts, preventing accidental resets when toggling purchase mode.
  * Tax ID selection/reset logic refined to avoid overwriting existing tax IDs on initial load and to choose appropriate defaults after country changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->