### PR TITLE
  fix(studio): invalidate file preview cache on rename/move in storage explorer

### DIFF
--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -684,7 +684,26 @@ function createStorageExplorerState({
         }
         await state.refetchAllOpenedFolders()
 
-        // TODO: Should we invalidate the file preview cache when renaming folders?
+        const queryClient = getQueryClient()
+        const pathToParent = state.openedFolders
+          .slice(0, columnIndex)
+          .map((f) => f.name)
+          .join('/')
+        const oldFolderPath =
+          pathToParent.length > 0 ? `${pathToParent}/${originalName}` : originalName
+        queryClient.removeQueries({
+          queryKey: [
+            state.projectRef,
+            'buckets',
+            state.selectedBucket.public,
+            state.selectedBucket.id,
+            'file',
+          ],
+          predicate: (query) => {
+            const filePath = query.queryKey[5]
+            return typeof filePath === 'string' && filePath.startsWith(`${oldFolderPath}/`)
+          },
+        })
       } catch (e: any) {
         toast.error(`Failed to rename folder to ${newName}: ${e.message}`, {
           id: toastId,
@@ -1418,7 +1437,24 @@ function createStorageExplorerState({
 
       toast.dismiss(toastId)
 
-      // TODO: invalidate the file preview cache when moving files
+      const queryClient = getQueryClient()
+      for (const item of state.selectedItemsToMove) {
+        const pathToFile = state.openedFolders
+          .slice(0, item.columnIndex)
+          .map((folder) => folder.name)
+          .join('/')
+        const fromPath = pathToFile.length > 0 ? `${pathToFile}/${item.name}` : item.name
+        queryClient.removeQueries({
+          queryKey: [
+            state.projectRef,
+            'buckets',
+            state.selectedBucket.public,
+            state.selectedBucket.id,
+            'file',
+            fromPath,
+          ],
+        })
+      }
       await state.refetchAllOpenedFolders()
       state.setSelectedItemsToMove([])
     },
@@ -1669,7 +1705,17 @@ function createStorageExplorerState({
 
           toast.success(`Successfully renamed "${originalName}" to "${newName}"`)
 
-          // TODO: Should we invalidate the file preview cache when renaming files?
+          const queryClient = getQueryClient()
+          queryClient.removeQueries({
+            queryKey: [
+              state.projectRef,
+              'buckets',
+              state.selectedBucket.public,
+              state.selectedBucket.id,
+              'file',
+              fromPath,
+            ],
+          })
 
           if (state.selectedFilePreview?.name === originalName) {
             const { previewUrl, ...fileData } = file as any


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

  YES

  ## What kind of change does this PR introduce?

  Bug fix

  ## What is the current behavior?

  `useFetchFileUrlQuery` caches signed/public storage URLs with a 1-week stale time, keyed by file path. When a file or folder is renamed or moved, the
   old cache entry is never cleared. Re-selecting the renamed/moved file serves the stale URL — for private buckets this results in a broken preview
  since the signed URL referenced the old path. Three TODO comments in `state/storage-explorer.tsx` called this out.

  ## What is the new behavior?

  After each successful mutation, the affected cache entries are removed via `queryClient.removeQueries` using the same key structure as
  `useFetchFileUrlQuery`:

  - **File rename** — removes the old path's cache entry
  - **File move** — removes each moved file's old path cache entry
  - **Folder rename** — removes all cache entries whose path starts with the old folder prefix

  The next preview load fetches a fresh URL. Unaffected files continue to use their cached URLs.

  ## Additional context

  `getQueryClient()` was already imported and used in the same file (`uploadFiles`), so no new infra was needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cache refresh handling when renaming folders to ensure all cached file data remains current with folder structure changes
  * Improved cache refresh handling when moving files to ensure updated file information displays correctly after file transfers
  * Improved cache refresh handling when renaming files to ensure changes are immediately reflected throughout the storage explorer

<!-- end of auto-generated comment: release notes by coderabbit.ai -->