### PR TITLE
docs: improve Next.js Auth quickstart setup

### DIFF
--- a/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/auth/quickstarts/nextjs.mdx
@@ -20,7 +20,7 @@ hideToc: true
 
      ```sql name=SQL_EDITOR
       select * from auth.users;
-      ````
+      ```
 
     </StepHikeCompact.Code>
 
@@ -42,7 +42,8 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash name=Terminal
-      npx create-next-app -e with-supabase
+      npx create-next-app --example with-supabase supabase-nextjs-auth
+      cd supabase-nextjs-auth
       ```
 
     </StepHikeCompact.Code>
@@ -64,7 +65,7 @@ hideToc: true
 
       ```text name=.env.local
       NEXT_PUBLIC_SUPABASE_URL=your-project-url
-      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=sb_publishable_... key
+      NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=your-publishable-key
       ```
 
       <$Partial path="api_settings_steps.mdx" variables={{ "framework": "nextjs", "tab": "frameworks" }} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update / developer experience improvement

## What is the current behavior?

The Next.js Auth quickstart uses a `create-next-app` command without an explicit project directory, then later tells users to run `npm run dev` without showing them to enter the generated app directory.

The page also has a malformed SQL code fence and an unclear publishable key placeholder.

## What is the new behavior?

This PR:

- makes the `create-next-app` command copy-paste runnable with a project directory
- adds `cd supabase-nextjs-auth` before later setup steps
- fixes the malformed SQL code fence
- clarifies the publishable key placeholder

## Additional context

This is a small follow-up docs improvement focused on making the Next.js Auth quickstart easier for new users to follow.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Next.js authentication quickstart guide with improved setup clarity, including more explicit project creation and navigation commands for streamlined configuration.
  * Updated environment variable examples with clearer placeholder values to reduce confusion during initial setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->