### PR TITLE
fix: adjust charge breakdown for prorated credits and subtotal calculation

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -254,14 +254,32 @@ export const SubscriptionPlanUpdateDialog = ({
   // Derives the itemized charge breakdown rows shown above "Charge today".
   // Example: Pro -> Team upgrade with proration, tax, and credits:
   //   Team Plan            $25.00
-  //   Unused Time on Pro   -$8.33
-  //   Subtotal             $16.67
   //   Tax (10%)             $1.67
+  //   Subtotal             $26.67
+  //   Unused Time on Pro   -$8.33
   //   Credits              -$5.00
   //   ─────────────────────────────
   //   Charge today         $13.34
   const breakdownItems = useMemo(() => {
     const items: BreakdownItem[] = []
+
+    if (hasTax && tax) {
+      items.push({
+        type: 'amount',
+        label: `Tax (${tax.tax_rate_percentage}%)`,
+        amount: tax.tax_amount,
+      })
+      if (taxableAmount !== newPlanCost) {
+        items.push({ type: 'amount', label: 'Subtotal', amount: taxableAmount! })
+      }
+    }
+
+    if (taxFailed) {
+      items.push({
+        type: 'notice',
+        label: 'Tax could not be estimated and may be applied separately',
+      })
+    }
 
     if (currentPlanId !== 'free' && proratedCredit > 0) {
       items.push({
@@ -269,25 +287,8 @@ export const SubscriptionPlanUpdateDialog = ({
         label: `Unused Time on ${currentPlanName} Plan`,
         amount: -proratedCredit,
         tooltip:
-          'Your previous plan was charged upfront, so a plan change will prorate any unused time in credits. If the prorated credits exceed the new plan charge, the excessive credits are added to your organization for future use.',
-      })
-    }
-
-    if (hasTax && tax) {
-      if (taxableAmount !== newPlanCost) {
-        items.push({ type: 'amount', label: 'Subtotal', amount: taxableAmount! })
-      }
-      items.push({
-        type: 'amount',
-        label: `Tax (${tax.tax_rate_percentage}%)`,
-        amount: tax.tax_amount,
-      })
-    }
-
-    if (taxFailed) {
-      items.push({
-        type: 'notice',
-        label: 'Tax could not be estimated and may be applied separately',
+          'Your previous plan was charged upfront, so a plan change will prorate any unused time in credits. If the prorated credits exceed the new plan charge, the excessive credits are added to your organization for future use.' +
+          (hasTax ? ' Includes proportional tax if applicable.' : ''),
       })
     }
 


### PR DESCRIPTION
Reorders the itemized charge breakdown in the subscription upgrade preview dialog to: Plan → Tax → Subtotal → Unused Time → Credits. Also appends a "Includes proportional tax if applicable" note to the unused time tooltip when tax is being applied, so users understand the prorated credit already reflects tax.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reorganized proration breakdown display order in subscription plan updates for improved clarity.
  * Enhanced unused time charge tooltip to conditionally include tax information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->