### PR TITLE
Update www changelog octokit declaration to use GITHUB_CHANGELOG_APP_PRIVATE_KEY

### DIFF
--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -142,7 +142,12 @@ export const getServerSideProps: GetServerSideProps = async ({ res, query }) => 
   const restPage = query.restPage ? Number(query.restPage) : 1
 
   const octokitRest = new OctokitRest({
-    auth: process.env.GITHUB_CHANGELOG_APP_REST_KEY,
+    authStrategy: createAppAuth,
+    auth: {
+      appId: process.env.GITHUB_CHANGELOG_APP_ID,
+      installationId: process.env.GITHUB_CHANGELOG_APP_INSTALLATION_ID,
+      privateKey: process.env.GITHUB_CHANGELOG_APP_PRIVATE_KEY,
+    },
   })
 
   // uses the rest api


### PR DESCRIPTION
## Context

Resolves FE-3044

Mainly to remove the usage of `GITHUB_CHANGELOG_APP_REST_KEY` - will need to verify on preview if this breaks anything (I'm not entirely sure where to check tbh - our changelog page doesn't have discussions or releases?)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub authentication configuration for changelog generation to use GitHub App credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->