### PR TITLE
fix: Fix infinite loading in the Cron jobs table

### DIFF
--- a/apps/studio/data/database-cron-jobs/database-cron-jobs-infinite-query.ts
+++ b/apps/studio/data/database-cron-jobs/database-cron-jobs-infinite-query.ts
@@ -5,7 +5,9 @@ import { databaseCronJobsKeys } from './keys'
 import { COST_THRESHOLD_ERROR, executeSql } from '@/data/sql/execute-sql-query'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from '@/types'
 
-export const CRON_JOBS_PAGE_LIMIT = 20
+// The value is intentionally high because the data grid needs to overflow so that `onScroll` event work and trigger
+// the infinite loading. If the value is too low, there won't be enough items to overflow and trigger the event.
+export const CRON_JOBS_PAGE_LIMIT = 40
 
 export type DatabaseCronJobRunsVariables = {
   projectRef?: string


### PR DESCRIPTION
This PR fixes an issue where the infinite list doesn't work for cron jobs. If the initial data (20 cronjobs) renders and you have a tall monitor to fit the entire table, the `react-data-grid` can't `onScroll` event which fetches the next page.

To test:
1. Add 40-50 cron jobs by running `SELECT cron.schedule('test 30', '0 2 * * 1', 'select 1');` repeatedly.
2. Open the /project/_/integrations/cron/jobs
3. See if you can scroll and trigger the second page.

Fixes https://linear.app/supabase/issue/FE-3117/cron-job-is-not-scrollable