### PR TITLE
chore(studio/www/docs): uniform changelog icon across apps

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/MenuIconPicker.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/MenuIconPicker.tsx
@@ -1,33 +1,33 @@
-import { Clock, Heart, Server, SquareStack, Telescope } from 'lucide-react'
+import { Clock, Heart, ScrollText, Server, SquareStack, Telescope } from 'lucide-react'
 
 import {
   IconBranching,
-  IconGitHub,
   IconGitBranch,
+  IconGitHub,
+  IconMenuAI,
   IconMenuApi,
   IconMenuAuth,
   IconMenuCli,
   IconMenuCsharp,
   IconMenuDatabase,
-  IconMenuGraphQL,
+  IconMenuDevCli,
   IconMenuEdgeFunctions,
   IconMenuFlutter,
   IconMenuGettingStarted,
+  IconMenuGraphQL,
   IconMenuHome,
   IconMenuIntegrations,
   IconMenuJavascript,
+  IconMenuKotlin,
   IconMenuPlatform,
   IconMenuPython,
   IconMenuRealtime,
   IconMenuResources,
-  IconMenuSelfHosting,
   IconMenuRestApis,
+  IconMenuSelfHosting,
+  IconMenuStatus,
   IconMenuStorage,
   IconMenuSwift,
-  IconMenuStatus,
-  IconMenuKotlin,
-  IconMenuAI,
-  IconMenuDevCli,
   IconSecurity,
   IconSupport,
   IconTroubleshooting,
@@ -98,6 +98,8 @@ function getMenuIcon(menuKey: string, width: number = 16, height: number = 16, c
       return <Telescope width={width} height={height} className={className} />
     case 'troubleshooting':
       return <IconTroubleshooting width={width} height={height} className={className} />
+    case 'changelog':
+      return <ScrollText width={width} height={height} className={className} />
     case 'contributing':
       return <Heart width={width} height={height} className={className} />
     case 'deployment':

--- a/apps/www/data/Developers.tsx
+++ b/apps/www/data/Developers.tsx
@@ -1,7 +1,6 @@
-import { Calendar, Pencil } from 'lucide-react'
+import { Calendar, Pencil, ScrollText } from 'lucide-react'
 import {
   IconBriefcase2,
-  IconChangelog,
   IconDocumentation,
   IconGitHubSolid,
   IconIntegrations,
@@ -57,7 +56,7 @@ export const data = {
           text: 'Changelog',
           description: 'See the latest updates and product improvements.',
           url: '/changelog',
-          icon: IconChangelog,
+          icon: ScrollText,
         },
         {
           text: 'Support',


### PR DESCRIPTION
Use same `changelog` icon on all apps.

## What is the current behavior?

Each app shows a different icon.

| app | preview |
|---|---|
| www | <img width="1166" height="403" alt="Screenshot 2026-05-06 at 10 52 25" src="https://github.com/user-attachments/assets/fac62c31-d76b-4f59-907e-824cdd840b1c" /> |
| docs | <img width="524" height="231" alt="Screenshot 2026-05-06 at 10 52 39" src="https://github.com/user-attachments/assets/749a2726-eb7e-47b3-84fe-24d191b56b72" /> |
| studio | <img width="367" height="423" alt="Screenshot 2026-05-06 at 10 51 20" src="https://github.com/user-attachments/assets/eec1a489-8544-4bb4-8408-37e1e0a9345e" /> |

## What is the new behavior?

| app | preview |
|---|---|
| www | <img width="1114" height="393" alt="Screenshot 2026-05-06 at 10 49 15" src="https://github.com/user-attachments/assets/1d0e9cff-6390-4005-9656-98f8f45a4657" />|
| docs | <img width="498" height="227" alt="Screenshot 2026-05-06 at 10 49 22" src="https://github.com/user-attachments/assets/3d41f219-f179-4fc7-b87b-fdb92626e0f7" /> |
| studio | <img width="367" height="423" alt="Screenshot 2026-05-06 at 10 51 20" src="https://github.com/user-attachments/assets/eec1a489-8544-4bb4-8408-37e1e0a9345e" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navigation menu icons and developer documentation icons for improved visual consistency across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->