### PR TITLE
feat: lint for pg_graphql introspection fix

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -332,6 +332,16 @@ export const lintInfoMap: LintInfo[] = [
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0025_public_bucket_allows_listing`,
     category: 'security',
   },
+  {
+    name: 'pg_graphql_anon_table_exposed',
+    title: 'pg_graphql Anon Role Exposes Objects in Introspection',
+    icon: <Eye className="text-foreground-muted" size={15} strokeWidth={1.5} />,
+    link: ({ projectRef, metadata }) =>
+      `/project/${projectRef}/editor?schema=${metadata?.schema}&table=${metadata?.name}`,
+    linkText: 'View object',
+    docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed`,
+    category: 'security',
+  },
 ]
 
 export const LintCTA = ({

--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -1507,4 +1507,63 @@ select
 from
     affected_buckets
 order by
-    bucket_id)`
+    bucket_id)
+union all
+(
+with graphql_installed as (
+    select 1 as installed
+    from pg_catalog.pg_extension
+    where extname = 'pg_graphql'
+),
+exposed_objects as (
+    select
+        n.nspname as schema_name,
+        c.relname as object_name,
+        c.relkind as object_relkind,
+        case c.relkind
+            when 'r' then 'table'
+            when 'p' then 'table'
+            when 'v' then 'view'
+            when 'm' then 'materialized view'
+        end as object_type
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind in ('r', 'p', 'v', 'm') -- tables, partitioned tables, views, materialized views
+        and pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        and exists (select 1 from graphql_installed)
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+)
+select
+    'pg_graphql_anon_table_exposed' as name,
+    'pg_graphql Anon Role Exposes Objects in Introspection' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables and views whose schema is visible via the public \`/graphql/v1\` introspection endpoint. When \`pg_graphql\` is installed, any table, view, or materialized view the \`anon\` role has \`SELECT\` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. Both forms of introspection are intentional behavior this lint surfaces the objects that are currently public so you can confirm each one is meant to be discoverable without authentication.' as description,
+    format(
+        'Extension \`pg_graphql\` is installed and the \`anon\` role has \`SELECT\` on %s \`%s.%s\`. Its name, columns, and relationships are visible via the public \`/graphql/v1\` introspection endpoint.',
+        object_type,
+        schema_name,
+        object_name
+    ) as detail,
+    ${literal(`${docsUrl}/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed`)} as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', object_name,
+        'type', object_type
+    ) as metadata,
+    format(
+        'pg_graphql_anon_table_exposed_%s_%s',
+        schema_name,
+        object_name
+    ) as cache_key
+from
+    exposed_objects
+order by
+    schema_name,
+    object_name)`


### PR DESCRIPTION
 ## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.                 

  YES                                                                                                                          
   
  ## What kind of change does this PR introduce?                                                                               
                  
  Feature — wires up the new advisor lint `pg_graphql_anon_table_exposed` so it renders properly in Studio and ships with      
  self-hosted Supabase. The lint itself was added to splinter in supabase/splinter#158 (already merged).
                                                                                                                               
  ## What is the current behavior?                                                                                             
   
  Splinter's `main` exposes lint `0026_pg_graphql_anon_table_exposed`, which detects tables, views, and materialized views     
  whose schema is visible through the public `/graphql/v1` introspection endpoint when the `anon` role has `SELECT` on them.
  The hosted advisor (mgmt-api) auto-fetches `splinter.sql` from raw.githubusercontent.com, so the lint will start firing on   
  cloud projects, but:

  - Studio has no `lintInfoMap` entry for it, so the row renders without an icon, title mapping, "Fix" CTA, or category        
  classification.
  - Self-hosted Supabase ships with a vendored copy of the lint SQL in `packages/pg-meta`; without an update there, self-hosted
   users never see the lint at all.                                                                                            
   
  ## What is the new behavior?                                                                                                 
                  
  Two minimal additions:

  - **`apps/studio/components/interfaces/Linter/Linter.utils.tsx`** — adds a `lintInfoMap` entry for                           
  `pg_graphql_anon_table_exposed`: title `"pg_graphql Anon Role Exposes Objects in Introspection"`, `Eye` icon, `security`
  category, `"View object"` CTA pointing at the table editor scoped by `metadata.schema` and `metadata.name`, docs link to the 
  splinter docs page.
  - **`packages/pg-meta/src/sql/studio/advisor/lints.ts`** — vendors the lint's SQL block into `getLintsSQL()` so self-hosted
  deployments include it. Follows the file's documented copy-paste convention from splinter: every backtick inside SQL string  
  literals is escaped (`` ` `` → `` \` ``), and the hardcoded docs URL is replaced with `${literal(\`${docsUrl}/...\`)}`.
                                                                                                                               
  No changes to the OpenAPI surface, no changes to the `LINT_TYPES` literal union (auto-generated; matches the precedent of how
   lints 0023–0025 were added — Studio's `LintInfo.name` is typed as `string`, not the strict enum).
                                                                                                                               
  ## Additional context

  - Splinter PR (merged): https://github.com/supabase/splinter/pull/158                                                        
  - Splinter lint source: https://github.com/supabase/splinter/blob/main/lints/0026_pg_graphql_anon_table_exposed.sql
  - Splinter docs page: https://github.com/supabase/splinter/blob/main/docs/0026_pg_graphql_anon_table_exposed.md              
  - The hosted advisor flow that fetches splinter.sql automatically lives in the platform mgmt-api (`getLintSql` in
  `advisors-utils.ts`), with a 1-hour cache TTL — cloud projects will pick up the new lint independently of this PR; this PR is
   about the Studio display mapping and the self-hosted SQL bundle.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new security linter check that identifies tables and views exposed to anonymous GraphQL access, with warnings and remediation guidance to help resolve the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->