### PR TITLE
fix(studio): add descriptions to dialog content

### DIFF
--- a/apps/studio/components/grid/components/header/ExportDialog.tsx
+++ b/apps/studio/components/grid/components/header/ExportDialog.tsx
@@ -5,6 +5,7 @@ import {
   cn,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -89,6 +90,9 @@ pg_dump -h ${db_host} -p ${db_port} -d ${db_name} -U ${db_user} --table="${table
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Export table data via CLI</DialogTitle>
+          <DialogDescription>
+            Copy a ready-to-run terminal command to export this table as CSV or SQL.
+          </DialogDescription>
         </DialogHeader>
 
         <DialogSectionSeparator />

--- a/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
@@ -13,6 +13,7 @@ import {
   cn,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogTitle,
   Tooltip,
@@ -180,6 +181,9 @@ export const AccountIdentities = () => {
                   ? `Updating email address for ${getProviderName(selectedProviderUpdateEmail ?? '')} identity`
                   : 'Update email address'}
               </DialogTitle>
+              <DialogDescription>
+                Review how this identity handles email updates before continuing.
+              </DialogDescription>
             </DialogHeader>
             {selectedProviderUpdateEmail === 'github' ? (
               <GitHubChangeEmailAddress />

--- a/apps/studio/components/interfaces/Database/ProtectedSchemaWarning.tsx
+++ b/apps/studio/components/interfaces/Database/ProtectedSchemaWarning.tsx
@@ -3,6 +3,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -19,6 +20,9 @@ export const ProtectedSchemaDialog = ({ onClose }: { onClose: () => void }) => {
     <>
       <DialogHeader>
         <DialogTitle>Schemas managed by Supabase</DialogTitle>
+        <DialogDescription>
+          Review which schemas are managed by Supabase and why dashboard edits are restricted.
+        </DialogDescription>
       </DialogHeader>
       <DialogSectionSeparator />
       <DialogSection className="space-y-2 prose">

--- a/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
+++ b/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
@@ -6,6 +6,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -68,6 +69,9 @@ export const SaveSnippetDialog = ({ open, sql, onOpenChange, onSave }: SaveSnipp
       <DialogContent size="small">
         <DialogHeader>
           <DialogTitle>Save snippet</DialogTitle>
+          <DialogDescription>
+            Choose a name for this SQL snippet before saving it to your project.
+          </DialogDescription>
         </DialogHeader>
         <DialogSectionSeparator />
         <DialogSection className="flex flex-col gap-y-4 py-5">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Some Studio dialogs render a `DialogTitle` without a corresponding description, which can trigger accessibility warnings in the console.

Related to supabase/supabase#44369.
This PR only addresses the dialog accessibility warnings and does not change the scrollbar behavior reported in that issue.

## What is the new behavior?

The updated dialogs now include `DialogDescription` content so they expose both a title and description to assistive technology without changing their existing behavior.

## Additional context

## Summary
- add missing `DialogDescription` content to four Studio dialogs that currently only render a title
- keep the change behavior-neutral and focused on accessibility metadata

## Test plan
- `git diff --check`
- manually review the four updated dialogs to confirm each now includes both title and description text