### PR TITLE
fix(studio): name the 5 MB/s throttle floor in disk IO banner

### DIFF
--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
@@ -53,15 +53,15 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
   disk_io_exhaustion: {
     bannerContent: {
       warning: {
-        title:
-          'Your project is about to deplete its Disk IO Budget, and may become unresponsive once fully exhausted',
+        title: 'Your project is about to deplete its Disk IO Budget',
         description:
-          'Upgrade your compute or use the AI Assistant to identify and optimize disk-intensive queries.',
+          'Once exhausted, disk throughput will be throttled to 5 MB/s until the budget resets. Upgrade your compute or use the AI Assistant to identify and optimize disk-intensive queries.',
       },
       critical: {
-        title: 'Your project has depleted its Disk IO Budget, and may become unresponsive',
+        title:
+          'Your project has depleted its Disk IO Budget. Disk throughput is throttled to 5 MB/s',
         description:
-          'Upgrade your compute or use the AI Assistant to identify and optimize disk-intensive queries.',
+          'Throughput will stay throttled until the budget resets. Upgrade your compute to restore full performance, or use the AI Assistant to identify and optimize disk-intensive queries.',
       },
     },
     cardContent: {


### PR DESCRIPTION
## Problem

The disk IO exhaustion banner currently warns that the project "may become unresponsive". That phrasing is vague and non-actionable. The actual behaviour when EBS burst credits hit zero is deterministic: sustained throughput is throttled to 5 MB/s until the budget resets. Users either ignore the warning or wait too long because they cannot picture what is about to happen.

Reported in [Linear DEBUG-62](https://linear.app/supabase/issue/DEBUG-62).

## Fix

Rewrite the `disk_io_exhaustion` banner copy in [ResourceExhaustionWarningBanner.constants.ts](apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts) to name the throttle floor explicitly:

- **Warning** (about to deplete): "Once exhausted, disk throughput will be throttled to 5 MB/s until the budget resets."
- **Critical** (depleted): title now reads "Disk throughput is throttled to 5 MB/s"; description explains the throttle stays until the budget resets and that upgrading restores full performance.

Card copy on the project list (the compact summary) is unchanged so the home page does not get noisy.

The banner already renders an "Upgrade compute" primary CTA (via `correctionUrlVariants.disk_io`), so no button changes are needed.

## Test plan

- [ ] Mock or trigger a `disk_io` warning at the warning level; confirm new copy renders correctly.
- [ ] Same at critical level; confirm both title and description are updated.
- [ ] Verify the project list card on the home page still shows the existing short summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Improved disk I/O exhaustion warning messages to clearly communicate that disk throughput will be throttled to 5 MB/s and explain when throttling will be lifted. Guidance on upgrading compute or optimizing disk-intensive queries remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->