### PR TITLE
feat: add api-catalog to .well-known

### DIFF
--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -89,7 +89,10 @@ const nextConfig = {
       },
       {
         source: '/.well-known/api-catalog',
-        headers: [{ key: 'content-type', value: 'application/linkset+json' }],
+        headers: [
+          { key: 'content-type', value: 'application/linkset+json' },
+          { key: 'access-control-allow-origin', value: '*' },
+        ],
       },
       {
         source: '/.well-known/vercel/flags',

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -79,6 +79,19 @@ const nextConfig = {
   async headers() {
     return [
       {
+        source: '/',
+        headers: [
+          {
+            key: 'Link',
+            value: '</.well-known/api-catalog>; rel="api-catalog"',
+          },
+        ],
+      },
+      {
+        source: '/.well-known/api-catalog',
+        headers: [{ key: 'content-type', value: 'application/linkset+json' }],
+      },
+      {
         source: '/.well-known/vercel/flags',
         headers: [
           {

--- a/apps/www/public/.well-known/api-catalog
+++ b/apps/www/public/.well-known/api-catalog
@@ -1,0 +1,23 @@
+{
+  "linkset": [
+    {
+      "anchor": "https://api.supabase.com/v1",
+      "service-desc": [
+        {
+          "href": "https://api.supabase.com/api/v1-json",
+          "type": "application/openapi+json"
+        }
+      ],
+      "service-doc": [
+        {
+          "href": "https://api.supabase.com/api/v1"
+        }
+      ],
+      "status": [
+        {
+          "href": "https://status.supabase.com"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Adds a `/.well-known/api-catalog` to advertise our management API. Motivation is for agents, but this is generally part of [RFC 9727](https://www.rfc-editor.org/rfc/rfc9727).

## Testing

Make an HTTP request to `/.well-known/api-catalog` and confirm it returns the JSON content with content type `application/linkset+json`:

```shell
curl -i https://zone-www-dot-com-git-feat-agent-catalog-supabase.vercel.app/.well-known/api-catalog
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API catalog (linkset) exposing API metadata, OpenAPI endpoint, documentation and status links.
  * Added HTTP headers to advertise the API catalog from the site root and to serve the catalog with the correct content type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->