### PR TITLE
chore(docs): add David Whittington to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -69,6 +69,7 @@ David Alvarez
 David Birdsong
 David Camacho Cateura
 David Weitzman
+David Whittington
 Davide Pellegatta
 Deepthi Sigireddi
 Deji I


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add myself to humans.txt

## What is the current behavior?

My name is not in humans.txt

## What is the new behavior?

My name will be in humans.txt

## Additional context

None

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added "David Whittington" to the public HUMANS team list in the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->