### PR TITLE
docs(ai-skills): add scope and cross-agent install guidance

### DIFF
--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -18,7 +18,19 @@ To install a specific skill from the repository:
 npx skills add supabase/agent-skills --skill SKILL_NAME
 ```
 
-Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others.
+Skills install at project scope by default, placing them in your repository so all contributors and cloud agents share the same setup. Pass `--global` to install once across all your projects instead:
+
+```bash
+npx skills add supabase/agent-skills --global
+```
+
+Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others. To install for all agents at once:
+
+```bash
+npx skills add supabase/agent-skills --all
+```
+
+If you use Claude Code, the [Supabase agent plugin](/docs/guides/getting-started/plugins) bundles both skills and the Supabase MCP server into a single install.
 
 ## Available skills
 

--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -18,19 +18,9 @@ To install a specific skill from the repository:
 npx skills add supabase/agent-skills --skill SKILL_NAME
 ```
 
-Skills install at project scope by default, placing them in your repository so all contributors and cloud agents share the same setup. Pass `--global` to install once across all your projects instead:
+Skills install at project scope by default, placing them in your repository so all contributors and cloud agents share the same setup. Pass `--global` to install once across all your projects instead. You can also install for all detected agents at the same time by passing `--all`. See the [skills package](https://github.com/vercel-labs/skills) for more options.
 
-```bash
-npx skills add supabase/agent-skills --global
-```
-
-Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others. To install for all agents at once:
-
-```bash
-npx skills add supabase/agent-skills --all
-```
-
-If you use Claude Code, the [Supabase agent plugin](/docs/guides/getting-started/plugins) bundles both skills and the Supabase MCP server into a single install.
+Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others. If you use Claude Code, the [Supabase agent plugin](/docs/guides/getting-started/plugins) bundles both skills and the Supabase MCP server into a single install.
 
 ## Available skills
 
@@ -49,3 +39,4 @@ npx skills find QUERY
 - [Agent Skills Repository](https://github.com/supabase/agent-skills)
 - [Agent Skills Documentation](https://agentskills.io/home)
 - [Agent Skills Overview](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/overview)
+- [skills npm package](https://github.com/vercel-labs/skills)

--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -18,7 +18,9 @@ To install a specific skill from the repository:
 npx skills add supabase/agent-skills --skill SKILL_NAME
 ```
 
-Skills install at project scope by default, placing them in your repository so all contributors and cloud agents share the same setup. Pass `--global` to install once across all your projects instead. You can also install for all detected agents at the same time by passing `--all`. See the [skills package](https://github.com/vercel-labs/skills) for more options.
+Skills are installed at project scope by default, placing them in your repository so contributors and cloud agents all share the same setup. Pass `--global` to install across all your projects instead.
+
+Add skills for all detected agents at the same time by passing `--all`. See the [skills package](https://github.com/vercel-labs/skills) for more options.
 
 You can also install the agent skills together with the Supabase MCP server using the [Supabase agent plugin](/docs/guides/getting-started/plugins) for an agent-first workflow.
 

--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -20,7 +20,7 @@ npx skills add supabase/agent-skills --skill SKILL_NAME
 
 Skills install at project scope by default, placing them in your repository so all contributors and cloud agents share the same setup. Pass `--global` to install once across all your projects instead. You can also install for all detected agents at the same time by passing `--all`. See the [skills package](https://github.com/vercel-labs/skills) for more options.
 
-Skills work with 18+ AI agents including Claude Code, GitHub Copilot, Cursor, Cline, and many others. If you use Claude Code, the [Supabase agent plugin](/docs/guides/getting-started/plugins) bundles both skills and the Supabase MCP server into a single install.
+You can also install the agent skills together with the Supabase MCP server using the [Supabase agent plugin](/docs/guides/getting-started/plugins) for an agent-first workflow.
 
 ## Available skills
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -30,6 +30,8 @@ To verify the client has access to the MCP server tools, try asking it to query 
 
 For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/docs/guides/getting-started/ai-prompts) collection.
 
+To also install Supabase agent skills alongside the MCP server, use the [Supabase agent plugin](/docs/guides/getting-started/plugins) for a combined one-step setup.
+
 ## Available tools
 
 The Supabase MCP server provides tools organized into feature groups. All groups except Storage are enabled by default. You can enable or disable specific groups using the [configuration panel above](#step-2-configure-your-ai-tool).

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -30,7 +30,7 @@ To verify the client has access to the MCP server tools, try asking it to query 
 
 For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/docs/guides/getting-started/ai-prompts) collection.
 
-To also install Supabase agent skills alongside the MCP server, use the [Supabase agent plugin](/docs/guides/getting-started/plugins) for a combined one-step setup.
+Additionally, you can install Supabase agent skills alongside the MCP server, use the [Supabase agent plugin](/docs/guides/getting-started/plugins) for a combined one-step setup.
 
 ## Available tools
 


### PR DESCRIPTION
## Summary

- Adds a note explaining that skills install at **project scope by default** (committed to git, shared with team and cloud agents) and that `--global` installs across all projects
- Mentions `--all` for users who work across multiple AI agents
- Cross-links the [Supabase agent plugin](/docs/guides/getting-started/plugins) from both the agent skills and MCP docs for users who want the MCP server and skills in a single install

Closes [AI-672](https://linear.app/supabase/issue/AI-672/add-other-plugins-to-docs-with-clearer-project-vs-global-level)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified AI skills installation: project-scoped by default, with options for global (--global) or install-for-all agents (--all)
  * Noted that agent skills can be installed alongside the MCP server using the Supabase agent plugin for a combined setup
  * Added a direct link to the skills npm package
  * Removed an outdated compatibility claim about support for 18+ AI agents
<!-- end of auto-generated comment: release notes by coderabbit.ai -->