### PR TITLE
fix: Fix the input group in database settings.

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/ConnectionPooling/ConnectionPooling.tsx
@@ -261,7 +261,7 @@ export const ConnectionPooling = () => {
                               {defaultPoolSize} based on your compute size of {computeSize}.
                             </p>
                           }
-                          className="[&>div]:md:w-1/2 [&>div]:xl:w-2/5 [&>div>div]:w-full [&>div>div>div]:min-w-100"
+                          className="[&>div]:md:w-1/2 [&>div]:xl:w-2/5 [&>div>div]:w-full"
                         >
                           <FormControl>
                             <InputGroup>
@@ -311,7 +311,7 @@ export const ConnectionPooling = () => {
                         <FormItemLayout
                           layout="flex-row-reverse"
                           label="Max client connections"
-                          className="[&>div]:md:w-1/2 [&>div]:xl:w-2/5 [&>div>div]:w-full [&>div>div>div]:min-w-100"
+                          className="[&>div]:md:w-1/2 [&>div]:xl:w-2/5 [&>div>div]:w-full"
                           description={
                             <>
                               <p>


### PR DESCRIPTION
The input groups in Database settings were rendered badly due to the Tailwind v4 bump.

Before:
<img width="767" height="585" alt="Screenshot 2026-04-30 at 16 59 55" src="https://github.com/user-attachments/assets/b55715b4-fdf2-4338-a10d-8c31138c49bc" />

After: 
<img width="763" height="628" alt="Screenshot 2026-04-30 at 17 04 56" src="https://github.com/user-attachments/assets/319e5894-7781-4e86-b892-214cc225c13e" />
