### PR TITLE
feat(docs): use publishable keys instead of anon keys in Auth guides

### DIFF
--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -13,7 +13,7 @@ In the browser, `signInWithOAuth` automatically redirects to the OAuth provider'
 
 ```js
 import { createClient, type Provider } from '@supabase/supabase-js';
-const supabase = createClient('url', 'anonKey')
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 const provider = 'provider' as Provider
 
 // ---cut---
@@ -33,7 +33,7 @@ In the server, you need to handle the redirect to the OAuth provider's authentic
 
 ```js
 import { createClient, type Provider } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 const provider = 'provider' as Provider
 const redirect = (url: string) => {}
 
@@ -69,6 +69,7 @@ Create a new file at `app/auth/callback/route.ts` and populate with the followin
 
 ```ts name=app/auth/callback/route.ts
 import { NextResponse } from 'next/server'
+
 // The client you created from the Server-Side Auth instructions
 import { createClient } from '@/utils/supabase/server'
 

--- a/apps/docs/content/_partials/oauth_pkce_flow.mdx
+++ b/apps/docs/content/_partials/oauth_pkce_flow.mdx
@@ -13,7 +13,7 @@ In the browser, `signInWithOAuth` automatically redirects to the OAuth provider'
 
 ```js
 import { createClient, type Provider } from '@supabase/supabase-js';
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 const provider = 'provider' as Provider
 
 // ---cut---
@@ -33,7 +33,7 @@ In the server, you need to handle the redirect to the OAuth provider's authentic
 
 ```js
 import { createClient, type Provider } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 const provider = 'provider' as Provider
 const redirect = (url: string) => {}
 

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -54,15 +54,11 @@ import fetchRetry from 'fetch-retry'
 const fetchWithRetry = fetchRetry(fetch)
 
 // Create a Supabase client instance with the custom fetch
-const supabase = createClient(
-  'https://your-supabase-url.supabase.co',
-  'sb_publishable_... or anon key',
-  {
-    global: {
-      fetch: fetchWithRetry,
-    },
-  }
-)
+const supabase = createClient('https://your-supabase-url.supabase.co', 'sb_publishable_...', {
+  global: {
+    fetch: fetchWithRetry,
+  },
+})
 ```
 
 ### 3. Configure retry options

--- a/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/automatic-retries-in-supabase-js.mdx
@@ -23,7 +23,7 @@ If you prefer to handle retries yourself, you can disable the built-in retry beh
 ```javascript
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-supabase-url.supabase.co', 'your-anon-key', {
+const supabase = createClient('https://your-project-id.supabase.co', 'your-anon-key', {
   db: {
     retry: false,
   },
@@ -54,7 +54,7 @@ import fetchRetry from 'fetch-retry'
 const fetchWithRetry = fetchRetry(fetch)
 
 // Create a Supabase client instance with the custom fetch
-const supabase = createClient('https://your-supabase-url.supabase.co', 'sb_publishable_...', {
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...', {
   global: {
     fetch: fetchWithRetry,
   },

--- a/apps/docs/content/guides/auth/auth-anonymous.mdx
+++ b/apps/docs/content/guides/auth/auth-anonymous.mdx
@@ -58,7 +58,7 @@ Call the [`signInAnonymously()`](/docs/reference/javascript/auth-signinanonymous
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInAnonymously()
@@ -131,7 +131,7 @@ You can use the [`updateUser()`](/docs/reference/javascript/auth-updateuser) met
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data: updateEmailData, error: updateEmailError } = await supabase.auth.updateUser({
@@ -224,7 +224,7 @@ You can use the [`linkIdentity()`](/docs/reference/javascript/auth-linkidentity)
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.linkIdentity({ provider: 'google' })

--- a/apps/docs/content/guides/auth/auth-anonymous.mdx
+++ b/apps/docs/content/guides/auth/auth-anonymous.mdx
@@ -57,7 +57,8 @@ Call the [`signInAnonymously()`](/docs/reference/javascript/auth-signinanonymous
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInAnonymously()
@@ -129,7 +130,8 @@ You can use the [`updateUser()`](/docs/reference/javascript/auth-updateuser) met
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data: updateEmailData, error: updateEmailError } = await supabase.auth.updateUser({
@@ -221,7 +223,8 @@ You can use the [`linkIdentity()`](/docs/reference/javascript/auth-linkidentity)
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.linkIdentity({ provider: 'google' })

--- a/apps/docs/content/guides/auth/auth-email-passwordless.mdx
+++ b/apps/docs/content/guides/auth/auth-email-passwordless.mdx
@@ -48,7 +48,7 @@ If the user hasn't signed up yet, they are automatically signed up by default. T
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithEmail() {
@@ -156,7 +156,7 @@ At the `/auth/confirm` endpoint, exchange the hash for the session:
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { error } = await supabase.auth.verifyOtp({
@@ -205,7 +205,7 @@ If the user hasn't signed up yet, they are automatically signed up by default. T
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithOtp({
@@ -302,7 +302,7 @@ Call the "verify OTP" method from your client library with the user's email addr
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const {

--- a/apps/docs/content/guides/auth/auth-email-passwordless.mdx
+++ b/apps/docs/content/guides/auth/auth-email-passwordless.mdx
@@ -47,7 +47,8 @@ If the user hasn't signed up yet, they are automatically signed up by default. T
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithEmail() {
@@ -154,7 +155,8 @@ At the `/auth/confirm` endpoint, exchange the hash for the session:
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { error } = await supabase.auth.verifyOtp({
@@ -202,7 +204,8 @@ If the user hasn't signed up yet, they are automatically signed up by default. T
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithOtp({
@@ -298,7 +301,8 @@ Call the "verify OTP" method from your client library with the user's email addr
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const {

--- a/apps/docs/content/guides/auth/auth-email-templates.mdx
+++ b/apps/docs/content/guides/auth/auth-email-templates.mdx
@@ -165,10 +165,8 @@ When the user clicks on the link, the request will hit `https://api.example.com/
 
 ```ts
 import { createClient, type EmailOtpType } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { token_hash, type } = Object.fromEntries(new URLSearchParams(window.location.search))

--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -36,7 +36,7 @@ Supabase Auth allows a user to initiate identity linking with a different email 
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.linkIdentity({ provider: 'google' })
@@ -164,7 +164,7 @@ You can use [`getUserIdentities()`](/docs/reference/javascript/auth-getuserident
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 // retrieve all identities linked to a user

--- a/apps/docs/content/guides/auth/auth-identity-linking.mdx
+++ b/apps/docs/content/guides/auth/auth-identity-linking.mdx
@@ -35,7 +35,8 @@ Supabase Auth allows a user to initiate identity linking with a different email 
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-supabase-url>', '<your-supabase-anon-key>')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.linkIdentity({ provider: 'google' })
@@ -162,7 +163,8 @@ You can use [`getUserIdentities()`](/docs/reference/javascript/auth-getuserident
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-supabase-url>', '<your-supabase-anon-key>')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 // retrieve all identities linked to a user

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -82,10 +82,8 @@ When a user unenrolls a factor, call `supabase.auth.mfa.unenroll()` with the ID 
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 supabase.auth.mfa.unenroll({ factorId: 'd30fd651-184e-4748-a928-0a4b9be1d429' })

--- a/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
+++ b/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
@@ -196,7 +196,7 @@ To initiate a sign-in request from your application's user interface (i.e. the S
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 supabase.auth.signInWithSSO({
@@ -489,7 +489,7 @@ Yes, also referred to as [cross-origin authentication within the same site](http
 ```ts
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithSSO({

--- a/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
+++ b/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
@@ -195,7 +195,8 @@ To initiate a sign-in request from your application's user interface (i.e. the S
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 supabase.auth.signInWithSSO({
@@ -487,7 +488,8 @@ Yes, also referred to as [cross-origin authentication within the same site](http
 
 ```ts
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithSSO({
@@ -506,6 +508,7 @@ When redirecting to a URL other than the Site URL, a `/callback` endpoint is nec
 
 ```ts
 import { error, redirect } from '@sveltejs/kit'
+
 import type { RequestHandler } from './$types'
 
 export const GET: RequestHandler = async ({ url, locals }) => {

--- a/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
@@ -334,6 +334,7 @@ export async function POST(request: Request) {
 // src/pages/OAuthConsent.tsx
 import { useEffect, useState } from 'react'
 import { useNavigate, useSearchParams } from 'react-router-dom'
+
 import { supabase } from './supabaseClient'
 
 export function OAuthConsent() {
@@ -525,7 +526,7 @@ You can register clients programmatically using the SDK admin endpoints or by ca
 import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(
-  'https://your-project.supabase.co',
+  'https://your-project-id.supabase.co',
   'your-service-role-key' // Use service_role key for admin operations
 )
 
@@ -555,7 +556,7 @@ if (error) {
 from supabase import create_client
 
 supabase = create_client(
-    'https://your-project.supabase.co',
+    'https://your-project-id.supabase.co',
     'your-service-role-key'  # Use service_role key for admin operations
 )
 

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -57,7 +57,8 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signUpNewUser() {
@@ -183,10 +184,10 @@ Create a new file at `app/auth/confirm/route.ts` and populate with the following
 
 ```ts app/auth/confirm/route.ts
 import { type EmailOtpType } from '@supabase/supabase-js'
+import { redirect } from 'next/navigation'
 import { type NextRequest } from 'next/server'
 
 import { createClient } from '@/utils/supabase/server'
-import { redirect } from 'next/navigation'
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url)
@@ -218,8 +219,8 @@ export async function GET(request: NextRequest) {
 Create a new file at `src/routes/auth/confirm/+server.ts` and populate with the following:
 
 ```ts src/routes/auth/confirm/+server.ts
-import { redirect } from '@sveltejs/kit'
 import { type EmailOtpType } from '@supabase/supabase-js'
+import { redirect } from '@sveltejs/kit'
 
 export const GET = async (event) => {
   const {
@@ -402,7 +403,8 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signUpNewUser() {
@@ -497,7 +499,8 @@ When your user signs in, call [`signInWithPassword()`](/docs/reference/javascrip
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithEmail() {
@@ -598,7 +601,8 @@ Collect the user's email address and request a password reset email. Specify the
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 await supabase.auth.resetPasswordForEmail('valid.email@supabase.io', {
@@ -704,6 +708,7 @@ Create a new file at `app/auth/confirm/route.ts` and populate with the following
 import { type EmailOtpType } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 import { NextRequest, NextResponse } from 'next/server'
+
 // The client you created from the Server-Side Auth instructions
 import { createClient } from '@/utils/supabase/server'
 
@@ -739,8 +744,8 @@ export async function GET(request: NextRequest) {
 Create a new file at `src/routes/auth/confirm/+server.ts` and populate with the following:
 
 ```ts src/routes/auth/confirm/+server.ts
-import { redirect } from '@sveltejs/kit'
 import { type EmailOtpType } from '@supabase/supabase-js'
+import { redirect } from '@sveltejs/kit'
 
 export const GET = async (event) => {
   const {
@@ -979,7 +984,8 @@ Once you have a session, collect the user's new password and call `updateUser` t
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 await supabase.auth.updateUser({ password: 'new_password' })
@@ -1121,7 +1127,8 @@ To sign up the user, call [`signUp()`](/docs/reference/javascript/auth-signup) w
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signUp({
@@ -1209,7 +1216,8 @@ You should present a form to the user so they can input the 6 digit pin, then se
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const {
@@ -1314,7 +1322,8 @@ Call the function to sign in with the user's phone number and password:
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithPassword({

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -58,7 +58,7 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signUpNewUser() {
@@ -404,7 +404,7 @@ If you don't specify a redirect URL, the user is automatically redirected to you
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signUpNewUser() {
@@ -500,7 +500,7 @@ When your user signs in, call [`signInWithPassword()`](/docs/reference/javascrip
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithEmail() {
@@ -602,7 +602,7 @@ Collect the user's email address and request a password reset email. Specify the
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 await supabase.auth.resetPasswordForEmail('valid.email@supabase.io', {
@@ -985,7 +985,7 @@ Once you have a session, collect the user's new password and call `updateUser` t
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 await supabase.auth.updateUser({ password: 'new_password' })
@@ -1128,7 +1128,7 @@ To sign up the user, call [`signUp()`](/docs/reference/javascript/auth-signup) w
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signUp({
@@ -1217,7 +1217,7 @@ You should present a form to the user so they can input the 6 digit pin, then se
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const {
@@ -1323,7 +1323,7 @@ Call the function to sign in with the user's phone number and password:
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithPassword({

--- a/apps/docs/content/guides/auth/phone-login.mdx
+++ b/apps/docs/content/guides/auth/phone-login.mdx
@@ -48,7 +48,8 @@ With OTP, a user can sign in without setting a password on their account. They n
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithOtp({
@@ -132,7 +133,8 @@ You should present a form to the user so they can input the 6 digit pin, then se
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const {
@@ -235,7 +237,8 @@ To update a user's phone number, the user must be logged in. Call [`updateUser()
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.updateUser({

--- a/apps/docs/content/guides/auth/phone-login.mdx
+++ b/apps/docs/content/guides/auth/phone-login.mdx
@@ -49,7 +49,7 @@ With OTP, a user can sign in without setting a password on their account. They n
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithOtp({
@@ -134,7 +134,7 @@ You should present a form to the user so they can input the 6 digit pin, then se
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const {
@@ -238,7 +238,7 @@ To update a user's phone number, the user must be logged in. Call [`updateUser()
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.updateUser({

--- a/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
@@ -64,7 +64,7 @@ hideToc: true
 
       ```text name=.env.local
       NEXT_PUBLIC_SUPABASE_URL=your-project-url
-      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_... or anon key
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_... key
       ```
 
       <$Partial path="api_settings_steps.mdx" variables={{ "framework": "nextjs", "tab": "frameworks" }} />

--- a/apps/docs/content/guides/auth/quickstarts/with-expo-react-native-social-auth.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/with-expo-react-native-social-auth.mdx
@@ -84,7 +84,7 @@ Now, create a helper file to initialize the Supabase client for both web and Rea
 
 ### Set up environment variables
 
-You need the API URL and the `anon` key copied [earlier](#get-the-api-keys).
+You need the API URL and the `publishable` key copied [earlier](#get-the-api-keys).
 These variables are safe to expose in your Expo app since Supabase has [Row Level Security](/docs/guides/database/postgres/row-level-security) enabled on your database.
 
 Create a `.env` file containing these variables:

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -563,25 +563,29 @@ You can now use any Supabase features from your client or server code!
 <TabPanel id="react-router-loader" label="Loader">
 
 ```ts _index.tsx
-import { LoaderFunctionArgs } from 'react-router'
 import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
+import { LoaderFunctionArgs } from 'react-router'
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const responseHeaders = new Headers()
 
-  const supabase = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!, {
-    cookies: {
-      getAll() {
-        return parseCookieHeader(request.headers.get('Cookie') ?? '')
+  const supabase = createServerClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return parseCookieHeader(request.headers.get('Cookie') ?? '')
+        },
+        setAll(cookiesToSet, cacheHeaders) {
+          cookiesToSet.forEach(({ name, value }) =>
+            responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value))
+          )
+          Object.entries(cacheHeaders).forEach(([key, value]) => responseHeaders.set(key, value))
+        },
       },
-      setAll(cookiesToSet, cacheHeaders) {
-        cookiesToSet.forEach(({ name, value }) =>
-          responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value))
-        )
-        Object.entries(cacheHeaders).forEach(([key, value]) => responseHeaders.set(key, value))
-      },
-    },
-  })
+    }
+  )
 
   return new Response('...', {
     headers: responseHeaders,
@@ -600,19 +604,23 @@ import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@s
 export async function action({ request }: ActionFunctionArgs) {
   const responseHeaders = new Headers()
 
-  const supabase = createServerClient(process.env.SUPABASE_URL!, process.env.SUPABASE_ANON_KEY!, {
-    cookies: {
-      getAll() {
-        return parseCookieHeader(request.headers.get('Cookie') ?? '')
+  const supabase = createServerClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return parseCookieHeader(request.headers.get('Cookie') ?? '')
+        },
+        setAll(cookiesToSet, cacheHeaders) {
+          cookiesToSet.forEach(({ name, value }) =>
+            responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value))
+          )
+          Object.entries(cacheHeaders).forEach(([key, value]) => responseHeaders.set(key, value))
+        },
       },
-      setAll(cookiesToSet, cacheHeaders) {
-        cookiesToSet.forEach(({ name, value }) =>
-          responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value))
-        )
-        Object.entries(cacheHeaders).forEach(([key, value]) => responseHeaders.set(key, value))
-      },
-    },
-  })
+    }
+  )
 
   return new Response('...', {
     headers: responseHeaders,
@@ -633,7 +641,7 @@ export async function loader({}: LoaderFunctionArgs) {
   return {
     env: {
       SUPABASE_URL: process.env.SUPABASE_URL!,
-      SUPABASE_ANON_KEY: process.env.SUPABASE_ANON_KEY!,
+      SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY!,
     },
   };
 }
@@ -641,7 +649,7 @@ export async function loader({}: LoaderFunctionArgs) {
 export default function Index() {
   const { env } = useLoaderData<typeof loader>();
 
-  const supabase = createBrowserClient(env.SUPABASE_URL, env.SUPABASE_ANON_KEY);
+  const supabase = createBrowserClient(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY);
 
   return ...
 }

--- a/apps/docs/content/guides/auth/sessions/pkce-flow.mdx
+++ b/apps/docs/content/guides/auth/sessions/pkce-flow.mdx
@@ -63,7 +63,7 @@ Putting it all together, your client library initialization may look like this:
 import { createClient } from '@supabase/supabase-js'
 
 // ---cut---
-const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key', {
+const supabase = createClient('https://xyzcompany.supabase.co', 'sb_publishable_...', {
   // ...
   auth: {
     // ...

--- a/apps/docs/content/guides/auth/sessions/pkce-flow.mdx
+++ b/apps/docs/content/guides/auth/sessions/pkce-flow.mdx
@@ -63,7 +63,7 @@ Putting it all together, your client library initialization may look like this:
 import { createClient } from '@supabase/supabase-js'
 
 // ---cut---
-const supabase = createClient('https://xyzcompany.supabase.co', 'sb_publishable_...', {
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...', {
   // ...
   auth: {
     // ...

--- a/apps/docs/content/guides/auth/signout.mdx
+++ b/apps/docs/content/guides/auth/signout.mdx
@@ -18,10 +18,8 @@ Call the sign out method from the client library. It removes the active session 
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {
@@ -93,10 +91,8 @@ You can invoke these by providing the `scope` option:
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 // defaults to the global scope

--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -87,7 +87,7 @@ The platform-specific examples below demonstrate how to implement this pattern f
 
     ```ts
     import { createClient } from '@supabase/supabase-js'
-    const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+    const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
     // ---cut---
     supabase.auth.signInWithOAuth({

--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -87,7 +87,7 @@ The platform-specific examples below demonstrate how to implement this pattern f
 
     ```ts
     import { createClient } from '@supabase/supabase-js'
-    const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+    const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
     // ---cut---
     supabase.auth.signInWithOAuth({

--- a/apps/docs/content/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-azure.mdx
@@ -164,7 +164,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithAzure() {
@@ -227,7 +227,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {
@@ -278,7 +278,7 @@ Azure OAuth2.0 doesn't return the `provider_refresh_token` by default. If you ne
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithAzure() {

--- a/apps/docs/content/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-azure.mdx
@@ -163,7 +163,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithAzure() {
@@ -225,7 +226,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {
@@ -275,7 +277,8 @@ Azure OAuth2.0 doesn't return the `provider_refresh_token` by default. If you ne
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithAzure() {

--- a/apps/docs/content/guides/auth/social-login/auth-bitbucket.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-bitbucket.mdx
@@ -61,10 +61,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithBitbucket() {
@@ -121,10 +119,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-discord.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-discord.mdx
@@ -78,10 +78,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithDiscord() {
@@ -140,10 +138,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -116,7 +116,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithFacebook() {
@@ -277,7 +278,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -117,7 +117,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithFacebook() {
@@ -279,7 +279,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-figma.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-figma.mdx
@@ -62,7 +62,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithFigma() {
@@ -120,7 +120,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-figma.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-figma.mdx
@@ -61,7 +61,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithFigma() {
@@ -118,7 +119,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-github.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-github.mdx
@@ -73,10 +73,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithGithub() {
@@ -149,10 +147,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-gitlab.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-gitlab.mdx
@@ -58,10 +58,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithGitLab() {
@@ -118,10 +116,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -238,7 +238,8 @@ To use your own application code for the signin button, call the `signInWithOAut
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('url', 'anonKey')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 supabase.auth.signInWithOAuth({
@@ -262,7 +263,8 @@ Google does not send out a refresh token by default, so you will need to pass pa
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_... or anon key')
+
+const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithOAuth({
@@ -366,10 +368,11 @@ If you're integrating Google One-Tap with your Next.js application, you can refe
 ```tsx
 'use client'
 
-import Script from 'next/script'
-import { createClient } from '@/utils/supabase/client'
 import type { accounts, CredentialResponse } from 'google-one-tap'
 import { useRouter } from 'next/navigation'
+import Script from 'next/script'
+
+import { createClient } from '@/utils/supabase/client'
 
 declare const google: { accounts: accounts }
 
@@ -462,6 +465,7 @@ import {
   GoogleSigninButton,
   statusCodes,
 } from '@react-native-google-signin/google-signin'
+
 import { supabase } from '../utils/supabase'
 
 export default function () {

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -239,7 +239,7 @@ To use your own application code for the signin button, call the `signInWithOAut
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 supabase.auth.signInWithOAuth({
@@ -264,7 +264,7 @@ Google does not send out a refresh token by default, so you will need to pass pa
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'sb_publishable_...')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 const { data, error } = await supabase.auth.signInWithOAuth({

--- a/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
@@ -105,7 +105,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithKakao() {

--- a/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
@@ -104,7 +104,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithKakao() {

--- a/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
@@ -76,7 +76,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithKeycloak() {
@@ -161,7 +162,7 @@ When your user signs out, call [signOut()](/docs/reference/kotlin/auth-signout) 
 
 ```kotlin
 import { createClient } from '@supabase/supabase-js';
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>');
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>');
 
 // ---cut---
 suspend fun signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-keycloak.mdx
@@ -77,7 +77,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithKeycloak() {
@@ -162,7 +162,7 @@ When your user signs out, call [signOut()](/docs/reference/kotlin/auth-signout) 
 
 ```kotlin
 import { createClient } from '@supabase/supabase-js';
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>');
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...');
 
 // ---cut---
 suspend fun signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
@@ -81,7 +81,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithLinkedIn() {
@@ -138,7 +139,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-linkedin.mdx
@@ -82,7 +82,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithLinkedIn() {
@@ -140,7 +140,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-notion.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-notion.mdx
@@ -61,7 +61,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithNotion() {
@@ -118,7 +119,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-notion.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-notion.mdx
@@ -62,7 +62,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithNotion() {
@@ -120,7 +120,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-slack.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-slack.mdx
@@ -97,7 +97,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithSlack() {
@@ -154,7 +155,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-slack.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-slack.mdx
@@ -98,7 +98,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithSlack() {
@@ -156,7 +156,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-spotify.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-spotify.mdx
@@ -91,7 +91,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithSpotify() {
@@ -148,7 +149,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-spotify.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-spotify.mdx
@@ -92,7 +92,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithSpotify() {
@@ -150,7 +150,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-twitch.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-twitch.mdx
@@ -77,7 +77,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithTwitch() {
@@ -135,7 +135,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-twitch.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-twitch.mdx
@@ -76,7 +76,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithTwitch() {
@@ -133,7 +134,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-twitter.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-twitter.mdx
@@ -94,10 +94,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithX() {
@@ -167,10 +165,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient(
-  'https://your-project-id.supabase.co',
-  'sb_publishable_... or anon key'
-)
+
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-workos.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-workos.mdx
@@ -73,7 +73,7 @@ When a user signs in, call `signInWithOAuth` with `workos` as the provider.
 
 ```javascript
 import { createClient } from '@supabase/supabase-js';
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>');
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...');
 const redirect = (url: string) => {}
 
 // ---cut---

--- a/apps/docs/content/guides/auth/social-login/auth-workos.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-workos.mdx
@@ -73,7 +73,7 @@ When a user signs in, call `signInWithOAuth` with `workos` as the provider.
 
 ```javascript
 import { createClient } from '@supabase/supabase-js';
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>');
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>');
 const redirect = (url: string) => {}
 
 // ---cut---

--- a/apps/docs/content/guides/auth/social-login/auth-zoom.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-zoom.mdx
@@ -93,7 +93,7 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signInWithZoom() {
@@ -151,7 +151,7 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 ```js
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
+const supabase = createClient('https://your-project-id.supabase.co', 'sb_publishable_...')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/auth/social-login/auth-zoom.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-zoom.mdx
@@ -92,7 +92,8 @@ When your user signs in, call [`signInWithOAuth()`](/docs/reference/javascript/a
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signInWithZoom() {
@@ -149,7 +150,8 @@ When your user signs out, call [signOut()](/docs/reference/javascript/auth-signo
 
 ```js
 import { createClient } from '@supabase/supabase-js'
-const supabase = createClient('<your-project-url>', '<sb_publishable_... or anon key>')
+
+const supabase = createClient('<your-project-url>', '<sb_publishable_... key>')
 
 // ---cut---
 async function signOut() {

--- a/apps/docs/content/guides/functions/deploy.mdx
+++ b/apps/docs/content/guides/functions/deploy.mdx
@@ -103,7 +103,7 @@ curl --request POST 'https://<project_id>.supabase.co/functions/v1/hello-world' 
 import { createClient } from '@supabase/supabase-js'
 
 // Create a single supabase client for interacting with your database
-const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key')
+const supabase = createClient('https://xyzcompany.supabase.co', 'sb_publishable_...')
 
 const { data, error } = await supabase.functions.invoke('hello-world', {
   body: { name: 'Functions' },

--- a/apps/docs/content/guides/platform/custom-domains.mdx
+++ b/apps/docs/content/guides/platform/custom-domains.mdx
@@ -130,7 +130,7 @@ If you wish to use the new domain in client code, change the URL used in your Su
 import { createClient } from '@supabase/supabase-js'
 
 // Use a custom domain as the supabase URL
-const supabase = createClient('https://api.example.com', 'publishable-or-anon-key')
+const supabase = createClient('https://api.example.com', 'sb_publishable_...')
 ```
 
 Similarly, your Edge Functions will now be available at `https://api.example.com/functions/v1/your_function_name`, and your Storage objects at `https://api.example.com/storage/v1/object/public/your_file_path.ext`.
@@ -208,7 +208,7 @@ If you wish to use the new domain in client code, you can set it up like so:
 import { createClient } from '@supabase/supabase-js'
 
 // Use a custom domain as the supabase URL
-const supabase = createClient('https://my-example-brand.supabase.co', 'publishable-or-anon-key')
+const supabase = createClient('https://my-example-brand.supabase.co', 'sb_publishable_...')
 ```
 
 When using [Sign in with Twitter](/docs/guides/auth/social-login/auth-twitter) make sure your frontend code is using the subdomain only.

--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -61,7 +61,7 @@ In most cases, you can get the correct key from [the Project's **Connect** dialo
     import { createClient } from '@supabase/supabase-js'
 
     const SUPABASE_URL = 'https://<project>.supabase.co'
-    const SUPABASE_KEY = '<sb_publishable_... or anon key>'
+    const SUPABASE_KEY = '<sb_publishable_... key>'
 
     const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
     ```
@@ -76,7 +76,7 @@ In most cases, you can get the correct key from [the Project's **Connect** dialo
     void main() async {
       Supabase.initialize(
         url: 'https://<project>.supabase.co',
-        anonKey: '<sb_publishable_... or anon key>',
+        anonKey: '<sb_publishable_... key>',
       );
       runApp(MyApp());
     }
@@ -93,7 +93,7 @@ In most cases, you can get the correct key from [the Project's **Connect** dialo
     import Supabase
 
     let SUPABASE_URL = "https://<project>.supabase.co"
-    let SUPABASE_KEY = "<sb_publishable_... or anon key>"
+    let SUPABASE_KEY = "<sb_publishable_... key>"
 
     let supabase = SupabaseClient(supabaseURL: URL(string: SUPABASE_URL)!, supabaseKey: SUPABASE_KEY)
     ```
@@ -105,7 +105,7 @@ In most cases, you can get the correct key from [the Project's **Connect** dialo
 
     ```kotlin
     val supabaseUrl = "https://<project>.supabase.co"
-    val supabaseKey = "<sb_publishable_... or anon key>"
+    val supabaseKey = "<sb_publishable_... key>"
     val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
         install(Realtime)
     }
@@ -121,7 +121,7 @@ In most cases, you can get the correct key from [the Project's **Connect** dialo
     from supabase import acreate_client
 
     URL = "https://<project>.supabase.co"
-    KEY = "<sb_publishable_... or anon key>"
+    KEY = "<sb_publishable_... key>"
 
     async def create_supabase():
       supabase = await acreate_client(URL, KEY)
@@ -149,7 +149,7 @@ You can receive Broadcast messages by providing a callback to the channel.
     ```js
     // @noImplicitAny: false
     import { createClient } from '@supabase/supabase-js'
-    const supabase = createClient('https://<project>.supabase.co', '<sb_publishable_... or anon key>')
+    const supabase = createClient('https://<project>.supabase.co', '<sb_publishable_... key>')
 
     // ---cut---
     // Join a room/topic. Can be anything except for 'realtime'.

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -139,7 +139,7 @@ In this example we'll set up a database table, secure it with Row Level Security
 
       const supabase = createClient(
         'https://<project>.supabase.co',
-        '<sb_publishable_... or anon key>'
+        '<sb_publishable_... key>'
       )
       ```
 

--- a/apps/docs/content/guides/realtime/presence.mdx
+++ b/apps/docs/content/guides/realtime/presence.mdx
@@ -65,7 +65,7 @@ In most cases, you can get the correct key from [the Project's **Connect** dialo
 import { createClient } from '@supabase/supabase-js'
 
 const SUPABASE_URL = 'https://<project>.supabase.co'
-const SUPABASE_KEY = '<sb_publishable_... or anon key>'
+const SUPABASE_KEY = '<sb_publishable_... key>'
 
 const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
 ```
@@ -78,7 +78,7 @@ const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
 void main() {
   Supabase.initialize(
     url: 'https://<project>.supabase.co',
-    anonKey: '<sb_publishable_... or anon key>',
+    anonKey: '<sb_publishable_... key>',
   );
 
   runApp(MyApp());
@@ -94,7 +94,7 @@ final supabase = Supabase.instance.client;
 
 ```swift
 let supabaseURL = "https://<project>.supabase.co"
-let supabaseKey = "<sb_publishable_... or anon key>"
+let supabaseKey = "<sb_publishable_... key>"
 let supabase = SupabaseClient(supabaseURL: URL(string: supabaseURL)!, supabaseKey: supabaseKey)
 
 let realtime = supabase.realtime
@@ -107,7 +107,7 @@ let realtime = supabase.realtime
 
 ```kotlin
 val supabaseUrl = "https://<project>.supabase.co"
-val supabaseKey = "<sb_publishable_... or anon key>"
+val supabaseKey = "<sb_publishable_... key>"
 val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
     install(Realtime)
 }
@@ -122,7 +122,7 @@ val supabase = createSupabaseClient(supabaseUrl, supabaseKey) {
 from supabase import create_client
 
 SUPABASE_URL = 'https://<project>.supabase.co'
-SUPABASE_KEY = '<sb_publishable_... or anon key>'
+SUPABASE_KEY = '<sb_publishable_... key>'
 
 supabase = create_client(SUPABASE_URL, SUPABASE_KEY)
 ```
@@ -146,6 +146,7 @@ Listen to the `sync`, `join`, and `leave` events triggered whenever any client j
 
 ```js
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
 // ---cut---
@@ -386,6 +387,7 @@ You can stop tracking presence using the `untrack()` method. This will trigger t
 
 ```js
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('your_project_url', 'your_supabase_api_key')
 const roomOne = supabase.channel('room_01')
 
@@ -467,6 +469,7 @@ By default, Presence will generate a unique `UUIDv1` key on the server to track 
 
 ```js
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('SUPABASE_URL', 'SUPABASE_PUBLISHABLE_KEY')
 
 const channelC = supabase.channel('test', {

--- a/apps/docs/content/guides/storage/analytics/creating-analytics-buckets.mdx
+++ b/apps/docs/content/guides/storage/analytics/creating-analytics-buckets.mdx
@@ -35,7 +35,7 @@ You can create an analytics bucket using either the Supabase SDK or the Supabase
 ```typescript
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'your-service-key')
+const supabase = createClient('https://your-project-id.supabase.co', 'your-service-key')
 
 const { data, error } = await supabase.storage.analytics.createBucket('analytics-data')
 
@@ -53,7 +53,7 @@ if (error) {
 ```python
 from supabase import create_client
 
-supabase = create_client('https://your-project.supabase.co', 'your-service-key')
+supabase = create_client('https://your-project-id.supabase.co', 'your-service-key')
 
 response = supabase.storage.analytics().create('analytics-data')
 

--- a/apps/docs/content/guides/storage/vector/creating-vector-buckets.mdx
+++ b/apps/docs/content/guides/storage/vector/creating-vector-buckets.mdx
@@ -39,7 +39,7 @@ Your vector bucket is now ready. The next step is to create indexes within it.
 ```typescript
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'your-service-key')
+const supabase = createClient('https://your-project-id.supabase.co', 'your-service-key')
 
 // Create a vector bucket
 await supabase.storage.vectors.createBucket('embeddings')
@@ -54,7 +54,7 @@ console.log('✓ Vector bucket created: embeddings')
 ```python
 from supabase import create_client
 
-supabase = create_client('https://your-project.supabase.co', 'your-service-key')
+supabase = create_client('https://your-project-id.supabase.co', 'your-service-key')
 
 # Create a vector bucket
 supabase.storage.vectors().create_bucket('embeddings')

--- a/apps/docs/content/guides/storage/vector/querying-vectors.mdx
+++ b/apps/docs/content/guides/storage/vector/querying-vectors.mdx
@@ -31,7 +31,7 @@ Vector buckets and any [Foreign Data Wrappers (FDW)](/docs/guides/database/exten
 ```typescript
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'your-service-key')
+const supabase = createClient('https://your-project-id.supabase.co', 'your-service-key')
 
 const index = supabase.storage.vectors.from('embeddings').index('documents-openai')
 
@@ -63,7 +63,7 @@ if (error) {
 ```python
 from supabase import create_client
 
-supabase = create_client('https://your-project.supabase.co', 'your-service-key')
+supabase = create_client('https://your-project-id.supabase.co', 'your-service-key')
 
 index = supabase.storage.vectors().from_('embeddings').index('documents-openai')
 

--- a/apps/docs/content/guides/storage/vector/storing-vectors.mdx
+++ b/apps/docs/content/guides/storage/vector/storing-vectors.mdx
@@ -25,7 +25,7 @@ Once you've created a bucket and index, you can start storing vectors. Vectors c
 ```typescript
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'your-service-key')
+const supabase = createClient('https://your-project-id.supabase.co', 'your-service-key')
 
 // Get bucket and index
 const bucket = supabase.storage.vectors.from('embeddings')
@@ -71,7 +71,7 @@ if (error) {
 ```python
 from supabase import create_client
 
-supabase = create_client('https://your-project.supabase.co', 'your-service-key')
+supabase = create_client('https://your-project-id.supabase.co', 'your-service-key')
 
 # Get bucket and index
 bucket = supabase.storage.vectors().from_('embeddings')
@@ -144,7 +144,7 @@ Generate embeddings using an LLM API and store them directly:
 import { createClient } from '@supabase/supabase-js'
 import OpenAI from 'openai'
 
-const supabase = createClient('https://your-project.supabase.co', 'your-service-key')
+const supabase = createClient('https://your-project-id.supabase.co', 'your-service-key')
 
 const openai = new OpenAI({
   apiKey: process.env.OPENAI_API_KEY,
@@ -205,7 +205,7 @@ from supabase import create_client
 from openai import OpenAI
 from datetime import datetime
 
-supabase = create_client('https://your-project.supabase.co', 'your-service-key')
+supabase = create_client('https://your-project-id.supabase.co', 'your-service-key')
 openai = OpenAI(api_key=os.environ.get('OPENAI_API_KEY'))
 
 # Documents to embed and store

--- a/apps/docs/content/guides/storage/vector/working-with-indexes.mdx
+++ b/apps/docs/content/guides/storage/vector/working-with-indexes.mdx
@@ -47,7 +47,7 @@ Think of an index as a table in a traditional database. It has a schema (dimensi
 ```typescript
 import { createClient } from '@supabase/supabase-js'
 
-const supabase = createClient('https://your-project.supabase.co', 'your-service-key')
+const supabase = createClient('https://your-project-id.supabase.co', 'your-service-key')
 
 const bucket = supabase.storage.vectors.from('embeddings')
 
@@ -73,7 +73,7 @@ if (error) {
 ```python
 from supabase import create_client
 
-supabase = create_client('https://your-project.supabase.co', 'your-service-key')
+supabase = create_client('https://your-project-id.supabase.co', 'your-service-key')
 
 bucket = supabase.storage.vectors().from_('embeddings')
 

--- a/apps/docs/content/guides/telemetry/logs.mdx
+++ b/apps/docs/content/guides/telemetry/logs.mdx
@@ -227,7 +227,7 @@ const options = {
     },
   },
 }
-const supabase = createClient('https://xyzcompany.supabase.co', 'publishable-or-anon-key', options)
+const supabase = createClient('https://xyzcompany.supabase.co', 'sb_publishable_...', options)
 ```
 
 ## Logs Explorer


### PR DESCRIPTION
With the upcoming deprecation of the anonymous and service role keys, this PR updates the Auth guides to use the publishable key instead of the soon-to-be-deprecated anonymous key.

It also standardizes the example strings to be: `'https://your-project-id.supabase.co'` and `'sb_publishable_...'` for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized client initialization examples to use a consistent publishable-key placeholder (`sb_publishable_...`) and full project URL format.
  * Replaced "anon key" wording with "publishable key" across auth and API guides and examples.
  * Minor formatting and import-order/whitespace improvements in code samples for clarity and consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->