### PR TITLE
feat: lint integration for pg_graphql introspection + SECURITY DEFINER functions

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -334,7 +334,7 @@ export const lintInfoMap: LintInfo[] = [
   },
   {
     name: 'pg_graphql_anon_table_exposed',
-    title: 'pg_graphql Anon Role Exposes Objects in Introspection',
+    title: 'Public Can See Object in GraphQL Schema',
     icon: <Eye className="text-foreground-muted" size={15} strokeWidth={1.5} />,
     link: ({ projectRef, metadata }) =>
       `/project/${projectRef}/editor?schema=${metadata?.schema}&table=${metadata?.name}`,
@@ -344,7 +344,7 @@ export const lintInfoMap: LintInfo[] = [
   },
   {
     name: 'pg_graphql_authenticated_table_exposed',
-    title: 'pg_graphql Authenticated Role Exposes Objects in Introspection',
+    title: 'Signed-In Users Can See Object in GraphQL Schema',
     icon: <Eye className="text-foreground-muted" size={15} strokeWidth={1.5} />,
     link: ({ projectRef, metadata }) =>
       `/project/${projectRef}/editor?schema=${metadata?.schema}&table=${metadata?.name}`,
@@ -354,8 +354,8 @@ export const lintInfoMap: LintInfo[] = [
   },
   {
     name: 'anon_security_definer_function_executable',
-    title: 'SECURITY DEFINER Function Executable by Anon',
-    icon: <Unlock className="text-foreground-muted" size={15} strokeWidth={1.5} />,
+    title: 'Public Can Execute SECURITY DEFINER Function',
+    icon: <LockIcon className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
       `/project/${projectRef}/database/functions?schema=${metadata?.schema}&search=${metadata?.name}`,
     linkText: 'View function',
@@ -364,8 +364,8 @@ export const lintInfoMap: LintInfo[] = [
   },
   {
     name: 'authenticated_security_definer_function_executable',
-    title: 'SECURITY DEFINER Function Executable by Authenticated',
-    icon: <Unlock className="text-foreground-muted" size={15} strokeWidth={1.5} />,
+    title: 'Signed-In Users Can Execute SECURITY DEFINER Function',
+    icon: <LockIcon className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
       `/project/${projectRef}/database/functions?schema=${metadata?.schema}&search=${metadata?.name}`,
     linkText: 'View function',
@@ -415,12 +415,7 @@ export const EntityTypeIcon = ({ type }: { type: string | undefined }) => {
 }
 
 export const LintEntity = ({ metadata }: { metadata: Lint['metadata'] }) => {
-  return (
-    (metadata &&
-      (metadata.entity ||
-        (metadata.schema && metadata.name && `${metadata.schema}.${metadata.name}`))) ??
-    undefined
-  )
+  return getLintEntityString(metadata)
 }
 
 export const LintCategoryBadge = ({ category }: { category: string }) => {
@@ -448,13 +443,7 @@ export const NoIssuesFound = ({ level }: { level: string }) => {
 
 export const createLintSummaryPrompt = (lint: Lint) => {
   const title = lintInfoMap.find((item) => item.name === lint.name)?.title ?? lint.title
-  const entity =
-    (lint.metadata &&
-      (lint.metadata.entity ||
-        (lint.metadata.schema &&
-          lint.metadata.name &&
-          `${lint.metadata.schema}.${lint.metadata.name}`))) ||
-    'N/A'
+  const entity = getLintEntityString(lint.metadata) || 'N/A'
   const schema = lint.metadata?.schema ?? 'N/A'
   const issue = lint.detail ? lint.detail.replace(/\\`/g, '`') : 'N/A'
   const description = lint.description ? lint.description.replace(/\\`/g, '`') : 'N/A'
@@ -464,4 +453,23 @@ Entity: ${entity}
 Schema: ${schema}
 Issue Details: ${issue}
 Description: ${description}`
+}
+
+export const getLintEntityString = (metadata: Lint['metadata']) => {
+  if (!metadata) {
+    return undefined
+  }
+
+  if (metadata.entity) {
+    return metadata.entity
+  }
+
+  if (metadata.schema && metadata.name) {
+    const extendedMetadata = metadata as typeof metadata & { arguments?: string }
+    const args =
+      typeof extendedMetadata.arguments === 'string' ? extendedMetadata.arguments : undefined
+    return `${metadata.schema}.${metadata.name}${args !== undefined ? `(${args})` : ''}`
+  }
+
+  return undefined
 }

--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -342,6 +342,36 @@ export const lintInfoMap: LintInfo[] = [
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed`,
     category: 'security',
   },
+  {
+    name: 'pg_graphql_authenticated_table_exposed',
+    title: 'pg_graphql Authenticated Role Exposes Objects in Introspection',
+    icon: <Eye className="text-foreground-muted" size={15} strokeWidth={1.5} />,
+    link: ({ projectRef, metadata }) =>
+      `/project/${projectRef}/editor?schema=${metadata?.schema}&table=${metadata?.name}`,
+    linkText: 'View object',
+    docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0027_pg_graphql_authenticated_table_exposed`,
+    category: 'security',
+  },
+  {
+    name: 'anon_security_definer_function_executable',
+    title: 'SECURITY DEFINER Function Executable by Anon',
+    icon: <Unlock className="text-foreground-muted" size={15} strokeWidth={1.5} />,
+    link: ({ projectRef, metadata }) =>
+      `/project/${projectRef}/database/functions?schema=${metadata?.schema}&search=${metadata?.name}`,
+    linkText: 'View function',
+    docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0028_anon_security_definer_function_executable`,
+    category: 'security',
+  },
+  {
+    name: 'authenticated_security_definer_function_executable',
+    title: 'SECURITY DEFINER Function Executable by Authenticated',
+    icon: <Unlock className="text-foreground-muted" size={15} strokeWidth={1.5} />,
+    link: ({ projectRef, metadata }) =>
+      `/project/${projectRef}/database/functions?schema=${metadata?.schema}&search=${metadata?.name}`,
+    linkText: 'View function',
+    docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable`,
+    category: 'security',
+  },
 ]
 
 export const LintCTA = ({

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.utils.ts
@@ -176,7 +176,10 @@ export const getLintEntityString = (lint: Lint | null): string | undefined => {
   }
 
   if (lint.metadata.schema && lint.metadata.name) {
-    return `${lint.metadata.schema}.${lint.metadata.name}`
+    const extendedMetadata = lint.metadata as typeof lint.metadata & { arguments?: string }
+    const args =
+      typeof extendedMetadata.arguments === 'string' ? extendedMetadata.arguments : undefined
+    return `${lint.metadata.schema}.${lint.metadata.name}${args !== undefined ? `(${args})` : ''}`
   }
 
   return undefined

--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -1548,13 +1548,13 @@ exposed_objects as (
 )
 select
     'pg_graphql_anon_table_exposed' as name,
-    'pg_graphql Anon Role Exposes Objects in Introspection' as title,
+    'Public Can See Object in GraphQL Schema' as title,
     'WARN' as level,
     'EXTERNAL' as facing,
     array['SECURITY'] as categories,
-    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the public \`/graphql/v1\` introspection endpoint. When \`pg_graphql\` is installed, any object the \`anon\` role has \`SELECT\` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. See lint 0027 for the equivalent check against the \`authenticated\` role; in default Supabase projects revoking from \`anon\` alone is not sufficient.' as description,
+    'Detects tables, views, materialized views, and foreign tables that are visible in the GraphQL schema to anyone using your public anon key. Revoke \`SELECT\` from \`anon\` for objects that should not be discoverable before sign-in, and check lint 0027 for the matching signed-in-user exposure.' as description,
     format(
-        'Extension \`pg_graphql\` is installed and the \`anon\` role has \`SELECT\` on %s \`%s.%s\`. Its name, columns, and relationships are visible via the public \`/graphql/v1\` introspection endpoint.',
+        '%s \`%s.%s\` is visible in the GraphQL schema because the \`anon\` role can \`SELECT\` it. Revoke \`SELECT\` from \`anon\` if it should not be discoverable without signing in.',
         object_type,
         schema_name,
         object_name
@@ -1615,13 +1615,13 @@ exposed_objects as (
 )
 select
     'pg_graphql_authenticated_table_exposed' as name,
-    'pg_graphql Authenticated Role Exposes Objects in Introspection' as title,
+    'Signed-In Users Can See Object in GraphQL Schema' as title,
     'WARN' as level,
     'EXTERNAL' as facing,
     array['SECURITY'] as categories,
-    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the \`/graphql/v1\` introspection endpoint to any signed-up user. When \`pg_graphql\` is installed, any object the \`authenticated\` role has \`SELECT\` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. In default Supabase projects \`authenticated\` is anyone with a valid JWT, which under open or auto-confirm signup is anyone with a throwaway email. See lint 0026 for the equivalent check against \`anon\`.' as description,
+    'Detects tables, views, materialized views, and foreign tables that are visible in the GraphQL schema to signed-in users. Revoke \`SELECT\` from \`authenticated\` for objects that signed-in users should not discover, and check lint 0026 for the matching public exposure.' as description,
     format(
-        'Extension \`pg_graphql\` is installed and the \`authenticated\` role has \`SELECT\` on %s \`%s.%s\`. Its name, columns, and relationships are visible via the \`/graphql/v1\` introspection endpoint to any signed-up user.',
+        '%s \`%s.%s\` is visible in the GraphQL schema to signed-in users because the \`authenticated\` role can \`SELECT\` it. Revoke \`SELECT\` from \`authenticated\` if it should not be discoverable to every account.',
         object_type,
         schema_name,
         object_name
@@ -1646,13 +1646,13 @@ union all
 (
 select
     'anon_security_definer_function_executable' as name,
-    'SECURITY DEFINER Function Executable by Anon' as title,
+    'Public Can Execute SECURITY DEFINER Function' as title,
     'WARN' as level,
     'EXTERNAL' as facing,
     array['SECURITY'] as categories,
-    'Detects SECURITY DEFINER functions that the \`anon\` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to \`anon\` lets any holder of the public anon key invoke a privileged operation via PostgREST \`/rest/v1/rpc/<name>\` (and via \`/graphql/v1\` when pg_graphql is installed and the function''s return type is supported). See lint 0029 for the equivalent check against the \`authenticated\` role.' as description,
+    'Detects \`SECURITY DEFINER\` functions that are callable without signing in. Revoke \`EXECUTE\`, switch the function to \`SECURITY INVOKER\`, or move it out of your exposed API schema if it is not meant to be public.' as description,
     format(
-        'SECURITY DEFINER function \`%s.%s(%s)\` is executable by the \`anon\` role. It runs with the privileges of its owner and bypasses RLS, so any unauthenticated caller can invoke it via \`/rest/v1/rpc/%s\`.',
+        'Function \`%s.%s(%s)\` can be executed by the \`anon\` role as a \`SECURITY DEFINER\` function via \`/rest/v1/rpc/%s\`. Revoke \`EXECUTE\` or switch it to \`SECURITY INVOKER\` if that is not intentional.',
         schema_name,
         function_name,
         function_args,
@@ -1701,13 +1701,13 @@ union all
 (
 select
     'authenticated_security_definer_function_executable' as name,
-    'SECURITY DEFINER Function Executable by Authenticated' as title,
+    'Signed-In Users Can Execute SECURITY DEFINER Function' as title,
     'WARN' as level,
     'EXTERNAL' as facing,
     array['SECURITY'] as categories,
-    'Detects SECURITY DEFINER functions that the \`authenticated\` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to \`authenticated\` lets any signed-up user invoke a privileged operation via PostgREST \`/rest/v1/rpc/<name>\` (and via \`/graphql/v1\` when pg_graphql is installed and the function''s return type is supported). Under open or auto-confirm signup \`authenticated\` is anyone with a throwaway email. See lint 0028 for the equivalent check against the \`anon\` role.' as description,
+    'Detects \`SECURITY DEFINER\` functions that are callable by signed-in users. Revoke \`EXECUTE\`, switch the function to \`SECURITY INVOKER\`, or move it out of your exposed API schema if signed-in users should not call it.' as description,
     format(
-        'SECURITY DEFINER function \`%s.%s(%s)\` is executable by the \`authenticated\` role. It runs with the privileges of its owner and bypasses RLS, so any signed-up user can invoke it via \`/rest/v1/rpc/%s\`.',
+        'Function \`%s.%s(%s)\` can be executed by the \`authenticated\` role as a \`SECURITY DEFINER\` function via \`/rest/v1/rpc/%s\`. Revoke \`EXECUTE\` or switch it to \`SECURITY INVOKER\` if that is not intentional.',
         schema_name,
         function_name,
         function_args,

--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -1522,20 +1522,28 @@ exposed_objects as (
         c.relkind as object_relkind,
         case c.relkind
             when 'r' then 'table'
-            when 'p' then 'table'
             when 'v' then 'view'
             when 'm' then 'materialized view'
+            when 'f' then 'foreign table'
         end as object_type
     from
         pg_catalog.pg_class c
         join pg_catalog.pg_namespace n
             on c.relnamespace = n.oid
     where
-        c.relkind in ('r', 'p', 'v', 'm') -- tables, partitioned tables, views, materialized views
-        and pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
+        c.relkind in ('r', 'v', 'm', 'f') -- tables, views, materialized views, foreign tables; matches pg_graphql
+        and exists (
+            -- Any selectable column (table-level or column-level grant)
+            select 1
+            from pg_catalog.pg_attribute a
+            where a.attrelid = c.oid
+                and a.attnum > 0
+                and not a.attisdropped
+                and pg_catalog.has_column_privilege('anon', c.oid, a.attnum, 'SELECT')
+        )
         and exists (select 1 from graphql_installed)
         and n.nspname not in (
-            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'pgtle', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
         )
 )
 select
@@ -1544,7 +1552,7 @@ select
     'WARN' as level,
     'EXTERNAL' as facing,
     array['SECURITY'] as categories,
-    'Detects tables and views whose schema is visible via the public \`/graphql/v1\` introspection endpoint. When \`pg_graphql\` is installed, any table, view, or materialized view the \`anon\` role has \`SELECT\` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. Both forms of introspection are intentional behavior this lint surfaces the objects that are currently public so you can confirm each one is meant to be discoverable without authentication.' as description,
+    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the public \`/graphql/v1\` introspection endpoint. When \`pg_graphql\` is installed, any object the \`anon\` role has \`SELECT\` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. See lint 0027 for the equivalent check against the \`authenticated\` role; in default Supabase projects revoking from \`anon\` alone is not sufficient.' as description,
     format(
         'Extension \`pg_graphql\` is installed and the \`anon\` role has \`SELECT\` on %s \`%s.%s\`. Its name, columns, and relationships are visible via the public \`/graphql/v1\` introspection endpoint.',
         object_type,
@@ -1566,4 +1574,181 @@ from
     exposed_objects
 order by
     schema_name,
-    object_name)`
+    object_name)
+union all
+(
+with graphql_installed as (
+    select 1 as installed
+    from pg_catalog.pg_extension
+    where extname = 'pg_graphql'
+),
+exposed_objects as (
+    select
+        n.nspname as schema_name,
+        c.relname as object_name,
+        c.relkind as object_relkind,
+        case c.relkind
+            when 'r' then 'table'
+            when 'v' then 'view'
+            when 'm' then 'materialized view'
+            when 'f' then 'foreign table'
+        end as object_type
+    from
+        pg_catalog.pg_class c
+        join pg_catalog.pg_namespace n
+            on c.relnamespace = n.oid
+    where
+        c.relkind in ('r', 'v', 'm', 'f') -- tables, views, materialized views, foreign tables; matches pg_graphql
+        and exists (
+            -- Any selectable column (table-level or column-level grant)
+            select 1
+            from pg_catalog.pg_attribute a
+            where a.attrelid = c.oid
+                and a.attnum > 0
+                and not a.attisdropped
+                and pg_catalog.has_column_privilege('authenticated', c.oid, a.attnum, 'SELECT')
+        )
+        and exists (select 1 from graphql_installed)
+        and n.nspname not in (
+            '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+        )
+)
+select
+    'pg_graphql_authenticated_table_exposed' as name,
+    'pg_graphql Authenticated Role Exposes Objects in Introspection' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects tables, views, materialized views, and foreign tables whose schema is visible via the \`/graphql/v1\` introspection endpoint to any signed-up user. When \`pg_graphql\` is installed, any object the \`authenticated\` role has \`SELECT\` on is visible in introspection — names, columns, types, and relationships — even when RLS is enabled. In default Supabase projects \`authenticated\` is anyone with a valid JWT, which under open or auto-confirm signup is anyone with a throwaway email. See lint 0026 for the equivalent check against \`anon\`.' as description,
+    format(
+        'Extension \`pg_graphql\` is installed and the \`authenticated\` role has \`SELECT\` on %s \`%s.%s\`. Its name, columns, and relationships are visible via the \`/graphql/v1\` introspection endpoint to any signed-up user.',
+        object_type,
+        schema_name,
+        object_name
+    ) as detail,
+    ${literal(`${docsUrl}/guides/database/database-linter?lint=0027_pg_graphql_authenticated_table_exposed`)} as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', object_name,
+        'type', object_type
+    ) as metadata,
+    format(
+        'pg_graphql_authenticated_table_exposed_%s_%s',
+        schema_name,
+        object_name
+    ) as cache_key
+from
+    exposed_objects
+order by
+    schema_name,
+    object_name)
+union all
+(
+select
+    'anon_security_definer_function_executable' as name,
+    'SECURITY DEFINER Function Executable by Anon' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects SECURITY DEFINER functions that the \`anon\` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to \`anon\` lets any holder of the public anon key invoke a privileged operation via PostgREST \`/rest/v1/rpc/<name>\` (and via \`/graphql/v1\` when pg_graphql is installed and the function''s return type is supported). See lint 0029 for the equivalent check against the \`authenticated\` role.' as description,
+    format(
+        'SECURITY DEFINER function \`%s.%s(%s)\` is executable by the \`anon\` role. It runs with the privileges of its owner and bypasses RLS, so any unauthenticated caller can invoke it via \`/rest/v1/rpc/%s\`.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    ${literal(`${docsUrl}/guides/database/database-linter?lint=0028_anon_security_definer_function_executable`)} as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'anon_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('anon', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args)
+union all
+(
+select
+    'authenticated_security_definer_function_executable' as name,
+    'SECURITY DEFINER Function Executable by Authenticated' as title,
+    'WARN' as level,
+    'EXTERNAL' as facing,
+    array['SECURITY'] as categories,
+    'Detects SECURITY DEFINER functions that the \`authenticated\` role has EXECUTE on. A SECURITY DEFINER function runs with the privileges of its owner and bypasses RLS, so granting EXECUTE to \`authenticated\` lets any signed-up user invoke a privileged operation via PostgREST \`/rest/v1/rpc/<name>\` (and via \`/graphql/v1\` when pg_graphql is installed and the function''s return type is supported). Under open or auto-confirm signup \`authenticated\` is anyone with a throwaway email. See lint 0028 for the equivalent check against the \`anon\` role.' as description,
+    format(
+        'SECURITY DEFINER function \`%s.%s(%s)\` is executable by the \`authenticated\` role. It runs with the privileges of its owner and bypasses RLS, so any signed-up user can invoke it via \`/rest/v1/rpc/%s\`.',
+        schema_name,
+        function_name,
+        function_args,
+        function_name
+    ) as detail,
+    ${literal(`${docsUrl}/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable`)} as remediation,
+    jsonb_build_object(
+        'schema', schema_name,
+        'name', function_name,
+        'arguments', function_args,
+        'language', function_language,
+        'security_definer', true
+    ) as metadata,
+    format(
+        'authenticated_security_definer_function_executable_%s_%s_%s',
+        schema_name,
+        function_name,
+        function_args
+    ) as cache_key
+from
+    (
+        select
+            n.nspname as schema_name,
+            p.proname as function_name,
+            pg_catalog.pg_get_function_identity_arguments(p.oid) as function_args,
+            l.lanname as function_language
+        from
+            pg_catalog.pg_proc p
+            join pg_catalog.pg_namespace n
+                on p.pronamespace = n.oid
+            join pg_catalog.pg_language l
+                on p.prolang = l.oid
+        where
+            p.prosecdef = true
+            and pg_catalog.has_function_privilege('authenticated', p.oid, 'EXECUTE')
+            and n.nspname = any(array(select trim(unnest(string_to_array(current_setting('pgrst.db_schemas', 't'), ',')))))
+            and n.nspname not in (
+                '_timescaledb_cache', '_timescaledb_catalog', '_timescaledb_config', '_timescaledb_internal', 'auth', 'cron', 'extensions', 'graphql', 'graphql_public', 'information_schema', 'net', 'pgmq', 'pgroonga', 'pgsodium', 'pgsodium_masks', 'pgtle', 'pgbouncer', 'pg_catalog', 'realtime', 'repack', 'storage', 'supabase_functions', 'supabase_migrations', 'tiger', 'topology', 'vault'
+            )
+    ) exposed_functions
+order by
+    schema_name,
+    function_name,
+    function_args)`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature — wires up three new advisor lints landed in splinter, and updates the self-hosted SQL bundle for the existing `pg_graphql_anon_table_exposed` lint to track splinter's correctness fixes. Companion to `supabase/splinter` #160 (already merged) and #162 (test fix in flight).

## What is the current behavior?

Splinter's `main` now exposes four lints in the pg_graphql / SECURITY DEFINER family:

- `pg_graphql_anon_table_exposed` (0026, existing) — wired into Studio in #45253; SQL in `packages/pg-meta` is the original version that uses `has_table_privilege` and the relkind set `('r','p','v','m')`.
- `pg_graphql_authenticated_table_exposed` (0027, new) — paired check against the `authenticated` role. Studio renders any new finding without a `lintInfoMap` entry as a row with no icon, no title mapping, and no "Fix" CTA. Self-hosted users do not see the lint at all because `packages/pg-meta` does not include it.
- `anon_security_definer_function_executable` (0028, new) — `SECURITY DEFINER` function executable by `anon`. Same Studio + self-hosted gaps as 0027.
- `authenticated_security_definer_function_executable` (0029, new) — same against `authenticated`.

Splinter has also updated 0026 itself (PR #160) in two ways that need to flow into the self-hosted SQL bundle:
1. **`relkind` filter:** `('r','p','v','m')` → `('r','v','m','f')`. Drops partitioned table roots (pg_graphql does not expose them; their leaf partitions are still covered as `'r'`) and adds foreign tables, which pg_graphql does expose.
2. **Privilege predicate:** `has_table_privilege(role, oid, 'SELECT')` → `EXISTS` over `pg_attribute` calling `has_column_privilege`. Catches column-level grants such as `GRANT SELECT (col) ON t TO anon`, which pg_graphql's introspection exposes but `has_table_privilege` missed.

Cloud projects auto-fetch `splinter.sql` via the platform mgmt-api's `getLintSql` (1-hour cache TTL), so they pick up #160's lint and SQL changes independently of this PR. This PR is about the Studio display mapping and the self-hosted SQL bundle.

## What is the new behavior?

Two minimal additions, mirroring the integration shape of #45253.

### `apps/studio/components/interfaces/Linter/Linter.utils.tsx`

Three new entries appended to `lintInfoMap`:

- `pg_graphql_authenticated_table_exposed` — `Eye` icon (paired with the existing `pg_graphql_anon_table_exposed` entry); link points to the Table Editor scoped to `metadata.schema` + `metadata.name`; `linkText: 'View object'`; `category: 'security'`.
- `anon_security_definer_function_executable` — `Unlock` icon (signals "this thing is callable when it shouldn't be"); link points to the Database Functions browser scoped to `metadata.schema` + `metadata.name`; `linkText: 'View function'`; `category: 'security'`.
- `authenticated_security_definer_function_executable` — same as 0028 against `authenticated`.

Each entry's `docsLink` points at the splinter-hosted lint doc.

### `packages/pg-meta/src/sql/studio/advisor/lints.ts`

The existing `pg_graphql_anon_table_exposed` SQL block is updated in place to match the new splinter version: new `relkind` set, `case` statement for `'f'`, and the `EXISTS` over `pg_attribute` privilege check. Three new `union all` blocks are appended for 0027/0028/0029. The function lints (0028/0029) include the `pgrst.db_schemas` filter (mirroring lint `0023_sensitive_columns_exposed`) so findings are scoped to schemas PostgREST actually exposes; the self-hosted query wrapper already sets the GUC when `exposedSchemas` is passed (`enrichLintsQuery`).

## Coverage of the four exposure paths

| Role | Tables/views/MVs/foreign tables | SECURITY DEFINER functions |
|------|---------|----------|
| `anon` | 0026 (existing, updated) | 0028 (new) |
| `authenticated` | 0027 (new) | 0029 (new) |

The 0026/0027 pair covers `pg_graphql` introspection visibility; the 0028/0029 pair covers RLS bypass via privileged function execution through `/rest/v1/rpc` (and `/graphql/v1` for compatible return types). Each lint's doc cross-references its sibling so an operator hitting one is steered toward the others.

## Verification

- `cd packages/pg-meta && npx tsc --noEmit` — clean.
- `cd apps/studio && npx tsc --noEmit` — clean for the changed file. (Other unrelated TS errors exist in the working tree but are pre-existing and not introduced by this PR.)
- `cd apps/studio && npx eslint components/interfaces/Linter/Linter.utils.tsx` — clean.

## Files

- `apps/studio/components/interfaces/Linter/Linter.utils.tsx` — adds three `lintInfoMap` entries (0027, 0028, 0029).
- `packages/pg-meta/src/sql/studio/advisor/lints.ts` — updates the 0026 SQL block to match splinter's correctness fixes, appends 0027/0028/0029 SQL blocks.

## Related

- supabase/splinter#160 — adds 0027/0028/0029 and rewrites 0026 (merged).
- supabase/splinter#162 — fixes test setup for 0028/0029 (in flight; does not affect the SQL shipped here).
- supabase/supabase#45253 — original 0026 Studio integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added security linting to detect authenticated-table exposure and executable SECURITY DEFINER functions.
  * Added signed-in visibility checks alongside anonymous checks.

* **Bug Fixes / Improvements**
  * Improved relation type handling for accurate table/foreign/partition classification.
  * Switched to column-level privilege analysis for visibility.
  * Improved entity naming shown in lints (includes function argument display).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->