### PR TITLE
chore(self-hosted): update images 2026-04-27

### DIFF
--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -22,7 +22,7 @@ Check updates for each service to learn more.
 ### Studio
 
 - Updated to `2026.04.27-sha-4afbe9c`
-- Added 4 new lints to the Security Advisor for `pg_graphql` - PR [#45253](https://github.com/supabase/supabase/pull/45253), PR [#45260](https://github.com/supabase/supabase/pull/45260). Read more in our [docs](https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0026_pg_graphql_anon_table_exposed) for lint rules 0026 - 0029.
+- Added 4 new lints to the Security Advisor - PR [#45253](https://github.com/supabase/supabase/pull/45253), PR [#45260](https://github.com/supabase/supabase/pull/45260). Read more in our [docs](https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0026_pg_graphql_anon_table_exposed) for lint rules 0026 - 0029.
 
 ## [2026-04-08]
 

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -17,6 +17,13 @@ Check updates for each service to learn more.
 
 ---
 
+## [2026-04-27]
+
+### Studio
+
+- Updated to `2026.04.27-sha-4afbe9c`
+- Added 4 new lints to the Security Advisor for `pg_graphql` - PR [#45253](https://github.com/supabase/supabase/pull/45253), PR [#45260](https://github.com/supabase/supabase/pull/45260). Read more in our [docs](https://supabase.com/docs/guides/database/database-advisors?queryGroups=lint&lint=0026_pg_graphql_anon_table_exposed) for lint rules 0026 - 0029.
+
 ## [2026-04-08]
 
 ### Documentation

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   studio:
     container_name: supabase-studio
-    image: supabase/studio:2026.04.08-sha-205cbe7
+    image: supabase/studio:2026.04.27-sha-4afbe9c
     restart: unless-stopped
     healthcheck:
       test:

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,5 +1,8 @@
 # Docker Image Versions
 
+## 2026-04-27
+- supabase/studio:2026.04.27-sha-4afbe9c (prev supabase/studio:2026.04.08-sha-205cbe7)
+
 ## 2026-04-08
 - supabase/studio:2026.04.08-sha-205cbe7 (prev supabase/studio:2026.03.16-sha-5528817)
 - postgrest/postgrest:v14.8 (prev postgrest/postgrest:v14.6)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update images in docker-compose.yml and add changes to versions.md:

## 2026-04-27
- supabase/studio:2026.04.27-sha-4afbe9c (prev supabase/studio:2026.04.08-sha-205cbe7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Studio service to use a newer runtime version for improved stability and performance.

* **Documentation**
  * Added a new dated release entry and updated version notes for the Docker stack.
  * Expanded the Security Advisor section with four additional lints and linked references for guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->