### PR TITLE
fix(studio): allow compute changes when disk is below 8GB

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.schema.ts
@@ -51,9 +51,11 @@ const baseSchema = z.object({
 export const CreateDiskStorageSchema = ({
   defaultTotalSize,
   cloudProvider,
+  isSpendCapEnabled,
 }: {
   defaultTotalSize: number
   cloudProvider: CloudProvider
+  isSpendCapEnabled: boolean
 }) => {
   const isFlyProject = cloudProvider === 'FLY'
   const isAwsNimbusProject = cloudProvider === 'AWS_NIMBUS'
@@ -69,10 +71,23 @@ export const CreateDiskStorageSchema = ({
       return COMPUTE_MAX_IOPS[parsedCompute.data] ?? Number.POSITIVE_INFINITY
     })()
 
-    if (validateDiskConfiguration && totalSize < 8) {
+    if (validateDiskConfiguration && totalSize < 8 && totalSize !== defaultTotalSize) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: 'Allocated disk size must be at least 8 GB.',
+        message: 'New disk size must be at least 8 GB.',
+        path: ['totalSize'],
+      })
+    }
+
+    if (
+      validateDiskConfiguration &&
+      isSpendCapEnabled &&
+      totalSize > 8 &&
+      totalSize !== defaultTotalSize
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Disable spend cap to increase disk above 8 GB.',
         path: ['totalSize'],
       })
     }

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -155,6 +155,7 @@ export function DiskManagementForm() {
       CreateDiskStorageSchema({
         defaultTotalSize: defaultValues.totalSize,
         cloudProvider: project?.cloud_provider as CloudProvider,
+        isSpendCapEnabled,
       })
     ),
     defaultValues,
@@ -223,13 +224,14 @@ export function DiskManagementForm() {
 
   const isBranch = project?.parent_project_ref !== undefined
 
-  const disableDiskInputs =
+  const disableDiskSizeInput =
     isRequestingChanges ||
     isPlanUpgradeRequired ||
     isWithinCooldownWindow ||
-    isSpendCapEnabled ||
     !canUpdateDiskConfiguration ||
     !isAws
+
+  const disableDiskInputs = disableDiskSizeInput || isSpendCapEnabled
 
   const disableComputeInputs = isPlanUpgradeRequired
   const isDirty = !!Object.keys(form.formState.dirtyFields).length
@@ -383,7 +385,7 @@ export function DiskManagementForm() {
 
             {isDiskNoticeVisible && <Separator />}
 
-            <SpendCapDisabledSection />
+            <SpendCapDisabledSection currentDiskSizeGb={defaultValues.totalSize} />
 
             <div className="flex flex-col gap-y-4">
               <NoticeBar
@@ -433,7 +435,7 @@ export function DiskManagementForm() {
 
                   <DiskSizeField
                     form={form}
-                    disableInput={disableDiskInputs}
+                    disableInput={disableDiskSizeInput}
                     setAdvancedSettingsOpenState={setAdvancedSettingsOpenState}
                   />
                 </>

--- a/apps/studio/components/interfaces/DiskManagement/fields/AutoScaleFields.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/AutoScaleFields.tsx
@@ -44,7 +44,7 @@ export const AutoScaleFields = ({ form }: AutoScaleFieldProps) => {
     200
   )
 
-  const totalSizeAfterGrowth = autoscaleGrowValue + totalSize
+  const totalSizeAfterGrowth = Math.max(autoscaleGrowValue + totalSize, 8)
   const formattedTotalSizeAfterGrowth =
     totalSizeAfterGrowth < _maxSizeGb ? totalSizeAfterGrowth : _maxSizeGb
   const formattedGrowValue = formattedTotalSizeAfterGrowth - totalSize

--- a/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/fields/DiskSizeField.tsx
@@ -149,7 +149,7 @@ export function DiskSizeField({
           <span className="text-foreground-lighter text-sm">
             {includedDiskGB > 0 &&
               org?.plan.id &&
-              `Your plan includes ${includedDiskGB} GB of disk size for ${watchedStorageType}.`}
+              `Your plan includes up to ${includedDiskGB} GB of ${watchedStorageType} storage.`}
 
             <div className="mt-3">
               <DocsButton abbrev={false} href={`${DOCS_URL}/guides/platform/database-size`} />

--- a/apps/studio/components/interfaces/DiskManagement/ui/SpendCapDisabledSection.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/ui/SpendCapDisabledSection.tsx
@@ -11,7 +11,11 @@ import { Admonition } from 'ui-patterns/admonition'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
-export function SpendCapDisabledSection() {
+interface SpendCapDisabledSectionProps {
+  currentDiskSizeGb?: number
+}
+
+export function SpendCapDisabledSection({ currentDiskSizeGb }: SpendCapDisabledSectionProps) {
   const { data: org, isPending: isOrgPending } = useSelectedOrganizationQuery()
   const { data: project, isPending: isProjectPending } = useSelectedProjectQuery()
 
@@ -22,6 +26,12 @@ export function SpendCapDisabledSection() {
     !org?.usage_billing_enabled &&
     project?.cloud_provider !== 'FLY'
 
+  const showAutoExpandNotice =
+    isSpendCapEnabled &&
+    currentDiskSizeGb !== undefined &&
+    currentDiskSizeGb > 0 &&
+    currentDiskSizeGb < 8
+
   return (
     <AnimatePresence>
       {isSpendCapEnabled && (
@@ -30,12 +40,23 @@ export function SpendCapDisabledSection() {
           animate={{ opacity: 1, height: 'auto' }}
           exit={{ opacity: 0, height: 0 }}
           transition={{ duration: 0.2 }}
+          className="flex flex-col gap-3"
         >
+          {showAutoExpandNotice && (
+            <Admonition type="default">
+              <AlertTitle>Your disk will auto-expand to 8 GB</AlertTitle>
+              <AlertDescription>
+                The first time your database usage triggers a resize, your disk will automatically
+                expand to at least 8 GB. You don&apos;t need to disable spend cap or do anything
+                manually for this to happen.
+              </AlertDescription>
+            </Admonition>
+          )}
           <Admonition type="default">
-            <AlertTitle>Disable spend cap to manage Disk configuration</AlertTitle>
+            <AlertTitle>Spend cap limits disk size to 8 GB</AlertTitle>
             <AlertDescription>
-              To access disk management features, you need to disable your spend cap. These features
-              offer more flexibility and control over your database disk size.
+              You can resize your disk up to 8 GB with spend cap enabled. To expand beyond 8 GB or
+              configure IOPS, throughput, and storage type, disable your spend cap.
             </AlertDescription>
             <div className="mt-3">
               <Link


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Projects that upgrade from free → paid keep their original sub-8 GB disk until the first usage-driven auto-expand fires. During that window, the compute-and-disk settings page is broken in several ways:

1. **Compute and autoscale changes are blocked entirely.** Form-level zod validation rejects the existing `totalSize < 8` regardless of whether the user touched the field, so even a compute-only submit fails.
2. **The disk size input is fully disabled on spend-cap plans**, even though customers are already entitled to 8 GB of disk under their Pro subscription. They have no way to claim that 8 GB manually without first disabling spend cap.
3. **There's no explanation of the automatic 8 GB bump**, so customers in this state don't know it's coming and reach out to support to expand their disk manually (which burns one of their 4 daily resize slots).

## What is the new behavior?

Four coordinated changes across three files.

**Schema (`DiskManagement.schema.ts`)**
- Relax the 8 GB floor to only fire when the user is actually changing the disk: `totalSize < 8 && totalSize !== defaultTotalSize`. Sub-8 disks can stay at their current size, unblocking compute resize submits.
- Add a new `isSpendCapEnabled` rule rejecting `totalSize > 8` when spend cap is on. This preserves the existing 8 GB ceiling policy for spend-cap customers, but enforces it at the validation layer instead of by disabling the input entirely.

**Form (`DiskManagementForm.tsx`)**
- Split `disableDiskInputs` into `disableDiskSizeInput` (no spend-cap gate) for the disk size field, and keep the full `disableDiskInputs` gate for IOPS / throughput / storage type. Premium configurations remain gated on spend cap; only disk size gets opened up.

**UI (`SpendCapDisabledSection.tsx`)**
- New reassurance admonition above the existing "spend cap" admonition, shown only when current disk < 8 GB: *"Your disk will auto-expand to 8 GB the first time your database usage triggers a resize. You don't need to disable spend cap or do anything manually for this to happen."*
- Updated the existing admonition's copy to reflect the new behavior: *"Spend cap limits disk size to 8 GB. You can resize your disk up to 8 GB with spend cap enabled. To expand beyond 8 GB or configure IOPS, throughput, and storage type, disable your spend cap."*

### Behavior matrix

| State | Disk field | 2 GB submit | 8 GB submit | 10 GB submit | Auto-expand callout |
|---|---|---|---|---|---|
| Spend cap on, 2 GB | editable | ✅ (unchanged) | ✅ | ❌ "disable spend cap" | ✅ shown |
| Spend cap on, 8 GB | editable | ❌ can't shrink | ✅ unchanged | ❌ "disable spend cap" | hidden |
| Spend cap off | editable | ✅ | ✅ | ✅ (up to 60 TB) | hidden |
| Free plan | blocked by plan gate | — | — | — | hidden |

### Test plan

- [x] Pro org, spend cap on, project disk = 2 GB: disk field editable; submit with `totalSize` unchanged + a compute change succeeds
- [x] Same project: submit with `totalSize = 8` succeeds; `totalSize = 10` shows "Disable spend cap to increase disk above 8 GB"; `totalSize = 4` shows "New disk size must be at least 8 GB"
- [x] Same project: IOPS / throughput / storage type fields still disabled; both admonitions shown
- [x] Pro org, spend cap on, disk = 8 GB: disk editable, capped at 8 GB; only spend-cap admonition shown (no auto-expand callout)
- [x] Pro org, spend cap off: full control, no admonitions, up to 60 TB (unchanged)
- [x] Free org: blocked by plan-upgrade gate (unchanged)
- [x] Within 6h resize cooldown: still blocked (unchanged)
- [x] Fly / AWS_K8S / AWS_NIMBUS: validation skipped as before (unchanged)

## Additional context

No backend changes. No billing impact — spend-cap disk allowance is already 8 GB; this PR just lets customers reach it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-expansion notice when disks will automatically grow to at least 8 GB on first usage-triggered resize while spend cap is enabled.

* **Improvements**
  * Validation prevents increasing disk above 8 GB unless spend cap is disabled; errors target the disk size field.
  * Spend-cap messaging clarified and expanded for current sizes between 0–8 GB.
  * Disk size input behavior refined so spend cap no longer globally disables the size field.
  * Autoscale growth now enforces a minimum resulting size of 8 GB.
  * Disk allowance phrasing updated to "up to" for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->