### PR TITLE
Fix read replica parameter name in curl command

### DIFF
--- a/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
+++ b/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
@@ -40,7 +40,7 @@ curl -X POST "https://api.supabase.com/v1/projects/$PROJECT_REF/read-replicas/se
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
   -d '{
-    "region": "us-east-1"
+    "read_replica_region": "us-east-1"
   }'
 
 # Delete a Read Replica


### PR DESCRIPTION
Updated the getting started guide to use the correct parameter name 'read_replica_region' instead of 'region' for creating read replicas using curl

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Getting Started guide for Read Replicas with corrected API request examples for improved accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->