### PR TITLE
feat(studio): wire list-page shortcuts on database replication and migrations pages

### DIFF
--- a/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
+++ b/apps/studio/components/interfaces/Database/Migrations/Migrations.tsx
@@ -1,6 +1,6 @@
 import { SupportCategories } from '@supabase/shared-types/out/constants'
 import { Search } from 'lucide-react'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   Button,
   Card,
@@ -28,10 +28,24 @@ import { DatabaseMigration, useMigrationsQuery } from '@/data/database/migration
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 import { formatMigrationVersionLabel, parseMigrationVersion } from '@/lib/migration-utils'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 const Migrations = () => {
   const [search, setSearch] = useState('')
   const [selectedMigration, setSelectedMigration] = useState<DatabaseMigration>()
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useShortcut(
+    SHORTCUT_IDS.LIST_PAGE_FOCUS_SEARCH,
+    () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
+    { label: 'Search migrations' }
+  )
+
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_RESET_FILTERS, () => setSearch(''))
 
   const { data: project } = useSelectedProjectQuery()
   const {
@@ -96,6 +110,7 @@ const Migrations = () => {
             {data.length > 0 && (
               <div className="flex flex-col gap-y-4">
                 <Input
+                  ref={searchInputRef}
                   size="tiny"
                   placeholder="Search for a migration"
                   value={search}

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -36,6 +36,7 @@ import {
 } from './useIsETLPrivateAlpha'
 import { AlertError } from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
+import { Shortcut } from '@/components/ui/Shortcut'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { useReplicationDestinationsQuery } from '@/data/replication/destinations-query'
 import { replicationKeys } from '@/data/replication/keys'
@@ -44,6 +45,8 @@ import { useReplicationPipelinesQuery } from '@/data/replication/pipelines-query
 import { useReplicationSourcesQuery } from '@/data/replication/sources-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { DOCS_URL } from '@/lib/constants'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export const Destinations = () => {
   const queryClient = useQueryClient()
@@ -65,6 +68,7 @@ export const Destinations = () => {
           : null
 
   const prefetchedRef = useRef(false)
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const [filterString, setFilterString] = useState<string>('')
   const [statusRefetchInterval, setStatusRefetchInterval] = useState<number | false>(5000)
   const [showDisableExternalReplicationDialog, setShowDisableExternalReplicationDialog] =
@@ -143,6 +147,17 @@ export const Destinations = () => {
     setDestinationType(newDestinationDefaultType)
   }
 
+  useShortcut(
+    SHORTCUT_IDS.LIST_PAGE_FOCUS_SEARCH,
+    () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
+    { label: 'Search destinations' }
+  )
+
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_RESET_FILTERS, () => setFilterString(''))
+
   useEffect(() => {
     if (
       projectRef &&
@@ -190,6 +205,7 @@ export const Destinations = () => {
         <div className="flex items-center justify-between">
           <div className="flex items-center">
             <Input
+              ref={searchInputRef}
               placeholder="Filter destinations"
               size="tiny"
               icon={<Search />}
@@ -209,14 +225,22 @@ export const Destinations = () => {
             />
           </div>
           <div className="flex items-center gap-x-2">
-            <Button
-              type="default"
-              icon={<Plus />}
-              disabled={!newDestinationDefaultType}
-              onClick={openDestinationPanel}
+            <Shortcut
+              id={SHORTCUT_IDS.LIST_PAGE_NEW_ITEM}
+              label="Add destination"
+              onTrigger={openDestinationPanel}
+              options={{ enabled: !!newDestinationDefaultType }}
+              side="bottom"
             >
-              Add destination
-            </Button>
+              <Button
+                type="default"
+                icon={<Plus />}
+                disabled={!newDestinationDefaultType}
+                onClick={openDestinationPanel}
+              >
+                Add destination
+              </Button>
+            </Shortcut>
             <DocsButton href={`${DOCS_URL}/guides/database/replication`} />
             {canDisableExternalReplication && (
               <DropdownMenu>


### PR DESCRIPTION
## Summary

Wires the existing `list-page.*` shortcuts up to the Database → Replication and Database → Migrations pages, so they get the same hotkey behavior as Roles, Tables, Publications, etc. No new shortcut IDs were added — these reuse the already-registered bindings.

**Migrations page**
- `Shift+F` → focus the migration search input (label: "Search migrations")
- `F` then `C` → clear the search filter

**Replication / Destinations page**
- `Shift+F` → focus the destinations filter input (label: "Search destinations")
- `F` then `C` → clear the filter
- `Shift+N` → open the Add Destination panel. Wrapped with `<Shortcut>` so the keybind tooltip shows on the toolbar button on hover, and gated on `!!newDestinationDefaultType` so it stays inert when no destination type is available.

All three are surfaced in the `Cmd+K` command menu under "Shortcuts" while on the respective page (via `registerInCommandMenu: true` on the registry entries). They are intentionally **not** listed in Account → Preferences — list-page shortcuts use `showInSettings: false` so users discover them through the command menu / hover tooltips rather than a toggle UI, matching the existing behavior on Roles, Tables, Publications, etc.

Closes [FE-3141](https://linear.app/supabase/issue/FE-3141/add-shortcuts-for-database-replication-and-migration-page).

## Test plan

- [x] On the Migrations page, press `Shift+F` → search input focuses and selects existing text.
- [x] On the Migrations page, type a query then press `F` `C` → search clears.
- [x] On the Replication page, press `Shift+F` → filter input focuses and selects.
- [x] On the Replication page, press `Shift+N` → Add Destination panel opens (when a destination type is available).
- [x] On the Replication page, hover the "Add destination" button → keybind tooltip shows `Shift+N`.
- [x] On the Replication page, type a filter then press `F` `C` → filter clears.
- [x] All three shortcuts appear in `Cmd+K` under "Shortcuts" while on the respective page.