### PR TITLE
chore(studio): align sidebar hover states

### DIFF
--- a/apps/studio/components/layouts/AccountLayout/WithSidebar.tsx
+++ b/apps/studio/components/layouts/AccountLayout/WithSidebar.tsx
@@ -1,9 +1,11 @@
 import { ArrowLeft } from 'lucide-react'
 import Link from 'next/link'
 import { PropsWithChildren, ReactNode } from 'react'
-import { cn, Menu } from 'ui'
+import { cn } from 'ui'
 
 import type { SidebarSection } from './AccountLayout.types'
+import { getActiveKey, toSubMenuSections } from './AccountLayout.utils'
+import { SubMenu } from '@/components/ui/ProductMenu/SubMenu'
 
 interface WithSidebarProps {
   title?: string
@@ -54,11 +56,13 @@ export const SidebarContent = ({
   header,
   sections,
   subitems,
-  subitemsParentKey,
   customSidebarContent,
   backToDashboardURL,
   className,
 }: PropsWithChildren<Omit<WithSidebarProps, 'breadcrumbs'>> & { className?: string }) => {
+  const page = subitems ? undefined : getActiveKey(sections)
+  const subMenuSections = toSubMenuSections(sections)
+
   return (
     <>
       <div
@@ -85,49 +89,9 @@ export const SidebarContent = ({
           )}
           {header && header}
           <div className="flex-1 overflow-auto">
-            <div className="flex flex-col space-y-8">
-              <Menu type="pills">
-                {customSidebarContent}
-                {sections.map((section, idx) => (
-                  <div key={section.key || section.heading}>
-                    {Boolean(section.heading) ? (
-                      <SectionWithHeaders
-                        key={section.key}
-                        section={section}
-                        subitems={subitems}
-                        subitemsParentKey={subitemsParentKey}
-                      />
-                    ) : (
-                      <div className="my-6 space-y-8">
-                        <div className="mx-3">
-                          {section.links.map((link, i: number) => {
-                            const isActive = link.isActive && !subitems
-                            return (
-                              <Menu.Item
-                                key={`${link.key}-${i}`}
-                                rounded
-                                active={isActive}
-                                icon={link.icon}
-                              >
-                                <Link href={link.href || ''} className="block">
-                                  <div className="flex w-full items-center justify-between gap-1">
-                                    <div className="flex items-center gap-2 truncate w-full">
-                                      <span className="truncate">{link.label}</span>
-                                    </div>
-                                  </div>
-                                </Link>
-                              </Menu.Item>
-                            )
-                          })}
-                        </div>
-                      </div>
-                    )}
-                    {idx !== sections.length - 1 && (
-                      <div className="h-px w-full bg-border-overlay" />
-                    )}
-                  </div>
-                ))}
-              </Menu>
+            <div className="flex flex-col">
+              {customSidebarContent}
+              <SubMenu sections={subMenuSections} page={page} />
             </div>
           </div>
         </div>
@@ -135,41 +99,3 @@ export const SidebarContent = ({
     </>
   )
 }
-
-interface SectionWithHeadersProps {
-  section: SidebarSection
-  subitems?: any[]
-  subitemsParentKey?: number
-}
-
-const SectionWithHeaders = ({ section, subitems }: SectionWithHeadersProps) => (
-  <div key={section.heading} className="my-6 space-y-8">
-    <div className="mx-3">
-      {section.heading && (
-        <Menu.Group
-          title={
-            <div className="flex flex-col space-y-2 uppercase font-mono">
-              <span>{section.heading}</span>
-            </div>
-          }
-        />
-      )}
-      <div>
-        {section.links.map((link, i: number) => {
-          const isActive = link.isActive && !subitems
-          return (
-            <Menu.Item key={`${link.key}-${i}`} rounded active={isActive} icon={link.icon}>
-              <Link href={link.href || ''} className="block">
-                <div className="flex w-full items-center justify-between gap-1">
-                  <div className="flex items-center gap-2 truncate w-full">
-                    <span className="truncate">{link.label}</span>
-                  </div>
-                </div>
-              </Link>
-            </Menu.Item>
-          )
-        })}
-      </div>
-    </div>
-  </div>
-)

--- a/apps/studio/components/layouts/AccountLayout/WithSidebar.tsx
+++ b/apps/studio/components/layouts/AccountLayout/WithSidebar.tsx
@@ -11,10 +11,6 @@ interface WithSidebarProps {
   title?: string
   sections: SidebarSection[]
   header?: ReactNode
-  subitems?: any[]
-  subitemsParentKey?: number
-  hideSidebar?: boolean
-  customSidebarContent?: ReactNode
   backToDashboardURL?: string
 }
 
@@ -23,24 +19,17 @@ export const WithSidebar = ({
   header,
   children,
   sections,
-  subitems,
-  subitemsParentKey,
-  hideSidebar = false,
-  customSidebarContent,
   backToDashboardURL,
 }: PropsWithChildren<WithSidebarProps>) => {
-  const noContent = !sections && !customSidebarContent
+  const noContent = !sections
 
   return (
     <div className="flex flex-col md:flex-row h-full">
-      {!hideSidebar && !noContent && (
+      {!noContent && (
         <SidebarContent
           title={title}
           header={header}
           sections={sections}
-          subitems={subitems}
-          subitemsParentKey={subitemsParentKey}
-          customSidebarContent={customSidebarContent}
           backToDashboardURL={backToDashboardURL}
           className="hidden md:flex"
         />
@@ -55,12 +44,10 @@ export const WithSidebar = ({
 export const SidebarContent = ({
   header,
   sections,
-  subitems,
-  customSidebarContent,
   backToDashboardURL,
   className,
 }: PropsWithChildren<Omit<WithSidebarProps, 'breadcrumbs'>> & { className?: string }) => {
-  const page = subitems ? undefined : getActiveKey(sections)
+  const page = getActiveKey(sections)
   const subMenuSections = toSubMenuSections(sections)
 
   return (
@@ -90,7 +77,6 @@ export const SidebarContent = ({
           {header && header}
           <div className="flex-1 overflow-auto">
             <div className="flex flex-col">
-              {customSidebarContent}
               <SubMenu sections={subMenuSections} page={page} />
             </div>
           </div>

--- a/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/OrganizationSettingsLayout.tsx
@@ -236,5 +236,3 @@ export function OrganizationSettingsLayout({ children }: PropsWithChildren) {
     </WithSidebar>
   )
 }
-
-export default OrganizationSettingsLayout

--- a/apps/studio/components/ui/ProductMenu/index.tsx
+++ b/apps/studio/components/ui/ProductMenu/index.tsx
@@ -28,7 +28,7 @@ export const ProductMenu = ({ page, menu, onItemClick }: ProductMenuProps) => {
                     ) : null
                   }
                 />
-                <div className="flex flex-col gap-0.5">
+                <div>
                   {group.items.map((item) => {
                     const isActive = !!item.pages
                       ? item.pages.includes(page ?? '')

--- a/apps/studio/components/ui/ProductMenu/index.tsx
+++ b/apps/studio/components/ui/ProductMenu/index.tsx
@@ -28,7 +28,7 @@ export const ProductMenu = ({ page, menu, onItemClick }: ProductMenuProps) => {
                     ) : null
                   }
                 />
-                <div>
+                <div className="flex flex-col gap-0.5">
                   {group.items.map((item) => {
                     const isActive = !!item.pages
                       ? item.pages.includes(page ?? '')

--- a/apps/studio/pages/org/[slug]/general.tsx
+++ b/apps/studio/pages/org/[slug]/general.tsx
@@ -11,7 +11,7 @@ import {
 import { GeneralSettings } from '@/components/interfaces/Organization/GeneralSettings/GeneralSettings'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import OrganizationLayout from '@/components/layouts/OrganizationLayout'
-import OrganizationSettingsLayout from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
+import { OrganizationSettingsLayout } from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import { usePermissionsQuery } from '@/data/permissions/permissions-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import type { NextPageWithLayout } from '@/types'

--- a/apps/studio/pages/org/[slug]/private-apps/index.tsx
+++ b/apps/studio/pages/org/[slug]/private-apps/index.tsx
@@ -25,9 +25,9 @@ import {
   PrivateAppsProvider,
   usePrivateApps,
 } from '@/components/interfaces/Organization/PrivateApps/PrivateAppsContext'
-import DefaultLayout from '@/components/layouts/DefaultLayout'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import OrganizationLayout from '@/components/layouts/OrganizationLayout'
-import OrganizationSettingsLayout from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
+import { OrganizationSettingsLayout } from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import type { NextPageWithLayout } from '@/types'
 
 function PrivateAppsContent() {

--- a/apps/studio/pages/org/[slug]/security.tsx
+++ b/apps/studio/pages/org/[slug]/security.tsx
@@ -10,7 +10,7 @@ import {
 import { SecuritySettings } from '@/components/interfaces/Organization/SecuritySettings'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import OrganizationLayout from '@/components/layouts/OrganizationLayout'
-import OrganizationSettingsLayout from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
+import { OrganizationSettingsLayout } from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import { UnknownInterface } from '@/components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from '@/types'

--- a/apps/studio/pages/org/[slug]/sso.tsx
+++ b/apps/studio/pages/org/[slug]/sso.tsx
@@ -8,9 +8,9 @@ import {
 } from 'ui-patterns/PageHeader'
 
 import { SSOConfig } from '@/components/interfaces/Organization/SSO/SSOConfig'
-import DefaultLayout from '@/components/layouts/DefaultLayout'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import OrganizationLayout from '@/components/layouts/OrganizationLayout'
-import OrganizationSettingsLayout from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
+import { OrganizationSettingsLayout } from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import { UnknownInterface } from '@/components/ui/UnknownInterface'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import type { NextPageWithLayout } from '@/types'

--- a/apps/studio/pages/org/[slug]/webhooks/[endpointId].tsx
+++ b/apps/studio/pages/org/[slug]/webhooks/[endpointId].tsx
@@ -1,9 +1,9 @@
 import { useRouter } from 'next/router'
 
 import { PlatformWebhooksPage } from '@/components/interfaces/Platform/Webhooks'
-import DefaultLayout from '@/components/layouts/DefaultLayout'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import OrganizationLayout from '@/components/layouts/OrganizationLayout'
-import OrganizationSettingsLayout from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
+import { OrganizationSettingsLayout } from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import type { NextPageWithLayout } from '@/types'
 
 const OrgWebhookEndpointSettings: NextPageWithLayout = () => {

--- a/apps/studio/pages/org/[slug]/webhooks/index.tsx
+++ b/apps/studio/pages/org/[slug]/webhooks/index.tsx
@@ -1,7 +1,7 @@
 import { PlatformWebhooksPage } from '@/components/interfaces/Platform/Webhooks'
-import DefaultLayout from '@/components/layouts/DefaultLayout'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import OrganizationLayout from '@/components/layouts/OrganizationLayout'
-import OrganizationSettingsLayout from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
+import { OrganizationSettingsLayout } from '@/components/layouts/ProjectLayout/OrganizationSettingsLayout'
 import type { NextPageWithLayout } from '@/types'
 
 const OrgWebhooksSettings: NextPageWithLayout = () => {

--- a/packages/ui/src/components/shadcn/ui/sidebar.tsx
+++ b/packages/ui/src/components/shadcn/ui/sidebar.tsx
@@ -503,7 +503,7 @@ SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
   cn(
-    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md py-2 px-1.5 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent/50 data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 text-foreground-lighter data-[active=true]:text-foreground'
+    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md py-2 px-1.5 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent/50 active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent/50 data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 text-foreground-lighter data-[active=true]:text-foreground'
   ),
   {
     variants: {
@@ -722,7 +722,7 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-6 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+        'flex h-6 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent/50 active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',

--- a/packages/ui/src/components/shadcn/ui/sidebar.tsx
+++ b/packages/ui/src/components/shadcn/ui/sidebar.tsx
@@ -453,7 +453,7 @@ const SidebarGroupAction = React.forwardRef<
       ref={ref}
       data-sidebar="group-action"
       className={cn(
-        'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-5 [&>svg]:shrink-0',
+        'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-5 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:md:hidden',
         'group-data-[collapsible=icon]:hidden',
@@ -503,14 +503,14 @@ SidebarMenuItem.displayName = 'SidebarMenuItem'
 
 const sidebarMenuButtonVariants = cva(
   cn(
-    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md py-2 px-1.5 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 text-foreground-lighter data-[active=true]:text-foreground'
+    'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md py-2 px-1.5 text-left text-sm outline-hidden ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-data-[sidebar=menu-action]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent/50 data-[state=open]:hover:text-sidebar-accent-foreground [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 text-foreground-lighter data-[active=true]:text-foreground'
   ),
   {
     variants: {
       variant: {
-        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        default: 'hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground',
         outline:
-          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
         default: 'h-8 text-sm',
@@ -614,7 +614,7 @@ const SidebarMenuAction = React.forwardRef<
       ref={ref}
       data-sidebar="menu-action"
       className={cn(
-        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-5 [&>svg]:shrink-0',
+        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-hidden ring-sidebar-ring transition-transform hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-5 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
         'after:absolute after:-inset-2 after:md:hidden',
         'peer-data-[size=sm]/menu-button:top-1',
@@ -722,7 +722,7 @@ const SidebarMenuSubButton = React.forwardRef<
       data-size={size}
       data-active={isActive}
       className={cn(
-        'flex h-6 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+        'flex h-6 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-hidden ring-sidebar-ring hover:bg-sidebar-accent/50 hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-5 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
         'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
         size === 'sm' && 'text-xs',
         size === 'md' && 'text-sm',

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -706,10 +706,11 @@ export default {
           rounded: `rounded-md`,
         },
         pills: {
-          base: `px-3 py-1`,
+          base: `px-3 py-[3px] rounded-md transition-colors`,
           normal: `
             font-normal
             border-default
+            hover:bg-sidebar-accent/50
             group-hover:border-foreground-muted`,
           active: `
             font-semibold

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -706,7 +706,7 @@ export default {
           rounded: `rounded-md`,
         },
         pills: {
-          base: `px-3 py-[3px] rounded-md transition-colors`,
+          base: `my-px px-3 py-[3px] rounded-md transition-colors`,
           normal: `
             font-normal
             border-default

--- a/packages/ui/src/lib/theme/defaultTheme.ts
+++ b/packages/ui/src/lib/theme/defaultTheme.ts
@@ -706,7 +706,7 @@ export default {
           rounded: `rounded-md`,
         },
         pills: {
-          base: `my-px px-3 py-[3px] rounded-md transition-colors`,
+          base: `my-px px-3 py-[3px] rounded-md transition-colors active:bg-sidebar-accent/50`,
           normal: `
             font-normal
             border-default


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI polish. Updates sidebar and submenu navigation hover and active styling.

## What is the current behavior?

Product submenu navigation items either lack a hover fill or use a hover fill that visually matches the active state. Adjacent hovered and selected rows can appear to touch.

## What is the new behavior?

Primary sidebar buttons, sidebar sub-buttons, and product submenu pills now share a muted hover fill while preserving the full accent fill for active/selected states. Product submenu rows also get a small visual gap with slightly reduced vertical padding to keep the overall spacing compact.

| After |
| --- |
| <img width="988" height="408" alt="CleanShot 2026-05-05 at 11 53 05@2x" src="https://github.com/user-attachments/assets/560ac8a5-1262-41af-a196-618c86580150" /> |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined sidebar hover/active states with subtle accent alpha colors for a more polished visual experience.
  * Updated sidebar menu spacing and rounded corners for improved touch and visual clarity.

* **UI Improvements**
  * Sidebar now only displays when sections exist and uses a streamlined submenu flow for more consistent, predictable navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->