### PR TITLE
fix(studio): restore WAL segment color in disk size breakdown bar

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/ui/DiskSpaceBar.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/ui/DiskSpaceBar.tsx
@@ -129,7 +129,7 @@ export const DiskSpaceBar = ({ form }: DiskSpaceBarProps) => {
                 </div>
 
                 <div
-                  className="relative overflow-hidden transition-all duration-500 ease-in-out bg-_secondary"
+                  className="relative overflow-hidden transition-all duration-500 ease-in-out bg-[hsl(var(--secondary-default))]"
                   style={{
                     width: `${showNewSize ? newUsedPercentageWAL : usedPercentageWAL}%`,
                   }}
@@ -216,7 +216,7 @@ export const DiskSpaceBar = ({ form }: DiskSpaceBarProps) => {
           <LegendItem
             name="WAL"
             size={diskBreakdownBytes.walSizeBytes}
-            color="bg-_secondary"
+            color="bg-[hsl(var(--secondary-default))]"
             description="Total space on disk used by the write-ahead log."
           />
 


### PR DESCRIPTION
## Summary

- The Tailwind v4 migration left `bg-_secondary` unresolved, so the WAL segment of the disk size breakdown bar (and its legend dot) rendered transparent — visible as the gap between Database and System in the screenshot on FE-3138.
- Switch both usages to `bg-[hsl(var(--secondary-default))]` to bypass the broken utility while still pulling from the existing per-theme CSS variable, restoring the original purple.

Closes [FE-3138](https://linear.app/supabase/issue/FE-3138/adjust-tiiiny-v4-disk-size-breakdown-ui).

## Test plan

- [x] On a project's Settings → Compute and Disk page, the WAL slice in the disk size bar renders in purple
- [x] The "WAL" legend dot below the bar matches that purple
- [x] Verify in light, dark, and classic-dark themes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of the WAL segment in the disk space visualization to improve consistency with the design system's color palette.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->