### PR TITLE
feat(www): rewrite to md for known llm user agents

### DIFF
--- a/apps/www/middleware.test.ts
+++ b/apps/www/middleware.test.ts
@@ -186,6 +186,15 @@ describe('www middleware', () => {
       expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/api-v2/md/auth')
     })
 
+    it('falls through for UAs that embed a match as a substring', () => {
+      for (const ua of ['chatgpt-userscript/2.0', 'NotPerplexityBot']) {
+        const req = makeRequest('/auth', { userAgent: ua })
+        const res = middleware(req)
+
+        expect(res.headers.get('x-middleware-rewrite')).toBeNull()
+      }
+    })
+
     it('falls through for browser user agents', () => {
       const req = makeRequest('/auth', {
         userAgent:

--- a/apps/www/middleware.test.ts
+++ b/apps/www/middleware.test.ts
@@ -15,11 +15,17 @@ vi.mock('./app/api-v2/md/content.generated', () => ({
 
 function makeRequest(
   url: string,
-  { referer, hasCookie, accept }: { referer?: string; hasCookie?: boolean; accept?: string } = {}
+  {
+    referer,
+    hasCookie,
+    accept,
+    userAgent,
+  }: { referer?: string; hasCookie?: boolean; accept?: string; userAgent?: string } = {}
 ): NextRequest {
   const headers: Record<string, string> = {}
   if (referer) headers.referer = referer
   if (accept) headers.accept = accept
+  if (userAgent) headers['user-agent'] = userAgent
   const req = new NextRequest(new URL(url, 'https://supabase.com'), { headers })
   if (hasCookie) {
     req.cookies.set(FIRST_REFERRER_COOKIE_NAME, 'existing')
@@ -143,6 +149,57 @@ describe('www middleware', () => {
 
     it('falls through when slug is not in the allowlist', () => {
       const req = makeRequest('/not-a-page', { accept: 'text/markdown' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBeNull()
+    })
+  })
+
+  describe('LLM user-agent routing', () => {
+    it('rewrites for Claude-User', () => {
+      const req = makeRequest('/pricing', {
+        userAgent: 'Claude-User (claude-code/2.1.119; +https://support.anthropic.com/)',
+      })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/api-v2/md/pricing')
+    })
+
+    it('rewrites for ChatGPT-User', () => {
+      const req = makeRequest('/auth', { userAgent: 'Mozilla/5.0 (compatible; ChatGPT-User/1.0)' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/api-v2/md/auth')
+    })
+
+    it('rewrites for PerplexityBot', () => {
+      const req = makeRequest('/auth/', { userAgent: 'PerplexityBot/1.0' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/api-v2/md/auth')
+    })
+
+    it('falls through for browser user agents', () => {
+      const req = makeRequest('/auth', {
+        userAgent:
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36',
+      })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBeNull()
+    })
+
+    it('falls through for training crawlers (GPTBot, ClaudeBot, CCBot)', () => {
+      for (const ua of ['GPTBot/1.0', 'ClaudeBot/1.0', 'CCBot/2.0']) {
+        const req = makeRequest('/auth', { userAgent: ua })
+        const res = middleware(req)
+
+        expect(res.headers.get('x-middleware-rewrite')).toBeNull()
+      }
+    })
+
+    it('falls through when slug is not in the allowlist', () => {
+      const req = makeRequest('/not-a-page', { userAgent: 'Claude-User' })
       const res = middleware(req)
 
       expect(res.headers.get('x-middleware-rewrite')).toBeNull()

--- a/apps/www/middleware.test.ts
+++ b/apps/www/middleware.test.ts
@@ -172,6 +172,13 @@ describe('www middleware', () => {
       expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/api-v2/md/auth')
     })
 
+    it('rewrites for Claude-Web', () => {
+      const req = makeRequest('/pricing', { userAgent: 'Claude-Web/1.0' })
+      const res = middleware(req)
+
+      expect(res.headers.get('x-middleware-rewrite')).toBe('https://supabase.com/api-v2/md/pricing')
+    })
+
     it('rewrites for PerplexityBot', () => {
       const req = makeRequest('/auth/', { userAgent: 'PerplexityBot/1.0' })
       const res = middleware(req)

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -7,7 +7,7 @@ import { MD_PAGES } from './app/api-v2/md/content.generated'
 // Training crawlers (GPTBot, CCBot, ClaudeBot, Anthropic-AI) are intentionally
 // excluded; they are governed by robots.txt and serving them content that
 // differs from the human HTML page would risk SEO and cloaking penalties.
-const LLM_USER_AGENT = /Claude-User|Claude-Web|ChatGPT-User|PerplexityBot/i
+const LLM_USER_AGENT = /\bClaude-User\b|\bClaude-Web\b|\bChatGPT-User\b|\bPerplexityBot\b/i
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
@@ -24,7 +24,8 @@ export function middleware(request: NextRequest) {
   // Cache-key safety: rewriting to /api-v2/md/<slug> partitions the response
   // by path, so no Vary: User-Agent is needed.
   const accept = (request.headers.get('accept') ?? '').toLowerCase()
-  const userAgent = request.headers.get('user-agent') ?? ''
+  // Cap UA length before regex test to bound CPU on the edge hot path.
+  const userAgent = (request.headers.get('user-agent') ?? '').slice(0, 512)
   if (accept.includes('text/markdown') || LLM_USER_AGENT.test(userAgent)) {
     // Strip trailing slash so /auth/ and /auth resolve to the same allowlist entry.
     // (NextURL's pathname setter preserves the trailing-slash style of the cloned

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -7,7 +7,7 @@ import { MD_PAGES } from './app/api-v2/md/content.generated'
 // Training crawlers (GPTBot, CCBot, ClaudeBot, Anthropic-AI) are intentionally
 // excluded; they are governed by robots.txt and serving them content that
 // differs from the human HTML page would risk SEO and cloaking penalties.
-const LLM_USER_AGENT = /Claude-User|Claude-Web|ChatGPT-User|OAI-SearchBot|PerplexityBot/i
+const LLM_USER_AGENT = /Claude-User|Claude-Web|ChatGPT-User|PerplexityBot/i
 
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -22,7 +22,7 @@ export function middleware(request: NextRequest) {
 
   // Serve markdown to known LLM clients (Accept header or UA match).
   // Cache-key safety: rewriting to /api-v2/md/<slug> partitions the response
-  // by path, so no Vary: User-Agent is needed (matches Vercel/Sentry pattern).
+  // by path, so no Vary: User-Agent is needed.
   const accept = (request.headers.get('accept') ?? '').toLowerCase()
   const userAgent = request.headers.get('user-agent') ?? ''
   if (accept.includes('text/markdown') || LLM_USER_AGENT.test(userAgent)) {

--- a/apps/www/middleware.ts
+++ b/apps/www/middleware.ts
@@ -3,6 +3,12 @@ import { NextResponse, type NextRequest } from 'next/server'
 
 import { MD_PAGES } from './app/api-v2/md/content.generated'
 
+// Live-fetch LLM agents that retrieve pages on behalf of a user prompt.
+// Training crawlers (GPTBot, CCBot, ClaudeBot, Anthropic-AI) are intentionally
+// excluded; they are governed by robots.txt and serving them content that
+// differs from the human HTML page would risk SEO and cloaking penalties.
+const LLM_USER_AGENT = /Claude-User|Claude-Web|ChatGPT-User|OAI-SearchBot|PerplexityBot/i
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl
 
@@ -14,9 +20,12 @@ export function middleware(request: NextRequest) {
     }
   }
 
-  // Content negotiation: Accept: text/markdown on known pages
+  // Serve markdown to known LLM clients (Accept header or UA match).
+  // Cache-key safety: rewriting to /api-v2/md/<slug> partitions the response
+  // by path, so no Vary: User-Agent is needed (matches Vercel/Sentry pattern).
   const accept = (request.headers.get('accept') ?? '').toLowerCase()
-  if (accept.includes('text/markdown')) {
+  const userAgent = request.headers.get('user-agent') ?? ''
+  if (accept.includes('text/markdown') || LLM_USER_AGENT.test(userAgent)) {
     // Strip trailing slash so /auth/ and /auth resolve to the same allowlist entry.
     // (NextURL's pathname setter preserves the trailing-slash style of the cloned
     // origin, which would otherwise leak through to the rewrite target.)


### PR DESCRIPTION
## Summary

External LLM agents (Claude search, ChatGPT browse, Perplexity) hit supabase.com pages and parse HTML even though we already serve clean markdown variants. Most agent clients identify themselves only via User-Agent and do not send `Accept: text/markdown`. This adds UA-based detection alongside the existing Accept-header path, so live-fetch LLM clients land on `/api-v2/md/<slug>` automatically.

The rewrite to a distinct internal path partitions the cache key, so no `Vary: User-Agent` is needed.

## Changes

- Add `LLM_USER_AGENT` regex covering `Claude-User`, `Claude-Web`, `ChatGPT-User`, `PerplexityBot`
- OR the UA match into the existing `Accept: text/markdown` rewrite condition in `apps/www/middleware.ts`
- Tests covering all matched UAs, browser fallthrough, training-crawler exclusion (GPTBot, ClaudeBot, CCBot), and allowlist gating

Training crawlers (`GPTBot`, `CCBot`, `ClaudeBot`, `Anthropic-AI`) are intentionally excluded. They are governed by `robots.txt`, and serving them content that differs from the human HTML page risks SEO and cloaking penalties.

## Testing (preview deploy)

Replace `<preview>` with the actual preview URL once the deploy completes.

```bash
# Default UA → HTML (humans unaffected)
curl -sI -o /dev/null -w "%{content_type}\n" https://<preview>/pricing
# Expected: text/html

# Accept: text/markdown → markdown (regression check)
curl -sI -o /dev/null -w "%{content_type}\n" -H "Accept: text/markdown" https://<preview>/pricing
# Expected: text/markdown

# Claude-User UA, default Accept → markdown (new)
curl -sI -o /dev/null -w "%{content_type}\n" -A "Claude-User (claude-code/2.1.119)" https://<preview>/pricing
# Expected: text/markdown

# ChatGPT-User UA → markdown (new)
curl -sI -o /dev/null -w "%{content_type}\n" -A "Mozilla/5.0 (compatible; ChatGPT-User/1.0)" https://<preview>/pricing
# Expected: text/markdown

# Browser UA → HTML
curl -sI -o /dev/null -w "%{content_type}\n" -A "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/130.0.0.0" https://<preview>/pricing
# Expected: text/html

# GPTBot (training crawler) → HTML (cloaking-safe)
curl -sI -o /dev/null -w "%{content_type}\n" -A "GPTBot/1.0" https://<preview>/pricing
# Expected: text/html
```

Cache poisoning probe (run sequentially, check `x-vercel-cache` and `content-type`):

1. Browser UA hits `/pricing` → `text/html`, eventually `HIT`
2. `Claude-User` UA hits `/pricing` → `text/markdown`, eventually `HIT`
3. Browser UA hits `/pricing` again → still `text/html`, no leak

## Linear

- fixes GROWTH-802


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Routing now serves markdown-formatted pages to requests identified as LLM clients (via Accept header or recognized user-agent), while regular browsers receive standard pages.

* **Tests**
  * Added middleware tests validating LLM/user-agent detection and routing for allowlisted vs non-allowlisted paths, ensuring normal browsers, partial matches, and known crawlers fall through without rewrite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->