### PR TITLE
refactor: use environment-based dashboard URLs instead of hardcoded p…

### DIFF
--- a/apps/www/components/CTABanner/index.tsx
+++ b/apps/www/components/CTABanner/index.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { DASHBOARD_SIGNUP_URL } from '~/lib/constants'
 import Link from 'next/link'
 import { Button, cn } from 'ui'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
@@ -28,7 +29,7 @@ const CTABanner = ({ darkerBg, className }: Props) => {
       <div className="flex items-center justify-center gap-2 col-span-12 mt-4">
         <Button asChild size="medium">
           <Link
-            href="https://supabase.com/dashboard"
+            href={DASHBOARD_SIGNUP_URL}
             onClick={() =>
               sendTelemetryEvent({
                 action: 'start_project_button_clicked',

--- a/apps/www/components/Hero/Hero.tsx
+++ b/apps/www/components/Hero/Hero.tsx
@@ -1,4 +1,5 @@
 import SectionContainer from '~/components/Layouts/SectionContainer'
+import { DASHBOARD_SIGNUP_URL } from '~/lib/constants'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
 import AnnouncementBadge from 'components/Announcement/Badge'
 import Link from 'next/link'
@@ -34,8 +35,8 @@ const Hero = () => {
                 <div className="flex items-center gap-2">
                   <Button asChild size="medium">
                     <Link
-                      href="https://supabase.com/dashboard"
-                      as="https://supabase.com/dashboard"
+                      href={DASHBOARD_SIGNUP_URL}
+                      as={DASHBOARD_SIGNUP_URL}
                       onClick={() =>
                         sendTelemetryEvent({
                           action: 'start_project_button_clicked',

--- a/apps/www/components/Nav/MobileMenu.tsx
+++ b/apps/www/components/Nav/MobileMenu.tsx
@@ -14,6 +14,7 @@ import MenuItem from './MenuItem'
 import staticContent from '@/.generated/staticContent/_index.json'
 import ProductModulesData from '@/data/ProductModules'
 import { DEFAULT_EASE } from '@/lib/animations'
+import { DASHBOARD_SIGNUP_URL, DASHBOARD_URL } from '@/lib/constants'
 import { useSendTelemetryEvent } from '@/lib/telemetry'
 
 interface Props {
@@ -259,7 +260,7 @@ const MobileMenu = ({ open, setOpen, menu }: Props) => {
                   ) : (
                     <>
                       <Link
-                        href="https://supabase.com/dashboard"
+                        href={DASHBOARD_URL}
                         passHref
                         legacyBehavior
                         onClick={() =>
@@ -276,7 +277,7 @@ const MobileMenu = ({ open, setOpen, menu }: Props) => {
                         </Button>
                       </Link>
                       <Link
-                        href="https://supabase.com/dashboard/sign-up"
+                        href={DASHBOARD_SIGNUP_URL}
                         passHref
                         legacyBehavior
                         onClick={() =>

--- a/apps/www/components/Nav/index.tsx
+++ b/apps/www/components/Nav/index.tsx
@@ -3,6 +3,7 @@
 import { useIsLoggedIn, useIsUserLoading, useUser } from 'common'
 import { getMenu } from 'data/nav'
 import { DevToolbarTrigger } from 'dev-tools'
+import { DASHBOARD_SIGNUP_URL, DASHBOARD_URL } from 'lib/constants'
 import { useSendTelemetryEvent } from 'lib/telemetry'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
@@ -185,7 +186,7 @@ const Nav = ({ hideNavbar, stickyNavbar = true }: Props) => {
                     <>
                       <Button type="default" className="hidden lg:block" asChild>
                         <Link
-                          href="https://supabase.com/dashboard"
+                          href={DASHBOARD_URL}
                           onClick={() =>
                             sendTelemetryEvent({
                               action: 'sign_in_button_clicked',
@@ -198,7 +199,7 @@ const Nav = ({ hideNavbar, stickyNavbar = true }: Props) => {
                       </Button>
                       <Button className="hidden lg:block" asChild>
                         <Link
-                          href="https://supabase.com/dashboard/sign-up"
+                          href={DASHBOARD_SIGNUP_URL}
                           onClick={() =>
                             sendTelemetryEvent({
                               action: 'start_project_button_clicked',

--- a/apps/www/components/Sections/ProductHeader.tsx
+++ b/apps/www/components/Sections/ProductHeader.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link'
 import { Button } from 'ui'
 import ProductIcon from '../ProductIcon'
 import { BookOpen } from 'lucide-react'
+import { DASHBOARD_SIGNUP_URL } from '~/lib/constants'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
 
 type subheader = string
@@ -51,8 +52,8 @@ const ProductHeader = (props: Types) => {
           <div className="flex flex-row md:flex-row md:items-center">
             <Button asChild size="medium">
               <Link
-                href="https://supabase.com/dashboard"
-                as="https://supabase.com/dashboard"
+                href={DASHBOARD_SIGNUP_URL}
+                as={DASHBOARD_SIGNUP_URL}
                 onClick={() =>
                   sendTelemetryEvent({
                     action: 'start_project_button_clicked',

--- a/apps/www/components/Sections/ProductsCta2.tsx
+++ b/apps/www/components/Sections/ProductsCta2.tsx
@@ -3,7 +3,7 @@ import React from 'react'
 import { Button, cn } from 'ui'
 import SectionContainer from '~/components/Layouts/SectionContainer'
 import MagnifiedProducts from '~/components/MagnifiedProducts'
-import { PRODUCT_SHORTNAMES } from '~/lib/constants'
+import { PRODUCT_SHORTNAMES, DASHBOARD_SIGNUP_URL } from '~/lib/constants'
 
 export type Products = PRODUCT_SHORTNAMES
 
@@ -27,7 +27,7 @@ function ProductsCta(props: Props) {
         <h2 className="h2 w-max">Ready to start building?</h2>
         <div className="flex gap-2 py-2">
           <Button asChild type="primary" size="small" className="h-full">
-            <Link href="https://supabase.com/dashboard">Start for free</Link>
+            <Link href={DASHBOARD_SIGNUP_URL}>Start for free</Link>
           </Button>
           <Button asChild type="default" size="small">
             <Link href="https://forms.supabase.com/enterprise">Contact Enterprise</Link>

--- a/apps/www/lib/constants.ts
+++ b/apps/www/lib/constants.ts
@@ -32,6 +32,9 @@ export const SITE_ORIGIN =
       ? `https://${process.env.NEXT_PUBLIC_VERCEL_BRANCH_URL}`
       : 'http://localhost:3000'
 
+export const DASHBOARD_URL = process.env.NEXT_PUBLIC_STUDIO_URL ?? 'https://supabase.com/dashboard'
+export const DASHBOARD_SIGNUP_URL = `${DASHBOARD_URL}/sign-up`
+
 export const LW_URL = `${SITE_ORIGIN}/launch-week`
 
 export const LW12_DATE = 'August 12-16 / 7am PT'


### PR DESCRIPTION
# refactor: use environment-based dashboard URLs instead of hardcoded production URLs

## Description

Replaces hardcoded production dashboard URLs with environment-based configuration to support local development. The change allows users running the www app locally to redirect to their local Studio instance instead of production.

## Changes

- Added `DASHBOARD_URL` and `DASHBOARD_SIGNUP_URL` constants that use `NEXT_PUBLIC_STUDIO_URL` env variable
- Updated 6 components to use these constants instead of hardcoded URLs
- Updated components: Nav, Hero, CTABanner, ProductsCta2, ProductHeader, MobileMenu

## Local Development Setup

Add to `.env.local`:
```
NEXT_PUBLIC_STUDIO_URL=http://localhost:8082
```

## Testing

- [x] Tested locally with local Studio instance
- [x] Signin/signup buttons redirect to local Studio
- [x] Maintained backward compatibility (production fallback)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Centralized configuration of navigation URLs (sign-in and project start links) across the website by consolidating hardcoded URLs into reusable constants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->