### PR TITLE
fix: update image download functionality and prevent UI interactions

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -11,7 +11,7 @@ import {
   ReactFlow,
   useReactFlow,
 } from '@xyflow/react'
-import { toPng, toSvg } from 'html-to-image'
+import { toBlob, toSvg } from 'html-to-image'
 import { Check, Copy, Download, Loader2, Plus } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
@@ -167,65 +167,75 @@ export const SchemaGraph = () => {
     }
   )
 
-  const downloadImage = (format: 'png' | 'svg') => {
-    const reactflowViewport = document.querySelector('.react-flow__viewport') as HTMLElement
+  const waitForNextPaint = () =>
+    new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+    })
+
+  const downloadBlob = (blob: Blob, fileName: string) => {
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.setAttribute('download', fileName)
+    a.setAttribute('href', url)
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const toErrorMessage = (error: unknown) =>
+    error instanceof Error ? error.message : 'Unexpected error while exporting'
+
+  const downloadImage = async (format: 'png' | 'svg') => {
+    if (isDownloading) return
+
+    const reactflowViewport = document.querySelector('.react-flow__viewport') as HTMLElement | null
     if (!reactflowViewport) return
 
-    setIsDownloading(true)
-    const width = reactflowViewport.clientWidth
-    const height = reactflowViewport.clientHeight
-    const { x, y, zoom } = reactFlowInstance.getViewport()
+    try {
+      setIsDownloading(true)
 
-    if (format === 'svg') {
-      toSvg(reactflowViewport, {
+      // Let React render lightweight download UI before starting image serialization.
+      await waitForNextPaint()
+
+      const width = reactflowViewport.clientWidth
+      const height = reactflowViewport.clientHeight
+      const { x, y, zoom } = reactFlowInstance.getViewport()
+      const commonOptions = {
         backgroundColor: 'white',
         width,
         height,
+        cacheBust: true,
         style: {
           width: width.toString(),
           height: height.toString(),
           transform: `translate(${x}px, ${y}px) scale(${zoom})`,
         },
+      }
+
+      if (format === 'svg') {
+        const dataUrl = await toSvg(reactflowViewport, commonOptions)
+        const svgBlob = await fetch(dataUrl).then((response) => response.blob())
+        downloadBlob(svgBlob, `supabase-schema-${ref}.svg`)
+        toast.success('Successfully downloaded as SVG')
+        return
+      }
+
+      const pngBlob = await toBlob(reactflowViewport, {
+        ...commonOptions,
+        // Keep performance predictable for high-DPI displays and large graphs.
+        pixelRatio: 1,
       })
-        .then((data) => {
-          const a = document.createElement('a')
-          a.setAttribute('download', `supabase-schema-${ref}.svg`)
-          a.setAttribute('href', data)
-          a.click()
-          toast.success('Successfully downloaded as SVG')
-        })
-        .catch((error) => {
-          console.error('Failed to download:', error)
-          toast.error('Failed to download current view:', error.message)
-        })
-        .finally(() => {
-          setIsDownloading(false)
-        })
-    } else if (format === 'png') {
-      toPng(reactflowViewport, {
-        backgroundColor: 'white',
-        width,
-        height,
-        style: {
-          width: width.toString(),
-          height: height.toString(),
-          transform: `translate(${x}px, ${y}px) scale(${zoom})`,
-        },
+
+      if (!pngBlob) throw new Error('Failed to generate PNG blob')
+
+      downloadBlob(pngBlob, `supabase-schema-${ref}.png`)
+      toast.success('Successfully downloaded as PNG')
+    } catch (error) {
+      console.error('Failed to download:', error)
+      toast.error('Failed to download current view', {
+        description: toErrorMessage(error),
       })
-        .then((data) => {
-          const a = document.createElement('a')
-          a.setAttribute('download', `supabase-schema-${ref}.png`)
-          a.setAttribute('href', data)
-          a.click()
-          toast.success('Successfully downloaded as PNG')
-        })
-        .catch((error) => {
-          console.error('Failed to download:', error)
-          toast.error('Failed to download current view:', error.message)
-        })
-        .finally(() => {
-          setIsDownloading(false)
-        })
+    } finally {
+      setIsDownloading(false)
     }
   }
 
@@ -427,14 +437,16 @@ export const SchemaGraph = () => {
                     variant={BackgroundVariant.Dots}
                     color={'inherit'}
                   />
-                  <MiniMap
-                    pannable
-                    zoomable
-                    nodeColor={miniMapNodeColor}
-                    maskColor={miniMapMaskColor}
-                    className="border rounded-md shadow-sm"
-                  />
-                  <SchemaGraphLegend />
+                  {!isDownloading && (
+                    <MiniMap
+                      pannable
+                      zoomable
+                      nodeColor={miniMapNodeColor}
+                      maskColor={miniMapMaskColor}
+                      className="border rounded-md shadow-sm"
+                    />
+                  )}
+                  {!isDownloading && <SchemaGraphLegend />}
                 </ReactFlow>
               </div>
             </SchemaGraphContextProvider>

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -242,50 +242,52 @@ export const TableNode = ({
                   className={cn(hiddenNodeConnector)}
                 />
               )}
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button
-                    type="text"
-                    // Use opacity to hide the button so that it remains accessible (users can tab to it)
-                    className="opacity-0 focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 absolute right-0 top-1/2 -translate-y-1/2 px-0 mr-1 w-[16px] h-[16px] rounded"
-                  >
-                    <MoreVertical size={10} />
-                    <span className="sr-only">
-                      {data.name} {column.name} actions
-                    </span>
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent side="bottom" align="end" className="w-32">
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <DropdownMenuItem
-                        disabled={!canUpdateColumns}
-                        onClick={() => schemaGraphContext.onEditColumn(data.id, column.id)}
-                        className="space-x-2"
-                      >
-                        <Edit size={12} />
-                        <p>Edit column</p>
-                      </DropdownMenuItem>
-                    </TooltipTrigger>
-                    {!canUpdateColumns && (
-                      <TooltipContent side="bottom">
-                        Additional permissions required to edit column
-                      </TooltipContent>
-                    )}
-                  </Tooltip>
+              {!schemaGraphContext.isDownloading && (
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button
+                      type="text"
+                      // Use opacity to hide the button so that it remains accessible (users can tab to it)
+                      className="opacity-0 focus:opacity-100 group-hover:opacity-100 data-[state=open]:opacity-100 absolute right-0 top-1/2 -translate-y-1/2 px-0 mr-1 w-[16px] h-[16px] rounded"
+                    >
+                      <MoreVertical size={10} />
+                      <span className="sr-only">
+                        {data.name} {column.name} actions
+                      </span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent side="bottom" align="end" className="w-32">
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <DropdownMenuItem
+                          disabled={!canUpdateColumns}
+                          onClick={() => schemaGraphContext.onEditColumn(data.id, column.id)}
+                          className="space-x-2"
+                        >
+                          <Edit size={12} />
+                          <p>Edit column</p>
+                        </DropdownMenuItem>
+                      </TooltipTrigger>
+                      {!canUpdateColumns && (
+                        <TooltipContent side="bottom">
+                          Additional permissions required to edit column
+                        </TooltipContent>
+                      )}
+                    </Tooltip>
 
-                  <DropdownMenuItem
-                    className="space-x-2"
-                    onClick={(e) => {
-                      e.stopPropagation()
-                      copyToClipboard(column.name)
-                    }}
-                  >
-                    <Copy size={12} />
-                    <span>Copy name</span>
-                  </DropdownMenuItem>
-                </DropdownMenuContent>
-              </DropdownMenu>
+                    <DropdownMenuItem
+                      className="space-x-2"
+                      onClick={(e) => {
+                        e.stopPropagation()
+                        copyToClipboard(column.name)
+                      }}
+                    >
+                      <Copy size={12} />
+                      <span>Copy name</span>
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              )}
             </div>
           ))}
         </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Improves responsiveness and reliability of PNG/SVG export for schemas with many tables by:

Async capture with frame wait: Replaced synchronous export with async function that waits for React to re-render (two animation frames) before `html-to-image` starts serialization. This ensures the lighter download UI renders, removing interactive elements from the DOM.

Reduce DOM complexity during export: Hide MiniMap, legend, and per-column action menus while downloading, dramatically cutting serialization overhead for large graphs.

Lower render cost for PNG: Set `pixelRatio: 1` to prevent doubling render work on high-DPI displays.

Blob download instead of data URLs: Convert PNG/SVG to Blob with object URLs for better reliability on large exports, avoiding data URL size limits.

Issue No : #44882 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced schema graph export functionality with improved image rendering and more reliable error handling
  * Column actions are now hidden during schema downloads to prevent UI elements from appearing in exports

<!-- end of auto-generated comment: release notes by coderabbit.ai -->