### PR TITLE
chore(billing): disable tax ID banner

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -5,7 +5,6 @@ import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 import { ClockSkewBanner } from '@/components/layouts/AppLayout/ClockSkewBanner'
 import { NoticeBanner } from '@/components/layouts/AppLayout/NoticeBanner'
 import { StatusPageBanner } from '@/components/layouts/AppLayout/StatusPageBanner'
-import { TaxIdBanner } from '@/components/layouts/AppLayout/TaxIdBanner'
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
   const showNoticeBanner = useFlag('showNoticeBanner')
@@ -17,7 +16,8 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
         <StatusPageBanner />
         {showNoticeBanner && <NoticeBanner />}
         <OrganizationResourceBanner />
-        <TaxIdBanner />
+        {/* Disabled until reintroduced or removed altogether. */}
+        {/* <TaxIdBanner /> */}
         {clockSkewBanner && <ClockSkewBanner />}
       </div>
       {children}


### PR DESCRIPTION
This PR disables the tax ID banner. I haven't removed the code just in case we need to reintroduce it later.

Will follow up with removing the code entirely or introducing a feature flag if we decide to keep it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled the tax identification banner display in the application interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->