### PR TITLE
fix nimbus search

### DIFF
--- a/packages/ai-commands/src/docs.ts
+++ b/packages/ai-commands/src/docs.ts
@@ -101,7 +101,10 @@ export async function clippy(
       break
     }
 
-    const pagePath = pageSection.page.path
+    const pagePath = options?.useAltSearchIndex
+      ? // @ts-ignore
+        pageSection.page_nimbus.path
+      : pageSection.page.path
 
     // Include source reference with each section
     contextText += `[Source ${sourceIndex}: ${pagePath}]\n${content.trim()}\n---\n`


### PR DESCRIPTION
Nimbus search is broken because it expects the page section to be joined with the page table, but this table is called page_nimbus in Nimbus mode.

Resolves AI-682

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed source reference attribution to use the correct path when using the alternate search index option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->