### PR TITLE
fix(docs): scope vitest run to target dir in js-libs-update workflow

### DIFF
--- a/.github/workflows/docs-js-libs-update.yml
+++ b/.github/workflows/docs-js-libs-update.yml
@@ -55,7 +55,7 @@ jobs:
         working-directory: apps/docs
         run: |
           echo "Generating new typespec snapshot for review..."
-          npx vitest run --update ./features/docs/Reference.typeSpec.test.ts
+          npx vitest run --update --dir features/docs
 
       - name: Generate token
         id: app-token


### PR DESCRIPTION
Vitest 4 no longer restricts test execution when a file path is passed as a positional filter, causing all docs tests to run and fail on unrelated tests. Use --dir to scope to the target directory. PR  #44833 made the update which broke the behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the test snapshot generation workflow to cover the expanded set of tests in the documentation features directory, broadening the scope of automated snapshot updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->