### PR TITLE
fix(studio): example to deter users from inputting the wrong working directory

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -582,12 +582,24 @@ export const GitHubIntegrationConnectionForm = ({
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Working directory"
-                          description="Path to working directory with your supabase folder"
+                          description={
+                            <>
+                              <span>
+                                Relative path to the directory that contains your <code>supabase</code>{' '}
+                                folder (not the <code>supabase</code> folder itself).
+                              </span>
+                              <span className="mt-1 block">
+                                For example, enter <code>.</code> if <code>supabase/</code> is at the
+                                repository root, or a path like <code>apps/web</code> if your layout
+                                is <code>apps/web/supabase/</code>.
+                              </span>
+                            </>
+                          }
                         >
                           <FormControl_Shadcn_>
                             <Input_Shadcn_
                               {...field}
-                              placeholder="supabase"
+                              placeholder="."
                               autoComplete="off"
                               disabled={!canUpdateGitHubConnection}
                             />

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -30,6 +30,7 @@ import {
 import { Admonition } from 'ui-patterns/admonition'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
 import * as z from 'zod'
 
 import { InlineLink } from '@/components/ui/InlineLink'
@@ -583,18 +584,29 @@ export const GitHubIntegrationConnectionForm = ({
                           layout="flex-row-reverse"
                           label="Working directory"
                           description={
-                            <>
-                              <span>
-                                Relative path to the directory that contains your{' '}
-                                <code>supabase</code> folder (not the <code>supabase</code> folder
-                                itself).
+                            <span>
+                              Relative path to the directory that contains your{' '}
+                              <code className="text-code-inline !break-keep">supabase</code> folder{' '}
+                              <span className="inline-flex align-middle [&>button]:ml-1 [&>button]:-translate-y-[2px]">
+                                <InfoTooltip side="bottom" className="w-72">
+                                  <p>Examples:</p>
+                                  <ul className="list-disc pl-4 space-y-1">
+                                    <li>
+                                      <code className="text-code-inline">.</code> if repository root
+                                      contains <code className="text-code-inline">supabase/</code>
+                                    </li>
+                                    <li>
+                                      <code className="text-code-inline">apps/web</code> if{' '}
+                                      <code className="text-code-inline">supabase/</code> is nested
+                                      at{' '}
+                                      <code className="text-code-inline !break-keep">
+                                        apps/web/supabase/
+                                      </code>
+                                    </li>
+                                  </ul>
+                                </InfoTooltip>
                               </span>
-                              <span className="mt-1 block">
-                                For example, enter <code>.</code> if <code>supabase/</code> is at
-                                the repository root, or a path like <code>apps/web</code> if your
-                                layout is <code>apps/web/supabase/</code>.
-                              </span>
-                            </>
+                            </span>
                           }
                         >
                           <FormControl_Shadcn_>

--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -585,13 +585,14 @@ export const GitHubIntegrationConnectionForm = ({
                           description={
                             <>
                               <span>
-                                Relative path to the directory that contains your <code>supabase</code>{' '}
-                                folder (not the <code>supabase</code> folder itself).
+                                Relative path to the directory that contains your{' '}
+                                <code>supabase</code> folder (not the <code>supabase</code> folder
+                                itself).
                               </span>
                               <span className="mt-1 block">
-                                For example, enter <code>.</code> if <code>supabase/</code> is at the
-                                repository root, or a path like <code>apps/web</code> if your layout
-                                is <code>apps/web/supabase/</code>.
+                                For example, enter <code>.</code> if <code>supabase/</code> is at
+                                the repository root, or a path like <code>apps/web</code> if your
+                                layout is <code>apps/web/supabase/</code>.
                               </span>
                             </>
                           }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Wording change

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Just provides an example of what to include
## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified the "Working directory" guidance in GitHub Integration settings: must be a relative path to the directory that contains the supabase/ folder (not the supabase folder itself). Added an example-driven tooltip and updated the placeholder to "." to reflect the expected format and reduce confusion. This improves clarity and prevents setup errors for repository-based workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->