### PR TITLE
fix(studio): resolve realtime channel state desync and stale closures

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
+++ b/apps/studio/components/interfaces/Realtime/Inspector/useRealtimeMessages.ts
@@ -196,7 +196,7 @@ export const useRealtimeMessages = (
 
         newChannel.unsubscribe()
         setChannel(undefined)
-        setRealtimeConfig({ ...config, channelName: '', enabled: false })
+        setRealtimeConfig((prev) => ({ ...prev, channelName: '', enabled: false }))
       }
     })
 
@@ -213,6 +213,7 @@ export const useRealtimeMessages = (
     enablePresence,
     filter,
     host,
+    isChannelPrivate,
     schema,
     table,
   ])


### PR DESCRIPTION
Fixes ##44947

What kind of change does this PR introduce?
[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

Description
This PR fixes critical state-sync issues in the Studio's Realtime Inspector (useRealtimeMessages.ts).

Added isChannelPrivate to the useEffect dependency array. Previously, toggling a channel between public and private updated the UI but failed to tear down and rebuild the supabase.channel(). This left users unknowingly streaming on a public channel while the UI indicated RLS was active.

Refactored setRealtimeConfig to use a functional updater. In the CHANNEL_ERROR callback, spreading the closure-captured config object was silently overwriting newer configuration state (like refreshed tokens) with stale data captured when the effect initially mounted. Using prev => ({ ...prev, log: ... }) ensures we always append to the latest state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed realtime channel configuration to properly handle errors and respect privacy setting changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->