### PR TITLE
fix: update edge functions jwks endpoint in docs

### DIFF
--- a/apps/docs/content/guides/functions/secrets.mdx
+++ b/apps/docs/content/guides/functions/secrets.mdx
@@ -13,7 +13,7 @@ Edge Functions have access to these secrets by default:
 - `SUPABASE_DB_URL`: The URL for your Postgres database. You can use this to connect directly to your database
 - `SUPABASE_PUBLISHABLE_KEYS`: The `publishable` keys JSON dictionary for your Supabase API. This is safe to use in a browser when you have Row Level Security enabled
 - `SUPABASE_SECRET_KEYS`: The `secret` keys JSON dictionary for your Supabase API. This is safe to use in Edge Functions, but it should NEVER be used in a browser. This key will bypass Row Level Security
-- `SUPABASE_JWKS`: The JSON Web Key Set used to verify user JWTs. Same value served at `https://<project-ref>.supabase.co/auth/v1/jwks`
+- `SUPABASE_JWKS`: The JSON Web Key Set used to verify user JWTs. Same value served at `https://<project-ref>.supabase.co/auth/v1/.well-known/jwks.json`
 
 Legacy keys:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the default SUPABASE_JWKS secret endpoint reference to the current well-known JWKS endpoint URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->