### PR TITLE
feat: serve homepage as markdown

### DIFF
--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -2,6 +2,13 @@ import { stampFirstReferrerCookie } from 'common/first-referrer-cookie'
 import { NextResponse, type NextRequest } from 'next/server'
 
 export function middleware(request: NextRequest) {
+  if (
+    request.nextUrl.pathname === '/' &&
+    request.headers.get('accept')?.includes('text/markdown')
+  ) {
+    return NextResponse.rewrite(new URL('/llms/homepage.txt', request.url))
+  }
+
   const response = NextResponse.next()
   stampFirstReferrerCookie(request, response)
   return response

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -79,6 +79,10 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/llms/:path*.txt',
+        headers: [{ key: 'content-type', value: 'text/markdown; charset=utf-8' }],
+      },
+      {
         source: '/.well-known/vercel/flags',
         headers: [
           {


### PR DESCRIPTION
Serves the root `https://supabase.com` homepage as markdown when HTTP clients request `text/markdown` via `Accept` header. Currently rewrites to the existing `/llms/homepage.txt` file. Gives agents a baseline on where to find content for the rest of the site.

In the future we can work towards giving every page a markdown-equivalent.

## Testing

Run this in a terminal:

```shell
curl -H "Accept: text/markdown" https://zone-www-dot-com-git-feat-homepage-markdown-supabase.vercel.app
```

You should see the same contents as https://zone-www-dot-com-git-feat-homepage-markdown-supabase.vercel.app/llms/homepage.txt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added markdown content serving support, enabling access to content in markdown format through standard HTTP requests and dedicated endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->