### PR TITLE
fix: switch fields aren't accessible with tab on Safari

### DIFF
--- a/packages/ui/src/components/shadcn/ui/switch.tsx
+++ b/packages/ui/src/components/shadcn/ui/switch.tsx
@@ -52,6 +52,7 @@ const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, 
       className={cn(switchRootVariants({ size }), className)}
       {...props}
       ref={ref}
+      tabIndex={0}
     >
       <SwitchPrimitives.Thumb className={cn(switchThumbVariants({ size }))} />
     </SwitchPrimitives.Root>

--- a/packages/ui/src/components/shadcn/ui/switch.tsx
+++ b/packages/ui/src/components/shadcn/ui/switch.tsx
@@ -50,9 +50,9 @@ const Switch = React.forwardRef<React.ElementRef<typeof SwitchPrimitives.Root>, 
   ({ className, size, ...props }, ref) => (
     <SwitchPrimitives.Root
       className={cn(switchRootVariants({ size }), className)}
+      tabIndex={0}
       {...props}
       ref={ref}
-      tabIndex={0}
     >
       <SwitchPrimitives.Thumb className={cn(switchThumbVariants({ size }))} />
     </SwitchPrimitives.Root>

--- a/packages/ui/src/components/shadcn/ui/toggle.tsx
+++ b/packages/ui/src/components/shadcn/ui/toggle.tsx
@@ -35,6 +35,7 @@ const Toggle = React.forwardRef<
   <TogglePrimitive.Root
     ref={ref}
     className={cn(toggleVariants({ variant, size, className }))}
+    tabIndex={0}
     {...props}
   />
 ))


### PR DESCRIPTION
## Problem

Similar to #45064, switch fields aren't accessible with tab on Safari.

Example:
- Open https://studio-staging-git-gildasgarcia-fe-2998-suggest-e7fb9e-supabase.vercel.app
- Create a new project
- Move through fields with tab, note that you can't focus _High Availability_

## Solution

- Add a `tabindex="0"` on `<Switch>`
- Add a `tabindex="0"` on `<Toggle>` (was a mistake as we don't actually use it yet but it will be needed when we do)


## How to test

- Open the staging
- Create a new project
- Move through fields with tab, note that you can focus _High Availability_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Switch and Toggle controls now correctly participate in keyboard tab order, improving focusability and keyboard navigation for accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->