### PR TITLE
docs: update humans.txt to include Roman Hernandez

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -200,6 +200,7 @@ Raúl Barroso
 Riccardo Busetti
 Rodrigo Esteves
 Rodrigo Mansueli
+Roman Hernandez
 Ronan Lehane
 Rory Wilding
 Ryan Goulet


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

documentation: This diff adds "Roman Hernandez" to humans.txt

## What is the current behavior?

I am not in humans.txt

## What is the new behavior?

I am in humans.txt :) 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team roster information in publicly available resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->