### PR TITLE
chore: remove format param from audit log query

### DIFF
--- a/apps/studio/components/interfaces/Account/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Account/AuditLogs.tsx
@@ -17,7 +17,7 @@ import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { FilterPopover } from '@/components/ui/FilterPopover'
 import {
   TIMESTAMP_MICROS_PER_MS,
-  type V2AuditLog,
+  type AuditLog,
 } from '@/data/organizations/organization-audit-logs-query'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useProfileAuditLogsQuery } from '@/data/profile/profile-audit-logs-query'
@@ -35,7 +35,7 @@ export const AuditLogs = () => {
     to: currentTime.toISOString(),
   })
 
-  const [selectedLog, setSelectedLog] = useState<V2AuditLog>()
+  const [selectedLog, setSelectedLog] = useState<AuditLog>()
   const [filters, setFilters] = useState<{ projects: string[] }>({
     projects: [],
   })

--- a/apps/studio/components/interfaces/Account/AuditLogs.utils.ts
+++ b/apps/studio/components/interfaces/Account/AuditLogs.utils.ts
@@ -1,12 +1,12 @@
-import type { V2AuditLog } from '@/data/organizations/organization-audit-logs-query'
+import type { AuditLog } from '@/data/organizations/organization-audit-logs-query'
 
-export function sortAuditLogs(logs: V2AuditLog[], descending: boolean): V2AuditLog[] {
+export function sortAuditLogs(logs: AuditLog[], descending: boolean): AuditLog[] {
   return [...logs].sort((a, b) =>
     descending ? b.timestamp - a.timestamp : a.timestamp - b.timestamp
   )
 }
 
-export function filterByProjects(logs: V2AuditLog[], projectRefs: string[]): V2AuditLog[] {
+export function filterByProjects(logs: AuditLog[], projectRefs: string[]): AuditLog[] {
   if (projectRefs.length === 0) return logs
   return logs.filter((log) => projectRefs.includes(log.project_ref ?? ''))
 }

--- a/apps/studio/components/interfaces/AuditLogs/LogDetailsPanel.tsx
+++ b/apps/studio/components/interfaces/AuditLogs/LogDetailsPanel.tsx
@@ -8,11 +8,11 @@ import {
 } from '@/components/ui/Forms/FormSection'
 import {
   TIMESTAMP_MICROS_PER_MS,
-  type V2AuditLog,
+  type AuditLog,
 } from '@/data/organizations/organization-audit-logs-query'
 
 interface LogDetailsPanelProps {
-  selectedLog?: V2AuditLog
+  selectedLog?: AuditLog
   onClose: () => void
 }
 

--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.utils.ts
@@ -1,20 +1,20 @@
 import dayjs from 'dayjs'
 
 import { DatePickerToFrom } from '@/components/interfaces/Settings/Logs/Logs.types'
-import type { V2AuditLog } from '@/data/organizations/organization-audit-logs-query'
+import type { AuditLog } from '@/data/organizations/organization-audit-logs-query'
 
-export function sortAuditLogs(logs: V2AuditLog[], descending: boolean): V2AuditLog[] {
+export function sortAuditLogs(logs: AuditLog[], descending: boolean): AuditLog[] {
   return [...logs].sort((a, b) =>
     descending ? b.timestamp - a.timestamp : a.timestamp - b.timestamp
   )
 }
 
-export function filterByUsers(logs: V2AuditLog[], userIds: string[]): V2AuditLog[] {
+export function filterByUsers(logs: AuditLog[], userIds: string[]): AuditLog[] {
   if (userIds.length === 0) return logs
   return logs.filter((log) => userIds.includes(log.actor.user_id ?? ''))
 }
 
-export function filterByProjects(logs: V2AuditLog[], projectRefs: string[]): V2AuditLog[] {
+export function filterByProjects(logs: AuditLog[], projectRefs: string[]): AuditLog[] {
   if (projectRefs.length === 0) return logs
   return logs.filter((log) => projectRefs.includes(log.project_ref ?? ''))
 }

--- a/apps/studio/data/organizations/organization-audit-logs-query.ts
+++ b/apps/studio/data/organizations/organization-audit-logs-query.ts
@@ -4,11 +4,11 @@ import { organizationKeys } from './keys'
 import { get, handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
-// V2 audit log timestamps are returned in microseconds, not milliseconds.
+// Audit log timestamps are returned in microseconds, not milliseconds.
 // Divide by this constant before passing to dayjs/Date to get a valid date.
 export const TIMESTAMP_MICROS_PER_MS = 1000
 
-export type V2AuditLog = {
+export type AuditLog = {
   organization_slug?: string
   project_ref?: string
   request_id: string
@@ -33,10 +33,8 @@ export type V2AuditLog = {
   timestamp: number
 }
 
-export type { V2AuditLog as AuditLog }
-
 export type OrganizationAuditLogsResponse = {
-  result: V2AuditLog[]
+  result: AuditLog[]
   retention_period: number
 }
 
@@ -53,7 +51,7 @@ export async function getOrganizationAuditLogs(
   if (!slug) throw new Error('slug is required')
 
   const { data, error } = await get('/platform/organizations/{slug}/audit', {
-    params: { path: { slug }, query: { iso_timestamp_start, iso_timestamp_end, format: 'v2' } },
+    params: { path: { slug }, query: { iso_timestamp_start, iso_timestamp_end } },
     signal,
   })
 

--- a/apps/studio/data/profile/profile-audit-logs-query.ts
+++ b/apps/studio/data/profile/profile-audit-logs-query.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query'
 
 import { profileKeys } from './keys'
 import { get, handleError } from '@/data/fetchers'
-import { V2AuditLog } from '@/data/organizations/organization-audit-logs-query'
+import { AuditLog } from '@/data/organizations/organization-audit-logs-query'
 import { IS_PLATFORM } from '@/lib/constants'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
@@ -20,7 +20,6 @@ export async function getProfileAuditLogs(
       query: {
         iso_timestamp_start,
         iso_timestamp_end,
-        format: 'v2',
       },
     },
     signal,
@@ -32,7 +31,7 @@ export async function getProfileAuditLogs(
 
 export type ProfileAuditLogsError = ResponseError
 export type ProfileAuditLogsData = {
-  result: V2AuditLog[]
+  result: AuditLog[]
   retention_period: number
 }
 

--- a/apps/studio/tests/components/AuditLogs/AuditLogs.utils.test.ts
+++ b/apps/studio/tests/components/AuditLogs/AuditLogs.utils.test.ts
@@ -8,7 +8,7 @@ import {
 } from '@/components/interfaces/Organization/AuditLogs/AuditLogs.utils'
 import {
   TIMESTAMP_MICROS_PER_MS,
-  type V2AuditLog,
+  type AuditLog,
 } from '@/data/organizations/organization-audit-logs-query'
 
 // Timestamps are in microseconds (e.g. 1777471903844000 = April 2026)
@@ -16,7 +16,7 @@ const TS_A = 1777471903844000
 const TS_B = 1777471903845000
 const TS_C = 1777471903846000
 
-function makeLog(overrides: Partial<V2AuditLog> = {}): V2AuditLog {
+function makeLog(overrides: Partial<AuditLog> = {}): AuditLog {
   return {
     timestamp: TS_A,
     request_id: 'req-1',


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Cleanup after shipping https://github.com/supabase/supabase/pull/45389, the backend is now defaulting to the new v2 `format`, and made `format` param optional.

So this:
- removes references to `v2` naming, as this is the only format
- removes the `format` query param from the audit logs API calls

## What is the current behavior?

Same audit log functionality shown in https://github.com/supabase/supabase/pull/45389

## What is the new behavior?

Functionally the same behavior for audit logs.

- [x] Manual test in staging

## Additional context

⚠️ Will leave the `do-not-merge` tag on until:
- [ ] backend `format` optional PR lands in production.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated audit log type definitions and updated internal API request formatting for audit endpoints across Account and Organization audit log components. No changes to user-facing functionality or audit log display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->