### PR TITLE
docs: make Prisma quickstart test script runnable with TypeScript

### DIFF
--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -369,7 +369,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             ```
             <Admonition type="note" label="conflict management">
 
-              If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma-troubleshooting) for more details
+              If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
             </Admonition>
 
@@ -427,35 +427,78 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>
-    <StepHikeCompact.Step step={6}>
+  <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Test your API">
-      Create a index.ts file and run it to test your connection
+      Create an <code>index.ts</code> file and run it to test your connection using the <code>Post</code> model created earlier.
     </StepHikeCompact.Details>
+
     <StepHikeCompact.Code>
-      ```ts index.ts
-      const { PrismaClient } = require('@prisma/client');
+    ```ts index.ts
+    import { PrismaClient } from '@prisma/client'
 
-      const prisma = new PrismaClient();
+    const prisma = new PrismaClient()
 
-      async function main() {
-        //change to reference a table in your schema
-        const val = await prisma.<SOME_TABLE_NAME>.findMany({
-          take: 10,
-        });
-        console.log(val);
-      }
+    async function main() {
+      const posts = await prisma.post.findMany({
+        take: 10,
+      })
 
-      main()
-        .then(async () => {
-          await prisma.$disconnect();
-        })
-        .catch(async (e) => {
-          console.error(e);
-          await prisma.$disconnect();
-        process.exit(1);
-      });
+      console.log(posts)
+    }
 
-      ```
+    main()
+      .catch((error) => {
+        console.error(error)
+        process.exit(1)
+      })
+      .finally(async () => {
+        await prisma.$disconnect()
+      })
+    ```
+
+    Run the script:
+
+    <Tabs
+      scrollable
+      size="small"
+      type="underlined"
+      defaultActiveId="npm_run"
+      queryGroup="run"
+    >
+    <TabPanel id="npm_run" label="npm">
+
+    ```bash
+    npx ts-node index.ts
+    ```
+
+    </TabPanel>
+
+    <TabPanel id="pnpm_run" label="pnpm">
+
+    ```bash
+    pnpx ts-node index.ts
+    ```
+
+    </TabPanel>
+
+    <TabPanel id="yarn_run" label="yarn">
+
+    ```bash
+    npx ts-node index.ts
+    ```
+
+    </TabPanel>
+
+    <TabPanel id="bun_run" label="bun">
+
+    ```bash
+    bun run index.ts
+    ```
+
+    </TabPanel>
+
+    </Tabs>
+
     </StepHikeCompact.Code>
 
   </StepHikeCompact.Step>


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file

YES

## What kind of change does this PR introduce?

Docs update / developer experience improvement

## What is the current behavior?

The Prisma quickstart "Test your API" section currently uses CommonJS require syntax in a TypeScript project, includes a placeholder table reference (`<SOME_TABLE_NAME>`) that is not runnable, and does not show how to run the example script.

There is also an incorrect troubleshooting documentation link in the Bun section.

## What is the new behavior?

This PR:

- updates the example to use proper TypeScript imports
- replaces placeholder code with a runnable example using the `Post` model introduced earlier in the guide
- adds package-manager specific commands for running the script (npm, pnpm, yarn, bun)
- fixes the incorrect Prisma troubleshooting documentation link

This makes the quickstart copy-paste runnable and improves developer experience for first-time Prisma users.

## Additional context

This is my first contribution to Supabase. I chose this because it improves the Prisma onboarding experience and aligns with the existing guide structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Enhanced Prisma guides with updated example code and clearer instructions for testing APIs
  * Added convenient package-manager-specific commands for running sample scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->