### PR TITLE
Shift feature preview badge on merge page

### DIFF
--- a/apps/studio/pages/project/[ref]/merge.tsx
+++ b/apps/studio/pages/project/[ref]/merge.tsx
@@ -447,9 +447,6 @@ const MergePage: NextPageWithLayout = () => {
   const pageTitle = () => (
     <div className="flex items-center gap-x-4">
       <span>Merge</span>
-      {pgDeltaDiffEnabled && (
-        <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_PG_DELTA_DIFF} />
-      )}
 
       <Link href={`/project/${ref}/editor`}>
         <Badge className="font-mono text-sm gap-1 px-2">
@@ -469,6 +466,10 @@ const MergePage: NextPageWithLayout = () => {
           {mainBranch?.name || 'main'}
         </Badge>
       </Link>
+
+      {pgDeltaDiffEnabled && (
+        <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_PG_DELTA_DIFF} />
+      )}
     </div>
   )
 
@@ -597,7 +598,7 @@ const MergePage: NextPageWithLayout = () => {
         visible={showConfirmDialog}
         title="Confirm Branch Merge"
         description={`Are you sure you want to merge "${currentBranch?.name}" into "${mainBranch?.name || 'main'}"? This action cannot be undone.`}
-        confirmLabel="Merge Branch"
+        confirmLabel="Merge branch"
         confirmLabelLoading="Merging..."
         onConfirm={() => {
           setShowConfirmDialog(false)


### PR DESCRIPTION
## Before
<img width="626" height="176" alt="image" src="https://github.com/user-attachments/assets/02db6dd4-aaba-4e3a-8073-52661bbd9058" />


## After
<img width="524" height="157" alt="image" src="https://github.com/user-attachments/assets/cdecb26d-1d51-444f-97df-23681bb84792" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout of the feature preview badge on the merge page.
  * Updated text capitalization in the merge confirmation dialog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->