### PR TITLE
fix(studio): add descriptions to utility dialogs

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -9,6 +9,7 @@ import {
   Checkbox_Shadcn_,
   Dialog,
   DialogContent,
+  DialogDescription,
   DialogHeader,
   DialogSectionSeparator,
   DialogTitle,
@@ -66,6 +67,10 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
       <DialogContent size="small">
         <DialogHeader>
           <DialogTitle>Create a new user</DialogTitle>
+          <DialogDescription className="sr-only">
+            Create a new auth user by entering their email address, password, and confirmation
+            preference.
+          </DialogDescription>
         </DialogHeader>
         <DialogSectionSeparator />
         <Form_Shadcn_ {...form}>

--- a/apps/studio/components/interfaces/Functions/TerminalInstructionsDialog.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructionsDialog.tsx
@@ -1,5 +1,5 @@
 import { parseAsString, useQueryState } from 'nuqs'
-import { Dialog, DialogContent, DialogSection, DialogTitle } from 'ui'
+import { Dialog, DialogContent, DialogDescription, DialogSection, DialogTitle } from 'ui'
 
 import { TerminalInstructions } from './TerminalInstructions'
 
@@ -16,6 +16,9 @@ export const TerminalInstructionsDialog = () => {
     <Dialog open={isOpen} onOpenChange={(open) => !open && handleClose()}>
       <DialogContent size="large">
         <DialogTitle className="sr-only">Create your first Edge Function via the CLI</DialogTitle>
+        <DialogDescription className="sr-only">
+          Follow the CLI instructions to create your first Edge Function for this project.
+        </DialogDescription>
         <DialogSection padding="small">
           <TerminalInstructions closable={false} />
         </DialogSection>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

A couple of Studio utility dialogs render a `DialogTitle` without a matching description, which weakens accessibility metadata for assistive technology.

No linked issue. This is a self-contained accessibility cleanup.

## What is the new behavior?

The Create User dialog and the Edge Function CLI instructions dialog now include screen-reader descriptions so they expose both a title and description to assistive technology.

## Additional context

## Summary
- add screen-reader descriptions to the Create User and Edge Function CLI instruction dialogs
- keep the change behavior-neutral and focused on accessibility metadata

## Test plan
- `git diff --check`
- manually review the updated dialogs to confirm the changes are accessibility-only and behavior-neutral

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved accessibility across modal dialogs by adding descriptive text to user creation and terminal instruction interfaces. These accessibility enhancements provide better support for screen readers and assistive technologies, ensuring all users, including those using accessibility tools, can more effectively understand dialog content and navigate workflows with greater clarity and confidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->