### PR TITLE
Expose self-hosted Observability through Query Performance

### DIFF
--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.test.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.test.tsx
@@ -129,15 +129,19 @@ describe('generateOtherRoutes', () => {
       isPlatform: false,
       showReports: true,
     })
-    expect(keys(routes)).not.toContain('observability')
+    expect(keys(routes)).toContain('observability')
+    const observabilityRoute = routes.find((r) => r.key === 'observability')
+    expect(observabilityRoute?.link).toBe(`/project/${REF}/observability/query-performance`)
   })
 
-  it('excludes observability in self-hosted mode when reports are disabled', () => {
+  it('includes observability in self-hosted mode when reports are disabled', () => {
     const routes = generateOtherRoutes(REF, activeProject, {
       isPlatform: false,
       showReports: false,
     })
-    expect(keys(routes)).not.toContain('observability')
+    expect(keys(routes)).toContain('observability')
+    const observabilityRoute = routes.find((r) => r.key === 'observability')
+    expect(observabilityRoute?.link).toBe(`/project/${REF}/observability/query-performance`)
   })
 
   it('does not include API Docs nav item', () => {

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -2,6 +2,10 @@ import { Auth, Database, EdgeFunctions, Realtime, SqlEditor, Storage, TableEdito
 import { Blocks, Lightbulb, List, Settings, Telescope } from 'lucide-react'
 
 import { ICON_SIZE, ICON_STROKE_WIDTH } from '@/components/interfaces/Sidebar'
+import {
+  canAccessObservability,
+  getObservabilityEntryRoute,
+} from '@/components/layouts/ObservabilityLayout/ObservabilityAccess.utils'
 import type { Route } from '@/components/ui/ui.types'
 import { EditorIndexPageLink } from '@/data/prefetchers/project.$ref.editor'
 import type { Project } from '@/data/projects/project-detail-query'
@@ -163,6 +167,10 @@ export const generateOtherRoutes = (
   const unifiedLogsEnabled = features?.unifiedLogs ?? false
   const reportsEnabled = features?.showReports ?? true
   const logsEnabled = features?.showLogs ?? true
+  const observabilityEnabled = canAccessObservability({
+    isPlatform,
+    reportsAll: reportsEnabled,
+  })
   return [
     {
       key: 'advisors',
@@ -172,15 +180,16 @@ export const generateOtherRoutes = (
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/advisors/security`),
       shortcutId: SHORTCUT_IDS.NAV_ADVISORS,
     },
-    // Observability is only available on the platform, not for self-hosted/CLI
-    ...(isPlatform && reportsEnabled
+    ...(observabilityEnabled
       ? [
           {
             key: 'observability',
             label: 'Observability',
             disabled: !isProjectActive,
             icon: <Telescope size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/observability`),
+            link:
+              ref &&
+              (isProjectBuilding ? buildingUrl : getObservabilityEntryRoute(ref, { isPlatform })),
             shortcutId: SHORTCUT_IDS.NAV_OBSERVABILITY,
           },
         ]

--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityAccess.utils.test.ts
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityAccess.utils.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  canAccessObservability,
+  getObservabilityEntryRoute,
+} from './ObservabilityAccess.utils'
+
+describe('canAccessObservability', () => {
+  it('allows observability on platform when reports are enabled', () => {
+    expect(canAccessObservability({ isPlatform: true, reportsAll: true })).toBe(true)
+  })
+
+  it('blocks observability on platform when reports are disabled', () => {
+    expect(canAccessObservability({ isPlatform: true, reportsAll: false })).toBe(false)
+  })
+
+  it('allows observability in self-hosted even when reports are disabled', () => {
+    expect(canAccessObservability({ isPlatform: false, reportsAll: false })).toBe(true)
+  })
+})
+
+describe('getObservabilityEntryRoute', () => {
+  it('uses the overview route on platform', () => {
+    expect(getObservabilityEntryRoute('project-ref', { isPlatform: true })).toBe(
+      '/project/project-ref/observability'
+    )
+  })
+
+  it('uses query performance as the self-hosted entry route', () => {
+    expect(getObservabilityEntryRoute('project-ref', { isPlatform: false })).toBe(
+      '/project/project-ref/observability/query-performance'
+    )
+  })
+})

--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityAccess.utils.ts
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityAccess.utils.ts
@@ -1,0 +1,23 @@
+import { IS_PLATFORM } from '@/lib/constants'
+
+type ObservabilityAccessOptions = {
+  isPlatform?: boolean
+  reportsAll?: boolean
+}
+
+export function canAccessObservability({
+  isPlatform = IS_PLATFORM,
+  reportsAll = false,
+}: ObservabilityAccessOptions): boolean {
+  return !isPlatform || reportsAll
+}
+
+export function getObservabilityEntryRoute(
+  ref: string | undefined,
+  options?: { isPlatform?: boolean }
+): string {
+  const isPlatform = options?.isPlatform ?? IS_PLATFORM
+  const baseRoute = `/project/${ref}/observability`
+
+  return isPlatform ? baseRoute : `${baseRoute}/query-performance`
+}

--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
@@ -3,6 +3,7 @@ import { usePathname } from 'next/navigation'
 import { PropsWithChildren, useEffect, useRef } from 'react'
 
 import { ProjectLayout } from '../ProjectLayout'
+import { canAccessObservability } from './ObservabilityAccess.utils'
 import ObservabilityMenu from './ObservabilityMenu'
 import { useIndexAdvisorStatus } from '@/components/interfaces/QueryPerformance/hooks/useIsIndexAdvisorStatus'
 import { BannerIndexAdvisor } from '@/components/ui/BannerStack/Banners/BannerIndexAdvisor'
@@ -82,7 +83,7 @@ const ObservabilityLayoutContent = ({
 
   const { reportsAll } = useIsFeatureEnabled(['reports:all'])
 
-  if (reportsAll) {
+  if (canAccessObservability({ reportsAll })) {
     return (
       <ProjectLayout
         product="Observability"
@@ -102,7 +103,7 @@ const ObservabilityLayout = (props: PropsWithChildren<ObservabilityLayoutProps>)
   const { ref } = useParams()
   const { reportsAll } = useIsFeatureEnabled(['reports:all'])
 
-  if (reportsAll) {
+  if (canAccessObservability({ reportsAll })) {
     return <ObservabilityLayoutContent {...props} />
   } else {
     return <UnknownInterface urlBack={`/project/${ref}`} />

--- a/apps/studio/pages/project/[ref]/observability/index.tsx
+++ b/apps/studio/pages/project/[ref]/observability/index.tsx
@@ -8,10 +8,12 @@ import { LogoLoader } from 'ui'
 import { ObservabilityOverview } from '@/components/interfaces/Observability/ObservabilityOverview'
 import { CreateReportModal } from '@/components/interfaces/Reports/CreateReportModal'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
+import { getObservabilityEntryRoute } from '@/components/layouts/ObservabilityLayout/ObservabilityAccess.utils'
 import ObservabilityLayout from '@/components/layouts/ObservabilityLayout/ObservabilityLayout'
 import ProductEmptyState from '@/components/to-be-cleaned/ProductEmptyState'
 import { useContentQuery } from '@/data/content/content-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { IS_PLATFORM } from '@/lib/constants'
 import { useProfile } from '@/lib/profile'
 import type { NextPageWithLayout } from '@/types'
 
@@ -45,7 +47,11 @@ export const UserReportPage: NextPageWithLayout = () => {
       .filter((x) => x.type === 'report')
       .sort((a, b) => a.name.localeCompare(b.name))
     if (reports.length >= 1) router.replace(`/project/${ref}/observability/${reports[0].id}`)
-    if (reports.length === 0) router.replace(`/project/${ref}/observability/api-overview`)
+    if (reports.length === 0) {
+      router.replace(
+        IS_PLATFORM ? `/project/${ref}/observability/api-overview` : getObservabilityEntryRoute(ref)
+      )
+    }
   }, [isSuccess, data, router, ref, showOverview, flagsLoaded])
 
   const { can: canCreateReport } = useAsyncCheckPermissions(


### PR DESCRIPTION
## Summary

This is a small first pass at loosening the self-hosted Observability lockout in Studio.

Right now, self-hosted users have some analytics/log plumbing in the repo, but the UI still blocks Observability very early:

- the nav hides Observability entirely for self-hosted
- the layout returns `UnknownInterface` unless `reports:all` is enabled
- the default Observability landing page falls back to `api-overview`, which is a poor fit for self-hosted

This patch does three things:

- adds a shared helper for Observability access / entry routing
- exposes Observability in self-hosted navigation
- points the self-hosted entry path at `query-performance`, which already has explicit self-hosted support in its data hook

## Changes

- allow self-hosted access to `ObservabilityLayout` even when `reports:all` is false
- show `Observability` in the sidebar for self-hosted projects
- use `/observability/query-performance` as the self-hosted entry route
- update the self-hosted fallback redirect on `/observability`
- add focused tests around the new access and entry-route behavior

## Notes

This does **not** try to solve full hosted/self-hosted observability parity.

It is meant as a narrower step that removes the blanket lockout and makes the already-supported query performance path reachable through Studio.

Closes #45489

## Testing

I added focused test coverage for the new helper and updated the existing navigation expectations.

I was **not** able to run the Studio test suite in this checkout because the JS workspace dependencies are not installed locally, so `vitest` was not available to execute here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability is now consistently available in self-hosted deployments and selects the appropriate entry route per environment.

* **Bug Fixes**
  * Navigation items and empty-state redirects now route users to the correct observability entry page for their deployment type.

* **Tests**
  * Added tests validating observability access rules and correct entry-route selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->