### PR TITLE
Remove feature flag for RLS tester

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
@@ -127,9 +127,7 @@ export const useIsJitDbAccessEnabled = () => {
 
 export const useIsRLSTesterEnabled = () => {
   const { flags } = useFeaturePreviewContext()
-  const rlsTesterEnabled = useFlag('rlsTester')
-
-  return rlsTesterEnabled && flags[LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER]
+  return flags[LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER]
 }
 
 export const useFeaturePreviewModal = () => {

--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -22,14 +22,13 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
   const pgDeltaDiffEnabled = useFlag('pgdeltaDiff')
   const platformWebhooksEnabled = useFlag('platformWebhooks')
   const jitDbAccessEnabled = useFlag('jitDbAccess')
-  const rlsTesterEnabled = useFlag('rlsTester')
 
   return [
     {
       key: LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER,
       name: 'RLS Tester',
       discussionsUrl: 'https://github.com/orgs/supabase/discussions/45233',
-      enabled: rlsTesterEnabled,
+      enabled: true,
       isNew: true,
       isPlatformOnly: false,
       isDefaultOptIn: false,

--- a/apps/studio/components/interfaces/Auth/RLSTester/UserSelector.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/UserSelector.tsx
@@ -91,12 +91,12 @@ export const UserSelector = () => {
               onValueChange={setSearchText}
             />
 
-            <CommandEmpty_Shadcn_>No user found</CommandEmpty_Shadcn_>
-
-            {isError && (
+            {isError ? (
               <Admonition showIcon={false} type="warning" className="border-0 rounded-none text-xs">
                 Failed to fetch users: {error.message}
               </Admonition>
+            ) : (
+              <CommandEmpty_Shadcn_>No user found</CommandEmpty_Shadcn_>
             )}
 
             <CommandList_Shadcn_>

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -115,7 +115,6 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
 
   const isInlineEditorEnabled = useIsInlineEditorEnabled()
   const rlsTesterEnabled = useIsRLSTesterEnabled()
-  const rlsTesterVisible = useFlag('rlsTester')
 
   const { openSidebar } = useSidebarManagerSnapshot()
   const {
@@ -237,7 +236,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
   const handleResetSearch = useCallback(() => setSearchString(''), [setSearchString])
 
   useEffect(() => {
-    if (!rlsTesterVisible || rlsTesterEnabled) return
+    if (rlsTesterEnabled) return
 
     if (!isRlsTesterBannerDismissed) {
       addBanner({
@@ -253,7 +252,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
     return () => {
       dismissBanner('rls-tester-banner')
     }
-  }, [addBanner, dismissBanner, isRlsTesterBannerDismissed, rlsTesterEnabled, rlsTesterVisible])
+  }, [addBanner, dismissBanner, isRlsTesterBannerDismissed, rlsTesterEnabled])
 
   useEffect(() => {
     if (!isTriggerPermissionsLoaded) return

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -1,6 +1,6 @@
 import type { PostgresPolicy, PostgresTable } from '@supabase/postgres-meta'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { LOCAL_STORAGE_KEYS, useFlag, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { Search, X } from 'lucide-react'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
 import { useCallback, useDeferredValue, useEffect, useMemo, useState } from 'react'


### PR DESCRIPTION
## Context

As per PR title - will make the RLS tester available for CLI / self-host (still as a feature preview)

## To test

- [x] Verify briefly locally that the RLS tester is available for use, and works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved user search error handling so failures show a clear warning instead of the empty-state message.

* **Refactor**
  * Simplified RLS Tester availability: the UI preview is now driven solely by the local preview toggle and banner behavior/visibility logic has been streamlined, removing redundant external flag checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->