### PR TITLE
docs: explain Next.js auth callback route

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -246,6 +246,35 @@ It's safe to trust `getClaims()` because it validates the JWT signature against 
   </$CodeTabs>
 </div>
 
+### Exchange an auth code for a session
+
+If your app uses PKCE email links, OAuth, or other flows that redirect back with a `code` query parameter, create an `auth/callback` route. This route exchanges the auth code for a session and lets the Supabase SSR client write the session cookies before redirecting the user.
+
+```ts name=app/auth/callback/route.ts
+import { NextResponse } from 'next/server'
+
+import { createClient } from '@/lib/supabase/server'
+
+export async function GET(request: Request) {
+  const { searchParams, origin } = new URL(request.url)
+  const code = searchParams.get('code')
+  const next = searchParams.get('next') ?? '/'
+
+  if (code) {
+    const supabase = await createClient()
+    const { error } = await supabase.auth.exchangeCodeForSession(code)
+
+    if (!error) {
+      return NextResponse.redirect(`${origin}${next}`)
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/auth/auth-code-error`)
+}
+```
+
+Add this route when your email template, OAuth `redirectTo` option, or starter app redirects users to `/auth/callback`. If you deploy this route at `https://your-site.com/auth/callback`, add that URL to your project's allow list in the Supabase Dashboard.
+
 ## Congratulations
 
 You're done! To recap, you've successfully:


### PR DESCRIPTION
## Summary
- document when a Next.js `auth/callback` route is needed for SSR auth flows
- add a route handler that exchanges the auth code for a session
- mention adding the deployed callback URL to the Supabase redirect allow list

## Tests
- Not run. Documentation-only change.

Fixes #35544


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guide for setting up authentication callback endpoints to handle OAuth/PKCE-style redirects, including session exchange procedures and deployment configuration instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->