### PR TITLE
feat(studio): add keyboard shortcuts reference

### DIFF
--- a/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.test.tsx
+++ b/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.test.tsx
@@ -17,9 +17,9 @@ vi.mock('@/state/shortcuts/useShortcut', () => ({
   useShortcut: mockUseShortcut,
 }))
 
-vi.mock('./ShortcutsReferenceDialog', () => ({
-  ShortcutsReferenceDialog: ({ open }: { open: boolean }) => (
-    <div data-testid="shortcuts-reference-dialog" data-open={open} />
+vi.mock('./ShortcutsReferenceSheet', () => ({
+  ShortcutsReferenceSheet: ({ open }: { open: boolean }) => (
+    <div data-testid="shortcuts-reference-sheet" data-open={open} />
   ),
 }))
 
@@ -38,13 +38,13 @@ describe('GlobalShortcuts', () => {
     )
   })
 
-  it('closes the command palette and opens the shortcuts reference dialog', () => {
+  it('closes the command palette and opens the shortcuts reference sheet', () => {
     render(<GlobalShortcuts />)
 
     const openReference = mockUseShortcut.mock.calls[0][1]
     act(() => openReference())
 
     expect(mockSetCommandMenuOpen).toHaveBeenCalledWith(false)
-    expect(screen.getByTestId('shortcuts-reference-dialog')).toHaveAttribute('data-open', 'true')
+    expect(screen.getByTestId('shortcuts-reference-sheet')).toHaveAttribute('data-open', 'true')
   })
 })

--- a/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.test.tsx
+++ b/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.test.tsx
@@ -1,0 +1,50 @@
+import { act, render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { GlobalShortcuts } from './GlobalShortcuts'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+
+const { mockSetCommandMenuOpen, mockUseShortcut } = vi.hoisted(() => ({
+  mockSetCommandMenuOpen: vi.fn(),
+  mockUseShortcut: vi.fn(),
+}))
+
+vi.mock('ui-patterns/CommandMenu', () => ({
+  useSetCommandMenuOpen: () => mockSetCommandMenuOpen,
+}))
+
+vi.mock('@/state/shortcuts/useShortcut', () => ({
+  useShortcut: mockUseShortcut,
+}))
+
+vi.mock('./ShortcutsReferenceDialog', () => ({
+  ShortcutsReferenceDialog: ({ open }: { open: boolean }) => (
+    <div data-testid="shortcuts-reference-dialog" data-open={open} />
+  ),
+}))
+
+describe('GlobalShortcuts', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('registers the shortcuts reference action in the command palette', () => {
+    render(<GlobalShortcuts />)
+
+    expect(mockUseShortcut).toHaveBeenCalledWith(
+      SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE,
+      expect.any(Function),
+      { registerInCommandMenu: true }
+    )
+  })
+
+  it('closes the command palette and opens the shortcuts reference dialog', () => {
+    render(<GlobalShortcuts />)
+
+    const openReference = mockUseShortcut.mock.calls[0][1]
+    act(() => openReference())
+
+    expect(mockSetCommandMenuOpen).toHaveBeenCalledWith(false)
+    expect(screen.getByTestId('shortcuts-reference-dialog')).toHaveAttribute('data-open', 'true')
+  })
+})

--- a/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.tsx
+++ b/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useSetCommandMenuOpen } from 'ui-patterns/CommandMenu'
 
-import { ShortcutsReferenceDialog } from './ShortcutsReferenceDialog'
+import { ShortcutsReferenceSheet } from './ShortcutsReferenceSheet'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
 
@@ -20,5 +20,5 @@ export function GlobalShortcuts() {
     }
   )
 
-  return <ShortcutsReferenceDialog open={referenceOpen} onOpenChange={setReferenceOpen} />
+  return <ShortcutsReferenceSheet open={referenceOpen} onOpenChange={setReferenceOpen} />
 }

--- a/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.tsx
+++ b/apps/studio/components/ui/GlobalShortcuts/GlobalShortcuts.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import { useSetCommandMenuOpen } from 'ui-patterns/CommandMenu'
+
+import { ShortcutsReferenceDialog } from './ShortcutsReferenceDialog'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
+
+export function GlobalShortcuts() {
+  const [referenceOpen, setReferenceOpen] = useState(false)
+  const setCommandMenuOpen = useSetCommandMenuOpen()
+
+  useShortcut(
+    SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE,
+    () => {
+      setCommandMenuOpen(false)
+      setReferenceOpen(true)
+    },
+    {
+      registerInCommandMenu: true,
+    }
+  )
+
+  return <ShortcutsReferenceDialog open={referenceOpen} onOpenChange={setReferenceOpen} />
+}

--- a/apps/studio/components/ui/GlobalShortcuts/ShortcutsReferenceDialog.tsx
+++ b/apps/studio/components/ui/GlobalShortcuts/ShortcutsReferenceDialog.tsx
@@ -1,0 +1,108 @@
+import { Fragment } from 'react'
+import { KeyboardShortcut, Sheet, SheetContent, SheetHeader, SheetSection, SheetTitle } from 'ui'
+
+import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
+import { SHORTCUT_DEFINITIONS } from '@/state/shortcuts/registry'
+import type { ShortcutDefinition } from '@/state/shortcuts/types'
+
+interface ShortcutsReferenceDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+}
+
+const GROUP_LABELS: Record<string, string> = {
+  'action-bar': 'Actions',
+  'ai-assistant': 'AI Assistant',
+  'command-menu': 'Command Menu',
+  'data-table': 'Data Tables',
+  'inline-editor': 'Inline Editor',
+  nav: 'Navigation',
+  'operation-queue': 'Operation Queue',
+  results: 'Results',
+  shortcuts: 'Shortcuts',
+  'table-editor': 'Table Editor',
+  'unified-logs': 'Logs',
+}
+
+const GROUP_ORDER = [
+  'command-menu',
+  'shortcuts',
+  'nav',
+  'ai-assistant',
+  'inline-editor',
+  'results',
+  'data-table',
+  'table-editor',
+  'action-bar',
+  'operation-queue',
+  'unified-logs',
+]
+
+const getGroupOrder = (group: string) => {
+  const index = GROUP_ORDER.indexOf(group)
+  return index === -1 ? GROUP_ORDER.length : index
+}
+
+const groupDefinitions = (): Array<{ group: string; definitions: ShortcutDefinition[] }> => {
+  const grouped = Object.values(SHORTCUT_DEFINITIONS).reduce<Record<string, ShortcutDefinition[]>>(
+    (acc, definition) => {
+      const prefix = definition.id.split('.')[0]
+      acc[prefix] = acc[prefix] ?? []
+      acc[prefix].push(definition)
+      return acc
+    },
+    {}
+  )
+
+  return Object.entries(grouped)
+    .map(([group, definitions]) => ({
+      group,
+      definitions,
+    }))
+    .sort((a, b) => getGroupOrder(a.group) - getGroupOrder(b.group))
+}
+
+const ShortcutSequence = ({ sequence }: Pick<ShortcutDefinition, 'sequence'>) => (
+  <div className="flex items-center gap-1">
+    {sequence.map((step, index) => (
+      <Fragment key={`${step}-${index}`}>
+        {index > 0 && <span className="text-foreground-lighter text-[11px]">then</span>}
+        <KeyboardShortcut keys={hotkeyToKeys(step)} />
+      </Fragment>
+    ))}
+  </div>
+)
+
+export function ShortcutsReferenceDialog({ open, onOpenChange }: ShortcutsReferenceDialogProps) {
+  const groups = groupDefinitions()
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent className="flex flex-col gap-0 p-0 sm:max-w-[520px]">
+        <SheetHeader className="shrink-0 py-3">
+          <SheetTitle>Keyboard shortcuts</SheetTitle>
+        </SheetHeader>
+        <SheetSection className="flex flex-1 flex-col gap-6 overflow-y-auto px-5 py-4">
+          {groups.map(({ group, definitions }) => (
+            <section key={group} className="flex flex-col gap-2">
+              <h3 className="text-xs text-foreground-lighter uppercase tracking-wider">
+                {GROUP_LABELS[group] ?? group}
+              </h3>
+              <ul className="flex flex-col">
+                {definitions.map((definition) => (
+                  <li
+                    key={definition.id}
+                    className="flex min-h-10 items-center justify-between gap-4 border-b py-2 last:border-b-0"
+                  >
+                    <span className="text-sm text-foreground">{definition.label}</span>
+                    <ShortcutSequence sequence={definition.sequence} />
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </SheetSection>
+      </SheetContent>
+    </Sheet>
+  )
+}

--- a/apps/studio/components/ui/GlobalShortcuts/ShortcutsReferenceSheet.tsx
+++ b/apps/studio/components/ui/GlobalShortcuts/ShortcutsReferenceSheet.tsx
@@ -5,7 +5,7 @@ import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
 import { SHORTCUT_DEFINITIONS } from '@/state/shortcuts/registry'
 import type { ShortcutDefinition } from '@/state/shortcuts/types'
 
-interface ShortcutsReferenceDialogProps {
+interface ShortcutsReferenceSheetProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
@@ -73,7 +73,7 @@ const ShortcutSequence = ({ sequence }: Pick<ShortcutDefinition, 'sequence'>) =>
   </div>
 )
 
-export function ShortcutsReferenceDialog({ open, onOpenChange }: ShortcutsReferenceDialogProps) {
+export function ShortcutsReferenceSheet({ open, onOpenChange }: ShortcutsReferenceSheetProps) {
   const groups = groupDefinitions()
 
   return (

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -53,6 +53,7 @@ import { RouteValidationWrapper } from '@/components/interfaces/App/RouteValidat
 import { UpdateBillingAddressModal } from '@/components/interfaces/App/UpdateBillingAddressModal'
 import { MainScrollContainerProvider } from '@/components/layouts/MainScrollContainerContext'
 import { GlobalErrorBoundaryState } from '@/components/ui/ErrorBoundary/GlobalErrorBoundaryState'
+import { GlobalShortcuts } from '@/components/ui/GlobalShortcuts/GlobalShortcuts'
 import { useRootQueryClient } from '@/data/query-client'
 import { customFont, sourceCodePro } from '@/fonts'
 import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
@@ -197,6 +198,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                                 <MainScrollContainerProvider>
                                   {getLayout(<Component {...pageProps} />)}
                                 </MainScrollContainerProvider>
+                                <GlobalShortcuts />
                                 <StudioCommandMenu />
                                 <FeaturePreviewModal />
                                 <UpdateBillingAddressModal />

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -48,6 +48,7 @@ export const SHORTCUT_IDS = {
   NAV_ORG_USAGE: 'nav.org-usage',
   NAV_ORG_BILLING: 'nav.org-billing',
   NAV_ORG_SETTINGS: 'nav.org-settings',
+  SHORTCUTS_OPEN_REFERENCE: 'shortcuts.open-reference',
 } as const
 
 /**
@@ -313,5 +314,12 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     label: 'Go to Organization Settings',
     sequence: ['G', 'O'],
     showInSettings: false,
+  },
+  [SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE]: {
+    id: SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE,
+    label: 'Show all keyboard shortcuts',
+    sequence: ['Mod+/'],
+    showInSettings: false,
+    options: { ignoreInputs: true },
   },
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature.

## What is the current behaviour?

Keyboard shortcuts can be discovered piecemeal through command palette entries, tooltips, and preferences, but there is no universal shortcut reference surface.

## What is the new behaviour?

Adds a global `Mod+/` shortcut and command palette action to open a keyboard shortcuts reference sheet. The sheet renders registered shortcuts grouped from general dashboard actions through navigation and more specific surfaces.

| Preview |
| --- |
| <img width="820" height="928" alt="CleanShot 2026-04-24 at 11 27 51@2x" src="https://github.com/user-attachments/assets/8ceb4a35-7adc-474b-8702-5c08a4219d25" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a comprehensive keyboard shortcuts reference sheet that displays all available shortcuts organized into logical categories.
  * New keyboard shortcut Mod+/ (Cmd+/ on Mac) opens the reference sheet instantly from anywhere within the application.
  * Shortcuts are displayed with their formatted keyboard combinations, with multi-step sequences clearly separated for easy reference and discovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->