### PR TITLE
feat(studio): add keyboard shortcuts to the SQL editor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -28,6 +28,8 @@ export type MonacoEditorProps = {
   monacoRef: MutableRefObject<Monaco | null>
   autoFocus?: boolean
   executeQuery: () => void
+  executeExplainQuery: () => void
+  prettifyQuery: () => void
   onHasSelection: (value: boolean) => void
   onMount?: (editor: IStandaloneCodeEditor) => void
   onPrompt?: (value: {
@@ -49,6 +51,8 @@ const MonacoEditor = ({
   placeholder = '',
   className,
   executeQuery,
+  executeExplainQuery,
+  prettifyQuery,
   onHasSelection,
   onPrompt,
   onMount,
@@ -80,6 +84,12 @@ const MonacoEditor = ({
   const executeQueryRef = useRef(executeQuery)
   executeQueryRef.current = executeQuery
 
+  const executeExplainQueryRef = useRef(executeExplainQuery)
+  executeExplainQueryRef.current = executeExplainQuery
+
+  const prettifyQueryRef = useRef(prettifyQuery)
+  prettifyQueryRef.current = prettifyQuery
+
   const aiHotkeyEnabledRef = useRef(isAIAssistantHotkeyEnabled)
   aiHotkeyEnabledRef.current = isAIAssistantHotkeyEnabled
 
@@ -91,6 +101,29 @@ const MonacoEditor = ({
     if (model !== null) {
       monacoRef.current.editor.setModelMarkers(model, 'owner', [])
     }
+
+    // Blur the editor on Escape so users can hop out to the rest of the UI.
+    // The precondition defers to Monaco's own Escape consumers (suggest widget,
+    // find widget, parameter hints, snippet/rename mode, inline suggestions) and
+    // to selection/multi-cursor cancellation, so inline features keep working.
+    editor.addCommand(
+      monaco.KeyCode.Escape,
+      () => {
+        ;(document.activeElement as HTMLElement | null)?.blur()
+      },
+      [
+        'editorTextFocus',
+        '!editorHasSelection',
+        '!editorHasMultipleSelections',
+        '!suggestWidgetVisible',
+        '!findWidgetVisible',
+        '!parameterHintsVisible',
+        '!renameInputVisible',
+        '!inSnippetMode',
+        '!accessibilityHelpWidgetVisible',
+        '!inlineSuggestionVisible',
+      ].join(' && ')
+    )
 
     editor.addAction({
       id: 'run-query',
@@ -104,6 +137,17 @@ const MonacoEditor = ({
     })
 
     editor.addAction({
+      id: 'run-explain-query',
+      label: 'Run EXPLAIN ANALYZE',
+      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter],
+      contextMenuGroupId: 'operation',
+      contextMenuOrder: 1,
+      run: () => {
+        executeExplainQueryRef.current()
+      },
+    })
+
+    editor.addAction({
       id: 'save-query',
       label: 'Save Query',
       keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.KeyS],
@@ -111,6 +155,17 @@ const MonacoEditor = ({
       contextMenuOrder: 0,
       run: () => {
         if (snippet) snapV2.addNeedsSaving(snippet.snippet.id)
+      },
+    })
+
+    editor.addAction({
+      id: 'prettify-query',
+      label: 'Prettify SQL',
+      keybindings: [monaco.KeyMod.Alt | monaco.KeyMod.Shift | monaco.KeyCode.KeyF],
+      contextMenuGroupId: 'operation',
+      contextMenuOrder: 2,
+      run: () => {
+        prettifyQueryRef.current()
       },
     })
 

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -82,6 +82,8 @@ import {
   isRoleImpersonationEnabled,
   useGetImpersonatedRoleState,
 } from '@/state/role-impersonation-state'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 import { getSqlEditorV2StateSnapshot, useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
 import { createTabId, useTabsStateSnapshot } from '@/state/tabs'
@@ -144,6 +146,22 @@ export const SQLEditor = () => {
       setTimeout(() => editorRef.current?.focus(), 0)
     })
   }, [])
+
+  useShortcut(SHORTCUT_IDS.SQL_EDITOR_FOCUS_EDITOR, refocusEditor, {
+    registerInCommandMenu: true,
+  })
+
+  const openNewSnippet = useCallback(() => {
+    if (!ref) return
+    // skip=true bypasses the "load last visited snippet" redirect on /sql/new.
+    // Without it, the effect in pages/project/[ref]/sql/[id].tsx bounces back
+    // to the previous snippet.
+    router.push(`/project/${ref}/sql/new?skip=true`)
+  }, [ref, router])
+
+  useShortcut(SHORTCUT_IDS.SQL_EDITOR_NEW_SNIPPET, openNewSnippet, {
+    registerInCommandMenu: true,
+  })
 
   const clearPendingRunRefocus = useCallback(() => {
     shouldRefocusAfterRunRef.current = false
@@ -309,6 +327,10 @@ export const SQLEditor = () => {
       }
     }
   }, [id, isDiffOpen, project, snapV2])
+
+  useShortcut(SHORTCUT_IDS.SQL_EDITOR_FORMAT, prettifyQuery, {
+    registerInCommandMenu: true,
+  })
 
   const executeQuery = useCallback(
     async (force: boolean = false, sqlOverride?: string) => {
@@ -499,6 +521,10 @@ export const SQLEditor = () => {
     lineHighlights,
     snapV2,
   ])
+
+  useShortcut(SHORTCUT_IDS.SQL_EDITOR_EXPLAIN, executeExplainQuery, {
+    registerInCommandMenu: true,
+  })
 
   const handleNewQuery = useCallback(
     async (sql: string, name: string) => {
@@ -925,6 +951,8 @@ export const SQLEditor = () => {
                       editorRef={editorRef}
                       monacoRef={monacoRef}
                       executeQuery={executeQuery}
+                      executeExplainQuery={executeExplainQuery}
+                      prettifyQuery={prettifyQuery}
                       onHasSelection={setHasSelection}
                       onMount={onMount}
                       onPrompt={({

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -21,6 +21,8 @@ import { RoleImpersonationPopover } from '@/components/interfaces/RoleImpersonat
 import { DatabaseSelector } from '@/components/ui/DatabaseSelector'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { IS_PLATFORM } from '@/lib/constants'
+import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
+import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
 
 export type UtilityActionsProps = {
@@ -55,6 +57,8 @@ export const UtilityActions = ({
 
   const snippet = snapV2.snippets[id]
   const isFavorite = snippet !== undefined ? snippet.snippet.favorite : false
+
+  const formatKeys = hotkeyToKeys(SHORTCUT_DEFINITIONS[SHORTCUT_IDS.SQL_EDITOR_FORMAT].sequence[0])
 
   const toggleIntellisense = () => {
     setIntellisenseEnabled(!intellisenseEnabled)
@@ -119,7 +123,7 @@ export const UtilityActions = ({
               <AlignLeft size={14} strokeWidth={2} className="text-foreground-light" />
               Prettify SQL
             </span>
-            <KeyboardShortcut keys={['Alt', 'Shift', 'f']} />
+            <KeyboardShortcut keys={formatKeys} />
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -180,7 +184,7 @@ export const UtilityActions = ({
           <TooltipContent side="bottom" className="p-1 pl-2.5">
             <div className="flex items-center gap-2.5">
               <span>Prettify SQL</span>
-              <KeyboardShortcut keys={['Alt', 'Shift', 'f']} />
+              <KeyboardShortcut keys={formatKeys} />
             </div>
           </TooltipContent>
         </Tooltip>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -1,3 +1,4 @@
+import { Hotkey } from '@tanstack/react-hotkeys'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { AlignLeft, Check, Heart, Keyboard, MoreVertical } from 'lucide-react'
 import { toast } from 'sonner'
@@ -58,7 +59,9 @@ export const UtilityActions = ({
   const snippet = snapV2.snippets[id]
   const isFavorite = snippet !== undefined ? snippet.snippet.favorite : false
 
-  const formatKeys = hotkeyToKeys(SHORTCUT_DEFINITIONS[SHORTCUT_IDS.SQL_EDITOR_FORMAT].sequence[0])
+  const hotkeySequnece: Hotkey | undefined =
+    SHORTCUT_DEFINITIONS[SHORTCUT_IDS.SQL_EDITOR_FORMAT].sequence[0]
+  const formatKeys = hotkeySequnece ? hotkeyToKeys(hotkeySequnece) : undefined
 
   const toggleIntellisense = () => {
     setIntellisenseEnabled(!intellisenseEnabled)
@@ -123,7 +126,7 @@ export const UtilityActions = ({
               <AlignLeft size={14} strokeWidth={2} className="text-foreground-light" />
               Prettify SQL
             </span>
-            <KeyboardShortcut keys={formatKeys} />
+            {formatKeys && <KeyboardShortcut keys={formatKeys} />}
           </DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
@@ -184,7 +187,7 @@ export const UtilityActions = ({
           <TooltipContent side="bottom" className="p-1 pl-2.5">
             <div className="flex items-center gap-2.5">
               <span>Prettify SQL</span>
-              <KeyboardShortcut keys={formatKeys} />
+              {formatKeys && <KeyboardShortcut keys={formatKeys} />}
             </div>
           </TooltipContent>
         </Tooltip>

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -73,7 +73,7 @@ export const DownloadResultsButton = ({
       return
     }
     copyToClipboard(markdownData, () => {
-      toast.success('Copied markdown to clipboard')
+      toast.success('Copied Markdown to clipboard')
       onCopyAsMarkdown?.()
     })
   }

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -1,3 +1,4 @@
+import { SQL_EDITOR_SHORTCUT_IDS, sqlEditorRegistry } from './registry/sql-editor'
 import { TABLE_EDITOR_SHORTCUT_IDS, tableEditorRegistry } from './registry/table-editor'
 import { ShortcutDefinition } from './types'
 
@@ -49,6 +50,9 @@ export const SHORTCUT_IDS = {
 
   // Table editor shortcuts
   ...TABLE_EDITOR_SHORTCUT_IDS,
+
+  // SQL editor shortcuts
+  ...SQL_EDITOR_SHORTCUT_IDS,
 } as const
 
 /**
@@ -297,4 +301,7 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
 
   // Table editor shortcut registration
   ...tableEditorRegistry,
+
+  // SQL editor shortcut registration
+  ...sqlEditorRegistry,
 }

--- a/apps/studio/state/shortcuts/registry/sql-editor.ts
+++ b/apps/studio/state/shortcuts/registry/sql-editor.ts
@@ -1,0 +1,45 @@
+import { RegistryDefinations } from '../types'
+
+export const SQL_EDITOR_SHORTCUT_IDS = {
+  SQL_EDITOR_BLUR_EDITOR: 'sql-editor.blur-editor',
+  SQL_EDITOR_FOCUS_EDITOR: 'sql-editor.focus-editor',
+  SQL_EDITOR_FORMAT: 'sql-editor.format',
+  SQL_EDITOR_EXPLAIN: 'sql-editor.explain',
+  SQL_EDITOR_NEW_SNIPPET: 'sql-editor.new-snippet',
+}
+
+export type SqlEditorShortcutId =
+  (typeof SQL_EDITOR_SHORTCUT_IDS)[keyof typeof SQL_EDITOR_SHORTCUT_IDS]
+
+export const sqlEditorRegistry: RegistryDefinations<SqlEditorShortcutId> = {
+  [SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_BLUR_EDITOR]: {
+    id: SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_BLUR_EDITOR,
+    label: 'Blur SQL editor',
+    sequence: ['Escape'],
+    showInSettings: false,
+  },
+  [SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_FOCUS_EDITOR]: {
+    id: SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_FOCUS_EDITOR,
+    label: 'Focus SQL editor',
+    sequence: ['Shift+E'],
+    showInSettings: false,
+  },
+  [SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_FORMAT]: {
+    id: SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_FORMAT,
+    label: 'Prettify SQL',
+    sequence: ['Alt+Shift+F'],
+    showInSettings: false,
+  },
+  [SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_EXPLAIN]: {
+    id: SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_EXPLAIN,
+    label: 'Run EXPLAIN ANALYZE',
+    sequence: ['Mod+Shift+Enter'],
+    showInSettings: false,
+  },
+  [SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_NEW_SNIPPET]: {
+    id: SQL_EDITOR_SHORTCUT_IDS.SQL_EDITOR_NEW_SNIPPET,
+    label: 'New SQL snippet',
+    sequence: ['Shift+N'],
+    showInSettings: false,
+  },
+}


### PR DESCRIPTION
## Summary

Adds the first batch of keyboard shortcuts for the SQL editor, following the registry pattern established for the table editor.

## Shortcuts

| Shortcut | Action | Notes |
| --- | --- | --- |
| `Esc` | Blur the SQL editor | Registered as a Monaco command with a context-key precondition so inline widgets keep owning `Esc` (suggest, find, parameter hints, snippet/rename mode, accessibility help, inline suggestions, and selection cancellation). |
| `Shift+E` | Focus the SQL editor | Pairs with `Esc` for mouse-free round-trip. |
| `Alt+Shift+F` | Prettify SQL | Now wired through the registry; the tooltip and dropdown badge in `UtilityActions` read the keybind from the same source of truth. Works from inside the editor (Monaco action) and from anywhere on the page (`useShortcut`). |
| `Mod+Shift+Enter` | Run EXPLAIN ANALYZE | Routes results into the Explain tab. Surfaces in the Monaco context menu next to "Run Query". |
| `Shift+N` | Open a new SQL snippet | Navigates to `/sql/new?skip=true` to avoid the redirect-to-last-visited effect that fires on plain `/sql/new`. |

All entries appear in the command menu (`Mod+P`) under "Shortcuts" while their host components are mounted. None are surfaced in Account → Preferences → Keyboard shortcuts yet (`showInSettings: false`), matching how the table editor shortcuts shipped.

## Notes

- The blur shortcut intentionally lives on the Monaco instance rather than the document-level hotkey listener — the document listener can't preempt Monaco's own `Esc` handling. Other shortcuts that need to fire while the editor has focus (run, save, format, explain) are registered as Monaco actions; everything else uses `useShortcut`.
- Format and explain are double-registered (Monaco action + `useShortcut`) so they fire whether the editor is focused or not. The Monaco actions don't read the user's enable/disable preference yet — same asymmetry as the existing run/save actions.
- `Shift+N` is scoped to the SQL editor route. To make it work globally we'd register it at a higher layout level.

## Test plan

- [x] Inside editor: `Esc` blurs; suggest/find/parameter hints still close on `Esc`; multi-cursor selection collapses on first `Esc`, blurs on second.
- [x] Outside editor: `Shift+E` returns focus to the editor.
- [x] `Alt+Shift+F` formats from inside and outside the editor; tooltip + dropdown badge show the correct keybind.
- [x] `Mod+Shift+Enter` runs EXPLAIN ANALYZE and switches to the Explain tab.
- [x] `Shift+N` opens a fresh snippet without bouncing back to the previous one.
- [x] All five shortcuts appear in `Mod+P` with the right badges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts for SQL editor: format SQL, run EXPLAIN ANALYZE, focus/blur editor, and open a new SQL snippet.
  * Added "Prettify SQL" and "Run EXPLAIN ANALYZE" actions to the editor context menu with shortcuts.
  * Centralized registration of SQL editor shortcuts so they appear across the app.

* **UX Improvements**
  * Escape key blurs editor focus when appropriate to allow easy exit without disrupting editor widgets.

* **Style**
  * Adjusted success toast capitalization for copied Markdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->