### PR TITLE
chore(studio): clarify pause project flow

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { Pause } from 'lucide-react'
+import { CirclePause } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
 import { toast } from 'sonner'
@@ -86,7 +86,7 @@ const PauseProjectButton = () => {
     <>
       <ButtonTooltip
         type="default"
-        icon={<Pause />}
+        icon={<CirclePause />}
         onClick={() => setIsModalOpen(true)}
         loading={isPausing}
         disabled={buttonDisabled}

--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.tsx
@@ -105,8 +105,8 @@ const PauseProjectButton = () => {
           <AlertDialogHeader>
             <AlertDialogTitle>Pause project?</AlertDialogTitle>
             <AlertDialogDescription>
-              This project will be unavailable while paused. Your data stays safe, and you can
-              resume it later from the dashboard while it remains within the restore window.
+              This project will be unavailable while paused. Paused projects can be resumed for 90
+              days. After that, backups remain available to download.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Minor UI and copywriting change.

## What is the current behavior?

- Vague dialog copy for pausing a project
- Plain pause icon looks like two Tim Tams

## What is the new behavior?

- Clearer dialog copy
- More standard pause button

## Additional context

| Before | After |
| --- | --- |
| <img width="912" height="502" alt="11317" src="https://github.com/user-attachments/assets/55a64d01-8171-498e-a03f-2e0060995400" /> | <img width="850" height="476" alt="67001" src="https://github.com/user-attachments/assets/054a8ca0-e06c-417c-9668-c3847013bbe2" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pause project confirmation dialog to clearly communicate the 90-day resume timeframe and backup availability after this period.

* **Style**
  * Updated pause icon display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->