### PR TITLE
docs: add details for unhealthy edge functions to troubleshooting guide

### DIFF
--- a/apps/docs/content/troubleshooting/project-status-reports-unhealthy-services.mdx
+++ b/apps/docs/content/troubleshooting/project-status-reports-unhealthy-services.mdx
@@ -18,3 +18,11 @@ Possible resolutions:
 - Restart the database in [Project Settings](/dashboard/project/_/settings/general) (this may be only a temporary fix if the project is undersized / unoptimized).
 - Increase project resources in [Compute and Disk](/dashboard/project/_/settings/compute-and-disk).
 - [Performance Tune](/docs/guides/platform/performance) the database.
+
+The "Edge Functions Unhealthy" indicator is based on a platform-level health check, not the project's own functions. Confirm the actual functions work by invoking them directly. If functions are working fine, this is likely a false positive.
+
+Check the following if only Edge Functions service reports unhealthy:
+
+- Verify actual function behavior by invoking the edge function directly (e.g., via cURL with a CORS request). If it responds correctly, the health indicator is likely a false positive.
+- Check invocation logs. Filter logs using the keyword `~"health"` to see if health check calls are failing and if any errors are presented.
+- Restart the database in [Project Settings](/dashboard/project/_/settings/general). This has resolved the unhealthy state in some cases, particularly when it's a transient issue.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update to add additional guidance when Edge Functions service shows unhealthy.






<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added troubleshooting guide for Edge Functions unhealthy state, including steps to verify functions, check invocation logs, and potential solutions for resolving the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->