### PR TITLE
fix(studio): invert tooltip condition for restart failed tables button

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationPipelineStatus/ReplicationPipelineStatus.tsx
@@ -444,7 +444,7 @@ export const ReplicationPipelineStatus = () => {
                       tooltip={{
                         content: {
                           side: 'left',
-                          text: hasErroredTables ? 'No tables require manual retry' : undefined,
+                          text: !hasErroredTables ? 'No tables require manual retry' : undefined,
                         },
                       }}
                     >


### PR DESCRIPTION
Closes #44920

The tooltip on the "Restart failed tables only" dropdown item never displays. The condition `hasErroredTables ? 'No tables require manual retry' : undefined` is inverted -- `DropdownMenuItemTooltip` only renders the tooltip when the item is disabled, and the item is disabled when `!hasErroredTables`. So the text is set when the button is enabled (ignored) and undefined when disabled (no tooltip).

Flipped to `!hasErroredTables` so the tooltip explains why the button is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip logic in the replication pipeline status interface to correctly display "No tables require manual retry" when no manual intervention is needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->