### PR TITLE
Add redirect from prompts to skills documentation page

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1,6 +1,11 @@
 module.exports = [
   {
     permanent: true,
+    source: '/ui/docs/ai-editors-rules/prompts',
+    destination: '/ui/docs/ai-editors-rules/skills',
+  },
+  {
+    permanent: true,
     source: '/auth/Auth',
     destination: '/auth',
   },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update (redirect)

## What is the current behavior?

The documentation page at `/ui/docs/ai-editors-rules/prompts` exists but should redirect to a new location.

## What is the new behavior?

Added a permanent redirect from `/ui/docs/ai-editors-rules/prompts` to `/ui/docs/ai-editors-rules/skills` to reflect documentation reorganization.

## Additional context

This redirect ensures that any existing links or bookmarks to the old prompts documentation path will automatically direct users to the new skills documentation page, maintaining a good user experience during the documentation restructuring.

https://claude.ai/code/session_015A5BSsfVyYUgsneE9LpFeM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation redirect rules to automatically forward users accessing legacy documentation paths to their updated locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->