### PR TITLE
docs: add exchangeCodeForSession to Flutter/Dart API reference

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -1694,6 +1694,24 @@ functions:
             ),
           );
           ```
+  - id: exchange-code-for-session
+    title: 'exchangeCodeForSession()'
+    $ref: '@supabase/gotrue-js.GoTrueClient.exchangeCodeForSession'
+    notes: |
+      - Used when `flowType` is set to `AuthFlowType.pkce` in the Auth configuration.
+    params:
+      - name: authCode
+        isOptional: false
+        type: String
+        description: The code to exchange.
+    examples:
+      - id: exchange-auth-code
+        name: Exchange Auth Code
+        isSpotlight: true
+        code: |
+          ```dart
+          await supabase.auth.exchangeCodeForSession('34e770dd-9ff9-416c-87fa-43b31d7ef225');
+          ```
   - id: refresh-session
     title: 'refreshSession()'
     notes: |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The exchangeCodeForSession method is missing from the Flutter/Dart API reference docs, making it difficult for Flutter developers to discover how to complete the PKCE auth flow after receiving a code from a redirect URL.

## What is the new behavior?

exchangeCodeForSession is now listed in the Flutter/Dart API reference docs, making it discoverable for developers implementing the PKCE auth flow in Flutter.

## Additional context

This PR closes the following [ issue ](https://github.com/supabase/supabase/issues/45051#issuecomment-4286414351)

This change upadtes the supabase_dart_v2.yml file

Before the update, the developer isn't able to understand how to complete the PKCE auth flow as other api references do.

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/7ea22299-4c74-4313-859c-70602a5d7a77" />

After the update, the developer is able to understand how to complete the PKCE auth flow as other api references do.

<img width="1470" height="956" alt="image" src="https://github.com/user-attachments/assets/00aefd3f-aea0-4f10-87f8-754bd9a1364e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `exchangeCodeForSession()` method to support PKCE authentication flow, including parameter specifications and code usage examples for Dart SDK users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->