### PR TITLE
fix(studio): encode special characters in database advisor lint links

### DIFF
--- a/apps/studio/components/interfaces/Linter/Linter.utils.test.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.test.tsx
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { lintInfoMap } from './Linter.utils'
+import { Lint } from '@/data/lint/lint-query'
+
+const projectRef = 'abc'
+const trickySchema = 'a&b=c'
+const trickyName = 'd e+f'
+
+describe('Linter.utils lintInfoMap link encoding', () => {
+  const cases: Array<{ name: string; nameParam?: string; hasSchema: boolean }> = [
+    { name: 'unindexed_foreign_keys', hasSchema: true },
+    { name: 'unused_index', nameParam: 'table', hasSchema: true },
+    { name: 'multiple_permissive_policies', nameParam: 'search', hasSchema: true },
+    { name: 'policy_exists_rls_disabled', nameParam: 'search', hasSchema: true },
+    { name: 'rls_enabled_no_policy', nameParam: 'search', hasSchema: true },
+    { name: 'duplicate_index', nameParam: 'table', hasSchema: true },
+    { name: 'function_search_path_mutable', nameParam: 'search', hasSchema: true },
+    { name: 'rls_disabled_in_public', nameParam: 'search', hasSchema: true },
+    { name: 'extension_in_public', nameParam: 'filter', hasSchema: false },
+    { name: 'sensitive_columns_exposed', nameParam: 'table', hasSchema: true },
+    { name: 'rls_policy_always_true', nameParam: 'search', hasSchema: true },
+    { name: 'pg_graphql_anon_table_exposed', nameParam: 'table', hasSchema: true },
+    { name: 'pg_graphql_authenticated_table_exposed', nameParam: 'table', hasSchema: true },
+    { name: 'anon_security_definer_function_executable', nameParam: 'search', hasSchema: true },
+    {
+      name: 'authenticated_security_definer_function_executable',
+      nameParam: 'search',
+      hasSchema: true,
+    },
+  ]
+
+  for (const { name, nameParam, hasSchema } of cases) {
+    it(`preserves special characters in metadata for ${name}`, () => {
+      const info = lintInfoMap.find((entry) => entry.name === name)
+      expect(info, `expected ${name} in lintInfoMap`).toBeDefined()
+
+      const url = info!.link({
+        projectRef,
+        metadata: {
+          schema: trickySchema,
+          name: trickyName,
+        } as unknown as Lint['metadata'],
+      })
+
+      const parsed = new URL(url, 'http://example.com')
+
+      if (hasSchema) {
+        expect(parsed.searchParams.get('schema')).toBe(trickySchema)
+      }
+      if (nameParam) {
+        expect(parsed.searchParams.get(nameParam)).toBe(trickyName)
+      }
+    })
+  }
+
+  it('preserves slash and space in bucket_id for public_bucket_allows_listing', () => {
+    const info = lintInfoMap.find((entry) => entry.name === 'public_bucket_allows_listing')
+    expect(info).toBeDefined()
+    const url = info!.link({
+      projectRef,
+      metadata: {
+        bucket_id: 'a/b c',
+      } as unknown as Lint['metadata'],
+    })
+    expect(url).toBe('/project/abc/storage/files/buckets/a%2Fb%20c')
+  })
+})

--- a/apps/studio/components/interfaces/Linter/Linter.utils.tsx
+++ b/apps/studio/components/interfaces/Linter/Linter.utils.tsx
@@ -24,7 +24,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Unindexed foreign keys',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/database/indexes?schema=${metadata?.schema}`,
+      `/project/${projectRef}/database/indexes?schema=${encodeURIComponent(metadata?.schema ?? '')}`,
     linkText: 'Create an index',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0001_unindexed_foreign_keys`,
     category: 'performance',
@@ -61,7 +61,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Unused Index',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/database/indexes?schema=${metadata?.schema}&table=${metadata?.name}`,
+      `/project/${projectRef}/database/indexes?schema=${encodeURIComponent(metadata?.schema ?? '')}&table=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View index',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0005_unused_index`,
     category: 'performance',
@@ -71,7 +71,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Multiple Permissive Policies',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/auth/policies?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/auth/policies?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View policies',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0006_multiple_permissive_policies`,
     category: 'performance',
@@ -81,7 +81,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Policy Exists RLS Disabled',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/auth/policies?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/auth/policies?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View policies',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0007_policy_exists_rls_disabled`,
     category: 'security',
@@ -91,7 +91,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'RLS Enabled No Policy',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/auth/policies?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/auth/policies?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View table',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0008_rls_enabled_no_policy`,
     category: 'security',
@@ -101,7 +101,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Duplicate Index',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/database/indexes?schema=${metadata?.schema}&table=${metadata?.name}`,
+      `/project/${projectRef}/database/indexes?schema=${encodeURIComponent(metadata?.schema ?? '')}&table=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View index',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0009_duplicate_index`,
     category: 'performance',
@@ -121,7 +121,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Function Search Path Mutable',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/database/functions?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/database/functions?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View functions',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0011_function_search_path_mutable`,
     category: 'security',
@@ -140,7 +140,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'RLS Disabled in Public',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/auth/policies?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/auth/policies?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View policies',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0013_rls_disabled_in_public`,
     category: 'security',
@@ -150,7 +150,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Extension in Public',
     icon: <Unlock className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/database/extensions?filter=${metadata?.name}`,
+      `/project/${projectRef}/database/extensions?filter=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View extension',
     docsLink: `${DOCS_URL}/guides/database/database-linter?queryGroups=lint&lint=0014_extension_in_public`,
     category: 'security',
@@ -314,7 +314,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Sensitive Columns Exposed',
     icon: <Eye className="text-foreground-muted" size={15} strokeWidth={1.5} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/editor?schema=${metadata?.schema}&table=${metadata?.name}`,
+      `/project/${projectRef}/editor?schema=${encodeURIComponent(metadata?.schema ?? '')}&table=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View table',
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0023_sensitive_columns_exposed`,
     category: 'security',
@@ -324,7 +324,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'RLS Policy Always True',
     icon: <Table2 className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/auth/policies?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/auth/policies?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View policies',
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0024_permissive_rls_policy`,
     category: 'security',
@@ -346,7 +346,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Public Can See Object in GraphQL Schema',
     icon: <Eye className="text-foreground-muted" size={15} strokeWidth={1.5} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/editor?schema=${metadata?.schema}&table=${metadata?.name}`,
+      `/project/${projectRef}/editor?schema=${encodeURIComponent(metadata?.schema ?? '')}&table=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View object',
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0026_pg_graphql_anon_table_exposed`,
     category: 'security',
@@ -356,7 +356,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Signed-In Users Can See Object in GraphQL Schema',
     icon: <Eye className="text-foreground-muted" size={15} strokeWidth={1.5} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/editor?schema=${metadata?.schema}&table=${metadata?.name}`,
+      `/project/${projectRef}/editor?schema=${encodeURIComponent(metadata?.schema ?? '')}&table=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View object',
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0027_pg_graphql_authenticated_table_exposed`,
     category: 'security',
@@ -366,7 +366,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Public Can Execute SECURITY DEFINER Function',
     icon: <LockIcon className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/database/functions?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/database/functions?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View function',
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0028_anon_security_definer_function_executable`,
     category: 'security',
@@ -376,7 +376,7 @@ export const lintInfoMap: LintInfo[] = [
     title: 'Signed-In Users Can Execute SECURITY DEFINER Function',
     icon: <LockIcon className="text-foreground-muted" size={15} strokeWidth={1} />,
     link: ({ projectRef, metadata }) =>
-      `/project/${projectRef}/database/functions?schema=${metadata?.schema}&search=${metadata?.name}`,
+      `/project/${projectRef}/database/functions?schema=${encodeURIComponent(metadata?.schema ?? '')}&search=${encodeURIComponent(metadata?.name ?? '')}`,
     linkText: 'View function',
     docsLink: `${DOCS_URL}/guides/database/database-linter?lint=0029_authenticated_security_definer_function_executable`,
     category: 'security',


### PR DESCRIPTION
The link builders in `apps/studio/components/interfaces/Linter/Linter.utils.tsx` interpolate `metadata.schema` and `metadata.name` directly into URL query strings. A schema or table name with `&`, `=`, `+`, or `#` breaks the destination filter on the linked page because `URLSearchParams` stops at the bare `&` and decodes `+` to a space.

The `public_bucket_allows_listing` lint at line 338 already wraps `bucket_id` in `encodeURIComponent`. The other 15 builders did not. This wraps each `metadata?.schema` and `metadata?.name` interpolation with `encodeURIComponent(value ?? '')` to match.

Added `Linter.utils.test.tsx` that constructs links with a schema `a&b=c` and a name `d e+f` and asserts `URLSearchParams` round-trips them. The bucket precedent is also covered.

Closes #45384

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL encoding for navigation links in the linter interface to ensure proper handling of special characters in database, schema, and table names.

* **Tests**
  * Added test coverage for URL generation functionality in the linter utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->