### PR TITLE
docs: remove OAuth token and verifier debug logs

### DIFF
--- a/apps/docs/content/guides/integrations/build-a-supabase-oauth-integration.mdx
+++ b/apps/docs/content/guides/integrations/build-a-supabase-oauth-integration.mdx
@@ -100,7 +100,6 @@ router.get('/connect-supabase/oauth2/callback', async (ctx) => {
       code_verifier: codeVerifier,
     }),
   }).then((res) => res.json())
-  console.log('tokens', tokens)
 
   // Store the tokens in your DB for future use.
 

--- a/examples/edge-functions/supabase/functions/connect-supabase/index.ts
+++ b/examples/edge-functions/supabase/functions/connect-supabase/index.ts
@@ -36,7 +36,6 @@ router.get('/connect-supabase/login', async (ctx) => {
 router.get('/connect-supabase/oauth2/callback', async (ctx) => {
   // Make sure the codeVerifier is present for the user's session.
   const codeVerifier = ctx.state.session.get('codeVerifier') as string
-  console.log('codeVerifier', codeVerifier)
   if (!codeVerifier) throw new Error('No codeVerifier!')
 
   // Exchange the authorization code for an access token.
@@ -54,7 +53,6 @@ router.get('/connect-supabase/oauth2/callback', async (ctx) => {
       code_verifier: codeVerifier,
     }),
   }).then((res) => res.json())
-  console.log('tokens', tokens)
   // TODO: Make sure to store the tokens in your DB for future use.
 
   // Use the access token to make an authenticated API request.


### PR DESCRIPTION
## What changed

Removed debug logs for sensitive OAuth values from the Supabase OAuth integration example:

- PKCE `codeVerifier` in the Edge Function example
- token exchange response in the Edge Function example and matching docs snippet

The authorization URL log is kept to preserve local example flow visibility.

## Why

Examples should not encourage logging PKCE verifiers or OAuth token responses.

## Testing

Not run. This only removes logging statements from an example and docs snippet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated OAuth integration guide with improved PKCE implementation details in code examples
  * Enhanced token exchange flow documentation with proper parameter handling

* **Chores**
  * Removed debug logging statements from code examples to reduce console noise

<!-- end of auto-generated comment: release notes by coderabbit.ai -->