### PR TITLE
fix: improve learn app home page design

### DIFF
--- a/apps/learn/app/(app)/page.tsx
+++ b/apps/learn/app/(app)/page.tsx
@@ -1,7 +1,8 @@
-import { WhatWillILearn } from '@/components/what-will-i-learn'
-import Link from 'next/link'
 import { Activity, BookOpen, Database, Gauge, Wrench } from 'lucide-react'
+import Link from 'next/link'
 import { Badge, Button, Card, CardDescription, CardHeader } from 'ui'
+
+import { WhatWillILearn } from '@/components/what-will-i-learn'
 
 // Horizontal grid line component
 const HorizontalGridLine = () => <div className="col-span-12 h-px bg-border/30" />
@@ -96,7 +97,9 @@ export default function Home() {
                               </div>
                               <div className="flex-1 min-w-0">
                                 <div className="flex items-start justify-between gap-4 mb-2">
-                                  <h3 className="text-lg font-bold">{course.title}</h3>
+                                  <h3 className="text-lg text-foreground font-bold">
+                                    {course.title}
+                                  </h3>
                                   <Badge variant="secondary" className="flex-shrink-0">
                                     {course.level}
                                   </Badge>
@@ -105,7 +108,7 @@ export default function Home() {
                                   {course.description}
                                 </CardDescription>
                                 <div className="flex items-center justify-between">
-                                  <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                  <div className="flex items-center gap-2 text-sm text-foreground-muted">
                                     <BookOpen className="w-4 h-4" />
                                     <span className="text-foreground-lighter">
                                       {course.chapters} chapters


### PR DESCRIPTION
Before:
<img width="3784" height="2094" alt="image" src="https://github.com/user-attachments/assets/c03b52f3-1033-40ec-974d-25d275d6bf6a" />

After:
<img width="2088" height="1768" alt="image" src="https://github.com/user-attachments/assets/f7dedd36-24ac-40e5-87b4-0cb0ecb74c00" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for course titles and chapter text displays to enhance visual clarity and ensure consistent presentation across the learning experience. Improved readability through refined text formatting and color treatment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->