### PR TITLE
chore(sentry): decrease tracesSampleRate to prevent blowing through quota

### DIFF
--- a/apps/studio/instrumentation-client.ts
+++ b/apps/studio/instrumentation-client.ts
@@ -97,7 +97,7 @@ Sentry.init({
   debug: false,
 
   // Enable performance monitoring
-  tracesSampleRate: 1.0, // Capture 100% of transactions for performance monitoring
+  tracesSampleRate: 0.02,
 
   integrations: (() => {
     const thirdPartyErrorFilterIntegration = (Sentry as any).thirdPartyErrorFilterIntegration

--- a/apps/studio/sentry.edge.config.ts
+++ b/apps/studio/sentry.edge.config.ts
@@ -14,7 +14,7 @@ Sentry.init({
   debug: false,
 
   // Enable performance monitoring
-  tracesSampleRate: 1.0, // Capture 100% of transactions for performance monitoring
+  tracesSampleRate: 0.02,
   ignoreErrors: [
     'NEXT_NOT_FOUND',
     'NEXT_REDIRECT',

--- a/apps/studio/sentry.server.config.ts
+++ b/apps/studio/sentry.server.config.ts
@@ -13,7 +13,7 @@ Sentry.init({
   debug: false,
 
   // Enable performance monitoring
-  tracesSampleRate: 1.0, // Capture 100% of transactions for performance monitoring
+  tracesSampleRate: 0.02,
   ignoreErrors: [
     'ResizeObserver',
     'Failed to load Stripe.js',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Chore

## What is the current behavior?

100% of traces are being sent to Sentry, which alone would blew through all of our quota leaving no spans available for other projects. For April we are already rate limited.

## What is the new behavior?

Change `tracesSampleRate` to more reasonable value (0.02).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted performance monitoring sampling across client, server, and edge deployments to significantly reduce telemetry volume and runtime overhead while preserving essential error tracking and diagnostics. This lowers monitoring noise and resource use without changing other monitoring behavior or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->