### PR TITLE
chore(studio): add method property to integration installation events

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/Integrations.constants.tsx
@@ -584,7 +584,11 @@ const TEMPLATE_INTEGRATIONS: Array<IntegrationDefinition> = [
       const startTime = Date.now()
       await installStripeSync({ projectRef, startTime, stripeSecretKey: stripe_api_key as string })
 
-      if (track) track('integration_install_submitted', { integrationName: 'stripe_sync_engine' })
+      if (track)
+        track('integration_install_submitted', {
+          integrationName: 'stripe_sync_engine',
+          method: 'template',
+        })
 
       const queryClient = getQueryClient()
       await queryClient.invalidateQueries({ queryKey: stripeSyncKeys.all })

--- a/apps/studio/data/database-integrations/stripe/stripe-sync-install-mutation.ts
+++ b/apps/studio/data/database-integrations/stripe/stripe-sync-install-mutation.ts
@@ -68,6 +68,7 @@ export const useStripeSyncInstallMutation = ({
 
       track('integration_install_submitted', {
         integrationName: 'stripe_sync_engine',
+        method: 'template',
       })
 
       // Invalidate schemas query to refresh installation status

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2928,10 +2928,10 @@ export interface IntegrationInstallCompletedEvent {
 export interface IntegrationInstallSubmittedEvent {
   action: 'integration_install_submitted'
   properties: {
-    /**
-     * The name of the integration being installed
-     */
+    /** The name of the integration being installed */
     integrationName: string
+    /** The integration method (will be 'template' for frontend-driven integrations.) */
+    method: string
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
Add new `method` property to existing event to distinguish from server-side emitted events added in https://github.com/supabase/platform/pull/32330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced Stripe integration installation tracking to record the installation method (e.g., "template") alongside the integration name, improving analytics and monitoring of how integrations are installed without changing user-facing installation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->