### PR TITLE
feat: open oauth apps in new tab to avoid losing studio context

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -27,7 +27,7 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
             toast.error('Failed to redirect because redirect URL is invalid')
             return
           }
-          window.location.href = data.redirectUrl
+          window.open(data.redirectUrl, '_blank', 'noreferrer')
         } else {
           toast.error('Failed to start integration installation')
         }


### PR DESCRIPTION
Currently when a user clicks the **Install integration** button on an OAuth integration like Grafana, they are redirected to the partner website in the same tab in which they clicked the button. This makes them lose context in the Supabase Studio. This PR changes the behaviour such that the partner website will be opened in a new tab.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth integration installation now opens the redirect URL in a new browser tab instead of redirecting the current window, allowing users to remain in the application while completing the integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->