### PR TITLE
fix: don't reset email template content

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -71,6 +71,10 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
   const [isSavingTemplate, setIsSavingTemplate] = useState(false)
   const [activeView, setActiveView] = useState<'source' | 'preview'>('source')
 
+  // Track pending changes in a ref so the authConfig effect can read the current value
+  // without being re-run every time hasChanges flips
+  const hasChangesRef = useRef(false)
+
   const spamRules = (validationResult?.rules ?? []).filter((rule) => rule.score > 0)
 
   const INITIAL_VALUES = useMemo(() => {
@@ -166,6 +170,7 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
   const baselineBodyValue = (authConfig && authConfig[messageSlug]) ?? ''
   const hasFormChanges = JSON.stringify(formValues) !== JSON.stringify(baselineValues)
   const hasChanges = hasFormChanges || baselineBodyValue !== bodyValue
+  hasChangesRef.current = hasChanges
 
   // Function to insert text at cursor position
   const insertTextAtCursor = (text: string) => {
@@ -195,9 +200,10 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
     }
   }
 
-  // Update form values when authConfig changes
+  // Update form values when authConfig changes, but skip if the user has unsaved edits
+  // (e.g. saving the Configuration card refetches authConfig and would otherwise wipe the Content form)
   useEffect(() => {
-    if (authConfig) {
+    if (authConfig && !hasChangesRef.current) {
       const values: { [key: string]: string } = {}
       Object.keys(properties).forEach((key) => {
         values[key] = ((authConfig && authConfig[key as keyof typeof authConfig]) ?? '') as string

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -74,6 +74,9 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
   // Track pending changes in a ref so the authConfig effect can read the current value
   // without being re-run every time hasChanges flips
   const hasChangesRef = useRef(false)
+  // Ensure the first authConfig sync always runs, even if hasChangesRef is already true
+  // (e.g. authConfig arrives after mount when form defaults were empty)
+  const hasHydratedFromAuthConfigRef = useRef(false)
 
   const spamRules = (validationResult?.rules ?? []).filter((rule) => rule.score > 0)
 
@@ -201,15 +204,17 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
   }
 
   // Update form values when authConfig changes, but skip if the user has unsaved edits
-  // (e.g. saving the Configuration card refetches authConfig and would otherwise wipe the Content form)
+  // (e.g. saving the Configuration card refetches authConfig and would otherwise wipe the Content form).
+  // Always run on first hydration so the form isn't left empty when authConfig arrives after mount.
   useEffect(() => {
-    if (authConfig && !hasChangesRef.current) {
+    if (authConfig && (!hasHydratedFromAuthConfigRef.current || !hasChangesRef.current)) {
       const values: { [key: string]: string } = {}
       Object.keys(properties).forEach((key) => {
         values[key] = ((authConfig && authConfig[key as keyof typeof authConfig]) ?? '') as string
       })
       form.reset(values)
       setBodyValue((authConfig && authConfig[messageSlug]) ?? '')
+      hasHydratedFromAuthConfigRef.current = true
     }
   }, [authConfig, properties, messageSlug, form])
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On a security email template page (e.g. Reauthentication), if you edit the Subject or Body without saving, then toggle **Enable notification** in the Configuration card and click **Save changes**, the Content edits are reverted to the last saved values.

Fixes DEPR-528

## What is the new behavior?

Saving the Configuration card no longer resets unsaved edits in the Content section (Subject/Body). The two sections are now independent.

**Root cause:** `updateAuthConfig` triggers a refetch of `authConfig`. A `useEffect` in `TemplateEditor` depended on `authConfig` and unconditionally called `form.reset()` + `setBodyValue()` on every update, wiping any in-progress edits.

**Fix:** Added a `hasChangesRef` (a `useRef` mirroring the current `hasChanges` value) so the effect can skip the reset when the user has unsaved edits — without adding `hasChanges` as a dependency (which would re-run the effect too often).

## Additional context

To reproduce:
1. Open a security email template (e.g. `/project/.../auth/templates/reauthentication`)
2. Edit the Subject or Body — don't save
3. Toggle **Enable notification** and click **Save changes** in the Configuration card
4. Before: Content edits are gone. After: Content edits are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the email template editor's handling of form state. The editor now properly preserves user modifications to email templates and prevents unexpected resets when the authentication configuration is refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->