### PR TITLE
docs: add documentation for postgres logs

### DIFF
--- a/apps/docs/content/guides/telemetry/logs.mdx
+++ b/apps/docs/content/guides/telemetry/logs.mdx
@@ -213,6 +213,11 @@ show log_min_messages;
 
 Note that `LOG` is a higher level than `WARNING` and `ERROR`, so if your level is set to `LOG`, you will not see `WARNING` and `ERROR` messages.
 
+### Limits and Caveats
+
+- PostgreSQL log events on the Supabase Platform are limited to 100,000 characters. If a log event exceeds this limit, it will be truncated. This does not apply to self-hosting.
+- Internal connection logs to PostgreSQL within the Supabase Platform by internal services are not logged. This does not apply to self-hosting.
+
 ## Logging realtime connections
 
 Realtime doesn't log new WebSocket connections or Channel joins by default. Enable connection logging per client by including an `info` `log_level` parameter when instantiating the Supabase client.

--- a/apps/docs/content/guides/telemetry/logs.mdx
+++ b/apps/docs/content/guides/telemetry/logs.mdx
@@ -213,10 +213,10 @@ show log_min_messages;
 
 Note that `LOG` is a higher level than `WARNING` and `ERROR`, so if your level is set to `LOG`, you will not see `WARNING` and `ERROR` messages.
 
-### Limits and Caveats
+### Limits and caveats
 
-- PostgreSQL log events on the Supabase Platform are limited to 100,000 characters. If a log event exceeds this limit, it will be truncated. This does not apply to self-hosting.
-- Internal connection logs to PostgreSQL within the Supabase Platform by internal services are not logged. This does not apply to self-hosting.
+- Postgres log events on the Supabase Platform are limited to 100,000 characters. If a log event exceeds this limit, it will be truncated. This does not apply to self-hosting.
+- Internal connection logs to Postgres within the Supabase Platform by internal services are not logged. This does not apply to self-hosting.
 
 ## Logging realtime connections
 


### PR DESCRIPTION
Small docs update on new postgres logs behaviour

part of O11Y-1519

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Limits and Caveats" section clarifying Supabase Platform-specific behavior for PostgreSQL RAISEd log messages: platform log events are truncated at 100,000 characters (no truncation for self-hosting), and certain internal PostgreSQL connection logs generated by infrastructure services are omitted (these omissions do not apply to self-hosted deployments).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->