### PR TITLE
Fix typo in deployment guide

### DIFF
--- a/apps/docs/content/guides/deployment/branching.mdx
+++ b/apps/docs/content/guides/deployment/branching.mdx
@@ -27,4 +27,4 @@ When you merge any branch into your main project, Supabase automatically runs a 
 6. **Seed** - Runs seed files to populate your branch with initial data (must be [enabled in config.toml](/docs/guides/deployment/branching/configuration#branch-configuration-with-remotes) for persistent branches)
 7. **Deploy** - Deploys any changed Edge Functions and updates function secrets
 
-If a parent deployment step fails, all dependent child steps will be skipped. For instance, if your database migrations failed at step 5, our runner will not seed your branch because step 6 is skipped. If you are using GitHub integration, the same deployment workflow will be run on every commit pushed to your git branch.
+If a parent deployment step fails, all dependent child steps will be skipped. For instance, if your database migrations failed at step 5, our runner will not seed your branch because step 6 is skipped. If you are using GitHub integration, the same deployment workflow will be run on ever commit pushed to your git branch.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.

- [ ] 
This pull request contains a minor change that corrects the wording in the deployment documentation for branch workflows.

* Documentation wording update:
  * Fixed a typo in the description of the deployment workflow to clarify that the workflow runs on every commit pushed to a git branch in the context of GitHub integration.
This pull request makes a minor change to the documentation in `apps/docs/content/guides/deployment/branching.mdx`, specifically in the section describing deployment workflows.

- Fixed a typo in the documentation by changing "every commit" to "ever commit".[](url)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified branching deployment workflow behavior regarding conditional execution when parent deployment steps fail and GitHub integration commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->