### PR TITLE
Update language around legacy key rotation

### DIFF
--- a/apps/docs/content/guides/api/api-keys.mdx
+++ b/apps/docs/content/guides/api/api-keys.mdx
@@ -150,8 +150,6 @@ Rotating a secret key (`sb_secret_...`) is easy and painless. Use the [API Keys]
 
 If you are still using the JWT-based `service_role` key, replace the `service_role` key with a new secret key instead. Follow the guide from above as if you are rotating an existing secret key.
 
-If you believe this is not possible for your implementation, [contact Support](/dashboard/support/new).
-
 ## Known limitations and compatibility differences
 
 As the publishable and secret keys are no longer JWT-based, there are some known limitations and compatibility differences that you may need to plan for:

--- a/apps/docs/content/guides/auth/signing-keys.mdx
+++ b/apps/docs/content/guides/auth/signing-keys.mdx
@@ -36,7 +36,7 @@ We've designed the Signing keys system to address many problems the legacy syste
 
 You can start migrating away from the legacy JWT secret through the Supabase dashboard. This process does not cause downtime for your application.
 
-1. Start off by clicking the _Migrate JWT secret_ button on the [JWT signing keys](/dashboard/project/_/settings/jwt) page. This step will import the existing legacy JWT secret into the new JWT signing keys system. Once this process completes, you will no longer be able to rotate the legacy JWT secret using the old system.
+1. Start off by clicking the _Migrate JWT secret_ button on the [JWT signing keys](/dashboard/project/_/settings/jwt) page. This step will import the existing legacy JWT secret into the new JWT signing keys system.
 2. Simultaneously, we're creating a new asymmetric JWT signing key for you to rotate to. This key starts off as standby key -- meaning it's being advertised as a key that Supabase Auth will use in the future to create JWTs.
 3. If you're not ready to switch away from the legacy JWT secret right now, you can stop here without any issue. If you wish to use a different signing key -- either to use a different signing algorithm (RSA, Elliptic Curve or shared secret) or to import a private key or shared secret you already have -- feel free to move the standby key to _Previously used_ before finally moving it to _Revoked._
 4. If you do wish to start using the standby key for all new JWT use the _Rotate keys_ button. A few important notes:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update to some language around legacy key rotation:
- Removes direction to contact support for legacy key rotation
- Removes reference to rotating legacy keys in JWT signing keys doc


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified API key guidance by removing an outdated instruction to contact Support regarding service role key replacement.
  * Updated signing-keys migration guidance to remove a restrictive statement about rotating legacy JWT secrets; the migration step now simply describes importing legacy secrets into the new signing keys system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->