### PR TITLE
fix(studio): clarify default privileges toggle covers tables

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
@@ -99,11 +99,10 @@ export const SecurityOptions = ({ form, layout = 'horizontal' }: SecurityOptions
                   <FormLabel
                     className={cn('text-sm text-foreground', !dataApi && 'text-foreground-muted')}
                   >
-                    Automatically expose new tables and functions
+                    Automatically expose new tables
                   </FormLabel>
                   <FormDescription className="text-foreground-lighter">
-                    Grants privileges to Data API roles by default, exposing new tables and
-                    functions.
+                    Grants privileges to Data API roles by default, exposing new tables.
                     <br />
                     <strong className="font-medium text-foreground-light">
                       We recommend disabling this to control access manually.

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -393,8 +393,8 @@ export const PostgrestConfig = () => {
                           <FormItem>
                             <FormItemLayout
                               layout="flex-row-reverse"
-                              label="Automatically expose new tables and functions"
-                              description="Grants privileges to Data API roles by default, exposing new tables and functions. We recommend disabling this to control access manually."
+                              label="Automatically expose new tables"
+                              description="Grants privileges to Data API roles by default, exposing new tables. We recommend disabling this to control access manually."
                             >
                               <FormControl>
                                 <div>

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -5,7 +5,7 @@ import { IS_TEST_ENV } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
 
 /**
- * Controls the default state of the "Automatically expose new tables and functions"
+ * Controls the default state of the "Automatically expose new tables"
  * checkbox at project creation. When the flag is on, the checkbox defaults
  * to unchecked (i.e. revoke SQL runs). When off/absent, the checkbox defaults
  * to checked (current behaviour — default grants remain).

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -356,11 +356,11 @@ const CreateProject = () => {
               htmlFor="dataApiDefaultPrivileges"
               className="text-sm text-foreground-light flex items-center space-x-2 leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
             >
-              Automatically expose new tables and functions
+              Automatically expose new tables
             </label>
             <p className="text-sm text-foreground-muted">
-              Grants privileges to Data API roles by default, exposing new tables and functions. We
-              recommend disabling this to control access manually.
+              Grants privileges to Data API roles by default, exposing new tables. We recommend
+              disabling this to control access manually.
             </p>
           </div>
         </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UI labels and descriptions across the Data API settings to clarify that default privileges apply to new tables only (removed references to functions).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->