### PR TITLE
[COM-205] feat(studio): add logs:all flag to hide all logs

### DIFF
--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -244,6 +244,7 @@ const ProjectLinks = () => {
   const { data: project } = useSelectedProjectQuery()
   const { securityLints, errorLints } = useLints()
   const showReports = useIsFeatureEnabled('reports:all')
+  const showLogs = useIsFeatureEnabled('logs:all')
 
   const { isEnabled: isUnifiedLogsEnabled } = useUnifiedLogsPreview()
 
@@ -274,6 +275,7 @@ const ProjectLinks = () => {
   const otherRoutes = generateOtherRoutes(ref, project, {
     unifiedLogs: isUnifiedLogsEnabled,
     showReports,
+    showLogs,
   })
   const settingsRoutes = generateSettingsRoutes(ref)
 

--- a/apps/studio/components/layouts/LogsLayout/Logs.Commands.tsx
+++ b/apps/studio/components/layouts/LogsLayout/Logs.Commands.tsx
@@ -10,58 +10,60 @@ export function useLogsGotoCommands(options?: CommandOptions) {
   let { ref } = useParams()
   ref ||= '_'
 
-  const { logsCollections } = useIsFeatureEnabled(['logs:collections'])
+  const { logsAll, logsCollections } = useIsFeatureEnabled(['logs:all', 'logs:collections'])
 
   useRegisterCommands(
     COMMAND_MENU_SECTIONS.NAVIGATE,
-    [
-      {
-        id: 'nav-logs-explorer',
-        name: 'Logs Explorer',
-        route: `/project/${ref}/logs/explorer`,
-        defaultHidden: true,
-      },
-      ...(logsCollections
-        ? ([
-            {
-              id: 'nav-logs-postgres',
-              name: 'Postgres Logs',
-              route: `/project/${ref}/logs/postgres-logs`,
-              defaultHidden: true,
-            },
-            {
-              id: 'nav-logs-postgrest',
-              name: 'PostgREST Logs',
-              route: `/project/${ref}/logs/postgrest-logs`,
-              defaultHidden: true,
-            },
-            {
-              id: 'nav-logs-pooler',
-              name: 'Pooler Logs',
-              route: `/project/${ref}/logs/pooler-logs`,
-              defaultHidden: true,
-            },
-            {
-              id: 'nav-logs-auth',
-              name: 'Auth Logs',
-              route: `/project/${ref}/logs/auth-logs`,
-              defaultHidden: true,
-            },
-            {
-              id: 'nav-logs-storage',
-              name: 'Storage Logs',
-              route: `/project/${ref}/logs/storage-logs`,
-              defaultHidden: true,
-            },
-            {
-              id: 'nav-logs-realtime',
-              name: 'Realtime Logs',
-              route: `/project/${ref}/logs/realtime-logs`,
-              defaultHidden: true,
-            },
-          ] as IRouteCommand[])
-        : []),
-    ],
+    logsAll
+      ? [
+          {
+            id: 'nav-logs-explorer',
+            name: 'Logs Explorer',
+            route: `/project/${ref}/logs/explorer`,
+            defaultHidden: true,
+          },
+          ...(logsCollections
+            ? ([
+                {
+                  id: 'nav-logs-postgres',
+                  name: 'Postgres Logs',
+                  route: `/project/${ref}/logs/postgres-logs`,
+                  defaultHidden: true,
+                },
+                {
+                  id: 'nav-logs-postgrest',
+                  name: 'PostgREST Logs',
+                  route: `/project/${ref}/logs/postgrest-logs`,
+                  defaultHidden: true,
+                },
+                {
+                  id: 'nav-logs-pooler',
+                  name: 'Pooler Logs',
+                  route: `/project/${ref}/logs/pooler-logs`,
+                  defaultHidden: true,
+                },
+                {
+                  id: 'nav-logs-auth',
+                  name: 'Auth Logs',
+                  route: `/project/${ref}/logs/auth-logs`,
+                  defaultHidden: true,
+                },
+                {
+                  id: 'nav-logs-storage',
+                  name: 'Storage Logs',
+                  route: `/project/${ref}/logs/storage-logs`,
+                  defaultHidden: true,
+                },
+                {
+                  id: 'nav-logs-realtime',
+                  name: 'Realtime Logs',
+                  route: `/project/${ref}/logs/realtime-logs`,
+                  defaultHidden: true,
+                },
+              ] as IRouteCommand[])
+            : []),
+        ]
+      : [],
     { ...options, deps: [ref] }
   )
 }

--- a/apps/studio/components/layouts/LogsLayout/LogsLayout.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsLayout.tsx
@@ -1,10 +1,13 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useParams } from 'common'
 import { PropsWithChildren } from 'react'
 
 import { ProjectLayout } from '../ProjectLayout'
 import { LogsSidebarMenuV2 } from './LogsSidebarMenuV2'
 import NoPermission from '@/components/ui/NoPermission'
+import { UnknownInterface } from '@/components/ui/UnknownInterface'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { withAuth } from '@/hooks/misc/withAuth'
 
 interface LogsLayoutProps {
@@ -12,10 +15,21 @@ interface LogsLayoutProps {
 }
 
 const LogsLayout = ({ title, children }: PropsWithChildren<LogsLayoutProps>) => {
+  const { ref } = useParams()
+  const logsEnabled = useIsFeatureEnabled('logs:all')
+
   const { isLoading, can: canUseLogsExplorer } = useAsyncCheckPermissions(
     PermissionAction.ANALYTICS_READ,
     'logflare'
   )
+
+  if (!logsEnabled) {
+    return (
+      <ProjectLayout product="Logs & Analytics" browserTitle={{ section: title }}>
+        <UnknownInterface urlBack={`/project/${ref}`} />
+      </ProjectLayout>
+    )
+  }
 
   if (!canUseLogsExplorer) {
     if (isLoading) {

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -27,6 +27,7 @@ interface OtherFeatures {
   isPlatform?: boolean
   unifiedLogs?: boolean
   showReports?: boolean
+  showLogs?: boolean
 }
 
 interface SettingsFeatures {
@@ -161,6 +162,7 @@ export const generateOtherRoutes = (
   const isPlatform = features?.isPlatform ?? IS_PLATFORM
   const unifiedLogsEnabled = features?.unifiedLogs ?? false
   const reportsEnabled = features?.showReports ?? true
+  const logsEnabled = features?.showLogs ?? true
   return [
     {
       key: 'advisors',
@@ -183,14 +185,20 @@ export const generateOtherRoutes = (
           },
         ]
       : []),
-    {
-      key: 'logs',
-      label: 'Logs',
-      disabled: false,
-      icon: <List size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-      link: ref && (unifiedLogsEnabled ? `/project/${ref}/logs` : `/project/${ref}/logs/explorer`),
-      shortcutId: SHORTCUT_IDS.NAV_LOGS,
-    },
+    ...(logsEnabled
+      ? [
+          {
+            key: 'logs',
+            label: 'Logs',
+            disabled: false,
+            icon: <List size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
+            link:
+              ref &&
+              (unifiedLogsEnabled ? `/project/${ref}/logs` : `/project/${ref}/logs/explorer`),
+            shortcutId: SHORTCUT_IDS.NAV_LOGS,
+          },
+        ]
+      : []),
     {
       key: 'integrations',
       label: 'Integrations',

--- a/apps/studio/pages/project/[ref]/logs/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/index.tsx
@@ -6,20 +6,33 @@ import { useUnifiedLogsPreview } from '@/components/interfaces/App/FeaturePrevie
 import { UnifiedLogs } from '@/components/interfaces/UnifiedLogs/UnifiedLogs'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import { ProjectLayout } from '@/components/layouts/ProjectLayout'
+import { UnknownInterface } from '@/components/ui/UnknownInterface'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from '@/types'
 
 export const LogPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { ref } = useParams()
 
+  const logsEnabled = useIsFeatureEnabled('logs:all')
   const { isEnabled: isUnifiedLogsEnabled, isLoading } = useUnifiedLogsPreview()
 
   useEffect(() => {
-    if (!isLoading && !isUnifiedLogsEnabled && ref) {
+    if (logsEnabled && !isLoading && !isUnifiedLogsEnabled && ref) {
       router.replace(`/project/${ref}/logs/explorer`)
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, isUnifiedLogsEnabled, ref])
+  }, [logsEnabled, isLoading, isUnifiedLogsEnabled, ref])
+
+  if (!logsEnabled) {
+    return (
+      <DefaultLayout>
+        <ProjectLayout browserTitle={{ section: 'Logs' }}>
+          <UnknownInterface urlBack={`/project/${ref}`} />
+        </ProjectLayout>
+      </DefaultLayout>
+    )
+  }
 
   if (isUnifiedLogsEnabled) {
     return (

--- a/packages/common/enabled-features/enabled-features.json
+++ b/packages/common/enabled-features/enabled-features.json
@@ -77,6 +77,7 @@
 
   "infrastructure:read_replicas": true,
 
+  "logs:all": true,
   "logs:templates": true,
   "logs:collections": true,
   "logs:metadata": true,

--- a/packages/common/enabled-features/enabled-features.schema.json
+++ b/packages/common/enabled-features/enabled-features.schema.json
@@ -266,6 +266,10 @@
       "description": "Enable read replicas management"
     },
 
+    "logs:all": {
+      "type": "boolean",
+      "description": "Enable the logs pages and navigation. Disable to hide all logs pages, for example when Logflare is not configured."
+    },
     "logs:templates": {
       "type": "boolean",
       "description": "Enable the logs templates page"
@@ -488,6 +492,7 @@
     "profile:show_information",
     "profile:show_analytics_and_marketing",
     "profile:show_account_deletion",
+    "logs:all",
     "logs:templates",
     "logs:collections",
     "logs:metadata",


### PR DESCRIPTION
Adds a top-level `logs:all` flag (default `true`) so self-hosted and local setups can hide the logs pages in Studio when Logflare isn't configured — no separate Studio build required. The flag itself works everywhere; the additional `ENABLED_FEATURES_LOGS_ALL` env-var override (from FE-3036) is the self-hosted escape hatch so deployers can flip it without a custom build — that part is a no-op on `IS_PLATFORM` because hosted feature gating flows through `profile.disabled_features` instead.

Addresses [COM-205](https://linear.app/supabase/issue/COM-205/add-feature-flag-to-disable-all-logs-in-studio).

**Added:**
- `logs:all` feature flag in `enabled-features.json` + schema

**Changed:**
- Sidebar "Logs" nav entry is hidden when `logs:all` is off (same pattern as `reports:all` / `billing:all`)
- Cmd-K "Logs Explorer" / "Auth Logs" / etc. routes are hidden when the flag is off
- `LogsLayout` renders `<UnknownInterface />` (soft-404) when the flag is off — covers all ~18 logs pages in one spot
- `/logs/index.tsx` applies the same soft-404 for the unified-logs entry point

## To test

Needs to be tested locally (preview doesn't let you flip the flag — hosted gating is profile-driven, not env-driven). Two ways:
- Temporarily edit `"logs:all": false` in `packages/common/enabled-features/enabled-features.json` and run `pnpm dev:studio`, or
- Run Studio locally with `ENABLED_FEATURES_LOGS_ALL=false` (env-var path, same as how self-hosted deployers would use it)

With the flag **off**:
- Sidebar "Logs" entry is hidden
- Cmd-K search for "Logs" / "Auth Logs" / "Postgres Logs" etc. returns nothing
- Direct navigation to `/project/<ref>/logs`, `/project/<ref>/logs/explorer`, `/project/<ref>/logs/auth-logs`, `/project/<ref>/logs/postgres-logs` (etc.) all render the "Looking for something?" soft-404 with a Head back button

With the flag **on** (default): everything works as it does today. **Check on the preview deploy too** — nothing should change, no behaviour difference on hosted.