### PR TITLE
fix(studio): remove CLI backup instructions from paused project state

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -36,7 +36,6 @@ import {
   extractPostgresVersionDetails,
   PostgresVersionSelector,
 } from '@/components/interfaces/ProjectCreation/PostgresVersionSelector'
-import { LogicalBackupCliInstructions } from '@/components/layouts/ProjectLayout/LogicalBackupCliInstructions'
 import AlertError from '@/components/ui/AlertError'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
@@ -226,12 +225,6 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
             </div>
           </div>
         </CardContent>
-
-        {!isRestoreDisabled && (
-          <div className="border-t px-6 py-4">
-            <LogicalBackupCliInstructions note="Your project must be resumed before running these commands." />
-          </div>
-        )}
 
         {isError && (
           <AlertError


### PR DESCRIPTION
## Problem

The CLI backup instructions added inline to `ProjectPausedState` (#44621) make the paused project card too tall to fit on smaller screens. Because the card itself doesn't scroll, users on smaller viewports cannot reach the Resume button — blocking them from resuming their project entirely.

## Fix

Remove the inline `LogicalBackupCliInstructions` section from `ProjectPausedState`. CLI backup instructions are still available in:
- The delete project modal (inline)
- The "Download backup" button dialog in `PauseFailedState` / `RestoreFailedState`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed CLI backup command instructions from the paused project state view, streamlining the interface and eliminating redundant messaging about project resumption requirements before running commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->