### PR TITLE
fix(studio): gate JWT migration behind a flag

### DIFF
--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/index.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/index.tsx
@@ -187,7 +187,7 @@ export const JWTSecretKeysTable = () => {
       <div className="-space-y-px">
         {!canReadAPIKeys ? null : legacyKey ? (
           <>
-            {standbyKey && (
+            {standbyKey ? (
               <ActionPanel
                 title="Rotate Signing Key"
                 description="Switch the standby key to in use. All new JSON Web Tokens issued by Supabase Auth will be signed with this key."
@@ -197,9 +197,7 @@ export const JWTSecretKeysTable = () => {
                 icon={<RotateCw className="size-4" />}
                 type="primary"
               />
-            )}
-
-            {!standbyKey && (
+            ) : (
               <ActionPanel
                 title="Create standby key"
                 description="Set up a new key which you can switch to once it has been picked up by all components of your application."
@@ -396,48 +394,6 @@ export const JWTSecretKeysTable = () => {
           </Card>
         </div>
       )}
-
-      {/* TODO(hf): For launch <div>
-        <h2 className="text-xl mb-4">Resources</h2>
-
-        <div className="flex flex-col lg:flex-row gap-6">
-          <Card className="bg-surface-75 overflow-hidden">
-            <div className="flex">
-              <div className="bg-surface-200 px-0 flex items-center justify-center w-[180px]">
-                <WhyRotateKeysIllustration />
-              </div>
-              <div className="flex-1 pl-8 border-l h-full py-6 px-5">
-                <h4 className="text-sm">Why Rotate keys?</h4>
-                <p className="text-xs text-foreground-light mb-4 max-w-xs">
-                  Create Standby keys ahead of time which can then be promoted to 'In use' at any
-                  time.
-                </p>
-                <Button type="outline" icon={<Book />}>
-                  View guide
-                </Button>
-              </div>
-            </div>
-          </Card>
-
-          <Card className="bg-surface-75 overflow-hidden">
-            <div className="flex">
-              <div className="bg-surface-200 px-0 flex items-center justify-center w-[180px]">
-                <WhyUseStandbyKeysIllustration />
-              </div>
-              <div className="flex-1 pl-8 border-l h-full py-6 px-5">
-                <h4 className="text-sm">Why use a Standby key?</h4>
-                <p className="text-xs text-foreground-light mb-4 max-w-xs">
-                  Create Standby keys ahead of time which can then be promoted to 'In use' at any
-                  time.
-                </p>
-                <Button type="outline" icon={<Book />}>
-                  View guide
-                </Button>
-              </div>
-            </div>
-          </Card>
-        </div>
-      </div> */}
 
       <Dialog open={shownDialog === 'legacy'} onOpenChange={resetDialog}>
         <DialogContent className="sm:max-w-[425px]">

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -418,24 +418,18 @@ const JWTSettings = () => {
                           </span>{' '}
                           on the JWT Signing Keys page to start signing new JWTs with the standby
                           key. Existing <code>anon</code>, <code>service_role</code>, and active
-                          user JWTs stay valid.
-                          <p className="mt-1 text-xs">
-                            Before rotating, switch any code that verifies JWTs directly against the
-                            legacy secret (e.g. <code>jose</code>, <code>jsonwebtoken</code>) to{' '}
-                            <code>supabase.auth.getClaims()</code> or a JWKS-based verifier, and
-                            disable the <em className="not-italic text-foreground">Verify JWT</em>{' '}
-                            setting on any affected Edge Functions.
-                          </p>
+                          user JWTs stay valid. Before rotating, switch any code that verifies JWTs
+                          directly against the legacy secret (e.g. <code>jose</code>,{' '}
+                          <code>jsonwebtoken</code>) to <code>supabase.auth.getClaims()</code> or a
+                          JWKS-based verifier, and disable the{' '}
+                          <em className="not-italic text-foreground">Verify JWT</em> setting on any
+                          affected Edge Functions.
                         </li>
                         <li>
-                          <span className="text-foreground">Revoke the legacy JWT secret</span> from
-                          the JWT Signing Keys page once everything is working.
-                          <p className="mt-1 text-xs">
-                            Wait at least one full access-token expiry window (e.g. 1 hour 15
-                            minutes for the default 1-hour expiry) before revoking so active users
-                            aren't signed out. Revoke immediately only during an active security
-                            incident.
-                          </p>
+                          <span className="text-foreground">
+                            Optionally, revoke the legacy JWT secret
+                          </span>{' '}
+                          from the JWT Signing Keys page once you're sure it's no longer in use.
                         </li>
                       </ol>
                       <Link

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -394,54 +394,42 @@ const JWTSettings = () => {
                     )}
                   </p>
                   {disableLegacyJwtSecretRotation ? (
-                    <>
-                      <ol className="text-sm text-foreground-light list-decimal list-inside space-y-2">
-                        <li>
-                          <span className="text-foreground">
-                            Click <em className="not-italic">Migrate JWT secret</em>
-                          </span>{' '}
-                          on the JWT Signing Keys page. This imports your legacy secret into the new
-                          system and generates a standby asymmetric key.
-                        </li>
-                        <li>
-                          <span className="text-foreground">Create and roll out new API keys.</span>{' '}
-                          On the API Keys page, create a publishable key (
-                          <code>sb_publishable_...</code>) and secret keys (
-                          <code>sb_secret_...</code>), then swap them into your apps in place of{' '}
-                          <code>anon</code> and <code>service_role</code>. Watch the{' '}
-                          <em className="not-italic text-foreground">last used</em> indicators to
-                          confirm no traffic still depends on the legacy keys.
-                        </li>
-                        <li>
-                          <span className="text-foreground">
-                            Click <em className="not-italic">Rotate keys</em>
-                          </span>{' '}
-                          on the JWT Signing Keys page to start signing new JWTs with the standby
-                          key. Existing <code>anon</code>, <code>service_role</code>, and active
-                          user JWTs stay valid. Before rotating, switch any code that verifies JWTs
-                          directly against the legacy secret (e.g. <code>jose</code>,{' '}
-                          <code>jsonwebtoken</code>) to <code>supabase.auth.getClaims()</code> or a
-                          JWKS-based verifier, and disable the{' '}
-                          <em className="not-italic text-foreground">Verify JWT</em> setting on any
-                          affected Edge Functions.
-                        </li>
-                        <li>
-                          <span className="text-foreground">
-                            Optionally, revoke the legacy JWT secret
-                          </span>{' '}
-                          from the JWT Signing Keys page once you're sure it's no longer in use.
-                        </li>
-                      </ol>
-                      <Link
-                        href="https://supabase.com/docs/guides/auth/signing-keys#getting-started"
-                        target="_blank"
-                        rel="noreferrer"
-                        className="text-sm text-foreground-light hover:text-foreground inline-flex items-center gap-1"
-                      >
-                        Read the full migration guide
-                        <ExternalLink className="size-3" />
-                      </Link>
-                    </>
+                    <ol className="text-sm text-foreground-light list-decimal list-inside space-y-2">
+                      <li>
+                        <span className="text-foreground">
+                          Click <em className="not-italic">Migrate JWT secret</em>
+                        </span>{' '}
+                        on the JWT Signing Keys page. This imports your legacy secret into the new
+                        system and generates a standby asymmetric key.
+                      </li>
+                      <li>
+                        <span className="text-foreground">Create and roll out new API keys.</span>{' '}
+                        On the API Keys page, create a publishable key (
+                        <code>sb_publishable_...</code>) and secret keys (<code>sb_secret_...</code>
+                        ), then swap them into your apps in place of <code>anon</code> and{' '}
+                        <code>service_role</code>. Watch the{' '}
+                        <em className="not-italic text-foreground">last used</em> indicators to
+                        confirm no traffic still depends on the legacy keys.
+                      </li>
+                      <li>
+                        <span className="text-foreground">
+                          Click <em className="not-italic">Rotate keys</em>
+                        </span>{' '}
+                        on the JWT Signing Keys page to start signing new JWTs with the standby key.
+                        Existing <code>anon</code>, <code>service_role</code>, and active user JWTs
+                        stay valid. Before rotating, switch any code that verifies JWTs directly
+                        against the legacy secret (e.g. <code>jose</code>, <code>jsonwebtoken</code>
+                        ) to <code>supabase.auth.getClaims()</code> or a JWKS-based verifier, and
+                        disable the <em className="not-italic text-foreground">Verify JWT</em>{' '}
+                        setting on any affected Edge Functions.
+                      </li>
+                      <li>
+                        <span className="text-foreground">
+                          Optionally, revoke the legacy JWT secret
+                        </span>{' '}
+                        from the JWT Signing Keys page once you're sure it's no longer in use.
+                      </li>
+                    </ol>
                   ) : (
                     <ul className="text-sm text-foreground-light list-disc list-inside">
                       <li>Zero-downtime, reversible change.</li>
@@ -477,6 +465,18 @@ const JWTSettings = () => {
                       Go to JWT Signing Keys
                     </Link>
                   </Button>
+
+                  {disableLegacyJwtSecretRotation && (
+                    <Button type="default" icon={<ExternalLink className="size-4" />} asChild>
+                      <Link
+                        href="https://supabase.com/docs/guides/auth/signing-keys#getting-started"
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        Read the full migration guide
+                      </Link>
+                    </Button>
+                  )}
 
                   {!disableLegacyJwtSecretRotation && (
                     <>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -384,40 +384,68 @@ const JWTSettings = () => {
                   <p className="text-sm text-foreground-light">
                     {disableLegacyJwtSecretRotation ? (
                       <>
-                        Rotating the legacy JWT secret is no longer supported — it forces downtime
-                        and invalidates your <code>anon</code> and <code>service_role</code> keys.
-                        Migrate to the new publishable (<code>sb_publishable_...</code>) and secret
-                        (<code>sb_secret_...</code>) API keys instead: they can be rotated
-                        independently with zero downtime, and the transition is reversible.
+                        Migrate to the new publishable and secret API keys to enable rotation with
+                        zero downtime. Combined with JWT Signing Keys, you can rotate each piece
+                        independently without signing users out, and the change stays reversible
+                        until you revoke the legacy secret.
                       </>
                     ) : (
                       'Instead of changing the legacy JWT secret use a combination of the JWT Signing Keys and API keys features. Consider these advantages:'
                     )}
                   </p>
                   {disableLegacyJwtSecretRotation ? (
-                    <ol className="text-sm text-foreground-light list-decimal list-inside space-y-1">
-                      <li>
-                        On the API Keys page, create a publishable key for client-side use and one
-                        or more secret keys for your backend components.
-                      </li>
-                      <li>
-                        Gradually roll out the new keys across your applications. The legacy{' '}
-                        <code>anon</code> and <code>service_role</code> keys stay active during the
-                        transition, so there is no downtime.
-                      </li>
-                      <li>
-                        Watch the <em className="not-italic text-foreground">last used</em>{' '}
-                        indicators on the legacy keys to confirm no traffic still depends on them.
-                      </li>
-                      <li>
-                        Deactivate the legacy <code>anon</code> and <code>service_role</code> keys
-                        from the API Keys page. You can re-activate them if you need to roll back.
-                      </li>
-                      <li>
-                        Optionally, use JWT Signing Keys to rotate the underlying signing key for
-                        any remaining legacy JWT consumers.
-                      </li>
-                    </ol>
+                    <>
+                      <ol className="text-sm text-foreground-light list-decimal list-inside space-y-2">
+                        <li>
+                          <span className="text-foreground">Migrate your legacy JWT secret</span> on
+                          the JWT Signing Keys page. Your project keeps using its existing symmetric
+                          secret while Supabase prepares it for asymmetric JWTs and generates a
+                          standby key pair.
+                        </li>
+                        <li>
+                          <span className="text-foreground">Create new API keys</span> — publishable
+                          (<code>sb_publishable_...</code>) and secret (<code>sb_secret_...</code>)
+                          — and roll them out in place of <code>anon</code> and{' '}
+                          <code>service_role</code>. Use the{' '}
+                          <em className="not-italic text-foreground">last used</em> indicators to
+                          confirm no traffic still depends on the legacy keys.
+                        </li>
+                        <li>
+                          <span className="text-foreground">Rotate to asymmetric JWTs</span> on the
+                          JWT Signing Keys page. Supabase Auth starts signing new JWTs with the new
+                          private key; existing <code>anon</code>, <code>service_role</code>, and
+                          active user JWTs remain valid.
+                          <p className="mt-1 text-xs">
+                            Before rotating, switch any code that verifies JWTs directly against the
+                            legacy secret (e.g. <code>jose</code>, <code>jsonwebtoken</code>) to{' '}
+                            <code>supabase.auth.getClaims()</code> or a JWKS-based verifier, and
+                            disable the <em className="not-italic text-foreground">Verify JWT</em>{' '}
+                            setting on any affected Edge Functions.
+                          </p>
+                        </li>
+                        <li>
+                          <span className="text-foreground">Revoke the legacy JWT secret</span> once
+                          you've verified everything works. JWTs signed with the old secret —
+                          including legacy <code>anon</code> and <code>service_role</code> — will
+                          then be rejected.
+                          <p className="mt-1 text-xs">
+                            Wait at least one full access-token expiry window (e.g. 1 hour 15
+                            minutes for the default 1-hour expiry) before revoking so active users
+                            aren't signed out. Revoke immediately only during an active security
+                            incident.
+                          </p>
+                        </li>
+                      </ol>
+                      <Link
+                        href="https://supabase.com/docs/guides/auth/signing-keys#getting-started"
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-sm text-foreground-light hover:text-foreground inline-flex items-center gap-1"
+                      >
+                        Read the full migration guide
+                        <ExternalLink className="size-3" />
+                      </Link>
+                    </>
                   ) : (
                     <ul className="text-sm text-foreground-light list-disc list-inside">
                       <li>Zero-downtime, reversible change.</li>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -118,9 +118,9 @@ export const JWTSettings = () => {
     useJwtSecretUpdateMutation()
 
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
-  const { data: legacyKey, isSuccess: isSuccessLegacyKey } = useLegacyJWTSigningKeyQuery(
+  const { data: legacyKey, isPending } = useLegacyJWTSigningKeyQuery(
     { projectRef },
-    { enabled: canReadAPIKeys }
+    { enabled: canReadAPIKeys, retry: false }
   )
   const { data: legacyAPIKeysStatus } = useLegacyAPIKeysStatusQuery(
     { projectRef },
@@ -354,7 +354,7 @@ export const JWTSettings = () => {
             </form>
           </Form_Shadcn_>
 
-          {isSuccessLegacyKey && !legacyKey && (
+          {!isPending && !legacyKey && (
             <>
               {isUpdatingJwtSecret && (
                 <div className="flex items-center space-x-2">

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -118,10 +118,8 @@ export const JWTSettings = () => {
     useJwtSecretUpdateMutation()
 
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
-  const { data: legacyKey } = useLegacyJWTSigningKeyQuery(
-    {
-      projectRef,
-    },
+  const { data: legacyKey, isSuccess: isSuccessLegacyKey } = useLegacyJWTSigningKeyQuery(
+    { projectRef },
     { enabled: canReadAPIKeys }
   )
   const { data: legacyAPIKeysStatus } = useLegacyAPIKeysStatusQuery(
@@ -356,7 +354,7 @@ export const JWTSettings = () => {
             </form>
           </Form_Shadcn_>
 
-          {!legacyKey && (
+          {isSuccessLegacyKey && !legacyKey && (
             <>
               {isUpdatingJwtSecret && (
                 <div className="flex items-center space-x-2">

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -385,8 +385,7 @@ const JWTSettings = () => {
                     {disableLegacyJwtSecretRotation ? (
                       <>
                         Migrate to the new publishable and secret API keys to enable rotation with
-                        zero downtime. Combined with JWT Signing Keys, you can rotate each piece
-                        independently without signing users out, and the change stays reversible
+                        zero downtime and without signing users out. The change is reversible
                         until you revoke the legacy secret.
                       </>
                     ) : (

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -5,7 +5,7 @@ import {
   JwtSecretUpdateProgress,
   JwtSecretUpdateStatus,
 } from '@supabase/shared-types/out/events'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import {
   AlertCircle,
   ChevronDown,
@@ -90,6 +90,8 @@ const customJwtSecretFormId = 'custom-jwt-secret-form'
 
 const JWTSettings = () => {
   const { ref: projectRef } = useParams()
+
+  const disableLegacyJwtSecretRotation = useFlag('disableLegacyJwtSecretRotation')
 
   const [customToken, setCustomToken] = useState<string>('')
   const [isCreatingKey, setIsCreatingKey] = useState<boolean>(false)
@@ -374,30 +376,70 @@ const JWTSettings = () => {
 
               <div className="flex flex-col gap-6 border rounded-md bg p-6">
                 <div className="flex flex-col gap-2">
-                  <h4 className="text-sm">How to change your JWT secret?</h4>
+                  <h4 className="text-sm">
+                    {disableLegacyJwtSecretRotation
+                      ? 'How to migrate to the new API keys'
+                      : 'How to change your JWT secret?'}
+                  </h4>
                   <p className="text-sm text-foreground-light">
-                    Instead of changing the legacy JWT secret use a combination of the JWT Signing
-                    Keys and API keys features. Consider these advantages:
+                    {disableLegacyJwtSecretRotation ? (
+                      <>
+                        Rotating the legacy JWT secret is no longer supported — it forces downtime
+                        and invalidates your <code>anon</code> and <code>service_role</code> keys.
+                        Migrate to the new publishable (<code>sb_publishable_...</code>) and secret
+                        (<code>sb_secret_...</code>) API keys instead: they can be rotated
+                        independently with zero downtime, and the transition is reversible.
+                      </>
+                    ) : (
+                      'Instead of changing the legacy JWT secret use a combination of the JWT Signing Keys and API keys features. Consider these advantages:'
+                    )}
                   </p>
-                  <ul className="text-sm text-foreground-light list-disc list-inside">
-                    <li>Zero-downtime, reversible change.</li>
-                    <li>Users remain signed in and bad actors out.</li>
-                    <li>
-                      Create multiple secret API keys that are immediately revocable and fully
-                      covered by audit logs.
-                    </li>
-                    <li>
-                      Private keys and shared secrets are no longer visible by organization members,
-                      so they can't leak.
-                    </li>
-                    <li>
-                      Maintain tighter alignment with SOC2 and other security compliance frameworks.
-                    </li>
-                    <li>
-                      Improve app's performance by using public keys to verify JWTs instead of
-                      calling <code>getUser()</code>.
-                    </li>
-                  </ul>
+                  {disableLegacyJwtSecretRotation ? (
+                    <ol className="text-sm text-foreground-light list-decimal list-inside space-y-1">
+                      <li>
+                        On the API Keys page, create a publishable key for client-side use and one
+                        or more secret keys for your backend components.
+                      </li>
+                      <li>
+                        Gradually roll out the new keys across your applications. The legacy{' '}
+                        <code>anon</code> and <code>service_role</code> keys stay active during the
+                        transition, so there is no downtime.
+                      </li>
+                      <li>
+                        Watch the <em className="not-italic text-foreground">last used</em>{' '}
+                        indicators on the legacy keys to confirm no traffic still depends on them.
+                      </li>
+                      <li>
+                        Deactivate the legacy <code>anon</code> and <code>service_role</code> keys
+                        from the API Keys page. You can re-activate them if you need to roll back.
+                      </li>
+                      <li>
+                        Optionally, use JWT Signing Keys to rotate the underlying signing key for
+                        any remaining legacy JWT consumers.
+                      </li>
+                    </ol>
+                  ) : (
+                    <ul className="text-sm text-foreground-light list-disc list-inside">
+                      <li>Zero-downtime, reversible change.</li>
+                      <li>Users remain signed in and bad actors out.</li>
+                      <li>
+                        Create multiple secret API keys that are immediately revocable and fully
+                        covered by audit logs.
+                      </li>
+                      <li>
+                        Private keys and shared secrets are no longer visible by organization
+                        members, so they can't leak.
+                      </li>
+                      <li>
+                        Maintain tighter alignment with SOC2 and other security compliance
+                        frameworks.
+                      </li>
+                      <li>
+                        Improve app's performance by using public keys to verify JWTs instead of
+                        calling <code>getUser()</code>.
+                      </li>
+                    </ul>
+                  )}
                 </div>
 
                 <div className="flex flex-row gap-4">
@@ -412,45 +454,49 @@ const JWTSettings = () => {
                     </Link>
                   </Button>
 
-                  <div className="grow" />
+                  {!disableLegacyJwtSecretRotation && (
+                    <>
+                      <div className="grow" />
 
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <ButtonTooltip
-                        disabled={!canGenerateNewJWTSecret}
-                        type="default"
-                        iconRight={<ChevronDown size={14} />}
-                        loading={isUpdatingJwtSecret}
-                        tooltip={{
-                          content: {
-                            side: 'bottom',
-                            text: !canGenerateNewJWTSecret
-                              ? 'You need additional permissions to generate a new JWT secret'
-                              : undefined,
-                          },
-                        }}
-                      >
-                        Change legacy JWT secret
-                      </ButtonTooltip>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" side="bottom">
-                      <DropdownMenuItem
-                        className="space-x-2"
-                        onClick={() => setIsGeneratingKey(true)}
-                      >
-                        <RefreshCw size={16} />
-                        <p>Generate a random secret</p>
-                      </DropdownMenuItem>
-                      <DropdownMenuSeparator />
-                      <DropdownMenuItem
-                        className="space-x-2"
-                        onClick={() => setIsCreatingKey(true)}
-                      >
-                        <PenTool size={16} />
-                        <p>Create my own secret</p>
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <ButtonTooltip
+                            disabled={!canGenerateNewJWTSecret}
+                            type="default"
+                            iconRight={<ChevronDown size={14} />}
+                            loading={isUpdatingJwtSecret}
+                            tooltip={{
+                              content: {
+                                side: 'bottom',
+                                text: !canGenerateNewJWTSecret
+                                  ? 'You need additional permissions to generate a new JWT secret'
+                                  : undefined,
+                              },
+                            }}
+                          >
+                            Change legacy JWT secret
+                          </ButtonTooltip>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" side="bottom">
+                          <DropdownMenuItem
+                            className="space-x-2"
+                            onClick={() => setIsGeneratingKey(true)}
+                          >
+                            <RefreshCw size={16} />
+                            <p>Generate a random secret</p>
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            className="space-x-2"
+                            onClick={() => setIsCreatingKey(true)}
+                          >
+                            <PenTool size={16} />
+                            <p>Create my own secret</p>
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </>
+                  )}
                 </div>
               </div>
             </>
@@ -461,7 +507,7 @@ const JWTSettings = () => {
       <TextConfirmModal
         variant="destructive"
         size="large"
-        visible={isRegeneratingKey}
+        visible={isRegeneratingKey && !disableLegacyJwtSecretRotation}
         title="Confirm legacy JWT secret change"
         confirmString="I understand and wish to proceed"
         confirmLabel={customToken ? 'Apply custom secret' : 'Generate random secret'}
@@ -553,7 +599,7 @@ const JWTSettings = () => {
 
       <Modal
         header="Pick a new JWT secret"
-        visible={isCreatingKey}
+        visible={isCreatingKey && !disableLegacyJwtSecretRotation}
         size="medium"
         variant="danger"
         onCancel={() => {

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -372,7 +372,7 @@ export const JWTSettings = () => {
                 </Admonition>
               )}
 
-              <Collapsible_Shadcn_ className="bg border rounded-md">
+              <Collapsible_Shadcn_ className="bg border rounded-md mt-4">
                 <CollapsibleTrigger_Shadcn_ className="p-4 w-full flex items-center justify-between [&[data-state=open]>svg]:!-rotate-180">
                   <p className="text-sm">
                     {disableLegacyJwtSecretRotation

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -26,7 +26,9 @@ import { useForm, type SubmitHandler } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
   Button,
-  CardContent,
+  Collapsible_Shadcn_,
+  CollapsibleContent_Shadcn_,
+  CollapsibleTrigger_Shadcn_,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -36,7 +38,6 @@ import {
   FormControl_Shadcn_,
   FormField_Shadcn_,
   FormInputGroupInput,
-  Input_Shadcn_,
   InputGroup,
   InputGroupAddon,
   InputGroupText,
@@ -53,6 +54,7 @@ import {
 } from './jwt.constants'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { FormActions } from '@/components/ui/Forms/FormActions'
+import { InlineLink } from '@/components/ui/InlineLink'
 import Panel from '@/components/ui/Panel'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useLegacyAPIKeysStatusQuery } from '@/data/api-keys/legacy-api-keys-status-query'
@@ -88,7 +90,7 @@ const customJwtSecretFormSchema = z.object({
 })
 const customJwtSecretFormId = 'custom-jwt-secret-form'
 
-const JWTSettings = () => {
+export const JWTSettings = () => {
   const { ref: projectRef } = useParams()
 
   const disableLegacyJwtSecretRotation = useFlag('disableLegacyJwtSecretRotation')
@@ -240,8 +242,8 @@ const JWTSettings = () => {
                       title="Legacy JWT secret has been migrated to new JWT Signing Keys"
                     >
                       <p className="!leading-normal">
-                        Changing the legacy JWT secret can only be done by rotating to a standby key
-                        and then revoking it. It is used to{' '}
+                        Legacy JWT secret can only be changed by rotating to a standby key and then
+                        revoking it. It is used to{' '}
                         <em className="text-foreground not-italic">
                           {legacyKey.status === 'in_use' ? 'sign and verify' : 'only verify'}
                         </em>{' '}
@@ -251,14 +253,15 @@ const JWTSettings = () => {
                       {legacyAPIKeysStatus && legacyAPIKeysStatus.enabled && (
                         <p className="!leading-normal">
                           <em className="text-warning not-italic">
-                            This includes the <code>anon</code> and <code>service_role</code> JWT
-                            based API keys.
+                            This includes the <code className="text-code-inline">anon</code> and{' '}
+                            <code className="text-code-inline">service_role</code> JWT based API
+                            keys.
                           </em>{' '}
                           Consider switching to publishable and secret API keys to disable them.
                         </p>
                       )}
 
-                      <Button type="default" asChild icon={<ExternalLink className="size-4" />}>
+                      <Button asChild type="default" icon={<ExternalLink />} className="mt-2">
                         <Link href={`/project/${projectRef}/settings/api-keys`}>
                           Go to API keys
                         </Link>
@@ -272,90 +275,87 @@ const JWTSettings = () => {
                       description="No new JSON Web Tokens are issued nor verified with it by Supabase products."
                     />
                   )}
-                  <CardContent>
-                    <FormItemLayout
-                      layout="flex-row-reverse"
+                  <FormItemLayout
+                    layout="flex-row-reverse"
+                    id="JWT_SECRET"
+                    label={
+                      legacyKey?.status === 'revoked'
+                        ? 'Revoked legacy JWT secret'
+                        : legacyKey
+                          ? 'Legacy JWT secret (still used)'
+                          : 'Legacy JWT secret'
+                    }
+                    description={
+                      legacyKey?.status === 'revoked'
+                        ? 'No longer used to sign JWTs by Supabase Auth.'
+                        : !legacyKey || legacyKey.status === 'in_use'
+                          ? 'Used to sign and verify JWTs issued by Supabase Auth.'
+                          : 'Used only to verify JWTs.'
+                    }
+                  >
+                    <Input
                       id="JWT_SECRET"
-                      label={
-                        legacyKey?.status === 'revoked'
-                          ? 'Revoked legacy JWT secret'
-                          : legacyKey
-                            ? 'Legacy JWT secret (still used)'
-                            : 'Legacy JWT secret'
+                      copy={canReadJWTSecret && isNotUpdatingJwtSecret}
+                      reveal={canReadJWTSecret && isNotUpdatingJwtSecret}
+                      readOnly
+                      value={
+                        !canReadJWTSecret
+                          ? 'You need additional permissions to view the JWT secret'
+                          : isJwtSecretUpdateFailed
+                            ? 'JWT secret update failed'
+                            : isUpdatingJwtSecret
+                              ? 'Updating JWT secret...'
+                              : config?.jwt_secret || ''
                       }
-                      description={
-                        legacyKey?.status === 'revoked'
-                          ? 'No longer used to sign JWTs by Supabase Auth.'
-                          : !legacyKey || legacyKey.status === 'in_use'
-                            ? 'Used to sign and verify JWTs issued by Supabase Auth.'
-                            : 'Used only to verify JWTs.'
-                      }
-                    >
-                      <Input
-                        id="JWT_SECRET"
-                        copy={canReadJWTSecret && isNotUpdatingJwtSecret}
-                        reveal={canReadJWTSecret && isNotUpdatingJwtSecret}
-                        readOnly
-                        value={
-                          !canReadJWTSecret
-                            ? 'You need additional permissions to view the JWT secret'
-                            : isJwtSecretUpdateFailed
-                              ? 'JWT secret update failed'
-                              : isUpdatingJwtSecret
-                                ? 'Updating JWT secret...'
-                                : config?.jwt_secret || ''
-                        }
-                      />
-                    </FormItemLayout>
-                  </CardContent>
-
-                  <CardContent>
-                    <FormField_Shadcn_
-                      control={form.control}
-                      name="JWT_EXP"
-                      disabled={!canUpdateConfig || isLoadingAuthConfig}
-                      render={({ field }) => (
-                        <FormItemLayout
-                          name="JWT_EXP"
-                          layout="flex-row-reverse"
-                          label="Access token expiry time"
-                          description={
-                            <>
-                              <div>
-                                How long access tokens are valid for before a refresh token has to
-                                be used.
-                              </div>
-                              <div>Recommendation: 3600 (1 hour).</div>
-                            </>
-                          }
-                        >
-                          <FormControl_Shadcn_>
-                            <InputGroup>
-                              <FormInputGroupInput
-                                {...field}
-                                id="JWT_EXP"
-                                type="number"
-                                min={0}
-                                max={MAX_JWT_EXP}
-                                onChange={(e) =>
-                                  field.onChange(
-                                    isNaN(e.target.valueAsNumber) ? '' : e.target.valueAsNumber
-                                  )
-                                }
-                              />
-                              <InputGroupAddon align="inline-end">
-                                <InputGroupText>seconds</InputGroupText>
-                              </InputGroupAddon>
-                            </InputGroup>
-                          </FormControl_Shadcn_>
-                        </FormItemLayout>
-                      )}
                     />
-                  </CardContent>
+                  </FormItemLayout>
+
+                  <FormField_Shadcn_
+                    control={form.control}
+                    name="JWT_EXP"
+                    disabled={!canUpdateConfig || isLoadingAuthConfig}
+                    render={({ field }) => (
+                      <FormItemLayout
+                        name="JWT_EXP"
+                        layout="flex-row-reverse"
+                        label="Access token expiry time"
+                        description={
+                          <>
+                            <p>
+                              How long access tokens are valid for before a refresh token has to be
+                              used.
+                            </p>
+                            <p>Recommendation: 3600 (1 hour).</p>
+                          </>
+                        }
+                      >
+                        <FormControl_Shadcn_>
+                          <InputGroup>
+                            <FormInputGroupInput
+                              {...field}
+                              id="JWT_EXP"
+                              type="number"
+                              min={0}
+                              max={MAX_JWT_EXP}
+                              onChange={(e) =>
+                                field.onChange(
+                                  isNaN(e.target.valueAsNumber) ? '' : e.target.valueAsNumber
+                                )
+                              }
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupText>seconds</InputGroupText>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </FormControl_Shadcn_>
+                      </FormItemLayout>
+                    )}
+                  />
                 </>
               )}
             </form>
           </Form_Shadcn_>
+
           {!legacyKey && (
             <>
               {isUpdatingJwtSecret && (
@@ -374,59 +374,79 @@ const JWTSettings = () => {
                 </Admonition>
               )}
 
-              <div className="flex flex-col gap-6 border rounded-md bg p-6">
-                <div className="flex flex-col gap-2">
-                  <h4 className="text-sm">
+              <Collapsible_Shadcn_ className="bg border rounded-md">
+                <CollapsibleTrigger_Shadcn_ className="p-4 w-full flex items-center justify-between [&[data-state=open]>svg]:!-rotate-180">
+                  <p className="text-sm">
                     {disableLegacyJwtSecretRotation
-                      ? 'How to migrate to the new API keys'
+                      ? 'How to migrate to the new API keys?'
                       : 'How to change your JWT secret?'}
-                  </h4>
-                  <p className="text-sm text-foreground-light">
-                    {disableLegacyJwtSecretRotation ? (
-                      <>
-                        Migrate to the new publishable and secret API keys to enable rotation with
-                        zero downtime and without signing users out. The change is reversible
-                        until you revoke the legacy secret.
-                      </>
-                    ) : (
-                      'Instead of changing the legacy JWT secret use a combination of the JWT Signing Keys and API keys features. Consider these advantages:'
-                    )}
                   </p>
+                  <ChevronDown size={14} className="transition-transform duration-200" />
+                </CollapsibleTrigger_Shadcn_>
+                <CollapsibleContent_Shadcn_ className="border-t p-4">
+                  <p className="text-sm text-foreground-light text-balance mb-2">
+                    {disableLegacyJwtSecretRotation
+                      ? 'Migrate to the new publishable and secret API keys to enable rotation with zero downtime and without signing users out. The change is reversible until you revoke the legacy secret.'
+                      : 'Instead of changing the legacy JWT secret use a combination of the JWT Signing Keys and API keys features. Consider these advantages:'}
+                  </p>
+
                   {disableLegacyJwtSecretRotation ? (
-                    <ol className="text-sm text-foreground-light list-decimal list-inside space-y-2">
+                    <ol className="text-sm text-foreground-light list-decimal list-outside pl-7 space-y-2">
                       <li>
-                        <span className="text-foreground">
-                          Click <em className="not-italic">Migrate JWT secret</em>
-                        </span>{' '}
-                        on the JWT Signing Keys page. This imports your legacy secret into the new
-                        system and generates a standby asymmetric key.
+                        <p className="text-foreground">
+                          Click "Migrate JWT secret" in{' '}
+                          <InlineLink href={`/project/${projectRef}/settings/jwt`}>
+                            JWT Signing Keys
+                          </InlineLink>
+                          .
+                        </p>
+                        <p className="text-foreground-lighter">
+                          This imports your legacy secret into the new system and generates a
+                          standby asymmetric key.
+                        </p>
                       </li>
                       <li>
-                        <span className="text-foreground">Create and roll out new API keys.</span>{' '}
-                        On the API Keys page, create a publishable key (
-                        <code>sb_publishable_...</code>) and secret keys (<code>sb_secret_...</code>
-                        ), then swap them into your apps in place of <code>anon</code> and{' '}
-                        <code>service_role</code>. Watch the{' '}
-                        <em className="not-italic text-foreground">last used</em> indicators to
-                        confirm no traffic still depends on the legacy keys.
+                        <p className="text-foreground">Create and roll out new API keys.</p>
+                        <p className="text-foreground-lighter">
+                          In{' '}
+                          <InlineLink href={`/project/${projectRef}/settings/api-keys`}>
+                            API Keys
+                          </InlineLink>
+                          , create a publishable key and secret key, then swap them into your apps
+                          in place of <code className="text-code-inline">anon</code> and{' '}
+                          <code className="text-code-inline !break-keep">service_role</code>{' '}
+                          respectively. Watch the "Last used" indicators to confirm no traffic still
+                          depends on the legacy keys.
+                        </p>
                       </li>
                       <li>
-                        <span className="text-foreground">
-                          Click <em className="not-italic">Rotate keys</em>
-                        </span>{' '}
-                        on the JWT Signing Keys page to start signing new JWTs with the standby key.
-                        Existing <code>anon</code>, <code>service_role</code>, and active user JWTs
-                        stay valid. Before rotating, switch any code that verifies JWTs directly
-                        against the legacy secret (e.g. <code>jose</code>, <code>jsonwebtoken</code>
-                        ) to <code>supabase.auth.getClaims()</code> or a JWKS-based verifier, and
-                        disable the <em className="not-italic text-foreground">Verify JWT</em>{' '}
-                        setting on any affected Edge Functions.
+                        <p className="text-foreground">
+                          Click "Rotate keys" in{' '}
+                          <InlineLink href={`/project/${projectRef}/settings/jwt`}>
+                            JWT Signing Keys
+                          </InlineLink>{' '}
+                          to start signing new JWTs with the standby key.
+                        </p>
+                        <p className="text-foreground-lighter">
+                          Existing <code className="text-code-inline">anon</code>,{' '}
+                          <code className="text-code-inline">service_role</code>, and active user
+                          JWTs stay valid. Before rotating, switch any code that verifies JWTs
+                          directly against the legacy secret (e.g.{' '}
+                          <code className="text-code-inline">jose</code>,{' '}
+                          <code className="text-code-inline">jsonwebtoken</code>) to{' '}
+                          <code className="text-code-inline">supabase.auth.getClaims()</code> or a
+                          JWKS-based verifier, and disable the "Verify JWT" setting on any affected
+                          Edge Functions.
+                        </p>
                       </li>
                       <li>
-                        <span className="text-foreground">
-                          Optionally, revoke the legacy JWT secret
-                        </span>{' '}
-                        from the JWT Signing Keys page once you're sure it's no longer in use.
+                        <p className="text-foreground">
+                          Optionally, revoke the legacy JWT secret in{' '}
+                          <InlineLink href={`/project/${projectRef}/settings/jwt`}>
+                            JWT Signing Keys
+                          </InlineLink>{' '}
+                          once you're sure it's no longer in use.
+                        </p>
                       </li>
                     </ol>
                   ) : (
@@ -447,40 +467,23 @@ const JWTSettings = () => {
                       </li>
                       <li>
                         Improve app's performance by using public keys to verify JWTs instead of
-                        calling <code>getUser()</code>.
+                        calling <code className="text-code-inline">getUser()</code>.
                       </li>
                     </ul>
                   )}
-                </div>
 
-                <div className="flex flex-row gap-4">
-                  <Button type="default" icon={<ExternalLink className="size-4" />} asChild>
-                    <Link href={`/project/${projectRef}/settings/api-keys/new`}>
-                      Go to API Keys
-                    </Link>
-                  </Button>
-                  <Button type="default" icon={<ExternalLink className="size-4" />} asChild>
-                    <Link href={`/project/${projectRef}/settings/jwt/signing-keys`}>
-                      Go to JWT Signing Keys
-                    </Link>
-                  </Button>
-
-                  {disableLegacyJwtSecretRotation && (
-                    <Button type="default" icon={<ExternalLink className="size-4" />} asChild>
-                      <Link
-                        href="https://supabase.com/docs/guides/auth/signing-keys#getting-started"
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Read the full migration guide
-                      </Link>
-                    </Button>
-                  )}
-
-                  {!disableLegacyJwtSecretRotation && (
-                    <>
-                      <div className="grow" />
-
+                  <div className="flex flex-row gap-x-2 mt-4">
+                    {disableLegacyJwtSecretRotation ? (
+                      <Button type="default" icon={<ExternalLink className="size-4" />} asChild>
+                        <Link
+                          href="https://supabase.com/docs/guides/auth/signing-keys#getting-started"
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Read the full migration guide
+                        </Link>
+                      </Button>
+                    ) : (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
                           <ButtonTooltip
@@ -500,7 +503,7 @@ const JWTSettings = () => {
                             Change legacy JWT secret
                           </ButtonTooltip>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent align="end" side="bottom">
+                        <DropdownMenuContent align="start" side="bottom">
                           <DropdownMenuItem
                             className="space-x-2"
                             onClick={() => setIsGeneratingKey(true)}
@@ -518,10 +521,10 @@ const JWTSettings = () => {
                           </DropdownMenuItem>
                         </DropdownMenuContent>
                       </DropdownMenu>
-                    </>
-                  )}
-                </div>
-              </div>
+                    )}
+                  </div>
+                </CollapsibleContent_Shadcn_>
+              </Collapsible_Shadcn_>
             </>
           )}
         </Panel.Content>
@@ -692,5 +695,3 @@ const JWTSettings = () => {
     </>
   )
 }
-
-export default JWTSettings

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -397,24 +397,28 @@ const JWTSettings = () => {
                     <>
                       <ol className="text-sm text-foreground-light list-decimal list-inside space-y-2">
                         <li>
-                          <span className="text-foreground">Migrate your legacy JWT secret</span> on
-                          the JWT Signing Keys page. Your project keeps using its existing symmetric
-                          secret while Supabase prepares it for asymmetric JWTs and generates a
-                          standby key pair.
+                          <span className="text-foreground">
+                            Click <em className="not-italic">Migrate JWT secret</em>
+                          </span>{' '}
+                          on the JWT Signing Keys page. This imports your legacy secret into the new
+                          system and generates a standby asymmetric key.
                         </li>
                         <li>
-                          <span className="text-foreground">Create new API keys</span> — publishable
-                          (<code>sb_publishable_...</code>) and secret (<code>sb_secret_...</code>)
-                          — and roll them out in place of <code>anon</code> and{' '}
-                          <code>service_role</code>. Use the{' '}
+                          <span className="text-foreground">Create and roll out new API keys.</span>{' '}
+                          On the API Keys page, create a publishable key (
+                          <code>sb_publishable_...</code>) and secret keys (
+                          <code>sb_secret_...</code>), then swap them into your apps in place of{' '}
+                          <code>anon</code> and <code>service_role</code>. Watch the{' '}
                           <em className="not-italic text-foreground">last used</em> indicators to
                           confirm no traffic still depends on the legacy keys.
                         </li>
                         <li>
-                          <span className="text-foreground">Rotate to asymmetric JWTs</span> on the
-                          JWT Signing Keys page. Supabase Auth starts signing new JWTs with the new
-                          private key; existing <code>anon</code>, <code>service_role</code>, and
-                          active user JWTs remain valid.
+                          <span className="text-foreground">
+                            Click <em className="not-italic">Rotate keys</em>
+                          </span>{' '}
+                          on the JWT Signing Keys page to start signing new JWTs with the standby
+                          key. Existing <code>anon</code>, <code>service_role</code>, and active
+                          user JWTs stay valid.
                           <p className="mt-1 text-xs">
                             Before rotating, switch any code that verifies JWTs directly against the
                             legacy secret (e.g. <code>jose</code>, <code>jsonwebtoken</code>) to{' '}
@@ -424,10 +428,8 @@ const JWTSettings = () => {
                           </p>
                         </li>
                         <li>
-                          <span className="text-foreground">Revoke the legacy JWT secret</span> once
-                          you've verified everything works. JWTs signed with the old secret —
-                          including legacy <code>anon</code> and <code>service_role</code> — will
-                          then be rejected.
+                          <span className="text-foreground">Revoke the legacy JWT secret</span> from
+                          the JWT Signing Keys page once everything is working.
                           <p className="mt-1 text-xs">
                             Wait at least one full access-token expiry window (e.g. 1 hour 15
                             minutes for the default 1-hour expiry) before revoking so active users

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -83,7 +83,7 @@ export const useGenerateSettingsMenu = () => {
         {
           name: 'API Keys',
           key: 'api-keys',
-          url: `/project/${ref}/settings/api-keys/new`,
+          url: `/project/${ref}/settings/api-keys`,
           items: [],
           disabled: !isProjectActive,
         },

--- a/apps/studio/pages/project/[ref]/settings/jwt/legacy.tsx
+++ b/apps/studio/pages/project/[ref]/settings/jwt/legacy.tsx
@@ -4,7 +4,7 @@ import { useParams } from 'common'
 import { useEffect, useRef } from 'react'
 import { toast } from 'sonner'
 
-import JWTSettings from '@/components/interfaces/JwtSecrets/jwt-settings'
+import { JWTSettings } from '@/components/interfaces/JwtSecrets/jwt-settings'
 import { JWT_SECRET_UPDATE_ERROR_MESSAGES } from '@/components/interfaces/JwtSecrets/jwt.constants'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import JWTKeysLayout from '@/components/layouts/JWTKeys/JWTKeysLayout'


### PR DESCRIPTION
## Summary

Updated copy on transition from JWT keys to new publishable keys



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JWT settings now toggle between legacy controls and a step-by-step migration guide via a feature flag; legacy rotation/creation modals are hidden when migration mode is enabled.
  * The “How to change” section is now a collapsible with context-sensitive content and a single link to the full migration guide.

* **UX Improvements**
  * Secrets table action now clearly shows either “Rotate” or “Create standby key” based on key state.
  * Updated copy and spacing for JWT informational text and external links.

* **Chores**
  * “API Keys” menu now links to the API Keys listing page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->