### PR TITLE
Fix FormItemLayout incorrect min-w-100 on FlexContainer for flex-row-reverse

### DIFF
--- a/packages/ui-patterns/src/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/src/form/Layout/FormLayout.tsx
@@ -227,7 +227,7 @@ const FlexContainer = cva('', {
     {
       layout: 'flex-row-reverse',
       className:
-        'flex flex-col justify-center items-start md:items-end shrink-0 md:w-1/2 xl:w-2/5 md:min-w-100 [&>div]:md:w-full',
+        'flex flex-col justify-center items-start md:items-end shrink-0 md:w-1/2 xl:w-2/5 [&>div]:md:w-full',
     },
   ],
 })


### PR DESCRIPTION
## Context

As per PR title - saw that there's a `md:min-w-100` on `FlexContainer` which overrides `md:w-1/2`. Removing the former resolves this

<img width="622" height="188" alt="image" src="https://github.com/user-attachments/assets/6414d546-7c27-4a3c-9fd9-83da89acc387" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved form layout responsiveness on medium-sized screens by adjusting width constraints for better flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->