### PR TITLE
fix(studio): unblock advisor panel loading state on self-hosted

### DIFF
--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanel.tsx
@@ -51,7 +51,7 @@ export const AdvisorPanel = () => {
     isError: isLintsError,
   } = useProjectLintsQuery({ projectRef: project?.ref }, { enabled: shouldLoadProjectAdvisorData })
 
-  const { data: signalItems, isPending: isSignalsPending } = useAdvisorSignals({
+  const { data: signalItems } = useAdvisorSignals({
     projectRef: project?.ref,
     enabled: shouldLoadProjectAdvisorData,
   })
@@ -157,11 +157,9 @@ export const AdvisorPanel = () => {
   // Only show loading state if the query is actually enabled
   const isLintsActuallyLoading = shouldLoadProjectAdvisorData && isLintsLoading
   const isNotificationsActuallyLoading = shouldLoadNotifications && isNotificationsLoading
-  const isSignalsActuallyLoading = shouldLoadProjectAdvisorData && isSignalsPending
-  const isLoading =
-    isLintsActuallyLoading || isNotificationsActuallyLoading || isSignalsActuallyLoading
 
-  // [Joshen] Opting to ignore error state of advisor signals for now - render lints irregardless of banned ips
+  // [Joshen] Opting to ignore loading and error state of advisor signals - render lints irregardless of banned ips
+  const isLoading = isLintsActuallyLoading || isNotificationsActuallyLoading
   const isError = isLintsError || isNotificationsError
 
   const handleTabChange = (tab: string) => {


### PR DESCRIPTION
## Summary

Fixes [FE-3080](https://linear.app/supabase/issue/FE-3080/self-hosted-studio-advisors-toolbar-shows-blank-panel). On self-hosted Studio, opening the Advisors panel rendered an infinite skeleton with no network traffic.

## Root cause

`useBannedIPsQuery` is gated by `IS_PLATFORM`. On self-hosted that disables the query — and a disabled React Query v5 query keeps `isPending: true` forever (only `isFetching` / `isLoading` go false). `useAdvisorSignals` re-exports that `isPending`, and `AdvisorPanel` folded it into its `isLoading` aggregate, pinning the panel into the skeleton state in `AdvisorPanelBody`.

The other consumers were already designed around this — `AdvisorSection` on the home page explicitly does not wait on signals, and `AdvisorButton` only reads `data`. Only `AdvisorPanel` had the regression, introduced in #44372.

## Fix

Drop `isSignalsActuallyLoading` from the panel's `isLoading` aggregate, mirroring the existing `[Joshen]` "ignore signal errors" exclusion two lines below and matching the home-page pattern.

## Test plan

- [x] Existing unit + integration tests pass (`AdvisorPanel.utils`, `useAdvisorSignals`, `AdvisorSignals.integration` — 6/6)
- [x] Verify on self-hosted Studio: open the Advisors sidebar and confirm lints render (or "no issues" empty state appears) instead of an infinite skeleton
- [x] Verify on hosted Studio: lints, banned-IP signals, and notifications still render together; loading skeleton still appears while lints/notifications are in flight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading state behavior in the Advisor Panel by excluding signal queries from blocking the panel's display. The loading indicator now only appears when actively fetching lints or notifications, allowing faster visibility of available content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->