### PR TITLE
fix(studio): add descriptions to auth provider dialogs

### DIFF
--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAuth0Dialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateAuth0Dialog.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -93,6 +94,10 @@ export const CreateAuth0IntegrationDialog = ({
           <DialogTitle className="truncate">
             {isCreating ? `Add new Auth0 connection` : `Update existing Auth0 connection`}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Add an Auth0 connection so JWTs issued by your Auth0 tenant can access this Supabase
+            project.
+          </DialogDescription>
         </DialogHeader>
         <Separator />
         <DialogSection>

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateClerkAuthDialog.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -99,6 +100,9 @@ export const CreateClerkAuthIntegrationDialog = ({
       <DialogContent>
         <DialogHeader>
           <DialogTitle className="truncate">Add new Clerk connection</DialogTitle>
+          <DialogDescription className="sr-only">
+            Add a Clerk connection by registering the Clerk domain for this Supabase project.
+          </DialogDescription>
         </DialogHeader>
 
         <Separator />

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
@@ -96,8 +96,8 @@ export const CreateFirebaseAuthIntegrationDialog = ({
               : `Update existing Firebase Auth connection`}
           </DialogTitle>
           <DialogDescription className="sr-only">
-            Add a Firebase Auth connection so JWTs from a Firebase project can access this
-            Supabase project.
+            Add a Firebase Auth connection so JWTs from a Firebase project can access this Supabase
+            project.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateFirebaseAuthDialog.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -94,6 +95,10 @@ export const CreateFirebaseAuthIntegrationDialog = ({
               ? `Add new Firebase Auth connection`
               : `Update existing Firebase Auth connection`}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Add a Firebase Auth connection so JWTs from a Firebase project can access this
+            Supabase project.
+          </DialogDescription>
         </DialogHeader>
 
         <Separator />

--- a/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateWorkOSDialog.tsx
+++ b/apps/studio/components/interfaces/Auth/ThirdPartyAuthForm/CreateWorkOSDialog.tsx
@@ -8,6 +8,7 @@ import {
   Button,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -98,6 +99,9 @@ export const CreateWorkOSIntegrationDialog = ({
           <DialogTitle className="truncate">
             {isCreating ? `Add new WorkOS connection` : `Update existing WorkOS connection`}
           </DialogTitle>
+          <DialogDescription className="sr-only">
+            Add a WorkOS connection by registering the issuer URL for this Supabase project.
+          </DialogDescription>
         </DialogHeader>
 
         <Separator />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Several third-party auth connection dialogs in Studio render a `DialogTitle` without a matching description, while the Cognito dialog in the same area already includes one.

No linked issue. This is a self-contained accessibility cleanup.

## What is the new behavior?

The Auth0, Clerk, Firebase Auth, and WorkOS connection dialogs now include screen-reader descriptions so they expose both a title and description to assistive technology.

## Additional context

## Summary
- add screen-reader descriptions to four third-party auth connection dialogs
- mirror the existing accessibility pattern already used by the Cognito dialog in the same feature area

## Test plan
- `git diff --check`
- manually review the four updated dialogs to confirm the changes are accessibility-only and behavior-neutral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accessibility in third-party authentication dialogs by adding screen-reader-only descriptions for Auth0, Clerk, Firebase, and WorkOS connections; no changes to visible UI behavior or component APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->