### PR TITLE
feat(docs): update admin operation examples to use secret key instead of service_role key

### DIFF
--- a/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
@@ -208,7 +208,7 @@ export default async function ConsentPage({
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
       cookies: {
         getAll: async () => (await cookies()).getAll(),
@@ -293,7 +293,7 @@ export async function POST(request: Request) {
 
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
     {
       cookies: {
         getAll: async () => (await cookies()).getAll(),
@@ -527,7 +527,7 @@ import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient(
   'https://your-project-id.supabase.co',
-  'your-service-role-key' // Use service_role key for admin operations
+  'sb_secret_...' // Use the secret key for admin operations
 )
 
 // Create an OAuth client
@@ -557,7 +557,7 @@ from supabase import create_client
 
 supabase = create_client(
     'https://your-project-id.supabase.co',
-    'your-service-role-key'  # Use service_role key for admin operations
+    'sb_secret_...'  # Use the secret key for admin operations
 )
 
 # Create an OAuth client

--- a/apps/docs/content/guides/auth/oauth-server/mcp-authentication.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/mcp-authentication.mdx
@@ -146,7 +146,7 @@ Always require explicit user approval for MCP clients:
 
 - Check RLS policies include the MCP client's `client_id`
 - Verify user has necessary permissions
-- Test with service role key to isolate RLS issues
+- Test with secret key to isolate RLS issues
 - Review [Token Security guide](/docs/guides/auth/oauth-server/token-security)
 
 ## Next steps

--- a/apps/docs/content/guides/auth/oauth-server/token-security.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/token-security.mdx
@@ -384,7 +384,7 @@ Or use the Supabase Dashboard's [RLS policy tester](/dashboard/project/_/auth/po
 1. Verify the policy includes the client's `client_id`
 2. Ensure RLS is enabled on the table
 3. Check for conflicting restrictive policies
-4. Test with service role key to isolate RLS issues
+4. Test with secret key to isolate RLS issues
 
 ```sql
 -- Debug: See what client_id is in the token


### PR DESCRIPTION
With the upcoming deprecation of anon and service role keys, this PR updates the OAuth server examples to use the secret and publishable keys instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth server authentication guides with revised client initialization examples
  * Improved environment variable references in code samples for server client setup
  * Enhanced troubleshooting sections with corrected terminology for debugging Row-Level Security policy issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->