### PR TITLE
chore: upgrade `framer-motion`

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -68,7 +68,7 @@
     "config": "workspace:*",
     "dev-tools": "workspace:*",
     "eslint-config-supabase": "workspace:*",
-    "framer-motion": "^11.0.3",
+    "framer-motion": "^11.18.2",
     "github-slugger": "^2.0.0",
     "graphql": "^16.10.0",
     "graphql-validation-complexity": "^0.4.2",

--- a/apps/learn/package.json
+++ b/apps/learn/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "common": "workspace:*",
     "contentlayer2": "0.4.6",
-    "framer-motion": "^11.0.3",
+    "framer-motion": "^11.18.2",
     "jotai": "^2.8.0",
     "lucide-react": "*",
     "next": "catalog:",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -90,7 +90,7 @@
     "dayjs": "^1.11.10",
     "dev-tools": "workspace:*",
     "file-saver": "^2.0.5",
-    "framer-motion": "^11.11.17",
+    "framer-motion": "^11.18.2",
     "generate-password-browser": "^1.1.0",
     "html-to-image": "^1.10.8",
     "http-status": "^2.1.0",

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -60,7 +60,7 @@
     "common-tags": "^1.8.2",
     "contentlayer2": "0.4.6",
     "eslint-config-supabase": "workspace:*",
-    "framer-motion": "^11.0.3",
+    "framer-motion": "^11.18.2",
     "icons": "workspace:*",
     "jotai": "^2.8.0",
     "lucide-react": "*",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -49,7 +49,7 @@
     "dayjs": "^1.11.12",
     "dev-tools": "workspace:*",
     "eslint-config-supabase": "workspace:*",
-    "framer-motion": "^11.0.3",
+    "framer-motion": "^11.18.2",
     "globby": "^13.2.2",
     "gray-matter": "^4.0.3",
     "gsap": "^3.13.0",

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -795,7 +795,7 @@
     "common": "workspace:*",
     "common-tags": "^1.8.2",
     "dayjs": "^1.11.13",
-    "framer-motion": "^11.1.9",
+    "framer-motion": "^11.18.2",
     "github-slugger": "^2.0.0",
     "icons": "workspace:*",
     "highlightjs-curl": "^1.3.0",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -53,7 +53,7 @@
     "cmdk": "^1.1.1",
     "color": "^4.2.3",
     "date-fns": "^2.30.0",
-    "framer-motion": "^11.0.3",
+    "framer-motion": "^11.18.2",
     "input-otp": "^1.2.3",
     "lodash": "catalog:",
     "lucide-react": "^0.436.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,8 +377,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eslint-config-supabase
       framer-motion:
-        specifier: ^11.0.3
-        version: 11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.18.2
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -699,8 +699,8 @@ importers:
         specifier: 0.4.6
         version: 0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1)
       framer-motion:
-        specifier: ^11.0.3
-        version: 11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.18.2
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       jotai:
         specifier: ^2.8.0
         version: 2.8.1(@types/react@18.3.3)(react@18.3.1)
@@ -1025,8 +1025,8 @@ importers:
         specifier: ^2.0.5
         version: 2.0.5
       framer-motion:
-        specifier: ^11.11.17
-        version: 11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.18.2
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       generate-password-browser:
         specifier: ^1.1.0
         version: 1.1.0
@@ -1497,8 +1497,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eslint-config-supabase
       framer-motion:
-        specifier: ^11.0.3
-        version: 11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.18.2
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       icons:
         specifier: workspace:*
         version: link:../../packages/icons
@@ -1759,8 +1759,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/eslint-config-supabase
       framer-motion:
-        specifier: ^11.0.3
-        version: 11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.18.2
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       globby:
         specifier: ^13.2.2
         version: 13.2.2
@@ -2543,8 +2543,8 @@ importers:
         specifier: ^2.30.0
         version: 2.30.0
       framer-motion:
-        specifier: ^11.0.3
-        version: 11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.18.2
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       input-otp:
         specifier: ^1.2.3
         version: 1.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2694,8 +2694,8 @@ importers:
         specifier: ^1.11.13
         version: 1.11.13
       framer-motion:
-        specifier: ^11.1.9
-        version: 11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^11.18.2
+        version: 11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       github-slugger:
         specifier: ^2.0.0
         version: 2.0.0
@@ -12344,12 +12344,12 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
-  framer-motion@11.11.17:
-    resolution: {integrity: sha512-O8QzvoKiuzI5HSAHbcYuL6xU+ZLXbrH7C8Akaato4JzQbX2ULNeniqC2Vo5eiCtFktX9XsJ+7nUhxcl2E2IjpA==}
+  framer-motion@11.18.2:
+    resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0
-      react-dom: ^18.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -14674,8 +14674,14 @@ packages:
     resolution: {integrity: sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==}
     engines: {node: '>= 0.8.0'}
 
+  motion-dom@11.18.1:
+    resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
+
   motion-dom@12.9.4:
     resolution: {integrity: sha512-25TWkQPj5I18m+qVjXGtCsxboY11DaRC5HMjd29tHKExazW4Zf4XtAagBdLpyKsVuAxEQ6cx5/E4AB21PFpLnQ==}
+
+  motion-utils@11.18.1:
+    resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
 
   motion-utils@12.9.4:
     resolution: {integrity: sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==}
@@ -30509,8 +30515,10 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
-  framer-motion@11.11.17(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  framer-motion@11.18.2(@emotion/is-prop-valid@1.4.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
+      motion-dom: 11.18.1
+      motion-utils: 11.18.1
       tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.4.0
@@ -33526,9 +33534,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  motion-dom@11.18.1:
+    dependencies:
+      motion-utils: 11.18.1
+
   motion-dom@12.9.4:
     dependencies:
       motion-utils: 12.9.4
+
+  motion-utils@11.18.1: {}
 
   motion-utils@12.9.4: {}
 


### PR DESCRIPTION
## Problem

We'd like to update react to `19` but many of our dependencies don't support it.

## Solution

Update those dependencies. This PR focuses on `framer-motion`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated animation library dependencies to the latest compatible versions across applications and packages to ensure consistent performance and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->