### PR TITLE
fix schema visualizer animations

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -175,9 +175,19 @@ export const SchemaGraph = () => {
     (params: OnSelectionChangeParams<Node<TableNodeData>, Edge<EdgeData>>) => {
       if (params.edges.length === 1) {
         setSelectedEdge(params.edges[0])
-        return
+      } else {
+        setSelectedEdge(undefined)
       }
-      setSelectedEdge(undefined)
+
+      const selectedNodeIds = new Set(params.nodes.map((n) => n.id))
+      reactFlowInstance.setEdges(
+        reactFlowInstance.getEdges().map((edge) => ({
+          ...edge,
+          animated:
+            selectedNodeIds.size > 0 &&
+            (selectedNodeIds.has(edge.source) || selectedNodeIds.has(edge.target)),
+        }))
+      )
     }
   )
 
@@ -382,7 +392,7 @@ export const SchemaGraph = () => {
                   defaultEdges={[]}
                   defaultEdgeOptions={{
                     type: 'default',
-                    animated: true,
+                    animated: false,
                     deletable: false,
                   }}
                   nodeTypes={nodeTypes}


### PR DESCRIPTION
The dashed-line animation between relations in the schema visualizer can get quite CPU-intensive for complicated schemas. Changed so it only runs on edges that target the selected relation, otherwise it's a solid line.

Resolves FE-3005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Relationships connected to selected tables now animate for enhanced visual feedback.

* **Bug Fixes**
  * Improved edge selection behavior in the schema graph—single selections now register correctly.
  * Optimized default animation settings for schema connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->