### PR TITLE
fix: null-coalesce columns in formatWrapperTables

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/Wrappers.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/Wrappers.utils.ts
@@ -208,7 +208,7 @@ export const formatWrapperTables = (
       ...options,
       index,
       id: table.id,
-      columns: table.columns,
+      columns: table.columns ?? [],
       is_new_schema: false,
       schema: table.schema,
       schema_name: table.schema,


### PR DESCRIPTION
## Summary

Follow-up to #44801 — fixes the data layer issue flagged in the review comment.

The previous fix handled the display crash (`table.columns.map` when `columns` is undefined) but left the edit/save path broken. When a Stripe wrapper table has `null` columns from the DB (e.g. `jsonb_agg` returns `NULL` when there are no rows), `formatWrapperTables` was forwarding that `null` directly into the react-hook-form state. The Zod `tableSchema` declares `columns` as a non-optional `z.array(...)`, so the zodResolver rejected the form silently on save — the Save button appeared to do nothing with no error shown to the user.

## Change

In `Wrappers.utils.ts`, `formatWrapperTables`:

```ts
// before
columns: table.columns,

// after
columns: table.columns ?? [],
```

This ensures the form is always initialized with a valid array, satisfying the Zod schema and allowing saves to proceed normally.

---

Slack thread: https://supabase.slack.com/archives/C063LNYJJKS/p1776067210776939?thread_ts=1776067141.988569&cid=C063LNYJJKS

https://claude.ai/code/session_01N6nyTggA68yktWg4b46ssL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where wrapper tables could fail to display correctly when column data was missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->