### PR TITLE
[FE-3081] fix(studio): remove false "schema not exposed" warning in Realtime policies editor

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Policies.tsx
+++ b/apps/studio/components/interfaces/Realtime/Policies.tsx
@@ -6,14 +6,12 @@ import { Policies } from '@/components/interfaces/Auth/Policies/Policies'
 import { PoliciesDataProvider } from '@/components/interfaces/Auth/Policies/PoliciesDataContext'
 import { PolicyEditorPanel } from '@/components/interfaces/Auth/Policies/PolicyEditorPanel'
 import AlertError from '@/components/ui/AlertError'
-import { useProjectPostgrestConfigQuery } from '@/data/config/project-postgrest-config-query'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useTablesQuery } from '@/data/tables/tables-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 export const RealtimePolicies = () => {
   const { data: project } = useSelectedProjectQuery()
-  const { data: postgrestConfig } = useProjectPostgrestConfigQuery({ projectRef: project?.ref })
 
   const [showPolicyEditor, setShowPolicyEditor] = useState(false)
   const [selectedPolicyToEdit, setSelectedPolicyToEdit] = useState<PostgresPolicy>()
@@ -47,15 +45,8 @@ export const RealtimePolicies = () => {
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const exposedSchemas = useMemo(() => {
-    const dbSchema = postgrestConfig?.db_schema
-    if (!dbSchema) return []
-
-    return dbSchema
-      .split(',')
-      .map((schema) => schema.trim())
-      .filter((schema) => schema.length > 0)
-  }, [postgrestConfig?.db_schema])
+  // realtime is never in PostgREST's db_schema — skip the config query to avoid a false warning
+  const exposedSchemas = useMemo(() => ['realtime'], [])
 
   return (
     <>


### PR DESCRIPTION
The Realtime policies editor was showing a warning banner on `realtime.messages` saying the schema isn't exposed through PostgREST. This is incorrect — the `realtime` schema is intentionally excluded from PostgREST (it's in `INTERNAL_SCHEMAS` and filtered out of the exposed schema picker), so the warning is always false in this context.

**Changed:**
- Removed `useProjectPostgrestConfigQuery` from `RealtimePolicies` — it was only used to derive `exposedSchemas`
- Hardcode `exposedSchemas` as `['realtime']` since this editor is for Realtime auth, not PostgREST access

## To test

- Go to the Realtime policies editor (`/project/_/realtime/policies`)
- Confirm the yellow "schema not exposed" warning banner no longer appears on `realtime.messages`
- Confirm policy rows still render correctly and other admonitions (e.g. publicly-readable if RLS is off) still show as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of Realtime Policies schema handling by simplifying configuration logic to consistently use the realtime schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->