### PR TITLE
chore: default staging to AWS provider

### DIFF
--- a/apps/studio/lib/constants/infrastructure.ts
+++ b/apps/studio/lib/constants/infrastructure.ts
@@ -38,7 +38,7 @@ export const PRICING_TIER_PRODUCT_IDS = {
 export function useDefaultProvider() {
   const defaultProvider: CloudProvider =
     process.env.NEXT_PUBLIC_ENVIRONMENT &&
-    ['staging', 'preview'].includes(process.env.NEXT_PUBLIC_ENVIRONMENT)
+    ['preview'].includes(process.env.NEXT_PUBLIC_ENVIRONMENT)
       ? 'AWS_K8S'
       : 'AWS'
 

--- a/apps/studio/lib/constants/infrastructure.ts
+++ b/apps/studio/lib/constants/infrastructure.ts
@@ -1,4 +1,3 @@
-import type { CloudProvider } from 'shared-data'
 import { AWS_REGIONS, FLY_REGIONS } from 'shared-data'
 
 import type { components } from '@/data/api'
@@ -36,11 +35,7 @@ export const PRICING_TIER_PRODUCT_IDS = {
 }
 
 export function useDefaultProvider() {
-  const defaultProvider: CloudProvider =
-    process.env.NEXT_PUBLIC_ENVIRONMENT &&
-    ['preview'].includes(process.env.NEXT_PUBLIC_ENVIRONMENT)
-      ? 'AWS_K8S'
-      : 'AWS'
+  const defaultProvider = 'AWS'
 
   const { infraCloudProviders: validCloudProviders } = useCustomContent(['infra:cloud_providers'])
 
@@ -48,7 +43,7 @@ export function useDefaultProvider() {
     return defaultProvider
   }
 
-  return (validCloudProviders?.[0] ?? 'AWS') as CloudProvider
+  return validCloudProviders?.[0] ?? 'AWS'
 }
 
 export const PROVIDERS = {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

chore

## What is the current behavior?

New project dialog defaults to AWS Revamped provider on staging. 

## What is the new behavior?

New project dialog defaults to AWS provider on staging. 

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the default cloud provider to AWS across all environments (staging/preview included), ensuring consistent infrastructure selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->