### PR TITLE
docs: remove claim flow admonition in docs

### DIFF
--- a/apps/docs/content/guides/integrations/supabase-for-platforms.mdx
+++ b/apps/docs/content/guides/integrations/supabase-for-platforms.mdx
@@ -375,12 +375,6 @@ curl https://api.supabase.com/v1/projects/database/backups/restore-pitr \
 
 Management API endpoint: [`GET /v1/oauth/authorize/project-claim`](https://api.supabase.com/api/v1#tag/oauth/get/v1/oauth/authorize/project-claim)
 
-<Admonition type="note" title="Contact us for access to claim flow">
-
-Only select customers have access to claim flow. Submit this [form](/solutions/ai-builders#talk-to-partnerships-team) to get access.
-
-</Admonition>
-
 Your users may want to claim the project that currently lives in your org so that they can have more control over it.
 
 We've enabled transferring the project from your org to your user's org while you continue to retain access to interact with the project through an [OAuth integration](/docs/guides/integrations/build-a-supabase-oauth-integration).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed an informational notice from the Supabase for Platforms integration guide that previously mentioned access restrictions for the claim flow feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->