### PR TITLE
fix: left-align deadline note in stripe contest

### DIFF
--- a/apps/www/_go/events/stripe-sessions-2026/contest.tsx
+++ b/apps/www/_go/events/stripe-sessions-2026/contest.tsx
@@ -68,7 +68,7 @@ stripe projects env --sync`}</code>
             </Link>
           </div>
 
-          <p className="text-foreground-light text-sm">
+          <p className="text-foreground-light text-sm w-full">
             Both options must be completed by Monday, May 11, 2026 at 12:00 PM PST.
           </p>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixing alignment on contest page

## What is the current behavior?

The "Both options must be completed by Monday, May 11, 2026 at 12:00 PM PST." deadline note added in https://github.com/supabase/supabase/issues/44861 renders centered instead of left-aligned, because the <p> element doesn't have w-full and the parent flex container uses items-center.

## What is the new behavior?

The deadline note is left-aligned, consistent with the Option 1 and Option 2 blocks above it.

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved deadline message layout to utilize full available width for optimal display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->