### PR TITLE
fix(studio): show Vercel-specific copy in delete connection dialog

### DIFF
--- a/apps/studio/components/interfaces/Integrations/VercelGithub/IntegrationConnection.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/IntegrationConnection.tsx
@@ -155,8 +155,9 @@ export const IntegrationConnectionItem = forwardRef<HTMLLIElement, IntegrationCo
           loading={isDeleting}
         >
           <p className="text-sm text-foreground-light">
-            Deleting this GitHub connection will stop automatic creation and merging of preview
-            branches. Existing preview branches will remain unchanged.
+            {type === 'Vercel'
+              ? 'Deleting this Vercel connection will stop syncing environment variables to your Vercel project. Existing environment variables will remain unchanged.'
+              : 'Deleting this GitHub connection will stop automatic creation and merging of preview branches. Existing preview branches will remain unchanged.'}
           </p>
         </ConfirmationModal>
       </>


### PR DESCRIPTION
## Summary

- The delete confirmation dialog for integration connections hard-coded GitHub-specific copy about preview branches, even when deleting a Vercel connection.
- Branch the dialog body on the connection `type` so Vercel connections explain that environment variable syncing to the Vercel project will stop.

Fixes [FE-3006](https://linear.app/supabase/issue/FE-3006/deleting-vercel-connection-confirmation-dialog-incorrectly).

## Test plan

- [x] Go to Organization > Integrations
- [x] Set up a Vercel integration linking a Supabase project to a Vercel project
- [x] Click Manage > Delete connection → dialog should reference Vercel env var syncing, not GitHub preview branches
- [x] Repeat with a GitHub connection → dialog should still reference preview branches

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated integration disconnection confirmation messages to provide type-specific guidance, clarifying exactly what happens when stopping synchronization for each integration type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->