### PR TITLE
fix link to prompt directory

### DIFF
--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -28,7 +28,7 @@ After you log in, check that the MCP server is connected. For instance, in Curso
 
 To verify the client has access to the MCP server tools, try asking it to query your project or database using natural language. For example: "What tables are there in the database? Use MCP tools."
 
-For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/examples/prompts) collection.
+For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/docs/guides/getting-started/ai-prompts) collection.
 
 ## Available tools
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -28,7 +28,7 @@ After you log in, check that the MCP server is connected. For instance, in Curso
 
 To verify the client has access to the MCP server tools, try asking it to query your project or database using natural language. For example: "What tables are there in the database? Use MCP tools."
 
-For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/guides/getting-started/ai-prompts) collection.
+For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/examples/prompts) collection.
 
 ## Available tools
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update, fix the link to example prompts directory

## What is the current behavior?

It redirected to a non existent url: https://supabase.com/guides/getting-started/ai-prompts

## What is the new behavior?

Redirects to the prompt directory.

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed the "AI Prompts" link in the MCP getting-started guide to point to the correct documentation resources page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->