### PR TITLE
fix(studio): escape SQL literals in logs query builders and validate user IDs

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UserLogs.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserLogs.tsx
@@ -19,8 +19,12 @@ interface UserLogsProps {
   user: User
 }
 
-const API_LOGS_QUERY = (userId: string) =>
-  `select\n  cast(timestamp as datetime) as timestamp,\n  event_message, metadata \nfrom edge_logs \nWHERE (\n  metadata[SAFE_OFFSET(0)].request[SAFE_OFFSET(0)].sb[SAFE_OFFSET(0)].auth_user\n    = '${userId}'\n)\nlimit 100`
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const API_LOGS_QUERY = (userId: string) => {
+  const safeUserId = UUID_REGEX.test(userId) ? userId : ''
+  return `select\n  cast(timestamp as datetime) as timestamp,\n  event_message, metadata \nfrom edge_logs \nWHERE (\n  metadata[SAFE_OFFSET(0)].request[SAFE_OFFSET(0)].sb[SAFE_OFFSET(0)].auth_user\n    = '${safeUserId}'\n)\nlimit 100`
+}
 
 export const UserLogs = ({ user }: UserLogsProps) => {
   const { ref } = useParams()

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -3,8 +3,9 @@ import dayjs from 'dayjs'
 import { DEFAULT_LOG_TYPES } from './UnifiedLogs.constants'
 import { QuerySearchParamsType, SearchParamsType } from './UnifiedLogs.types'
 
-// Escape single quotes in BigQuery string literals to prevent SQL injection
-const escapeSqlLiteral = (value: string): string => value.replace(/'/g, "\\'")
+// Escape single quotes in BigQuery string literals using SQL-standard quote doubling.
+// Prefer '' over \' so backslashes in the input cannot neutralize the escape.
+const escapeSqlLiteral = (value: string): string => value.replace(/'/g, "''")
 
 // Pagination and control parameters
 const PAGINATION_PARAMS = ['sort', 'start', 'size', 'uuid', 'cursor', 'direction', 'live'] as const

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -3,6 +3,9 @@ import dayjs from 'dayjs'
 import { DEFAULT_LOG_TYPES } from './UnifiedLogs.constants'
 import { QuerySearchParamsType, SearchParamsType } from './UnifiedLogs.types'
 
+// Escape single quotes in BigQuery string literals to prevent SQL injection
+const escapeSqlLiteral = (value: string): string => value.replace(/'/g, "\\'")
+
 // Pagination and control parameters
 const PAGINATION_PARAMS = ['sort', 'start', 'size', 'uuid', 'cursor', 'direction', 'live'] as const
 
@@ -29,16 +32,18 @@ const buildQueryConditions = (search: QuerySearchParamsType) => {
 
     // Handle array filters (IN clause)
     if (Array.isArray(value) && value.length > 0) {
-      whereConditions.push(`${key} IN (${value.map((v) => `'${v}'`).join(',')})`)
+      whereConditions.push(
+        `${key} IN (${value.map((v) => `'${escapeSqlLiteral(String(v))}'`).join(',')})`
+      )
       return
     }
 
     // Handle scalar values
     if (value !== null && value !== undefined) {
       if (['host', 'pathname'].includes(key)) {
-        whereConditions.push(`${key} LIKE '%${value}%'`)
+        whereConditions.push(`${key} LIKE '%${escapeSqlLiteral(String(value))}%'`)
       } else {
-        whereConditions.push(`${key} = '${value}'`)
+        whereConditions.push(`${key} = '${escapeSqlLiteral(String(value))}'`)
       }
     }
   })
@@ -379,16 +384,18 @@ const buildFacetWhere = (search: QuerySearchParamsType, excludeField: string): s
 
     // Handle array filters (IN clause)
     if (Array.isArray(value) && value.length > 0) {
-      conditions.push(`${key} IN (${value.map((v) => `'${v}'`).join(',')})`)
+      conditions.push(
+        `${key} IN (${value.map((v) => `'${escapeSqlLiteral(String(v))}'`).join(',')})`
+      )
       return
     }
 
     // Handle scalar values
     if (value !== null && value !== undefined) {
       if (['host', 'pathname'].includes(key)) {
-        conditions.push(`${key} LIKE '%${value}%'`)
+        conditions.push(`${key} LIKE '%${escapeSqlLiteral(String(value))}%'`)
       } else {
-        conditions.push(`${key} = '${value}'`)
+        conditions.push(`${key} = '${escapeSqlLiteral(String(value))}'`)
       }
     }
   })
@@ -413,7 +420,7 @@ ${facet}_count AS (
   FROM unified_logs
   ${buildFacetWhere(search, `${facet}`) || `WHERE ${facet} IS NOT NULL`}
   ${buildFacetWhere(search, `${facet}`) ? ` AND ${facet} IS NOT NULL` : ''}
-  ${!!facetSearch ? `AND ${facet} LIKE '%${facetSearch}%'` : ''}
+  ${!!facetSearch ? `AND ${facet} LIKE '%${escapeSqlLiteral(facetSearch)}%'` : ''}
   GROUP BY ${facet}
   LIMIT ${MAX_FACETS_QUANTITY}
 )

--- a/apps/studio/pages/api/platform/projects/[ref]/config/index.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/index.ts
@@ -24,8 +24,7 @@ const handleGetAll = async (_req: NextApiRequest, res: NextApiResponse) => {
     db_anon_role: 'anon',
     db_extra_search_path: 'public',
     db_schema: 'public, storage',
-    jwt_secret:
-      process.env.AUTH_JWT_SECRET ?? 'super-secret-jwt-token-with-at-least-32-characters-long',
+    jwt_secret: process.env.AUTH_JWT_SECRET ?? '',
     max_rows: 100,
     role_claim_key: '.role',
   })

--- a/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
@@ -22,8 +22,7 @@ const handleGet = async (_req: NextApiRequest, res: NextApiResponse) => {
     db_anon_role: 'anon',
     db_extra_search_path: process.env.PGRST_DB_EXTRA_SEARCH_PATH ?? 'public',
     db_schema: process.env.PGRST_DB_SCHEMAS ?? 'public,storage,graphql_public',
-    jwt_secret:
-      process.env.AUTH_JWT_SECRET ?? 'super-secret-jwt-token-with-at-least-32-characters-long',
+    jwt_secret: process.env.AUTH_JWT_SECRET ?? '',
     max_rows: Number(process.env.PGRST_DB_MAX_ROWS) || 1000,
     role_claim_key: '.role',
   }


### PR DESCRIPTION
Closes #45544
Closes #45545

## Summary

Three security fixes continuing the ongoing `safeSql` / identifier-escaping migration (see #44727, #44674, #44589):

- **`UnifiedLogs.queries.ts`** — `buildQueryConditions` and `buildFacetWhere` embed user-controlled URL parameter values into BigQuery WHERE clauses without escaping. A value containing a single quote (e.g. `it's`) would malform the query; a crafted value like `' OR '1'='1` could manipulate filter logic. Added `escapeSqlLiteral` (uses SQL-standard quote doubling `''` to avoid backslash injection) and applied it to all string values in IN-clause lists, LIKE patterns, and equality conditions. Also applied to `facetSearch` in `getFacetCountCTE`.

- **`UserLogs.tsx`** — `API_LOGS_QUERY` builds a BigQuery SQL string by interpolating `user.id` directly. In practice `user.id` is a database-generated UUID and safe, but the pattern is fragile. Added a UUID regex guard so only well-formed UUIDs are embedded.

- **`config/postgrest.ts` / `config/index.ts`** — Both self-hosted PostgREST config endpoints returned the well-known Supabase CLI default JWT secret (`super-secret-jwt-token-with-at-least-32-characters-long`) when `AUTH_JWT_SECRET` is unset. Replaced the fallback with an empty string so the known-default is never exposed via the API response.

## Affected files

| File | Change |
|---|---|
| `apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts` | Add `escapeSqlLiteral`; apply to all WHERE-clause value interpolations |
| `apps/studio/components/interfaces/Auth/Users/UserLogs.tsx` | Validate UUID before embedding in log query |
| `apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts` | Remove hardcoded JWT secret fallback |
| `apps/studio/pages/api/platform/projects/[ref]/config/index.ts` | Remove hardcoded JWT secret fallback |

## Test plan

- [ ] Open Unified Logs with a filter value containing a single quote (e.g. host = `it's.example.com`). Verify the query runs without error.
- [ ] Verify a user with a valid UUID still sees their logs in `UserLogs`.
- [ ] In self-hosted mode, verify PostgREST config endpoint returns `""` for `jwt_secret` when `AUTH_JWT_SECRET` is unset (rather than the well-known default).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)