### PR TITLE
docs: Metrics Key changes

### DIFF
--- a/apps/docs/content/guides/telemetry/log-drains.mdx
+++ b/apps/docs/content/guides/telemetry/log-drains.mdx
@@ -47,7 +47,7 @@ Unsigned requests to HTTP endpoints are temporary and all requests will signed i
 
 1. Create and deploy the edge function
 
-Generate a new edge function template and update it to log out the received JSON payload. For simplicity, we will accept any request with an Anon Key.
+Generate a new edge function template and update it to log out the received JSON payload. For simplicity, we will accept any request with a Publishable Key.
 
 ```bash
 supabase functions new hello-world
@@ -86,7 +86,7 @@ Create an HTTP drain under the [Project Settings > Log Drains](/dashboard/projec
 
 - Disable the Gzip, as we want to receive the payload without compression.
 - Under URL, set it to your edge function URL `https://[PROJECT REF].supabase.co/functions/v1/hello-world`
-- Under Headers, set the `Authorization: Bearer [ANON KEY]`
+- Under Headers, set the `Authorization: Bearer [PUBLISHABLE KEY]`
 
 <ProjectConfigVariables variable="publishableKey" />
 

--- a/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
@@ -31,7 +31,7 @@ Grafana maintains a [Supabase integration guide](https://grafana.com/docs/grafan
 2. Provide:
    - Your Supabase project ref (e.g. `abcd1234`).
    - The Metrics API endpoint: `https://<project-ref>.supabase.co/customer/v1/privileged/metrics`.
-   - HTTP Basic Auth credentials (`service_role` / `sb_secret_...`).
+   - HTTP Basic Auth credentials (`sb_secret_...`).
 3. Choose the scrape interval (1 minute recommended) and test the connection. Grafana Cloud will deploy an agent in the background that scrapes the Metrics API and forwards the data to Prometheus.
 
 If you prefer to reuse an existing Grafana Agent deployment, configure an [integration pipeline](https://grafana.com/docs/grafana-cloud/send-data/agent/integrations/integration-reference/integration-supabase/) with the same URL and credentials.

--- a/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
@@ -31,7 +31,7 @@ scrape_configs:
     metrics_path: /customer/v1/privileged/metrics
     scheme: https
     basic_auth:
-      username: service_role
+      username: username
       password: '<secret API key (sb_secret_...)>'
     static_configs:
       - targets:

--- a/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
@@ -24,7 +24,7 @@ No matter which collector you use, you need to hit the Metrics API once per minu
   metrics_path: /customer/v1/privileged/metrics
   scheme: https
   basic_auth:
-    username: service_role
+    username: username
     password: '<secret API key (sb_secret_...)>'
   static_configs:
     - targets:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry log drain configuration guides to use Publishable Key instead of Anon Key for HTTP authorization.
  * Simplified HTTP Basic Auth credentials across Grafana Cloud, self-hosted Prometheus, and vendor-agnostic metrics integration documentation for improved consistency and clarity in setup instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->