### PR TITLE
chore: Add new OAuth scopes for analytics config to studio

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/AuthorizeRequesterDetails.tsx
@@ -99,6 +99,11 @@ export const AuthorizeRequesterDetails = ({
             hasWriteScope={scopes.includes(OAuthScope.ANALYTICS_WRITE)}
           />
           <ScopeSection
+            description={PERMISSIONS_DESCRIPTIONS.ANALYTICS_CONFIG}
+            hasReadScope={scopes.includes(OAuthScope.ANALYTICS_CONFIG_READ)}
+            hasWriteScope={scopes.includes(OAuthScope.ANALYTICS_CONFIG_WRITE)}
+          />
+          <ScopeSection
             description={PERMISSIONS_DESCRIPTIONS.AUTH}
             hasReadScope={scopes.includes(OAuthScope.AUTH_READ)}
             hasWriteScope={scopes.includes(OAuthScope.AUTH_WRITE)}

--- a/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.constants.ts
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/OAuthApps.constants.ts
@@ -1,5 +1,6 @@
 export const PERMISSIONS_DESCRIPTIONS = {
   ANALYTICS: 'access to analytics logs.',
+  ANALYTICS_CONFIG: 'access to analytics logs configurations.',
   AUTH: 'access to auth configurations and SSO providers.',
   DATABASE:
     'access to Postgres configurations, SQL snippets, SSL enforcement configurations and Typescript schema types.',

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/Scopes.tsx
@@ -117,6 +117,14 @@ export const ScopesPanel = ({
         setScopes={setScopes}
       />
       <Scope
+        title="Analytics Config"
+        description={PERMISSIONS_DESCRIPTIONS.ANALYTICS_CONFIG}
+        readScopeName={OAuthScope.ANALYTICS_CONFIG_READ}
+        writeScopeName={OAuthScope.ANALYTICS_CONFIG_WRITE}
+        scopes={scopes}
+        setScopes={setScopes}
+      />
+      <Scope
         title="Auth"
         description={PERMISSIONS_DESCRIPTIONS.AUTH}
         readScopeName={OAuthScope.AUTH_READ}

--- a/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
@@ -40,7 +40,7 @@ export const ProjectClaimConfirm = ({
   const { invalidateProjectsQuery } = useInvalidateProjectsInfiniteQuery()
 
   const { mutateAsync: approveRequest, isPending: isApproving } =
-    useApiAuthorizationApproveMutation({ onError: () => { } })
+    useApiAuthorizationApproveMutation({ onError: () => {} })
 
   const { mutateAsync: claimProject, isPending: isClaiming } = useOrganizationProjectClaimMutation()
 

--- a/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
+++ b/apps/studio/components/interfaces/Organization/ProjectClaim/confirm.tsx
@@ -40,7 +40,7 @@ export const ProjectClaimConfirm = ({
   const { invalidateProjectsQuery } = useInvalidateProjectsInfiniteQuery()
 
   const { mutateAsync: approveRequest, isPending: isApproving } =
-    useApiAuthorizationApproveMutation({ onError: () => {} })
+    useApiAuthorizationApproveMutation({ onError: () => { } })
 
   const { mutateAsync: claimProject, isPending: isClaiming } = useOrganizationProjectClaimMutation()
 
@@ -198,6 +198,11 @@ export const ProjectClaimConfirm = ({
                     description={PERMISSIONS_DESCRIPTIONS.ANALYTICS}
                     hasReadScope={requester.scopes.includes(OAuthScope.ANALYTICS_READ)}
                     hasWriteScope={requester.scopes.includes(OAuthScope.ANALYTICS_WRITE)}
+                  />
+                  <ScopeSection
+                    description={PERMISSIONS_DESCRIPTIONS.ANALYTICS_CONFIG}
+                    hasReadScope={requester.scopes.includes(OAuthScope.ANALYTICS_CONFIG_READ)}
+                    hasWriteScope={requester.scopes.includes(OAuthScope.ANALYTICS_CONFIG_WRITE)}
                   />
                   <ScopeSection
                     description={PERMISSIONS_DESCRIPTIONS.AUTH}

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -64,7 +64,7 @@
     "@supabase/mcp-utils": "^0.4.0",
     "@supabase/pg-meta": "workspace:*",
     "@supabase/realtime-js": "catalog:",
-    "@supabase/shared-types": "0.1.84",
+    "@supabase/shared-types": "0.1.88",
     "@supabase/sql-to-rest": "^0.1.6",
     "@supabase/supabase-js": "catalog:",
     "@tanstack/react-query": "^5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -959,8 +959,8 @@ importers:
         specifier: 'catalog:'
         version: 2.103.0
       '@supabase/shared-types':
-        specifier: 0.1.84
-        version: 0.1.84
+        specifier: 0.1.88
+        version: 0.1.88
       '@supabase/sql-to-rest':
         specifier: ^0.1.6
         version: 0.1.6(encoding@0.1.13)(supports-color@8.1.1)
@@ -8773,8 +8773,8 @@ packages:
     resolution: {integrity: sha512-gcPtXzZ6izyyBVf2of7K3dEt8CScPJn8VcSlQq6oWL9QoE1kqfQl0oFrOMHd5qrcADewxI7OxxosLB8W4XqtIQ==}
     engines: {node: '>=20.0.0'}
 
-  '@supabase/shared-types@0.1.84':
-    resolution: {integrity: sha512-0bcV8Il0r5zybdY6gIWEmbJ/5VGGw60p9SOZ8tUe3x7iKxW/2H+CmPezyqQHuwYURxF4Gf18zJfENlaDyn+g8w==}
+  '@supabase/shared-types@0.1.88':
+    resolution: {integrity: sha512-9LYy+pD6cD2o8ZSxeUeJ1nrHPigeoP1kzhd2+k6MmzrwBHwxwUhWjywQJVjpU6fLNQxdkoNqxPfI7UQgOjG7Lg==}
 
   '@supabase/sql-to-rest@0.1.6':
     resolution: {integrity: sha512-06KgjeINtc6405XQvfnchBE1azEsU8G2NElfadmvVHKmHa5l2bFzjbtFbpaYgpgTzccHlcDmBaCgedVf2Gyl8Q==}
@@ -26414,7 +26414,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@supabase/shared-types@0.1.84': {}
+  '@supabase/shared-types@0.1.88': {}
 
   '@supabase/sql-to-rest@0.1.6(encoding@0.1.13)(supports-color@8.1.1)':
     dependencies:


### PR DESCRIPTION
## Summary

Adds support for new OAuth scopes for reading and writing analytics config to the app creation dialog and consent screen.

Depends on https://github.com/supabase/platform/pull/31539

## Test Plan

- [ ] Create app and assign it the new scopes.
- [ ] Use an OAuth client to initiate authorization flow for the app.
- [ ] Verify that new scopes are present in the consent screen.

<img width="1427" height="1140" alt="Screenshot 2026-04-13 at 3 55 01 PM" src="https://github.com/user-attachments/assets/7fae1939-5651-48d2-9a3d-798ae0dca81e" />
<img width="1427" height="1140" alt="Screenshot 2026-04-13 at 3 55 24 PM" src="https://github.com/user-attachments/assets/0679e7e8-4c36-4590-b6e1-a2f3ea9adf52" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics configuration access permission for OAuth apps, allowing users to grant read/write access to analytics logs configurations during app authorization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->