### PR TITLE
test(e2e): add E2E test verifying Cline appears in MCP Client dropdown

### DIFF
--- a/e2e/studio/features/connect.spec.ts
+++ b/e2e/studio/features/connect.spec.ts
@@ -53,4 +53,57 @@ test.describe('Connect', async () => {
     // Verify the URL has the showConnect query param
     await expect(page).toHaveURL(/showConnect=true/)
   })
+
+  test('MCP mode shows Cline as a selectable client', async ({ page, ref }) => {
+    // Navigate to project page with ConnectSheet open
+    await page.goto(toUrl(`/project/${ref}?showConnect=true`))
+
+    // Wait for the ConnectSheet to be visible
+    await expect(
+      page.getByRole('heading', { name: 'Connect to your project' }),
+      'ConnectSheet heading should be visible after navigation'
+    ).toBeVisible({ timeout: 30000 })
+
+    // Switch to MCP mode
+    await page.getByRole('button', { name: /MCP/i }).click()
+
+    // The Client dropdown should be visible
+    await expect(
+      page.getByText('Client'),
+      'Client label should be visible after switching to MCP mode'
+    ).toBeVisible({ timeout: 10000 })
+
+    // Open the client dropdown and search for Cline
+    // The dropdown trigger button should show the default client (Claude Code)
+    // Click to open it
+    const clientDropdownTrigger = page
+      .locator('button')
+      .filter({ hasText: /Claude Code|Cursor|Cline/ })
+      .first()
+    await clientDropdownTrigger.click()
+
+    // Search for Cline in the dropdown search
+    await page.getByPlaceholder('Search...').fill('Cline')
+
+    // Cline should appear in the dropdown options
+    await expect(
+      page.getByRole('option', { name: /Cline/ }),
+      'Cline should appear as an option in the client dropdown'
+    ).toBeVisible({ timeout: 10000 })
+
+    // Select Cline
+    await page.getByRole('option', { name: /Cline/ }).click()
+
+    // Verify the dropdown now shows Cline as selected
+    await expect(
+      clientDropdownTrigger,
+      'Client dropdown trigger should show Cline after selection'
+    ).toContainText('Cline')
+
+    // Verify the configuration display shows the .cline/mcp_settings.json config file reference
+    await expect(
+      page.getByText('.cline/mcp_settings.json'),
+      'Cline MCP config file path should be shown after selecting Cline'
+    ).toBeVisible({ timeout: 10000 })
+  })
 })


### PR DESCRIPTION
Adds a new Playwright E2E test to `e2e/studio/features/connect.spec.ts` that verifies the full Cline MCP client flow in the ConnectSheet:

## What this test covers

1. Opens the ConnectSheet via `?showConnect=true` query param
2. Switches to MCP mode
3. Opens the client dropdown and searches for "Cline"
4. Verifies Cline appears as a selectable option
5. Selects Cline from the dropdown
6. Verifies the dropdown updates to show Cline as selected
7. Verifies the `.cline/mcp_settings.json` config file path is displayed

## Conventions followed

- Uses `test` from `../utils/test.js` and `toUrl` from `../utils/to-url.js`
- Descriptive messages on all `expect()` calls for debugging
- Generous timeouts (30s for page loads, 10s for interactions)
- No `waitForTimeout` or `force: true` anti-patterns

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added E2E test coverage for MCP mode functionality, including Cline client selection through a dropdown interface and configuration file validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->