### PR TITLE
docs(dart): require onError handler in onAuthStateChange examples

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1502,19 +1502,6 @@ functions:
             (data) {
               final AuthChangeEvent event = data.event;
               final Session? session = data.session;
-
-              print('event: $event, session: $session');
-
-              switch (event) {
-                case AuthChangeEvent.initialSession:
-                case AuthChangeEvent.signedIn:
-                case AuthChangeEvent.signedOut:
-                case AuthChangeEvent.passwordRecovery:
-                case AuthChangeEvent.tokenRefreshed:
-                case AuthChangeEvent.userUpdated:
-                case AuthChangeEvent.userDeleted:
-                case AuthChangeEvent.mfaChallengeVerified:
-              }
             },
             onError: (error, stackTrace) {
               // Network errors (e.g. offline) are emitted here.

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1502,6 +1502,7 @@ functions:
             (data) {
               final AuthChangeEvent event = data.event;
               final Session? session = data.session;
+              // handle event
             },
             onError: (error, stackTrace) {
               // Network errors (e.g. offline) are emitted here.

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1491,54 +1491,69 @@ functions:
       Receive a notification every time an auth event happens.
     notes: |
       - Types of auth events: `AuthChangeEvent.passwordRecovery`, `AuthChangeEvent.signedIn`, `AuthChangeEvent.signedOut`, `AuthChangeEvent.tokenRefreshed`, `AuthChangeEvent.userUpdated`and `AuthChangeEvent.userDeleted`
+      - **You must provide an `onError` handler.** Network errors (e.g. an offline token refresh) are emitted as stream errors. If no `onError` is provided, Dart rethrows them as unhandled zone exceptions, crashing the app.
     examples:
       - id: listen-to-auth-changes
         name: Listen to auth changes
         isSpotlight: true
         code: |
           ```dart
-          final authSubscription = supabase.auth.onAuthStateChange.listen((data) {
-            final AuthChangeEvent event = data.event;
-            final Session? session = data.session;
+          final authSubscription = supabase.auth.onAuthStateChange.listen(
+            (data) {
+              final AuthChangeEvent event = data.event;
+              final Session? session = data.session;
 
-            print('event: $event, session: $session');
+              print('event: $event, session: $session');
 
-            switch (event) {
-              case AuthChangeEvent.initialSession:
-              // handle initial session
-              case AuthChangeEvent.signedIn:
-              // handle signed in
-              case AuthChangeEvent.signedOut:
-              // handle signed out
-              case AuthChangeEvent.passwordRecovery:
-              // handle password recovery
-              case AuthChangeEvent.tokenRefreshed:
-              // handle token refreshed
-              case AuthChangeEvent.userUpdated:
-              // handle user updated
-              case AuthChangeEvent.userDeleted:
-              // handle user deleted
-              case AuthChangeEvent.mfaChallengeVerified:
-              // handle mfa challenge verified
-            }
-          });
+              switch (event) {
+                case AuthChangeEvent.initialSession:
+                // handle initial session
+                case AuthChangeEvent.signedIn:
+                // handle signed in
+                case AuthChangeEvent.signedOut:
+                // handle signed out
+                case AuthChangeEvent.passwordRecovery:
+                // handle password recovery
+                case AuthChangeEvent.tokenRefreshed:
+                // handle token refreshed
+                case AuthChangeEvent.userUpdated:
+                // handle user updated
+                case AuthChangeEvent.userDeleted:
+                // handle user deleted
+                case AuthChangeEvent.mfaChallengeVerified:
+                // handle mfa challenge verified
+              }
+            },
+            onError: (error, stackTrace) {
+              // Network errors (e.g. offline) are emitted here.
+              // Handle or log them to avoid an unhandled exception crash.
+            },
+          );
           ```
       - id: listen-to-a-specific-event
         name: Listen to a specific event
         code: |
           ```dart
-          final authSubscription = supabase.auth.onAuthStateChange.listen((data) {
-            final AuthChangeEvent event = data.event;
-            if (event == AuthChangeEvent.signedIn) {
-              // handle signIn
-            }
-          });
+          final authSubscription = supabase.auth.onAuthStateChange.listen(
+            (data) {
+              final AuthChangeEvent event = data.event;
+              if (event == AuthChangeEvent.signedIn) {
+                // handle signIn
+              }
+            },
+            onError: (error, stackTrace) {
+              // Handle or log network / auth errors here.
+            },
+          );
           ```
       - id: unsubscribe-from-auth-subscription
         name: Unsubscribe from auth subscription
         code: |
           ```dart
-          final authSubscription = supabase.auth.onAuthStateChange.listen((data) {});
+          final authSubscription = supabase.auth.onAuthStateChange.listen(
+            (data) {},
+            onError: (error, stackTrace) {},
+          );
 
           authSubscription.cancel();
           ```

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1490,8 +1490,8 @@ functions:
     description: |
       Receive a notification every time an auth event happens.
     notes: |
-      - Types of auth events: `AuthChangeEvent.passwordRecovery`, `AuthChangeEvent.signedIn`, `AuthChangeEvent.signedOut`, `AuthChangeEvent.tokenRefreshed`, `AuthChangeEvent.userUpdated`and `AuthChangeEvent.userDeleted`
       - **You must provide an `onError` handler.** Network errors (e.g. an offline token refresh) are emitted as stream errors. If no `onError` is provided, Dart rethrows them as unhandled zone exceptions, crashing the app.
+      - Auth event types: `initialSession`, `signedIn`, `signedOut`, `passwordRecovery`, `tokenRefreshed`, `userUpdated`, `userDeleted`, `mfaChallengeVerified`
     examples:
       - id: listen-to-auth-changes
         name: Listen to auth changes
@@ -1507,21 +1507,13 @@ functions:
 
               switch (event) {
                 case AuthChangeEvent.initialSession:
-                // handle initial session
                 case AuthChangeEvent.signedIn:
-                // handle signed in
                 case AuthChangeEvent.signedOut:
-                // handle signed out
                 case AuthChangeEvent.passwordRecovery:
-                // handle password recovery
                 case AuthChangeEvent.tokenRefreshed:
-                // handle token refreshed
                 case AuthChangeEvent.userUpdated:
-                // handle user updated
                 case AuthChangeEvent.userDeleted:
-                // handle user deleted
                 case AuthChangeEvent.mfaChallengeVerified:
-                // handle mfa challenge verified
               }
             },
             onError: (error, stackTrace) {


### PR DESCRIPTION
## Summary

- Adds a warning note to `onAuthStateChange()` that an `onError` handler is **required**
- Updates all three Dart code examples (spotlight, specific-event, unsubscribe) to include `onError`

## Background

Network errors (e.g. a token refresh attempted while the device is offline) are emitted as stream errors on `onAuthStateChange`. If no `onError` handler is provided, Dart rethrows them as unhandled zone exceptions, crashing the app.

This is tracked in supabase/supabase-flutter#1281. The SDK itself already handles this internally (`supabase_auth.dart` has its own `onError`), but user-facing code that calls `.listen()` without `onError` is still vulnerable.

The companion SDK fix (example app + doc comment in `gotrue_client.dart`) is in a separate PR in `supabase/supabase-flutter`.

## Test plan

- [ ] Review the rendered diff in the Dart reference docs (`/docs/reference/dart/auth-onauthstatechange`)
- [ ] Confirm all three code examples now show `onError`
- [ ] Confirm the new note is visible in the Notes section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified auth-state change docs to require explicit error handling in listeners and updated all examples to show an error callback to avoid unhandled exceptions.
  * Updated the documented list of auth event names to the new set (including initialSession and mfaChallengeVerified) and adjusted examples accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->