### PR TITLE
chore(www): explicit AI crawler rules + homepage canonical URL

### DIFF
--- a/apps/www/pages/index.tsx
+++ b/apps/www/pages/index.tsx
@@ -1,8 +1,9 @@
-import dynamic from 'next/dynamic'
-import getContent from '~/data/home/content'
-import Layout from '~/components/Layouts/Default'
 import Hero from '~/components/Hero/Hero'
+import Layout from '~/components/Layouts/Default'
 import Logos from '~/components/logos'
+import getContent from '~/data/home/content'
+import { NextSeo } from 'next-seo'
+import dynamic from 'next/dynamic'
 
 const Products = dynamic(() => import('~/components/Products/index'))
 const HeroFrameworks = dynamic(() => import('~/components/Hero/HeroFrameworks'))
@@ -19,18 +20,21 @@ const Index = () => {
   const content = getContent()
 
   return (
-    <Layout>
-      <Hero />
-      <Logos />
-      <Products {...content.productsSection} />
-      <HeroFrameworks />
-      <CustomerStories />
-      <BuiltWithSupabase />
-      <DashboardFeatures {...content.dashboardFeatures} />
-      <TwitterSocialSection {...content.twitterSocialSection} />
-      <OpenSourceSection />
-      <CTABanner className="border-none" />
-    </Layout>
+    <>
+      <NextSeo canonical="https://supabase.com/" />
+      <Layout>
+        <Hero />
+        <Logos />
+        <Products {...content.productsSection} />
+        <HeroFrameworks />
+        <CustomerStories />
+        <BuiltWithSupabase />
+        <DashboardFeatures {...content.dashboardFeatures} />
+        <TwitterSocialSection {...content.twitterSocialSection} />
+        <OpenSourceSection />
+        <CTABanner className="border-none" />
+      </Layout>
+    </>
   )
 }
 

--- a/apps/www/public/robots.txt
+++ b/apps/www/public/robots.txt
@@ -1,3 +1,11 @@
 User-agent: *
+Allow: /
+
+User-agent: GPTBot
+User-agent: ClaudeBot
+User-agent: Google-Extended
+User-agent: PerplexityBot
+Allow: /
+
 Sitemap: https://supabase.com/sitemap.xml
 Content-Signal: ai-train=yes, search=yes, ai-input=yes


### PR DESCRIPTION
## Summary

Two small `apps/www` audit-driven fixes bundled into one PR. Both are low-risk, no behavior change for human visitors.

### 1. Explicit AI crawler rules in `robots.txt`

Agent-readiness audits (ora.run/score, isitagentready.com) flag two issues with the current `apps/www/public/robots.txt`:

- The `User-agent: *` block has no `Allow:` / `Disallow:` directive — technically malformed per RFC 9309.
- No AI-specific bot rules.

Added explicit per-bot allows for the four major AI operators, stacked under a single rule block. **Same allow-all behavior as today** — just makes intent explicit.

- Added `Allow: /` to the `User-agent: *` block (RFC 9309 compliance).
- Added a stacked rule block naming `GPTBot`, `ClaudeBot`, `Google-Extended`, `PerplexityBot` with `Allow: /`.
- Kept the existing Cloudflare `Content-Signal: ai-train=yes, search=yes, ai-input=yes`.

Did **not** add `/.well-known/mcp` (also flagged by ora.run): no spec is ratified, no peer providers (Cloudflare, GitHub, Stripe, Linear, Vercel, Sentry) currently serve one, and the schema is in flux. Revisit when the MCP spec absorbs `.well-known` (likely mid-to-late 2026).

### 2. Canonical URL on the homepage

isitagentready.com flagged "3/4 metadata signals present — missing canonical URL". The shared `DefaultSeo` block in `apps/www/pages/_app.tsx` sets `openGraph.url` but no `canonical`, so the homepage emits no `<link rel="canonical">`.

Added `<NextSeo canonical="https://supabase.com/" />` to `apps/www/pages/index.tsx`. Composes with `DefaultSeo` (overrides per-key); emits `<link rel="canonical" href="https://supabase.com/" />`.

**Why scoped to homepage only:** setting `canonical` on `DefaultSeo` would propagate to every page that doesn't override (so `/pricing`'s canonical would point to `/`, etc.) — incorrect and worse than no canonical. The correct sitewide fix is per-page `NextSeo canonical={...}`, a real chore touching dozens of files. Sitewide sweep is a follow-up.

## Testing (Vercel preview)

```bash
# Verify robots.txt
curl -s https://<preview>/robots.txt
# Expect: stacked AI bot block + Allow: / on wildcard

# Verify canonical
curl -s https://<preview>/ | grep 'rel="canonical"'
# Expect: <link rel="canonical" href="https://supabase.com/"/>

# Re-run audits
# https://isitagentready.com/<preview-host>      — "AI-specific bot rules", "wildcard rules", "metadata signals" should all pass
# https://ora.run/score/<preview-host>           — "AI crawler tier differentiation" should pass
```

## Linear

- fixes GROWTH-813
- fixes GROWTH-815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated site crawler permissions to improve discoverability across search engines and AI assistant platforms.
* **New Features**
  * Added SEO metadata to the homepage to enhance search indexing and link previews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->