### PR TITLE
fix(docs): fix self-hosting broken links

### DIFF
--- a/apps/docs/app/guides/self-hosting/analytics/config/page.tsx
+++ b/apps/docs/app/guides/self-hosting/analytics/config/page.tsx
@@ -21,7 +21,7 @@ const AnalyticsConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/analytics/config/page.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/self-hosting/analytics/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />

--- a/apps/docs/app/guides/self-hosting/auth/config/page.tsx
+++ b/apps/docs/app/guides/self-hosting/auth/config/page.tsx
@@ -21,7 +21,7 @@ const AuthConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/auth/config/page.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/self-hosting/auth/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />

--- a/apps/docs/app/guides/self-hosting/realtime/config/page.tsx
+++ b/apps/docs/app/guides/self-hosting/realtime/config/page.tsx
@@ -21,7 +21,7 @@ const RealtimeConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/realtime/config/page.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/self-hosting/realtime/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />

--- a/apps/docs/app/guides/self-hosting/storage/config/page.tsx
+++ b/apps/docs/app/guides/self-hosting/storage/config/page.tsx
@@ -21,7 +21,7 @@ const StorageConfigPage = async () => {
     <GuideTemplate
       meta={meta}
       editLink={newEditLink(
-        'supabase/supabase/blob/master/apps/docs/app/guides/(with-sidebar)/self-hosting/storage/config/page.tsx'
+        'supabase/supabase/blob/master/apps/docs/app/guides/self-hosting/storage/config/page.tsx'
       )}
     >
       <MDXRemoteBase source={descriptionMdx} />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix broken links on self-hosting docs.

## Additional context

<img width="763" height="441" alt="Screenshot_2026-04-23_11-45-37" src="https://github.com/user-attachments/assets/11479aff-f517-421d-8bcd-ef60b97faec3" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed edit links in self-hosting configuration documentation guides for Analytics, Auth, Realtime, and Storage features to ensure they point to the correct source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->