### PR TITLE
fix(sql-editor): prevent Monaco from auto-replacing text inside string literals

### DIFF
--- a/apps/studio/components/ui/AIEditor/index.tsx
+++ b/apps/studio/components/ui/AIEditor/index.tsx
@@ -323,7 +323,7 @@ export const AIEditor = ({
     }
   }
 
-  const defaultOptions: monacoEditor.IStandaloneEditorConstructionOptions = {
+const defaultOptions: monacoEditor.IStandaloneEditorConstructionOptions = {
     tabSize: 2,
     fontSize: 13,
     readOnly,
@@ -333,6 +333,16 @@ export const AIEditor = ({
     folding: false,
     padding: { top: 4 },
     lineNumbersMinChars: 3,
+    // --- Prevent aggressive auto-replace ---
+    acceptSuggestionOnCommitCharacter: false,
+    acceptSuggestionOnEnter: 'smart',
+    wordBasedSuggestions: 'off', // Stops Monaco from recycling words in your document
+    quickSuggestions: {
+        other: true,
+        comments: false,
+        strings: false // Strictly disables popup suggestions inside strings
+    },
+    inlineSuggest: { enabled: false }, // Explicitly kills rogue "ghost text"
     ...options,
   }
 

--- a/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
+++ b/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
@@ -94,6 +94,11 @@ export const CodeEditor = ({
       lineNumbersMinChars: hideLineNumbers ? 0 : 4,
       folding: hideLineNumbers ? false : undefined,
       scrollBeyondLastLine: false,
+      // --- ANTI-BUG SETTINGS ---
+      acceptSuggestionOnCommitCharacter: false, // Stops auto-replacing when typing spaces/punctuation
+      acceptSuggestionOnEnter: 'smart', // Only accepts suggestions deliberately
+      wordBasedSuggestions: 'off', // Prevents editor from randomly suggesting words from your own strings
+      // --- END SETTINGS ---
     },
     options
   )

--- a/apps/studio/components/ui/CodeEditor/Providers/PgSQLCompletionProvider.ts
+++ b/apps/studio/components/ui/CodeEditor/Providers/PgSQLCompletionProvider.ts
@@ -12,6 +12,21 @@ export default function getPgsqlCompletionProvider(monaco: any, pgInfoRef: RefOb
     triggerCharacters: [' ', '.', '"'],
     provideCompletionItems: function (model: any, position: any, context: any) {
       try {
+        // --- STRING LITERAL DETECTION ---
+        // Get the text on the current line up to the cursor position
+        const lineContent = model.getLineContent(position.lineNumber);
+        const textUntilPosition = lineContent.substring(0, position.column - 1);
+
+        // Count unescaped single quotes to see if we are inside a string literal.
+        // If the count is odd, the quote is currently open.
+        const unescapedSingleQuotes = (textUntilPosition.match(/(^|[^\\])'/g) || []).length;
+        const isInsideString = unescapedSingleQuotes % 2 !== 0;
+
+        if (isInsideString) {
+          // Abort all autocomplete suggestions, as we are inside data, not code.
+          return { suggestions: [] };
+        }
+
         // position.column should minus 2 as it returns 2 for first char
         // position.lineNumber should minus 1
         let iterator = new BackwardIterator(model, position.column - 2, position.lineNumber - 1)

--- a/apps/studio/components/ui/CodeEditor/Providers/PgSQLCompletionProvider.ts
+++ b/apps/studio/components/ui/CodeEditor/Providers/PgSQLCompletionProvider.ts
@@ -14,8 +14,12 @@ export default function getPgsqlCompletionProvider(monaco: any, pgInfoRef: RefOb
       try {
         // --- STRING LITERAL DETECTION ---
         // Get the text on the current line up to the cursor position
-        const lineContent = model.getLineContent(position.lineNumber);
-        const textUntilPosition = lineContent.substring(0, position.column - 1);
+        const textUntilPosition = model.getValueInRange({
+          startLineNumber: 1,
+          startColumn: 1,
+          endLineNumber: position.lineNumber,
+          endColumn: position.column,
+        });
 
         // Count unescaped single quotes to see if we are inside a string literal.
         // If the count is odd, the quote is currently open.


### PR DESCRIPTION
I have read the CONTRIBUTING.md file.
YES

What kind of change does this PR introduce?
Bug fix

What is the current behavior?

Monaco Editor’s autocomplete and word-based suggestions actively overwrite text inside single-quoted string literals. This causes data corruption when typing or pasting SQL (e.g., 'Pulseiras e Braceletes' becomes 'Pulseiras e Pulseiras') because the editor treats data as code suggestions.

Fixes #45474

What is the new behavior?

1. String Detection: PgSQLCompletionProvider now detects if the cursor is inside unescaped single quotes and aborts suggestions.
2. Config Lockdown: Disables wordBasedSuggestions and acceptSuggestionOnCommitCharacter in CodeEditor and AIEditor.
3. Literal Protection: Sets quickSuggestions.strings to false to prevent widgets from appearing inside data values.

Additional context
The fix overrides Monaco's default aggressive autocomplete behaviors (wordBasedSuggestions defaults to true) to ensure string literals are treated as untouchable data. Since this only affects editor UI configuration, there is no risk to backend services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented unintended autocomplete acceptance from commit characters and refined Enter behavior to reduce accidental completions.
  * Disabled inline “ghost” suggestions and limited quick-suggestion popups to exclude comment and string suggestions.
  * Stopped SQL suggestions from appearing when the cursor is inside single-quoted string literals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->