### PR TITLE
[FE-3023] feat(studio): default privileges toggle at project creation

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.schema.ts
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreation.schema.ts
@@ -34,6 +34,7 @@ export const FormSchema = z
     dbPassStrengthWarning: z.string().default(''),
     instanceSize: z.string().optional(),
     dataApi: z.boolean(),
+    dataApiDefaultPrivileges: z.boolean(),
     enableRlsEventTrigger: z.boolean(),
     postgresVersionSelection: z.string(),
     useOrioleDb: z.boolean(),

--- a/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
@@ -101,14 +101,14 @@ export const SecurityOptions = ({ form, layout = 'horizontal' }: SecurityOptions
                   <FormLabel_Shadcn_
                     className={cn('text-sm text-foreground', !dataApi && 'text-foreground-muted')}
                   >
-                    Default privileges for new entities
+                    Automatically expose new tables and functions
                   </FormLabel_Shadcn_>
                   <FormDescription_Shadcn_ className="text-foreground-lighter">
-                    When enabled, new tables and functions in the <code>public</code> schema are
-                    automatically accessible via the Data API.
+                    Grants privileges to Data API roles by default, exposing new tables and
+                    functions.
                     <br />
                     <strong className="font-medium text-foreground-light">
-                      We recommend disabling this and manually granting access to each new entity.
+                      We recommend disabling this to control access manually.
                     </strong>
                   </FormDescription_Shadcn_>
                 </div>

--- a/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
@@ -2,11 +2,15 @@ import Link from 'next/link'
 import { UseFormReturn } from 'react-hook-form'
 import {
   Checkbox_Shadcn_,
+  cn,
   FormControl_Shadcn_,
   FormDescription_Shadcn_,
   FormField_Shadcn_,
   FormItem_Shadcn_,
   FormLabel_Shadcn_,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
   useWatch_Shadcn_,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
@@ -54,6 +58,55 @@ export const SecurityOptions = ({ form, layout = 'horizontal' }: SecurityOptions
                       supabase-js
                     </Link>
                     .
+                  </FormDescription_Shadcn_>
+                </div>
+              </FormItem_Shadcn_>
+            )}
+          />
+
+          <FormField_Shadcn_
+            name="dataApiDefaultPrivileges"
+            control={form.control}
+            render={({ field }) => (
+              <FormItem_Shadcn_
+                className={cn(
+                  'flex items-start gap-3',
+                  !dataApi && 'opacity-50 cursor-not-allowed'
+                )}
+              >
+                <FormControl_Shadcn_>
+                  {dataApi ? (
+                    <Checkbox_Shadcn_
+                      checked={field.value}
+                      disabled={field.disabled}
+                      onCheckedChange={(value) => field.onChange(value === true)}
+                    />
+                  ) : (
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="cursor-not-allowed">
+                          <Checkbox_Shadcn_ checked={field.value} disabled />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent side="top">
+                        Enable the Data API to configure default privileges.
+                      </TooltipContent>
+                    </Tooltip>
+                  )}
+                </FormControl_Shadcn_>
+                <div className="space-y-1">
+                  <FormLabel_Shadcn_
+                    className={cn('text-sm text-foreground', !dataApi && 'text-foreground-muted')}
+                  >
+                    Default privileges for new entities
+                  </FormLabel_Shadcn_>
+                  <FormDescription_Shadcn_ className="text-foreground-lighter">
+                    When enabled, new tables and functions in the <code>public</code> schema are
+                    automatically accessible via the Data API.
+                    <br />
+                    <strong className="font-medium text-foreground-light">
+                      We recommend disabling this and manually granting access to each new entity.
+                    </strong>
                   </FormDescription_Shadcn_>
                 </div>
               </FormItem_Shadcn_>

--- a/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
@@ -18,6 +18,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CreateProjectForm } from './ProjectCreation.schema'
 import Panel from '@/components/ui/Panel'
+import { useTrackDefaultPrivilegesExposure } from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
 
 interface SecurityOptionsProps {
   form: UseFormReturn<CreateProjectForm>
@@ -26,6 +27,8 @@ interface SecurityOptionsProps {
 
 export const SecurityOptions = ({ form, layout = 'horizontal' }: SecurityOptionsProps) => {
   const dataApi = useWatch_Shadcn_({ control: form.control, name: 'dataApi' })
+
+  useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: dataApi ?? true })
 
   return (
     <Panel.Content className="pb-8">

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -426,15 +426,8 @@ export const PostgrestConfig = () => {
                             <FormItem_Shadcn_>
                               <FormItemLayout
                                 layout="flex-row-reverse"
-                                label="Default privileges for new entities"
-                                description={
-                                  <>
-                                    When enabled, new tables and functions in the{' '}
-                                    <code>public</code> schema are automatically accessible via the
-                                    Data API. We recommend disabling this and manually granting
-                                    access to each new entity.
-                                  </>
-                                }
+                                label="Automatically expose new tables and functions"
+                                description="Grants privileges to Data API roles by default, exposing new tables and functions. We recommend disabling this to control access manually."
                               >
                                 <FormControl_Shadcn_>
                                   <div>

--- a/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
@@ -1,13 +1,13 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { usePHFlag } from '@/hooks/ui/useFlag'
-import * as constants from '@/lib/constants'
-import { useTrack } from '@/lib/telemetry/track'
 import {
   useDataApiRevokeOnCreateDefaultEnabled,
   useTrackDefaultPrivilegesExposure,
 } from '../useDataApiRevokeOnCreateDefault'
+import { usePHFlag } from '@/hooks/ui/useFlag'
+import * as constants from '@/lib/constants'
+import { useTrack } from '@/lib/telemetry/track'
 
 vi.mock('@/hooks/ui/useFlag', () => ({
   usePHFlag: vi.fn(),

--- a/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
@@ -1,9 +1,13 @@
 import { renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { useDataApiRevokeOnCreateDefaultEnabled } from '../useDataApiRevokeOnCreateDefault'
 import { usePHFlag } from '@/hooks/ui/useFlag'
 import * as constants from '@/lib/constants'
+import { useTrack } from '@/lib/telemetry/track'
+import {
+  useDataApiRevokeOnCreateDefaultEnabled,
+  useTrackDefaultPrivilegesExposure,
+} from '../useDataApiRevokeOnCreateDefault'
 
 vi.mock('@/hooks/ui/useFlag', () => ({
   usePHFlag: vi.fn(),
@@ -16,6 +20,10 @@ vi.mock('@/lib/constants', async () => {
     IS_TEST_ENV: false,
   }
 })
+
+vi.mock('@/lib/telemetry/track', () => ({
+  useTrack: vi.fn(),
+}))
 
 describe('useDataApiRevokeOnCreateDefaultEnabled', () => {
   afterEach(() => {
@@ -46,5 +54,78 @@ describe('useDataApiRevokeOnCreateDefaultEnabled', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
     const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
     expect(result.current).toBe(false)
+  })
+})
+
+describe('useTrackDefaultPrivilegesExposure', () => {
+  const track = vi.fn()
+
+  beforeEach(() => {
+    vi.mocked(useTrack).mockReturnValue(track)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not fire while the flag is undefined', () => {
+    vi.mocked(usePHFlag).mockReturnValue(undefined)
+    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true }))
+    expect(track).not.toHaveBeenCalled()
+  })
+
+  it('fires once when the flag resolves to true on the main surface', () => {
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true }))
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith('project_creation_default_privileges_exposed', {
+      surface: 'main',
+      dataApiEnabled: true,
+      dataApiRevokeOnCreateDefaultEnabled: true,
+    })
+  })
+
+  it('fires once when the flag resolves to false on the main surface', () => {
+    vi.mocked(usePHFlag).mockReturnValue(false)
+    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: false }))
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith('project_creation_default_privileges_exposed', {
+      surface: 'main',
+      dataApiEnabled: false,
+      dataApiRevokeOnCreateDefaultEnabled: false,
+    })
+  })
+
+  it('omits dataApiEnabled on the vercel surface', () => {
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'vercel' }))
+    expect(track).toHaveBeenCalledWith('project_creation_default_privileges_exposed', {
+      surface: 'vercel',
+      dataApiRevokeOnCreateDefaultEnabled: true,
+    })
+  })
+
+  it('deduplicates across re-renders', () => {
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    const { rerender } = renderHook(() =>
+      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true })
+    )
+    rerender()
+    rerender()
+    expect(track).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-fire if the flag flips after initial exposure', () => {
+    vi.mocked(usePHFlag).mockReturnValue(false)
+    const { rerender } = renderHook(() =>
+      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true })
+    )
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    rerender()
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      expect.objectContaining({ dataApiRevokeOnCreateDefaultEnabled: false })
+    )
   })
 })

--- a/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
@@ -1,0 +1,50 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { useDataApiRevokeOnCreateDefaultEnabled } from '../useDataApiRevokeOnCreateDefault'
+import { usePHFlag } from '@/hooks/ui/useFlag'
+import * as constants from '@/lib/constants'
+
+vi.mock('@/hooks/ui/useFlag', () => ({
+  usePHFlag: vi.fn(),
+}))
+
+vi.mock('@/lib/constants', async () => {
+  const actual = await vi.importActual<typeof import('@/lib/constants')>('@/lib/constants')
+  return {
+    ...actual,
+    IS_TEST_ENV: false,
+  }
+})
+
+describe('useDataApiRevokeOnCreateDefaultEnabled', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.mocked(constants, { partial: true }).IS_TEST_ENV = false
+  })
+
+  it('returns false when the PostHog flag is undefined (not yet resolved)', () => {
+    vi.mocked(usePHFlag).mockReturnValue(undefined)
+    const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns false when the PostHog flag is false', () => {
+    vi.mocked(usePHFlag).mockReturnValue(false)
+    const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
+    expect(result.current).toBe(false)
+  })
+
+  it('returns true when the PostHog flag is true', () => {
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
+    expect(result.current).toBe(true)
+  })
+
+  it('returns false in test env regardless of flag value', () => {
+    vi.mocked(constants, { partial: true }).IS_TEST_ENV = true
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
+    expect(result.current).toBe(false)
+  })
+})

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -1,0 +1,24 @@
+import { usePHFlag } from '../ui/useFlag'
+import { IS_TEST_ENV } from '@/lib/constants'
+
+/**
+ * Controls the default state of the "Default privileges for new entities"
+ * checkbox at project creation. When the flag is on, the checkbox defaults
+ * to unchecked (i.e. revoke SQL runs). When off/absent, the checkbox defaults
+ * to checked (current behaviour — default grants remain).
+ *
+ * Scoped to project-creation only. The existing `tableEditorApiAccessToggle`
+ * flag continues to gate the integrations → Data API settings surface.
+ */
+export const useDataApiRevokeOnCreateDefaultEnabled = (): boolean => {
+  const flag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
+
+  // Preserve current behaviour (default grants remain) in tests so existing
+  // E2E flows don't change silently. Tests that need the revoke-default path
+  // should opt in explicitly.
+  if (IS_TEST_ENV) {
+    return false
+  }
+
+  return !!flag
+}

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -1,5 +1,8 @@
+import { useEffect, useRef } from 'react'
+
 import { usePHFlag } from '../ui/useFlag'
 import { IS_TEST_ENV } from '@/lib/constants'
+import { useTrack } from '@/lib/telemetry/track'
 
 /**
  * Controls the default state of the "Default privileges for new entities"
@@ -21,4 +24,37 @@ export const useDataApiRevokeOnCreateDefaultEnabled = (): boolean => {
   }
 
   return !!flag
+}
+
+type DefaultPrivilegesExposureOptions =
+  | { surface: 'main'; dataApiEnabled: boolean }
+  | { surface: 'vercel' }
+
+/**
+ * Fires `project_creation_default_privileges_exposed` once per mount after the
+ * `dataApiRevokeOnCreateDefault` flag resolves. Gating on flag resolution keeps
+ * cohort attribution clean — users whose flag never resolves are not counted in
+ * either cohort. Deduplicated via ref so re-renders and mid-session flag flips
+ * don't re-fire.
+ */
+export const useTrackDefaultPrivilegesExposure = (
+  options: DefaultPrivilegesExposureOptions
+) => {
+  const track = useTrack()
+  const flag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
+  const hasTracked = useRef(false)
+
+  const { surface } = options
+  const dataApiEnabled = options.surface === 'main' ? options.dataApiEnabled : null
+
+  useEffect(() => {
+    if (hasTracked.current) return
+    if (flag === undefined) return
+    hasTracked.current = true
+    track('project_creation_default_privileges_exposed', {
+      surface,
+      ...(dataApiEnabled !== null && { dataApiEnabled }),
+      dataApiRevokeOnCreateDefaultEnabled: flag,
+    })
+  }, [flag, track, surface, dataApiEnabled])
 }

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -37,9 +37,7 @@ type DefaultPrivilegesExposureOptions =
  * either cohort. Deduplicated via ref so re-renders and mid-session flag flips
  * don't re-fire.
  */
-export const useTrackDefaultPrivilegesExposure = (
-  options: DefaultPrivilegesExposureOptions
-) => {
+export const useTrackDefaultPrivilegesExposure = (options: DefaultPrivilegesExposureOptions) => {
   const track = useTrack()
   const flag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
   const hasTracked = useRef(false)

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -317,8 +317,8 @@ const CreateProject = () => {
       <div className="py-2 pb-4">
         <Checkbox
           name="dataApiDefaultPrivileges"
-          label="Default privileges for new entities"
-          description="When enabled, new tables and functions in the public schema are automatically accessible via the Data API. We recommend disabling this and manually granting access to each new entity."
+          label="Automatically expose new tables and functions"
+          description="Grants privileges to Data API roles by default, exposing new tables and functions. We recommend disabling this to control access manually."
           checked={dataApiDefaultPrivileges}
           onChange={(e) => setDataApiDefaultPrivileges(e.target.checked)}
         />

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -16,7 +16,7 @@ import { useIntegrationVercelConnectionsCreateMutation } from '@/data/integratio
 import { useVercelProjectsQuery } from '@/data/integrations/integrations-vercel-projects-query'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useProjectCreateMutation } from '@/data/projects/project-create-mutation'
-import { useDataApiGrantTogglesEnabled } from '@/hooks/misc/useDataApiGrantTogglesEnabled'
+import { useDataApiRevokeOnCreateDefaultEnabled } from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { BASE_PATH, PROVIDERS } from '@/lib/constants'
 import { getInitialMigrationSQLFromGitHubRepo } from '@/lib/integration-utils'
@@ -63,7 +63,10 @@ const CreateProject = () => {
   const [dbRegion, setDbRegion] = useState(PROVIDERS.AWS.default_region.displayName)
 
   const snapshot = useIntegrationInstallationSnapshot()
-  const isDataApiGrantTogglesEnabled = useDataApiGrantTogglesEnabled()
+  const isDataApiRevokeOnCreateDefault = useDataApiRevokeOnCreateDefaultEnabled()
+  const [dataApiDefaultPrivileges, setDataApiDefaultPrivileges] = useState(
+    !isDataApiRevokeOnCreateDefault
+  )
 
   async function checkPasswordStrength(value: string) {
     const { message, strength } = await passwordStrength(value)
@@ -145,7 +148,7 @@ const CreateProject = () => {
       if (migrationSql) dbSqlParts.push(migrationSql)
       toast.success(`Done fetching initial migrations`, { id })
     }
-    if (isDataApiGrantTogglesEnabled) {
+    if (!dataApiDefaultPrivileges) {
       dbSqlParts.push(buildDefaultPrivilegesSql('revoke'))
     }
 
@@ -285,6 +288,15 @@ const CreateProject = () => {
           description="To get you started quickly, we can create new tables for you with seed (sample) data. You can delete these tables later."
           checked={shouldRunMigrations}
           onChange={(e) => setShouldRunMigrations(e.target.checked)}
+        />
+      </div>
+      <div className="py-2 pb-4">
+        <Checkbox
+          name="dataApiDefaultPrivileges"
+          label="Default privileges for new entities"
+          description="When enabled, new tables and functions in the public schema are automatically accessible via the Data API. We recommend disabling this and manually granting access to each new entity."
+          checked={dataApiDefaultPrivileges}
+          onChange={(e) => setDataApiDefaultPrivileges(e.target.checked)}
         />
       </div>
       <div className="flex flex-row w-full justify-end">

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -16,12 +16,17 @@ import { useIntegrationVercelConnectionsCreateMutation } from '@/data/integratio
 import { useVercelProjectsQuery } from '@/data/integrations/integrations-vercel-projects-query'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useProjectCreateMutation } from '@/data/projects/project-create-mutation'
-import { useDataApiRevokeOnCreateDefaultEnabled } from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
+import {
+  useDataApiRevokeOnCreateDefaultEnabled,
+  useTrackDefaultPrivilegesExposure,
+} from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { usePHFlag } from '@/hooks/ui/useFlag'
 import { BASE_PATH, PROVIDERS } from '@/lib/constants'
 import { getInitialMigrationSQLFromGitHubRepo } from '@/lib/integration-utils'
 import { passwordStrength, PasswordStrengthScore } from '@/lib/password-strength'
 import { generateStrongPassword } from '@/lib/project'
+import { useTrack } from '@/lib/telemetry/track'
 import { useIntegrationInstallationSnapshot } from '@/state/integration-installation'
 import type { NextPageWithLayout } from '@/types'
 
@@ -62,11 +67,15 @@ const CreateProject = () => {
   const [shouldRunMigrations, setShouldRunMigrations] = useState(true)
   const [dbRegion, setDbRegion] = useState(PROVIDERS.AWS.default_region.displayName)
 
+  const track = useTrack()
   const snapshot = useIntegrationInstallationSnapshot()
   const isDataApiRevokeOnCreateDefault = useDataApiRevokeOnCreateDefaultEnabled()
+  const dataApiRevokeOnCreateDefaultFlag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
   const [dataApiDefaultPrivileges, setDataApiDefaultPrivileges] = useState(
     !isDataApiRevokeOnCreateDefault
   )
+
+  useTrackDefaultPrivilegesExposure({ surface: 'vercel' })
 
   async function checkPasswordStrength(value: string) {
     const { message, strength } = await passwordStrength(value)
@@ -126,6 +135,21 @@ const CreateProject = () => {
   const { mutate: createProject } = useProjectCreateMutation({
     onSuccess: (res) => {
       setNewProjectRef(res.ref)
+      track(
+        'project_creation_simple_version_submitted',
+        {
+          surface: 'vercel',
+          dataApiEnabled: true,
+          dataApiDefaultPrivilegesGranted: dataApiDefaultPrivileges,
+          ...(dataApiRevokeOnCreateDefaultFlag !== undefined && {
+            dataApiRevokeOnCreateDefaultEnabled: dataApiRevokeOnCreateDefaultFlag,
+          }),
+        },
+        {
+          project: res.ref,
+          organization: res.organization_slug,
+        }
+      )
     },
     onError: (error) => {
       toast.error(error.message)

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -59,7 +59,7 @@ import {
 } from '@/data/projects/project-create-mutation'
 import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { useDataApiGrantTogglesEnabled } from '@/hooks/misc/useDataApiGrantTogglesEnabled'
+import { useDataApiRevokeOnCreateDefaultEnabled } from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -101,11 +101,12 @@ const Wizard: NextPageWithLayout = () => {
   const showPostgresVersionSelector = useFlag('showPostgresVersionSelector')
   const cloudProviderEnabled = useFlag('enableFlyCloudProvider')
 
-  const isDataApiGrantTogglesEnabled = useDataApiGrantTogglesEnabled()
-  // Read the raw flag for telemetry — useDataApiGrantTogglesEnabled coerces undefined→false,
-  // which would record false for users whose flags haven't loaded yet. The raw value preserves
-  // undefined (omitted from PostHog) so we only record true/false when the flag is resolved.
+  // Read the raw flag for telemetry — coerce-undefined-to-false would record false for
+  // users whose flags haven't loaded yet. The raw value preserves undefined (omitted from
+  // PostHog) so we only record true/false when the flag is resolved.
   const tableEditorApiAccessToggleFlag = usePHFlag<boolean>('tableEditorApiAccessToggle')
+  const dataApiRevokeOnCreateDefaultFlag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
+  const isDataApiRevokeOnCreateDefault = useDataApiRevokeOnCreateDefaultEnabled()
 
   const showNonProdFields = process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod'
   const isNotOnHigherPlan = !['team', 'enterprise', 'platform'].includes(currentOrg?.plan.id ?? '')
@@ -138,6 +139,7 @@ const Wizard: NextPageWithLayout = () => {
       dbRegion: undefined,
       instanceSize: canChooseInstanceSize ? sizes[0] : undefined,
       dataApi: true,
+      dataApiDefaultPrivileges: !isDataApiRevokeOnCreateDefault,
       enableRlsEventTrigger: false,
       postgresVersionSelection: '',
       useOrioleDb: false,
@@ -269,9 +271,13 @@ const Wizard: NextPageWithLayout = () => {
           instanceSize: form.getValues('instanceSize'),
           enableRlsEventTrigger: form.getValues('enableRlsEventTrigger'),
           dataApiEnabled: form.getValues('dataApi'),
+          dataApiDefaultPrivilegesGranted: form.getValues('dataApiDefaultPrivileges'),
           useOrioleDb: form.getValues('useOrioleDb'),
           ...(tableEditorApiAccessToggleFlag !== undefined && {
             tableEditorApiAccessToggleEnabled: tableEditorApiAccessToggleFlag,
+          }),
+          ...(dataApiRevokeOnCreateDefaultFlag !== undefined && {
+            dataApiRevokeOnCreateDefaultEnabled: dataApiRevokeOnCreateDefaultFlag,
           }),
         },
         {
@@ -310,6 +316,7 @@ const Wizard: NextPageWithLayout = () => {
       postgresVersion,
       instanceSize,
       dataApi,
+      dataApiDefaultPrivileges,
       enableRlsEventTrigger,
       postgresVersionSelection,
       useOrioleDb,
@@ -345,9 +352,7 @@ const Wizard: NextPageWithLayout = () => {
       dbSql:
         [
           enableRlsEventTrigger && AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL,
-          // [Alaister]: temporarily disable the default secure sql
-          // To re-enable, remove the false &&
-          false && isDataApiGrantTogglesEnabled && buildDefaultPrivilegesSql('revoke'),
+          dataApi && !dataApiDefaultPrivileges && buildDefaultPrivilegesSql('revoke'),
         ]
           .filter(Boolean)
           .join('\n') || undefined,

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -268,6 +268,7 @@ const Wizard: NextPageWithLayout = () => {
       track(
         'project_creation_simple_version_submitted',
         {
+          surface: 'main',
           instanceSize: form.getValues('instanceSize'),
           enableRlsEventTrigger: form.getValues('enableRlsEventTrigger'),
           dataApiEnabled: form.getValues('dataApi'),

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -368,14 +368,14 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
      */
     tableEditorApiAccessToggleEnabled?: boolean
     /**
-     * Raw checkbox state for "Default privileges for new entities" at submission.
+     * Raw checkbox state for "Automatically expose new tables and functions" at submission.
      * true = default privileges are granted on new entities (current behaviour)
      * false = revoke SQL ran; user must manually grant access per entity
      */
     dataApiDefaultPrivilegesGranted?: boolean
     /**
      * Whether the dataApiRevokeOnCreateDefault PostHog flag was enabled for this user.
-     * Controls only the default checkbox state of "Default privileges for new entities"
+     * Controls only the default checkbox state of "Automatically expose new tables and functions"
      * at project creation. Tracking it lets us correlate flag cohort with user choice.
      * true = user is in the staged rollout cohort (checkbox defaulted to unchecked)
      * false = user is outside the rollout (checkbox defaulted to checked)

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -283,15 +283,52 @@ export interface ProjectCreationRlsOptionExperimentExposedEvent {
 }
 
 /**
- * Existing project creation form was submitted and the project was created.
+ * Top-of-funnel event for the dataApiRevokeOnCreateDefault rollout. Fires once per
+ * mount after the flag resolves so cohort attribution is clean — pair with
+ * project_creation_simple_version_submitted to measure the flag's impact on
+ * project creation completion rate.
  *
  * @group Events
  * @source studio
- * @page new/{slug}
+ * @page new/{slug} and /integrations/vercel/{slug}/deploy-button/new-project
+ */
+export interface ProjectCreationDefaultPrivilegesExposedEvent {
+  action: 'project_creation_default_privileges_exposed'
+  properties: {
+    /** Where the checkbox was shown. */
+    surface: 'main' | 'vercel'
+    /**
+     * State of the "Enable Data API" toggle at exposure time. Main flow only —
+     * the Vercel surface has no such toggle, so this is omitted there.
+     */
+    dataApiEnabled?: boolean
+    /**
+     * Raw value of the dataApiRevokeOnCreateDefault PostHog flag at exposure time.
+     * true = revoke cohort (checkbox defaulted to unchecked)
+     * false = control cohort (checkbox defaulted to checked)
+     */
+    dataApiRevokeOnCreateDefaultEnabled: boolean
+  }
+  groups: Omit<TelemetryGroups, 'project'>
+}
+
+/**
+ * Project creation form was submitted and the project was created. Fires from both
+ * the main project creation wizard and the Vercel deploy-button flow — disambiguate
+ * by the `surface` property.
+ *
+ * @group Events
+ * @source studio
+ * @page new/{slug} and /integrations/vercel/{slug}/deploy-button/new-project
  */
 export interface ProjectCreationSimpleVersionSubmittedEvent {
   action: 'project_creation_simple_version_submitted'
   properties: {
+    /**
+     * Which surface produced the submission. Omitted on events emitted before this
+     * property was introduced; treat absent as 'main' for backfill.
+     */
+    surface?: 'main' | 'vercel'
     /**
      * The instance size selected in the project creation form.
      */
@@ -3193,6 +3230,7 @@ export type TelemetryEvent =
   | FeaturePreviewEnabledEvent
   | FeaturePreviewDisabledEvent
   | ProjectCreationRlsOptionExperimentExposedEvent
+  | ProjectCreationDefaultPrivilegesExposedEvent
   | ProjectCreationSimpleVersionSubmittedEvent
   | ProjectCreationSimpleVersionConfirmModalOpenedEvent
   | TableApiAccessToggleClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -323,13 +323,28 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
      */
     useOrioleDb?: boolean
     /**
-     * Whether the tableEditorApiAccessToggle PostHog flag was enabled for this user,
-     * meaning the project was created with default public schema grants revoked.
-     * true = user is in the staged rollout cohort (revoke SQL ran at creation)
-     * false = user is outside the rollout (default grants left intact)
+     * Whether the tableEditorApiAccessToggle PostHog flag was enabled for this user.
+     * Gates the integrations → Data API settings surface only; no longer controls
+     * project-creation revoke behaviour (see dataApiRevokeOnCreateDefaultEnabled).
+     * true/false = flag state when project was created
      * omitted = PostHog flags had not loaded at the time of project creation
      */
     tableEditorApiAccessToggleEnabled?: boolean
+    /**
+     * Raw checkbox state for "Default privileges for new entities" at submission.
+     * true = default privileges are granted on new entities (current behaviour)
+     * false = revoke SQL ran; user must manually grant access per entity
+     */
+    dataApiDefaultPrivilegesGranted?: boolean
+    /**
+     * Whether the dataApiRevokeOnCreateDefault PostHog flag was enabled for this user.
+     * Controls only the default checkbox state of "Default privileges for new entities"
+     * at project creation. Tracking it lets us correlate flag cohort with user choice.
+     * true = user is in the staged rollout cohort (checkbox defaulted to unchecked)
+     * false = user is outside the rollout (checkbox defaulted to checked)
+     * omitted = PostHog flags had not loaded at the time of project creation
+     */
+    dataApiRevokeOnCreateDefaultEnabled?: boolean
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
<img width="783" height="414" alt="Screenshot 2026-04-20 at 3 02 37 PM" src="https://github.com/user-attachments/assets/a353c35a-3de5-4bfa-ab31-829c79c43165" />

Adds a "Default privileges for new entities" checkbox under "Enable Data API" in both the main create flow and the Vercel deploy-button flow. Default checked (current behaviour). When unchecked, runs `buildDefaultPrivilegesSql('revoke')` after the base init script so new entities in `public` aren't auto-granted to `anon` / `authenticated` / `service_role`.

This PR decouples the two surfaces:

- **`tableEditorApiAccessToggle`** — unchanged; still gates only the integrations → Data API settings UI.
- **`dataApiRevokeOnCreateDefault`** (new) — controls only the default state of the new checkbox at project creation. `true` → checkbox unchecked by default (revoke runs); `false`/absent → checkbox checked by default (no behaviour change).

The new flag is already live in PostHog at **0% rollout, off for everyone**, so shipping this PR changes nothing until the flag is explicitly flipped.

## Added

- `apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts` — reads the new PostHog flag. Returns `false` in `IS_TEST_ENV` so existing E2E flows don't silently change default behaviour.
- Checkbox UI in `SecurityOptions.tsx` (main flow) and `pages/integrations/vercel/[slug]/deploy-button/new-project.tsx` (Vercel flow), with copy matching the integrations → Data API settings page.
- Tooltip + dimmed state for the main-flow checkbox when "Enable Data API" is unchecked (can't configure default privileges if Data API is off).
- Telemetry: `dataApiDefaultPrivilegesGranted` (raw checkbox value) and `dataApiRevokeOnCreateDefaultEnabled` (raw flag, conditionally included using the existing raw-flag pattern so undefined flag state → omitted property, not `false`).
- Vitest unit tests for the new hook.

## Changed

- `pages/new/[slug].tsx`: removed the `false &&` rollback guard. Revoke SQL now runs only when `dataApi && !dataApiDefaultPrivileges`. Dropped the now-unused `useDataApiGrantTogglesEnabled` import.
- `pages/integrations/vercel/[slug]/deploy-button/new-project.tsx`: this flow was **never rolled back** — it still ran revoke whenever `tableEditorApiAccessToggle` was on for a user. Now correctly gated on the new flag + checkbox state.
- `packages/common/telemetry-constants.ts`: added the two new properties and corrected the `tableEditorApiAccessToggleEnabled` docstring (it no longer claims to control project-creation revoke behaviour).

## Kill switch

Flipping `dataApiRevokeOnCreateDefault` to off in PostHog fully disables the revoke SQL for new projects without needing a redeploy — the checkbox just defaults to checked again.

## Follow-ups (not blockers)

- joshenlim's review comments on PR 43704: (1) Auth Policies table row incorrectly showing "exposed via Data API" based on schema-level check instead of table-level at `apps/studio/components/interfaces/Auth/Policies/PolicyTableRow/index.tsx:64`; (2) Data API integrations page showing zero exposed tables even after exposing one. Both unrelated to this PR but will be more visible once the checkbox lands.
- Once this flag fully rolls out, the old `tableEditorApiAccessToggle` docstring/comments elsewhere should stop claiming it controls project creation.

## To test

- **Flag off (default state, simulates post-merge):** create a project with and without "Enable Data API" checked. The new "Default privileges for new entities" checkbox should default to **checked**. Submitting should produce an identical result to today — new tables in `public` are reachable via the Data API.
- **Flag on (simulate rollout):** override the flag locally. The checkbox should default to **unchecked**. Creating a project with it unchecked should run the revoke SQL; create a new table in `public` afterwards and confirm it's not reachable via the Data API until grants are added.
- **Enable Data API off:** the new checkbox should render disabled + dimmed with a tooltip reading "Enable the Data API to configure default privileges." The revoke SQL should not run in this case regardless of checkbox state.
- **Vercel flow:** repeat at `/integrations/vercel/<slug>/deploy-button/new-project` — verify both checkbox states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Automatically expose new tables and functions" checkbox to project creation and Vercel deploy flow; enabled only when Data API is available (disabled with tooltip otherwise) and affects initial project provisioning.

* **Telemetry**
  * Tracks exposure of the default-privileges control and includes checkbox state and feature-flag status on project-creation submissions.

* **Tests**
  * Added tests for flag behavior, exposure tracking, deduplication, and submission telemetry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->