### PR TITLE
fix for connect modal being stuck loading for non JS frameworks

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/useConnectState.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/useConnectState.ts
@@ -254,7 +254,6 @@ export function useConnectState(initialState?: Partial<ConnectState>): UseConnec
         const libraryKey = resolveFrameworkLibraryKey({
           framework: next.framework,
           frameworkVariant: next.frameworkVariant,
-          library: next.library,
         })
         if (libraryKey) {
           next.library = libraryKey
@@ -268,7 +267,6 @@ export function useConnectState(initialState?: Partial<ConnectState>): UseConnec
         const libraryKey = resolveFrameworkLibraryKey({
           framework: prev.framework,
           frameworkVariant: String(value),
-          library: next.library,
         })
         if (libraryKey) next.library = libraryKey
       }
@@ -297,7 +295,6 @@ export function useConnectState(initialState?: Partial<ConnectState>): UseConnec
           const libraryKey = resolveFrameworkLibraryKey({
             framework: next.framework,
             frameworkVariant: next.frameworkVariant,
-            library: next.library,
           })
           if (libraryKey) next.library = libraryKey
         }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
It makes the connect modal responsive to other non JS frameworks selection.


## What is the current behavior?
Modal is stuck when non JS is selected.

Closes #44985

## What is the new behavior?

It's now responsive:


<img width="999" height="848" alt="Screenshot 2026-04-17 at 18 40 47" src="https://github.com/user-attachments/assets/e00449df-207a-401a-9e25-01944489de9c" />

<img width="976" height="959" alt="Screenshot 2026-04-17 at 18 40 59" src="https://github.com/user-attachments/assets/e5fcee6b-7f5e-4edb-8a00-629965026493" />

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal optimization to the framework library resolution logic with no visible user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->