### PR TITLE
fix(studio): use useStaticEffectEvent in SSOConfig

### DIFF
--- a/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
+++ b/apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx
@@ -34,6 +34,7 @@ import { useOrgSSOConfigQuery } from '@/data/sso/sso-config-query'
 import { useSSOConfigUpdateMutation } from '@/data/sso/sso-config-update-mutation'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 import { DOCS_URL } from '@/lib/constants'
 
 const FormSchema = z
@@ -189,7 +190,7 @@ export const SSOConfig = () => {
     deleteSSOConfig({ slug: organization.slug })
   }
 
-  useEffect(() => {
+  const syncFormFromConfig = useStaticEffectEvent(() => {
     if (!organization?.slug) return
 
     // Only reset form if it's not dirty (user hasn't made changes)
@@ -212,15 +213,23 @@ export const SSOConfig = () => {
         roleOnJoin: ssoConfig.join_org_on_signup_role,
       })
     }
-  }, [ssoConfig, organization?.slug])
+  })
+
+  useEffect(() => {
+    syncFormFromConfig()
+  }, [ssoConfig, organization?.slug, syncFormFromConfig])
 
   // Automatically add an empty domain field when SP-initiated is enabled
-  useEffect(() => {
+  const ensureDomainField = useStaticEffectEvent(() => {
     const currentDomains = form.getValues('domains')
     if (enableSpInitiated && (!currentDomains || currentDomains.length === 0)) {
       form.setValue('domains', [{ value: '' }], { shouldValidate: false })
     }
-  }, [enableSpInitiated])
+  })
+
+  useEffect(() => {
+    ensureDomainField()
+  }, [enableSpInitiated, ensureDomainField])
 
   return (
     <ScaffoldContainer size="small" className="px-6 xl:px-10">


### PR DESCRIPTION
## Summary

- Fixes the `react-hooks/exhaustive-deps` eslint warning on `apps/studio/components/interfaces/Organization/SSO/SSOConfig.tsx`.
- Replaces two `useEffect` bodies that closed over `form` (from `useForm()`) with `useStaticEffectEvent`, mirroring the pattern already in use at `apps/studio/components/interfaces/Settings/API/DataApiEnableSwitch.tsx:58-65`.
- No behavior change: effects still re-run on the same data triggers (`ssoConfig` / `organization?.slug` for the reset effect, `enableSpInitiated` for the domain-seed effect).

## Why not just add `form` to the deps?

React-hook-form's `form` object is stable-by-reference in practice, but adding it to the deps array (a) encourages unnecessary re-runs in edge cases and (b) obscures the real intent — we only want to react to *data* changes, not to the form wrapper. `useStaticEffectEvent` is this repo's existing pattern for the same situation.

## Test plan

- [x] `pnpm lint --filter=studio` passes without the exhaustive-deps warning on `SSOConfig.tsx`
- [x] Load `/org/<slug>/sso` for an org with an existing SSO config — form populates from the query
- [x] Edit a field, wait for query refetch — user edits are preserved (`isDirty` guard still works)
- [x] Toggle "Enable SP-initiated login" on — an empty domain row appears
- [x] Save a new SSO config — `createSSOConfig` fires and form resets via the mutation `onSuccess`