### PR TITLE
chore(docs): add lowercase postgres to rule003

### DIFF
--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -305,7 +305,7 @@ allow_list = [
     "PostGIS",
     "PostQUEL",
     "PostgREST",
-    "Postgres",
+    "[Pp]ostgres",
     "postgres-meta",
     # We prefer Postgres, but check for vocabulary preference in a separate rule
     "PostgreSQL",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Adds an option to use lowercase "postgres" as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced spelling validation to accept both "Postgres" and "postgres" variants, improving documentation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->