### PR TITLE
fix: restore pitr duration inputs label

### DIFF
--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -280,6 +280,9 @@ const PITRSidePanel = () => {
                 />
               ) : null}
 
+              <label className="block text-sm text-foreground-light mb-4" htmlFor="pitr">
+                Choose the duration of recovery
+              </label>
               <RadioGroupCard
                 id="pitr"
                 className="flex flex-wrap gap-3"


### PR DESCRIPTION
## Problem 

#45218 removed the PITR duration input label: _Choose the duration of recovery_

## Solution

Restore it

## Screenshots

Before:
<img width="1534" height="1130" alt="image" src="https://github.com/user-attachments/assets/f1f7fc5b-0fba-4356-b6d6-9bffcaa211bd" />

After:
<img width="760" height="734" alt="image" src="https://github.com/user-attachments/assets/5df7a986-9c3b-48a3-84d7-4de151dd7f5f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved accessibility of the PITR (Point-In-Time Recovery) settings control by adding proper label association for the recovery-duration selection option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->