### PR TITLE
feat(docs): update social guides to use publishable keys instead of anon

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -534,7 +534,7 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
     import Supabase
 
     struct SignInView: View {
-        let client = SupabaseClient(supabaseURL: URL(string: "your url")!, supabaseKey: "your anon key")
+        let client = SupabaseClient(supabaseURL: URL(string: "https://your-project-id.supabase.co")!, supabaseKey: "sb_publishable_...")
 
         var body: some View {
           SignInWithAppleButton { request in


### PR DESCRIPTION
Updates social guides (only Apple remains) to use the publishable key instead of anon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Swift code example in the Apple social login guide to use a concrete Supabase project URL format, providing clearer guidance for developers implementing authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->