### PR TITLE
docs: add Supabase Agent Plugin page

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -501,6 +501,10 @@ export const gettingstarted: NavMenuConstant = {
       url: undefined,
       items: [
         {
+          name: 'Supabase Agent Plugin',
+          url: '/guides/getting-started/plugins' as `/${string}`,
+        },
+        {
           name: 'Prompts',
           url: '/guides/getting-started/ai-prompts' as `/${string}`,
         },

--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -18,15 +18,6 @@ To install a specific skill from the repository:
 npx skills add supabase/agent-skills --skill SKILL_NAME
 ```
 
-### Claude Code plugin
-
-You can also install the skills as Claude Code plugins:
-
-```bash
-/plugin marketplace add supabase/agent-skills
-/plugin install supabase@supabase-agent-skills
-```
-
 Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others.
 
 ## Available skills

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -1,0 +1,32 @@
+---
+id: 'ai-tools-plugins'
+title: 'Supabase Agent Plugins'
+subtitle: 'Install Supabase agent plugin for your AI coding agent'
+description: 'Install Supabase agent plugin for your AI coding agent'
+sidebar_label: 'Supabase Agent Plugin'
+---
+
+The Supabase agent plugin bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) into a single install for your AI coding agent. Once installed, your agent can query your database, manage migrations, and follow Supabase and Postgres best practices without manual configuration.
+
+## Installation
+
+Choose your AI coding agent and follow the installation steps:
+
+<AgentPluginsPanel />
+
+## What's included
+
+Each plugin bundles:
+
+### MCP server
+
+The [Supabase MCP server](/docs/guides/getting-started/mcp) connects your AI coding agent directly to your Supabase projects. Once authenticated, your agent can query your database, manage migrations, deploy Edge Functions, and more — see the [full list of available tools](/docs/guides/getting-started/mcp#available-tools).
+
+### Agent skills
+
+Skills provide your agent with Supabase-specific procedural knowledge:
+
+- **supabase** — Core guidance for working with Supabase products (Database, Auth, Edge Functions, Storage, Realtime)
+- **supabase-postgres-best-practices** — Postgres query optimization, schema design, connection management, and RLS patterns
+
+For a full list of available skills and supported agents, see [Agent Skills](/docs/guides/getting-started/ai-skills).

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -33,6 +33,7 @@ import { IconPanel } from 'ui-patterns/IconPanel'
 import SqlToRest from 'ui-patterns/SqlToRest'
 import { Heading } from 'ui/src/components/CustomHTMLElements'
 
+import { AgentPluginsPanel } from '../ui/AgentPluginsPanel'
 import { ErrorCodes } from '../ui/ErrorCodes'
 import { McpConfigPanel } from '../ui/McpConfigPanel'
 
@@ -45,6 +46,7 @@ const components = {
   Accordion,
   AccordionItem,
   Admonition: AdmonitionWithMargin,
+  AgentPluginsPanel,
   AiPromptsIndex,
   AiSkillsIndex,
   AuthSmsProviderConfig,

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -28,7 +28,7 @@ interface PluginClient {
   docsUrl?: string
 }
 
-const AGENT_PLUGINS: PluginClient[] = [
+const PLUGIN_CLIENTS: PluginClient[] = [
   {
     key: 'claude-code',
     label: 'Claude Code',
@@ -59,22 +59,6 @@ const AGENT_PLUGINS: PluginClient[] = [
     docsUrl: 'https://geminicli.com/docs/extensions/',
   },
 ]
-
-const CONNECTORS: PluginClient[] = [
-  {
-    key: 'claude-ai',
-    label: 'Claude.ai',
-    icon: 'claude',
-  },
-  {
-    key: 'chatgpt',
-    label: 'ChatGPT',
-    icon: 'openai',
-    hasDistinctDarkIcon: true,
-  },
-]
-
-const ALL_CLIENTS = [...AGENT_PLUGINS, ...CONNECTORS]
 
 function ClientDropdown({
   theme,
@@ -125,40 +109,8 @@ function ClientDropdown({
           <CommandInput_Shadcn_ placeholder="Search..." />
           <CommandList_Shadcn_>
             <CommandEmpty_Shadcn_>No results found.</CommandEmpty_Shadcn_>
-            <CommandGroup_Shadcn_ heading="Agent Plugins">
-              {AGENT_PLUGINS.map((client) => (
-                <CommandItem_Shadcn_
-                  key={client.key}
-                  value={client.key}
-                  onSelect={() => {
-                    onClientChange(client.key)
-                    setOpen(false)
-                  }}
-                  className="flex gap-2 items-center"
-                >
-                  {client.icon ? (
-                    <ConnectionIcon
-                      connection={client.icon}
-                      theme={theme}
-                      hasDistinctDarkIcon={client.hasDistinctDarkIcon}
-                    />
-                  ) : (
-                    <Bot size={12} aria-hidden />
-                  )}
-                  {client.label}
-                  <Check
-                    size={15}
-                    aria-label={client.key === selectedClient.key ? 'selected' : undefined}
-                    className={cn(
-                      'ml-auto',
-                      client.key === selectedClient.key ? 'opacity-100' : 'opacity-0'
-                    )}
-                  />
-                </CommandItem_Shadcn_>
-              ))}
-            </CommandGroup_Shadcn_>
-            <CommandGroup_Shadcn_ heading="Connectors">
-              {CONNECTORS.map((client) => (
+            <CommandGroup_Shadcn_>
+              {PLUGIN_CLIENTS.map((client) => (
                 <CommandItem_Shadcn_
                   key={client.key}
                   value={client.key}
@@ -293,54 +245,16 @@ function PluginInstructions({ client }: { client: PluginClient }) {
     )
   }
 
-  if (client.key === 'claude-ai') {
-    return (
-      <div className="space-y-3">
-        <p className="text-sm text-foreground-light">
-          Connect Supabase to Claude.ai to access your projects directly in the Claude.ai interface.
-        </p>
-        <Button size="small" type="default" asChild iconRight={<ExternalLink size={12} />}>
-          <a
-            href="https://claude.ai/directory/11ca66fc-1e98-49d5-ab9b-7cb4672a8f10"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Connect Supabase to Claude.ai
-          </a>
-        </Button>
-      </div>
-    )
-  }
-
-  if (client.key === 'chatgpt') {
-    return (
-      <div className="space-y-3">
-        <p className="text-sm text-foreground-light">
-          Connect Supabase to ChatGPT to access your projects directly in the ChatGPT interface.
-        </p>
-        <Button size="small" type="default" asChild iconRight={<ExternalLink size={12} />}>
-          <a
-            href="https://chatgpt.com/apps/supabase/asdk_app_69d3e5ee6a708191baa733f7b8931995"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Connect Supabase to ChatGPT
-          </a>
-        </Button>
-      </div>
-    )
-  }
-
   return null
 }
 
 export function AgentPluginsPanel() {
-  const [selectedClientKey, setSelectedClientKey] = useState(ALL_CLIENTS[0].key)
+  const [selectedClientKey, setSelectedClientKey] = useState(PLUGIN_CLIENTS[0].key)
   const { resolvedTheme } = useTheme()
 
   const theme = (resolvedTheme as 'light' | 'dark') ?? 'light'
-  const selectedClient = ALL_CLIENTS.find((c) => c.key === selectedClientKey) ?? ALL_CLIENTS[0]
-  const isConnector = CONNECTORS.some((c) => c.key === selectedClientKey)
+  const selectedClient =
+    PLUGIN_CLIENTS.find((c) => c.key === selectedClientKey) ?? PLUGIN_CLIENTS[0]
 
   return (
     <div className="not-prose">
@@ -352,32 +266,30 @@ export function AgentPluginsPanel() {
       <div className="mt-4 rounded-lg border border-muted p-4">
         <PluginInstructions client={selectedClient} />
       </div>
-      {!isConnector && (
-        <div className="mt-2 flex gap-4">
-          {selectedClient.docsUrl && (
-            <a
-              href={selectedClient.docsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
-            >
-              <ExternalLink size={10} />
-              {selectedClient.label} plugin docs
-            </a>
-          )}
-          {selectedClient.repoUrl && (
-            <a
-              href={selectedClient.repoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
-            >
-              <ExternalLink size={10} />
-              Plugin repository
-            </a>
-          )}
-        </div>
-      )}
+      <div className="mt-2 flex gap-4">
+        {selectedClient.docsUrl && (
+          <a
+            href={selectedClient.docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
+          >
+            <ExternalLink size={10} />
+            {selectedClient.label} plugin docs
+          </a>
+        )}
+        {selectedClient.repoUrl && (
+          <a
+            href={selectedClient.repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
+          >
+            <ExternalLink size={10} />
+            Plugin repository
+          </a>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -1,0 +1,383 @@
+'use client'
+
+import { Bot, Check, ChevronDown, ExternalLink } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { useState } from 'react'
+import {
+  Button,
+  cn,
+  Command_Shadcn_,
+  CommandEmpty_Shadcn_,
+  CommandGroup_Shadcn_,
+  CommandInput_Shadcn_,
+  CommandItem_Shadcn_,
+  CommandList_Shadcn_,
+  Popover_Shadcn_,
+  PopoverContent_Shadcn_,
+  PopoverTrigger_Shadcn_,
+} from 'ui'
+import { CodeBlock } from 'ui-patterns/CodeBlock'
+import { ConnectionIcon } from 'ui-patterns/McpUrlBuilder'
+
+interface PluginClient {
+  key: string
+  label: string
+  icon?: string
+  hasDistinctDarkIcon?: boolean
+  repoUrl?: string
+  docsUrl?: string
+}
+
+const AGENT_PLUGINS: PluginClient[] = [
+  {
+    key: 'claude-code',
+    label: 'Claude Code',
+    icon: 'claude',
+    repoUrl: 'https://github.com/supabase-community/supabase-plugin',
+    docsUrl: 'https://code.claude.com/docs/en/discover-plugins',
+  },
+  {
+    key: 'codex',
+    label: 'Codex',
+    icon: 'openai',
+    hasDistinctDarkIcon: true,
+    repoUrl: 'https://github.com/supabase-community/codex-plugin',
+    docsUrl: 'https://developers.openai.com/codex/plugins',
+  },
+  {
+    key: 'cursor',
+    label: 'Cursor',
+    icon: 'cursor',
+    repoUrl: 'https://github.com/supabase-community/cursor-plugin',
+    docsUrl: 'https://cursor.com/docs/plugins',
+  },
+  {
+    key: 'gemini-cli',
+    label: 'Gemini CLI',
+    icon: 'gemini-cli',
+    repoUrl: 'https://github.com/supabase-community/gemini-extension',
+    docsUrl: 'https://geminicli.com/docs/extensions/',
+  },
+]
+
+const CONNECTORS: PluginClient[] = [
+  {
+    key: 'claude-ai',
+    label: 'Claude.ai',
+    icon: 'claude',
+  },
+  {
+    key: 'chatgpt',
+    label: 'ChatGPT',
+    icon: 'openai',
+    hasDistinctDarkIcon: true,
+  },
+]
+
+const ALL_CLIENTS = [...AGENT_PLUGINS, ...CONNECTORS]
+
+function ClientDropdown({
+  theme,
+  selectedClient,
+  onClientChange,
+}: {
+  theme: 'light' | 'dark'
+  selectedClient: PluginClient
+  onClientChange: (key: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>
+      <div className="flex">
+        <span className="flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
+          Client
+        </span>
+        <PopoverTrigger_Shadcn_ asChild>
+          <Button
+            size="small"
+            type="default"
+            className="gap-0 rounded-l-none"
+            iconRight={
+              <ChevronDown
+                strokeWidth={1.5}
+                className={cn('transition-transform duration-200', open && 'rotate-180')}
+              />
+            }
+          >
+            <div className="flex items-center gap-2">
+              {selectedClient.icon ? (
+                <ConnectionIcon
+                  connection={selectedClient.icon}
+                  theme={theme}
+                  hasDistinctDarkIcon={selectedClient.hasDistinctDarkIcon}
+                />
+              ) : (
+                <Bot size={12} aria-hidden />
+              )}
+              {selectedClient.label}
+            </div>
+          </Button>
+        </PopoverTrigger_Shadcn_>
+      </div>
+      <PopoverContent_Shadcn_ className="mt-0 p-0 max-w-48" side="bottom" align="start">
+        <Command_Shadcn_>
+          <CommandInput_Shadcn_ placeholder="Search..." />
+          <CommandList_Shadcn_>
+            <CommandEmpty_Shadcn_>No results found.</CommandEmpty_Shadcn_>
+            <CommandGroup_Shadcn_ heading="Agent Plugins">
+              {AGENT_PLUGINS.map((client) => (
+                <CommandItem_Shadcn_
+                  key={client.key}
+                  value={client.key}
+                  onSelect={() => {
+                    onClientChange(client.key)
+                    setOpen(false)
+                  }}
+                  className="flex gap-2 items-center"
+                >
+                  {client.icon ? (
+                    <ConnectionIcon
+                      connection={client.icon}
+                      theme={theme}
+                      hasDistinctDarkIcon={client.hasDistinctDarkIcon}
+                    />
+                  ) : (
+                    <Bot size={12} aria-hidden />
+                  )}
+                  {client.label}
+                  <Check
+                    size={15}
+                    aria-label={client.key === selectedClient.key ? 'selected' : undefined}
+                    className={cn(
+                      'ml-auto',
+                      client.key === selectedClient.key ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                </CommandItem_Shadcn_>
+              ))}
+            </CommandGroup_Shadcn_>
+            <CommandGroup_Shadcn_ heading="Connectors">
+              {CONNECTORS.map((client) => (
+                <CommandItem_Shadcn_
+                  key={client.key}
+                  value={client.key}
+                  onSelect={() => {
+                    onClientChange(client.key)
+                    setOpen(false)
+                  }}
+                  className="flex gap-2 items-center"
+                >
+                  {client.icon ? (
+                    <ConnectionIcon
+                      connection={client.icon}
+                      theme={theme}
+                      hasDistinctDarkIcon={client.hasDistinctDarkIcon}
+                    />
+                  ) : (
+                    <Bot size={12} aria-hidden />
+                  )}
+                  {client.label}
+                  <Check
+                    size={15}
+                    aria-label={client.key === selectedClient.key ? 'selected' : undefined}
+                    className={cn(
+                      'ml-auto',
+                      client.key === selectedClient.key ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                </CommandItem_Shadcn_>
+              ))}
+            </CommandGroup_Shadcn_>
+          </CommandList_Shadcn_>
+        </Command_Shadcn_>
+      </PopoverContent_Shadcn_>
+    </Popover_Shadcn_>
+  )
+}
+
+function PluginInstructions({ client }: { client: PluginClient }) {
+  if (client.key === 'claude-code') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Add the Supabase{' '}
+          <a
+            href="https://skills.sh"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            agent skills
+          </a>{' '}
+          marketplace, then install the plugin from the{' '}
+          <a
+            href="https://claude.com/plugins"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            official Anthropic marketplace
+          </a>
+          :
+        </p>
+        <CodeBlock
+          value={`claude plugin marketplace add supabase/agent-skills\nclaude plugin install supabase@claude-plugins-official`}
+          language="bash"
+          focusable={false}
+          className="block"
+        />
+        <p className="text-xs text-foreground-lighter">
+          After installing, run <code>/reload-plugins</code> inside Claude Code to activate the
+          plugin.
+        </p>
+      </div>
+    )
+  }
+
+  if (client.key === 'codex') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Start Codex and open the plugin browser with <code>/plugins</code>. Search for Supabase
+          and select <strong>Install plugin</strong>.
+        </p>
+        <CodeBlock value="codex" language="bash" focusable={false} className="block" />
+        <p className="text-xs text-foreground-lighter">
+          Then type <code>/plugins</code> inside Codex and search for Supabase. Some plugins ask you
+          to authenticate during install; others wait until first use.
+        </p>
+      </div>
+    )
+  }
+
+  if (client.key === 'cursor') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Run the following command inside Cursor&apos;s chat to install the Supabase plugin from
+          the{' '}
+          <a
+            href="https://cursor.com/marketplace/supabase"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            Cursor marketplace
+          </a>
+          :
+        </p>
+        <CodeBlock
+          value="/add-plugin supabase"
+          language="bash"
+          focusable={false}
+          className="block"
+        />
+      </div>
+    )
+  }
+
+  if (client.key === 'gemini-cli') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Install the Supabase extension for Gemini CLI:
+        </p>
+        <CodeBlock
+          value="gemini extensions install https://github.com/supabase-community/gemini-extension"
+          language="bash"
+          focusable={false}
+          className="block"
+        />
+      </div>
+    )
+  }
+
+  if (client.key === 'claude-ai') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Connect Supabase to Claude.ai to access your projects directly in the Claude.ai interface.
+        </p>
+        <Button size="small" type="default" asChild iconRight={<ExternalLink size={12} />}>
+          <a
+            href="https://claude.ai/directory/11ca66fc-1e98-49d5-ab9b-7cb4672a8f10"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Connect Supabase to Claude.ai
+          </a>
+        </Button>
+      </div>
+    )
+  }
+
+  if (client.key === 'chatgpt') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Connect Supabase to ChatGPT to access your projects directly in the ChatGPT interface.
+        </p>
+        <Button size="small" type="default" asChild iconRight={<ExternalLink size={12} />}>
+          <a
+            href="https://chatgpt.com/apps/supabase/asdk_app_69d3e5ee6a708191baa733f7b8931995"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Connect Supabase to ChatGPT
+          </a>
+        </Button>
+      </div>
+    )
+  }
+
+  return null
+}
+
+export function AgentPluginsPanel() {
+  const [selectedClientKey, setSelectedClientKey] = useState(ALL_CLIENTS[0].key)
+  const { resolvedTheme } = useTheme()
+
+  const theme = (resolvedTheme as 'light' | 'dark') ?? 'light'
+  const selectedClient = ALL_CLIENTS.find((c) => c.key === selectedClientKey) ?? ALL_CLIENTS[0]
+  const isConnector = CONNECTORS.some((c) => c.key === selectedClientKey)
+
+  return (
+    <div className="not-prose">
+      <ClientDropdown
+        theme={theme}
+        selectedClient={selectedClient}
+        onClientChange={setSelectedClientKey}
+      />
+      <div className="mt-4 rounded-lg border border-muted p-4">
+        <PluginInstructions client={selectedClient} />
+      </div>
+      {!isConnector && (
+        <div className="mt-2 flex gap-4">
+          {selectedClient.docsUrl && (
+            <a
+              href={selectedClient.docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
+            >
+              <ExternalLink size={10} />
+              {selectedClient.label} plugin docs
+            </a>
+          )}
+          {selectedClient.repoUrl && (
+            <a
+              href={selectedClient.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
+            >
+              <ExternalLink size={10} />
+              Plugin repository
+            </a>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -9,9 +9,9 @@ import { ClientSelectDropdown } from './components/ClientSelectDropdown'
 import { McpConfigurationDisplay } from './components/McpConfigurationDisplay'
 import { McpConfigurationOptions } from './components/McpConfigurationOptions'
 import {
-  CONNECTOR_CLIENT_KEYS,
   FEATURE_GROUPS_NON_PLATFORM,
   FEATURE_GROUPS_PLATFORM,
+  MCP_CLIENT_GROUPS,
   MCP_CLIENTS,
 } from './constants'
 import type { McpClient, McpOnCopyCallback } from './types'
@@ -110,20 +110,12 @@ export function McpConfigPanel({
         <ClientSelectDropdown
           label="Client"
           clients={MCP_CLIENTS}
-          groups={[
-            {
-              heading: 'Connectors',
-              clients: MCP_CLIENTS.filter((c) =>
-                (CONNECTOR_CLIENT_KEYS as readonly string[]).includes(c.key)
-              ),
-            },
-            {
-              heading: 'MCP Clients',
-              clients: MCP_CLIENTS.filter(
-                (c) => !(CONNECTOR_CLIENT_KEYS as readonly string[]).includes(c.key)
-              ),
-            },
-          ]}
+          groups={MCP_CLIENT_GROUPS.map((group) => ({
+            heading: group.heading,
+            clients: group.keys
+              .map((key) => MCP_CLIENTS.find((c) => c.key === key))
+              .filter(Boolean) as (typeof MCP_CLIENTS)[number][],
+          }))}
           selectedClient={selectedClient}
           onClientChange={handleClientChange}
           theme={theme}

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -8,7 +8,12 @@ import { InfoTooltip } from '../info-tooltip'
 import { ClientSelectDropdown } from './components/ClientSelectDropdown'
 import { McpConfigurationDisplay } from './components/McpConfigurationDisplay'
 import { McpConfigurationOptions } from './components/McpConfigurationOptions'
-import { FEATURE_GROUPS_NON_PLATFORM, FEATURE_GROUPS_PLATFORM, MCP_CLIENTS } from './constants'
+import {
+  CONNECTOR_CLIENT_KEYS,
+  FEATURE_GROUPS_NON_PLATFORM,
+  FEATURE_GROUPS_PLATFORM,
+  MCP_CLIENTS,
+} from './constants'
 import type { McpClient, McpOnCopyCallback } from './types'
 import { getMcpUrl } from './utils/getMcpUrl'
 
@@ -105,6 +110,20 @@ export function McpConfigPanel({
         <ClientSelectDropdown
           label="Client"
           clients={MCP_CLIENTS}
+          groups={[
+            {
+              heading: 'Connectors',
+              clients: MCP_CLIENTS.filter((c) =>
+                (CONNECTOR_CLIENT_KEYS as readonly string[]).includes(c.key)
+              ),
+            },
+            {
+              heading: 'MCP Clients',
+              clients: MCP_CLIENTS.filter(
+                (c) => !(CONNECTOR_CLIENT_KEYS as readonly string[]).includes(c.key)
+              ),
+            },
+          ]}
           selectedClient={selectedClient}
           onClientChange={handleClientChange}
           theme={theme}

--- a/packages/ui-patterns/src/McpUrlBuilder/components/ClientSelectDropdown.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/components/ClientSelectDropdown.tsx
@@ -19,10 +19,16 @@ import {
 import type { McpClient } from '../types'
 import { ConnectionIcon } from './ConnectionIcon'
 
+export interface ClientGroup {
+  heading: string
+  clients: McpClient[]
+}
+
 interface ClientSelectDropdownProps {
   theme?: 'light' | 'dark'
   label?: string
   clients: McpClient[]
+  groups?: ClientGroup[]
   selectedClient: McpClient
   onClientChange: (clientKey: string) => void
 }
@@ -31,6 +37,7 @@ export const ClientSelectDropdown = ({
   theme = 'light',
   label = 'Client',
   clients,
+  groups,
   selectedClient,
   onClientChange,
 }: ClientSelectDropdownProps) => {
@@ -39,6 +46,33 @@ export const ClientSelectDropdown = ({
   function onSelectClient(key: string) {
     onClientChange(key)
     setOpen(false)
+  }
+
+  function renderClient(client: McpClient) {
+    return (
+      <CommandItem_Shadcn_
+        key={client.key}
+        value={client.key}
+        onSelect={() => onSelectClient(client.key)}
+        className="flex gap-2 items-center"
+      >
+        {client.icon ? (
+          <ConnectionIcon
+            connection={client.icon}
+            theme={theme}
+            hasDistinctDarkIcon={client.hasDistinctDarkIcon}
+          />
+        ) : (
+          <Bot size={12} aria-hidden={true} />
+        )}
+        {client.label}
+        <Check
+          aria-label={client.key === selectedClient.key ? 'selected' : undefined}
+          size={15}
+          className={cn('ml-auto', client.key === selectedClient.key ? 'opacity-100' : 'opacity-0')}
+        />
+      </CommandItem_Shadcn_>
+    )
   }
 
   return (
@@ -79,38 +113,15 @@ export const ClientSelectDropdown = ({
           <CommandInput_Shadcn_ placeholder="Search..." />
           <CommandList_Shadcn_>
             <CommandEmpty_Shadcn_>No results found.</CommandEmpty_Shadcn_>
-            <CommandGroup_Shadcn_>
-              {clients.map((client) => (
-                <CommandItem_Shadcn_
-                  key={client.key}
-                  value={client.key}
-                  onSelect={() => {
-                    onSelectClient(client.key)
-                    setOpen(false)
-                  }}
-                  className="flex gap-2 items-center"
-                >
-                  {client.icon ? (
-                    <ConnectionIcon
-                      connection={client.icon}
-                      theme={theme}
-                      hasDistinctDarkIcon={client.hasDistinctDarkIcon}
-                    />
-                  ) : (
-                    <Bot size={12} aria-hidden={true} />
-                  )}
-                  {client.label}
-                  <Check
-                    aria-label={client.key === selectedClient.key ? 'selected' : undefined}
-                    size={15}
-                    className={cn(
-                      'ml-auto',
-                      client.key === selectedClient.key ? 'opacity-100' : 'opacity-0'
-                    )}
-                  />
-                </CommandItem_Shadcn_>
-              ))}
-            </CommandGroup_Shadcn_>
+            {groups ? (
+              groups.map((group) => (
+                <CommandGroup_Shadcn_ key={group.heading} heading={group.heading}>
+                  {group.clients.map(renderClient)}
+                </CommandGroup_Shadcn_>
+              ))
+            ) : (
+              <CommandGroup_Shadcn_>{clients.map(renderClient)}</CommandGroup_Shadcn_>
+            )}
           </CommandList_Shadcn_>
         </Command_Shadcn_>
       </PopoverContent_Shadcn_>

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -554,6 +554,47 @@ export const MCP_CLIENTS: McpClient[] = [
       </>
     ),
   },
+  {
+    key: 'claude-ai',
+    label: 'Claude.ai',
+    icon: 'claude',
+    primaryInstructions: (_config, _onCopy) => (
+      <div className="space-y-2">
+        <p className="text-xs text-foreground-light">
+          Connect Supabase to Claude.ai to access your projects directly in the Claude.ai interface.
+        </p>
+        <a
+          href="https://claude.ai/directory/11ca66fc-1e98-49d5-ab9b-7cb4672a8f10"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs text-brand-link hover:underline"
+        >
+          Connect Supabase to Claude.ai
+        </a>
+      </div>
+    ),
+  },
+  {
+    key: 'chatgpt',
+    label: 'ChatGPT',
+    icon: 'openai',
+    hasDistinctDarkIcon: true,
+    primaryInstructions: (_config, _onCopy) => (
+      <div className="space-y-2">
+        <p className="text-xs text-foreground-light">
+          Connect Supabase to ChatGPT to access your projects directly in the ChatGPT interface.
+        </p>
+        <a
+          href="https://chatgpt.com/apps/supabase/asdk_app_69d3e5ee6a708191baa733f7b8931995"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1.5 text-xs text-brand-link hover:underline"
+        >
+          Connect Supabase to ChatGPT
+        </a>
+      </div>
+    ),
+  },
 ]
 
 export const DEFAULT_MCP_URL_PLATFORM = 'http://localhost:8080/mcp'

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -558,46 +558,35 @@ export const MCP_CLIENTS: McpClient[] = [
     key: 'claude-ai',
     label: 'Claude.ai',
     icon: 'claude',
-    primaryInstructions: (_config, _onCopy) => (
-      <div className="space-y-2">
-        <p className="text-xs text-foreground-light">
-          Connect Supabase to Claude.ai to access your projects directly in the Claude.ai interface.
-        </p>
-        <a
-          href="https://claude.ai/directory/11ca66fc-1e98-49d5-ab9b-7cb4672a8f10"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-xs text-brand-link hover:underline"
-        >
-          Connect Supabase to Claude.ai
-        </a>
-      </div>
-    ),
+    externalDocsUrl: 'https://claude.com/docs/connectors/overview',
+    generateDeepLink: () =>
+      'https://claude.ai/directory/connectors/11ca66fc-1e98-49d5-ab9b-7cb4672a8f10',
   },
   {
     key: 'chatgpt',
     label: 'ChatGPT',
     icon: 'openai',
     hasDistinctDarkIcon: true,
-    primaryInstructions: (_config, _onCopy) => (
-      <div className="space-y-2">
-        <p className="text-xs text-foreground-light">
-          Connect Supabase to ChatGPT to access your projects directly in the ChatGPT interface.
-        </p>
-        <a
-          href="https://chatgpt.com/apps/supabase/asdk_app_69d3e5ee6a708191baa733f7b8931995"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-xs text-brand-link hover:underline"
-        >
-          Connect Supabase to ChatGPT
-        </a>
-      </div>
-    ),
+    externalDocsUrl: 'https://chatgpt.com/features/apps/',
+    generateDeepLink: () =>
+      'https://chatgpt.com/apps/supabase/asdk_app_69d3e5ee6a708191baa733f7b8931995',
   },
 ]
 
-export const CONNECTOR_CLIENT_KEYS = ['claude-ai', 'chatgpt'] as const
+export const MCP_CLIENT_GROUPS = [
+  {
+    heading: 'AI Agent CLI',
+    keys: ['claude-code', 'codex', 'gemini-cli', 'opencode', 'factory'],
+  },
+  {
+    heading: 'Web Clients',
+    keys: ['claude-ai', 'chatgpt', 'goose'],
+  },
+  {
+    heading: 'IDE',
+    keys: ['cursor', 'vscode', 'antigravity', 'kiro', 'windsurf'],
+  },
+] as const
 
 export const DEFAULT_MCP_URL_PLATFORM = 'http://localhost:8080/mcp'
 export const DEFAULT_MCP_URL_NON_PLATFORM = 'http://localhost:54321/mcp'

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -597,5 +597,7 @@ export const MCP_CLIENTS: McpClient[] = [
   },
 ]
 
+export const CONNECTOR_CLIENT_KEYS = ['claude-ai', 'chatgpt'] as const
+
 export const DEFAULT_MCP_URL_PLATFORM = 'http://localhost:8080/mcp'
 export const DEFAULT_MCP_URL_NON_PLATFORM = 'http://localhost:54321/mcp'

--- a/packages/ui-patterns/src/McpUrlBuilder/index.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/index.ts
@@ -8,7 +8,7 @@ export {
   FEATURE_GROUPS_PLATFORM,
   FEATURE_GROUPS_NON_PLATFORM,
   MCP_CLIENTS,
-  CONNECTOR_CLIENT_KEYS,
+  MCP_CLIENT_GROUPS,
 } from './constants'
 export { getMcpUrl } from './utils/getMcpUrl'
 export { createMcpCopyHandler, type McpCopyType } from './utils/createMcpCopyHandler'

--- a/packages/ui-patterns/src/McpUrlBuilder/index.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/index.ts
@@ -1,4 +1,4 @@
-export { ClientSelectDropdown } from './components/ClientSelectDropdown'
+export { ClientSelectDropdown, type ClientGroup } from './components/ClientSelectDropdown'
 export { ConnectionIcon } from './components/ConnectionIcon'
 export { McpConfigurationDisplay } from './components/McpConfigurationDisplay'
 export { McpConfigurationOptions } from './components/McpConfigurationOptions'
@@ -8,6 +8,7 @@ export {
   FEATURE_GROUPS_PLATFORM,
   FEATURE_GROUPS_NON_PLATFORM,
   MCP_CLIENTS,
+  CONNECTOR_CLIENT_KEYS,
 } from './constants'
 export { getMcpUrl } from './utils/getMcpUrl'
 export { createMcpCopyHandler, type McpCopyType } from './utils/createMcpCopyHandler'


### PR DESCRIPTION
## Summary

- Adds a new **Supabase Agent Plugin** page (`/guides/getting-started/plugins`) with a grouped dropdown UI covering agent plugins (Claude Code, Codex, Cursor, Gemini CLI) and connectors (Claude.ai, ChatGPT)
- Removes the Claude Code plugin subsection from the Agent Skills page — now covered in the new page

Closes [AI-690](https://linear.app/supabase/issue/AI-690/agent-plugins-documentation)