### PR TITLE
Add Syslog destination support to Log Drains

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrainDestinationSheetForm.tsx
@@ -29,6 +29,7 @@ import {
   SheetSection,
   SheetTitle,
   Switch,
+  Textarea,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { KeyValueFieldArray } from 'ui-patterns/form/KeyValueFieldArray/KeyValueFieldArray'
@@ -180,6 +181,16 @@ const otlpSubmitSchema = z.object({
 
 const syslogSchema = z.object({
   type: z.literal('syslog'),
+  host: z.string().min(1, { message: 'Host is required' }),
+  port: z.coerce
+    .number()
+    .int({ message: 'Port must be an integer' })
+    .min(1, { message: 'Port must be between 1 and 65535' })
+    .max(65535, { message: 'Port must be between 1 and 65535' }),
+  tls: z.boolean().default(false),
+  ca_cert: z.string().optional(),
+  client_cert: z.string().optional(),
+  client_key: z.string().optional(),
 })
 
 const formUnion = z.discriminatedUnion('type', [
@@ -351,6 +362,12 @@ export function LogDrainDestinationSheetForm({
       api_token: defaultConfig?.api_token || '',
       endpoint: defaultConfig?.endpoint || '',
       protocol: defaultConfig?.protocol || 'http/protobuf',
+      host: defaultConfig?.host || '',
+      port: defaultConfig?.port ?? 514,
+      tls: defaultConfig?.tls ?? false,
+      ca_cert: defaultConfig?.ca_cert || '',
+      client_cert: defaultConfig?.client_cert || '',
+      client_key: defaultConfig?.client_key || '',
     },
   })
 
@@ -802,6 +819,103 @@ export function LogDrainDestinationSheetForm({
                       formControl={form.control}
                       description="Password for authentication from Last9 OTEL integration."
                     />
+                  </div>
+                )}
+                {type === 'syslog' && (
+                  <div className="grid gap-4 px-content">
+                    <LogDrainFormItem
+                      value="host"
+                      label="Host"
+                      placeholder="logs.example.com"
+                      formControl={form.control}
+                      description="The hostname or IP address of the syslog server."
+                    />
+                    <LogDrainFormItem
+                      type="number"
+                      value="port"
+                      label="Port"
+                      placeholder="514"
+                      formControl={form.control}
+                      description="The port number the syslog server listens on (1–65535)."
+                    />
+                    <FormField
+                      control={form.control}
+                      name="tls"
+                      render={({ field }) => (
+                        <FormItem className="space-y-2 px-0">
+                          <div className="flex gap-2 items-center">
+                            <FormControl>
+                              <Switch checked={field.value} onCheckedChange={field.onChange} />
+                            </FormControl>
+                            <FormLabel className="text-base">TLS Encryption</FormLabel>
+                            <InfoTooltip align="start">
+                              Enable TLS to encrypt the connection to the syslog server.
+                            </InfoTooltip>
+                          </div>
+                        </FormItem>
+                      )}
+                    />
+                    {form.watch('tls') && (
+                      <>
+                        <FormField
+                          control={form.control}
+                          name="ca_cert"
+                          render={({ field }) => (
+                            <FormItemLayout
+                              layout="horizontal"
+                              label="CA Certificate"
+                              description="PEM-encoded CA certificate to verify the server's TLS certificate."
+                            >
+                              <FormControl>
+                                <Textarea
+                                  className="font-mono min-h-[100px]"
+                                  placeholder={'-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----'}
+                                  {...field}
+                                />
+                              </FormControl>
+                            </FormItemLayout>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name="client_cert"
+                          render={({ field }) => (
+                            <FormItemLayout
+                              layout="horizontal"
+                              label="Client Certificate"
+                              description="PEM-encoded client certificate for mutual TLS authentication."
+                            >
+                              <FormControl>
+                                <Textarea
+                                  className="font-mono min-h-[100px]"
+                                  placeholder={'-----BEGIN CERTIFICATE-----\n...\n-----END CERTIFICATE-----'}
+                                  {...field}
+                                />
+                              </FormControl>
+                            </FormItemLayout>
+                          )}
+                        />
+                        <FormField
+                          control={form.control}
+                          name="client_key"
+                          render={({ field }) => (
+                            <FormItemLayout
+                              layout="horizontal"
+                              label="Client Key"
+                              description="PEM-encoded private key for the client certificate."
+                            >
+                              <FormControl>
+                                <Textarea
+                                  className="font-mono min-h-[100px]"
+                                  placeholder={'-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----'}
+                                  {...field}
+                                />
+                              </FormControl>
+                            </FormItemLayout>
+                          )}
+                        />
+                      </>
+                    )}
                   </div>
                 )}
                 {HEADER_ENABLED_TYPES.includes(type as (typeof HEADER_ENABLED_TYPES)[number]) && (

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.constants.tsx
@@ -1,6 +1,6 @@
 import { components } from 'api-types'
 import { Axiom, Datadog, Grafana, Last9, Otlp, Sentry } from 'icons'
-import { BracesIcon, Cloud } from 'lucide-react'
+import { BracesIcon, Cloud, Server } from 'lucide-react'
 
 const iconProps = {
   height: 24,
@@ -61,6 +61,12 @@ export const LOG_DRAIN_TYPES = [
     name: 'Last9',
     description: 'Last9 is an observability platform for monitoring and telemetry data',
     icon: <Last9 {...iconProps} fill="currentColor" />,
+  },
+  {
+    value: 'syslog',
+    name: 'Syslog',
+    description: 'Forward logs to a Syslog server over TCP or UDP with optional TLS encryption',
+    icon: <Server {...iconProps} />,
   },
 ] as const
 
@@ -124,4 +130,13 @@ export type LogDrainOtlpConfig = {
   protocol?: string
   gzip?: boolean
   headers?: Record<string, string>
+}
+
+export type LogDrainSyslogConfig = {
+  host: string
+  port: number
+  tls: boolean
+  ca_cert?: string
+  client_cert?: string
+  client_key?: string
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Log Drains currently support destinations like Datadog, Grafana, Axiom, Sentry, Last9, and OTLP, but do not support Syslog servers.

## What is the new behavior?

This PR adds Syslog as a new Log Drain destination type. Users can now configure log forwarding to Syslog servers with the following features:

- **Host and Port Configuration**: Specify the hostname/IP address and port (1-65535) of the Syslog server
- **TLS Encryption Support**: Optional TLS encryption for secure connections
- **Mutual TLS Authentication**: When TLS is enabled, users can provide:
  - CA Certificate for server verification
  - Client Certificate for mutual TLS authentication
  - Client Key for the client certificate

The implementation includes:
- Zod schema validation for Syslog configuration fields
- Form UI with conditional rendering of TLS certificate fields
- Type definitions for `LogDrainSyslogConfig`
- Syslog added to the LOG_DRAIN_TYPES list with Server icon

## Additional context

The form dynamically shows/hides TLS certificate fields based on the TLS toggle state, providing a clean UX. All certificate fields accept PEM-encoded content with appropriate placeholders and descriptions.

https://claude.ai/code/session_01QUogrssnnVKFTYAHYk6PWZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Syslog as a new log drain destination type
  * Configure Syslog connections with host and port settings
  * Optional TLS encryption support for secure connections
  * Manage CA certificate, client certificate, and client key when TLS is enabled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->