### PR TITLE
fix: don't reset payment method form on backend error

### DIFF
--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -260,7 +260,6 @@ export const NewOrgForm = ({
     },
     onError: (data) => {
       toast.error(data.message, { duration: 10_000 })
-      resetPaymentMethod()
       setNewOrgLoading(false)
     },
   })
@@ -355,23 +354,21 @@ export const NewOrgForm = ({
 
     if (formValues.plan === 'FREE') {
       await createOrg(formValues)
-    } else if (!paymentMethod) {
-      const result = await paymentRef.current?.createPaymentMethod()
-      if (result) {
-        setPaymentMethod(result.paymentMethod)
-        const customerData = {
-          address: result.address,
-          billing_name: result.customerName,
-          tax_id: result.taxId,
-        }
-
-        createOrg(formValues, result.paymentMethod.id, customerData)
-      } else {
-        setNewOrgLoading(false)
-      }
-    } else {
-      createOrg(formValues, paymentMethod.id)
+      return
     }
+
+    const result = await paymentRef.current?.createPaymentMethod()
+    if (!result) {
+      setNewOrgLoading(false)
+      return
+    }
+
+    setPaymentMethod(result.paymentMethod)
+    createOrg(formValues, result.paymentMethod.id, {
+      address: result.address,
+      billing_name: result.customerName,
+      tax_id: result.taxId,
+    })
   }
 
   const resetPaymentMethod = () => {


### PR DESCRIPTION
## Problem

When creating a new paid organization, if the backend rejects the request (e.g. invalid tax ID, invalid billing address, name conflict, rate-limit), the Stripe payment UI was torn down and remounted empty. 

## Solution

- Remove `resetPaymentMethod()` from the org-create mutation's `onError`. Server-side validation failures don't consume or invalidate the Stripe payment method, so there's no reason to tear down the Elements. 
- Collapse the paid-plan submit flow so that `createPaymentMethod()` is called on every attempt (not just the first). This materializes a fresh `PaymentMethod` from whatever is currently in the Stripe Elements - correctly capturing edits the user made between attempts (including card number changes), and guaranteeing the latest address/tax ID are sent.

## Test plan

- [ ] Go to `/new`, pick **Pro**, fill a valid card (`4242 4242 4242 4242`) and address, tick "I'm purchasing as a business", select a tax ID type and enter an **invalid** tax ID value → submit
- [ ] Confirm: error toast appears, card number + address fields + tax ID selector + tax ID value remain populated, loading state clears
- [ ] Correct the tax ID and resubmit → confirm the network request contains the **corrected** `tax_id` (not `undefined`) and succeeds
- [ ] Regression: create a Free org still works
- [ ] Regression: a 3DS failure on a paid org still resets the payment method (that path goes through `PaymentConfirmation.onError`, unchanged). Use card `4000002760003184`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved payment method handling during organization creation for paid plans. The system now consistently attempts to create payment methods and properly handles failures. Payment information is preserved on errors, providing a more reliable organization setup experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->