### PR TITLE
docs: add Docker runtime and port availability note

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -147,6 +147,8 @@ First, make sure you have the Docker installed on your device. You can download 
 
 3. Run docker:
 
+    Make sure Docker is running and required ports are free.
+
    ```sh
    docker compose up
    ```

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -147,7 +147,7 @@ First, make sure you have the Docker installed on your device. You can download 
 
 3. Run docker:
 
-    Make sure Docker is running and required ports are free.
+   Make sure Docker is running and required ports are free.
 
    ```sh
    docker compose up


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Docker setup instructions assume Docker is already running and required ports are available, which can lead to confusion during local setup.

## What is the new behavior?

Adds a note reminding contributors to ensure:
- Docker is running
- Required ports are free

## Additional context

This is a small improvement to help prevent common local setup issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer setup guide with additional prerequisite checks to verify Docker is running and required ports are available before starting local development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->