### PR TITLE
docs: add pgjwt dependency check for upgrades

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -175,11 +175,14 @@ To check whether your database has objects that depend on `pgjwt` before disabli
 
 ```sql
 select
-  classid::regclass as object_type,
-  objid::regclass as object_name,
-  objsubid
-from pg_depend
-where refobjid = 'pgjwt'::regextension;
+  pg_describe_object(d.classid, d.objid, d.objsubid) as dependent_object
+from pg_depend d
+where d.refclassid = 'pg_extension'::regclass
+  and d.refobjid = (
+    select oid
+    from pg_extension
+    where extname = 'pgjwt'
+  );
 ```
 
 Existing projects on lower versions of Postgres are not impacted, and the extensions will continue to be supported on projects using Postgres 15, until the end of life of Postgres 15 on the Supabase platform.

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -179,7 +179,7 @@ select
   p.proname as function_name
 from pg_proc p
 join pg_namespace n on n.oid = p.pronamespace
-where pg_get_functiondef(p.oid) ~* '\m(sign|verify)\s*\(';
+where pg_get_functiondef(p.oid) ~* '\m(sign|verify)[[:space:]]*\(';
 ```
 
 To check whether your database has objects that depend on `pgjwt` before disabling the extension, query `pg_depend`:

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -171,6 +171,17 @@ Projects planning to upgrade from Postgres 15 to Postgres 17 need to first disab
 
 `pgjwt` was enabled by default on every Supabase project up until Postgres 17. If you weren’t explicitly using `pgjwt` in your project, it’s most likely safe to disable.
 
+The most common way to use `pgjwt` is through the `sign()` and `verify()` functions. Search your application code and database functions for calls to these functions before disabling the extension. To check database functions, run:
+
+```sql
+select
+  n.nspname as schema_name,
+  p.proname as function_name
+from pg_proc p
+join pg_namespace n on n.oid = p.pronamespace
+where pg_get_functiondef(p.oid) ~* '\m(sign|verify)\s*\(';
+```
+
 To check whether your database has objects that depend on `pgjwt` before disabling the extension, query `pg_depend`:
 
 ```sql

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -171,4 +171,15 @@ Projects planning to upgrade from Postgres 15 to Postgres 17 need to first disab
 
 `pgjwt` was enabled by default on every Supabase project up until Postgres 17. If you weren’t explicitly using `pgjwt` in your project, it’s most likely safe to disable.
 
+To check whether your database has objects that depend on `pgjwt` before disabling the extension, query `pg_depend`:
+
+```sql
+select
+  classid::regclass as object_type,
+  objid::regclass as object_name,
+  objsubid
+from pg_depend
+where refobjid = 'pgjwt'::regextension;
+```
+
 Existing projects on lower versions of Postgres are not impacted, and the extensions will continue to be supported on projects using Postgres 15, until the end of life of Postgres 15 on the Supabase platform.


### PR DESCRIPTION
## Summary
- add a `pg_depend` query for checking whether database objects depend on `pgjwt`
- make the Postgres 17 upgrade note more actionable before users disable the deprecated extension

## Tests
- Not run. Documentation-only change.

Fixes #36403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Postgres 17 upgrade guide: added two SQL verification checks—one to scan functions for usage of signing/verification calls and another to list database objects that depend on the pgjwt extension—placed after the guidance on safely disabling pgjwt to help ensure safer extension removals during upgrades.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->