### PR TITLE
feat: add loading indicator and  ChargeBreakdown in NewOrgForm

### DIFF
--- a/apps/studio/components/interfaces/Billing/ChargeBreakdown.tsx
+++ b/apps/studio/components/interfaces/Billing/ChargeBreakdown.tsx
@@ -4,6 +4,7 @@ import { formatCurrency } from '@/lib/helpers'
 
 export interface ChargeBreakdownProps {
   subtotal: number
+  subtotalLabel?: string
   total: number
   tax?: { amount: number; percentage: number }
   taxStatus?: 'calculated' | 'failed' | 'not_applicable'
@@ -12,6 +13,7 @@ export interface ChargeBreakdownProps {
 
 export const ChargeBreakdown = ({
   subtotal,
+  subtotalLabel = 'Subtotal',
   total,
   tax,
   taxStatus,
@@ -23,7 +25,7 @@ export const ChargeBreakdown = ({
     >
       {total !== subtotal && (
         <div className="flex items-center justify-between gap-2 border-b border-muted text-sm">
-          <div className="py-2">Subtotal</div>
+          <div className="py-2">{subtotalLabel}</div>
           <div className="py-2 text-right tabular-nums" translate="no">
             {formatCurrency(subtotal)}
           </div>

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -14,7 +14,6 @@ import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
   Button,
-  cn,
   Form,
   FormControl,
   FormField,
@@ -27,9 +26,11 @@ import {
   Switch,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { z } from 'zod'
 
 import { UpgradeExistingOrganizationCallout } from './UpgradeExistingOrganizationCallout'
+import { ChargeBreakdown } from '@/components/interfaces/Billing/ChargeBreakdown'
 import { getStripeElementsAppearanceOptions } from '@/components/interfaces/Billing/Payment/Payment.utils'
 import { PaymentConfirmation } from '@/components/interfaces/Billing/Payment/PaymentConfirmation'
 import {
@@ -49,7 +50,6 @@ import { useConfirmPendingSubscriptionCreateMutation } from '@/data/subscription
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { PRICING_TIER_LABELS_ORG, STRIPE_PUBLIC_KEY } from '@/lib/constants'
-import { formatCurrency } from '@/lib/helpers'
 import { useProfile } from '@/lib/profile'
 
 const ORG_KIND_TYPES = {
@@ -407,7 +407,7 @@ export const NewOrgForm = ({
                 htmlType="submit"
                 type="primary"
                 loading={newOrgLoading}
-                disabled={newOrgLoading}
+                disabled={newOrgLoading || creationPreviewIsFetching}
               >
                 Create organization
               </Button>
@@ -605,49 +605,31 @@ export const NewOrgForm = ({
                   />
                 </Elements>
 
+                {!!billingAddress && !creationPreviewInitialized && (
+                  <div className="space-y-2 mt-4">
+                    <ShimmeringLoader />
+                    <ShimmeringLoader className="w-3/4" />
+                    <ShimmeringLoader className="w-1/2" />
+                  </div>
+                )}
+
                 {creationPreviewInitialized && !!billingAddress && (
-                  <div
-                    className={cn(
-                      'text-foreground-light text-sm transition-opacity mt-4',
-                      creationPreviewIsFetching && 'opacity-50'
-                    )}
-                  >
-                    {creationPreview.total !== creationPreview.plan_price && (
-                      <div className="flex items-center justify-between gap-2 border-b border-muted text-sm">
-                        <div className="py-2">Plan price</div>
-                        <div className="py-2 text-right tabular-nums" translate="no">
-                          {formatCurrency(creationPreview.plan_price)}
-                        </div>
-                      </div>
-                    )}
-
-                    {creationPreview.tax_status === 'calculated' &&
-                      creationPreview.tax &&
-                      creationPreview.tax.tax_amount > 0 && (
-                        <div className="flex items-center justify-between gap-2 border-b border-muted text-sm">
-                          <div className="py-2">
-                            Tax ({creationPreview.tax.tax_rate_percentage}%)
-                          </div>
-                          <div className="py-2 text-right tabular-nums" translate="no">
-                            {formatCurrency(creationPreview.tax.tax_amount)}
-                          </div>
-                        </div>
-                      )}
-
-                    {creationPreview.tax_status === 'failed' && (
-                      <div className="flex items-center justify-between gap-2 border-b border-muted text-sm">
-                        <div className="py-2 text-foreground-lighter">
-                          Tax could not be estimated and may be applied separately
-                        </div>
-                      </div>
-                    )}
-
-                    <div className="flex items-center justify-between gap-2 text-foreground text-base">
-                      <div className="py-2">Total due today</div>
-                      <div className="py-2 text-right tabular-nums" translate="no">
-                        {formatCurrency(creationPreview.total)}
-                      </div>
-                    </div>
+                  <div className="mt-4">
+                    <ChargeBreakdown
+                      subtotal={creationPreview.plan_price}
+                      subtotalLabel="Plan price"
+                      total={creationPreview.total}
+                      tax={
+                        creationPreview.tax
+                          ? {
+                              amount: creationPreview.tax.tax_amount,
+                              percentage: creationPreview.tax.tax_rate_percentage,
+                            }
+                          : undefined
+                      }
+                      taxStatus={creationPreview.tax_status}
+                      isFetching={creationPreviewIsFetching}
+                    />
                   </div>
                 )}
               </Panel.Content>


### PR DESCRIPTION
## Summary

- Show a `ShimmeringLoader` skeleton in the new-org form while the creation preview is fetching for the first time, so users see feedback after entering their billing address.
- Disable the **Create organization** button while the preview is refetching, to prevent submitting on stale totals.
- Replace the inline charge summary with the shared `ChargeBreakdown` component, extending it with an optional `subtotalLabel` prop (defaults to `"Subtotal"`, `"Plan price"` here) to preserve the existing copy.

## Test plan

- [ ]  Navigate to `/new` → pick Pro/Team → enter a billing address → confirm shimmer shows until the first preview resolves.
- [ ]  Change address/tax ID → confirm existing totals fade to 50% while refetching and the submit button is disabled during the fetch.
- [ ]  Confirm the breakdown still renders "Plan price", "Tax (x%)", and "Total due today" correctly
- [ ]  FREE plan path unaffected — no preview request, submit button behaves as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Organization creation form now displays loading placeholders while billing preview data is being fetched, providing clearer visual feedback during the calculation process
  * Submit button is now properly disabled during billing information retrieval
  * Billing breakdown display has been refined for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->