### PR TITLE
fix(docs): correct hash parsing in auth redirect examples

### DIFF
--- a/apps/docs/content/guides/auth/redirect-urls.mdx
+++ b/apps/docs/content/guides/auth/redirect-urls.mdx
@@ -121,9 +121,9 @@ Read more about deep linking and find code examples for different frameworks [he
 When authentication fails, the user will still be redirected to the redirect URL provided. However, the error details will be returned as query fragments in the URL. You can parse these query fragments and show a custom error message to the user. For example:
 
 ```js
-const params = new URLSearchParams(window.location.hash.slice())
+const params = new URLSearchParams(window.location.hash.slice(1))
 
-if (params.get('error_code').startsWith('4')) {
+if (params.get('error_code')?.startsWith('4')) {
   // show error message if error is a 4xx error
   window.alert(params.get('error_description'))
 }

--- a/apps/docs/content/guides/auth/social-login/auth-google.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-google.mdx
@@ -808,7 +808,7 @@ chrome.identity.launchWebAuthFlow(
     } else {
       // auth was successful, extract the ID token from the redirectedTo URL
       const url = new URL(redirectedTo)
-      const params = new URLSearchParams(url.hash)
+      const params = new URLSearchParams(url.hash.slice(1))
 
       const { data, error } = await supabase.auth.signInWithIdToken({
         provider: 'google',


### PR DESCRIPTION
## Problem

Two auth documentation examples demonstrate parsing URL hash fragments using `URLSearchParams`, but both have bugs that mean the code as written does not work:

### Bug 1 — `URLSearchParams` does not strip leading `#`

Per the WHATWG URL spec, `URLSearchParams` strips a leading `?` but **not** a leading `#`. Passing `window.location.hash` or `url.hash` (which include the `#`) means the first key is parsed with `#` as part of its name.

Verified under Node 22:
new URLSearchParams('#error_code=401&error_description=Bad')
params.get('error_code') // null
[...params.keys()] // ['#error_code', 'error_description']

### Bug 2 — crash on success-path
In `redirect-urls.mdx`, `params.get('error_code').startsWith('4')` throws `TypeError: Cannot read properties of null (reading 'startsWith')` whenever the redirect URL has no `error_code` (the success case, or a direct visit). Even if Bug 1 did not exist, `error_code` being absent would still crash.
## Fix
1. `apps/docs/content/guides/auth/redirect-urls.mdx` — use `hash.slice(1)` to strip the `#`, and add `?.` optional chaining so the example does not throw on non-error URLs.
2. `apps/docs/content/guides/auth/social-login/auth-google.mdx` — use `hash.slice(1)` (same hash-prefix bug; ID token retrieval silently failed without it).
## Scope
- Docs-only change; no code or test changes needed elsewhere.
- Diff: `+3 / -3` across 2 files.
- All existing prose is preserved — only the code blocks are corrected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced authentication setup guides with improved URL parsing and error handling examples
  * Refined Chrome extensions authentication flow documentation for proper ID token extraction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->