### PR TITLE
Add assistant CTA for query errors in RLS tester

### DIFF
--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -108,7 +108,7 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
     }
   }
 
-  const assistantSql = +format === 'lib' && inferredSQL ? acceptUntrustedSql(inferredSQL) : value
+  const assistantSql = format === 'lib' && inferredSQL ? acceptUntrustedSql(inferredSQL) : value
 
   const getDebugPrompt = ({ includeSql = false }: { includeSql?: boolean } = {}) => {
     const prompt = `Help me fix my RLS policy based on the attached SQL snippet that gave the following error: \n\n${executeSqlError?.message}\n\nEvaluate if the problem might be query first, before checking my RLS policies.`

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -108,9 +108,12 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
     }
   }
 
+  const assistantSql = +format === 'lib' && inferredSQL ? acceptUntrustedSql(inferredSQL) : value
+
   const getDebugPrompt = ({ includeSql = false }: { includeSql?: boolean } = {}) => {
     const prompt = `Help me fix my RLS policy based on the attached SQL snippet that gave the following error: \n\n${executeSqlError?.message}\n\nEvaluate if the problem might be query first, before checking my RLS policies.`
-    return includeSql ? `${prompt}\n\nSQL Query:\n\`\`\`sql\n${value}\n\`\`\`` : prompt
+
+    return includeSql ? `${prompt}\n\nSQL Query:\n\`\`\`sql\n${assistantSql}\n\`\`\`` : prompt
   }
 
   const onDebugWithAssistant = () => {
@@ -118,7 +121,7 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
     openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
     aiSnap.newChat({
       name: 'Debug RLS policies',
-      sqlSnippets: [value],
+      sqlSnippets: [assistantSql],
       initialInput: prompt,
     })
     setOpen(false)

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -108,13 +108,18 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
     }
   }
 
+  const getDebugPrompt = ({ includeSql = false }: { includeSql?: boolean } = {}) => {
+    const prompt = `Help me fix my RLS policy based on the attached SQL snippet that gave the following error: \n\n${executeSqlError?.message} \n\nEvaluate if the problem might be query first, before checking my RLS policies.`
+    return includeSql ? `${prompt}\n\nSQL Query:\n\`\`\`sql\n${value}\n\`\`\`` : prompt
+  }
+
   const onDebugWithAssistant = () => {
-    console.log({ parseQueryResults })
+    const prompt = getDebugPrompt()
     openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
     aiSnap.newChat({
       name: 'Debug RLS policies',
       sqlSnippets: [value],
-      initialInput: `Help me fix my RLS policy based on the attached SQL snippet that gave the following error: \n\n${executeSqlError?.message} \n\nEvaluate if the problem might be query first, before checking my RLS policies.`,
+      initialInput: prompt,
     })
     setOpen(false)
   }
@@ -242,7 +247,7 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
                       key="ai-assistant"
                       label="Ask Assistant"
                       telemetrySource="rls_tester"
-                      buildPrompt={() => 'asd'}
+                      buildPrompt={() => getDebugPrompt({ includeSql: true })}
                       onOpenAssistant={onDebugWithAssistant}
                     />,
                   ]}

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -39,14 +39,20 @@ import { UserSelector } from './UserSelector'
 import { UserSqlEditor } from './UserSqlEditor'
 import { useTestQueryRLS } from './useTestQueryRLS'
 import type { Policy } from '@/components/interfaces/Auth/Policies/PolicyTableRow/PolicyTableRow.utils'
+import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
 import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
+import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
+import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 interface RLSTesterSheetProps {
   handleSelectEditPolicy: (policy: Policy) => void
 }
 
 export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) => {
+  const aiSnap = useAiAssistantStateSnapshot()
+  const { openSidebar } = useSidebarManagerSnapshot()
   const { setRole } = useRoleImpersonationStateSnapshot()
 
   const [open, setOpen] = useState(false)
@@ -100,6 +106,17 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
     } else {
       await testQuery({ value, ...executionCallbacks })
     }
+  }
+
+  const onDebugWithAssistant = () => {
+    console.log({ parseQueryResults })
+    openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+    aiSnap.newChat({
+      name: 'Debug RLS policies',
+      sqlSnippets: [value],
+      initialInput: `Help me fix my RLS policy based on the attached SQL snippet that gave the following error: \n\n${executeSqlError?.message} \n\nEvaluate if the problem might be query first, before checking my RLS policies.`,
+    })
+    setOpen(false)
   }
 
   useEffect(() => {
@@ -197,7 +214,7 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
 
           <DialogSectionSeparator />
 
-          {parseQueryError && (
+          {parseQueryError ? (
             <div className="p-4">
               <Admonition
                 type="warning"
@@ -205,9 +222,7 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
                 description={parseQueryError.message}
               />
             </div>
-          )}
-
-          {parseClientCodeError && (
+          ) : parseClientCodeError ? (
             <div className="p-4">
               <Admonition
                 type="warning"
@@ -215,20 +230,29 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
                 description={parseClientCodeError.message}
               />
             </div>
-          )}
-
-          {executeSqlError && (
-            <div className="p-4">
-              <Admonition
-                type="warning"
-                title="Error running SQL query"
-                description={executeSqlError.message}
-              />
-            </div>
+          ) : (
+            executeSqlError && (
+              <div className="p-4">
+                <Admonition
+                  type="warning"
+                  title="Error running SQL query"
+                  description={executeSqlError.message}
+                  actions={[
+                    <AiAssistantDropdown
+                      key="ai-assistant"
+                      label="Ask Assistant"
+                      telemetrySource="rls_tester"
+                      buildPrompt={() => 'asd'}
+                      onOpenAssistant={onDebugWithAssistant}
+                    />,
+                  ]}
+                />
+              </div>
+            )
           )}
 
           {results === null ? (
-            <RLSTesterEmptyState />
+            !parseQueryError && !parseClientCodeError && !executeSqlError && <RLSTesterEmptyState />
           ) : !!parseQueryResults ? (
             <RLSTesterResults
               results={results}

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -109,7 +109,7 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
   }
 
   const getDebugPrompt = ({ includeSql = false }: { includeSql?: boolean } = {}) => {
-    const prompt = `Help me fix my RLS policy based on the attached SQL snippet that gave the following error: \n\n${executeSqlError?.message} \n\nEvaluate if the problem might be query first, before checking my RLS policies.`
+    const prompt = `Help me fix my RLS policy based on the attached SQL snippet that gave the following error: \n\n${executeSqlError?.message}\n\nEvaluate if the problem might be query first, before checking my RLS policies.`
     return includeSql ? `${prompt}\n\nSQL Query:\n\`\`\`sql\n${value}\n\`\`\`` : prompt
   }
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2706,6 +2706,7 @@ export type AiAssistantSource =
   | 'log_explorer'
   | 'error_code'
   | 'advisor_signal_detail'
+  | 'rls_tester'
 
 /**
  * User copied an AI prompt to clipboard instead of using the built-in assistant.


### PR DESCRIPTION
## Context

Adding an "Ask Assistant" CTA in the RLS tester if the query executed returns an error
<img width="618" height="375" alt="image" src="https://github.com/user-attachments/assets/8b0a5069-3ec5-44aa-aa0b-f1cd8041960d" />

Which will open the Assistant panel with the following prompt (attaches the query as well)
<img width="427" height="281" alt="image" src="https://github.com/user-attachments/assets/16debd7b-9447-4b84-bef5-05debd0062ee" />

Theres a chance that the error might be just from the query and not related to the policy hence the last sentence in the prompt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated AI assistant into the RLS tester so users can open the assistant prefilled with a debug prompt and relevant SQL to troubleshoot policy issues.
  * Added an "Ask Assistant" action on execution error messages to quickly start guided debugging.
  * Streamlined error display to prioritize parse errors, then client-code parse errors, then execution errors for clearer diagnostics.

* **Chores**
  * Added telemetry source identifier for the RLS tester to track assistant usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->