### PR TITLE
feat: show installed marketplace apps and remove official badge from them

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/IntegrationCard.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/IntegrationCard.tsx
@@ -37,6 +37,7 @@ export const IntegrationLoadingCard = () => {
 
 export const IntegrationCard = ({
   id,
+  listingId,
   status,
   name,
   icon,
@@ -46,6 +47,7 @@ export const IntegrationCard = ({
   image,
 }: IntegrationCardProps) => {
   const { data: project } = useSelectedProjectQuery()
+  const shouldShowOfficialBadge = !listingId
 
   if (featured) {
     return (
@@ -73,7 +75,7 @@ export const IntegrationCard = ({
               <p className="text-foreground-light text-sm">{description}</p>
               <div className="flex items-center gap-x-1 mt-4">
                 {status && <Badge variant="warning">{status}</Badge>}
-                <Badge>Official</Badge>
+                {shouldShowOfficialBadge && <Badge>Official</Badge>}
               </div>
             </div>
           </CardContent>
@@ -103,7 +105,7 @@ export const IntegrationCard = ({
             <p className="text-foreground-light text-xs flex-1">{description}</p>
             <div className="flex items-center gap-x-1 mt-4">
               {status && <Badge variant="warning">{status}</Badge>}
-              <Badge>Official</Badge>
+              {shouldShowOfficialBadge && <Badge>Official</Badge>}
             </div>
           </div>
         </CardContent>

--- a/apps/studio/components/interfaces/Integrations/Landing/useInstalledIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useInstalledIntegrations.tsx
@@ -2,33 +2,47 @@ import { useMemo } from 'react'
 import { parseSchemaComment } from 'stripe-experiment-sync/supabase'
 
 import { wrapperMetaComparator } from '../Wrappers/Wrappers.utils'
-import { INTEGRATIONS } from './Integrations.constants'
+import { useAvailableIntegrations } from './useAvailableIntegrations'
 import {
   isInstalled as checkIsInstalled,
   findStripeSchema,
 } from '@/components/interfaces/Integrations/templates/StripeSyncEngine/stripe-sync-status'
+import { useAPIKeysQuery } from '@/data/api-keys/api-keys-query'
 import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useFDWsQuery } from '@/data/fdw/fdws-query'
-import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { EMPTY_ARR } from '@/lib/void'
 
 export const useInstalledIntegrations = () => {
   const { data: project } = useSelectedProjectQuery()
-  const { integrationsWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
+  const {
+    data: allIntegrations = EMPTY_ARR,
+    error: availableIntegrationsError,
+    isPending: isAvailableIntegrationsLoading,
+    isSuccess: isSuccessAvailableIntegrations,
+    isError: isErrorAvailableIntegrations,
+  } = useAvailableIntegrations()
 
-  const allIntegrations = useMemo(() => {
-    return INTEGRATIONS.filter((integration) => {
-      if (
-        !integrationsWrappers &&
-        (integration.type === 'wrapper' || integration.id.endsWith('_wrapper'))
-      ) {
-        return false
-      }
-      return true
-    })
-  }, [integrationsWrappers])
+  const hasSecretKeyPrefixIntegration = useMemo(() => {
+    return allIntegrations.some(
+      (integration) =>
+        integration.type === 'oauth' &&
+        integration.installIdentificationMethod === 'secret_key_prefix' &&
+        !!integration.secretKeyPrefix
+    )
+  }, [allIntegrations])
+
+  const {
+    data: apiKeys,
+    error: apiKeysError,
+    isError: isErrorApiKeys,
+    isLoading: isApiKeysLoading,
+    isSuccess: isSuccessApiKeys,
+  } = useAPIKeysQuery(
+    { projectRef: project?.ref, reveal: false },
+    { enabled: !!project?.ref && hasSecretKeyPrefixIntegration }
+  )
 
   const {
     data,
@@ -89,15 +103,44 @@ export const useInstalledIntegrations = () => {
             return !!foundExtension?.installed_version
           })
         }
+        if (integration.type === 'oauth') {
+          const prefix = integration.secretKeyPrefix
+
+          if (integration.installIdentificationMethod !== 'secret_key_prefix' || !prefix) {
+            return false
+          }
+
+          return (apiKeys ?? []).some((key) => key.type === 'secret' && key.name.startsWith(prefix))
+        }
         return false
       })
       .sort((a, b) => a.name.localeCompare(b.name))
-  }, [allIntegrations, wrappers, extensions, schemas, isHooksEnabled])
+  }, [allIntegrations, wrappers, extensions, schemas, isHooksEnabled, apiKeys])
 
-  const error = fdwError || extensionsError || schemasError
-  const isLoading = isSchemasLoading || isFDWLoading || isExtensionsLoading
-  const isError = isErrorFDWs || isErrorExtensions || isErrorSchemas
-  const isSuccess = isSuccessFDWs && isSuccessExtensions && isSuccessSchemas
+  const error =
+    fdwError ||
+    extensionsError ||
+    schemasError ||
+    availableIntegrationsError ||
+    (hasSecretKeyPrefixIntegration ? apiKeysError : null)
+  const isLoading =
+    isSchemasLoading ||
+    isFDWLoading ||
+    isExtensionsLoading ||
+    isAvailableIntegrationsLoading ||
+    (hasSecretKeyPrefixIntegration && isApiKeysLoading)
+  const isError =
+    isErrorFDWs ||
+    isErrorExtensions ||
+    isErrorSchemas ||
+    isErrorAvailableIntegrations ||
+    (hasSecretKeyPrefixIntegration && isErrorApiKeys)
+  const isSuccess =
+    isSuccessFDWs &&
+    isSuccessExtensions &&
+    isSuccessSchemas &&
+    isSuccessAvailableIntegrations &&
+    (!hasSecretKeyPrefixIntegration || isSuccessApiKeys)
 
   return {
     // show all integrations at once instead of showing partial results

--- a/apps/studio/pages/project/[ref]/integrations/index.tsx
+++ b/apps/studio/pages/project/[ref]/integrations/index.tsx
@@ -190,7 +190,7 @@ const IntegrationsPage: NextPageWithLayout = () => {
                     {/* Featured Integrations */}
                     {groupedIntegrations.featured.length > 0 && (
                       <div
-                        className="grid grid-cols-2 @4xl:grid-cols-3 gap-4 mb-4 items-stretch pb-6 mb-6 border-b"
+                        className="grid grid-cols-2 @4xl:grid-cols-3 gap-4 mb-4 items-stretch pb-6 border-b"
                         style={{ gridAutoRows: 'minmax(110px, auto)' }}
                       >
                         {groupedIntegrations.featured.map((integration) => (


### PR DESCRIPTION
This PR shows installed marketplace apps in the left pane on the integrations page and shows the `Installed` badge on the card. `Official` badge is not shown on marketplace listings. 

<img width="1652" height="892" alt="image" src="https://github.com/user-attachments/assets/16c0a218-1658-426e-9b5b-d28e44c5c3b6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed excessive spacing on the integrations page
  * Enhanced integration installation detection for improved accuracy

* **Style**
  * Updated official badge display on integration cards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->