### PR TITLE
Update humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -171,6 +171,7 @@ Marcus Weiner
 Margarita Sandomirskaia
 Mark Burggraf
 Matthew Hambright
+Matt Hudson
 Matt Johnston
 Matt Rossman
 Matthias Luft


### PR DESCRIPTION
Adding myself to humans.txt

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This adds me to humans.txt

## What is the current behavior?

humans.txt currently lacks a line with my name

## What is the new behavior?

humans.txt contains a line with my name

## Additional context

no, thank you


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team contributors information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->