### PR TITLE
feat(www): add canonical URL on homepage

### DIFF
--- a/apps/www/pages/index.tsx
+++ b/apps/www/pages/index.tsx
@@ -1,8 +1,9 @@
-import dynamic from 'next/dynamic'
-import getContent from '~/data/home/content'
-import Layout from '~/components/Layouts/Default'
 import Hero from '~/components/Hero/Hero'
+import Layout from '~/components/Layouts/Default'
 import Logos from '~/components/logos'
+import getContent from '~/data/home/content'
+import { NextSeo } from 'next-seo'
+import dynamic from 'next/dynamic'
 
 const Products = dynamic(() => import('~/components/Products/index'))
 const HeroFrameworks = dynamic(() => import('~/components/Hero/HeroFrameworks'))
@@ -19,18 +20,21 @@ const Index = () => {
   const content = getContent()
 
   return (
-    <Layout>
-      <Hero />
-      <Logos />
-      <Products {...content.productsSection} />
-      <HeroFrameworks />
-      <CustomerStories />
-      <BuiltWithSupabase />
-      <DashboardFeatures {...content.dashboardFeatures} />
-      <TwitterSocialSection {...content.twitterSocialSection} />
-      <OpenSourceSection />
-      <CTABanner className="border-none" />
-    </Layout>
+    <>
+      <NextSeo canonical="https://supabase.com/" />
+      <Layout>
+        <Hero />
+        <Logos />
+        <Products {...content.productsSection} />
+        <HeroFrameworks />
+        <CustomerStories />
+        <BuiltWithSupabase />
+        <DashboardFeatures {...content.dashboardFeatures} />
+        <TwitterSocialSection {...content.twitterSocialSection} />
+        <OpenSourceSection />
+        <CTABanner className="border-none" />
+      </Layout>
+    </>
   )
 }
 


### PR DESCRIPTION
## Summary

Adds `<link rel="canonical" href="https://supabase.com/" />` to the homepage. Triggered by an isitagentready.com audit finding ("3/4 metadata signals present — missing canonical URL").

## Why this is scoped to the homepage only

The shared `DefaultSeo` block in `apps/www/pages/_app.tsx` sets `openGraph.url` but no `canonical`. A canonical on `DefaultSeo` would propagate to every page that doesn't override (so `/pricing`'s canonical would point to `/`, `/database`'s would point to `/`, etc.) which is incorrect and worse than no canonical.

The correct sitewide fix is per-page `NextSeo canonical={...}`, which is a chore touching dozens of files and a real follow-up PR. This PR scopes the win to the page where it matters most.

## Change

`apps/www/pages/index.tsx`: add `<NextSeo canonical="https://supabase.com/" />` next to the `<Layout>`. `NextSeo` overrides `DefaultSeo` per-key, so OG/Twitter still inherit from `_app.tsx`; only `canonical` is added.

## Testing (Vercel preview)

`curl -s https://<preview>/ | grep 'rel=\"canonical\"'`

Expect: `<link rel=\"canonical\" href=\"https://supabase.com/\"/>`

Re-run https://isitagentready.com/ against the preview host: \"metadata signals\" check should report 4/4.

## Linear

- fixes GROWTH-815

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced SEO metadata on the homepage to improve search engine visibility and link sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->