### PR TITLE
fix: cron parsing

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -238,6 +238,19 @@ describe('parseCronJobCommand', () => {
     })
   })
 
+  it('should parse a POST body without swallowing later quoted arguments', () => {
+    const command = `select net.http_post( url:='https://example.com/api/endpoint', body:='{"payload":"ok"}'::jsonb, headers:='{"Authorization":"Bearer demo"}'::jsonb, timeout_milliseconds:=5000 );`
+    expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
+      endpoint: 'https://example.com/api/endpoint',
+      method: 'POST',
+      httpHeaders: [{ name: 'Authorization', value: 'Bearer demo' }],
+      httpBody: '{"payload":"ok"}',
+      timeoutMs: 5000,
+      type: 'http_request',
+      snippet: command,
+    })
+  })
+
   it('should return SQL snippet type if the command is an HTTP request that cannot be parsed properly due to positional notation', () => {
     const command = `SELECT net.http_post( 'https://webhook.site/dacc2028-a588-462c-9597-c8968e61d0fa', '{"message":"Hello from Supabase"}'::jsonb, '{}'::jsonb, '{"Content-Type":"application/json"}'::jsonb );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
@@ -54,7 +54,7 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
     const urlMatch = command.match(/url:='([^']+)'/i)
     const url = urlMatch?.[1] || ''
 
-    const bodyMatch = command.match(/body:='(.*)'/i)
+    const bodyMatch = command.match(/body:='(.*?)'/i)
     const body = bodyMatch?.[1] || ''
 
     const timeoutMatch = command.match(/timeout_milliseconds:=(\d+)/i)


### PR DESCRIPTION
## TL;DR

fixes a cron job parsing issue where the `HTTP request body` 
could include content from a later argument when editing an existing job


## ex: 
<table>
  <tr>
    <td valign="top" width="50%">
      <strong>Before:</strong>
      <br />
      when editing some existing <code>net.http_post(...)</code> cron jobs, studio populated the <code>HTTP Request Body</code> field with extra content from the following argument instead of only the body value
      <br /><br />
      <img width="532" height="108" alt="before" src="https://github.com/user-attachments/assets/eccf1f6b-3e4c-4d6d-8611-e144794fac8f" />
    </td>
    <td valign="top" width="50%">
      <strong>After:</strong>
      <br />
      now it stops parsing the body at the correct boundary, so the <code>HTTP Request Body</code> field only contains the intended body content
      <br /><br />
      <img width="165" height="69" alt="after" src="https://github.com/user-attachments/assets/92f5cf44-ad8c-409c-a0f5-5b9c1664ccd0" />
    </td>
  </tr>
</table>
added a smol regress test aswell :) 

## ref:

- closes https://github.com/supabase/supabase/issues/44794


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of cron job commands with quoted JSON body parameters and additional arguments to ensure headers and timeout parameters are correctly recognized.

* **Tests**
  * Added test case to validate correct parsing of complex cron job command configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->