### PR TITLE
feat(studio): add Disk IO Burst Balance chart to DB Report

### DIFF
--- a/apps/studio/components/ui/Charts/ChartHeader.tsx
+++ b/apps/studio/components/ui/Charts/ChartHeader.tsx
@@ -9,8 +9,7 @@ import {
 } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
-import { Badge, cn } from 'ui'
-import { InfoTooltip } from 'ui-patterns/info-tooltip'
+import { Badge, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import { formatPercentage, numberFormatter } from './Charts.utils'
 import { useChartHoverState } from './useChartHoverState'
@@ -183,21 +182,26 @@ export const ChartHeader = ({
           {title}
         </h3>
         {titleTooltip && (
-          <InfoTooltip side="top" className="max-w-xs">
-            {titleTooltip}
-            {docsUrl && (
-              <>
-                {' '}
-                <Link
-                  href={docsUrl}
-                  target="_blank"
-                  className="underline text-foreground hover:text-foreground-light"
-                >
-                  Read docs
-                </Link>
-              </>
-            )}
-          </InfoTooltip>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <InfoIcon className="w-4 h-4 text-foreground-lighter" />
+            </TooltipTrigger>
+            <TooltipContent side="top" className="max-w-xs">
+              {titleTooltip}
+              {docsUrl && (
+                <>
+                  {' '}
+                  <Link
+                    href={docsUrl}
+                    target="_blank"
+                    className="underline text-foreground hover:text-foreground-light"
+                  >
+                    Read docs
+                  </Link>
+                </>
+              )}
+            </TooltipContent>
+          </Tooltip>
         )}
       </div>
       {!titleTooltip && docsUrl && (

--- a/apps/studio/components/ui/Charts/ChartHeader.tsx
+++ b/apps/studio/components/ui/Charts/ChartHeader.tsx
@@ -182,9 +182,25 @@ export const ChartHeader = ({
         <h3 className={'text-foreground-lighter ' + (minimalHeader ? 'text-xs' : 'text-sm')}>
           {title}
         </h3>
-        {titleTooltip && <InfoTooltip>{titleTooltip}</InfoTooltip>}
+        {titleTooltip && (
+          <InfoTooltip side="top" className="max-w-xs">
+            {titleTooltip}
+            {docsUrl && (
+              <>
+                {' '}
+                <Link
+                  href={docsUrl}
+                  target="_blank"
+                  className="underline text-foreground hover:text-foreground-light"
+                >
+                  Read docs
+                </Link>
+              </>
+            )}
+          </InfoTooltip>
+        )}
       </div>
-      {docsUrl && (
+      {!titleTooltip && docsUrl && (
         <ButtonTooltip
           type="text"
           className="px-1"

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -276,7 +276,7 @@ export const getReportAttributesV2: (
     {
       id: 'disk-io-burst-balance',
       label: 'Disk IO Burst Balance',
-      titleTooltip: `Distinct from IOPS and throughput. This is the burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput is throttled to ${baselineThroughputLabel} (the baseline for this compute size) until it refills.`,
+      titleTooltip: `The burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput is throttled to ${baselineThroughputLabel} (the baseline for this compute size) until it refills.`,
       docsUrl: `${DOCS_URL}/guides/platform/compute-add-ons#disk-throughput-and-iops`,
       syncId: 'database-reports',
       hide: !showBurstBalanceChart,

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -1,4 +1,4 @@
-import { COMPUTE_MAX_IOPS } from 'shared-data'
+import { COMPUTE_DISK, COMPUTE_MAX_IOPS } from 'shared-data'
 
 import { mapComputeSizeNameToAddonVariantId } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
 import { compactNumberFormatter } from '@/components/ui/Charts/Charts.utils'
@@ -48,6 +48,9 @@ export const getReportAttributesV2: (
       : provisionedDiskIops
   const hasBurstableIO = BURSTABLE_IO_VARIANTS.has(computeVariantId)
   const showBurstBalanceChart = !!showDiskIOBurstBalanceChart && hasBurstableIO
+  const baselineThroughputMBps = COMPUTE_DISK[computeVariantId]?.baselineThroughputMBps
+  const baselineThroughputLabel =
+    typeof baselineThroughputMBps === 'number' ? `${baselineThroughputMBps} MB/s` : 'its baseline'
 
   return [
     {
@@ -273,8 +276,7 @@ export const getReportAttributesV2: (
     {
       id: 'disk-io-burst-balance',
       label: 'Disk IO Burst Balance',
-      titleTooltip:
-        'Distinct from IOPS and throughput. This is the burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput is throttled to 5 MB/s until it refills.',
+      titleTooltip: `Distinct from IOPS and throughput. This is the burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput is throttled to ${baselineThroughputLabel} (the baseline for this compute size) until it refills.`,
       docsUrl: `${DOCS_URL}/guides/platform/compute-add-ons#disk-throughput-and-iops`,
       syncId: 'database-reports',
       hide: !showBurstBalanceChart,
@@ -298,8 +300,7 @@ export const getReportAttributesV2: (
           provider: 'infra-monitoring',
           label: 'Burst credits remaining',
           format: '%',
-          tooltip:
-            'Percentage of EBS burst credits remaining. Drops only matter while the instance is bursting above its baseline IO. Reaching 0% throttles sustained throughput to 5 MB/s until it refills.',
+          tooltip: `Percentage of EBS burst credits remaining. Drops only matter while the instance is bursting above its baseline IO. Reaching 0% throttles sustained throughput to ${baselineThroughputLabel} until it refills.`,
         },
       ],
     },

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -9,6 +9,19 @@ import { Project } from '@/data/projects/project-detail-query'
 import { DOCS_URL } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 
+// Compute variants below 4XL run on EBS instances that draw on a burst
+// credit pool for disk IO, so the burst balance chart only makes sense for
+// these. Larger instances have dedicated IOPS and don't expose this metric.
+const BURSTABLE_IO_VARIANTS = new Set([
+  'ci_nano',
+  'ci_micro',
+  'ci_small',
+  'ci_medium',
+  'ci_large',
+  'ci_xlarge',
+  'ci_2xlarge',
+])
+
 export const getReportAttributesV2: (
   entitledFeatures: string[],
   project: Project,
@@ -24,13 +37,14 @@ export const getReportAttributesV2: (
   pgBouncerMaxConnections,
   isSpendCapEnabled
 ) => {
+  const computeVariantId = mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)
   const provisionedDiskIops = diskConfig?.attributes?.iops
-  const computeIopsLimit =
-    COMPUTE_MAX_IOPS[mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)]
+  const computeIopsLimit = COMPUTE_MAX_IOPS[computeVariantId]
   const effectiveMaxIops =
     typeof provisionedDiskIops === 'number' && typeof computeIopsLimit === 'number'
       ? Math.min(provisionedDiskIops, computeIopsLimit)
       : provisionedDiskIops
+  const hasBurstableIO = BURSTABLE_IO_VARIANTS.has(computeVariantId)
 
   return [
     {
@@ -250,6 +264,39 @@ export const getReportAttributesV2: (
               : undefined,
           tooltip: 'Maximum disk throughput for your current compute size',
           isMaxValue: true,
+        },
+      ],
+    },
+    {
+      id: 'disk-io-burst-balance',
+      label: 'Disk IO Burst Balance',
+      titleTooltip:
+        'Distinct from IOPS and throughput. This is the burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput is throttled to 5 MB/s until it refills.',
+      docsUrl: `${DOCS_URL}/guides/platform/compute-add-ons#disk-throughput-and-iops`,
+      syncId: 'database-reports',
+      hide: !hasBurstableIO,
+      format: '%',
+      valuePrecision: 0,
+      showTooltip: true,
+      showLegend: false,
+      showMaxValue: false,
+      showGrid: true,
+      YAxisProps: {
+        width: 55,
+        domain: [0, 100] as [number, number],
+        allowDataOverflow: true,
+        tickFormatter: (v: number) => `${Math.round(v)}%`,
+      },
+      hideChartType: false,
+      defaultChartStyle: 'bar',
+      attributes: [
+        {
+          attribute: 'disk_io_budget',
+          provider: 'infra-monitoring',
+          label: 'Burst credits remaining',
+          format: '%',
+          tooltip:
+            'Percentage of EBS burst credits remaining. Drops only matter while the instance is bursting above its baseline IO. Reaching 0% throttles sustained throughput to 5 MB/s until it refills.',
         },
       ],
     },

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -276,7 +276,7 @@ export const getReportAttributesV2: (
     {
       id: 'disk-io-burst-balance',
       label: 'Disk IO Burst Balance',
-      titleTooltip: `The burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput is throttled to ${baselineThroughputLabel} (the baseline for this compute size) until it refills.`,
+      titleTooltip: `The burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput returns to its baseline of ${baselineThroughputLabel} until it refills.`,
       docsUrl: `${DOCS_URL}/guides/platform/compute-add-ons#disk-throughput-and-iops`,
       syncId: 'database-reports',
       hide: !showBurstBalanceChart,
@@ -300,7 +300,7 @@ export const getReportAttributesV2: (
           provider: 'infra-monitoring',
           label: 'Burst credits remaining',
           format: '%',
-          tooltip: `Percentage of EBS burst credits remaining. Drops only matter while the instance is bursting above its baseline IO. Reaching 0% throttles sustained throughput to ${baselineThroughputLabel} until it refills.`,
+          tooltip: `Percentage of EBS burst credits remaining. Drops only matter while the instance is bursting above its baseline IO. At 0%, sustained throughput returns to its baseline of ${baselineThroughputLabel} until it refills.`,
         },
       ],
     },

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -28,14 +28,16 @@ export const getReportAttributesV2: (
   diskConfig?: DiskAttributesData,
   maxConnections?: MaxConnectionsData,
   pgBouncerMaxConnections?: number,
-  isSpendCapEnabled?: boolean
+  isSpendCapEnabled?: boolean,
+  showDiskIOBurstBalanceChart?: boolean
 ) => ReportAttributes[] = (
   entitledFeatures,
   project,
   diskConfig,
   maxConnections,
   pgBouncerMaxConnections,
-  isSpendCapEnabled
+  isSpendCapEnabled,
+  showDiskIOBurstBalanceChart
 ) => {
   const computeVariantId = mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)
   const provisionedDiskIops = diskConfig?.attributes?.iops
@@ -45,6 +47,7 @@ export const getReportAttributesV2: (
       ? Math.min(provisionedDiskIops, computeIopsLimit)
       : provisionedDiskIops
   const hasBurstableIO = BURSTABLE_IO_VARIANTS.has(computeVariantId)
+  const showBurstBalanceChart = !!showDiskIOBurstBalanceChart && hasBurstableIO
 
   return [
     {
@@ -274,7 +277,7 @@ export const getReportAttributesV2: (
         'Distinct from IOPS and throughput. This is the burst credit pool that smaller compute instances draw on to sustain IO above their baseline. When the balance hits 0%, sustained throughput is throttled to 5 MB/s until it refills.',
       docsUrl: `${DOCS_URL}/guides/platform/compute-add-ons#disk-throughput-and-iops`,
       syncId: 'database-reports',
-      hide: !hasBurstableIO,
+      hide: !showBurstBalanceChart,
       format: '%',
       valuePrecision: 0,
       showTooltip: true,

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useQueryClient } from '@tanstack/react-query'
-import { useParams } from 'common'
+import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, ExternalLink, RefreshCw } from 'lucide-react'
 import Link from 'next/link'
@@ -134,13 +134,16 @@ const DatabaseUsage = () => {
     !org?.usage_billing_enabled &&
     project?.cloud_provider !== 'FLY'
 
+  const showDiskIOBurstBalanceChart = useFlag('showDiskIOBurstBalanceChart')
+
   const REPORT_ATTRIBUTES = getReportAttributesV2(
     entitledFeatures,
     project!,
     diskConfig,
     maxConnections,
     defaultMaxClientConn,
-    isSpendCapEnabled
+    isSpendCapEnabled,
+    showDiskIOBurstBalanceChart
   )
 
   const { isPending: isUpdatingDiskSize } = useProjectDiskResizeMutation({


### PR DESCRIPTION
## Problem

When users hit a disk IO exhaustion notification, they open the Database Observability report and find IOPS and throughput charts, but no view of the metric that actually fired the warning: the EBS burst credit balance. That signal is currently only available behind Custom Reports, so the warning feels disconnected from the visible data.

> "The Dashboard actually shows them their burst budget, not their normal disk usage. It leads to a lot of confusion." — support
> "Customers may receive an 'exhausting multiple resources' warning and it's confusing because all the charts are 'fine', but it's the burst credits exhaustion that fails them." — Maksym

Reported in [Linear DEBUG-60](https://linear.app/supabase/issue/DEBUG-60).

## Fix

Add a clearly-labeled "Disk IO Burst Balance" chart to [getReportAttributesV2](apps/studio/data/reports/database-charts.ts) plotting `disk_io_budget` (% remaining) on a 0-100 axis. Tooltip and titleTooltip explain the 5 MB/s throttle floor so users can correlate this chart with the exhaustion banner copy (also being updated in [supabase#45514](https://github.com/supabase/supabase/pull/45514)).

The chart is hidden for compute variants that have dedicated I/O resources (4XL and above) since the burst credit pool does not apply there. Burstable variants (nano through 2XL) see the chart inline next to the existing IOPS and throughput charts.

DEBUG-61 ("replace Disk IO Usage % chart with disk throughput") was already addressed in the V2 migration (the report only renders `disk-iops` and `disk-throughput`; the old burst-percentage chart is gone). I'll close that issue as completed once this lands.

## Test plan

- [ ] Visit `/project/{ref}/observability/database` on a project running `nano`/`micro`/`small`/`medium`/`large`/`xlarge`/`2xlarge` compute. Confirm the new "Disk IO Burst Balance" chart appears between throughput and connections.
- [ ] On a project running `4xlarge` or larger compute, confirm the chart is hidden (chart is omitted by `hide: !hasBurstableIO`).
- [ ] Hover the chart and a data point. Confirm the title tooltip and inline attribute tooltip both surface the 5 MB/s throttle behaviour.
- [ ] Series renders 0-100 on the Y-axis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Disk IO Burst Balance chart to monitor remaining burst credits; displays percentage (0–100%) with tooltip referencing baseline throughput. Shown only for supported compute variants and when the feature flag is enabled.

* **Bug Fixes / UI Improvements**
  * Improved chart header tooltip presentation: uses a unified tooltip, includes inline docs links when available, and avoids duplicate docs icons.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45516)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->