### PR TITLE
feat: add global feature preview badge for enabled preview features

### DIFF
--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksHeader.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksHeader.tsx
@@ -19,6 +19,7 @@ import {
 } from 'ui-patterns/PageHeader'
 
 import { DocsButton } from '@/components/ui/DocsButton'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 
 interface PlatformWebhooksHeaderProps {
   hasSelectedEndpoint: boolean
@@ -28,6 +29,7 @@ interface PlatformWebhooksHeaderProps {
   endpointActions?: ReactNode
   webhooksHref: string
   scopeLabel: string
+  featureKey: string
 }
 
 export const PlatformWebhooksHeader = ({
@@ -38,6 +40,7 @@ export const PlatformWebhooksHeader = ({
   endpointActions,
   webhooksHref,
   scopeLabel,
+  featureKey,
 }: PlatformWebhooksHeaderProps) => {
   return (
     <PageHeader size="default" className="pb-6">
@@ -69,6 +72,7 @@ export const PlatformWebhooksHeader = ({
                   {endpointStatus === 'enabled' ? 'Enabled' : 'Disabled'}
                 </Badge>
               )}
+              {!hasSelectedEndpoint && <FeaturePreviewBadge featureKey={featureKey} />}
             </span>
           </PageHeaderTitle>
           <PageHeaderDescription>{headerDescription}</PageHeaderDescription>

--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksPage.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksPage.tsx
@@ -50,7 +50,6 @@ import {
   shouldHandleEndpointNotFound,
 } from './PlatformWebhooksPage.utils'
 import { useIsPlatformWebhooksEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 

--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksPage.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksPage.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { EllipsisVertical, Pencil, RotateCw, Trash2 } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
@@ -50,6 +50,7 @@ import {
   shouldHandleEndpointNotFound,
 } from './PlatformWebhooksPage.utils'
 import { useIsPlatformWebhooksEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
@@ -316,6 +317,7 @@ export const PlatformWebhooksPage = ({ scope, endpointId }: PlatformWebhooksPage
       <PlatformWebhooksHeader
         hasSelectedEndpoint={!!selectedEndpoint}
         headerTitle={headerTitle}
+        featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_PLATFORM_WEBHOOKS}
         headerDescription={headerDescription}
         endpointStatus={
           selectedEndpoint ? (selectedEndpoint.enabled ? 'enabled' : 'disabled') : undefined

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction, SupportCategories } from '@supabase/shared-types/out/constants'
-import { useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { Loader2 } from 'lucide-react'
 import Link from 'next/link'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
@@ -44,6 +44,7 @@ import { JitDbAccessRulesTable } from './JitDbAccessRulesTable'
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
 import AlertError from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useDatabaseRolesQuery } from '@/data/database-roles/database-roles-query'
 import { useJitDbAccessMembersQuery } from '@/data/jit-db-access/jit-db-access-members-query'
@@ -290,7 +291,12 @@ export const JitDbAccessConfiguration = () => {
       <PageSection id="jit-db-access-configuration">
         <PageSectionMeta>
           <PageSectionSummary>
-            <PageSectionTitle>Temporary access</PageSectionTitle>
+            <PageSectionTitle>
+              <span className="flex items-center gap-2">
+                Temporary access
+                <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_JIT_DB_ACCESS} />
+              </span>
+            </PageSectionTitle>
           </PageSectionSummary>
           <DocsButton href={`${DOCS_URL}/guides/platform/temporary-access`} />
         </PageSectionMeta>

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -13,7 +13,7 @@ import {
   useReactTable,
   VisibilityState,
 } from '@tanstack/react-table'
-import { useDebounce, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useDebounce, useParams } from 'common'
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useQueryStates } from 'nuqs'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -52,6 +52,7 @@ import { LiveButton } from '@/components/ui/DataTable/LiveButton'
 import { Kbd } from '@/components/ui/DataTable/primitives/Kbd'
 import { DataTableProvider } from '@/components/ui/DataTable/providers/DataTableProvider'
 import { TimelineChart } from '@/components/ui/DataTable/TimelineChart'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 import { useUnifiedLogsChartQuery } from '@/data/logs/unified-logs-chart-query'
 import { useUnifiedLogsCountQuery } from '@/data/logs/unified-logs-count-query'
 import { useUnifiedLogsInfiniteQuery } from '@/data/logs/unified-logs-infinite-query'
@@ -409,6 +410,7 @@ export const UnifiedLogs = () => {
                   <DataTableFilterControlsDrawer />
                 </div>
                 <div className="ml-auto flex items-center gap-2">
+                  <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS} />
                   <RefreshButton isLoading={isRefetchingData} onRefresh={refetchAllData} />
                   <DataTableViewOptions />
                   <DownloadLogsButton searchParameters={searchParameters} />

--- a/apps/studio/components/layouts/AdvisorsLayout/AdvisorRulesLayout.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/AdvisorRulesLayout.tsx
@@ -1,17 +1,27 @@
-import { useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { PropsWithChildren } from 'react'
 
 import DefaultLayout from '../DefaultLayout'
 import { PageLayout } from '../PageLayout/PageLayout'
 import AdvisorsLayout from './AdvisorsLayout'
+import { useIsAdvisorRulesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 
 export const AdvisorRulesLayout = ({ children }: PropsWithChildren<{}>) => {
   const { ref } = useParams()
+  const isAdvisorRulesEnabled = useIsAdvisorRulesEnabled()
   return (
     <DefaultLayout>
       <AdvisorsLayout>
         <PageLayout
-          title="Advisor Settings"
+          title={
+            <span className="flex items-center gap-2">
+              Advisor Settings
+              {isAdvisorRulesEnabled && (
+                <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_ADVISOR_RULES} />
+              )}
+            </span>
+          }
           subtitle="Disable specific advisor categories or rules"
           navigationItems={[
             {

--- a/apps/studio/components/ui/FeaturePreviewBadge.tsx
+++ b/apps/studio/components/ui/FeaturePreviewBadge.tsx
@@ -1,0 +1,33 @@
+import { FlaskConical } from 'lucide-react'
+import { Badge, cn } from 'ui'
+
+import { useFeaturePreviewModal } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+
+interface FeaturePreviewBadgeProps {
+  featureKey: string
+  className?: string
+}
+
+export const FeaturePreviewBadge = ({ featureKey, className }: FeaturePreviewBadgeProps) => {
+  const { selectFeaturePreview } = useFeaturePreviewModal()
+
+  return (
+    <button
+      type="button"
+      onClick={() => selectFeaturePreview(featureKey)}
+      className="group"
+      title="Feature preview — click to manage"
+    >
+      <Badge
+        variant="default"
+        className={cn(
+          'cursor-pointer group-hover:border-foreground-light group-hover:text-foreground transition-colors',
+          className
+        )}
+      >
+        <FlaskConical size={8} strokeWidth={1.5} />
+        Feature preview
+      </Badge>
+    </button>
+  )
+}

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -35,6 +35,7 @@ import { BannerRlsEventTrigger } from '@/components/ui/BannerStack/Banners/Banne
 import { BannerRlsTester } from '@/components/ui/BannerStack/Banners/BannerRlsTester'
 import { useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
 import { DocsButton } from '@/components/ui/DocsButton'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 import { NoPermission } from '@/components/ui/NoPermission'
 import { SchemaSelector } from '@/components/ui/SchemaSelector'
 import { useProjectPostgrestConfigQuery } from '@/data/config/project-postgrest-config-query'
@@ -297,7 +298,14 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
       <PageHeader size="large">
         <PageHeaderMeta>
           <PageHeaderSummary>
-            <PageHeaderTitle>Policies</PageHeaderTitle>
+            <PageHeaderTitle>
+              <span className="flex items-center gap-2">
+                Policies
+                {rlsTesterEnabled && (
+                  <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER} />
+                )}
+              </span>
+            </PageHeaderTitle>
             <PageHeaderDescription>
               Manage Row Level Security policies for your tables
             </PageHeaderDescription>

--- a/apps/studio/pages/project/[ref]/database/column-privileges.tsx
+++ b/apps/studio/pages/project/[ref]/database/column-privileges.tsx
@@ -24,6 +24,7 @@ import DefaultLayout from '@/components/layouts/DefaultLayout'
 import { ScaffoldContainer, ScaffoldSection } from '@/components/layouts/Scaffold'
 import AlertError from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 import { PgRole, useDatabaseRolesQuery } from '@/data/database-roles/database-roles-query'
 import { useColumnPrivilegesQuery } from '@/data/privileges/column-privileges-query'
 import { useTablePrivilegesQuery } from '@/data/privileges/table-privileges-query'
@@ -224,10 +225,15 @@ const PrivilegesPage: NextPageWithLayout = () => {
         <div className="col-span-12 flex flex-col pb-4 gap-y-4">
           <div className="flex items-center justify-between">
             <div>
-              <h3 className="mb-1 text-xl">Column-level privileges</h3>
-              <div className="text-sm text-lighter">
-                <p>Grant or revoke privileges on a column based on user role.</p>
+              <div className="flex items-center gap-2 mb-1">
+                <h3 className="text-xl">Column-level privileges</h3>
+                {isEnabled && (
+                  <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_CLS} />
+                )}
               </div>
+              <p className="text-sm text-lighter">
+                Grant or revoke privileges on a column based on user role.
+              </p>
             </div>
             <DocsButton href={`${DOCS_URL}/guides/auth/column-level-security`} />
           </div>

--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import dayjs from 'dayjs'
 import { AlertTriangle, GitBranchIcon, GitMerge, MoreVertical, Shield, X } from 'lucide-react'
 import Link from 'next/link'
@@ -30,6 +30,7 @@ import { ProjectLayoutWithAuth } from '@/components/layouts/ProjectLayout'
 import { ScaffoldContainer } from '@/components/layouts/Scaffold'
 import ProductEmptyState from '@/components/to-be-cleaned/ProductEmptyState'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
 import { useBranchDeleteMutation } from '@/data/branches/branch-delete-mutation'
 import { useBranchMergeMutation } from '@/data/branches/branch-merge-mutation'
 import { useBranchPushMutation } from '@/data/branches/branch-push-mutation'
@@ -446,6 +447,9 @@ const MergePage: NextPageWithLayout = () => {
   const pageTitle = () => (
     <div className="flex items-center gap-x-2">
       <span>Merge</span>
+      {pgDeltaDiffEnabled && (
+        <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_PG_DELTA_DIFF} />
+      )}
 
       <Link href={`/project/${ref}/editor`}>
         <Badge className="font-mono text-sm gap-1 px-2">


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes FE-2526. 

Adds a global Feature Preview badge to pages enabled via Feature Previews, improving visibility and making it clearer to users that the feature can be managed (or disabled) from the Feature Previews settings.

## Why

Previously, once a feature preview was enabled, there was no clear indication within the UI that:

- the feature was still in preview, or
- where to go to disable it

This lead to confusion and made the feature feel “permanent”.

## What’s included

New FeaturePreviewBadge UI component

<img width="417" height="80" alt="CleanShot 2026-04-29 at 17 20 10" src="https://github.com/user-attachments/assets/6fbc96e3-35ef-46d1-893a-2188c4d237a3" />

</br>

Added badge across pages enabled via Feature Previews:
- Webhooks
- Unified Logs
- JIT DB Access
- Column Privileges
- Policies
- Merge page
- Advisor Rules

Consistent placement and styling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Feature preview badges now appear across the platform on preview features, including Platform Webhooks, Database functionality, Unified Logs, Advisor Rules, and other features, providing quick identification and access to manage preview settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->