### PR TITLE
fix(docs): remove edge function Authorization header from cron example

### DIFF
--- a/apps/docs/content/guides/cron/quickstart.mdx
+++ b/apps/docs/content/guides/cron/quickstart.mdx
@@ -279,7 +279,7 @@ select
     select
       net.http_post(
           url:='https://project-ref.supabase.co/functions/v1/function-name',
-          headers:=jsonb_build_object('Content-Type','application/json', 'Authorization', 'Bearer ' || 'YOUR_ANON_KEY'),
+          headers:=jsonb_build_object('Content-Type','application/json', 'apikey', 'YOUR_PUBLISHABLE_KEY'),
           body:=jsonb_build_object('time', now() ),
           timeout_milliseconds:=5000
       ) as request_id;


### PR DESCRIPTION
Removes `Authorization` header from cron quickstart example to align with the new API keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Edge Function invocation example in the quickstart guide: the request headers now use the publishable API key header alongside Content-Type instead of an Authorization Bearer header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->