### PR TITLE
fix(studio): server-side tool execution via needsApproval flow (AI-658)

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage as MessageType } from '@ai-sdk/react'
 import { useChat } from '@ai-sdk/react'
-import { lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
 import { useParams, useSearchParamsShallow } from 'common/hooks'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -159,6 +159,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     sendMessage,
     setMessages,
     addToolResult,
+    addToolApprovalResponse,
     stop,
     regenerate,
   } = useChat({
@@ -166,7 +167,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     ...(snap.activeChatId && snap.chatInstances[snap.activeChatId]
       ? { chat: snap.chatInstances[snap.activeChatId] }
       : {}),
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     onError: onErrorChat,
   })
 
@@ -282,6 +283,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             isLoading={chatStatus === 'submitted' || chatStatus === 'streaming'}
             readOnly={message.role === 'user'}
             addToolResult={addToolResult}
+            addToolApprovalResponse={addToolApprovalResponse}
             onDelete={deleteMessageFromHere}
             onEdit={editMessage}
             isAfterEditedMessage={isAfterEditedMessage}
@@ -301,6 +303,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
       editingMessageId,
       chatStatus,
       addToolResult,
+      addToolApprovalResponse,
       handleRateMessage,
       messageRatings,
     ]

--- a/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
@@ -1,5 +1,4 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { useRouter } from 'next/router'
 import { useRef, useState, type DragEvent, type PropsWithChildren } from 'react'
@@ -8,10 +7,6 @@ import { DEFAULT_CHART_CONFIG, QueryBlock } from '../QueryBlock/QueryBlock'
 import { identifyQueryType } from './AIAssistant.utils'
 import { ConfirmFooter } from './ConfirmFooter'
 import { ChartConfig } from '@/components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
-import { entityTypeKeys } from '@/data/entity-types/keys'
-import { lintKeys } from '@/data/lint/keys'
-import { usePrimaryDatabase } from '@/data/read-replicas/replicas-query'
-import { useExecuteSqlMutation } from '@/data/sql/execute-sql-mutation'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useChangedSync } from '@/hooks/misc/useChanged'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
@@ -19,7 +14,7 @@ import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganizati
 import { useProfile } from '@/lib/profile'
 
 interface DisplayBlockRendererProps {
-  messageId: string
+  messageId?: string
   toolCallId: string
   initialArgs: {
     sql: string
@@ -30,33 +25,32 @@ interface DisplayBlockRendererProps {
     yAxis?: string
   }
   initialResults?: unknown
-  onResults?: (args: { messageId: string; results: unknown }) => void
-  onError?: (args: { messageId: string; errorText: string }) => void
-  toolState?: 'input-streaming' | 'input-available' | 'output-available' | 'output-error'
+  onApprove?: () => void
+  onDeny?: () => void
+  toolState?:
+    | 'input-streaming'
+    | 'input-available'
+    | 'approval-requested'
+    | 'output-available'
+    | 'output-error'
   isLastPart?: boolean
   isLastMessage?: boolean
-  showConfirmFooter?: boolean
   onChartConfigChange?: (chartConfig: ChartConfig) => void
   onQueryRun?: (queryType: 'select' | 'mutation') => void
 }
 
 export const DisplayBlockRenderer = ({
-  messageId,
   toolCallId,
   initialArgs,
   initialResults,
-  onResults,
-  onError,
+  onApprove,
+  onDeny,
   toolState,
   isLastPart = false,
   isLastMessage = false,
-  showConfirmFooter = true,
   onChartConfigChange,
   onQueryRun,
 }: PropsWithChildren<DisplayBlockRendererProps>) => {
-  const queryClient = useQueryClient()
-
-  const savedInitialArgs = useRef(initialArgs)
   const savedInitialResults = useRef(initialResults)
   const savedInitialConfig = useRef<ChartConfig>({
     ...DEFAULT_CHART_CONFIG,
@@ -94,29 +88,13 @@ export const DisplayBlockRenderer = ({
   const isHomePage = router.pathname === '/project/[ref]'
   const isDraggableToReports = canCreateSQLSnippet && (isReportsPage || isHomePage)
   const label = initialArgs.label || 'SQL Results'
-  const [isWriteQuery, setIsWriteQuery] = useState<boolean>(initialArgs.isWriteQuery || false)
+  const isWriteQuery = initialArgs.isWriteQuery || false
   const sqlQuery = initialArgs.sql
-
-  const { database: primaryDatabase } = usePrimaryDatabase({ projectRef: ref })
-
-  const readOnlyConnectionString = primaryDatabase?.connection_string_read_only
-  const postgresConnectionString = primaryDatabase?.connectionString
-
-  const {
-    mutate: executeSql,
-    error: executeSqlError,
-    isPending: executeSqlLoading,
-  } = useExecuteSqlMutation({
-    onError: () => {
-      // Suppress toast because error message is displayed inline
-    },
-  })
 
   const toolCallIdChanged = useChangedSync(toolCallId)
   if (toolCallIdChanged) {
     setChartConfig(savedInitialConfig.current)
     onChartConfigChange?.(savedInitialConfig.current)
-    setIsWriteQuery(savedInitialArgs.current.isWriteQuery || false)
     setRows(Array.isArray(savedInitialResults.current) ? savedInitialResults.current : undefined)
   }
 
@@ -129,9 +107,7 @@ export const DisplayBlockRenderer = ({
 
   const handleRunQuery = (queryType: 'select' | 'mutation') => {
     if (!sqlQuery) return
-
     onQueryRun?.(queryType)
-
     sendEvent({
       action: 'assistant_suggestion_run_query_clicked',
       properties: {
@@ -143,60 +119,6 @@ export const DisplayBlockRenderer = ({
         organization: org?.slug ?? 'Unknown',
       },
     })
-  }
-
-  const runQuery = (queryType: 'select' | 'mutation') => {
-    if (!ref || !sqlQuery) return
-
-    const connectionString =
-      queryType === 'mutation'
-        ? postgresConnectionString
-        : (readOnlyConnectionString ?? postgresConnectionString)
-
-    if (!connectionString) {
-      const fallbackMessage = 'Unable to find a database connection to execute this query.'
-      onError?.({ messageId, errorText: fallbackMessage })
-      return
-    }
-
-    if (queryType === 'mutation') {
-      setIsWriteQuery(true)
-    }
-    executeSql(
-      { projectRef: ref, connectionString, sql: sqlQuery },
-      {
-        onSuccess: (data) => {
-          setRows(Array.isArray(data.result) ? data.result : undefined)
-          setIsWriteQuery(queryType === 'mutation' || initialArgs.isWriteQuery || false)
-          onResults?.({
-            messageId,
-            results: Array.isArray(data.result) ? data.result : undefined,
-          })
-          if (queryType === 'mutation') {
-            queryClient.invalidateQueries({ queryKey: lintKeys.lint(ref) })
-            queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(ref) })
-          }
-        },
-        onError: (error) => {
-          const lowerMessage = error.message.toLowerCase()
-          const isReadOnlyError =
-            lowerMessage.includes('read-only transaction') ||
-            lowerMessage.includes('permission denied') ||
-            lowerMessage.includes('must be owner')
-
-          if (queryType === 'select' && isReadOnlyError) {
-            setIsWriteQuery(true)
-          }
-
-          onError?.({ messageId, errorText: error.message })
-        },
-      }
-    )
-  }
-
-  const handleExecute = (queryType: 'select' | 'mutation') => {
-    handleRunQuery(queryType)
-    runQuery(queryType)
   }
 
   const handleUpdateChartConfig = ({
@@ -218,13 +140,7 @@ export const DisplayBlockRenderer = ({
     )
   }
 
-  const resolvedHasDecision = initialResults !== undefined || rows !== undefined
-  const shouldShowConfirmFooter =
-    showConfirmFooter &&
-    !resolvedHasDecision &&
-    toolState === 'input-available' &&
-    isLastPart &&
-    isLastMessage
+  const shouldShowConfirmFooter = toolState === 'approval-requested' && isLastPart && isLastMessage
 
   return (
     <div className="display-block w-auto overflow-x-hidden">
@@ -234,14 +150,12 @@ export const DisplayBlockRenderer = ({
           isWriteQuery={isWriteQuery}
           sql={sqlQuery}
           results={rows}
-          errorText={executeSqlError?.message}
           chartConfig={chartConfig}
-          onExecute={handleExecute}
+          onExecute={handleRunQuery}
           onUpdateChartConfig={handleUpdateChartConfig}
           draggable={isDraggableToReports}
           onDragStart={handleDragStart}
           disabled={shouldShowConfirmFooter}
-          isExecuting={executeSqlLoading}
         />
       </div>
       {shouldShowConfirmFooter && (
@@ -249,13 +163,11 @@ export const DisplayBlockRenderer = ({
           <ConfirmFooter
             message="Assistant wants to run this query"
             cancelLabel="Skip"
-            confirmLabel={executeSqlLoading ? 'Running...' : 'Run Query'}
-            isLoading={executeSqlLoading}
-            onCancel={async () => {
-              onResults?.({ messageId, results: 'User skipped running the query' })
-            }}
+            confirmLabel="Run Query"
+            onCancel={() => onDeny?.()}
             onConfirm={() => {
-              handleExecute(isWriteQuery ? 'mutation' : 'select')
+              handleRunQuery(isWriteQuery ? 'mutation' : 'select')
+              onApprove?.()
             }}
           />
         </div>

--- a/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
@@ -1,9 +1,10 @@
 import { useParams } from 'common'
-import { useMemo, type PropsWithChildren } from 'react'
+import { useMemo, useState, type PropsWithChildren } from 'react'
 
 import { EdgeFunctionBlock } from '../EdgeFunctionBlock/EdgeFunctionBlock'
 import { ConfirmFooter } from './ConfirmFooter'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
+import { useEdgeFunctionQuery } from '@/data/edge-functions/edge-function-query'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
@@ -29,8 +30,13 @@ export const EdgeFunctionRenderer = ({
   const { ref } = useParams()
   const { data: org } = useSelectedOrganizationQuery()
   const { mutate: sendEvent } = useSendEventMutation()
+  const [showReplaceWarning, setShowReplaceWarning] = useState(false)
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: ref }, { enabled: !!ref })
+  const { data: existingFunction } = useEdgeFunctionQuery(
+    { projectRef: ref, slug: functionName },
+    { enabled: !!ref && !!functionName && showApprovalFooter }
+  )
 
   const functionUrl = useMemo(() => {
     const endpoint = settings?.app_config?.endpoint
@@ -57,7 +63,7 @@ export const EdgeFunctionRenderer = ({
     return `supabase functions download ${functionName}`
   }, [functionName])
 
-  const handleApprove = () => {
+  const fireApprove = () => {
     sendEvent({
       action: 'edge_function_deploy_button_clicked',
       properties: { origin: 'functions_ai_assistant' },
@@ -67,6 +73,14 @@ export const EdgeFunctionRenderer = ({
       },
     })
     onApprove?.()
+  }
+
+  const handleApprove = () => {
+    if (existingFunction) {
+      setShowReplaceWarning(true)
+      return
+    }
+    fireApprove()
   }
 
   return (
@@ -80,6 +94,9 @@ export const EdgeFunctionRenderer = ({
         functionUrl={functionUrl}
         deploymentDetailsUrl={deploymentDetailsUrl}
         downloadCommand={downloadCommand}
+        showReplaceWarning={showReplaceWarning}
+        onCancelReplace={() => setShowReplaceWarning(false)}
+        onConfirmReplace={fireApprove}
         hideDeployButton={showApprovalFooter}
       />
       {showApprovalFooter && (

--- a/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
@@ -1,12 +1,9 @@
 import { useParams } from 'common'
-import { useMemo, useState, type PropsWithChildren } from 'react'
-import { toast } from 'sonner'
+import { useMemo, type PropsWithChildren } from 'react'
 
 import { EdgeFunctionBlock } from '../EdgeFunctionBlock/EdgeFunctionBlock'
 import { ConfirmFooter } from './ConfirmFooter'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
-import { useEdgeFunctionQuery } from '@/data/edge-functions/edge-function-query'
-import { useEdgeFunctionDeployMutation } from '@/data/edge-functions/edge-functions-deploy-mutation'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
@@ -14,49 +11,26 @@ interface EdgeFunctionRendererProps {
   label: string
   code: string
   functionName: string
-  onDeployed?: (result: { success: true } | { success: false; errorText: string }) => void
+  onApprove?: () => void
+  onDeny?: () => void
   initialIsDeployed?: boolean
-  showConfirmFooter?: boolean
+  showApprovalFooter?: boolean
 }
 
 export const EdgeFunctionRenderer = ({
   label,
   code,
   functionName,
-  onDeployed,
+  onApprove,
+  onDeny,
   initialIsDeployed,
-  showConfirmFooter = true,
+  showApprovalFooter = false,
 }: PropsWithChildren<EdgeFunctionRendererProps>) => {
   const { ref } = useParams()
   const { data: org } = useSelectedOrganizationQuery()
   const { mutate: sendEvent } = useSendEventMutation()
-  const [isDeployed, setIsDeployed] = useState(!!initialIsDeployed)
-  const [showReplaceWarning, setShowReplaceWarning] = useState(false)
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef: ref }, { enabled: !!ref })
-  const { data: existingFunction } = useEdgeFunctionQuery(
-    { projectRef: ref, slug: functionName },
-    { enabled: !!ref && !!functionName }
-  )
-
-  const {
-    mutate: deployFunction,
-    error: deployError,
-    isPending: isDeploying,
-  } = useEdgeFunctionDeployMutation({
-    onSuccess: () => {
-      setIsDeployed(true)
-      toast.success('Successfully deployed edge function')
-      onDeployed?.({ success: true })
-    },
-    onError: (error) => {
-      const errMsg = error?.message ?? 'Unknown error'
-      const message = `Failed to deploy function: ${errMsg}`
-      toast.error(message)
-      setIsDeployed(false)
-      onDeployed?.({ success: false, errorText: errMsg })
-    },
-  })
 
   const functionUrl = useMemo(() => {
     const endpoint = settings?.app_config?.endpoint
@@ -83,20 +57,7 @@ export const EdgeFunctionRenderer = ({
     return `supabase functions download ${functionName}`
   }, [functionName])
 
-  const performDeploy = async () => {
-    if (!ref || !functionName || !code) return
-
-    deployFunction({
-      projectRef: ref,
-      slug: functionName,
-      metadata: {
-        entrypoint_path: 'index.ts',
-        name: functionName,
-        verify_jwt: true,
-      },
-      files: [{ name: 'index.ts', content: code }],
-    })
-
+  const handleApprove = () => {
     sendEvent({
       action: 'edge_function_deploy_button_clicked',
       properties: { origin: 'functions_ai_assistant' },
@@ -105,19 +66,7 @@ export const EdgeFunctionRenderer = ({
         organization: org?.slug ?? 'Unknown',
       },
     })
-
-    setShowReplaceWarning(false)
-  }
-
-  const handleDeploy = () => {
-    if (!code || isDeploying || !ref) return
-
-    if (existingFunction) {
-      setShowReplaceWarning(true)
-      return
-    }
-
-    void performDeploy()
+    onApprove?.()
   }
 
   return (
@@ -126,30 +75,21 @@ export const EdgeFunctionRenderer = ({
         label={label}
         code={code}
         functionName={functionName}
-        disabled={showConfirmFooter}
-        isDeploying={isDeploying}
-        isDeployed={isDeployed}
-        errorText={deployError?.message}
+        disabled={showApprovalFooter}
+        isDeployed={!!initialIsDeployed}
         functionUrl={functionUrl}
         deploymentDetailsUrl={deploymentDetailsUrl}
         downloadCommand={downloadCommand}
-        showReplaceWarning={showReplaceWarning}
-        onCancelReplace={() => setShowReplaceWarning(false)}
-        onConfirmReplace={() => void performDeploy()}
-        onDeploy={handleDeploy}
-        hideDeployButton={showConfirmFooter}
+        hideDeployButton={showApprovalFooter}
       />
-      {showConfirmFooter && (
+      {showApprovalFooter && (
         <div className="mx-4">
           <ConfirmFooter
             message="Assistant wants to deploy this Edge Function"
             cancelLabel="Skip"
-            confirmLabel={isDeploying ? 'Deploying...' : 'Deploy'}
-            isLoading={isDeploying}
-            onCancel={() => {
-              onDeployed?.({ success: false, errorText: 'Skipped' })
-            }}
-            onConfirm={() => handleDeploy()}
+            confirmLabel="Deploy"
+            onCancel={() => onDeny?.()}
+            onConfirm={handleApprove}
           />
         </div>
       )}

--- a/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
@@ -35,7 +35,7 @@ export const EdgeFunctionRenderer = ({
   const { data: settings } = useProjectSettingsV2Query({ projectRef: ref }, { enabled: !!ref })
   const { data: existingFunction } = useEdgeFunctionQuery(
     { projectRef: ref, slug: functionName },
-    { enabled: !!ref && !!functionName && showApprovalFooter }
+    { enabled: !!ref && !!functionName }
   )
 
   const functionUrl = useMemo(() => {

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Context.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Context.tsx
@@ -6,6 +6,8 @@ export type AddToolResult = (args: {
   output: unknown
 }) => Promise<void>
 
+export type AddToolApprovalResponse = (args: { id: string; approved: boolean }) => void
+
 export interface MessageInfo {
   id: string
 
@@ -23,6 +25,7 @@ export interface MessageInfo {
 
 export interface MessageActions {
   addToolResult?: AddToolResult
+  addToolApprovalResponse?: AddToolApprovalResponse
 
   onDelete: (id: string) => void
   onEdit: (id: string) => void

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -1,6 +1,9 @@
 import { UIMessage as VercelMessage } from '@ai-sdk/react'
+import { useQueryClient } from '@tanstack/react-query'
 import { type DynamicToolUIPart, type ReasoningUIPart, type TextUIPart, type ToolUIPart } from 'ai'
+import { useParams } from 'common'
 import { BrainIcon, CheckIcon, Loader2 } from 'lucide-react'
+import { useEffect } from 'react'
 import { cn } from 'ui'
 
 import { DisplayBlockRenderer } from './DisplayBlockRenderer'
@@ -13,6 +16,8 @@ import {
   parseExecuteSqlChartResult,
 } from './Message.utils'
 import { MessageMarkdown } from './MessageMarkdown'
+import { entityTypeKeys } from '@/data/entity-types/keys'
+import { lintKeys } from '@/data/lint/keys'
 
 function MessagePartText({ textPart }: { textPart: TextUIPart }) {
   const { id, isLoading, readOnly, isUserMessage, state } = useMessageInfoContext()
@@ -111,9 +116,20 @@ function MessagePartExecuteSql({
   isLastPart?: boolean
 }) {
   const { id, isLastMessage } = useMessageInfoContext()
-  const { addToolResult } = useMessageActionsContext()
+  const { addToolApprovalResponse } = useMessageActionsContext()
+  const queryClient = useQueryClient()
+  const { ref } = useParams()
 
   const { toolCallId, state, input, output } = toolPart
+
+  // Invalidate write-related queries once a write SQL result is available
+  useEffect(() => {
+    if (state !== 'output-available') return
+    const isWriteQuery = (input as any)?.isWriteQuery
+    if (!isWriteQuery || !ref) return
+    queryClient.invalidateQueries({ queryKey: lintKeys.lint(ref) })
+    queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(ref) })
+  }, [state, input, ref, queryClient])
 
   if (state === 'input-streaming') {
     return <ToolDisplayExecuteSqlLoading />
@@ -126,7 +142,11 @@ function MessagePartExecuteSql({
   const { data: chart, success } = parseExecuteSqlChartResult(input)
   if (!success) return null
 
-  if (state === 'input-available' || state === 'output-available') {
+  if (
+    state === 'approval-requested' ||
+    state === 'input-available' ||
+    state === 'output-available'
+  ) {
     return (
       <div className="w-auto overflow-x-hidden my-4 space-y-2">
         <DisplayBlockRenderer
@@ -144,21 +164,11 @@ function MessagePartExecuteSql({
           toolState={state}
           isLastPart={isLastPart}
           isLastMessage={isLastMessage}
-          onResults={(args: { messageId: string; results: unknown }) => {
-            const results = args.results as any[]
-
-            addToolResult?.({
-              tool: 'execute_sql',
-              toolCallId: String(toolCallId),
-              output: results,
-            })
+          onApprove={() => {
+            addToolApprovalResponse?.({ id: toolCallId, approved: true })
           }}
-          onError={({ errorText }) => {
-            addToolResult?.({
-              tool: 'execute_sql',
-              toolCallId: String(toolCallId),
-              output: `Error: ${errorText}`,
-            })
+          onDeny={() => {
+            addToolApprovalResponse?.({ id: toolCallId, approved: false })
           }}
         />
       </div>
@@ -168,11 +178,15 @@ function MessagePartExecuteSql({
   return null
 }
 
-const TOOL_DEPLOY_EDGE_FUNCTION_STATES_WITH_INPUT = new Set(['input-available', 'output-available'])
+const TOOL_DEPLOY_EDGE_FUNCTION_STATES_WITH_INPUT = new Set([
+  'approval-requested',
+  'input-available',
+  'output-available',
+])
 
 function MessagePartDeployEdgeFunction({ toolPart }: { toolPart: ToolUIPart }) {
   const { toolCallId, state, input, output } = toolPart
-  const { addToolResult } = useMessageActionsContext()
+  const { addToolApprovalResponse } = useMessageActionsContext()
 
   if (state === 'input-streaming') {
     return (
@@ -201,15 +215,10 @@ function MessagePartDeployEdgeFunction({ toolPart }: { toolPart: ToolUIPart }) {
       label={parsedInput.data.label}
       code={parsedInput.data.code}
       functionName={parsedInput.data.functionName}
-      showConfirmFooter={!output}
+      showApprovalFooter={state === 'approval-requested'}
       initialIsDeployed={isInitiallyDeployed}
-      onDeployed={(result) => {
-        addToolResult?.({
-          tool: 'deploy_edge_function',
-          toolCallId: String(toolCallId),
-          output: result,
-        })
-      }}
+      onApprove={() => addToolApprovalResponse?.({ id: toolCallId, approved: true })}
+      onDeny={() => addToolApprovalResponse?.({ id: toolCallId, approved: false })}
     />
   )
 }

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -125,8 +125,8 @@ function MessagePartExecuteSql({
   // Invalidate write-related queries once a write SQL result is available
   useEffect(() => {
     if (state !== 'output-available') return
-    const isWriteQuery = (input as any)?.isWriteQuery
-    if (!isWriteQuery || !ref) return
+    const parsed = parseExecuteSqlChartResult(input)
+    if (!parsed.success || !parsed.data.isWriteQuery || !ref) return
     queryClient.invalidateQueries({ queryKey: lintKeys.lint(ref) })
     queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(ref) })
   }, [state, input, ref, queryClient])

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -142,8 +142,12 @@ function MessagePartExecuteSql({
   const { data: chart, success } = parseExecuteSqlChartResult(input)
   if (!success) return null
 
-  if (toolPart.state === 'approval-requested') {
-    const approvalId = toolPart.approval.id
+  if (
+    toolPart.state === 'approval-requested' ||
+    state === 'input-available' ||
+    state === 'output-available'
+  ) {
+    const approvalId = toolPart.state === 'approval-requested' ? toolPart.approval.id : undefined
     return (
       <div className="w-auto overflow-x-hidden my-4 space-y-2">
         <DisplayBlockRenderer
@@ -161,31 +165,16 @@ function MessagePartExecuteSql({
           toolState={toolPart.state}
           isLastPart={isLastPart}
           isLastMessage={isLastMessage}
-          onApprove={() => addToolApprovalResponse?.({ id: approvalId, approved: true })}
-          onDeny={() => addToolApprovalResponse?.({ id: approvalId, approved: false })}
-        />
-      </div>
-    )
-  }
-
-  if (state === 'input-available' || state === 'output-available') {
-    return (
-      <div className="w-auto overflow-x-hidden my-4 space-y-2">
-        <DisplayBlockRenderer
-          messageId={id}
-          toolCallId={toolCallId}
-          initialArgs={{
-            sql: chart.sql,
-            label: chart.label,
-            isWriteQuery: chart.isWriteQuery,
-            view: chart.view,
-            xAxis: chart.xAxis,
-            yAxis: chart.yAxis,
-          }}
-          initialResults={output}
-          toolState={state}
-          isLastPart={isLastPart}
-          isLastMessage={isLastMessage}
+          onApprove={
+            approvalId
+              ? () => addToolApprovalResponse?.({ id: approvalId, approved: true })
+              : undefined
+          }
+          onDeny={
+            approvalId
+              ? () => addToolApprovalResponse?.({ id: approvalId, approved: false })
+              : undefined
+          }
         />
       </div>
     )

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -142,11 +142,33 @@ function MessagePartExecuteSql({
   const { data: chart, success } = parseExecuteSqlChartResult(input)
   if (!success) return null
 
-  if (
-    state === 'approval-requested' ||
-    state === 'input-available' ||
-    state === 'output-available'
-  ) {
+  if (toolPart.state === 'approval-requested') {
+    const approvalId = toolPart.approval.id
+    return (
+      <div className="w-auto overflow-x-hidden my-4 space-y-2">
+        <DisplayBlockRenderer
+          messageId={id}
+          toolCallId={toolCallId}
+          initialArgs={{
+            sql: chart.sql,
+            label: chart.label,
+            isWriteQuery: chart.isWriteQuery,
+            view: chart.view,
+            xAxis: chart.xAxis,
+            yAxis: chart.yAxis,
+          }}
+          initialResults={output}
+          toolState={toolPart.state}
+          isLastPart={isLastPart}
+          isLastMessage={isLastMessage}
+          onApprove={() => addToolApprovalResponse?.({ id: approvalId, approved: true })}
+          onDeny={() => addToolApprovalResponse?.({ id: approvalId, approved: false })}
+        />
+      </div>
+    )
+  }
+
+  if (state === 'input-available' || state === 'output-available') {
     return (
       <div className="w-auto overflow-x-hidden my-4 space-y-2">
         <DisplayBlockRenderer
@@ -164,12 +186,6 @@ function MessagePartExecuteSql({
           toolState={state}
           isLastPart={isLastPart}
           isLastMessage={isLastMessage}
-          onApprove={() => {
-            addToolApprovalResponse?.({ id: toolCallId, approved: true })
-          }}
-          onDeny={() => {
-            addToolApprovalResponse?.({ id: toolCallId, approved: false })
-          }}
         />
       </div>
     )
@@ -185,8 +201,9 @@ const TOOL_DEPLOY_EDGE_FUNCTION_STATES_WITH_INPUT = new Set([
 ])
 
 function MessagePartDeployEdgeFunction({ toolPart }: { toolPart: ToolUIPart }) {
-  const { toolCallId, state, input, output } = toolPart
+  const { state, input, output } = toolPart
   const { addToolApprovalResponse } = useMessageActionsContext()
+  const approvalId = toolPart.state === 'approval-requested' ? toolPart.approval.id : undefined
 
   if (state === 'input-streaming') {
     return (
@@ -217,8 +234,12 @@ function MessagePartDeployEdgeFunction({ toolPart }: { toolPart: ToolUIPart }) {
       functionName={parsedInput.data.functionName}
       showApprovalFooter={state === 'approval-requested'}
       initialIsDeployed={isInitiallyDeployed}
-      onApprove={() => addToolApprovalResponse?.({ id: toolCallId, approved: true })}
-      onDeny={() => addToolApprovalResponse?.({ id: toolCallId, approved: false })}
+      onApprove={() => {
+        if (approvalId) addToolApprovalResponse?.({ id: approvalId, approved: true })
+      }}
+      onDeny={() => {
+        if (approvalId) addToolApprovalResponse?.({ id: approvalId, approved: false })
+      }}
     />
   )
 }

--- a/apps/studio/components/ui/AIAssistantPanel/Message.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.tsx
@@ -5,7 +5,7 @@ import { cn } from 'ui'
 
 import { DeleteMessageConfirmModal } from './DeleteMessageConfirmModal'
 import { MessageActions } from './Message.Actions'
-import type { AddToolResult, MessageInfo } from './Message.Context'
+import type { AddToolApprovalResponse, AddToolResult, MessageInfo } from './Message.Context'
 import { MessageProvider, useMessageActionsContext, useMessageInfoContext } from './Message.Context'
 import { MessageDisplay } from './Message.Display'
 
@@ -93,6 +93,7 @@ interface MessageProps {
   readOnly?: boolean
   variant?: 'default' | 'warning'
   addToolResult?: AddToolResult
+  addToolApprovalResponse?: AddToolApprovalResponse
   onDelete: (id: string) => void
   onEdit: (id: string) => void
   isAfterEditedMessage: boolean
@@ -124,6 +125,7 @@ export function Message(props: MessageProps) {
 
   const messageActions = {
     addToolResult: props.addToolResult,
+    addToolApprovalResponse: props.addToolApprovalResponse,
     onDelete: props.onDelete,
     onEdit: props.onEdit,
     onCancelEdit: props.onCancelEdit,

--- a/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/MessageMarkdown.tsx
@@ -272,8 +272,6 @@ export const MarkdownPre = ({
               xAxis: xAxis ?? '',
               yAxis: yAxis ?? '',
             }}
-            onError={() => {}}
-            showConfirmFooter={false}
             onChartConfigChange={(config) => {
               chartConfig.current = { ...config }
             }}

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -1,6 +1,7 @@
 import * as ai from 'ai'
 import {
   convertToModelMessages,
+  getToolName,
   isToolUIPart,
   stepCountIs,
   type LanguageModel,
@@ -15,6 +16,7 @@ import { buildAssistantEvalOutput } from '@/evals/output'
 import type { AssistantEvalInput, AssistantEvalOutput } from '@/evals/scorer'
 import type { AiOptInLevel } from '@/hooks/misc/useOrgOptedIntoAi'
 import { IS_TRACING_ENABLED } from '@/lib/ai/braintrust-logger'
+import { getLastUserText, isApprovalContinuation } from '@/lib/ai/message-utils'
 import { CHAT_PROMPT, GENERAL_PROMPT, LIMITATIONS_PROMPT, SECURITY_PROMPT } from '@/lib/ai/prompts'
 import { sanitizeMessagePart } from '@/lib/ai/tools/tool-sanitizer'
 
@@ -38,8 +40,6 @@ export async function generateAssistantResponse({
   requestedModel,
   abortSignal,
   onSpanCreated,
-  onSpanExported,
-  parentSpanContext,
 }: {
   messages: UIMessage[]
   model: LanguageModel
@@ -58,19 +58,13 @@ export async function generateAssistantResponse({
   providerOptions?: Record<string, any>
   abortSignal?: AbortSignal
   onSpanCreated?: (spanId: string) => void
-  onSpanExported?: (ctx: string) => void
-  parentSpanContext?: string
 }) {
   const shouldTrace = allowTracing ?? IS_TRACING_ENABLED
 
   // Turn 2 (post-approval) is uniquely identifiable upfront: the assistant message
   // from Turn 1 will already have tool parts in 'approval-responded' state. All other
   // turns (Turn 1 itself, and normal turns) look identical at request time.
-  const isPostApprovalTurn = rawMessages.some(
-    (msg) =>
-      msg.role === 'assistant' &&
-      msg.parts?.some((part) => isToolUIPart(part) && part.state === 'approval-responded')
-  )
+  const isPostApprovalTurn = isApprovalContinuation(rawMessages)
 
   const run = async (span?: Span) => {
     // Only returns last 7 messages
@@ -195,22 +189,37 @@ export async function generateAssistantResponse({
           // that eval scorers see the full picture.
           const approvedToolNames: string[] = []
           const approvedSqlQueries: string[] = []
+          let approvedStepText = ''
           for (const msg of rawMessages) {
             if (msg.role !== 'assistant' || !msg.parts) continue
+            const hasApprovedTools = msg.parts.some(
+              (p) =>
+                isToolUIPart(p) &&
+                (p.state === 'approval-responded' || p.state === 'output-available')
+            )
+            if (!hasApprovedTools) continue
             for (const part of msg.parts) {
-              if (!isToolUIPart(part)) continue
-              if (part.state !== 'approval-responded' && part.state !== 'output-available') continue
-              approvedToolNames.push(part.type.replace('tool-', ''))
-              if (part.type === 'tool-execute_sql') {
-                const sql = (part.input as any)?.sql
-                if (typeof sql === 'string') approvedSqlQueries.push(sql)
+              if (part.type === 'text') {
+                approvedStepText += part.text
+              } else if (isToolUIPart(part)) {
+                if (part.state !== 'approval-responded' && part.state !== 'output-available')
+                  continue
+                approvedToolNames.push(getToolName(part))
+                if (part.type === 'tool-execute_sql') {
+                  const sql = (part.input as any)?.sql
+                  if (typeof sql === 'string') approvedSqlQueries.push(sql)
+                }
               }
             }
           }
 
           const baseOutput = buildAssistantEvalOutput(finishReason, steps)
+          const priorStep = approvedStepText
+            ? [{ text: approvedStepText, toolCalls: [] as { toolName: string; input: unknown }[] }]
+            : []
           const output = {
             ...baseOutput,
+            steps: [...priorStep, ...baseOutput.steps],
             toolNames: [...approvedToolNames, ...baseOutput.toolNames],
             sqlQueries: [...approvedSqlQueries, ...baseOutput.sqlQueries],
           } satisfies AssistantEvalOutput
@@ -221,13 +230,8 @@ export async function generateAssistantResponse({
           } else {
             // Normal turn: input was deferred so we can skip it entirely for Turn 1.
             // Log input + output together here.
-            const lastUserMessage = rawMessages.findLast((m) => m.role === 'user')
-            const lastUserText = lastUserMessage?.parts
-              ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-              .map((p) => p.text)
-              .join('\n')
             span.log({
-              input: { prompt: lastUserText ?? '' } satisfies AssistantEvalInput,
+              input: { prompt: getLastUserText(rawMessages) } satisfies AssistantEvalInput,
               output,
               metadata: {
                 projectRef,
@@ -253,25 +257,14 @@ export async function generateAssistantResponse({
   if (shouldTrace) {
     // startSpan instead of traced() so we control when the span closes — onFinish logs
     // output to the span before we call span.end(), ensuring online scoring sees the output.
-    const span = startSpan({
-      name: 'generateAssistantResponse',
-      type: 'function',
-      ...(parentSpanContext && { parent: parentSpanContext }),
-    })
+    const span = startSpan({ name: 'generateAssistantResponse', type: 'function' })
     onSpanCreated?.(span.id)
-    onSpanExported?.(await span.export())
 
     if (isPostApprovalTurn) {
       // Log input upfront only for Turn 2. For Turn 1 and normal turns, input is deferred
       // to onFinish so that Turn 1 spans end with no data and don't trigger online scoring.
-      const lastUserMessage = rawMessages.findLast((m) => m.role === 'user')
-      const lastUserText = lastUserMessage?.parts
-        ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-        .map((p) => p.text)
-        .join('\n')
-
       span.log({
-        input: { prompt: lastUserText ?? '' } satisfies AssistantEvalInput,
+        input: { prompt: getLastUserText(rawMessages) } satisfies AssistantEvalInput,
         metadata: {
           projectRef,
           chatId,

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -38,6 +38,8 @@ export async function generateAssistantResponse({
   requestedModel,
   abortSignal,
   onSpanCreated,
+  onSpanExported,
+  parentSpanContext,
 }: {
   messages: UIMessage[]
   model: LanguageModel
@@ -56,6 +58,8 @@ export async function generateAssistantResponse({
   providerOptions?: Record<string, any>
   abortSignal?: AbortSignal
   onSpanCreated?: (spanId: string) => void
+  onSpanExported?: (ctx: string) => void
+  parentSpanContext?: string
 }) {
   const shouldTrace = allowTracing ?? IS_TRACING_ENABLED
 
@@ -249,8 +253,13 @@ export async function generateAssistantResponse({
   if (shouldTrace) {
     // startSpan instead of traced() so we control when the span closes — onFinish logs
     // output to the span before we call span.end(), ensuring online scoring sees the output.
-    const span = startSpan({ name: 'generateAssistantResponse', type: 'function' })
+    const span = startSpan({
+      name: 'generateAssistantResponse',
+      type: 'function',
+      ...(parentSpanContext && { parent: parentSpanContext }),
+    })
     onSpanCreated?.(span.id)
+    onSpanExported?.(await span.export())
 
     if (isPostApprovalTurn) {
       // Log input upfront only for Turn 2. For Turn 1 and normal turns, input is deferred

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -73,7 +73,12 @@ export async function generateAssistantResponse({
         const cleanedParts = msg.parts
           .filter((part) => {
             if (isToolUIPart(part)) {
-              const invalidStates = ['input-streaming', 'input-available', 'output-error']
+              const invalidStates = [
+                'input-streaming',
+                'input-available',
+                'approval-requested',
+                'output-error',
+              ]
               return !invalidStates.includes(part.state)
             }
             return true
@@ -157,8 +162,46 @@ export async function generateAssistantResponse({
               }
             }
           }
+
+          // Skip output logging when ending on an approval boundary — Turn 1 has no
+          // result yet. Turn 2 (post-approval) will log the complete output instead.
+          const approvalPending = steps.some((step) =>
+            step.toolCalls.some(
+              (tc) =>
+                (tc.toolName === 'execute_sql' || tc.toolName === 'deploy_edge_function') &&
+                !step.toolResults.some((tr) => tr.toolCallId === tc.toolCallId)
+            )
+          )
+          if (approvalPending) {
+            span.end()
+            return
+          }
+
+          // For Turn 2, the approved tool execution happens before steps[] are recorded
+          // by the SDK. Recover those tool calls from the incoming message history so
+          // that eval scorers see the full picture.
+          const approvedToolNames: string[] = []
+          const approvedSqlQueries: string[] = []
+          for (const msg of rawMessages) {
+            if (msg.role !== 'assistant' || !msg.parts) continue
+            for (const part of msg.parts) {
+              if (!isToolUIPart(part)) continue
+              if (part.state !== 'approval-responded' && part.state !== 'output-available') continue
+              approvedToolNames.push(part.type.replace('tool-', ''))
+              if (part.type === 'tool-execute_sql') {
+                const sql = (part.input as any)?.sql
+                if (typeof sql === 'string') approvedSqlQueries.push(sql)
+              }
+            }
+          }
+
+          const baseOutput = buildAssistantEvalOutput(finishReason, steps)
           span.log({
-            output: buildAssistantEvalOutput(finishReason, steps) satisfies AssistantEvalOutput,
+            output: {
+              ...baseOutput,
+              toolNames: [...approvedToolNames, ...baseOutput.toolNames],
+              sqlQueries: [...approvedSqlQueries, ...baseOutput.sqlQueries],
+            } satisfies AssistantEvalOutput,
           })
           span.end()
         },

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -59,6 +59,15 @@ export async function generateAssistantResponse({
 }) {
   const shouldTrace = allowTracing ?? IS_TRACING_ENABLED
 
+  // Turn 2 (post-approval) is uniquely identifiable upfront: the assistant message
+  // from Turn 1 will already have tool parts in 'approval-responded' state. All other
+  // turns (Turn 1 itself, and normal turns) look identical at request time.
+  const isPostApprovalTurn = rawMessages.some(
+    (msg) =>
+      msg.role === 'assistant' &&
+      msg.parts?.some((part) => isToolUIPart(part) && part.state === 'approval-responded')
+  )
+
   const run = async (span?: Span) => {
     // Only returns last 7 messages
     // Filters out tools with invalid states
@@ -163,8 +172,8 @@ export async function generateAssistantResponse({
             }
           }
 
-          // Skip output logging when ending on an approval boundary — Turn 1 has no
-          // result yet. Turn 2 (post-approval) will log the complete output instead.
+          // Turn 1 ends at an approval boundary — no output to log yet. End the span
+          // with no data so online scorers don't fire. Turn 2 will carry the full output.
           const approvalPending = steps.some((step) =>
             step.toolCalls.some(
               (tc) =>
@@ -196,13 +205,41 @@ export async function generateAssistantResponse({
           }
 
           const baseOutput = buildAssistantEvalOutput(finishReason, steps)
-          span.log({
-            output: {
-              ...baseOutput,
-              toolNames: [...approvedToolNames, ...baseOutput.toolNames],
-              sqlQueries: [...approvedSqlQueries, ...baseOutput.sqlQueries],
-            } satisfies AssistantEvalOutput,
-          })
+          const output = {
+            ...baseOutput,
+            toolNames: [...approvedToolNames, ...baseOutput.toolNames],
+            sqlQueries: [...approvedSqlQueries, ...baseOutput.sqlQueries],
+          } satisfies AssistantEvalOutput
+
+          if (isPostApprovalTurn) {
+            // Input was logged upfront — only log output now.
+            span.log({ output })
+          } else {
+            // Normal turn: input was deferred so we can skip it entirely for Turn 1.
+            // Log input + output together here.
+            const lastUserMessage = rawMessages.findLast((m) => m.role === 'user')
+            const lastUserText = lastUserMessage?.parts
+              ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+              .map((p) => p.text)
+              .join('\n')
+            span.log({
+              input: { prompt: lastUserText ?? '' } satisfies AssistantEvalInput,
+              output,
+              metadata: {
+                projectRef,
+                chatId,
+                chatName,
+                aiOptInLevel,
+                userId,
+                orgId,
+                planId,
+                requestedModel,
+                gitBranch: process.env.VERCEL_GIT_COMMIT_REF,
+                environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
+              },
+            })
+          }
+
           span.end()
         },
       }),
@@ -215,27 +252,31 @@ export async function generateAssistantResponse({
     const span = startSpan({ name: 'generateAssistantResponse', type: 'function' })
     onSpanCreated?.(span.id)
 
-    const lastUserMessage = rawMessages.findLast((m) => m.role === 'user')
-    const lastUserText = lastUserMessage?.parts
-      ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
-      .map((p) => p.text)
-      .join('\n')
+    if (isPostApprovalTurn) {
+      // Log input upfront only for Turn 2. For Turn 1 and normal turns, input is deferred
+      // to onFinish so that Turn 1 spans end with no data and don't trigger online scoring.
+      const lastUserMessage = rawMessages.findLast((m) => m.role === 'user')
+      const lastUserText = lastUserMessage?.parts
+        ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+        .map((p) => p.text)
+        .join('\n')
 
-    span.log({
-      input: { prompt: lastUserText ?? '' } satisfies AssistantEvalInput,
-      metadata: {
-        projectRef,
-        chatId,
-        chatName,
-        aiOptInLevel,
-        userId,
-        orgId,
-        planId,
-        requestedModel,
-        gitBranch: process.env.VERCEL_GIT_COMMIT_REF,
-        environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
-      },
-    })
+      span.log({
+        input: { prompt: lastUserText ?? '' } satisfies AssistantEvalInput,
+        metadata: {
+          projectRef,
+          chatId,
+          chatName,
+          aiOptInLevel,
+          userId,
+          orgId,
+          planId,
+          requestedModel,
+          gitBranch: process.env.VERCEL_GIT_COMMIT_REF,
+          environment: process.env.NEXT_PUBLIC_ENVIRONMENT,
+        },
+      })
+    }
 
     return withCurrent(span, () => run(span))
   }

--- a/apps/studio/lib/ai/message-utils.ts
+++ b/apps/studio/lib/ai/message-utils.ts
@@ -1,4 +1,22 @@
-import type { UIMessage } from 'ai'
+import { isToolUIPart, type UIMessage } from 'ai'
+
+export function isApprovalContinuation(messages: UIMessage[]): boolean {
+  return messages.some(
+    (msg) =>
+      msg.role === 'assistant' &&
+      msg.parts?.some((part) => isToolUIPart(part) && part.state === 'approval-responded')
+  )
+}
+
+export function getLastUserText(messages: UIMessage[]): string {
+  const lastUserMessage = messages.findLast((m) => m.role === 'user')
+  return (
+    lastUserMessage?.parts
+      ?.filter((p): p is { type: 'text'; text: string } => p.type === 'text')
+      .map((p) => p.text)
+      .join('\n') ?? ''
+  )
+}
 
 /**
  * Prepares messages for API transmission by cleaning and limiting history

--- a/apps/studio/lib/ai/tools/index.ts
+++ b/apps/studio/lib/ai/tools/index.ts
@@ -25,7 +25,7 @@ export const getTools = async ({
   baseUrl?: string
 }) => {
   // Always include studio tools
-  let tools: ToolSet = getStudioTools()
+  let tools: ToolSet = getStudioTools({ projectRef, connectionString, authorization })
 
   // If self-hosted, only add fallback tools
   if (!IS_PLATFORM) {

--- a/apps/studio/lib/ai/tools/studio-tools.test.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.test.ts
@@ -15,14 +15,16 @@ describe('ai/tools/studio-tools', () => {
       const tools = getStudioTools()
 
       expect(tools.execute_sql).toBeDefined()
-      expect(tools.execute_sql.description).toContain('execute a SQL statement')
+      expect(tools.execute_sql.description.toLowerCase()).toContain('execute a sql statement')
     })
 
     it('should include deploy_edge_function tool', () => {
       const tools = getStudioTools()
 
       expect(tools.deploy_edge_function).toBeDefined()
-      expect(tools.deploy_edge_function.description).toContain('deploy a Supabase Edge Function')
+      expect(tools.deploy_edge_function.description.toLowerCase()).toContain(
+        'deploy a supabase edge function'
+      )
     })
 
     it('should include rename_chat tool', () => {

--- a/apps/studio/lib/ai/tools/studio-tools.test.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.test.ts
@@ -15,14 +15,16 @@ describe('ai/tools/studio-tools', () => {
       const tools = getStudioTools()
 
       expect(tools.execute_sql).toBeDefined()
-      expect(tools.execute_sql.description.toLowerCase()).toContain('execute a sql statement')
+      expect((tools.execute_sql.description ?? '').toLowerCase()).toContain(
+        'execute a sql statement'
+      )
     })
 
     it('should include deploy_edge_function tool', () => {
       const tools = getStudioTools()
 
       expect(tools.deploy_edge_function).toBeDefined()
-      expect(tools.deploy_edge_function.description.toLowerCase()).toContain(
+      expect((tools.deploy_edge_function.description ?? '').toLowerCase()).toContain(
         'deploy a supabase edge function'
       )
     })

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -82,6 +82,7 @@ export const getStudioTools = (ctx: StudioToolsContext = {}) => {
           throw new Error('projectRef is required')
         }
 
+        const files = [{ name: 'index.ts', content: code }]
         const { data, error } = await post('/v1/projects/{ref}/functions/deploy', {
           params: { path: { ref: projectRef }, query: { slug: name } },
           headers: authorization ? { Authorization: authorization } : {},
@@ -91,13 +92,14 @@ export const getStudioTools = (ctx: StudioToolsContext = {}) => {
               entrypoint_path: 'index.ts',
               verify_jwt: true,
             },
-            file: [{ name: 'index.ts', content: code }] as any,
+            file: files as any,
           },
           bodySerializer(body) {
             const formData = new FormData()
             formData.append('metadata', JSON.stringify(body.metadata))
-            const blob = new Blob([(body.file as any)[0].content], { type: 'text/plain' })
-            formData.append('file', blob, 'index.ts')
+            files.forEach((f) => {
+              formData.append('file', new Blob([f.content], { type: 'text/plain' }), f.name)
+            })
             return formData
           },
         })

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -1,6 +1,9 @@
 import { tool } from 'ai'
+import { IS_PLATFORM } from 'common'
 import { z } from 'zod'
 
+import { handleError, post } from '@/data/fetchers'
+import { executeSql } from '@/data/sql/execute-sql-query'
 import {
   EDGE_FUNCTION_PROMPT,
   PG_BEST_PRACTICES,
@@ -8,6 +11,7 @@ import {
   RLS_PROMPT,
 } from '@/lib/ai/prompts'
 import { fixSqlBackslashEscapes } from '@/lib/ai/util'
+import { executeQuery } from '@/lib/api/self-hosted/query'
 
 const KNOWLEDGE = {
   pg_best_practices: PG_BEST_PRACTICES,
@@ -18,54 +22,108 @@ const KNOWLEDGE = {
 
 type KnowledgeName = keyof typeof KNOWLEDGE
 
-export const getStudioTools = () => ({
-  execute_sql: tool({
-    description: 'Asks the user to execute a SQL statement and return the results',
-    inputSchema: z.object({
-      // Transform at parse time so the corrected SQL is what gets stored in
-      // toolCall.input — ensuring evals and logs reflect what actually runs.
-      sql: z.string().describe('The SQL statement to execute.').transform(fixSqlBackslashEscapes),
-      label: z.string().describe('A short 2-4 word label for the SQL statement.'),
-      chartConfig: z
-        .object({
-          view: z.enum(['table', 'chart']).describe('How to render the results after execution'),
-          xAxis: z.string().optional().describe('The column to use for the x-axis of the chart.'),
-          yAxis: z.string().optional().describe('The column to use for the y-axis of the chart.'),
+type StudioToolsContext = {
+  projectRef?: string
+  connectionString?: string
+  authorization?: string
+}
+
+export const getStudioTools = (ctx: StudioToolsContext = {}) => {
+  const { projectRef, connectionString, authorization } = ctx
+
+  return {
+    execute_sql: tool({
+      description: 'Execute a SQL statement and return the results',
+      needsApproval: true,
+      inputSchema: z.object({
+        sql: z.string().describe('The SQL statement to execute.').transform(fixSqlBackslashEscapes),
+        label: z.string().describe('A short 2-4 word label for the SQL statement.'),
+        chartConfig: z
+          .object({
+            view: z.enum(['table', 'chart']).describe('How to render the results after execution'),
+            xAxis: z.string().optional().describe('The column to use for the x-axis of the chart.'),
+            yAxis: z.string().optional().describe('The column to use for the y-axis of the chart.'),
+          })
+          .describe('Chart configuration for rendering the results'),
+        isWriteQuery: z
+          .boolean()
+          .default(false)
+          .describe(
+            'Whether the SQL statement performs a write operation of any kind instead of a read operation'
+          ),
+      }),
+      execute: async ({ sql }) => {
+        if (!projectRef || !connectionString) {
+          throw new Error('projectRef and connectionString are required')
+        }
+
+        const { result } = await executeSql(
+          { projectRef, connectionString, sql },
+          undefined,
+          {
+            'Content-Type': 'application/json',
+            ...(authorization && { Authorization: authorization }),
+          },
+          IS_PLATFORM ? undefined : executeQuery
+        )
+        return result
+      },
+    }),
+    deploy_edge_function: tool({
+      description:
+        'Deploy a Supabase Edge Function from provided code. User will confirm before deploying.',
+      needsApproval: true,
+      inputSchema: z.object({
+        name: z.string().describe('The URL-friendly name/slug of the Edge Function.'),
+        code: z.string().describe('The TypeScript code for the Edge Function.'),
+      }),
+      execute: async ({ name, code }) => {
+        if (!projectRef) {
+          throw new Error('projectRef is required')
+        }
+
+        const { data, error } = await post('/v1/projects/{ref}/functions/deploy', {
+          params: { path: { ref: projectRef }, query: { slug: name } },
+          headers: authorization ? { Authorization: authorization } : {},
+          body: {
+            metadata: {
+              name,
+              entrypoint_path: 'index.ts',
+              verify_jwt: true,
+            },
+            file: [{ name: 'index.ts', content: code }] as any,
+          },
+          bodySerializer(body) {
+            const formData = new FormData()
+            formData.append('metadata', JSON.stringify(body.metadata))
+            const blob = new Blob([(body.file as any)[0].content], { type: 'text/plain' })
+            formData.append('file', blob, 'index.ts')
+            return formData
+          },
         })
-        .describe('Chart configuration for rendering the results'),
-      isWriteQuery: z
-        .boolean()
-        .default(false)
-        .describe(
-          'Whether the SQL statement performs a write operation of any kind instead of a read operation'
-        ),
+
+        if (error) handleError(error)
+        return { success: true, function: data }
+      },
     }),
-  }),
-  deploy_edge_function: tool({
-    description:
-      'Ask the user to deploy a Supabase Edge Function from provided code on the client. Client will confirm before deploying and return the result',
-    inputSchema: z.object({
-      name: z.string().describe('The URL-friendly name/slug of the Edge Function.'),
-      code: z.string().describe('The TypeScript code for the Edge Function.'),
+    rename_chat: tool({
+      description: `Rename the current chat session when the current chat name doesn't describe the conversation topic.`,
+      inputSchema: z.object({
+        newName: z.string().describe('The new name for the chat session. Five words or less.'),
+      }),
+      execute: async () => {
+        return { status: 'Chat request sent to client' }
+      },
     }),
-  }),
-  rename_chat: tool({
-    description: `Rename the current chat session when the current chat name doesn't describe the conversation topic.`,
-    inputSchema: z.object({
-      newName: z.string().describe('The new name for the chat session. Five words or less.'),
+    load_knowledge: tool({
+      description:
+        'Load detailed knowledge about a Supabase topic before answering questions about it.',
+      inputSchema: z.object({
+        name: z
+          .enum(Object.keys(KNOWLEDGE) as [KnowledgeName, ...KnowledgeName[]])
+          .describe('The knowledge to load'),
+      }),
+      execute: ({ name }) => KNOWLEDGE[name],
     }),
-    execute: async () => {
-      return { status: 'Chat request sent to client' }
-    },
-  }),
-  load_knowledge: tool({
-    description:
-      'Load detailed knowledge about a Supabase topic before answering questions about it.',
-    inputSchema: z.object({
-      name: z
-        .enum(Object.keys(KNOWLEDGE) as [KnowledgeName, ...KnowledgeName[]])
-        .describe('The knowledge to load'),
-    }),
-    execute: ({ name }) => KNOWLEDGE[name],
-  }),
-})
+  }
+}

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -74,7 +74,7 @@
     "@vercel/functions": "^2.1.0",
     "@xyflow/react": "^12.10.1",
     "@zip.js/zip.js": "^2.7.29",
-    "ai": "^6.0.116",
+    "ai": "^6.0.173",
     "ai-commands": "workspace:*",
     "awesome-debounce-promise": "^2.1.0",
     "common": "workspace:*",

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -64,7 +64,6 @@ const requestBodySchema = z.object({
   chatName: z.string().optional(),
   orgSlug: z.string().optional(),
   model: z.string().optional(),
-  braintrustParentSpanContext: z.string().optional(),
 })
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: JwtPayload) {
@@ -92,7 +91,6 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
     chatId,
     chatName,
     model: rawRequestedModel,
-    braintrustParentSpanContext,
   } = data
 
   const requestedModel: AssistantModelId | undefined =
@@ -221,12 +219,8 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       requestedModel,
       promptProviderOptions,
       abortSignal: abortController.signal,
-      parentSpanContext: braintrustParentSpanContext,
       onSpanCreated: (spanId) => {
         res.setHeader('x-braintrust-span-id', spanId)
-      },
-      onSpanExported: (ctx) => {
-        res.setHeader('x-braintrust-span-context', ctx)
       },
     })
 

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -64,6 +64,7 @@ const requestBodySchema = z.object({
   chatName: z.string().optional(),
   orgSlug: z.string().optional(),
   model: z.string().optional(),
+  braintrustParentSpanContext: z.string().optional(),
 })
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: JwtPayload) {
@@ -91,6 +92,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
     chatId,
     chatName,
     model: rawRequestedModel,
+    braintrustParentSpanContext,
   } = data
 
   const requestedModel: AssistantModelId | undefined =
@@ -219,8 +221,12 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse, claims?: Jw
       requestedModel,
       promptProviderOptions,
       abortSignal: abortController.signal,
+      parentSpanContext: braintrustParentSpanContext,
       onSpanCreated: (spanId) => {
         res.setHeader('x-braintrust-span-id', spanId)
+      },
+      onSpanExported: (ctx) => {
+        res.setHeader('x-braintrust-span-context', ctx)
       },
     })
 

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -1,5 +1,5 @@
 import { Chat, type UIMessage as MessageType } from '@ai-sdk/react'
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithToolCalls } from 'ai'
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { DBSchema, IDBPDatabase, openDB } from 'idb'
 import { debounce } from 'lodash'
@@ -232,7 +232,7 @@ function createChatInstance(
   return new Chat<MessageType>({
     id: options.id,
     messages: options.initialMessages.map((message) => sanitizeForCloning(message)),
-    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithToolCalls,
+    sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
     transport: new DefaultChatTransport({
       api: `${BASE_PATH}/api/ai/sql/generate-v4`,
       fetch: async (url, init) => {

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -241,6 +241,12 @@ function createChatInstance(
         if (spanId) {
           state.pendingSpanIds[options.id] = spanId
         }
+        // Store the exported span context once per chat so all turns share the same
+        // root trace. Subsequent turns send this back as parentSpanContext.
+        const spanCtx = response.headers.get('x-braintrust-span-context')
+        if (spanCtx && !state.braintrustSpanContexts[options.id]) {
+          state.braintrustSpanContexts[options.id] = spanCtx
+        }
         return response
       },
       async prepareSendMessagesRequest({ messages, ...opts }) {
@@ -262,6 +268,7 @@ function createChatInstance(
             orgSlug: state.context.orgSlug,
             context: state.context,
             model: state.model,
+            braintrustParentSpanContext: state.braintrustSpanContexts[options.id],
             ...opts.body,
           },
           ...(IS_PLATFORM ? { headers: { Authorization: authorizationHeader ?? '' } } : {}),
@@ -315,6 +322,7 @@ export const createAiAssistantState = (): AiAssistantState => {
     chatInstances: {},
     pendingSpanIds: {},
     messageSpanIds: {},
+    braintrustSpanContexts: {},
 
     setContext: (context: Partial<AiAssistantContext>) => {
       state.context = { ...state.context, ...context }
@@ -391,6 +399,7 @@ export const createAiAssistantState = (): AiAssistantState => {
     deleteChat: (id: string) => {
       const { [id]: _, ...remainingChats } = state.chats
       state.chats = remainingChats
+      delete state.braintrustSpanContexts[id]
 
       if (id === state.activeChatId) {
         const remainingChatIds = Object.keys(remainingChats)
@@ -423,6 +432,7 @@ export const createAiAssistantState = (): AiAssistantState => {
         state.suggestions = undefined
         state.sqlSnippets = []
         state.initialInput = ''
+        delete state.braintrustSpanContexts[chat.id]
       }
     },
 
@@ -538,6 +548,7 @@ export type AiAssistantState = AiAssistantData & {
   chatInstances: Record<string, Chat<MessageType>>
   pendingSpanIds: Record<string, string>
   messageSpanIds: Record<string, string>
+  braintrustSpanContexts: Record<string, string>
   setContext: (context: Partial<AiAssistantContext>) => void
   setModel: (model: AssistantModel) => void
   newChat: (

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -1,5 +1,9 @@
 import { Chat, type UIMessage as MessageType } from '@ai-sdk/react'
-import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
+import {
+  DefaultChatTransport,
+  isToolUIPart,
+  lastAssistantMessageIsCompleteWithApprovalResponses,
+} from 'ai'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { DBSchema, IDBPDatabase, openDB } from 'idb'
 import { debounce } from 'lodash'
@@ -241,10 +245,11 @@ function createChatInstance(
         if (spanId) {
           state.pendingSpanIds[options.id] = spanId
         }
-        // Store the exported span context once per chat so all turns share the same
-        // root trace. Subsequent turns send this back as parentSpanContext.
+        // Always update the stored span context so it tracks the most recent turn.
+        // It is only sent back as a parent when the next request is an approval
+        // continuation — keeping each normal conversation turn as its own trace.
         const spanCtx = response.headers.get('x-braintrust-span-context')
-        if (spanCtx && !state.braintrustSpanContexts[options.id]) {
+        if (spanCtx) {
           state.braintrustSpanContexts[options.id] = spanCtx
         }
         return response
@@ -257,6 +262,14 @@ function createChatInstance(
         // Get the chat specific to this request to ensure we have the correct name
         const chat = state.chats[options.id]
 
+        // Only thread the parent span context when this request is an approval
+        // continuation (Turn 2). Normal turns get their own independent trace.
+        const isApprovalContinuation = messages.some(
+          (msg) =>
+            msg.role === 'assistant' &&
+            msg.parts?.some((part) => isToolUIPart(part) && part.state === 'approval-responded')
+        )
+
         return {
           ...opts,
           body: {
@@ -268,7 +281,9 @@ function createChatInstance(
             orgSlug: state.context.orgSlug,
             context: state.context,
             model: state.model,
-            braintrustParentSpanContext: state.braintrustSpanContexts[options.id],
+            braintrustParentSpanContext: isApprovalContinuation
+              ? state.braintrustSpanContexts[options.id]
+              : undefined,
             ...opts.body,
           },
           ...(IS_PLATFORM ? { headers: { Authorization: authorizationHeader ?? '' } } : {}),

--- a/apps/studio/state/ai-assistant-state.tsx
+++ b/apps/studio/state/ai-assistant-state.tsx
@@ -1,9 +1,5 @@
 import { Chat, type UIMessage as MessageType } from '@ai-sdk/react'
-import {
-  DefaultChatTransport,
-  isToolUIPart,
-  lastAssistantMessageIsCompleteWithApprovalResponses,
-} from 'ai'
+import { DefaultChatTransport, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { DBSchema, IDBPDatabase, openDB } from 'idb'
 import { debounce } from 'lodash'
@@ -245,13 +241,6 @@ function createChatInstance(
         if (spanId) {
           state.pendingSpanIds[options.id] = spanId
         }
-        // Always update the stored span context so it tracks the most recent turn.
-        // It is only sent back as a parent when the next request is an approval
-        // continuation — keeping each normal conversation turn as its own trace.
-        const spanCtx = response.headers.get('x-braintrust-span-context')
-        if (spanCtx) {
-          state.braintrustSpanContexts[options.id] = spanCtx
-        }
         return response
       },
       async prepareSendMessagesRequest({ messages, ...opts }) {
@@ -261,14 +250,6 @@ function createChatInstance(
 
         // Get the chat specific to this request to ensure we have the correct name
         const chat = state.chats[options.id]
-
-        // Only thread the parent span context when this request is an approval
-        // continuation (Turn 2). Normal turns get their own independent trace.
-        const isApprovalContinuation = messages.some(
-          (msg) =>
-            msg.role === 'assistant' &&
-            msg.parts?.some((part) => isToolUIPart(part) && part.state === 'approval-responded')
-        )
 
         return {
           ...opts,
@@ -281,9 +262,6 @@ function createChatInstance(
             orgSlug: state.context.orgSlug,
             context: state.context,
             model: state.model,
-            braintrustParentSpanContext: isApprovalContinuation
-              ? state.braintrustSpanContexts[options.id]
-              : undefined,
             ...opts.body,
           },
           ...(IS_PLATFORM ? { headers: { Authorization: authorizationHeader ?? '' } } : {}),
@@ -337,7 +315,6 @@ export const createAiAssistantState = (): AiAssistantState => {
     chatInstances: {},
     pendingSpanIds: {},
     messageSpanIds: {},
-    braintrustSpanContexts: {},
 
     setContext: (context: Partial<AiAssistantContext>) => {
       state.context = { ...state.context, ...context }
@@ -414,7 +391,6 @@ export const createAiAssistantState = (): AiAssistantState => {
     deleteChat: (id: string) => {
       const { [id]: _, ...remainingChats } = state.chats
       state.chats = remainingChats
-      delete state.braintrustSpanContexts[id]
 
       if (id === state.activeChatId) {
         const remainingChatIds = Object.keys(remainingChats)
@@ -447,7 +423,6 @@ export const createAiAssistantState = (): AiAssistantState => {
         state.suggestions = undefined
         state.sqlSnippets = []
         state.initialInput = ''
-        delete state.braintrustSpanContexts[chat.id]
       }
     },
 
@@ -563,7 +538,6 @@ export type AiAssistantState = AiAssistantData & {
   chatInstances: Record<string, Chat<MessageType>>
   pendingSpanIds: Record<string, string>
   messageSpanIds: Record<string, string>
-  braintrustSpanContexts: Record<string, string>
   setContext: (context: Partial<AiAssistantContext>) => void
   setModel: (model: AssistantModel) => void
   newChat: (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -980,8 +980,8 @@ importers:
         specifier: ^2.7.29
         version: 2.7.30
       ai:
-        specifier: ^6.0.116
-        version: 6.0.116(zod@3.25.76)
+        specifier: ^6.0.173
+        version: 6.0.173(zod@3.25.76)
       ai-commands:
         specifier: workspace:*
         version: link:../../packages/ai-commands
@@ -2749,6 +2749,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4
 
+  '@ai-sdk/gateway@3.0.108':
+    resolution: {integrity: sha512-hOtwiM6E/m1PgqHnx0/grvh0P/kjENHsN222OL5iYPQwfWmcX+26oFXM7HGL/UzonB+RORMkYAbskgAiANVwCQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.66':
     resolution: {integrity: sha512-SIQ0YY0iMuv+07HLsZ+bB990zUJ6S4ujORAh+Jv1V2KGNn73qQKnGO0JBk+w+Res8YqOFSycwDoWcFlQrVxS4A==}
     engines: {node: '>=18'}
@@ -2797,12 +2803,22 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.26':
+    resolution: {integrity: sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@1.1.3':
     resolution: {integrity: sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@2.0.0':
     resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.10':
+    resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
     engines: {node: '>=18'}
 
   '@ai-sdk/provider@3.0.8':
@@ -8780,6 +8796,10 @@ packages:
     resolution: {integrity: sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w==}
     engines: {node: '>= 20'}
 
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
   '@vitejs/plugin-react@6.0.1':
     resolution: {integrity: sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -9112,6 +9132,12 @@ packages:
 
   ai@6.0.116:
     resolution: {integrity: sha512-7yM+cTmyRLeNIXwt4Vj+mrrJgVQ9RMIW5WO0ydoLoYkewIvsMcvUmqS4j2RJTUXaF1HphwmSKUMQ/HypNRGOmA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@6.0.173:
+    resolution: {integrity: sha512-X2noFb82kouYQ4nlKGm1cR1Wvlp4Xit7fjJzwXv/msKQmtqkQn9NiXH6kCX4Gl4G+9DRWsJHIKANtWk8Ix1nTw==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -11340,9 +11366,6 @@ packages:
 
   fast-shallow-equal@1.0.0:
     resolution: {integrity: sha512-HPtaa38cPgWvaCFmRNhlc6NG7pv6NUHqjPgVAkWGoB9mQMwYB27/K0CvOM5Czy+qpT3e8XJ6Q4aPAnzpNpzNaw==}
-
-  fast-uri@3.0.6:
-    resolution: {integrity: sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==}
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
@@ -18074,6 +18097,13 @@ snapshots:
       '@ai-sdk/provider-utils': 3.0.9(zod@3.25.76)
       zod: 3.25.76
 
+  '@ai-sdk/gateway@3.0.108(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@3.25.76)
+      '@vercel/oidc': 3.2.0
+      zod: 3.25.76
+
   '@ai-sdk/gateway@3.0.66(zod@3.25.76)':
     dependencies:
       '@ai-sdk/provider': 3.0.8
@@ -18104,7 +18134,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 3.25.76
       zod-to-json-schema: 3.24.5(zod@3.25.76)
 
@@ -18112,7 +18142,7 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 2.0.0
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
       zod: 3.25.76
 
   '@ai-sdk/provider-utils@4.0.19(zod@3.25.76)':
@@ -18126,7 +18156,14 @@ snapshots:
     dependencies:
       '@ai-sdk/provider': 3.0.8
       '@standard-schema/spec': 1.1.0
-      eventsource-parser: 3.0.6
+      eventsource-parser: 3.0.8
+      zod: 3.25.76
+
+  '@ai-sdk/provider-utils@4.0.26(zod@3.25.76)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.10
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
       zod: 3.25.76
 
   '@ai-sdk/provider@1.1.3':
@@ -18134,6 +18171,10 @@ snapshots:
       json-schema: 0.4.0
 
   '@ai-sdk/provider@2.0.0':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.10':
     dependencies:
       json-schema: 0.4.0
 
@@ -25602,6 +25643,8 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
+  '@vercel/oidc@3.2.0': {}
+
   '@vitejs/plugin-react@6.0.1(vite@8.0.8(@types/node@22.13.14)(esbuild@0.25.2)(jiti@2.6.1)(sass@1.77.4)(terser@5.46.2)(tsx@4.20.3)(yaml@2.8.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
@@ -26047,6 +26090,14 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       zod: 3.25.76
 
+  ai@6.0.173(zod@3.25.76):
+    dependencies:
+      '@ai-sdk/gateway': 3.0.108(zod@3.25.76)
+      '@ai-sdk/provider': 3.0.10
+      '@ai-sdk/provider-utils': 4.0.26(zod@3.25.76)
+      '@opentelemetry/api': 1.9.0
+      zod: 3.25.76
+
   ajv-formats@2.1.1(ajv@8.18.0):
     optionalDependencies:
       ajv: 8.18.0
@@ -26089,7 +26140,7 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.0.6
+      fast-uri: 3.1.0
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -28679,8 +28730,6 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-shallow-equal@1.0.0: {}
-
-  fast-uri@3.0.6: {}
 
   fast-uri@3.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -52,6 +52,7 @@ minimumReleaseAgeExclude:
   - '@ai-sdk/*'
   - '@supabase/*'
   - '@supabase-labs/*'
+  - ai
   - braintrust # Included for bugfix in v3.9.0
   # The following packages are excluded from the minimum release age check because they had a vulneralibity
   # Delete them the next time you update this list


### PR DESCRIPTION
Second attempt at fixing AI-658, superseding https://github.com/supabase/supabase/pull/45339.

Instead of patching tracing around client-side SQL execution, this refactors `execute_sql` and `deploy_edge_function` to use AI SDK's `needsApproval` pattern — execution moves to the server, which resolves the split-trace problem structurally.

- `execute_sql` and `deploy_edge_function` tools now have `needsApproval: true` and server-side `execute` handlers; client no longer runs mutations directly
- UI approval flow uses `addToolApprovalResponse` instead of `addToolResult`; `DisplayBlockRenderer` and `EdgeFunctionRenderer` are stripped of client-side mutation hooks
- Braintrust span context is threaded across the approval boundary so Turn 1 and Turn 2 land in the same trace; Turn 1 suppresses online scoring until Turn 2 logs the combined output
- Restores edge function replace-warning guard (regression from initial attempt)

Closes AI-658

**References**
- https://github.com/supabase/supabase/pull/45339
- https://ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling#tool-execution-approval