### PR TITLE
chore: use ro connstring for observability

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
@@ -138,7 +138,7 @@ export const useQueryPerformanceInfiniteQuery = (
   const { data: databases } = useReadReplicasQuery({ projectRef: project?.ref })
   const connectionString = (databases || []).find(
     (db) => db.identifier === state.selectedDatabaseId
-  )?.connectionString
+  )?.connection_string_read_only // default to read_only connection string
 
   // Clamp pageSize the same way generateQueryPerformanceSql does so getNextPageParam
   // and the queryKey are always consistent with the SQL actually executed.

--- a/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
+++ b/apps/studio/components/interfaces/QueryPerformance/useQueryPerformanceQuery.ts
@@ -120,7 +120,7 @@ export const useQueryPerformanceInfiniteQuery = (
   const { data: databases } = useReadReplicasQuery({ projectRef: project?.ref })
   const connectionString = (databases || []).find(
     (db) => db.identifier === state.selectedDatabaseId
-  )?.connectionString
+  )?.connection_string_read_only // default to read_only connection string
 
   // Clamp pageSize the same way generateQueryPerformanceSql does so getNextPageParam
   // and the queryKey are always consistent with the SQL actually executed.

--- a/apps/studio/hooks/analytics/useDbQuery.tsx
+++ b/apps/studio/hooks/analytics/useDbQuery.tsx
@@ -43,7 +43,7 @@ const useDbQuery = ({
   const { data: databases } = useReadReplicasQuery({ projectRef: project?.ref })
   const connectionString = (databases || []).find(
     (db) => db.identifier === state.selectedDatabaseId
-  )?.connectionString
+  )?.connection_string_read_only // default to using the read_only string
   const identifier = state.selectedDatabaseId
 
   const resolvedSql = typeof sql === 'function' ? sql([]) : sql

--- a/apps/studio/hooks/analytics/useDbQuery.tsx
+++ b/apps/studio/hooks/analytics/useDbQuery.tsx
@@ -42,7 +42,7 @@ const useDbQuery = ({
   const { data: databases } = useReadReplicasQuery({ projectRef: project?.ref })
   const connectionString = (databases || []).find(
     (db) => db.identifier === state.selectedDatabaseId
-  )?.connectionString
+  )?.connection_string_read_only // default to using the read_only string
   const identifier = state.selectedDatabaseId
 
   const resolvedSql = typeof sql === 'function' ? sql([]) : sql

--- a/apps/studio/hooks/analytics/useDbQuery.tsx
+++ b/apps/studio/hooks/analytics/useDbQuery.tsx
@@ -10,6 +10,7 @@ import {
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { executeSql } from '@/data/sql/execute-sql-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { IS_PLATFORM } from '@/lib/constants'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 export interface DbQueryHook<T = any> {
@@ -46,6 +47,13 @@ const useDbQuery = ({
   )?.connection_string_read_only // default to using the read_only string
   const identifier = state.selectedDatabaseId
 
+  // When a read-replica is selected, require its connection string before fetching.
+  // Falling back to the primary's connection string would silently query the wrong database.
+  const isPrimarySelected = !state.selectedDatabaseId || state.selectedDatabaseId === project?.ref
+  const effectiveConnectionString = isPrimarySelected
+    ? (connectionString ?? project?.connectionString)
+    : connectionString
+
   const resolvedSql = typeof sql === 'function' ? sql([]) : sql
 
   const {
@@ -59,7 +67,7 @@ const useDbQuery = ({
       'projects',
       project?.ref,
       'db',
-      { ...params, sql: resolvedSql, identifier },
+      { ...params, sql: resolvedSql, identifier, connectionString: effectiveConnectionString },
       where,
       orderBy,
     ],
@@ -67,13 +75,17 @@ const useDbQuery = ({
       return executeSql(
         {
           projectRef: project?.ref,
-          connectionString: connectionString || project?.connectionString,
+          connectionString: effectiveConnectionString,
           sql: resolvedSql,
         },
         signal
       ).then((res) => res.result) as Promise<MetaQueryResponse>
     },
-    enabled: Boolean(resolvedSql),
+    // Don't run until we have a connection string for the selected database.
+    // For replicas this prevents a silent fallback to the primary before replicas load.
+    // In self-hosted mode (IS_PLATFORM=false) there is no real connection string, so we
+    // skip the check — executeSql works fine without one on self-hosted deployments.
+    enabled: Boolean(resolvedSql) && (!IS_PLATFORM || Boolean(effectiveConnectionString)),
     refetchOnWindowFocus: false,
     refetchOnReconnect: false,
   })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

function change

## What is the current behavior?

defaults to the read-write connection string when doing observability report queries

## What is the new behavior?

uses the read-only connection string instead

## Additional context

these should only ever be read-only operations, reporting should not have side effects and this adds a guardrail to ensure that remains the case


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Corrected database replica query handling by using read-only connection strings for replica database access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->