### PR TITLE
fix(studio): Fix Support Form prefill for failed upgrades

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/UpgradingState/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/UpgradingState/index.tsx
@@ -66,8 +66,8 @@ export const UpgradingState = () => {
     if (ref) await invalidateProjectDetailsQuery(ref)
   }
 
-  const subject = 'Upgrade%20failed%20for%20project'
-  const message = `Upgrade information:%0A• Initiated at: ${initiated_at}%0A• Target Version: ${target_version}%0A• Error: ${error}`
+  const subject = 'Upgrade failed for project'
+  const message = `Upgrade information:\n• Initiated at: ${initiated_at}\n• Target Version: ${target_version}\n• Error: ${error}`
 
   return (
     <div className="w-full mx-auto my-16 space-y-16 max-w-7xl">

--- a/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
+++ b/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
@@ -32,8 +32,8 @@ export const ProjectUpgradeFailedBanner = () => {
     .tz(guessLocalTimezone())
     .format('DD MMM YYYY HH:mm:ss')
 
-  const subject = 'Upgrade%20failed%20for%20project'
-  const message = `Upgrade information:%0A• Initiated at: ${initiated_at}%0A• Error: ${error}`
+  const subject = 'Upgrade failed for project'
+  const message = `Upgrade information:\n• Initiated at: ${initiated_at}\n• Error: ${error}`
 
   const initiatedAtEncoded = encodeURIComponent(
     dayjs.utc(initiated_at ?? 0).format('YYYY-MM-DDTHH:mm:ss')


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix incorrect pre-fills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved formatting of upgrade failure details sent through support communications to use standard text representation instead of URL-encoded formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->