### PR TITLE
chore(studio): skip Sentry source map upload for local builds

### DIFF
--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -613,9 +613,12 @@ const nextConfig = {
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
+const platformConfig =
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' ? withBundleAnalyzer(nextConfig) : nextConfig
+
 module.exports =
   process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VERCEL === '1'
-    ? withSentryConfig(withBundleAnalyzer(nextConfig), {
+    ? withSentryConfig(platformConfig, {
         silent: true,
 
         // For all available options, see:
@@ -647,4 +650,4 @@ module.exports =
           applicationKey: 'supabase-studio',
         },
       })
-    : nextConfig
+    : platformConfig

--- a/apps/studio/next.config.js
+++ b/apps/studio/next.config.js
@@ -614,7 +614,7 @@ const nextConfig = {
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins
 module.exports =
-  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true'
+  process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VERCEL === '1'
     ? withSentryConfig(withBundleAnalyzer(nextConfig), {
         silent: true,
 


### PR DESCRIPTION
Only wrap with `withSentryConfig` when running on Vercel (`VERCEL === '1'`), matching the existing pattern used for HSTS headers on line 510. The Sentry webpack plugin's `runAfterProductionCompile` step adds ~24s to local production builds for source map upload that isn't needed outside of deployments.

**Changed:**
- Gate `withSentryConfig` on `process.env.VERCEL === '1'` in addition to `NEXT_PUBLIC_IS_PLATFORM === 'true'`

## To test

- Run `pnpm build:studio` locally with `NEXT_PUBLIC_IS_PLATFORM=true` – confirm no `runAfterProductionCompile` step
- Verify Vercel preview deploys still upload source maps to Sentry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refined configuration so error-tracking is enabled only in the designated deployment environment (adds an additional environment check).
  * Adjusted build-tooling to be conditionally enabled on the platform flag, and ensured non-tracked builds export the platform-aware configuration consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->