### PR TITLE
fix(studio): use satisfies for next.config to avoid cross-version type mismatch

### DIFF
--- a/apps/studio/next.config.ts
+++ b/apps/studio/next.config.ts
@@ -29,7 +29,11 @@ function getAssetPrefix() {
   return `${SUPABASE_ASSETS_URL}/${process.env.SITE_NAME}/${process.env.VERCEL_GIT_COMMIT_SHA?.substring(0, 12) ?? 'unknown'}`
 }
 
-const nextConfig: NextConfig = {
+// Use `satisfies` instead of `: NextConfig` so TypeScript preserves narrow
+// inferred types (e.g. async headers → Promise). This avoids TS2345 when
+// wrapper functions (bundle-analyzer, sentry) resolve their `next` peer
+// types to a different major version than studio's own next dependency.
+const nextConfig = {
   basePath: process.env.NEXT_PUBLIC_BASE_PATH,
   assetPrefix: getAssetPrefix(),
   output: 'standalone',
@@ -41,7 +45,7 @@ const nextConfig: NextConfig = {
       {
         source: `/.well-known/vercel/flags`,
         destination: `https://supabase.com/.well-known/vercel/flags`,
-        basePath: false,
+        basePath: false as const,
       },
     ]
   },
@@ -609,7 +613,7 @@ const nextConfig: NextConfig = {
     // For production, we run typechecks separate from the build command (pnpm typecheck && pnpm build)
     ignoreBuildErrors: true,
   },
-}
+} satisfies NextConfig
 
 // Make sure adding Sentry options is the last code to run before exporting, to
 // ensure that your source maps include changes from all other Webpack plugins


### PR DESCRIPTION
Fixes the intermittent TS2345 build failure on Vercel where `nextConfig` (typed via next@16) is not assignable to `withBundleAnalyzer`'s parameter (typed via next@15).

**Root cause**

The monorepo has two Next.js versions — studio uses next@16 (via catalog) while www and docs use next@15. On Vercel, pnpm sometimes resolves `@next/bundle-analyzer`'s `next` peer types to v15 instead of v16. The `NextConfig` type changed between versions: next@16 widens the `headers` return type to `Header[] | Promise<Header[]>`, but next@15 expects `Promise<Header[]>` only. When the config object is annotated as `NextConfig` (from next@16), its `headers` property gets the wider type — which is not assignable to the narrower next@15 type expected by the wrapper function.

**Fix**

Switch from `: NextConfig` type annotation to `satisfies NextConfig`. With `satisfies`, TypeScript preserves the narrow inferred types from the object literal (e.g. `async headers()` infers as `() => Promise<Header[]>`) while still validating the shape. These narrower types are assignable to both next@15 and next@16 `NextConfig`, so the build succeeds regardless of which version the wrapper functions resolve to.

Also adds `as const` to `basePath: false` in the rewrites config, since without the type annotation TypeScript would widen `false` to `boolean`, which doesn't satisfy the `Rewrite` type's literal `false` requirement.

**Changed:**
- `const nextConfig: NextConfig = { ... }` → `const nextConfig = { ... } satisfies NextConfig`
- `basePath: false` → `basePath: false as const` in rewrites

## To test

- Typecheck passes locally: `pnpm typecheck --filter=studio`
- Verify the next Vercel deploy doesn't hit the TS2345 error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved TypeScript type safety in build configuration with better type narrowing and inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->