### PR TITLE
fix(ui-library): stack dual-panel previews vertically on mobile (chat + monaco)

### DIFF
--- a/apps/ui-library/components/dual-realtime-chat.tsx
+++ b/apps/ui-library/components/dual-realtime-chat.tsx
@@ -4,7 +4,7 @@ export function DualRealtimeChat() {
   const roomName = `room-${Math.floor(Math.random() * 1000)}`
 
   return (
-    <div className="flex flex-row -space-x-px w-full">
+    <div className="flex flex-col lg:flex-row lg:-space-x-px w-full">
       <BlockPreview name={`realtime-chat-demo?roomName=${roomName}`} isPair />
       <BlockPreview name={`realtime-chat-demo?roomName=${roomName}`} isPair />
     </div>

--- a/apps/ui-library/components/dual-realtime-monaco.tsx
+++ b/apps/ui-library/components/dual-realtime-monaco.tsx
@@ -4,7 +4,7 @@ import { BlockPreview } from './block-preview'
 
 export function DualRealtimeMonaco() {
   return (
-    <div className="flex flex-row -space-x-px w-full">
+    <div className="flex flex-col lg:flex-row lg:-space-x-px w-full">
       <BlockPreview name="realtime-monaco-demo" isPair />
       <BlockPreview name="realtime-monaco-demo" isPair />
     </div>


### PR DESCRIPTION
## Problem

`DualRealtimeChat` and `DualRealtimeMonaco` preview components use `flex flex-row` with no responsive breakpoint. On small screens both panels are forced side by side at ~180px each, text clips, inputs are unusable, and the layout breaks completely.

## Fix

- Changed wrapper from `flex flex-row -space-x-px` to `flex flex-col lg:flex-row lg:-space-x-px`
- Used `lg` (1024px) breakpoint since dual panels need ~512px each to be usable
- `-space-x-px` moved behind `lg:` so border-collapse only applies when panels are side by side

## Files changed

- `apps/ui-library/components/dual-realtime-chat.tsx`
- `apps/ui-library/components/dual-realtime-monaco.tsx`

## Screenshots

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/119d20aa-3d1a-4ee6-b961-c02cf8b06805" width="300" /> | <img src="https://github.com/user-attachments/assets/4c724b9c-61c6-4056-8829-fda6e54f4210" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsive layout to stack components vertically on mobile devices and horizontally on larger screens for better user experience across all device sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->