### PR TITLE
fix: Fix the admonition in `pg_net` page in docs

### DIFF
--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -56,11 +56,10 @@ Creates an HTTP GET request returning the request's ID. HTTP requests are not st
 
 ### Signature [#get-signature]
 
-<Admonition type="caution">
-  This is a Postgres [SECURITY
-  DEFINER](/docs/guides/database/postgres/row-level-security#use-security-definer-functions)
-  function.
-</Admonition>
+<Admonition
+  type="caution"
+  description="This is a Postgres [SECURITY DEFINER](/docs/guides/database/postgres/row-level-security#use-security-definer-functions) function."
+/>
 
 ```sql
 net.http_get(

--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -57,9 +57,9 @@ Creates an HTTP GET request returning the request's ID. HTTP requests are not st
 ### Signature [#get-signature]
 
 <Admonition type="caution">
-
-This is a Postgres [SECURITY DEFINER](/docs/guides/database/postgres/row-level-security#use-security-definer-functions) function.
-
+  This is a Postgres [SECURITY
+  DEFINER](/docs/guides/database/postgres/row-level-security#use-security-definer-functions)
+  function.
 </Admonition>
 
 ```sql


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved formatting of security guidance in the pg_net extension documentation for better clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->