### PR TITLE
fix: top-up loading state and show plan item on downgrade

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -426,13 +426,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                   loading={
                     form.formState.isSubmitting || executingTopUp || paymentConfirmationLoading
                   }
-                  disabled={
-                    form.formState.isSubmitting ||
-                    executingTopUp ||
-                    paymentConfirmationLoading ||
-                    isPreviewStale ||
-                    creditPreviewIsFetching
-                  }
+                  disabled={isPreviewStale || creditPreviewIsFetching}
                 >
                   Top Up
                 </Button>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -410,7 +410,7 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                   {creditPreview.tax_status === 'calculated' &&
                     creditPreview.tax &&
                     creditPreview.tax.tax_amount > 0 && (
-                      <p className="mt-2 text-xs text-foreground-muted">
+                      <p className="mt-2 text-xs text-foreground-light">
                         You'll receive {formatCurrency(creditPreview.amount)} in credits.
                       </p>
                     )}
@@ -423,8 +423,16 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
                 <Button
                   htmlType="submit"
                   type="primary"
-                  loading={executingTopUp || paymentConfirmationLoading}
-                  disabled={isPreviewStale || creditPreviewIsFetching}
+                  loading={
+                    form.formState.isSubmitting || executingTopUp || paymentConfirmationLoading
+                  }
+                  disabled={
+                    form.formState.isSubmitting ||
+                    executingTopUp ||
+                    paymentConfirmationLoading ||
+                    isPreviewStale ||
+                    creditPreviewIsFetching
+                  }
                 >
                   Top Up
                 </Button>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -321,7 +321,6 @@ export const SubscriptionPlanUpdateDialog = ({
     newPlanCost,
     taxFailed,
     customerBalance,
-    changeType,
     subscriptionPlanMeta?.name,
   ])
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -302,7 +302,7 @@ export const SubscriptionPlanUpdateDialog = ({
     }
 
     // Prepend the plan cost row when there are adjustment items to show
-    if (changeType !== 'downgrade' && items.length > 0) {
+    if (items.length > 0) {
       items.unshift({
         type: 'amount',
         label: `${subscriptionPlanMeta?.name} Plan`,


### PR DESCRIPTION

## Summary

- **Subscription downgrade dialog**: The plan name row was being hidden in the charge breakdown when `changeType === 'downgrade'`, so users downgrading (e.g. Team → Pro) couldn't see which plan the cost referred to. Removed the downgrade exclusion so the plan name row renders consistently across upgrade/downgrade flows.
- **Credit Top Up dialog**: The submit button only reflected `executingTopUp`/`paymentConfirmationLoading`, but the `onSubmit` handler runs several async steps first (hCaptcha, billing profile validation, Stripe `createPaymentMethod`) before the mutation flips `isPending`. That left a clickable window where users could trigger multiple top-ups. Added `form.formState.isSubmitting` to both `loading` and `disabled` so the button is locked for the full submit lifecycle.

## Test plan

- [ ]  Downgrade from Team → Pro and confirm the Pro plan row appears in the charge breakdown
- [ ]  Open Credit Top Up, submit, and rapidly click the Top Up button — verify only one charge is initiated
- [ ]  Verify Top Up button shows a loading state immediately on click (before the mutation starts)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consistently show subscription plan cost during billing adjustments, including downgrades.
  * Improve Top Up button to reflect form submission state and prevent duplicate submissions.

* **Style**
  * Enhanced text contrast for better readability in billing information displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->