### PR TITLE
fix: auth provider form for sms is invalid when using sms hook

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -40,6 +40,7 @@ interface FormFieldProps {
   control: Control
   hasAccess: boolean
   disabled?: boolean
+  readOnly?: boolean
 }
 
 const FormField = ({
@@ -50,6 +51,7 @@ const FormField = ({
   control,
   hasAccess,
   disabled: disabledProp,
+  readOnly,
 }: FormFieldProps) => {
   const { description: originalDescription } = properties
   let description = originalDescription
@@ -95,7 +97,7 @@ const FormField = ({
             <FormField_Shadcn_
               control={control}
               name={name}
-              disabled={disabled}
+              disabled={disabled || readOnly}
               render={({ field }) => (
                 <FormItemLayout
                   layout="horizontal"
@@ -160,9 +162,16 @@ const FormField = ({
                 >
                   <FormControl_Shadcn_ className="col-span-6">
                     {properties.isSecret ? (
-                      <DataInput {...field} id={name} size="small" copy reveal />
+                      <DataInput
+                        {...field}
+                        id={name}
+                        size="small"
+                        copy
+                        reveal
+                        readOnly={readOnly}
+                      />
                     ) : (
-                      <Input_Shadcn_ {...field} id={name} />
+                      <Input_Shadcn_ {...field} id={name} readOnly={readOnly} />
                     )}
                   </FormControl_Shadcn_>
                 </FormItemLayout>
@@ -198,6 +207,7 @@ const FormField = ({
                       rows={4}
                       placeholder="Enter multi-line text"
                       className="resize-none"
+                      readOnly={readOnly}
                     />
                   </FormControl_Shadcn_>
                 </FormItemLayout>
@@ -234,6 +244,7 @@ const FormField = ({
                           id={name}
                           type="number"
                           onChange={(e) => field.onChange(Number(e.target.value))}
+                          readOnly={readOnly}
                         />
                         <InputGroupAddon align="inline-end">
                           <ReactMarkdown unwrapDisallowed disallowedElements={['p']}>
@@ -246,6 +257,7 @@ const FormField = ({
                         {...field}
                         id={name}
                         type="number"
+                        readOnly={readOnly}
                         onChange={(e) => field.onChange(Number(e.target.value))}
                       />
                     )}

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -277,7 +277,7 @@ const FormField = ({
             <FormField_Shadcn_
               control={control}
               name={name}
-              disabled={disabled}
+              disabled={disabled || readOnly}
               render={({ field }) => (
                 <FormItemLayout
                   layout="horizontal"
@@ -320,7 +320,7 @@ const FormField = ({
             <FormField_Shadcn_
               control={control}
               name={name}
-              disabled={disabled}
+              disabled={disabled || readOnly}
               render={({ field }) => (
                 <FormItemLayout
                   layout="horizontal"

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -231,7 +231,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
                     name={x}
                     properties={provider.properties[x]}
                     control={form.control}
-                    disabled={shouldDisableField(x) || !canUpdateConfig}
+                    readOnly={shouldDisableField(x) || !canUpdateConfig}
                     hasAccess={hasAccess}
                   />
                 )

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -111,8 +111,12 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
   )
 
   const INITIAL_VALUES = useMemo(() => {
+    // This check will always be true but let us avoid adding an eslint disable comment on unused memo dependencies
+    // which could hide real issues in the future.
+    // Adding the provider in the memo dependencies ensures the INITIAL_VALUES is properly applied
+    if (!provider) return
     return getValuesForProvider(config)
-  }, [config, getValuesForProvider])
+  }, [config, getValuesForProvider, provider])
 
   const onSubmit = (values: any) => {
     const payload = { ...values }


### PR DESCRIPTION
## Problem

When users have enabled a SMS hook, they can't update the TOPT test values anymore.
This is because `formik` sent disabled inputs values in the form payload while `react-hook-form` correctly does not.

## Solution

Make the inputs read only instead of disabled

## How to test

- Enable SMS auth
- Add a SMS hook
- Update the SMS auth settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Authentication provider form fields now use read-only mode instead of being disabled, preserving focus and interaction while preventing edits across text, secret, multiline, numeric, select, boolean, and datetime inputs.
  * A new optional read-only prop was added to form fields for consistent behavior.

* **Fixes**
  * Initial form values recalculation was corrected so they update reliably when the selected provider changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->