### PR TITLE
feat(studio): wire up database advisor rule 12 (auth_allow_anonymous_sign_ins)

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -127,6 +127,15 @@ export const lintInfoMap: LintInfo[] = [
     category: 'security',
   },
   {
+    name: 'auth_allow_anonymous_sign_ins',
+    title: 'Anonymous Sign-Ins Allowed',
+    icon: <User className="text-foreground-muted" size={15} strokeWidth={1} />,
+    link: ({ projectRef }) => `/project/${projectRef}/auth/providers`,
+    linkText: 'View settings',
+    docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0012_auth_allow_anonymous_sign_ins`,
+    category: 'security',
+  },
+  {
     name: 'rls_disabled_in_public',
     title: 'RLS Disabled in Public',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,


### PR DESCRIPTION
## Summary

Wires up database advisor rule `0012_auth_allow_anonymous_sign_ins` in the Studio Linter so it shows up with the right title, icon, action link, and docs link instead of falling back to a generic display.

The rule entry navigates to `/auth/providers` (where the "Allow anonymous sign-ins" toggle lives), modeled after rule 0019 (`auth_otp_long_expiry`) which uses the same target.

## Test plan

- [x] Trigger rule 0012 on a test project (enable anonymous sign-ins on a project with RLS-protected tables)
- [x] Verify the lint appears in Security Advisor with title "Anonymous Sign-Ins Allowed" and User icon
- [x] Verify the "View settings" CTA navigates to `/project/<ref>/auth/providers`
- [x] Verify the "Learn more" link points to the 0012 docs section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new authentication lint rule that identifies anonymous sign-in configuration issues and provides integrated guidance to the auth providers settings page with relevant documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->