### PR TITLE
refactor(pg-meta): consolidate test scripts and support parallel test runs across worktrees

### DIFF
--- a/packages/pg-meta/package.json
+++ b/packages/pg-meta/package.json
@@ -8,11 +8,8 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "clean": "rimraf node_modules .turbo tsconfig.tsbuildinfo",
-    "test": "run-s db:clean db:run test:run db:clean",
-    "db:clean": "cd test/db && docker compose down",
-    "db:run": "cd test/db && docker compose up --detach --wait",
-    "test:run": "vitest run --coverage",
-    "test:update": "vitest run --update",
+    "test": "test/run-tests.sh vitest run --coverage",
+    "test:update": "test/run-tests.sh vitest run --update",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/pg-meta/test/db/docker-compose.yml
+++ b/packages/pg-meta/test/db/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   db:
     build: .
     ports:
-      - 5432:5432
+      - ${PG_TEST_PORT:-5432}:5432
     volumes:
       - .:/docker-entrypoint-initdb.d
     environment:

--- a/packages/pg-meta/test/run-tests.sh
+++ b/packages/pg-meta/test/run-tests.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PACKAGE_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DB_DIR="$SCRIPT_DIR/db"
+
+# Unique project name per worktree so containers don't collide
+PROJECT_HASH=$(echo "$PACKAGE_DIR" | shasum | cut -c1-8)
+COMPOSE_PROJECT_NAME="pg-meta-${PROJECT_HASH}"
+export COMPOSE_PROJECT_NAME
+
+# Find an available port in the range 5432-5531
+PG_TEST_PORT=5432
+MAX_PORT=5531
+while nc -z localhost "$PG_TEST_PORT" 2>/dev/null; do
+  if [ "$PG_TEST_PORT" -ge "$MAX_PORT" ]; then
+    echo "error: no available port found in range 5432-${MAX_PORT}" >&2
+    exit 1
+  fi
+  PG_TEST_PORT=$((PG_TEST_PORT + 1))
+done
+export PG_TEST_PORT
+
+DATABASE_URL="postgresql://postgres:postgres@localhost:${PG_TEST_PORT}"
+export DATABASE_URL
+
+cleanup() {
+  cd "$DB_DIR"
+  docker compose down 2>/dev/null || true
+}
+trap cleanup EXIT
+
+cd "$DB_DIR"
+docker compose down 2>/dev/null || true
+docker compose up --detach --wait
+
+cd "$PACKAGE_DIR"
+"$@"
+rc=$?
+exit $rc


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor of the pg-meta test setup scripts.

## What is the current behavior?

The test command runs multiple sequential npm-run-s scripts (`db:clean`, `db:run`, `test:run`, `db:clean`) with a hardcoded port 5432, causing container name and port collisions when running tests across multiple git worktrees in parallel.

## What is the new behavior?

A single `test/run-tests.sh` wrapper script handles the full test lifecycle: it finds an available port dynamically (scanning 5432–5531), sets a unique Docker Compose project name based on a hash of the package directory path, starts the DB, runs the test command, and tears down on exit. This allows pg-meta tests to run in parallel across multiple worktrees without conflicts.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined test execution to centralize setup and teardown for reliable runs.
  * Made the test database port configurable with automatic local port discovery and fail-fast behavior.
  * Created isolated test environments per workspace to avoid container/name collisions and improve cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->