### PR TITLE
fix: redirects for docs/guides markdown files

### DIFF
--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -186,7 +186,21 @@ const nextConfig = {
     return rewrites
   },
   async redirects() {
-    return redirects
+    // For static (no-param) /docs/guides/ redirects, auto-generate .md variants so
+    // renamed/deleted pages redirect correctly when fetched as markdown.
+    // Wildcard redirects (/:match*, /:path*) already capture the .md suffix naturally
+    // and don't need duplicates.
+    const docsMdRedirects = redirects
+      .filter(
+        (r) =>
+          r.source.startsWith('/docs/guides/') &&
+          !r.source.includes(':') &&
+          typeof r.destination === 'string' &&
+          r.destination.startsWith('/')
+      )
+      .map((r) => ({ ...r, source: `${r.source}.md`, destination: `${r.destination}.md` }))
+
+    return [...docsMdRedirects, ...redirects]
   },
   typescript: {
     // On previews, typechecking is run via GitHub Action only for efficiency

--- a/apps/www/next.config.mjs
+++ b/apps/www/next.config.mjs
@@ -186,15 +186,12 @@ const nextConfig = {
     return rewrites
   },
   async redirects() {
-    // For static (no-param) /docs/guides/ redirects, auto-generate .md variants so
-    // renamed/deleted pages redirect correctly when fetched as markdown.
-    // Wildcard redirects (/:match*, /:path*) already capture the .md suffix naturally
-    // and don't need duplicates.
+    // For /docs/guides/ redirects, auto-generate .md variants so renamed/deleted pages
+    // redirect correctly when fetched as markdown
     const docsMdRedirects = redirects
       .filter(
         (r) =>
           r.source.startsWith('/docs/guides/') &&
-          !r.source.includes(':') &&
           typeof r.destination === 'string' &&
           r.destination.startsWith('/')
       )


### PR DESCRIPTION
## Problem

We added support for `*.md` guides in our docs, but our redirects don't apply to them. This means that when we directly link to a guide using the `.md` extension and that guide gets renamed or deleted, the links begin to 404.

This happened already once in our agent-skills where we linked to `https://supabase.com/docs/guides/database/data-api.md` which was deleted and moved yesterday to `https://supabase.com/docs/guides/api/securing-your-api.md`. Note that there was a redirect on the regular path `/docs/guides/database/data-api -> /docs/guides/api/securing-your-api`, but this didn't apply to the `.md` version.

## Fix

This PR adds rules to redirect all the `/docs/guides/**/*.md` files to their respective pages. Rather than manually duplicating all our existing (and future) redirects by hand for `.md`, this dynamically generates the `.md` redirect rules based on the path. Specifically it assumes that all redirect rules under `/docs/guides` support the `.md` extension, so it generates a redirect for all of these rules automatically.

## How to test

Use curl to confirm that `.md` redirects are applied:

```shell
curl -I https://zone-www-dot-com-git-fix-doc-markdown-redirects-supabase.vercel.app/docs/guides/database/data-api.md

HTTP/2 308
cache-control: public, max-age=0, must-revalidate
content-type: text/plain
date: Wed, 29 Apr 2026 17:35:58 GMT
location: /docs/guides/api/securing-your-api.md
...
```

You can also verify that this didn't previously work:

```shell
curl -I https://supabase.com/docs/guides/database/data-api.md

HTTP/2 404
age: 0
cache-control: public, max-age=0, must-revalidate
content-type: text/plain;charset=UTF-8
date: Wed, 29 Apr 2026 17:38:00 GMT
...
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced documentation route redirects to support markdown file extensions for guides, ensuring proper navigation for both standard and markdown-variant paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->