### PR TITLE
fix(growth): exclude hidden services from consent coverage check

### DIFF
--- a/packages/common/consent-state.test.ts
+++ b/packages/common/consent-state.test.ts
@@ -311,7 +311,7 @@ describe('detectPriorConsent', () => {
 })
 
 describe('applyPriorDecisionToSDK', () => {
-  type MockService = { id: string; isEssential: boolean }
+  type MockService = { id: string; isEssential: boolean; isHidden?: boolean }
 
   const makeMockUC = (
     opts: {
@@ -401,6 +401,29 @@ describe('applyPriorDecisionToSDK', () => {
       services: [
         { id: 'essential_new', isEssential: true }, // not in decisions, but essential
         { id: 'tracking1', isEssential: false },
+      ],
+    })
+
+    applyPriorDecisionToSDK(
+      UC as never,
+      { initialLayer: 0 },
+      { kind: 'decisions', decisions: [{ serviceId: 'tracking1', status: false }] }
+    )
+
+    expect(UC.updateServices).toHaveBeenCalledOnce()
+    expect(consentState.showConsentToast).toBe(false)
+  })
+
+  // Hidden services are managed independently by the SDK and don't appear
+  // in the user's Privacy Settings UI, so the user cannot have stored a
+  // decision for them. Like essentials, they must be excluded from the
+  // coverage check — otherwise a ruleset containing any hidden non-essential
+  // service would force every returning user to re-prompt forever.
+  it('decisions with uncovered hidden non-essential: still restores (hidden services ignored in coverage check)', () => {
+    const UC = makeMockUC({
+      services: [
+        { id: 'tracking1', isEssential: false, isHidden: false },
+        { id: 'tracking_hidden', isEssential: false, isHidden: true }, // not in decisions, but hidden
       ],
     })
 

--- a/packages/common/consent-state.ts
+++ b/packages/common/consent-state.ts
@@ -221,13 +221,16 @@ export function applyPriorDecisionToSDK(
     }
 
     // priorDecision.kind === 'decisions'. Only suppress the banner if the
-    // stored decisions cover every non-essential service the SDK currently
-    // knows about. If the ruleset has grown since the user's ucData/
-    // uc_settings was written, force a re-prompt rather than silently
+    // stored decisions cover every non-essential, non-hidden service the SDK
+    // currently knows about. If the ruleset has grown since the user's
+    // ucData/uc_settings was written, force a re-prompt rather than silently
     // defaulting the new service. Essentials are skipped because the SDK
-    // forces them on regardless of user decision.
+    // forces them on regardless of user decision; hidden services are skipped
+    // because they don't appear in the Privacy Settings UI, so the user
+    // cannot have a stored decision for them and the SDK manages their state
+    // independently.
     const currentNonEssentialIds = UC.getServicesBaseInfo()
-      .filter((s) => !s.isEssential)
+      .filter((s) => !s.isEssential && !s.isHidden)
       .map((s) => s.id)
     const coveredIds = new Set(priorDecision.decisions.map((d) => d.serviceId))
     const allCovered = currentNonEssentialIds.every((id) => coveredIds.has(id))


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In `applyPriorDecisionToSDK`, the coverage check that decides whether to silently restore prior consent or re-prompt filters services from `UC.getServicesBaseInfo()` by `!s.isEssential` only.

The Usercentrics SDK also exposes `isHidden: boolean` on each service — services that exist in the ruleset but aren't surfaced in the Privacy Settings UI. Those still get counted in coverage. A user can never have a stored decision for a service the modal doesn't show them, so any ruleset containing a hidden non-essential would force every returning user to re-prompt forever.

GROWTH-790.

## What is the new behavior?

The filter excludes both `isEssential` and `isHidden`. Coverage matches what the user can actually decide about in the UI — same intent as the existing essential exclusion (skip services the user can't meaningfully consent to).

## Additional context

**Scope.** Defense-in-depth. The Usercentrics ruleset currently has no hidden non-essentials, so this isn't expected to resolve any active customer-reported re-prompts. The contract was wrong as written — adding any hidden service to the ruleset later would silently regress every returning user without this fix.

**Companion PR:** #45341 — independent write-path fix for the Privacy Settings modal.

**Testing.**

- `npx vitest run packages/common/consent-state.test.ts` — 28/28 pass (existing 27 + one new regression test asserting that a hidden non-essential service not in the user's stored decisions doesn't break coverage).
- `pnpm -F common typecheck` — pass.
- Walked the failure path mentally to confirm the new test exercises the actual bug: without `&& !s.isHidden`, the hidden service stays in `currentNonEssentialIds`, isn't in `coveredIds`, `allCovered` becomes false, banner shows. With the filter, it passes.

GROWTH-790