### PR TITLE
fix(www): normalize blog frontmatter dates to ISO 8601

### DIFF
--- a/apps/www/_blog/2020-05-01-supabase-alpha-april-2020.mdx
+++ b/apps/www/_blog/2020-05-01-supabase-alpha-april-2020.mdx
@@ -9,7 +9,7 @@ categories:
   - product
 tags:
   - supabase
-date: '06-01-2020'
+date: '2020-05-01'
 ---
 
 Now in [Supabase](https://supabase.com/dashboard):

--- a/apps/www/_blog/2020-06-01-supabase-alpha-may-2020.mdx
+++ b/apps/www/_blog/2020-06-01-supabase-alpha-may-2020.mdx
@@ -9,7 +9,7 @@ categories:
   - product
 tags:
   - supabase
-date: '06-01-2020'
+date: '2020-06-01'
 video: https://www.youtube.com/v/e4qXmcEFaUs
 ---
 

--- a/apps/www/_blog/2020-06-15-supabase-steve-chavez.mdx
+++ b/apps/www/_blog/2020-06-15-supabase-steve-chavez.mdx
@@ -10,7 +10,7 @@ categories:
 tags:
   - supabase
   - hiring
-date: '06-15-2020'
+date: '2020-06-15'
 ---
 
 This month we welcome [Steve Chavez](https://github.com/steve-chavez) to the team. Steve is a maintainer of PostgREST, one of the core tools which makes Supabase possible.

--- a/apps/www/_blog/2020-07-01-supabase-alpha-june-2020.mdx
+++ b/apps/www/_blog/2020-07-01-supabase-alpha-june-2020.mdx
@@ -9,7 +9,7 @@ categories:
   - product
 tags:
   - supabase
-date: '07-01-2020'
+date: '2020-07-01'
 ---
 
 We're now 4 months into building [Supabase](/), which means another major update. Here's a few things we think you'll love in this release.

--- a/apps/www/_blog/2020-07-10-alpha-launch-postmortem.mdx
+++ b/apps/www/_blog/2020-07-10-alpha-launch-postmortem.mdx
@@ -9,7 +9,7 @@ categories:
   - launch-week
 tags:
   - supabase
-date: '07-10-2020'
+date: '2020-07-10'
 ---
 
 On May 27 Supabase hit the [top of Hacker News](https://news.ycombinator.com/item?id=23319901) and stayed on the front page for more than 24 hours.

--- a/apps/www/_blog/2020-08-02-supabase-alpha-july-2020.mdx
+++ b/apps/www/_blog/2020-08-02-supabase-alpha-july-2020.mdx
@@ -9,7 +9,7 @@ categories:
   - product
 tags:
   - supabase
-date: '08-02-2020'
+date: '2020-08-02'
 ---
 
 After 5 months of building, we're releasing one of our most anticipated features: Supabase Auth.

--- a/apps/www/_blog/2020-08-05-supabase-auth.mdx
+++ b/apps/www/_blog/2020-08-05-supabase-auth.mdx
@@ -10,7 +10,7 @@ categories:
   - product
 tags:
   - supabase
-date: '08-05-2020'
+date: '2020-08-05'
 ---
 
 Supabase is an open source Firebase alternative. We are building the features of Firebase using scalable, open source products.

--- a/apps/www/_blog/2020-09-03-supabase-alpha-august-2020.mdx
+++ b/apps/www/_blog/2020-09-03-supabase-alpha-august-2020.mdx
@@ -9,7 +9,7 @@ categories:
   - product
 tags:
   - supabase
-date: '09-03-2020'
+date: '2020-09-03'
 ---
 
 We're 6 months into building our hosted database platform and we've made some major improvements to our auth system and table view.

--- a/apps/www/_blog/2020-09-11-supabase-hacktoberfest-2020.mdx
+++ b/apps/www/_blog/2020-09-11-supabase-hacktoberfest-2020.mdx
@@ -11,7 +11,7 @@ categories:
 tags:
   - supabase
   - hacktoberfest
-date: '09-11-2020'
+date: '2020-09-11'
 ---
 
 October is looming, and for open source communities and contributors this means one thing: [Hacktoberfest](https://hacktoberfest.digitalocean.com/).

--- a/apps/www/_blog/2020-10-03-supabase-alpha-september-2020.mdx
+++ b/apps/www/_blog/2020-10-03-supabase-alpha-september-2020.mdx
@@ -10,7 +10,7 @@ categories:
   - product
 tags:
   - supabase
-date: '10-03-2020'
+date: '2020-10-03'
 ---
 
 We're now 7 months into building Supabase. This update is a big one!

--- a/apps/www/_blog/2020-10-30-improved-dx.mdx
+++ b/apps/www/_blog/2020-10-30-improved-dx.mdx
@@ -10,7 +10,7 @@ categories:
   - product
 tags:
   - supabase
-date: '10-30-2020'
+date: '2020-10-30'
 ---
 
 **UPDATE 16/08/2022**: supabase-js v2 is out and focuses on “quality-of-life” improvements for developers. V2 includes Type support, new auth methods, realtime multiplayer sneak peek, and more: [**Read the blog post**](https://supabase.com/blog/supabase-js-v2)

--- a/apps/www/_blog/2020-11-02-supabase-alpha-october-2020.mdx
+++ b/apps/www/_blog/2020-11-02-supabase-alpha-october-2020.mdx
@@ -10,7 +10,7 @@ categories:
   - product
 tags:
   - supabase
-date: '11-02-2020'
+date: '2020-11-02'
 video: https://www.youtube.com/v/1gNDMMsUPI0
 ---
 

--- a/apps/www/_blog/2020-12-01-supabase-alpha-november-2020.mdx
+++ b/apps/www/_blog/2020-12-01-supabase-alpha-november-2020.mdx
@@ -10,7 +10,7 @@ categories:
   - product
 tags:
   - supabase
-date: '12-01-2020'
+date: '2020-12-01'
 video: https://www.youtube.com/v/unC_de7iytA
 ---
 

--- a/apps/www/_blog/2020-12-02-case-study-monitoro.mdx
+++ b/apps/www/_blog/2020-12-02-case-study-monitoro.mdx
@@ -10,7 +10,7 @@ categories:
   - company
 tags:
   - no-code
-date: '12-02-2020'
+date: '2020-12-02'
 video: https://www.youtube.com/v/8A6_pg41M2s
 ---
 

--- a/apps/www/_blog/2020-12-02-case-study-tayfa.mdx
+++ b/apps/www/_blog/2020-12-02-case-study-tayfa.mdx
@@ -10,7 +10,7 @@ categories:
   - company
 tags:
   - no-code
-date: '12-02-2020'
+date: '2020-12-02'
 ---
 
 [**TAYFA**](https://usetayfa.com) is the fastest no-code approach to create and iterate on bespoke frontends. Learn how its solo founder, [Sarup Banskota](https://twitter.com/sarupbanskota?lang=en), was able to launch quickly with [Supabase](/), Next.js, and Vercel.

--- a/apps/www/_blog/2020-12-02-case-study-xendit.mdx
+++ b/apps/www/_blog/2020-12-02-case-study-xendit.mdx
@@ -11,7 +11,7 @@ categories:
   - company
 tags:
   - fintech
-date: '12-02-2020'
+date: '2020-12-02'
 ---
 
 [Xendit](https://www.xendit.co/) is one of South East Asia's largest payment processors. They use Supabase to run automated checks against international sanctions lists.

--- a/apps/www/_blog/2020-12-02-supabase-striveschool.mdx
+++ b/apps/www/_blog/2020-12-02-supabase-striveschool.mdx
@@ -12,7 +12,7 @@ categories:
 tags:
   - supabase
   - striveschool
-date: '12-02-2020'
+date: '2020-12-02'
 ---
 
 ### Supabase and Strive School - YC Summer 20 batchmates

--- a/apps/www/_blog/2020-12-13-supabase-dashboard-performance.mdx
+++ b/apps/www/_blog/2020-12-13-supabase-dashboard-performance.mdx
@@ -9,7 +9,7 @@ categories:
   - product
 tags:
   - supabase
-date: '12-13-2020'
+date: '2020-12-13'
 ---
 
 The Supabase dashboard has become more feature-rich in the last month. We have a powerful SQL editor backed by [Monaco](https://microsoft.github.io/monaco-editor/). We built an Airtable-like view of your database, making editing a breeze.

--- a/apps/www/_blog/2021-01-02-supabase-beta-december-2020.mdx
+++ b/apps/www/_blog/2021-01-02-supabase-beta-december-2020.mdx
@@ -11,7 +11,7 @@ categories:
   - product
 tags:
   - supabase
-date: '01-02-2021'
+date: '2021-01-02'
 video: https://www.youtube.com/v/ofSm4BJkZ1g
 ---
 

--- a/apps/www/_blog/2021-02-02-supabase-beta-january-2021.mdx
+++ b/apps/www/_blog/2021-02-02-supabase-beta-january-2021.mdx
@@ -11,7 +11,7 @@ categories:
   - product
 tags:
   - supabase
-date: '02-02-2021'
+date: '2021-02-02'
 video: https://www.youtube.com/v/DlybOLANG4s
 ---
 

--- a/apps/www/_blog/2021-02-09-case-study-roboflow.mdx
+++ b/apps/www/_blog/2021-02-09-case-study-roboflow.mdx
@@ -11,7 +11,7 @@ categories:
   - company
 tags:
   - AI
-date: '02-09-2021'
+date: '2021-02-09'
 ---
 
 Brad Dwyer is the founder of [Roboflow](https://roboflow.com/?ref=supabase), a startup helping developers build computer vision into their applications. Their solution allows developers, with zero computer vision experience, to go from images to a trained computer vision model in minutes.

--- a/apps/www/_blog/2021-02-27-cracking-postgres-interview.mdx
+++ b/apps/www/_blog/2021-02-27-cracking-postgres-interview.mdx
@@ -13,7 +13,7 @@ tags:
   - sql
   - postgres
   - planetpg
-date: '02-27-2021'
+date: '2021-02-27'
 ---
 
 There are plenty of resources out there for preparing for PostgreSQL interview questions. Most posts are for technical interviews with a focus on PostgreSQL, however many just cover the basics and the advanced resources often conflate transactional SQL with analytical SQL (WINDOW/RANK functions, aggregates etc.).

--- a/apps/www/_blog/2021-03-02-supabase-beta-february-2021.mdx
+++ b/apps/www/_blog/2021-03-02-supabase-beta-february-2021.mdx
@@ -10,7 +10,7 @@ categories:
   - product
 tags:
   - release-notes
-date: '03-02-2021'
+date: '2021-03-02'
 video: https://www.youtube.com/v/h-ses99G45g
 ---
 

--- a/apps/www/_blog/2021-03-05-postgres-as-a-cron-server.mdx
+++ b/apps/www/_blog/2021-03-05-postgres-as-a-cron-server.mdx
@@ -12,7 +12,7 @@ categories:
 tags:
   - postgres
   - planetpg
-date: '03-05-2021'
+date: '2021-03-05'
 ---
 
 A Supabase user asked recently if they can trigger a webhook periodically. We haven't yet released Functions yet, so we checked whether it's possible with Postgres.

--- a/apps/www/_blog/2021-03-08-toad-a-link-shortener-with-simple-apis-for-low-coders.mdx
+++ b/apps/www/_blog/2021-03-08-toad-a-link-shortener-with-simple-apis-for-low-coders.mdx
@@ -11,7 +11,7 @@ categories:
   - engineering
 tags:
   - supabase
-date: '03-08-2021'
+date: '2021-03-08'
 ---
 
 Zach Waterfield is an engineer, investor, and founder of Kopa - a short term furnished rental marketplace with operations in over 400 cities in the USA. Zach's latest project, [Toad](https://toadli.co/), is an easy-to-use link shortening tool with simple APIs, aimed to empower low-coders. Toad provides a simple dashboard, analytics, and API designed with low-coders in mind.

--- a/apps/www/_blog/2021-03-11-using-supabase-replit.mdx
+++ b/apps/www/_blog/2021-03-11-using-supabase-replit.mdx
@@ -13,7 +13,7 @@ tags:
   - replit
   - node-js
   - postgres
-date: '03-11-2021'
+date: '2021-03-11'
 video: https://www.youtube.com/v/lQ5iIxaYduI
 ---
 

--- a/apps/www/_blog/2021-03-22-In-The-Loop.mdx
+++ b/apps/www/_blog/2021-03-22-In-The-Loop.mdx
@@ -10,7 +10,7 @@ tags:
   - supabase
   - postgres
   - open-source
-date: '03-22-2021'
+date: '2021-03-22'
 ---
 
 Kevin Grüneberg is a freelance engineer who has been programming since he was 12 years old. His latest project, intheloop.dev, provides a single gateway for developers to stay up to date.

--- a/apps/www/_blog/2021-03-29-pricing.mdx
+++ b/apps/www/_blog/2021-03-29-pricing.mdx
@@ -7,7 +7,7 @@ categories:
   - company
 tags:
   - supabase
-date: '03-29-2021'
+date: '2021-03-29'
 ---
 
 <Admonition type="warning" title="Out of date blog">

--- a/apps/www/_blog/2021-03-30-supabase-storage.mdx
+++ b/apps/www/_blog/2021-03-30-supabase-storage.mdx
@@ -9,7 +9,7 @@ categories:
 tags:
   - supabase
   - storage
-date: '03-30-2021'
+date: '2021-03-30'
 ---
 
 <div className="bg-gray-300 rounded-lg px-6 py-2 italic">

--- a/apps/www/_blog/2021-03-31-supabase-cli.mdx
+++ b/apps/www/_blog/2021-03-31-supabase-cli.mdx
@@ -9,7 +9,7 @@ categories:
 tags:
   - supabase
   - storage
-date: '03-31-2021'
+date: '2021-03-31'
 ---
 
 **UPDATE 15/08/2022:** [Supabase CLI V1 is Generally Available](/blog/supabase-cli-v1-and-admin-api-beta) and we also released a Management API (in beta).
@@ -72,6 +72,7 @@ Now that your application is now prepared, you can use Supabase anywhere in your
 
 ```jsx
 import { createClient } from '@supabase/supabase-js'
+
 const SUPABASE_URL = 'http://localhost:8000'
 const SUPABASE_ANON_KEY =
   'eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJzdXBhYmFzZSIsImlhdCI6MTYwMzk2ODgzNCwiZXhwIjoyNTUwNjUzNjM0LCJyb2xlIjoiYW5vbiJ9.36fUebxgx1mcBo4s19v0SzqmzunP--hm_hep0uLX0ew'

--- a/apps/www/_blog/2021-04-01-supabase-nft-marketplace.mdx
+++ b/apps/www/_blog/2021-04-01-supabase-nft-marketplace.mdx
@@ -12,7 +12,7 @@ categories:
 tags:
   - supabase
   - nfts
-date: '04-01-2021'
+date: '2021-04-01'
 ---
 
 ### Crypto at Supabase

--- a/apps/www/_blog/2025-06-25-natural-db.mdx
+++ b/apps/www/_blog/2025-06-25-natural-db.mdx
@@ -7,7 +7,7 @@ tags:
   - postgres
   - ai
   - personal-assistant
-date: '2025-06-25:00:00'
+date: '2025-06-25T00:00'
 toc_depth: 3
 author: saxon_fletcher
 imgSocial: 2025-06-10-natural-db/og.png

--- a/apps/www/_blog/2025-07-14-jwt-signing-keys.mdx
+++ b/apps/www/_blog/2025-07-14-jwt-signing-keys.mdx
@@ -6,7 +6,7 @@ categories:
   - launch-week
 tags:
   - launch-week
-date: '2025-07-14:00:00'
+date: '2025-07-14T00:00'
 toc_depth: 3
 author: stojan
 imgSocial: launch-week-15/day-1-jwt-signing-keys/og.jpg

--- a/apps/www/_blog/2025-07-14-supabase-ui-platform-kit.mdx
+++ b/apps/www/_blog/2025-07-14-supabase-ui-platform-kit.mdx
@@ -7,7 +7,7 @@ categories:
 tags:
   - launch-week
   - studio
-date: '2025-07-14:00:00'
+date: '2025-07-14T00:00'
 toc_depth: 3
 author: saxon_fletcher
 imgSocial: launch-week-15/day-1-ui-platform-kit/og.jpg

--- a/apps/www/_blog/2025-07-15-analytics-buckets.mdx
+++ b/apps/www/_blog/2025-07-15-analytics-buckets.mdx
@@ -7,7 +7,7 @@ categories:
 tags:
   - launch-week
   - storage
-date: '2025-07-15:10:00'
+date: '2025-07-15T10:00'
 toc_depth: 3
 author: oli_rice,fabrizio
 imgSocial: launch-week-15/day-2-analytics-buckets/og.png

--- a/apps/www/_blog/2025-07-15-figma-make-support-for-supabase.mdx
+++ b/apps/www/_blog/2025-07-15-figma-make-support-for-supabase.mdx
@@ -6,7 +6,7 @@ categories:
 tags:
   - launch-week
   - figma
-date: '2025-07-15:00:00'
+date: '2025-07-15T00:00'
 toc_depth: 2
 author: prashant
 imgSocial: launch-week-15/day-2-figma-make/og.png

--- a/apps/www/_blog/2025-07-15-stripe-engine-as-sync-library.mdx
+++ b/apps/www/_blog/2025-07-15-stripe-engine-as-sync-library.mdx
@@ -68,7 +68,6 @@ To use the Stripe-Sync-Engine in an [Edge Function](https://supabase.com/edge-fu
 
 ```tsx
 import { runMigrations } from '@supabase/stripe-sync-engine'
-
 ;(async () => {
   await runMigrations({
     databaseUrl: 'postgresql://postgres:..@db.<ref>.supabase.co:5432/postgres',

--- a/apps/www/_blog/2025-07-15-stripe-engine-as-sync-library.mdx
+++ b/apps/www/_blog/2025-07-15-stripe-engine-as-sync-library.mdx
@@ -7,7 +7,7 @@ categories:
 tags:
   - launch-week
   - stripe
-date: '2025-07-15:15:00'
+date: '2025-07-15T15:00'
 toc_depth: 3
 author: kevcodez
 imgSocial: launch-week-15/day-2-stripe-engine/og.png
@@ -68,6 +68,7 @@ To use the Stripe-Sync-Engine in an [Edge Function](https://supabase.com/edge-fu
 
 ```tsx
 import { runMigrations } from '@supabase/stripe-sync-engine'
+
 ;(async () => {
   await runMigrations({
     databaseUrl: 'postgresql://postgres:..@db.<ref>.supabase.co:5432/postgres',
@@ -83,6 +84,7 @@ Once the schema and tables are in place, you can start syncing your Stripe data 
 
 ```tsx
 import 'jsr:@supabase/functions-js/edge-runtime.d.ts'
+
 import { StripeSync } from 'npm:@supabase/stripe-sync-engine@0.39.0'
 
 // Load secrets from environment variables

--- a/apps/www/_blog/2025-07-16-branching-2-0.mdx
+++ b/apps/www/_blog/2025-07-16-branching-2-0.mdx
@@ -7,7 +7,7 @@ categories:
 tags:
   - launch-week
   - studio
-date: '2025-07-16:00:00'
+date: '2025-07-16T00:00'
 toc_depth: 3
 author: saxon_fletcher
 imgSocial: launch-week-15/day-3-branching-2-0/og.png

--- a/apps/www/_blog/2025-07-16-improved-security-controls.mdx
+++ b/apps/www/_blog/2025-07-16-improved-security-controls.mdx
@@ -8,7 +8,7 @@ tags:
   - launch-week
   - security
   - realtime
-date: '2025-07-16:15:00'
+date: '2025-07-16T15:00'
 toc_depth: 3
 author: staaldraad,hieu,filipe
 imgSocial: launch-week-15/day-3-security-controls/og.png

--- a/apps/www/_blog/2025-07-17-algolia-connector-for-supabase.mdx
+++ b/apps/www/_blog/2025-07-17-algolia-connector-for-supabase.mdx
@@ -6,7 +6,7 @@ categories:
 tags:
   - launch-week
   - algolia
-date: '2025-07-17:00:00'
+date: '2025-07-17T00:00'
 toc_depth: 2
 author: prashant
 imgSocial: launch-week-15/day-4-algolia-connector/og.png

--- a/apps/www/_blog/2025-07-17-new-observability-features-in-supabase.mdx
+++ b/apps/www/_blog/2025-07-17-new-observability-features-in-supabase.mdx
@@ -7,7 +7,7 @@ categories:
 tags:
   - launch-week
   - studio
-date: '2025-07-17:00:00'
+date: '2025-07-17T00:00'
 toc_depth: 3
 author: jonny,saxon_fletcher,jordi,fsansalvadore
 imgSocial: launch-week-15/day-4-o11y-day/og.png

--- a/apps/www/_blog/2025-07-18-lw15-hackathon.mdx
+++ b/apps/www/_blog/2025-07-18-lw15-hackathon.mdx
@@ -10,7 +10,7 @@ categories:
 tags:
   - launch-week
   - hackathon
-date: '2025-07-18:11:00'
+date: '2025-07-18T11:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-07-18-persistent-storage-for-faster-edge-functions.mdx
+++ b/apps/www/_blog/2025-07-18-persistent-storage-for-faster-edge-functions.mdx
@@ -9,7 +9,7 @@ tags:
   - launch-week
   - edge-functions
   - storage
-date: '2025-07-18:00:00'
+date: '2025-07-18T00:00'
 toc_depth: 3
 author: laktek,nyannyacha
 imgSocial: launch-week-15/day-5-persistent-storage-for-functions/og.png

--- a/apps/www/_blog/2025-07-18-storage-500gb-uploads-cheaper-egress-pricing.mdx
+++ b/apps/www/_blog/2025-07-18-storage-500gb-uploads-cheaper-egress-pricing.mdx
@@ -6,7 +6,7 @@ categories:
 tags:
   - launch-week
   - algolia
-date: '2025-07-18:10:00'
+date: '2025-07-18T10:00'
 toc_depth: 2
 author: inian
 imgSocial: launch-week-15/day-5-storage-cheaper-egress/og.png

--- a/apps/www/_blog/2025-08-12-supabase-auth-build-vs-buy.mdx
+++ b/apps/www/_blog/2025-08-12-supabase-auth-build-vs-buy.mdx
@@ -5,7 +5,7 @@ categories:
   - auth
 tags:
   - auth
-date: '2025-08-12:10:00'
+date: '2025-08-12T10:00'
 toc_depth: 2
 author: prashant
 imgSocial: supabase-auth-build-vs-buy/supabase-auth-build-vs-buy-og.png

--- a/apps/www/_blog/2025-08-16-testing-for-vibe-coders-from-zero-to-production-confidence.mdx
+++ b/apps/www/_blog/2025-08-16-testing-for-vibe-coders-from-zero-to-production-confidence.mdx
@@ -5,7 +5,7 @@ categories:
   - developers
 tags:
   - vibe-coding
-date: '2025-08-16:10:00'
+date: '2025-08-16T10:00'
 toc_depth: 3
 author: prashant
 ---
@@ -50,6 +50,7 @@ Write one simple test to verify everything works:
 
 ```tsx
 import { expect, test } from 'vitest'
+
 import { formatPrice } from '../src/lib/format'
 
 test('formats cents into dollars', () => {
@@ -76,7 +77,8 @@ export const supabase = createClient(
 Write integration tests that verify your most critical systems work together. This test confirms that Supabase Auth, database triggers, and Row Level Security all work correctly:
 
 ```tsx
-import { expect, test, beforeEach } from 'vitest'
+import { beforeEach, expect, test } from 'vitest'
+
 import { supabase } from './setup'
 
 beforeEach(async () => {
@@ -256,8 +258,8 @@ For tests that need volume, write a seed script that populates your database wit
 
 ```tsx
 // tests/seed.ts
-import { createClient } from '@supabase/supabase-js'
 import { faker } from '@faker-js/faker'
+import { createClient } from '@supabase/supabase-js'
 
 const supabase = createClient('http://localhost:54321', process.env.SUPABASE_SERVICE_ROLE_KEY)
 

--- a/apps/www/_blog/2025-08-16-the-vibe-coding-master-checklist.mdx
+++ b/apps/www/_blog/2025-08-16-the-vibe-coding-master-checklist.mdx
@@ -5,7 +5,7 @@ categories:
   - developers
 tags:
   - vibe-coding
-date: '2025-08-16:10:00'
+date: '2025-08-16T10:00'
 toc_depth: 3
 author: prashant
 ---

--- a/apps/www/_blog/2025-08-16-vibe-coding-best-practices-for-prompting.mdx
+++ b/apps/www/_blog/2025-08-16-vibe-coding-best-practices-for-prompting.mdx
@@ -5,7 +5,7 @@ categories:
   - developers
 tags:
   - vibe-coding
-date: '2025-08-16:10:00'
+date: '2025-08-16T10:00'
 toc_depth: 3
 author: prashant
 ---

--- a/apps/www/_blog/2025-08-17-the-vibe-coders-guide-to-supabase-environments.mdx
+++ b/apps/www/_blog/2025-08-17-the-vibe-coders-guide-to-supabase-environments.mdx
@@ -5,7 +5,7 @@ categories:
   - developers
 tags:
   - vibe-coding
-date: '2025-08-17:10:00'
+date: '2025-08-17T10:00'
 toc_depth: 3
 author: prashant
 ---

--- a/apps/www/_blog/2025-08-20-lw15-hackathon-winners.mdx
+++ b/apps/www/_blog/2025-08-20-lw15-hackathon-winners.mdx
@@ -10,7 +10,7 @@ categories:
 tags:
   - launch-week
   - hackathon
-date: '2025-08-20:08:00'
+date: '2025-08-20T08:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-09-09-orioledb-patent-free.mdx
+++ b/apps/www/_blog/2025-09-09-orioledb-patent-free.mdx
@@ -9,7 +9,7 @@ categories:
 tags:
   - postgres
   - orioledb
-date: '2025-09-09:08:00'
+date: '2025-09-09T08:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-09-12-processing-large-jobs-with-edge-functions.mdx
+++ b/apps/www/_blog/2025-09-12-processing-large-jobs-with-edge-functions.mdx
@@ -9,7 +9,7 @@ categories:
   - edge functions
   - cron
   - queues
-date: 2025-09-16:08:00
+date: 2025-09-16T08:00
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-09-16-defense-in-depth-mcp.mdx
+++ b/apps/www/_blog/2025-09-16-defense-in-depth-mcp.mdx
@@ -8,7 +8,7 @@ categories:
   - postgres
   - mcp
   - security
-date: 2025-09-16:08:00
+date: 2025-09-16T08:00
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-09-29-lovable-cloud-launch.mdx
+++ b/apps/www/_blog/2025-09-29-lovable-cloud-launch.mdx
@@ -8,7 +8,7 @@ categories:
   - product
   - lovable
   - ai
-date: 2025-09-29:08:00
+date: 2025-09-29T08:00
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-09-30-bolt-cloud-launch.mdx
+++ b/apps/www/_blog/2025-09-30-bolt-cloud-launch.mdx
@@ -8,7 +8,7 @@ categories:
   - product
   - bolt
   - enterprise
-date: 2025-09-30:08:00
+date: 2025-09-30T08:00
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-10-03-1000-yc-companies.mdx
+++ b/apps/www/_blog/2025-10-03-1000-yc-companies.mdx
@@ -9,7 +9,7 @@ categories:
   - launch-week
 tags:
   - select
-date: '2025-10-03:10:00:00'
+date: '2025-10-03T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-10-03-login-with-solana-ethereum.mdx
+++ b/apps/www/_blog/2025-10-03-login-with-solana-ethereum.mdx
@@ -9,7 +9,7 @@ categories:
   - launch-week
 tags:
   - select
-date: '2025-10-03:10:00:00'
+date: '2025-10-03T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-10-03-remote-mcp-server.mdx
+++ b/apps/www/_blog/2025-10-03-remote-mcp-server.mdx
@@ -9,7 +9,7 @@ categories:
   - launch-week
 tags:
   - select
-date: '2025-10-03:10:00:00'
+date: '2025-10-03T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-10-03-supabase-series-e.mdx
+++ b/apps/www/_blog/2025-10-03-supabase-series-e.mdx
@@ -9,7 +9,7 @@ categories:
   - launch-week
 tags:
   - select
-date: '2025-10-03:12:00:00'
+date: '2025-10-03T12:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-10-08-triplit-joins-supabase.mdx
+++ b/apps/www/_blog/2025-10-08-triplit-joins-supabase.mdx
@@ -6,7 +6,7 @@ imgSocial: triplit-joins-supabase/thumb.png
 imgThumb: triplit-joins-supabase/thumb.png
 categories:
   - company
-date: '2025-10-08:10:00:00'
+date: '2025-10-08T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-10-16-snap-launches-snap-cloud.mdx
+++ b/apps/www/_blog/2025-10-16-snap-launches-snap-cloud.mdx
@@ -6,7 +6,7 @@ imgSocial: 2025-10-16-snap-launches-snap-cloud/og.png
 imgThumb: 2025-10-16-snap-launches-snap-cloud/og.png
 categories:
   - product
-date: '2025-10-16:10:00:00'
+date: '2025-10-16T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-12-02-introducing-analytics-buckets.mdx
+++ b/apps/www/_blog/2025-12-02-introducing-analytics-buckets.mdx
@@ -7,7 +7,7 @@ imgThumb: 2025-12-02-introducing-analytics-buckets/thumb.png
 categories:
   - product
   - launch-week
-date: '2025-12-02:10:00'
+date: '2025-12-02T10:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-12-02-introducing-supabase-etl.mdx
+++ b/apps/www/_blog/2025-12-02-introducing-supabase-etl.mdx
@@ -7,7 +7,7 @@ imgThumb: 2025-12-02-introducing-supabase-etl/thumb.png
 categories:
   - product
   - launch-week
-date: '2025-12-02:11:00'
+date: '2025-12-02T11:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2025-12-03-introducing-seven-new-email-templates-for-auth.mdx
+++ b/apps/www/_blog/2025-12-03-introducing-seven-new-email-templates-for-auth.mdx
@@ -6,7 +6,7 @@ imgSocial: 2025-12-03-introducing-seven-new-email-templates-for-auth/og.png
 imgThumb: 2025-12-03-introducing-seven-new-email-templates-for-auth/og.png
 categories:
   - product
-date: '2025-12-03:10:00:00'
+date: '2025-12-03T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2026-02-03-bknd-joins-supabase.mdx
+++ b/apps/www/_blog/2026-02-03-bknd-joins-supabase.mdx
@@ -6,7 +6,7 @@ imgSocial: bknd-joins-supabase/og.png
 imgThumb: bknd-joins-supabase/thumb.png
 categories:
   - company
-date: '2026-02-03:10:00:00'
+date: '2026-02-03T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2026-02-04-hydra-joins-supabase.mdx
+++ b/apps/www/_blog/2026-02-04-hydra-joins-supabase.mdx
@@ -6,7 +6,7 @@ imgSocial: https://zhfonblqamxferhoguzj.supabase.co/functions/v1/generate-og?tem
 imgThumb: https://zhfonblqamxferhoguzj.supabase.co/functions/v1/generate-og?template=partnerships&layout=icon-only&copy=BKND+is+joining+Supabase&icon=1770827339509-Hydra.png&icon2=supabase.svg
 categories:
   - company
-date: '2026-02-10:10:00:00'
+date: '2026-02-10T10:00:00'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2026-04-28-introducing-osscar-index.mdx
+++ b/apps/www/_blog/2026-04-28-introducing-osscar-index.mdx
@@ -9,7 +9,7 @@ categories:
 tags:
   - open-source
   - community
-date: '2026-04-28:12:00:00'
+date: '2026-04-28T12:00:00'
 toc_depth: 2
 ---
 


### PR DESCRIPTION
## Summary

Normalizes all malformed `date:` frontmatter in `apps/www/_blog/*.mdx` to ISO 8601 (`YYYY-MM-DD` or `YYYY-MM-DDTHH:MM[:SS]`).

## Why this matters

The blog has been in steady state and most posts are already ISO. This PR exists because the new `BlogPosting.datePublished` JSON-LD field shipped in [#45451](https://github.com/supabase/supabase/pull/45451) reads `blogPost.date` straight through (`datePublished: blogPost.date`), and Schema.org requires ISO 8601. Concrete consequences of the malformed values:

- **JSON-LD `datePublished` validation:** Google's structured-data parser may reject a BlogPosting on malformed dates, costing rich result eligibility (Top Stories, dated snippet, etc.) for those posts.
- **OpenGraph `article:published_time`:** the same string feeds X/LinkedIn/Slack unfurls. Pre-existing, was silently wrong on the affected posts.
- **`getSortedPosts` ordering:** `new Date('YYYY-MM-DD:HH:MM:SS').getTime()` returns `NaN` (invalid). Those posts sort to undefined positions in the related-posts list and the blog index sort math.
- **AI assistant disambiguation:** `'06-15-2020'` is ambiguous (DD-MM-YYYY vs MM-DD-YYYY) for non-US readers and AI consumers reading the page.

## Scope: what was wrong, and what wasn't

Most posts were already correct. Two distinct historical drift patterns produced 67 outliers:

| Class | Format | Count | % | When |
|---|---|---|---|---|
| C (already correct, no change) | `'YYYY-MM-DD'` | 316 | 78.0% | most posts |
| D (already correct, no change) | `'YYYY-MM-DDTHH:MM:SS'` | 22 | 5.4% | scattered |
| A (`:` typo) | `'YYYY-MM-DD:HH:MM[:SS]'` | 36 | 8.9% | concentrated mid-2025 → early 2026 |
| B (US format) | `'MM-DD-YYYY'` | 31 | 7.7% | concentrated 2020-2021 |
| **Total** | | **405** | | |

Class B clusters in early Supabase (2020-2021) — original blog template was US-style.

Class A clusters mid-2025 onward — looks like a copy-pasted bad template propagated for ~6 months. **Worth investigating whether there's a content scaffold somewhere that should be fixed so the next post written from a 2025 copy-paste doesn't reintroduce Class A.**

## Changes

### Commit 1: `:` typo → `T` separator (36 files, Class A)

Mechanical regex substitution; one date-line per file.

One file (`2025-08-16-testing-for-vibe-coders-from-zero-to-production-confidence.mdx`) has 3 incidental prettier changes inside `tsx` code fences (alphabetic destructure import order + blank-line separator) — collateral from the project's commit hook. No runtime impact; happy to revert if reviewers prefer.

### Commit 2: MM-DD-YYYY → ISO YYYY-MM-DD (31 files, Class B)

Each conversion was verified against the file's `YYYY-MM-DD-...` filename prefix. 30 of 31 matched directly. One file (`2020-05-01-supabase-alpha-april-2020.mdx`) had a typo'd frontmatter date `'06-01-2020'` that disagreed with both the filename (May 1, 2020) and the post topic ("April 2020" newsletter, naturally published in early May). Trusted the filename and corrected to `'2020-05-01'`.

## Verification

```
grep -lE "^date: ['\"]?[0-9]{4}-[0-9]{2}-[0-9]{2}:" apps/www/_blog/*.mdx | wc -l   # 0 (was 36)
grep -lE "^date: ['\"]?[0-9]{2}-[0-9]{2}-[0-9]{4}['\"]?$" apps/www/_blog/*.mdx | wc -l   # 0 (was 31)
```

All 405 blog posts now have ISO 8601 `date:` frontmatter.

## Linear

- fixes GROWTH-814

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Reformatted blog publication dates across the archive from legacy formats to standardized ISO-8601 timestamps (YYYY-MM-DDTHH:MM:SS).
* Enhanced code examples throughout blog documentation with improved formatting, including better line spacing and cleaner import statement ordering for readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->