### PR TITLE
docs(auth): fix redirect_to -> redirect_url in OAuth 2.1 server examples

### DIFF
--- a/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
@@ -313,7 +313,7 @@ export async function POST(request: Request) {
     }
 
     // Redirect back to the client with authorization code
-    return NextResponse.redirect(data.redirect_to)
+    return NextResponse.redirect(data.redirect_url)
   } else {
     const { data, error } = await supabase.auth.oauth.denyAuthorization(authorizationId)
 
@@ -322,7 +322,7 @@ export async function POST(request: Request) {
     }
 
     // Redirect back to the client with error
-    return NextResponse.redirect(data.redirect_to)
+    return NextResponse.redirect(data.redirect_url)
   }
 }
 ```
@@ -387,7 +387,7 @@ export function OAuthConsent() {
       setError(error.message)
     } else {
       // Redirect to client app
-      window.location.href = data.redirect_to
+      window.location.href = data.redirect_url
     }
   }
 
@@ -400,7 +400,7 @@ export function OAuthConsent() {
       setError(error.message)
     } else {
       // Redirect to client app with error
-      window.location.href = data.redirect_to
+      window.location.href = data.redirect_url
     }
   }
 
@@ -454,8 +454,8 @@ export function OAuthConsent() {
 6. **Handle decision** - When the user clicks approve/deny:
    - Call `supabase.auth.oauth.approveAuthorization(authorization_id)` or `denyAuthorization(authorization_id)`
    - These methods handle all OAuth logic internally (generating authorization codes, etc.)
-   - They return a `redirect_to` URL
-7. **Redirect back** - Redirect the user to the `redirect_to` URL, which sends them back to the third-party app with either an authorization code (approved) or error (denied)
+   - They return a `redirect_url`
+7. **Redirect back** - Redirect the user to the `redirect_url`, which sends them back to the third-party app with either an authorization code (approved) or error (denied)
 
 ## Register an OAuth client
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -71,7 +71,7 @@ Here's a visual representation of the complete authorization code flow:
        │                              │                                 │
        │                              │  6. approveAuthorization()      │
        │                              ├────────────────────────────────>│
-       │                              │  Return redirect_to with code   │
+       │                              │  Return redirect_url with code  │
        │                              │<────────────────────────────────┤
        │                              │                                 │
        │  7. Redirect to client callback with code                      │
@@ -189,7 +189,7 @@ Your frontend application at the authorization path should:
 5. **Handle user decision** - When the user approves or denies:
    - Call `supabase.auth.oauth.approveAuthorization(authorization_id)` to approve
    - Call `supabase.auth.oauth.denyAuthorization(authorization_id)` to deny
-   - Redirect user to the returned `redirect_to` URL
+   - Redirect user to the returned `redirect_url`
 
 This is a **frontend implementation** using `supabase-js`. Supabase Auth handles all the backend OAuth logic (generating authorization codes, validating requests, etc.) after you call the approve/deny methods.
 


### PR DESCRIPTION
## Summary

The OAuth 2.1 Server docs showed consent examples using `data.redirect_to` from `supabase.auth.oauth.approveAuthorization()` / `denyAuthorization()`, but the SDK returns `data.redirect_url`. Following the docs verbatim left `window.location.href = undefined`, which resolved as a relative URL (`/oauth/undefined`) and caused an infinite redirect loop after consent.

## Issue

Fixes #45006

## Changes

- `apps/docs/content/guides/auth/oauth-server/getting-started.mdx` — replace `data.redirect_to` with `data.redirect_url` in all four consent code examples (Next.js route handler, React SPA approve/deny), and update the \"How it works\" section to match.
- `apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx` — update the sequence-diagram label and step description to `redirect_url` for consistency.

## Source of truth

[\`GoTrueClient.ts L5557\`](https://github.com/supabase/supabase-js/blob/master/packages/core/auth-js/src/GoTrueClient.ts#L5557) returns \`response.data.redirect_url\`:

\`\`\`ts
if (response.data && response.data.redirect_url) {
  if (isBrowser() && !options?.skipBrowserRedirect) {
    window.location.assign(response.data.redirect_url)
  }
}
\`\`\`

## Testing

- Docs-only change; no runtime code touched.
- Verified all 8 references in the \`oauth-server/\` guide now use \`redirect_url\`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth authorization flow documentation and code examples to reflect the correct field name returned during authorization approval and denial steps, ensuring proper redirect handling in integration guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->