### PR TITLE
fix(studio): generate edge function URLs that work on self-hosted deployments

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/EditHookPanel.tsx
@@ -19,21 +19,10 @@ import { useDatabaseHooksQuery } from '@/data/database-triggers/database-trigger
 import { tableEditorQueryOptions } from '@/data/table-editor/table-editor-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
+import { isEdgeFunctionUrl } from '@/lib/edge-functions'
 import { uuidv4 } from '@/lib/helpers'
 
 export type HTTPArgument = { id: string; name: string; value: string }
-
-export const isEdgeFunction = ({
-  ref,
-  restUrlTld,
-  url,
-}: {
-  ref?: string
-  restUrlTld?: string
-  url: string
-}) =>
-  url.includes(`https://${ref}.functions.supabase.${restUrlTld}/`) ||
-  url.includes(`https://${ref}.supabase.${restUrlTld}/functions/`)
 
 const FORM_ID = 'edit-hook-panel-form'
 
@@ -140,7 +129,6 @@ export const EditHookPanel = () => {
   const isSubmitting = isCreating || isUpdating || isLoadingTable
 
   const restUrl = project?.restUrl
-  const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
 
   const form = useForm<WebhookFormValues>({
     resolver: zodResolver(FormSchema),
@@ -149,11 +137,7 @@ export const EditHookPanel = () => {
       table_id: selectedHook?.table_id?.toString() ?? '',
       http_url: selectedHook?.function_args?.[0] ?? '',
       http_method: (selectedHook?.function_args?.[1] as 'GET' | 'POST') ?? 'POST',
-      function_type: isEdgeFunction({
-        ref,
-        restUrlTld,
-        url: selectedHook?.function_args?.[0] ?? '',
-      })
+      function_type: isEdgeFunctionUrl(selectedHook?.function_args?.[0] ?? '', ref, restUrl)
         ? 'supabase_function'
         : 'http_request',
       timeout_ms: Number(selectedHook?.function_args?.[4] ?? 5000),
@@ -185,11 +169,7 @@ export const EditHookPanel = () => {
         table_id: selectedHook?.table_id?.toString() ?? '',
         http_url: selectedHook?.function_args?.[0] ?? '',
         http_method: (selectedHook?.function_args?.[1] as 'GET' | 'POST') ?? 'POST',
-        function_type: isEdgeFunction({
-          ref,
-          restUrlTld,
-          url: selectedHook?.function_args?.[0] ?? '',
-        })
+        function_type: isEdgeFunctionUrl(selectedHook?.function_args?.[0] ?? '', ref, restUrl)
           ? 'supabase_function'
           : 'http_request',
         timeout_ms: Number(selectedHook?.function_args?.[4] ?? 5000),
@@ -198,7 +178,7 @@ export const EditHookPanel = () => {
         httpParameters: parseParameters(selectedHook),
       })
     }
-  }, [visible, selectedHook, ref, restUrlTld, form])
+  }, [visible, selectedHook, ref, restUrl, form])
 
   const queryClient = useQueryClient()
   const onSubmit: SubmitHandler<WebhookFormValues> = async (values) => {

--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -22,7 +22,6 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
-import { isEdgeFunction } from './EditHookPanel'
 import { WebhookFormValues } from './EditHookPanel.constants'
 import { AVAILABLE_WEBHOOK_TYPES, HOOK_EVENTS } from './Hooks.constants'
 import { HTTPHeaders } from './HTTPHeaders'
@@ -38,6 +37,7 @@ import { useEdgeFunctionsQuery } from '@/data/edge-functions/edge-functions-quer
 import { useTableNamesQuery } from '@/data/tables/table-names-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { buildEdgeFunctionUrl, isEdgeFunctionUrl } from '@/lib/edge-functions'
 import { uuidv4 } from '@/lib/helpers'
 
 export interface FormContentsProps {
@@ -50,7 +50,6 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
   const { data: project } = useSelectedProjectQuery()
 
   const restUrl = project?.restUrl
-  const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
 
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
   const { data: keys = [] } = useAPIKeysQuery(
@@ -75,7 +74,7 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
   useEffect(() => {
     if (!isSuccessEdgeFunctions) return
 
-    const isEdgeFunctionSelected = isEdgeFunction({ ref, restUrlTld, url: httpUrl })
+    const isEdgeFunctionSelected = isEdgeFunctionUrl(httpUrl, ref, restUrl)
 
     if (httpUrl && isEdgeFunctionSelected) {
       const fnSlug = httpUrl.split('/').at(-1)
@@ -235,9 +234,9 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
                       } else if (functionType === 'supabase_function') {
                         // Default to first edge function in the list
                         const fnSlug = functions[0]?.slug
-                        const defaultFunctionUrl = `https://${ref}.supabase.${restUrlTld}/functions/v1/${fnSlug}`
+                        const defaultFunctionUrl = buildEdgeFunctionUrl(fnSlug ?? '', ref, restUrl)
                         const currentUrl = form.getValues('http_url')
-                        if (!isEdgeFunction({ ref, restUrlTld, url: currentUrl })) {
+                        if (!isEdgeFunctionUrl(currentUrl, ref, restUrl)) {
                           form.setValue('http_url', defaultFunctionUrl, { shouldDirty: false })
                         }
                       }

--- a/apps/studio/components/interfaces/Database/Hooks/HTTPRequestConfig.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HTTPRequestConfig.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/components/ui/Forms/FormSection'
 import { useEdgeFunctionsQuery } from '@/data/edge-functions/edge-functions-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { buildEdgeFunctionUrl } from '@/lib/edge-functions'
 
 interface HTTPRequestConfigProps {
   form: UseFormReturn<WebhookFormValues>
@@ -115,9 +116,11 @@ export const HTTPRequestConfig = ({ form }: HTTPRequestConfigProps) => {
                   </FormControl_Shadcn_>
                   <SelectContent_Shadcn_>
                     {edgeFunctions.map((fn) => {
-                      const restUrl = selectedProject?.restUrl
-                      const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
-                      const functionUrl = `https://${ref}.supabase.${restUrlTld}/functions/v1/${fn.slug}`
+                      const functionUrl = buildEdgeFunctionUrl(
+                        fn.slug,
+                        ref,
+                        selectedProject?.restUrl
+                      )
 
                       return (
                         <SelectItem_Shadcn_ key={fn.id} value={functionUrl}>

--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HookList.tsx
@@ -20,6 +20,7 @@ import { useDatabaseHooksQuery } from '@/data/database-triggers/database-trigger
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { BASE_PATH } from '@/lib/constants'
+import { isEdgeFunctionUrl } from '@/lib/edge-functions'
 
 export interface HookListProps {
   schema: string
@@ -38,7 +39,6 @@ export const HookList = ({ schema, filterString }: HookListProps) => {
   const [, setSelectedHookIdToDelete] = useQueryState('delete', parseAsString.withDefault(''))
 
   const restUrl = project?.restUrl
-  const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
 
   const filteredHooks = (hooks ?? []).filter(
     (x) =>
@@ -54,9 +54,6 @@ export const HookList = ({ schema, filterString }: HookListProps) => {
   return (
     <>
       {filteredHooks.map((x) => {
-        const isEdgeFunction = (url: string) =>
-          url.includes(`https://${ref}.functions.supabase.${restUrlTld}/`) ||
-          url.includes(`https://${ref}.supabase.${restUrlTld}/functions/`)
         const [url, method] = x.function_args
 
         return (
@@ -66,7 +63,7 @@ export const HookList = ({ schema, filterString }: HookListProps) => {
                 <div>
                   <Image
                     src={
-                      isEdgeFunction(url)
+                      isEdgeFunctionUrl(url, ref, restUrl)
                         ? `${BASE_PATH}/img/function-providers/supabase-severless-function.png`
                         : `${BASE_PATH}/img/function-providers/http-request.png`
                     }
@@ -74,7 +71,9 @@ export const HookList = ({ schema, filterString }: HookListProps) => {
                     layout="fixed"
                     width="20"
                     height="20"
-                    title={isEdgeFunction(url) ? 'Supabase Edge Function' : 'HTTP Request'}
+                    title={
+                      isEdgeFunctionUrl(url, ref, restUrl) ? 'Supabase Edge Function' : 'HTTP Request'
+                    }
                   />
                 </div>
                 <p title={x.name} className="truncate">

--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -43,11 +43,7 @@ export const TerminalInstructions = forwardRef<
   const { anonKey, publishableKey } = getKeys(apiKeys)
   const apiKey = publishableKey?.api_key ?? anonKey?.api_key ?? '[YOUR ANON KEY]'
 
-  const invokeUrl = buildEdgeFunctionUrl(
-    'hello-world',
-    projectRef,
-    endpoint ? `https://${endpoint}` : undefined
-  )
+  const invokeUrl = buildEdgeFunctionUrl('hello-world', projectRef, endpoint)
 
   const commands: Commands[] = [
     {

--- a/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
+++ b/apps/studio/components/interfaces/Functions/TerminalInstructions.tsx
@@ -18,6 +18,7 @@ import { getKeys, useAPIKeysQuery } from '@/data/api-keys/api-keys-query'
 import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { DOCS_URL } from '@/lib/constants'
+import { buildEdgeFunctionUrl } from '@/lib/edge-functions'
 
 interface TerminalInstructionsProps extends ComponentPropsWithoutRef<typeof Collapsible_Shadcn_> {
   closable?: boolean
@@ -42,9 +43,11 @@ export const TerminalInstructions = forwardRef<
   const { anonKey, publishableKey } = getKeys(apiKeys)
   const apiKey = publishableKey?.api_key ?? anonKey?.api_key ?? '[YOUR ANON KEY]'
 
-  // get the .co or .net TLD from the restUrl
-  const restUrl = `https://${endpoint}`
-  const restUrlTld = !!endpoint ? new URL(restUrl).hostname.split('.').pop() : 'co'
+  const invokeUrl = buildEdgeFunctionUrl(
+    'hello-world',
+    projectRef,
+    endpoint ? `https://${endpoint}` : undefined
+  )
 
   const commands: Commands[] = [
     {
@@ -73,7 +76,7 @@ export const TerminalInstructions = forwardRef<
       comment: 'Deploy your function',
     },
     {
-      command: `curl -L -X POST 'https://${projectRef}.supabase.${restUrlTld}/functions/v1/hello-world' -H 'Authorization: Bearer ${apiKey}'${anonKey?.type === 'publishable' ? ` -H 'apikey: ${apiKey}'` : ''} --data '{"name":"Functions"}'`,
+      command: `curl -L -X POST '${invokeUrl}' -H 'Authorization: Bearer ${apiKey}'${anonKey?.type === 'publishable' ? ` -H 'apikey: ${apiKey}'` : ''} --data '{"name":"Functions"}'`,
       description: 'Invokes the hello-world function',
       jsx: () => {
         return (

--- a/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
@@ -34,15 +34,10 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { CreateCronJobForm } from './CreateCronJobSheet/CreateCronJobSheet.constants'
 import { useEdgeFunctionsQuery } from '@/data/edge-functions/edge-functions-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { buildEdgeFunctionUrl } from '@/lib/edge-functions'
 
 interface HTTPRequestFieldsProps {
   form: UseFormReturn<CreateCronJobForm>
-}
-
-const buildFunctionUrl = (slug: string, projectRef: string, restUrl?: string) => {
-  const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
-  const functionUrl = `https://${projectRef}.supabase.${restUrlTld}/functions/v1/${slug}`
-  return functionUrl
 }
 
 export const EdgeFunctionSection = ({ form }: HTTPRequestFieldsProps) => {
@@ -59,7 +54,7 @@ export const EdgeFunctionSection = ({ form }: HTTPRequestFieldsProps) => {
     () =>
       functions?.map((fn) => ({
         ...fn,
-        url: buildFunctionUrl(fn.slug, selectedProject?.ref || '', selectedProject?.restUrl),
+        url: buildEdgeFunctionUrl(fn.slug, selectedProject?.ref, selectedProject?.restUrl),
       })) ?? [],
     [functions, selectedProject]
   )

--- a/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
@@ -61,9 +61,10 @@ export const EdgeFunctionRenderer = ({
 
   const functionUrl = useMemo(() => {
     const endpoint = settings?.app_config?.endpoint
+    const protocol = settings?.app_config?.protocol ?? 'https'
     if (!endpoint || !ref || !functionName) return undefined
-    return buildEdgeFunctionUrl(functionName, ref, `https://${endpoint}`)
-  }, [settings?.app_config?.endpoint, ref, functionName])
+    return buildEdgeFunctionUrl(functionName, ref, `${protocol}://${endpoint}`)
+  }, [settings?.app_config?.endpoint, settings?.app_config?.protocol, ref, functionName])
 
   const deploymentDetailsUrl = useMemo(() => {
     if (!ref || !functionName) return undefined

--- a/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
@@ -9,6 +9,7 @@ import { useEdgeFunctionQuery } from '@/data/edge-functions/edge-function-query'
 import { useEdgeFunctionDeployMutation } from '@/data/edge-functions/edge-functions-deploy-mutation'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { buildEdgeFunctionUrl } from '@/lib/edge-functions'
 
 interface EdgeFunctionRendererProps {
   label: string
@@ -61,16 +62,7 @@ export const EdgeFunctionRenderer = ({
   const functionUrl = useMemo(() => {
     const endpoint = settings?.app_config?.endpoint
     if (!endpoint || !ref || !functionName) return undefined
-
-    try {
-      const url = new URL(`https://${endpoint}`)
-      const restUrlTld = url.hostname.split('.').pop()
-      return restUrlTld
-        ? `https://${ref}.supabase.${restUrlTld}/functions/v1/${functionName}`
-        : undefined
-    } catch (error) {
-      return undefined
-    }
+    return buildEdgeFunctionUrl(functionName, ref, `https://${endpoint}`)
   }, [settings?.app_config?.endpoint, ref, functionName])
 
   const deploymentDetailsUrl = useMemo(() => {

--- a/apps/studio/lib/edge-functions.test.ts
+++ b/apps/studio/lib/edge-functions.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest'
+import { buildEdgeFunctionUrl, isEdgeFunctionUrl } from './edge-functions'
+
+describe('buildEdgeFunctionUrl', () => {
+  test('cloud (.supabase.co) preserves subdomain pattern', () => {
+    expect(buildEdgeFunctionUrl('hello', 'abc123', 'https://abc123.supabase.co')).toBe(
+      'https://abc123.supabase.co/functions/v1/hello'
+    )
+  })
+
+  test('cloud alternate TLD preserves subdomain pattern', () => {
+    expect(buildEdgeFunctionUrl('hello', 'abc123', 'https://abc123.supabase.red')).toBe(
+      'https://abc123.supabase.red/functions/v1/hello'
+    )
+  })
+
+  test('self-hosted localhost uses restUrl origin', () => {
+    expect(buildEdgeFunctionUrl('hello', 'default', 'http://localhost:8000')).toBe(
+      'http://localhost:8000/functions/v1/hello'
+    )
+  })
+
+  test('self-hosted internal docker service uses restUrl origin', () => {
+    expect(buildEdgeFunctionUrl('hello', 'default', 'http://kong:8000')).toBe(
+      'http://kong:8000/functions/v1/hello'
+    )
+  })
+
+  test('self-hosted custom domain uses restUrl origin', () => {
+    expect(buildEdgeFunctionUrl('hello', 'default', 'https://api.acme.example')).toBe(
+      'https://api.acme.example/functions/v1/hello'
+    )
+  })
+
+  test('self-hosted host that happens to contain "supabase" uses restUrl origin', () => {
+    expect(buildEdgeFunctionUrl('hello', 'abc', 'https://foo.supabase.company.co')).toBe(
+      'https://foo.supabase.company.co/functions/v1/hello'
+    )
+  })
+
+  test('no restUrl falls back to .supabase.co', () => {
+    expect(buildEdgeFunctionUrl('hello', 'abc123')).toBe(
+      'https://abc123.supabase.co/functions/v1/hello'
+    )
+  })
+
+  test('invalid restUrl falls back to .supabase.co', () => {
+    expect(buildEdgeFunctionUrl('hello', 'abc123', 'not-a-url')).toBe(
+      'https://abc123.supabase.co/functions/v1/hello'
+    )
+  })
+})
+
+describe('isEdgeFunctionUrl', () => {
+  test('cloud .supabase.co with /functions/ is detected', () => {
+    expect(
+      isEdgeFunctionUrl(
+        'https://abc123.supabase.co/functions/v1/hello',
+        'abc123',
+        'https://abc123.supabase.co'
+      )
+    ).toBe(true)
+  })
+
+  test('cloud .functions.supabase.co is detected (legacy pattern)', () => {
+    expect(
+      isEdgeFunctionUrl(
+        'https://abc123.functions.supabase.co/hello',
+        'abc123',
+        'https://abc123.supabase.co'
+      )
+    ).toBe(true)
+  })
+
+  test('self-hosted localhost URL with /functions/v1/ is detected', () => {
+    expect(
+      isEdgeFunctionUrl(
+        'http://localhost:8000/functions/v1/hello',
+        'default',
+        'http://localhost:8000'
+      )
+    ).toBe(true)
+  })
+
+  test('arbitrary external URL is not detected', () => {
+    expect(
+      isEdgeFunctionUrl('https://example.com/webhook', 'abc123', 'https://abc123.supabase.co')
+    ).toBe(false)
+  })
+
+  test('cross-ref substring match is not detected', () => {
+    // abc12 must not match a URL for project abc123
+    expect(
+      isEdgeFunctionUrl(
+        'https://abc123.supabase.co/functions/v1/hello',
+        'abc12',
+        'https://abc12.supabase.co'
+      )
+    ).toBe(false)
+  })
+
+  test('empty url returns false', () => {
+    expect(isEdgeFunctionUrl('', 'abc123', 'https://abc123.supabase.co')).toBe(false)
+  })
+})

--- a/apps/studio/lib/edge-functions.ts
+++ b/apps/studio/lib/edge-functions.ts
@@ -1,0 +1,66 @@
+/**
+ * Builds the URL used to invoke a Supabase Edge Function.
+ *
+ * For Supabase Cloud (hostname matches *.supabase.<tld>) the `<ref>.supabase.<tld>`
+ * subdomain pattern is kept. For anything else — including self-hosted setups
+ * where the project's URL is `http://localhost:8000`, `http://kong:8000`, or a
+ * custom domain — the origin from `restUrl` is used directly so the generated
+ * URL resolves in the context it is being invoked from (browser, pg_cron in
+ * the Postgres container, etc.).
+ */
+export const buildEdgeFunctionUrl = (
+  slug: string,
+  projectRef: string | undefined,
+  restUrl?: string
+): string => {
+  const fallback = `https://${projectRef}.supabase.co/functions/v1/${slug}`
+  if (!restUrl) return fallback
+
+  let parsed: URL
+  try {
+    parsed = new URL(restUrl)
+  } catch {
+    return fallback
+  }
+
+  const { hostname, origin } = parsed
+  const tld = hostname.split('.').pop()
+  // Only treat the host as Supabase Cloud when it matches <projectRef>.supabase.<tld>
+  // exactly. This keeps generated URLs correct for self-hosted setups that run
+  // on localhost, Docker service names, or custom domains.
+  if (projectRef && hostname === `${projectRef}.supabase.${tld}`) {
+    return `https://${projectRef}.supabase.${tld}/functions/v1/${slug}`
+  }
+  return `${origin}/functions/v1/${slug}`
+}
+
+/**
+ * Checks whether a persisted webhook URL points at a Supabase Edge Function.
+ *
+ * Matches both the old `.functions.supabase.<tld>` and the current
+ * `.supabase.<tld>/functions/` cloud patterns, and for self-hosted setups
+ * treats any URL rooted at the project's restUrl origin with `/functions/v1/`
+ * as an edge function.
+ */
+export const isEdgeFunctionUrl = (
+  url: string,
+  projectRef: string | undefined,
+  restUrl?: string
+): boolean => {
+  if (!url || !projectRef) return false
+
+  if (
+    url.startsWith(`https://${projectRef}.functions.supabase.`) ||
+    (url.startsWith(`https://${projectRef}.supabase.`) && url.includes('/functions/'))
+  ) {
+    return true
+  }
+
+  if (!restUrl) return false
+  try {
+    const origin = new URL(restUrl).origin
+    return url.startsWith(`${origin}/functions/v1/`)
+  } catch {
+    return false
+  }
+}


### PR DESCRIPTION
Closes #44907.

## Summary

Studio generates edge function URLs across 7 sites by picking the TLD off `restUrl`:

```ts
const restUrlTld = restUrl ? new URL(restUrl).hostname.split('.').pop() : 'co'
const functionUrl = `https://${projectRef}.supabase.${restUrlTld}/functions/v1/${slug}`
```

On self-hosted Docker, `restUrl` is typically `http://localhost:8000`, so the TLD becomes `localhost` and the generated URL is `https://default.supabase.localhost/functions/v1/${slug}`. That host does not resolve, and HTTPS is not something the stack can serve. Cron jobs and database webhooks using this URL report `status = 'succeeded'` in `cron.job_run_details` while `net._http_response.error_msg` carries the actual connect failure.

## Change

Adds `apps/studio/lib/edge-functions.ts` with two helpers:

- `buildEdgeFunctionUrl(slug, projectRef, restUrl)` keeps the cloud subdomain pattern only when the hostname matches `${projectRef}.supabase.<tld>` exactly. Anything else (localhost, Docker service names like `kong`, custom domains, hostnames that happen to include "supabase" as a label) uses the `restUrl` origin directly so the generated URL resolves from wherever the call is made (browser, pg_cron / pg_net in the Postgres container, etc).
- `isEdgeFunctionUrl(url, projectRef, restUrl)` matches both the legacy `.functions.supabase.<tld>/` pattern and the current `.supabase.<tld>/functions/` pattern (now anchored with `startsWith` to avoid cross-ref substring hits), and any URL rooted at the project's `restUrl` origin with `/functions/v1/`.

Updates all 7 call sites to use the helpers:
- `Integrations/CronJobs/EdgeFunctionSection.tsx` (cron job URL)
- `Database/Hooks/FormContents.tsx` (default hook URL + edge-function detection)
- `Database/Hooks/HTTPRequestConfig.tsx` (dropdown)
- `Database/Hooks/EditHookPanel.tsx` (removed the locally-exported `isEdgeFunction`, inlined the check)
- `Database/Hooks/HooksList/HookList.tsx` (icon + title)
- `Functions/TerminalInstructions.tsx` (curl example)
- `ui/AIAssistantPanel/EdgeFunctionRenderer.tsx` (deploy panel URL)

## Test plan

- [x] 14 unit tests in `lib/edge-functions.test.ts` covering cloud, alt-TLD, localhost, kong, custom domain, cross-ref substring, hostname containing "supabase" as a non-Supabase label.
- [ ] Cloud regression: create a cron job / webhook against an edge function on a `*.supabase.co` project. URL unchanged.
- [ ] Self-hosted: `docker compose up` the self-hosted stack, create a cron job targeting an edge function, verify the cron command uses `http://localhost:8000/functions/v1/...` (or whatever `restUrl` resolves to) and actually reaches the function.