### PR TITLE
feat: add Syslog log drain type

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -415,6 +415,7 @@ export function LogDrainDestinationSheetForm({
     if (!open || mode !== 'create') return
 
     form.setValue('headerEntries', headerRecordToRows(getDefaultHeadersByType(type)))
+    form.clearErrors('headerEntries')
   }, [form, mode, open, type])
 
   return (

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { IS_PLATFORM, useFlag, useParams } from 'common'
 import Link from 'next/link'
-import { ReactNode, useEffect } from 'react'
+import { ReactNode, useEffect, useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -340,8 +340,12 @@ export function LogDrainDestinationSheetForm({
   // out of it, therefore for an ease of use now, we bail to `any` until the better time come.
   const defaultConfig = (defaultValues?.config || {}) as any
   const defaultType = defaultValues?.type || 'webhook'
-  const defaultHeaderEntries = headerRecordToRows(
-    mode === 'create' ? getDefaultHeadersByType(defaultType) : defaultConfig?.headers || {}
+  const defaultHeaderEntries = useMemo(
+    () =>
+      headerRecordToRows(
+        mode === 'create' ? getDefaultHeadersByType(defaultType) : defaultConfig?.headers || {}
+      ),
+    [mode, defaultType, defaultConfig]
   )
 
   const sentryEnabled = useFlag('SentryLogDrain')
@@ -358,9 +362,8 @@ export function LogDrainDestinationSheetForm({
 
   const track = useTrack()
 
-  const form = useForm<LogDrainDestinationFormValues>({
-    resolver: zodResolver(formSchema),
-    values: {
+  const formValues = useMemo(
+    () => ({
       name: defaultValues?.name || '',
       description: defaultValues?.description || '',
       type: defaultType,
@@ -383,14 +386,20 @@ export function LogDrainDestinationSheetForm({
       endpoint: defaultConfig?.endpoint || '',
       protocol: defaultConfig?.protocol || 'http/protobuf',
       host: defaultConfig?.host || '',
-      port: defaultConfig?.port ?? ('' as unknown as number),
+      port: (defaultConfig?.port ?? '') as number,
       tls: defaultConfig?.tls ?? false,
       structured_data: defaultConfig?.structured_data || '',
       cipher_key: defaultConfig?.cipher_key || '',
       ca_cert: defaultConfig?.ca_cert || '',
       client_cert: defaultConfig?.client_cert || '',
       client_key: defaultConfig?.client_key || '',
-    },
+    }),
+    [defaultValues, defaultType, defaultConfig, defaultHeaderEntries, mode]
+  )
+
+  const form = useForm<LogDrainDestinationFormValues>({
+    resolver: zodResolver(formSchema),
+    values: formValues,
   })
 
   const type = form.watch('type')
@@ -405,9 +414,7 @@ export function LogDrainDestinationSheetForm({
   useEffect(() => {
     if (!open || mode !== 'create') return
 
-    form.setValue('headerEntries', headerRecordToRows(getDefaultHeadersByType(type)), {
-      shouldValidate: true,
-    })
+    form.setValue('headerEntries', headerRecordToRows(getDefaultHeadersByType(type)))
   }, [form, mode, open, type])
 
   return (

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -263,8 +263,8 @@ const submitSchema = z
   })
   .and(submitUnion)
 
-type LogDrainDestinationFormValues = z.infer
-type LogDrainDestinationSubmitValues = z.infer
+type LogDrainDestinationFormValues = z.infer<typeof formSchema>
+type LogDrainDestinationSubmitValues = z.infer<typeof submitSchema>
 
 const HEADER_ENABLED_TYPES = ['webhook', 'loki', 'otlp'] as const
 
@@ -317,7 +317,7 @@ function LogDrainFormItem({
   )
 }
 
-type DefaultValues = { type: LogDrainType } & Partial
+type DefaultValues = { type: LogDrainType } & Partial<LogDrainData>
 
 export function LogDrainDestinationSheetForm({
   open,

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -29,6 +29,7 @@ import {
   SheetSection,
   SheetTitle,
   Switch,
+  TextArea_Shadcn_,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { KeyValueFieldArray } from 'ui-patterns/form/KeyValueFieldArray/KeyValueFieldArray'
@@ -180,6 +181,18 @@ const otlpSubmitSchema = z.object({
 
 const syslogSchema = z.object({
   type: z.literal('syslog'),
+  host: z.string().min(1, { message: 'Host is required' }),
+  port: z.coerce
+    .number()
+    .int({ message: 'Port must be an integer' })
+    .min(0, { message: 'Port must be between 0 and 65535' })
+    .max(65535, { message: 'Port must be between 0 and 65535' }),
+  tls: z.boolean().optional().default(false),
+  structured_data: z.string().optional(),
+  cipher_key: z.string().optional(),
+  ca_cert: z.string().optional(),
+  client_cert: z.string().optional(),
+  client_key: z.string().optional(),
 })
 
 const formUnion = z.discriminatedUnion('type', [
@@ -223,6 +236,23 @@ const formSchema = z
     description: z.string().optional(),
   })
   .and(formUnion)
+  .superRefine((data, ctx) => {
+    if (data.type !== 'syslog') return
+    if (data.client_cert && !data.client_key) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Client key is required when a client certificate is provided',
+        path: ['client_key'],
+      })
+    }
+    if (data.client_key && !data.client_cert) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Client certificate is required when a client key is provided',
+        path: ['client_cert'],
+      })
+    }
+  })
 
 const submitSchema = z
   .object({
@@ -233,8 +263,8 @@ const submitSchema = z
   })
   .and(submitUnion)
 
-type LogDrainDestinationFormValues = z.infer<typeof formSchema>
-type LogDrainDestinationSubmitValues = z.infer<typeof submitSchema>
+type LogDrainDestinationFormValues = z.infer
+type LogDrainDestinationSubmitValues = z.infer
 
 const HEADER_ENABLED_TYPES = ['webhook', 'loki', 'otlp'] as const
 
@@ -287,7 +317,7 @@ function LogDrainFormItem({
   )
 }
 
-type DefaultValues = { type: LogDrainType } & Partial<LogDrainData>
+type DefaultValues = { type: LogDrainType } & Partial
 
 export function LogDrainDestinationSheetForm({
   open,
@@ -319,6 +349,7 @@ export function LogDrainDestinationSheetForm({
   const axiomEnabled = useFlag('axiomLogDrain')
   const otlpEnabled = useFlag('otlpLogDrain')
   const last9Enabled = useFlag('Last9LogDrain')
+  const syslogEnabled = useFlag('syslogLogDrain')
 
   const { ref } = useParams()
   const { data: logDrains } = useLogDrainsQuery({
@@ -351,6 +382,14 @@ export function LogDrainDestinationSheetForm({
       api_token: defaultConfig?.api_token || '',
       endpoint: defaultConfig?.endpoint || '',
       protocol: defaultConfig?.protocol || 'http/protobuf',
+      host: defaultConfig?.host || '',
+      port: defaultConfig?.port ?? ('' as unknown as number),
+      tls: defaultConfig?.tls ?? false,
+      structured_data: defaultConfig?.structured_data || '',
+      cipher_key: defaultConfig?.cipher_key || '',
+      ca_cert: defaultConfig?.ca_cert || '',
+      client_cert: defaultConfig?.client_cert || '',
+      client_key: defaultConfig?.client_key || '',
     },
   })
 
@@ -437,6 +476,7 @@ export function LogDrainDestinationSheetForm({
                           if (t.value === 'axiom') return axiomEnabled
                           if (t.value === 'otlp') return otlpEnabled
                           if (t.value === 'last9') return last9Enabled
+                          if (t.value === 'syslog') return syslogEnabled
                           return true
                         }).map((type) => (
                           <SelectItem_Shadcn_
@@ -803,6 +843,125 @@ export function LogDrainDestinationSheetForm({
                       description="Password for authentication from Last9 OTEL integration."
                     />
                   </div>
+                )}
+                {type === 'syslog' && (
+                  <>
+                    <div className="grid gap-4 px-content">
+                      <LogDrainFormItem
+                        value="host"
+                        label="Host"
+                        placeholder="logs.example.com"
+                        formControl={form.control}
+                        description="Hostname or IP address of the syslog receiver."
+                      />
+                      <LogDrainFormItem
+                        type="number"
+                        value="port"
+                        label="Port"
+                        placeholder="514"
+                        formControl={form.control}
+                        description="Port of the syslog receiver (0–65535)."
+                      />
+                      <LogDrainFormItem
+                        value="structured_data"
+                        label="Structured Data"
+                        placeholder='[exampleSDID@32473 iut="3" eventSource="Application"]'
+                        formControl={form.control}
+                        description="Static RFC 5424 Structured Data included in every log frame."
+                      />
+                      <LogDrainFormItem
+                        type="password"
+                        value="cipher_key"
+                        label="Cipher Key"
+                        placeholder="••••••••••••••••"
+                        formControl={form.control}
+                        description="Base64-encoded 32-byte key for AES-256-GCM encryption of the log body."
+                      />
+                    </div>
+
+                    <FormField
+                      control={form.control}
+                      name="tls"
+                      render={({ field }) => (
+                        <FormItem className="space-y-2 px-4">
+                          <div className="flex gap-2 items-center">
+                            <FormControl>
+                              <Switch checked={field.value} onCheckedChange={field.onChange} />
+                            </FormControl>
+                            <FormLabel className="text-base">TLS</FormLabel>
+                            <InfoTooltip align="start">
+                              Connect via SSL/TLS instead of plain TCP.
+                            </InfoTooltip>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+
+                    {form.watch('tls') && (
+                      <div className="grid gap-4 px-content">
+                        <FormField
+                          name="ca_cert"
+                          control={form.control}
+                          render={({ field }) => (
+                            <FormItemLayout
+                              layout="horizontal"
+                              label="CA Certificate"
+                              description="PEM encoded CA certificate for verifying the server. Falls back to the system CA bundle if omitted."
+                            >
+                              <FormControl>
+                                <TextArea_Shadcn_
+                                  className="font-mono text-xs"
+                                  placeholder="-----BEGIN CERTIFICATE-----"
+                                  rows={4}
+                                  {...field}
+                                />
+                              </FormControl>
+                            </FormItemLayout>
+                          )}
+                        />
+                        <FormField
+                          name="client_cert"
+                          control={form.control}
+                          render={({ field }) => (
+                            <FormItemLayout
+                              layout="horizontal"
+                              label="Client Certificate"
+                              description="PEM encoded client certificate for mTLS."
+                            >
+                              <FormControl>
+                                <TextArea_Shadcn_
+                                  className="font-mono text-xs"
+                                  placeholder="-----BEGIN CERTIFICATE-----"
+                                  rows={4}
+                                  {...field}
+                                />
+                              </FormControl>
+                            </FormItemLayout>
+                          )}
+                        />
+                        <FormField
+                          name="client_key"
+                          control={form.control}
+                          render={({ field }) => (
+                            <FormItemLayout
+                              layout="horizontal"
+                              label="Client Key"
+                              description="PEM encoded client private key for mTLS. Required when a client certificate is provided."
+                            >
+                              <FormControl>
+                                <TextArea_Shadcn_
+                                  className="font-mono text-xs"
+                                  placeholder="-----BEGIN PRIVATE KEY-----"
+                                  rows={4}
+                                  {...field}
+                                />
+                              </FormControl>
+                            </FormItemLayout>
+                          )}
+                        />
+                      </div>
+                    )}
+                  </>
                 )}
                 {HEADER_ENABLED_TYPES.includes(type as (typeof HEADER_ENABLED_TYPES)[number]) && (
                   <div className="px-content">

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -338,7 +338,6 @@ export function LogDrainDestinationSheetForm({
   // it produces a correct union type of all possible configs. Unfortunately, this type was not designed correctly
   // and it does not include `type` inside the config itself, so it's not trivial to create `discriminatedUnion`
   // out of it, therefore for an ease of use now, we bail to `any` until the better time come.
-  const defaultConfig = (defaultValues?.config || {}) as any
   const defaultType = defaultValues?.type || 'webhook'
   const defaultHeaderEntries = useMemo(() => {
     const config = (defaultValues?.config || {}) as any

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -340,13 +340,13 @@ export function LogDrainDestinationSheetForm({
   // out of it, therefore for an ease of use now, we bail to `any` until the better time come.
   const defaultConfig = (defaultValues?.config || {}) as any
   const defaultType = defaultValues?.type || 'webhook'
-  const defaultHeaderEntries = useMemo(
-    () =>
-      headerRecordToRows(
-        mode === 'create' ? getDefaultHeadersByType(defaultType) : defaultConfig?.headers || {}
-      ),
-    [mode, defaultType, defaultConfig]
-  )
+  const defaultHeaderEntries = useMemo(() => {
+    const config = (defaultValues?.config || {}) as any
+    const type = defaultValues?.type || 'webhook'
+    return headerRecordToRows(
+      mode === 'create' ? getDefaultHeadersByType(type) : config?.headers || {}
+    )
+  }, [defaultValues, mode])
 
   const sentryEnabled = useFlag('SentryLogDrain')
   const s3Enabled = useFlag('S3logdrain')
@@ -362,40 +362,41 @@ export function LogDrainDestinationSheetForm({
 
   const track = useTrack()
 
-  const formValues = useMemo(
-    () => ({
+  const formValues = useMemo(() => {
+    const config = (defaultValues?.config || {}) as any
+    const type = defaultValues?.type || 'webhook'
+    return {
       name: defaultValues?.name || '',
       description: defaultValues?.description || '',
-      type: defaultType,
-      http: defaultConfig?.http || 'http2',
-      gzip: mode === 'create' ? true : defaultConfig?.gzip || false,
+      type,
+      http: config?.http || 'http2',
+      gzip: mode === 'create' ? true : config?.gzip || false,
       headerEntries: defaultHeaderEntries,
-      url: defaultConfig?.url || '',
-      api_key: defaultConfig?.api_key || '',
-      region: defaultConfig?.region || '',
-      username: defaultConfig?.username || '',
-      password: defaultConfig?.password || '',
-      dsn: defaultConfig?.dsn || '',
-      s3_bucket: defaultConfig?.s3_bucket || '',
-      storage_region: defaultConfig?.storage_region || '',
-      access_key_id: defaultConfig?.access_key_id || '',
-      secret_access_key: defaultConfig?.secret_access_key || '',
-      batch_timeout: defaultConfig?.batch_timeout ?? 3000,
-      dataset_name: defaultConfig?.dataset_name || '',
-      api_token: defaultConfig?.api_token || '',
-      endpoint: defaultConfig?.endpoint || '',
-      protocol: defaultConfig?.protocol || 'http/protobuf',
-      host: defaultConfig?.host || '',
-      port: (defaultConfig?.port ?? '') as number,
-      tls: defaultConfig?.tls ?? false,
-      structured_data: defaultConfig?.structured_data || '',
-      cipher_key: defaultConfig?.cipher_key || '',
-      ca_cert: defaultConfig?.ca_cert || '',
-      client_cert: defaultConfig?.client_cert || '',
-      client_key: defaultConfig?.client_key || '',
-    }),
-    [defaultValues, defaultType, defaultConfig, defaultHeaderEntries, mode]
-  )
+      url: config?.url || '',
+      api_key: config?.api_key || '',
+      region: config?.region || '',
+      username: config?.username || '',
+      password: config?.password || '',
+      dsn: config?.dsn || '',
+      s3_bucket: config?.s3_bucket || '',
+      storage_region: config?.storage_region || '',
+      access_key_id: config?.access_key_id || '',
+      secret_access_key: config?.secret_access_key || '',
+      batch_timeout: config?.batch_timeout ?? 3000,
+      dataset_name: config?.dataset_name || '',
+      api_token: config?.api_token || '',
+      endpoint: config?.endpoint || '',
+      protocol: config?.protocol || 'http/protobuf',
+      host: config?.host || '',
+      port: (config?.port ?? '') as number,
+      tls: config?.tls ?? false,
+      structured_data: config?.structured_data || '',
+      cipher_key: config?.cipher_key || '',
+      ca_cert: config?.ca_cert || '',
+      client_cert: config?.client_cert || '',
+      client_key: config?.client_key || '',
+    }
+  }, [defaultValues, mode, defaultHeaderEntries])
 
   const form = useForm<LogDrainDestinationFormValues>({
     resolver: zodResolver(formSchema),

--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -394,6 +394,7 @@ export function LogDrainDestinationSheetForm({
   })
 
   const type = form.watch('type')
+  const tls = form.watch('tls')
 
   useEffect(() => {
     if (mode === 'create' && !open) {
@@ -897,7 +898,7 @@ export function LogDrainDestinationSheetForm({
                       )}
                     />
 
-                    {form.watch('tls') && (
+                    {tls && (
                       <div className="grid gap-4 px-content">
                         <FormField
                           name="ca_cert"

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
@@ -129,5 +129,5 @@ export type LogDrainOtlpConfig = {
   endpoint: string
   protocol?: string
   gzip?: boolean
-  headers?: Record
+  headers?: Record<string, string>
 }

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
@@ -1,6 +1,6 @@
 import { components } from 'api-types'
 import { Axiom, Datadog, Grafana, Last9, Otlp, Sentry } from 'icons'
-import { BracesIcon, Cloud } from 'lucide-react'
+import { BracesIcon, Cloud, Server } from 'lucide-react'
 
 const iconProps = {
   height: 24,
@@ -61,6 +61,12 @@ export const LOG_DRAIN_TYPES = [
     name: 'Last9',
     description: 'Last9 is an observability platform for monitoring and telemetry data',
     icon: <Last9 {...iconProps} fill="currentColor" />,
+  },
+  {
+    value: 'syslog',
+    name: 'Syslog',
+    description: 'Forward logs to a remote Syslog receiver using TCP or TLS, adhering to RFC 5424',
+    icon: <Server {...iconProps} />,
   },
 ] as const
 
@@ -123,5 +129,5 @@ export type LogDrainOtlpConfig = {
   endpoint: string
   protocol?: string
   gzip?: boolean
-  headers?: Record<string, string>
+  headers?: Record
 }

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
@@ -59,6 +59,7 @@ export function LogDrains({
   const axiomEnabled = useFlag('axiomLogDrain')
   const otlpEnabled = useFlag('otlpLogDrain')
   const last9Enabled = useFlag('Last9LogDrain')
+  const syslogEnabled = useFlag('syslogLogDrain')
   const hasLogDrains = !!logDrains?.length
 
   const { mutate: deleteLogDrain } = useDeleteLogDrainMutation({
@@ -99,6 +100,7 @@ export function LogDrains({
             if (t.value === 'axiom') return axiomEnabled
             if (t.value === 'otlp') return otlpEnabled
             if (t.value === 'last9') return last9Enabled
+            if (t.value === 'syslog') return syslogEnabled
             return true
           }).map((src) => (
             <LogDrainsCard

--- a/apps/studio/pages/project/[ref]/settings/log-drains.tsx
+++ b/apps/studio/pages/project/[ref]/settings/log-drains.tsx
@@ -58,6 +58,7 @@ const LogDrainsSettings: NextPageWithLayout = () => {
   const axiomEnabled = useFlag('axiomLogDrain')
   const otlpEnabled = useFlag('otlpLogDrain')
   const last9Enabled = useFlag('Last9LogDrain')
+  const syslogEnabled = useFlag('syslogLogDrain')
 
   const { data: logDrains } = useLogDrainsQuery(
     { ref },
@@ -226,6 +227,7 @@ const LogDrainsSettings: NextPageWithLayout = () => {
                       if (t.value === 'axiom') return axiomEnabled
                       if (t.value === 'otlp') return otlpEnabled
                       if (t.value === 'last9') return last9Enabled
+                      if (t.value === 'syslog') return syslogEnabled
                       return true
                     }).map((drainType) => (
                       <DropdownMenuItem


### PR DESCRIPTION
## Summary

- Adds `syslog` as a new log drain destination type in Studio
- Implements RFC 5424 syslog over TCP or TLS with octet-counting framing (backed by the existing Logflare syslog backend)
- All fields match the Logflare backend config: `host`, `port`, `tls`, `structured_data`, `cipher_key`, `ca_cert`, `client_cert`, `client_key`
- TLS cert fields (CA cert, client cert, client key) are shown only when the TLS toggle is on
- Cross-field validation: `client_cert` and `client_key` must be provided together
- Gated behind a `syslogLogDrain` feature flag (consistent with other drain types)
closes FE-2865

## Test plan
- go to log drains
- create a syslog log drain
- it creates it 

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Syslog added as a new log drain destination with configurable host, port (0–65535), TLS toggle, and optional RFC5424 structured data.
  * Supports CA and client certificate/key input for TLS or mTLS; client certificate and key must be provided together.
  * Form validation, inline defaults, initial values for Syslog fields, and availability controlled by a feature flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->