### PR TITLE
fix: incorrect docs link in queues settings

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueuesSettings.tsx
@@ -319,7 +319,9 @@ export const QueuesSettings = () => {
               </FormPanelContent>
 
               <FormPanelFooter className="flex px-8 py-4 flex items-center justify-between">
-                <DocsButton href="https://github.com/tembo-io/pgmq?tab=readme-ov-file#sql-examples" />
+                <DocsButton
+                  href={`${DOCS_URL}/guides/queues/quickstart#expose-queues-to-client-side-consumers`}
+                />
                 <div className="flex items-center gap-x-2">
                   <Button
                     type="default"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Fixes FE-2304. 

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the documentation link in Queues Settings to direct users to the internal quickstart guide for exposing queues to client-side consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->