### PR TITLE
docs: prefer publishable/secret key naming in SDK specs

### DIFF
--- a/apps/docs/spec/storage_v0_config.yaml
+++ b/apps/docs/spec/storage_v0_config.yaml
@@ -5,9 +5,9 @@ info:
   id: 'storage' # {string} A unique ID for this tool.
   version: 'next' # {string} The current version number of the tool.
   title: 'Storage' # {string} A readable name.
-  source: 'https://github.com/supabase/storage-api' # {string} Where developers can find the source code.
-  bugs: 'https://github.com/supabase/storage-api/issues' # {string} Where developers can file bugs.
-  spec: 'https://github.com/supabase/supabase/blob/master/spec/storage_v1_config.yml' # {string} Where developers can find this spec (to link directly in the docs).
+  source: 'https://github.com/supabase/storage' # {string} Where developers can find the source code.
+  bugs: 'https://github.com/supabase/storage/issues' # {string} Where developers can file bugs.
+  spec: 'https://github.com/supabase/supabase/blob/master/spec/storage_v0_config.yml' # {string} Where developers can find this spec (to link directly in the docs).
   description: |
     A sample `.env` file is located in the [storage repository](https://github.com/supabase/storage-api/blob/master/.env.sample).
 
@@ -29,7 +29,7 @@ parameters:
     required: true
     # default: '5432'
     description: |
-      A long-lived JWT with anonymous Postgres privileges.
+      A long-lived publishable JWT used for unauthenticated client requests against this Storage tenant.
 
   - id: 'SERVICE_KEY' # {string} A unique identifier for this param.
     title: 'SERVICE_KEY' # {string} Any name.
@@ -38,7 +38,7 @@ parameters:
     required: true
     # default: '5432'
     description: |
-      A long-lived JWT with Postgres privileges to bypass Row Level Security.
+      A long-lived secret JWT used to bypass Row Level Security on this Storage tenant. Never expose this key in client applications.
 
   - id: 'TENANT_ID' # {string} A unique identifier for this param.
     title: 'TENANT_ID' # {string} Any name.

--- a/apps/docs/spec/storage_v0_config.yaml
+++ b/apps/docs/spec/storage_v0_config.yaml
@@ -29,7 +29,7 @@ parameters:
     required: true
     # default: '5432'
     description: |
-      A long-lived publishable JWT used for unauthenticated client requests against this Storage tenant.
+      A long-lived JWT with anonymous Postgres privileges.
 
   - id: 'SERVICE_KEY' # {string} A unique identifier for this param.
     title: 'SERVICE_KEY' # {string} Any name.
@@ -38,7 +38,7 @@ parameters:
     required: true
     # default: '5432'
     description: |
-      A long-lived secret JWT used to bypass Row Level Security on this Storage tenant. Never expose this key in client applications.
+      A long-lived JWT with Postgres privileges to bypass Row Level Security.
 
   - id: 'TENANT_ID' # {string} A unique identifier for this param.
     title: 'TENANT_ID' # {string} Any name.

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -26,10 +26,10 @@ functions:
         isOptional: false
         type: string
         description: The unique Supabase URL which is supplied when you create a new project in your project dashboard.
-      - name: anonKey
+      - name: publishableKey
         isOptional: false
         type: string
-        description: The unique Supabase Key which is supplied when you create a new project in your project dashboard.
+        description: Your project's publishable key. Find this in your project's API settings.
       - name: headers
         isOptional: true
         type: Map<String, String>
@@ -94,7 +94,7 @@ functions:
           Future<void> main() async {
             await Supabase.initialize(
               url: 'https://xyzcompany.supabase.co',
-              anonKey: 'publishable-or-anon-key',
+              publishableKey: 'your-publishable-key',
             );
 
             runApp(MyApp());
@@ -109,7 +109,7 @@ functions:
           ```dart
           final supabase = SupabaseClient(
             'https://xyzcompany.supabase.co',
-            'publishable-or-anon-key',
+            'your-publishable-key',
           );
           ```
 
@@ -2114,15 +2114,15 @@ functions:
   - id: admin-api
     title: 'Overview'
     notes: |
-      - Any method under the `supabase.auth.admin` namespace requires a `service_role` key.
-      - These methods are considered admin methods and should be called on a trusted server. Never expose your `service_role` key in the Flutter app.
+      - Any method under the `supabase.auth.admin` namespace requires a `secret` key.
+      - These methods are considered admin methods and should be called on a trusted server. Never expose your `secret` key in the Flutter app.
     examples:
       - id: create-auth-admin-client
         name: Create server-side auth client
         isSpotlight: true
         code: |
           ```dart
-          final supabase = SupabaseClient(supabaseUrl, serviceRoleKey);
+          final supabase = SupabaseClient(supabaseUrl, secretKey);
           ```
   - id: get-user-by-id
     title: 'getUserById()'

--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -26,10 +26,10 @@ functions:
         isOptional: false
         type: string
         description: The unique Supabase URL which is supplied when you create a new project in your project dashboard.
-      - name: publishableKey
+      - name: anonKey
         isOptional: false
         type: string
-        description: Your project's publishable key. Find this in your project's API settings.
+        description: The unique Supabase Key which is supplied when you create a new project in your project dashboard.
       - name: headers
         isOptional: true
         type: Map<String, String>
@@ -94,7 +94,7 @@ functions:
           Future<void> main() async {
             await Supabase.initialize(
               url: 'https://xyzcompany.supabase.co',
-              publishableKey: 'your-publishable-key',
+              anonKey: 'publishable-or-anon-key',
             );
 
             runApp(MyApp());
@@ -109,7 +109,7 @@ functions:
           ```dart
           final supabase = SupabaseClient(
             'https://xyzcompany.supabase.co',
-            'your-publishable-key',
+            'publishable-or-anon-key',
           );
           ```
 

--- a/apps/docs/spec/supabase_js_v2.yml
+++ b/apps/docs/spec/supabase_js_v2.yml
@@ -33,7 +33,7 @@ functions:
           ```js
           import { createClient } from '@supabase/supabase-js'
 
-          const supabase = createClient(supabase_url, anon_key)
+          const supabase = createClient(supabase_url, publishable_key)
           ```
       - id: create-auth-client-server-side
         name: Create auth client (server-side)
@@ -42,7 +42,7 @@ functions:
           ```js
           import { createClient } from '@supabase/supabase-js'
 
-          const supabase = createClient(supabase_url, anon_key, {
+          const supabase = createClient(supabase_url, publishable_key, {
             auth: {
               autoRefreshToken: false,
               persistSession: false,
@@ -159,8 +159,8 @@ functions:
   - id: admin-api
     title: Overview
     notes: |
-      - Any method under the `supabase.auth.admin` namespace requires a `service_role` key.
-      - These methods are considered admin methods and should be called on a trusted server. Never expose your `service_role` key in the browser.
+      - Any method under the `supabase.auth.admin` namespace requires a `secret` key.
+      - These methods are considered admin methods and should be called on a trusted server. Never expose your `secret` key in the browser.
     examples:
       - id: create-auth-admin-client
         name: Create server-side auth client
@@ -169,7 +169,7 @@ functions:
           ```js
           import { createClient } from '@supabase/supabase-js'
 
-          const supabase = createClient(supabase_url, service_role_key, {
+          const supabase = createClient(supabase_url, secret_key, {
             auth: {
               autoRefreshToken: false,
               persistSession: false
@@ -213,7 +213,7 @@ functions:
     title: Custom OIDC/OAuth Provider Admin API
     notes: |
       - These methods allow you to manage custom OIDC/OAuth providers programmatically.
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - Custom providers use the `custom:` prefix when signing in (e.g., `custom:my-oidc-provider`).
   - id: admin-custom-providers-create
     $ref: '@supabase/auth-js.GoTrueAdminCustomProvidersApi.createProvider'
@@ -590,7 +590,7 @@ functions:
     notes: |
       The OAuth Admin API allows you to manage OAuth clients programmatically.
       Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
-      These functions should only be called on a server. Never expose your `service_role` key in the browser.
+      These functions should only be called on a server. Never expose your `secret` key in the browser.
   - id: auth-js-gotrueadminoauthapi-createclient
     $ref: '@supabase/auth-js.GoTrueAdminOAuthApi.createClient'
   - id: auth-js-gotrueadminoauthapi-deleteclient

--- a/apps/docs/spec/supabase_kt_v2.yml
+++ b/apps/docs/spec/supabase_kt_v2.yml
@@ -127,7 +127,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Auth)
               install(Postgrest)
@@ -140,7 +140,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Auth) {
                   alwaysAutoRefresh = false // default: true
@@ -197,7 +197,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Postgrest) {
                   defaultSchema = "schema" // default: "public"
@@ -219,7 +219,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Storage) {
                   transferTimeout = 90.seconds // Default: 120 seconds
@@ -246,7 +246,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Realtime) {
                   reconnectDelay = 5.seconds // Default: 7 seconds
@@ -273,7 +273,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Functions) {
                   //no custom settings
@@ -290,7 +290,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(GraphQL) {
                   apolloConfiguration {
@@ -2816,7 +2816,7 @@ functions:
         isSpotlight: true
         code: |
           ```kotlin
-          val supabase = createSupabaseClient(supabaseURL = "https://xyzcompany.supabase.co'", supabaseKey = "publishable-or-anon-key") { ... }
+          val supabase = createSupabaseClient(supabaseURL = "https://xyzcompany.supabase.co'", supabaseKey = "your-publishable-key") { ... }
           val auth = supabase.auth
           ```
   - id: sign-up
@@ -3973,8 +3973,8 @@ functions:
   - id: admin-api
     title: 'Overview'
     notes: |
-      - Any method under the `supabase.auth.admin` namespace requires a `service_role` key.
-      - These methods are considered admin methods and should be called on a trusted server. Never expose your `service_role` key in the browser.
+      - Any method under the `supabase.auth.admin` namespace requires a `secret` key.
+      - These methods are considered admin methods and should be called on a trusted server. Never expose your `secret` key in the browser.
     examples:
       - id: create-auth-admin-client
         name: Create server-side auth client
@@ -3988,9 +3988,9 @@ functions:
               install(Auth) {
                   minimalSettings() //disables session saving and auto-refreshing
               }
-              // install other plugins (these will use the service role key)
+              // install other plugins (these will use the secret key)
           }
-          supabase.auth.importAuthToken("service_role")
+          supabase.auth.importAuthToken("your-secret-key")
 
           // Access auth admin api
           val adminAuthClient = supabase.auth.admin

--- a/apps/docs/spec/supabase_kt_v2.yml
+++ b/apps/docs/spec/supabase_kt_v2.yml
@@ -2816,7 +2816,7 @@ functions:
         isSpotlight: true
         code: |
           ```kotlin
-          val supabase = createSupabaseClient(supabaseURL = "https://xyzcompany.supabase.co'", supabaseKey = "your-publishable-key") { ... }
+          val supabase = createSupabaseClient(supabaseUrl = "https://xyzcompany.supabase.co", supabaseKey = "your-publishable-key") { ... }
           val auth = supabase.auth
           ```
   - id: sign-up

--- a/apps/docs/spec/supabase_kt_v3.yml
+++ b/apps/docs/spec/supabase_kt_v3.yml
@@ -2911,7 +2911,7 @@ functions:
         isSpotlight: true
         code: |
           ```kotlin
-          val supabase = createSupabaseClient(supabaseUrl = "https://xyzcompany.supabase.co'", supabaseKey = "your-publishable-key") { ... }
+          val supabase = createSupabaseClient(supabaseUrl = "https://xyzcompany.supabase.co", supabaseKey = "your-publishable-key") { ... }
           val auth = supabase.auth
           ```
   - id: sign-up

--- a/apps/docs/spec/supabase_kt_v3.yml
+++ b/apps/docs/spec/supabase_kt_v3.yml
@@ -132,7 +132,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Auth)
               install(Postgrest)
@@ -145,7 +145,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Auth) {
                   alwaysAutoRefresh = false // default: true
@@ -202,7 +202,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Postgrest) {
                   defaultSchema = "schema" // default: "public"
@@ -228,7 +228,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Storage) {
                   transferTimeout = 90.seconds // Default: 120 seconds
@@ -255,7 +255,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Realtime) {
                   reconnectDelay = 5.seconds // Default: 7 seconds
@@ -282,7 +282,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(Functions) {
                   //no custom settings
@@ -299,7 +299,7 @@ functions:
           ```kotlin
           val supabase = createSupabaseClient(
               supabaseUrl = "https://xyzcompany.supabase.co",
-              supabaseKey = "publishable-or-anon-key"
+              supabaseKey = "your-publishable-key"
           ) {
               install(GraphQL) {
                   apolloConfiguration {
@@ -2911,7 +2911,7 @@ functions:
         isSpotlight: true
         code: |
           ```kotlin
-          val supabase = createSupabaseClient(supabaseUrl = "https://xyzcompany.supabase.co'", supabaseKey = "publishable-or-anon-key") { ... }
+          val supabase = createSupabaseClient(supabaseUrl = "https://xyzcompany.supabase.co'", supabaseKey = "your-publishable-key") { ... }
           val auth = supabase.auth
           ```
   - id: sign-up
@@ -4165,8 +4165,8 @@ functions:
   - id: admin-api
     title: 'Overview'
     notes: |
-      - Any method under the `supabase.auth.admin` namespace requires a `service_role` key.
-      - These methods are considered admin methods and should be called on a trusted server. Never expose your `service_role` key in the browser.
+      - Any method under the `supabase.auth.admin` namespace requires a `secret` key.
+      - These methods are considered admin methods and should be called on a trusted server. Never expose your `secret` key in the browser.
     examples:
       - id: create-auth-admin-client
         name: Create server-side auth client
@@ -4180,9 +4180,9 @@ functions:
               install(Auth) {
                   minimalConfig() //disables session saving and auto-refreshing
               }
-              // install other plugins (these will use the service role key)
+              // install other plugins (these will use the secret key)
           }
-          supabase.auth.importAuthToken("service_role")
+          supabase.auth.importAuthToken("your-secret-key")
 
           // Access auth admin api
           val adminAuthClient = supabase.auth.admin

--- a/apps/docs/spec/supabase_py_v2.yml
+++ b/apps/docs/spec/supabase_py_v2.yml
@@ -2135,8 +2135,8 @@ functions:
   - id: admin-api
     title: 'Overview'
     notes: |
-      - Any method under the `supabase.auth.admin` namespace requires a `service_role` key.
-      - These methods are considered admin methods and should be called on a trusted server. Never expose your `service_role` key in the browser.
+      - Any method under the `supabase.auth.admin` namespace requires a `secret` key.
+      - These methods are considered admin methods and should be called on a trusted server. Never expose your `secret` key in the browser.
     examples:
       - id: create-auth-admin-client
         name: Create server-side auth client
@@ -2148,7 +2148,7 @@ functions:
 
           supabase = create_client(
               supabase_url,
-              service_role_key,
+              secret_key,
               options=ClientOptions(
                   auto_refresh_token=False,
                   persist_session=False,
@@ -2168,7 +2168,7 @@ functions:
         description: |
           The user's unique identifier
 
-          This function should only be called on a server. Never expose your `service_role` key in the browser.
+          This function should only be called on a server. Never expose your `secret` key in the browser.
     notes: |
       - Fetches the user object from the database based on the user's id.
       - The `get_user_by_id()` method requires the user's id which maps to the `auth.users.id` column.
@@ -2397,8 +2397,8 @@ functions:
         description: |
           If true, then the user will be soft-deleted (setting `deleted_at` to the current timestamp and disabling their account while preserving their data) from the auth schema. Defaults to false for backward compatibility.
 
-          This function should only be called on a server. Never expose your `service_role` key in the browser.
-    description: Delete a user. Requires a `service_role` key.
+          This function should only be called on a server. Never expose your `secret` key in the browser.
+    description: Delete a user. Requires a `secret` key.
     notes: |
       - The `delete_user()` method requires the user's ID, which maps to the `auth.users.id` column.
     examples:
@@ -2655,7 +2655,7 @@ functions:
         description: |
           The data you want to update.
 
-          This function should only be called on a server. Never expose your `service_role` key in the browser.
+          This function should only be called on a server. Never expose your `secret` key in the browser.
         subContent:
           - name: app_metadata
             isOptional: true
@@ -2825,7 +2825,7 @@ functions:
     title: 'Overview'
     notes: |
       - OAuth 2.1 client administration endpoints are available via the `supabase.auth.admin.oauth` namespace.
-      - These methods require a `service_role` key and should only be called server-side.
+      - These methods require a `secret` key and should only be called server-side.
       - Only relevant when the OAuth 2.1 server is enabled in Supabase Auth.
       - This is an alpha feature and may change in the future.
 
@@ -2834,7 +2834,7 @@ functions:
     description: |
       Lists OAuth clients with optional pagination.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - Only available when OAuth 2.1 server is enabled.
       - This is an alpha feature and may change in the future.
     params:
@@ -2872,7 +2872,7 @@ functions:
     description: |
       Creates a new OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - Only available when OAuth 2.1 server is enabled.
       - This is an alpha feature and may change in the future.
     params:
@@ -2923,7 +2923,7 @@ functions:
     description: |
       Updates an existing OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - Only available when OAuth 2.1 server is enabled.
       - This is an alpha feature and may change in the future.
     params:
@@ -2971,7 +2971,7 @@ functions:
     description: |
       Retrieves details of an OAuth client by ID.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - Only available when OAuth 2.1 server is enabled.
       - This is an alpha feature and may change in the future.
     params:
@@ -2992,7 +2992,7 @@ functions:
     description: |
       Deletes an OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - Only available when OAuth 2.1 server is enabled.
       - This is an alpha feature and may change in the future.
     params:
@@ -3013,7 +3013,7 @@ functions:
     description: |
       Regenerates the client secret for an OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - Only available when OAuth 2.1 server is enabled.
       - This is an alpha feature and may change in the future.
     params:

--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -27,7 +27,7 @@ functions:
           ```swift
           import Supabase
 
-          let client = SupabaseClient(supabaseURL: URL(string: "https://xyzcompany.supabase.co")!, supabaseKey: "publishable-or-anon-key")
+          let client = SupabaseClient(supabaseURL: URL(string: "https://xyzcompany.supabase.co")!, supabaseKey: "your-publishable-key")
           ```
       - id: initialize-client-custom-options
         name: Initialize Client with custom options
@@ -37,7 +37,7 @@ functions:
 
           let supabase = SupabaseClient(
             supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
-            supabaseKey: "publishable-or-anon-key",
+            supabaseKey: "your-publishable-key",
             options: SupabaseClientOptions(
               db: .init(
                 schema: "public"
@@ -63,7 +63,7 @@ functions:
 
           let supabase = SupabaseClient(
             supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
-            supabaseKey: "publishable-or-anon-key",
+            supabaseKey: "your-publishable-key",
             options: SupabaseClientOptions(
               db: .init(
                 // Disable automatic retries for this client
@@ -86,7 +86,7 @@ functions:
 
           let supabase = SupabaseClient(
             supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
-            supabaseKey: "publishable-or-anon-key",
+            supabaseKey: "your-publishable-key",
             options: SupabaseClientOptions(
               global: SupabaseClientOptions.GlobalOptions(
                 logger: AppLogger()
@@ -102,7 +102,7 @@ functions:
 
           let supabase = SupabaseClient(
             supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
-            supabaseKey: "publishable-or-anon-key",
+            supabaseKey: "your-publishable-key",
             options: SupabaseClientOptions(
               db: .init(
                 // Provide a custom schema. Defaults to "public".
@@ -174,7 +174,7 @@ functions:
         isSpotlight: true
         code: |
           ```swift
-          let supabase = SupabaseClient(supabaseURL: URL(string: "https://xyzcompany.supabase.co")!, supabaseKey: "publishable-or-anon-key")
+          let supabase = SupabaseClient(supabaseURL: URL(string: "https://xyzcompany.supabase.co")!, supabaseKey: "your-publishable-key")
           let auth = supabase.auth
           ```
       - id: create-auth-client-with-custom-storage
@@ -184,7 +184,7 @@ functions:
           ```swift
           let supabase = SupabaseClient(
             supabaseURL: URL(string: "https://xyzcompany.supabase.co")!,
-            supabaseKey: "publishable-or-anon-key",
+            supabaseKey: "your-publishable-key",
             options: .init(
               auth: .init(
                 MyCustomLocalStorage()
@@ -1350,8 +1350,8 @@ functions:
   - id: admin-api
     title: 'Overview'
     notes: |
-      - Any method under the `supabase.auth.admin` namespace requires a `service_role` key.
-      - These methods are considered admin methods and should be called on a trusted server. Never expose your `service_role` key in the browser.
+      - Any method under the `supabase.auth.admin` namespace requires a `secret` key.
+      - These methods are considered admin methods and should be called on a trusted server. Never expose your `secret` key in the browser.
     examples:
       - id: create-auth-admin-client
         name: Create server-side auth client
@@ -1362,7 +1362,7 @@ functions:
 
           let supabase = SupabaseClient(
             supabaseURL: supabaseURL,
-            supabaseKey: serviceRoleKey
+            supabaseKey: secretKey
           )
 
           // Access auth admin api
@@ -1483,7 +1483,7 @@ functions:
     description: |
       List all OAuth clients with optional pagination.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - This method is part of the OAuth 2.1 server administration API.
       - Only works when the OAuth 2.1 server is enabled in your Supabase Auth configuration.
     overwriteParams:
@@ -1515,7 +1515,7 @@ functions:
     description: |
       Create a new OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - This method is part of the OAuth 2.1 server administration API.
       - Only works when the OAuth 2.1 server is enabled in your Supabase Auth configuration.
     overwriteParams:
@@ -1543,7 +1543,7 @@ functions:
     description: |
       Get details of a specific OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - This method is part of the OAuth 2.1 server administration API.
     overwriteParams:
       - name: clientId
@@ -1566,7 +1566,7 @@ functions:
     description: |
       Delete an OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - This method is part of the OAuth 2.1 server administration API.
       - This action cannot be undone.
     overwriteParams:
@@ -1590,7 +1590,7 @@ functions:
     description: |
       Regenerate the secret for an OAuth client.
     notes: |
-      - Requires `service_role` key.
+      - Requires `secret` key.
       - This method is part of the OAuth 2.1 server administration API.
       - The old secret will be immediately invalidated.
       - Make sure to update your application with the new secret.


### PR DESCRIPTION
## Description

Replaces legacy `anon` / `service_role` key references with the new `publishable` / `secret` naming across SDK spec files under `apps/docs/spec/`. Mirrors the rename table established by [supabase-js#2280](https://github.com/supabase/supabase-js/pull/2280), so the auto-generated reference docs at supabase.com/docs/reference/{js,dart,kotlin,python,swift} stay consistent with the SDK source.

## Files changed

| File | Highlights |
| --- | --- |
| `supabase_js_v2.yml` | Rename example vars `anon_key` → `publishable_key`, `service_role_key` → `secret_key`; admin notes use `secret`. |
| `supabase_dart_v2.yml` | Rename `anonKey` param → `publishableKey` (matches the live Flutter SDK — see [supabase-flutter/supabase.dart#L81](https://github.com/supabase/supabase-flutter/blob/main/packages/supabase_flutter/lib/src/supabase.dart#L81)); update call-site; example var `serviceRoleKey` → `secretKey`; admin notes use `secret`. |
| `supabase_kt_v2.yml`, `supabase_kt_v3.yml` | Replace `'publishable-or-anon-key'` placeholders with `'your-publishable-key'`; admin notes use `secret`; fix `importAuthToken(\"service_role\")` → `importAuthToken(\"your-secret-key\")` (the Kotlin SDK's `importAuthToken(accessToken: String, …)` takes a JWT, not a role name). |
| `supabase_py_v2.yml` | All `service_role` references → `secret`; example var `service_role_key` → `secret_key`. |
| `supabase_swift_v2.yml` | Replace placeholders with `'your-publishable-key'`; admin notes use `secret`; example var `serviceRoleKey` → `secretKey`. |
| `storage_v0_config.yaml` | Rewrite `ANON_KEY` / `SERVICE_KEY` env var **descriptions** in publishable/secret terms. **Env var names kept** — see below. |

## Why the storage env var names are unchanged

`storage_v0_config.yaml` documents the env vars used to configure the storage server (multi-tenant deployments). The `id` and `title` fields must match the actual env var names the binary reads. The storage server still reads its config from env vars literally named `ANON_KEY` and `SERVICE_KEY`:

- [`storage/src/config.ts#L614`](https://github.com/supabase/storage/blob/master/src/config.ts#L614) — `getOptionalConfigFromEnv('SERVICE_KEY')`
- [`storage/src/config.ts#L625`](https://github.com/supabase/storage/blob/master/src/config.ts#L625) — `getOptionalConfigFromEnv('ANON_KEY')`

There is no `PUBLISHABLE_KEY` / `SECRET_KEY` reader on master. Renaming the doc IDs would break self-hosted deployments — users following the docs would set the wrong env var and the storage server would silently fall back to generating its own JWT. Until the storage server itself adds publishable/secret env support, only descriptions can be updated.

(Same reasoning for not bumping `storage_v0_config.yaml` → `storage_v1_config.yaml`: the `_v0_` tracks the storage server's own API version, paired with `storage_v0_openapi.json` downloaded from `supabase.github.io/storage/api.json`. The server hasn't shipped a v1 API.)

## What we deliberately did NOT rename

Per the same rules established in supabase-js#2280:

- **JWT role claims** like `role: 'anon'` / `role: 'service_role'` — these are functional Postgres role names in JWT payloads, not key labels.
- **Real SDK identifiers** that haven't been renamed in the source (we only rename in the doc when the underlying SDK rename has shipped). The Dart `anonKey` rename was safe to apply because the Flutter SDK already ships `publishableKey` as the preferred named parameter (with `anonKey` `@Deprecated`).

## Out of scope

- **All `*_v1.yml` SDK spec files** (`supabase_js_v1`, `supabase_dart_v1`, `supabase_kt_v1`, `supabase_swift_v1`). Older SDK versions, not worth churning.
- **`cli_v1_commands.yaml`**. This file is auto-generated by the CLI repo's release workflow ([`cli/tools/bumpdoc/main.go`](https://github.com/supabase/cli/blob/develop/tools/bumpdoc/main.go)) and the example outputs come from [`cli/docs/templates/examples.yaml`](https://github.com/supabase/cli/blob/develop/docs/templates/examples.yaml) — embedded in the CLI binary at build time. Any edits we make here would be clobbered by the next CLI release. The fix needs to land upstream in the CLI repo (note: the CLI itself already ships publishable/secret naming in \`supabase status\` output — see [`cli/internal/status/status.go#L40-L44`](https://github.com/supabase/cli/blob/develop/internal/status/status.go#L40-L44) — but the doc-generation template is stale).
- **`supabase_csharp_v0.yml` / `supabase_csharp_v1.yml`** — checked, already neutral. Both files use a generic `SUPABASE_KEY` env var with no `anon` / `service_role` references.
- **Renaming the legacy Dart `anonKey` parameter itself** — that's an SDK-side change. The Flutter SDK already exposes `publishableKey` as the preferred parameter; full removal of `anonKey` will happen in a future major version per the SDK's own deprecation comment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized API key naming across SDK docs: use publishable (client) and secret (server/admin) key terminology
  * Updated server-side admin examples and warnings to require secret keys and emphasize never exposing them in client code
  * Unified initialization examples across JavaScript, Dart, Kotlin, Python, and Swift
  * Corrected Storage spec metadata to point to the proper configuration file
<!-- end of auto-generated comment: release notes by coderabbit.ai -->