### PR TITLE
fix(studio): escape SQL identifiers in policy create query

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyEditorPanel.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/PolicyEditorPanel.utils.ts
@@ -1,3 +1,4 @@
+import { ident } from '@supabase/pg-meta/src/pg-format'
 import type { PostgresPolicy } from '@supabase/postgres-meta'
 import { isEqual } from 'lodash'
 
@@ -65,7 +66,7 @@ export const generateCreatePolicyQuery = ({
   using?: string
   check?: string
 }) => {
-  const querySkeleton = `create policy "${name}" on "${schema}"."${table}" as ${behavior} for ${command} to ${roles}`
+  const querySkeleton = `create policy ${ident(name)} on ${ident(schema)}.${ident(table)} as ${behavior} for ${command} to ${roles}`
   const query =
     command === 'insert'
       ? `${querySkeleton} with check (${check});`


### PR DESCRIPTION
Closes #45179.

## Summary

`generateCreatePolicyQuery` in `PolicyEditorPanel.utils.ts` builds a `CREATE POLICY` statement with raw double-quote interpolation for name/schema/table, then executes it via `useExecuteSqlMutation` from `PolicyEditorPanel/index.tsx:192`. Any of those values containing a `\"` character breaks out of the identifier quoting in the executed statement.

Applies `ident()` to the three identifier interpolations. Same pattern as #44555 (queue), #44589 (index), #44721 (view autofix), #44723 (auth hooks). The helper is already used at `Policies.utils.ts:319`.

## Scope

The preview-only SQL in `Policies.utils.ts` (`createSQLStatementForCreatePolicy` / `createSQLStatementForUpdatePolicy`) has the same pattern but is not executed. That string is only rendered in the review modal while the mutation uses a structured payload. Tracking separately.

## Test plan

- [ ] Create a policy with a name containing a double quote. Verify it applies correctly with the fix (and produces broken SQL without).
- [ ] Create a policy on a table/schema name containing a double quote. Same check.
- [ ] Regression: create a plain-named policy. Works as before.