### PR TITLE
feat(mcp): add Claude.ai and ChatGPT connectors with grouped client dropdown

### DIFF
--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { cn, Separator } from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
@@ -16,6 +16,13 @@ import {
 } from './constants'
 import type { McpClient, McpOnCopyCallback } from './types'
 import { getMcpUrl } from './utils/getMcpUrl'
+
+const CLIENT_GROUPS = MCP_CLIENT_GROUPS.map((group) => ({
+  heading: group.heading,
+  clients: group.keys
+    .map((key) => MCP_CLIENTS.find((c) => c.key === key))
+    .filter(Boolean) as (typeof MCP_CLIENTS)[number][],
+}))
 
 export interface McpConfigPanelProps {
   baseUrl?: string
@@ -44,15 +51,6 @@ export function McpConfigPanel({
   const [readonly, setReadonly] = useState(false)
   const [selectedFeatures, setSelectedFeatures] = useState<string[]>([])
   const [selectedClient, setSelectedClient] = useState(initialSelectedClient ?? MCP_CLIENTS[0])
-
-  const clientGroups = useRef(
-    MCP_CLIENT_GROUPS.map((group) => ({
-      heading: group.heading,
-      clients: group.keys
-        .map((key) => MCP_CLIENTS.find((c) => c.key === key))
-        .filter(Boolean) as (typeof MCP_CLIENTS)[number][],
-    }))
-  )
 
   const supportedFeatures = isPlatform ? FEATURE_GROUPS_PLATFORM : FEATURE_GROUPS_NON_PLATFORM
   const selectedFeaturesSupported = useMemo(() => {
@@ -119,7 +117,7 @@ export function McpConfigPanel({
         <ClientSelectDropdown
           label="Client"
           clients={MCP_CLIENTS}
-          groups={clientGroups.current}
+          groups={CLIENT_GROUPS}
           selectedClient={selectedClient}
           onClientChange={handleClientChange}
           theme={theme}

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useMemo, useState } from 'react'
+import React, { useMemo, useRef, useState } from 'react'
 import { cn, Separator } from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
@@ -44,6 +44,15 @@ export function McpConfigPanel({
   const [readonly, setReadonly] = useState(false)
   const [selectedFeatures, setSelectedFeatures] = useState<string[]>([])
   const [selectedClient, setSelectedClient] = useState(initialSelectedClient ?? MCP_CLIENTS[0])
+
+  const clientGroups = useRef(
+    MCP_CLIENT_GROUPS.map((group) => ({
+      heading: group.heading,
+      clients: group.keys
+        .map((key) => MCP_CLIENTS.find((c) => c.key === key))
+        .filter(Boolean) as (typeof MCP_CLIENTS)[number][],
+    }))
+  )
 
   const supportedFeatures = isPlatform ? FEATURE_GROUPS_PLATFORM : FEATURE_GROUPS_NON_PLATFORM
   const selectedFeaturesSupported = useMemo(() => {
@@ -110,12 +119,7 @@ export function McpConfigPanel({
         <ClientSelectDropdown
           label="Client"
           clients={MCP_CLIENTS}
-          groups={MCP_CLIENT_GROUPS.map((group) => ({
-            heading: group.heading,
-            clients: group.keys
-              .map((key) => MCP_CLIENTS.find((c) => c.key === key))
-              .filter(Boolean) as (typeof MCP_CLIENTS)[number][],
-          }))}
+          groups={clientGroups.current}
           selectedClient={selectedClient}
           onClientChange={handleClientChange}
           theme={theme}

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -43,7 +43,9 @@ export function McpConfigPanel({
 }: McpConfigPanelProps) {
   const [readonly, setReadonly] = useState(false)
   const [selectedFeatures, setSelectedFeatures] = useState<string[]>([])
-  const [selectedClient, setSelectedClient] = useState(initialSelectedClient ?? MCP_CLIENTS[0])
+  const [selectedClient, setSelectedClient] = useState(
+    initialSelectedClient ?? MCP_CLIENTS.find((c) => c.key === 'claude-code') ?? MCP_CLIENTS[0]
+  )
 
   const supportedFeatures = isPlatform ? FEATURE_GROUPS_PLATFORM : FEATURE_GROUPS_NON_PLATFORM
   const selectedFeaturesSupported = useMemo(() => {

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -43,9 +43,7 @@ export function McpConfigPanel({
 }: McpConfigPanelProps) {
   const [readonly, setReadonly] = useState(false)
   const [selectedFeatures, setSelectedFeatures] = useState<string[]>([])
-  const [selectedClient, setSelectedClient] = useState(
-    initialSelectedClient ?? MCP_CLIENTS.find((c) => c.key === 'claude-code') ?? MCP_CLIENTS[0]
-  )
+  const [selectedClient, setSelectedClient] = useState(initialSelectedClient ?? MCP_CLIENTS[0])
 
   const supportedFeatures = isPlatform ? FEATURE_GROUPS_PLATFORM : FEATURE_GROUPS_NON_PLATFORM
   const selectedFeaturesSupported = useMemo(() => {

--- a/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/McpConfigPanel.tsx
@@ -8,7 +8,12 @@ import { InfoTooltip } from '../info-tooltip'
 import { ClientSelectDropdown } from './components/ClientSelectDropdown'
 import { McpConfigurationDisplay } from './components/McpConfigurationDisplay'
 import { McpConfigurationOptions } from './components/McpConfigurationOptions'
-import { FEATURE_GROUPS_NON_PLATFORM, FEATURE_GROUPS_PLATFORM, MCP_CLIENTS } from './constants'
+import {
+  FEATURE_GROUPS_NON_PLATFORM,
+  FEATURE_GROUPS_PLATFORM,
+  MCP_CLIENT_GROUPS,
+  MCP_CLIENTS,
+} from './constants'
 import type { McpClient, McpOnCopyCallback } from './types'
 import { getMcpUrl } from './utils/getMcpUrl'
 
@@ -105,6 +110,12 @@ export function McpConfigPanel({
         <ClientSelectDropdown
           label="Client"
           clients={MCP_CLIENTS}
+          groups={MCP_CLIENT_GROUPS.map((group) => ({
+            heading: group.heading,
+            clients: group.keys
+              .map((key) => MCP_CLIENTS.find((c) => c.key === key))
+              .filter(Boolean) as (typeof MCP_CLIENTS)[number][],
+          }))}
           selectedClient={selectedClient}
           onClientChange={handleClientChange}
           theme={theme}

--- a/packages/ui-patterns/src/McpUrlBuilder/components/ClientSelectDropdown.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/components/ClientSelectDropdown.tsx
@@ -19,10 +19,16 @@ import {
 import type { McpClient } from '../types'
 import { ConnectionIcon } from './ConnectionIcon'
 
+export interface ClientGroup {
+  heading: string
+  clients: McpClient[]
+}
+
 interface ClientSelectDropdownProps {
   theme?: 'light' | 'dark'
   label?: string
   clients: McpClient[]
+  groups?: ClientGroup[]
   selectedClient: McpClient
   onClientChange: (clientKey: string) => void
 }
@@ -31,6 +37,7 @@ export const ClientSelectDropdown = ({
   theme = 'light',
   label = 'Client',
   clients,
+  groups,
   selectedClient,
   onClientChange,
 }: ClientSelectDropdownProps) => {
@@ -39,6 +46,33 @@ export const ClientSelectDropdown = ({
   function onSelectClient(key: string) {
     onClientChange(key)
     setOpen(false)
+  }
+
+  function renderClient(client: McpClient) {
+    return (
+      <CommandItem_Shadcn_
+        key={client.key}
+        value={client.key}
+        onSelect={() => onSelectClient(client.key)}
+        className="flex gap-2 items-center"
+      >
+        {client.icon ? (
+          <ConnectionIcon
+            connection={client.icon}
+            theme={theme}
+            hasDistinctDarkIcon={client.hasDistinctDarkIcon}
+          />
+        ) : (
+          <Bot size={12} aria-hidden={true} />
+        )}
+        {client.label}
+        <Check
+          aria-label={client.key === selectedClient.key ? 'selected' : undefined}
+          size={15}
+          className={cn('ml-auto', client.key === selectedClient.key ? 'opacity-100' : 'opacity-0')}
+        />
+      </CommandItem_Shadcn_>
+    )
   }
 
   return (
@@ -79,38 +113,15 @@ export const ClientSelectDropdown = ({
           <CommandInput_Shadcn_ placeholder="Search..." />
           <CommandList_Shadcn_>
             <CommandEmpty_Shadcn_>No results found.</CommandEmpty_Shadcn_>
-            <CommandGroup_Shadcn_>
-              {clients.map((client) => (
-                <CommandItem_Shadcn_
-                  key={client.key}
-                  value={client.key}
-                  onSelect={() => {
-                    onSelectClient(client.key)
-                    setOpen(false)
-                  }}
-                  className="flex gap-2 items-center"
-                >
-                  {client.icon ? (
-                    <ConnectionIcon
-                      connection={client.icon}
-                      theme={theme}
-                      hasDistinctDarkIcon={client.hasDistinctDarkIcon}
-                    />
-                  ) : (
-                    <Bot size={12} aria-hidden={true} />
-                  )}
-                  {client.label}
-                  <Check
-                    aria-label={client.key === selectedClient.key ? 'selected' : undefined}
-                    size={15}
-                    className={cn(
-                      'ml-auto',
-                      client.key === selectedClient.key ? 'opacity-100' : 'opacity-0'
-                    )}
-                  />
-                </CommandItem_Shadcn_>
-              ))}
-            </CommandGroup_Shadcn_>
+            {groups ? (
+              groups.map((group) => (
+                <CommandGroup_Shadcn_ key={group.heading} heading={group.heading}>
+                  {group.clients.map(renderClient)}
+                </CommandGroup_Shadcn_>
+              ))
+            ) : (
+              <CommandGroup_Shadcn_>{clients.map(renderClient)}</CommandGroup_Shadcn_>
+            )}
           </CommandList_Shadcn_>
         </Command_Shadcn_>
       </PopoverContent_Shadcn_>

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -554,7 +554,39 @@ export const MCP_CLIENTS: McpClient[] = [
       </>
     ),
   },
+  {
+    key: 'claude-ai',
+    label: 'Claude.ai',
+    icon: 'claude',
+    externalDocsUrl: 'https://claude.com/docs/connectors/overview',
+    generateDeepLink: () =>
+      'https://claude.ai/directory/connectors/11ca66fc-1e98-49d5-ab9b-7cb4672a8f10',
+  },
+  {
+    key: 'chatgpt',
+    label: 'ChatGPT',
+    icon: 'openai',
+    hasDistinctDarkIcon: true,
+    externalDocsUrl: 'https://chatgpt.com/features/apps/',
+    generateDeepLink: () =>
+      'https://chatgpt.com/apps/supabase/asdk_app_69d3e5ee6a708191baa733f7b8931995',
+  },
 ]
+
+export const MCP_CLIENT_GROUPS = [
+  {
+    heading: 'AI Agent CLI',
+    keys: ['claude-code', 'codex', 'gemini-cli', 'opencode', 'factory'],
+  },
+  {
+    heading: 'Web Clients',
+    keys: ['claude-ai', 'chatgpt', 'goose'],
+  },
+  {
+    heading: 'IDE',
+    keys: ['cursor', 'vscode', 'antigravity', 'kiro', 'windsurf'],
+  },
+] as const
 
 export const DEFAULT_MCP_URL_PLATFORM = 'http://localhost:8080/mcp'
 export const DEFAULT_MCP_URL_NON_PLATFORM = 'http://localhost:54321/mcp'

--- a/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
+++ b/packages/ui-patterns/src/McpUrlBuilder/constants.tsx
@@ -67,22 +67,6 @@ export const FEATURE_GROUPS_NON_PLATFORM = FEATURE_GROUPS_PLATFORM.filter((group
 /** Only set hasDistinctDarkIcon: true when the client has a separate -icon-dark.svg that looks different. Otherwise the same -icon.svg is used for both themes. */
 export const MCP_CLIENTS: McpClient[] = [
   {
-    key: 'cursor',
-    label: 'Cursor',
-    icon: 'cursor',
-    configFile: '.cursor/mcp.json',
-    externalDocsUrl: 'https://docs.cursor.com/context/mcp',
-    generateDeepLink: (config) => {
-      const name = 'supabase'
-      const mcpUrl = getMcpUrl(config)
-      const serverConfig = {
-        url: mcpUrl,
-      }
-      const base64Config = Buffer.from(JSON.stringify(serverConfig)).toString('base64')
-      return `cursor://anysphere.cursor-deeplink/mcp/install?name=${name}&config=${encodeURIComponent(base64Config)}`
-    },
-  },
-  {
     key: 'claude-code',
     label: 'Claude Code',
     icon: 'claude',
@@ -136,6 +120,22 @@ export const MCP_CLIENTS: McpClient[] = [
         </p>
       </div>
     ),
+  },
+  {
+    key: 'cursor',
+    label: 'Cursor',
+    icon: 'cursor',
+    configFile: '.cursor/mcp.json',
+    externalDocsUrl: 'https://docs.cursor.com/context/mcp',
+    generateDeepLink: (config) => {
+      const name = 'supabase'
+      const mcpUrl = getMcpUrl(config)
+      const serverConfig = {
+        url: mcpUrl,
+      }
+      const base64Config = Buffer.from(JSON.stringify(serverConfig)).toString('base64')
+      return `cursor://anysphere.cursor-deeplink/mcp/install?name=${name}&config=${encodeURIComponent(base64Config)}`
+    },
   },
   {
     key: 'vscode',

--- a/packages/ui-patterns/src/McpUrlBuilder/index.ts
+++ b/packages/ui-patterns/src/McpUrlBuilder/index.ts
@@ -1,4 +1,4 @@
-export { ClientSelectDropdown } from './components/ClientSelectDropdown'
+export { ClientSelectDropdown, type ClientGroup } from './components/ClientSelectDropdown'
 export { ConnectionIcon } from './components/ConnectionIcon'
 export { McpConfigurationDisplay } from './components/McpConfigurationDisplay'
 export { McpConfigurationOptions } from './components/McpConfigurationOptions'
@@ -8,6 +8,7 @@ export {
   FEATURE_GROUPS_PLATFORM,
   FEATURE_GROUPS_NON_PLATFORM,
   MCP_CLIENTS,
+  MCP_CLIENT_GROUPS,
 } from './constants'
 export { getMcpUrl } from './utils/getMcpUrl'
 export { createMcpCopyHandler, type McpCopyType } from './utils/createMcpCopyHandler'


### PR DESCRIPTION
## Summary

- Adds Claude.ai and ChatGPT as MCP connectors in the existing `/guides/getting-started/mcp` dropdown

<img width="1511" height="744" alt="Screenshot 2026-05-04 at 14 53 24" src="https://github.com/user-attachments/assets/8de5b3a4-56e2-45a7-bcce-1051baac30cd" />

- Groups all MCP clients into three categories: **Web Clients** (Claude.ai, ChatGPT, Goose), **AI Agent CLIs** (Claude Code, Codex, Gemini CLI, Opencode, Factory), **IDE** (Cursor, VS Code, Antigravity, Kiro, Windsurf)

<img width="1511" height="744" alt="image" src="https://github.com/user-attachments/assets/eb3ecdaa-878a-4f87-abfe-41a9144db5b8" />

- Both connectors use `generateDeepLink` to render a one-click "Connect" button linking to the Supabase connector directory entry
- Includes external docs links for each connector
- Sets Claude Code as the default selected client

Closes [AI-699](https://linear.app/supabase/issue/AI-699/add-claudeai-and-chatgpt-connectors-to-mcp-docs)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Claude.ai and ChatGPT as selectable client options.
  * Reorganized the client selector into categorized groups (AI Agent CLI, Web Clients, IDE) for easier discovery.
  * Improved dropdown rendering and selection behavior for more consistent visuals and interaction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->