### PR TITLE
chore(ai): remove DPA signer killswitch for assistant tracing

### DIFF
--- a/apps/studio/lib/ai/ai-details.test.ts
+++ b/apps/studio/lib/ai/ai-details.test.ts
@@ -30,10 +30,6 @@ vi.mock('@/data/entitlements/entitlements-query', () => ({
   checkEntitlement: vi.fn(),
 }))
 
-vi.mock('@/data/fetchers', () => ({
-  get: vi.fn(),
-}))
-
 const AUTH = 'Bearer token'
 const HEADERS = { 'Content-Type': 'application/json', Authorization: AUTH }
 
@@ -43,7 +39,6 @@ describe('getOrgAIDetails', () => {
   let mockGetAiOptInLevel: ReturnType<typeof vi.fn>
   let mockSubscriptionHasHipaaAddon: ReturnType<typeof vi.fn>
   let mockCheckEntitlement: ReturnType<typeof vi.fn>
-  let mockGet: ReturnType<typeof vi.fn>
 
   beforeEach(async () => {
     vi.clearAllMocks()
@@ -54,19 +49,16 @@ describe('getOrgAIDetails', () => {
     const subscriptionUtils =
       await import('@/components/interfaces/Billing/Subscription/Subscription.utils')
     const entitlementsQuery = await import('@/data/entitlements/entitlements-query')
-    const fetchers = await import('@/data/fetchers')
 
     mockGetOrganizations = vi.mocked(orgsQuery.getOrganizations)
     mockGetOrgSubscription = vi.mocked(subscriptionQuery.getOrgSubscription)
     mockGetAiOptInLevel = vi.mocked(aiHook.getAiOptInLevel)
     mockSubscriptionHasHipaaAddon = vi.mocked(subscriptionUtils.subscriptionHasHipaaAddon)
     mockCheckEntitlement = vi.mocked(entitlementsQuery.checkEntitlement)
-    mockGet = vi.mocked(fetchers.get)
 
     mockGetOrgSubscription.mockResolvedValue({ addons: [] })
     mockSubscriptionHasHipaaAddon.mockReturnValue(false)
     mockCheckEntitlement.mockResolvedValue({ hasAccess: false })
-    mockGet.mockResolvedValue({ data: { signed: false } })
   })
 
   it('returns org-level fields', async () => {
@@ -81,7 +73,6 @@ describe('getOrgAIDetails', () => {
       aiOptInLevel: 'schema',
       hasAccessToAdvanceModel: false,
       hasHipaaAddon: false,
-      isDpaSigned: false,
       orgId: 1,
       planId: 'pro',
     })
@@ -109,30 +100,6 @@ describe('getOrgAIDetails', () => {
     const result = await getOrgAIDetails({ orgSlug: 'test-org', authorization: AUTH })
 
     expect(result.hasHipaaAddon).toBe(true)
-  })
-
-  it('returns isDpaSigned true when endpoint returns signed: true', async () => {
-    mockGetOrganizations.mockResolvedValue([
-      { id: 1, slug: 'test-org', plan: { id: 'pro' }, opt_in_tags: [] },
-    ])
-    mockGetAiOptInLevel.mockReturnValue('schema')
-    mockGet.mockResolvedValue({ data: { signed: true } })
-
-    const result = await getOrgAIDetails({ orgSlug: 'test-org', authorization: AUTH })
-
-    expect(result.isDpaSigned).toBe(true)
-  })
-
-  it('returns isDpaSigned undefined when endpoint fails', async () => {
-    mockGetOrganizations.mockResolvedValue([
-      { id: 1, slug: 'test-org', plan: { id: 'pro' }, opt_in_tags: [] },
-    ])
-    mockGetAiOptInLevel.mockReturnValue('schema')
-    mockGet.mockResolvedValue({ data: null, error: { message: 'Unauthorized' } })
-
-    const result = await getOrgAIDetails({ orgSlug: 'test-org', authorization: AUTH })
-
-    expect(result.isDpaSigned).toBeUndefined()
   })
 
   it('calls getAiOptInLevel with the matched org opt_in_tags', async () => {

--- a/apps/studio/lib/ai/ai-details.ts
+++ b/apps/studio/lib/ai/ai-details.ts
@@ -1,7 +1,6 @@
 import { subscriptionHasHipaaAddon } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
 import { getProjectSettings } from '@/data/config/project-settings-v2-query'
 import { checkEntitlement } from '@/data/entitlements/entitlements-query'
-import { get } from '@/data/fetchers'
 import { getOrganizations } from '@/data/organizations/organizations-query'
 import { getProjectDetail } from '@/data/projects/project-detail-query'
 import { getOrgSubscription } from '@/data/subscriptions/org-subscription-query'
@@ -19,14 +18,10 @@ export const getOrgAIDetails = async ({
     ...(authorization && { Authorization: authorization }),
   }
 
-  const [organizations, subscription, advanceModelAccess, dpaSignedStatus] = await Promise.all([
+  const [organizations, subscription, advanceModelAccess] = await Promise.all([
     getOrganizations({ headers }),
     getOrgSubscription({ orgSlug }, undefined, headers),
     checkEntitlement(orgSlug, 'assistant.advance_model', undefined, headers),
-    get('/platform/organizations/{slug}/documents/dpa-signed', {
-      params: { path: { slug: orgSlug } },
-      headers,
-    }),
   ])
 
   const selectedOrg = organizations.find((org) => org.slug === orgSlug)
@@ -35,7 +30,6 @@ export const getOrgAIDetails = async ({
     aiOptInLevel: getAiOptInLevel(selectedOrg?.opt_in_tags),
     hasAccessToAdvanceModel: advanceModelAccess.hasAccess,
     hasHipaaAddon: subscriptionHasHipaaAddon(subscription),
-    isDpaSigned: dpaSignedStatus.data?.signed,
     orgId: selectedOrg?.id,
     planId: selectedOrg?.plan.id,
   }

--- a/apps/studio/lib/ai/braintrust-logger.test.ts
+++ b/apps/studio/lib/ai/braintrust-logger.test.ts
@@ -5,7 +5,6 @@ import { isTracingAllowed } from './braintrust-logger'
 const baseAllowed = {
   orgHasHipaaAddon: false,
   projectIsSensitive: false,
-  orgIsDpaSigned: false,
   projectRegion: 'us-east-1',
 }
 
@@ -32,10 +31,6 @@ describe('isTracingAllowed', () => {
     ).toBe(true)
   })
 
-  it('disallows tracing when DPA is signed', () => {
-    expect(isTracingAllowed({ ...baseAllowed, orgIsDpaSigned: true })).toBe(false)
-  })
-
   it('disallows tracing for EU regions', () => {
     expect(isTracingAllowed({ ...baseAllowed, projectRegion: 'eu-west-1' })).toBe(false)
     expect(isTracingAllowed({ ...baseAllowed, projectRegion: 'eu-central-1' })).toBe(false)
@@ -60,11 +55,9 @@ describe('isTracingAllowed', () => {
       isTracingAllowed({
         orgHasHipaaAddon: undefined,
         projectIsSensitive: undefined,
-        orgIsDpaSigned: undefined,
         projectRegion: undefined,
       })
     ).toBe(false)
-    expect(isTracingAllowed({ ...baseAllowed, orgIsDpaSigned: undefined })).toBe(false)
     expect(isTracingAllowed({ ...baseAllowed, projectRegion: undefined })).toBe(false)
     expect(isTracingAllowed({ ...baseAllowed, orgHasHipaaAddon: undefined })).toBe(false)
     // projectIsSensitive unknown only matters when orgHasHipaaAddon is also unknown

--- a/apps/studio/lib/ai/braintrust-logger.ts
+++ b/apps/studio/lib/ai/braintrust-logger.ts
@@ -18,17 +18,12 @@ if (IS_TRACING_ENABLED) {
 export function isTracingAllowed({
   orgHasHipaaAddon,
   projectIsSensitive,
-  orgIsDpaSigned,
   projectRegion,
 }: {
   orgHasHipaaAddon: boolean | undefined
   projectIsSensitive: boolean | null | undefined
-  orgIsDpaSigned: boolean | undefined
   projectRegion: string | undefined
 }) {
-  // Disable tracing for orgs with a signed (or unknown) DPA status
-  if (orgIsDpaSigned !== false) return false
-
   // Disable tracing for EU (or unknown) regions
   if (projectRegion === undefined || projectRegion.startsWith('eu-')) return false
 

--- a/apps/studio/lib/api/generate-v4.test.ts
+++ b/apps/studio/lib/api/generate-v4.test.ts
@@ -47,7 +47,6 @@ test('generateV4 calls the tool sanitizer', async () => {
     getOrgAIDetails: vi.fn().mockResolvedValue({
       aiOptInLevel: 'schema_and_log_and_data',
       hasAccessToAdvanceModel: true,
-      isDpaSigned: false,
     }),
     getProjectAIDetails: vi.fn().mockResolvedValue({
       region: 'us-east-1',

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -57,7 +57,6 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   let aiOptInLevel: AiOptInLevel = 'disabled'
   let orgHasHipaaAddon: boolean | undefined
   let projectIsSensitive: boolean | undefined
-  let orgIsDpaSigned: boolean | undefined
   let projectRegion: string | undefined
 
   if (!IS_PLATFORM) {
@@ -73,7 +72,6 @@ export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
 
       aiOptInLevel = orgDetails.aiOptInLevel
       orgHasHipaaAddon = orgDetails.hasHipaaAddon
-      orgIsDpaSigned = orgDetails.isDpaSigned
       projectIsSensitive = projectDetails.isSensitive
       projectRegion = projectDetails.region
     } catch (error) {
@@ -138,7 +136,7 @@ Instructions:
     // Log feedback to Braintrust if tracing is enabled and span ID is available
     if (
       IS_TRACING_ENABLED &&
-      isTracingAllowed({ orgHasHipaaAddon, projectIsSensitive, orgIsDpaSigned, projectRegion }) &&
+      isTracingAllowed({ orgHasHipaaAddon, projectIsSensitive, projectRegion }) &&
       spanId
     ) {
       try {

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -111,7 +111,6 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
   let hasAccessToAdvanceModel = false
   let orgHasHipaaAddon: boolean | undefined
   let projectIsSensitive: boolean | undefined
-  let orgIsDpaSigned: boolean | undefined
   let projectRegion: string | undefined
   let orgId: number | undefined
   let planId: string | undefined
@@ -131,7 +130,6 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       aiOptInLevel = orgDetails.aiOptInLevel
       hasAccessToAdvanceModel = orgDetails.hasAccessToAdvanceModel
       orgHasHipaaAddon = orgDetails.hasHipaaAddon
-      orgIsDpaSigned = orgDetails.isDpaSigned
       orgId = orgDetails.orgId
       planId = orgDetails.planId
       projectIsSensitive = projectDetails.isSensitive
@@ -213,7 +211,6 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       allowTracing: isTracingAllowed({
         orgHasHipaaAddon,
         projectIsSensitive,
-        orgIsDpaSigned,
         projectRegion,
       }),
       userId,


### PR DESCRIPTION
Removes the temporary killswitch added when Braintrust was onboarded as a subprocessor, to satisfy the 30-day DPA notice obligation. The window has elapsed and legal has cleared removal.

Drops the `orgIsDpaSigned` check from `isTracingAllowed`, removes the extra `/platform/organizations/{slug}/documents/dpa-signed` network hop from `getOrgAIDetails`, and cleans up all call sites and tests.

Closes AI-596

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified AI tracing eligibility logic by removing DPA signing status checks. Tracing authorization decisions now depend solely on region, HIPAA addon status, and project sensitivity settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->