### PR TITLE
feat(studio): cross-link disk IO usage to observability charts

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -1,9 +1,10 @@
 import { useParams } from 'common'
 import dayjs from 'dayjs'
 import { capitalize } from 'lodash'
-import { BarChart2, ExternalLink } from 'lucide-react'
+import { BarChart2, ChartLine, ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { Fragment, useMemo, useState } from 'react'
+import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -430,6 +431,19 @@ export const InfrastructureActivity = () => {
                         </div>
                       </Panel.Content>
                     </Panel>
+                  )}
+                  {attribute.key === 'disk_io_consumption' && (
+                    <Admonition
+                      type="default"
+                      title="Looking for actual disk activity?"
+                      description="The chart above shows your remaining burst budget, not real disk throughput. For detailed read/write IOPS and throughput charts, head to the Database Observability page."
+                    >
+                      <Button asChild type="default" icon={<ChartLine size={14} />}>
+                        <Link href={`/project/${projectRef}/observability/database`}>
+                          View detailed IOPS and throughput
+                        </Link>
+                      </Button>
+                    </Admonition>
                   )}
                 </ScaffoldSectionContent>
               </ScaffoldSection>

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx
@@ -432,7 +432,7 @@ export const InfrastructureActivity = () => {
                       </Panel.Content>
                     </Panel>
                   )}
-                  {attribute.key === 'disk_io_consumption' && (
+                  {attribute.key === 'disk_io_consumption' && !hasDedicatedIOResources && (
                     <Admonition
                       type="default"
                       title="Looking for actual disk activity?"

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
@@ -13,6 +13,9 @@ interface ResourceWarningMessage {
     critical: { title?: string; description?: string }
   }
   docsUrl?: string
+  // In-app destination for inspecting the metric (e.g. observability charts).
+  // [ref] is replaced with the current project ref at render time.
+  metricsHref?: string
   buttonText?: string
   aiPrompt?: string
   metric: string | null
@@ -75,6 +78,7 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
       },
     },
     docsUrl: `${DOCS_URL}/guides/troubleshooting/exhaust-disk-io`,
+    metricsHref: '/project/[ref]/observability/database',
     buttonText: 'Upgrade compute',
     aiPrompt:
       'My database is running out of Disk IO budget. Can you query pg_stat_statements to find the top queries by shared blocks read and written, identify which are causing the most disk I/O, and suggest specific optimizations to reduce disk usage?',

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
@@ -89,10 +89,8 @@ export const ResourceExhaustionWarningBanner = () => {
       : RESOURCE_WARNING_MESSAGES[activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES]
           ?.docsUrl
 
-  const hasSingleWarning = activeWarnings.length === 1
-  const singleWarningMessage = hasSingleWarning
-    ? RESOURCE_WARNING_MESSAGES[activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES]
-    : undefined
+  const singleWarningMessage =
+    activeWarnings.length === 1 ? RESOURCE_WARNING_MESSAGES[activeWarnings[0]] : undefined
   const metricsHref = singleWarningMessage?.metricsHref?.replace('[ref]', ref ?? 'default')
 
   const metric =

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import { AlertTriangle, BookOpen, ChevronDown, Sparkles, Wrench } from 'lucide-react'
+import { AlertTriangle, BookOpen, ChartLine, ChevronDown, Sparkles, Wrench } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import {
@@ -88,6 +88,13 @@ export const ResourceExhaustionWarningBanner = () => {
       ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.docsUrl
       : RESOURCE_WARNING_MESSAGES[activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES]
           ?.docsUrl
+
+  const metricsHref =
+    activeWarnings.length > 1
+      ? undefined
+      : RESOURCE_WARNING_MESSAGES[
+          activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES
+        ]?.metricsHref?.replace('[ref]', ref ?? 'default')
 
   const metric =
     activeWarnings.length > 1
@@ -232,6 +239,14 @@ export const ResourceExhaustionWarningBanner = () => {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
+              {metricsHref !== undefined && (
+                <DropdownMenuItem asChild>
+                  <Link href={metricsHref} className="flex items-center gap-x-2 cursor-pointer">
+                    <ChartLine size={14} />
+                    View metrics
+                  </Link>
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem asChild>
                 <a
                   href={learnMoreUrl}

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
@@ -89,12 +89,11 @@ export const ResourceExhaustionWarningBanner = () => {
       : RESOURCE_WARNING_MESSAGES[activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES]
           ?.docsUrl
 
-  const metricsHref =
-    activeWarnings.length > 1
-      ? undefined
-      : RESOURCE_WARNING_MESSAGES[
-          activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES
-        ]?.metricsHref?.replace('[ref]', ref ?? 'default')
+  const hasSingleWarning = activeWarnings.length === 1
+  const singleWarningMessage = hasSingleWarning
+    ? RESOURCE_WARNING_MESSAGES[activeWarnings[0] as keyof typeof RESOURCE_WARNING_MESSAGES]
+    : undefined
+  const metricsHref = singleWarningMessage?.metricsHref?.replace('[ref]', ref ?? 'default')
 
   const metric =
     activeWarnings.length > 1


### PR DESCRIPTION
## Problem

Users on the Infrastructure activity tab see a Disk IO Bandwidth chart that plots burst budget percentage rather than real disk activity. The more granular IOPS and throughput charts live in Observability, but there is no path between the two pages — users either dismiss real warnings or file support tickets.

Reported in [Linear DEBUG-64](https://linear.app/supabase/issue/DEBUG-64).

## Fix

Two cross-links into Observability/Database:

1. **Below the Disk IO Bandwidth chart** ([InfrastructureActivity.tsx](apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureActivity.tsx)) an Admonition with a "View detailed IOPS and throughput" button. Only shown for the disk IO section, not CPU/RAM.
2. **In the disk IO exhaustion banner's Troubleshoot dropdown** ([ResourceExhaustionWarningBanner.tsx](apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx)) a "View metrics" item alongside Documentation and Ask AI Assistant.

The banner part is wired via a new optional `metricsHref` on `ResourceWarningMessage`, so CPU/RAM warnings can opt in later by adding their own observability path.

## Test plan

- [ ] Visit `/project/{ref}/settings/infrastructure` on a project that does not have dedicated I/O resources. Confirm the new Admonition appears under the Disk IO chart and the button navigates to `/project/{ref}/observability/database`.
- [ ] On a project with dedicated I/O resources, confirm only the existing "dedicated I/O" Admonition shows (no double-Admonition).
- [ ] Trigger (or mock) a `disk_io` resource warning; confirm the banner's Troubleshoot dropdown shows "View metrics" first and links to Observability.
- [ ] Trigger a `cpu` or `ram` warning; confirm the dropdown does NOT show the new item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clarifies that the disk IO consumption chart shows remaining burst budget, not real throughput.
  * Adds a quick-access button to jump to the Database Observability page for detailed read/write IOPS and throughput.
  * Adds a "View metrics" link in resource exhaustion warnings for disk IO issues (shown when a single warning is active).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->