### PR TITLE
chore: Add additional path for auth-v1-open-callback

### DIFF
--- a/docker/volumes/api/kong.yml
+++ b/docker/volumes/api/kong.yml
@@ -55,6 +55,7 @@ services:
         strip_path: true
         paths:
           - /auth/v1/callback
+          - /callback
     plugins:
       - name: cors
   - name: auth-v1-open-authorize


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- mirrors proposed fix in the CLI: https://github.com/supabase/cli/pull/5089

## What is the current behavior?

see https://github.com/supabase/cli/pull/5089

## What is the new behavior?

see https://github.com/supabase/cli/pull/5089

## Additional context

see https://github.com/supabase/cli/pull/5089


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication callback handling by enabling additional routing paths to ensure proper request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->