### PR TITLE
fix: role selection 

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -81,7 +81,18 @@ const FormSchema = z.object({
 
 type FormValues = z.infer<typeof FormSchema>
 
-export const EdgeFunctionTesterSheet = ({ visible, onClose }: EdgeFunctionTesterSheetProps) => {
+export const EdgeFunctionTesterSheet = (props: EdgeFunctionTesterSheetProps) => {
+  const { ref: projectRef } = useParams()
+
+  // [Alaister]: We're using a fresh context here as edge functions don't allow impersonating users.
+  return (
+    <RoleImpersonationStateContextProvider key={`role-impersonation-state-${projectRef}`}>
+      <EdgeFunctionTesterSheetContent {...props} />
+    </RoleImpersonationStateContextProvider>
+  )
+}
+
+const EdgeFunctionTesterSheetContent = ({ visible, onClose }: EdgeFunctionTesterSheetProps) => {
   const { data: org } = useSelectedOrganizationQuery()
   const { ref: projectRef, functionSlug } = useParams()
   const getImpersonatedRoleState = useGetImpersonatedRoleState()
@@ -446,15 +457,10 @@ export const EdgeFunctionTesterSheet = ({ visible, onClose }: EdgeFunctionTester
 
             <SheetFooter className="px-5 py-3 border-t">
               <div className="flex items-center gap-2">
-                {/* [Alaister]: We're using a fresh context here as edge functions don't allow impersonating users. */}
-                <RoleImpersonationStateContextProvider
-                  key={`role-impersonation-state-${projectRef}`}
-                >
-                  <RoleImpersonationPopover
-                    disallowAuthenticatedOption
-                    header="Run edge function as a role"
-                  />
-                </RoleImpersonationStateContextProvider>
+                <RoleImpersonationPopover
+                  disallowAuthenticatedOption
+                  header="Run edge function as a role"
+                />
                 <Button
                   type="primary"
                   htmlType="submit"


### PR DESCRIPTION
## TL;DR

The edge function tester was sending service role tokens even when anonymous was selected,
Fixed by moving the role context provider to wrap both the selector and the submit handler

## sol:


| Before | After |
|--------|-------|
| <img width="589" alt="Service role JWT sent when Anonymous selected" src="https://github.com/user-attachments/assets/f4072838-4031-4325-9fd6-7519e50bd080" /> | <img width="471" alt="Anon JWT correctly sent when Anonymous selected" src="https://github.com/user-attachments/assets/86160946-398e-456e-9585-66e3e49f16ed" /> |
| Selecting "Anonymous" had no effect, always sent `service_role`  | Selecting "Anonymous" correctly sends it now |

## ref:

- Closes https://github.com/supabase/supabase/issues/45619


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code structure improvements to enhance maintainability and component organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->