### PR TITLE
chore: Add max age to the turbo cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:studio:docker": "docker build . -f apps/studio/Dockerfile --target production -t supabase-studio:local --build-arg NEXT_PUBLIC_STUDIO_AUTH_MODE=supabase --no-cache",
     "build:design-system": "turbo run build --filter=design-system",
     "build:docs": "turbo run build --filter=docs",
-    "clean": "turbo run clean --parallel && rimraf -G node_modules/{*,.bin,.modules.yaml}",
+    "clean": "turbo run clean --parallel && rimraf -G node_modules/{*,.bin,.modules.yaml} .turbo/cache",
     "dev": "turbo run dev --parallel",
     "dev:studio": "turbo run dev --filter=studio --parallel",
     "dev:studio-local": "pnpm setup:cli && NODE_ENV=test pnpm --prefix ./apps/studio dev",

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -1,6 +1,7 @@
 {
   "$schema": "./node_modules/turbo/schema.json",
   "ui": "stream",
+  "cacheMaxAge": "14d",
   "tasks": {
     "build": {
       "dependsOn": ["^build"],


### PR DESCRIPTION
This pull request introduces improvements to the project's build and cache management processes. The main changes focus on enhancing the cleaning of build artifacts and optimizing Turbo's caching behavior.

**Build and cache improvements:**

* Updated the `clean` script in `package.json` to also remove the `.turbo/cache` directory, ensuring a more thorough cleanup of build artifacts.
* Added a `cacheMaxAge` setting of 14 days to `turbo.jsonc`, which controls how long Turbo's cache is retained, helping to balance cache efficiency and disk usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build system caching configuration with extended cache validity period (14 days) to improve build performance through longer retention of build artifacts and reduced unnecessary recompilation.
  * Enhanced cleanup procedures for build artifacts, cached files, and temporary data to maintain a consistent and clean build environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->