### PR TITLE
chore(self-hosted): when adding new keys update docker config too

### DIFF
--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -143,9 +143,6 @@ echo ""
 echo "SUPABASE_PUBLISHABLE_KEY=${SUPABASE_PUBLISHABLE_KEY}"
 echo "SUPABASE_SECRET_KEY=${SUPABASE_SECRET_KEY}"
 echo ""
-echo "ANON_KEY_ASYMMETRIC=${ANON_KEY_ASYMMETRIC}"
-echo "SERVICE_ROLE_KEY_ASYMMETRIC=${SERVICE_ROLE_KEY_ASYMMETRIC}"
-echo ""
 echo "JWT_KEYS=${JWT_KEYS}"
 echo ""
 echo "JWT_JWKS=${JWT_JWKS}"
@@ -186,3 +183,20 @@ for var in SUPABASE_PUBLISHABLE_KEY SUPABASE_SECRET_KEY ANON_KEY_ASYMMETRIC SERV
         echo "${var}=${val}" >> .env
     fi
 done
+
+# Uncomment the JWKS lines in docker-compose.yml so the new keys take effect.
+echo "Uncommenting JWKS lines in docker-compose.yml..."
+if [ ! -f docker-compose.yml ]; then
+    echo "Error: docker-compose.yml not found in $(pwd)."
+    exit 1
+fi
+
+if sed -i.old \
+    -e '/^[ ]*#GOTRUE_JWT_KEYS:/ s/#//' \
+    -e '/^[ ]*#API_JWT_JWKS:/ s/#//' \
+    -e '/^[ ]*#JWT_JWKS:/ s/#//' \
+    docker-compose.yml; then
+    echo "Done."
+else
+    echo "Warning: could not edit docker-compose.yml. Uncomment the JWKS lines manually."
+fi

--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -187,16 +187,21 @@ done
 # Uncomment new auth configuration in docker-compose.yml
 echo "Updating docker-compose.yml..."
 if [ ! -f docker-compose.yml ]; then
-    echo "Error: docker-compose.yml not found in $(pwd)."
+    echo "Error: docker-compose.yml not found in $(pwd)"
     exit 1
 fi
 
-if sed -i.old \
+# Always fall through to the grep check
+sed -i.old \
     -e '/^[ ]*#GOTRUE_JWT_KEYS:/ s/#//' \
     -e '/^[ ]*#API_JWT_JWKS:/ s/#//' \
     -e '/^[ ]*#JWT_JWKS:/ s/#//' \
-    docker-compose.yml; then
+    docker-compose.yml || true
+
+if grep -q '^[ ]*GOTRUE_JWT_KEYS:' docker-compose.yml && \
+   grep -q '^[ ]*API_JWT_JWKS:' docker-compose.yml && \
+   grep -q '^[ ]*JWT_JWKS:' docker-compose.yml; then
     echo "Done."
 else
-    echo "Warning: could not edit docker-compose.yml."
+    echo "Warning: could not edit docker-compose.yml. Uncomment auth configuration manually."
 fi

--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -147,7 +147,7 @@ echo "JWT_KEYS=${JWT_KEYS}"
 echo ""
 echo "JWT_JWKS=${JWT_JWKS}"
 echo ""
-echo "To enable asymmetric key support, uncomment these lines in docker-compose.yml:"
+echo "To enable asymmetric key pair, the following should be enabled in docker-compose.yml:"
 echo ""
 echo "  Auth:     GOTRUE_JWT_KEYS: \${JWT_KEYS:-[]}"
 echo "  Realtime: API_JWT_JWKS: \${JWT_JWKS:-{\"keys\":[]}}"
@@ -184,8 +184,8 @@ for var in SUPABASE_PUBLISHABLE_KEY SUPABASE_SECRET_KEY ANON_KEY_ASYMMETRIC SERV
     fi
 done
 
-# Uncomment the JWKS lines in docker-compose.yml so the new keys take effect.
-echo "Uncommenting JWKS lines in docker-compose.yml..."
+# Uncomment new auth configuration in docker-compose.yml
+echo "Updating docker-compose.yml..."
 if [ ! -f docker-compose.yml ]; then
     echo "Error: docker-compose.yml not found in $(pwd)."
     exit 1
@@ -198,5 +198,5 @@ if sed -i.old \
     docker-compose.yml; then
     echo "Done."
 else
-    echo "Warning: could not edit docker-compose.yml. Uncomment the JWKS lines manually."
+    echo "Warning: could not edit docker-compose.yml."
 fi


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update the `utils/add-new-auth-keys.sh` script added in PR #43554:

- Edit `docker-compose.yml` automatically to enable new env vars for Realtime, Storage, and Auth to pick up the new auth configuration (PostgREST is already configured with a fallback env var conf)
- Reduces manual operations and prevents errors
- Matches installation steps in the updated Docker setup guide (PR #45011)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auth key setup script now attempts to update the container compose configuration when run with the update flag, verifies the compose file exists, and reports success or a manual-update warning.

* **Chores**
  * Improved user messaging and guidance language (now refers to an "asymmetric key pair") and stopped printing specific asymmetric key identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->