### PR TITLE
fix(auth): remove banner from email notification templates

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.tsx
@@ -1,13 +1,12 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
-import { ChevronRight, ExternalLink, X } from 'lucide-react'
+import { useParams } from 'common'
+import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
-  Badge,
   Button,
   Card,
   CardContent,
@@ -16,9 +15,6 @@ import {
   FormControl_Shadcn_,
   FormField_Shadcn_,
   Switch,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import {
@@ -38,7 +34,6 @@ import { InlineLink } from '@/components/ui/InlineLink'
 import { useAuthConfigQuery } from '@/data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { DOCS_URL } from '@/lib/constants'
 
 const notificationEnabledKeys = TEMPLATES_SCHEMAS.filter(
@@ -62,11 +57,6 @@ export const EmailTemplates = () => {
   const { can: canUpdateConfig } = useAsyncCheckPermissions(
     PermissionAction.UPDATE,
     'custom_config_gotrue'
-  )
-
-  const [acknowledged, setAcknowledged] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.SECURITY_NOTIFICATIONS_ACKNOWLEDGED(projectRef ?? ''),
-    false
   )
 
   const {
@@ -202,51 +192,6 @@ export const EmailTemplates = () => {
               </PageSectionSummary>
             </PageSectionMeta>
             <PageSectionContent>
-              {!acknowledged && (
-                <Admonition showIcon={false} type="tip" className="relative mb-6">
-                  <Tooltip>
-                    <TooltipTrigger
-                      onClick={() => setAcknowledged(true)}
-                      className="absolute top-3 right-3 opacity-30 hover:opacity-100 transition-opacity"
-                    >
-                      <X size={14} className="text-foreground-light" />
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">Dismiss</TooltipContent>
-                  </Tooltip>
-                  <div className="flex flex-col md:flex-row md:items-center gap-y-2 md:gap-x-8 justify-between px-2 py-1">
-                    <div className="flex flex-col gap-y-0.5">
-                      <div className="flex flex-col gap-y-2 items-start">
-                        <Badge variant="success" className="-ml-0.5 uppercase">
-                          New
-                        </Badge>
-                        <p className="text-sm font-medium">
-                          Notify users about security-sensitive actions on their accounts
-                        </p>
-                      </div>
-                      <p className="text-sm text-foreground-lighter text-balance">
-                        We’ve expanded our email templates to handle security-sensitive actions. The
-                        list of templates will continue to grow as our feature-set changes, and as
-                        we{' '}
-                        <InlineLink href="https://github.com/orgs/supabase/discussions/40349">
-                          gather feedback
-                        </InlineLink>{' '}
-                        from our community .
-                      </p>
-                    </div>
-                    <Button
-                      asChild
-                      type="default"
-                      icon={<ExternalLink strokeWidth={1.5} />}
-                      className="mt-2"
-                    >
-                      <Link href={`${DOCS_URL}/guides/auth/auth-email-templates`} target="_blank">
-                        Docs
-                      </Link>
-                    </Button>
-                  </div>
-                </Admonition>
-              )}
-
               <Form_Shadcn_ {...notificationsForm}>
                 <form onSubmit={notificationsForm.handleSubmit(onSubmit)} className="space-y-4">
                   <Card>

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -50,10 +50,6 @@ export const LOCAL_STORAGE_KEYS = {
   SQL_EDITOR_SECTION_STATE: (ref: string) => `sql-editor-section-state-${ref}`,
   SQL_EDITOR_SORT: (ref: string) => `sql-editor-sort-${ref}`,
 
-  // Key to track if the user has acknowledged the security notifications preview
-  SECURITY_NOTIFICATIONS_ACKNOWLEDGED: (ref: string) =>
-    `security-notifications-acknowledged-${ref}`,
-
   LOG_EXPLORER_SPLIT_SIZE: 'supabase_log-explorer-split-size',
   GRAPHIQL_RLS_BYPASS_WARNING: 'graphiql-rls-bypass-warning-dismissed',
   CLS_DIFF_WARNING: 'cls-diff-warning-dismissed',


### PR DESCRIPTION
Removes the "New" banner from the email notification templates section as the features has been GA-ed for ~6 months now.

<img width="1844" height="758" alt="CleanShot 2026-04-15 at 10 30 33@2x" src="https://github.com/user-attachments/assets/4415f651-7274-4565-8e2d-4a66f8bbd100" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the security notifications acknowledgement feature from the email templates interface, including the dismissible notification tip and associated state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->