### PR TITLE
feat: add TaxDisclaimer for addons

### DIFF
--- a/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
@@ -39,6 +39,7 @@ import {
 } from 'ui-patterns/PageSection'
 import * as z from 'zod'
 
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import AlertError from '@/components/ui/AlertError'
 import NoPermission from '@/components/ui/NoPermission'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
@@ -610,6 +611,7 @@ export const MfaAuthSettingsForm = () => {
           Billing will start immediately upon enabling this add-on, regardless of whether your
           customers are using SMS MFA.
         </p>
+        <TaxDisclaimer className="mt-2" />
       </ConfirmationModal>
 
       <PageSection>

--- a/apps/studio/components/interfaces/Billing/TaxDisclaimer.tsx
+++ b/apps/studio/components/interfaces/Billing/TaxDisclaimer.tsx
@@ -1,0 +1,13 @@
+import { cn } from 'ui'
+
+interface TaxDisclaimerProps {
+  className?: string
+}
+
+export const TaxDisclaimer = ({ className }: TaxDisclaimerProps) => {
+  return (
+    <p className={cn('text-xs text-foreground-muted', className)}>
+      Prices shown do not include applicable taxes.
+    </p>
+  )
+}

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -40,6 +40,7 @@ import {
   estimateDiskCost,
   estimateRestoreTime,
 } from './BranchManagement.utils'
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { BranchingPITRNotice } from '@/components/layouts/AppLayout/EnableBranchingButton/BranchingPITRNotice'
 import AlertError from '@/components/ui/AlertError'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -605,6 +606,7 @@ export const CreateBranchModal = () => {
               </div>
 
               {!hasPitrEnabled && <BranchingPITRNotice />}
+              <TaxDisclaimer />
             </DialogSection>
 
             <DialogFooter className="justify-end gap-2" padding="medium">

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaPricingDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/ReadReplicaForm/ReadReplicaPricingDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from 'ui'
 
 import { useGetReplicaCost } from './useGetReplicaCost'
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -104,6 +105,7 @@ export const ReadReplicaPricingDialog = () => {
               .
             </p>
           )}
+          <TaxDisclaimer className="mt-3" />
         </DialogSection>
 
         <DialogFooter>

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.tsx
@@ -27,6 +27,7 @@ import {
   ValueChange,
 } from './DiskManagementReviewAndSubmitDialog.components'
 import { useDiskManagementReviewChanges } from './DiskManagementReviewAndSubmitDialog.hooks'
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -154,6 +155,7 @@ export const DiskManagementReviewAndSubmitDialog = ({
                 </span>
               </div>
             </div>
+            <TaxDisclaimer className="px-5 py-2 text-center border-b" />
           </>
         )}
 

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -50,6 +50,7 @@ import {
   logDrainHeaderEntriesSchema,
   type LogDrainHeaderRow,
 } from './LogDrains.utils'
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { LogDrainData, useLogDrainsQuery } from '@/data/log-drains/log-drains-query'
 import { DOCS_URL } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
@@ -859,16 +860,19 @@ export function LogDrainDestinationSheetForm({
           </SheetSection>
 
           <SheetFooter className="p-content !mt-0 !justify-between !flex-row w-full items-center">
-            <span className="text-sm text-foreground-light">
-              <span>See full pricing breakdown</span>{' '}
-              <Link
-                href={`${DOCS_URL}/guides/platform/manage-your-usage/log-drains`}
-                target="_blank"
-                className="text-foreground underline underline-offset-2 decoration-foreground-muted hover:decoration-foreground transition-all"
-              >
-                here
-              </Link>
-            </span>
+            <div className="flex flex-col gap-0.5">
+              <span className="text-sm text-foreground-light">
+                <span>See full pricing breakdown</span>{' '}
+                <Link
+                  href={`${DOCS_URL}/guides/platform/manage-your-usage/log-drains`}
+                  target="_blank"
+                  className="text-foreground underline underline-offset-2 decoration-foreground-muted hover:decoration-foreground transition-all"
+                >
+                  here
+                </Link>
+              </span>
+              <TaxDisclaimer />
+            </div>
             <Button form={FORM_ID} loading={isLoading} htmlType="submit" type="primary">
               Save destination
             </Button>

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -14,6 +14,7 @@ import {
   SidePanel,
 } from 'ui'
 
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
 import { useProjectAddonRemoveMutation } from '@/data/subscriptions/project-addon-remove-mutation'
@@ -206,6 +207,7 @@ const CustomDomainSidePanel = () => {
                 />
               ))}
             </RadioGroupCard>
+            <TaxDisclaimer className="mt-3" />
           </div>
 
           {hasChanges && selectedOption !== 'cd_none' && (

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -5,6 +5,7 @@ import { toast } from 'sonner'
 import { cn, RadioGroup_Shadcn_, RadioGroupLargeItem_Shadcn_, SidePanel } from 'ui'
 import { Admonition } from 'ui-patterns'
 
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
@@ -198,6 +199,7 @@ const IPv4SidePanel = () => {
                   </RadioGroupLargeItem_Shadcn_>
                 ))}
               </RadioGroup_Shadcn_>
+              <TaxDisclaimer className="mt-3" />
             </div>
           )}
 

--- a/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/PITRSidePanel.tsx
@@ -16,6 +16,7 @@ import {
 } from 'ui'
 
 import { subscriptionHasHipaaAddon } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
+import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
@@ -318,6 +319,7 @@ const PITRSidePanel = () => {
                   />
                 ))}
               </RadioGroupCard>
+              <TaxDisclaimer className="mt-3" />
             </div>
           )}
 


### PR DESCRIPTION
## Summary

Adds a reusable `TaxDisclaimer` component ("Prices shown do not include applicable taxes.") and places it on surfaces where users see a price before confirming a billable action. 

## Where it appears

- **Disk resize review dialog** — `DiskManagementReviewAndSubmitDialog` (below the before/after price comparison)
- **Add-on side panels** — PITR, Custom Domain, IPv4 (below the price options)
- **Log drain destination form** — stacked under "See full pricing breakdown here" in the footer
- **SMS MFA confirmation modal** — below the $75/$10 billing copy
- **Read replica pricing dialog** — at the end of the cost breakdown
- **Create branch modal** — below the disk/compute cost estimates

## Test plan

- [ ]  Open disk/compute resize review dialog — disclaimer appears below the before/after panel
- [ ]  Open each add-on side panel (PITR / Custom Domain / IPv4) — disclaimer appears below the price options
- [ ]  Open log drain destination sheet — disclaimer stacks under the pricing breakdown link in the footer
- [ ]  Trigger SMS MFA confirmation — disclaimer appears below the billing copy
- [ ]  Open read replica pricing dialog ("Learn more" from deploy replica) — disclaimer at the bottom
- [ ]  Open create branch modal — disclaimer appears after the compute cost block

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tax disclaimers across multiple billing and pricing interfaces throughout the platform. Users will now see notices regarding applicable taxes displayed in various authentication settings, branch creation workflows, database disk management dialogs, database replica pricing screens, log drain configuration panels, custom domain settings, IPv4 address configuration, and Point-in-Time Recovery options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->