### PR TITLE
chore(studio): clean up temporary access response typing

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccess.types.ts
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccess.types.ts
@@ -12,11 +12,6 @@ export type JitStatusBadge = {
   variant: 'default' | 'success' | 'warning'
 }
 
-export type JitDbAccessUnavailableReason =
-  | 'postgres_upgrade_required'
-  | 'manual_migration_required'
-  | 'temporarily_unavailable'
-
 export type JitMemberOption = {
   id: string
   email: string

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -256,8 +256,7 @@ export const JitDbAccessConfiguration = () => {
 
   const showToggleFailedWarning =
     isSuccessConfiguration &&
-    !!jitDbAccessConfiguration &&
-    'appliedSuccessfully' in jitDbAccessConfiguration &&
+    jitDbAccessConfiguration?.state !== 'unavailable' &&
     !jitDbAccessConfiguration.appliedSuccessfully
 
   const projectReference = ref ? (

--- a/apps/studio/data/jit-db-access/jit-db-access-grant-mutation.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-grant-mutation.ts
@@ -57,7 +57,7 @@ export const useJitDbAccessGrantMutation = ({
     },
     async onError(data, variables, context) {
       if (onError === undefined) {
-        toast.error(`Failed to grant JIT database access: ${data.message}`)
+        toast.error(`Failed to grant temporary access: ${data.message}`)
       } else {
         onError(data, variables, context)
       }

--- a/apps/studio/data/jit-db-access/jit-db-access-revoke-mutation.ts
+++ b/apps/studio/data/jit-db-access/jit-db-access-revoke-mutation.ts
@@ -44,7 +44,7 @@ export const useJitDbAccessRevokeMutation = ({
     },
     async onError(data, variables, context) {
       if (onError === undefined) {
-        toast.error(`Failed to revoke JIT database access: ${data.message}`)
+        toast.error(`Failed to revoke temporary access: ${data.message}`)
       } else {
         onError(data, variables, context)
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Cleanup.

## What is the current behavior?

Temporary access still has a couple of leftover JIT fallback messages and an unnecessary local unavailable-reason type after the Platform response types were split into `JitAccessResponse` and `JitStateResponse`.

## What is the new behavior?

Studio relies on the generated `JitStateResponse` discriminated union for the toggle warning and uses temporary access copy consistently in the remaining fallback toasts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined error messaging for temporary database access grant and revoke operations.
  * Enhanced condition detection for toggle failure warnings in database access configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->