### PR TITLE
fix(auth): load form values on client-side nav

### DIFF
--- a/apps/studio/components/interfaces/Auth/Passkeys/PasskeysSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/Passkeys/PasskeysSettingsForm.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -253,23 +252,19 @@ export const PasskeysSettingsForm = () => {
     'custom_config_gotrue'
   )
 
+  const formValues =
+    isSuccess && authConfig ? buildPasskeysFormValues(authConfig, project) : undefined
+
   const form = useForm<PasskeysSettings>({
     resolver: zodResolver(schema),
-    defaultValues: {
+    defaultValues: formValues ?? {
       PASSKEY_ENABLED: false,
       WEBAUTHN_RP_ID: '',
       WEBAUTHN_RP_DISPLAY_NAME: '',
       WEBAUTHN_RP_ORIGINS: '',
     },
+    values: formValues,
   })
-
-  useEffect(() => {
-    if (isSuccess && authConfig) {
-      form.reset(buildPasskeysFormValues(authConfig, project))
-    }
-    // form.reset is stable; authConfig/project drive when to sync from server
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isSuccess, authConfig, project])
 
   const onSubmit = (values: PasskeysSettings) => {
     if (!projectRef) return


### PR DESCRIPTION
Previously, when a user performed a client-side navigation to the passkeys page, the settings would not be shown despite passkeys being enabled. This was a result of the stale form data being passed as the initial values.

This PR removes the `useEffect` in favour of the `values` prop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved passkeys settings form initialization logic for better stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->