### PR TITLE
fix(studio): fix execute_sql tracing continuity across user prompts

### DIFF
--- a/apps/studio/evals/output.ts
+++ b/apps/studio/evals/output.ts
@@ -17,7 +17,7 @@ type ParsedToolCall = {
 
 function parseToolCall(
   toolCall: TypedToolCall<ToolSet>,
-  toolResult: TypedToolResult<ToolSet>
+  toolResult: TypedToolResult<ToolSet> | undefined
 ): ParsedToolCall {
   switch (toolCall.toolName) {
     case 'execute_sql': {
@@ -26,7 +26,7 @@ function parseToolCall(
       return { sqlQuery }
     }
     case 'search_docs': {
-      const content = toolResult.output?.content
+      const content = toolResult?.output?.content
       if (!content || !Array.isArray(content)) return {}
       const docs = content
         .map((item) => item?.text)
@@ -64,9 +64,7 @@ export function buildAssistantEvalOutput(
   for (const step of steps) {
     for (const [i, toolCall] of step.toolCalls.entries()) {
       toolNames.push(toolCall.toolName)
-      const toolResult = step.toolResults.at(i)
-      if (!toolResult) continue
-      const parsed = parseToolCall(toolCall, toolResult)
+      const parsed = parseToolCall(toolCall, step.toolResults.at(i))
       if (parsed.sqlQuery) sqlQueries.push(parsed.sqlQuery)
       if (parsed.docs) docs.push(...parsed.docs)
     }

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -37,7 +37,9 @@ export async function generateAssistantResponse({
   providerOptions,
   requestedModel,
   abortSignal,
+  parentSpanExport,
   onSpanCreated,
+  onSpanExported,
 }: {
   messages: UIMessage[]
   model: LanguageModel
@@ -55,7 +57,9 @@ export async function generateAssistantResponse({
   promptProviderOptions?: Record<string, any>
   providerOptions?: Record<string, any>
   abortSignal?: AbortSignal
+  parentSpanExport?: string
   onSpanCreated?: (spanId: string) => void
+  onSpanExported?: (exportedSpan: string) => void
 }) {
   const shouldTrace = allowTracing ?? IS_TRACING_ENABLED
 
@@ -169,8 +173,17 @@ export async function generateAssistantResponse({
   if (shouldTrace) {
     // startSpan instead of traced() so we control when the span closes — onFinish logs
     // output to the span before we call span.end(), ensuring online scoring sees the output.
-    const span = startSpan({ name: 'generateAssistantResponse', type: 'function' })
+    const span = startSpan({
+      name: 'generateAssistantResponse',
+      type: 'function',
+      ...(parentSpanExport && { parent: parentSpanExport }),
+    })
     onSpanCreated?.(span.id)
+
+    // Export span for cross-process continuation so follow-up turns (e.g. after
+    // the user runs an execute_sql result) can attach as child spans in the same trace.
+    const exportedSpan = await span.export()
+    onSpanExported?.(exportedSpan)
 
     const lastUserMessage = rawMessages.findLast((m) => m.role === 'user')
     const lastUserText = lastUserMessage?.parts

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -8,7 +8,15 @@ import {
   type ToolSet,
   type UIMessage,
 } from 'ai'
-import { startSpan, traced, withCurrent, wrapAISDK, type Span } from 'braintrust'
+import {
+  startSpan,
+  traced,
+  updateSpan,
+  withCurrent,
+  withParent,
+  wrapAISDK,
+  type Span,
+} from 'braintrust'
 import { source } from 'common-tags'
 
 import { buildAssistantEvalOutput } from '@/evals/output'
@@ -156,32 +164,83 @@ export async function generateAssistantResponse({
           for (const step of steps) {
             for (const toolCall of step.toolCalls) {
               if (toolCall.toolName === 'rename_chat') {
-                const { newName } = toolCall.input as { newName: string }
-                span.log({ metadata: { chatName: newName } })
+                const { input } = toolCall
+                if (
+                  typeof input === 'object' &&
+                  input !== null &&
+                  'newName' in input &&
+                  typeof input.newName === 'string'
+                ) {
+                  span.log({ metadata: { chatName: input.newName } })
+                }
               }
             }
           }
-          span.log({
-            output: buildAssistantEvalOutput(finishReason, steps) satisfies AssistantEvalOutput,
-          })
-          span.end()
+
+          const UI_EXECUTED_TOOLS = ['execute_sql', 'deploy_edge_function']
+          const hasDynamicToolCalls = steps.some((step) =>
+            step.toolCalls.some((tc) => UI_EXECUTED_TOOLS.includes(tc.toolName))
+          )
+
+          if (!hasDynamicToolCalls) {
+            span.log({
+              output: buildAssistantEvalOutput(finishReason, steps) satisfies AssistantEvalOutput,
+            })
+            span.end()
+          }
+          // If hasDynamicToolCalls: don't log output or end span — Turn 2 will close it
+          // with the combined output via updateSpan
         },
       }),
     } satisfies Parameters<typeof ai.streamText>[0])
   }
 
   if (shouldTrace) {
+    if (parentSpanExport) {
+      // Continuation turn (e.g. after user runs execute_sql result).
+      // Don't create a new span — run under Turn 1's span context so wrapAISDK's
+      // streamText span becomes a sibling of Turn 1's streamText, not a new wrapper.
+      return withParent(parentSpanExport, async () => {
+        const result = await run(undefined)
+
+        // Reconstruct Turn 1's tool calls from the prior assistant message parts.
+        // These appear as tool-invocation parts with state 'output-available'.
+        const priorToolCalls = rawMessages
+          .filter((m) => m.role === 'assistant')
+          .flatMap((m) => m.parts)
+          .filter(isToolUIPart)
+          .filter((p) => p.state === 'output-available')
+          .map((p) => ({
+            type: 'tool-call' as const,
+            toolCallId: p.toolCallId,
+            toolName: p.type === 'dynamic-tool' ? p.toolName : p.type.slice('tool-'.length),
+            input: p.input,
+          }))
+
+        const [finishReason, steps] = await Promise.all([result.finishReason, result.steps])
+
+        const combinedSteps = [{ text: '', toolCalls: priorToolCalls, toolResults: [] }, ...steps]
+
+        updateSpan({
+          exported: parentSpanExport,
+          output: buildAssistantEvalOutput(
+            finishReason,
+            combinedSteps
+          ) satisfies AssistantEvalOutput,
+          metrics: { end: Date.now() / 1000 },
+        })
+
+        return result
+      })
+    }
+
     // startSpan instead of traced() so we control when the span closes — onFinish logs
     // output to the span before we call span.end(), ensuring online scoring sees the output.
-    const span = startSpan({
-      name: 'generateAssistantResponse',
-      type: 'function',
-      ...(parentSpanExport && { parent: parentSpanExport }),
-    })
+    const span = startSpan({ name: 'generateAssistantResponse', type: 'function' })
     onSpanCreated?.(span.id)
 
     // Export span for cross-process continuation so follow-up turns (e.g. after
-    // the user runs an execute_sql result) can attach as child spans in the same trace.
+    // the user runs an execute_sql result) can attach to this span.
     const exportedSpan = await span.export()
     onSpanExported?.(exportedSpan)
 

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -201,6 +201,8 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
         : "You don't have access to any schemas."
     }
 
+    const parentSpanExport = req.headers['x-braintrust-parent-span-export'] as string | undefined
+
     const result = await generateAssistantResponse({
       messages,
       ...modelParams,
@@ -222,8 +224,12 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       requestedModel,
       promptProviderOptions,
       abortSignal: abortController.signal,
+      parentSpanExport,
       onSpanCreated: (spanId) => {
         res.setHeader('x-braintrust-span-id', spanId)
+      },
+      onSpanExported: (exportedSpan) => {
+        res.setHeader('x-braintrust-parent-span-export', exportedSpan)
       },
     })
 

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -201,7 +201,9 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
         : "You don't have access to any schemas."
     }
 
-    const parentSpanExport = req.headers['x-braintrust-parent-span-export'] as string | undefined
+    const parentSpanExportHeader = req.headers['x-braintrust-parent-span-export']
+    const parentSpanExport =
+      typeof parentSpanExportHeader === 'string' ? parentSpanExportHeader : undefined
 
     const result = await generateAssistantResponse({
       messages,

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -241,6 +241,10 @@ function createChatInstance(
         if (spanId) {
           state.pendingSpanIds[options.id] = spanId
         }
+        const spanExport = response.headers.get('x-braintrust-parent-span-export')
+        if (spanExport) {
+          state.lastSpanExports[options.id] = spanExport
+        }
         return response
       },
       async prepareSendMessagesRequest({ messages, ...opts }) {
@@ -250,6 +254,13 @@ function createChatInstance(
 
         // Get the chat specific to this request to ensure we have the correct name
         const chat = state.chats[options.id]
+
+        // When the last message is an assistant message (not a fresh user prompt), this
+        // is an automatic continuation triggered by completed tool results (e.g. execute_sql).
+        // Attach to the previous span so the follow-up turn stays in the same trace.
+        const lastMsg = messages[messages.length - 1]
+        const isContinuation = lastMsg?.role === 'assistant'
+        const parentSpanExport = isContinuation ? state.lastSpanExports[options.id] : undefined
 
         return {
           ...opts,
@@ -264,7 +275,10 @@ function createChatInstance(
             model: state.model,
             ...opts.body,
           },
-          ...(IS_PLATFORM ? { headers: { Authorization: authorizationHeader ?? '' } } : {}),
+          headers: {
+            ...(IS_PLATFORM ? { Authorization: authorizationHeader ?? '' } : {}),
+            ...(parentSpanExport ? { 'x-braintrust-parent-span-export': parentSpanExport } : {}),
+          },
         }
       },
     }),
@@ -315,6 +329,7 @@ export const createAiAssistantState = (): AiAssistantState => {
     chatInstances: {},
     pendingSpanIds: {},
     messageSpanIds: {},
+    lastSpanExports: {},
 
     setContext: (context: Partial<AiAssistantContext>) => {
       state.context = { ...state.context, ...context }
@@ -538,6 +553,7 @@ export type AiAssistantState = AiAssistantData & {
   chatInstances: Record<string, Chat<MessageType>>
   pendingSpanIds: Record<string, string>
   messageSpanIds: Record<string, string>
+  lastSpanExports: Record<string, string>
   setContext: (context: Partial<AiAssistantContext>) => void
   setModel: (model: AssistantModel) => void
   newChat: (


### PR DESCRIPTION
When the assistant calls `execute_sql` and the user runs the query in the UI, the follow-up turn was starting a fresh Braintrust span, causing online scorers to fire twice with half the conversation context each time.

- Use `withParent` for continuation turns instead of starting a new span, so the follow-up `streamText` nests under the original span rather than creating a new wrapper
- Keep Turn 1's span open when UI-executed tools are pending; close it from Turn 2 via `updateSpan` with combined output so scoring fires exactly once with full context
- Fix `sqlQueries` being empty in continuation traces — `parseToolCall` was being skipped when no tool result was present, even though the SQL comes from the call input
- Remove pre-existing `as` cast for `rename_chat` input in `onFinish` in favour of type narrowing

Closes AI-658