### PR TITLE
feat(www): include pricing FAQ in generated pricing.md

### DIFF
--- a/apps/www/lib/llms.ts
+++ b/apps/www/lib/llms.ts
@@ -2,6 +2,7 @@ import { plans } from 'shared-data/plans'
 import { pricing } from 'shared-data/pricing'
 
 import addOnTable from '@/data/PricingAddOnTable.json'
+import pricingFaq from '@/data/PricingFAQ.json'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -245,6 +246,20 @@ function buildFeatureComparisonSection(): string {
 }
 
 // ---------------------------------------------------------------------------
+// FAQ
+// ---------------------------------------------------------------------------
+
+function buildFAQSection(): string {
+  const lines: string[] = ['## Frequently Asked Questions', '']
+
+  for (const { question, answer } of pricingFaq) {
+    lines.push(`### ${question}`, '', answer, '')
+  }
+
+  return lines.join('\n')
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 
@@ -269,6 +284,7 @@ export function generatePricingContent(): string {
     buildDiskSection(),
     buildAddOnsSection(),
     buildFeatureComparisonSection(),
+    buildFAQSection(),
     '## Links',
     '',
     '- Pricing page: https://supabase.com/pricing',


### PR DESCRIPTION
## Summary

- The `/pricing.md` endpoint served from `generatePricingContent()` (in `apps/www/lib/llms.ts`) was missing the FAQ that's rendered on `supabase.com/pricing`.
- Reads the same `apps/www/data/PricingFAQ.json` source the page uses and appends it as a `## Frequently Asked Questions` section so the LLM-facing markdown stays in sync with the marketing page.

## Test plan

- [ ] `curl https://<preview>/pricing.md` and confirm the new "Frequently Asked Questions" section appears with all 10 entries from `PricingFAQ.json`.
- [ ] Spot-check that question/answer pairs match what's shown on the live `/pricing` page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added FAQ section to pricing content, displaying frequently asked questions and answers in an organized format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->