### PR TITLE
fix: keep API key migration instructions visible after JWT migration

### DIFF
--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -354,7 +354,7 @@ export const JWTSettings = () => {
             </form>
           </Form_Shadcn_>
 
-          {!isPending && !legacyKey && (
+          {!isPending && (disableLegacyJwtSecretRotation || !legacyKey) && (
             <>
               {isUpdatingJwtSecret && (
                 <div className="flex items-center space-x-2">


### PR DESCRIPTION
## Summary

Fixes [FE-3055](https://linear.app/supabase/issue/FE-3055/keep-api-key-migration-instructions-visible-after-click).

Fix: keep the callout mounted whenever `disableLegacyJwtSecretRotation` is on, while preserving the original behavior for the legacy flow.

```diff
- {!isPending && !legacyKey && (
+ {!isPending && (disableLegacyJwtSecretRotation || !legacyKey) && (
```

## Test plan

- [x] On a project with a legacy JWT secret and `disableLegacyJwtSecretRotation` enabled, open the legacy JWT secret page — callout is visible
- [x] Click **Migrate JWT secret** on the JWT Signing Keys page, return to the legacy JWT secret page — callout remains visible with all 4 steps
- [x] With `disableLegacyJwtSecretRotation` off, verify the original behavior is unchanged (callout hides once `legacyKey` exists)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Features**
  * Expanded legacy JWT secret rotation UI visibility to display under additional configuration scenarios, enhancing access to secret migration functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->