### PR TITLE
chore(self-hosted): update studio to the latest build from 2026-04-27

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   studio:
     container_name: supabase-studio
-    image: supabase/studio:2026.04.27-sha-4afbe9c
+    image: supabase/studio:2026.04.27-sha-5f60601
     restart: unless-stopped
     healthcheck:
       test:

--- a/docker/versions.md
+++ b/docker/versions.md
@@ -1,7 +1,7 @@
 # Docker Image Versions
 
 ## 2026-04-27
-- supabase/studio:2026.04.27-sha-4afbe9c (prev supabase/studio:2026.04.08-sha-205cbe7)
+- supabase/studio:2026.04.27-sha-5f60601 (prev supabase/studio:2026.04.08-sha-205cbe7)
 
 ## 2026-04-08
 - supabase/studio:2026.04.08-sha-205cbe7 (prev supabase/studio:2026.03.16-sha-5528817)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Update Studio to `2026.04.27-sha-5f60601` (the latest build from 2026-04-27)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Supabase Studio container to the latest release with recent improvements and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->