### PR TITLE
docs(functions): update Edge Functions secrets docs for new API keys

### DIFF
--- a/apps/docs/content/guides/functions/secrets.mdx
+++ b/apps/docs/content/guides/functions/secrets.mdx
@@ -38,20 +38,17 @@ Deno.env.get('NAME_OF_SECRET')
 
 For example, in a function:
 
-```js
+```ts
 import { createClient } from 'npm:@supabase/supabase-js@2'
 
+const SUPABASE_PUBLISHABLE_KEYS = JSON.parse(Deno.env.get('SUPABASE_PUBLISHABLE_KEYS')!)
+const SUPABASE_SECRET_KEYS = JSON.parse(Deno.env.get('SUPABASE_SECRET_KEYS')!)
+
 // For user-facing operations (respects RLS)
-const supabase = createClient(
-  Deno.env.get('SUPABASE_URL')!,
-  Deno.env.get('SUPABASE_ANON_KEY')!
-)
+const supabase = createClient(Deno.env.get('SUPABASE_URL')!, SUPABASE_PUBLISHABLE_KEYS['default'])
 
 // For admin operations (bypasses RLS)
-const supabaseAdmin = createClient(
-  Deno.env.get('SUPABASE_URL')!,
-  Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!
-)
+const supabaseAdmin = createClient(Deno.env.get('SUPABASE_URL')!, SUPABASE_SECRET_KEYS['default'])
 ```
 
 ---

--- a/apps/docs/content/guides/functions/secrets.mdx
+++ b/apps/docs/content/guides/functions/secrets.mdx
@@ -44,6 +44,8 @@ import { createClient } from 'npm:@supabase/supabase-js@2'
 const SUPABASE_PUBLISHABLE_KEYS = JSON.parse(Deno.env.get('SUPABASE_PUBLISHABLE_KEYS')!)
 const SUPABASE_SECRET_KEYS = JSON.parse(Deno.env.get('SUPABASE_SECRET_KEYS')!)
 
+// If you want to use a different api key, change 'default' to your preferred key name
+
 // For user-facing operations (respects RLS)
 const supabase = createClient(Deno.env.get('SUPABASE_URL')!, SUPABASE_PUBLISHABLE_KEYS['default'])
 

--- a/apps/docs/content/guides/functions/secrets.mdx
+++ b/apps/docs/content/guides/functions/secrets.mdx
@@ -12,7 +12,8 @@ Edge Functions have access to these secrets by default:
 - `SUPABASE_URL`: The API gateway for your Supabase project
 - `SUPABASE_DB_URL`: The URL for your Postgres database. You can use this to connect directly to your database
 - `SUPABASE_PUBLISHABLE_KEYS`: The `publishable` keys JSON dictionary for your Supabase API. This is safe to use in a browser when you have Row Level Security enabled
-- `SUPABASE_SECRET_KEYS`: The `secrets` keys JSON dictionary for your Supabase API. This is safe to use in Edge Functions, but it should NEVER be used in a browser. This key will bypass Row Level Security
+- `SUPABASE_SECRET_KEYS`: The `secret` keys JSON dictionary for your Supabase API. This is safe to use in Edge Functions, but it should NEVER be used in a browser. This key will bypass Row Level Security
+- `SUPABASE_JWKS`: The JSON Web Key Set used to verify user JWTs. Same value served at `https://<project-ref>.supabase.co/auth/v1/jwks`
 
 Legacy keys:
 


### PR DESCRIPTION
## Summary
- Add `SUPABASE_JWKS` to the default secrets list, noting it matches the public JWKS endpoint
- Update the example in "Accessing environment variables" to use `SUPABASE_PUBLISHABLE_KEYS` / `SUPABASE_SECRET_KEYS` (matches the pattern in `functions/auth.mdx`)
- Add an inline note that `'default'` can be swapped for another key name

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Edge Functions secrets guide with improved code examples.
  * Introduced `SUPABASE_JWKS` environment variable for JWT verification.
  * Enhanced examples demonstrating environment variable configuration and Supabase client initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->