### PR TITLE
fix(www): partner integration links

### DIFF
--- a/apps/www/components/Partners/TileGrid.tsx
+++ b/apps/www/components/Partners/TileGrid.tsx
@@ -27,7 +27,7 @@ export default function TileGrid({
           <h2 className="h2">Featured</h2>
           <div className="grid grid-cols-1 gap-5 lg:max-w-none lg:grid-cols-2 xl:grid-cols-3">
             {featuredPartners?.map((p) => (
-              <Link key={p.slug} href={`/partners/${p.slug}`}>
+              <Link key={p.slug} href={`/partners/integrations/${p.slug}`}>
                 <div
                   className="
                 bg-surface-100
@@ -70,7 +70,7 @@ export default function TileGrid({
           {!hideCategories && <h2 className="h2">{category}</h2>}
           <div className="grid  grid-cols-1 gap-5 lg:max-w-none lg:grid-cols-2 xl:grid-cols-3">
             {partnersByCategory[category].map((p) => (
-              <Link key={p.slug} href={`/partners/${p.slug}`}>
+              <Link key={p.slug} href={`/partners/integrations/${p.slug}`}>
                 <div
                   className="
                 bg-surface-100

--- a/apps/www/pages/partners/[slug].tsx
+++ b/apps/www/pages/partners/[slug].tsx
@@ -3,31 +3,17 @@ import supabase from '~/lib/supabaseMisc'
 import Error404 from '../404'
 
 function PartnerPage() {
-  // Should be redirected to ./experts/:slug or ./integrations/:slug
+  // Existing short partner URLs redirect to their current integration pages.
   return <Error404 />
 }
 
-// This function gets called at build time
 export const getStaticPaths: GetStaticPaths = async () => {
-  const { data: slugs } = await supabase.from('partners').select('slug')
-
-  const paths: {
-    params: { slug: string }
-    locale?: string | undefined
-  }[] =
-    slugs?.map(({ slug }) => ({
-      params: {
-        slug,
-      },
-    })) ?? []
-
   return {
-    paths,
+    paths: [],
     fallback: 'blocking',
   }
 }
 
-// This also gets called at build time
 export const getStaticProps: GetStaticProps = async ({ params }) => {
   let { data: partner } = await supabase
     .from('partners')
@@ -36,7 +22,7 @@ export const getStaticProps: GetStaticProps = async ({ params }) => {
     .eq('slug', params!.slug as string)
     .single()
 
-  if (!partner || partner.type === 'expert' || process.env.npm_lifecycle_event === 'build') {
+  if (!partner || partner.type === 'expert') {
     return {
       notFound: true,
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behaviour?

The integrations listing links tiles to short partner URLs such as `/partners/vercel`, while the canonical integration pages live at `/partners/integrations/vercel`.

Those short URLs are handled by the legacy `/partners/[slug]` route, which is meant to redirect technology partners to `/partners/integrations/[slug]`. However, that route currently pre-renders partner slugs and returns `notFound` when `npm_lifecycle_event === 'build'`, which can bake and cache static 404s for URLs that are meant to redirect.

This was reportedly working as recently as last week, and the relevant partners page code has not changed recently. The most likely explanation is that old legacy-route behaviour was surfaced by a recent production build/deployment/prerender cache interaction, rather than a fresh change to the integrations tile code itself.

## What is the new behaviour?

Integration tiles now link directly to the canonical `/partners/integrations/[slug]` URL, so the listing no longer depends on the legacy short-url redirect.

The legacy short partner URL route also no longer pre-renders partner slugs as build-time 404s. It remains as a blocking fallback redirect for old external links, bookmarks, search results, and historical references that may still point at `/partners/[slug]`.


## Testing

This URL:

```
https://zone-www-dot-com-git-dnywh-fix-partner-integrat-b3fb68-supabase.vercel.app/partners/integrations/vercel
```


...should resolve to:

```
https://zone-www-dot-com-git-dnywh-fix-partner-integrat-b3fb68-supabase.vercel.app/partners/vercel
```