### PR TITLE
fix(ui-patterns): revert fixed height on filter chip causing text clipping

### DIFF
--- a/packages/ui-patterns/src/FilterBar/FilterCondition.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterCondition.tsx
@@ -265,7 +265,7 @@ export function FilterCondition({
     <div
       ref={wrapperRef}
       className={cn(
-        'flex items-stretch px-0 h-[26px] bg-muted group shrink-0',
+        'flex items-stretch px-0 py-1 bg-muted group shrink-0',
         variant === 'pill' ? 'rounded border' : 'border-r',
         isHighlighted && 'ring-2 ring-primary'
       )}


### PR DESCRIPTION
## Summary
- Reverts `h-[26px]` back to `py-1` on `FilterCondition` component, which was changed in #44022
- The fixed height clips the filter chip content (e.g. "hue > 1C" text gets cut off)
- Using padding instead lets the chip size naturally based on its content

## Test plan
- [ ] Verify filter chips in the table editor are no longer clipped
- [ ] Check various filter value lengths to ensure wrapping/sizing is correct