### PR TITLE
Merge rls tester callouts

### DIFF
--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterResults.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterResults.tsx
@@ -84,35 +84,37 @@ export const RLSTesterResults = ({
         )}
 
         <TabsContent_Shadcn_ value="policies" className="mt-0">
-          {!isServiceRole && !!tableWithRLSEnabledButNoPolicies && (
-            <Admonition showIcon={false} type="default" className="rounded mt-2">
-              <p className="!mb-0.5">This user has no access to any rows from this query</p>
-              <p className="text-foreground-light">
-                The table{' '}
-                <code className="text-code-inline">
-                  {tableWithRLSEnabledButNoPolicies.schema}.{tableWithRLSEnabledButNoPolicies.table}
-                </code>{' '}
-                has RLS enabled but no policies set up for the{' '}
-                <code className="text-code-inline !break-keep">{parseQueryResults.role}</code> role.
-              </p>
-            </Admonition>
-          )}
-
-          {!isServiceRole && tableWithRLSEnabledWithPolicyFalse && (
-            <Admonition showIcon={false} type="default" className="rounded mt-2">
-              <p className="!mb-0.5">This user has no access to any rows from this query</p>
-              <p className="text-foreground-light">
-                The table{' '}
-                <code className="text-code-inline">
-                  {tableWithRLSEnabledWithPolicyFalse.schema}.
-                  {tableWithRLSEnabledWithPolicyFalse.table}
-                </code>{' '}
-                has a policy that evaluates to
-                <code className="text-code-inline !break-keep">false</code> for the{' '}
-                <code className="text-code-inline !break-keep">{parseQueryResults.role}</code> role.
-              </p>
-            </Admonition>
-          )}
+          {!isServiceRole &&
+            (!!tableWithRLSEnabledButNoPolicies ? (
+              <Admonition showIcon={false} type="default" className="rounded mt-2">
+                <p className="!mb-0.5">This user has no access to any rows from this query</p>
+                <p className="text-foreground-light">
+                  The table{' '}
+                  <code className="text-code-inline">
+                    {tableWithRLSEnabledButNoPolicies.schema}.
+                    {tableWithRLSEnabledButNoPolicies.table}
+                  </code>{' '}
+                  has RLS enabled but no policies set up for the{' '}
+                  <code className="text-code-inline !break-keep">{parseQueryResults.role}</code>{' '}
+                  role.
+                </p>
+              </Admonition>
+            ) : tableWithRLSEnabledWithPolicyFalse ? (
+              <Admonition showIcon={false} type="default" className="rounded mt-2">
+                <p className="!mb-0.5">This user has no access to any rows from this query</p>
+                <p className="text-foreground-light">
+                  The table{' '}
+                  <code className="text-code-inline">
+                    {tableWithRLSEnabledWithPolicyFalse.schema}.
+                    {tableWithRLSEnabledWithPolicyFalse.table}
+                  </code>{' '}
+                  has a policy that evaluates to
+                  <code className="text-code-inline !break-keep">false</code> for the{' '}
+                  <code className="text-code-inline !break-keep">{parseQueryResults.role}</code>{' '}
+                  role.
+                </p>
+              </Admonition>
+            ) : null)}
 
           {isServiceRole && (
             <Admonition showIcon={false} type="default" className="rounded mt-2">


### PR DESCRIPTION
## Context

Just merging the callouts - only show one at a time, instead of both

### Before
<img width="610" height="518" alt="image" src="https://github.com/user-attachments/assets/58567f7e-99bf-4c84-8392-35573c646af6" />

### After
<img width="605" height="428" alt="image" src="https://github.com/user-attachments/assets/975a5a30-2b36-4602-af8f-b79c2383f38b" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced RLS Tester to prevent conflicting policy status messages from appearing simultaneously. The interface now properly displays only the relevant message about policy configuration and evaluation status, improving clarity when reviewing row-level security results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->