### PR TITLE
fix: using 'authMode' instead of 'authType'

### DIFF
--- a/apps/docs/content/guides/functions/auth.mdx
+++ b/apps/docs/content/guides/functions/auth.mdx
@@ -249,14 +249,14 @@ export default {
 
 ### Combining modes
 
-Functions that answer both users and internal callers take an array on `auth`. Modes are tried in order. The first match wins, and `ctx.authType` tells you which matched.
+Functions that answer both users and internal callers take an array on `auth`. Modes are tried in order. The first match wins, and `ctx.authMode` tells you which matched.
 
 ```ts
 import { withSupabase } from 'npm:@supabase/server'
 
 export default {
   fetch: withSupabase({ auth: ['user', 'secret:automations'] }, async (req, ctx) => {
-    if (ctx.authType === 'user') {
+    if (ctx.authMode === 'user') {
       // your business logic for user calls. ctx.supabase is scoped to them
       return Response.json({ ok: true })
     }


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Current docs using `authType`

## What is the new behavior?

Using new `authMode` syntax

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated the authentication guide section on combining multiple authentication modes with corrected code examples and narrative explanations. The updated documentation now accurately demonstrates the proper approach for accessing authentication mode information within your code, helping developers correctly implement complex authentication patterns and effectively integrate multiple authentication strategies in their applications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->