### PR TITLE
fix(studio): replace next/router with next/compat/router to fix static build

### DIFF
--- a/apps/studio/data/telemetry/send-event-mutation.ts
+++ b/apps/studio/data/telemetry/send-event-mutation.ts
@@ -1,7 +1,7 @@
 import { useMutation } from '@tanstack/react-query'
 import { sendTelemetryEvent } from 'common'
 import { TelemetryEvent } from 'common/telemetry-constants'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/compat/router'
 
 import { handleError } from '@/data/fetchers'
 import { API_URL } from '@/lib/constants'
@@ -34,7 +34,7 @@ export const useSendEventMutation = ({
 
   return useMutation<SendEventData, ResponseError, TelemetryEvent>({
     mutationFn: (event) => {
-      return sendEvent({ event, pathname: router.pathname })
+      return sendEvent({ event, pathname: router?.pathname })
     },
     async onSuccess(data, variables, context) {
       await onSuccess?.(data, variables, context)

--- a/apps/studio/lib/profile.tsx
+++ b/apps/studio/lib/profile.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from '@sentry/nextjs'
 import { useIsLoggedIn, useUser } from 'common'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/compat/router'
 import { createContext, PropsWithChildren, useContext, useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
 
@@ -91,7 +91,7 @@ export const ProfileProvider = ({ children }: PropsWithChildren<{}>) => {
     // on every page load, we can check for a 401 here and sign the user out if
     // they have a bad token.
     if (error?.code === 401) {
-      signOut().then(() => router.push('/sign-in'))
+      signOut().then(() => router?.push('/sign-in'))
     }
   }, [error, signOut, router, createProfile, isError])
 

--- a/apps/studio/lib/telemetry/track.ts
+++ b/apps/studio/lib/telemetry/track.ts
@@ -1,6 +1,6 @@
 import { sendTelemetryEvent } from 'common'
 import { TelemetryEvent, TelemetryGroups } from 'common/telemetry-constants'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/compat/router'
 import { useCallback } from 'react'
 
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -53,9 +53,9 @@ export const useTrack = () => {
         ...(groups && { groups }),
       } as EventMap[A]
 
-      sendTelemetryEvent(API_URL, event, router.pathname)
+      sendTelemetryEvent(API_URL, event, router?.pathname)
     },
-    [project?.ref, org?.slug, router.pathname]
+    [project?.ref, org?.slug, router?.pathname]
   )
 
   return track

--- a/packages/common/MetaFavicons/pages-router.tsx
+++ b/packages/common/MetaFavicons/pages-router.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Head from 'next/head'
-import { useRouter } from 'next/router'
+import { useRouter } from 'next/compat/router'
 
 export const DEFAULT_FAVICON_THEME_COLOR = '1E1E1E'
 export const DEFAULT_FAVICON_ROUTE = '/favicon'
@@ -26,7 +26,8 @@ const MetaFaviconsPagesRouter = ({
   // include browserconfig.xml
   includeMsApplicationConfig?: boolean
 }) => {
-  const { basePath } = useRouter()
+  const router = useRouter()
+  const basePath = router?.basePath ?? process.env.NEXT_PUBLIC_BASE_PATH ?? ''
 
   return (
     <Head>


### PR DESCRIPTION
## Summary

- `useRouter` from `next/router` throws `NextRouter was not mounted` during Next.js static page generation, causing the studio build to fail across all pages
- Replaced with `useRouter` from `next/compat/router` which safely returns `null` instead of throwing
- Added null-safe optional chaining (`?.`) where the router value is used

## Files changed

| File | Usage |
|------|-------|
| `apps/studio/lib/profile.tsx` | `ProfileProvider` — used `router.push` for 401 sign-out redirect |
| `apps/studio/data/telemetry/send-event-mutation.ts` | `useSendEventMutation` — used `router.pathname` for telemetry |
| `apps/studio/lib/telemetry/track.ts` | `useTrack` — used `router.pathname` for telemetry |
| `packages/common/MetaFavicons/pages-router.tsx` | `MetaFaviconsPagesRouter` — used `router.basePath` for favicon URLs |

## Test plan

- [ ] Run `mise studio:build` (or `pnpm run build:studio` in the supabase repo) and confirm it completes without prerender errors
- [ ] Verify studio loads normally in dev mode (`mise studio:dev`)
- [ ] Confirm 401 sign-out redirect still works (navigates to `/sign-in`)
- [ ] Confirm favicon links render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved router-related error handling across telemetry, authentication, and favicon logic to avoid crashes when the router is unavailable.
  * Made router property access defensive (nullable guards) and added a fallback for base path resolution to ensure consistent behavior and stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->