### PR TITLE
fix(studio): replace empty error closures with toast notifications in analytics mutations

### DIFF
--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -80,7 +80,11 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
   const { mutateAsync: updateFDW } = useFDWUpdateMutation()
   const { mutateAsync: dropForeignTable } = useFDWDropForeignTableMutation()
   const { mutateAsync: deleteNamespaceTable, isPending: isDeletingNamespaceTable } =
-    useIcebergNamespaceTableDeleteMutation({ onError: () => {} })
+    useIcebergNamespaceTableDeleteMutation({
+      onError: (error: any) => {
+        toast.error(`Failed to delete namespace table: ${error.message}`)
+      },
+    })
   const { mutateAsync: updatePublication } = useUpdatePublicationMutation()
   const { mutateAsync: startPipeline } = useStartPipelineMutation()
 

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/NamespaceWithTables/TableRowComponent.tsx
@@ -241,7 +241,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
       toast.success('Successfully removed table!')
       setShowRemoveTableModal(false)
     } catch (error: any) {
-      toast.error(`Failed to remove table: ${error.message}`)
+      // Error handled by mutation onError
     } finally {
       setIsRemovingTable(false)
     }
@@ -280,7 +280,7 @@ export const TableRowComponent = ({ table, schema, namespace }: TableRowComponen
 
       toast.success(`Successfully removed table "${table.name}"!`)
     } catch (error: any) {
-      toast.error(`Failed to remove table: ${error.message}`)
+      // Error handled by mutation onError
     } finally {
       setIsRemovingTable(false)
     }

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketAssociatedEntities.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/useAnalyticsBucketAssociatedEntities.tsx
@@ -1,4 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { toast } from 'sonner'
 
 import {
   getAnalyticsBucketPublicationName,
@@ -98,17 +99,31 @@ export const useAnalyticsBucketDeleteCleanUp = ({
     destination,
   } = useAnalyticsBucketAssociatedEntities({ projectRef, bucketId: bucketId })
 
-  // Default error handlers from all mutations will be silenced
+  // Default error handlers from all mutations were previously silenced, now reporting via toast
   const { mutateAsync: deleteFDW, isPending: isDeletingWrapper } = useFDWDeleteMutation({
-    onError: () => {},
+    onError: (error: any) => {
+      toast.error(`Failed to delete FDW wrapper: ${error.message}`)
+    },
   })
   const { mutateAsync: deleteS3AccessKey, isPending: isDeletingKey } = useS3AccessKeyDeleteMutation(
-    { onError: () => {} }
+    {
+      onError: (error: any) => {
+        toast.error(`Failed to delete S3 access key: ${error.message}`)
+      },
+    }
   )
   const { mutateAsync: deletePublication, isPending: isDeletingPublication } =
-    useDeletePublicationMutation({ onError: () => {} })
+    useDeletePublicationMutation({
+      onError: (error: any) => {
+        toast.error(`Failed to delete publication: ${error.message}`)
+      },
+    })
   const { mutateAsync: deletePipeline, isPending: isDeletingPipeline } =
-    useDeleteDestinationPipelineMutation({ onError: () => {} })
+    useDeleteDestinationPipelineMutation({
+      onError: (error: any) => {
+        toast.error(`Failed to delete pipeline: ${error.message}`)
+      },
+    })
 
   const isDeleting =
     isDeletingWrapper || isDeletingKey || isDeletingPublication || isDeletingPipeline


### PR DESCRIPTION
This PR patches a critical architectural flaw where destructive TanStack Query mutations were swallowing errors with empty closures (`onError: () => {}`). 

Specifically, this updates `useAnalyticsBucketAssociatedEntities.tsx` and `TableRowComponent.tsx` to properly catch and surface errors via `toast.error` during namespace table and analytics bucket cleanup operations, ensuring the UI does not fail silently if the API rejects the mutation.

Fixes #45547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error visibility during storage cleanup by displaying specific error messages to users when deletion of associated entities fails (data wrapper, access keys, publications, pipelines).
  * Unified error reporting for table/namespace removals so failed deletions now surface clear toast notifications instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->