### PR TITLE
fix(studio): detect update-without-where on quoted table names

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -40,8 +40,12 @@ export const destructiveSqlRegex = [
   /^(.*;)?\s*(drop|delete|truncate|alter\s+table\s+.*\s+drop\s+column)\s/is,
 ]
 
+// Matches `UPDATE <table> SET ...` where <table> is any combination of bareword
+// or double-quoted identifiers, optionally schema-qualified. Quoted identifiers
+// can contain any character (including spaces) and use `""` to escape an inner
+// quote, mirroring Postgres syntax.
 export const updateWithoutWhereRegex =
-  /(?:^|;)\s*update\s+(?:"[\w.]+"\."[\w.]+"|[\w.]+)\s+set\s+[\w\W]+?(?!\s*where\s)/is
+  /(?:^|;)\s*update\s+(?:"(?:[^"]|"")+"|[\w]+)(?:\.(?:"(?:[^"]|"")+"|[\w]+))?\s+set\s+[\w\W]+?(?!\s*where\s)/is
 
 export const alterDatabasePreventConnectionStatements = [
   'alter database postgres connection limit 0',

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
@@ -244,6 +244,36 @@ describe('SQLEditor.utils:updateWithoutWhere', () => {
     expect(match).toBe(true)
   })
 
+  it('catches update on a single quoted table name without a where clause', () => {
+    const match = isUpdateWithoutWhere(`UPDATE "messages" SET id = 1;`)
+    expect(match).toBe(true)
+  })
+
+  it('does not flag update on a single quoted table name with a where clause', () => {
+    const match = isUpdateWithoutWhere(`UPDATE "messages" SET id = 1 WHERE id = 2;`)
+    expect(match).toBe(false)
+  })
+
+  it('catches update on a quoted schema with a bareword table without a where clause', () => {
+    const match = isUpdateWithoutWhere(`UPDATE "public".messages SET id = 1;`)
+    expect(match).toBe(true)
+  })
+
+  it('catches update on a bareword schema with a quoted table without a where clause', () => {
+    const match = isUpdateWithoutWhere(`UPDATE public."messages" SET id = 1;`)
+    expect(match).toBe(true)
+  })
+
+  it('catches update on a quoted table name containing a space without a where clause', () => {
+    const match = isUpdateWithoutWhere(`UPDATE "my table" SET id = 1;`)
+    expect(match).toBe(true)
+  })
+
+  it('catches update on a quoted table name containing escaped quotes without a where clause', () => {
+    const match = isUpdateWithoutWhere(`UPDATE "weird""name" SET id = 1;`)
+    expect(match).toBe(true)
+  })
+
   it('contains both an update query and a delete query, triggers destructive', () => {
     const match = checkDestructiveQuery(stripIndent`
       delete from countries; update countries set name = 'hello';

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
@@ -274,6 +274,21 @@ describe('SQLEditor.utils:updateWithoutWhere', () => {
     expect(match).toBe(true)
   })
 
+  it('catches update where a quoted identifier contains the word where', () => {
+    const match = isUpdateWithoutWhere(`UPDATE "where table" SET id = 1;`)
+    expect(match).toBe(true)
+  })
+
+  it('catches update where a string literal contains the word where', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET name = 'where x';`)
+    expect(match).toBe(true)
+  })
+
+  it('does not flag update where the only "where" sits inside a string literal but a real where clause exists', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET name = 'where x' WHERE id = 1;`)
+    expect(match).toBe(false)
+  })
+
   it('contains both an update query and a delete query, triggers destructive', () => {
     const match = checkDestructiveQuery(stripIndent`
       delete from countries; update countries set name = 'hello';

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -91,13 +91,22 @@ export function checkDestructiveQuery(sql: string) {
   return destructiveSqlRegex.some((regex) => regex.test(cleanedSql))
 }
 
+// Replace the contents of single-quoted string literals and double-quoted
+// identifiers with empty quotes, so a downstream `where` scan can't be fooled
+// by tokens like `UPDATE "where table" SET ...` or `SET name = 'where x'`.
+// Postgres uses doubled quotes to escape, so `''` and `""` are matched as
+// part of the same span rather than terminating it.
+const stripQuotedSpans = (sql: string) =>
+  sql.replace(/'(?:''|[^'])*'/g, "''").replace(/"(?:""|[^"])*"/g, '""')
+
 // Function to check for UPDATE queries without WHERE clause
 export function isUpdateWithoutWhere(sql: string): boolean {
   const updateStatements = sql
     .split(';')
     .filter((statement) => statement.trim().toLowerCase().startsWith('update'))
   return updateStatements.some(
-    (statement) => updateWithoutWhereRegex.test(statement) && !/where\s/i.test(statement)
+    (statement) =>
+      updateWithoutWhereRegex.test(statement) && !/where\s/i.test(stripQuotedSpans(statement))
   )
 }
 


### PR DESCRIPTION
The previous \`updateWithoutWhereRegex\` only matched bareword table identifiers (\`messages\`, \`public.messages\`) or a fully qualified \`"schema"."table"\` pair, so statements like \`UPDATE "messages" SET id = 1\` skipped the pre-execution warning entirely.

**Changed:**
- Broaden each identifier slot in \`updateWithoutWhereRegex\` to accept either a bareword or a double-quoted identifier independently — covers \`"messages"\`, \`"public".messages\`, \`public."messages"\`, \`"my table"\`, and \`"weird""name"\` (escaped quote).

**Added:**
- 6 unit tests covering single quoted, mixed quoted/bareword, spaces in identifiers, and escaped quotes — both with and without \`WHERE\`.

## To test

- Run \`pnpm --filter studio test -- SQLEditor.utils.test.ts\` — should pass 79 tests
- In the SQL editor, run \`UPDATE "messages" SET id = 1\` — warning modal should now appear
- Same statement with \`WHERE id = 2\` appended — no warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL UPDATE detection in the SQL Editor to handle double-quoted identifiers, schema-qualified names, names with spaces, and escaped quotes.
  * Prevented false positives by ignoring quoted string and identifier contents when checking for a WHERE clause.

* **Tests**
  * Added comprehensive tests covering varied quoting/qualification scenarios and quoted-content edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->