### PR TITLE
fix: Database tables filter has a smaller tap-target than its visual container

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -266,7 +266,7 @@ export const TableList = ({
         <div className="flex grow justify-between gap-2 items-center">
           <Input
             size="tiny"
-            className="grow lg:grow-0 w-52"
+            containerClassName="grow lg:grow-0 w-52"
             placeholder="Search for a table"
             value={filterString}
             onChange={(e) => setFilterString(e.target.value)}


### PR DESCRIPTION
## Problem

The Database tables filter has a smaller tap-target than its visual container.
This was probably introduced when we added the Shadcn `input-group`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated internal styling implementation for improved code maintainability.

---

**Note:** This is a minor internal refactor with no visible changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->