### PR TITLE
RLS Tester to include policies that are applied to public

### DIFF
--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterResults.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterResults.tsx
@@ -11,6 +11,7 @@ import { Admonition } from 'ui-patterns'
 import { Results } from '../../SQLEditor/UtilityPanel/Results'
 import { RLSTableCard } from './RLSTableCard'
 import { ParseQueryResults } from './RLSTester.types'
+import { deriveRLSTestState } from './RLSTesterResults.utils'
 import { useTestQueryRLS } from './useTestQueryRLS'
 import type { Policy } from '@/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils'
 
@@ -29,16 +30,12 @@ export const RLSTesterResults = ({
 }: RLSTesterResultsProps) => {
   const { limit } = useTestQueryRLS()
 
-  const isServiceRole = parseQueryResults?.role === undefined
-  const tableWithRLSEnabledButNoPolicies = parseQueryResults?.tables.find(
-    (x) => x.isRLSEnabled && x.tablePolicies.length === 0
-  )
-  const tableWithRLSEnabledWithPolicyFalse = parseQueryResults?.tables.find(
-    (x) => x.isRLSEnabled && x.tablePolicies.some((y) => y.definition === 'false')
-  )
-
-  const noAccessToData =
-    !isServiceRole && (!!tableWithRLSEnabledButNoPolicies || !!tableWithRLSEnabledWithPolicyFalse)
+  const {
+    isServiceRole,
+    tableWithRLSEnabledButNoPolicies,
+    tableWithRLSEnabledWithPolicyFalse,
+    noAccessToData,
+  } = deriveRLSTestState(parseQueryResults)
 
   return (
     <div className="p-5 pt-4">

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterResults.utils.ts
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterResults.utils.ts
@@ -1,0 +1,20 @@
+import type { ParseQueryResults } from './RLSTester.types'
+
+export function deriveRLSTestState(parseQueryResults: ParseQueryResults | undefined) {
+  const isServiceRole = parseQueryResults?.role === undefined
+  const tableWithRLSEnabledButNoPolicies = parseQueryResults?.tables.find(
+    (x) => x.isRLSEnabled && x.tablePolicies.length === 0
+  )
+  const tableWithRLSEnabledWithPolicyFalse = parseQueryResults?.tables.find(
+    (x) => x.isRLSEnabled && x.tablePolicies.some((y) => y.definition === 'false')
+  )
+  const noAccessToData =
+    !isServiceRole && (!!tableWithRLSEnabledButNoPolicies || !!tableWithRLSEnabledWithPolicyFalse)
+
+  return {
+    isServiceRole,
+    tableWithRLSEnabledButNoPolicies,
+    tableWithRLSEnabledWithPolicyFalse,
+    noAccessToData,
+  }
+}

--- a/apps/studio/components/interfaces/Auth/RLSTester/__tests__/RLSTesterResults.test.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/__tests__/RLSTesterResults.test.tsx
@@ -1,0 +1,199 @@
+import type { SafeSqlFragment } from '@supabase/pg-meta'
+import { screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import type { Policy } from '@/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils'
+import type { ParseQueryResults } from '@/components/interfaces/Auth/RLSTester/RLSTester.types'
+import { RLSTesterResults } from '@/components/interfaces/Auth/RLSTester/RLSTesterResults'
+import { render } from '@/tests/helpers'
+
+vi.mock('@/components/interfaces/Auth/RLSTester/useTestQueryRLS', () => ({
+  useTestQueryRLS: () => ({ limit: 100 }),
+}))
+
+vi.mock('@/components/interfaces/Auth/RLSTester/RLSTableCard', () => ({
+  RLSTableCard: () => <div data-testid="rls-table-card" />,
+}))
+
+vi.mock('@/components/interfaces/SQLEditor/UtilityPanel/Results', () => ({
+  Results: () => <div data-testid="results" />,
+}))
+
+const sql = (s: string) => s as unknown as SafeSqlFragment
+
+const makePolicy = (definition: string | null = null): Policy =>
+  ({ definition: definition !== null ? sql(definition) : null }) as Policy
+
+const makeTable = (
+  overrides?: Partial<ParseQueryResults['tables'][number]>
+): ParseQueryResults['tables'][number] => ({
+  schema: 'public',
+  table: 'items',
+  isRLSEnabled: true,
+  tablePolicies: [],
+  ...overrides,
+})
+
+const defaultProps = {
+  results: [],
+  autoLimit: false,
+  handleSelectEditPolicy: vi.fn(),
+}
+
+describe('RLSTesterResults', () => {
+  describe('access badge', () => {
+    it('shows "No access" badge when table has RLS enabled but no policies', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [makeTable()],
+            operation: 'SELECT',
+            role: 'anon',
+          }}
+        />
+      )
+      expect(screen.getByText('No access')).toBeInTheDocument()
+    })
+
+    it('shows "No access" badge when a policy definition is false', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [makeTable({ tablePolicies: [makePolicy('false')] })],
+            operation: 'SELECT',
+            role: 'anon',
+          }}
+        />
+      )
+      expect(screen.getByText('No access')).toBeInTheDocument()
+    })
+
+    it('shows "Has access" badge when results are empty and user has access', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          results={[]}
+          parseQueryResults={{
+            tables: [makeTable({ tablePolicies: [makePolicy('auth.uid() = user_id')] })],
+            operation: 'SELECT',
+            role: 'authenticated',
+          }}
+        />
+      )
+      expect(screen.getByText('Has access')).toBeInTheDocument()
+    })
+
+    it('shows "Can access" badge when results are returned', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          results={[{ id: 1 }]}
+          parseQueryResults={{
+            tables: [makeTable({ tablePolicies: [makePolicy('auth.uid() = user_id')] })],
+            operation: 'SELECT',
+            role: 'authenticated',
+          }}
+        />
+      )
+      expect(screen.getByText('Can access')).toBeInTheDocument()
+    })
+  })
+
+  describe('policy admonitions', () => {
+    it('shows service role admonition for postgres role', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [makeTable()],
+            operation: 'SELECT',
+            role: undefined,
+          }}
+        />
+      )
+      expect(screen.getByText(/bypasses all RLS policies/)).toBeInTheDocument()
+    })
+
+    it('shows "no policies" admonition when RLS is enabled but no policies exist', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [makeTable({ table: 'profiles', tablePolicies: [] })],
+            operation: 'SELECT',
+            role: 'anon',
+          }}
+        />
+      )
+      expect(screen.getByText(/no policies set up/)).toBeInTheDocument()
+      expect(screen.getByText(/public.profiles/)).toBeInTheDocument()
+    })
+
+    it('shows "policy false" admonition when a policy evaluates to false', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [makeTable({ table: 'secrets', tablePolicies: [makePolicy('false')] })],
+            operation: 'SELECT',
+            role: 'anon',
+          }}
+        />
+      )
+      expect(screen.getByText(/evaluates to/)).toBeInTheDocument()
+      expect(screen.getByText(/public.secrets/)).toBeInTheDocument()
+    })
+  })
+
+  describe('"Ran as" section', () => {
+    it('shows postgres for service role', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [],
+            operation: 'SELECT',
+            role: undefined,
+          }}
+        />
+      )
+      expect(screen.getAllByText('postgres').length).toBeGreaterThan(0)
+    })
+
+    it('shows "an Anonymous user" for anon role', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [],
+            operation: 'SELECT',
+            role: 'anon',
+          }}
+        />
+      )
+      expect(screen.getByText('an Anonymous user')).toBeInTheDocument()
+      expect(screen.getByText('Not logged in user')).toBeInTheDocument()
+    })
+
+    it('shows user email and ID when a user is present', () => {
+      render(
+        <RLSTesterResults
+          {...defaultProps}
+          parseQueryResults={{
+            tables: [],
+            operation: 'SELECT',
+            role: 'authenticated',
+            user: {
+              id: 'user-123',
+              email: 'alice@example.com',
+            } as any,
+          }}
+        />
+      )
+      expect(screen.getByText('alice@example.com')).toBeInTheDocument()
+      expect(screen.getByText('ID: user-123')).toBeInTheDocument()
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Auth/RLSTester/__tests__/RLSTesterResults.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/RLSTester/__tests__/RLSTesterResults.utils.test.ts
@@ -1,0 +1,192 @@
+import type { SafeSqlFragment } from '@supabase/pg-meta'
+import { describe, expect, it } from 'vitest'
+
+import type { Policy } from '@/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils'
+import type { ParseQueryResults } from '@/components/interfaces/Auth/RLSTester/RLSTester.types'
+import { deriveRLSTestState } from '@/components/interfaces/Auth/RLSTester/RLSTesterResults.utils'
+
+const sql = (s: string) => s as unknown as SafeSqlFragment
+
+const makePolicy = (definition: string | null = null): Policy =>
+  ({ definition: definition !== null ? sql(definition) : null }) as Policy
+
+const makeTable = (
+  overrides?: Partial<ParseQueryResults['tables'][number]>
+): ParseQueryResults['tables'][number] => ({
+  schema: 'public',
+  table: 'items',
+  isRLSEnabled: true,
+  tablePolicies: [],
+  ...overrides,
+})
+
+const makeResults = (overrides?: Partial<ParseQueryResults>): ParseQueryResults => ({
+  tables: [],
+  operation: 'SELECT',
+  role: 'anon',
+  ...overrides,
+})
+
+describe('deriveRLSTestState', () => {
+  describe('isServiceRole', () => {
+    it('is true when parseQueryResults is undefined', () => {
+      const { isServiceRole } = deriveRLSTestState(undefined)
+      expect(isServiceRole).toBe(true)
+    })
+
+    it('is true when role is undefined (postgres / service role)', () => {
+      const { isServiceRole } = deriveRLSTestState(makeResults({ role: undefined }))
+      expect(isServiceRole).toBe(true)
+    })
+
+    it('is false when role is anon', () => {
+      const { isServiceRole } = deriveRLSTestState(makeResults({ role: 'anon' }))
+      expect(isServiceRole).toBe(false)
+    })
+
+    it('is false when role is authenticated', () => {
+      const { isServiceRole } = deriveRLSTestState(makeResults({ role: 'authenticated' }))
+      expect(isServiceRole).toBe(false)
+    })
+  })
+
+  describe('noAccessToData', () => {
+    it('is false when parseQueryResults is undefined', () => {
+      const { noAccessToData } = deriveRLSTestState(undefined)
+      expect(noAccessToData).toBe(false)
+    })
+
+    it('is false for service role even when tables have no policies', () => {
+      const { noAccessToData } = deriveRLSTestState(
+        makeResults({ role: undefined, tables: [makeTable()] })
+      )
+      expect(noAccessToData).toBe(false)
+    })
+
+    it('is false when RLS is disabled on table', () => {
+      const { noAccessToData } = deriveRLSTestState(
+        makeResults({ tables: [makeTable({ isRLSEnabled: false, tablePolicies: [] })] })
+      )
+      expect(noAccessToData).toBe(false)
+    })
+
+    it('is true when RLS is enabled and table has no policies', () => {
+      const { noAccessToData } = deriveRLSTestState(
+        makeResults({ tables: [makeTable({ isRLSEnabled: true, tablePolicies: [] })] })
+      )
+      expect(noAccessToData).toBe(true)
+    })
+
+    it('is true when RLS is enabled and a policy definition is false', () => {
+      const { noAccessToData } = deriveRLSTestState(
+        makeResults({
+          tables: [makeTable({ tablePolicies: [makePolicy('false')] })],
+        })
+      )
+      expect(noAccessToData).toBe(true)
+    })
+
+    it('is false when RLS is enabled and policies are valid (not false)', () => {
+      const { noAccessToData } = deriveRLSTestState(
+        makeResults({
+          tables: [makeTable({ tablePolicies: [makePolicy('auth.uid() = user_id')] })],
+        })
+      )
+      expect(noAccessToData).toBe(false)
+    })
+
+    it('is false when all tables have RLS disabled regardless of policy state', () => {
+      const { noAccessToData } = deriveRLSTestState(
+        makeResults({
+          tables: [
+            makeTable({ isRLSEnabled: false, tablePolicies: [] }),
+            makeTable({
+              table: 'other',
+              isRLSEnabled: false,
+              tablePolicies: [makePolicy('false')],
+            }),
+          ],
+        })
+      )
+      expect(noAccessToData).toBe(false)
+    })
+  })
+
+  describe('tableWithRLSEnabledButNoPolicies', () => {
+    it('is undefined when no tables', () => {
+      const { tableWithRLSEnabledButNoPolicies } = deriveRLSTestState(makeResults({ tables: [] }))
+      expect(tableWithRLSEnabledButNoPolicies).toBeUndefined()
+    })
+
+    it('is undefined when RLS disabled', () => {
+      const { tableWithRLSEnabledButNoPolicies } = deriveRLSTestState(
+        makeResults({ tables: [makeTable({ isRLSEnabled: false })] })
+      )
+      expect(tableWithRLSEnabledButNoPolicies).toBeUndefined()
+    })
+
+    it('is undefined when table has policies', () => {
+      const { tableWithRLSEnabledButNoPolicies } = deriveRLSTestState(
+        makeResults({ tables: [makeTable({ tablePolicies: [makePolicy('true')] })] })
+      )
+      expect(tableWithRLSEnabledButNoPolicies).toBeUndefined()
+    })
+
+    it('returns the matching table when RLS enabled with no policies', () => {
+      const table = makeTable({ table: 'profiles', tablePolicies: [] })
+      const { tableWithRLSEnabledButNoPolicies } = deriveRLSTestState(
+        makeResults({ tables: [table] })
+      )
+      expect(tableWithRLSEnabledButNoPolicies).toEqual(table)
+    })
+
+    it('returns the first matching table among multiple', () => {
+      const first = makeTable({ table: 'profiles', tablePolicies: [] })
+      const second = makeTable({ table: 'posts', tablePolicies: [] })
+      const { tableWithRLSEnabledButNoPolicies } = deriveRLSTestState(
+        makeResults({ tables: [first, second] })
+      )
+      expect(tableWithRLSEnabledButNoPolicies).toEqual(first)
+    })
+  })
+
+  describe('tableWithRLSEnabledWithPolicyFalse', () => {
+    it('is undefined when no tables', () => {
+      const { tableWithRLSEnabledWithPolicyFalse } = deriveRLSTestState(makeResults({ tables: [] }))
+      expect(tableWithRLSEnabledWithPolicyFalse).toBeUndefined()
+    })
+
+    it('is undefined when RLS disabled even with false policy', () => {
+      const { tableWithRLSEnabledWithPolicyFalse } = deriveRLSTestState(
+        makeResults({
+          tables: [makeTable({ isRLSEnabled: false, tablePolicies: [makePolicy('false')] })],
+        })
+      )
+      expect(tableWithRLSEnabledWithPolicyFalse).toBeUndefined()
+    })
+
+    it('is undefined when no policy has definition of false', () => {
+      const { tableWithRLSEnabledWithPolicyFalse } = deriveRLSTestState(
+        makeResults({
+          tables: [makeTable({ tablePolicies: [makePolicy('auth.uid() = user_id')] })],
+        })
+      )
+      expect(tableWithRLSEnabledWithPolicyFalse).toBeUndefined()
+    })
+
+    it('returns the table when a policy definition is exactly "false"', () => {
+      const table = makeTable({ table: 'secrets', tablePolicies: [makePolicy('false')] })
+      const { tableWithRLSEnabledWithPolicyFalse } = deriveRLSTestState(
+        makeResults({ tables: [table] })
+      )
+      expect(tableWithRLSEnabledWithPolicyFalse).toEqual(table)
+    })
+
+    it('is undefined when policy definition is null (no definition)', () => {
+      const { tableWithRLSEnabledWithPolicyFalse } = deriveRLSTestState(
+        makeResults({ tables: [makeTable({ tablePolicies: [makePolicy(null)] })] })
+      )
+      expect(tableWithRLSEnabledWithPolicyFalse).toBeUndefined()
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Auth/RLSTester/useTestQueryRLS.ts
+++ b/apps/studio/components/interfaces/Auth/RLSTester/useTestQueryRLS.ts
@@ -128,7 +128,8 @@ export const useTestQueryRLS = () => {
             (x) =>
               x.schema === schema &&
               x.table === table &&
-              x.roles.includes(role?.role ?? '') &&
+              (x.roles.includes(role?.role ?? '') ||
+                (x.roles.length === 1 && x.roles[0] === 'public')) &&
               x.command === data.operation
           )
           return {


### PR DESCRIPTION
## Context

For a table that has RLS enabled, but a policy with just `true` for the role `public`
The RLS tester was incorrectly reporting that `anon` doesn't have access

Was happening as we weren't considering policies that apply to the `public` role (which applies to _all_ roles)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RLS tester now treats explicitly-public policies as applicable regardless of the impersonated role, improving policy coverage accuracy.
* **Refactor**
  * Consolidated RLS test state computation to improve consistency of access badges and policy messaging.
* **Tests**
  * Added comprehensive tests validating RLS scenarios, badge states, and policy/role messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->