### PR TITLE
fix(pg-meta): reject trigger creation with empty events

### DIFF
--- a/packages/pg-meta/src/pg-meta-triggers.ts
+++ b/packages/pg-meta/src/pg-meta-triggers.ts
@@ -98,7 +98,7 @@ export const pgTriggerCreateZod = z.object({
   function_name: z.string(),
   function_args: z.array(z.string()).optional(),
   activation: z.enum(['BEFORE', 'AFTER', 'INSTEAD OF']),
-  events: z.array(z.string()),
+  events: z.array(z.string()).min(1),
   orientation: z.enum(['ROW', 'STATEMENT']).optional(),
   condition: z.string().optional(),
 })
@@ -120,6 +120,19 @@ export function create({
   sql: string
   zod: z.ZodType<void>
 } {
+  pgTriggerCreateZod.parse({
+    name,
+    schema,
+    table,
+    function_schema,
+    function_name,
+    function_args,
+    activation,
+    events,
+    orientation,
+    condition,
+  })
+
   const qualifiedTableName = `${ident(schema)}.${ident(table)}`
   const qualifiedFunctionName = `${ident(function_schema)}.${ident(function_name)}`
   const triggerEvents = events.join(' or ')

--- a/packages/pg-meta/test/triggers.test.ts
+++ b/packages/pg-meta/test/triggers.test.ts
@@ -363,3 +363,17 @@ withTestDatabase('triggers on capitalized schema and table names', async ({ exec
     ]
   `)
 })
+
+test('create trigger validation rejects empty events array', () => {
+  expect(() =>
+    pgMeta.triggers.create({
+      name: 'invalid_trigger',
+      schema: 'public',
+      table: 'users',
+      function_schema: 'public',
+      function_name: 'audit_action',
+      activation: 'BEFORE',
+      events: [],
+    })
+  ).toThrow()
+})


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`pgMeta.triggers.create()` allows creating a trigger with an empty `events` array, which generates invalid SQL.

## What is the new behavior?

Adds validation to require at least one trigger event during trigger creation using Zod validation. Also adds a regression test to ensure empty `events` arrays are rejected.

## Additional context

Validation is enforced both at the schema level and at runtime inside `create()`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Trigger creation now enforces validation requiring at least one event to be specified.

* **Tests**
  * Added test coverage to validate rejection of empty event arrays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->