### PR TITLE
fix(studio): restore 3xx/4xx log status badge colors

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsFormatters.tsx
@@ -106,7 +106,7 @@ export const ResponseCodeFormatter = ({ value }: { value: string }) => {
     // 4XX || 3XX responses
     case '4':
     case '3':
-      return <ResponseCodeItem className="bg-amber-300 text-amber-1100">{value}</ResponseCodeItem>
+      return <ResponseCodeItem className="bg-warning/10 text-warning">{value}</ResponseCodeItem>
 
     // All other responses
     default:


### PR DESCRIPTION
## Problem

After the Tailwind v4 upgrade, the 3xx/4xx HTTP status badge in the Logs explorer rendered with a saturated yellow background and washed-out text, because `bg-amber-300`/`text-amber-1100` no longer resolve as they did under v3.

## Fix

Switch the 3xx/4xx case in `ResponseCodeFormatter` to the existing `bg-warning/10 text-warning` semantic tokens, matching the pattern used by the shared `Badge` warning variant.

## Before
<img width="798" height="722" alt="CleanShot 2026-05-05 at 12 13 23@2x" src="https://github.com/user-attachments/assets/a2d37f37-4260-4ec6-bf1c-ff96b6f51be0" />

## After
<img width="642" height="530" alt="CleanShot 2026-05-05 at 12 12 55@2x" src="https://github.com/user-attachments/assets/7c82aee2-0d40-4213-8533-14ffb04fb5de" />


## How to test

- Run `pnpm dev:studio`
- Open any project's Logs explorer (API, Edge Functions, Auth, etc.)
- Find a row with a 3xx or 4xx status code
- Expected: faint yellow background with a darker amber/yellow text, consistent with other warning badges in the app
- Confirm 2xx (brand) and 5xx (red) badges still render as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual styling of response codes in the logs display for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->