### PR TITLE
feat(docs): Supabase Agent Plugin page

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -501,6 +501,10 @@ export const gettingstarted: NavMenuConstant = {
       url: undefined,
       items: [
         {
+          name: 'Supabase Agent Plugin',
+          url: '/guides/getting-started/plugins' as `/${string}`,
+        },
+        {
           name: 'Prompts',
           url: '/guides/getting-started/ai-prompts' as `/${string}`,
         },

--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -18,15 +18,6 @@ To install a specific skill from the repository:
 npx skills add supabase/agent-skills --skill SKILL_NAME
 ```
 
-### Claude Code plugin
-
-You can also install the skills as Claude Code plugins:
-
-```bash
-/plugin marketplace add supabase/agent-skills
-/plugin install supabase@supabase-agent-skills
-```
-
 Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others.
 
 ## Available skills

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -16,13 +16,11 @@ Choose your AI coding agent and follow the installation steps:
 
 ## What's included
 
-Each plugin bundles:
-
-### MCP server
+### Supabase MCP server
 
 The [Supabase MCP server](/docs/guides/getting-started/mcp) connects your AI coding agent directly to your Supabase projects. Once authenticated, your agent can query your database, manage migrations, deploy Edge Functions, and more — see the [full list of available tools](/docs/guides/getting-started/mcp#available-tools).
 
-### Agent skills
+### Supabase Agent skills
 
 Skills provide your agent with Supabase-specific procedural knowledge:
 

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -10,8 +10,6 @@ The Supabase agent plugin is a single install that gives your AI coding agent ev
 
 ## Why use the plugin?
 
-You can install the [MCP server](/docs/guides/getting-started/mcp) and [agent skills](/docs/guides/getting-started/ai-skills) separately. The plugin is the recommended way to get started because it sets everything up in a single step and keeps your MCP connection and skills in sync as updates are released.
-
 Agent plugins are packages of AI agent extensions. A single plugin can bundle any combination of:
 
 - **MCP servers** — external tool integrations that let your agent interact with services like Supabase
@@ -20,9 +18,7 @@ Agent plugins are packages of AI agent extensions. A single plugin can bundle an
 - **Agents** — specialized subagents with specific personas and tool configurations
 - **Slash commands** — custom commands you can invoke directly in chat
 
-The Supabase plugin currently bundles an MCP server and skills. Support for additional components may be added in future releases.
-
-You can install the plugin globally to use it across all your projects, or per project to keep it isolated.
+Bundling the [MCP server](/docs/guides/getting-started/mcp) and [agent skills](/docs/guides/getting-started/ai-skills) into a single plugin means you can set up both in one step. You can also install them separately if you prefer. The plugin can be installed globally to use it across all your projects, or per project to keep it isolated.
 
 ## Supported clients
 

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -1,0 +1,32 @@
+---
+id: 'ai-tools-plugins'
+title: 'Supabase Agent Plugins'
+subtitle: 'Install Supabase agent plugin for your AI coding agent'
+description: 'Install Supabase agent plugin for your AI coding agent'
+sidebar_label: 'Supabase Agent Plugin'
+---
+
+The Supabase agent plugin bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) into a single install for your AI coding agent. Once installed, your agent can query your database, manage migrations, and follow Supabase and Postgres best practices without manual configuration.
+
+## Installation
+
+Choose your AI coding agent and follow the installation steps:
+
+<AgentPluginsPanel />
+
+## What's included
+
+Each plugin bundles:
+
+### MCP server
+
+The [Supabase MCP server](/docs/guides/getting-started/mcp) connects your AI coding agent directly to your Supabase projects. Once authenticated, your agent can query your database, manage migrations, deploy Edge Functions, and more — see the [full list of available tools](/docs/guides/getting-started/mcp#available-tools).
+
+### Agent skills
+
+Skills provide your agent with Supabase-specific procedural knowledge:
+
+- **supabase** — Core guidance for working with Supabase products (Database, Auth, Edge Functions, Storage, Realtime)
+- **supabase-postgres-best-practices** — Postgres query optimization, schema design, connection management, and RLS patterns
+
+For a full list of available skills and supported agents, see [Agent Skills](/docs/guides/getting-started/ai-skills).

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -18,7 +18,7 @@ Agent plugins are packages of AI agent extensions. A single plugin can bundle an
 - **Agents** — specialized sub-agents with specific personas and tool configurations
 - **Slash commands** — custom commands you can invoke directly in chat
 
-Bundling the [MCP server](/docs/guides/getting-started/mcp) and [agent skills](/docs/guides/getting-started/ai-skills) into a single plugin means you can set up both in one step. You can also install them separately if you prefer. The plugin can be installed globally to use it across all your projects, or per project to keep it isolated.
+Bundling the [MCP server](/docs/guides/getting-started/mcp) and [agent skills](/docs/guides/getting-started/ai-skills) into a single plugin means you can set up both in one step. You can also install them separately if you prefer. You can install the plugin globally to use it across all your projects, or per project to keep it isolated.
 
 ## Installation
 

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -20,11 +20,11 @@ Choose your AI coding agent and follow the installation steps:
 
 The [Supabase MCP server](/docs/guides/getting-started/mcp) connects your AI coding agent directly to your Supabase projects. Once authenticated, your agent can query your database, manage migrations, deploy Edge Functions, and more — see the [full list of available tools](/docs/guides/getting-started/mcp#available-tools).
 
-### Supabase Agent skills
+### Supabase agent skills
 
 Skills provide your agent with Supabase-specific procedural knowledge:
 
-- **supabase** — Core guidance for working with Supabase products (Database, Auth, Edge Functions, Storage, Realtime)
-- **supabase-postgres-best-practices** — Postgres query optimization, schema design, connection management, and RLS patterns
+- **Supabase** — Core guidance for working with Supabase products (Database, Auth, Edge Functions, Storage, Realtime)
+- **Supabase-postgres-best-practices** — Postgres query optimization, schema design, connection management, and RLS patterns
 
 For a full list of available skills and supported agents, see [Agent Skills](/docs/guides/getting-started/ai-skills).

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -15,19 +15,10 @@ Agent plugins are packages of AI agent extensions. A single plugin can bundle an
 - **MCP servers** — external tool integrations that let your agent interact with services like Supabase
 - **Skills** — procedural knowledge and context your agent loads on demand to work more accurately
 - **Hooks** — event handlers that run at agent lifecycle points (e.g. before or after a tool call)
-- **Agents** — specialized subagents with specific personas and tool configurations
+- **Agents** — specialized sub-agents with specific personas and tool configurations
 - **Slash commands** — custom commands you can invoke directly in chat
 
 Bundling the [MCP server](/docs/guides/getting-started/mcp) and [agent skills](/docs/guides/getting-started/ai-skills) into a single plugin means you can set up both in one step. You can also install them separately if you prefer. The plugin can be installed globally to use it across all your projects, or per project to keep it isolated.
-
-## Supported clients
-
-| Client      | Type                       |
-| ----------- | -------------------------- |
-| Claude Code | AI agent CLI               |
-| Codex       | AI agent CLI + desktop app |
-| Cursor      | IDE (desktop + web)        |
-| Gemini CLI  | AI agent CLI               |
 
 ## Installation
 

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -24,7 +24,7 @@ The [Supabase MCP server](/docs/guides/getting-started/mcp) connects your AI cod
 
 Skills provide your agent with Supabase-specific procedural knowledge:
 
-- **Supabase** — Core guidance for working with Supabase products (Database, Auth, Edge Functions, Storage, Realtime)
-- **Supabase-postgres-best-practices** — Postgres query optimization, schema design, connection management, and RLS patterns
+- **`supabase`** — Core guidance for working with Supabase products (Database, Auth, Edge Functions, Storage, Realtime)
+- **`supabase-postgres-best-practices`** — Postgres query optimization, schema design, connection management, and RLS patterns
 
 For a full list of available skills and supported agents, see [Agent Skills](/docs/guides/getting-started/ai-skills).

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -1,12 +1,37 @@
 ---
 id: 'ai-tools-plugins'
-title: 'Supabase Agent Plugins'
-subtitle: 'Install Supabase agent plugin for your AI coding agent'
-description: 'Install Supabase agent plugin for your AI coding agent'
+title: 'Supabase Agent Plugin'
+subtitle: 'One-click setup for Supabase in your AI coding agent'
+description: 'The Supabase agent plugin bundles the MCP server and agent skills into a single install for your AI coding agent.'
 sidebar_label: 'Supabase Agent Plugin'
 ---
 
-The Supabase agent plugin bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) into a single install for your AI coding agent. Once installed, your agent can query your database, manage migrations, and follow Supabase and Postgres best practices without manual configuration.
+The Supabase agent plugin is a single install that gives your AI coding agent everything it needs to work with Supabase. It bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) so your agent can query your database, manage migrations, deploy Edge Functions, and follow Supabase and Postgres best practices — without manual configuration.
+
+## Why use the plugin?
+
+You can install the [MCP server](/docs/guides/getting-started/mcp) and [agent skills](/docs/guides/getting-started/ai-skills) separately. The plugin is the recommended way to get started because it sets everything up in a single step and keeps your MCP connection and skills in sync as updates are released.
+
+Agent plugins are packages of AI agent extensions. A single plugin can bundle any combination of:
+
+- **MCP servers** — external tool integrations that let your agent interact with services like Supabase
+- **Skills** — procedural knowledge and context your agent loads on demand to work more accurately
+- **Hooks** — event handlers that run at agent lifecycle points (e.g. before or after a tool call)
+- **Agents** — specialized subagents with specific personas and tool configurations
+- **Slash commands** — custom commands you can invoke directly in chat
+
+The Supabase plugin currently bundles an MCP server and skills. Support for additional components may be added in future releases.
+
+You can install the plugin globally to use it across all your projects, or per project to keep it isolated.
+
+## Supported clients
+
+| Client      | Type                       |
+| ----------- | -------------------------- |
+| Claude Code | AI agent CLI               |
+| Codex       | AI agent CLI + desktop app |
+| Cursor      | IDE (desktop + web)        |
+| Gemini CLI  | AI agent CLI               |
 
 ## Installation
 

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -33,6 +33,7 @@ import { IconPanel } from 'ui-patterns/IconPanel'
 import SqlToRest from 'ui-patterns/SqlToRest'
 import { Heading } from 'ui/src/components/CustomHTMLElements'
 
+import { AgentPluginsPanel } from '../ui/AgentPluginsPanel'
 import { ErrorCodes } from '../ui/ErrorCodes'
 import { McpConfigPanel } from '../ui/McpConfigPanel'
 
@@ -45,6 +46,7 @@ const components = {
   Accordion,
   AccordionItem,
   Admonition: AdmonitionWithMargin,
+  AgentPluginsPanel,
   AiPromptsIndex,
   AiSkillsIndex,
   AuthSmsProviderConfig,

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -109,25 +109,16 @@ function PluginInstructions({ client }: { client: PluginClient }) {
     return (
       <div className="space-y-3">
         <p className="text-sm text-foreground-light">
-          In the{' '}
-          <a
-            href="https://cursor.com/docs/plugins"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-brand-link hover:underline"
-          >
-            Cursor desktop or web app
-          </a>
-          , type the following in the chat to install the Supabase plugin from the{' '}
+          In the Cursor desktop or web app, type the following in the chat to install the{' '}
           <a
             href="https://cursor.com/marketplace/supabase"
             target="_blank"
             rel="noopener noreferrer"
             className="text-brand-link hover:underline"
           >
-            Cursor marketplace
-          </a>
-          :
+            Supabase
+          </a>{' '}
+          plugin from the Cursor plugin marketplace
         </p>
         <CodeBlock
           value="/add-plugin supabase"

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -57,7 +57,6 @@ function PluginInstructions({ client }: { client: PluginClient }) {
           >
             official Anthropic marketplace
           </a>
-          :
         </p>
         <CodeBlock
           value={`claude plugin marketplace add anthropics/claude-plugins-official\nclaude plugin install supabase@claude-plugins-official`}
@@ -93,7 +92,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
         </div>
         <div className="space-y-2">
           <h4 className="text-sm font-medium">CLI</h4>
-          <p className="text-xs text-foreground-lighter">Open the Codex CLI by running:</p>
+          <p className="text-xs text-foreground-lighter">Open the Codex CLI by running</p>
           <CodeBlock value="codex" language="bash" focusable={false} className="block" />
           <p className="text-xs text-foreground-lighter">Inside Codex, type:</p>
           <CodeBlock value="/plugins" language="bash" focusable={false} className="block" />
@@ -134,7 +133,8 @@ function PluginInstructions({ client }: { client: PluginClient }) {
     return (
       <div className="space-y-3">
         <p className="text-sm text-foreground-light">
-          Install the Supabase extension for Gemini CLI:
+          Install the official Supabase extension for Gemini CLI by running the following command in
+          your terminal.
         </p>
         <CodeBlock
           value="gemini extensions install https://github.com/supabase-community/gemini-extension"
@@ -142,6 +142,18 @@ function PluginInstructions({ client }: { client: PluginClient }) {
           focusable={false}
           className="block"
         />
+        <p className="text-xs text-foreground-lighter">
+          You can also find the extension in the{' '}
+          <a
+            href="https://geminicli.com/extensions/?name=supabase-communitygemini-extension"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            Gemini CLI extensions directory
+          </a>
+          .
+        </p>
       </div>
     )
   }
@@ -178,7 +190,7 @@ export function AgentPluginsPanel() {
               rel="noopener noreferrer"
               className="text-brand-link hover:underline inline-flex items-center"
             >
-              View {selectedClient.label} plugin docs
+              View {selectedClient.label} extensions docs
               <ExternalLink className="h-3 w-3 ml-1" />
             </a>
           </div>

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -153,10 +153,10 @@ export function AgentPluginsPanel() {
       <div className="mt-4 rounded-lg border border-muted p-4">
         <PluginInstructions client={selectedClient} />
       </div>
-      {(selectedClient.docsUrl || selectedClient.repoUrl) && (
-        <div className="mt-3 flex items-center gap-2 text-xs text-foreground-light">
-          <span>Need help?</span>
-          {selectedClient.docsUrl && (
+      <div className="mt-3 flex flex-col gap-1 text-xs text-foreground-light">
+        {selectedClient.docsUrl && (
+          <div className="flex items-center gap-2">
+            <span>Need help?</span>
             <a
               href={selectedClient.docsUrl}
               target="_blank"
@@ -166,20 +166,20 @@ export function AgentPluginsPanel() {
               View {selectedClient.label} plugin docs
               <ExternalLink className="h-3 w-3 ml-1" />
             </a>
-          )}
-          {selectedClient.repoUrl && (
-            <a
-              href={selectedClient.repoUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-brand-link hover:underline inline-flex items-center"
-            >
-              Give feedback
-              <ExternalLink className="h-3 w-3 ml-1" />
-            </a>
-          )}
-        </div>
-      )}
+          </div>
+        )}
+        {selectedClient.repoUrl && (
+          <a
+            href={selectedClient.repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline inline-flex items-center"
+          >
+            Give feedback
+            <ExternalLink className="h-3 w-3 ml-1" />
+          </a>
+        )}
+      </div>
     </div>
   )
 }

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -150,7 +150,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
         <p className="text-xs text-foreground-lighter">
           You can also find the extension in the{' '}
           <a
-            href="https://geminicli.com/extensions/?name=supabase-community-gemini-extension"
+            href="https://geminicli.com/extensions/?name=supabase-communitygemini-extension"
             target="_blank"
             rel="noopener noreferrer"
             className="text-brand-link hover:underline"

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -83,7 +83,20 @@ function PluginInstructions({ client }: { client: PluginClient }) {
         <p className="text-xs text-foreground-lighter">Inside Codex, type:</p>
         <CodeBlock value="/plugins" language="bash" focusable={false} className="block" />
         <p className="text-xs text-foreground-lighter">
-          Search for <strong>Supabase</strong> and select <strong>Install</strong>.
+          The plugin browser groups plugins by marketplace. Open the Supabase plugin and select{' '}
+          <strong>Install</strong>.
+        </p>
+        <p className="text-xs text-foreground-lighter">
+          You can also install it directly from the{' '}
+          <a
+            href="https://developers.openai.com/codex/plugins#plugin-directory-in-the-codex-app"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            Codex desktop app plugin directory
+          </a>
+          .
         </p>
       </div>
     )

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -150,7 +150,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
         <p className="text-xs text-foreground-lighter">
           You can also find the extension in the{' '}
           <a
-            href="https://geminicli.com/extensions/?name=supabase-communitygemini-extension"
+            href="https://geminicli.com/extensions/?name=supabase-community-gemini-extension"
             target="_blank"
             rel="noopener noreferrer"
             className="text-brand-link hover:underline"

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -77,13 +77,13 @@ function PluginInstructions({ client }: { client: PluginClient }) {
     return (
       <div className="space-y-3">
         <p className="text-sm text-foreground-light">
-          Start Codex and open the plugin browser with <code>/plugins</code>. Search for Supabase
-          and select <strong>Install plugin</strong>.
+          Install the Supabase plugin from the official OpenAI plugin marketplace:
         </p>
         <CodeBlock value="codex" language="bash" focusable={false} className="block" />
+        <p className="text-xs text-foreground-lighter">Inside Codex, type:</p>
+        <CodeBlock value="/plugins" language="bash" focusable={false} className="block" />
         <p className="text-xs text-foreground-lighter">
-          Then type <code>/plugins</code> inside Codex and search for Supabase. Some plugins ask you
-          to authenticate during install; others wait until first use.
+          Search for <strong>Supabase</strong> and select <strong>Install</strong>.
         </p>
       </div>
     )

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -1,29 +1,12 @@
 'use client'
 
-import { Bot, Check, ChevronDown, ExternalLink } from 'lucide-react'
+import { ExternalLink } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import { useState } from 'react'
-import {
-  Button,
-  cn,
-  Command_Shadcn_,
-  CommandEmpty_Shadcn_,
-  CommandGroup_Shadcn_,
-  CommandInput_Shadcn_,
-  CommandItem_Shadcn_,
-  CommandList_Shadcn_,
-  Popover_Shadcn_,
-  PopoverContent_Shadcn_,
-  PopoverTrigger_Shadcn_,
-} from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
-import { ConnectionIcon } from 'ui-patterns/McpUrlBuilder'
+import { ClientSelectDropdown, type McpClient } from 'ui-patterns/McpUrlBuilder'
 
-interface PluginClient {
-  key: string
-  label: string
-  icon?: string
-  hasDistinctDarkIcon?: boolean
+interface PluginClient extends McpClient {
   repoUrl?: string
   docsUrl?: string
 }
@@ -59,94 +42,6 @@ const PLUGIN_CLIENTS: PluginClient[] = [
     docsUrl: 'https://geminicli.com/docs/extensions/',
   },
 ]
-
-function ClientDropdown({
-  theme,
-  selectedClient,
-  onClientChange,
-}: {
-  theme: 'light' | 'dark'
-  selectedClient: PluginClient
-  onClientChange: (key: string) => void
-}) {
-  const [open, setOpen] = useState(false)
-
-  return (
-    <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>
-      <div className="flex">
-        <span className="flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
-          Client
-        </span>
-        <PopoverTrigger_Shadcn_ asChild>
-          <Button
-            size="small"
-            type="default"
-            className="gap-0 rounded-l-none"
-            iconRight={
-              <ChevronDown
-                strokeWidth={1.5}
-                className={cn('transition-transform duration-200', open && 'rotate-180')}
-              />
-            }
-          >
-            <div className="flex items-center gap-2">
-              {selectedClient.icon ? (
-                <ConnectionIcon
-                  connection={selectedClient.icon}
-                  theme={theme}
-                  hasDistinctDarkIcon={selectedClient.hasDistinctDarkIcon}
-                />
-              ) : (
-                <Bot size={12} aria-hidden />
-              )}
-              {selectedClient.label}
-            </div>
-          </Button>
-        </PopoverTrigger_Shadcn_>
-      </div>
-      <PopoverContent_Shadcn_ className="mt-0 p-0 max-w-48" side="bottom" align="start">
-        <Command_Shadcn_>
-          <CommandInput_Shadcn_ placeholder="Search..." />
-          <CommandList_Shadcn_>
-            <CommandEmpty_Shadcn_>No results found.</CommandEmpty_Shadcn_>
-            <CommandGroup_Shadcn_>
-              {PLUGIN_CLIENTS.map((client) => (
-                <CommandItem_Shadcn_
-                  key={client.key}
-                  value={client.key}
-                  onSelect={() => {
-                    onClientChange(client.key)
-                    setOpen(false)
-                  }}
-                  className="flex gap-2 items-center"
-                >
-                  {client.icon ? (
-                    <ConnectionIcon
-                      connection={client.icon}
-                      theme={theme}
-                      hasDistinctDarkIcon={client.hasDistinctDarkIcon}
-                    />
-                  ) : (
-                    <Bot size={12} aria-hidden />
-                  )}
-                  {client.label}
-                  <Check
-                    size={15}
-                    aria-label={client.key === selectedClient.key ? 'selected' : undefined}
-                    className={cn(
-                      'ml-auto',
-                      client.key === selectedClient.key ? 'opacity-100' : 'opacity-0'
-                    )}
-                  />
-                </CommandItem_Shadcn_>
-              ))}
-            </CommandGroup_Shadcn_>
-          </CommandList_Shadcn_>
-        </Command_Shadcn_>
-      </PopoverContent_Shadcn_>
-    </Popover_Shadcn_>
-  )
-}
 
 function PluginInstructions({ client }: { client: PluginClient }) {
   if (client.key === 'claude-code') {
@@ -258,8 +153,9 @@ export function AgentPluginsPanel() {
 
   return (
     <div className="not-prose">
-      <ClientDropdown
+      <ClientSelectDropdown
         theme={theme}
+        clients={PLUGIN_CLIENTS}
         selectedClient={selectedClient}
         onClientChange={setSelectedClientKey}
       />

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -75,29 +75,33 @@ function PluginInstructions({ client }: { client: PluginClient }) {
 
   if (client.key === 'codex') {
     return (
-      <div className="space-y-3">
-        <p className="text-sm text-foreground-light">
-          Install the Supabase plugin from the official OpenAI plugin marketplace:
-        </p>
-        <CodeBlock value="codex" language="bash" focusable={false} className="block" />
-        <p className="text-xs text-foreground-lighter">Inside Codex, type:</p>
-        <CodeBlock value="/plugins" language="bash" focusable={false} className="block" />
-        <p className="text-xs text-foreground-lighter">
-          The plugin browser groups plugins by marketplace. Open the Supabase plugin and select{' '}
-          <strong>Install</strong>.
-        </p>
-        <p className="text-xs text-foreground-lighter">
-          You can also install it directly from the{' '}
-          <a
-            href="https://developers.openai.com/codex/plugins#plugin-directory-in-the-codex-app"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-brand-link hover:underline"
-          >
-            Codex desktop app plugin directory
-          </a>
-          .
-        </p>
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium">Desktop app</h4>
+          <p className="text-xs text-foreground-lighter">
+            Install the Supabase plugin directly from the{' '}
+            <a
+              href="https://developers.openai.com/codex/plugins#plugin-directory-in-the-codex-app"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-link hover:underline"
+            >
+              Codex desktop app plugin directory
+            </a>
+            .
+          </p>
+        </div>
+        <div className="space-y-2">
+          <h4 className="text-sm font-medium">CLI</h4>
+          <p className="text-xs text-foreground-lighter">Open the Codex CLI by running:</p>
+          <CodeBlock value="codex" language="bash" focusable={false} className="block" />
+          <p className="text-xs text-foreground-lighter">Inside Codex, type:</p>
+          <CodeBlock value="/plugins" language="bash" focusable={false} className="block" />
+          <p className="text-xs text-foreground-lighter">
+            The plugin browser groups plugins by marketplace. Open the Supabase plugin and select{' '}
+            <strong>Install</strong>.
+          </p>
+        </div>
       </div>
     )
   }

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -109,8 +109,16 @@ function PluginInstructions({ client }: { client: PluginClient }) {
     return (
       <div className="space-y-3">
         <p className="text-sm text-foreground-light">
-          Run the following command inside Cursor&apos;s chat to install the Supabase plugin from
-          the{' '}
+          In the{' '}
+          <a
+            href="https://cursor.com/docs/plugins"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            Cursor desktop or web app
+          </a>
+          , type the following in the chat to install the Supabase plugin from the{' '}
           <a
             href="https://cursor.com/marketplace/supabase"
             target="_blank"

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -50,7 +50,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
         <p className="text-sm text-foreground-light">
           Install the Supabase plugin from the{' '}
           <a
-            href="https://claude.com/plugins"
+            href="https://claude.com/plugins/supabase"
             target="_blank"
             rel="noopener noreferrer"
             className="text-brand-link hover:underline"
@@ -153,30 +153,33 @@ export function AgentPluginsPanel() {
       <div className="mt-4 rounded-lg border border-muted p-4">
         <PluginInstructions client={selectedClient} />
       </div>
-      <div className="mt-2 flex gap-4">
-        {selectedClient.docsUrl && (
-          <a
-            href={selectedClient.docsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
-          >
-            <ExternalLink size={10} />
-            {selectedClient.label} plugin docs
-          </a>
-        )}
-        {selectedClient.repoUrl && (
-          <a
-            href={selectedClient.repoUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
-          >
-            <ExternalLink size={10} />
-            Plugin repository
-          </a>
-        )}
-      </div>
+      {(selectedClient.docsUrl || selectedClient.repoUrl) && (
+        <div className="mt-3 flex items-center gap-2 text-xs text-foreground-light">
+          <span>Need help?</span>
+          {selectedClient.docsUrl && (
+            <a
+              href={selectedClient.docsUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-link hover:underline inline-flex items-center"
+            >
+              View {selectedClient.label} plugin docs
+              <ExternalLink className="h-3 w-3 ml-1" />
+            </a>
+          )}
+          {selectedClient.repoUrl && (
+            <a
+              href={selectedClient.repoUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-link hover:underline inline-flex items-center"
+            >
+              Give feedback
+              <ExternalLink className="h-3 w-3 ml-1" />
+            </a>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -48,16 +48,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
     return (
       <div className="space-y-3">
         <p className="text-sm text-foreground-light">
-          Add the Supabase{' '}
-          <a
-            href="https://skills.sh"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-brand-link hover:underline"
-          >
-            agent skills
-          </a>{' '}
-          marketplace, then install the plugin from the{' '}
+          Install the Supabase plugin from the{' '}
           <a
             href="https://claude.com/plugins"
             target="_blank"
@@ -69,7 +60,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
           :
         </p>
         <CodeBlock
-          value={`claude plugin marketplace add supabase/agent-skills\nclaude plugin install supabase@claude-plugins-official`}
+          value={`claude plugin marketplace add anthropics/claude-plugins-official\nclaude plugin install supabase@claude-plugins-official`}
           language="bash"
           focusable={false}
           className="block"

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -98,8 +98,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
           <p className="text-xs text-foreground-lighter">Inside Codex, type:</p>
           <CodeBlock value="/plugins" language="bash" focusable={false} className="block" />
           <p className="text-xs text-foreground-lighter">
-            The plugin browser groups plugins by marketplace. Open the Supabase plugin and select{' '}
-            <strong>Install</strong>.
+            Search for <strong>Supabase</strong> and select <strong>Install plugin</strong>.
           </p>
         </div>
       </div>

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -68,6 +68,11 @@ function PluginInstructions({ client }: { client: PluginClient }) {
           After installing, run <code>/reload-plugins</code> inside Claude Code to activate the
           plugin.
         </p>
+        <p className="text-xs text-foreground-lighter">
+          Installs with <code>--scope user</code> by default, making it available across all your
+          projects. Use <code>--scope project</code> to track it in source control — useful for
+          teams where all contributors and cloud agents should follow the same Supabase guidance.
+        </p>
       </div>
     )
   }

--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -1,0 +1,295 @@
+'use client'
+
+import { Bot, Check, ChevronDown, ExternalLink } from 'lucide-react'
+import { useTheme } from 'next-themes'
+import { useState } from 'react'
+import {
+  Button,
+  cn,
+  Command_Shadcn_,
+  CommandEmpty_Shadcn_,
+  CommandGroup_Shadcn_,
+  CommandInput_Shadcn_,
+  CommandItem_Shadcn_,
+  CommandList_Shadcn_,
+  Popover_Shadcn_,
+  PopoverContent_Shadcn_,
+  PopoverTrigger_Shadcn_,
+} from 'ui'
+import { CodeBlock } from 'ui-patterns/CodeBlock'
+import { ConnectionIcon } from 'ui-patterns/McpUrlBuilder'
+
+interface PluginClient {
+  key: string
+  label: string
+  icon?: string
+  hasDistinctDarkIcon?: boolean
+  repoUrl?: string
+  docsUrl?: string
+}
+
+const PLUGIN_CLIENTS: PluginClient[] = [
+  {
+    key: 'claude-code',
+    label: 'Claude Code',
+    icon: 'claude',
+    repoUrl: 'https://github.com/supabase-community/supabase-plugin',
+    docsUrl: 'https://code.claude.com/docs/en/discover-plugins',
+  },
+  {
+    key: 'codex',
+    label: 'Codex',
+    icon: 'openai',
+    hasDistinctDarkIcon: true,
+    repoUrl: 'https://github.com/supabase-community/codex-plugin',
+    docsUrl: 'https://developers.openai.com/codex/plugins',
+  },
+  {
+    key: 'cursor',
+    label: 'Cursor',
+    icon: 'cursor',
+    repoUrl: 'https://github.com/supabase-community/cursor-plugin',
+    docsUrl: 'https://cursor.com/docs/plugins',
+  },
+  {
+    key: 'gemini-cli',
+    label: 'Gemini CLI',
+    icon: 'gemini-cli',
+    repoUrl: 'https://github.com/supabase-community/gemini-extension',
+    docsUrl: 'https://geminicli.com/docs/extensions/',
+  },
+]
+
+function ClientDropdown({
+  theme,
+  selectedClient,
+  onClientChange,
+}: {
+  theme: 'light' | 'dark'
+  selectedClient: PluginClient
+  onClientChange: (key: string) => void
+}) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Popover_Shadcn_ open={open} onOpenChange={setOpen} modal={false}>
+      <div className="flex">
+        <span className="flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
+          Client
+        </span>
+        <PopoverTrigger_Shadcn_ asChild>
+          <Button
+            size="small"
+            type="default"
+            className="gap-0 rounded-l-none"
+            iconRight={
+              <ChevronDown
+                strokeWidth={1.5}
+                className={cn('transition-transform duration-200', open && 'rotate-180')}
+              />
+            }
+          >
+            <div className="flex items-center gap-2">
+              {selectedClient.icon ? (
+                <ConnectionIcon
+                  connection={selectedClient.icon}
+                  theme={theme}
+                  hasDistinctDarkIcon={selectedClient.hasDistinctDarkIcon}
+                />
+              ) : (
+                <Bot size={12} aria-hidden />
+              )}
+              {selectedClient.label}
+            </div>
+          </Button>
+        </PopoverTrigger_Shadcn_>
+      </div>
+      <PopoverContent_Shadcn_ className="mt-0 p-0 max-w-48" side="bottom" align="start">
+        <Command_Shadcn_>
+          <CommandInput_Shadcn_ placeholder="Search..." />
+          <CommandList_Shadcn_>
+            <CommandEmpty_Shadcn_>No results found.</CommandEmpty_Shadcn_>
+            <CommandGroup_Shadcn_>
+              {PLUGIN_CLIENTS.map((client) => (
+                <CommandItem_Shadcn_
+                  key={client.key}
+                  value={client.key}
+                  onSelect={() => {
+                    onClientChange(client.key)
+                    setOpen(false)
+                  }}
+                  className="flex gap-2 items-center"
+                >
+                  {client.icon ? (
+                    <ConnectionIcon
+                      connection={client.icon}
+                      theme={theme}
+                      hasDistinctDarkIcon={client.hasDistinctDarkIcon}
+                    />
+                  ) : (
+                    <Bot size={12} aria-hidden />
+                  )}
+                  {client.label}
+                  <Check
+                    size={15}
+                    aria-label={client.key === selectedClient.key ? 'selected' : undefined}
+                    className={cn(
+                      'ml-auto',
+                      client.key === selectedClient.key ? 'opacity-100' : 'opacity-0'
+                    )}
+                  />
+                </CommandItem_Shadcn_>
+              ))}
+            </CommandGroup_Shadcn_>
+          </CommandList_Shadcn_>
+        </Command_Shadcn_>
+      </PopoverContent_Shadcn_>
+    </Popover_Shadcn_>
+  )
+}
+
+function PluginInstructions({ client }: { client: PluginClient }) {
+  if (client.key === 'claude-code') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Add the Supabase{' '}
+          <a
+            href="https://skills.sh"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            agent skills
+          </a>{' '}
+          marketplace, then install the plugin from the{' '}
+          <a
+            href="https://claude.com/plugins"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            official Anthropic marketplace
+          </a>
+          :
+        </p>
+        <CodeBlock
+          value={`claude plugin marketplace add supabase/agent-skills\nclaude plugin install supabase@claude-plugins-official`}
+          language="bash"
+          focusable={false}
+          className="block"
+        />
+        <p className="text-xs text-foreground-lighter">
+          After installing, run <code>/reload-plugins</code> inside Claude Code to activate the
+          plugin.
+        </p>
+      </div>
+    )
+  }
+
+  if (client.key === 'codex') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Start Codex and open the plugin browser with <code>/plugins</code>. Search for Supabase
+          and select <strong>Install plugin</strong>.
+        </p>
+        <CodeBlock value="codex" language="bash" focusable={false} className="block" />
+        <p className="text-xs text-foreground-lighter">
+          Then type <code>/plugins</code> inside Codex and search for Supabase. Some plugins ask you
+          to authenticate during install; others wait until first use.
+        </p>
+      </div>
+    )
+  }
+
+  if (client.key === 'cursor') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Run the following command inside Cursor&apos;s chat to install the Supabase plugin from
+          the{' '}
+          <a
+            href="https://cursor.com/marketplace/supabase"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-brand-link hover:underline"
+          >
+            Cursor marketplace
+          </a>
+          :
+        </p>
+        <CodeBlock
+          value="/add-plugin supabase"
+          language="bash"
+          focusable={false}
+          className="block"
+        />
+      </div>
+    )
+  }
+
+  if (client.key === 'gemini-cli') {
+    return (
+      <div className="space-y-3">
+        <p className="text-sm text-foreground-light">
+          Install the Supabase extension for Gemini CLI:
+        </p>
+        <CodeBlock
+          value="gemini extensions install https://github.com/supabase-community/gemini-extension"
+          language="bash"
+          focusable={false}
+          className="block"
+        />
+      </div>
+    )
+  }
+
+  return null
+}
+
+export function AgentPluginsPanel() {
+  const [selectedClientKey, setSelectedClientKey] = useState(PLUGIN_CLIENTS[0].key)
+  const { resolvedTheme } = useTheme()
+
+  const theme = (resolvedTheme as 'light' | 'dark') ?? 'light'
+  const selectedClient =
+    PLUGIN_CLIENTS.find((c) => c.key === selectedClientKey) ?? PLUGIN_CLIENTS[0]
+
+  return (
+    <div className="not-prose">
+      <ClientDropdown
+        theme={theme}
+        selectedClient={selectedClient}
+        onClientChange={setSelectedClientKey}
+      />
+      <div className="mt-4 rounded-lg border border-muted p-4">
+        <PluginInstructions client={selectedClient} />
+      </div>
+      <div className="mt-2 flex gap-4">
+        {selectedClient.docsUrl && (
+          <a
+            href={selectedClient.docsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
+          >
+            <ExternalLink size={10} />
+            {selectedClient.label} plugin docs
+          </a>
+        )}
+        {selectedClient.repoUrl && (
+          <a
+            href={selectedClient.repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex items-center gap-1 text-xs text-foreground-lighter hover:text-foreground-light transition-colors"
+          >
+            <ExternalLink size={10} />
+            Plugin repository
+          </a>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- Adds a new `/guides/getting-started/plugins` docs page with an `AgentPluginsPanel` component
- Per-client install instructions for Claude Code, Codex, Cursor, and Gemini CLI
- Adds the page to the navigation under AI Tools
- Removes the Claude Code plugin subsection from the AI Skills page (now covered here)

Closes [AI-690](https://linear.app/supabase/issue/AI-690/agent-plugins-documentation)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive plugin installation panel to choose from multiple AI coding agents with agent-specific setup instructions and quick links for help/feedback.

* **Documentation**
  * New "Supabase Agent Plugin" guide describing features, included components, and one‑click installation UI.
  * Navigation updated to include the Supabase Agent Plugin guide under Getting Started → AI Tools.
  * AI skills guide streamlined by removing a specific plugin install snippet and clarifying agent compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->