### PR TITLE
chore: migrate `Input` usages to Shadcn component in integrations screens/components

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/EdgeFunctionSection.tsx
@@ -17,7 +17,10 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-  Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
   Popover_Shadcn_,
   PopoverContent_Shadcn_,
   PopoverTrigger_Shadcn_,
@@ -192,12 +195,12 @@ export const EdgeFunctionSection = ({ form }: HTTPRequestFieldsProps) => {
         name="values.timeoutMs"
         render={({ field: { ref, ...rest } }) => (
           <FormItemLayout label="Timeout" layout="vertical" className="gap-1">
-            <Input
-              {...rest}
-              type="number"
-              placeholder="1000"
-              actions={<p className="text-foreground-light pr-2">ms</p>}
-            />
+            <InputGroup>
+              <InputGroupInput {...rest} type="number" placeholder="1000" />
+              <InputGroupAddon align="inline-end">
+                <InputGroupText> ms</InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
           </FormItemLayout>
         )}
       />

--- a/apps/studio/components/interfaces/Integrations/CronJobs/HttpRequestSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/HttpRequestSection.tsx
@@ -5,7 +5,11 @@ import {
   FormItem,
   FormLabel,
   FormMessage,
-  Input,
+  Input_Shadcn_ as Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectItem_Shadcn_,
@@ -63,12 +67,12 @@ export const HttpRequestSection = ({ form }: HttpRequestSectionProps) => {
         name="values.timeoutMs"
         render={({ field: { ref, ...rest } }) => (
           <FormItemLayout label="Timeout" className="gap-1">
-            <Input
-              {...rest}
-              type="number"
-              placeholder="1000"
-              actions={<p className="text-foreground-light pr-2">ms</p>}
-            />
+            <InputGroup>
+              <InputGroupInput {...rest} type="number" placeholder="1000" />
+              <InputGroupAddon align="inline-end">
+                <InputGroupText> ms</InputGroupText>
+              </InputGroupAddon>
+            </InputGroup>
           </FormItemLayout>
         )}
       />

--- a/apps/studio/components/interfaces/Integrations/Queues/CreateQueueSheet/PartitionConfigFields.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/CreateQueueSheet/PartitionConfigFields.tsx
@@ -1,5 +1,13 @@
 import { UseFormReturn } from 'react-hook-form'
-import { FormField, Input, Separator, SheetSection } from 'ui'
+import {
+  FormField,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+  Separator,
+  SheetSection,
+} from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CreateQueueForm } from './CreateQueueSheet.schema'
@@ -21,12 +29,12 @@ export function PartitionConfigFields({ form }: { form: UseFormReturn<CreateQueu
               description="Number of messages per partition"
               className="gap-1"
             >
-              <Input
-                {...rest}
-                type="number"
-                placeholder="10000"
-                actions={<p className="text-foreground-light pr-2">messages</p>}
-              />
+              <InputGroup>
+                <InputGroupInput {...rest} type="number" placeholder="10000" />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupText>messages</InputGroupText>
+                </InputGroupAddon>
+              </InputGroup>
             </FormItemLayout>
           )}
         />
@@ -39,12 +47,12 @@ export function PartitionConfigFields({ form }: { form: UseFormReturn<CreateQueu
               description="Partitions older than this many messages behind the latest will be dropped"
               className="gap-1"
             >
-              <Input
-                {...rest}
-                type="number"
-                placeholder="100000"
-                actions={<p className="text-foreground-light pr-2">messages</p>}
-              />
+              <InputGroup>
+                <InputGroupInput {...rest} type="number" placeholder="10000" />
+                <InputGroupAddon align="inline-end">
+                  <InputGroupText>messages</InputGroupText>
+                </InputGroupAddon>
+              </InputGroup>
             </FormItemLayout>
           )}
         />

--- a/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/SendMessageModal.tsx
@@ -3,7 +3,16 @@ import { useParams } from 'common'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import { Form, FormControl, FormField, Input, Modal } from 'ui'
+import {
+  Form,
+  FormControl,
+  FormField,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  InputGroupText,
+  Modal,
+} from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import z from 'zod'
 
@@ -102,12 +111,12 @@ export const SendMessageModal = ({ visible, onClose }: SendMessageModalProps) =>
                   description="Time in seconds before the message becomes available for reading."
                 >
                   <FormControl>
-                    <Input
-                      {...rest}
-                      type="number"
-                      placeholder="1"
-                      actions={<p className="text-foreground-light pr-2">sec</p>}
-                    />
+                    <InputGroup>
+                      <InputGroupInput {...rest} type="number" placeholder="1" />
+                      <InputGroupAddon align="inline-end">
+                        <InputGroupText>sec</InputGroupText>
+                      </InputGroupAddon>
+                    </InputGroup>
                   </FormControl>
                 </FormItemLayout>
               )}


### PR DESCRIPTION
## Screenshots

### New cron job edge function timeout
Before:
<img width="1157" height="259" alt="image" src="https://github.com/user-attachments/assets/b5e056e7-6216-45a6-9cc6-15e56621c62a" />


After:
<img width="1162" height="258" alt="image" src="https://github.com/user-attachments/assets/bfb12a20-8a11-47f1-b7e6-c1ebc2fc187e" />

### New cron job http request timeout
Before:
<img width="1161" height="237" alt="image" src="https://github.com/user-attachments/assets/ad1dc7ef-e9ec-4219-8f84-f20025aa1c68" />

After:
<img width="1160" height="231" alt="image" src="https://github.com/user-attachments/assets/eb4d0df2-db20-4e04-a78d-fa36656a2987" />

### New queue, partition configuration
Before:
<img width="786" height="677" alt="image" src="https://github.com/user-attachments/assets/34b3f1fc-b1e8-434f-bfc7-8a5686bd1c29" />

After:
<img width="778" height="668" alt="image" src="https://github.com/user-attachments/assets/f7423240-b810-47d6-af1d-9d5647c78843" />

### Queue: send message dialog
Before:
<img width="522" height="411" alt="image" src="https://github.com/user-attachments/assets/f9cf5993-c7e4-4bd0-9718-0c9e85e41378" />

After:
<img width="532" height="414" alt="image" src="https://github.com/user-attachments/assets/d965bfcc-c074-44a1-8a8f-ecdd4e766221" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced input field presentation for timeout, delay, and interval configurations with inline unit labels (milliseconds, seconds, messages) for improved clarity and consistency across integration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->