### PR TITLE
www: properly surface not-found blog slugs

### DIFF
--- a/apps/www/app/blog/[slug]/page.tsx
+++ b/apps/www/app/blog/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next'
 import { draftMode } from 'next/headers'
+import { notFound } from 'next/navigation'
 
 import BlogPostClient from './BlogPostClient'
 import authors from '@/lib/authors.json'
@@ -181,6 +182,8 @@ export default async function BlogPostPage({ params }: { params: Promise<Params>
       </>
     )
   } catch (err) {
+    if (err instanceof Error && (err as Error & { code?: string }).code === 'POST_NOT_FOUND')
+      notFound()
     throw err
   }
 }

--- a/apps/www/lib/posts.tsx
+++ b/apps/www/lib/posts.tsx
@@ -1,6 +1,7 @@
 import fs from 'fs'
-import matter from 'gray-matter'
 import path from 'path'
+import matter from 'gray-matter'
+
 import { validateBlogFrontmatterImages } from './blog-images'
 import { generateReadingTime } from './helpers'
 
@@ -171,6 +172,10 @@ export const getPostdata = async (slug: string, directory: string) => {
    * even if the mdx file is date namednamed like '2022-01-01-blog-post.mdx'
    */
   const found = folderfiles.filter((x) => x.includes(slug))[0]
+
+  if (!found) {
+    throw Object.assign(new Error(`Post not found: ${slug}`), { code: 'POST_NOT_FOUND' })
+  }
 
   const fullPath = path.join(postDirectory, found)
   const postContent = fs.readFileSync(fullPath, 'utf8')


### PR DESCRIPTION
Recent changes to blog pages surfaced existing errors because we stopped silently swallowing errors. We were not properly handing the case when the requested slug was not found, now this properly calls notFound()

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for missing blog posts to display a proper "Not Found" page instead of showing an application error when users attempt to access unavailable blog content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->