### PR TITLE
fix(studio): make paused project dashboard view responsive on mobile

### DIFF
--- a/apps/studio/components/interfaces/Home/Home.tsx
+++ b/apps/studio/components/interfaces/Home/Home.tsx
@@ -100,7 +100,7 @@ export const Home = () => {
 
   if (isPaused) {
     return (
-      <div className="w-full h-full flex items-center justify-center">
+      <div className="w-full h-full flex items-center justify-center px-4">
         <ProjectPausedState />
       </div>
     )

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/PauseDisabledState.tsx
@@ -164,7 +164,7 @@ export const PauseDisabledState = () => {
           </ul>
         </div>
       </Admonition>
-      <div className="border-t flex justify-between items-center px-6 py-4 bg-alternative">
+      <div className="border-t flex flex-col gap-3 sm:flex-row sm:justify-between sm:items-center px-6 py-4 bg-alternative">
         <div>
           <p className="text-sm">Export your data</p>
           <p className="text-sm text-foreground-lighter">

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -141,7 +141,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
 
   return (
     <>
-      <Card className="w-[40rem] mx-auto">
+      <Card className="w-full max-w-[40rem] mx-auto">
         <CardContent>
           <PauseCircle
             size={48}
@@ -235,7 +235,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
         )}
 
         {isPauseStatusSuccess && !isRestoreDisabled && (
-          <CardFooter className="flex justify-end items-center gap-x-2">
+          <CardFooter className="flex flex-wrap justify-end items-center gap-2">
             <ButtonTooltip
               size="tiny"
               type="default"

--- a/apps/studio/components/layouts/ProjectLayout/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/index.tsx
@@ -266,7 +266,7 @@ export const ProjectLayout = forwardRef<HTMLDivElement, PropsWithChildren<Projec
                 ref={combinedRef}
               >
                 {showPausedState ? (
-                  <div className="mx-auto my-16 w-full h-full max-w-7xl flex items-center">
+                  <div className="mx-auto my-16 w-full h-full max-w-7xl flex items-center px-4">
                     <div className="w-full">
                       <ProjectPausedState product={product} />
                     </div>


### PR DESCRIPTION
Closes [FE-3040](https://linear.app/supabase/issue/FE-3040/fix-paused-project-dashboard-view-on-mobile)

## Summary

The paused project dashboard card was locked to a fixed `w-[40rem]` (640px) width, causing horizontal overflow on mobile viewports. The Resume project button was pushed off-screen, which drove users into Project Settings → General, where the only visible action (Restart) is disabled for paused projects.

## Changes

- `ProjectPausedState` card: `w-[40rem]` → `w-full max-w-[40rem]`
- `CardFooter`: added `flex-wrap` so Resume + Upgrade-to-Pro/View-settings buttons stay visible on narrow screens
- `PauseDisabledState` export-data footer: stacks on mobile, row layout on `sm:`+
- Parent wrappers (`ProjectLayout/index.tsx`, `Home.tsx`): added `px-4` so the card has breathing room from viewport edges

## Follow-up (not in this PR)

The Linear issue also suggests adding a Resume action (or differentiated messaging) to Project Settings → General's "Project availability" section, so users who land there on a paused project have a clear path forward. Happy to tackle that separately.

## Test plan

- [x] Paused Free-plan project on mobile viewport (≤640px): Resume + Upgrade buttons visible, text wraps within the card
- [x] Paused Pro-plan project on mobile viewport: Resume + View settings buttons visible
- [x] Non-restorable (>90 days paused) project on mobile: Recovery options list readable, "Download backups" dropdown visible and stacks below description
- [x] Desktop (≥640px): card still renders at 40rem max width, layout unchanged
- [x] Verified via `/project/[ref]` and `/project/[ref]/home` entry points

## Demo
<img width="443" height="832" alt="image" src="https://github.com/user-attachments/assets/d5b7713e-c0b5-44e8-82fe-98c3308d5e8b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added horizontal padding to the paused project state interface and wrapper.
  * Made the export data section layout responsive, stacking vertically on mobile and horizontally on larger screens.
  * Updated the paused state card container styling to use responsive width constraints instead of fixed dimensions.
  * Adjusted footer element spacing, gap sizing, and wrapping behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->