### PR TITLE
chore: extend format/lint hook to all apps and packages

### DIFF
--- a/.claude/scripts/format_and_lint.sh
+++ b/.claude/scripts/format_and_lint.sh
@@ -1,9 +1,20 @@
 #!/bin/bash
 #
-# PostToolUse hook: format and lint apps/studio/ files after Write or Edit.
+# PostToolUse hook: format and lint files in apps/ or packages/ after Write or Edit.
 # Receives hook JSON on stdin from Claude Code.
 
 set -euo pipefail
+
+# Apps/packages that have ESLint configured.
+# Add new entries here when a new workspace gets ESLint set up.
+ESLINT_PACKAGES=(
+  "apps/design-system:design-system"
+  "apps/docs:docs"
+  "apps/learn:learn"
+  "apps/studio:studio"
+  "apps/ui-library:ui-library"
+  "apps/www:www"
+)
 
 # Extract the file path from stdin JSON.
 # Falls back to .tool_response.filePath for Write tool compat.
@@ -13,17 +24,25 @@ if [[ -z "$file_path" || "$file_path" == "null" ]]; then
   exit 0
 fi
 
-# Only run for files under apps/studio/
-case "$file_path" in
-  *apps/studio/*)
-    cd "$CLAUDE_PROJECT_DIR"
-    pnpm exec prettier --config prettier.config.mjs --write "$file_path"
+cd "$CLAUDE_PROJECT_DIR"
 
-    # ESLint only for JS/TS files
-    case "$file_path" in
-      *.ts|*.tsx|*.js|*.jsx)
-        pnpm --filter=studio exec eslint --fix "$file_path"
-        ;;
-    esac
+# Prettier and ESLint for supported file types
+case "$file_path" in
+  *.ts|*.tsx|*.js|*.jsx|*.json|*.css|*.scss|*.md|*.mdx|*.html|*.yaml|*.yml|*.sql)
+    pnpm exec prettier --config prettier.config.mjs --write "$file_path"
+    ;;
+esac
+
+# ESLint only for JS/TS files in supported workspaces
+case "$file_path" in
+  *.ts|*.tsx|*.js|*.jsx)
+    for entry in "${ESLINT_PACKAGES[@]}"; do
+      dir="${entry%%:*}"
+      filter="${entry##*:}"
+      if [[ "$file_path" == *"$dir/"* ]]; then
+        pnpm --filter="$filter" exec eslint --fix "$file_path"
+        break
+      fi
+    done
     ;;
 esac


### PR DESCRIPTION
The Claude Code post-tool-use format/lint hook was hardcoded to only run on `apps/studio/` files. This updates it to work across the whole repo.

**Changed:**
- Prettier now runs on any supported file type in the repo (not just Studio)
- ESLint runs for any workspace that has it configured, using a simple lookup table
- Unsupported file types (e.g. `.sh`) are skipped to avoid "no parser" errors

## To test

- Edit a file in `apps/studio/` with bad formatting — should get auto-formatted and linted
- Edit a file in `packages/common/` — should get auto-formatted (no ESLint since it's not configured there)
- Edit a `.sh` file — should be skipped with no errors