### PR TITLE
feat: update CreditTopUp to mention pre-tax credits

### DIFF
--- a/apps/docs/content/guides/platform/credits.mdx
+++ b/apps/docs/content/guides/platform/credits.mdx
@@ -29,7 +29,7 @@ As an example, if you start a Pro Plan subscription on January 1 and downgrade t
 
 ## Credit top-ups
 
-You can top up credits at any time, with a maximum of <Price price="2000" /> per top-up. These credits do not expire and are non-refundable.
+You can top up credits at any time, with a maximum of <Price price="2000" /> per top-up. These credits do not expire and are non-refundable. Credits are granted on the pre-tax amount. Any applicable taxes added at checkout are not credited.
 You may want to consider this option to avoid issues with recurring payments, gain more control over how often your credit card is charged, and potentially make things easier for your accounting department.
 
 <Admonition type="note">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -29,6 +29,7 @@ import {
   Input_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { z } from 'zod'
 
 import type { PaymentMethodElementRef } from '../../Billing/Payment/PaymentMethods/NewPaymentMethodElement'
@@ -45,6 +46,7 @@ import type { CustomerAddress, CustomerTaxId } from '@/data/organizations/types'
 import { subscriptionKeys } from '@/data/subscriptions/keys'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { STRIPE_PUBLIC_KEY } from '@/lib/constants'
+import { formatCurrency } from '@/lib/helpers'
 
 const stripePromise = loadStripe(STRIPE_PUBLIC_KEY)
 
@@ -295,9 +297,9 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
           <DialogTitle>Top Up Credits</DialogTitle>
           <DialogDescription className="space-y-2">
             <p className="prose text-sm">
-              On successful payment, an invoice will be issued and you'll be granted credits.
-              Credits will be applied to future invoices only and are not refundable. The topped up
-              credits do not expire.
+              On successful payment, an invoice will be issued and you'll be granted credits equal
+              to the pre-tax amount. Credits will be applied to future invoices only and are not
+              refundable. The topped up credits do not expire.
             </p>
             <p className="prose text-sm">
               For larger discounted credit packages, please reach out to us via{' '}
@@ -381,6 +383,14 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                 </Alert_Shadcn_>
               )}
 
+              {!!validAmount && !creditPreviewInitialized && creditPreviewIsFetching && (
+                <div className="space-y-2 mt-4">
+                  <ShimmeringLoader />
+                  <ShimmeringLoader className="w-3/4" />
+                  <ShimmeringLoader className="w-1/2" />
+                </div>
+              )}
+
               {creditPreviewInitialized && !!validAmount && (
                 <div className="mt-4">
                   <ChargeBreakdown
@@ -397,6 +407,13 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                     taxStatus={creditPreview.tax_status}
                     isFetching={creditPreviewIsFetching}
                   />
+                  {creditPreview.tax_status === 'calculated' &&
+                    creditPreview.tax &&
+                    creditPreview.tax.tax_amount > 0 && (
+                      <p className="mt-2 text-xs text-foreground-muted">
+                        You'll receive {formatCurrency(creditPreview.amount)} in credits.
+                      </p>
+                    )}
                 </div>
               )}
             </DialogSection>


### PR DESCRIPTION
## Summary

- Clarify in the credit top-up modal that granted credits equal the pre-tax amount, both in the dialog description and as a small note under the charge breakdown when tax applies.
- Show a `ShimmeringLoader` skeleton during the initial credit preview fetch so the modal isn't blank while the breakdown loads.

<img width="549" height="543" alt="image" src="https://github.com/user-attachments/assets/c1513f6d-7223-4ce0-ae5d-4875d2e02d7c" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clarified credit top-up dialog to state credits equal the pre-tax amount
  * Added shimmering loaders during credit preview retrieval
  * Included expected credits line in the charge breakdown once preview is available

* **Documentation**
  * Updated guide to explain credits are based on pre-tax amounts; taxes are excluded from credited value
<!-- end of auto-generated comment: release notes by coderabbit.ai -->