### PR TITLE
fix: write gh url to frontmatter

### DIFF
--- a/apps/docs/features/docs/Troubleshooting.script.mjs
+++ b/apps/docs/features/docs/Troubleshooting.script.mjs
@@ -65,8 +65,8 @@ function octokit() {
 export function supabaseAdmin() {
   if (!supabaseAdminClient) {
     supabaseAdminClient = createClient(
-      /** @type {string} */ (process.env.NEXT_PUBLIC_SUPABASE_URL),
-      /** @type {string} */ (process.env.SUPABASE_SECRET_KEY)
+      /** @type {string} */(process.env.NEXT_PUBLIC_SUPABASE_URL),
+      /** @type {string} */(process.env.SUPABASE_SECRET_KEY)
     )
   }
 
@@ -480,6 +480,7 @@ async function updateFileId(entry, id) {
     engines: { toml: parse },
   })
   data.database_id = id
+  data.github_url = entry.data.github_url
 
   const newFrontmatter = stringify(data)
   const newContent = `---\n${newFrontmatter}\n---\n${content}`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates script used in troubleshooting docs sync action so that the GitHub URL for corresponding GitHub discussions are written to the frontmatter of troubleshooting guide markdown file.
