### PR TITLE
feat(billing): prepaid credits in upcoming invoice

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
@@ -84,9 +84,8 @@ const BillingBreakdown = () => {
               </>
             ) : (
               <>
-                Your upcoming invoice will continue to update until the end of
-                your billing cycle on {billingCycleEnd.format('MMMM DD')}. For a more detailed
-                breakdown, visit the{' '}
+                Your upcoming invoice will continue to update until the end of your billing cycle on{' '}
+                {billingCycleEnd.format('MMMM DD')}. For a more detailed breakdown, visit the{' '}
                 <InlineLink href={`/org/${orgSlug}/usage`}>usage page.</InlineLink>
               </>
             )}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/BillingBreakdown.tsx
@@ -84,7 +84,7 @@ const BillingBreakdown = () => {
               </>
             ) : (
               <>
-                Your upcoming invoice (excluding credits) will continue to update until the end of
+                Your upcoming invoice will continue to update until the end of
                 your billing cycle on {billingCycleEnd.format('MMMM DD')}. For a more detailed
                 breakdown, visit the{' '}
                 <InlineLink href={`/org/${orgSlug}/usage`}>usage page.</InlineLink>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -315,8 +315,6 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   </TableCell>
                 </TableRow>
 
-                
-
                 {(!!upcomingInvoice.amount_projected || hasTax || taxFailed) && (
                   <TableRow>
                     <TableCell className="font-medium py-2 px-0 flex items-center">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -60,8 +60,11 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
 
   // For non-platform customers, compute is broken down per project and contains a breakdown array
   const computeItems =
-    upcomingInvoice?.lines?.filter((item) => item.description?.toLowerCase().includes('compute')) ||
-    []
+    upcomingInvoice?.lines?.filter(
+      (item) =>
+        item.description?.toLowerCase().includes('compute') &&
+        !item.description.startsWith('Compute Credits')
+    ) || []
 
   const computeCreditsItem =
     upcomingInvoice?.lines?.find((item) => item.description.startsWith('Compute Credits')) ?? null
@@ -89,6 +92,9 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
           item.amount_before_discount > 0
       )
       .sort((a, b) => b.amount_before_discount - a.amount_before_discount) || []
+
+  const prepaidCreditsItem =
+    upcomingInvoice?.lines?.find((item) => item.item_name === 'Prepaid Credits') ?? null
 
   const hasTax =
     upcomingInvoice?.tax_status === 'calculated' && (upcomingInvoice?.tax?.tax_amount ?? 0) > 0
@@ -295,6 +301,18 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   </TableCell>
                 </TableRow>
 
+                {prepaidCreditsItem && (
+                  <TableRow>
+                    <TableCell className="py-2 px-0 flex items-center">
+                      <span className="mr-2">{prepaidCreditsItem.item_name}</span>
+                      <InfoTooltip>{prepaidCreditsItem.description}</InfoTooltip>
+                    </TableCell>
+                    <TableCell className="text-right py-2 px-0" translate="no">
+                      {formatCurrency(prepaidCreditsItem.amount) ?? '-'}
+                    </TableCell>
+                  </TableRow>
+                )}
+
                 {(!!upcomingInvoice.amount_projected || hasTax || taxFailed) && (
                   <TableRow>
                     <TableCell className="font-medium py-2 px-0 flex items-center">
@@ -431,7 +449,8 @@ function ComputeLineItem({
 
   const discountedComputeCosts = Math.max(
     0,
-    computeItems.reduce((prev, cur) => prev + (cur.amount ?? 0), 0) + (computeCredits?.amount ?? 0)
+    computeItems.reduce((prev, cur) => prev + (cur.amount ?? 0), 0) +
+      (computeCredits?.amount ?? 0)
   )
 
   if (!computeItems.length) return null

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -305,7 +305,10 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   <TableRow>
                     <TableCell className="py-2 px-0 flex items-center">
                       <span className="mr-2">{prepaidCreditsItem.item_name}</span>
-                      <InfoTooltip>{prepaidCreditsItem.description}</InfoTooltip>
+                      <InfoTooltip className="max-w-xs">
+                        Prepaid credits purchased upfront, applied automatically against your
+                        invoice. Any remaining balance rolls over to the next billing cycle.
+                      </InfoTooltip>
                     </TableCell>
                     <TableCell className="text-right py-2 px-0" translate="no">
                       {formatCurrency(prepaidCreditsItem.amount) ?? '-'}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -449,8 +449,7 @@ function ComputeLineItem({
 
   const discountedComputeCosts = Math.max(
     0,
-    computeItems.reduce((prev, cur) => prev + (cur.amount ?? 0), 0) +
-      (computeCredits?.amount ?? 0)
+    computeItems.reduce((prev, cur) => prev + (cur.amount ?? 0), 0) + (computeCredits?.amount ?? 0)
   )
 
   if (!computeItems.length) return null

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -289,18 +289,6 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
               </TableBody>
 
               <TableFooter>
-                <TableRow>
-                  <TableCell className="font-medium py-2 px-0 flex items-center">
-                    <span className="mr-2">Current Costs</span>
-                    <InfoTooltip>
-                      Costs accumulated from the beginning of the billing cycle up to now.
-                    </InfoTooltip>
-                  </TableCell>
-                  <TableCell className="text-right font-medium py-2 px-0" translate="no">
-                    {formatCurrency(upcomingInvoice?.amount_total) ?? '-'}
-                  </TableCell>
-                </TableRow>
-
                 {prepaidCreditsItem && (
                   <TableRow>
                     <TableCell className="py-2 px-0 flex items-center">
@@ -315,6 +303,19 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                     </TableCell>
                   </TableRow>
                 )}
+                <TableRow>
+                  <TableCell className="font-medium py-2 px-0 flex items-center">
+                    <span className="mr-2">Current Costs</span>
+                    <InfoTooltip>
+                      Costs accumulated from the beginning of the billing cycle up to now.
+                    </InfoTooltip>
+                  </TableCell>
+                  <TableCell className="text-right font-medium py-2 px-0" translate="no">
+                    {formatCurrency(upcomingInvoice?.amount_total) ?? '-'}
+                  </TableCell>
+                </TableRow>
+
+                
 
                 {(!!upcomingInvoice.amount_projected || hasTax || taxFailed) && (
                   <TableRow>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -320,72 +320,53 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   <TableRow>
                     <TableCell className="font-medium py-2 px-0 flex items-center">
                       <span className="mr-2">Projected Costs</span>
-                      <InfoTooltip className="max-w-xs">
-                        Projected costs at the end of the billing cycle. Includes predictable costs
-                        for Compute Hours, IPv4, Custom Domain and Point-In-Time-Recovery, but no
-                        costs for metrics like MAU, storage or function invocations. Final amounts
-                        may vary depending on your usage.
+                      <InfoTooltip className="max-w-sm">
+                        <p className="mb-2">
+                          Projected costs at the end of the billing cycle. Includes predictable
+                          costs for Compute Hours, IPv4, Custom Domain and Point-In-Time-Recovery,
+                          but no costs for metrics like MAU, storage or function invocations. Final
+                          amounts may vary depending on your usage.
+                        </p>
+
+                        {hasTax && (
+                          <div className="mt-3 border-t border-muted pt-2 space-y-1">
+                            <div className="flex items-center justify-between gap-4 text-xs">
+                              <span>Subtotal</span>
+                              <span translate="no">
+                                {formatCurrency(upcomingInvoice.tax!.total_amount_excluding_tax)}
+                              </span>
+                            </div>
+                            <div className="flex items-center justify-between gap-4 text-xs">
+                              <span>
+                                Tax
+                                {upcomingInvoice.tax?.tax_rate_percentage != null &&
+                                  ` (${upcomingInvoice.tax.tax_rate_percentage}%)`}
+                              </span>
+                              <span translate="no">
+                                {formatCurrency(upcomingInvoice.tax!.tax_amount)}
+                              </span>
+                            </div>
+                            <p className="text-foreground-lighter pt-1 text-xs">
+                              Estimated based on your organization's billing address. The final
+                              amount may be adjusted at the end of the billing cycle.
+                            </p>
+                          </div>
+                        )}
+
+                        {taxFailed && (
+                          <p className="mt-3 border-t border-muted pt-2 text-warning">
+                            We were unable to estimate tax for your organization. Please verify your
+                            billing address in your organization settings.
+                          </p>
+                        )}
                       </InfoTooltip>
                     </TableCell>
                     <TableCell className="text-right font-medium py-2 px-0" translate="no">
                       {formatCurrency(
                         hasTax
-                          ? upcomingInvoice.tax!.total_amount_excluding_tax
+                          ? upcomingInvoice.tax!.total_amount_including_tax
                           : upcomingInvoice.amount_projected
                       ) ?? '-'}
-                    </TableCell>
-                  </TableRow>
-                )}
-
-                {hasTax && (
-                  <>
-                    <TableRow>
-                      <TableCell className="py-2 px-0">
-                        <div className="flex items-center gap-1">
-                          <span>Projected Tax</span>
-                          <InfoTooltip>
-                            Estimated tax
-                            {upcomingInvoice?.tax?.tax_rate_percentage != null &&
-                              ` at ${upcomingInvoice.tax.tax_rate_percentage}%`}{' '}
-                            based on your organization's billing address. The final amount may be
-                            adjusted at the end of the billing cycle.
-                          </InfoTooltip>
-                        </div>
-                      </TableCell>
-                      <TableCell className="text-right py-2 px-0" translate="no">
-                        {formatCurrency(upcomingInvoice?.tax?.tax_amount) ?? '-'}
-                      </TableCell>
-                    </TableRow>
-                    <TableRow>
-                      <TableCell className="font-medium py-2 px-0 flex items-center">
-                        <span className="mr-2">Projected Total</span>
-                        <InfoTooltip>
-                          Projected costs including applicable tax. The final amount may be adjusted
-                          at the end of the billing cycle.
-                        </InfoTooltip>
-                      </TableCell>
-                      <TableCell className="text-right font-medium py-2 px-0" translate="no">
-                        {formatCurrency(upcomingInvoice?.tax!.total_amount_including_tax) ?? '-'}
-                      </TableCell>
-                    </TableRow>
-                  </>
-                )}
-
-                {taxFailed && (
-                  <TableRow>
-                    <TableCell className="py-2 px-0">
-                      <div className="flex items-center gap-1">
-                        <span>Projected Tax</span>
-                        <InfoTooltip>
-                          We were unable to estimate tax for your organization. Please verify your
-                          billing address in your organization settings.
-                        </InfoTooltip>
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-right py-2 px-0">
-                      <div className="flex items-center justify-end gap-1">
-                        <span className="text-warning">Could not be estimated</span>
-                      </div>
                     </TableCell>
                   </TableRow>
                 )}


### PR DESCRIPTION
## Summary

- Display a "Prepaid Credits" line in the upcoming invoice breakdown, shown directly below Current Costs when the upcoming invoice contains a `Prepaid Credits` line item
- Surfaces the credit amount being applied (e.g. `-$300`) so users can see how prepaid credits offset their projected bill
- Consolidates the projected tax items into the tooltip for `Projected Costs`
<img width="1416" height="426" alt="image" src="https://github.com/user-attachments/assets/b3455e82-d03b-40c3-ad5f-493a56004ddf" />


## Test plan

- [x]  On an org with prepaid credits applied, verify the "Prepaid Credits" row appears below Current Costs with the negative amount and a tooltip showing the backend description
- [x]  On an org without prepaid credits, verify the row is not rendered

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Improvements**
  * Clarified the "Upcoming Invoice" explanatory copy for non–AWS Marketplace-managed organizations: it now notes the invoice will continue updating until the end of your billing cycle.
  * Improved invoice breakdown: compute charges and compute credits are distinguished, and a dedicated "Prepaid Credits" row is shown before projected costs for clearer billing totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->