### PR TITLE
fix: relation hint

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -114,10 +114,11 @@ export const InputField = ({
             <span className="text-sm text-foreground-lighter">
               {field.comment && '('}Has a foreign key relation to
             </span>
-            <span className="text-code font-mono text-xs text-foreground-lighter">
+            <br />
+            <code className="text-code-inline">
               {field.foreignKey.target_table_schema}.{field.foreignKey.target_table_name}.
               {field.foreignKey.target_column_name}
-            </span>
+            </code>
             {field.comment && <span className="text-sm text-foreground-lighter">{`)`}</span>}
           </>
         }


### PR DESCRIPTION
smol fix


<table>
  <tr>
    <th align="center">Before</th>
    <th align="center">After</th>
  </tr>
  <tr>
    <td align="center">
      <img width="360" alt="Before" src="https://github.com/user-attachments/assets/a715fdae-26be-461f-91f0-d25db89cfde2" />
    </td>
    <td align="center">
      <img width="360" alt="After" src="https://github.com/user-attachments/assets/4b3dc4cb-2993-41b5-be5a-878d26bc9b7f" />
    </td>
  </tr>
</table>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the visual formatting of foreign key reference information displayed in the table editor. Target table details are now presented on a dedicated separate line with improved styling, making relationship information significantly clearer and easier to read when viewing or editing table rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->