### PR TITLE
fix(envoy): only accept asymmetric api keys when sb translation is enabled

### DIFF
--- a/docker/volumes/api/envoy/lds.template.yaml
+++ b/docker/volumes/api/envoy/lds.template.yaml
@@ -867,8 +867,11 @@ resources:
                     inline_code: |
                       local ANON_KEY = "${ANON_KEY}"
                       local SERVICE_ROLE_KEY = "${SERVICE_ROLE_KEY}"
+                      local SUPABASE_PUBLISHABLE_KEY = "${SUPABASE_PUBLISHABLE_KEY}"
+                      local SUPABASE_SECRET_KEY = "${SUPABASE_SECRET_KEY}"
                       local ANON_KEY_ASYMMETRIC = "${ANON_KEY_ASYMMETRIC}"
                       local SERVICE_ROLE_KEY_ASYMMETRIC = "${SERVICE_ROLE_KEY_ASYMMETRIC}"
+                      local TRANSLATION_ENABLED = SUPABASE_SECRET_KEY ~= "" and SUPABASE_PUBLISHABLE_KEY ~= "" and SERVICE_ROLE_KEY_ASYMMETRIC ~= "" and ANON_KEY_ASYMMETRIC ~= ""
 
                       local PROTECTED_ROUTES = {
                         ["auth-v1-protected"] = true,
@@ -900,11 +903,11 @@ resources:
                           return true
                         end
 
-                        if SERVICE_ROLE_KEY_ASYMMETRIC ~= "" and apikey == SERVICE_ROLE_KEY_ASYMMETRIC then
+                        if TRANSLATION_ENABLED and apikey == SERVICE_ROLE_KEY_ASYMMETRIC then
                           return true
                         end
 
-                        if ANON_KEY_ASYMMETRIC ~= "" and apikey == ANON_KEY_ASYMMETRIC then
+                        if TRANSLATION_ENABLED and apikey == ANON_KEY_ASYMMETRIC then
                           return true
                         end
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES
## What kind of change does this PR introduce?
Bug fix (Envoy API key validation behavior)
## What is the current behavior?
When `SUPABASE_PUBLISHABLE_KEY` / `SUPABASE_SECRET_KEY` are not configured (translation mode disabled), requests can still pass API key validation using `ANON_KEY_ASYMMETRIC` or `SERVICE_ROLE_KEY_ASYMMETRIC` if those values are set.
This allows asymmetric internal JWTs to be accepted directly as API keys outside the intended `sb_* -> internal JWT` translation flow.
## What is the new behavior?
Asymmetric keys are now accepted by the `401` API key validation filter **only when translation mode is enabled** (all required translation env vars are present).
- If translation is disabled, only legacy keys are accepted by that filter.
- If translation is enabled, behavior remains the same for translated asymmetric values.
## Additional context
This is a minimal, low-risk fix in `docker/volumes/api/envoy/lds.template.yaml`:
- Added `TRANSLATION_ENABLED` check in the API key validation Lua filter.
- Gated acceptance of `ANON_KEY_ASYMMETRIC` and `SERVICE_ROLE_KEY_ASYMMETRIC` behind that condition.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced authorization validation to ensure asymmetric key-based authentication requires proper Supabase configuration to be enabled. Requests using these authentication methods without the required configuration will now correctly return a 401 response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->