### PR TITLE
feat: block adding new owners to stripe orgs

### DIFF
--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -26,9 +26,6 @@ import {
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
   Switch,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -323,26 +320,22 @@ export const InviteMemberButton = () => {
                                   ? 'Additional permissions required to assign role'
                                   : undefined
 
-                              const item = (
+                              return (
                                 <SelectItem_Shadcn_
                                   key={role.id}
                                   value={role.id.toString()}
                                   className="text-sm"
                                   disabled={disabled}
                                 >
-                                  {role.name}
+                                  <div className="flex flex-col gap-0.5">
+                                    <span>{role.name}</span>
+                                    {disabledReason && (
+                                      <span className="text-xs text-foreground-lighter">
+                                        {disabledReason}
+                                      </span>
+                                    )}
+                                  </div>
                                 </SelectItem_Shadcn_>
-                              )
-
-                              if (!disabledReason) return item
-
-                              return (
-                                <Tooltip key={role.id}>
-                                  <TooltipTrigger asChild>
-                                    <span style={{ pointerEvents: 'all' }}>{item}</span>
-                                  </TooltipTrigger>
-                                  <TooltipContent side="right">{disabledReason}</TooltipContent>
-                                </Tooltip>
                               )
                             })}
                           </SelectGroup_Shadcn_>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -26,6 +26,9 @@ import {
   SelectTrigger_Shadcn_,
   SelectValue_Shadcn_,
   Switch,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -56,6 +59,7 @@ import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
 import { DOCS_URL } from '@/lib/constants'
+import { MANAGED_BY } from '@/lib/constants/infrastructure'
 import { useProfile } from '@/lib/profile'
 
 export const InviteMemberButton = () => {
@@ -93,6 +97,8 @@ export const InviteMemberButton = () => {
   const hasOrgRole =
     (userMemberData?.role_ids ?? []).length === 1 &&
     orgScopedRoles.some((r) => r.id === userMemberData?.role_ids[0])
+
+  const isStripeProjectsOrg = organization?.managed_by === MANAGED_BY.STRIPE_PROJECTS
 
   const { rolesAddable } = useGetRolesManagementPermissions(
     organization?.slug,
@@ -308,19 +314,35 @@ export const InviteMemberButton = () => {
                           <SelectGroup_Shadcn_>
                             {orgScopedRoles.map((role) => {
                               const canAssignRole = rolesAddable.includes(role.id)
+                              const isOwnerRole = role.name === 'Owner'
+                              const disabledForStripe = isStripeProjectsOrg && isOwnerRole
+                              const disabled = !canAssignRole || disabledForStripe
+                              const disabledReason = disabledForStripe
+                                ? 'Owner cannot be assigned in Stripe Projects organizations'
+                                : !canAssignRole
+                                  ? 'Additional permissions required to assign role'
+                                  : undefined
 
-                              return (
+                              const item = (
                                 <SelectItem_Shadcn_
                                   key={role.id}
                                   value={role.id.toString()}
-                                  className="text-sm [&>span:nth-child(2)]:w-full [&>span:nth-child(2)]:flex [&>span:nth-child(2)]:items-center [&>span:nth-child(2)]:justify-between"
-                                  disabled={!canAssignRole}
+                                  className="text-sm"
+                                  disabled={disabled}
                                 >
-                                  <span>{role.name}</span>
-                                  {!canAssignRole && (
-                                    <span>Additional permissions required to assign role</span>
-                                  )}
+                                  {role.name}
                                 </SelectItem_Shadcn_>
+                              )
+
+                              if (!disabledReason) return item
+
+                              return (
+                                <Tooltip key={role.id}>
+                                  <TooltipTrigger asChild>
+                                    <span style={{ pointerEvents: 'all' }}>{item}</span>
+                                  </TooltipTrigger>
+                                  <TooltipContent side="right">{disabledReason}</TooltipContent>
+                                </Tooltip>
                               )
                             })}
                           </SelectGroup_Shadcn_>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/InviteMemberButton.tsx
@@ -315,7 +315,7 @@ export const InviteMemberButton = () => {
                               const disabledForStripe = isStripeProjectsOrg && isOwnerRole
                               const disabled = !canAssignRole || disabledForStripe
                               const disabledReason = disabledForStripe
-                                ? 'Owner cannot be assigned in Stripe Projects organizations'
+                                ? 'Cannot be assigned in Stripe Projects organizations'
                                 : !canAssignRole
                                   ? 'Additional permissions required to assign role'
                                   : undefined

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
@@ -290,26 +290,22 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
                                       ? 'Additional permissions required to assign role'
                                       : undefined
 
-                                  const item = (
+                                  return (
                                     <SelectItem_Shadcn_
                                       key={role.id}
                                       value={role.id.toString()}
                                       className="text-sm hover:bg-selection cursor-pointer"
                                       disabled={disabled}
                                     >
-                                      {role.name}
+                                      <div className="flex flex-col gap-0.5">
+                                        <span>{role.name}</span>
+                                        {disabledReason && (
+                                          <span className="text-xs text-foreground-lighter">
+                                            {disabledReason}
+                                          </span>
+                                        )}
+                                      </div>
                                     </SelectItem_Shadcn_>
-                                  )
-
-                                  if (!disabledReason) return item
-
-                                  return (
-                                    <Tooltip key={role.id}>
-                                      <TooltipTrigger asChild>
-                                        <span style={{ pointerEvents: 'all' }}>{item}</span>
-                                      </TooltipTrigger>
-                                      <TooltipContent side="right">{disabledReason}</TooltipContent>
-                                    </Tooltip>
                                   )
                                 })}
                               </SelectGroup_Shadcn_>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
@@ -47,6 +47,7 @@ import {
 import { useHasAccessToProjectLevelPermissions } from '@/data/subscriptions/org-subscription-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { DOCS_URL } from '@/lib/constants'
+import { MANAGED_BY } from '@/lib/constants/infrastructure'
 
 interface UpdateRolesPanelProps {
   visible: boolean
@@ -77,6 +78,7 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
     permissions ?? []
   )
   const cannotAddAnyRoles = orgScopedRoles.every((r) => !rolesAddable.includes(r.id))
+  const isStripeProjectsOrg = organization?.managed_by === MANAGED_BY.STRIPE_PROJECTS
 
   const [showConfirmation, setShowConfirmation] = useState(false)
   const [showProjectDropdown, setShowProjectDropdown] = useState(false)
@@ -279,16 +281,35 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
                               <SelectGroup_Shadcn_>
                                 {(orgScopedRoles ?? []).map((role) => {
                                   const canAssignRole = rolesAddable.includes(role.id)
+                                  const isOwnerRole = role.name === 'Owner'
+                                  const disabledForStripe = isStripeProjectsOrg && isOwnerRole
+                                  const disabled = !canAssignRole || disabledForStripe
+                                  const disabledReason = disabledForStripe
+                                    ? 'Owner cannot be assigned in Stripe Projects organizations'
+                                    : !canAssignRole
+                                      ? 'Additional permissions required to assign role'
+                                      : undefined
 
-                                  return (
+                                  const item = (
                                     <SelectItem_Shadcn_
                                       key={role.id}
                                       value={role.id.toString()}
                                       className="text-sm hover:bg-selection cursor-pointer"
-                                      disabled={!canAssignRole}
+                                      disabled={disabled}
                                     >
                                       {role.name}
                                     </SelectItem_Shadcn_>
+                                  )
+
+                                  if (!disabledReason) return item
+
+                                  return (
+                                    <Tooltip key={role.id}>
+                                      <TooltipTrigger asChild>
+                                        <span style={{ pointerEvents: 'all' }}>{item}</span>
+                                      </TooltipTrigger>
+                                      <TooltipContent side="right">{disabledReason}</TooltipContent>
+                                    </Tooltip>
                                   )
                                 })}
                               </SelectGroup_Shadcn_>

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
@@ -285,7 +285,7 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
                                   const disabledForStripe = isStripeProjectsOrg && isOwnerRole
                                   const disabled = !canAssignRole || disabledForStripe
                                   const disabledReason = disabledForStripe
-                                    ? 'Owner cannot be assigned in Stripe Projects organizations'
+                                    ? 'Cannot be assigned in Stripe Projects organizations'
                                     : !canAssignRole
                                       ? 'Additional permissions required to assign role'
                                       : undefined

--- a/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
+++ b/apps/studio/components/interfaces/Organization/TeamSettings/UpdateRolesPanel/UpdateRolesPanel.tsx
@@ -277,7 +277,7 @@ export const UpdateRolesPanel = ({ visible, member, onClose }: UpdateRolesPanelP
                             >
                               {role?.name ?? 'Please select a role'}
                             </SelectTrigger_Shadcn_>
-                            <SelectContent_Shadcn_>
+                            <SelectContent_Shadcn_ align="end">
                               <SelectGroup_Shadcn_>
                                 {(orgScopedRoles ?? []).map((role) => {
                                   const canAssignRole = rolesAddable.includes(role.id)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

> [!IMPORTANT]  
> This is only for Stripe managed organizations

New feature / Bug fix (Fixes https://linear.app/supabase/issue/FE-3151/disable-the-option-of-adding-new-owners-to-an-organization-connected)

## What is the current behavior?

<img width="1270" height="1036" alt="CleanShot 2026-05-05 at 17 46 05@2x" src="https://github.com/user-attachments/assets/311aa536-c08e-4b8e-948b-70a6fd3f42ad" />

<img width="1216" height="498" alt="CleanShot 2026-05-05 at 17 49 32@2x" src="https://github.com/user-attachments/assets/0a26f92d-372b-45a2-958e-aa3cc78114aa" />


## What is the new behavior?

<img width="1284" height="1060" alt="CleanShot 2026-05-06 at 14 44 51@2x" src="https://github.com/user-attachments/assets/cbc1b44f-358b-4c7b-8abb-aa53f5fc2e76" />

<img width="1232" height="590" alt="CleanShot 2026-05-06 at 14 44 29@2x" src="https://github.com/user-attachments/assets/20262d11-4a62-4c84-84f2-2ba8636f2976" />

## Additional context

- This also updates the treatment of previous warning message. This one was living next to the name of the role which made the whole select element quite crowded. Decided to add a tooltip for better UX.
- Proper API fix lives on https://github.com/supabase/platform/pull/32443

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * "Owner" role is now disabled for certain managed organizations to prevent unsupported assignments.
  * Disabled role options now show clear tooltips explaining why a role cannot be assigned, applied to member invitations and role update workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->