### PR TITLE
feat(shortcuts): add showInSettings flag to ShortcutDefinition

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/HotkeySettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/HotkeySettings.tsx
@@ -11,7 +11,9 @@ import {
 import { HotkeyToggle } from './HotkeyToggle'
 import { SHORTCUT_DEFINITIONS } from '@/state/shortcuts/registry'
 
-const SHORTCUT_ORDER = Object.values(SHORTCUT_DEFINITIONS)
+const SHORTCUT_ORDER = Object.values(SHORTCUT_DEFINITIONS).filter(
+  (definition) => definition.showInSettings !== false
+)
 
 export const HotkeySettings = () => {
   return (

--- a/apps/studio/state/shortcuts/types.ts
+++ b/apps/studio/state/shortcuts/types.ts
@@ -77,4 +77,14 @@ export interface ShortcutDefinition {
    * is overridable by the caller of `useShortcut`.
    */
   options?: ShortcutOptions
+
+  /**
+   * Whether this shortcut appears as a toggleable entry in Account →
+   * Preferences → Keyboard shortcuts. Defaults to `true`.
+   *
+   * Set to `false` for shortcuts that users shouldn't be able to disable (e.g.
+   * the command menu opener) or for shortcuts that aren't meaningful as a
+   * standalone user preference.
+   */
+  showInSettings?: boolean
 }


### PR DESCRIPTION
Closes [FE-3021](https://linear.app/supabase/issue/FE-3021/hide-shortcut-in-settings-option-for-new-api).

## Summary
- Adds an optional `showInSettings` field to `ShortcutDefinition` (defaults to `true`).
- `HotkeySettings` filters out entries where `showInSettings === false` before rendering the Account → Preferences → Keyboard shortcuts list.
- No registry entries are flipped in this PR — opt-in per shortcut as needed.

## Test plan
- [x] Confirm all existing shortcuts still appear under Account → Preferences → Keyboard shortcuts.
- [x] Temporarily set `showInSettings: false` on one entry and verify it disappears from the list.
- [x] `pnpm --filter studio exec tsc --noEmit` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts can now be selectively hidden from the Account preferences settings based on configuration.

* **Refactor**
  * Updated keyboard shortcut filtering logic to respect visibility settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->