### PR TITLE
fix(ui): restore AiIconAnimation loading spin after framer-motion upgrade

### DIFF
--- a/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
+++ b/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
@@ -43,17 +43,17 @@ const AiIconAnimationComponent = ({
     y.set(mouseY / 5)
   }
 
-  const outerVariants = {
-    rest: { rotate: 0 },
-    loading: { rotate: [0, 360] },
-    hover: { rotate: 10 },
-  }
+  const outerAnimate = loading ? { rotate: [0, 360] } : { rotate: isHovering ? 10 : 0 }
 
-  const innerVariants = {
-    rest: { scale: 1, x: 0, y: 0 },
-    loading: { scale: [1, 1.1, 1], x: 0, y: 0 },
-    hover: { scale: 1.1 },
-  }
+  const outerTransition = loading
+    ? { duration: 2, repeat: Infinity, ease: 'linear' as const, repeatType: 'loop' as const }
+    : { type: 'spring' as const, stiffness: 300, damping: 30 }
+
+  const innerAnimate = loading ? { scale: [1, 1.1, 1] } : { scale: isHovering ? 1.1 : 1 }
+
+  const innerTransition = loading
+    ? { duration: 2, repeat: Infinity, ease: 'easeInOut' as const, repeatType: 'loop' as const }
+    : { type: 'spring' as const, stiffness: 300, damping: 30 }
 
   return (
     <div
@@ -92,14 +92,10 @@ const AiIconAnimationComponent = ({
           fill="none"
           stroke="currentColor"
           strokeWidth={strokeWidth}
-          initial="rest"
-          animate={loading ? 'loading' : isHovering ? 'hover' : 'rest'}
-          variants={outerVariants}
-          transition={{
-            duration: 2,
-            repeat: loading ? Infinity : 0,
-            ease: 'linear',
-          }}
+          initial={{ rotate: 0 }}
+          animate={outerAnimate}
+          transition={outerTransition}
+          style={{ transformBox: 'fill-box', transformOrigin: 'center' }}
         />
         <motion.path
           fillRule="evenodd"
@@ -108,15 +104,15 @@ const AiIconAnimationComponent = ({
           fill="none"
           stroke="currentColor"
           strokeWidth={strokeWidth}
-          initial="rest"
-          variants={innerVariants}
-          animate={isHovering ? 'hover' : loading ? 'loading' : 'rest'}
-          style={{ x: springX, y: springY }}
-          transition={{
-            duration: 2,
-            repeat: loading ? Infinity : 0,
-            ease: 'easeInOut',
+          initial={{ scale: 1 }}
+          animate={innerAnimate}
+          style={{
+            x: springX,
+            y: springY,
+            transformBox: 'fill-box',
+            transformOrigin: 'center',
           }}
+          transition={innerTransition}
         />
       </motion.svg>
     </div>

--- a/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
+++ b/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
@@ -45,7 +45,7 @@ const AiIconAnimationComponent = ({
 
   const outerVariants = {
     rest: { rotate: 0 },
-    loading: { rotate: 360 },
+    loading: { rotate: [0, 360] },
     hover: { rotate: 10 },
   }
 
@@ -92,6 +92,7 @@ const AiIconAnimationComponent = ({
           fill="none"
           stroke="currentColor"
           strokeWidth={strokeWidth}
+          initial="rest"
           animate={loading ? 'loading' : isHovering ? 'hover' : 'rest'}
           variants={outerVariants}
           transition={{
@@ -107,6 +108,7 @@ const AiIconAnimationComponent = ({
           fill="none"
           stroke="currentColor"
           strokeWidth={strokeWidth}
+          initial="rest"
           variants={innerVariants}
           animate={isHovering ? 'hover' : loading ? 'loading' : 'rest'}
           style={{ x: springX, y: springY }}

--- a/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
+++ b/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
@@ -101,7 +101,7 @@ const AiIconAnimationComponent = ({
           initial={{ rotate: 0 }}
           animate={outerAnimate}
           transition={outerTransition}
-          style={{ transformBox: 'fill-box', transformOrigin: 'center' }}
+          style={{ transformBox: 'view-box', transformOrigin: 'center' }}
         />
         <motion.path
           fillRule="evenodd"
@@ -115,7 +115,7 @@ const AiIconAnimationComponent = ({
           style={{
             x: springX,
             y: springY,
-            transformBox: 'fill-box',
+            transformBox: 'view-box',
             transformOrigin: 'center',
           }}
           transition={innerTransition}

--- a/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
+++ b/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
@@ -43,10 +43,16 @@ const AiIconAnimationComponent = ({
     y.set(mouseY / 5)
   }
 
-  const outerAnimate = loading ? { rotate: [0, 360] } : { rotate: isHovering ? 10 : 0 }
+  const outerAnimate = loading ? { rotate: 360 } : { rotate: isHovering ? 10 : 0 }
 
   const outerTransition = loading
-    ? { duration: 2, repeat: Infinity, ease: 'linear' as const, repeatType: 'loop' as const }
+    ? {
+        type: 'spring' as const,
+        stiffness: 60,
+        damping: 10,
+        repeat: Infinity,
+        repeatType: 'loop' as const,
+      }
     : { type: 'spring' as const, stiffness: 300, damping: 30 }
 
   const innerAnimate = loading ? { scale: [1, 1.1, 1] } : { scale: isHovering ? 1.1 : 1 }

--- a/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
+++ b/packages/ui/src/layout/ai-icon-animation/ai-icon-animation.tsx
@@ -97,10 +97,7 @@ const AiIconAnimationComponent = ({
           transition={{
             duration: 2,
             repeat: loading ? Infinity : 0,
-            ease: 'circInOut',
-            type: 'spring',
-            stiffness: 60,
-            damping: 10,
+            ease: 'linear',
           }}
         />
         <motion.path


### PR DESCRIPTION
## Problem

The AI icon in the new filter bar renders but no longer animates when an AI filter is generating. This regressed after #44906 upgraded `framer-motion` from `^11.0.3` to `^11.18.2`.

## Cause

The outer rotation transition in `AiIconAnimation` mixed tween props (`duration`, `ease`) with spring physics (`type: 'spring'`, `stiffness`, `damping`):

```tsx
transition={{
  duration: 2,
  repeat: loading ? Infinity : 0,
  ease: 'circInOut',
  type: 'spring',
  stiffness: 60,
  damping: 10,
}}
```

`framer-motion@11.0.3` tolerated this combination and produced a continuous rotation. `11.18.x` resolves it strictly as a physics spring — `duration`/`ease` are dropped, the spring settles at 360°, and `repeat: Infinity` no longer produces a visible continuous spin. The icon ends up looking static.

## Fix

Drop the spring config and keep a simple linear repeating tween — the original intent was a continuous rotation loader, not a bouncy settle.

## Test plan

- [x] Open a table in the Table Editor, type an AI prompt into the filter bar, submit it, and confirm the icon rotates continuously while the mutation is pending.
- [x] Confirm the inner circle's scale pulse is still present and synced.
- [x] Confirm no regressions in other usages of `AiIconAnimation` (e.g. AI Assistant).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined AI icon animation: continuous rotation during loading, subtle pulsing (scale) while loading, and enhanced hover interactions with gentle rotation and scale.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->