### PR TITLE
chore: migrate `Input` usages to Shadcn component in settings

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/DNSRecord.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/DNSRecord.tsx
@@ -1,4 +1,4 @@
-import { Input } from 'ui'
+import { Input } from 'ui-patterns/DataInputs/Input'
 
 export type DNSRecordProps = {
   type: string
@@ -12,8 +12,23 @@ const DNSRecord = ({ type, name, value }: DNSRecordProps) => {
       <div className="w-[50px]">
         <p className="font-mono text-base">{type.toUpperCase()}</p>
       </div>
-      <Input readOnly copy disabled className="input-mono flex-1" value={name} layout="vertical" />
-      <Input readOnly copy disabled className="input-mono flex-1" value={value} layout="vertical" />
+
+      <Input
+        readOnly
+        copy
+        disabled
+        containerClassName="flex-1"
+        className="font-mono"
+        value={name}
+      />
+      <Input
+        readOnly
+        copy
+        disabled
+        containerClassName="flex-1"
+        className="font-mono"
+        value={value}
+      />
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -2,7 +2,7 @@ import { LOCAL_STORAGE_KEYS } from 'common'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { Input } from 'ui'
+import { TextArea_Shadcn_ as TextArea } from 'ui'
 
 import { CANCELLATION_REASONS } from '@/components/interfaces/Billing/Billing.constants'
 import { LogicalBackupCliInstructions } from '@/components/layouts/ProjectLayout/LogicalBackupCliInstructions'
@@ -141,7 +141,7 @@ export const DeleteProjectModal = ({
     >
       <div className="space-y-6">
         <LogicalBackupCliInstructions enabled={visible} showResetPassword={false} />
-        {/* 
+        {/*
           [Joshen] This is basically ExitSurvey.tsx, ideally we have one shared component but the one
           in ExitSurvey has a Form wrapped around it already. Will probably need some effort to refactor
           but leaving that for the future.
@@ -182,10 +182,10 @@ export const DeleteProjectModal = ({
                 })}
               </div>
               <div className="text-area-text-sm flex flex-col gap-y-2">
-                <label className="text-sm whitespace-pre-line wrap-break-word">
+                <label htmlFor="message" className="text-sm whitespace-pre-line wrap-break-word">
                   {textareaLabel}
                 </label>
-                <Input.TextArea
+                <TextArea
                   name="message"
                   rows={3}
                   value={message}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -1,7 +1,18 @@
 import { useParams } from 'common'
 import Link from 'next/link'
-import { Badge, Button, Input, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import {
+  Badge,
+  Button,
+  Input_Shadcn_ as Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { ProjectUpgradeAlert } from '../General/Infrastructure/ProjectUpgradeAlert'
@@ -133,65 +144,78 @@ export const InfrastructureInfo = () => {
                     {isSuccessServiceVersions && (
                       <>
                         {authEnabled && (
-                          <Input
-                            readOnly
-                            disabled
+                          <FormItemLayout
                             label="Auth version"
-                            value={serviceVersions?.gotrue ?? ''}
-                          />
+                            layout="vertical"
+                            isReactForm={false}
+                          >
+                            <Input readOnly disabled value={serviceVersions?.gotrue ?? ''} />
+                          </FormItemLayout>
                         )}
-                        <Input
-                          readOnly
-                          disabled
+                        <FormItemLayout
                           label="PostgREST version"
-                          value={serviceVersions?.postgrest ?? ''}
-                        />
-                        <Input
-                          readOnly
-                          disabled
-                          value={currentPgVersion || serviceVersions?.['supabase-postgres'] || ''}
+                          layout="vertical"
+                          isReactForm={false}
+                        >
+                          <Input readOnly disabled value={serviceVersions?.postgrest ?? ''} />
+                        </FormItemLayout>
+                        <FormItemLayout
                           label="Postgres version"
-                          actions={[
-                            isVisibleReleaseChannel && (
-                              <Tooltip key="release-channel">
-                                <TooltipTrigger>
-                                  <Badge variant="warning" className="mr-1">
-                                    {isVisibleReleaseChannel}
-                                  </Badge>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom" className="w-44 text-center">
-                                  This project uses a {isVisibleReleaseChannel} database version
-                                  release
-                                </TooltipContent>
-                              </Tooltip>
-                            ),
-                            isOrioleDb && (
-                              <Tooltip key="orioledb">
-                                <TooltipTrigger>
-                                  <Badge variant="default" className="mr-1">
-                                    OrioleDB
-                                  </Badge>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom" className="w-44 text-center">
-                                  This project uses OrioleDB
-                                </TooltipContent>
-                              </Tooltip>
-                            ),
-                            isOnLatestVersion && (
-                              <Tooltip key="latest-version">
-                                <TooltipTrigger>
-                                  <Badge variant="success" className="mr-1">
-                                    Latest
-                                  </Badge>
-                                </TooltipTrigger>
-                                <TooltipContent side="bottom" className="w-52 text-center">
-                                  Project is on the latest version of Postgres that Supabase
-                                  supports
-                                </TooltipContent>
-                              </Tooltip>
-                            ),
-                          ]}
-                        />
+                          layout="vertical"
+                          isReactForm={false}
+                        >
+                          <InputGroup>
+                            <InputGroupInput
+                              readOnly
+                              disabled
+                              value={
+                                currentPgVersion || serviceVersions?.['supabase-postgres'] || ''
+                              }
+                            />
+                            <InputGroupAddon align="inline-end">
+                              {[
+                                isVisibleReleaseChannel && (
+                                  <Tooltip key="release-channel">
+                                    <TooltipTrigger>
+                                      <Badge variant="warning" className="mr-1">
+                                        {isVisibleReleaseChannel}
+                                      </Badge>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" className="w-44 text-center">
+                                      This project uses a {isVisibleReleaseChannel} database version
+                                      release
+                                    </TooltipContent>
+                                  </Tooltip>
+                                ),
+                                isOrioleDb && (
+                                  <Tooltip key="orioledb">
+                                    <TooltipTrigger>
+                                      <Badge variant="default" className="mr-1">
+                                        OrioleDB
+                                      </Badge>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" className="w-44 text-center">
+                                      This project uses OrioleDB
+                                    </TooltipContent>
+                                  </Tooltip>
+                                ),
+                                isOnLatestVersion && (
+                                  <Tooltip key="latest-version">
+                                    <TooltipTrigger>
+                                      <Badge variant="success" className="mr-1">
+                                        Latest
+                                      </Badge>
+                                    </TooltipTrigger>
+                                    <TooltipContent side="bottom" className="w-52 text-center">
+                                      Project is on the latest version of Postgres that Supabase
+                                      supports
+                                    </TooltipContent>
+                                  </Tooltip>
+                                ),
+                              ]}
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </FormItemLayout>
                       </>
                     )}
 

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -135,7 +135,7 @@ const PreviewFilterPanel = ({
               <div className="flex items-center gap-x-1">
                 {hasEdits && (
                   <Tooltip>
-                    <TooltipTrigger>
+                    <TooltipTrigger asChild>
                       <InputGroupButton type="text" onClick={() => handleInputSearch(search)}>
                         <span>↲</span>
                       </InputGroupButton>
@@ -146,7 +146,7 @@ const PreviewFilterPanel = ({
 
                 {search.length > 0 && (
                   <Tooltip>
-                    <TooltipTrigger>
+                    <TooltipTrigger asChild>
                       <InputGroupButton type="text" onClick={() => handleInputSearch('')}>
                         <X />
                       </InputGroupButton>

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -147,7 +147,13 @@ const PreviewFilterPanel = ({
                 {search.length > 0 && (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <InputGroupButton type="text" onClick={() => handleInputSearch('')}>
+                      <InputGroupButton
+                        type="text"
+                        onClick={() => {
+                          setSearch('')
+                          handleInputSearch('')
+                        }}
+                      >
                         <X />
                       </InputGroupButton>
                     </TooltipTrigger>

--- a/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/PreviewFilterPanel.tsx
@@ -3,7 +3,17 @@ import { Eye, EyeOff, RefreshCw, Search, Terminal, X } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import { Button, cn, Input, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import {
+  Button,
+  cn,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
 
 import {
   FILTER_OPTIONS,
@@ -14,7 +24,6 @@ import {
 import { DatePickerValue, LogsDatePicker } from './Logs.DatePickers'
 import type { Filters, LogSearchCallback, LogTemplate } from './Logs.types'
 import LogsFilterPopover from './LogsFilterPopover'
-import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { DatabaseSelector } from '@/components/ui/DatabaseSelector'
 import { DownloadResultsButton } from '@/components/ui/DownloadResultsButton'
 import { useLoadBalancersQuery } from '@/data/read-replicas/load-balancers-query'
@@ -108,45 +117,46 @@ const PreviewFilterPanel = ({
             handleInputSearch(search)
           }}
         >
-          <Input
-            className="w-60"
-            size="tiny"
-            placeholder="Search events"
-            onChange={(e) => setSearch(e.target.value)}
-            onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
-              setSearch(e.target.value)
-              handleInputSearch(e.target.value)
-            }}
-            icon={
-              <div className="text-foreground-lighter">
-                <Search size={14} />
-              </div>
-            }
-            value={search}
-            actions={
-              <div className="flex items-center gap-x-1 mr-0.5">
+          <InputGroup className="w-60">
+            <InputGroupInput
+              size="tiny"
+              placeholder="Search events"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              onBlur={(e: React.FocusEvent<HTMLInputElement>) => {
+                setSearch(e.target.value)
+                handleInputSearch(e.target.value)
+              }}
+            />
+            <InputGroupAddon>
+              <Search />
+            </InputGroupAddon>
+            <InputGroupAddon align="inline-end">
+              <div className="flex items-center gap-x-1">
                 {hasEdits && (
-                  <ButtonTooltip
-                    icon={<span>↲</span>}
-                    type="text"
-                    className="px-1 h-[20px]"
-                    onClick={() => handleInputSearch(search)}
-                    tooltip={{ content: { side: 'bottom', text: 'Search for events' } }}
-                  />
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <InputGroupButton type="text" onClick={() => handleInputSearch(search)}>
+                        <span>↲</span>
+                      </InputGroupButton>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Search for events</TooltipContent>
+                  </Tooltip>
                 )}
 
                 {search.length > 0 && (
-                  <ButtonTooltip
-                    icon={<X />}
-                    type="text"
-                    className="p-px h-[20px]"
-                    onClick={() => handleInputSearch('')}
-                    tooltip={{ content: { side: 'bottom', text: 'Clear search' } }}
-                  />
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <InputGroupButton type="text" onClick={() => handleInputSearch('')}>
+                        <X />
+                      </InputGroupButton>
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">Clear search</TooltipContent>
+                  </Tooltip>
                 )}
               </div>
-            }
-          />
+            </InputGroupAddon>
+          </InputGroup>
         </form>
 
         <Tooltip>


### PR DESCRIPTION
screens/components

## Screeshots

### Delete project modal textarea
Before:
<img width="792" height="928" alt="image" src="https://github.com/user-attachments/assets/f8276696-7bc0-415e-958c-b8794762013b" />

After:
<img width="788" height="928" alt="image" src="https://github.com/user-attachments/assets/4b0991c1-7926-4b0a-b1cb-942f809f4a02" />

### Edge functions logs search input
Before:
<img width="667" height="219" alt="image" src="https://github.com/user-attachments/assets/991b09ce-8d4f-4ccc-b787-3da611c78893" />

After:
<img width="695" height="231" alt="image" src="https://github.com/user-attachments/assets/2623faeb-d636-4dec-8244-8e9bdad3acfb" />

### Infrastructure
Before:
<img width="1144" height="419" alt="image" src="https://github.com/user-attachments/assets/25b27819-a3f6-4d67-9edc-f8225d07d592" />

After:
<img width="1153" height="440" alt="image" src="https://github.com/user-attachments/assets/10eea888-09b0-463b-a307-6c58b4feb948" />

### DNS Record

Haven't been able to test this one

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined form and input layouts across Settings: DNS, Project Deletion, Infrastructure Info, and Log Preview panels for a more consistent, accessible editing experience.
  * Replaced various single-line inputs with grouped controls, read-only/display variants, and input-with-addon patterns, improving readability, copy/readonly behavior, and control affordances (buttons, badges, tooltips) in settings and log search.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->