### PR TITLE
fix(docs): guard against null session in auth-anonymous example

### DIFF
--- a/apps/docs/content/guides/auth/auth-anonymous.mdx
+++ b/apps/docs/content/guides/auth/auth-anonymous.mdx
@@ -334,7 +334,7 @@ if (updateError) {
     password: 'user_password',
   })
 
-  if (existingUser) {
+  if (existingUser && anonData.session) {
     // 5. Reassign entities tied to the anonymous user
     // This step will vary based on your specific use case and data model
     const { data: reassignData, error: reassignError } = await supabase


### PR DESCRIPTION
## Problem

The "Linking an anonymous user to an existing account" example in `apps/docs/content/guides/auth/auth-anonymous.mdx` retrieves the anonymous session and later dereferences `anonData.session.user.id` without checking that `session` is non-null:

```js
const { data: anonData, error: anonError } = await supabase.auth.getSession()
// ...
if (existingUser) {
  const { data: reassignData, error: reassignError } = await supabase
    .from('your_table')
    .update({ user_id: existingUser.id })
    .eq('user_id', anonData.session.user.id)

  await resolveDataConflicts(anonData.session.user.id, existingUser.id)
}
```

`supabase.auth.getSession()` returns `{ data: { session: Session | null } }`. When `session` is `null`, the next line throws:

> `TypeError: Cannot read properties of null (reading 'user')`

Realistic ways `session` can be `null` here:

- The anonymous session expired between `getSession()` and `signInWithPassword()`
- Session storage was cleared by another tab or auth event in between
- A developer copies the example into a code path where the user never actually signed in anonymously

In any of those cases, the example crashes inside the conflict-resolution branch instead of exiting cleanly.

## Fix

Extend the existing guard so the conflict-resolution block also requires that an anonymous session is present:

```js
if (existingUser && anonData.session) {
```

This is the smallest correct change — no new abstractions, no restructuring, no behavior change in the happy path. The block now correctly skips reassignment when there is no anonymous user to reassign entities from.

## Scope

- Docs-only.
- One file: `apps/docs/content/guides/auth/auth-anonymous.mdx`.
- Diff: `+1 / -1`.
- All surrounding prose, comments, and step numbering preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the authentication guide example for handling anonymous-to-authenticated user transitions to clarify the specific conditions required for entity reassignment, ensuring both a validated authenticated user state and the availability of the prior anonymous session context are properly confirmed before reassignment and associated conflict-resolution logic execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->