### PR TITLE
Add note to use /sign on resumable endpoint when using signed upload URLs.

### DIFF
--- a/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/resumable-uploads.mdx
@@ -305,6 +305,7 @@ Uppy has integrations with different frameworks:
 ### Presigned uploads
 
 Resumable uploads also supports using signed upload tokens to created time-limited URLs that you can share to your users by invoking the `createSignedUploadUrl` method on the SDK and including the returned token in the `x-signature` header of the resumable upload.
+The endpoint URL must also end with `/sign` so the TUS server knows to look for the `x-signature` header, e.g. `{host}/storage/v1/upload/resumable/sign`.
 
 <Tabs
   scrollable


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Current docs do not make mention of needing `/sign` at the end of the resumable upload URL when using storage sdk signed urls. The TUS server rejects without `/sign` with an error of "Invalid Compact JWS", presumably because it is looking for an Authorization header. 

## What is the new behavior?

Added a note that developers must add `/sign` at the end of the upload URL so the TUS server knows to look for the `x-signature` header and thus avoid the (unhelpful) error of "Invalid Compact JWS".

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated resumable uploads guide with clarification on TUS endpoint URL configuration for presigned uploads. The endpoint must end with `/sign` for the server to properly read the signature header, with an example endpoint path included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->