### PR TITLE
docs: fix "support support" duplicate-word typo in quickstart guides

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/react.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/react.mdx
@@ -109,7 +109,7 @@ hideToc: true
   <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Customize email template">
 
-    Before proceeding, change the email template to support support a server-side authentication flow that sends a token hash:
+    Before proceeding, change the email template to support a server-side authentication flow that sends a token hash:
 
     - Go to the [Auth templates](/dashboard/project/_/auth/templates) page in your dashboard.
     - Select the Confirm sign up template.

--- a/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
@@ -180,7 +180,7 @@ meta="name=app/error/page.tsx"
 
 ### Email template
 
-Before proceeding, change the email template to support support a server-side authentication flow that sends a token hash:
+Before proceeding, change the email template to support a server-side authentication flow that sends a token hash:
 
 - Go to the [Auth templates](/dashboard/project/_/auth/templates) page in your dashboard.
 - Select the **Confirm signup** template.


### PR DESCRIPTION
Fixes the same duplicate-word typo ("support support") in two quickstart guides:

- `apps/docs/content/guides/auth/quickstarts/react.mdx`
- `apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx`

Both occurrences are in the "Customize email template" / "Email template" sections:

> Before proceeding, change the email template to support ~~support~~ a server-side authentication flow that sends a token hash:

Pure docs typo fix — no functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected typographical errors in authentication guides to improve clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->