### PR TITLE
Fix cron job form does not focus invalid inputs

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CreateCronJobSheet.tsx
@@ -176,10 +176,14 @@ export const CreateCronJobSheet = ({ open, selectedCronJob, onClose }: CreateCro
         const nameExists = !!checkExistingJob
 
         if (nameExists) {
-          return form.setError('name', {
-            type: 'manual',
-            message: 'A cron job with this name already exists',
-          })
+          return form.setError(
+            'name',
+            {
+              type: 'manual',
+              message: 'A cron job with this name already exists',
+            },
+            { shouldFocus: true }
+          )
         }
       } catch (error: any) {
         toast.error(`Failed to validate cron job name: ${error.message}`)


### PR DESCRIPTION
## Problem

When trying to create a new CRON job with an already used name, the `name` input isn't focused. As a result, users don't see the error.

## Solution

Fix the call to `form.setError` so that it focuses the input

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling in cron job creation. When a duplicate job name is detected, the form now automatically focuses on the name field, providing clearer feedback to help you quickly identify and correct validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->