### PR TITLE
chore(design-system): redo safer Admonition updates

### DIFF
--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -126,6 +126,17 @@ export const Index: Record<string, any> = {
       subcategory: "undefined",
       chunks: []
     },
+    "admonition-description-only": {
+      name: "admonition-description-only",
+      type: "components:example",
+      registryDependencies: ["admonition"],
+      component: React.lazy(() => import("@/registry/default/example/admonition-description-only")),
+      source: "",
+      files: ["registry/default/example/admonition-description-only.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "admonition-warning": {
       name: "admonition-warning",
       type: "components:example",
@@ -133,6 +144,17 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/admonition-warning")),
       source: "",
       files: ["registry/default/example/admonition-warning.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "admonition-success": {
+      name: "admonition-success",
+      type: "components:example",
+      registryDependencies: ["admonition"],
+      component: React.lazy(() => import("@/registry/default/example/admonition-success")),
+      source: "",
+      files: ["registry/default/example/admonition-success.tsx"],
       category: "undefined",
       subcategory: "undefined",
       chunks: []

--- a/apps/design-system/content/docs/fragments/admonition.mdx
+++ b/apps/design-system/content/docs/fragments/admonition.mdx
@@ -15,6 +15,12 @@ Admonition provides focus for situations that require a callout.
 
 Use Admonition instead of [Alert](../components/alert) unless you specifically need the primitives. If in doubt, stick with Admonition.
 
+Use `title` for the heading slot when the callout needs its own heading. `title` is optional: short callouts may use `description` without a title when nearby content already provides enough context.
+
+Avoid title-only Admonitions in new code. A callout with `title` should also include `description` or `children` so it does not read like an incomplete heading.
+
+`label` is still supported for older Docs content, but new code should use `title`.
+
 ## Usage
 
 ```tsx
@@ -71,6 +77,24 @@ There are several components that wrap the `warning` Admonition type with reusab
 - NoPermission
 
 AlertError for example rolls up consistent error handling and support contact methods.
+
+### Description only
+
+Use description-only Admonitions for short callouts that sit near a heading or form label with enough context.
+
+<ComponentPreview
+  name="admonition-description-only"
+  className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
+/>
+
+### Success
+
+Use `success` for positive, completed states where the user does not need to take corrective action.
+
+<ComponentPreview
+  name="admonition-success"
+  className="[&_.preview>[data-orientation=vertical]]:sm:max-w-[70%]"
+/>
 
 ### Destructive
 

--- a/apps/design-system/registry/default/example/admonition-description-only.tsx
+++ b/apps/design-system/registry/default/example/admonition-description-only.tsx
@@ -1,0 +1,10 @@
+import { Admonition } from 'ui-patterns/admonition'
+
+export default function AdmonitionDescriptionOnly() {
+  return (
+    <Admonition
+      type="default"
+      description="Changes to these settings can take a few minutes to appear across all projects."
+    />
+  )
+}

--- a/apps/design-system/registry/default/example/admonition-success.tsx
+++ b/apps/design-system/registry/default/example/admonition-success.tsx
@@ -1,0 +1,11 @@
+import { Admonition } from 'ui-patterns/admonition'
+
+export default function AdmonitionSuccess() {
+  return (
+    <Admonition
+      type="success"
+      title="Connection confirmed"
+      description="You can now close this tab."
+    />
+  )
+}

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -26,10 +26,22 @@ export const examples: Registry = [
     files: ['example/admonition-button.tsx'],
   },
   {
+    name: 'admonition-description-only',
+    type: 'components:example',
+    registryDependencies: ['admonition'],
+    files: ['example/admonition-description-only.tsx'],
+  },
+  {
     name: 'admonition-warning',
     type: 'components:example',
     registryDependencies: ['admonition'],
     files: ['example/admonition-warning.tsx'],
+  },
+  {
+    name: 'admonition-success',
+    type: 'components:example',
+    registryDependencies: ['admonition'],
+    files: ['example/admonition-success.tsx'],
   },
   {
     name: 'admonition-destructive',

--- a/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
@@ -85,6 +85,9 @@ export const ConfirmationModal = forwardRef<
       if (loading_ !== undefined) setLoading(loading_)
     }, [loading_])
 
+    const { title: _alertBaseTitle, children: _alertBaseChildren, ...alertBase } = alert?.base ?? {}
+    const alertTitleProps = alert?.title ? { label: alert.title } : {}
+
     return (
       <Dialog
         open={visible}
@@ -108,10 +111,10 @@ export const ConfirmationModal = forwardRef<
           {alert && (
             <Admonition
               type={variant as 'default' | 'destructive' | 'warning'}
-              label={alert.title}
               description={alert.description}
+              {...alertTitleProps}
               className="border-x-0 rounded-none -mt-px"
-              {...alert?.base}
+              {...alertBase}
             />
           )}
           {children && (

--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -128,6 +128,9 @@ export const TextConfirmModal = forwardRef<
       return () => clearTimeout(timer)
     }, [showCopied])
 
+    const { title: _alertBaseTitle, children: _alertBaseChildren, ...alertBase } = alert?.base ?? {}
+    const alertTitleProps = alert?.title ? { label: alert.title } : {}
+
     return (
       <Dialog
         open={visible}
@@ -145,10 +148,10 @@ export const TextConfirmModal = forwardRef<
           {alert && (
             <Admonition
               type={variant as 'default' | 'destructive' | 'warning'}
-              label={alert.title}
               description={alert.description}
+              {...alertTitleProps}
               className="border-x-0 rounded-none -mt-px"
-              {...alert?.base}
+              {...alertBase}
             />
           )}
           {children && (

--- a/packages/ui-patterns/src/admonition.test.tsx
+++ b/packages/ui-patterns/src/admonition.test.tsx
@@ -80,6 +80,21 @@ describe('Admonition', () => {
     expect(alert.querySelector('svg path')?.getAttribute('d')).toContain('M10.5 19.5')
   })
 
+  it('does not render the destructive icon when showIcon is false', () => {
+    render(
+      <Admonition
+        type="destructive"
+        showIcon={false}
+        title="Deletion blocked"
+        description="Resolve dependent resources before retrying."
+      />
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Deletion blocked')
+    expect(alert.querySelector('svg')).not.toBeInTheDocument()
+  })
+
   it('prefers title over legacy label when both are provided', () => {
     render(
       <Admonition

--- a/packages/ui-patterns/src/admonition.test.tsx
+++ b/packages/ui-patterns/src/admonition.test.tsx
@@ -97,6 +97,7 @@ describe('Admonition', () => {
     const alert = screen.getByRole('alert')
     expect(alert).toHaveTextContent('Connection confirmed')
     expect(alert).toHaveTextContent('You can now close this tab.')
+    expect(alert).toHaveClass('bg-brand-400/15')
     expect(alert).toHaveClass('border-brand-400')
     expect(alert.querySelector('svg path')?.getAttribute('d')).toContain('M10.5 19.5')
   })

--- a/packages/ui-patterns/src/admonition.test.tsx
+++ b/packages/ui-patterns/src/admonition.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen, within } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { Admonition, type AdmonitionStrictProps } from './admonition'
+
+const validDescriptionOnly = {
+  description: 'Description-only copy.',
+} satisfies AdmonitionStrictProps
+const validChildrenOnly = {
+  children: <p>Children-only copy.</p>,
+} satisfies AdmonitionStrictProps
+const validTitleWithDescription = {
+  title: 'Title',
+  description: 'Body copy.',
+} satisfies AdmonitionStrictProps
+const validLabelWithChildren = {
+  label: 'Legacy label',
+  children: <p>Body copy.</p>,
+} satisfies AdmonitionStrictProps
+// @ts-expect-error title-only usage is intentionally not part of the TS contract.
+const invalidTitleOnly: AdmonitionStrictProps = { title: 'Missing body' }
+// @ts-expect-error label-only usage is intentionally not part of the TS contract.
+const invalidLabelOnly: AdmonitionStrictProps = { label: 'Missing body' }
+
+void [
+  validDescriptionOnly,
+  validChildrenOnly,
+  validTitleWithDescription,
+  validLabelWithChildren,
+  invalidTitleOnly,
+  invalidLabelOnly,
+]
+
+describe('Admonition', () => {
+  it('renders description-only content', () => {
+    render(<Admonition type="default" description="Changes can take a few minutes to apply." />)
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Changes can take a few minutes to apply.')
+  })
+
+  it('renders children-only rich MDX-like content', () => {
+    render(
+      <Admonition type="note">
+        <p>
+          This is a Postgres{' '}
+          <a href="/docs/guides/database/postgres/row-level-security">SECURITY DEFINER</a> function.
+        </p>
+        <ul>
+          <li>Keep privileges scoped.</li>
+        </ul>
+      </Admonition>
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(within(alert).getByText('SECURITY DEFINER')).toHaveAttribute(
+      'href',
+      '/docs/guides/database/postgres/row-level-security'
+    )
+    expect(within(alert).getByText('Keep privileges scoped.')).toBeVisible()
+  })
+
+  it('renders title and description together', () => {
+    render(
+      <Admonition
+        type="warning"
+        title="Manual approval required"
+        description="Review the pending changes before continuing."
+      />
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Manual approval required')
+    expect(alert).toHaveTextContent('Review the pending changes before continuing.')
+  })
+
+  it('renders title and children together', () => {
+    render(
+      <Admonition type="caution" title="Security definer function">
+        <p>Review ownership before exposing this function.</p>
+      </Admonition>
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Security definer function')
+    expect(alert).toHaveTextContent('Review ownership before exposing this function.')
+  })
+
+  it('renders success state with success styling', () => {
+    render(
+      <Admonition
+        type="success"
+        title="Connection confirmed"
+        description="You can now close this tab."
+      />
+    )
+
+    const alert = screen.getByRole('alert')
+    expect(alert).toHaveTextContent('Connection confirmed')
+    expect(alert).toHaveTextContent('You can now close this tab.')
+    expect(alert).toHaveClass('border-brand-400')
+    expect(alert.querySelector('svg path')?.getAttribute('d')).toContain('M10.5 19.5')
+  })
+
+  it('prefers title over legacy label when both are provided', () => {
+    render(
+      <Admonition
+        type="note"
+        label="Legacy heading"
+        title="Preferred heading"
+        description="Body copy."
+      />
+    )
+
+    expect(screen.getByText('Preferred heading')).toBeVisible()
+    expect(screen.queryByText('Legacy heading')).not.toBeInTheDocument()
+  })
+})

--- a/packages/ui-patterns/src/admonition.test.tsx
+++ b/packages/ui-patterns/src/admonition.test.tsx
@@ -1,35 +1,13 @@
 import { render, screen, within } from '@testing-library/react'
 import { describe, expect, it } from 'vitest'
 
-import { Admonition, type AdmonitionStrictProps } from './admonition'
+import { Admonition, type AdmonitionProps } from './admonition'
 
-const validDescriptionOnly = {
+const stringDescriptionProps = {
   description: 'Description-only copy.',
-} satisfies AdmonitionStrictProps
-const validChildrenOnly = {
-  children: <p>Children-only copy.</p>,
-} satisfies AdmonitionStrictProps
-const validTitleWithDescription = {
-  title: 'Title',
-  description: 'Body copy.',
-} satisfies AdmonitionStrictProps
-const validLabelWithChildren = {
-  label: 'Legacy label',
-  children: <p>Body copy.</p>,
-} satisfies AdmonitionStrictProps
-// @ts-expect-error title-only usage is intentionally not part of the TS contract.
-const invalidTitleOnly: AdmonitionStrictProps = { title: 'Missing body' }
-// @ts-expect-error label-only usage is intentionally not part of the TS contract.
-const invalidLabelOnly: AdmonitionStrictProps = { label: 'Missing body' }
+} satisfies AdmonitionProps
 
-void [
-  validDescriptionOnly,
-  validChildrenOnly,
-  validTitleWithDescription,
-  validLabelWithChildren,
-  invalidTitleOnly,
-  invalidLabelOnly,
-]
+void stringDescriptionProps
 
 describe('Admonition', () => {
   it('renders description-only content', () => {

--- a/packages/ui-patterns/src/admonition.tsx
+++ b/packages/ui-patterns/src/admonition.tsx
@@ -124,7 +124,7 @@ const admonitionSVG = cva('', {
   variants: {
     type: {
       default: `[&>svg]:bg-foreground-muted`,
-      success: `bg-brand-400 dark:bg-brand bg-opacity-15 dark:bg-opacity-10 border-brand-400 dark:border-brand-500 [&>svg]:text-white dark:[&>svg]:text-brand-link [&>svg]:bg-brand dark:[&>svg]:bg-brand-500/50`,
+      success: `bg-brand-400/15 dark:bg-brand/10 border-brand-400 dark:border-brand-500 [&>svg]:text-white dark:[&>svg]:text-brand-link [&>svg]:bg-brand dark:[&>svg]:bg-brand-500/50`,
       warning: ``,
       destructive: ``,
     },

--- a/packages/ui-patterns/src/admonition.tsx
+++ b/packages/ui-patterns/src/admonition.tsx
@@ -147,7 +147,7 @@ export const Admonition = forwardRef<
           icon
         ) : showIcon && typeStyle === 'success' ? (
           <SuccessIcon />
-        ) : (showIcon && typeMapped === 'warning') || typeMapped === 'destructive' ? (
+        ) : showIcon && (typeMapped === 'warning' || typeMapped === 'destructive') ? (
           <WarningIcon />
         ) : showIcon ? (
           <InfoIcon />

--- a/packages/ui-patterns/src/admonition.tsx
+++ b/packages/ui-patterns/src/admonition.tsx
@@ -13,41 +13,13 @@ export type AdmonitionType =
   | 'success'
   | 'warning'
 
-type AdmonitionBodyContent =
-  | {
-      description: ReactNode
-      children?: ReactNode
-    }
-  | {
-      description?: ReactNode
-      children: ReactNode
-    }
-
-type AdmonitionStrictContentProps =
-  | ({
-      title: string
-      label?: string
-    } & AdmonitionBodyContent)
-  | ({
-      label: string
-      title?: string
-    } & AdmonitionBodyContent)
-  | {
-      title?: never
-      label?: never
-      description?: ReactNode
-      children?: ReactNode
-    }
-
-type AdmonitionRuntimeContentProps = {
+export interface AdmonitionProps {
+  type?: AdmonitionType
   title?: string
+  /** @deprecated Prefer title for new usage. label remains supported for existing MDX content. */
   label?: string
   description?: ReactNode
   children?: ReactNode
-}
-
-interface AdmonitionBaseProps {
-  type?: AdmonitionType
   showIcon?: boolean
   childProps?: {
     title?: ComponentProps<typeof AlertTitle_Shadcn_>
@@ -58,10 +30,6 @@ interface AdmonitionBaseProps {
   icon?: ReactNode
   className?: string
 }
-
-export type AdmonitionStrictProps = AdmonitionBaseProps & AdmonitionStrictContentProps
-
-export type AdmonitionProps = AdmonitionBaseProps & AdmonitionRuntimeContentProps
 
 const admonitionToAlertMapping: Record<AdmonitionType, 'default' | 'destructive' | 'warning'> = {
   note: 'default',

--- a/packages/ui-patterns/src/admonition.tsx
+++ b/packages/ui-patterns/src/admonition.tsx
@@ -2,19 +2,52 @@ import { cva } from 'class-variance-authority'
 import { ComponentProps, forwardRef, ReactNode } from 'react'
 import { Alert_Shadcn_, AlertDescription_Shadcn_, AlertTitle_Shadcn_, cn } from 'ui'
 
-export interface AdmonitionProps {
-  type:
-    | 'note'
-    | 'tip'
-    | 'caution'
-    | 'danger'
-    | 'deprecation'
-    | 'default'
-    | 'destructive'
-    | 'warning'
-  label?: string
+export type AdmonitionType =
+  | 'note'
+  | 'tip'
+  | 'caution'
+  | 'danger'
+  | 'deprecation'
+  | 'default'
+  | 'destructive'
+  | 'success'
+  | 'warning'
+
+type AdmonitionBodyContent =
+  | {
+      description: ReactNode
+      children?: ReactNode
+    }
+  | {
+      description?: ReactNode
+      children: ReactNode
+    }
+
+type AdmonitionStrictContentProps =
+  | ({
+      title: string
+      label?: string
+    } & AdmonitionBodyContent)
+  | ({
+      label: string
+      title?: string
+    } & AdmonitionBodyContent)
+  | {
+      title?: never
+      label?: never
+      description?: ReactNode
+      children?: ReactNode
+    }
+
+type AdmonitionRuntimeContentProps = {
   title?: string
-  description?: string | ReactNode
+  label?: string
+  description?: ReactNode
+  children?: ReactNode
+}
+
+interface AdmonitionBaseProps {
+  type?: AdmonitionType
   showIcon?: boolean
   childProps?: {
     title?: ComponentProps<typeof AlertTitle_Shadcn_>
@@ -26,10 +59,11 @@ export interface AdmonitionProps {
   className?: string
 }
 
-const admonitionToAlertMapping: Record<
-  AdmonitionProps['type'],
-  'default' | 'destructive' | 'warning'
-> = {
+export type AdmonitionStrictProps = AdmonitionBaseProps & AdmonitionStrictContentProps
+
+export type AdmonitionProps = AdmonitionBaseProps & AdmonitionRuntimeContentProps
+
+const admonitionToAlertMapping: Record<AdmonitionType, 'default' | 'destructive' | 'warning'> = {
   note: 'default',
   tip: 'default',
   caution: 'warning',
@@ -38,6 +72,7 @@ const admonitionToAlertMapping: Record<
   default: 'default',
   warning: 'warning',
   destructive: 'destructive',
+  success: 'default',
 }
 
 const InfoIcon = () => (
@@ -51,6 +86,21 @@ const InfoIcon = () => (
       fillRule="evenodd"
       clipRule="evenodd"
       d="M0.625 9.8252C0.625 4.44043 4.99023 0.0751953 10.375 0.0751953C15.7598 0.0751953 20.125 4.44043 20.125 9.8252C20.125 15.21 15.7598 19.5752 10.375 19.5752C4.99023 19.5752 0.625 15.21 0.625 9.8252ZM9.3584 4.38135C9.45117 4.28857 9.55518 4.20996 9.66699 4.14648C9.88086 4.02539 10.1245 3.96045 10.375 3.96045C10.5845 3.96045 10.7896 4.00586 10.9766 4.09229C11.1294 4.1626 11.2705 4.26025 11.3916 4.38135C11.6611 4.65088 11.8125 5.0166 11.8125 5.39795C11.8125 5.5249 11.7959 5.6499 11.7637 5.77002C11.6987 6.01172 11.5718 6.23438 11.3916 6.41455C11.1221 6.68408 10.7563 6.83545 10.375 6.83545C9.99365 6.83545 9.62793 6.68408 9.3584 6.41455C9.08887 6.14502 8.9375 5.7793 8.9375 5.39795C8.9375 5.29492 8.94873 5.19287 8.97021 5.09375C9.02783 4.82568 9.16162 4.57812 9.3584 4.38135ZM10.375 15.6899C10.0933 15.6899 9.82275 15.5781 9.62354 15.3789C9.42432 15.1797 9.3125 14.9092 9.3125 14.6274V9.31494C9.3125 9.0332 9.42432 8.7627 9.62354 8.56348C9.82275 8.36426 10.0933 8.25244 10.375 8.25244C10.6567 8.25244 10.9272 8.36426 11.1265 8.56348C11.3257 8.7627 11.4375 9.0332 11.4375 9.31494V14.6274C11.4375 14.7944 11.3979 14.9575 11.3242 15.104C11.2739 15.2046 11.2075 15.2979 11.1265 15.3789C10.9272 15.5781 10.6567 15.6899 10.375 15.6899Z"
+    />
+  </svg>
+)
+
+const SuccessIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 21 20"
+    className="w-6 h-6"
+    fill="currentColor"
+  >
+    <path
+      fillRule="evenodd"
+      clipRule="evenodd"
+      d="M10.5 19.5C5.25329 19.5 1 15.2467 1 10C1 4.75329 5.25329 0.5 10.5 0.5C15.7467 0.5 20 4.75329 20 10C20 15.2467 15.7467 19.5 10.5 19.5ZM14.7803 7.78033C15.0732 7.48744 15.0732 7.01256 14.7803 6.71967C14.4874 6.42678 14.0126 6.42678 13.7197 6.71967L9.25 11.1893L7.28033 9.21967C6.98744 8.92678 6.51256 8.92678 6.21967 9.21967C5.92678 9.51256 5.92678 9.98744 6.21967 10.2803L8.71967 12.7803C9.01256 13.0732 9.48744 13.0732 9.78033 12.7803L14.7803 7.78033Z"
     />
   </svg>
 )
@@ -74,15 +124,20 @@ const admonitionSVG = cva('', {
   variants: {
     type: {
       default: `[&>svg]:bg-foreground-muted`,
+      success: `bg-brand-400 dark:bg-brand bg-opacity-15 dark:bg-opacity-10 border-brand-400 dark:border-brand-500 [&>svg]:text-white dark:[&>svg]:text-brand-link [&>svg]:bg-brand dark:[&>svg]:bg-brand-500/50`,
       warning: ``,
       destructive: ``,
     },
   },
 })
 
+const admonitionBodyClassName =
+  '[&_p]:!mt-0 [&_p]:!mb-1.5 [&_p:last-child]:!mb-0 [&_p:only-child]:!mb-0 [&_ul]:!my-1.5 [&_ol]:!my-1.5 [&_li]:!my-0.5'
+
 export const Admonition = forwardRef<
   React.ElementRef<typeof Alert_Shadcn_>,
-  React.ComponentPropsWithoutRef<typeof Alert_Shadcn_> & AdmonitionProps
+  Omit<React.ComponentPropsWithoutRef<typeof Alert_Shadcn_>, keyof AdmonitionProps | 'children'> &
+    AdmonitionProps
 >(
   (
     {
@@ -102,6 +157,8 @@ export const Admonition = forwardRef<
     ref
   ) => {
     const typeMapped = variant ? admonitionToAlertMapping[variant] : admonitionToAlertMapping[type]
+    const typeStyle = type === 'success' ? 'success' : typeMapped
+    const heading = title ?? label
 
     return (
       <Alert_Shadcn_
@@ -114,12 +171,14 @@ export const Admonition = forwardRef<
           // Container query context for responsive layout
           layout === 'responsive' && '@container',
           // SVG icon
-          admonitionSVG({ type: typeMapped }),
+          admonitionSVG({ type: typeStyle }),
           props.className
         )}
       >
         {!!icon ? (
           icon
+        ) : showIcon && typeStyle === 'success' ? (
+          <SuccessIcon />
         ) : (showIcon && typeMapped === 'warning') || typeMapped === 'destructive' ? (
           <WarningIcon />
         ) : showIcon ? (
@@ -134,8 +193,8 @@ export const Admonition = forwardRef<
               'flex-col @md:flex-row @md:items-center @md:justify-between @md:gap-x-6 @lg:gap-x-8'
           )}
         >
-          {label || title ? (
-            <div>
+          <div>
+            {heading && (
               <AlertTitle_Shadcn_
                 {...childProps.title}
                 className={cn(
@@ -144,28 +203,35 @@ export const Admonition = forwardRef<
                   childProps.title?.className
                 )}
               >
-                {label || title}
+                {heading}
               </AlertTitle_Shadcn_>
-              {description && (
-                <AlertDescription_Shadcn_ className={childProps.description?.className}>
-                  {description}
-                </AlertDescription_Shadcn_>
-              )}
-              {/* // children is to handle Docs and MDX issues with children and <p> elements */}
-              {children && (
-                <AlertDescription_Shadcn_
-                  {...childProps.description}
-                  className={cn('', childProps?.description?.className)}
-                >
-                  {children}
-                </AlertDescription_Shadcn_>
-              )}
-            </div>
-          ) : (
-            <div className="text my-0.5 [&_p]:mt-0 [&_p]:mb-1.5 [&_p:last-child]:mb-0">
-              {children}
-            </div>
-          )}
+            )}
+            {description && (
+              <AlertDescription_Shadcn_
+                {...childProps.description}
+                className={cn(
+                  admonitionBodyClassName,
+                  !heading && 'my-0.5',
+                  childProps.description?.className
+                )}
+              >
+                {description}
+              </AlertDescription_Shadcn_>
+            )}
+            {/* // children is to handle Docs and MDX issues with children and <p> elements */}
+            {children && (
+              <AlertDescription_Shadcn_
+                {...childProps.description}
+                className={cn(
+                  admonitionBodyClassName,
+                  !heading && !description && 'my-0.5',
+                  childProps?.description?.className
+                )}
+              >
+                {children}
+              </AlertDescription_Shadcn_>
+            )}
+          </div>
           {actions && (
             <div
               className={cn(


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature and design-system update. Resolves DEPR-551.

This is a narrower redo of #45302 after the revert in #45535.

## What is the current behaviour?

The reverted implementation made Admonition more flexible, but it also changed Studio callsites, touched shared Alert styling, renamed the design-system Tailwind config, and changed Docs-facing content/API assumptions in a way that broke production docs static generation.

## What is the new behaviour?

Admonition now supports description-only content, children-only content, optional `title`, legacy `label`, and `type="success"` without touching `apps/docs/content/**` or shared Alert styling.

`title` wins over `label` when both are provided. The runtime component props stay backwards-compatible for existing MDX and Studio usage, while `AdmonitionStrictProps` captures the stricter new-usage contract for tests and future callsites.

The design-system docs and registry include description-only and success examples, and the Admonition tests cover the rendering paths that broke production previously.

| After |
| --- |
| <img width="1668" height="1768" alt="CleanShot 2026-05-06 at 17 35 13@2x" src="https://github.com/user-attachments/assets/1c00ea7f-e3ca-45eb-8af9-3536b657c341" /> |

## Additional context

These things that were in #45302 have been left out (unless checked):

- [ ] Studio callsite rewrites from title/label to description
- [ ] Shared Alert text-colour changes
- [ ] Design-system Tailwind config rename
- [ ] Design-system global CSS changes
- [ ] Any docs content migration or label deprecation
- [ ] Any production docs workaround


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added success admonition variant with dedicated styling and icon.
  * Added description-only admonition example and registry entries.

* **Documentation**
  * Expanded admonition guidance on title vs description usage and best practices.
  * Added example sections showcasing description-only and success variants.

* **Tests**
  * Added comprehensive tests covering admonition variants, rendering, and precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->