### PR TITLE
fix: reset identity and serial sequences after CSV import

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -1,4 +1,6 @@
+// AFTER — add these two imports:
 import * as Sentry from '@sentry/nextjs'
+import { getUpdateIdentitySequenceSQL, getUpdateSerialSequenceSQL } from '@supabase/pg-meta'
 import type { PostgresColumn, PostgresTable } from '@supabase/postgres-meta'
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
@@ -50,6 +52,7 @@ import { entityTypeKeys } from '@/data/entity-types/keys'
 import { lintKeys } from '@/data/lint/keys'
 import { privilegeKeys } from '@/data/privileges/keys'
 import { useTableApiAccessPrivilegesMutation } from '@/data/privileges/table-api-access-mutation'
+import { executeSql } from '@/data/sql/execute-sql-query'
 import { tableEditorKeys } from '@/data/table-editor/keys'
 import { isTableLike, type Entity } from '@/data/table-editor/table-editor-types'
 import { tableRowKeys } from '@/data/table-rows/keys'
@@ -901,6 +904,52 @@ export const SidePanelEditor = ({
       }
     }
 
+    // Reset sequences for identity and serial columns to avoid unique key
+    // violations on subsequent inserts (fixes #43993).
+    // selectedTable.columns uses snake_case (RetrieveTableResult shape).
+    const identityColumns = (selectedTable.columns ?? []).filter((col) => col.is_identity)
+    const serialColumns = (selectedTable.columns ?? []).filter(
+      (col) =>
+        !col.is_identity &&
+        typeof col.default_value === 'string' &&
+        col.default_value.startsWith('nextval(')
+    )
+
+    const sequenceSQLStatements = [
+      ...identityColumns.map((col) =>
+        getUpdateIdentitySequenceSQL({
+          schema: selectedTable.schema,
+          table: selectedTable.name,
+          column: col.name,
+        })
+      ),
+      ...serialColumns.map((col) =>
+        getUpdateSerialSequenceSQL({
+          schema: selectedTable.schema,
+          table: selectedTable.name,
+          column: col.name,
+        })
+      ),
+    ]
+
+    if (sequenceSQLStatements.length > 0) {
+      try {
+        await executeSql({
+          projectRef: project.ref,
+          connectionString: project.connectionString,
+          sql: sequenceSQLStatements.join(';\n'),
+          queryKey: ['sequences', 'update-batch'],
+        })
+      } catch (error) {
+        console.warn('Failed to update sequences after CSV import:', error)
+        toast.warning(
+          'Data imported successfully, but sequences could not be updated. ' +
+            'New inserts may fail until sequences are manually reset.',
+          { id: toastId }
+        )
+      }
+    }
+
     await queryClient.invalidateQueries({
       queryKey: tableRowKeys.tableRowsAndCount(project?.ref, selectedTable?.id),
     })
@@ -909,105 +958,105 @@ export const SidePanelEditor = ({
     })
     resolve()
     snap.closeSidePanel()
-  }
 
-  const onClosePanel = confirmOnClose
+    const onClosePanel = confirmOnClose
 
-  return (
-    <>
-      {!isUndefined(selectedTable) && (
-        <RowEditor
-          row={snap.sidePanel?.type === 'row' ? snap.sidePanel.row : undefined}
-          selectedTable={selectedTable}
-          visible={snap.sidePanel?.type === 'row'}
-          editable={editable}
-          closePanel={onClosePanel}
-          saveChanges={saveRow}
-          updateEditorDirty={() => setIsEdited(true)}
-        />
-      )}
-      {!isUndefined(selectedTable) && (
-        <ColumnEditor
-          column={
-            snap.sidePanel?.type === 'column'
-              ? (snap.sidePanel.column as unknown as PostgresColumn)
+    return (
+      <>
+        {!isUndefined(selectedTable) && (
+          <RowEditor
+            row={snap.sidePanel?.type === 'row' ? snap.sidePanel.row : undefined}
+            selectedTable={selectedTable}
+            visible={snap.sidePanel?.type === 'row'}
+            editable={editable}
+            closePanel={onClosePanel}
+            saveChanges={saveRow}
+            updateEditorDirty={() => setIsEdited(true)}
+          />
+        )}
+        {!isUndefined(selectedTable) && (
+          <ColumnEditor
+            column={
+              snap.sidePanel?.type === 'column'
+                ? (snap.sidePanel.column as unknown as PostgresColumn)
+                : undefined
+            }
+            selectedTable={selectedTable}
+            visible={snap.sidePanel?.type === 'column'}
+            closePanel={onClosePanel}
+            saveChanges={saveColumn}
+            updateEditorDirty={() => setIsEdited(true)}
+          />
+        )}
+        <TableEditor
+          table={
+            snap.sidePanel?.type === 'table' &&
+            (snap.sidePanel.mode === 'edit' || snap.sidePanel.mode === 'duplicate')
+              ? selectedTable
               : undefined
           }
-          selectedTable={selectedTable}
-          visible={snap.sidePanel?.type === 'column'}
+          isDuplicating={isDuplicating}
+          templateData={
+            snap.sidePanel?.type === 'table' && snap.sidePanel.templateData
+              ? {
+                  ...snap.sidePanel.templateData,
+                  columns: snap.sidePanel.templateData.columns
+                    ? [...snap.sidePanel.templateData.columns]
+                    : undefined,
+                }
+              : undefined
+          }
+          visible={snap.sidePanel?.type === 'table'}
           closePanel={onClosePanel}
-          saveChanges={saveColumn}
+          saveChanges={saveTable}
           updateEditorDirty={() => setIsEdited(true)}
+          apiAccessToggleHandler={apiAccessToggleHandler}
         />
-      )}
-      <TableEditor
-        table={
-          snap.sidePanel?.type === 'table' &&
-          (snap.sidePanel.mode === 'edit' || snap.sidePanel.mode === 'duplicate')
-            ? selectedTable
-            : undefined
-        }
-        isDuplicating={isDuplicating}
-        templateData={
-          snap.sidePanel?.type === 'table' && snap.sidePanel.templateData
-            ? {
-                ...snap.sidePanel.templateData,
-                columns: snap.sidePanel.templateData.columns
-                  ? [...snap.sidePanel.templateData.columns]
-                  : undefined,
-              }
-            : undefined
-        }
-        visible={snap.sidePanel?.type === 'table'}
-        closePanel={onClosePanel}
-        saveChanges={saveTable}
-        updateEditorDirty={() => setIsEdited(true)}
-        apiAccessToggleHandler={apiAccessToggleHandler}
-      />
-      <SchemaEditor
-        visible={snap.sidePanel?.type === 'schema'}
-        onSuccess={onClosePanel}
-        closePanel={onClosePanel}
-      />
-      <JsonEditor
-        visible={snap.sidePanel?.type === 'json'}
-        row={(snap.sidePanel?.type === 'json' && snap.sidePanel.jsonValue.row) || {}}
-        column={(snap.sidePanel?.type === 'json' && snap.sidePanel.jsonValue.column) || ''}
-        backButtonLabel="Cancel"
-        applyButtonLabel={isQueueOperationsEnabled ? 'Queue changes' : 'Save changes'}
-        readOnly={!editable}
-        closePanel={onClosePanel}
-        onSaveJSON={onSaveColumnValue}
-      />
-      <TextEditor
-        visible={snap.sidePanel?.type === 'cell'}
-        column={(snap.sidePanel?.type === 'cell' && snap.sidePanel.value?.column) || ''}
-        row={(snap.sidePanel?.type === 'cell' && snap.sidePanel.value?.row) || {}}
-        closePanel={onClosePanel}
-        onSaveField={onSaveColumnValue}
-      />
-      <ForeignRowSelector
-        visible={snap.sidePanel?.type === 'foreign-row-selector'}
-        // @ts-ignore
-        foreignKey={
-          snap.sidePanel?.type === 'foreign-row-selector'
-            ? snap.sidePanel.foreignKey.foreignKey
-            : undefined
-        }
-        isSaving={isEditPending}
-        closePanel={onClosePanel}
-        onSelect={onSaveForeignRow}
-      />
-      <SpreadsheetImport
-        key={csvImportKey}
-        visible={snap.sidePanel?.type === 'csv-import'}
-        selectedTable={selectedTable}
-        saveContent={onImportData}
-        closePanel={onClosePanel}
-        updateEditorDirty={setIsEdited}
-      />
-      <OperationQueueSidePanel />
-      <DiscardChangesConfirmationDialog {...modalProps} />
-    </>
-  )
+        <SchemaEditor
+          visible={snap.sidePanel?.type === 'schema'}
+          onSuccess={onClosePanel}
+          closePanel={onClosePanel}
+        />
+        <JsonEditor
+          visible={snap.sidePanel?.type === 'json'}
+          row={(snap.sidePanel?.type === 'json' && snap.sidePanel.jsonValue.row) || {}}
+          column={(snap.sidePanel?.type === 'json' && snap.sidePanel.jsonValue.column) || ''}
+          backButtonLabel="Cancel"
+          applyButtonLabel={isQueueOperationsEnabled ? 'Queue changes' : 'Save changes'}
+          readOnly={!editable}
+          closePanel={onClosePanel}
+          onSaveJSON={onSaveColumnValue}
+        />
+        <TextEditor
+          visible={snap.sidePanel?.type === 'cell'}
+          column={(snap.sidePanel?.type === 'cell' && snap.sidePanel.value?.column) || ''}
+          row={(snap.sidePanel?.type === 'cell' && snap.sidePanel.value?.row) || {}}
+          closePanel={onClosePanel}
+          onSaveField={onSaveColumnValue}
+        />
+        <ForeignRowSelector
+          visible={snap.sidePanel?.type === 'foreign-row-selector'}
+          // @ts-ignore
+          foreignKey={
+            snap.sidePanel?.type === 'foreign-row-selector'
+              ? snap.sidePanel.foreignKey.foreignKey
+              : undefined
+          }
+          isSaving={isEditPending}
+          closePanel={onClosePanel}
+          onSelect={onSaveForeignRow}
+        />
+        <SpreadsheetImport
+          key={csvImportKey}
+          visible={snap.sidePanel?.type === 'csv-import'}
+          selectedTable={selectedTable}
+          saveContent={onImportData}
+          closePanel={onClosePanel}
+          updateEditorDirty={setIsEdited}
+        />
+        <OperationQueueSidePanel />
+        <DiscardChangesConfirmationDialog {...modalProps} />
+      </>
+    )
+  }
 }

--- a/apps/studio/tests/components/Editor/SpreadsheetImport.utils.test.ts
+++ b/apps/studio/tests/components/Editor/SpreadsheetImport.utils.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from 'vitest'
+import { getUpdateIdentitySequenceSQL, getUpdateSerialSequenceSQL } from '@supabase/pg-meta'
+import { describe, expect, it, test } from 'vitest'
 
 import {
   inferColumnType,
@@ -112,5 +113,51 @@ describe('SpreadsheetImport.utils: parseSpreadsheetText', () => {
       emptyStringAsNullHeaders: undefined,
     })
     expect(headers).toEqual(['name', 'age'])
+  })
+})
+
+describe('getUpdateSerialSequenceSQL', () => {
+  it('generates setval with pg_get_serial_sequence for a basic serial column', () => {
+    const sql = getUpdateSerialSequenceSQL({
+      schema: 'public',
+      table: 'users',
+      column: 'id',
+    })
+    expect(sql).toContain('pg_get_serial_sequence')
+    expect(sql).toContain('setval')
+    expect(sql).toContain('"id"')
+  })
+
+  it('uses CASE to distinguish empty vs non-empty tables', () => {
+    const sql = getUpdateSerialSequenceSQL({
+      schema: 'public',
+      table: 'orders',
+      column: 'order_id',
+    })
+    // 3-arg setval: is_called=false for empty, is_called=true for non-empty
+    expect(sql).toContain('IS NULL')
+    expect(sql).toContain('false')
+    expect(sql).toContain('true')
+  })
+
+  it('safely handles schema/table names that contain single quotes', () => {
+    // literal() should escape these — no raw single quotes in output
+    const sql = getUpdateSerialSequenceSQL({
+      schema: "o'reilly",
+      table: "user's_data",
+      column: 'id',
+    })
+    // The raw unescaped quote should NOT appear (would cause SQL injection)
+    expect(sql).not.toMatch(/pg_get_serial_sequence\('[^']*'[^']*',/)
+  })
+
+  it('handles non-public schemas correctly', () => {
+    const sql = getUpdateSerialSequenceSQL({
+      schema: 'myschema',
+      table: 'products',
+      column: 'product_id',
+    })
+    expect(sql).toContain('"product_id"')
+    expect(sql).toContain('"myschema"."products"')
   })
 })

--- a/packages/pg-meta/src/sql/studio/table-editor/identity.ts
+++ b/packages/pg-meta/src/sql/studio/table-editor/identity.ts
@@ -1,4 +1,4 @@
-import { ident } from '../../../pg-format'
+import { ident, literal } from '../../../pg-format'
 
 export const getUpdateIdentitySequenceSQL = ({
   schema,
@@ -10,6 +10,35 @@ export const getUpdateIdentitySequenceSQL = ({
   column: string
 }) => {
   return `SELECT setval('${ident(schema)}.${ident(`${table}_${column}_seq`)}', (SELECT COALESCE(MAX(${ident(column)}), 1) FROM ${ident(schema)}.${ident(table)}))`
+}
+
+export const getUpdateSerialSequenceSQL = ({
+  schema,
+  table,
+  column,
+}: {
+  schema: string
+  table: string
+  column: string
+}) => {
+  // literal() wraps in single quotes safely — prevents SQL injection
+  // ident() wraps in double quotes for identifiers
+  const seqTable = literal(`${schema}.${table}`)
+  const seqColumn = literal(column)
+  const tableRef = `${ident(schema)}.${ident(table)}`
+  const colRef = ident(column)
+
+  // 3-argument setval(seq, val, is_called):
+  //   is_called=true  → next nextval() returns val+1  (use when rows exist)
+  //   is_called=false → next nextval() returns val itself (use when table is empty)
+  return `
+    SELECT CASE
+      WHEN MAX(${colRef}) IS NULL
+        THEN setval(pg_get_serial_sequence(${seqTable}, ${seqColumn}), 1, false)
+      ELSE setval(pg_get_serial_sequence(${seqTable}, ${seqColumn}), MAX(${colRef}), true)
+    END
+    FROM ${tableRef}
+  `.trim()
 }
 
 export const getDuplicateIdentitySequenceSQL = ({


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.
YES

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When importing data via CSV into a table with identity or serial primary key columns, PostgreSQL sequences are not updated to reflect the imported values. This causes unique key violations on subsequent inserts because the sequence still starts from its previous value, conflicting with the imported IDs.

Fixes #43993

## What is the new behavior?
After a successful CSV import, sequences are reset for both column types:
- **IDENTITY columns** (`GENERATED ALWAYS/BY DEFAULT AS IDENTITY`) via the existing `getUpdateIdentitySequenceSQL`
- **SERIAL columns** (`smallserial`, `serial`, `bigserial`) via the new `getUpdateSerialSequenceSQL`, detected by `nextval(...)` default value

The new `getUpdateSerialSequenceSQL` uses the 3-argument form of `setval(seq, val, is_called)` to correctly handle empty tables — setting `is_called=false` when the table has no rows, so the next insert gets ID 1 rather than 2.

## Additional context
Two existing PRs address this issue but each only covers one column type:
- #44037 handles IDENTITY columns only
- #44304 handles SERIAL columns only, but the function was never wired into the import flow (no call site), and used the 2-arg `setval` which skips ID 1 on empty tables

This PR covers both column types in a single pass and includes unit tests for `getUpdateSerialSequenceSQL`.

**Files changed:**
- `packages/pg-meta/src/sql/studio/table-editor/identity.ts` — adds `getUpdateSerialSequenceSQL`
- `apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx` — wires sequence reset into `onImportData` for both column types
- `apps/studio/tests/components/Editor/SpreadsheetImport.utils.test.ts` — adds unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Auto-incrementing columns now have their sequences automatically updated after CSV/spreadsheet imports.

* **Bug Fixes**
  * Sequence reset failures no longer block data imports; a warning notification is shown instead.

* **Tests**
  * Added test coverage for sequence reset functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->