### PR TITLE
Add callout for feature preview rls tester

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -32,7 +32,9 @@ import { PlatformWebhooksPreview } from './PlatformWebhooksPreview'
 import { RLSTesterPreview } from './RLSTesterPreview'
 import { UnifiedLogsPreview } from './UnifiedLogsPreview'
 import { FeaturePreview, useFeaturePreviews } from './useFeaturePreviews'
+import { useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { IS_PLATFORM } from '@/lib/constants'
 
@@ -62,6 +64,12 @@ export const FeaturePreviewModal = () => {
   const featurePreviewContext = useFeaturePreviewContext()
   const { mutate: sendEvent } = useSendEventMutation()
 
+  const { dismissBanner } = useBannerStack()
+  const [, setIsDismissedRlsTesterBanner] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.RLS_TESTER_BANNER_DISMISSED(ref ?? ''),
+    false
+  )
+
   const { flags, onUpdateFlag } = featurePreviewContext
   const allFeaturePreviews = (
     IS_PLATFORM ? featurePreviews : featurePreviews.filter((x) => !x.isPlatformOnly)
@@ -74,6 +82,12 @@ export const FeaturePreviewModal = () => {
 
   const toggleFeature = () => {
     if (!selectedFeature) return
+
+    if (selectedFeature.key === LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER) {
+      dismissBanner('rls-tester-banner')
+      setIsDismissedRlsTesterBanner(true)
+    }
+
     onUpdateFlag(selectedFeature.key, !isSelectedFeatureEnabled)
     sendEvent({
       action: isSelectedFeatureEnabled ? 'feature_preview_disabled' : 'feature_preview_enabled',

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -194,13 +194,25 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
           ) : null}
         </div>
 
-        <SheetFooter>
-          <Button type="default" disabled={isLoading} onClick={() => setOpen(false)}>
-            Cancel
+        <SheetFooter className="sm:justify-between">
+          <Button asChild type="text">
+            <a
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-foreground-light hover:text-foreground"
+              href="https://github.com/orgs/supabase/discussions/45233"
+            >
+              Give feedback
+            </a>
           </Button>
-          <Button type="primary" loading={isLoading} onClick={onRunQuery}>
-            Run query
-          </Button>
+          <div className="flex items-center gap-x-2">
+            <Button type="default" disabled={isLoading} onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="primary" loading={isLoading} onClick={onRunQuery}>
+              Run query
+            </Button>
+          </div>
         </SheetFooter>
       </SheetContent>
     </Sheet>

--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -4,7 +4,6 @@ import { PropsWithChildren, useEffect, useState } from 'react'
 import { ResizablePanel, ResizablePanelGroup, SidebarProvider } from 'ui'
 
 import { BannerStack } from '../ui/BannerStack/BannerStack'
-import { BannerStackProvider } from '../ui/BannerStack/BannerStackProvider'
 import { LayoutHeader } from './Navigation/LayoutHeader/LayoutHeader'
 import MobileNavigationBar from './Navigation/NavigationBar/MobileNavigationBar'
 import { MobileSheetProvider } from './Navigation/NavigationBar/MobileSheetContext'
@@ -82,50 +81,48 @@ export const DefaultLayout = ({
       <LayoutSidebarProvider>
         <ProjectContextProvider projectRef={ref}>
           <MobileSheetProvider>
-            <BannerStackProvider>
-              <div className="flex flex-col h-screen w-screen">
-                {/* Top Banner */}
-                <AppBannerWrapper />
-                <div className="flex-shrink-0">
-                  {isMobile && (
-                    <MobileNavigationBar
-                      hideMobileMenu={hideMobileMenu}
-                      backToDashboardURL={backToDashboardURL}
-                    />
-                  )}
-                  <LayoutHeader headerTitle={headerTitle} backToDashboardURL={backToDashboardURL} />
-                </div>
-                {/* Main Content Area */}
-                <div className="flex flex-1 w-full overflow-y-hidden">
-                  {/* Sidebar - Only show for project pages, not account pages */}
-                  {!router.pathname.startsWith('/account') && <Sidebar />}
-                  {/* Main Content with Layout Sidebar */}
-                  <ResizablePanelGroup
-                    orientation="horizontal"
-                    className="h-full w-full overflow-x-hidden flex-1 flex flex-row gap-0"
-                    autoSaveId="default-layout-content"
-                  >
-                    <ResizablePanel
-                      id="panel-content"
-                      className="w-full"
-                      minSize={`${contentMinSizePercentage}`}
-                      maxSize={`${contentMaxSizePercentage}`}
-                      defaultSize={`${contentMaxSizePercentage}`}
-                    >
-                      <div className="h-full overflow-y-auto">{children}</div>
-                    </ResizablePanel>
-                    <LayoutSidebar
-                      minSize={`${100 - contentMaxSizePercentage}`}
-                      maxSize={`${100 - contentMinSizePercentage}`}
-                      defaultSize={`${100 - contentMaxSizePercentage}`}
-                    />
-                  </ResizablePanelGroup>
-                </div>
+            <div className="flex flex-col h-screen w-screen">
+              {/* Top Banner */}
+              <AppBannerWrapper />
+              <div className="flex-shrink-0">
+                {isMobile && (
+                  <MobileNavigationBar
+                    hideMobileMenu={hideMobileMenu}
+                    backToDashboardURL={backToDashboardURL}
+                  />
+                )}
+                <LayoutHeader headerTitle={headerTitle} backToDashboardURL={backToDashboardURL} />
               </div>
+              {/* Main Content Area */}
+              <div className="flex flex-1 w-full overflow-y-hidden">
+                {/* Sidebar - Only show for project pages, not account pages */}
+                {!router.pathname.startsWith('/account') && <Sidebar />}
+                {/* Main Content with Layout Sidebar */}
+                <ResizablePanelGroup
+                  orientation="horizontal"
+                  className="h-full w-full overflow-x-hidden flex-1 flex flex-row gap-0"
+                  autoSaveId="default-layout-content"
+                >
+                  <ResizablePanel
+                    id="panel-content"
+                    className="w-full"
+                    minSize={`${contentMinSizePercentage}`}
+                    maxSize={`${contentMaxSizePercentage}`}
+                    defaultSize={`${contentMaxSizePercentage}`}
+                  >
+                    <div className="h-full overflow-y-auto">{children}</div>
+                  </ResizablePanel>
+                  <LayoutSidebar
+                    minSize={`${100 - contentMaxSizePercentage}`}
+                    maxSize={`${100 - contentMinSizePercentage}`}
+                    defaultSize={`${100 - contentMaxSizePercentage}`}
+                  />
+                </ResizablePanelGroup>
+              </div>
+            </div>
 
-              <BannerStack />
-              <StudioMobileSheetNav />
-            </BannerStackProvider>
+            <BannerStack />
+            <StudioMobileSheetNav />
           </MobileSheetProvider>
         </ProjectContextProvider>
       </LayoutSidebarProvider>

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
@@ -5,6 +5,7 @@ export const BANNER_ID = {
   INDEX_ADVISOR: 'index-advisor-banner',
   TABLE_EDITOR_QUEUE_OPERATIONS: 'table-editor-queue-operations-banner',
   RLS_EVENT_TRIGGER: 'rls-event-trigger-banner',
+  RLS_TESTER: 'rls-tester-banner',
   FREE_MICRO_UPGRADE: 'free-micro-upgrade-banner',
 } as const
 

--- a/apps/studio/components/ui/BannerStack/Banners/BannerRlsTester.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerRlsTester.tsx
@@ -1,0 +1,113 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { useParams } from 'common/hooks'
+import { AnimatePresence, motion } from 'framer-motion'
+import { Check, Loader2, Terminal } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Badge, Button, cn } from 'ui'
+
+import { BannerCard } from '../BannerCard'
+import { useBannerStack } from '../BannerStackProvider'
+import { useFeaturePreviewModal } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+
+const text = 'select * from colors'
+
+export const BannerRlsTester = () => {
+  const { ref } = useParams()
+  const { selectFeaturePreview } = useFeaturePreviewModal()
+
+  const [runQueryAnimate, setRunQueryAnimate] = useState(false)
+  const [showSummary, setShowSummary] = useState(false)
+
+  const { dismissBanner } = useBannerStack()
+  const [, setIsDismissed] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.RLS_TESTER_BANNER_DISMISSED(ref ?? ''),
+    false
+  )
+
+  useEffect(() => {
+    setTimeout(() => setRunQueryAnimate(true), 2400)
+  }, [])
+
+  useEffect(() => {
+    if (runQueryAnimate) {
+      setTimeout(() => setShowSummary(true), 1700)
+    }
+  }, [runQueryAnimate])
+
+  return (
+    <BannerCard
+      onDismiss={() => {
+        setIsDismissed(true)
+        dismissBanner('rls-tester-banner')
+      }}
+    >
+      <div className="flex flex-col gap-y-4">
+        <div className="flex flex-col gap-y-2 items-start">
+          <Badge variant="success" className="-ml-0.5 uppercase inline-flex items-center mb-2">
+            Preview
+          </Badge>
+
+          <div className={cn('transition-all bg-surface-100 w-full border rounded-md')}>
+            <div className="flex items-center gap-x-2 p-2">
+              {runQueryAnimate && !showSummary ? (
+                <Loader2 size={12} className="animate-spin" />
+              ) : (
+                <Terminal size={12} />
+              )}
+              <p
+                className="uppercase tracking-tight text-xs font-mono overflow-hidden whitespace-nowrap border-r-2 border-overlay"
+                style={{
+                  width: `${text.length}ch`,
+                  animation: `typewriter 2s steps(${text.length}) forwards, blink-caret 0.75s step-end infinite`,
+                }}
+              >
+                {text}
+              </p>
+            </div>
+
+            <AnimatePresence>
+              {showSummary && (
+                <motion.div
+                  initial={{ height: 0 }}
+                  animate={{ height: '50px' }}
+                  exit={{ height: 0 }}
+                  transition={{
+                    type: 'spring',
+                    stiffness: 420,
+                    damping: 30,
+                    mass: 0.4,
+                  }}
+                  className="border-t text-xs p-2"
+                >
+                  <div className="flex items-center gap-x-2">
+                    <Check size={12} strokeWidth={3} className="text-brand" />
+                    <p>
+                      Can access <code className="text-code-inline">public.colors</code>
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-foreground-light mt-0.5 ml-5">2 policies applied</p>
+                  </div>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          </div>
+        </div>
+        <div className="flex flex-col gap-y-1 mb-2">
+          <p className="text-sm font-medium">Row Level Security (RLS) Tester</p>
+          <p className="text-xs text-foreground-lighter text-balance">
+            Verify your RLS policies are correct by running queries as a specific user
+          </p>
+        </div>
+        <Button
+          type="default"
+          className="w-min"
+          onClick={() => selectFeaturePreview(LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER)}
+        >
+          Enable feature preview
+        </Button>
+      </div>
+    </BannerCard>
+  )
+}

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -52,6 +52,7 @@ import { MonacoThemeProvider } from '@/components/interfaces/App/MonacoThemeProv
 import { RouteValidationWrapper } from '@/components/interfaces/App/RouteValidationWrapper'
 import { UpdateBillingAddressModal } from '@/components/interfaces/App/UpdateBillingAddressModal'
 import { MainScrollContainerProvider } from '@/components/layouts/MainScrollContainerContext'
+import { BannerStackProvider } from '@/components/ui/BannerStack/BannerStackProvider'
 import { GlobalErrorBoundaryState } from '@/components/ui/ErrorBoundary/GlobalErrorBoundaryState'
 import { GlobalShortcuts } from '@/components/ui/GlobalShortcuts/GlobalShortcuts'
 import { useRootQueryClient } from '@/data/query-client'
@@ -194,15 +195,17 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                         <DevToolbarProvider apiUrl={API_URL}>
                           <AiAssistantStateContextProvider>
                             <CommandProvider>
-                              <FeaturePreviewContextProvider>
-                                <MainScrollContainerProvider>
-                                  {getLayout(<Component {...pageProps} />)}
-                                </MainScrollContainerProvider>
-                                <GlobalShortcuts />
-                                <StudioCommandMenu />
-                                <FeaturePreviewModal />
-                                <UpdateBillingAddressModal />
-                              </FeaturePreviewContextProvider>
+                              <BannerStackProvider>
+                                <FeaturePreviewContextProvider>
+                                  <MainScrollContainerProvider>
+                                    {getLayout(<Component {...pageProps} />)}
+                                  </MainScrollContainerProvider>
+                                  <GlobalShortcuts />
+                                  <StudioCommandMenu />
+                                  <FeaturePreviewModal />
+                                  <UpdateBillingAddressModal />
+                                </FeaturePreviewContextProvider>
+                              </BannerStackProvider>
                               <Toaster />
                               <MonacoThemeProvider />
                             </CommandProvider>

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -253,7 +253,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
     return () => {
       dismissBanner('rls-tester-banner')
     }
-  }, [])
+  }, [addBanner, dismissBanner, isRlsTesterBannerDismissed, rlsTesterEnabled, rlsTesterVisible])
 
   useEffect(() => {
     if (!isTriggerPermissionsLoaded) return

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -1,6 +1,6 @@
 import type { PostgresPolicy, PostgresTable } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useFlag, useParams } from 'common'
 import { Search, X } from 'lucide-react'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'
@@ -30,11 +30,12 @@ import { RLSTesterSheet } from '@/components/interfaces/Auth/RLSTester/RLSTester
 import AuthLayout from '@/components/layouts/AuthLayout/AuthLayout'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
-import AlertError from '@/components/ui/AlertError'
+import { AlertError } from '@/components/ui/AlertError'
 import { BannerRlsEventTrigger } from '@/components/ui/BannerStack/Banners/BannerRlsEventTrigger'
+import { BannerRlsTester } from '@/components/ui/BannerStack/Banners/BannerRlsTester'
 import { useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
 import { DocsButton } from '@/components/ui/DocsButton'
-import NoPermission from '@/components/ui/NoPermission'
+import { NoPermission } from '@/components/ui/NoPermission'
 import { SchemaSelector } from '@/components/ui/SchemaSelector'
 import { useProjectPostgrestConfigQuery } from '@/data/config/project-postgrest-config-query'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
@@ -114,6 +115,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
 
   const isInlineEditorEnabled = useIsInlineEditorEnabled()
   const rlsTesterEnabled = useIsRLSTesterEnabled()
+  const rlsTesterVisible = useFlag('rlsTester')
 
   const { openSidebar } = useSidebarManagerSnapshot()
   const {
@@ -133,6 +135,11 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
 
   const [isRlsBannerDismissed] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.RLS_EVENT_TRIGGER_BANNER_DISMISSED(projectRef ?? ''),
+    false
+  )
+
+  const [isRlsTesterBannerDismissed] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.RLS_TESTER_BANNER_DISMISSED(projectRef ?? ''),
     false
   )
 
@@ -228,6 +235,25 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
   )
 
   const handleResetSearch = useCallback(() => setSearchString(''), [setSearchString])
+
+  useEffect(() => {
+    if (!rlsTesterVisible || rlsTesterEnabled) return
+
+    if (!isRlsTesterBannerDismissed) {
+      addBanner({
+        id: 'rls-tester-banner',
+        isDismissed: false,
+        content: <BannerRlsTester />,
+        priority: 3,
+      })
+    } else {
+      dismissBanner('rls-tester-banner')
+    }
+
+    return () => {
+      dismissBanner('rls-tester-banner')
+    }
+  }, [])
 
   useEffect(() => {
     if (!isTriggerPermissionsLoaded) return

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -98,6 +98,8 @@ export const LOCAL_STORAGE_KEYS = {
   // RLS event trigger banner dismissed
   RLS_EVENT_TRIGGER_BANNER_DISMISSED: (ref: string) => `rls-event-trigger-banner-dismissed-${ref}`,
 
+  RLS_TESTER_BANNER_DISMISSED: (ref: string) => `rls-tester-banner-dismissed-${ref}`,
+
   // Observability banner dismissed
   OBSERVABILITY_BANNER_DISMISSED: (ref: string) => `observability-banner-dismissed-${ref}`,
   ORGANIZATION_MARKETPLACE_BANNER_DISMISSED: (orgSlug: string, managedBy: string) =>


### PR DESCRIPTION
## Context

Adds a banner on the auth policies page for the new RLS tester feature preview
<img width="307" height="310" alt="image" src="https://github.com/user-attachments/assets/6864c2cb-c3b8-4c1f-8dce-57411425e17d" />

Also adds a Give feedback button in the RLS Tester sheet footer
<img width="616" height="73" alt="image" src="https://github.com/user-attachments/assets/64755f56-4e27-4b54-92b2-a894badc0b88" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * RLS Tester preview banner added to the policies page with animated content and a locally persisted dismissed state.
  * Enabling the RLS Tester via the preview also dismisses and records the banner dismissal.
  * New feedback link added to the RLS Tester UI that opens in a new tab.

* **Layout/Providers**
  * Banner stack context moved so banner state is available more broadly across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->