### PR TITLE
feat(studio): add disable action for custom OAuth providers

### DIFF
--- a/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/CustomAuthProviders/CreateOrUpdateCustomProviderSheet.tsx
@@ -209,7 +209,6 @@ export const CreateOrUpdateCustomProviderSheet = ({
         scopes: values.scopes.split(',').map((s) => s.trim()),
         issuer: values.issuer,
         pkce_enabled: true,
-        enabled: true,
         email_optional: values.email_optional,
         ...payload,
       })

--- a/apps/studio/components/interfaces/Auth/CustomAuthProviders/CustomAuthProvidersList.tsx
+++ b/apps/studio/components/interfaces/Auth/CustomAuthProviders/CustomAuthProvidersList.tsx
@@ -1,6 +1,6 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { Edit, MoreVertical, Plus, Search, Trash, X } from 'lucide-react'
+import { Edit, MoreVertical, Plus, Power, PowerOff, Search, Trash, X } from 'lucide-react'
 import { parseAsBoolean, parseAsStringLiteral, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -35,11 +35,14 @@ import {
   getNextPlanForCustomProviders,
 } from './customProviders.utils'
 import { DeleteCustomProviderModal } from './DeleteCustomProviderModal'
+import { DisableCustomProviderModal } from './DisableCustomProviderModal'
 import AlertError from '@/components/ui/AlertError'
 import { FilterPopover } from '@/components/ui/FilterPopover'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
 import { useAuthConfigQuery } from '@/data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-mutation'
+import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
+import { useOAuthCustomProviderUpdateMutation } from '@/data/oauth-custom-providers/oauth-custom-provider-update-mutation'
 import { useOAuthCustomProvidersQuery } from '@/data/oauth-custom-providers/oauth-custom-providers-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
@@ -87,6 +90,7 @@ export const CustomAuthProvidersList = () => {
 
   const { data: organization } = useSelectedOrganizationQuery()
   const { data: authConfig, isPending: isAuthConfigLoading } = useAuthConfigQuery({ projectRef })
+  const { hostEndpoint: clientEndpoint } = useProjectApiUrl({ projectRef })
   const nextPlan = getNextPlanForCustomProviders(organization?.plan?.id)
   const isCustomProvidersEnabled = !!authConfig?.CUSTOM_OAUTH_ENABLED
   const providerLimit = authConfig?.CUSTOM_OAUTH_MAX_PROVIDERS || 0
@@ -102,6 +106,12 @@ export const CustomAuthProvidersList = () => {
     },
   })
 
+  const { mutate: updateCustomProvider } = useOAuthCustomProviderUpdateMutation({
+    onSuccess: () => {
+      toast.success('Custom provider enabled')
+    },
+  })
+
   const handleEnableCustomProviders = () => {
     if (projectRef) {
       updateAuthConfig({ projectRef, config: { CUSTOM_OAUTH_ENABLED: true } })
@@ -110,6 +120,7 @@ export const CustomAuthProvidersList = () => {
 
   const [selectedProviderToEdit, setSelectedProviderToEdit] = useState<string | null>(null)
   const [selectedProviderToDelete, setSelectedProviderToDelete] = useState<string | null>(null)
+  const [selectedProviderToDisable, setSelectedProviderToDisable] = useState<string | null>(null)
   const [filteredProviderTypes, setFilteredProviderTypes] = useState<string[]>([])
   const [filteredEnabledStatuses, setFilteredEnabledStatuses] = useState<string[]>([])
 
@@ -149,6 +160,11 @@ export const CustomAuthProvidersList = () => {
   const providerToDelete = useMemo(
     () => customProviders?.find((p) => p.id === selectedProviderToDelete),
     [customProviders, selectedProviderToDelete]
+  )
+
+  const providerToDisable = useMemo(
+    () => customProviders?.find((p) => p.id === selectedProviderToDisable),
+    [customProviders, selectedProviderToDisable]
   )
 
   const filteredAndSortedCustomProviders = useMemo(() => {
@@ -439,6 +455,30 @@ export const CustomAuthProvidersList = () => {
                                 <Edit size={12} />
                                 <p>Update</p>
                               </DropdownMenuItem>
+                              {provider.enabled ? (
+                                <DropdownMenuItem
+                                  className="space-x-2"
+                                  onClick={() => setSelectedProviderToDisable(provider.id)}
+                                >
+                                  <PowerOff size={12} />
+                                  <p>Disable</p>
+                                </DropdownMenuItem>
+                              ) : (
+                                <DropdownMenuItem
+                                  className="space-x-2"
+                                  onClick={() =>
+                                    updateCustomProvider({
+                                      identifier: provider.identifier,
+                                      projectRef,
+                                      clientEndpoint,
+                                      enabled: true,
+                                    })
+                                  }
+                                >
+                                  <Power size={12} />
+                                  <p>Enable</p>
+                                </DropdownMenuItem>
+                              )}
                               <DropdownMenuItem
                                 className="space-x-2"
                                 onClick={() => setSelectedProviderToDelete(provider.id)}
@@ -471,6 +511,12 @@ export const CustomAuthProvidersList = () => {
         visible={!!providerToDelete}
         selectedProvider={providerToDelete}
         onClose={() => setSelectedProviderToDelete(null)}
+      />
+
+      <DisableCustomProviderModal
+        visible={!!providerToDisable}
+        selectedProvider={providerToDisable}
+        onClose={() => setSelectedProviderToDisable(null)}
       />
     </>
   )

--- a/apps/studio/components/interfaces/Auth/CustomAuthProviders/DisableCustomProviderModal.tsx
+++ b/apps/studio/components/interfaces/Auth/CustomAuthProviders/DisableCustomProviderModal.tsx
@@ -1,0 +1,71 @@
+import type { CustomOAuthProvider } from '@supabase/auth-js'
+import { useParams } from 'common'
+import { toast } from 'sonner'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
+import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
+import { useOAuthCustomProviderUpdateMutation } from '@/data/oauth-custom-providers/oauth-custom-provider-update-mutation'
+
+interface DisableCustomProviderModalProps {
+  visible: boolean
+  selectedProvider?: CustomOAuthProvider
+  onClose: () => void
+}
+
+export const DisableCustomProviderModal = ({
+  visible,
+  selectedProvider,
+  onClose,
+}: DisableCustomProviderModalProps) => {
+  const { ref: projectRef } = useParams()
+  const { hostEndpoint: clientEndpoint } = useProjectApiUrl({ projectRef })
+  const { mutate, isPending } = useOAuthCustomProviderUpdateMutation({
+    onSuccess: () => {
+      toast.success('Custom provider disabled')
+      onClose()
+    },
+  })
+
+  const onConfirmDisable = () => {
+    mutate({
+      identifier: selectedProvider?.identifier,
+      projectRef,
+      clientEndpoint,
+      enabled: false,
+    })
+  }
+
+  return (
+    <ConfirmationModal
+      variant="warning"
+      size="medium"
+      loading={isPending}
+      visible={visible}
+      title={
+        <>
+          Confirm to disable custom provider{' '}
+          <code className="text-sm">{selectedProvider?.name}</code>
+        </>
+      }
+      confirmLabel="Confirm disable"
+      confirmLabelLoading="Disabling..."
+      onCancel={() => onClose()}
+      onConfirm={() => onConfirmDisable()}
+      alert={{
+        title: 'Users will not be able to sign in with this provider',
+        description:
+          'You can re-enable it at any time. Existing sessions are not affected, but new sign-ins will fail until the provider is re-enabled.',
+      }}
+    >
+      <p className="text-sm">Before disabling this custom provider, consider:</p>
+      <ul className="space-y-2 mt-2 text-sm text-foreground-light">
+        <li className="list-disc ml-6">
+          Users authenticating with this provider will be unable to sign in
+        </li>
+        <li className="list-disc ml-6">
+          Applications relying on this provider should be updated or paused
+        </li>
+      </ul>
+    </ConfirmationModal>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds an Enable/Disable dropdown action in each row of the custom OAuth providers list.
- Disabling opens a confirmation modal that calls the existing update API with `enabled: false`; enabling is immediate (restorative, no confirmation).
- Removes the hardcoded `enabled: true` from the edit sheet's update payload so editing a disabled provider no longer silently re-enables it.

Closes [FE-3067](https://linear.app/supabase/issue/FE-3067/add-disable-button-for-custom-oauth-providers).

## Test plan

- [x] Create a custom OAuth provider — it is enabled by default.
- [x] Click the row menu → "Disable". Confirm in the modal. Row shows `Disabled` badge.
- [x] Click the row menu → "Enable". Row immediately flips back to `Enabled`.
- [x] Edit a disabled provider via the "Update" action, save. Verify it remains `Disabled` (no silent re-enable).
- [x] Delete action still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added enable/disable toggle controls for individual custom OAuth providers in the provider list
  * Added confirmation dialog when disabling a provider to prevent accidental changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->