### PR TITLE
fix(studio): add descriptions to JWT dialogs

### DIFF
--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
@@ -5,6 +5,7 @@ import {
   Badge,
   Button,
   Checkbox_Shadcn_,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -150,6 +151,10 @@ export const CreateKeyDialog = ({
     <>
       <DialogHeader>
         <DialogTitle>Create a new Standby Key</DialogTitle>
+        <DialogDescription className="sr-only">
+          Create a standby JWT signing key that you can rotate into use after your application has
+          picked it up.
+        </DialogDescription>
       </DialogHeader>
       <DialogSectionSeparator />
       <DialogSection className="space-y-4">

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/index.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/index.tsx
@@ -19,6 +19,7 @@ import {
   DialogContent,
   DialogFooter,
   DialogHeader,
+  DialogDescription,
   DialogSection,
   DialogSectionSeparator,
   DialogTitle,
@@ -399,6 +400,9 @@ export const JWTSecretKeysTable = () => {
         <DialogContent className="sm:max-w-[425px]">
           <DialogHeader>
             <DialogTitle>Start using new JWT signing keys</DialogTitle>
+            <DialogDescription className="sr-only">
+              Migrate your project from the legacy JWT secret to the new JWT signing key workflow.
+            </DialogDescription>
           </DialogHeader>
           <DialogSectionSeparator />
           <DialogSection className="flex flex-col gap-2 text-sm text-foreground-light">

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
@@ -2,6 +2,7 @@ import { FileKey } from 'lucide-react'
 import { useMemo } from 'react'
 import {
   Button,
+  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSection,
@@ -30,6 +31,9 @@ export function KeyDetailsDialog({
     <>
       <DialogHeader>
         <DialogTitle>Key Details</DialogTitle>
+        <DialogDescription className="sr-only">
+          Review this JWT signing key&apos;s identifier, discovery URL, and public key details.
+        </DialogDescription>
       </DialogHeader>
       <DialogSectionSeparator />
       <DialogSection className="flex flex-col gap-6">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Several JWT signing key dialogs in Studio render a `DialogTitle` without a matching description, which weakens accessibility metadata for assistive technology.

No linked issue. This is a self-contained accessibility cleanup.

## What is the new behavior?

The JWT signing key creation, key details, and migration dialogs now include screen-reader descriptions so they expose both a title and description to assistive technology.

## Additional context

## Summary
- add screen-reader descriptions to three JWT signing key dialogs in Studio
- keep the change behavior-neutral and focused on accessibility metadata

## Test plan
- `git diff --check`
- manually review the updated dialogs to confirm the changes are accessibility-only and behavior-neutral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced accessibility for JWT secret management dialogs by adding descriptive labels for screen reader users, improving the experience for assistive technology users across the Create Key, Key Details, and JWT migration dialogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->