### PR TITLE
fix(studio): await saveRow and surface foreign row errors to UI and Sentry

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -361,8 +361,15 @@ export const SidePanelEditor = ({
       const isNewRecord = false
       const configuration = { identifiers, rowIdx: row.idx }
 
-      saveRow(value, isNewRecord, configuration, () => {})
-    } catch (error) {}
+      await saveRow(value, isNewRecord, configuration, (error) => {
+        if (error) {
+          toast.error(`Failed to save row: ${error?.message ?? 'Unknown error'}`)
+        }
+      })
+    } catch (error: any) {
+      toast.error(`Failed to save row: ${error?.message ?? 'Unknown error'}`)
+      Sentry.captureException(error, { tags: { workflow: 'save-foreign-row' } })
+    }
   }
 
   const saveColumn = async (


### PR DESCRIPTION
Fixes #44949 

What kind of change does this PR introduce?
[x] Bug fix (non-breaking change which fixes an issue)

[ ] New feature (non-breaking change which adds functionality)

Description
This PR fixes a silent failure state in the Foreign Row Selector (SidePanelEditor.tsx).

Previously, onSaveForeignRow called saveRow without awaiting it, and included an entirely empty catch block. This meant that any database write failures (RLS violations, network drops, foreign key constraint violations) were swallowed into the void. The user received no visual feedback that their save failed.

Changes:

Added await to saveRow to ensure the promise rejection is actually caught by the try/catch block.
Added a toast.error notification to alert the user when the save fails.
Added Sentry.captureException to ensure these silent failures are actually tracked in production observability. (Sentry was already imported in the file).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and user notifications when saving data in the table editor, ensuring failures are properly communicated and logged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->