### PR TITLE
feat(studio): show expand affordance for large SQL result cells

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultCell.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ResultCell.tsx
@@ -1,0 +1,48 @@
+import { Expand } from 'lucide-react'
+import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
+import { formatCellValue, isLargeValue } from './Results.utils'
+
+interface ResultCellProps {
+  column: string
+  value: unknown
+  onContextMenu: (e: React.MouseEvent, column: string, value: unknown) => void
+  onExpand: (column: string, value: unknown) => void
+}
+
+export const ResultCell = ({ column, value, onContextMenu, onExpand }: ResultCellProps) => {
+  const showExpand = isLargeValue(value)
+
+  return (
+    <div
+      className={cn(
+        'group/cell relative flex items-center h-full font-mono text-xs w-full whitespace-pre',
+        value === null && 'text-foreground-lighter'
+      )}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        onContextMenu(e, column, value)
+      }}
+    >
+      {formatCellValue(value)}
+      {showExpand && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              type="default"
+              size="tiny"
+              className="absolute right-1 top-1/2 -translate-y-1/2 px-1 opacity-0 group-hover/cell:opacity-100 focus-visible:opacity-100"
+              icon={<Expand size={10} />}
+              aria-label="View full cell content"
+              onClick={(e) => {
+                e.stopPropagation()
+                onExpand(column, value)
+              }}
+            />
+          </TooltipTrigger>
+          <TooltipContent side="left">View full cell content</TooltipContent>
+        </Tooltip>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -2,20 +2,16 @@ import { Copy, Expand } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import DataGrid, { CalculatedColumn } from 'react-data-grid'
 import {
-  Button,
-  cn,
   ContextMenu_Shadcn_,
   ContextMenuContent_Shadcn_,
   ContextMenuItem_Shadcn_,
   ContextMenuTrigger_Shadcn_,
   copyToClipboard,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
 
 import { CellDetailPanel } from './CellDetailPanel'
-import { formatCellValue, formatClipboardValue, isLargeValue } from './Results.utils'
+import { ResultCell } from './ResultCell'
+import { formatClipboardValue } from './Results.utils'
 import { handleCellKeyDown } from '@/components/grid/SupabaseGrid.utils'
 
 export const Results = ({ rows }: { rows: readonly any[] }) => {
@@ -75,42 +71,14 @@ export const Results = ({ rows }: { rows: readonly any[] }) => {
           frozen: false,
           sortable: false,
           isLastFrozenColumn: false,
-          renderCell: ({ row }: { row: any }) => {
-            const cellValue = row[key]
-            const showExpand = isLargeValue(cellValue)
-            return (
-              <div
-                className={cn(
-                  'group/cell relative flex items-center h-full font-mono text-xs w-full whitespace-pre',
-                  cellValue === null && 'text-foreground-lighter'
-                )}
-                onContextMenu={(e) => {
-                  e.preventDefault()
-                  handleContextMenu(e, key, cellValue)
-                }}
-              >
-                {formatCellValue(cellValue)}
-                {showExpand && (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Button
-                        type="default"
-                        size="tiny"
-                        className="absolute right-1 top-1/2 -translate-y-1/2 px-1 opacity-0 group-hover/cell:opacity-100 focus-visible:opacity-100"
-                        icon={<Expand size={10} />}
-                        aria-label="View full cell content"
-                        onClick={(e) => {
-                          e.stopPropagation()
-                          setExpandedCell({ column: key, value: cellValue })
-                        }}
-                      />
-                    </TooltipTrigger>
-                    <TooltipContent side="left">View full cell content</TooltipContent>
-                  </Tooltip>
-                )}
-              </div>
-            )
-          },
+          renderCell: ({ row }: { row: any }) => (
+            <ResultCell
+              column={key}
+              value={row[key]}
+              onContextMenu={handleContextMenu}
+              onExpand={(column, value) => setExpandedCell({ column, value })}
+            />
+          ),
           renderHeaderCell: () => columnRender(key),
         }
       }),

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.tsx
@@ -2,21 +2,24 @@ import { Copy, Expand } from 'lucide-react'
 import { useCallback, useMemo, useRef, useState } from 'react'
 import DataGrid, { CalculatedColumn } from 'react-data-grid'
 import {
+  Button,
   cn,
   ContextMenu_Shadcn_,
   ContextMenuContent_Shadcn_,
   ContextMenuItem_Shadcn_,
   ContextMenuTrigger_Shadcn_,
   copyToClipboard,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 
 import { CellDetailPanel } from './CellDetailPanel'
-import { formatCellValue, formatClipboardValue } from './Results.utils'
+import { formatCellValue, formatClipboardValue, isLargeValue } from './Results.utils'
 import { handleCellKeyDown } from '@/components/grid/SupabaseGrid.utils'
 
 export const Results = ({ rows }: { rows: readonly any[] }) => {
-  const [expandCell, setExpandCell] = useState(false)
-  const [cellPosition, setCellPosition] = useState<{ column: any; row: any; rowIdx: number }>()
+  const [expandedCell, setExpandedCell] = useState<{ column: string; value: any } | null>(null)
   const contextMenuCellRef = useRef<{ column: string; value: any } | null>(null)
   const triggerRef = useRef<HTMLDivElement>(null)
 
@@ -74,10 +77,11 @@ export const Results = ({ rows }: { rows: readonly any[] }) => {
           isLastFrozenColumn: false,
           renderCell: ({ row }: { row: any }) => {
             const cellValue = row[key]
+            const showExpand = isLargeValue(cellValue)
             return (
               <div
                 className={cn(
-                  'flex items-center h-full font-mono text-xs w-full whitespace-pre',
+                  'group/cell relative flex items-center h-full font-mono text-xs w-full whitespace-pre',
                   cellValue === null && 'text-foreground-lighter'
                 )}
                 onContextMenu={(e) => {
@@ -86,6 +90,24 @@ export const Results = ({ rows }: { rows: readonly any[] }) => {
                 }}
               >
                 {formatCellValue(cellValue)}
+                {showExpand && (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button
+                        type="default"
+                        size="tiny"
+                        className="absolute right-1 top-1/2 -translate-y-1/2 px-1 opacity-0 group-hover/cell:opacity-100 focus-visible:opacity-100"
+                        icon={<Expand size={10} />}
+                        aria-label="View full cell content"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setExpandedCell({ column: key, value: cellValue })
+                        }}
+                      />
+                    </TooltipTrigger>
+                    <TooltipContent side="left">View full cell content</TooltipContent>
+                  </Tooltip>
+                )}
               </div>
             )
           },
@@ -123,7 +145,10 @@ export const Results = ({ rows }: { rows: readonly any[] }) => {
               </ContextMenuItem_Shadcn_>
               <ContextMenuItem_Shadcn_
                 className="gap-x-2"
-                onSelect={() => setExpandCell(true)}
+                onSelect={() => {
+                  const cell = contextMenuCellRef.current
+                  if (cell) setExpandedCell({ column: cell.column, value: cell.value })
+                }}
                 onFocusCapture={(e) => e.stopPropagation()}
               >
                 <Expand size={12} />
@@ -136,14 +161,13 @@ export const Results = ({ rows }: { rows: readonly any[] }) => {
             rows={rows}
             className="grow min-h-0 border-t-0"
             rowClass={() => '[&>.rdg-cell]:items-center'}
-            onSelectedCellChange={setCellPosition}
             onCellKeyDown={handleCellKeyDown}
           />
           <CellDetailPanel
-            column={cellPosition?.column.name ?? ''}
-            value={cellPosition?.row?.[cellPosition.column.name]}
-            visible={expandCell}
-            onClose={() => setExpandCell(false)}
+            column={expandedCell?.column ?? ''}
+            value={expandedCell?.value}
+            visible={expandedCell !== null}
+            onClose={() => setExpandedCell(null)}
           />
         </>
       )}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.test.ts
@@ -6,6 +6,7 @@ import {
   convertResultsToMarkdown,
   formatResults,
   getResultsHeaders,
+  isLargeValue,
 } from './Results.utils'
 
 describe('Results.utils', () => {
@@ -99,6 +100,52 @@ describe('Results.utils', () => {
     it('should use only the first row for headers', () => {
       const results = [{ id: 1 }, { id: 2, extra: 'bonus' }]
       expect(getResultsHeaders(results)).toEqual(['id'])
+    })
+  })
+
+  describe('isLargeValue', () => {
+    it('returns false for null', () => {
+      expect(isLargeValue(null)).toBe(false)
+    })
+
+    it('returns false for undefined', () => {
+      expect(isLargeValue(undefined)).toBe(false)
+    })
+
+    it('returns false for an empty string', () => {
+      expect(isLargeValue('')).toBe(false)
+    })
+
+    it('returns false for a short string under the threshold', () => {
+      expect(isLargeValue('hello')).toBe(false)
+    })
+
+    it('returns false for a string at the 60-char boundary', () => {
+      expect(isLargeValue('a'.repeat(60))).toBe(false)
+    })
+
+    it('returns true for a string just over the 60-char threshold', () => {
+      expect(isLargeValue('a'.repeat(61))).toBe(true)
+    })
+
+    it('returns true for a short string containing a newline', () => {
+      expect(isLargeValue('hello\nworld')).toBe(true)
+    })
+
+    it('returns true for an object', () => {
+      expect(isLargeValue({ a: 1 })).toBe(true)
+    })
+
+    it('returns true for an array', () => {
+      expect(isLargeValue([1, 2, 3])).toBe(true)
+    })
+
+    it('returns false for a number', () => {
+      expect(isLargeValue(42)).toBe(false)
+    })
+
+    it('returns false for a boolean', () => {
+      expect(isLargeValue(true)).toBe(false)
     })
   })
 

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/Results.utils.ts
@@ -17,6 +17,15 @@ export function formatCellValue(value: unknown) {
   return JSON.stringify(value)
 }
 
+const LARGE_VALUE_CHAR_THRESHOLD = 60
+
+export function isLargeValue(value: unknown) {
+  if (value === null || value === undefined) return false
+  if (typeof value === 'object') return true
+  const str = String(value)
+  return str.length > LARGE_VALUE_CHAR_THRESHOLD || str.includes('\n')
+}
+
 export function formatResults(
   results: ResultRow[]
 ): Record<string, string | number | boolean | null | undefined>[] {

--- a/apps/studio/tests/components/SQLEditor/ResultCell.test.tsx
+++ b/apps/studio/tests/components/SQLEditor/ResultCell.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { expect, test, vi } from 'vitest'
+
+import { ResultCell } from '@/components/interfaces/SQLEditor/UtilityPanel/ResultCell'
+import { customRender as render } from '@/tests/lib/custom-render'
+
+const noop = () => {}
+
+test('renders the formatted cell value', () => {
+  render(<ResultCell column="name" value="alice" onContextMenu={noop} onExpand={noop} />)
+  expect(screen.getByText('alice')).toBeTruthy()
+})
+
+test('renders NULL for null values', () => {
+  render(<ResultCell column="name" value={null} onContextMenu={noop} onExpand={noop} />)
+  expect(screen.getByText('NULL')).toBeTruthy()
+})
+
+test('does not render the expand button for short string values', () => {
+  render(<ResultCell column="name" value="alice" onContextMenu={noop} onExpand={noop} />)
+  expect(screen.queryByRole('button', { name: 'View full cell content' })).toBeNull()
+})
+
+test('renders the expand button for object values', () => {
+  render(<ResultCell column="data" value={{ nested: true }} onContextMenu={noop} onExpand={noop} />)
+  expect(screen.getByRole('button', { name: 'View full cell content' })).toBeTruthy()
+})
+
+test('renders the expand button for long string values', () => {
+  render(<ResultCell column="bio" value={'a'.repeat(120)} onContextMenu={noop} onExpand={noop} />)
+  expect(screen.getByRole('button', { name: 'View full cell content' })).toBeTruthy()
+})
+
+test('clicking the expand button calls onExpand with column and value', async () => {
+  const onExpand = vi.fn()
+  const value = { nested: true }
+  render(<ResultCell column="data" value={value} onContextMenu={noop} onExpand={onExpand} />)
+
+  await userEvent.click(screen.getByRole('button', { name: 'View full cell content' }))
+
+  expect(onExpand).toHaveBeenCalledTimes(1)
+  expect(onExpand).toHaveBeenCalledWith('data', value)
+})
+
+test('right-clicking the cell calls onContextMenu with column and value', () => {
+  const onContextMenu = vi.fn()
+  render(<ResultCell column="name" value="alice" onContextMenu={onContextMenu} onExpand={noop} />)
+
+  fireEvent.contextMenu(screen.getByText('alice'))
+
+  expect(onContextMenu).toHaveBeenCalledTimes(1)
+  const [, column, value] = onContextMenu.mock.calls[0]
+  expect(column).toBe('name')
+  expect(value).toBe('alice')
+})


### PR DESCRIPTION
## Summary

- Adds a hover-revealed expand button to SQL result cells whose value is unlikely to fit on one line (objects, arrays, strings >60 chars, or strings with newlines). Clicking opens the existing `CellDetailPanel` for that cell.
- Switches the expand state from a boolean tied to the selected cell to a direct `{ column, value }` reference, so the context menu and the new button both target the right-clicked / clicked cell.
- Extracts the per-cell renderer into its own `ResultCell` component to keep `Results.tsx` digestible and the new affordance isolated.
- Covers the new logic with exhaustive `isLargeValue` unit tests and a `ResultCell` component test (visibility, click, right-click).

Linear: [FE-3130](https://linear.app/supabase/issue/FE-3130)

## Test plan

- [x] Run a SQL query that returns mixed cell types (short strings, long strings, JSON objects, arrays, nulls) and confirm the expand button appears only on cells where content is likely truncated.
- [x] Hover a large cell and click the expand button — `CellDetailPanel` opens with the correct column + value.
- [x] Right-click a large cell and choose "View cell content" — same panel opens with the right cell.
- [x] Right-click a small cell and "Copy cell content" — clipboard contains the raw value.
- [x] Resize a column wider than its content and confirm the button still positions correctly.
- [x] `pnpm vitest` for `Results.utils.test.ts`, `Results.test.tsx`, `ResultCell.test.tsx` — all green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced SQL result cells with automatic detection and expansion functionality for large values (exceeding 60 characters or containing line breaks)
  * Added expand button to view full cell content directly in results
  * Integrated right-click context menu for cell content options
  * Improved display of null values in query results

<!-- end of auto-generated comment: release notes by coderabbit.ai -->