### PR TITLE
fix(studio): add descriptions to storage dialogs

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/CreateAnalyticsBucketModal.tsx
@@ -1,4 +1,11 @@
-import { Dialog, DialogContent, DialogHeader, DialogSectionSeparator, DialogTitle } from 'ui'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogSectionSeparator,
+  DialogTitle,
+} from 'ui'
 
 import { BUCKET_TYPES } from '../Storage.constants'
 import { CreateAnalyticsBucketForm } from './CreateAnalyticsBucketForm'
@@ -16,9 +23,12 @@ export const CreateAnalyticsBucketModal = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent size="medium" aria-describedby={undefined}>
+      <DialogContent size="medium">
         <DialogHeader>
           <DialogTitle>Create {config.singularName} bucket</DialogTitle>
+          <DialogDescription className="sr-only">
+            Create a new {config.singularName} bucket and configure it with the form below.
+          </DialogDescription>
         </DialogHeader>
         <DialogSectionSeparator />
         <CreateAnalyticsBucketForm type="dialog" onOpenChange={onOpenChange} />

--- a/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/CreateBucketModal.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -189,9 +190,13 @@ export const CreateBucketModal = ({ open, onOpenChange }: CreateBucketModalProps
         }
       }}
     >
-      <DialogContent aria-describedby={undefined}>
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>Create file bucket</DialogTitle>
+          <DialogDescription className="sr-only">
+            Create a file bucket and configure its visibility, upload limits, and allowed MIME
+            types.
+          </DialogDescription>
         </DialogHeader>
 
         <DialogSectionSeparator />

--- a/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EditBucketModal.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -198,6 +199,9 @@ export const EditBucketModal = ({ visible, bucket, onClose }: EditBucketModalPro
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{`Edit bucket “${bucket?.name}”`}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Update this bucket&apos;s visibility, upload limits, and allowed MIME types.
+          </DialogDescription>
         </DialogHeader>
 
         <DialogSectionSeparator />

--- a/apps/studio/components/interfaces/Storage/EmptyBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/EmptyBucketModal.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -56,6 +57,9 @@ export const EmptyBucketModal = ({ visible, bucket, onClose }: EmptyBucketModalP
       <DialogContent>
         <DialogHeader>
           <DialogTitle>{`Empty bucket “${bucket?.name}”`}</DialogTitle>
+          <DialogDescription className="sr-only">
+            Review the consequences before permanently deleting every object in this bucket.
+          </DialogDescription>
         </DialogHeader>
         <DialogSectionSeparator />
         <Admonition

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/CreateVectorBucketDialog.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -169,6 +170,10 @@ export const CreateVectorBucketDialog = ({
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Create vector bucket</DialogTitle>
+          <DialogDescription className="sr-only">
+            Create a vector bucket and set up the required integration for querying it from
+            Postgres.
+          </DialogDescription>
         </DialogHeader>
 
         <DialogSectionSeparator />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Several Storage dialogs either disable `aria-describedby` or render a `DialogTitle` without a matching description, which weakens accessibility metadata for assistive technology.

No linked issue. This is a self-contained accessibility cleanup.

## What is the new behavior?

The updated Storage dialogs now provide screen-reader descriptions, and dialogs that had `aria-describedby={undefined}` now rely on those descriptions instead.

## Additional context

## Summary
- add screen-reader descriptions to five Storage dialogs in Studio
- remove `aria-describedby={undefined}` where those dialogs now provide descriptions

## Test plan
- `git diff --check`
- manually review the touched dialogs to confirm the changes are accessibility-only and behavior-neutral