### PR TITLE
fix(studio): add circuit breaker to prevent auth-js steal cascade deadlock

### DIFF
--- a/packages/common/gotrue.ts
+++ b/packages/common/gotrue.ts
@@ -174,6 +174,43 @@ async function debuggableNavigatorLock<R>(
         bc.close()
       }
     })
+  } catch (e: any) {
+    // Circuit breaker for the steal-cascade deadlock (Issue #44642).
+    //
+    // When a Chrome tab is suspended, navigator.locks can become orphaned —
+    // the lock is held at the browser level but the JS holding it is frozen.
+    // auth-js recovers by using { steal: true }, but per the Web Locks spec
+    // the original holder's fn() continues running as an orphaned task. When
+    // it resumes and calls navigatorLock() again, auth-js detects that OUR
+    // lock was stolen and throws NavigatorLockAcquireTimeoutError with the
+    // "stole it" message. If we re-throw here, the caller gets an unhandled
+    // error and any pending auth operations never complete — the app freezes.
+    //
+    // Fix: run fn() directly, without the lock. This is safe because at this
+    // point we are already running as an orphaned background task (the lock
+    // we held was stolen). Completing fn() harmlessly and exiting breaks the
+    // infinite queue — the stealer already holds the lock and will complete
+    // its own fn(), so the two runs are racing (bad), but no worse than the
+    // status quo from auth-js's own steal recovery which also runs fn() twice.
+    // Crucially, it prevents the infinite steal-back loop that freezes the UI.
+    if (
+      e?.name === 'NavigatorLockAcquireTimeoutError' ||
+      (typeof e?.message === 'string' && e.message.includes('stole it'))
+    ) {
+      console.warn(
+        '[Supabase Auth] Circuit breaker tripped: Lock cascade detected. ' +
+          'Bypassing lock to unfreeze app. ' +
+          `Lock name: "${name}". Original error: ${e?.message}`
+      )
+
+      if (captureException) {
+        captureException(e)
+      }
+
+      return await fn()
+    }
+
+    throw e
   } finally {
     clearTimeout(debugTimeout)
   }


### PR DESCRIPTION
Mitigates #44642 for Studio

What kind of change does this PR introduce?
[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

Description
This PR implements a circuit breaker in the Studio's debuggableNavigatorLock wrapper to protect the application from an infinite Web Lock steal cascade originating in @supabase/auth-js.

The Context:
When a Chrome tab is suspended, the background JavaScript context freezes. If navigatorLock is held, it triggers a 5000ms timeout and recovers via steal: true. However, the W3C spec for steal revokes exclusion but does not cancel the original callback. When the tab resumes, both the stolen and original promises execute concurrently, queuing against each other and triggering an infinite loop of timeouts and steals that permanently freezes the UI thread.

The Fix:
We cannot modify the root steal behavior from this repository, so this PR patches the Studio's consumption of it:

Wraps the navigatorLock call in a try/catch.

Uses a dual guard (e.name + string matching) to robustly detect the NavigatorLockAcquireTimeoutError thrown when auth-js detects a steal-back.

Bypasses the lock by immediately returning await fn(), exiting the infinite queuing cascade.

Logs a console.warn and fires captureException to track real-world occurrences via Sentry without crashing the client.

Testing Instructions
Spin up Studio locally.

Open the app in Chrome, force tab suspension (or simulate a heavily throttled CPU that delays the microtask queue past 5000ms during an auth refresh).

Resume the tab.

Verify the Circuit breaker tripped warning appears in the console and the dashboard remains responsive instead of deadlocking.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced resilience to lock acquisition failures by gracefully handling specific timeout conditions, allowing the application to continue operating in edge cases where synchronization issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->