### PR TITLE
fix: show plan name on empty orgs

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -523,21 +523,23 @@ export const SubscriptionPlanUpdateDialog = ({
 
                                       const content = (
                                         <>
+                                          {planItem && (
+                                            <TableRow className="text-foreground-light">
+                                              <TableCell className="!py-2 px-0">
+                                                {planItem.description}
+                                              </TableCell>
+                                              <TableCell
+                                                className="text-right py-2 px-0"
+                                                translate="no"
+                                              >
+                                                {formatCurrency(planItem.total_price)}
+                                              </TableCell>
+                                            </TableRow>
+                                          )}
+
                                           {/* Combined projects section */}
                                           {allProjects.length > 0 && (
                                             <>
-                                              <TableRow className="text-foreground-light">
-                                                <TableCell className="!py-2 px-0">
-                                                  {planItem?.description}
-                                                </TableCell>
-                                                <TableCell
-                                                  className="text-right py-2 px-0"
-                                                  translate="no"
-                                                >
-                                                  {formatCurrency(planItem?.total_price)}
-                                                </TableCell>
-                                              </TableRow>
-
                                               <TableRow className="text-foreground-light">
                                                 <TableCell className="!py-2 px-0 flex items-center gap-1">
                                                   <span>Compute</span>


### PR DESCRIPTION
## Summary

- Show the plan name row in the monthly invoice estimate tooltip even when the organization has no projects, so the section no longer appears headerless next to the tax line.

## Test plan

- [ ]  Open an org with no projects → Subscription plan update dialog → hover the "Monthly invoice estimate" tooltip → verify the plan name + price row is visible.
- [ ]  Repeat on an org with projects → verify plan, Compute row, and project breakdown all still render as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved rendering of the Monthly invoice estimate table in the subscription plan update dialog, with reorganized display logic for plan and project billing rows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->