### PR TITLE
fix: select fields aren't accessible with tab on Safari

### DIFF
--- a/packages/ui/src/components/shadcn/ui/select.tsx
+++ b/packages/ui/src/components/shadcn/ui/select.tsx
@@ -54,6 +54,7 @@ const SelectTrigger = React.forwardRef<
       SelectTriggerVariants({ size }),
       className
     )}
+    tabIndex={0}
     {...props}
   >
     {children}


### PR DESCRIPTION
## Problem

`select` fields aren't accessible with tab on Safari.
This is a known issue on Safari that can be solved by users if they adjust their settings:
<img width="820" height="210" alt="image" src="https://github.com/user-attachments/assets/6f26dd0e-487f-4a36-ad5f-bb20ef7b2029" />

## Solution

We can simply add a `tabindex` attribute on the Shadcn `<SelectTrigger>` to fix it.

## How to test

- Create a new org. Tab on the form. It should highlight each field, including the _Type_ and _Plan_ select.
- Edit your _Account preferences_. You should be able to tab to the _Primary email_ field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard navigation support for select components by improving focus handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->