### PR TITLE
chore: Bump `tailwind-merge`

### DIFF
--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -27,7 +27,7 @@
     "@tanstack/react-query": "^5.83.0",
     "api-types": "workspace:*",
     "axios": "^1.12.0",
-    "class-variance-authority": "*",
+    "class-variance-authority": "^0.7.1",
     "cmdk": "^1.1.1",
     "common": "workspace:*",
     "common-tags": "^1.8.2",

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -40,7 +40,7 @@
     "animejs": "^4.0.2",
     "class-variance-authority": "^0.7.1",
     "classnames": "^2.3.1",
-    "clsx": "^1.2.1",
+    "clsx": "^2.1.1",
     "cobe": "^0.6.5",
     "common": "workspace:*",
     "common-tags": "^1.8.2",

--- a/blocks/vue/package.json
+++ b/blocks/vue/package.json
@@ -18,7 +18,7 @@
     "h3": "^1.15.10",
     "lucide-vue-next": "^0.562.0",
     "nuxt": "^4.4.0",
-    "tailwind-merge": "^3.3.1",
+    "tailwind-merge": "^3.5.0",
     "vue": "^3.5.21",
     "vue-router": "^4.5.1"
   },

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -787,7 +787,7 @@
     "@supabase/supabase-js": "catalog:",
     "@tanstack/react-table": "^8.21.3",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^1.2.1",
+    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "common": "workspace:*",
     "common-tags": "^1.8.2",

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -786,7 +786,7 @@
     "@supabase/sql-to-rest": "^0.1.6",
     "@supabase/supabase-js": "catalog:",
     "@tanstack/react-table": "^8.21.3",
-    "class-variance-authority": "^0.6.0",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",
     "cmdk": "^1.1.1",
     "common": "workspace:*",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -38,7 +38,7 @@
     "react-resizable-panels": "^4.6.5",
     "recharts": "catalog:",
     "sonner": "^1.5.0",
-    "tailwind-merge": "^1.13.2",
+    "tailwind-merge": "^3.5.0",
     "tailwindcss": "catalog:",
     "vaul": "^0.9.9"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
-    "class-variance-authority": "^0.6.1",
+    "class-variance-authority": "^0.7.1",
     "clsx": "^1.2.1",
     "cmdk": "^1.1.1",
     "color": "^4.2.3",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -18,7 +18,7 @@
     "@tailwindcss/forms": "^0.5.11",
     "@tailwindcss/typography": "^0.5.19",
     "class-variance-authority": "^0.7.1",
-    "clsx": "^1.2.1",
+    "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "color": "^4.2.3",
     "date-fns": "^2.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1395,8 +1395,8 @@ importers:
         specifier: ^1.12.0
         version: 1.15.0
       class-variance-authority:
-        specifier: '*'
-        version: 0.6.1
+        specifier: ^0.7.1
+        version: 0.7.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2378,8 +2378,8 @@ importers:
         specifier: ^0.5.19
         version: 0.5.19(tailwindcss@4.2.4)
       class-variance-authority:
-        specifier: ^0.6.1
-        version: 0.6.1
+        specifier: ^0.7.1
+        version: 0.7.1
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -2514,8 +2514,8 @@ importers:
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
-        specifier: ^0.6.0
-        version: 0.6.1
+        specifier: ^0.7.1
+        version: 0.7.1
       clsx:
         specifier: ^1.2.1
         version: 1.2.1
@@ -9667,9 +9667,6 @@ packages:
 
   cjs-module-lexer@1.4.1:
     resolution: {integrity: sha512-cuSVIHi9/9E/+821Qjdvngor+xpnlwnuwIyZOaLmHBVdXL+gP+I6QQB9VkO7RI77YIcTV+S1W9AreJ5eN63JBA==}
-
-  class-variance-authority@0.6.1:
-    resolution: {integrity: sha512-eurOEGc7YVx3majOrOb099PNKgO3KnKSApOprXI4BTq6bcfbqbQXPN2u+rPPmIJ2di23bMwhk0SxCCthBmszEQ==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -26540,10 +26537,6 @@ snapshots:
   citty@0.2.1: {}
 
   cjs-module-lexer@1.4.1: {}
-
-  class-variance-authority@0.6.1:
-    dependencies:
-      clsx: 1.2.1
 
   class-variance-authority@0.7.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1651,8 +1651,8 @@ importers:
         specifier: ^2.3.1
         version: 2.3.2
       clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^2.1.1
+        version: 2.1.1
       cobe:
         specifier: ^0.6.5
         version: 0.6.5
@@ -2381,8 +2381,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^2.1.1
+        version: 2.1.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2517,8 +2517,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       clsx:
-        specifier: ^1.2.1
-        version: 1.2.1
+        specifier: ^2.1.1
+        version: 2.1.1
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1907,8 +1907,8 @@ importers:
         specifier: ^4.4.0
         version: 4.4.2(@babel/core@7.29.0(supports-color@8.1.1))(@babel/plugin-syntax-jsx@7.27.1(@babel/core@7.29.0(supports-color@8.1.1)))(@electric-sql/pglite@0.2.15)(@parcel/watcher@2.5.1)(@types/node@22.13.14)(@vue/compiler-sfc@3.5.30)(aws4fetch@1.0.20)(cac@6.7.14)(db0@0.3.4(@electric-sql/pglite@0.2.15))(encoding@0.1.13)(eslint@9.37.0(jiti@2.6.1)(supports-color@8.1.1))(ioredis@5.10.0(supports-color@8.1.1))(lightningcss@1.32.0)(magicast@0.5.2)(rolldown@1.0.0-rc.15)(rollup-plugin-visualizer@6.0.11(rolldown@1.0.0-rc.15)(rollup@4.59.0))(rollup@4.59.0)(sass@1.77.4)(supports-color@8.1.1)(terser@5.39.0)(tsx@4.20.3)(typescript@6.0.2)(vite@7.3.2(@types/node@22.13.14)(jiti@2.6.1)(lightningcss@1.32.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.20.3)(yaml@2.8.3))(yaml@2.8.3)
       tailwind-merge:
-        specifier: ^3.3.1
-        version: 3.3.1
+        specifier: ^3.5.0
+        version: 3.5.0
       vue:
         specifier: ^3.5.21
         version: 3.5.30(typescript@6.0.2)
@@ -2441,8 +2441,8 @@ importers:
         specifier: ^1.5.0
         version: 1.5.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
-        specifier: ^1.13.2
-        version: 1.14.0
+        specifier: ^3.5.0
+        version: 3.5.0
       tailwindcss:
         specifier: 'catalog:'
         version: 4.2.4
@@ -16483,11 +16483,8 @@ packages:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
 
-  tailwind-merge@1.14.0:
-    resolution: {integrity: sha512-3mFKyCo/MBcgyOTlrY8T7odzZFx+w+qKSMAmdFzRvqBfLlSigU6TZnlFHK0lkMwj9Bj8OYU+9yW9lmGuS0QEnQ==}
-
-  tailwind-merge@3.3.1:
-    resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwindcss-animate@1.0.7:
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
@@ -34700,7 +34697,7 @@ snapshots:
       remark-gfm: 4.0.1(supports-color@8.1.1)
       remark-math: 6.0.0(supports-color@8.1.1)
       shiki: 3.13.0
-      tailwind-merge: 3.3.1
+      tailwind-merge: 3.5.0
     transitivePeerDependencies:
       - '@types/react'
       - supports-color
@@ -35019,9 +35016,7 @@ snapshots:
 
   tagged-tag@1.0.0: {}
 
-  tailwind-merge@1.14.0: {}
-
-  tailwind-merge@3.3.1: {}
+  tailwind-merge@3.5.0: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.2.4):
     dependencies:


### PR DESCRIPTION
The format of some Tailwind classes changed from `px-[--card-padding-x]` to `px-(--card-padding-x)`. Because `tailwind-merge` is on a older version (pre Tailwind v4), it doesn't deduplicate the class when it encounters 
```
px-(--card-padding-x) p-0
```
With the new version, it should result in `p-0`.

By bumping `tailwind-merge` and other `cn` related deps, the `cn` util function is aware of the new class format.

Before:
<img width="819" height="357" alt="Screenshot 2026-04-30 at 15 27 39" src="https://github.com/user-attachments/assets/6d16497a-86a6-4a31-bc7c-eab17bb17ab3" />
After:
<img width="837" height="389" alt="Screenshot 2026-04-30 at 15 28 04" src="https://github.com/user-attachments/assets/2b53d7fe-2a61-493a-9aa0-abb34007738f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated dependencies across UI library, patterns, and component packages to latest compatible versions for improved stability and consistency across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->