### PR TITLE
Update pgnet alter settings doc

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -329,16 +329,22 @@ where "name" like 'pg_net%';
 
 ### Alter settings
 
-Change variables:
+You must change the `pg_net` settings at the system level.
+
+<Admonition type="note">
+
+Changing these settings requires superuser privileges. Contact Support to have the required permission granted for the parameter you want to change, e.g.:
 
 ```sql
-alter role "postgres" set pg_net.ttl to '24 hours';
-alter role "postgres" set pg_net.batch_size to 500;
+grant alter system on parameter pg_net.ttl to postgres;
 ```
 
-Then reload the settings and restart the `pg_net` background worker with:
+</Admonition>
+
+Once the privilege is assigned, apply the setting at the system level and restart the background worker:
 
 ```sql
+alter system set pg_net.ttl to '24 hours';
 select net.worker_restart();
 ```
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Current docs are wrong and yield `ERROR:  parameter "pg_net.ttl" cannot be changed now`

## What is the new behavior?

Additional permissions required, setting should be at the system level




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pg_net setup guidance to require system-level configuration, added note that changing pg_net parameters requires superuser privileges (with grant example), and clarified applying parameter changes via system-level set followed by restarting the pg_net background worker.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->