### PR TITLE
feat(dev-tools): add resource warnings tab to dev toolbar

### DIFF
--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -21,7 +21,7 @@ const WARNING_TYPES = [
 
 type WarningKey = (typeof WARNING_TYPES)[number]['key']
 
-const INITIAL_STATE: Record<WarningKey, Severity> = {
+const INITIAL_STATE: Record = {
   disk_io_exhaustion: null,
   cpu_exhaustion: null,
   memory_and_swap_exhaustion: null,
@@ -35,7 +35,7 @@ export const ResourceWarningsTab = () => {
   const { data: selectedOrg, isLoading: isOrgLoading } = useSelectedOrganizationQuery()
   const orgSlug = selectedOrg?.slug
   const [isReadOnly, setIsReadOnly] = useState(false)
-  const [severities, setSeverities] = useState<Record<WarningKey, Severity>>(INITIAL_STATE)
+  const [severities, setSeverities] = useState<Record>(INITIAL_STATE)
 
   // Track latest ref/orgSlug so the unmount cleanup always invalidates the
   // correct cache keys, even when orgSlug was still loading at mount time.
@@ -44,10 +44,16 @@ export const ResourceWarningsTab = () => {
     latestValues.current = { ref, orgSlug }
   })
 
+  // Only invalidate on unmount if overrides were actually applied to avoid
+  // unnecessary refetches when the user opens the toolbar but never uses
+  // the Warnings tab.
+  const hasOverridesRef = useRef(false)
+
   // Invalidate both cache keys on unmount so banners revert to real data
   // when the toolbar sheet closes (which unmounts this component).
   useEffect(() => {
     return () => {
+      if (!hasOverridesRef.current) return
       const { ref: latestRef, orgSlug: latestOrgSlug } = latestValues.current
       queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, latestRef) })
       if (latestOrgSlug) {
@@ -59,17 +65,28 @@ export const ResourceWarningsTab = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  // Reset state when the user navigates to a different project so project A's
-  // overrides don't carry over to project B (this component never unmounts).
+  // When navigating to a different project: reset UI state and invalidate the
+  // departing project's cache keys (the cleanup closure captures the old ref).
+  // This component never unmounts during client-side navigation, so without
+  // this project A's mocked banners would linger on project B.
   useEffect(() => {
-    setSeverities(INITIAL_STATE)
-    setIsReadOnly(false)
+    return () => {
+      if (!hasOverridesRef.current) return
+      queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
+      const { orgSlug: currentOrgSlug } = latestValues.current
+      if (currentOrgSlug) {
+        queryClient.invalidateQueries({
+          queryKey: usageKeys.resourceWarnings(currentOrgSlug, undefined),
+        })
+      }
+      setSeverities(INITIAL_STATE)
+      setIsReadOnly(false)
+      hasOverridesRef.current = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref])
 
-  const applyOverrides = (
-    nextSeverities: Record<WarningKey, Severity>,
-    nextIsReadOnly: boolean
-  ) => {
+  const applyOverrides = (nextSeverities: Record, nextIsReadOnly: boolean) => {
     if (!orgSlug || !ref) return
     const mockWarning: ResourceWarning = {
       project: ref,
@@ -83,6 +100,7 @@ export const ResourceWarningsTab = () => {
     // slug-based (ProjectLayout, TopSection, ProjectList) consumers.
     queryClient.setQueryData(usageKeys.resourceWarnings(undefined, ref), [mockWarning])
     queryClient.setQueryData(usageKeys.resourceWarnings(orgSlug, undefined), [mockWarning])
+    hasOverridesRef.current = true
   }
 
   const handleSeverityChange = (key: WarningKey, value: Severity) => {
@@ -99,6 +117,7 @@ export const ResourceWarningsTab = () => {
   const handleReset = () => {
     setSeverities(INITIAL_STATE)
     setIsReadOnly(false)
+    hasOverridesRef.current = false
     queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
     if (orgSlug) {
       queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })

--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -7,6 +7,7 @@ import { cn } from 'ui'
 
 import { usageKeys } from '@/data/usage/keys'
 import type { ResourceWarning } from '@/data/usage/resource-warnings-query'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
 type Severity = 'warning' | 'critical' | null
 
@@ -31,6 +32,8 @@ const INITIAL_STATE: Record<WarningKey, Severity> = {
 export const ResourceWarningsTab = () => {
   const { ref } = useParams()
   const queryClient = useQueryClient()
+  const { data: selectedOrg } = useSelectedOrganizationQuery()
+  const orgSlug = selectedOrg?.slug
   const [isReadOnly, setIsReadOnly] = useState(false)
   const [severities, setSeverities] = useState<Record<WarningKey, Severity>>(INITIAL_STATE)
 
@@ -46,7 +49,10 @@ export const ResourceWarningsTab = () => {
       auth_restricted_email_sending: null,
       need_pitr: null,
     }
+    // Write to both cache keys: ref-based (ResourceExhaustionWarningBanner) and
+    // slug-based (ProjectLayout, TopSection, ProjectList) consumers.
     queryClient.setQueryData(usageKeys.resourceWarnings(undefined, ref), [mockWarning])
+    queryClient.setQueryData(usageKeys.resourceWarnings(orgSlug, undefined), [mockWarning])
   }
 
   const handleSeverityChange = (key: WarningKey, value: Severity) => {
@@ -64,6 +70,7 @@ export const ResourceWarningsTab = () => {
     setSeverities(INITIAL_STATE)
     setIsReadOnly(false)
     queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
+    queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })
   }
 
   return (

--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { useParams } from 'common'
+import { useState } from 'react'
+import { cn } from 'ui'
+
+import { usageKeys } from '@/data/usage/keys'
+import type { ResourceWarning } from '@/data/usage/resource-warnings-query'
+
+type Severity = 'warning' | 'critical' | null
+
+const WARNING_TYPES = [
+  { key: 'disk_io_exhaustion', label: 'Disk IO', hasCritical: true },
+  { key: 'cpu_exhaustion', label: 'CPU', hasCritical: true },
+  { key: 'memory_and_swap_exhaustion', label: 'Memory & Swap', hasCritical: true },
+  { key: 'disk_space_exhaustion', label: 'Disk Space', hasCritical: true },
+  { key: 'auth_rate_limit_exhaustion', label: 'Auth Rate Limit', hasCritical: false },
+] as const
+
+type WarningKey = (typeof WARNING_TYPES)[number]['key']
+
+const INITIAL_STATE: Record<WarningKey, Severity> = {
+  disk_io_exhaustion: null,
+  cpu_exhaustion: null,
+  memory_and_swap_exhaustion: null,
+  disk_space_exhaustion: null,
+  auth_rate_limit_exhaustion: null,
+}
+
+export const ResourceWarningsTab = () => {
+  const { ref } = useParams()
+  const queryClient = useQueryClient()
+  const [isReadOnly, setIsReadOnly] = useState(false)
+  const [severities, setSeverities] = useState<Record<WarningKey, Severity>>(INITIAL_STATE)
+
+  const applyOverrides = (
+    nextSeverities: Record<WarningKey, Severity>,
+    nextIsReadOnly: boolean
+  ) => {
+    const mockWarning: ResourceWarning = {
+      project: ref ?? '',
+      is_readonly_mode_enabled: nextIsReadOnly,
+      ...nextSeverities,
+      auth_email_offender: null,
+      auth_restricted_email_sending: null,
+      need_pitr: null,
+    }
+    queryClient.setQueryData(usageKeys.resourceWarnings(undefined, ref), [mockWarning])
+  }
+
+  const handleSeverityChange = (key: WarningKey, value: Severity) => {
+    const next = { ...severities, [key]: value }
+    setSeverities(next)
+    applyOverrides(next, isReadOnly)
+  }
+
+  const handleReadOnlyChange = (value: boolean) => {
+    setIsReadOnly(value)
+    applyOverrides(severities, value)
+  }
+
+  const handleReset = () => {
+    setSeverities(INITIAL_STATE)
+    setIsReadOnly(false)
+    queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
+  }
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-foreground-light">
+          Override resource warning banners for the current project.
+        </p>
+        <button
+          onClick={handleReset}
+          className="text-xs text-foreground-lighter hover:text-foreground transition underline"
+        >
+          Reset to real data
+        </button>
+      </div>
+
+      <div className="space-y-3">
+        <div className="flex items-center justify-between py-2 border-b border-overlay">
+          <span className="text-sm font-medium">Read-only mode</span>
+          <div className="flex gap-1">
+            <SeverityButton
+              active={!isReadOnly}
+              variant="off"
+              onClick={() => handleReadOnlyChange(false)}
+            >
+              Off
+            </SeverityButton>
+            <SeverityButton
+              active={isReadOnly}
+              variant="critical"
+              onClick={() => handleReadOnlyChange(true)}
+            >
+              On
+            </SeverityButton>
+          </div>
+        </div>
+
+        {WARNING_TYPES.map(({ key, label, hasCritical }) => (
+          <div key={key} className="flex items-center justify-between">
+            <span className="text-sm text-foreground-light">{label}</span>
+            <div className="flex gap-1">
+              <SeverityButton
+                active={severities[key] === null}
+                variant="off"
+                onClick={() => handleSeverityChange(key, null)}
+              >
+                Off
+              </SeverityButton>
+              <SeverityButton
+                active={severities[key] === 'warning'}
+                variant="warning"
+                onClick={() => handleSeverityChange(key, 'warning')}
+              >
+                Warn
+              </SeverityButton>
+              {hasCritical && (
+                <SeverityButton
+                  active={severities[key] === 'critical'}
+                  variant="critical"
+                  onClick={() => handleSeverityChange(key, 'critical')}
+                >
+                  Crit
+                </SeverityButton>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface SeverityButtonProps {
+  active: boolean
+  variant: 'off' | 'warning' | 'critical'
+  onClick: () => void
+  children: React.ReactNode
+}
+
+const SeverityButton = ({ active, variant, onClick, children }: SeverityButtonProps) => (
+  <button
+    onClick={onClick}
+    className={cn(
+      'px-1.5 py-0.5 rounded text-xs font-mono transition border',
+      active
+        ? variant === 'off'
+          ? 'bg-surface-300 text-foreground border-strong'
+          : variant === 'warning'
+            ? 'bg-warning/20 text-warning border-warning'
+            : 'bg-destructive/20 text-destructive border-destructive'
+        : 'bg-transparent text-foreground-muted border-transparent hover:border-border'
+    )}
+  >
+    {children}
+  </button>
+)

--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { cn } from 'ui'
 
 import { usageKeys } from '@/data/usage/keys'
@@ -32,15 +32,26 @@ const INITIAL_STATE: Record<WarningKey, Severity> = {
 export const ResourceWarningsTab = () => {
   const { ref } = useParams()
   const queryClient = useQueryClient()
-  const { data: selectedOrg } = useSelectedOrganizationQuery()
+  const { data: selectedOrg, isLoading: isOrgLoading } = useSelectedOrganizationQuery()
   const orgSlug = selectedOrg?.slug
   const [isReadOnly, setIsReadOnly] = useState(false)
   const [severities, setSeverities] = useState<Record<WarningKey, Severity>>(INITIAL_STATE)
+
+  // Invalidate both cache keys on unmount so banners revert to real data
+  // when the toolbar sheet closes (which unmounts this component).
+  useEffect(() => {
+    return () => {
+      queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
+      queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const applyOverrides = (
     nextSeverities: Record<WarningKey, Severity>,
     nextIsReadOnly: boolean
   ) => {
+    if (!orgSlug) return
     const mockWarning: ResourceWarning = {
       project: ref ?? '',
       is_readonly_mode_enabled: nextIsReadOnly,
@@ -73,6 +84,8 @@ export const ResourceWarningsTab = () => {
     queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })
   }
 
+  const isDisabled = isOrgLoading || !orgSlug
+
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
@@ -81,13 +94,16 @@ export const ResourceWarningsTab = () => {
         </p>
         <button
           onClick={handleReset}
-          className="text-xs text-foreground-lighter hover:text-foreground transition underline"
+          disabled={isDisabled}
+          className="text-xs text-foreground-lighter hover:text-foreground transition underline disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Reset to real data
         </button>
       </div>
 
-      <div className="space-y-3">
+      {isDisabled && <p className="text-xs text-foreground-muted">Loading org context...</p>}
+
+      <div className={cn('space-y-3', isDisabled && 'opacity-50 pointer-events-none')}>
         <div className="flex items-center justify-between py-2 border-b border-overlay">
           <span className="text-sm font-medium">Read-only mode</span>
           <div className="flex gap-1">

--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { cn } from 'ui'
 
 import { usageKeys } from '@/data/usage/keys'
@@ -37,23 +37,42 @@ export const ResourceWarningsTab = () => {
   const [isReadOnly, setIsReadOnly] = useState(false)
   const [severities, setSeverities] = useState<Record<WarningKey, Severity>>(INITIAL_STATE)
 
+  // Track latest ref/orgSlug so the unmount cleanup always invalidates the
+  // correct cache keys, even when orgSlug was still loading at mount time.
+  const latestValues = useRef({ ref, orgSlug })
+  useEffect(() => {
+    latestValues.current = { ref, orgSlug }
+  })
+
   // Invalidate both cache keys on unmount so banners revert to real data
   // when the toolbar sheet closes (which unmounts this component).
   useEffect(() => {
     return () => {
-      queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
-      queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })
+      const { ref: latestRef, orgSlug: latestOrgSlug } = latestValues.current
+      queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, latestRef) })
+      if (latestOrgSlug) {
+        queryClient.invalidateQueries({
+          queryKey: usageKeys.resourceWarnings(latestOrgSlug, undefined),
+        })
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
+
+  // Reset state when the user navigates to a different project so project A's
+  // overrides don't carry over to project B (this component never unmounts).
+  useEffect(() => {
+    setSeverities(INITIAL_STATE)
+    setIsReadOnly(false)
+  }, [ref])
 
   const applyOverrides = (
     nextSeverities: Record<WarningKey, Severity>,
     nextIsReadOnly: boolean
   ) => {
-    if (!orgSlug) return
+    if (!orgSlug || !ref) return
     const mockWarning: ResourceWarning = {
-      project: ref ?? '',
+      project: ref,
       is_readonly_mode_enabled: nextIsReadOnly,
       ...nextSeverities,
       auth_email_offender: null,
@@ -81,10 +100,14 @@ export const ResourceWarningsTab = () => {
     setSeverities(INITIAL_STATE)
     setIsReadOnly(false)
     queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
-    queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })
+    if (orgSlug) {
+      queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })
+    }
   }
 
-  const isDisabled = isOrgLoading || !orgSlug
+  // Disabled when org is loading, org slug is unavailable, or we're not on a
+  // project page (ref is undefined on org-level pages like /org/[slug]/settings).
+  const isDisabled = isOrgLoading || !orgSlug || !ref
 
   return (
     <div className="p-6 space-y-4">
@@ -101,7 +124,11 @@ export const ResourceWarningsTab = () => {
         </button>
       </div>
 
-      {isDisabled && <p className="text-xs text-foreground-muted">Loading org context...</p>}
+      {isDisabled && (
+        <p className="text-xs text-foreground-muted">
+          {!ref ? 'Navigate to a project page to use this tab.' : 'Loading org context...'}
+        </p>
+      )}
 
       <div className={cn('space-y-3', isDisabled && 'opacity-50 pointer-events-none')}>
         <div className="flex items-center justify-between py-2 border-b border-overlay">

--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -20,8 +20,9 @@ const WARNING_TYPES = [
 ] as const
 
 type WarningKey = (typeof WARNING_TYPES)[number]['key']
+type WarningState = Record<WarningKey, Severity>
 
-const INITIAL_STATE: Record = {
+const INITIAL_STATE: WarningState = {
   disk_io_exhaustion: null,
   cpu_exhaustion: null,
   memory_and_swap_exhaustion: null,
@@ -35,7 +36,7 @@ export const ResourceWarningsTab = () => {
   const { data: selectedOrg, isLoading: isOrgLoading } = useSelectedOrganizationQuery()
   const orgSlug = selectedOrg?.slug
   const [isReadOnly, setIsReadOnly] = useState(false)
-  const [severities, setSeverities] = useState<Record>(INITIAL_STATE)
+  const [severities, setSeverities] = useState<WarningState>(INITIAL_STATE)
 
   // Track latest ref/orgSlug so the unmount cleanup always invalidates the
   // correct cache keys, even when orgSlug was still loading at mount time.
@@ -86,7 +87,7 @@ export const ResourceWarningsTab = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref])
 
-  const applyOverrides = (nextSeverities: Record, nextIsReadOnly: boolean) => {
+  const applyOverrides = (nextSeverities: WarningState, nextIsReadOnly: boolean) => {
     if (!orgSlug || !ref) return
     const mockWarning: ResourceWarning = {
       project: ref,

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -36,7 +36,8 @@ import duration from 'dayjs/plugin/duration'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import timezone from 'dayjs/plugin/timezone'
 import utc from 'dayjs/plugin/utc'
-import { DevToolbar, DevToolbarProvider, DevToolbarTrigger } from 'dev-tools'
+import { DevToolbar, DevToolbarProvider, DevToolbarTrigger, type ExtraTab } from 'dev-tools'
+import dynamic from 'next/dynamic'
 import Head from 'next/head'
 import { NuqsAdapter } from 'nuqs/adapters/next/pages'
 import { ErrorInfo, useCallback, type ComponentProps } from 'react'
@@ -69,6 +70,20 @@ dayjs.extend(utc)
 dayjs.extend(timezone)
 dayjs.extend(relativeTime)
 dayjs.extend(duration)
+
+// Keep dev-only components out of the production bundle
+const env = process.env.NEXT_PUBLIC_ENVIRONMENT
+const IS_DEV_TOOLBAR_ENABLED = env === 'local' || env === 'staging'
+
+const ResourceWarningsTab = IS_DEV_TOOLBAR_ENABLED
+  ? dynamic(() =>
+      import('@/components/ui/DevToolbar/ResourceWarningsTab').then((m) => m.ResourceWarningsTab)
+    )
+  : () => null
+
+const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
+  ? [{ id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> }]
+  : []
 
 const FeatureFlagProviderWithOrgContext = ({
   children,
@@ -190,7 +205,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                               <MonacoThemeProvider />
                             </CommandProvider>
                           </AiAssistantStateContextProvider>
-                          <DevToolbar />
+                          <DevToolbar extraTabs={devToolbarExtraTabs} />
                           <DevToolbarTrigger />
                         </DevToolbarProvider>
                       </ThemeProvider>

--- a/packages/dev-tools/DevToolbar.tsx
+++ b/packages/dev-tools/DevToolbar.tsx
@@ -32,7 +32,7 @@ import {
 } from 'ui'
 
 import { useDevToolbar } from './DevToolbarContext'
-import type { DevTelemetryEvent } from './types'
+import type { DevTelemetryEvent, ExtraTab } from './types'
 import {
   CC_ORIGINALS_KEY,
   deleteCookie,
@@ -204,7 +204,7 @@ function FlagRow({
   )
 }
 
-export function DevToolbar() {
+export function DevToolbar({ extraTabs = [] }: { extraTabs?: ExtraTab[] }) {
   const { isEnabled, isOpen, setIsOpen, events, setEvents, dismissToolbar } = useDevToolbar()
   const [activeTab, setActiveTab] = useState<string>('events')
   const [flagsSubTab, setFlagsSubTab] = useState<'posthog' | 'configcat'>('posthog')
@@ -398,6 +398,15 @@ export function DevToolbar() {
                 >
                   Flags {totalOverrideCount > 0 && `(${totalOverrideCount})`}
                 </TabsTrigger>
+                {extraTabs.map((tab) => (
+                  <TabsTrigger
+                    key={tab.id}
+                    value={tab.id}
+                    className="text-xs py-3 border-b-[1px] font-mono uppercase"
+                  >
+                    {tab.label}
+                  </TabsTrigger>
+                ))}
               </TabsList>
               <div className="ml-auto flex items-center gap-2">
                 <Tooltip>
@@ -553,6 +562,15 @@ export function DevToolbar() {
                 </div>
               </div>
             )}
+
+            {extraTabs.map((tab) => (
+              <div
+                key={tab.id}
+                className={cn('flex-1 min-h-0 overflow-y-auto', activeTab !== tab.id && 'hidden')}
+              >
+                {tab.content}
+              </div>
+            ))}
           </div>
         </Tabs>
       </SheetContent>

--- a/packages/dev-tools/index.ts
+++ b/packages/dev-tools/index.ts
@@ -31,7 +31,9 @@ export const useDevToolbar = !isToolbarEnabled
   ? () => noopContext
   : DevToolbarContextModule.useDevToolbar
 
-export const DevToolbar = !isToolbarEnabled ? () => null : DevToolbarModule.DevToolbar
+export const DevToolbar = !isToolbarEnabled
+  ? (_props: { extraTabs?: import('./types').ExtraTab[] }) => null
+  : DevToolbarModule.DevToolbar
 
 export const DevToolbarTrigger = !isToolbarEnabled
   ? () => null

--- a/packages/dev-tools/index.ts
+++ b/packages/dev-tools/index.ts
@@ -37,4 +37,4 @@ export const DevToolbarTrigger = !isToolbarEnabled
   ? () => null
   : DevToolbarTriggerModule.DevToolbarTrigger
 
-export type { DevTelemetryEvent, DevToolbarConfig } from './types'
+export type { DevTelemetryEvent, DevToolbarConfig, ExtraTab } from './types'

--- a/packages/dev-tools/types.ts
+++ b/packages/dev-tools/types.ts
@@ -1,4 +1,4 @@
-import type { Dispatch, SetStateAction } from 'react'
+import type { Dispatch, ReactNode, SetStateAction } from 'react'
 
 export interface DevTelemetryEvent {
   id: string
@@ -23,6 +23,12 @@ export interface ServerTelemetryEvent {
 
 export interface DevToolbarConfig {
   apiUrl: string
+}
+
+export interface ExtraTab {
+  id: string
+  label: string
+  content: ReactNode
 }
 
 export interface DevTelemetryToolbarContextType {


### PR DESCRIPTION
## Problem

There was no way to trigger resource warning banners in the dev toolbar, making it hard to test different warning states (warn/critical, read-only mode) without manually mocking API responses or waiting for real exhaustion events.

## Fix

- Adds an ExtraTab extension point to DevToolbar so Studio can inject custom tabs without coupling the package to app-specific hooks
- Adds a ResourceWarningsTab in Studio with per-type off/warn/crit toggles for disk IO, CPU, memory, disk space, and auth rate limit warnings, plus a read-only mode toggle
- Auth rate limit only exposes warn (no crit) since critical is not a valid API return value
- The tab component is dynamically imported so it stays out of production bundles, controlled by the same NEXT_PUBLIC_ENVIRONMENT guard used by the toolbar

## How to test

1. Run Studio locally or open a Vercel preview deployment
2. Open the browser console and run window.devTelemetry() to enable the toolbar
3. Click the toolbar trigger to open the panel
4. Switch to the "Warnings" tab
5. Toggle any warning type to "Warn" or "Crit" and confirm the banner appears at the top of the page
6. Toggle read-only mode on and confirm the read-only banner appears
7. Click "Reset to real data" and confirm banners return to their actual state
8. Confirm the Auth Rate Limit row only has Off and Warn buttons (no Crit)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New "Warnings" tab in the developer toolbar (enabled in local and staging) for managing resource warning banners.
  * Per-resource severity overrides (Off / Warning / Critical) with immediate preview in the toolbar.
  * Local "read-only" toggle to simulate read-only mode.
  * "Reset to real data" clears overrides, disables the local toggle, and refreshes server state.
  * Tab loads lazily and shows a disabled/loading state if org/project context is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->