### PR TITLE
feat: Handle the `classic-dark` theme in `www` and `docs` apps

### DIFF
--- a/apps/design-system/app/Providers.tsx
+++ b/apps/design-system/app/Providers.tsx
@@ -1,20 +1,19 @@
 'use client'
 
+import { ThemeProvider } from 'common'
 import { Provider as JotaiProvider } from 'jotai'
-import { ThemeProvider as NextThemesProvider } from 'next-themes'
-import { ThemeProviderProps } from 'next-themes/dist/types'
 import { TooltipProvider } from 'ui'
 
 import { MobileSidebarProvider } from '@/context/mobile-sidebar-context'
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+export function Providers({ children }: { children: React.ReactNode }) {
   return (
     <JotaiProvider>
-      <NextThemesProvider {...props}>
+      <ThemeProvider>
         <TooltipProvider delayDuration={0}>
           <MobileSidebarProvider>{children}</MobileSidebarProvider>
         </TooltipProvider>
-      </NextThemesProvider>
+      </ThemeProvider>
     </JotaiProvider>
   )
 }

--- a/apps/design-system/app/layout.tsx
+++ b/apps/design-system/app/layout.tsx
@@ -4,7 +4,7 @@ import '@/styles/globals.css'
 import type { Metadata, Viewport } from 'next'
 
 import { customFont, sourceCodePro } from './fonts'
-import { ThemeProvider } from './Providers'
+import { Providers } from './Providers'
 import { Toaster } from './toaster'
 
 const className = `${customFont.variable} ${sourceCodePro.variable}`
@@ -131,16 +131,12 @@ export default async function Layout({ children }: RootLayoutProps) {
         />
       </head>
       <body>
-        <ThemeProvider
-          themes={['dark', 'light', 'classic-dark']}
-          defaultTheme="system"
-          enableSystem
-        >
+        <Providers>
           <div vaul-drawer-wrapper="">
             <div className="relative flex min-h-screen flex-col bg-background">{children}</div>
           </div>
           <Toaster />
-        </ThemeProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/apps/design-system/app/layout.tsx
+++ b/apps/design-system/app/layout.tsx
@@ -4,7 +4,7 @@ import '../../studio/styles/typography.css'
 import type { Metadata, Viewport } from 'next'
 
 import { customFont, sourceCodePro } from './fonts'
-import { ThemeProvider } from './Providers'
+import { Providers } from './Providers'
 import { Toaster } from './toaster'
 
 const className = `${customFont.variable} ${sourceCodePro.variable}`
@@ -131,16 +131,12 @@ export default async function Layout({ children }: RootLayoutProps) {
         />
       </head>
       <body>
-        <ThemeProvider
-          themes={['dark', 'light', 'classic-dark']}
-          defaultTheme="system"
-          enableSystem
-        >
+        <Providers>
           <div vaul-drawer-wrapper="">
             <div className="relative flex min-h-screen flex-col bg-background">{children}</div>
           </div>
           <Toaster />
-        </ThemeProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -20,6 +20,7 @@
     "@hookform/resolvers": "^3.1.1",
     "@tanstack/react-table": "^8.21.3",
     "contentlayer2": "0.4.6",
+    "common": "workspace:*",
     "date-fns": "^2.30.0",
     "dayjs": "1.11.13",
     "eslint-config-supabase": "workspace:*",

--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -29,7 +29,7 @@
     "markdown-wasm": "^1.2.0",
     "next": "catalog:",
     "next-contentlayer2": "0.4.6",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "react": "catalog:",
     "react-data-grid": "7.0.0-beta.47",
     "react-day-picker": "^9.11.1",

--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -1,13 +1,13 @@
 'use client'
 
-import { ChevronRight, Play, Sparkles } from 'lucide-react'
-import Link from 'next/link'
-import { useTheme } from 'next-themes'
 // End of third-party imports
-
 import { isFeatureEnabled, useBreakpoint } from 'common'
+import { ChevronRight, Play, Sparkles } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import Link from 'next/link'
 import { cn, IconBackground } from 'ui'
 import { IconPanel } from 'ui-patterns/IconPanel'
+
 import { getCustomContent } from '../lib/custom-content/getCustomContent'
 import DocsCoverLogo from './DocsCoverLogo'
 
@@ -41,7 +41,7 @@ const HomePageCover = (props) => {
   const iconSize = isXs ? 'sm' : 'lg'
   const { homepageHeading } = getCustomContent(['homepage:heading'])
   const { resolvedTheme } = useTheme()
-  const isLightMode = resolvedTheme !== 'dark'
+  const isLightMode = !resolvedTheme?.includes('dark')
 
   const frameworks = [
     {

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavDropdown.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavDropdown.tsx
@@ -1,10 +1,13 @@
 'use client'
 
-import React, { Fragment } from 'react'
-import Link from 'next/link'
-import { useTheme } from 'next-themes'
+import { isFeatureEnabled } from 'common'
 import { Menu } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import Link from 'next/link'
+import React, { Fragment } from 'react'
 import {
+  buttonVariants,
+  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
@@ -14,13 +17,10 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Theme,
-  buttonVariants,
-  cn,
   themes,
 } from 'ui'
+
 import MenuIconPicker from './MenuIconPicker'
-import { isFeatureEnabled } from 'common'
 
 const menu = [
   [
@@ -105,13 +105,11 @@ const TopNavDropdown = () => {
               setTheme(value)
             }}
           >
-            {themes
-              .filter((x) => x.value === 'light' || x.value === 'dark' || x.value === 'system')
-              .map((theme: Theme) => (
-                <DropdownMenuRadioItem key={`topnav-theme-${theme.value}`} value={theme.value}>
-                  {theme.name}
-                </DropdownMenuRadioItem>
-              ))}
+            {themes.map((theme) => (
+              <DropdownMenuRadioItem key={`topnav-theme-${theme.value}`} value={theme.value}>
+                {theme.name}
+              </DropdownMenuRadioItem>
+            ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/apps/docs/components/Navigation/NavigationMenu/TopNavDropdown.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/TopNavDropdown.tsx
@@ -1,13 +1,10 @@
 'use client'
 
-import { isFeatureEnabled } from 'common'
-import { Menu } from 'lucide-react'
-import { useTheme } from 'next-themes'
-import Link from 'next/link'
 import React, { Fragment } from 'react'
+import Link from 'next/link'
+import { useTheme } from 'next-themes'
+import { Menu } from 'lucide-react'
 import {
-  buttonVariants,
-  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuGroup,
@@ -17,10 +14,13 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Theme,
+  buttonVariants,
+  cn,
   themes,
 } from 'ui'
-
 import MenuIconPicker from './MenuIconPicker'
+import { isFeatureEnabled } from 'common'
 
 const menu = [
   [
@@ -105,11 +105,13 @@ const TopNavDropdown = () => {
               setTheme(value)
             }}
           >
-            {themes.map((theme) => (
-              <DropdownMenuRadioItem key={`topnav-theme-${theme.value}`} value={theme.value}>
-                {theme.name}
-              </DropdownMenuRadioItem>
-            ))}
+            {themes
+              .filter((x) => x.value === 'light' || x.value === 'dark' || x.value === 'system')
+              .map((theme: Theme) => (
+                <DropdownMenuRadioItem key={`topnav-theme-${theme.value}`} value={theme.value}>
+                  {theme.name}
+                </DropdownMenuRadioItem>
+              ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/apps/docs/features/app.providers.tsx
+++ b/apps/docs/features/app.providers.tsx
@@ -24,7 +24,7 @@ function GlobalProviders({ children }: PropsWithChildren) {
           <DevToolbarProvider apiUrl={API_URL}>
             <PageTelemetry />
             <ScrollRestoration />
-            <ThemeProvider defaultTheme="system" enableSystem disableTransitionOnChange>
+            <ThemeProvider>
               <TooltipProvider delayDuration={0}>
                 <DocsCommandProvider>
                   <div className="flex flex-col">

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -93,7 +93,7 @@
     "next": "^15.5.15",
     "next-mdx-remote": "^6.0.0",
     "next-plugin-yaml": "^1.0.1",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "nuqs": "^1.19.1",
     "openai": "^4.75.1",
     "openapi-fetch": "0.12.4",

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -96,7 +96,7 @@
     "next": "^15.5.15",
     "next-mdx-remote": "^6.0.0",
     "next-plugin-yaml": "^1.0.1",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "nuqs": "^1.19.1",
     "openai": "^4.75.1",
     "openapi-fetch": "0.12.4",

--- a/apps/docs/styles/main.css
+++ b/apps/docs/styles/main.css
@@ -2,7 +2,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
-@import './../../../packages/ui/build/css/themes/classic-dark.css';
+@import './../../../packages/ui/build/css/themes/faux-classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @config '../tailwind.config.cjs';

--- a/apps/docs/styles/main.css
+++ b/apps/docs/styles/main.css
@@ -2,6 +2,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
+@import './../../../packages/ui/build/css/themes/classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @config '../tailwind.config.cjs';

--- a/apps/docs/styles/main.css
+++ b/apps/docs/styles/main.css
@@ -4,7 +4,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
-@import './../../../packages/ui/build/css/themes/classic-dark.css';
+@import './../../../packages/ui/build/css/themes/faux-classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @font-face {

--- a/apps/docs/styles/main.css
+++ b/apps/docs/styles/main.css
@@ -4,6 +4,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
+@import './../../../packages/ui/build/css/themes/classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @font-face {

--- a/apps/learn/app/Providers.tsx
+++ b/apps/learn/app/Providers.tsx
@@ -1,25 +1,24 @@
 'use client'
 
+import { AuthProvider, ThemeProvider } from 'common'
 import { Provider as JotaiProvider } from 'jotai'
-import { ThemeProvider as NextThemesProvider } from 'next-themes'
-import { ThemeProviderProps } from 'next-themes/dist/types'
+import { PropsWithChildren } from 'react'
+import { TooltipProvider } from 'ui'
 
 import { FrameworkProvider } from '@/context/framework-context'
 import { MobileMenuProvider } from '@/context/mobile-menu-context'
-import { AuthProvider } from 'common'
-import { TooltipProvider } from 'ui'
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+export function Providers({ children }: PropsWithChildren) {
   return (
     <AuthProvider>
       <JotaiProvider>
-        <NextThemesProvider {...props}>
+        <ThemeProvider>
           <MobileMenuProvider>
             <FrameworkProvider>
               <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
             </FrameworkProvider>
           </MobileMenuProvider>
-        </NextThemesProvider>
+        </ThemeProvider>
       </JotaiProvider>
     </AuthProvider>
   )

--- a/apps/learn/app/layout.tsx
+++ b/apps/learn/app/layout.tsx
@@ -6,7 +6,7 @@ import { FeatureFlagProvider, TelemetryTagManager } from 'common'
 import { genFaviconData } from 'common/MetaFavicons/app-router'
 import { Inter } from 'next/font/google'
 
-import { ThemeProvider } from './Providers'
+import { Providers } from './Providers'
 import { Toaster } from './toaster'
 import { API_URL } from '@/lib/constants'
 
@@ -47,14 +47,10 @@ export default async function Layout({ children }: RootLayoutProps) {
       <body className={`${inter.className} antialiased`}>
         <TelemetryTagManager />
         <FeatureFlagProvider API_URL={API_URL}>
-          <ThemeProvider
-            themes={['dark', 'light', 'classic-dark']}
-            defaultTheme="system"
-            enableSystem
-          >
+          <Providers>
             {children}
             <Toaster />
-          </ThemeProvider>
+          </Providers>
         </FeatureFlagProvider>
       </body>
     </html>

--- a/apps/learn/package.json
+++ b/apps/learn/package.json
@@ -23,7 +23,7 @@
     "lucide-react": "*",
     "next": "catalog:",
     "next-contentlayer2": "0.4.6",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-wrap-balancer": "^1.1.0",

--- a/apps/lite-studio/app/app.css
+++ b/apps/lite-studio/app/app.css
@@ -2,6 +2,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
+@import './../../../packages/ui/build/css/themes/classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @config '../tailwind.config.js';

--- a/apps/lite-studio/app/app.css
+++ b/apps/lite-studio/app/app.css
@@ -1,5 +1,6 @@
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
+@import './../../../packages/ui/build/css/themes/classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @tailwind components;

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -104,7 +104,7 @@
     "mime-db": "^1.53.0",
     "monaco-editor": "0.52.2",
     "next": "catalog:",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "nuqs": "2.7.1",
     "openai": "^4.104.0",
     "openapi-fetch": "0.12.4",

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -107,7 +107,7 @@
     "mime-db": "^1.53.0",
     "monaco-editor": "0.52.2",
     "next": "catalog:",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "nuqs": "2.7.1",
     "openai": "^4.104.0",
     "openapi-fetch": "0.12.4",

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -13,8 +13,6 @@ import '@/styles/storage.css'
 import '@/styles/stripe.css'
 import '@/styles/ui.css'
 import 'ui-patterns/ShimmeringLoader/index.css'
-import 'ui/build/css/themes/dark.css'
-import 'ui/build/css/themes/light.css'
 
 import { loader } from '@monaco-editor/react'
 import * as Sentry from '@sentry/nextjs'
@@ -184,12 +182,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                   <MetaFaviconsPagesRouter applicationName="Supabase Studio" includeManifest />
                   <TooltipProvider delayDuration={0}>
                     <RouteValidationWrapper>
-                      <ThemeProvider
-                        defaultTheme="system"
-                        themes={['dark', 'light', 'classic-dark']}
-                        enableSystem
-                        disableTransitionOnChange
-                      >
+                      <ThemeProvider>
                         <DevToolbarProvider apiUrl={API_URL}>
                           <AiAssistantStateContextProvider>
                             <CommandProvider>

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -15,8 +15,6 @@ import '@/styles/toast.css'
 import '@/styles/typography.css'
 import '@/styles/ui.css'
 import 'ui-patterns/ShimmeringLoader/index.css'
-import 'ui/build/css/themes/dark.css'
-import 'ui/build/css/themes/light.css'
 
 import { loader } from '@monaco-editor/react'
 import * as Sentry from '@sentry/nextjs'
@@ -184,12 +182,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                   <MetaFaviconsPagesRouter applicationName="Supabase Studio" includeManifest />
                   <TooltipProvider delayDuration={0}>
                     <RouteValidationWrapper>
-                      <ThemeProvider
-                        defaultTheme="system"
-                        themes={['dark', 'light', 'classic-dark']}
-                        enableSystem
-                        disableTransitionOnChange
-                      >
+                      <ThemeProvider>
                         <DevToolbarProvider apiUrl={API_URL}>
                           <AiAssistantStateContextProvider>
                             <CommandProvider>

--- a/apps/ui-library/app/Providers.tsx
+++ b/apps/ui-library/app/Providers.tsx
@@ -1,30 +1,29 @@
 'use client'
 
 import { QueryClientProvider } from '@tanstack/react-query'
-import { AuthProvider } from 'common'
+import { AuthProvider, ThemeProvider } from 'common'
 import { Provider as JotaiProvider } from 'jotai'
-import { ThemeProvider as NextThemesProvider } from 'next-themes'
-import { ThemeProviderProps } from 'next-themes/dist/types'
+import { PropsWithChildren } from 'react'
 import { TooltipProvider } from 'ui'
 
 import { FrameworkProvider } from '@/context/framework-context'
 import { MobileMenuProvider } from '@/context/mobile-menu-context'
 import { useRootQueryClient } from '@/lib/fetch/queryClient'
 
-export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
+export function Providers({ children }: PropsWithChildren) {
   const queryClient = useRootQueryClient()
 
   return (
     <AuthProvider>
       <QueryClientProvider client={queryClient}>
         <JotaiProvider>
-          <NextThemesProvider {...props}>
+          <ThemeProvider>
             <MobileMenuProvider>
               <FrameworkProvider>
                 <TooltipProvider delayDuration={0}>{children}</TooltipProvider>
               </FrameworkProvider>
             </MobileMenuProvider>
-          </NextThemesProvider>
+          </ThemeProvider>
         </JotaiProvider>
       </QueryClientProvider>
     </AuthProvider>

--- a/apps/ui-library/app/example/password-based-auth/layout.tsx
+++ b/apps/ui-library/app/example/password-based-auth/layout.tsx
@@ -1,7 +1,8 @@
+import { html } from 'monaco-editor'
 import { Metadata } from 'next'
 
 import { BaseInjector } from './../base-injector'
-import { ThemeProvider } from '@/app/Providers'
+import { Providers } from '@/app/Providers'
 
 export const metadata: Metadata = {
   title: 'Password Based Auth Example',
@@ -27,11 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body style={{ height: '100%', margin: 0, padding: 0, overflow: 'hidden' }}>
         <BaseInjector />
-        <ThemeProvider
-          themes={['dark', 'light', 'classic-dark']}
-          defaultTheme="system"
-          enableSystem
-        >
+        <Providers>
           <div
             className="flex w-full h-full items-center justify-center p-6 md:p-10 preview bg-surface-100"
             style={{ minHeight: '100%' }}
@@ -39,7 +36,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="z-0 pointer-events-none absolute h-full w-full bg-[radial-gradient(hsla(var(--foreground-default)/0.05)_1px,transparent_1px)] bg-size-[16px_16px] mask-[radial-gradient(ellipse_50%_50%_at_50%_50%,#000_70%,transparent_100%)]"></div>
             <div className="w-full max-w-sm">{children}</div>
           </div>
-        </ThemeProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/apps/ui-library/app/example/password-based-auth/layout.tsx
+++ b/apps/ui-library/app/example/password-based-auth/layout.tsx
@@ -1,7 +1,8 @@
+import { html } from 'monaco-editor'
 import { Metadata } from 'next'
 
 import { BaseInjector } from './../base-injector'
-import { ThemeProvider } from '@/app/Providers'
+import { Providers } from '@/app/Providers'
 
 export const metadata: Metadata = {
   title: 'Password Based Auth Example',
@@ -27,11 +28,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body style={{ height: '100%', margin: 0, padding: 0, overflow: 'hidden' }}>
         <BaseInjector />
-        <ThemeProvider
-          themes={['dark', 'light', 'classic-dark']}
-          defaultTheme="system"
-          enableSystem
-        >
+        <Providers>
           <div
             className="flex w-full h-full items-center justify-center p-6 md:p-10 preview bg-surface-100"
             style={{ minHeight: '100%' }}
@@ -39,7 +36,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="z-0 pointer-events-none absolute h-full w-full bg-[radial-gradient(hsla(var(--foreground-default)/0.05)_1px,transparent_1px)] [background-size:16px_16px] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_70%,transparent_100%)]"></div>
             <div className="w-full max-w-sm">{children}</div>
           </div>
-        </ThemeProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/apps/ui-library/app/example/social-auth/layout.tsx
+++ b/apps/ui-library/app/example/social-auth/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 
 import { BaseInjector } from './../base-injector'
-import { ThemeProvider } from '@/app/Providers'
+import { Providers } from '@/app/Providers'
 
 export const metadata: Metadata = {
   title: 'Social Auth Example',
@@ -27,11 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body style={{ height: '100%', margin: 0, padding: 0, overflow: 'hidden' }}>
         <BaseInjector />
-        <ThemeProvider
-          themes={['dark', 'light', 'classic-dark']}
-          defaultTheme="system"
-          enableSystem
-        >
+        <Providers>
           <div
             className="flex w-full h-full items-center justify-center p-6 md:p-10 preview bg-surface-100"
             style={{ minHeight: '100%' }}
@@ -39,7 +35,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="z-0 pointer-events-none absolute h-full w-full bg-[radial-gradient(hsla(var(--foreground-default)/0.05)_1px,transparent_1px)] bg-size-[16px_16px] mask-[radial-gradient(ellipse_50%_50%_at_50%_50%,#000_70%,transparent_100%)]"></div>
             <div className="w-full max-w-sm">{children}</div>
           </div>
-        </ThemeProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/apps/ui-library/app/example/social-auth/layout.tsx
+++ b/apps/ui-library/app/example/social-auth/layout.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next'
 
 import { BaseInjector } from './../base-injector'
-import { ThemeProvider } from '@/app/Providers'
+import { Providers } from '@/app/Providers'
 
 export const metadata: Metadata = {
   title: 'Social Auth Example',
@@ -27,11 +27,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body style={{ height: '100%', margin: 0, padding: 0, overflow: 'hidden' }}>
         <BaseInjector />
-        <ThemeProvider
-          themes={['dark', 'light', 'classic-dark']}
-          defaultTheme="system"
-          enableSystem
-        >
+        <Providers>
           <div
             className="flex w-full h-full items-center justify-center p-6 md:p-10 preview bg-surface-100"
             style={{ minHeight: '100%' }}
@@ -39,7 +35,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="z-0 pointer-events-none absolute h-full w-full bg-[radial-gradient(hsla(var(--foreground-default)/0.05)_1px,transparent_1px)] [background-size:16px_16px] [mask-image:radial-gradient(ellipse_50%_50%_at_50%_50%,#000_70%,transparent_100%)]"></div>
             <div className="w-full max-w-sm">{children}</div>
           </div>
-        </ThemeProvider>
+        </Providers>
       </body>
     </html>
   )

--- a/apps/ui-library/app/layout.tsx
+++ b/apps/ui-library/app/layout.tsx
@@ -6,7 +6,7 @@ import { FeatureFlagProvider, TelemetryTagManager } from 'common'
 import { genFaviconData } from 'common/MetaFavicons/app-router'
 import { Inter } from 'next/font/google'
 
-import { ThemeProvider } from './Providers'
+import { Providers } from './Providers'
 import { Toaster } from './toaster'
 import { API_URL } from '@/lib/constants'
 
@@ -47,14 +47,10 @@ export default async function Layout({ children }: RootLayoutProps) {
       <body className={`${inter.className} antialiased`}>
         <TelemetryTagManager />
         <FeatureFlagProvider API_URL={API_URL}>
-          <ThemeProvider
-            themes={['dark', 'light', 'classic-dark']}
-            defaultTheme="system"
-            enableSystem
-          >
+          <Providers>
             {children}
             <Toaster />
-          </ThemeProvider>
+          </Providers>
         </FeatureFlagProvider>
       </body>
     </html>

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -40,7 +40,7 @@
     "monaco-editor": "^0.55.1",
     "next": "catalog:",
     "next-contentlayer2": "0.4.6",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "openai": "^5.9.0",
     "openapi-fetch": "0.12.4",
     "radix-ui": "catalog:",

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -67,7 +67,7 @@
     "monaco-editor": "^0.55.1",
     "next": "catalog:",
     "next-contentlayer2": "0.4.6",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "openai": "^5.9.0",
     "openapi-fetch": "0.12.4",
     "react": "catalog:",

--- a/apps/www/app/providers.tsx
+++ b/apps/www/app/providers.tsx
@@ -12,7 +12,7 @@ import {
 import { WwwCommandMenu } from 'components/CommandMenu'
 import { DevToolbar, DevToolbarProvider } from 'dev-tools'
 import { API_URL } from 'lib/constants'
-import { themes, TooltipProvider } from 'ui'
+import { TooltipProvider } from 'ui'
 import { CommandProvider } from 'ui-patterns/CommandMenu'
 import { useConsentToast } from 'ui-patterns/consent'
 
@@ -26,7 +26,7 @@ function Providers({ children }: { children: React.ReactNode }) {
     <AuthProvider>
       <FeatureFlagProvider API_URL={API_URL} enabled={IS_PLATFORM}>
         <DevToolbarProvider apiUrl={API_URL}>
-          <ThemeProvider themes={themes.map((t) => t.value)} enableSystem disableTransitionOnChange>
+          <ThemeProvider>
             <TooltipProvider delayDuration={0}>
               <CommandProvider>
                 <TelemetryTagManager />

--- a/apps/www/app/providers.tsx
+++ b/apps/www/app/providers.tsx
@@ -14,7 +14,7 @@ import { DevToolbar, DevToolbarProvider } from 'dev-tools'
 import { API_URL } from 'lib/constants'
 import { NuqsAdapter } from 'nuqs/adapters/next/app'
 import { Suspense } from 'react'
-import { SonnerToaster, themes, TooltipProvider } from 'ui'
+import { TooltipProvider } from 'ui'
 import { CommandProvider } from 'ui-patterns/CommandMenu'
 import { useConsentToast } from 'ui-patterns/consent'
 
@@ -29,11 +29,7 @@ function Providers({ children }: { children: React.ReactNode }) {
       <AuthProvider>
         <FeatureFlagProvider API_URL={API_URL} enabled={IS_PLATFORM}>
           <DevToolbarProvider apiUrl={API_URL}>
-            <ThemeProvider
-              themes={themes.map((t) => t.value)}
-              enableSystem
-              disableTransitionOnChange
-            >
+            <ThemeProvider>
               <TooltipProvider delayDuration={0}>
                 <CommandProvider>
                   <TelemetryTagManager />

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -67,7 +67,7 @@
     "next": "^15.5.15",
     "next-mdx-remote": "^6.0.0",
     "next-seo": "^6.5.0",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "nuqs": "^2.8.1",
     "openai": "^4.75.1",
     "parse-numeric-range": "^1.3.0",

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -21,7 +21,7 @@ import { DefaultSeo } from 'next-seo'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { themes, TooltipProvider } from 'ui'
+import { TooltipProvider } from 'ui'
 import { CommandProvider } from 'ui-patterns/CommandMenu'
 import { useConsentToast } from 'ui-patterns/consent'
 
@@ -105,12 +105,7 @@ export default function App({ Component, pageProps }: AppProps) {
         {/* [TODO] I think we need to deconflict with the providers in layout.tsx? */}
         <FeatureFlagProvider API_URL={API_URL} enabled={{ cc: true, ph: false }}>
           <DevToolbarProvider apiUrl={API_URL}>
-            <ThemeProvider
-              themes={themes.map((theme) => theme.value)}
-              enableSystem
-              disableTransitionOnChange
-              forcedTheme={forceDarkMode ? 'dark' : undefined}
-            >
+            <ThemeProvider forcedTheme={forceDarkMode ? 'dark' : undefined}>
               <TooltipProvider delayDuration={0}>
                 <CommandProvider app="www" onTelemetry={onTelemetry}>
                   <Toaster />

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -20,7 +20,7 @@ import { DefaultSeo } from 'next-seo'
 import type { AppProps } from 'next/app'
 import Head from 'next/head'
 import { useRouter } from 'next/router'
-import { themes, TooltipProvider } from 'ui'
+import { TooltipProvider } from 'ui'
 import { CommandProvider } from 'ui-patterns/CommandMenu'
 import { useConsentToast } from 'ui-patterns/consent'
 
@@ -93,12 +93,7 @@ export default function App({ Component, pageProps }: AppProps) {
         {/* [TODO] I think we need to deconflict with the providers in layout.tsx? */}
         <FeatureFlagProvider API_URL={API_URL} enabled={{ cc: true, ph: false }}>
           <DevToolbarProvider apiUrl={API_URL}>
-            <ThemeProvider
-              themes={themes.map((theme) => theme.value)}
-              enableSystem
-              disableTransitionOnChange
-              forcedTheme={forceDarkMode ? 'dark' : undefined}
-            >
+            <ThemeProvider forcedTheme={forceDarkMode ? 'dark' : undefined}>
               <TooltipProvider delayDuration={0}>
                 <CommandProvider app="www" onTelemetry={onTelemetry}>
                   <Toaster />

--- a/apps/www/styles/index.css
+++ b/apps/www/styles/index.css
@@ -2,6 +2,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
+@import './../../../packages/ui/build/css/themes/classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @config '../tailwind.config.js';

--- a/apps/www/styles/index.css
+++ b/apps/www/styles/index.css
@@ -2,7 +2,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
-@import './../../../packages/ui/build/css/themes/classic-dark.css';
+@import './../../../packages/ui/build/css/themes/faux-classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @config '../tailwind.config.js';

--- a/apps/www/styles/index.css
+++ b/apps/www/styles/index.css
@@ -6,6 +6,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
+@import './../../../packages/ui/build/css/themes/classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @layer utilities {

--- a/apps/www/styles/index.css
+++ b/apps/www/styles/index.css
@@ -6,7 +6,7 @@
 
 @import './../../../packages/ui/build/css/source/global.css';
 @import './../../../packages/ui/build/css/themes/dark.css';
-@import './../../../packages/ui/build/css/themes/classic-dark.css';
+@import './../../../packages/ui/build/css/themes/faux-classic-dark.css';
 @import './../../../packages/ui/build/css/themes/light.css';
 
 @layer utilities {

--- a/packages/common/Providers.tsx
+++ b/packages/common/Providers.tsx
@@ -1,13 +1,16 @@
 'use client'
 
-import { ThemeProvider as NextThemesProvider } from 'next-themes'
-import type { ThemeProviderProps } from 'next-themes/dist/types'
+import { ThemeProvider as NextThemesProvider, type ThemeProviderProps } from 'next-themes'
 
 export function ThemeProvider({ children, ...props }: ThemeProviderProps) {
-  // @ts-ignore next-themes is old :/
-
   return (
-    <NextThemesProvider themes={['dark', 'light']} defaultTheme="dark" {...props}>
+    <NextThemesProvider
+      themes={['dark', 'light', 'classic-dark']}
+      defaultTheme="system"
+      enableSystem
+      disableTransitionOnChange
+      {...props}
+    >
       {children}
     </NextThemesProvider>
   )

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -20,7 +20,7 @@
     "dat.gui": "^0.7.9",
     "flags": "^4.0.0",
     "lodash": "catalog:",
-    "next-themes": "^0.3.0",
+    "next-themes": "catalog:",
     "posthog-js": "^1.333.0",
     "react-use": "^17.4.0",
     "valtio": "catalog:"

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -802,7 +802,7 @@
     "mdast": "^3.0.0",
     "mermaid": "^11.12.1",
     "monaco-editor": "*",
-    "next-themes": "*",
+    "next-themes": "catalog:",
     "openai": "^4.75.1",
     "prism-react-renderer": "^2.3.1",
     "radix-ui": "catalog:",

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -804,7 +804,7 @@
     "mermaid": "^11.12.1",
     "mdast": "^3.0.0",
     "monaco-editor": "*",
-    "next-themes": "*",
+    "next-themes": "catalog:",
     "openai": "^4.75.1",
     "prism-react-renderer": "^2.3.1",
     "react": "catalog:",

--- a/packages/ui-patterns/src/ThemeToggle.tsx
+++ b/packages/ui-patterns/src/ThemeToggle.tsx
@@ -65,11 +65,13 @@ export const ThemeToggle = ({
               setTheme(value)
             }}
           >
-            {themes.map((theme) => (
-              <DropdownMenuRadioItem key={theme.value} value={theme.value}>
-                {theme.name}
-              </DropdownMenuRadioItem>
-            ))}
+            {themes
+              .filter((x) => x.value === 'dark' || x.value === 'light' || x.value === 'system')
+              .map((theme: Theme) => (
+                <DropdownMenuRadioItem key={theme.value} value={theme.value}>
+                  {theme.name}
+                </DropdownMenuRadioItem>
+              ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/packages/ui-patterns/src/ThemeToggle.tsx
+++ b/packages/ui-patterns/src/ThemeToggle.tsx
@@ -65,13 +65,11 @@ export const ThemeToggle = ({
               setTheme(value)
             }}
           >
-            {themes
-              .filter((x) => x.value === 'dark' || x.value === 'light' || x.value === 'system')
-              .map((theme: Theme) => (
-                <DropdownMenuRadioItem key={theme.value} value={theme.value}>
-                  {theme.name}
-                </DropdownMenuRadioItem>
-              ))}
+            {themes.map((theme) => (
+              <DropdownMenuRadioItem key={theme.value} value={theme.value}>
+                {theme.name}
+              </DropdownMenuRadioItem>
+            ))}
           </DropdownMenuRadioGroup>
         </DropdownMenuGroup>
       </DropdownMenuContent>

--- a/packages/ui/build/css/themes/faux-classic-dark.css
+++ b/packages/ui/build/css/themes/faux-classic-dark.css
@@ -1,0 +1,68 @@
+/* 
+ * This theme has the same values as the dark theme meant to be used in www and docs. www and docs can only support
+ * light and dark themes because they only have images for light and dark themes. 
+ */
+[data-theme='classic-dark'],
+.classic-dark {
+  --helpers-os-appearance: Dark;
+  --code-block-5: 13.8deg 89.7% 69.6%;
+  --code-block-4: 276.1deg 67.7% 74.5%;
+  --code-block-3: 83.8deg 61.7% 63.1%;
+  --code-block-2: 33.2deg 90.3% 75.7%;
+  --code-block-1: 170.8deg 43.1% 61.4%;
+  --secondary-default: 247.8deg 100% 70%;
+  --secondary-400: 248.3deg 54.5% 25.9%;
+  --secondary-200: 248deg 53.6% 11%;
+  --brand-link: 155deg 100% 38.6%;
+  --brand-default: 153.1deg 60.2% 52.7%;
+  --brand-600: 154.9deg 59.5% 70%;
+  --brand-500: 154.9deg 100% 19.2%;
+  --brand-400: 155.5deg 100% 9.6%;
+  --brand-300: 155.1deg 100% 8%;
+  --brand-200: 162deg 100% 2%;
+  --warning-default: 38.9deg 100% 42.9%; /* warning-600 */
+  --warning-600: 38.9deg 100% 42.9%;
+  --warning-500: 34.8deg 90.9% 21.6%;
+  --warning-400: 33.2deg 100% 14.5%;
+  --warning-300: 32.3deg 100% 10.2%;
+  --warning-200: 36.6deg 100% 8%;
+  --destructive-default: 10.2deg 77.9% 53.9%;
+  --destructive-600: 9.7deg 85.2% 62.9%;
+  --destructive-500: 7.9deg 71.6% 29%;
+  --destructive-400: 6.7deg 60% 20.6%;
+  --destructive-300: 7.5deg 51.3% 15.3%;
+  --destructive-200: 10.9deg 23.4% 9.2%;
+  --border-stronger: 0deg 0% 27.1%;
+  --border-strong: 0deg 0% 21.2%;
+  --border-alternative: 0deg 0% 26.7%;
+  --border-control: 0deg 0% 22.4%;
+  --border-overlay: 0deg 0% 20%;
+  --border-secondary: 0deg 0% 14.1%;
+  --border-muted: 0deg 0% 14.1%;
+  --border-default: 0deg 0% 18%;
+  --background-dash-canvas: 0deg 0% 7.1%;
+  --background-dash-sidebar: 0deg 0% 9%;
+  --background-dialog-default: 0deg 0% 7.1%;
+  --background-muted: 0deg 0% 14.1%;
+  --background-overlay-hover: 0deg 0% 18%;
+  --background-overlay-default: 0deg 0% 14.1%;
+  --background-surface-400: 0deg 0% 16.1%;
+  --background-surface-300: 0deg 0% 16.1%;
+  --background-surface-200: 0deg 0% 12.9%;
+  --background-surface-100: 0deg 0% 12.2%;
+  --background-surface-75: 0deg 0% 9%;
+  --background-control: 0deg 0% 14.1%;
+  --background-selection: 0deg 0% 19.2%;
+  --background-alternative-default: 0deg 0% 5.9%;
+  --background-default: 0deg 0% 7.1%;
+  --background-200: 0deg 0% 9%;
+  --foreground-contrast: 0deg 0% 8.6%;
+  --foreground-muted: 0deg 0% 30.2%;
+  --foreground-lighter: 0deg 0% 53.7%;
+  --foreground-light: 0deg 0% 70.6%;
+  --foreground-default: 0deg 0% 98%;
+  --border-button-hover: var(--colors-gray-dark-800);
+  --border-button-default: var(--colors-gray-dark-700);
+  --background-button-default: var(--colors-gray-dark-500);
+  --background-alternative-200: var(--colors-gray-dark-200);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     next:
       specifier: 16.2.3
       version: 16.2.3
+    next-themes:
+      specifier: ^0.4.6
+      version: 0.4.6
     radix-ui:
       specifier: ^1.4.3
       version: 1.4.3
@@ -200,8 +203,8 @@ importers:
         specifier: 0.4.6
         version: 0.4.6(contentlayer2@0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1))(esbuild@0.25.2)(markdown-wasm@1.2.0)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -462,8 +465,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: ^1.19.1
         version: 1.19.1(next@15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
@@ -715,8 +718,8 @@ importers:
         specifier: 0.4.6
         version: 0.4.6(contentlayer2@0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1))(esbuild@0.25.2)(markdown-wasm@1.2.0)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -913,7 +916,7 @@ importers:
         version: 0.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))
+        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))
       '@std/path':
         specifier: npm:@jsr/std__path@^1.0.8
         version: '@jsr/std__path@1.0.8'
@@ -1065,11 +1068,11 @@ importers:
         specifier: 'catalog:'
         version: 16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: 2.7.1
-        version: 2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.104.0
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -1319,7 +1322,7 @@ importers:
         version: 2.11.3(@types/node@22.13.14)(typescript@6.0.2)
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
+        version: 0.9.13(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
       node-mocks-http:
         specifier: ^1.17.2
         version: 1.17.2(@types/node@22.13.14)
@@ -1426,8 +1429,8 @@ importers:
         specifier: 0.4.6
         version: 0.4.6(contentlayer2@0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1))(esbuild@0.25.2)(markdown-wasm@1.2.0)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^5.9.0
         version: 5.9.0(ws@8.19.0)(zod@3.25.76)
@@ -1724,8 +1727,8 @@ importers:
         specifier: ^6.5.0
         version: 6.5.0(next@15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: ^2.8.1
         version: 2.8.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -2082,8 +2085,8 @@ importers:
         specifier: 'catalog:'
         version: 16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       posthog-js:
         specifier: ^1.333.0
         version: 1.357.0
@@ -2206,7 +2209,7 @@ importers:
         version: link:../config
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
+        version: 0.9.13(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.4
@@ -2563,8 +2566,8 @@ importers:
         specifier: 'catalog:'
         version: 16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       next-themes:
-        specifier: '*'
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.75.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -2688,7 +2691,7 @@ importers:
         version: link:../config
       next-router-mock:
         specifier: ^0.9.13
-        version: 0.9.13(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
+        version: 0.9.13(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)
       tailwindcss:
         specifier: ^4.2.4
         version: 4.2.4
@@ -3460,23 +3463,14 @@ packages:
   '@electric-sql/pglite@0.2.15':
     resolution: {integrity: sha512-Jiq31Dnk+rg8rMhcSxs4lQvHTyizNo5b269c1gCC3ldQ0sCLrNVPGzy+KnmonKy1ZArTUuXZf23/UamzFMKVaA==}
 
-  '@emnapi/core@1.9.0':
-    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
-
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
 
   '@emnapi/runtime@0.43.1':
     resolution: {integrity: sha512-Q5sMc4Z4gsD4tlmlyFu+MpNAwpR7Gv2errDhVJ+SOhNjWcx8UTqy+hswb8L31RfC8jBvDgcnT87l3xI2w08rAg==}
 
-  '@emnapi/runtime@1.7.1':
-    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
-
   '@emnapi/runtime@1.9.2':
     resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
-
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -13886,11 +13880,11 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
 
-  next-themes@0.3.0:
-    resolution: {integrity: sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==}
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
-      react: ^16.8 || ^17 || ^18
-      react-dom: ^16.8 || ^17 || ^18
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
@@ -19310,12 +19304,6 @@ snapshots:
   '@electric-sql/pglite@0.2.15':
     optional: true
 
-  '@emnapi/core@1.9.0':
-    dependencies:
-      '@emnapi/wasi-threads': 1.2.0
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/core@1.9.2':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -19326,17 +19314,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@emnapi/runtime@1.7.1':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
   '@emnapi/runtime@1.9.2':
-    dependencies:
-      tslib: 2.8.1
-    optional: true
-
-  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -20336,7 +20314,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/runtime': 1.9.2
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -20745,8 +20723,8 @@ snapshots:
 
   '@napi-rs/wasm-runtime@1.1.1':
     dependencies:
-      '@emnapi/core': 1.9.0
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -23591,7 +23569,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))':
+  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -31613,7 +31591,7 @@ snapshots:
     dependencies:
       js-yaml-loader: 1.2.2
 
-  next-router-mock@0.9.13(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1):
+  next-router-mock@0.9.13(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1):
     dependencies:
       next: 16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       react: 18.3.1
@@ -31624,7 +31602,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next-themes@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-themes@0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -31946,7 +31924,7 @@ snapshots:
       mitt: 3.0.1
       next: 15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
 
-  nuqs@2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  nuqs@2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      common:
+        specifier: workspace:*
+        version: link:../../packages/common
       contentlayer2:
         specifier: 0.4.6
         version: 0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -168,6 +168,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      common:
+        specifier: workspace:*
+        version: link:../../packages/common
       contentlayer2:
         specifier: 0.4.6
         version: 0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     next:
       specifier: 16.2.3
       version: 16.2.3
+    next-themes:
+      specifier: ^0.4.6
+      version: 0.4.6
     react:
       specifier: ^18.3.0
       version: 18.3.1
@@ -196,8 +199,8 @@ importers:
         specifier: 0.4.6
         version: 0.4.6(contentlayer2@0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1))(esbuild@0.25.2)(markdown-wasm@1.2.0)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -470,8 +473,8 @@ importers:
         specifier: ^1.0.1
         version: 1.0.1
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: ^1.19.1
         version: 1.19.1(next@15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))
@@ -723,8 +726,8 @@ importers:
         specifier: 0.4.6
         version: 0.4.6(contentlayer2@0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1))(esbuild@0.25.2)(markdown-wasm@1.2.0)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 'catalog:'
         version: 18.3.1
@@ -1082,8 +1085,8 @@ importers:
         specifier: 'catalog:'
         version: 16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: 2.7.1
         version: 2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -1527,8 +1530,8 @@ importers:
         specifier: 0.4.6
         version: 0.4.6(contentlayer2@0.4.6(esbuild@0.25.2)(markdown-wasm@1.2.0)(supports-color@8.1.1))(esbuild@0.25.2)(markdown-wasm@1.2.0)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(supports-color@8.1.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^5.9.0
         version: 5.9.0(ws@8.19.0)(zod@3.25.76)
@@ -1822,8 +1825,8 @@ importers:
         specifier: ^6.5.0
         version: 6.5.0(next@15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: ^2.8.1
         version: 2.8.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
@@ -2174,8 +2177,8 @@ importers:
         specifier: 'catalog:'
         version: 16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       next-themes:
-        specifier: ^0.3.0
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       posthog-js:
         specifier: ^1.333.0
         version: 1.357.0
@@ -2724,8 +2727,8 @@ importers:
         specifier: 'catalog:'
         version: 16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       next-themes:
-        specifier: '*'
-        version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.75.1
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -14869,11 +14872,11 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
 
-  next-themes@0.3.0:
-    resolution: {integrity: sha512-/QHIrsYpd6Kfk7xakK4svpDI5mmXP0gfvCoJdGpZQ2TOrQZmsW0QxjaiLn8wbIKjtm4BTSqLoix4lxYYOnLJ/w==}
+  next-themes@0.4.6:
+    resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
-      react: ^16.8 || ^17 || ^18
-      react-dom: ^16.8 || ^17 || ^18
+      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
   next-tick@1.1.0:
     resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
@@ -33601,7 +33604,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next-themes@0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-themes@0.4.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ catalog:
   lodash: ^4.18.1
   lodash-es: ^4.18.1
   next: 16.2.3
+  next-themes: ^0.4.6
   postcss: ^8.5.10
   radix-ui: ^1.4.3
   react: ^18.3.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -17,6 +17,7 @@ catalog:
   lodash: ^4.18.1
   lodash-es: ^4.18.1
   next: 16.2.3
+  next-themes: ^0.4.6
   react: ^18.3.0
   react-dom: ^18.3.0
   recharts: ^2.15.4
@@ -50,7 +51,7 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/*'
   - '@supabase/*'
   - '@supabase-labs/*'
-  - braintrust  # Included for bugfix in v3.9.0
+  - braintrust # Included for bugfix in v3.9.0
   # The following packages are excluded from the minimum release age check because they had a vulneralibity
   # Delete them the next time you update this list
   - follow-redirects


### PR DESCRIPTION
This PR fixes a bug where a user might choose `classic-dark` as a theme in `studio` but then `docs` and `marketing` apps will look weird.

To test:
- Change the localStorage value of `theme` to `classic-dark`
- Open `www` and `docs` apps, they should look ok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "classic-dark" theme option for enhanced visual customization.

* **Improvements**
  * Unified and simplified theme handling across apps for more consistent behavior.
  * Improved system-theme detection and smoother transitions when switching themes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->