### PR TITLE
feat: request confirmation before applying auto-layout to the schema visualiser

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -22,6 +22,15 @@ import '@xyflow/react/dist/style.css'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { toast } from 'sonner'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
   Button,
   copyToClipboard,
   DropdownMenu,
@@ -130,7 +139,7 @@ export const SchemaGraph = () => {
 
   const canAddTables = canUpdateTables && !isSchemaLocked
 
-  const resetLayout = () => {
+  const resetLayout = async () => {
     const nodes = reactFlowInstance.getNodes()
     const edges = reactFlowInstance.getEdges()
 
@@ -140,7 +149,12 @@ export const SchemaGraph = () => {
     )
     reactFlowInstance.setNodes(nodes)
     reactFlowInstance.setEdges(edges)
-    setTimeout(() => reactFlowInstance.fitView({}))
+    await new Promise<void>((resolve) =>
+      setTimeout(async () => {
+        await reactFlowInstance.fitView({})
+        resolve()
+      })
+    )
     saveNodePositions()
   }
 
@@ -286,9 +300,7 @@ export const SchemaGraph = () => {
           <div className="h-[34px] w-[260px] bg-foreground-lighter rounded shimmering-loader" />
         )}
 
-        {isErrorSchemas && (
-          <AlertError error={errorSchemas as any} subject="Failed to retrieve schemas" />
-        )}
+        {isErrorSchemas && <AlertError error={errorSchemas} subject="Failed to retrieve schemas" />}
 
         {isSuccessSchemas && (
           <>
@@ -347,18 +359,33 @@ export const SchemaGraph = () => {
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
-                <ButtonTooltip
-                  type="default"
-                  onClick={resetLayout}
-                  tooltip={{
-                    content: {
-                      side: 'bottom',
-                      text: 'Automatically arrange the layout of all nodes',
-                    },
-                  }}
-                >
-                  Auto layout
-                </ButtonTooltip>
+                <AlertDialog>
+                  <AlertDialogTrigger asChild>
+                    <ButtonTooltip
+                      type="default"
+                      tooltip={{
+                        content: {
+                          side: 'bottom',
+                          text: 'Automatically arrange the layout of all nodes',
+                        },
+                      }}
+                    >
+                      Auto layout
+                    </ButtonTooltip>
+                  </AlertDialogTrigger>
+                  <AlertDialogContent>
+                    <AlertDialogHeader>
+                      <AlertDialogTitle>Auto layout</AlertDialogTitle>
+                      <AlertDialogDescription>
+                        Applying auto layout will rearrange all nodes in the graph.
+                      </AlertDialogDescription>
+                    </AlertDialogHeader>
+                    <AlertDialogFooter>
+                      <AlertDialogCancel>Close</AlertDialogCancel>
+                      <AlertDialogAction onClick={resetLayout}>Apply</AlertDialogAction>
+                    </AlertDialogFooter>
+                  </AlertDialogContent>
+                </AlertDialog>
               </div>
             )}
           </>

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -375,10 +375,9 @@ export const SchemaGraph = () => {
                   </AlertDialogTrigger>
                   <AlertDialogContent>
                     <AlertDialogHeader>
-                      <AlertDialogTitle>Confirm to arrange the layout of nodes</AlertDialogTitle>
+                      <AlertDialogTitle>Confirm to rearrange all nodes</AlertDialogTitle>
                       <AlertDialogDescription>
-                        Applying auto layout will rearrange all nodes in the graph, and this action
-                        cannot be undone.
+                        Auto layout will rearrange all nodes in the graph. This cannot be undone.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -375,9 +375,10 @@ export const SchemaGraph = () => {
                   </AlertDialogTrigger>
                   <AlertDialogContent>
                     <AlertDialogHeader>
-                      <AlertDialogTitle>Auto layout</AlertDialogTitle>
+                      <AlertDialogTitle>Confirm to arrange the layout of nodes</AlertDialogTitle>
                       <AlertDialogDescription>
-                        Applying auto layout will rearrange all nodes in the graph.
+                        Applying auto layout will rearrange all nodes in the graph, and this action
+                        cannot be undone.
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -381,7 +381,7 @@ export const SchemaGraph = () => {
                       </AlertDialogDescription>
                     </AlertDialogHeader>
                     <AlertDialogFooter>
-                      <AlertDialogCancel>Close</AlertDialogCancel>
+                      <AlertDialogCancel>Cancel</AlertDialogCancel>
                       <AlertDialogAction onClick={resetLayout}>Apply</AlertDialogAction>
                     </AlertDialogFooter>
                   </AlertDialogContent>


### PR DESCRIPTION
## Problem

If users accidentally click the _Auto layout_ button in the schema visualiser, they immediately lose all their changes.

## Solution

- Ask for confirmation before applying auto layout
- Fix auto layout changes aren't persisted

<img width="457" height="232" alt="image" src="https://github.com/user-attachments/assets/d58e2995-6537-43b4-9b99-b1447fb03e1f" />

## How to test

- Go to database/schema
- Make changes to the layout
- Refresh the page and check changes are still applied
- Click the _Auto layout_ button and click _Cancel_
- Check auto layout wasn't applied
- Refresh the page and check users changes are still applied
- Click the _Auto layout_ button and click _Apply_
- Check auto layout was applied
- Refresh the page and check auto layout changes are still applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a confirmation dialog for the "Auto layout" action so users can review and confirm before changes are applied.

* **Bug Fixes**
  * Ensured layout fitting completes before node positions are saved, preventing incorrect or premature persistence.

* **Style**
  * Simplified schema error rendering to present error messages more directly and clearly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->