### PR TITLE
feat(www): add Notion database as form destination for /go pages

### DIFF
--- a/apps/www/_go/lead-gen/example-lead-gen.tsx
+++ b/apps/www/_go/lead-gen/example-lead-gen.tsx
@@ -261,15 +261,15 @@ alter table posts enable row level security;`,
       disclaimer:
         'By submitting this form, I confirm that I have read and understood the [Privacy Policy](https://supabase.com/privacy).',
       crm: {
-        hubspot: {
-          formGuid: 'b9abbf77-86ae-4fe7-9147-d15922bf58ca',
-          fieldMap: {
-            firstName: 'firstname',
-            lastName: 'lastname',
-          },
-          consent:
-            'By submitting this form, I confirm that I have read and understood the Privacy Policy.',
-        },
+        // hubspot: {
+        //   formGuid: 'b9abbf77-86ae-4fe7-9147-d15922bf58ca',
+        //   fieldMap: {
+        //     firstName: 'firstname',
+        //     lastName: 'lastname',
+        //   },
+        //   consent:
+        //     'By submitting this form, I confirm that I have read and understood the Privacy Policy.',
+        // },
         notion: {
           database_id: '3525004b775f8018ae80000c6e0920e7',
           columnMap: {

--- a/apps/www/_go/lead-gen/example-lead-gen.tsx
+++ b/apps/www/_go/lead-gen/example-lead-gen.tsx
@@ -273,13 +273,10 @@ alter table posts enable row level security;`,
         notion: {
           database_id: '3525004b775f8018ae80000c6e0920e7',
           columnMap: {
-            firstName: 'first_name',
-            lastName: 'last_name',
-            email: 'email',
-            interest: 'interest',
-          },
-          staticProperties: {
-            source: 'Example Ebook /go page',
+            firstName: 'First Name',
+            lastName: 'Last Name',
+            email: 'Company Email',
+            interest: 'What are you interested in?',
           },
         },
       },

--- a/apps/www/_go/lead-gen/example-lead-gen.tsx
+++ b/apps/www/_go/lead-gen/example-lead-gen.tsx
@@ -270,6 +270,18 @@ alter table posts enable row level security;`,
           consent:
             'By submitting this form, I confirm that I have read and understood the Privacy Policy.',
         },
+        notion: {
+          database_id: '3525004b775f8018ae80000c6e0920e7',
+          columnMap: {
+            firstName: 'first_name',
+            lastName: 'last_name',
+            email: 'email',
+            interest: 'interest',
+          },
+          staticProperties: {
+            source: 'Example Ebook /go page',
+          },
+        },
       },
     },
   ],

--- a/apps/www/_go/lead-gen/example-lead-gen.tsx
+++ b/apps/www/_go/lead-gen/example-lead-gen.tsx
@@ -271,7 +271,7 @@ alter table posts enable row level security;`,
         //     'By submitting this form, I confirm that I have read and understood the Privacy Policy.',
         // },
         notion: {
-          database_id: '3525004b775f8018ae80000c6e0920e7',
+          database_id: '3525004b775f80419b2ac0245affad06',
           columnMap: {
             firstName: 'First Name',
             lastName: 'Last Name',

--- a/packages/marketing/src/crm/hubspot.ts
+++ b/packages/marketing/src/crm/hubspot.ts
@@ -71,8 +71,13 @@ export class HubSpotClient {
       }
     }
 
+    // portalId comes from env; formGuid is validated at the zod layer to a
+    // UUID-like shape, but encodeURIComponent keeps this safe even if the
+    // client is constructed from an untrusted source.
     const response = await fetch(
-      `https://api.hsforms.com/submissions/v3/integration/submit/${this.portalId}/${this.formGuid}`,
+      `https://api.hsforms.com/submissions/v3/integration/submit/${encodeURIComponent(
+        this.portalId
+      )}/${encodeURIComponent(this.formGuid)}`,
       {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/packages/marketing/src/crm/index.ts
+++ b/packages/marketing/src/crm/index.ts
@@ -2,76 +2,59 @@ import 'server-only'
 
 import { CustomerIOClient, type CustomerIOConfig } from './customerio'
 import { HubSpotClient, type HubSpotConfig } from './hubspot'
+import { NotionClient, type NotionConfig } from './notion'
 
 export type { CustomerIOConfig } from './customerio'
 export type { HubSpotConfig } from './hubspot'
+export type { NotionConfig } from './notion'
 export { CustomerIOClient } from './customerio'
 export { HubSpotClient } from './hubspot'
+export { NotionClient } from './notion'
 
-// --- Provider config types ---
-
-interface HubSpotProviderConfig {
-  hubspot: HubSpotConfig
-  customerio?: never
+export interface CRMConfig {
+  hubspot?: HubSpotConfig
+  customerio?: CustomerIOConfig
+  notion?: NotionConfig
 }
 
-interface CustomerIOProviderConfig {
-  hubspot?: never
-  customerio: CustomerIOConfig
-}
-
-interface BothProvidersConfig {
-  hubspot: HubSpotConfig
-  customerio: CustomerIOConfig
-}
-
-export type CRMConfig = HubSpotProviderConfig | CustomerIOProviderConfig | BothProvidersConfig
-
-// --- Event option types per provider ---
-
-interface HubSpotEventFields {
+export interface CRMEventOptions {
+  /** Email used as identifier */
+  email: string
   /** Fields submitted to HubSpot form (key = HubSpot field name, value = field value) */
-  hubspotFields: Record<string, string>
+  hubspotFields?: Record<string, string>
   /** HubSpot form context */
   context?: { pageUri?: string; pageName?: string }
   /** Legal consent text for HubSpot */
   consent?: string
-}
-
-interface CustomerIOEventFields {
   /** Event name for Customer.io tracking */
-  event: string
+  event?: string
   /** Properties attached to the Customer.io event */
   properties?: Record<string, unknown>
   /** Profile attributes to set on the Customer.io contact */
   customerioProfile?: Record<string, unknown>
+  /** Notion page creation — values are keyed by Notion database column name */
+  notion?: {
+    databaseId: string
+    properties: Record<string, unknown>
+  }
 }
 
-type BaseEventOptions = {
-  /** Email used as identifier */
-  email: string
-}
-
-type SubmitEventFor<T extends CRMConfig> = BaseEventOptions &
-  (T extends { hubspot: HubSpotConfig } ? HubSpotEventFields : Partial<HubSpotEventFields>) &
-  (T extends { customerio: CustomerIOConfig }
-    ? CustomerIOEventFields
-    : Partial<CustomerIOEventFields>)
-
-export class CRMClient<T extends CRMConfig = CRMConfig> {
+export class CRMClient {
   private hubspot: HubSpotClient | null
   private customerio: CustomerIOClient | null
+  private notion: NotionClient | null
 
-  constructor(config: T) {
+  constructor(config: CRMConfig) {
     this.hubspot = config.hubspot ? new HubSpotClient(config.hubspot) : null
     this.customerio = config.customerio ? new CustomerIOClient(config.customerio) : null
+    this.notion = config.notion ? new NotionClient(config.notion) : null
   }
 
   /**
    * Submit an event to configured providers in parallel.
-   * Required fields are determined by which providers were configured.
+   * Each provider is invoked only when both its client and its payload are present.
    */
-  async submitEvent(options: SubmitEventFor<T>): Promise<{ errors: Error[] }> {
+  async submitEvent(options: CRMEventOptions): Promise<{ errors: Error[] }> {
     const promises: Promise<void>[] = []
     const errors: Error[] = []
 
@@ -108,6 +91,15 @@ export class CRMClient<T extends CRMConfig = CRMConfig> {
             errors.push(new Error(`Customer.io: ${err.message}`))
           }
         })()
+      )
+    }
+
+    if (this.notion && options.notion) {
+      const { databaseId, properties } = options.notion
+      promises.push(
+        this.notion.createDatabasePage(databaseId, properties).catch((err) => {
+          errors.push(new Error(`Notion: ${err.message}`))
+        })
       )
     }
 

--- a/packages/marketing/src/crm/notion.ts
+++ b/packages/marketing/src/crm/notion.ts
@@ -48,7 +48,13 @@ export class NotionClient {
   private getSchema(databaseId: string): Promise<NotionDatabaseSchema> {
     let pending = this.schemaCache.get(databaseId)
     if (!pending) {
-      pending = this.request<NotionDatabaseSchema>(`/databases/${databaseId}`, 'GET')
+      // databaseId is validated at the schema layer, but encodeURIComponent
+      // keeps this safe as defense-in-depth if the client ever grows a caller
+      // that bypasses the zod boundary.
+      pending = this.request<NotionDatabaseSchema>(
+        `/databases/${encodeURIComponent(databaseId)}`,
+        'GET'
+      )
       this.schemaCache.set(databaseId, pending)
     }
     return pending

--- a/packages/marketing/src/crm/notion.ts
+++ b/packages/marketing/src/crm/notion.ts
@@ -1,0 +1,118 @@
+import 'server-only'
+
+const NOTION_API_BASE = 'https://api.notion.com/v1'
+const NOTION_VERSION = '2022-06-28'
+
+export interface NotionConfig {
+  apiKey: string
+}
+
+interface NotionDatabaseProperty {
+  id: string
+  name: string
+  type: string
+}
+
+interface NotionDatabaseSchema {
+  properties: Record<string, NotionDatabaseProperty>
+}
+
+export class NotionClient {
+  private apiKey: string
+  private schemaCache = new Map<string, Promise<NotionDatabaseSchema>>()
+
+  constructor(config: NotionConfig) {
+    if (!config.apiKey) throw new Error('NotionClient: apiKey is required')
+    this.apiKey = config.apiKey
+  }
+
+  private async request<T>(path: string, method: 'GET' | 'POST', body?: unknown): Promise<T> {
+    const response = await fetch(`${NOTION_API_BASE}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Notion-Version': NOTION_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    })
+
+    if (!response.ok) {
+      const errorText = await response.text()
+      throw new Error(`Notion API request failed: ${response.status} - ${errorText}`)
+    }
+
+    return (await response.json()) as T
+  }
+
+  private getSchema(databaseId: string): Promise<NotionDatabaseSchema> {
+    let pending = this.schemaCache.get(databaseId)
+    if (!pending) {
+      pending = this.request<NotionDatabaseSchema>(`/databases/${databaseId}`, 'GET')
+      this.schemaCache.set(databaseId, pending)
+    }
+    return pending
+  }
+
+  /**
+   * Create a page in the given database. Property types are auto-detected from
+   * the database schema, so values can be passed as plain strings/numbers and
+   * will be wrapped in the correct Notion property shape.
+   * Unknown columns (not present in the database) are silently skipped.
+   */
+  async createDatabasePage(databaseId: string, values: Record<string, unknown>): Promise<void> {
+    const schema = await this.getSchema(databaseId)
+    const properties: Record<string, unknown> = {}
+
+    for (const [name, value] of Object.entries(values)) {
+      if (value === undefined || value === null || value === '') continue
+      const schemaProp = schema.properties[name]
+      if (!schemaProp) continue
+      const encoded = encodePropertyValue(schemaProp.type, value)
+      if (encoded !== undefined) properties[name] = encoded
+    }
+
+    await this.request('/pages', 'POST', {
+      parent: { database_id: databaseId },
+      properties,
+    })
+  }
+}
+
+function encodePropertyValue(type: string, value: unknown): unknown {
+  const str = typeof value === 'string' ? value : String(value)
+
+  switch (type) {
+    case 'title':
+      return { title: [{ text: { content: str } }] }
+    case 'rich_text':
+      return { rich_text: [{ text: { content: str } }] }
+    case 'email':
+      return { email: str }
+    case 'phone_number':
+      return { phone_number: str }
+    case 'url':
+      return { url: str }
+    case 'number': {
+      const n = typeof value === 'number' ? value : Number(str)
+      return Number.isFinite(n) ? { number: n } : undefined
+    }
+    case 'checkbox': {
+      const b = typeof value === 'boolean' ? value : str === 'true' || str === 'on'
+      return { checkbox: b }
+    }
+    case 'date':
+      return { date: { start: str } }
+    case 'select':
+      return { select: { name: str } }
+    case 'multi_select':
+      return {
+        multi_select: str
+          .split(',')
+          .map((s) => ({ name: s.trim() }))
+          .filter((o) => o.name),
+      }
+    default:
+      return { rich_text: [{ text: { content: str } }] }
+  }
+}

--- a/packages/marketing/src/go/actions/submitForm.ts
+++ b/packages/marketing/src/go/actions/submitForm.ts
@@ -24,37 +24,40 @@ function debug(message: string, data?: unknown) {
 }
 
 function buildCrmConfig(crm: GoFormCrmConfig): CRMConfig {
-  const hubspotPortalId = process.env.HUBSPOT_PORTAL_ID
-  const customerioSiteId = process.env.CUSTOMERIO_SITE_ID
-  const customerioApiKey = process.env.CUSTOMERIO_API_KEY
+  const config: CRMConfig = {}
 
-  if (crm.hubspot && crm.customerio) {
+  if (crm.hubspot) {
+    const hubspotPortalId = process.env.HUBSPOT_PORTAL_ID
     if (!hubspotPortalId) throw new Error('HUBSPOT_PORTAL_ID env var is not set')
+    config.hubspot = { portalId: hubspotPortalId, formGuid: crm.hubspot.formGuid }
+  }
+
+  if (crm.customerio) {
+    const customerioSiteId = process.env.CUSTOMERIO_SITE_ID
+    const customerioApiKey = process.env.CUSTOMERIO_API_KEY
     if (!customerioSiteId) throw new Error('CUSTOMERIO_SITE_ID env var is not set')
     if (!customerioApiKey) throw new Error('CUSTOMERIO_API_KEY env var is not set')
-    return {
-      hubspot: { portalId: hubspotPortalId, formGuid: crm.hubspot.formGuid },
-      customerio: { siteId: customerioSiteId, apiKey: customerioApiKey },
-    }
+    config.customerio = { siteId: customerioSiteId, apiKey: customerioApiKey }
   }
-  if (crm.hubspot) {
-    if (!hubspotPortalId) throw new Error('HUBSPOT_PORTAL_ID env var is not set')
-    return { hubspot: { portalId: hubspotPortalId, formGuid: crm.hubspot.formGuid } }
+
+  if (crm.notion) {
+    const notionApiKey = process.env.NOTION_API_KEY
+    if (!notionApiKey) throw new Error('NOTION_API_KEY env var is not set')
+    config.notion = { apiKey: notionApiKey }
   }
-  // customerio only (guaranteed by schema refinement that at least one exists)
-  if (!customerioSiteId) throw new Error('CUSTOMERIO_SITE_ID env var is not set')
-  if (!customerioApiKey) throw new Error('CUSTOMERIO_API_KEY env var is not set')
-  return { customerio: { siteId: customerioSiteId, apiKey: customerioApiKey } }
+
+  return config
 }
 
 /**
- * Submit form values to the configured CRM providers (HubSpot and/or Customer.io).
+ * Submit form values to the configured CRM providers (HubSpot, Customer.io, Notion).
  *
  * Credentials are read from environment variables:
  *   - HubSpot:     HUBSPOT_PORTAL_ID
  *   - Customer.io: CUSTOMERIO_SITE_ID, CUSTOMERIO_API_KEY
+ *   - Notion:      NOTION_API_KEY
  *
- * Per-form config (formGuid, event name, field mappings) lives in the page definition.
+ * Per-form config (formGuid, event name, database_id, field mappings) lives in the page definition.
  */
 export async function submitFormAction(
   crm: GoFormCrmConfig,
@@ -85,6 +88,7 @@ export async function submitFormAction(
         providers: Object.keys(crmConfig),
         hubspot: crm.hubspot ? { formGuid: crm.hubspot.formGuid } : undefined,
         customerio: crm.customerio ? { event: crm.customerio.event } : undefined,
+        notion: crm.notion ? { database_id: crm.notion.database_id } : undefined,
       })
       client = new CRMClient(crmConfig)
     } catch (err: any) {
@@ -122,9 +126,24 @@ export async function submitFormAction(
       })
     }
 
-    // submitEvent is typed via generics — cast to any to avoid fighting the conditional types
-    // (the runtime behavior is correct: CRMClient checks which clients are configured)
-    const { errors } = await (client as CRMClient).submitEvent({
+    // Build Notion page properties: map form fields via columnMap, then merge staticProperties
+    let notion: { databaseId: string; properties: Record<string, unknown> } | undefined
+    if (crm.notion) {
+      const columnMap = crm.notion.columnMap ?? {}
+      const properties: Record<string, unknown> = {}
+      for (const [formField, columnName] of Object.entries(columnMap)) {
+        if (formField in values) {
+          properties[columnName] = values[formField]
+        }
+      }
+      if (crm.notion.staticProperties) {
+        Object.assign(properties, crm.notion.staticProperties)
+      }
+      notion = { databaseId: crm.notion.database_id, properties }
+      debug('Notion payload', { databaseId: crm.notion.database_id, properties })
+    }
+
+    const { errors } = await client.submitEvent({
       email,
       hubspotFields,
       context,
@@ -134,7 +153,8 @@ export async function submitFormAction(
         ? { ...(values as Record<string, unknown>), ...crm.customerio.staticProperties }
         : undefined,
       customerioProfile,
-    } as any)
+      notion,
+    })
 
     if (errors.length > 0) {
       debug(

--- a/packages/marketing/src/go/actions/submitForm.ts
+++ b/packages/marketing/src/go/actions/submitForm.ts
@@ -41,8 +41,8 @@ function buildCrmConfig(crm: GoFormCrmConfig): CRMConfig {
   }
 
   if (crm.notion) {
-    const notionApiKey = process.env.NOTION_API_KEY
-    if (!notionApiKey) throw new Error('NOTION_API_KEY env var is not set')
+    const notionApiKey = process.env.NOTION_FORMS_API_KEY
+    if (!notionApiKey) throw new Error('NOTION_FORMS_API_KEY env var is not set')
     config.notion = { apiKey: notionApiKey }
   }
 
@@ -55,7 +55,7 @@ function buildCrmConfig(crm: GoFormCrmConfig): CRMConfig {
  * Credentials are read from environment variables:
  *   - HubSpot:     HUBSPOT_PORTAL_ID
  *   - Customer.io: CUSTOMERIO_SITE_ID, CUSTOMERIO_API_KEY
- *   - Notion:      NOTION_API_KEY
+ *   - Notion:      NOTION_FORMS_API_KEY
  *
  * Per-form config (formGuid, event name, database_id, field mappings) lives in the page definition.
  */

--- a/packages/marketing/src/go/schemas.ts
+++ b/packages/marketing/src/go/schemas.ts
@@ -171,13 +171,35 @@ export const customerioFormConfigSchema = z.object({
   staticProperties: z.record(z.string(), z.unknown()).optional(),
 })
 
+export const notionFormConfigSchema = z.object({
+  /**
+   * Notion database ID to create a page in. The integration token is read
+   * from the NOTION_API_KEY env var and must have write access to the database.
+   */
+  database_id: z.string().min(1),
+  /**
+   * Map each form field `name` to a Notion database column name.
+   * Only fields listed here are sent. Property types (title, rich_text,
+   * email, etc.) are auto-detected from the database schema.
+   * Example: { email_address: 'email', first_name: 'first_name' }
+   */
+  columnMap: z.record(z.string(), z.string()).optional(),
+  /**
+   * Static properties merged into the Notion page. Keys must match column
+   * names in the target database.
+   * Example: { source: 'Website Go Page' }
+   */
+  staticProperties: z.record(z.string(), z.unknown()).optional(),
+})
+
 export const formCrmConfigSchema = z
   .object({
     hubspot: hubspotFormConfigSchema.optional(),
     customerio: customerioFormConfigSchema.optional(),
+    notion: notionFormConfigSchema.optional(),
   })
-  .refine((v) => v.hubspot || v.customerio, {
-    message: 'At least one CRM provider (hubspot or customerio) must be configured',
+  .refine((v) => v.hubspot || v.customerio || v.notion, {
+    message: 'At least one CRM provider (hubspot, customerio, or notion) must be configured',
   })
 
 export const formSectionSchema = z.object({
@@ -371,6 +393,7 @@ export type GoFormField = z.infer<typeof formFieldSchema>
 export type GoFormSection = z.infer<typeof formSectionSchema>
 export type GoHubSpotFormConfig = z.infer<typeof hubspotFormConfigSchema>
 export type GoCustomerIOFormConfig = z.infer<typeof customerioFormConfigSchema>
+export type GoNotionFormConfig = z.infer<typeof notionFormConfigSchema>
 export type GoFormCrmConfig = z.infer<typeof formCrmConfigSchema>
 export type GoFeatureGridItem = z.infer<typeof featureGridItemSchema>
 export type GoFeatureGridSection = z.infer<typeof featureGridSectionSchema>

--- a/packages/marketing/src/go/schemas.ts
+++ b/packages/marketing/src/go/schemas.ts
@@ -136,11 +136,24 @@ export const formFieldSchema = z.discriminatedUnion('type', [
 
 // ----- Form CRM config schemas -----
 
+/**
+ * Matches a 32-hex ID, optionally formatted as a dashed UUID. Used to validate
+ * ID-shaped values (HubSpot formGuid, Notion database_id) that are interpolated
+ * into outbound API URLs — the `crm` config travels over the server-action wire
+ * and must be treated as untrusted input.
+ */
+const uuidLikeIdSchema = z
+  .string()
+  .regex(
+    /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i,
+    'Must be a 32-character hex ID, optionally dashed (UUID format)'
+  )
+
 export const hubspotFormConfigSchema = z.object({
   /**
    * HubSpot form GUID. The portal ID is read from HUBSPOT_PORTAL_ID env var.
    */
-  formGuid: z.string().min(1),
+  formGuid: uuidLikeIdSchema,
   /**
    * Map each form field `name` to a HubSpot field name.
    * If omitted, the form field name is used as-is.
@@ -176,7 +189,7 @@ export const notionFormConfigSchema = z.object({
    * Notion database ID to create a page in. The integration token is read
    * from the NOTION_API_KEY env var and must have write access to the database.
    */
-  database_id: z.string().min(1),
+  database_id: uuidLikeIdSchema,
   /**
    * Map each form field `name` to a Notion database column name.
    * Only fields listed here are sent. Property types (title, rich_text,

--- a/packages/marketing/src/go/schemas.ts
+++ b/packages/marketing/src/go/schemas.ts
@@ -137,17 +137,15 @@ export const formFieldSchema = z.discriminatedUnion('type', [
 // ----- Form CRM config schemas -----
 
 /**
- * Matches a 32-hex ID, optionally formatted as a dashed UUID. Used to validate
- * ID-shaped values (HubSpot formGuid, Notion database_id) that are interpolated
- * into outbound API URLs — the `crm` config travels over the server-action wire
- * and must be treated as untrusted input.
+ * Matches a UUID or a bare 32-char hex ID (Notion's database IDs often come
+ * without dashes). Used for values interpolated into outbound API URLs — the
+ * `crm` config travels over the server-action wire and must be treated as
+ * untrusted input.
  */
-const uuidLikeIdSchema = z
-  .string()
-  .regex(
-    /^(?:[0-9a-f]{32}|[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i,
-    'Must be a 32-character hex ID, optionally dashed (UUID format)'
-  )
+const uuidLikeIdSchema = z.union([
+  z.string().uuid(),
+  z.string().regex(/^[0-9a-f]{32}$/i, 'Must be a 32-character hex ID'),
+])
 
 export const hubspotFormConfigSchema = z.object({
   /**

--- a/packages/marketing/src/go/schemas.ts
+++ b/packages/marketing/src/go/schemas.ts
@@ -185,7 +185,7 @@ export const customerioFormConfigSchema = z.object({
 export const notionFormConfigSchema = z.object({
   /**
    * Notion database ID to create a page in. The integration token is read
-   * from the NOTION_API_KEY env var and must have write access to the database.
+   * from the NOTION_FORMS_API_KEY env var and must have write access to the database.
    */
   database_id: uuidLikeIdSchema,
   /**


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

`/go` page form submissions can be routed to HubSpot and Customer.io, but there's no way to send the same data to a Notion database. Partnerships needs Notion as a third destination.

Relates to [DEBR-265](https://linear.app/supabase/issue/DEBR-265/notion-database-for-go-pages).

## What is the new behavior?

Adds a `notion` provider alongside `hubspot` and `customerio` in the form CRM config. Each page can now declare:

```ts
notion: {
  database_id: '21b5004b775f8058872fe8fa81e2c7ac',
  columnMap: { email_address: 'email', first_name: 'first_name' },
  staticProperties: { source: 'Website Go Page' },
}
```

A new `NotionClient` fetches the target database schema once per submission to auto-detect each column's property type (`title`, `rich_text`, `email`, `number`, `select`, etc.) so the config stays a plain string→string map. Unknown columns are silently skipped. The submit action reads `NOTION_API_KEY` from env and dispatches in parallel with the existing providers.

## Additional context

- New env var required on Vercel: `NOTION_API_KEY` (a Notion internal integration token with write access to the target database).
- Simplified `CRMConfig` from a discriminated-union-of-all-combinations to a plain object with optional providers; the "at least one provider" invariant still lives in the Zod schema refinement. This avoided a 2^3 - 1 = 7 member union and a generic `CRMClient<T>` whose call site was already casting to `any`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Notion as a CRM provider for form submissions with schema-backed mapping, validation, and automatic creation of Notion database pages.
  * Exposed a typed Notion form config for configuration and validation; example lead-gen form includes a Notion mapping.

* **Bug Fixes / Improvements**
  * Simplified CRM option handling and made submission behavior clearer.
  * HubSpot submissions now URI-encode identifiers to avoid endpoint errors.
  * Improved Notion request handling, caching, and error reporting; Notion sends in parallel when configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->