### PR TITLE
fix(studio): preserve EXTERNAL_PHONE_ENABLED on phone provider save

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -378,10 +378,12 @@ export const getPhoneProviderValidationSchema = (config: ProjectAuthConfigData) 
           return enabledSchema.parse(values)
         }
       })
-      // Trick: use transform to ensure the correct shape when EXTERNAL_PHONE_ENABLED is true
+      // Trick: use transform to ensure the correct shape when EXTERNAL_PHONE_ENABLED is true.
+      // enabledSchema strips EXTERNAL_PHONE_ENABLED (not declared on its branches), so re-add it
+      // to keep the flag in the submitted payload.
       .transform((values) => {
         if (values.EXTERNAL_PHONE_ENABLED === true) {
-          return enabledSchema.parse(values)
+          return { ...enabledSchema.parse(values), EXTERNAL_PHONE_ENABLED: true as const }
         }
         return values
       })


### PR DESCRIPTION
## Summary

Toggling the Phone auth provider on in Studio appeared to save (success toast) but snapped back to **Disabled** immediately. The backend value never changed.

## Root cause

In `AuthProvidersFormValidation.tsx`, the phone schema's final `.transform` replaced the parsed values with `enabledSchema.parse(values)`:

```
.transform((values) => {
  if (values.EXTERNAL_PHONE_ENABLED === true) {
    return enabledSchema.parse(values)   // ← strips EXTERNAL_PHONE_ENABLED
  }
  return values
})
```

`enabledSchema` is a `z.discriminatedUnion('SMS_PROVIDER', [...])` whose branch schemas (twilio / twilio_verify / messagebird / vonage / textlocal) don't declare `EXTERNAL_PHONE_ENABLED`. Zod objects strip unknown keys by default, so the flag was dropped from the submitted payload. The PATCH request to `/platform/auth/{ref}/config` went out without `EXTERNAL_PHONE_ENABLED`, the backend kept its previous value, and `form.reset` on the response snapped the toggle back to disabled.

Regression was introduced in #44865 (zod migration). The recent #44974 fix addressed the `shouldUnregister` side of the form but not this transform.

## Fix

Spread `enabledSchema.parse(values)` and re-add `EXTERNAL_PHONE_ENABLED: true` so the flag survives the transform.

## Test plan

- [x] On a project with no phone provider configured, pick an SMS provider (e.g. Twilio), fill credentials, toggle Phone on, Save → toggle stays **Enabled**, network tab shows `EXTERNAL_PHONE_ENABLED: true` in PATCH payload and response
- [x] Toggle Phone off → stays **Disabled** (unchanged behavior)
- [x] Change SMS provider credentials while enabled → saves correctly
- [x] With SMS hook enabled, phone provider fields remain optional as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where phone authentication provider settings were not being properly retained during form submission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->