### PR TITLE
feat(studio): add Copy as CSV option to SQL editor results

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/HotkeySettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/HotkeySettings.tsx
@@ -22,6 +22,7 @@ const HotkeySchema = z.object({
   inlineEditorEnabled: z.boolean(),
   copyMarkdownEnabled: z.boolean(),
   copyJsonEnabled: z.boolean(),
+  copyCsvEnabled: z.boolean(),
   downloadCsvEnabled: z.boolean(),
 })
 
@@ -46,6 +47,10 @@ export const HotkeySettings = () => {
     LOCAL_STORAGE_KEYS.HOTKEY_COPY_JSON,
     true
   )
+  const [copyCsvEnabled, setCopyCsvEnabled] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.HOTKEY_COPY_CSV,
+    true
+  )
   const [downloadCsvEnabled, setDownloadCsvEnabled] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.HOTKEY_DOWNLOAD_CSV,
     true
@@ -59,6 +64,7 @@ export const HotkeySettings = () => {
       inlineEditorEnabled: inlineEditorEnabled ?? true,
       copyMarkdownEnabled: copyMarkdownEnabled ?? true,
       copyJsonEnabled: copyJsonEnabled ?? true,
+      copyCsvEnabled: copyCsvEnabled ?? true,
       downloadCsvEnabled: downloadCsvEnabled ?? true,
     },
   })
@@ -110,6 +116,13 @@ export const HotkeySettings = () => {
               keys={['Shift', 'Meta', 'j']}
               label="Copy results as JSON"
               onToggle={setCopyJsonEnabled}
+            />
+            <HotkeyToggle
+              form={form}
+              name="copyCsvEnabled"
+              keys={['Shift', 'Meta', 'c']}
+              label="Copy results as CSV"
+              onToggle={setCopyCsvEnabled}
             />
             <HotkeyToggle
               form={form}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -172,6 +172,12 @@ const UtilityPanel = ({
                   groups: { project: ref ?? '', organization: org?.slug ?? '' },
                 })
               }}
+              onCopyAsCSV={() => {
+                sendEvent({
+                  action: 'sql_editor_result_copy_csv_clicked',
+                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
+                })
+              }}
             />
           )}
         </div>

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -33,6 +33,7 @@ interface DownloadResultsButtonProps {
   onDownloadAsCSV?: () => void
   onCopyAsMarkdown?: () => void
   onCopyAsJSON?: () => void
+  onCopyAsCSV?: () => void
 }
 
 export const DownloadResultsButton = ({
@@ -45,12 +46,14 @@ export const DownloadResultsButton = ({
   onDownloadAsCSV,
   onCopyAsMarkdown,
   onCopyAsJSON,
+  onCopyAsCSV,
 }: DownloadResultsButtonProps) => {
   const { ref } = useParams()
   const pathname = usePathname()
   const isLogs = pathname?.includes?.('/logs') ?? false
   const [copyMarkdownEnabled] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.HOTKEY_COPY_MARKDOWN, true)
   const [copyJsonEnabled] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.HOTKEY_COPY_JSON, true)
+  const [copyCsvEnabled] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.HOTKEY_COPY_CSV, true)
   const [downloadCsvEnabled] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.HOTKEY_DOWNLOAD_CSV, true)
 
   const isEmpty = useMemo(() => results.length === 0, [results])
@@ -92,6 +95,18 @@ export const DownloadResultsButton = ({
     })
   }
 
+  const copyAsCSV = () => {
+    const csv = convertResultsToCSV(results)
+    if (!csv) {
+      toast('Results are empty')
+      return
+    }
+    copyToClipboard(csv, () => {
+      toast.success('Copied CSV to clipboard')
+      onCopyAsCSV?.()
+    })
+  }
+
   useHotKey(
     (e) => {
       e.preventDefault()
@@ -108,6 +123,15 @@ export const DownloadResultsButton = ({
     },
     'j',
     { enabled: copyJsonEnabled ?? isEmpty, shift: true }
+  )
+
+  useHotKey(
+    (e) => {
+      e.preventDefault()
+      copyAsCSV()
+    },
+    'c',
+    { enabled: copyCsvEnabled ?? isEmpty, shift: true }
   )
 
   useHotKey(
@@ -153,6 +177,13 @@ export const DownloadResultsButton = ({
           <p>Copy as JSON</p>
           <span className="ml-auto">
             <KeyboardShortcut keys={['Shift', 'Meta', 'j']} />
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={copyAsCSV} className="gap-x-2">
+          <Copy size={14} />
+          <p>Copy as CSV</p>
+          <span className="ml-auto">
+            <KeyboardShortcut keys={['Shift', 'Meta', 'c']} />
           </span>
         </DropdownMenuItem>
         <DropdownMenuItem className="gap-x-2" onClick={() => downloadAsCSV()}>

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -96,6 +96,7 @@ export const LOCAL_STORAGE_KEYS = {
 
   HOTKEY_COPY_MARKDOWN: 'supabase-dashboard-hotkey-copy-markdown',
   HOTKEY_COPY_JSON: 'supabase-dashboard-hotkey-copy-json',
+  HOTKEY_COPY_CSV: 'supabase-dashboard-hotkey-copy-csv',
   HOTKEY_DOWNLOAD_CSV: 'supabase-dashboard-hotkey-download-csv',
 
   // Index Advisor notice dismissed

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -660,6 +660,18 @@ export interface SqlEditorResultCopyJsonClickedEvent {
 }
 
 /**
+ * User clicked the "Result copy CSV" button in the SQL editor
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/sql
+ */
+export interface SqlEditorResultCopyCsvClickedEvent {
+  action: 'sql_editor_result_copy_csv_clicked'
+  groups: TelemetryGroups
+}
+
+/**
  * User submitted a prompt to the assistant sidebar.
  *
  * @group Events
@@ -3186,6 +3198,7 @@ export type TelemetryEvent =
   | SqlEditorResultDownloadCsvClickedEvent
   | SqlEditorResultCopyMarkdownClickedEvent
   | SqlEditorResultCopyJsonClickedEvent
+  | SqlEditorResultCopyCsvClickedEvent
   | AssistantPromptSubmittedEvent
   | AssistantDebugSubmittedEvent
   | AssistantSuggestionRunQueryClickedEvent


### PR DESCRIPTION
## Summary
- Adds a new "Copy as CSV" action to the export dropdown in the SQL editor results panel, alongside the existing Copy as Markdown, Copy as JSON, and Download CSV options
- Registers a `Shift+Cmd+C` keyboard shortcut for the action, with a toggle in Account > Preferences > Keyboard shortcuts
- Works everywhere `DownloadResultsButton` is used: SQL editor, logs, query performance, and linter pages

Fixes FE-2991

## Test plan
- [x] Run a SELECT query in the SQL editor, open the Export dropdown, and verify "Copy as CSV" appears between "Copy as JSON" and "Download CSV"
- [x] Click "Copy as CSV" and verify CSV data is copied to clipboard
- [x] Use `Shift+Cmd+C` shortcut and verify it copies CSV to clipboard
- [x] Go to Account > Preferences > Keyboard shortcuts and verify the "Copy results as CSV" toggle is present and functional
- [x] Disable the shortcut in preferences, verify `Shift+Cmd+C` no longer triggers the copy
- [x] Verify the same option appears in the logs export dropdown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "Copy as CSV" action to the results download menu, allowing users to quickly copy query results in CSV format to the clipboard.
  * Introduced a new hotkey preference setting to enable/disable the Shift+Meta+C keyboard shortcut for copying results as CSV.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->