### PR TITLE
feat(studio): link edge function errors to troubleshooting docs

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -252,7 +252,6 @@ export const EdgeFunctionRecentErrors = ({
                       const displayMessage = getDisplayErrorMessage(group)
                       const docsUrl = buildTroubleshootingDocsUrl({
                         statusCode: group.lastStatusCode,
-                        errorMessage: displayMessage,
                       })
 
                       return (

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -1,4 +1,4 @@
-import { Check, ExternalLink, Eye } from 'lucide-react'
+import { BookOpen, Check, ExternalLink, Eye } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { Fragment, useMemo } from 'react'
 import {
@@ -26,8 +26,10 @@ import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import {
   buildGroupAssistantPrompt,
+  buildTroubleshootingDocsUrl,
   formatLogTimestamp,
   formatSingleLineMessage,
+  getDisplayErrorMessage,
   getFunctionRuntimeLogsSql,
   getRecentErrorGroups,
   getRecentErrorGroupsBase,
@@ -242,85 +244,122 @@ export const EdgeFunctionRecentErrors = ({
                       <TableHead>Method</TableHead>
                       <TableHead>Status</TableHead>
                       <TableHead>Duration</TableHead>
-                      <TableHead className="text-right">Assistant</TableHead>
+                      <TableHead className="text-right">Troubleshoot</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {recentErrorGroups.map((group) => (
-                      <Fragment key={group.message}>
-                        <TableRow key={`${group.message}-summary`}>
-                          <TableCell className="max-w-[420px]">
-                            <span
-                              className="block truncate whitespace-nowrap text-foreground"
-                              title={formatSingleLineMessage(group.message)}
-                            >
-                              {formatSingleLineMessage(group.message)}
-                            </span>
-                          </TableCell>
-                          <TableCell className="text-foreground-light">{group.count}</TableCell>
-                          <TableCell className="text-foreground-light">
-                            {formatLogTimestamp(group.lastSeen, 'relative')}
-                          </TableCell>
-                          <TableCell className="text-foreground-light">
-                            {group.lastMethod ?? '-'}
-                          </TableCell>
-                          <TableCell>
-                            {group.lastStatusCode ? (
-                              <Badge
-                                variant={getStatusBadgeVariant(group.lastStatusCode)}
-                                className="font-mono"
+                    {recentErrorGroups.map((group) => {
+                      const displayMessage = getDisplayErrorMessage(group)
+                      const docsUrl = buildTroubleshootingDocsUrl({
+                        statusCode: group.lastStatusCode,
+                        errorMessage: displayMessage,
+                      })
+
+                      return (
+                        <Fragment key={group.message}>
+                          <TableRow key={`${group.message}-summary`}>
+                            <TableCell className="max-w-[420px]">
+                              <span
+                                className="block truncate whitespace-nowrap text-foreground"
+                                title={displayMessage}
                               >
-                                {group.lastStatusCode}
-                              </Badge>
-                            ) : (
-                              <Badge variant="destructive" className="font-mono">
-                                Error
-                              </Badge>
-                            )}
-                          </TableCell>
-                          <TableCell className="text-foreground-light">
-                            {group.executionTime ?? '-'}
-                          </TableCell>
-                          <TableCell className="text-right">
-                            <div className="flex justify-end">
-                              <AiAssistantDropdown
-                                label="Ask Assistant"
-                                size="tiny"
-                                buildPrompt={() => buildGroupAssistantPrompt(group, functionSlug)}
-                                onOpenAssistant={() => handleOpenAssistant(group)}
-                              />
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                        <TableRow key={`${group.message}-logs`} className="bg-surface-100/30">
-                          <TableCell colSpan={7} className="p-0">
-                            <div className="max-h-64 overflow-auto bg-surface-75 py-3 text-foreground-light">
-                              {group.logs.length === 0 ? (
-                                <div className="px-4">
-                                  No related runtime logs found for this error group.
-                                </div>
+                                {displayMessage}
+                              </span>
+                            </TableCell>
+                            <TableCell className="text-foreground-light">{group.count}</TableCell>
+                            <TableCell className="text-foreground-light">
+                              {formatLogTimestamp(group.lastSeen, 'relative')}
+                            </TableCell>
+                            <TableCell className="text-foreground-light">
+                              {group.lastMethod ?? '-'}
+                            </TableCell>
+                            <TableCell>
+                              {group.lastStatusCode ? (
+                                <Badge
+                                  variant={getStatusBadgeVariant(group.lastStatusCode)}
+                                  className="font-mono"
+                                >
+                                  {group.lastStatusCode}
+                                </Badge>
                               ) : (
-                                group.logs.map((log) => (
-                                  <div
-                                    key={log.key}
-                                    className={cn(
-                                      'break-words px-4',
-                                      log.level === 'error'
-                                        ? 'bg-destructive-300 font-mono text-destructive'
-                                        : 'text-foreground-light'
-                                    )}
-                                  >
-                                    [{formatLogTimestamp(log.lastSeen, 'time')}] [
-                                    {log.level.toUpperCase()}] [{log.count}x]{' '}
-                                    {formatSingleLineMessage(log.message)}
-                                  </div>
-                                ))
+                                <Badge variant="destructive" className="font-mono">
+                                  Error
+                                </Badge>
                               )}
-                            </div>
-                          </TableCell>
-                        </TableRow>
-                      </Fragment>
-                    ))}
+                            </TableCell>
+                            <TableCell className="text-foreground-light">
+                              {group.executionTime ?? '-'}
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <div className="flex justify-end">
+                                <AiAssistantDropdown
+                                  label="Ask Assistant"
+                                  size="tiny"
+                                  buildPrompt={() => buildGroupAssistantPrompt(group, functionSlug)}
+                                  onOpenAssistant={() => handleOpenAssistant(group)}
+                                  additionalDropdownItems={[
+                                    {
+                                      label: 'View troubleshooting guide',
+                                      icon: <BookOpen size={14} />,
+                                      onClick: () =>
+                                        window.open(docsUrl, '_blank', 'noopener,noreferrer'),
+                                    },
+                                  ]}
+                                />
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                          <TableRow key={`${group.message}-logs`} className="hover:bg-transparent">
+                            <TableCell colSpan={7} className="p-0">
+                              <div className="max-h-64 overflow-auto bg-surface-75 font-mono text-xs">
+                                {group.logs.length === 0 ? (
+                                  <div className="px-4 py-3 text-foreground-lighter">
+                                    No related runtime logs found for this error group.
+                                  </div>
+                                ) : (
+                                  group.logs.map((log, index) => {
+                                    const isError = log.level === 'error'
+                                    return (
+                                      <div
+                                        key={log.key}
+                                        className={cn(
+                                          'flex items-start gap-3 px-4 py-2',
+                                          index !== 0 && 'border-t border-default',
+                                          isError && 'bg-destructive-200/40'
+                                        )}
+                                      >
+                                        <span className="shrink-0 tabular-nums text-foreground-muted">
+                                          {formatLogTimestamp(log.lastSeen, 'time')}
+                                        </span>
+                                        <Badge
+                                          variant={isError ? 'destructive' : 'default'}
+                                          className="shrink-0"
+                                        >
+                                          {log.level}
+                                        </Badge>
+                                        {log.count > 1 && (
+                                          <span className="shrink-0 text-foreground-muted tabular-nums">
+                                            ×{log.count}
+                                          </span>
+                                        )}
+                                        <span
+                                          className={cn(
+                                            'flex-1 break-words whitespace-pre-wrap',
+                                            isError ? 'text-destructive' : 'text-foreground-light'
+                                          )}
+                                        >
+                                          {formatSingleLineMessage(log.message)}
+                                        </span>
+                                      </div>
+                                    )
+                                  })
+                                )}
+                              </div>
+                            </TableCell>
+                          </TableRow>
+                        </Fragment>
+                      )
+                    })}
                   </TableBody>
                 </Table>
               </Card>

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
@@ -319,26 +319,18 @@ limit 25`)
     ).toBe('https://example.supabase.red/functions/v1/hello-world')
   })
 
-  it('builds a troubleshooting docs URL using error type and status code', () => {
+  it('builds a troubleshooting docs URL keyed off the response status code', () => {
+    expect(buildTroubleshootingDocsUrl({ statusCode: '500' })).toBe(
+      'https://supabase.com/docs/guides/troubleshooting/edge-function-500-response'
+    )
+    expect(buildTroubleshootingDocsUrl({ statusCode: '503' })).toBe(
+      'https://supabase.com/docs/guides/troubleshooting/edge-function-503-response'
+    )
     expect(buildTroubleshootingDocsUrl({})).toBe(
       'https://supabase.com/docs/guides/troubleshooting?search=edge%20function'
     )
-    expect(buildTroubleshootingDocsUrl({ statusCode: '500' })).toBe(
-      'https://supabase.com/docs/guides/troubleshooting?search=edge%20function%20500'
+    expect(buildTroubleshootingDocsUrl({ statusCode: 'not-a-number' })).toBe(
+      'https://supabase.com/docs/guides/troubleshooting?search=edge%20function'
     )
-    expect(
-      buildTroubleshootingDocsUrl({
-        statusCode: '500',
-        errorMessage: "SyntaxError: Expected ',' or '}'",
-      })
-    ).toBe(
-      'https://supabase.com/docs/guides/troubleshooting?search=edge%20function%20SyntaxError%20500'
-    )
-    expect(
-      buildTroubleshootingDocsUrl({
-        statusCode: '503',
-        errorMessage: 'no error type prefix here',
-      })
-    ).toBe('https://supabase.com/docs/guides/troubleshooting?search=edge%20function%20503')
   })
 })

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
@@ -2,8 +2,10 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   buildGroupAssistantPrompt,
+  buildTroubleshootingDocsUrl,
   formatLogTimestamp,
   formatSingleLineMessage,
+  getDisplayErrorMessage,
   getFunctionRuntimeLogsSql,
   getNoErrorsSinceLastDeployMessage,
   getRecentErrorGroups,
@@ -14,6 +16,7 @@ import {
   getSinceLastDeployInvocationPhrase,
   getSinceLastDeployLogRange,
   getStatusBadgeVariant,
+  summarizeErrorMessage,
   toAlertError,
   toIsoTimestamp,
 } from './EdgeFunctionRecentErrors.utils'
@@ -266,5 +269,76 @@ limit 25`)
     expect(getStatusBadgeVariant()).toBe('destructive')
     expect(getStatusBadgeVariant('500')).toBe('destructive')
     expect(getStatusBadgeVariant('404')).toBe('default')
+  })
+
+  it('summarizes verbose error messages by trimming the stack trace', () => {
+    expect(summarizeErrorMessage('')).toBe('')
+    expect(summarizeErrorMessage('boom')).toBe('boom')
+    expect(
+      summarizeErrorMessage(
+        "SyntaxError: Expected ',' or '}' after property value in JSON at position 22 at parse (<anonymous>) at packageData (ext:deno_fetch/22_body.js:408:14)"
+      )
+    ).toBe("SyntaxError: Expected ',' or '}' after property value in JSON at position 22")
+    expect(summarizeErrorMessage('  multi\n  line\t error  ')).toBe('multi line error')
+  })
+
+  it('prefers the first runtime error log message and falls back to invocation message', () => {
+    expect(
+      getDisplayErrorMessage({
+        message: 'https://example.supabase.red/functions/v1/hello-world',
+        count: 1,
+        lastSeen: 0,
+        executionIds: [],
+        logs: [
+          {
+            key: 'log:booted (time: 22ms)',
+            message: 'booted (time: 22ms)',
+            level: 'log',
+            count: 1,
+            lastSeen: 1,
+          },
+          {
+            key: 'error:SyntaxError: bad json at parse (<anonymous>)',
+            message: 'SyntaxError: bad json at parse (<anonymous>)',
+            level: 'error',
+            count: 1,
+            lastSeen: 2,
+          },
+        ],
+      })
+    ).toBe('SyntaxError: bad json')
+
+    expect(
+      getDisplayErrorMessage({
+        message: 'https://example.supabase.red/functions/v1/hello-world',
+        count: 1,
+        lastSeen: 0,
+        executionIds: [],
+        logs: [],
+      })
+    ).toBe('https://example.supabase.red/functions/v1/hello-world')
+  })
+
+  it('builds a troubleshooting docs URL using error type and status code', () => {
+    expect(buildTroubleshootingDocsUrl({})).toBe(
+      'https://supabase.com/docs/guides/troubleshooting?search=edge%20function'
+    )
+    expect(buildTroubleshootingDocsUrl({ statusCode: '500' })).toBe(
+      'https://supabase.com/docs/guides/troubleshooting?search=edge%20function%20500'
+    )
+    expect(
+      buildTroubleshootingDocsUrl({
+        statusCode: '500',
+        errorMessage: "SyntaxError: Expected ',' or '}'",
+      })
+    ).toBe(
+      'https://supabase.com/docs/guides/troubleshooting?search=edge%20function%20SyntaxError%20500'
+    )
+    expect(
+      buildTroubleshootingDocsUrl({
+        statusCode: '503',
+        errorMessage: 'no error type prefix here',
+      })
+    ).toBe('https://supabase.com/docs/guides/troubleshooting?search=edge%20function%20503')
   })
 })

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
@@ -75,21 +75,14 @@ export const getDisplayErrorMessage = (group: RecentErrorGroup): string => {
   return summarizeErrorMessage(group.message)
 }
 
-const TROUBLESHOOTING_DOCS_URL = 'https://supabase.com/docs/guides/troubleshooting'
+const TROUBLESHOOTING_DOCS_BASE = 'https://supabase.com/docs/guides/troubleshooting'
 
-export const buildTroubleshootingDocsUrl = ({
-  statusCode,
-  errorMessage,
-}: {
-  statusCode?: string
-  errorMessage?: string
-}): string => {
-  const errorType = errorMessage?.match(/^([A-Z][A-Za-z0-9]*Error)\b/)?.[1]
-  const terms = ['edge function', errorType, statusCode].filter((term): term is string =>
-    Boolean(term)
-  )
-  const search = terms.length > 0 ? terms.join(' ') : 'edge function'
-  return `${TROUBLESHOOTING_DOCS_URL}?search=${encodeURIComponent(search)}`
+export const buildTroubleshootingDocsUrl = ({ statusCode }: { statusCode?: string }): string => {
+  const numericStatusCode = Number(statusCode)
+  if (Number.isFinite(numericStatusCode) && numericStatusCode >= 100) {
+    return `${TROUBLESHOOTING_DOCS_BASE}/edge-function-${numericStatusCode}-response`
+  }
+  return `${TROUBLESHOOTING_DOCS_BASE}?search=${encodeURIComponent('edge function')}`
 }
 
 export const toAlertError = (error: unknown): AlertErrorProps['error'] | undefined => {

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
@@ -45,6 +45,53 @@ export const escapeSqlString = (value: string) => value.replace(/'/g, "''")
 
 export const formatSingleLineMessage = (message: string) => message.replace(/\s+/g, ' ').trim()
 
+/**
+ * Trims a runtime error message down to the meaningful summary, dropping the
+ * stack trace that follows the first ` at ` frame so we can show it inline in
+ * a table cell.
+ */
+export const summarizeErrorMessage = (message: string): string => {
+  const collapsed = formatSingleLineMessage(message)
+  if (!collapsed) return collapsed
+
+  const stackFrameMatch = collapsed.match(/\s+at\s+\S+\s+\(/)
+  if (stackFrameMatch && stackFrameMatch.index !== undefined) {
+    return collapsed.slice(0, stackFrameMatch.index).trim()
+  }
+  return collapsed
+}
+
+/**
+ * Picks the most useful error description for a group. The invocation
+ * `event_message` only contains the request URL, so when we have a related
+ * runtime error log we surface its summary instead.
+ */
+export const getDisplayErrorMessage = (group: RecentErrorGroup): string => {
+  const errorLog = group.logs.find((log) => log.level === 'error')
+  if (errorLog) {
+    const summary = summarizeErrorMessage(errorLog.message)
+    if (summary) return summary
+  }
+  return summarizeErrorMessage(group.message)
+}
+
+const TROUBLESHOOTING_DOCS_URL = 'https://supabase.com/docs/guides/troubleshooting'
+
+export const buildTroubleshootingDocsUrl = ({
+  statusCode,
+  errorMessage,
+}: {
+  statusCode?: string
+  errorMessage?: string
+}): string => {
+  const errorType = errorMessage?.match(/^([A-Z][A-Za-z0-9]*Error)\b/)?.[1]
+  const terms = ['edge function', errorType, statusCode].filter((term): term is string =>
+    Boolean(term)
+  )
+  const search = terms.length > 0 ? terms.join(' ') : 'edge function'
+  return `${TROUBLESHOOTING_DOCS_URL}?search=${encodeURIComponent(search)}`
+}
+
 export const toAlertError = (error: unknown): AlertErrorProps['error'] | undefined => {
   if (typeof error === 'string') return { message: error }
 


### PR DESCRIPTION
## Summary

Improve the "Errors since last deploy" panel on the new edge function overview page.

- **Error column**: stop showing the function URL. Pull the actual error from the related runtime logs, trim the stack trace to a one-line summary, and use that for the cell text and tooltip.
- **Troubleshoot column**: rename "Assistant" to "Troubleshoot" and add a "View troubleshooting guide" item to the dropdown that opens `supabase.com/docs/guides/troubleshooting` prefilled with `edge function <ErrorType> <statusCode>`.
- **Runtime log block**: restyle the expanded per-row log section. Monospace rows with structured timestamp / level badge / count / message, a divider between entries, and destructive tinting only on error rows. The previous layout ran text together with no separation.

## Test plan
- [x] `pnpm test:studio` for `EdgeFunctionRecentErrors.utils.test.ts` (10 passing, including new cases for `summarizeErrorMessage`, `getDisplayErrorMessage`, and `buildTroubleshootingDocsUrl`)
- [x] `pnpm typecheck` clean
- [x] `eslint` clean for changed files
- [ ] Visual check of the panel: Error cell shows the runtime error summary, Troubleshoot dropdown opens docs in a new tab, log rows render with the new structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "View troubleshooting guide" action that opens a status-code-specific docs page for each recent error.
  * Errors now show level badges and repetition counts in the logs for clearer scanning.

* **Bug Fixes**
  * Error text is summarized and normalized for concise, single-line display with clearer per-line styling.

* **Tests**
  * New tests validate error-summary, display-fallback, and troubleshooting-URL behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->