### PR TITLE
fix: add query params for simple-redirect integrations

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -57,15 +57,15 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
       if (!integration.listingId) return toast.error('Listing ID is required')
       installOAuthIntegration({ projectRef, id: integration.listingId })
     } else {
-      let redirectUrl
+      let redirectUrl = '/'
+
       if (integration.installUrl) {
         const url = new URL(integration.installUrl)
         url.searchParams.append('organization_slug', selectedOrg?.slug ?? '')
         url.searchParams.append('project_id', projectRef)
         redirectUrl = url.href
-      } else {
-        redirectUrl = '/'
       }
+
       window.open(redirectUrl, '_blank', 'noreferrer')
     }
   }

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -6,6 +6,7 @@ import { Button } from 'ui'
 import type { IntegrationDefinition } from '@/components/interfaces/Integrations/Landing/Integrations.constants'
 import { useAPIKeysQuery } from '@/data/api-keys/api-keys-query'
 import { useInstallOAuthIntegrationMutation } from '@/data/marketplace/install-oauth-integration-mutation'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
 interface InstallOAuthIntegrationButtonProps {
   integration: IntegrationDefinition
@@ -13,6 +14,7 @@ interface InstallOAuthIntegrationButtonProps {
 
 export function InstallOAuthIntegrationButton({ integration }: InstallOAuthIntegrationButtonProps) {
   const { ref: projectRef } = useParams()
+  const { data: selectedOrg } = useSelectedOrganizationQuery()
 
   const { data: apiKeys, isLoading: isApiKeysLoading } = useAPIKeysQuery(
     { projectRef, reveal: false },
@@ -55,7 +57,16 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
       if (!integration.listingId) return toast.error('Listing ID is required')
       installOAuthIntegration({ projectRef, id: integration.listingId })
     } else {
-      window.location.href = integration.installUrl ?? '/'
+      let redirectUrl
+      if (integration.installUrl) {
+        const url = new URL(integration.installUrl)
+        url.searchParams.append('organization_slug', selectedOrg?.slug ?? '')
+        url.searchParams.append('project_id', projectRef)
+        redirectUrl = url.href
+      } else {
+        redirectUrl = '/'
+      }
+      window.open(redirectUrl, '_blank', 'noreferrer')
     }
   }
 


### PR DESCRIPTION
This change updates the handler for simple GET installations to correctly appending the organization_slug and project_ref parameters as documented in our Partner Integrations Guide.

Fixes INT-111

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Integration installs now open in a new browser tab instead of replacing the current page.
  * Organization and project context are appended to integration installation links so setups receive correct context.
  * Missing or invalid installation links now fall back to the home page to avoid navigation errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->