### PR TITLE
fix: pass OPENAI_BASE_URL to Studio AI client for self-hosted instances

### DIFF
--- a/apps/studio/lib/ai/model.test.ts
+++ b/apps/studio/lib/ai/model.test.ts
@@ -1,12 +1,16 @@
-import { openai } from '@ai-sdk/openai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as bedrockModule from './bedrock'
 import { getModel } from './model'
 import { DEFAULT_COMPLETION_MODEL, openaiModelEntry } from './model.utils'
 
+const { mockOpenaiModelFn } = vi.hoisted(() => ({
+  mockOpenaiModelFn: vi.fn(() => 'openai-model'),
+}))
+
 vi.mock('@ai-sdk/openai', () => ({
-  openai: vi.fn(() => 'openai-model'),
+  createOpenAI: vi.fn(() => mockOpenaiModelFn),
 }))
 
 vi.mock('./bedrock', async () => ({
@@ -56,7 +60,8 @@ describe('getModel', () => {
     })
 
     expect(modelParams?.model).toEqual('openai-model')
-    expect(openai).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(createOpenAI).toHaveBeenCalledWith({ apiKey: 'test-key' })
+    expect(mockOpenaiModelFn).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(systemProviderOptions).toBeUndefined()
   })
 
@@ -81,7 +86,7 @@ describe('getModel', () => {
 
     expect(error).toBeUndefined()
     expect(modelParams?.model).toEqual('openai-model')
-    expect(openai).toHaveBeenCalledWith('gpt-5.3-codex')
+    expect(mockOpenaiModelFn).toHaveBeenCalledWith('gpt-5.3-codex')
     expect(modelParams?.providerOptions?.openai?.reasoningEffort).toBe('low')
   })
 
@@ -94,7 +99,22 @@ describe('getModel', () => {
     })
 
     expect(error).toBeUndefined()
-    expect(openai).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(mockOpenaiModelFn).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(modelParams?.providerOptions?.openai?.reasoningEffort).toBe('none')
+  })
+
+  it('passes OPENAI_BASE_URL to createOpenAI when set', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test-key')
+    vi.stubEnv('OPENAI_BASE_URL', 'https://integrate.api.example.com/v1')
+
+    await getModel({
+      provider: 'openai',
+      modelEntry: openaiModelEntry({ id: 'gpt-5.4-nano' }),
+    })
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      baseURL: 'https://integrate.api.example.com/v1',
+    })
   })
 })

--- a/apps/studio/lib/ai/model.ts
+++ b/apps/studio/lib/ai/model.ts
@@ -1,4 +1,4 @@
-import { openai } from '@ai-sdk/openai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { LanguageModel } from 'ai'
 
 import { checkAwsCredentials, createRoutedBedrock } from './bedrock'
@@ -84,16 +84,22 @@ export async function getModel(params: GetModelParams): Promise<ModelResponse> {
   }
 
   if (provider === 'openai') {
-    if (!process.env.OPENAI_API_KEY) {
+    const apiKey = process.env.OPENAI_API_KEY
+    if (!apiKey) {
       return { error: new Error('OPENAI_API_KEY not available') }
     }
+    const baseURL = process.env.OPENAI_BASE_URL
+    const openaiProvider = createOpenAI({
+      apiKey,
+      ...(baseURL ? { baseURL } : {}),
+    })
     const baseProviderOptions = providerRegistry.providerOptions?.openai ?? {}
     const openaiProviderOptions = modelEntry?.reasoningEffort
       ? { ...baseProviderOptions, reasoningEffort: modelEntry.reasoningEffort }
       : baseProviderOptions
     return {
       modelParams: {
-        model: openai(chosenModelId as OpenAIModelId),
+        model: openaiProvider(chosenModelId as OpenAIModelId),
         providerOptions: { openai: openaiProviderOptions },
       },
       systemProviderOptions: models[chosenModelId as OpenAIModelId]?.systemProviderOptions,

--- a/apps/studio/pages/api/ai/docs.ts
+++ b/apps/studio/pages/api/ai/docs.ts
@@ -92,7 +92,11 @@ export default async function handler(req: NextRequest) {
 }
 
 async function handlePost(request: NextRequest) {
-  const openai = new OpenAI({ apiKey: openAiKey })
+  const openAiBaseUrl = process.env.OPENAI_BASE_URL
+  const openai = new OpenAI({
+    apiKey: openAiKey,
+    ...(openAiBaseUrl ? { baseURL: openAiBaseUrl } : {}),
+  })
 
   const body = await (request.json() as Promise<{
     messages: { content: string; role: 'user' | 'assistant' }[]


### PR DESCRIPTION
## Problem
Self-hosted Supabase Studio ignores the `OPENAI_BASE_URL` environment variable, always sending AI requests to the default OpenAI API endpoint, preventing use of custom/local providers.

## Change
Pass `OPENAI_BASE_URL` from the environment to the OpenAI client `baseURL` configuration so self-hosted instances can use custom OpenAI-compatible providers.

Fixes #45269.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom OpenAI base URLs via environment configuration, enabling integration with OpenAI-compatible providers and alternative endpoints.

* **Tests**
  * Enhanced test coverage for OpenAI model integration, including validation of custom base URL configuration and initialization parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->