### PR TITLE
Remove clone-of-clone restriction in RestoreToNewProject

### DIFF
--- a/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
+++ b/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
@@ -92,7 +92,6 @@ export const RestoreToNewProject = () => {
       enabled: PHYSICAL_BACKUPS_ENABLED || PITR_ENABLED,
     }
   )
-  const IS_CLONED_PROJECT = cloneStatus?.cloned_from?.source_project?.ref ? true : false
   const isLoading = !isPermissionsLoaded || cloneBackupsLoading || cloneStatusLoading
 
   useEffect(() => {
@@ -184,22 +183,6 @@ export const RestoreToNewProject = () => {
 
   if (isLoading) {
     return <GenericSkeletonLoader />
-  }
-
-  if (IS_CLONED_PROJECT) {
-    return (
-      <Admonition type="default" title="This project cannot be restored to a new project">
-        <Markdown
-          className="max-w-full [&>p]:!leading-normal"
-          content={`This is a temporary limitation whereby projects that were originally restored from another project cannot be restored to yet another project.`}
-        />
-        <Button asChild type="default">
-          <Link href={`/project/${cloneStatus?.cloned_from?.source_project?.ref || ''}`}>
-            Go to original project
-          </Link>
-        </Button>
-      </Admonition>
-    )
   }
 
   if (isError) {


### PR DESCRIPTION
## Summary

- Removes the UI guard in `RestoreToNewProject.tsx` that blocked projects cloned from another cloned project from being restored to a new project
- The API now supports a ConfigCat feature flag (`INDATA-559`) to allow specific customers to clone clones, so the client-side restriction is no longer needed
- Removes the unused `IS_CLONED_PROJECT` constant alongside the block

## Test plan

- [x] Verify a cloned project can now reach the restore-to-new-project UI without hitting the "cannot be restored" admonition
- [x] Verify non-cloned projects are unaffected
- [x] Verify the feature flag at the API level correctly gates access for customers without the flag enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed unnecessary warning message that displayed during database restoration when restoring a cloned or previously restored project to a new project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->