### PR TITLE
feat(studio): remove live row from unified logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -45,7 +45,6 @@ import { DataTableSideBarLayout } from '@/components/ui/DataTable/DataTableSideB
 import { DataTableToolbar } from '@/components/ui/DataTable/DataTableToolbar'
 import { FilterSideBar } from '@/components/ui/DataTable/FilterSideBar'
 import { LiveButton } from '@/components/ui/DataTable/LiveButton'
-import { LiveRow } from '@/components/ui/DataTable/LiveRow'
 import { DataTableProvider } from '@/components/ui/DataTable/providers/DataTableProvider'
 import { TimelineChart } from '@/components/ui/DataTable/TimelineChart'
 import { useUnifiedLogsChartQuery } from '@/data/logs/unified-logs-chart-query'
@@ -410,11 +409,6 @@ export const UnifiedLogs = () => {
                         totalRowsFetched={totalFetched}
                         fetchNextPage={fetchNextPage}
                         hasNextPage={hasNextPage}
-                        renderLiveRow={(props) => {
-                          if (!liveMode.timestamp) return null
-                          if (props?.row?.original.id !== liveMode?.row?.id) return null
-                          return <LiveRow colSpan={UNIFIED_LOGS_COLUMNS.length - 1} />
-                        }}
                         setColumnOrder={setColumnOrder}
                         setColumnVisibility={setColumnVisibility}
                         searchParamsParser={SEARCH_PARAMS_PARSER}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

When unified logs are in "live" mode, we inserted a bar into the list that got pushed down with new logs appearing. Doesn't seem to add much value and our live mode button is visibly green when switched on.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed live-updating row functionality from UnifiedLogs component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->