### PR TITLE
docs: fix "an" → "a" grammar errors before consonant words

### DIFF
--- a/apps/docs/content/guides/ai/examples/nextjs-vector-search.mdx
+++ b/apps/docs/content/guides/ai/examples/nextjs-vector-search.mdx
@@ -364,7 +364,7 @@ All of this is glued together in a [Vercel Edge Function](https://vercel.com/doc
   <StepHikeCompact.Step step={2}>
     <StepHikeCompact.Details title="Perform similarity search">
 
-    Using the `embeddingResponse` we can now perform similarity search by performing an remote procedure call (RPC) to the database function we created earlier.
+    Using the `embeddingResponse` we can now perform similarity search by performing a remote procedure call (RPC) to the database function we created earlier.
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/troubleshooting/how-postgres-chooses-which-index-to-use-_JHrf4.mdx
+++ b/apps/docs/content/troubleshooting/how-postgres-chooses-which-index-to-use-_JHrf4.mdx
@@ -17,7 +17,7 @@ Postgres, internally, contains a few components that manage query execution:
 
 | Module            | Description                                                                                                   |
 | ----------------- | ------------------------------------------------------------------------------------------------------------- |
-| Parser            | Converts SQL into an traversable query tree                                                                   |
+| Parser            | Converts SQL into a traversable query tree                                                                    |
 | Planner/Optimizer | Takes the query tree and uses rules and database statistics to find the optimal strategy for getting the data |
 | Executor          | Executes the plan created by the planner                                                                      |
 


### PR DESCRIPTION
Fixes two indefinite-article grammar errors where 'an' is used before a consonant-starting word:

- `apps/docs/content/troubleshooting/how-postgres-chooses-which-index-to-use-_JHrf4.mdx`: "an traversable" → "a traversable"
- `apps/docs/content/guides/ai/examples/nextjs-vector-search.mdx`: "an remote procedure" → "a remote procedure"

Pure docs grammar fix — no functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fixed a grammar typo in the AI vector search guide to improve clarity in the “Perform similarity search” step.
  * Normalized trailing whitespace in the PostgreSQL indexing troubleshooting guide’s “Postgres internals” table to tidy formatting and ensure consistent display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->