### PR TITLE
fix(studio): unused credit card expiry label in test

### DIFF
--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/CreditCard.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/CreditCard.tsx
@@ -57,7 +57,6 @@ const CreditCard = ({
   const tokenExpiry = spt?.expires_at
     ? `${new Date(spt.expires_at * 1000).getMonth() + 1}/${new Date(spt.expires_at * 1000).getFullYear()}`
     : undefined
-  const cardExpiryLabel = `${expiryMonth}/${expiryYear}`
 
   const stripeStatus = (() => {
     if (!isSpt) return null


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

PR #44965 introduced an unused `cardExpiryLabel` constant in `CreditCard.tsx`, which causes `studio#typecheck` to fail with `TS6133` after the branch is merged into `master`.

## What is the new behavior?

Removes the unused constant so Studio typecheck passes again without changing payment method behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused code to improve code quality and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->