### PR TITLE
fix(studio): surface FK constraint errors and remove false-success timeout in CSV import

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.mutations.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.mutations.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockExecuteSql = vi.fn()
+const mockFetchQuery = vi.fn()
+const mockInvalidateQueries = vi.fn()
+const mockPrefetchTableEditor = vi.fn()
+const mockToastError = vi.fn()
+const mockUpdateTableMutation = vi.fn()
+const mockGetTable = vi.fn()
+
+vi.mock('@supabase/pg-meta', () => ({
+  default: {},
+  getAddForeignKeySQL: vi.fn(() => 'alter table add foreign key'),
+  getAddPrimaryKeySQL: vi.fn(() => 'alter table add primary key'),
+  getDropConstraintSQL: vi.fn(() => 'alter table drop constraint'),
+  getDuplicateIdentitySequenceSQL: vi.fn(() => ''),
+  getDuplicateRowsSQL: vi.fn(() => ''),
+  getDuplicateTableSQL: vi.fn(() => ''),
+  getEnableRLSSQL: vi.fn(() => ''),
+  getRemoveForeignKeySQL: vi.fn(() => 'alter table drop foreign key'),
+  getUpdateIdentitySequenceSQL: vi.fn(() => ''),
+}))
+
+vi.mock('@supabase/pg-meta/src/query', () => ({
+  Query: class {
+    private schema = ''
+    private table = ''
+
+    from(table: string, schema: string) {
+      this.table = table
+      this.schema = schema
+      return this
+    }
+
+    insert() {
+      return this
+    }
+
+    toSql() {
+      return `insert into ${this.schema}.${this.table}`
+    }
+  },
+}))
+
+vi.mock('@/data/query-client', () => ({
+  getQueryClient: () => ({
+    fetchQuery: mockFetchQuery,
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}))
+
+vi.mock('@/data/sql/execute-sql-query', () => ({
+  executeSql: (...args: unknown[]) => mockExecuteSql(...args),
+}))
+
+vi.mock('@/data/table-editor/table-editor-query', () => ({
+  prefetchTableEditor: (...args: unknown[]) => mockPrefetchTableEditor(...args),
+}))
+
+vi.mock('@/data/tables/table-retrieve-query', () => ({
+  getTable: (...args: unknown[]) => mockGetTable(...args),
+}))
+
+vi.mock('@/data/tables/table-update-mutation', () => ({
+  updateTable: (...args: unknown[]) => mockUpdateTableMutation(...args),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (...args: unknown[]) => mockToastError(...args),
+    info: vi.fn(),
+    loading: vi.fn(),
+    success: vi.fn(),
+    warning: vi.fn(),
+  },
+}))
+
+vi.mock('@/components/ui/SparkBar', () => ({
+  default: () => null,
+}))
+
+import { insertTableRows, updateTable } from './SidePanelEditor.utils'
+
+describe('SidePanelEditor mutation utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockInvalidateQueries.mockResolvedValue(undefined)
+    mockUpdateTableMutation.mockResolvedValue(undefined)
+    mockGetTable.mockResolvedValue(undefined)
+  })
+
+  it('marks table updates as partial failures when foreign key updates fail', async () => {
+    const updatedTable = {
+      id: 42,
+      name: 'demo',
+      schema: 'public',
+      columns: [],
+      primary_keys: [],
+    }
+
+    mockFetchQuery.mockResolvedValue(updatedTable)
+    mockPrefetchTableEditor.mockResolvedValue(updatedTable)
+    mockExecuteSql.mockRejectedValueOnce(new Error('referenced columns must be unique'))
+
+    const result = await updateTable({
+      projectRef: 'project-ref',
+      connectionString: 'postgresql://localhost:5432/postgres',
+      toastId: 'toast-id',
+      table: {
+        id: 42,
+        name: 'demo',
+        schema: 'public',
+        columns: [],
+        primary_keys: [],
+      } as any,
+      payload: {},
+      columns: [],
+      foreignKeyRelations: [
+        {
+          id: 'new-fk',
+          name: 'demo_parent_name_fkey',
+          source_schema: 'public',
+          source_table_name: 'demo',
+          source_column_name: 'parent_name',
+          target_table_schema: 'public',
+          target_table_name: 'parent_no_pk',
+          target_column_name: 'name',
+        },
+      ] as any,
+      existingForeignKeyRelations: [],
+      primaryKey: undefined,
+    })
+
+    expect(result).toEqual({
+      table: updatedTable,
+      hasError: true,
+    })
+    expect(mockToastError).toHaveBeenCalledWith(
+      'Failed to update foreign key constraints: referenced columns must be unique'
+    )
+    expect(mockPrefetchTableEditor).toHaveBeenCalled()
+  })
+
+  it('waits for inserts to finish before resolving a successful import', async () => {
+    let resolveInsert: (() => void) | undefined
+    const insertFinished = new Promise<void>((resolve) => {
+      resolveInsert = resolve
+    })
+
+    mockExecuteSql.mockImplementation(() => insertFinished)
+
+    const onProgressUpdate = vi.fn()
+    let settled = false
+
+    const pendingImport = insertTableRows({
+      projectRef: 'project-ref',
+      connectionString: 'postgresql://localhost:5432/postgres',
+      table: {
+        id: 7,
+        name: 'slow_import',
+        schema: 'public',
+        columns: [],
+      } as any,
+      rows: [{ id: 1, payload: 'test' }],
+      selectedHeaders: ['id', 'payload'],
+      onProgressUpdate,
+    }).then((result) => {
+      settled = true
+      return result
+    })
+
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+    expect(onProgressUpdate).not.toHaveBeenCalled()
+
+    resolveInsert?.()
+
+    await expect(pendingImport).resolves.toEqual({ error: undefined })
+    expect(onProgressUpdate).toHaveBeenCalledWith(100)
+  })
+})

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -52,7 +52,7 @@ import {
 } from '@/data/tables/table-update-mutation'
 import { getTables } from '@/data/tables/tables-query'
 import { sendEvent } from '@/data/telemetry/send-event-mutation'
-import { isObject, isObjectContainingKeys, timeout, tryParseJson } from '@/lib/helpers'
+import { isObject, isObjectContainingKeys, tryParseJson } from '@/lib/helpers'
 import type { SafePostgresColumn } from '@/lib/postgres-types'
 import type { DeepReadonly } from '@/lib/type-helpers'
 import type { SidePanel } from '@/state/table-editor'
@@ -921,13 +921,20 @@ export const updateTable = async ({
   }
 
   // Foreign keys will get updated here accordingly
-  await updateForeignKeys({
-    projectRef,
-    connectionString,
-    table: updatedTable,
-    foreignKeys: foreignKeyRelations,
-    existingForeignKeyRelations,
-  })
+  try {
+    await updateForeignKeys({
+      projectRef,
+      connectionString,
+      table: updatedTable,
+      foreignKeys: foreignKeyRelations,
+      existingForeignKeyRelations,
+    })
+  } catch (error: any) {
+    hasError = true
+    toast.error(
+      `Failed to update foreign key constraints: ${error.message}`
+    )
+  }
 
   await Promise.all([
     queryClient.invalidateQueries({ queryKey: tableEditorKeys.tableEditor(projectRef, table.id) }),
@@ -1135,22 +1142,10 @@ export async function insertTableRows({
 
   const batches = chunk(formattedRows, BATCH_SIZE)
   const tasks = batches.map((batch) => {
-    return () => {
-      return Promise.race([
-        new Promise(async (resolve, reject) => {
-          const insertQuery = new Query().from(table.name, table.schema).insert(batch).toSql()
-          try {
-            await executeSql({ projectRef, connectionString, sql: insertQuery })
-          } catch (error) {
-            insertError = error
-            reject(error)
-          }
-
-          insertProgress = insertProgress + batch.length / rows.length
-          resolve({})
-        }),
-        timeout(30_000),
-      ])
+    return async () => {
+      const insertQuery = new Query().from(table.name, table.schema).insert(batch).toSql()
+      await executeSql({ projectRef, connectionString, sql: insertQuery })
+      insertProgress = insertProgress + batch.length / rows.length
     }
   })
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -751,7 +751,25 @@ export const createTable = async ({
   return { table, failedPolicies }
 }
 
-/** TODO: Refactor to do in a single transaction */
+/**
+ * Updates a table's schema, constraints, and foreign key relations.
+ * This handles primary keys, RLS enablement, adding/removing columns, and foreign keys.
+ * 
+ * TODO: Refactor to execute in a single transaction for better atomicity.
+ * 
+ * @param params - The parameters for updating the table.
+ * @param params.projectRef - The unique reference of the project.
+ * @param params.connectionString - The database connection string.
+ * @param params.toastId - Identifier for the loading toast notification.
+ * @param params.table - The existing table definition.
+ * @param params.payload - The updated table payload.
+ * @param params.columns - The new column definitions.
+ * @param params.foreignKeyRelations - The updated list of foreign keys.
+ * @param params.existingForeignKeyRelations - The existing foreign key relations.
+ * @param params.primaryKey - The primary key constraint, if updated.
+ * @param params.organizationSlug - The organization slug for telemetry tracking.
+ * @returns The updated table definition and a boolean indicating if any error occurred.
+ */
 export const updateTable = async ({
   projectRef,
   connectionString,
@@ -1012,6 +1030,19 @@ export const formatRowsForInsert = ({
   })
 }
 
+/**
+ * Parses a CSV spreadsheet and inserts its rows into a specified table in batches.
+ * 
+ * @param params - The parameters for importing spreadsheet data.
+ * @param params.projectRef - The unique reference of the project.
+ * @param params.connectionString - The database connection string.
+ * @param params.file - The CSV file to import.
+ * @param params.table - The table to insert rows into.
+ * @param params.selectedHeaders - The column headers to include in the import.
+ * @param params.emptyStringAsNullHeaders - Headers that should treat empty strings as null.
+ * @param params.onProgressUpdate - Callback to report import progress percentage.
+ * @returns An object containing an error if the import failed, or undefined if successful.
+ */
 export async function insertRowsViaSpreadsheet({
   projectRef,
   connectionString,
@@ -1113,6 +1144,19 @@ export async function insertRowsViaSpreadsheet({
   })
 }
 
+/**
+ * Inserts an array of raw row objects into a specified table in batches.
+ * 
+ * @param params - The parameters for inserting rows.
+ * @param params.projectRef - The unique reference of the project.
+ * @param params.connectionString - The database connection string.
+ * @param params.table - The table to insert rows into.
+ * @param params.rows - The raw array of row objects to insert.
+ * @param params.selectedHeaders - The column headers to include.
+ * @param params.emptyStringAsNullHeaders - Headers that should treat empty strings as null.
+ * @param params.onProgressUpdate - Callback to report import progress percentage.
+ * @returns An object containing an error if the insertion failed, or undefined if successful.
+ */
 export async function insertTableRows({
   projectRef,
   connectionString,
@@ -1142,10 +1186,12 @@ export async function insertTableRows({
 
   const batches = chunk(formattedRows, BATCH_SIZE)
   const tasks = batches.map((batch) => {
-    return async () => {
+    return () => {
       const insertQuery = new Query().from(table.name, table.schema).insert(batch).toSql()
-      await executeSql({ projectRef, connectionString, sql: insertQuery })
-      insertProgress = insertProgress + batch.length / rows.length
+      return executeSql({ projectRef, connectionString, sql: insertQuery })
+        .then(() => {
+          insertProgress = insertProgress + batch.length / rows.length
+        })
     }
   })
 


### PR DESCRIPTION
## Summary

This fixes two false-success paths in Studio's table editor:

1. Table updates could appear successful even when the follow-up foreign key constraint update failed.
2. CSV imports could appear successful after 30 seconds even if the underlying insert was still running.

## Why this matters

Both issues can leave users thinking their change completed when the database is actually in a different state.

That makes these failures easy to miss, especially during schema edits or slower imports, and can lead to follow-up errors that are harder to debug because Studio reported success too early.

## What changed

- Catch and surface foreign key constraint update failures during table edits.
- Mark the table update flow as a partial failure when the base table update succeeds but FK updates fail.
- Remove the 30s timeout race from CSV imports so success is only reported after the insert actually completes.
- Add tests covering:
  - FK update failures being surfaced correctly
  - Slow imports not resolving early

## Scope and edge cases

- This only affects foreign key updates triggered through the `SidePanelEditor` table update flow.
- It does not change foreign key behavior in other Studio flows.
- Large CSV imports may still take time, but they will no longer be reported as successful before the database finishes processing them.
- Import batching is unchanged, and this does not add extra database round trips or additional work per batch.

## Reviewer notes

The main behavioral change is that we now prefer accurate status over optimistic success:
- if a table update succeeds but FK constraint creation fails, the user now sees the FK failure instead of a silent success
- if an import is slow, the UI waits for the real database result instead of timing out into a false positive

## Testing

- `pnpm --filter studio exec vitest run components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.mutations.test.ts`


## Screenshots

### Foreign key flow

Before saving:

<img width="784" height="774" alt="test1_save_with_fk_config" src="https://github.com/user-attachments/assets/0815cae4-3b69-41e3-80cd-812f04b7ccd5" />

Resulting table state:

<img width="784" height="774" alt="test1_final_table_state" src="https://github.com/user-attachments/assets/9a27d790-ac01-44e7-b913-a1b8134ed4f7" />

### Slow import flow

Import still in progress:

<img width="980" height="968" alt="test3_progress_10s" src="https://github.com/user-attachments/assets/bd581c97-e377-47cd-acc6-d1656dccdfc0" />

Data visible after completion:

<img width="980" height="968" alt="test3_data_finally_appeared" src="https://github.com/user-attachments/assets/894e3081-f3d8-4fbf-9931-86046b66af0e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for foreign-key update failures with clear user-facing error messages.
  * More reliable batch data insertion and consistent progress reporting during inserts.

* **Tests**
  * Added tests verifying foreign-key error handling, toast notifications, and insertion progress behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->