### PR TITLE
fix(studio): increase body size limit for SQL snippet save API to support large files

### DIFF
--- a/apps/studio/pages/api/platform/projects/[ref]/content/index.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/content/index.ts
@@ -132,4 +132,12 @@ const handleDelete = async (req: NextApiRequest, res: NextApiResponse) => {
   }
 }
 
+export const config = {
+  api: {
+    bodyParser: {
+      sizeLimit: '5mb',
+    },
+  },
+}
+
 export default wrappedHandler


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Large SQL snippets (3k+ lines) cannot be saved in the SQL Editor when placed inside a folder. The save silently fails or errors because the Next.js API route for content upsert (`/platform/projects/{ref}/content`) uses the default body parser size limit of **1MB**, which large SQL payloads can exceed.

Fixes #45060

## What is the new behavior?

Added a `config` export to the content API route to increase the body parser `sizeLimit` to **5mb**, consistent with the limit used by other large-payload API routes (e.g. the AI SQL generator at `pages/api/ai/sql/generate-v4.ts`).

```ts
export const config = {
  api: {
    bodyParser: {
      sizeLimit: '5mb',
    },
  },
}
```

Large SQL snippets (3k+ lines) can now be saved successfully.

## Additional context

The fix is a one-line config addition to `apps/studio/pages/api/platform/projects/[ref]/content/index.ts`. No behavioural changes for normal-sized snippets.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the maximum request body size limit for the content API endpoint to 5MB, enabling the platform to process larger payload requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->