### PR TITLE
chore(self-hosted): standardize on override vs overlay for compose configs

### DIFF
--- a/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
@@ -33,7 +33,7 @@ If you already run [HAProxy](https://www.haproxy.com/), [Traefik](https://traefi
 
 <Admonition type="note" label="Using Envoy instead of Kong?">
 
-Envoy is an optional [API gateway](/docs/guides/self-hosting/self-hosted-envoy), enabled via the `docker-compose.envoy.yml` overlay. If you already run Envoy instead of Kong, edit `docker-compose.caddy.yml` or `docker-compose.nginx.yml` to comment out the `kong:` block and uncomment the `api-gw:` block (and the matching `depends_on` entry) so the reverse proxy sits in front of Envoy.
+Envoy is an optional [API gateway](/docs/guides/self-hosting/self-hosted-envoy), enabled via the `docker-compose.envoy.yml` override. If you already run Envoy instead of Kong, edit `docker-compose.caddy.yml` or `docker-compose.nginx.yml` to comment out the `kong:` block and uncomment the `api-gw:` block (and the matching `depends_on` entry) so the reverse proxy sits in front of Envoy.
 
 </Admonition>
 
@@ -56,7 +56,7 @@ CERTBOT_EMAIL=admin@your-domain.example.com
 
 ### Step 2: Start the reverse proxy
 
-Pick one of the options below and use the corresponding Docker Compose overlay.
+Pick one of the options below and use the corresponding Docker Compose override.
 
 <Tabs
 scrollable
@@ -68,7 +68,7 @@ defaultActiveId="caddy"
 
 [Caddy](https://caddyserver.com/) automatically provisions and renews Let's Encrypt TLS certificates with zero configuration. It also handles HTTP-to-HTTPS redirects, WebSocket upgrades, and HTTP/2 and HTTP/3 out of the box.
 
-Start Caddy by using the pre-configured `docker-compose.caddy.yml` overlay:
+Start Caddy by using the pre-configured `docker-compose.caddy.yml` override:
 
 ```sh
 docker compose -f docker-compose.yml -f docker-compose.caddy.yml up -d
@@ -81,7 +81,7 @@ Caddy configuration is in `volumes/proxy/caddy/Caddyfile`.
 
 This option uses a third-party Nginx Docker image ([`jonasal/nginx-certbot`](https://github.com/JonasAlfredsson/docker-nginx-certbot)), which includes Certbot for automatic Let's Encrypt certificate issuance and renewal in a single container.
 
-Start Nginx by using the pre-configured `docker-compose.nginx.yml` overlay:
+Start Nginx by using the pre-configured `docker-compose.nginx.yml` override:
 
 ```sh
 docker compose -f docker-compose.yml -f docker-compose.nginx.yml up -d

--- a/apps/docs/content/guides/self-hosting/self-hosted-s3.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-s3.mdx
@@ -88,7 +88,7 @@ Depending on your setup, you may need to adjust these values - for example, to u
 ### Using RustFS
 
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-An overlay `docker-compose.rustfs.yml` configuration can be added to enable RustFS container and provide an S3-compatible API for Storage backend:
+An override `docker-compose.rustfs.yml` can be added to enable RustFS container and provide an S3-compatible API for Storage backend:
 
 ```sh
 docker compose -f docker-compose.yml -f docker-compose.rustfs.yml up -d
@@ -109,7 +109,7 @@ MinIO no longer publishes open source Docker images or maintains their open sour
 </Admonition>
 
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-An overlay `docker-compose.s3.yml` configuration can be added to enable MinIO container and provide an S3-compatible API for Storage backend:
+An override `docker-compose.s3.yml` can be added to enable MinIO container and provide an S3-compatible API for Storage backend:
 
 ```sh
 docker compose -f docker-compose.yml -f docker-compose.s3.yml up -d

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -72,7 +72,7 @@ See per-service updates below for details.
 - Updated to `v1.36.1` - [Release](https://github.com/Logflare/logflare/releases/tag/v1.36.1)
 
 ### Postgres
-- ⚠️ Added `docker-compose.pg17.yml` overlay configuration - PR [#44147](https://github.com/supabase/supabase/pull/44147)
+- ⚠️ Added `docker-compose.pg17.yml` override - PR [#44147](https://github.com/supabase/supabase/pull/44147)
 - ⚠️ Added `upgrade-pg17.sh` - PR [#44147](https://github.com/supabase/supabase/pull/44147)
 - ⚠️ Added [documentation](https://supabase.com/docs/guides/self-hosting/postgres-upgrade-17) explaining the upgrade to Postgres 17
 

--- a/docker/tests/docker-compose.rustfs.test.yml
+++ b/docker/tests/docker-compose.rustfs.test.yml
@@ -1,4 +1,4 @@
-# Test overlay: exposes the S3 backend port for direct testing.
+# Test override: exposes the S3 backend port for direct testing.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.rustfs.yml \

--- a/docker/tests/docker-compose.s3.test.yml
+++ b/docker/tests/docker-compose.s3.test.yml
@@ -1,4 +1,4 @@
-# Test overlay: exposes the S3 backend port for direct testing.
+# Test override: exposes the S3 backend port for direct testing.
 #
 # Usage:
 #   docker compose -f docker-compose.yml -f docker-compose.s3.yml \

--- a/docker/tests/test-s3-backend.sh
+++ b/docker/tests/test-s3-backend.sh
@@ -11,7 +11,7 @@
 #   sh test-s3-backend.sh <backend_url>     # Custom URL
 #
 # Prerequisites:
-#   - Running self-hosted Supabase instance with S3 backend + test overlay:
+#   - Running self-hosted Supabase instance with S3 backend + test override:
 #       docker compose -f docker-compose.yml -f docker-compose.s3.yml \
 #         -f ./tests/docker-compose.s3.test.yml up -d
 #   - .env file with MINIO_ROOT_USER, MINIO_ROOT_PASSWORD, GLOBAL_S3_BUCKET
@@ -90,7 +90,7 @@ list_ok=$(echo "$list_output" | jq -r 'if .Buckets then "true" else "false" end'
 check "Backend reachable (ListBuckets)" "true" "$list_ok"
 
 if [ "$list_ok" != "true" ]; then
-    echo "  Cannot reach backend. Is the test overlay running?"
+    echo "  Cannot reach backend. Is the test override running?"
     echo "  Response: $list_output"
     echo ""
     echo "=== Results: $pass passed, $fail failed ==="

--- a/docker/utils/upgrade-pg17.sh
+++ b/docker/utils/upgrade-pg17.sh
@@ -158,7 +158,7 @@ preflight() {
         | grep -E '^db-config$|_db-config$' | head -n 1)
     [ -n "$db_config_vol" ] || die "Could not find db-config volume. Is Supabase running?"
 
-    # Read the target PG17 image from the compose overlay (what the user will run)
+    # Read the target PG17 image from the compose override (what the user will run)
     PG17_TARGET_IMAGE=$(grep 'image:.*postgres' docker-compose.pg17.yml | awk '{print $2}' | head -n 1)
     [ -n "$PG17_TARGET_IMAGE" ] || die "Could not read image from docker-compose.pg17.yml."
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Use "override" instead of "overlay" when referring to docker-compose files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosting guides to use correct Docker Compose override terminology across Envoy proxy, Caddy/Nginx, RustFS, and MinIO configuration sections for consistency and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->