### PR TITLE
Add recommendation on schema isolation

### DIFF
--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -68,6 +68,10 @@ alter default privileges for role postgres in schema public
   revoke execute on functions from public;
 ```
 
+## Use a dedicated API schema
+
+If you want an extra boundary around your Data API, lock down the `public` schema and expose a dedicated schema, such as `api`, instead. You can control access with grants in any schema, but this can make the surface easier to reason about: objects in `api` represent your Data API, while internal tables and helper functions stay in schemas that are not exposed. See [Using Custom Schemas](/docs/guides/api/using-custom-schemas) for setup steps.
+
 ## Disable the Data API
 
 If your app never uses Supabase client libraries, REST, or GraphQL data endpoints, turn the Data API off:

--- a/apps/studio/components/interfaces/Settings/API/HardenAPIModal.tsx
+++ b/apps/studio/components/interfaces/Settings/API/HardenAPIModal.tsx
@@ -123,7 +123,7 @@ export const HardenAPIModal = ({ visible, onClose }: HardenAPIModalProps) => {
           <DocsButton
             abbrev={false}
             className="w-min mt-4"
-            href={`${DOCS_URL}/guides/database/hardening-data-api`}
+            href={`${DOCS_URL}/guides/api/using-custom-schemas`}
           />
         </DialogSection>
 


### PR DESCRIPTION
Adjusts our hardening api modal in Studio to point to custom schema data api docs and adds a section within security your api recommending schema isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on securing the Data API by using dedicated schemas to prevent public exposure.
  * Updated documentation links in API settings to reference current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->