### PR TITLE
fix: footer social links open in new tab with security attributes

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -118,6 +118,8 @@ const Footer = (props: Props) => {
             </Link>
             <div className="flex space-x-5">
               <a
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://twitter.com/supabase"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
@@ -126,6 +128,8 @@ const Footer = (props: Props) => {
               </a>
 
               <a
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://github.com/supabase"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
@@ -134,6 +138,8 @@ const Footer = (props: Props) => {
               </a>
 
               <a
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://discord.supabase.com/"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
@@ -142,6 +148,8 @@ const Footer = (props: Props) => {
               </a>
 
               <a
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://youtube.com/c/supabase"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
@@ -150,6 +158,8 @@ const Footer = (props: Props) => {
               </a>
 
               <a
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://www.tiktok.com/@supabase.com"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
@@ -158,6 +168,8 @@ const Footer = (props: Props) => {
               </a>
 
               <a
+                target="_blank"
+                rel="noopener noreferrer"
                 href="https://www.instagram.com/supabasecom"
                 className="text-foreground-lighter hover:text-foreground transition"
               >


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

---

## What kind of change does this PR introduce?

Bug fix

---

## What is the current behavior?

Footer social links (X, GitHub, Discord, YouTube, TikTok, Instagram) open in the same tab, navigating users away from the Supabase website.

Issue: https://github.com/supabase/supabase/issues/45342

---

## What is the new behavior?

Footer social links now open in a new tab while keeping the Supabase website open.

Added:

* `target="_blank"`
* `rel="noopener noreferrer"`

to all external social links in the footer.

---

## Additional context

This change improves:

* User experience (users don’t lose their current page)
* Security (prevents reverse tabnabbing via `window.opener`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Footer social media links now open in new browser tabs, allowing users to visit external platforms while keeping the website accessible in their original tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->