### PR TITLE
feat(docs): update local dev guides to use the new key format

### DIFF
--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -243,16 +243,37 @@ This takes time on your first run because the CLI needs to download the Docker i
 Once all of the Supabase services are running, you'll see output containing your local Supabase credentials. It should look like this, with urls and keys that you'll use in your local project:
 
 ```
-
 Started supabase local development setup.
 
-         API URL: http://localhost:54321
-          DB URL: postgresql://postgres:postgres@localhost:54322/postgres
-      Studio URL: http://localhost:54323
-     Mailpit URL: http://localhost:54324
-        anon key: eyJh......
-service_role key: eyJh......
+╭──────────────────────────────────────╮
+│ 🔧 Development Tools                 │
+├─────────┬────────────────────────────┤
+│ Studio  │ http://127.0.0.1:54323     │
+│ Mailpit │ http://127.0.0.1:54324     │
+│ MCP     │ http://127.0.0.1:54321/mcp │
+╰─────────┴────────────────────────────╯
 
+╭──────────────────────────────────────────────────────╮
+│ 🌐 APIs                                              │
+├────────────────┬─────────────────────────────────────┤
+│ Project URL    │ http://127.0.0.1:54321              │
+│ REST           │ http://127.0.0.1:54321/rest/v1      │
+│ GraphQL        │ http://127.0.0.1:54321/graphql/v1   │
+│ Edge Functions │ http://127.0.0.1:54321/functions/v1 │
+╰────────────────┴─────────────────────────────────────╯
+
+╭───────────────────────────────────────────────────────────────╮
+│ ⛁ Database                                                    │
+├─────┬─────────────────────────────────────────────────────────┤
+│ URL │ postgresql://postgres:postgres@127.0.0.1:54322/postgres │
+╰─────┴─────────────────────────────────────────────────────────╯
+
+╭──────────────────────────────────────────────────────────────╮
+│ 🔑 Authentication Keys                                       │
+├─────────────┬────────────────────────────────────────────────┤
+│ Publishable │ sb_publishable_...                             │
+│ Secret      │ sb_secret_...                                  │
+╰─────────────┴────────────────────────────────────────────────╯
 ```
 
 <Tabs
@@ -305,8 +326,7 @@ If you are accessing these services without the client libraries, you may need t
 
 ```sh
 curl 'http://localhost:54321/rest/v1/' \
-    -H "apikey: <anon key>" \
-    -H "Authorization: Bearer <anon key>"
+    -H "apikey: sb_publishable_..."
 
 http://localhost:54321/rest/v1/           # REST (PostgREST)
 http://localhost:54321/realtime/v1/       # Realtime
@@ -316,7 +336,7 @@ http://localhost:54321/auth/v1/           # Auth (GoTrue)
 
 <Admonition type="note">
 
-`<anon key>` is provided when you run the command `supabase start`.
+`sb_publishable_...` is the publishable key output when you run the command `supabase start`.
 
 </Admonition>
 

--- a/apps/docs/content/guides/local-development/testing/overview.mdx
+++ b/apps/docs/content/guides/local-development/testing/overview.mdx
@@ -132,9 +132,9 @@ Instead, design your tests to be independent by using unique user IDs for each t
 Here's an example using TypeScript that mirrors the pgTAP tests above:
 
 ```typescript
+import crypto from 'crypto'
 import { createClient } from '@supabase/supabase-js'
 import { beforeAll, describe, expect, it } from 'vitest'
-import crypto from 'crypto'
 
 describe('Todos RLS', () => {
   // Generate unique IDs for this test suite to avoid conflicts with other tests
@@ -145,7 +145,7 @@ describe('Todos RLS', () => {
 
   beforeAll(async () => {
     // Setup test data specific to this test suite
-    const adminSupabase = createClient(process.env.SUPABASE_URL!, process.env.SERVICE_ROLE_KEY!)
+    const adminSupabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SECRET_KEY!)
 
     // Create test users with unique IDs
     await adminSupabase.auth.admin.createUser({


### PR DESCRIPTION
Updates local development guide to use the new API keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked CLI getting-started output into organized table sections for Development Tools, APIs, Database, and Authentication Keys.
  * Simplified API Gateway example to use a single publishable-key header in curl requests.
  * Updated testing guide to reference the correct environment variable for creating an admin test client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->