### PR TITLE
docs: fix broken Vecs source link in DEVELOPERS guide

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -192,7 +192,7 @@ We support "federating" docs, meaning doc content can come directly from externa
 
 Federated docs work using Next.js's build pipeline. We use `getStaticProps()` to fetch remote documentation (ie. markdown) at build time which is processed and passed to the respective page within the docs.
 
-See the [Vecs Python source code](https://github.com/supabase/supabase/tree/master/apps/docs/app/guides/ai/python/%5Bslug%5D to see how we do this for [`supabase/vecs`](https://github.com/supabase/vecs). Use this as a starting point for federating other docs.
+See the [Vecs Python source code](https://github.com/supabase/supabase/tree/master/apps/docs/app/guides/ai/python/%5Bslug%5D) to see how we do this for [`supabase/vecs`](https://github.com/supabase/vecs). Use this as a starting point for federating other docs.
 
 Some things to consider:
 


### PR DESCRIPTION
## Summary
- fix the Markdown link to the Vecs Python source example in `DEVELOPERS.md`

## Why
The current link is missing a closing parenthesis, which breaks the link target in the federated docs section. This restores the intended reference for contributors working with external docs sources.

## Testing
- docs-only change

AI-assisted: yes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a formatting issue in developer documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->