### PR TITLE
Fix multi selector content not scrollable if rendered in a sheet

### DIFF
--- a/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
@@ -20,7 +20,6 @@ import { useSqlFilterGenerateMutation } from '@/data/ai/sql-filter-mutation'
 import { useTableEditorTableStateSnapshot } from '@/state/table-editor-table'
 
 export interface FilterPopoverProps {
-  portal?: boolean
   isRefetching?: boolean
 }
 

--- a/packages/ui-patterns/src/multi-select/multi-select.tsx
+++ b/packages/ui-patterns/src/multi-select/multi-select.tsx
@@ -530,6 +530,7 @@ const MultiSelectorList = React.forwardRef<
         className
       )}
       style={{ maxHeight: dropdownMaxHeight }}
+      onWheel={(e) => e.stopPropagation()}
     >
       {children}
       {creatable && inputValue.length > 0 && !isOptionExists ? (


### PR DESCRIPTION
## Context

Realised that MultiSelector's content is not scrollable when rendered within a sheet (e.g Auth policies, Database indexes)

### Explanation from Claude:
- The issue is that Radix Dialog (Sheet) adds @radix-ui/react-remove-scroll which intercepts wheel events. The Popover portal renders outside the Sheet's DOM tree, so the scroll lock blocks wheel events on CommandList.
- The fix is to stop wheel event propagation on the CommandList so it doesn't reach the RemoveScroll handler.

### To test
- [ ] Verify that MultiSelector can be scrollable within a sheet (e.g Auth policies roles) and outside of a sheet (e.g Data API -> Exposed schemas)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed scroll wheel propagation in multi-select dropdown to prevent unintended scrolling of parent elements.

* **Updates**
  * Simplified filter component interface by removing an unused configuration property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->