### PR TITLE
chore(self-host-tests-smoke): use --quiet-pull for docker compose

### DIFF
--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -31,4 +31,4 @@ jobs:
           cd docker
           cp .env.example .env
           yq -i '.services.supavisor.environment.RLIMIT_NOFILE=1024' docker-compose.yml
-          docker compose up --wait --wait-timeout 180
+          docker compose up --quiet-pull --wait --wait-timeout 180


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

CI

## What is the new behavior?

Use `--quiet-pull` to reduce verbose img pull logs during docker compose up



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized smoke test workflow configuration for reduced output verbosity during Docker operations.

---

**Note:** This change is internal and does not impact end-user functionality or experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->