### PR TITLE
chore(docs): add Daniel Mitterdorfer to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -60,6 +60,7 @@ Colum Ferry
 Craig Cannon
 Cuong Do
 Dane Harrigan
+Daniel Mitterdorfer
 Daniel Velázquez Lara
 Danny White
 Dave Wilson


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to add `Daniel Mitterdorfer` to `humans.txt`.

## What is the current behavior?

`Daniel Mitterdorfer`is not present in `humans.txt`.

## What is the new behavior?

`Daniel Mitterdorfer`is present in `humans.txt`.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the team roster in public documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->