### PR TITLE
fix: org slug filter

### DIFF
--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -347,7 +347,7 @@ export const AuditLogs = () => {
                         const logOrgSlug = log.target.metadata.org_slug ?? log.target.metadata.slug
 
                         const project = projects?.find((project) => project.ref === logProjectRef)
-                        const organization = organizations?.find((org) => logOrgSlug)
+                        const organization = organizations?.find((org) => org.slug === logOrgSlug)
 
                         const hasStatusCode = log.action.metadata[0]?.status !== undefined
                         const userIcon =


### PR DESCRIPTION
missing a filter on org slug in org-level audit logs, causing events to be matched to the first org in the array. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed organization label display in audit logs to correctly show the organization associated with each log entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->