### PR TITLE
Auto enable RLS trigger shift into confirmation dialog

### DIFF
--- a/apps/studio/components/ui/BannerStack/Banners/BannerRlsEventTrigger.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerRlsEventTrigger.tsx
@@ -4,7 +4,21 @@ import { useParams } from 'common/hooks'
 import { ShieldCheck } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useMemo, useState } from 'react'
-import { Button, cn } from 'ui'
+import { toast } from 'sonner'
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
+import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import { BannerCard } from '../BannerCard'
 import { useBannerStack } from '../BannerStackProvider'
@@ -22,16 +36,11 @@ export const BannerRlsEventTrigger = () => {
   const { dismissBanner } = useBannerStack()
   const { data: project } = useSelectedProjectQuery()
   const projectRef = ref ?? project?.ref
+
   const [hasCreated, setHasCreated] = useState(false)
-  const track = useTrack()
   const [, setIsDismissed] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.RLS_EVENT_TRIGGER_BANNER_DISMISSED(projectRef ?? 'unknown'),
     false
-  )
-
-  const { can: canCreateTriggers } = useAsyncCheckPermissions(
-    PermissionAction.TENANT_SQL_ADMIN_WRITE,
-    'triggers'
   )
 
   const { data: eventTriggers = [], isLoading: isLoadingEventTriggers } =
@@ -48,26 +57,11 @@ export const BannerRlsEventTrigger = () => {
     [eventTriggers]
   )
 
-  const { mutate: createEventTrigger, isPending: isCreating } =
-    useDatabaseEventTriggerCreateMutation({
-      onSuccess: () => setHasCreated(true),
-    })
-
   useEffect(() => {
     if (hasDefaultTrigger) {
       setHasCreated(true)
     }
   }, [hasDefaultTrigger])
-
-  const handleCreateTrigger = () => {
-    if (!project) return
-    track('rls_event_trigger_banner_create_button_clicked')
-    createEventTrigger({
-      projectRef: project.ref,
-      connectionString: project.connectionString,
-      sql: AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL,
-    })
-  }
 
   if (!projectRef || isLoadingEventTriggers) return null
 
@@ -105,26 +99,98 @@ export const BannerRlsEventTrigger = () => {
               <Link href={`/project/${projectRef}/database/triggers/event`}>View triggers</Link>
             </Button>
           ) : (
-            <ButtonTooltip
-              type="primary"
-              size="tiny"
-              loading={isCreating}
-              disabled={!canCreateTriggers}
-              onClick={handleCreateTrigger}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  text: !canCreateTriggers
-                    ? 'You need additional permissions to create triggers'
-                    : undefined,
-                },
-              }}
-            >
-              Create ensure_rls trigger
-            </ButtonTooltip>
+            <CreateEnsureRLSTriggerDialog onCreateSuccess={() => setHasCreated(true)} />
           )}
         </div>
       </div>
     </BannerCard>
+  )
+}
+
+const CreateEnsureRLSTriggerDialog = ({ onCreateSuccess }: { onCreateSuccess: () => void }) => {
+  const track = useTrack()
+  const { data: project } = useSelectedProjectQuery()
+
+  const [open, setOpen] = useState(false)
+
+  const { can: canCreateTriggers } = useAsyncCheckPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'triggers'
+  )
+
+  const { mutate: createEventTrigger, isPending: isCreating } =
+    useDatabaseEventTriggerCreateMutation({
+      onSuccess: () => {
+        toast.success(
+          'Successfully set up database trigger to automatically enable RLS on all new tables'
+        )
+        onCreateSuccess()
+        setOpen(false)
+      },
+    })
+
+  const handleCreateTrigger = () => {
+    if (!project) return
+    track('rls_event_trigger_banner_create_button_clicked')
+    createEventTrigger({
+      projectRef: project.ref,
+      connectionString: project.connectionString,
+      sql: AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL,
+    })
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <ButtonTooltip
+          type="primary"
+          size="tiny"
+          disabled={!canCreateTriggers}
+          tooltip={{
+            content: {
+              side: 'bottom',
+              text: !canCreateTriggers
+                ? 'You need additional permissions to create triggers'
+                : undefined,
+            },
+          }}
+        >
+          Learn more
+        </ButtonTooltip>
+      </DialogTrigger>
+      <DialogContent size="large">
+        <DialogHeader>
+          <DialogTitle>Automatically enable RLS for newly created tables</DialogTitle>
+          <DialogDescription>Secure your data using Postgres Row Level Security</DialogDescription>
+        </DialogHeader>
+
+        <DialogSectionSeparator />
+
+        <DialogSection className="text-sm flex flex-col gap-y-2">
+          <p>
+            Tables in exposed schemas (default being the{' '}
+            <code className="text-code-inline">public</code> schema) are accessible to anyone.
+            Hence, we highly recommend enabling RLS on all such tables.
+          </p>
+          <p>
+            You can set up a database trigger to enable RLS automatically on all new tables with the
+            following SQL:
+          </p>
+        </DialogSection>
+
+        <CodeBlock language="sql" className="language-sql px-0 border-x-0 rounded-none h-64">
+          {AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL.trim()}
+        </CodeBlock>
+
+        <DialogFooter>
+          <Button type="default" disabled={isCreating} onClick={() => setOpen(false)}>
+            Close
+          </Button>
+          <Button loading={isCreating} onClick={handleCreateTrigger}>
+            Create ensure_rls trigger
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Context

Shifts the "auto enable RLS" banner in the auth policies page into a dialog for transparency on what SQL will be run as a result of creating the `ensure_rls` database trigger

<img width="320" height="239" alt="image" src="https://github.com/user-attachments/assets/9d1dd071-697d-4b40-aaa3-63f4147899b3" />

<img width="606" height="536" alt="image" src="https://github.com/user-attachments/assets/68765278-b2f2-489b-89a7-2383d37ffe9f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Redesigned RLS trigger creation with a dialog-driven flow for better user guidance
  * Added permission-based access controls with informational tooltips when unavailable
  * Display of trigger SQL code for transparency
  * Enhanced success notifications on completion

<!-- end of auto-generated comment: release notes by coderabbit.ai -->