### PR TITLE
feat: add rls testing playground with pglite

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
+.research
 .expo
 .next
 node_modules

--- a/apps/studio/components/interfaces/Auth/RLSPlayground/RLSPlayground.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSPlayground/RLSPlayground.tsx
@@ -539,7 +539,17 @@ export function RLSPlayground() {
                 <Admonition
                   type="warning"
                   title="No data in sandbox"
-                  description='Click "Seed data" to load data into the sandbox.'
+                  description="Load data into the sandbox to test your queries."
+                  actions={
+                    <Button
+                      type="default"
+                      size="tiny"
+                      icon={<Download size={12} />}
+                      onClick={() => setSeedModalOpen(true)}
+                    >
+                      Seed data
+                    </Button>
+                  }
                 />
               )}
 

--- a/apps/studio/components/interfaces/Auth/RLSPlayground/RLSPlayground.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSPlayground/RLSPlayground.tsx
@@ -1,0 +1,631 @@
+import { useMonaco } from '@monaco-editor/react'
+import { DatabaseZap, Download, Plus, RefreshCw, ShieldCheck, Sparkles } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { toast } from 'sonner'
+import { Button, cn, Modal, TextArea_Shadcn_ } from 'ui'
+import { Admonition } from 'ui-patterns'
+import { PageContainer } from 'ui-patterns/PageContainer'
+import {
+  PageHeader,
+  PageHeaderAside,
+  PageHeaderDescription,
+  PageHeaderMeta,
+  PageHeaderSummary,
+  PageHeaderTitle,
+} from 'ui-patterns/PageHeader'
+import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
+
+import { RLSTile } from './RLSTile'
+import { CodeEditor } from '@/components/ui/CodeEditor/CodeEditor'
+import getPgsqlCompletionProvider from '@/components/ui/CodeEditor/Providers/PgSQLCompletionProvider'
+import getPgsqlSignatureHelpProvider from '@/components/ui/CodeEditor/Providers/PgSQLSignatureHelpProvider'
+import { useGenerateSeedMutation } from '@/data/ai/generate-seed-mutation'
+import { useUsersInfiniteQuery } from '@/data/auth/users-infinite-query'
+import { useDatabaseFunctionsQuery } from '@/data/database-functions/database-functions-query'
+import { useKeywordsQuery } from '@/data/database/keywords-query'
+import { useSchemasQuery } from '@/data/database/schemas-query'
+import { useTableColumnsQuery } from '@/data/database/table-columns-query'
+import { useProjectSchemaDDLQuery } from '@/data/rls-sandbox/project-schema-ddl-query'
+import { useProjectSeedDataQuery } from '@/data/rls-sandbox/project-seed-data-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { getErrorMessage } from '@/lib/get-error-message'
+import type { TileConfig, TileResult } from '@/lib/rls-sandbox/sandbox-core'
+import { useSandbox } from '@/lib/rls-sandbox/SandboxProvider'
+
+const SEED_ROW_LIMIT = 100
+const DDL_SCHEMAS = ['public']
+
+export interface LocalTile {
+  id: string
+  role: TileConfig['role']
+  userId?: string
+  userEmail?: string
+}
+
+export function isAuthenticatedWithoutUser(tile: LocalTile): boolean {
+  return tile.role === 'authenticated' && (!tile.userId || !tile.userEmail)
+}
+
+function toTileConfig(tile: LocalTile): TileConfig {
+  if (tile.role !== 'authenticated') return { id: tile.id, role: tile.role }
+  if (tile.userId && tile.userEmail) {
+    return { id: tile.id, role: 'authenticated', userId: tile.userId, userEmail: tile.userEmail }
+  }
+  return { id: tile.id, role: 'anon' }
+}
+
+function makeTile(role: LocalTile['role'] = 'anon'): LocalTile {
+  return { id: crypto.randomUUID(), role }
+}
+
+type SyncStatus = 'idle' | 'syncing' | 'synced' | 'error'
+type SeedMode = 'import' | 'sql' | 'ai'
+
+export function RLSPlayground() {
+  const { status: sandboxStatus, core } = useSandbox()
+  const { data: project } = useSelectedProjectQuery()
+
+  const [tiles, setTiles] = useState<LocalTile[]>(() => [
+    makeTile('anon'),
+    makeTile('authenticated'),
+  ])
+  const [query, setQuery] = useState('select * from public.profiles limit 20')
+  const [results, setResults] = useState<Record<string, TileResult | null>>({})
+  const [loadingTiles, setLoadingTiles] = useState<Set<string>>(new Set())
+  const [policySQL, setPolicySQL] = useState(
+    '-- Write policy changes here, then click Apply\n-- e.g. DROP POLICY "profiles: public read" ON public.profiles;\n-- CREATE POLICY "profiles: owner only" ON public.profiles FOR SELECT USING (id = auth.uid());'
+  )
+  const [applyingPolicy, setApplyingPolicy] = useState(false)
+  const [runningQuery, setRunningQuery] = useState(false)
+  const [schemaSyncStatus, setSchemaSyncStatus] = useState<SyncStatus>('idle')
+  const [seedStatus, setSeedStatus] = useState<SyncStatus>('idle')
+
+  const [seedModalOpen, setSeedModalOpen] = useState(false)
+  const [seedMode, setSeedMode] = useState<SeedMode>('import')
+  const [customSeedSQL, setCustomSeedSQL] = useState(
+    "-- Write INSERT statements to populate the sandbox\n-- e.g. INSERT INTO public.profiles (id, username) VALUES (gen_random_uuid(), 'alice');"
+  )
+  const [aiSeedPrompt, setAiSeedPrompt] = useState('')
+  const [aiGeneratedSQL, setAiGeneratedSQL] = useState('')
+
+  const { mutate: generateSeed, isPending: generatingSeed } = useGenerateSeedMutation({
+    onSuccess: ({ sql }) => setAiGeneratedSQL(sql),
+  })
+
+  const { data: schemaDDL, refetch: refetchSchema } = useProjectSchemaDDLQuery(
+    { projectRef: project?.ref, connectionString: project?.connectionString, schemas: DDL_SCHEMAS },
+    { enabled: false }
+  )
+
+  const { refetch: refetchSeed } = useProjectSeedDataQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      tables: schemaDDL?.rlsStatuses ?? [],
+      rowLimit: SEED_ROW_LIMIT,
+    },
+    { enabled: false }
+  )
+
+  const { data: usersData } = useUsersInfiniteQuery(
+    { projectRef: project?.ref, connectionString: project?.connectionString },
+    { enabled: !!project?.ref }
+  )
+  const users = usersData?.pages.flatMap((p) => p.result) ?? []
+
+  // ── Postgres IntelliSense ──────────────────────────────────────────────────
+  const monaco = useMonaco()
+  const pgInfoRef = useRef<any>(null)
+
+  const { data: keywords, isSuccess: isKeywordsSuccess } = useKeywordsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+  const { data: dbFunctions, isSuccess: isFunctionsSuccess } = useDatabaseFunctionsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+  const { data: schemas, isSuccess: isSchemasSuccess } = useSchemasQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+  const { data: tableColumns, isSuccess: isTableColumnsSuccess } = useTableColumnsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
+  const isPgInfoReady =
+    isKeywordsSuccess && isFunctionsSuccess && isSchemasSuccess && isTableColumnsSuccess
+  if (isPgInfoReady) {
+    pgInfoRef.current ??= {}
+    pgInfoRef.current.keywords = keywords
+    pgInfoRef.current.functions = dbFunctions
+    pgInfoRef.current.schemas = schemas
+    pgInfoRef.current.tableColumns = tableColumns
+  }
+
+  useEffect(() => {
+    if (!monaco || !isPgInfoReady) return
+    const complete = monaco.languages.registerCompletionItemProvider(
+      'pgsql',
+      getPgsqlCompletionProvider(monaco, pgInfoRef)
+    )
+    const signature = monaco.languages.registerSignatureHelpProvider(
+      'pgsql',
+      getPgsqlSignatureHelpProvider(monaco, pgInfoRef)
+    )
+    return () => {
+      complete.dispose()
+      signature.dispose()
+    }
+  }, [isPgInfoReady, monaco])
+  // ──────────────────────────────────────────────────────────────────────────
+
+  const syncSchema = useCallback(async () => {
+    if (!core) return
+    setSchemaSyncStatus('syncing')
+    try {
+      const { data } = await refetchSchema()
+      if (!data) throw new Error('No schema data returned')
+      await core.setSchema(data)
+      setSchemaSyncStatus('synced')
+      toast.success('Schema synced into sandbox')
+    } catch (err) {
+      setSchemaSyncStatus('error')
+      toast.error(`Schema sync failed: ${getErrorMessage(err) ?? ''}`)
+    }
+  }, [core, refetchSchema])
+
+  const seedFromProject = useCallback(async () => {
+    if (!core) return
+    setSeedStatus('syncing')
+    try {
+      const { data } = await refetchSeed()
+      if (!data) throw new Error('No seed data returned')
+      await core.setSeed(data)
+      const total = data.reduce((sum, t) => sum + t.rows.length, 0)
+      setSeedStatus('synced')
+      toast.success(`Seeded ${total} rows across ${data.length} tables`)
+      setSeedModalOpen(false)
+    } catch (err) {
+      setSeedStatus('error')
+      toast.error(`Seed failed: ${getErrorMessage(err) ?? ''}`)
+    }
+  }, [core, refetchSeed])
+
+  const closeSeedModal = () => {
+    setSeedModalOpen(false)
+    setAiGeneratedSQL('')
+    setAiSeedPrompt('')
+  }
+
+  const applySeed = useCallback(
+    async (sql: string) => {
+      if (!core || !sql.trim()) return
+      setSeedStatus('syncing')
+      try {
+        await core.broadcastSql(sql)
+        setSeedStatus('synced')
+        toast.success('Seed applied to sandbox')
+        setSeedModalOpen(false)
+        setAiGeneratedSQL('')
+        setAiSeedPrompt('')
+      } catch (err) {
+        setSeedStatus('error')
+        toast.error(`Seed failed: ${getErrorMessage(err) ?? ''}`)
+      }
+    },
+    [core]
+  )
+
+  const handleGenerateSeed = () =>
+    generateSeed({
+      schema: [
+        ...(schemaDDL?.entityDefinitions ?? []),
+        ...(schemaDDL?.policies.length
+          ? [
+              '-- Row Level Security Policies',
+              ...schemaDDL.policies.map(
+                (p) => `-- "${p.name}" on ${p.schema}.${p.table} FOR ${p.command}`
+              ),
+            ]
+          : []),
+      ].join('\n\n'),
+      users: users.flatMap((u) => (u.id ? [{ id: u.id, email: u.email ?? u.id }] : [])),
+      prompt: aiSeedPrompt,
+    })
+
+  const applyPolicy = useCallback(async () => {
+    if (!core || !policySQL.trim()) return
+    setApplyingPolicy(true)
+    try {
+      await core.broadcastSql(policySQL)
+      toast.success('Policy applied to sandbox')
+    } catch (err) {
+      toast.error(`Policy apply failed: ${getErrorMessage(err) ?? ''}`)
+    } finally {
+      setApplyingPolicy(false)
+    }
+  }, [core, policySQL])
+
+  const runQuery = useCallback(async () => {
+    if (!core || !query.trim() || runningQuery) return
+    setRunningQuery(true)
+    setLoadingTiles(new Set(tiles.map((t) => t.id)))
+    setResults({})
+    try {
+      const all = await core.runAll(tiles.map(toTileConfig), query)
+      const next: Record<string, TileResult | null> = {}
+      for (const tile of tiles) {
+        if (all[tile.id] !== undefined) next[tile.id] = all[tile.id]
+      }
+      setResults(next)
+    } catch (err) {
+      toast.error(`Query failed: ${getErrorMessage(err) ?? ''}`)
+    } finally {
+      setRunningQuery(false)
+      setLoadingTiles(new Set())
+    }
+  }, [core, tiles, query, runningQuery])
+
+  const addTile = () => setTiles((prev) => [...prev, makeTile('anon')])
+
+  const removeTile = (id: string) => {
+    setTiles((prev) => prev.filter((t) => t.id !== id))
+    setResults((prev) => {
+      const next = { ...prev }
+      delete next[id]
+      return next
+    })
+  }
+
+  const updateTileRole = (id: string, role: LocalTile['role']) => {
+    setTiles((prev) =>
+      prev.map((t) =>
+        t.id === id ? { id: t.id, role, userId: undefined, userEmail: undefined } : t
+      )
+    )
+  }
+
+  const updateTileUser = (id: string, userId: string, userEmail: string) => {
+    setTiles((prev) =>
+      prev.map((t) =>
+        t.id === id ? { ...t, role: 'authenticated' as const, userId, userEmail } : t
+      )
+    )
+  }
+
+  const isSandboxReady = sandboxStatus === 'ready'
+
+  useEffect(() => {
+    if (isSandboxReady && schemaSyncStatus === 'idle') {
+      syncSchema()
+    }
+  }, [isSandboxReady, schemaSyncStatus, syncSchema])
+
+  return (
+    <>
+      <PageHeader size="large">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>RLS Playground</PageHeaderTitle>
+            <PageHeaderDescription>
+              Test your Row Level Security policies against real data — entirely in your browser
+            </PageHeaderDescription>
+          </PageHeaderSummary>
+          <PageHeaderAside>
+            <Button
+              type="default"
+              icon={
+                <Download size={14} className={seedStatus === 'syncing' ? 'animate-pulse' : ''} />
+              }
+              disabled={
+                !isSandboxReady || schemaSyncStatus !== 'synced' || seedStatus === 'syncing'
+              }
+              onClick={() => setSeedModalOpen(true)}
+            >
+              {seedStatus === 'synced' ? 'Re-seed data' : 'Seed data'}
+            </Button>
+            <Button
+              type="default"
+              icon={
+                <RefreshCw
+                  size={14}
+                  className={schemaSyncStatus === 'syncing' ? 'animate-spin' : ''}
+                />
+              }
+              disabled={!isSandboxReady || schemaSyncStatus === 'syncing'}
+              onClick={syncSchema}
+            >
+              {schemaSyncStatus === 'synced' ? 'Re-sync schema' : 'Sync schema'}
+            </Button>
+          </PageHeaderAside>
+        </PageHeaderMeta>
+      </PageHeader>
+
+      <Modal
+        visible={seedModalOpen}
+        onCancel={closeSeedModal}
+        header="Seed sandbox data"
+        size="large"
+        hideFooter
+      >
+        <Modal.Content className="flex flex-col gap-4 py-4">
+          <div className="flex gap-2">
+            {(
+              [
+                {
+                  id: 'import',
+                  title: 'Import from project',
+                  description: `Sample up to ${SEED_ROW_LIMIT} rows per table from your real project`,
+                },
+                {
+                  id: 'sql',
+                  title: 'Custom SQL',
+                  description: 'Write INSERT statements to populate the sandbox manually',
+                },
+                {
+                  id: 'ai',
+                  title: 'Generate with AI',
+                  description: 'Let AI create meaningful test data from your schema',
+                  icon: <Sparkles size={12} />,
+                },
+              ] as const
+            ).map(({ id, title, description, icon }) => (
+              <button
+                key={id}
+                onClick={() => setSeedMode(id)}
+                className={cn(
+                  'flex-1 rounded-md border px-3 py-2 text-sm text-left transition-colors',
+                  seedMode === id
+                    ? 'border-foreground bg-surface-200'
+                    : 'border-border hover:border-foreground-muted'
+                )}
+              >
+                <p className="font-medium flex items-center gap-1.5">
+                  {icon}
+                  {title}
+                </p>
+                <p className="text-foreground-lighter text-xs mt-0.5">{description}</p>
+              </button>
+            ))}
+          </div>
+
+          {seedMode === 'import' && (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-foreground-light">
+                Fetches rows from each table in the{' '}
+                <code className="text-xs bg-surface-300 px-1 py-0.5 rounded">public</code> schema of
+                your project and loads them into the sandbox.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button type="default" onClick={closeSeedModal}>
+                  Cancel
+                </Button>
+                <Button type="primary" loading={seedStatus === 'syncing'} onClick={seedFromProject}>
+                  Import from project
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {seedMode === 'sql' && (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-foreground-light">
+                SQL runs as the postgres superuser directly against the sandbox.
+              </p>
+              <div className="h-56 rounded border overflow-hidden">
+                <CodeEditor
+                  id="rls-playground-custom-seed"
+                  language="pgsql"
+                  value={customSeedSQL}
+                  onInputChange={(val) => setCustomSeedSQL(val ?? '')}
+                  actions={{
+                    runQuery: {
+                      enabled: isSandboxReady,
+                      callback: () => applySeed(customSeedSQL),
+                    },
+                  }}
+                />
+              </div>
+              <div className="flex justify-end gap-2">
+                <Button type="default" onClick={closeSeedModal}>
+                  Cancel
+                </Button>
+                <Button
+                  type="primary"
+                  loading={seedStatus === 'syncing'}
+                  disabled={!customSeedSQL.trim() || seedStatus === 'syncing'}
+                  onClick={() => applySeed(customSeedSQL)}
+                >
+                  Apply SQL
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {seedMode === 'ai' && (
+            <div className="flex flex-col gap-3">
+              <p className="text-sm text-foreground-light">
+                AI reads your table schema and RLS policies to generate INSERT statements. Only the
+                schema DDL is sent — no actual data from your database.
+              </p>
+              {schemaSyncStatus !== 'synced' && (
+                <Admonition
+                  type="warning"
+                  title="Schema not synced"
+                  description="Sync your schema first so the AI can read your table structure."
+                />
+              )}
+              <TextArea_Shadcn_
+                value={aiSeedPrompt}
+                onChange={(e) => setAiSeedPrompt(e.target.value)}
+                placeholder="Describe what you need (optional) — e.g. '3 organisations, 10 users across different roles, tasks assigned to multiple users'"
+                rows={3}
+                className="text-sm resize-none"
+              />
+              {aiGeneratedSQL && (
+                <div className="h-56 rounded border overflow-hidden">
+                  <CodeEditor
+                    id="rls-playground-ai-seed"
+                    language="pgsql"
+                    value={aiGeneratedSQL}
+                    onInputChange={(val) => setAiGeneratedSQL(val ?? '')}
+                    actions={{
+                      runQuery: {
+                        enabled: isSandboxReady,
+                        callback: () => applySeed(aiGeneratedSQL),
+                      },
+                    }}
+                  />
+                </div>
+              )}
+              <div className="flex justify-end gap-2">
+                <Button type="default" onClick={closeSeedModal}>
+                  Cancel
+                </Button>
+                <Button
+                  type="default"
+                  icon={<Sparkles size={14} />}
+                  loading={generatingSeed}
+                  disabled={schemaSyncStatus !== 'synced' || generatingSeed}
+                  onClick={handleGenerateSeed}
+                >
+                  {aiGeneratedSQL ? 'Regenerate' : 'Generate'}
+                </Button>
+                {aiGeneratedSQL && (
+                  <Button
+                    type="primary"
+                    loading={seedStatus === 'syncing'}
+                    disabled={seedStatus === 'syncing'}
+                    onClick={() => applySeed(aiGeneratedSQL)}
+                  >
+                    Apply SQL
+                  </Button>
+                )}
+              </div>
+            </div>
+          )}
+        </Modal.Content>
+      </Modal>
+
+      <PageContainer size="large">
+        <PageSection>
+          <PageSectionContent>
+            <div className="flex flex-col gap-6">
+              <Admonition
+                type="default"
+                title="Client-side sandbox — your database is never modified"
+                description="Your schema and a sample of your data are loaded into a Postgres instance running entirely in this browser tab via WebAssembly. No queries reach your real database."
+              />
+
+              {sandboxStatus === 'booting' && (
+                <Admonition
+                  type="default"
+                  title="Starting sandbox…"
+                  description="Loading Postgres into your browser."
+                />
+              )}
+
+              {sandboxStatus === 'error' && (
+                <Admonition
+                  type="destructive"
+                  title="Sandbox failed to start"
+                  description="Try refreshing the page."
+                />
+              )}
+
+              {schemaSyncStatus === 'synced' && seedStatus === 'idle' && (
+                <Admonition
+                  type="warning"
+                  title="No data in sandbox"
+                  description='Click "Seed data" to load data into the sandbox.'
+                />
+              )}
+
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium">Policy</p>
+                  <Button
+                    type="default"
+                    icon={<ShieldCheck size={14} />}
+                    loading={applyingPolicy}
+                    disabled={!isSandboxReady || schemaSyncStatus !== 'synced' || applyingPolicy}
+                    onClick={applyPolicy}
+                  >
+                    Apply policy
+                  </Button>
+                </div>
+                <div className="h-32 rounded border overflow-hidden">
+                  <CodeEditor
+                    id="rls-playground-policy"
+                    language="pgsql"
+                    value={policySQL}
+                    onInputChange={(val) => setPolicySQL(val ?? '')}
+                    actions={{
+                      runQuery: {
+                        enabled: isSandboxReady && schemaSyncStatus === 'synced',
+                        callback: applyPolicy,
+                      },
+                    }}
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium">Query</p>
+                  <Button
+                    type="primary"
+                    icon={<DatabaseZap size={14} />}
+                    loading={runningQuery}
+                    disabled={!isSandboxReady || schemaSyncStatus !== 'synced' || runningQuery}
+                    onClick={runQuery}
+                  >
+                    Run query
+                  </Button>
+                </div>
+                <div className="h-32 rounded border overflow-hidden">
+                  <CodeEditor
+                    id="rls-playground-query"
+                    language="pgsql"
+                    value={query}
+                    onInputChange={(val) => setQuery(val ?? '')}
+                    actions={{
+                      runQuery: {
+                        enabled: isSandboxReady && schemaSyncStatus === 'synced',
+                        callback: runQuery,
+                      },
+                    }}
+                  />
+                </div>
+              </div>
+
+              <div className="flex flex-col gap-3">
+                {tiles.map((tile) => (
+                  <RLSTile
+                    key={tile.id}
+                    tile={tile}
+                    result={results[tile.id] ?? null}
+                    isLoading={loadingTiles.has(tile.id)}
+                    users={users}
+                    onChangeRole={updateTileRole}
+                    onChangeUser={updateTileUser}
+                    onRemove={removeTile}
+                  />
+                ))}
+                <button
+                  onClick={addTile}
+                  className="flex items-center justify-center gap-2 border border-dashed rounded-lg text-foreground-lighter hover:text-foreground hover:border-foreground-light transition-colors py-3"
+                >
+                  <Plus size={14} />
+                  <span className="text-xs">Add tile</span>
+                </button>
+              </div>
+            </div>
+          </PageSectionContent>
+        </PageSection>
+      </PageContainer>
+    </>
+  )
+}

--- a/apps/studio/components/interfaces/Auth/RLSPlayground/RLSPlayground.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSPlayground/RLSPlayground.tsx
@@ -1,6 +1,6 @@
 import { useMonaco } from '@monaco-editor/react'
 import { DatabaseZap, Download, Plus, RefreshCw, ShieldCheck, Sparkles } from 'lucide-react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Button, cn, Modal, TextArea_Shadcn_ } from 'ui'
 import { Admonition } from 'ui-patterns'
@@ -28,12 +28,12 @@ import { useTableColumnsQuery } from '@/data/database/table-columns-query'
 import { useProjectSchemaDDLQuery } from '@/data/rls-sandbox/project-schema-ddl-query'
 import { useProjectSeedDataQuery } from '@/data/rls-sandbox/project-seed-data-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 import { getErrorMessage } from '@/lib/get-error-message'
 import type { TileConfig, TileResult } from '@/lib/rls-sandbox/sandbox-core'
 import { useSandbox } from '@/lib/rls-sandbox/SandboxProvider'
 
 const SEED_ROW_LIMIT = 100
-const DDL_SCHEMAS = ['public']
 
 export interface LocalTile {
   id: string
@@ -92,28 +92,12 @@ export function RLSPlayground() {
     onSuccess: ({ sql }) => setAiGeneratedSQL(sql),
   })
 
-  const { data: schemaDDL, refetch: refetchSchema } = useProjectSchemaDDLQuery(
-    { projectRef: project?.ref, connectionString: project?.connectionString, schemas: DDL_SCHEMAS },
-    { enabled: false }
-  )
-
-  const { refetch: refetchSeed } = useProjectSeedDataQuery(
-    {
-      projectRef: project?.ref,
-      connectionString: project?.connectionString,
-      tables: schemaDDL?.rlsStatuses ?? [],
-      rowLimit: SEED_ROW_LIMIT,
-    },
-    { enabled: false }
-  )
-
   const { data: usersData } = useUsersInfiniteQuery(
     { projectRef: project?.ref, connectionString: project?.connectionString },
     { enabled: !!project?.ref }
   )
   const users = usersData?.pages.flatMap((p) => p.result) ?? []
 
-  // ── Postgres IntelliSense ──────────────────────────────────────────────────
   const monaco = useMonaco()
   const pgInfoRef = useRef<any>(null)
 
@@ -133,6 +117,23 @@ export function RLSPlayground() {
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+
+  const ddlSchemas = useMemo(() => schemas?.map((s) => s.name) ?? [], [schemas])
+
+  const { data: schemaDDL, refetch: refetchSchema } = useProjectSchemaDDLQuery(
+    { projectRef: project?.ref, connectionString: project?.connectionString, schemas: ddlSchemas },
+    { enabled: false }
+  )
+
+  const { refetch: refetchSeed } = useProjectSeedDataQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      tables: schemaDDL?.rlsStatuses ?? [],
+      rowLimit: SEED_ROW_LIMIT,
+    },
+    { enabled: false }
+  )
 
   const isPgInfoReady =
     isKeywordsSuccess && isFunctionsSuccess && isSchemasSuccess && isTableColumnsSuccess
@@ -161,8 +162,11 @@ export function RLSPlayground() {
   }, [isPgInfoReady, monaco])
   // ──────────────────────────────────────────────────────────────────────────
 
+  const syncInProgress = useRef(false)
+
   const syncSchema = useCallback(async () => {
-    if (!core) return
+    if (!core || syncInProgress.current) return
+    syncInProgress.current = true
     setSchemaSyncStatus('syncing')
     try {
       const { data } = await refetchSchema()
@@ -173,8 +177,12 @@ export function RLSPlayground() {
     } catch (err) {
       setSchemaSyncStatus('error')
       toast.error(`Schema sync failed: ${getErrorMessage(err) ?? ''}`)
+    } finally {
+      syncInProgress.current = false
     }
   }, [core, refetchSchema])
+
+  const onAutoSync = useStaticEffectEvent(syncSchema)
 
   const seedFromProject = useCallback(async () => {
     if (!core) return
@@ -298,10 +306,10 @@ export function RLSPlayground() {
   const isSandboxReady = sandboxStatus === 'ready'
 
   useEffect(() => {
-    if (isSandboxReady && schemaSyncStatus === 'idle') {
-      syncSchema()
+    if (isSandboxReady && ddlSchemas.length > 0 && schemaSyncStatus === 'idle') {
+      onAutoSync()
     }
-  }, [isSandboxReady, schemaSyncStatus, syncSchema])
+  }, [isSandboxReady, ddlSchemas.length, schemaSyncStatus, onAutoSync])
 
   return (
     <>

--- a/apps/studio/components/interfaces/Auth/RLSPlayground/RLSTile.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSPlayground/RLSTile.tsx
@@ -1,0 +1,178 @@
+import { X } from 'lucide-react'
+import {
+  Button,
+  cn,
+  Select_Shadcn_,
+  SelectContent_Shadcn_,
+  SelectItem_Shadcn_,
+  SelectTrigger_Shadcn_,
+  SelectValue_Shadcn_,
+} from 'ui'
+import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+
+import { isAuthenticatedWithoutUser, type LocalTile } from './RLSPlayground'
+import type { User } from '@/data/auth/users-infinite-query'
+import type { TileResult } from '@/lib/rls-sandbox/sandbox-core'
+
+function roleLabelFor(tile: LocalTile): string {
+  switch (tile.role) {
+    case 'anon':
+      return 'Anonymous'
+    case 'service_role':
+      return 'Service role'
+    case 'authenticated':
+      return tile.userEmail || 'Authenticated'
+  }
+}
+
+interface RLSTileProps {
+  tile: LocalTile
+  result: TileResult | null
+  isLoading: boolean
+  users: User[]
+  onChangeRole: (tileId: string, role: LocalTile['role']) => void
+  onChangeUser: (tileId: string, userId: string, userEmail: string) => void
+  onRemove: (tileId: string) => void
+}
+
+export function RLSTile({
+  tile,
+  result,
+  isLoading,
+  users,
+  onChangeRole,
+  onChangeUser,
+  onRemove,
+}: RLSTileProps) {
+  const columns = result?.rows?.[0] ? Object.keys(result.rows[0]) : []
+
+  return (
+    <div className="flex flex-col border rounded-lg overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-2 px-3 py-2 bg-surface-100 border-b">
+        <Select_Shadcn_
+          value={tile.role}
+          onValueChange={(v) => onChangeRole(tile.id, v as LocalTile['role'])}
+        >
+          <SelectTrigger_Shadcn_ size="tiny" className="w-36 shrink-0">
+            <SelectValue_Shadcn_ />
+          </SelectTrigger_Shadcn_>
+          <SelectContent_Shadcn_>
+            <SelectItem_Shadcn_ value="anon">Anonymous</SelectItem_Shadcn_>
+            <SelectItem_Shadcn_ value="authenticated">Authenticated</SelectItem_Shadcn_>
+            <SelectItem_Shadcn_ value="service_role">Service role</SelectItem_Shadcn_>
+          </SelectContent_Shadcn_>
+        </Select_Shadcn_>
+
+        {tile.role === 'authenticated' && (
+          <Select_Shadcn_
+            value={tile.userId ?? ''}
+            onValueChange={(userId) => {
+              const user = users.find((u) => u.id === userId)
+              if (user?.id) onChangeUser(tile.id, user.id, user.email ?? user.id)
+            }}
+          >
+            <SelectTrigger_Shadcn_ size="tiny" className="w-56 shrink-0">
+              <SelectValue_Shadcn_ placeholder="Pick a user to impersonate…" />
+            </SelectTrigger_Shadcn_>
+            <SelectContent_Shadcn_>
+              {users.length === 0 && (
+                <SelectItem_Shadcn_ value="__none__" disabled>
+                  No users found
+                </SelectItem_Shadcn_>
+              )}
+              {users
+                .flatMap((u) => (u.id ? [{ id: u.id, email: u.email }] : []))
+                .map((u) => (
+                  <SelectItem_Shadcn_ key={u.id} value={u.id}>
+                    {u.email ?? u.id}
+                  </SelectItem_Shadcn_>
+                ))}
+            </SelectContent_Shadcn_>
+          </Select_Shadcn_>
+        )}
+
+        <div className="flex-1 min-w-0">
+          {isAuthenticatedWithoutUser(tile) ? (
+            <span className="text-xs text-warning truncate">No user selected — runs as anon</span>
+          ) : result && !result.error ? (
+            <span className="text-xs text-foreground-lighter">
+              {result.rows.length} row{result.rows.length === 1 ? '' : 's'}
+            </span>
+          ) : result?.error ? (
+            <span className="text-xs text-destructive truncate">{result.error}</span>
+          ) : null}
+        </div>
+
+        <span className="text-xs text-foreground-lighter shrink-0 hidden sm:block">
+          {roleLabelFor(tile)}
+        </span>
+
+        <Button
+          type="text"
+          icon={<X size={12} />}
+          className="px-1 shrink-0"
+          onClick={() => onRemove(tile.id)}
+        />
+      </div>
+
+      {/* Results */}
+      <div className="overflow-auto max-h-64">
+        {isLoading ? (
+          <div className="p-3">
+            <GenericSkeletonLoader />
+          </div>
+        ) : result === null ? (
+          <div className="flex items-center justify-center h-16 text-foreground-lighter text-sm">
+            Run a query to see results
+          </div>
+        ) : result.error ? (
+          <div className="p-3 text-sm text-destructive font-mono whitespace-pre-wrap">
+            {result.error}
+          </div>
+        ) : result.rows.length === 0 ? (
+          <div className="flex items-center justify-center h-16 text-foreground-lighter text-sm">
+            0 rows — blocked by RLS
+          </div>
+        ) : (
+          <table className="w-full text-xs">
+            <thead className="bg-surface-100 sticky top-0">
+              <tr>
+                {columns.map((col) => (
+                  <th
+                    key={col}
+                    className="px-3 py-1.5 text-left font-medium text-foreground-light border-b whitespace-nowrap"
+                  >
+                    {col}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {result.rows.map((row, i) => (
+                <tr
+                  key={i}
+                  className={cn('border-b last:border-0', i % 2 === 0 ? '' : 'bg-surface-100/50')}
+                >
+                  {columns.map((col) => (
+                    <td
+                      key={col}
+                      className="px-3 py-1.5 text-foreground font-mono max-w-[240px] truncate"
+                      title={String(row[col] ?? '')}
+                    >
+                      {row[col] === null ? (
+                        <span className="text-foreground-lighter italic">null</span>
+                      ) : (
+                        String(row[col])
+                      )}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
+++ b/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
@@ -73,6 +73,13 @@ export function generateAuthMenu(options: GenerateAuthMenuOptions): ProductMenuG
           url: `${baseUrl}/policies`,
           items: [],
         },
+        {
+          name: 'RLS Playground',
+          key: 'rls-playground',
+          url: `${baseUrl}/rls-playground`,
+          items: [],
+          label: 'Beta',
+        },
         ...(isPlatform
           ? [
               ...(features.signInProviders

--- a/apps/studio/csp.ts
+++ b/apps/studio/csp.ts
@@ -192,8 +192,29 @@ export function getCSP() {
 
   const workerSrcDirective = [`worker-src 'self'`, `blob:`, `data:`].join(' ')
 
+  const connectSrcDirective = [
+    `connect-src 'self'`,
+    `data:`,
+    `blob:`,
+    ...DEFAULT_SRC_URLS,
+    ...(isDevOrStaging
+      ? [
+          SUPABASE_STAGING_PROJECTS_URL,
+          SUPABASE_STAGING_PROJECTS_URL_WS,
+          NIMBUS_STAGING_PROJECTS_URL,
+          NIMBUS_STAGING_PROJECTS_URL_WS,
+          VERCEL_LIVE_URL,
+          SUPABASE_DOCS_PROJECT_URL,
+          SUPABASE_CONTENT_API_URL,
+        ]
+      : []),
+    PUSHER_URL_WS,
+    SENTRY_URL,
+  ].join(' ')
+
   const cspDirectives = [
     defaultSrcDirective,
+    connectSrcDirective,
     imgSrcDirective,
     scriptSrcDirective,
     frameSrcDirective,

--- a/apps/studio/data/ai/generate-seed-mutation.ts
+++ b/apps/studio/data/ai/generate-seed-mutation.ts
@@ -1,0 +1,58 @@
+import { useMutation } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { constructHeaders, fetchHandler } from '@/data/fetchers'
+import { BASE_PATH } from '@/lib/constants'
+import { ResponseError, UseCustomMutationOptions } from '@/types'
+
+export type GenerateSeedVariables = {
+  schema: string
+  users: Array<{ id: string; email: string }>
+  prompt?: string
+}
+
+export type GenerateSeedResponse = {
+  sql: string
+}
+
+export async function generateSeed({ schema, users, prompt }: GenerateSeedVariables) {
+  const url = `${BASE_PATH}/api/ai/sql/generate-seed`
+  const headers = await constructHeaders({ 'Content-Type': 'application/json' })
+  const response = await fetchHandler(url, {
+    headers,
+    method: 'POST',
+    body: JSON.stringify({ schema, users, prompt }),
+  })
+  let body: any
+  try {
+    body = await response.json()
+  } catch {}
+  if (!response.ok) throw new ResponseError(body?.error ?? body?.message, response.status)
+  return body as GenerateSeedResponse
+}
+
+type GenerateSeedData = Awaited<ReturnType<typeof generateSeed>>
+
+export const useGenerateSeedMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseCustomMutationOptions<GenerateSeedData, ResponseError, GenerateSeedVariables>,
+  'mutationFn'
+> = {}) => {
+  return useMutation<GenerateSeedData, ResponseError, GenerateSeedVariables>({
+    mutationFn: (vars) => generateSeed(vars),
+    async onSuccess(data, variables, context) {
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(data, variables, context) {
+      if (onError === undefined) {
+        toast.error(`Failed to generate seed data: ${data.message}`)
+      } else {
+        await onError(data, variables, context)
+      }
+    },
+    ...options,
+  })
+}

--- a/apps/studio/data/rls-sandbox/project-schema-ddl-query.ts
+++ b/apps/studio/data/rls-sandbox/project-schema-ddl-query.ts
@@ -4,6 +4,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { getDatabasePolicies } from '@/data/database-policies/database-policies-query'
 import { executeSql } from '@/data/sql/execute-sql-query'
+import { quoteLiteral } from '@/lib/pg-format'
 import type { UseCustomQueryOptions } from '@/types'
 
 export interface RlsTableStatus {
@@ -18,6 +19,7 @@ export interface CustomRole {
 }
 
 export interface ProjectSchemaDDL {
+  typeDefinitions: string[]
   entityDefinitions: string[]
   functionDefinitions: string[]
   policies: PostgresPolicy[]
@@ -51,21 +53,56 @@ const SYSTEM_ROLES = [
 const CUSTOM_ROLES_SQL = `
   SELECT rolname AS name
   FROM pg_roles
-  WHERE rolname NOT IN (${SYSTEM_ROLES.map((r) => `'${r}'`).join(',')})
+  WHERE rolname NOT IN (${SYSTEM_ROLES.map(quoteLiteral).join(',')})
     AND rolname NOT LIKE 'pg_%'
     AND rolname NOT LIKE 'supabase_%'
   ORDER BY rolname
 `
 
+function toSqlList(schemas: string[]) {
+  return schemas.map(quoteLiteral).join(', ')
+}
+
+function getTypeDefinitionsSql(schemas: string[]) {
+  return `
+    SELECT
+      CASE t.typtype
+        WHEN 'e' THEN
+          'CREATE TYPE ' || quote_ident(n.nspname) || '.' || quote_ident(t.typname) ||
+          ' AS ENUM (' ||
+          (SELECT string_agg(quote_literal(e.enumlabel), ', ' ORDER BY e.enumsortorder)
+           FROM pg_enum e WHERE e.enumtypid = t.oid) ||
+          ')'
+        WHEN 'c' THEN
+          'CREATE TYPE ' || quote_ident(n.nspname) || '.' || quote_ident(t.typname) ||
+          ' AS (' ||
+          (SELECT string_agg(quote_ident(a.attname) || ' ' || pg_catalog.format_type(a.atttypid, a.atttypmod), ', ' ORDER BY a.attnum)
+           FROM pg_attribute a WHERE a.attrelid = t.typrelid AND a.attnum > 0 AND NOT a.attisdropped) ||
+          ')'
+        WHEN 'd' THEN
+          'CREATE DOMAIN ' || quote_ident(n.nspname) || '.' || quote_ident(t.typname) ||
+          ' AS ' || pg_catalog.format_type(t.typbasetype, t.typtypmod)
+      END AS definition
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    LEFT JOIN pg_class c ON c.oid = t.typrelid
+    LEFT JOIN pg_depend d ON d.objid = t.oid AND d.deptype = 'e'
+    WHERE n.nspname IN (${toSqlList(schemas)})
+      AND t.typtype IN ('e', 'c', 'd')
+      AND d.objid IS NULL
+      AND (t.typtype != 'c' OR c.relkind = 'c')
+    ORDER BY t.typtype, n.nspname, t.typname
+  `
+}
+
 function getFunctionDefinitionsSql(schemas: string[]) {
-  const list = schemas.map((s) => `'${s}'`).join(', ')
   return `
     SELECT pg_get_functiondef(p.oid) AS definition
     FROM pg_proc p
     JOIN pg_namespace n ON n.oid = p.pronamespace
     JOIN pg_language l ON l.oid = p.prolang
     LEFT JOIN pg_depend d ON d.objid = p.oid AND d.deptype = 'e'
-    WHERE n.nspname IN (${list})
+    WHERE n.nspname IN (${toSqlList(schemas)})
       AND p.prokind = 'f'
       AND l.lanname IN ('sql', 'plpgsql')
       AND p.prorettype <> 'pg_catalog.trigger'::regtype
@@ -75,7 +112,6 @@ function getFunctionDefinitionsSql(schemas: string[]) {
 }
 
 function getRlsStatusSql(schemas: string[]) {
-  const list = schemas.map((s) => `'${s}'`).join(', ')
   return `
     SELECT
       n.nspname AS schema,
@@ -85,7 +121,7 @@ function getRlsStatusSql(schemas: string[]) {
     FROM pg_class c
     JOIN pg_namespace n ON c.relnamespace = n.oid
     WHERE c.relkind = 'r'
-      AND n.nspname IN (${list})
+      AND n.nspname IN (${toSqlList(schemas)})
     ORDER BY n.nspname, c.relname
   `
 }
@@ -102,8 +138,8 @@ async function getProjectSchemaDDL(
 ): Promise<ProjectSchemaDDL> {
   const entitySql = getEntityDefinitionsSql({ schemas })
 
-  const [entityResult, policiesResult, rlsResult, rolesResult, functionsResult] = await Promise.all(
-    [
+  const [entityResult, policiesResult, rlsResult, rolesResult, functionsResult, typesResult] =
+    await Promise.all([
       executeSql(
         { projectRef, connectionString, sql: entitySql, queryKey: ['rls-sandbox-ddl'] },
         signal
@@ -131,10 +167,19 @@ async function getProjectSchemaDDL(
         },
         signal
       ),
-    ]
-  )
+      executeSql(
+        {
+          projectRef,
+          connectionString,
+          sql: getTypeDefinitionsSql(schemas),
+          queryKey: ['rls-sandbox-types'],
+        },
+        signal
+      ),
+    ])
 
   return {
+    typeDefinitions: (typesResult.result as { definition: string }[]).map((r) => r.definition),
     entityDefinitions: (entityResult.result[0]?.data?.definitions ?? []).map(
       (d: { sql: string }) => d.sql
     ),
@@ -155,7 +200,7 @@ export const useProjectSchemaDDLQuery = <TData = ProjectSchemaDDLData>(
   options: UseCustomQueryOptions<ProjectSchemaDDLData, ProjectSchemaDDLError, TData> = {}
 ) =>
   useQuery<ProjectSchemaDDLData, ProjectSchemaDDLError, TData>({
-    queryKey: ['rls-sandbox', 'schema', projectRef, schemas],
+    queryKey: ['rls-sandbox', 'schema', projectRef, [...schemas].sort().join(',')],
     queryFn: ({ signal }) => getProjectSchemaDDL({ projectRef, connectionString, schemas }, signal),
     enabled: options.enabled !== false && !!projectRef && schemas.length > 0,
     staleTime: 5 * 60 * 1000,

--- a/apps/studio/data/rls-sandbox/project-schema-ddl-query.ts
+++ b/apps/studio/data/rls-sandbox/project-schema-ddl-query.ts
@@ -1,0 +1,163 @@
+import { getEntityDefinitionsSql } from '@supabase/pg-meta'
+import type { PostgresPolicy } from '@supabase/postgres-meta'
+import { useQuery } from '@tanstack/react-query'
+
+import { getDatabasePolicies } from '@/data/database-policies/database-policies-query'
+import { executeSql } from '@/data/sql/execute-sql-query'
+import type { UseCustomQueryOptions } from '@/types'
+
+export interface RlsTableStatus {
+  schema: string
+  table: string
+  rls_enabled: boolean
+  rls_forced: boolean
+}
+
+export interface CustomRole {
+  name: string
+}
+
+export interface ProjectSchemaDDL {
+  entityDefinitions: string[]
+  functionDefinitions: string[]
+  policies: PostgresPolicy[]
+  rlsStatuses: RlsTableStatus[]
+  customRoles: CustomRole[]
+}
+
+const SYSTEM_ROLES = [
+  'postgres',
+  'anon',
+  'authenticated',
+  'service_role',
+  'supabase_admin',
+  'supabase_auth_admin',
+  'supabase_storage_admin',
+  'supabase_replication_admin',
+  'supabase_read_only_user',
+  'pg_monitor',
+  'pg_read_all_settings',
+  'pg_read_all_stats',
+  'pg_stat_scan_tables',
+  'pg_read_server_files',
+  'pg_write_server_files',
+  'pg_execute_server_program',
+  'pg_signal_backend',
+  'dashboard_user',
+  'pgbouncer',
+  'authenticator',
+]
+
+const CUSTOM_ROLES_SQL = `
+  SELECT rolname AS name
+  FROM pg_roles
+  WHERE rolname NOT IN (${SYSTEM_ROLES.map((r) => `'${r}'`).join(',')})
+    AND rolname NOT LIKE 'pg_%'
+    AND rolname NOT LIKE 'supabase_%'
+  ORDER BY rolname
+`
+
+function getFunctionDefinitionsSql(schemas: string[]) {
+  const list = schemas.map((s) => `'${s}'`).join(', ')
+  return `
+    SELECT pg_get_functiondef(p.oid) AS definition
+    FROM pg_proc p
+    JOIN pg_namespace n ON n.oid = p.pronamespace
+    JOIN pg_language l ON l.oid = p.prolang
+    LEFT JOIN pg_depend d ON d.objid = p.oid AND d.deptype = 'e'
+    WHERE n.nspname IN (${list})
+      AND p.prokind = 'f'
+      AND l.lanname IN ('sql', 'plpgsql')
+      AND p.prorettype <> 'pg_catalog.trigger'::regtype
+      AND d.objid IS NULL
+    ORDER BY n.nspname, p.proname
+  `
+}
+
+function getRlsStatusSql(schemas: string[]) {
+  const list = schemas.map((s) => `'${s}'`).join(', ')
+  return `
+    SELECT
+      n.nspname AS schema,
+      c.relname AS table,
+      c.relrowsecurity AS rls_enabled,
+      c.relforcerowsecurity AS rls_forced
+    FROM pg_class c
+    JOIN pg_namespace n ON c.relnamespace = n.oid
+    WHERE c.relkind = 'r'
+      AND n.nspname IN (${list})
+    ORDER BY n.nspname, c.relname
+  `
+}
+
+type Variables = {
+  projectRef?: string
+  connectionString?: string | null
+  schemas: string[]
+}
+
+async function getProjectSchemaDDL(
+  { projectRef, connectionString, schemas }: Variables,
+  signal?: AbortSignal
+): Promise<ProjectSchemaDDL> {
+  const entitySql = getEntityDefinitionsSql({ schemas })
+
+  const [entityResult, policiesResult, rlsResult, rolesResult, functionsResult] = await Promise.all(
+    [
+      executeSql(
+        { projectRef, connectionString, sql: entitySql, queryKey: ['rls-sandbox-ddl'] },
+        signal
+      ),
+      getDatabasePolicies({ projectRef, connectionString }, signal),
+      executeSql(
+        {
+          projectRef,
+          connectionString,
+          sql: getRlsStatusSql(schemas),
+          queryKey: ['rls-sandbox-rls'],
+        },
+        signal
+      ),
+      executeSql(
+        { projectRef, connectionString, sql: CUSTOM_ROLES_SQL, queryKey: ['rls-sandbox-roles'] },
+        signal
+      ),
+      executeSql(
+        {
+          projectRef,
+          connectionString,
+          sql: getFunctionDefinitionsSql(schemas),
+          queryKey: ['rls-sandbox-functions'],
+        },
+        signal
+      ),
+    ]
+  )
+
+  return {
+    entityDefinitions: (entityResult.result[0]?.data?.definitions ?? []).map(
+      (d: { sql: string }) => d.sql
+    ),
+    functionDefinitions: (functionsResult.result as { definition: string }[]).map(
+      (r) => r.definition
+    ),
+    policies: (policiesResult ?? []) as PostgresPolicy[],
+    rlsStatuses: rlsResult.result as RlsTableStatus[],
+    customRoles: rolesResult.result as CustomRole[],
+  }
+}
+
+export type ProjectSchemaDDLData = Awaited<ReturnType<typeof getProjectSchemaDDL>>
+export type ProjectSchemaDDLError = Error
+
+export const useProjectSchemaDDLQuery = <TData = ProjectSchemaDDLData>(
+  { projectRef, connectionString, schemas }: Variables,
+  options: UseCustomQueryOptions<ProjectSchemaDDLData, ProjectSchemaDDLError, TData> = {}
+) =>
+  useQuery<ProjectSchemaDDLData, ProjectSchemaDDLError, TData>({
+    queryKey: ['rls-sandbox', 'schema', projectRef, schemas],
+    queryFn: ({ signal }) => getProjectSchemaDDL({ projectRef, connectionString, schemas }, signal),
+    enabled: options.enabled !== false && !!projectRef && schemas.length > 0,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })

--- a/apps/studio/data/rls-sandbox/project-schema-ddl-query.ts
+++ b/apps/studio/data/rls-sandbox/project-schema-ddl-query.ts
@@ -1,9 +1,10 @@
-import { getEntityDefinitionsSql } from '@supabase/pg-meta'
+import pgMeta, { getEntityDefinitionsSql } from '@supabase/pg-meta'
 import type { PostgresPolicy } from '@supabase/postgres-meta'
 import { useQuery } from '@tanstack/react-query'
+import { z } from 'zod'
 
-import { getDatabasePolicies } from '@/data/database-policies/database-policies-query'
 import { executeSql } from '@/data/sql/execute-sql-query'
+import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
 import { quoteLiteral } from '@/lib/pg-format'
 import type { UseCustomQueryOptions } from '@/types'
 
@@ -14,11 +15,10 @@ export interface RlsTableStatus {
   rls_forced: boolean
 }
 
-export interface CustomRole {
-  name: string
-}
+export type CustomRole = z.infer<typeof pgMeta.roles.zod>
 
 export interface ProjectSchemaDDL {
+  schemas: string[]
   typeDefinitions: string[]
   entityDefinitions: string[]
   functionDefinitions: string[]
@@ -27,7 +27,13 @@ export interface ProjectSchemaDDL {
   customRoles: CustomRole[]
 }
 
-const SYSTEM_ROLES = [
+// Extension-owned / platform-specific schemas whose DDL depends on C extensions,
+// custom operators, and platform functions that PGlite cannot replicate.
+// We skip entity/function/type DDL for these but still fetch their policies —
+// those may reference user tables we do load.
+const SUPABASE_INTERNAL_SCHEMAS = new Set([...INTERNAL_SCHEMAS, '_realtime'])
+
+const SYSTEM_ROLES = new Set([
   'postgres',
   'anon',
   'authenticated',
@@ -47,17 +53,12 @@ const SYSTEM_ROLES = [
   'pg_signal_backend',
   'dashboard_user',
   'pgbouncer',
-  'authenticator',
-]
+])
 
-const CUSTOM_ROLES_SQL = `
-  SELECT rolname AS name
-  FROM pg_roles
-  WHERE rolname NOT IN (${SYSTEM_ROLES.map(quoteLiteral).join(',')})
-    AND rolname NOT LIKE 'pg_%'
-    AND rolname NOT LIKE 'supabase_%'
-  ORDER BY rolname
-`
+const pgMetaRolesList = pgMeta.roles.list()
+const pgMetaFunctionsZod = pgMeta.functions.list().zod
+const pgMetaPoliciesZod = pgMeta.policies.list().zod
+const pgMetaTablesZod = pgMeta.tables.list().zod
 
 function toSqlList(schemas: string[]) {
   return schemas.map(quoteLiteral).join(', ')
@@ -95,37 +96,6 @@ function getTypeDefinitionsSql(schemas: string[]) {
   `
 }
 
-function getFunctionDefinitionsSql(schemas: string[]) {
-  return `
-    SELECT pg_get_functiondef(p.oid) AS definition
-    FROM pg_proc p
-    JOIN pg_namespace n ON n.oid = p.pronamespace
-    JOIN pg_language l ON l.oid = p.prolang
-    LEFT JOIN pg_depend d ON d.objid = p.oid AND d.deptype = 'e'
-    WHERE n.nspname IN (${toSqlList(schemas)})
-      AND p.prokind = 'f'
-      AND l.lanname IN ('sql', 'plpgsql')
-      AND p.prorettype <> 'pg_catalog.trigger'::regtype
-      AND d.objid IS NULL
-    ORDER BY n.nspname, p.proname
-  `
-}
-
-function getRlsStatusSql(schemas: string[]) {
-  return `
-    SELECT
-      n.nspname AS schema,
-      c.relname AS table,
-      c.relrowsecurity AS rls_enabled,
-      c.relforcerowsecurity AS rls_forced
-    FROM pg_class c
-    JOIN pg_namespace n ON c.relnamespace = n.oid
-    WHERE c.relkind = 'r'
-      AND n.nspname IN (${toSqlList(schemas)})
-    ORDER BY n.nspname, c.relname
-  `
-}
-
 type Variables = {
   projectRef?: string
   connectionString?: string | null
@@ -136,7 +106,12 @@ async function getProjectSchemaDDL(
   { projectRef, connectionString, schemas }: Variables,
   signal?: AbortSignal
 ): Promise<ProjectSchemaDDL> {
-  const entitySql = getEntityDefinitionsSql({ schemas })
+  const userSchemas = schemas.filter((s) => !SUPABASE_INTERNAL_SCHEMAS.has(s))
+
+  const entitySql = getEntityDefinitionsSql({ schemas: userSchemas })
+  const functionsSql = pgMeta.functions.list({ includedSchemas: userSchemas }).sql
+  const policiesSql = pgMeta.policies.list({ includedSchemas: schemas }).sql
+  const tablesSql = pgMeta.tables.list({ includedSchemas: userSchemas }).sql
 
   const [entityResult, policiesResult, rlsResult, rolesResult, functionsResult, typesResult] =
     await Promise.all([
@@ -144,25 +119,23 @@ async function getProjectSchemaDDL(
         { projectRef, connectionString, sql: entitySql, queryKey: ['rls-sandbox-ddl'] },
         signal
       ),
-      getDatabasePolicies({ projectRef, connectionString }, signal),
+      executeSql(
+        { projectRef, connectionString, sql: policiesSql, queryKey: ['rls-sandbox-policies'] },
+        signal
+      ),
+      executeSql(
+        { projectRef, connectionString, sql: tablesSql, queryKey: ['rls-sandbox-rls'] },
+        signal
+      ),
+      executeSql(
+        { projectRef, connectionString, sql: pgMetaRolesList.sql, queryKey: ['rls-sandbox-roles'] },
+        signal
+      ),
       executeSql(
         {
           projectRef,
           connectionString,
-          sql: getRlsStatusSql(schemas),
-          queryKey: ['rls-sandbox-rls'],
-        },
-        signal
-      ),
-      executeSql(
-        { projectRef, connectionString, sql: CUSTOM_ROLES_SQL, queryKey: ['rls-sandbox-roles'] },
-        signal
-      ),
-      executeSql(
-        {
-          projectRef,
-          connectionString,
-          sql: getFunctionDefinitionsSql(schemas),
+          sql: functionsSql,
           queryKey: ['rls-sandbox-functions'],
         },
         signal
@@ -171,24 +144,36 @@ async function getProjectSchemaDDL(
         {
           projectRef,
           connectionString,
-          sql: getTypeDefinitionsSql(schemas),
+          sql: getTypeDefinitionsSql(userSchemas),
           queryKey: ['rls-sandbox-types'],
         },
         signal
       ),
     ])
 
+  const roles = (rolesResult.result as z.infer<typeof pgMetaRolesList.zod>).filter(
+    (r) => !SYSTEM_ROLES.has(r.name) && !r.name.startsWith('pg_') && !r.name.startsWith('supabase_')
+  )
+
+  const functions = (functionsResult.result as z.infer<typeof pgMetaFunctionsZod>).filter(
+    (f) => (f.language === 'sql' || f.language === 'plpgsql') && f.return_type !== 'trigger'
+  )
+
   return {
+    schemas: userSchemas,
     typeDefinitions: (typesResult.result as { definition: string }[]).map((r) => r.definition),
     entityDefinitions: (entityResult.result[0]?.data?.definitions ?? []).map(
       (d: { sql: string }) => d.sql
     ),
-    functionDefinitions: (functionsResult.result as { definition: string }[]).map(
-      (r) => r.definition
-    ),
-    policies: (policiesResult ?? []) as PostgresPolicy[],
-    rlsStatuses: rlsResult.result as RlsTableStatus[],
-    customRoles: rolesResult.result as CustomRole[],
+    functionDefinitions: functions.map((f) => f.complete_statement),
+    policies: policiesResult.result as z.infer<typeof pgMetaPoliciesZod> as PostgresPolicy[],
+    rlsStatuses: (rlsResult.result as z.infer<typeof pgMetaTablesZod>).map((t) => ({
+      schema: t.schema,
+      table: t.name,
+      rls_enabled: t.rls_enabled,
+      rls_forced: t.rls_forced,
+    })),
+    customRoles: roles,
   }
 }
 

--- a/apps/studio/data/rls-sandbox/project-seed-data-query.ts
+++ b/apps/studio/data/rls-sandbox/project-seed-data-query.ts
@@ -1,0 +1,84 @@
+import { useQuery } from '@tanstack/react-query'
+
+import type { RlsTableStatus } from '@/data/rls-sandbox/project-schema-ddl-query'
+import { executeSql } from '@/data/sql/execute-sql-query'
+import type { UseCustomQueryOptions } from '@/types'
+
+export interface TableSeedData {
+  schema: string
+  table: string
+  rows: Record<string, unknown>[]
+}
+
+type Variables = {
+  projectRef?: string
+  connectionString?: string | null
+  tables: RlsTableStatus[]
+  rowLimit: number
+}
+
+async function fetchTableSeed(
+  {
+    projectRef,
+    connectionString,
+    schema,
+    table,
+    rowLimit,
+  }: Omit<Variables, 'tables'> & { schema: string; table: string },
+  signal?: AbortSignal
+): Promise<TableSeedData> {
+  try {
+    const { result } = await executeSql(
+      {
+        projectRef,
+        connectionString,
+        sql: `SELECT * FROM "${schema}"."${table}" LIMIT ${rowLimit}`,
+        queryKey: ['rls-sandbox-seed', schema, table],
+      },
+      signal
+    )
+    return { schema, table, rows: (result ?? []) as Record<string, unknown>[] }
+  } catch {
+    return { schema, table, rows: [] }
+  }
+}
+
+const SEED_CONCURRENCY = 8
+
+export async function getProjectSeedData(
+  { projectRef, connectionString, tables, rowLimit }: Variables,
+  signal?: AbortSignal
+): Promise<TableSeedData[]> {
+  const results: TableSeedData[] = []
+  const queue = tables.slice()
+  const workers = Array.from({ length: Math.min(SEED_CONCURRENCY, queue.length) }, async () => {
+    while (queue.length > 0) {
+      const entry = queue.shift()
+      if (!entry) break
+      results.push(
+        await fetchTableSeed(
+          { projectRef, connectionString, schema: entry.schema, table: entry.table, rowLimit },
+          signal
+        )
+      )
+    }
+  })
+  await Promise.all(workers)
+  return results.filter((t) => t.rows.length > 0)
+}
+
+export type ProjectSeedDataData = TableSeedData[]
+export type ProjectSeedDataError = Error
+
+export const useProjectSeedDataQuery = <TData = ProjectSeedDataData>(
+  { projectRef, connectionString, tables, rowLimit }: Variables,
+  options: UseCustomQueryOptions<ProjectSeedDataData, ProjectSeedDataError, TData> = {}
+) =>
+  useQuery<ProjectSeedDataData, ProjectSeedDataError, TData>({
+    queryKey: ['rls-sandbox', 'seed', projectRef, tables.map((t) => `${t.schema}.${t.table}`)],
+    queryFn: ({ signal }) =>
+      getProjectSeedData({ projectRef, connectionString, tables, rowLimit }, signal),
+    enabled: false,
+    staleTime: 5 * 60 * 1000,
+    ...options,
+  })

--- a/apps/studio/lib/rls-sandbox/SandboxProvider.tsx
+++ b/apps/studio/lib/rls-sandbox/SandboxProvider.tsx
@@ -1,0 +1,51 @@
+import { createContext, useContext, useEffect, useState, type ReactNode } from 'react'
+
+import { getSandboxCore, type SandboxCore } from './sandbox-core'
+import { getErrorMessage } from '@/lib/get-error-message'
+
+type SandboxStatus = 'idle' | 'booting' | 'ready' | 'error'
+
+interface SandboxContextValue {
+  status: SandboxStatus
+  error?: string
+  core: SandboxCore | null
+}
+
+const SandboxContext = createContext<SandboxContextValue>({ status: 'idle', core: null })
+
+export function SandboxProvider({ children }: { children: ReactNode }) {
+  const [status, setStatus] = useState<SandboxStatus>('idle')
+  const [error, setError] = useState<string>()
+  const [core, setCore] = useState<SandboxCore | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    setStatus('booting')
+
+    getSandboxCore()
+      .then((c) => {
+        if (!cancelled) {
+          setCore(c)
+          setStatus('ready')
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(getErrorMessage(err) ?? '')
+          setStatus('error')
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  return (
+    <SandboxContext.Provider value={{ status, error, core }}>{children}</SandboxContext.Provider>
+  )
+}
+
+export function useSandbox() {
+  return useContext(SandboxContext)
+}

--- a/apps/studio/lib/rls-sandbox/apply-schema.ts
+++ b/apps/studio/lib/rls-sandbox/apply-schema.ts
@@ -1,0 +1,135 @@
+import type { PostgresPolicy } from '@supabase/postgres-meta'
+
+import type { CustomRole, RlsTableStatus } from '@/data/rls-sandbox/project-schema-ddl-query'
+import { getErrorMessage } from '@/lib/get-error-message'
+
+interface Executor {
+  execSql(sql: string): Promise<void>
+}
+
+function buildPolicySQL(policy: PostgresPolicy): string {
+  const target = `"${policy.schema}"."${policy.table}"`
+  const permissiveness = policy.action === 'RESTRICTIVE' ? 'AS RESTRICTIVE' : ''
+  const command = policy.command === 'ALL' ? '' : `FOR ${policy.command}`
+  const roles = policy.roles?.length ? `TO ${policy.roles.join(', ')}` : ''
+  const using = policy.definition ? `USING (${policy.definition})` : ''
+  const withCheck = policy.check ? `WITH CHECK (${policy.check})` : ''
+
+  const drop = `DROP POLICY IF EXISTS "${policy.name}" ON ${target}`
+  const create = [
+    `CREATE POLICY "${policy.name}"`,
+    `ON ${target}`,
+    permissiveness,
+    command,
+    roles,
+    using,
+    withCheck,
+  ]
+    .filter(Boolean)
+    .join(' ')
+  return `${drop}; ${create}`
+}
+
+async function tryExec(sandbox: Executor, sql: string, label: string): Promise<void> {
+  try {
+    await sandbox.execSql(sql)
+  } catch (err) {
+    console.warn(`[rls-sandbox] skipped ${label}:`, getErrorMessage(err) ?? err)
+  }
+}
+
+async function applyDDLWithRetries(sandbox: Executor, ddlStatements: string[]): Promise<void> {
+  let pending = ddlStatements.slice()
+
+  while (pending.length > 0) {
+    const failed: Array<{ ddl: string; error: string }> = []
+    for (const ddl of pending) {
+      try {
+        await sandbox.execSql(ddl)
+      } catch (err) {
+        failed.push({ ddl, error: getErrorMessage(err) ?? String(err) })
+      }
+    }
+    if (failed.length === pending.length) {
+      for (const { ddl, error } of failed) {
+        console.warn(
+          `[rls-sandbox] skipped DDL: ${ddl.slice(0, 80).replace(/\s+/g, ' ')} — ${error}`
+        )
+      }
+      break
+    }
+    pending = failed.map((f) => f.ddl)
+  }
+}
+
+export async function applySchema(
+  sandbox: Executor,
+  {
+    entityDefinitions,
+    functionDefinitions,
+    policies,
+    rlsStatuses,
+    customRoles,
+  }: {
+    entityDefinitions: string[]
+    functionDefinitions: string[]
+    policies: PostgresPolicy[]
+    rlsStatuses: RlsTableStatus[]
+    customRoles: CustomRole[]
+  }
+): Promise<void> {
+  for (const role of customRoles) {
+    const safeName = role.name.replace(/"/g, '""')
+    const safeNameLiteral = role.name.replace(/'/g, "''")
+    await tryExec(
+      sandbox,
+      `DO $$ BEGIN
+        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${safeNameLiteral}') THEN
+          CREATE ROLE "${safeName}" NOLOGIN;
+        END IF;
+      END $$`,
+      `role ${role.name}`
+    )
+  }
+
+  await applyDDLWithRetries(sandbox, entityDefinitions)
+
+  // Grant Supabase roles access to public schema — mirrors real Supabase grants
+  await tryExec(
+    sandbox,
+    `GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role`,
+    'grant schema usage'
+  )
+
+  for (const table of rlsStatuses) {
+    await tryExec(
+      sandbox,
+      `GRANT SELECT, INSERT, UPDATE, DELETE ON "${table.schema}"."${table.table}" TO anon, authenticated, service_role`,
+      `grant roles on ${table.schema}.${table.table}`
+    )
+    if (table.rls_enabled) {
+      await tryExec(
+        sandbox,
+        `ALTER TABLE "${table.schema}"."${table.table}" ENABLE ROW LEVEL SECURITY`,
+        `enable RLS ${table.schema}.${table.table}`
+      )
+    }
+  }
+
+  // Apply user-defined functions before policies — policies reference them and Postgres resolves
+  // function bodies at query time, not at CREATE POLICY time. Disable check_function_bodies so a
+  // function referencing a not-yet-created object doesn't abort the batch.
+  await tryExec(sandbox, `SET check_function_bodies = off`, 'set check_function_bodies')
+  for (const fn of functionDefinitions) {
+    await tryExec(sandbox, fn, `function ${fn.slice(0, 60).replace(/\s+/g, ' ')}`)
+  }
+  await tryExec(sandbox, `RESET check_function_bodies`, 'reset check_function_bodies')
+
+  for (const policy of policies) {
+    await tryExec(
+      sandbox,
+      buildPolicySQL(policy),
+      `policy ${policy.schema}.${policy.table} "${policy.name}"`
+    )
+  }
+}

--- a/apps/studio/lib/rls-sandbox/apply-schema.ts
+++ b/apps/studio/lib/rls-sandbox/apply-schema.ts
@@ -65,6 +65,7 @@ async function applyDDLWithRetries(sandbox: Executor, ddlStatements: string[]): 
 export async function applySchema(
   sandbox: Executor,
   {
+    schemas,
     typeDefinitions,
     entityDefinitions,
     functionDefinitions,
@@ -73,6 +74,17 @@ export async function applySchema(
     customRoles,
   }: ProjectSchemaDDL
 ): Promise<void> {
+  for (const schema of schemas) {
+    if (schema === 'public') continue
+    const safe = schema.replace(/"/g, '""')
+    await tryExec(sandbox, `CREATE SCHEMA IF NOT EXISTS "${safe}"`, `schema ${schema}`)
+    await tryExec(
+      sandbox,
+      `GRANT USAGE ON SCHEMA "${safe}" TO anon, authenticated, service_role`,
+      `grant schema ${schema}`
+    )
+  }
+
   if (customRoles.length > 0) {
     const checks = customRoles
       .map(({ name }) => {
@@ -87,28 +99,25 @@ export async function applySchema(
   await applyDDLWithRetries(sandbox, typeDefinitions)
   await applyDDLWithRetries(sandbox, entityDefinitions)
 
-  await tryExec(
-    sandbox,
-    `GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role`,
-    'grant schema usage'
-  )
+  for (const schema of [...new Set(rlsStatuses.map((t) => t.schema))]) {
+    const safe = schema.replace(/"/g, '""')
+    await tryExec(
+      sandbox,
+      `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA "${safe}" TO anon, authenticated, service_role`,
+      `grant tables in schema ${schema}`
+    )
+  }
 
-  if (rlsStatuses.length > 0) {
-    const grants = rlsStatuses
-      .map(
-        (t) =>
-          `GRANT SELECT, INSERT, UPDATE, DELETE ON "${t.schema}"."${t.table}" TO anon, authenticated, service_role`
-      )
-      .join('; ')
-    await tryExec(sandbox, grants, 'grant roles on all tables')
-
-    const rlsEnables = rlsStatuses
-      .filter((t) => t.rls_enabled)
-      .map((t) => `ALTER TABLE "${t.schema}"."${t.table}" ENABLE ROW LEVEL SECURITY`)
-      .join('; ')
-    if (rlsEnables) {
-      await tryExec(sandbox, rlsEnables, 'enable RLS on all tables')
-    }
+  for (const { schema, table, rls_enabled, rls_forced } of rlsStatuses) {
+    const actions: string[] = []
+    if (rls_enabled) actions.push('ENABLE ROW LEVEL SECURITY')
+    if (rls_forced) actions.push('FORCE ROW LEVEL SECURITY')
+    if (actions.length === 0) continue
+    await tryExec(
+      sandbox,
+      `ALTER TABLE "${schema}"."${table}" ${actions.join(', ')}`,
+      `RLS on ${schema}.${table}`
+    )
   }
 
   // Disable check_function_bodies so functions referencing not-yet-created objects don't abort.

--- a/apps/studio/lib/rls-sandbox/apply-schema.ts
+++ b/apps/studio/lib/rls-sandbox/apply-schema.ts
@@ -1,6 +1,6 @@
 import type { PostgresPolicy } from '@supabase/postgres-meta'
 
-import type { CustomRole, RlsTableStatus } from '@/data/rls-sandbox/project-schema-ddl-query'
+import type { ProjectSchemaDDL } from '@/data/rls-sandbox/project-schema-ddl-query'
 import { getErrorMessage } from '@/lib/get-error-message'
 
 interface Executor {
@@ -65,60 +65,54 @@ async function applyDDLWithRetries(sandbox: Executor, ddlStatements: string[]): 
 export async function applySchema(
   sandbox: Executor,
   {
+    typeDefinitions,
     entityDefinitions,
     functionDefinitions,
     policies,
     rlsStatuses,
     customRoles,
-  }: {
-    entityDefinitions: string[]
-    functionDefinitions: string[]
-    policies: PostgresPolicy[]
-    rlsStatuses: RlsTableStatus[]
-    customRoles: CustomRole[]
-  }
+  }: ProjectSchemaDDL
 ): Promise<void> {
-  for (const role of customRoles) {
-    const safeName = role.name.replace(/"/g, '""')
-    const safeNameLiteral = role.name.replace(/'/g, "''")
-    await tryExec(
-      sandbox,
-      `DO $$ BEGIN
-        IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${safeNameLiteral}') THEN
-          CREATE ROLE "${safeName}" NOLOGIN;
-        END IF;
-      END $$`,
-      `role ${role.name}`
-    )
+  if (customRoles.length > 0) {
+    const checks = customRoles
+      .map(({ name }) => {
+        const safeLiteral = name.replace(/'/g, "''")
+        const safeIdent = name.replace(/"/g, '""')
+        return `IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '${safeLiteral}') THEN CREATE ROLE "${safeIdent}" NOLOGIN; END IF;`
+      })
+      .join('\n')
+    await tryExec(sandbox, `DO $$ BEGIN\n${checks}\nEND $$`, 'custom roles')
   }
 
+  await applyDDLWithRetries(sandbox, typeDefinitions)
   await applyDDLWithRetries(sandbox, entityDefinitions)
 
-  // Grant Supabase roles access to public schema — mirrors real Supabase grants
   await tryExec(
     sandbox,
     `GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role`,
     'grant schema usage'
   )
 
-  for (const table of rlsStatuses) {
-    await tryExec(
-      sandbox,
-      `GRANT SELECT, INSERT, UPDATE, DELETE ON "${table.schema}"."${table.table}" TO anon, authenticated, service_role`,
-      `grant roles on ${table.schema}.${table.table}`
-    )
-    if (table.rls_enabled) {
-      await tryExec(
-        sandbox,
-        `ALTER TABLE "${table.schema}"."${table.table}" ENABLE ROW LEVEL SECURITY`,
-        `enable RLS ${table.schema}.${table.table}`
+  if (rlsStatuses.length > 0) {
+    const grants = rlsStatuses
+      .map(
+        (t) =>
+          `GRANT SELECT, INSERT, UPDATE, DELETE ON "${t.schema}"."${t.table}" TO anon, authenticated, service_role`
       )
+      .join('; ')
+    await tryExec(sandbox, grants, 'grant roles on all tables')
+
+    const rlsEnables = rlsStatuses
+      .filter((t) => t.rls_enabled)
+      .map((t) => `ALTER TABLE "${t.schema}"."${t.table}" ENABLE ROW LEVEL SECURITY`)
+      .join('; ')
+    if (rlsEnables) {
+      await tryExec(sandbox, rlsEnables, 'enable RLS on all tables')
     }
   }
 
-  // Apply user-defined functions before policies — policies reference them and Postgres resolves
-  // function bodies at query time, not at CREATE POLICY time. Disable check_function_bodies so a
-  // function referencing a not-yet-created object doesn't abort the batch.
+  // Disable check_function_bodies so functions referencing not-yet-created objects don't abort.
+  // Postgres resolves policy→function references at query time, not at CREATE POLICY time.
   await tryExec(sandbox, `SET check_function_bodies = off`, 'set check_function_bodies')
   for (const fn of functionDefinitions) {
     await tryExec(sandbox, fn, `function ${fn.slice(0, 60).replace(/\s+/g, ' ')}`)

--- a/apps/studio/lib/rls-sandbox/apply-seed.ts
+++ b/apps/studio/lib/rls-sandbox/apply-seed.ts
@@ -1,0 +1,73 @@
+import type { TableSeedData } from '@/data/rls-sandbox/project-seed-data-query'
+
+interface Executor {
+  execSql(sql: string): Promise<void>
+}
+
+function serializeValue(val: unknown): string {
+  if (val === null || val === undefined) return 'NULL'
+  if (typeof val === 'boolean') return val ? 'TRUE' : 'FALSE'
+  if (typeof val === 'number') return String(val)
+  if (val instanceof Date) return `'${val.toISOString()}'`
+  if (Array.isArray(val)) return `ARRAY[${val.map(serializeValue).join(', ')}]`
+  if (typeof val === 'object') return `'${JSON.stringify(val).replace(/'/g, "''")}'::jsonb`
+  return `'${String(val).replace(/'/g, "''")}'`
+}
+
+function buildInsertSQL(schema: string, table: string, rows: Record<string, unknown>[]): string {
+  if (rows.length === 0) throw new Error(`buildInsertSQL requires at least one row`)
+  const columns = Object.keys(rows[0])
+  const colList = columns.map((c) => `"${c}"`).join(', ')
+  const valuesList = rows
+    .map((row) => `(${columns.map((c) => serializeValue(row[c])).join(', ')})`)
+    .join(',\n  ')
+  return `INSERT INTO "${schema}"."${table}" (${colList}) VALUES\n  ${valuesList};`
+}
+
+export async function applySeed(sandbox: Executor, tables: TableSeedData[]): Promise<void> {
+  // Disable FK triggers so we can delete and re-insert in any order.
+  // Requires superuser (ALTER ROLE postgres SUPERUSER in SANDBOX_SETUP_STATEMENTS).
+  // Falls back gracefully if the privilege is not available.
+  let triggersDisabled = false
+  try {
+    await sandbox.execSql(`SET session_replication_role = replica`)
+    triggersDisabled = true
+  } catch {
+    // postgres not yet a superuser in this PGlite build — proceed without it
+  }
+
+  try {
+    // Always clear before inserting so re-seed reflects the latest data.
+    for (const { schema, table } of tables) {
+      try {
+        await sandbox.execSql(`DELETE FROM "${schema}"."${table}"`)
+      } catch {
+        // table may not exist yet — ignore
+      }
+    }
+
+    // Retry loop handles any remaining FK ordering constraints.
+    let pending = tables.filter((t) => t.rows.length > 0)
+    while (pending.length > 0) {
+      const failed: TableSeedData[] = []
+      for (const entry of pending) {
+        try {
+          await sandbox.execSql(buildInsertSQL(entry.schema, entry.table, entry.rows))
+        } catch {
+          failed.push(entry)
+        }
+      }
+      if (failed.length === pending.length) {
+        for (const entry of failed) {
+          console.warn(`[rls-sandbox] seed skipped ${entry.schema}.${entry.table}: unresolved FK`)
+        }
+        break
+      }
+      pending = failed
+    }
+  } finally {
+    if (triggersDisabled) {
+      await sandbox.execSql(`SET session_replication_role = DEFAULT`)
+    }
+  }
+}

--- a/apps/studio/lib/rls-sandbox/pglite.worker.ts
+++ b/apps/studio/lib/rls-sandbox/pglite.worker.ts
@@ -1,0 +1,13 @@
+import { PGlite } from '@electric-sql/pglite'
+import { pgcrypto } from '@electric-sql/pglite/contrib/pgcrypto'
+import { uuid_ossp } from '@electric-sql/pglite/contrib/uuid_ossp'
+import { worker } from '@electric-sql/pglite/worker'
+
+worker({
+  async init() {
+    return new PGlite({
+      dataDir: 'memory://',
+      extensions: { pgcrypto, uuid_ossp },
+    })
+  },
+})

--- a/apps/studio/lib/rls-sandbox/pglite.worker.ts
+++ b/apps/studio/lib/rls-sandbox/pglite.worker.ts
@@ -8,6 +8,7 @@ worker({
     return new PGlite({
       dataDir: 'memory://',
       extensions: { pgcrypto, uuid_ossp },
+      debug: 0,
     })
   },
 })

--- a/apps/studio/lib/rls-sandbox/sandbox-core.ts
+++ b/apps/studio/lib/rls-sandbox/sandbox-core.ts
@@ -23,7 +23,6 @@ export interface SandboxCore {
   destroy(): Promise<void>
 }
 
-// All superuser-required setup runs as the PGlite bootstrap user.
 // ALTER ROLE postgres SUPERUSER succeeds because the bootstrap connection owns the cluster.
 // Each statement is individual so a single failure cannot abort the rest.
 const SANDBOX_SETUP_STATEMENTS = [
@@ -37,6 +36,18 @@ const SANDBOX_SETUP_STATEMENTS = [
     END IF;
     IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
       CREATE ROLE service_role NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticator') THEN
+      CREATE ROLE authenticator NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'dashboard_user') THEN
+      CREATE ROLE dashboard_user NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'pgbouncer') THEN
+      CREATE ROLE pgbouncer NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'supabase_admin') THEN
+      CREATE ROLE supabase_admin NOLOGIN;
     END IF;
   END $$`,
   `ALTER ROLE service_role BYPASSRLS`,
@@ -56,9 +67,75 @@ const SANDBOX_SETUP_STATEMENTS = [
   `GRANT EXECUTE ON FUNCTION auth.uid() TO anon, authenticated, service_role`,
   `GRANT EXECUTE ON FUNCTION auth.role() TO anon, authenticated, service_role`,
   `GRANT EXECUTE ON FUNCTION auth.email() TO anon, authenticated, service_role`,
+  // Minimal auth table stubs — enough for FK references and policy expressions.
+  // Projects commonly have FKs to auth.users from public schema tables (e.g. profiles),
+  // so without this stub those tables fail to create and their policies can't be tested.
+  `CREATE TABLE IF NOT EXISTS auth.users (
+    instance_id uuid,
+    id uuid NOT NULL PRIMARY KEY,
+    aud varchar(255),
+    role varchar(255),
+    email varchar(255),
+    encrypted_password varchar(255),
+    email_confirmed_at timestamptz,
+    invited_at timestamptz,
+    confirmation_token varchar(255),
+    confirmation_sent_at timestamptz,
+    recovery_token varchar(255),
+    recovery_sent_at timestamptz,
+    email_change_token_new varchar(255),
+    email_change varchar(255),
+    email_change_sent_at timestamptz,
+    last_sign_in_at timestamptz,
+    raw_app_meta_data jsonb,
+    raw_user_meta_data jsonb,
+    is_super_admin boolean,
+    created_at timestamptz,
+    updated_at timestamptz,
+    phone text DEFAULT NULL,
+    phone_confirmed_at timestamptz,
+    phone_change text DEFAULT '',
+    phone_change_token varchar(255) DEFAULT '',
+    phone_change_sent_at timestamptz,
+    confirmed_at timestamptz,
+    email_change_token_current varchar(255) DEFAULT '',
+    email_change_confirm_status smallint DEFAULT 0,
+    banned_until timestamptz,
+    reauthentication_token varchar(255) DEFAULT '',
+    reauthentication_sent_at timestamptz,
+    is_sso_user boolean NOT NULL DEFAULT false,
+    deleted_at timestamptz,
+    is_anonymous boolean NOT NULL DEFAULT false
+  )`,
+  `CREATE TABLE IF NOT EXISTS auth.sessions (
+    id uuid NOT NULL PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    created_at timestamptz,
+    updated_at timestamptz,
+    factor_id uuid,
+    aal text,
+    not_after timestamptz,
+    refreshed_at timestamp,
+    user_agent text,
+    ip inet,
+    tag text
+  )`,
+  `CREATE TABLE IF NOT EXISTS auth.mfa_factors (
+    id uuid NOT NULL PRIMARY KEY,
+    user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    friendly_name text,
+    factor_type text NOT NULL,
+    status text NOT NULL,
+    created_at timestamptz NOT NULL,
+    updated_at timestamptz NOT NULL,
+    secret text,
+    phone text,
+    last_challenged_at timestamptz,
+    web_authn_credential jsonb,
+    web_authn_aaguid uuid
+  )`,
+  `GRANT SELECT, INSERT, UPDATE, DELETE ON auth.users, auth.sessions, auth.mfa_factors TO anon, authenticated, service_role`,
 ]
-
-// ── Singleton ────────────────────────────────────────────────────────────────
 
 let instance: SandboxCore | null = null
 let initPromise: Promise<SandboxCore> | null = null
@@ -79,8 +156,6 @@ export function destroySandboxCore(): Promise<void> {
   initPromise = null
   return current?.destroy() ?? Promise.resolve()
 }
-
-// ── Boot ─────────────────────────────────────────────────────────────────────
 
 async function boot(): Promise<SandboxCore> {
   const webWorker = new Worker(new URL('./pglite.worker.ts', import.meta.url), { type: 'module' })

--- a/apps/studio/lib/rls-sandbox/sandbox-core.ts
+++ b/apps/studio/lib/rls-sandbox/sandbox-core.ts
@@ -1,0 +1,151 @@
+import { PGliteWorker } from '@electric-sql/pglite/worker'
+
+import { applySchema } from './apply-schema'
+import { applySeed } from './apply-seed'
+import type { ProjectSchemaDDLData } from '@/data/rls-sandbox/project-schema-ddl-query'
+import type { TableSeedData } from '@/data/rls-sandbox/project-seed-data-query'
+import { getErrorMessage } from '@/lib/get-error-message'
+
+export type TileConfig =
+  | { id: string; role: 'anon' | 'service_role' }
+  | { id: string; role: 'authenticated'; userId: string; userEmail: string }
+
+export interface TileResult {
+  rows: Record<string, unknown>[]
+  error?: string
+}
+
+export interface SandboxCore {
+  setSchema(data: ProjectSchemaDDLData): Promise<void>
+  setSeed(tables: TableSeedData[]): Promise<void>
+  broadcastSql(sql: string): Promise<void>
+  runAll(tiles: TileConfig[], sql: string): Promise<Record<string, TileResult>>
+  destroy(): Promise<void>
+}
+
+// All superuser-required setup runs as the PGlite bootstrap user.
+// ALTER ROLE postgres SUPERUSER succeeds because the bootstrap connection owns the cluster.
+// Each statement is individual so a single failure cannot abort the rest.
+const SANDBOX_SETUP_STATEMENTS = [
+  `ALTER ROLE postgres SUPERUSER`,
+  `DO $$ BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'anon') THEN
+      CREATE ROLE anon NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'authenticated') THEN
+      CREATE ROLE authenticated NOLOGIN;
+    END IF;
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = 'service_role') THEN
+      CREATE ROLE service_role NOLOGIN;
+    END IF;
+  END $$`,
+  `ALTER ROLE service_role BYPASSRLS`,
+  `GRANT anon TO postgres WITH ADMIN OPTION`,
+  `GRANT authenticated TO postgres WITH ADMIN OPTION`,
+  `GRANT service_role TO postgres WITH ADMIN OPTION`,
+  `GRANT CONNECT ON DATABASE postgres TO anon, authenticated, service_role`,
+  `CREATE SCHEMA IF NOT EXISTS auth`,
+  `GRANT USAGE ON SCHEMA auth TO anon, authenticated, service_role`,
+  `GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role`,
+  `CREATE OR REPLACE FUNCTION auth.uid() RETURNS uuid LANGUAGE sql STABLE AS
+    $fn$ SELECT NULLIF(current_setting('request.jwt.claim.sub', true), '')::uuid $fn$`,
+  `CREATE OR REPLACE FUNCTION auth.role() RETURNS text LANGUAGE sql STABLE AS
+    $fn$ SELECT COALESCE(NULLIF(current_setting('request.jwt.claim.role', true), ''), 'anon') $fn$`,
+  `CREATE OR REPLACE FUNCTION auth.email() RETURNS text LANGUAGE sql STABLE AS
+    $fn$ SELECT NULLIF(current_setting('request.jwt.claim.email', true), '') $fn$`,
+  `GRANT EXECUTE ON FUNCTION auth.uid() TO anon, authenticated, service_role`,
+  `GRANT EXECUTE ON FUNCTION auth.role() TO anon, authenticated, service_role`,
+  `GRANT EXECUTE ON FUNCTION auth.email() TO anon, authenticated, service_role`,
+]
+
+// ── Singleton ────────────────────────────────────────────────────────────────
+
+let instance: SandboxCore | null = null
+let initPromise: Promise<SandboxCore> | null = null
+
+export async function getSandboxCore(): Promise<SandboxCore> {
+  if (instance) return instance
+  if (!initPromise) {
+    initPromise = boot().finally(() => {
+      initPromise = null
+    })
+  }
+  return initPromise
+}
+
+export function destroySandboxCore(): Promise<void> {
+  const current = instance
+  instance = null
+  initPromise = null
+  return current?.destroy() ?? Promise.resolve()
+}
+
+// ── Boot ─────────────────────────────────────────────────────────────────────
+
+async function boot(): Promise<SandboxCore> {
+  const webWorker = new Worker(new URL('./pglite.worker.ts', import.meta.url), { type: 'module' })
+  const pg = await PGliteWorker.create(webWorker)
+
+  for (const sql of SANDBOX_SETUP_STATEMENTS) {
+    try {
+      await pg.exec(sql)
+    } catch (err) {
+      console.warn('[rls-sandbox] setup:', (err as Error).message, `— ${sql.slice(0, 60)}`)
+    }
+  }
+
+  function makeExecutor() {
+    return { execSql: (sql: string) => pg.exec(sql).then(() => undefined as void) }
+  }
+
+  async function setSchema(data: ProjectSchemaDDLData): Promise<void> {
+    await applySchema(makeExecutor(), data)
+  }
+
+  async function setSeed(tables: TableSeedData[]): Promise<void> {
+    await applySeed(makeExecutor(), tables)
+  }
+
+  async function broadcastSql(sql: string): Promise<void> {
+    await pg.exec(sql)
+  }
+
+  async function runTileQuery(tile: TileConfig, sql: string): Promise<TileResult> {
+    // BEGIN/COMMIT wraps each tile so SET LOCAL ROLE and set_config(local=true) are
+    // transaction-scoped, preventing session state from leaking between tiles.
+    await pg.exec('BEGIN')
+    try {
+      const claims =
+        tile.role === 'authenticated'
+          ? { role: tile.role, sub: tile.userId, email: tile.userEmail }
+          : { role: tile.role, sub: '', email: '' }
+
+      await pg.exec(`SET LOCAL ROLE ${claims.role}`)
+      await pg.query(`SELECT set_config('request.jwt.claim.sub', $1, true)`, [claims.sub])
+      await pg.query(`SELECT set_config('request.jwt.claim.role', $1, true)`, [claims.role])
+      await pg.query(`SELECT set_config('request.jwt.claim.email', $1, true)`, [claims.email])
+
+      const result = await pg.query<Record<string, unknown>>(sql)
+      await pg.exec('COMMIT')
+      return { rows: result.rows }
+    } catch (err) {
+      await pg.exec('ROLLBACK').catch(() => {})
+      return { rows: [], error: getErrorMessage(err) ?? String(err) }
+    }
+  }
+
+  async function runAll(tiles: TileConfig[], sql: string): Promise<Record<string, TileResult>> {
+    const results: Record<string, TileResult> = {}
+    for (const tile of tiles) {
+      results[tile.id] = await runTileQuery(tile, sql)
+    }
+    return results
+  }
+
+  async function destroy(): Promise<void> {
+    webWorker.terminate()
+  }
+
+  instance = { setSchema, setSeed, broadcastSql, runAll, destroy }
+  return instance
+}

--- a/apps/studio/next.config.ts
+++ b/apps/studio/next.config.ts
@@ -601,6 +601,16 @@ const nextConfig = {
   },
   transpilePackages: ['ui', 'ui-patterns', 'common', 'shared-data', 'api-types', 'icons'],
   serverExternalPackages: ['libpg-query'],
+  webpack(config, { isServer }) {
+    if (!isServer) {
+      config.experiments = { ...config.experiments, asyncWebAssembly: true }
+      config.output = {
+        ...config.output,
+        webassemblyModuleFilename: 'static/wasm/[modulehash].wasm',
+      }
+    }
+    return config
+  },
   turbopack: {
     rules: {
       '*.md': {

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -31,6 +31,8 @@
     "scorers:deploy": "IS_BRAINTRUST_PUSH=true braintrust push evals/scorer-online.ts"
   },
   "dependencies": {
+    "@electric-sql/pglite": "0.4.5",
+    "@electric-sql/pglite-tools": "^0.3.4",
     "@ai-sdk/amazon-bedrock": "^4.0.81",
     "@ai-sdk/mcp": "^1.0.25",
     "@ai-sdk/openai": "^3.0.41",

--- a/apps/studio/pages/api/ai/sql/generate-seed.ts
+++ b/apps/studio/pages/api/ai/sql/generate-seed.ts
@@ -1,0 +1,85 @@
+import { generateText } from 'ai'
+import { source } from 'common-tags'
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import { getModel } from '@/lib/ai/model'
+import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
+import apiWrapper from '@/lib/api/apiWrapper'
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req
+  switch (method) {
+    case 'POST':
+      return handlePost(req, res)
+    default:
+      res.setHeader('Allow', ['POST'])
+      res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
+  }
+}
+
+export async function handlePost(req: NextApiRequest, res: NextApiResponse) {
+  const { schema, users, prompt } = req.body as {
+    schema: string
+    users: Array<{ id: string; email: string }>
+    prompt?: string
+  }
+
+  if (!schema) return res.status(400).json({ error: 'schema is required' })
+
+  try {
+    const { modelParams, error: modelError } = await getModel({
+      provider: 'openai',
+      modelEntry: DEFAULT_COMPLETION_MODEL,
+    })
+
+    if (modelError) return res.status(500).json({ error: modelError.message })
+
+    const usersSection =
+      users.length > 0
+        ? `The following auth users exist in the project — use their exact UUIDs where the schema references user identity (e.g. profile IDs or owner/created_by columns):\n${users.map((u) => `  id: '${u.id}', email: '${u.email}'`).join('\n')}`
+        : `No auth users are available. Use hardcoded UUID literals in the format 'a0000000-0000-0000-0000-00000000000N' for any user-identity columns, and add a comment noting they should be replaced with real user IDs.`
+
+    const result = await generateText({
+      ...modelParams,
+      prompt: source`
+        Generate SQL INSERT statements to seed a Postgres database for Row Level Security (RLS) testing.
+
+        Schema:
+        ${schema}
+
+        ${usersSection}
+
+        ${prompt ? `Additional context from the developer: ${prompt}` : ''}
+
+        Rules:
+        - Use hardcoded UUID literals (e.g. 'b0000000-0000-0000-0000-000000000001') for any IDs you need to cross-reference between inserts, so no PL/pgSQL DO block is needed
+        - Insert parent tables before child tables to satisfy foreign key constraints
+        - Use ON CONFLICT DO NOTHING on every INSERT (no conflict target column list — avoids PL/pgSQL variable ambiguity)
+        - Generate realistic data: real-looking names, titles, emails, descriptions
+        - Create multiple data scenarios that exercise different RLS policy branches (e.g. rows owned by different users, private vs public visibility)
+        - Do NOT insert into auth.users — only insert into public schema tables
+
+        Return ONLY the SQL, no markdown code fences, no explanations.
+      `,
+    })
+
+    return res.json({ sql: result.text.trim() })
+  } catch (error) {
+    if (error instanceof Error) {
+      console.error(`AI seed generation failed: ${error.message}`)
+      if (error.message.includes('context_length') || error.message.includes('too long')) {
+        return res.status(400).json({
+          error: 'Schema is too large for the AI to process. Try reducing the number of tables.',
+        })
+      }
+    } else {
+      console.error('AI seed generation failed with unknown error:', error)
+    }
+    return res.status(500).json({ error: 'Failed to generate seed data. Please try again.' })
+  }
+}
+
+const wrapper = (req: NextApiRequest, res: NextApiResponse) =>
+  apiWrapper(req, res, handler, { withAuth: true })
+
+export default wrapper

--- a/apps/studio/pages/project/[ref]/auth/rls-playground.tsx
+++ b/apps/studio/pages/project/[ref]/auth/rls-playground.tsx
@@ -1,0 +1,21 @@
+import { RLSPlayground } from '@/components/interfaces/Auth/RLSPlayground/RLSPlayground'
+import AuthLayout from '@/components/layouts/AuthLayout/AuthLayout'
+import DefaultLayout from '@/components/layouts/DefaultLayout'
+import { SandboxProvider } from '@/lib/rls-sandbox/SandboxProvider'
+import type { NextPageWithLayout } from '@/types'
+
+const RLSPlaygroundPage: NextPageWithLayout = () => {
+  return (
+    <SandboxProvider>
+      <RLSPlayground />
+    </SandboxProvider>
+  )
+}
+
+RLSPlaygroundPage.getLayout = (page) => (
+  <DefaultLayout>
+    <AuthLayout title="RLS Playground">{page}</AuthLayout>
+  </DefaultLayout>
+)
+
+export default RLSPlaygroundPage

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -881,6 +881,12 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@electric-sql/pglite':
+        specifier: 0.4.5
+        version: 0.4.5
+      '@electric-sql/pglite-tools':
+        specifier: ^0.3.4
+        version: 0.3.4(@electric-sql/pglite@0.4.5)
       '@graphiql/react':
         specifier: ^0.37.3
         version: 0.37.3(@emotion/is-prop-valid@1.4.0)(@types/node@22.13.14)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.14.1(graphql@16.11.0))(graphql@16.11.0)(immer@10.1.1)(react-compiler-runtime@19.1.0-rc.1(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(use-sync-external-store@1.6.0(react@18.3.1))
@@ -1271,10 +1277,10 @@ importers:
         version: 4.4.2
       '@typescript-eslint/utils':
         specifier: 8.48.0
-        version: 8.48.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
+        version: 8.48.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.4(vitest@4.1.4)
@@ -1298,10 +1304,10 @@ importers:
         version: link:../../packages/eslint-config-supabase
       eslint-plugin-barrel-files:
         specifier: ^2.0.7
-        version: 2.0.7(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))
+        version: 2.0.7(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
-        version: 6.10.2(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))
+        version: 6.10.2(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
       graphql-ws:
         specifier: 5.14.1
         version: 5.14.1(graphql@16.11.0)
@@ -1346,13 +1352,13 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+        version: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
 
   apps/ui-library:
     dependencies:
@@ -1903,7 +1909,7 @@ importers:
         version: 0.562.0(vue@3.5.30(typescript@6.0.2))
       nuxt:
         specifier: ^4.4.0
-        version: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
+        version: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
       tailwind-merge:
         specifier: ^3.5.0
         version: 3.5.0
@@ -3457,8 +3463,13 @@ packages:
   '@effect-ts/system@0.57.5':
     resolution: {integrity: sha512-/crHGujo0xnuHIYNc1VgP0HGJGFSoSqq88JFXe6FmFyXPpWt8Xu39LyLg7rchsxfXFeEdA9CrIZvLV5eswXV5g==}
 
-  '@electric-sql/pglite@0.2.15':
-    resolution: {integrity: sha512-Jiq31Dnk+rg8rMhcSxs4lQvHTyizNo5b269c1gCC3ldQ0sCLrNVPGzy+KnmonKy1ZArTUuXZf23/UamzFMKVaA==}
+  '@electric-sql/pglite-tools@0.3.4':
+    resolution: {integrity: sha512-bnIb2tN7zkFuo/yLF92I2ZvDDVigCNED37F2aEggatYyKi9QmzYvEg2fh2G2yLGHpPb0AoCO0aI/eOP4aBUiZQ==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.4.4
+
+  '@electric-sql/pglite@0.4.5':
+    resolution: {integrity: sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -19307,8 +19318,11 @@ snapshots:
 
   '@effect-ts/system@0.57.5': {}
 
-  '@electric-sql/pglite@0.2.15':
-    optional: true
+  '@electric-sql/pglite-tools@0.3.4(@electric-sql/pglite@0.4.5)':
+    dependencies:
+      '@electric-sql/pglite': 0.4.5
+
+  '@electric-sql/pglite@0.4.5': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -19455,6 +19469,11 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.2':
     optional: true
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))':
+    dependencies:
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))':
     dependencies:
@@ -21056,7 +21075,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(ebcc12d5dc3cf0522b061183d2f1062e)':
+  '@nuxt/nitro-server@4.4.2(93014e84d3d03f3f67b5db0e374b874b)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@nuxt/devalue': 2.0.2
@@ -21074,8 +21093,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.1(@electric-sql/pglite@0.2.15)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1)
-      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.5)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1)
+      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -21084,7 +21103,7 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unctx: 2.5.0
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.2.15))(ioredis@5.10.0(supports-color@8.1.1))
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.5))(ioredis@5.10.0(supports-color@8.1.1))
       vue: 3.5.30(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -21139,7 +21158,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.4.2(a9c0b4b771d69d61084a5c4199181b69)':
+  '@nuxt/vite-builder@4.4.2(8ca202e14818a230e2b4912f3a3de316)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
@@ -21157,7 +21176,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -25225,6 +25244,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.48.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.48.0
+      '@typescript-eslint/types': 8.48.0
+      '@typescript-eslint/typescript-estree': 8.48.0(supports-color@8.1.1)(typescript@6.0.2)
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.48.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))
@@ -25306,10 +25336,10 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
 
   '@vitejs/plugin-vue-jsx@5.1.5(supports-color@8.1.1)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(vue@3.5.30(typescript@6.0.2))':
     dependencies:
@@ -25341,7 +25371,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -25351,6 +25381,15 @@ snapshots:
       '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.3(@types/node@22.13.14)(typescript@6.0.2)
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.4(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
@@ -25388,7 +25427,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -27270,9 +27309,9 @@ snapshots:
 
   dayjs@1.11.18: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.2.15):
+  db0@0.3.4(@electric-sql/pglite@0.4.5):
     optionalDependencies:
-      '@electric-sql/pglite': 0.2.15
+      '@electric-sql/pglite': 0.4.5
 
   dc-browser@1.0.4: {}
 
@@ -27841,9 +27880,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-barrel-files@2.0.7(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1)):
+  eslint-plugin-barrel-files@2.0.7(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.37.0(jiti@2.6.1)(supports-color@8.1.1)
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
       eslint-barrel-file-utils: 0.0.10
       requireindex: 1.2.0
 
@@ -27875,6 +27914,25 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.8
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.4
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
@@ -27940,6 +27998,48 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.4.0
+      '@eslint/core': 0.16.0
+      '@eslint/eslintrc': 3.3.1(supports-color@8.1.1)
+      '@eslint/js': 9.37.0
+      '@eslint/plugin-kit': 0.4.0
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.4
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1):
     dependencies:
@@ -31686,7 +31786,7 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitropack@2.13.1(@electric-sql/pglite@0.2.15)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1):
+  nitropack@2.13.1(@electric-sql/pglite@0.4.5)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.59.0)
@@ -31707,7 +31807,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.2.15)
+      db0: 0.3.4(@electric-sql/pglite@0.4.5)
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -31753,7 +31853,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.7.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.2.15))(ioredis@5.10.0(supports-color@8.1.1))
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.5))(ioredis@5.10.0(supports-color@8.1.1))
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0
@@ -31964,16 +32064,16 @@ snapshots:
       next: 15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       react-router: 7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  nuxt@4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3):
+  nuxt@4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)(supports-color@8.1.1)
       '@nuxt/devtools': 3.2.4(supports-color@8.1.1)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(vue@3.5.30(typescript@6.0.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(ebcc12d5dc3cf0522b061183d2f1062e)
+      '@nuxt/nitro-server': 4.4.2(93014e84d3d03f3f67b5db0e374b874b)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(a9c0b4b771d69d61084a5c4199181b69)
+      '@nuxt/vite-builder': 4.4.2(8ca202e14818a230e2b4912f3a3de316)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@6.0.2))
       '@vue/shared': 3.5.30
       c12: 3.3.3(magicast@0.5.2)
@@ -35538,7 +35638,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.3
 
-  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.2.15))(ioredis@5.10.0(supports-color@8.1.1)):
+  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.5))(ioredis@5.10.0(supports-color@8.1.1)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -35550,7 +35650,7 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.2.15)
+      db0: 0.3.4(@electric-sql/pglite@0.4.5)
       ioredis: 5.10.0(supports-color@8.1.1)
 
   until-async@3.0.2: {}
@@ -35868,6 +35968,16 @@ snapshots:
       - supports-color
       - typescript
 
+  vite-tsconfig-paths@6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      globrex: 0.1.2
+      tsconfck: 3.0.3(typescript@6.0.2)
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite-tsconfig-paths@6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -35896,6 +36006,23 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.3
 
+  vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.13.14
+      esbuild: 0.25.2
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.77.4
+      terser: 5.39.0
+      tsx: 4.20.3
+      yaml: 2.8.3
+
   vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -35916,6 +36043,37 @@ snapshots:
   vitefu@1.1.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+
+  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.13.14
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      '@vitest/ui': 4.1.4(vitest@4.1.4)
+      jsdom: 28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -892,6 +892,12 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@electric-sql/pglite':
+        specifier: 0.4.5
+        version: 0.4.5
+      '@electric-sql/pglite-tools':
+        specifier: ^0.3.4
+        version: 0.3.4(@electric-sql/pglite@0.4.5)
       '@graphiql/react':
         specifier: ^0.19.4
         version: 0.19.4(@codemirror/language@6.11.0)(@types/node@22.13.14)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.14.1(graphql@16.11.0))(graphql@16.11.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -924,7 +930,7 @@ importers:
         version: 0.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@sentry/nextjs':
         specifier: 'catalog:'
-        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))
+        version: 10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))
       '@std/path':
         specifier: npm:@jsr/std__path@^1.0.8
         version: '@jsr/std__path@1.0.8'
@@ -1080,7 +1086,7 @@ importers:
         version: 0.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       nuqs:
         specifier: 2.7.1
-        version: 2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        version: 2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ^4.104.0
         version: 4.104.0(encoding@0.1.13)(ws@8.19.0)(zod@3.25.76)
@@ -1288,10 +1294,10 @@ importers:
         version: 4.4.2
       '@typescript-eslint/utils':
         specifier: 8.48.0
-        version: 8.48.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
+        version: 8.48.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)
       '@vitejs/plugin-react':
         specifier: 'catalog:'
-        version: 6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.4(vitest@4.1.4)
@@ -1315,10 +1321,10 @@ importers:
         version: link:../../packages/eslint-config-supabase
       eslint-plugin-barrel-files:
         specifier: ^2.0.7
-        version: 2.0.7(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))
+        version: 2.0.7(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
       eslint-plugin-jsx-a11y:
         specifier: ^6.10.2
-        version: 6.10.2(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))
+        version: 6.10.2(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
       graphql-ws:
         specifier: 5.14.1
         version: 5.14.1(graphql@16.11.0)
@@ -1363,13 +1369,13 @@ importers:
         version: 6.0.2
       vite:
         specifier: 'catalog:'
-        version: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+        version: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
       vite-tsconfig-paths:
         specifier: 'catalog:'
-        version: 6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+        version: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
 
   apps/ui-library:
     dependencies:
@@ -1914,7 +1920,7 @@ importers:
         version: 0.562.0(vue@3.5.30(typescript@6.0.2))
       nuxt:
         specifier: ^4.4.0
-        version: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
+        version: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
       tailwind-merge:
         specifier: ^3.3.1
         version: 3.3.1
@@ -3447,8 +3453,13 @@ packages:
   '@effect-ts/system@0.57.5':
     resolution: {integrity: sha512-/crHGujo0xnuHIYNc1VgP0HGJGFSoSqq88JFXe6FmFyXPpWt8Xu39LyLg7rchsxfXFeEdA9CrIZvLV5eswXV5g==}
 
-  '@electric-sql/pglite@0.2.15':
-    resolution: {integrity: sha512-Jiq31Dnk+rg8rMhcSxs4lQvHTyizNo5b269c1gCC3ldQ0sCLrNVPGzy+KnmonKy1ZArTUuXZf23/UamzFMKVaA==}
+  '@electric-sql/pglite-tools@0.3.4':
+    resolution: {integrity: sha512-bnIb2tN7zkFuo/yLF92I2ZvDDVigCNED37F2aEggatYyKi9QmzYvEg2fh2G2yLGHpPb0AoCO0aI/eOP4aBUiZQ==}
+    peerDependencies:
+      '@electric-sql/pglite': 0.4.4
+
+  '@electric-sql/pglite@0.4.5':
+    resolution: {integrity: sha512-aGG2zGEyZzGWKy8P+9ZoNUV0jxt1+hgbeTf+bVAYyxVZZLXg3/9aFlfLxb08AYZVAfAkQlQIysmWjhc5hwDG8g==}
 
   '@emnapi/core@1.9.0':
     resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
@@ -19330,8 +19341,11 @@ snapshots:
 
   '@effect-ts/system@0.57.5': {}
 
-  '@electric-sql/pglite@0.2.15':
-    optional: true
+  '@electric-sql/pglite-tools@0.3.4(@electric-sql/pglite@0.4.5)':
+    dependencies:
+      '@electric-sql/pglite': 0.4.5
+
+  '@electric-sql/pglite@0.4.5': {}
 
   '@emnapi/core@1.9.0':
     dependencies:
@@ -19486,6 +19500,11 @@ snapshots:
 
   '@esbuild/win32-x64@0.25.2':
     optional: true
+
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))':
+    dependencies:
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
+      eslint-visitor-keys: 3.4.3
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))':
     dependencies:
@@ -21094,7 +21113,7 @@ snapshots:
     transitivePeerDependencies:
       - magicast
 
-  '@nuxt/nitro-server@4.4.2(ebcc12d5dc3cf0522b061183d2f1062e)':
+  '@nuxt/nitro-server@4.4.2(93014e84d3d03f3f67b5db0e374b874b)':
     dependencies:
       '@babel/plugin-syntax-typescript': 7.28.6(@babel/core@7.29.0(supports-color@8.1.1))
       '@nuxt/devalue': 2.0.2
@@ -21112,8 +21131,8 @@ snapshots:
       impound: 1.1.5
       klona: 2.0.6
       mocked-exports: 0.1.1
-      nitropack: 2.13.1(@electric-sql/pglite@0.2.15)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1)
-      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
+      nitropack: 2.13.1(@electric-sql/pglite@0.4.5)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1)
+      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       ohash: 2.0.11
       pathe: 2.0.3
@@ -21122,7 +21141,7 @@ snapshots:
       std-env: 4.0.0
       ufo: 1.6.3
       unctx: 2.5.0
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.2.15))(ioredis@5.10.0(supports-color@8.1.1))
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.5))(ioredis@5.10.0(supports-color@8.1.1))
       vue: 3.5.30(typescript@6.0.2)
       vue-bundle-renderer: 2.2.0
       vue-devtools-stub: 0.1.0
@@ -21177,7 +21196,7 @@ snapshots:
       rc9: 3.0.0
       std-env: 3.10.0
 
-  '@nuxt/vite-builder@4.4.2(a9c0b4b771d69d61084a5c4199181b69)':
+  '@nuxt/vite-builder@4.4.2(8ca202e14818a230e2b4912f3a3de316)':
     dependencies:
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
       '@rollup/plugin-replace': 6.0.3(rollup@4.59.0)
@@ -21195,7 +21214,7 @@ snapshots:
       magic-string: 0.30.21
       mlly: 1.8.1
       mocked-exports: 0.1.1
-      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
+      nuxt: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
       nypm: 0.6.5
       pathe: 2.0.3
       pkg-types: 2.3.0
@@ -23629,7 +23648,7 @@ snapshots:
       - supports-color
       - webpack
 
-  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))':
+  '@sentry/nextjs@10.27.0(@opentelemetry/context-async-hooks@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0))(encoding@0.1.13)(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react@18.3.1)(supports-color@8.1.1)(webpack@5.105.4(esbuild@0.25.2))':
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.38.0
@@ -25200,6 +25219,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/utils@8.48.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.48.0
+      '@typescript-eslint/types': 8.48.0
+      '@typescript-eslint/typescript-estree': 8.48.0(supports-color@8.1.1)(typescript@6.0.2)
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
+      typescript: 6.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.48.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.2)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))
@@ -25281,10 +25311,10 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
-      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
 
   '@vitejs/plugin-vue-jsx@5.1.5(supports-color@8.1.1)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(vue@3.5.30(typescript@6.0.2))':
     dependencies:
@@ -25316,7 +25346,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:
@@ -25326,6 +25356,15 @@ snapshots:
       '@vitest/utils': 4.1.4
       chai: 6.2.2
       tinyrainbow: 3.1.0
+
+  '@vitest/mocker@4.1.4(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 4.1.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.3(@types/node@22.13.14)(typescript@6.0.2)
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.4(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
@@ -25363,7 +25402,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
 
   '@vitest/utils@4.1.4':
     dependencies:
@@ -27265,9 +27304,9 @@ snapshots:
 
   dayjs@1.11.18: {}
 
-  db0@0.3.4(@electric-sql/pglite@0.2.15):
+  db0@0.3.4(@electric-sql/pglite@0.4.5):
     optionalDependencies:
-      '@electric-sql/pglite': 0.2.15
+      '@electric-sql/pglite': 0.4.5
 
   dc-browser@1.0.4: {}
 
@@ -27847,9 +27886,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-barrel-files@2.0.7(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1)):
+  eslint-plugin-barrel-files@2.0.7(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1)):
     dependencies:
-      eslint: 9.37.0(jiti@2.6.1)(supports-color@8.1.1)
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
       eslint-barrel-file-utils: 0.0.10
       requireindex: 1.2.0
 
@@ -27881,6 +27920,25 @@ snapshots:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
+
+  eslint-plugin-jsx-a11y@6.10.2(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1)):
+    dependencies:
+      aria-query: 5.3.2
+      array-includes: 3.1.8
+      array.prototype.flatmap: 1.3.3
+      ast-types-flow: 0.0.8
+      axe-core: 4.10.3
+      axobject-query: 4.1.0
+      damerau-levenshtein: 1.0.8
+      emoji-regex: 9.2.2
+      eslint: 9.37.0(jiti@1.21.7)(supports-color@8.1.1)
+      hasown: 2.0.2
+      jsx-ast-utils: 3.3.5
+      language-tags: 1.0.9
+      minimatch: 3.1.4
+      object.fromentries: 2.0.8
+      safe-regex-test: 1.1.0
+      string.prototype.includes: 2.0.1
 
   eslint-plugin-jsx-a11y@6.10.2(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1)):
     dependencies:
@@ -27946,6 +28004,48 @@ snapshots:
   eslint-visitor-keys@3.4.3: {}
 
   eslint-visitor-keys@4.2.1: {}
+
+  eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@1.21.7)(supports-color@8.1.1))
+      '@eslint-community/regexpp': 4.12.1
+      '@eslint/config-array': 0.21.0(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.4.0
+      '@eslint/core': 0.16.0
+      '@eslint/eslintrc': 3.3.1(supports-color@8.1.1)
+      '@eslint/js': 9.37.0
+      '@eslint/plugin-kit': 0.4.0
+      '@humanfs/node': 0.16.7
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      ajv: 6.14.0
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 8.4.0
+      eslint-visitor-keys: 4.2.1
+      espree: 10.4.0
+      esquery: 1.5.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      lodash.merge: 4.6.2
+      minimatch: 3.1.4
+      natural-compare: 1.4.0
+      optionator: 0.9.3
+    optionalDependencies:
+      jiti: 1.21.7
+    transitivePeerDependencies:
+      - supports-color
 
   eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1):
     dependencies:
@@ -31686,7 +31786,7 @@ snapshots:
 
   nice-try@1.0.5: {}
 
-  nitropack@2.13.1(@electric-sql/pglite@0.2.15)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1):
+  nitropack@2.13.1(@electric-sql/pglite@0.4.5)(aws4fetch@1.0.20)(encoding@0.1.13)(rolldown@1.0.0-rc.15)(supports-color@8.1.1):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.59.0)
@@ -31707,7 +31807,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(@electric-sql/pglite@0.2.15)
+      db0: 0.3.4(@electric-sql/pglite@0.4.5)
       defu: 6.1.7
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -31753,7 +31853,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.7.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.2.15))(ioredis@5.10.0(supports-color@8.1.1))
+      unstorage: 1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.5))(ioredis@5.10.0(supports-color@8.1.1))
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0
@@ -31946,7 +32046,7 @@ snapshots:
       mitt: 3.0.1
       next: 15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
 
-  nuqs@2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
+  nuqs@2.7.1(@tanstack/react-router@1.168.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(next@16.2.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4))(react-router@7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1):
     dependencies:
       '@standard-schema/spec': 1.0.0
       react: 18.3.1
@@ -31964,16 +32064,16 @@ snapshots:
       next: 15.5.15(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.4)
       react-router: 7.13.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  nuxt@4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3):
+  nuxt@4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.4.5)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.4.5))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3):
     dependencies:
       '@dxup/nuxt': 0.4.0(magicast@0.5.2)(typescript@6.0.2)
       '@nuxt/cli': 3.34.0(@nuxt/schema@4.4.2)(cac@6.7.14)(magicast@0.5.2)(supports-color@8.1.1)
       '@nuxt/devtools': 3.2.4(supports-color@8.1.1)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(vue@3.5.30(typescript@6.0.2))
       '@nuxt/kit': 4.4.2(magicast@0.5.2)
-      '@nuxt/nitro-server': 4.4.2(ebcc12d5dc3cf0522b061183d2f1062e)
+      '@nuxt/nitro-server': 4.4.2(93014e84d3d03f3f67b5db0e374b874b)
       '@nuxt/schema': 4.4.2
       '@nuxt/telemetry': 2.7.0(@nuxt/kit@4.4.2(magicast@0.5.2))
-      '@nuxt/vite-builder': 4.4.2(a9c0b4b771d69d61084a5c4199181b69)
+      '@nuxt/vite-builder': 4.4.2(8ca202e14818a230e2b4912f3a3de316)
       '@unhead/vue': 2.1.12(vue@3.5.30(typescript@6.0.2))
       '@vue/shared': 3.5.30
       c12: 3.3.3(magicast@0.5.2)
@@ -35662,7 +35762,7 @@ snapshots:
       escape-string-regexp: 5.0.0
       ufo: 1.6.3
 
-  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.2.15))(ioredis@5.10.0(supports-color@8.1.1)):
+  unstorage@1.17.4(aws4fetch@1.0.20)(db0@0.3.4(@electric-sql/pglite@0.4.5))(ioredis@5.10.0(supports-color@8.1.1)):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -35674,7 +35774,7 @@ snapshots:
       ufo: 1.6.3
     optionalDependencies:
       aws4fetch: 1.0.20
-      db0: 0.3.4(@electric-sql/pglite@0.2.15)
+      db0: 0.3.4(@electric-sql/pglite@0.4.5)
       ioredis: 5.10.0(supports-color@8.1.1)
 
   until-async@3.0.2: {}
@@ -35990,6 +36090,16 @@ snapshots:
       - supports-color
       - typescript
 
+  vite-tsconfig-paths@6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      globrex: 0.1.2
+      tsconfck: 3.0.3(typescript@6.0.2)
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   vite-tsconfig-paths@6.1.1(supports-color@8.1.1)(typescript@6.0.2)(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -36018,6 +36128,23 @@ snapshots:
       tsx: 4.20.3
       yaml: 2.8.3
 
+  vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.10
+      rolldown: 1.0.0-rc.15
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      '@types/node': 22.13.14
+      esbuild: 0.25.2
+      fsevents: 2.3.3
+      jiti: 1.21.7
+      sass: 1.77.4
+      terser: 5.39.0
+      tsx: 4.20.3
+      yaml: 2.8.3
+
   vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
@@ -36038,6 +36165,37 @@ snapshots:
   vitefu@1.1.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
     optionalDependencies:
       vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+
+  vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
+    dependencies:
+      '@vitest/expect': 4.1.4
+      '@vitest/mocker': 4.1.4(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))
+      '@vitest/pretty-format': 4.1.4
+      '@vitest/runner': 4.1.4
+      '@vitest/snapshot': 4.1.4
+      '@vitest/spy': 4.1.4
+      '@vitest/utils': 4.1.4
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 4.0.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.4
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@1.21.7)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.0
+      '@types/node': 22.13.14
+      '@vitest/coverage-v8': 4.1.4(vitest@4.1.4)
+      '@vitest/ui': 4.1.4(vitest@4.1.4)
+      jsdom: 28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - msw
 
   vitest@4.1.4(@opentelemetry/api@1.9.0)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3)):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,7 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/*'
   - '@supabase/*'
   - '@supabase-labs/*'
+  - '@electric-sql/pglite'
   - braintrust # Included for bugfix in v3.9.0
   # The following packages are excluded from the minimum release age check because they had a vulneralibity
   # Delete them the next time you update this list


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?
RLS playground using pglite to load the schema, seed data and test multiple use cases

<img width="2985" height="1644" alt="Screenshot 2026-04-29 at 11 15 38" src="https://github.com/user-attachments/assets/ae56cce1-6cef-466c-9085-b57e8e6723c7" />
<img width="2982" height="1641" alt="Screenshot 2026-04-29 at 11 15 52" src="https://github.com/user-attachments/assets/174d874f-98f6-4ec1-a8c9-d1190ba21bfd" />
<img width="2983" height="1646" alt="Screenshot 2026-04-29 at 11 15 59" src="https://github.com/user-attachments/assets/76cb5022-7855-4ac4-a2f6-1d992fadceaa" />
<img width="2985" height="1644" alt="Screenshot 2026-04-29 at 11 16 09" src="https://github.com/user-attachments/assets/74c08706-af4b-4af0-9cd4-d17e29f7c8d0" />
<img width="2977" height="1640" alt="Screenshot 2026-04-29 at 11 16 40" src="https://github.com/user-attachments/assets/3edafa54-edeb-4618-8ec9-17a4f324e7c1" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added RLS Playground—a new interface for testing Row-Level Security policies in a sandboxed PostgreSQL environment.
  * Test RLS policies with multiple role configurations simultaneously.
  * Seed sandbox with test data via project import, custom SQL, or AI-generated statements.
  * Added to Auth Configuration menu for easy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->