### PR TITLE
fix(docs): replace undefined variable `host` with `connectionString` in Drizzle snippet

### DIFF
--- a/apps/docs/content/guides/database/drizzle.mdx
+++ b/apps/docs/content/guides/database/drizzle.mdx
@@ -81,8 +81,8 @@ If you plan on solely using Drizzle instead of the Supabase Data API (PostgREST)
     import postgres from 'postgres'
 
     let connectionString = process.env.DATABASE_URL
-    if (host.includes('postgres:postgres@supabase_db_')) {
-      const url = URL.parse(host)!
+    if (connectionString.includes('postgres:postgres@supabase_db_')) {
+      const url = new URL(connectionString)
       url.hostname = url.hostname.split('_')[1]
       connectionString = url.href
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs fix.

## What is the current behavior?

The Drizzle connection code snippet in `apps/docs/content/guides/database/drizzle.mdx` references an undefined variable `host` on lines 84-85. This was introduced in #40288.

## What is the new behavior?

Replaces the undefined `host` with the correctly defined `connectionString` variable. Also uses `new URL()` instead of `URL.parse()` for broader Node.js compatibility.

## Steps to reproduce

See issue #43920 — the code snippet at https://supabase.com/docs/guides/database/drizzle#connecting-with-drizzle references `host` which is never declared, making the snippet invalid.

Closes #43920

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Drizzle database connection guide for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->