### PR TITLE
blog: update Stripe Projects CLI commands to new syntax

### DIFF
--- a/apps/www/_blog/2026-03-19-supabase-joins-the-stripe-projects-developer-preview.mdx
+++ b/apps/www/_blog/2026-03-19-supabase-joins-the-stripe-projects-developer-preview.mdx
@@ -1,5 +1,5 @@
 ---
-title: 'Supabase joins the Stripe Projects developer preview'
+title: 'Supabase Joins the Stripe Projects Developer Preview'
 description: 'Supabase is a co-design partner in the Stripe Projects developer preview.'
 author: gregor_vand, ana_mogul
 date: '2026-03-19'

--- a/apps/www/_blog/2026-03-19-supabase-joins-the-stripe-projects-developer-preview.mdx
+++ b/apps/www/_blog/2026-03-19-supabase-joins-the-stripe-projects-developer-preview.mdx
@@ -29,7 +29,7 @@ Install the Stripe CLI, then run:
 ```bash
 stripe plugin install projects
 stripe projects init my-app
-stripe projects add supabase/supabase:free
+stripe projects add supabase/project
 stripe projects env --sync
 ```
 
@@ -60,7 +60,7 @@ The database lives in your own Supabase account. You keep full access to the Sup
 You can rotate your database credentials at any time:
 
 ```bash
-stripe projects rotate supabase-supabase:free
+stripe projects rotate supabase/project
 ```
 
 This updates the stored secrets in your Stripe Project automatically.
@@ -71,7 +71,7 @@ This is a developer preview. Install the Stripe CLI, then run:
 
 ```bash
 stripe projects init my-app
-stripe projects add supabase/supabase:free
+stripe projects add supabase/project
 ```
 
 [Install the Stripe CLI](https://docs.stripe.com/stripe-cli/install)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Blog post update

## What is the current behavior?

n/a

## What is the new behavior?

`supabase/supabase:free` → `supabase/project` for add command, `supabase-supabase:free` → `supabase/project` for rotate command.

## Additional context

n/a


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected Stripe Projects CLI catalog identifiers in the integration examples.
  * Updated blog post title wording/capitalization for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->