### PR TITLE
fix(growth): preserve untouched services in Privacy Settings save

### DIFF
--- a/packages/ui-patterns/src/PrivacySettings/index.test.tsx
+++ b/packages/ui-patterns/src/PrivacySettings/index.test.tsx
@@ -1,0 +1,181 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PrivacySettings } from './index'
+
+const updateServices = vi.fn()
+
+const categories = [
+  {
+    slug: 'essential',
+    label: 'Essential',
+    description: 'Required for site operation',
+    isEssential: true,
+    services: [{ id: 'essential-1', consent: { status: true } }],
+  },
+  {
+    slug: 'analytics',
+    label: 'Analytics',
+    description: 'Measure product usage',
+    isEssential: false,
+    services: [{ id: 'analytics-1', consent: { status: true } }],
+  },
+  {
+    slug: 'marketing',
+    label: 'Marketing',
+    description: 'Track campaign performance',
+    isEssential: false,
+    services: [{ id: 'marketing-1', consent: { status: true } }],
+  },
+]
+
+// Mutable so individual tests can simulate the SDK init window where
+// `categories` starts null and arrives asynchronously. Reset to the
+// populated default in beforeEach.
+let mockCategories: typeof categories | null = categories
+
+vi.mock('common', () => ({
+  useConsentState: () => ({
+    categories: mockCategories,
+    updateServices,
+  }),
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.ComponentProps<'a'>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+// The Admonition component pulls in Shadcn primitives we don't otherwise need;
+// stub it out to keep the mock surface minimal.
+vi.mock('../admonition', () => ({
+  Admonition: ({ title }: { title: string }) => <div role="alert">{title}</div>,
+}))
+
+vi.mock('ui', () => {
+  const Modal = ({
+    children,
+    visible,
+    onConfirm,
+    onCancel,
+    header,
+  }: {
+    children: React.ReactNode
+    visible?: boolean
+    onConfirm?: () => void
+    onCancel?: () => void
+    header?: string
+  }) =>
+    visible ? (
+      <div>
+        <div>{header}</div>
+        {children}
+        <button onClick={onConfirm}>Confirm</button>
+        <button onClick={onCancel}>Cancel</button>
+      </div>
+    ) : null
+
+  Modal.Content = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+
+  const Toggle = ({
+    checked,
+    disabled,
+    onChange,
+    label,
+    descriptionText,
+  }: {
+    checked: boolean
+    disabled?: boolean
+    onChange?: () => void
+    label: string
+    descriptionText?: React.ReactNode
+  }) => (
+    <label>
+      <input
+        type="checkbox"
+        aria-label={label}
+        checked={checked}
+        disabled={disabled}
+        onChange={onChange}
+      />
+      {label}
+      {descriptionText}
+    </label>
+  )
+
+  return { Modal, Toggle }
+})
+
+describe('PrivacySettings', () => {
+  beforeEach(() => {
+    updateServices.mockReset()
+    mockCategories = categories
+  })
+
+  it('submits the full non-essential decision set after toggling one category', async () => {
+    const user = userEvent.setup()
+
+    render(<PrivacySettings>Privacy settings</PrivacySettings>)
+
+    await user.click(screen.getByRole('button', { name: 'Privacy settings' }))
+    await user.click(screen.getByRole('checkbox', { name: 'Marketing' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(updateServices).toHaveBeenCalledTimes(1)
+
+    const decisions = updateServices.mock.calls[0][0]
+    expect(decisions).toHaveLength(2)
+    expect(decisions).toEqual(
+      expect.arrayContaining([
+        { serviceId: 'analytics-1', status: true },
+        { serviceId: 'marketing-1', status: false },
+      ])
+    )
+  })
+
+  // Race window: user opens the modal during SDK init while `categories`
+  // is still null. The modal renders the "Unable to Load Privacy Settings"
+  // admonition (no toggles). Then `categories` arrives asynchronously and
+  // toggles render. Without the categories-aware reseed effect, the
+  // `serviceConsentMap` would still be empty, and a subsequent toggle +
+  // Confirm would submit only the toggled service — exactly the partial-
+  // submit bug this fix is meant to prevent.
+  it('reseeds the consent map when categories transition from null to populated while the modal is open', async () => {
+    mockCategories = null
+
+    const user = userEvent.setup()
+    const { rerender } = render(<PrivacySettings>Privacy settings</PrivacySettings>)
+
+    // Open modal during the SDK init window
+    await user.click(screen.getByRole('button', { name: 'Privacy settings' }))
+
+    // No toggles render while categories is null
+    expect(screen.queryByRole('checkbox', { name: 'Marketing' })).not.toBeInTheDocument()
+
+    // Categories arrive — simulate by updating the mock value and re-rendering
+    mockCategories = categories
+    rerender(<PrivacySettings>Privacy settings</PrivacySettings>)
+
+    // Toggles now render, and the useEffect should have reseeded the map
+    expect(screen.getByRole('checkbox', { name: 'Marketing' })).toBeInTheDocument()
+
+    await user.click(screen.getByRole('checkbox', { name: 'Marketing' }))
+    await user.click(screen.getByRole('button', { name: 'Confirm' }))
+
+    expect(updateServices).toHaveBeenCalledTimes(1)
+    const decisions = updateServices.mock.calls[0][0]
+    expect(decisions).toHaveLength(2)
+    expect(decisions).toEqual(
+      expect.arrayContaining([
+        { serviceId: 'analytics-1', status: true },
+        { serviceId: 'marketing-1', status: false },
+      ])
+    )
+  })
+})

--- a/packages/ui-patterns/src/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/src/PrivacySettings/index.tsx
@@ -2,13 +2,39 @@
 
 import { useConsentState } from 'common'
 import Link from 'next/link'
-import { PropsWithChildren, useState } from 'react'
+import { PropsWithChildren, useEffect, useState } from 'react'
 import { Modal, Toggle } from 'ui'
 
 import { Admonition } from '../admonition'
 
 interface PrivacySettingsProps {
   className?: string
+}
+
+function buildServiceConsentMap(
+  categories:
+    | {
+        isEssential: boolean
+        services: readonly {
+          id: string
+          consent: {
+            status: boolean
+          }
+        }[]
+      }[]
+    | null
+) {
+  const consentMap = new Map<string, boolean>()
+
+  categories?.forEach((category) => {
+    if (category.isEssential) return
+
+    category.services.forEach((service) => {
+      consentMap.set(service.id, service.consent.status)
+    })
+  })
+
+  return consentMap
 }
 
 export const PrivacySettings = ({
@@ -18,14 +44,40 @@ export const PrivacySettings = ({
   const [isOpen, setIsOpen] = useState(false)
   const { categories, updateServices } = useConsentState()
 
-  const [serviceConsentMap, setServiceConsentMap] = useState(() => new Map<string, boolean>())
+  const [serviceConsentMap, setServiceConsentMap] = useState(() =>
+    buildServiceConsentMap(categories)
+  )
+
+  // Reseed the consent map if categories arrive while the modal is open. The
+  // useState initializer above runs once at mount, and the button onClick
+  // below reseeds when the modal opens — but if the user opens the modal
+  // during the SDK init window (categories === null), the modal renders an
+  // "Unable to Load Privacy Settings" admonition with no toggles, then
+  // categories arrives asynchronously and the toggles render. Without this
+  // effect, the map stays empty and a subsequent toggle + Confirm would
+  // submit only the toggled service — exactly the partial-submit bug this
+  // component is meant to prevent.
+  //
+  // The empty-map guard prevents this effect from clobbering in-progress
+  // user toggles in any unforeseen scenario where categories' reference
+  // changes mid-session.
+  useEffect(() => {
+    if (!isOpen || !categories) return
+    setServiceConsentMap((current) =>
+      current.size === 0 ? buildServiceConsentMap(categories) : current
+    )
+  }, [isOpen, categories])
 
   function handleServicesChange(services: { id: string; status: boolean }[]) {
-    let newServiceConsentMap = new Map(serviceConsentMap)
-    services.forEach((service) => {
-      newServiceConsentMap.set(service.id, service.status)
+    setServiceConsentMap((currentConsentMap) => {
+      const nextConsentMap = new Map(currentConsentMap)
+
+      services.forEach((service) => {
+        nextConsentMap.set(service.id, service.status)
+      })
+
+      return nextConsentMap
     })
-    setServiceConsentMap(newServiceConsentMap)
   }
 
   const handleConfirmPreferences = () => {
@@ -44,7 +96,13 @@ export const PrivacySettings = ({
 
   return (
     <>
-      <button {...props} onClick={() => setIsOpen(true)}>
+      <button
+        {...props}
+        onClick={() => {
+          setServiceConsentMap(buildServiceConsentMap(categories))
+          setIsOpen(true)
+        }}
+      >
         {children}
       </button>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The Privacy Settings modal was submitting only the services the user toggled, not the full non-essential set the SDK expects. `serviceConsentMap` started empty and was only filled in via `handleServicesChange` on toggle, so untouched services were silently dropped from the `updateServices()` payload on Confirm.

There's also an SDK-init race: if the user opens the modal while `categories === null` (the "Unable to Load Privacy Settings" admonition state), toggles render asynchronously when categories arrive — but the map was only seeded at mount and on the open-button click. It stays empty, and the same partial-submit fires on Confirm.

GROWTH-790.

## What is the new behavior?

`serviceConsentMap` is seeded from the current non-essential consent set in three places: the `useState` initializer, the button `onClick`, and a `useEffect` keyed on `[isOpen, categories]` for the null-to-populated transition. The effect uses an empty-map guard so in-progress user toggles aren't clobbered if `categories` re-references mid-session for any other reason.

Confirm always sends the full non-essential decision set.

## Additional context

**Scope.** Only affects the Privacy Settings modal. The banner's Accept/Opt out buttons and Studio's Analytics toggle use `acceptAll`/`denyAll` (different SDK methods that already submit complete state) — not touched here.

**This probably doesn't resolve the active customer-reported re-prompts.** The Usercentrics ruleset currently exposes a single toggleable non-essential category, so for that shape, pre-fix and post-fix code emit the same payload when the user flips it. Shipping as SDK-contract correctness and defense against future ruleset changes that introduce additional non-essential categories.

**Companion PR:** #45350 — independent read-side `isHidden` filter fix.

**Testing.**

- `pnpm -F ui-patterns test --run` — 185/185 pass (two new PrivacySettings cases: the already-loaded path and the SDK-init race).
- Typecheck across `ui-patterns`, `docs`, `studio` — pass.
- Browser QA on Vercel preview covered the already-loaded path (staging short-circuit temporarily bypassed): toggled "Analytics and Marketing" off, confirmed; `localStorage.uc_settings` retained all 21 services with correct statuses. Plus four GDPR scenarios via Sweden VPN — fresh load, accept + reload, opt out + reload, Privacy Settings + reload — all healthy.
- The SDK-init race path is covered by the new unit test only; not separately exercised in-browser because the timing window is hard to hit deterministically.

GROWTH-790