### PR TITLE
fix(studio): show effective Max IOPS in DB observability

### DIFF
--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -1,3 +1,6 @@
+import { COMPUTE_MAX_IOPS } from 'shared-data'
+
+import { mapComputeSizeNameToAddonVariantId } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
 import { compactNumberFormatter } from '@/components/ui/Charts/Charts.utils'
 import { ReportAttributes } from '@/components/ui/Charts/ComposedChart.utils'
 import { DiskAttributesData } from '@/data/config/disk-attributes-query'
@@ -15,12 +18,20 @@ export const getReportAttributesV2: (
   isSpendCapEnabled?: boolean
 ) => ReportAttributes[] = (
   entitledFeatures,
-  _project,
+  project,
   diskConfig,
   maxConnections,
   pgBouncerMaxConnections,
   isSpendCapEnabled
 ) => {
+  const provisionedDiskIops = diskConfig?.attributes?.iops
+  const computeIopsLimit =
+    COMPUTE_MAX_IOPS[mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)]
+  const effectiveMaxIops =
+    typeof provisionedDiskIops === 'number' && typeof computeIopsLimit === 'number'
+      ? Math.min(provisionedDiskIops, computeIopsLimit)
+      : provisionedDiskIops
+
   return [
     {
       id: 'ram-usage',
@@ -190,9 +201,9 @@ export const getReportAttributesV2: (
           attribute: 'disk_iops_max',
           provider: 'reference-line',
           label: 'Max IOPS',
-          value: diskConfig?.attributes?.iops,
+          value: effectiveMaxIops,
           tooltip:
-            'Maximum IOPS (Input/Output Operations Per Second) for your current compute size',
+            'Effective maximum IOPS for your current compute and disk configuration. Equal to the lower of the compute IOPS limit and the provisioned disk IOPS',
           isMaxValue: true,
         },
       ],


### PR DESCRIPTION
## Problem

The Max IOPS reference line in the Database Observability report displays the provisioned disk IOPS, but its tooltip claims it shows the "Maximum IOPS for your current compute size". The real effective ceiling is `min(compute IOPS limit, provisioned disk IOPS)`. Users who upgrade their disk IOPS without upgrading compute see an inflated number and may draw incorrect conclusions about their IO headroom.

Reported in [Linear DEBUG-63](https://linear.app/supabase/issue/DEBUG-63) (originally [FE-2856](https://linear.app/supabase/issue/FE-2856)).

## Fix

In [apps/studio/data/reports/database-charts.ts](apps/studio/data/reports/database-charts.ts), use the existing `mapComputeSizeNameToAddonVariantId` + `COMPUTE_MAX_IOPS` lookup (already used in DiskManagement) to compute the effective ceiling and pass it as the `disk_iops_max` reference line value. Tooltip rewritten to match.

```ts
const provisionedDiskIops = diskConfig?.attributes?.iops
const computeIopsLimit =
  COMPUTE_MAX_IOPS[mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)]
const effectiveMaxIops =
  typeof provisionedDiskIops === 'number' && typeof computeIopsLimit === 'number'
    ? Math.min(provisionedDiskIops, computeIopsLimit)
    : provisionedDiskIops
```

## Test plan

- [ ] On a project where compute IOPS limit < provisioned disk IOPS (e.g. Micro compute with upgraded disk), confirm the Max IOPS reference line on `/project/{ref}/observability/database` reflects the compute limit, not the disk IOPS.
- [ ] On a project where provisioned disk IOPS < compute IOPS limit, confirm the reference line still shows the disk IOPS.
- [ ] Hover the line and confirm the tooltip reads "Effective maximum IOPS for your current compute and disk configuration..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced IOPS limit calculations in database reports to account for both compute size and disk provisioning constraints, resulting in more accurate Max IOPS reference values. Improved chart tooltips to better reflect the effective combined compute and disk IOPS constraints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->