### PR TITLE
fix: Don't include fonts when rendering the svg in Schema visualizer

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/useExportSchemaToImage.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/useExportSchemaToImage.ts
@@ -40,6 +40,7 @@ export const useExportSchemaToImage = () => {
           height: height.toString(),
           transform: `translate(${x}px, ${y}px) scale(${zoom})`,
         },
+        skipFonts: true,
       }
       try {
         if (format === 'svg') {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rendering and visual consistency of exported database schema images by refining font handling during SVG and PNG export processes. Schema diagrams now display with better visual fidelity when exported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->