### PR TITLE
Skip invalidating auth config when toggling security email notification in template editor page

### DIFF
--- a/apps/studio/data/auth/auth-config-update-mutation.ts
+++ b/apps/studio/data/auth/auth-config-update-mutation.ts
@@ -10,6 +10,7 @@ import type { ResponseError, UseCustomMutationOptions } from '@/types'
 export type AuthConfigUpdateVariables = {
   projectRef: string
   config: Partial<components['schemas']['UpdateGoTrueConfigBody']>
+  skipInvalidation?: boolean
 }
 
 export async function updateAuthConfig({ projectRef, config }: AuthConfigUpdateVariables) {
@@ -41,9 +42,10 @@ export const useAuthConfigUpdateMutation = ({
   return useMutation<AuthConfigUpdateData, ResponseError, AuthConfigUpdateVariables>({
     mutationFn: (vars) => updateAuthConfig(vars),
     async onSuccess(data, variables, context) {
-      const { projectRef } = variables
+      const { projectRef, skipInvalidation = false } = variables
       await Promise.all([
-        queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) }),
+        !skipInvalidation &&
+          queryClient.invalidateQueries({ queryKey: authKeys.authConfig(projectRef) }),
         queryClient.invalidateQueries({ queryKey: lintKeys.lint(projectRef) }),
       ])
       await queryClient.refetchQueries({

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -127,9 +127,9 @@ const RedirectToTemplates = () => {
     defaultValues,
   })
 
-  const onSubmit = (values: any) => {
+  const onSubmit = (values: z.infer<typeof TemplateFormSchema>) => {
     if (!projectRef) return console.error('Project ref is required')
-    updateAuthConfig({ projectRef: projectRef, config: { ...values } })
+    updateAuthConfig({ projectRef: projectRef, config: { ...values }, skipInvalidation: true })
   }
 
   useEffect(() => {


### PR DESCRIPTION
## Context

Preferred fix to this PR [here](https://github.com/supabase/supabase/pull/44886)

On a security email template page (e.g. Reauthentication), if you edit the Subject or Body without saving, then toggle **Enable notification** in the Configuration card and click **Save changes**, the Content edits are reverted to the last saved values.

## Changes involved

Opting to not invalidate the `authConfig` RQ cache on a successful mutation when toggling the security email notification while on the template editor page

## To test

- [ ] Open a security email template
- [ ] Make some changes to the template without saving 
- [ ] Toggle the notification and save
- [ ] Ensure that the template changes are still present and not reverted

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized query cache handling for authentication configuration updates to reduce unnecessary refresh operations.
  * Enhanced type safety for form submissions in authentication settings to prevent data validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->