### PR TITLE
Self hosted/docs saml sso auth v1

### DIFF
--- a/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
@@ -300,6 +300,21 @@ On the IdP side, create a new SAML application and configure it with your SP det
 
 </TabPanel>
 
+<TabPanel id="auth0" label="Auth0">
+
+**Auth0:**
+
+- Dashboard → Applications → Applications → Create Application → Regular Web Application
+- Settings tab → Advanced Settings → Endpoints tab
+- Copy the **SAML Metadata URL** (this is the IdP metadata URL for Supabase)
+- Settings tab → Advanced Settings → Add-ons → SAML2 Web App
+- Enable SAML2 Web App add-on
+- Settings tab in the add-on:
+  - Application Callback URL (ACS): `{API_EXTERNAL_URL}/auth/v1/sso/saml/acs`
+- Enable the add-on
+
+</TabPanel>
+
 </Tabs>
 
 ## Attribute mapping

--- a/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
@@ -23,7 +23,7 @@ You need:
 - Open SSL installed (for key generation)
 - Your IdP's SAML metadata URL or metadata XML
 - The `SERVICE_ROLE_KEY` from your `.env` file (needed for admin API calls)
-- `API_EXTERNAL_URL` set to the publicly-accessible URL of your Supabase Auth service (e.g., `https://<your-domain>`). This URL is used as the SAML Service Provider entity ID and for constructing the ACS endpoint URL
+- `API_EXTERNAL_URL` set to the publicly-accessible URL of your Supabase Auth service (e.g., `https://<your-domain>`). This URL is used as the base for constructing the SAML Service Provider entity ID and ACS endpoint URL
 
 ## How SAML SSO works in Supabase
 
@@ -37,7 +37,7 @@ The login flow works as follows:
 1. Your app calls `POST /auth/v1/sso` with a domain or provider_id
 2. Auth generates a SAML `AuthnRequest` and returns a redirect URL to the IdP
 3. The user authenticates at the IdP
-4. The IdP POSTs a SAML Response to `POST /sso/saml/acs`
+4. The IdP POSTs a SAML Response to `POST /auth/v1/sso/saml/acs`
 5. Auth validates the assertion, creates or links the user, and issues a session
 6. The user is redirected back to your app with session tokens
 
@@ -89,10 +89,6 @@ SAML_PRIVATE_KEY=<your-base64-encoded-private-key>
 # Optional: how long relay state tokens remain valid (default: 2m0s)
 # SAML_RELAY_STATE_VALIDITY_PERIOD=2m0s
 
-# Optional: override the SAML entity ID / ACS base URL
-# Defaults to API_EXTERNAL_URL if not set
-# SAML_EXTERNAL_URL=https://supabase.example.com:8000
-
 # Optional: rate limit on the ACS endpoint (requests per second, default: 15)
 # SAML_RATE_LIMIT_ASSERTION=15
 ```
@@ -109,9 +105,9 @@ auth:
     # SAML SSO
     GOTRUE_SAML_ENABLED: ${SAML_ENABLED}
     GOTRUE_SAML_PRIVATE_KEY: ${SAML_PRIVATE_KEY}
+    GOTRUE_SAML_EXTERNAL_URL: ${API_EXTERNAL_URL}/auth/v1
     # GOTRUE_SAML_ALLOW_ENCRYPTED_ASSERTIONS: ${SAML_ALLOW_ENCRYPTED_ASSERTIONS}
     # GOTRUE_SAML_RELAY_STATE_VALIDITY_PERIOD: ${SAML_RELAY_STATE_VALIDITY_PERIOD}
-    # GOTRUE_SAML_EXTERNAL_URL: ${SAML_EXTERNAL_URL}
     # GOTRUE_SAML_RATE_LIMIT_ASSERTION: ${SAML_RATE_LIMIT_ASSERTION}
 ```
 
@@ -132,12 +128,12 @@ docker compose ps auth
 
 ## Step 5: Retrieve your service provider metadata
 
-Once SAML is enabled, your Supabase instance exposes service provider (SP) metadata at `{API_EXTERNAL_URL}/sso/saml/metadata`.
+Once SAML is enabled, your Supabase instance exposes service provider (SP) metadata at `{API_EXTERNAL_URL}/auth/v1/sso/saml/metadata`.
 
 Verify it using `curl`:
 
 ```sh
-curl http://<your-domain>/sso/saml/metadata
+curl http://<your-domain>/auth/v1/sso/saml/metadata
 ```
 
 This returns an XML document containing your SP entity ID, ACS endpoint URL, and signing certificate. You will need to provide this to your IdP.
@@ -154,8 +150,8 @@ Key values in the metadata:
 {/* supa-mdx-lint-disable Rule003Spelling */}
 | Field | Value |
 |---|---|
-| Entity ID | `{API_EXTERNAL_URL}/sso/saml/metadata` |
-| ACS URL | `{API_EXTERNAL_URL}/sso/saml/acs` |
+| Entity ID | `{API_EXTERNAL_URL}/auth/v1/sso/saml/metadata` |
+| ACS URL | `{API_EXTERNAL_URL}/auth/v1/sso/saml/acs` |
 | NameID formats | `persistent`, `emailAddress` |
 | Signing certificate | Derived from your `SAML_PRIVATE_KEY` |
 {/* supa-mdx-lint-enable Rule003Spelling */}
@@ -252,8 +248,8 @@ On the IdP side, create a new SAML application and configure it with your SP det
 {/* supa-mdx-lint-disable Rule003Spelling */}
 | IdP setting | Value |
 |---|---|
-| SP Entity ID / Audience | `{API_EXTERNAL_URL}/sso/saml/metadata` |
-| ACS URL / Reply URL | `{API_EXTERNAL_URL}/sso/saml/acs` |
+| SP Entity ID / Audience | `{API_EXTERNAL_URL}/auth/v1/sso/saml/metadata` |
+| ACS URL / Reply URL | `{API_EXTERNAL_URL}/auth/v1/sso/saml/acs` |
 | NameID format | `persistent` (recommended) or `emailAddress` |
 | Signing certificate | Upload from the SP metadata XML or provide the metadata URL |
 {/* supa-mdx-lint-enable Rule003Spelling */}
@@ -273,8 +269,8 @@ On the IdP side, create a new SAML application and configure it with your SP det
 {/* supa-mdx-lint-disable Rule003Spelling */}
 
 - Create a "SAML 2.0" application
-- Single Sign-On URL: `{API_EXTERNAL_URL}/sso/saml/acs`
-- Audience URI (SP Entity ID): `{API_EXTERNAL_URL}/sso/saml/metadata`
+- Single Sign-On URL: `{API_EXTERNAL_URL}/auth/v1/sso/saml/acs`
+- Audience URI (SP Entity ID): `{API_EXTERNAL_URL}/auth/v1/sso/saml/metadata`
 - Default RelayState: leave blank
 - Name ID format: `Persistent`
   {/* supa-mdx-lint-enable Rule003Spelling */}
@@ -287,8 +283,8 @@ On the IdP side, create a new SAML application and configure it with your SP det
 
 - Create an "Enterprise Application" → "Non-gallery application"
 - Set up single sign-on → SAML
-- Identifier (Entity ID): `{API_EXTERNAL_URL}/sso/saml/metadata`
-- Reply URL (ACS): `{API_EXTERNAL_URL}/sso/saml/acs`
+- Identifier (Entity ID): `{API_EXTERNAL_URL}/auth/v1/sso/saml/metadata`
+- Reply URL (ACS): `{API_EXTERNAL_URL}/auth/v1/sso/saml/acs`
 - Metadata URL for Auth: App Federation Metadata URL (from the SAML Signing Certificate section)
 
 </TabPanel>
@@ -298,8 +294,8 @@ On the IdP side, create a new SAML application and configure it with your SP det
 **Google Workspace:**
 
 - Admin console → Apps → Web and mobile apps → Add custom SAML app
-- ACS URL: `{API_EXTERNAL_URL}/sso/saml/acs`
-- Entity ID: `{API_EXTERNAL_URL}/sso/saml/metadata`
+- ACS URL: `{API_EXTERNAL_URL}/auth/v1/sso/saml/acs`
+- Entity ID: `{API_EXTERNAL_URL}/auth/v1/sso/saml/metadata`
 - Name ID format: `PERSISTENT`
 
 </TabPanel>
@@ -528,7 +524,6 @@ The response should include `app_metadata.provider: "sso:saml"` and any mapped a
 | `SAML_PRIVATE_KEY` | - | Base64-encoded PKCS#1 RSA private key (min 2048-bit). Used to sign SAML requests and optionally decrypt assertions. |
 | `SAML_ALLOW_ENCRYPTED_ASSERTIONS` | `false` | Accept encrypted SAML assertions from IdPs |
 | `SAML_RELAY_STATE_VALIDITY_PERIOD` | `2m0s` | How long relay state tokens remain valid. Increase if users on slow networks time out during the IdP redirect. |
-| `SAML_EXTERNAL_URL` | `API_EXTERNAL_URL` | Override the base URL used for the SAML entity ID and ACS endpoint. Only needed if the SAML endpoints are served on a different URL than the rest of the Auth API. |
 | `SAML_RATE_LIMIT_ASSERTION` | `15` | Maximum ACS requests per second. Protects against assertion replay floods. |
 {/* supa-mdx-lint-enable Rule003Spelling */}
 
@@ -561,7 +556,7 @@ base64 -w 0 -i pk_rsa1.der
 ### IdP cannot reach the ACS endpoint
 
 - Verify `API_EXTERNAL_URL` is set to a URL the IdP can reach (not `localhost` unless testing locally)
-- Check that the Kong routes for `/sso/saml/acs` and `/sso/saml/metadata` are configured as open (no `key-auth` plugin).
+- Check that the Kong routes for `/auth/v1/sso/saml/acs` and `/auth/v1/sso/saml/metadata` are configured as open (no `key-auth` plugin).
 - Check the Auth container logs: `docker compose logs auth`
 
 ### "No SSO provider found for this domain"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The SAML SSO documentation referenced old endpoints at `/sso/saml/*` and included `SAML_EXTERNAL_URL` configuration that is no longer needed.

## What is the new behavior?

- Updates all SAML endpoint URLs from `/sso/saml/acs` and `/sso/saml/metadata` to `/auth/v1/sso/saml/acs` and `/auth/v1/sso/saml/metadata`
- Removes documentation for `SAML_EXTERNAL_URL` environment variable
- Updates `GOTRUE_SAML_EXTERNAL_URL` in docker-compose example to use fixed value
- Updates all IdP configuration examples (Okta, Azure AD, Google Workspace) with new endpoint URLs
- Adds Auth0 as a new IdP option with complete setup instructions
- Updates troubleshooting section to reference new Kong route paths

## Additional context

This documentation update aligns with the technical changes made to move SAML endpoints under the `/auth/v1` base path. The Auth0 addition provides users with another enterprise IdP option for SAML SSO.
**Files changed:**
- `apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx`
**Related PR:** #44824 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosted SAML SSO configuration guide with corrected API endpoint paths for proper setup
  * Added Auth0-specific SAML Web App configuration instructions
  * Enhanced troubleshooting guidance for verifying SAML routes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->