### PR TITLE
fix(studio): use nuqs for database functions search to prevent caret jumping

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -1,7 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useParams } from 'common'
 import { Search } from 'lucide-react'
-import { useRouter } from 'next/router'
 import { parseAsBoolean, parseAsJson, parseAsString, useQueryState } from 'nuqs'
 import { useEffect } from 'react'
 import { toast } from 'sonner'
@@ -45,8 +43,6 @@ end;
 $$;`
 
 export const FunctionsList = () => {
-  const router = useRouter()
-  const { search } = useParams()
   const { data: project } = useSelectedProjectQuery()
   const aiSnap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
@@ -96,7 +92,10 @@ export const FunctionsList = () => {
     }
   }
 
-  const filterString = search ?? ''
+  const [filterString, setFilterString] = useQueryState(
+    'search',
+    parseAsString.withDefault('').withOptions({ clearOnDefault: true })
+  )
 
   // Filters
   const [returnTypeFilter, setReturnTypeFilter] = useQueryState(
@@ -107,16 +106,6 @@ export const FunctionsList = () => {
     'security',
     parseAsJson(selectFilterSchema.parse)
   )
-
-  const setFilterString = (str: string) => {
-    const url = new URL(document.URL)
-    if (str === '') {
-      url.searchParams.delete('search')
-    } else {
-      url.searchParams.set('search', str)
-    }
-    router.push(url)
-  }
 
   const { can: canCreateFunctions } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
@@ -254,10 +243,7 @@ export const FunctionsList = () => {
                 selectedSchemaName={selectedSchema}
                 onSelectSchema={(schema) => {
                   setFilterString('')
-                  // Wait for the filter to be cleared from the URL
-                  setTimeout(() => {
-                    setSelectedSchema(schema)
-                  }, 50)
+                  setSelectedSchema(schema)
                 }}
               />
               <Input


### PR DESCRIPTION
## Summary
- Fixes the cursor jumping to end of input on every keystroke in the database functions search
- Replaced manual `useParams` + `router.push` URL sync with `useQueryState` from nuqs, which updates state synchronously — matching the pattern already used for the other filters on this page
- Removed the `setTimeout` hack in the SchemaSelector onChange that was only needed because of the async URL update

Fixes FE-3000

## Test plan
- [x] Navigate to Database > Functions
- [x] Type a search string, then click in the middle of the string and type — cursor should stay in place
- [x] Verify search filtering still works correctly
- [x] Verify switching schemas still clears the search input
- [x] Verify the `?search=` query param is still reflected in the URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness of schema selection in the Functions list—search filters now clear immediately when switching schemas, eliminating previous delays.

* **Improvements**
  * Enhanced URL state synchronization for better consistency with browser history and navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->