### PR TITLE
fix(self-hosted): remove expose of app.settings.jwt_secret

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -273,7 +273,6 @@ services:
       PGRST_JWT_SECRET: ${JWT_JWKS:-${JWT_SECRET}}
 
       PGRST_DB_USE_LEGACY_GUCS: "false"
-      PGRST_APP_SETTINGS_JWT_SECRET: ${JWT_SECRET}
       PGRST_APP_SETTINGS_JWT_EXP: ${JWT_EXPIRY}
     command:
       [

--- a/docker/volumes/db/jwt.sql
+++ b/docker/volumes/db/jwt.sql
@@ -1,5 +1,3 @@
-\set jwt_secret `echo "$JWT_SECRET"`
 \set jwt_exp `echo "$JWT_EXP"`
 
-ALTER DATABASE postgres SET "app.settings.jwt_secret" TO :'jwt_secret';
 ALTER DATABASE postgres SET "app.settings.jwt_exp" TO :'jwt_exp';


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix for #43513 

## What is the current behavior?

Supabase self-hosted still exposes `app.settings.jwt_secret` via a database init script and docker compose env vars (`PGRST_APP_SETTINGS_JWT_SECRET`) which isn't aligned with the Supabase platform. (See #30606).

## What is the new behavior?

`app.settings.jwt_secret` is no longer exposed on fresh self-hosted containers.

```
docker compose exec -it db bash
root@3e6494e74c19:/# psql -U supabase_admin -d postgres
psql (15.8)
Type "help" for help.

postgres=# SHOW app.settings.jwt_exp;
 app.settings.jwt_exp 
----------------------
 3600
(1 row)

postgres=# SHOW app.settings.jwt_secret;
ERROR:  unrecognized configuration parameter "app.settings.jwt_secret"
postgres=#
```

## Additional context

For users currently using self-hosted who have custom SQL functions that call `current_setting('app.settings.jwt_secret')`, they would need to migrate the same way as discussed on #30606:

```
select vault.create_secret('your-self-hosted-jwt-secret-value', 'app.jwt_secret', 'The jwt secret');

-- retrieve the value, this replaces select current_setting('app.settings.jwt_secret')
select decrypted_secret 
   from vault.decrypted_secrets 
   where name = 'app.jwt_secret';
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed explicit configuration of the PostgREST app-settings JWT secret from deployment and database initialization.
  * JWT authentication continues using the configured JWT secret, while JWT expiration settings remain available.

* **Documentation**
  * Updated self-hosted configuration guidance to reflect the revised JWT secret handling and clarify that the secret is not exposed to SQL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->