### PR TITLE
fix: clear tax ID fields on billing country change

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingCustomerData/BillingCustomerDataForm.tsx
@@ -5,7 +5,7 @@ import type {
   StripeAddressElementOptions,
 } from '@stripe/stripe-js'
 import { Check, ChevronsUpDown, Info, X } from 'lucide-react'
-import { useId, useMemo, useState } from 'react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import {
   Button,
@@ -86,6 +86,23 @@ export const BillingCustomerDataForm = ({
       (a, b) => a.country.localeCompare(b.country)
     )
   }, [addressCountry])
+
+  // Clear tax ID fields when the billing country changes so a stale tax ID
+  // from the previous country doesn't persist under the new one.
+  const prevCountryRef = useRef(addressCountry)
+  useEffect(() => {
+    if (!addressCountry) return
+
+    const isCountryChange =
+      prevCountryRef.current !== undefined && prevCountryRef.current !== addressCountry
+    prevCountryRef.current = addressCountry
+
+    if (isCountryChange) {
+      form.setValue('tax_id_type', '', { shouldDirty: true })
+      form.setValue('tax_id_value', '', { shouldDirty: true })
+      form.setValue('tax_id_name', '', { shouldDirty: true })
+    }
+  }, [addressCountry, form])
 
   return (
     <div className={cn('flex flex-col space-y-4', className)}>


### PR DESCRIPTION
### Summary

Mirrors the tax-ID-clearing behavior already present in `NewPaymentMethodElement` (used by `AddPaymentMethodForm`) over to `BillingCustomerDataForm`. When a user changes their billing country, the previously selected tax ID (type, value, name) is now cleared so a stale tax ID from the previous country doesn't silently persist under the new one.

### Test plan

- [x]  Open **Organization Settings → Billing → Billing Address** for an org with a saved billing address + tax ID
- [x]  Verify the saved tax ID is shown on initial load (not cleared)
- [x]  Change the country in the address element to a different country
- [x]  Verify the tax ID combobox resets to "Select tax ID" and the tax ID value input disappears
- [x]  Change the country back to the original country → tax ID still cleared (does not re-populate)
- [x]  Pick a new tax ID for the new country, enter a value, save → confirm it persists
- [x]  Reload the page → saved tax ID shows correctly and is not cleared on mount

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tax ID fields in organization billing settings are now automatically cleared when the billing address country is changed, preventing country-specific tax ID mismatches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->