### PR TITLE
fix(ui-library): make realtime-cursor dual preview responsive on mobile

### DIFF
--- a/apps/ui-library/components/dual-realtime-chat.tsx
+++ b/apps/ui-library/components/dual-realtime-chat.tsx
@@ -4,7 +4,7 @@ export function DualRealtimeChat() {
   const roomName = `room-${Math.floor(Math.random() * 1000)}`
 
   return (
-    <div className="flex flex-row -space-x-px w-full">
+    <div className="flex flex-col lg:flex-row lg:-space-x-px w-full">
       <BlockPreview name={`realtime-chat-demo?roomName=${roomName}`} isPair />
       <BlockPreview name={`realtime-chat-demo?roomName=${roomName}`} isPair />
     </div>

--- a/apps/ui-library/components/dual-realtime-cursor.tsx
+++ b/apps/ui-library/components/dual-realtime-cursor.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { BlockPreview } from './block-preview'
+
+export function DualRealtimeCursor() {
+  return (
+    <div className="flex flex-col lg:flex-row lg:-space-x-px w-full">
+      <BlockPreview name="realtime-cursor-demo" isPair />
+      <BlockPreview name="realtime-cursor-demo" isPair />
+    </div>
+  )
+}

--- a/apps/ui-library/components/dual-realtime-monaco.tsx
+++ b/apps/ui-library/components/dual-realtime-monaco.tsx
@@ -4,7 +4,7 @@ import { BlockPreview } from './block-preview'
 
 export function DualRealtimeMonaco() {
   return (
-    <div className="flex flex-row -space-x-px w-full">
+    <div className="flex flex-col lg:flex-row lg:-space-x-px w-full">
       <BlockPreview name="realtime-monaco-demo" isPair />
       <BlockPreview name="realtime-monaco-demo" isPair />
     </div>

--- a/apps/ui-library/components/mdx-components.tsx
+++ b/apps/ui-library/components/mdx-components.tsx
@@ -14,6 +14,7 @@ import { Callout } from './callout'
 import { ComponentPreview } from './component-preview'
 import { CopyButton } from './copy-button'
 import { DualRealtimeChat } from './dual-realtime-chat'
+import { DualRealtimeCursor } from './dual-realtime-cursor'
 import { DualRealtimeMonaco } from './dual-realtime-monaco'
 import { RegistryBlock } from './registry-block'
 import { StyleWrapper } from './style-wrapper'
@@ -181,6 +182,7 @@ const components = {
   BlockPreview,
   DualRealtimeChat,
   DualRealtimeMonaco,
+  DualRealtimeCursor,
   TanstackDBGenerator,
 }
 

--- a/apps/ui-library/content/docs/nextjs/realtime-cursor.mdx
+++ b/apps/ui-library/content/docs/nextjs/realtime-cursor.mdx
@@ -3,10 +3,7 @@ title: Realtime Cursor
 description: Real-time cursor sharing for collaborative applications
 ---
 
-<div className="flex flex-row -space-x-px w-full">
-  <BlockPreview name="realtime-cursor-demo" isPair />
-  <BlockPreview name="realtime-cursor-demo" isPair />
-</div>
+<DualRealtimeCursor />
 
 ## Installation
 

--- a/apps/ui-library/content/docs/nuxtjs/realtime-cursor.mdx
+++ b/apps/ui-library/content/docs/nuxtjs/realtime-cursor.mdx
@@ -3,10 +3,7 @@ title: Realtime Cursor
 description: Real-time cursor sharing for collaborative applications
 ---
 
-<div className="flex flex-row -space-x-px w-full">
-  <BlockPreview name="realtime-cursor-demo" isPair />
-  <BlockPreview name="realtime-cursor-demo" isPair />
-</div>
+<DualRealtimeCursor />
 
 ## Installation
 

--- a/apps/ui-library/content/docs/react-router/realtime-cursor.mdx
+++ b/apps/ui-library/content/docs/react-router/realtime-cursor.mdx
@@ -3,10 +3,7 @@ title: Realtime Cursor
 description: Real-time cursor sharing for collaborative applications
 ---
 
-<div className="flex flex-row -space-x-px w-full">
-  <BlockPreview name="realtime-cursor-demo" isPair />
-  <BlockPreview name="realtime-cursor-demo" isPair />
-</div>
+<DualRealtimeCursor />
 
 ## Installation
 

--- a/apps/ui-library/content/docs/react/realtime-cursor.mdx
+++ b/apps/ui-library/content/docs/react/realtime-cursor.mdx
@@ -3,10 +3,7 @@ title: Realtime Cursor
 description: Real-time cursor sharing for collaborative applications
 ---
 
-<div className="flex flex-row -space-x-px w-full">
-  <BlockPreview name="realtime-cursor-demo" isPair />
-  <BlockPreview name="realtime-cursor-demo" isPair />
-</div>
+<DualRealtimeCursor />
 
 ## Installation
 

--- a/apps/ui-library/content/docs/tanstack/realtime-cursor.mdx
+++ b/apps/ui-library/content/docs/tanstack/realtime-cursor.mdx
@@ -3,10 +3,7 @@ title: Realtime Cursor
 description: Real-time cursor sharing for collaborative applications
 ---
 
-<div className="flex flex-row -space-x-px w-full">
-  <BlockPreview name="realtime-cursor-demo" isPair />
-  <BlockPreview name="realtime-cursor-demo" isPair />
-</div>
+<DualRealtimeCursor />
 
 ## Installation
 

--- a/apps/ui-library/content/docs/vue/realtime-cursor.mdx
+++ b/apps/ui-library/content/docs/vue/realtime-cursor.mdx
@@ -3,10 +3,7 @@ title: Realtime Cursor
 description: Real-time cursor sharing for collaborative applications
 ---
 
-<div className="flex flex-row -space-x-px w-full">
-  <BlockPreview name="realtime-cursor-demo" isPair />
-  <BlockPreview name="realtime-cursor-demo" isPair />
-</div>
+<DualRealtimeCursor />
 
 ## Installation
 


### PR DESCRIPTION
## Problem

The realtime-cursor docs pages embed the dual preview directly as inline JSX across 6 framework variants (nextjs, nuxtjs, react, react-router, tanstack, vue) using `flex flex-row -space-x-px` with no responsive breakpoint.

On small screens both panels are forced side by side at ~180px each, cursors are invisible, inputs are unusable, and the layout breaks completely.

## Fix

- Extracted inline preview JSX into a dedicated `DualRealtimeCursor` component, consistent with how `DualRealtimeChat` and `DualRealtimeMonaco` are structured
- Registered `DualRealtimeCursor` in `mdx-components.tsx` 
- Replaced inline div block with `<DualRealtimeCursor />` in all 6 MDX files
- Component uses `flex flex-col lg:flex-row lg:-space-x-px` so panels 
  stack on mobile and go side by side on `lg+` screens

## Files changed

- `apps/ui-library/components/dual-realtime-cursor.tsx` ← new file
- `apps/ui-library/components/mdx-components.tsx`
- `apps/ui-library/content/docs/nextjs/realtime-cursor.mdx`
- `apps/ui-library/content/docs/nuxtjs/realtime-cursor.mdx`
- `apps/ui-library/content/docs/react/realtime-cursor.mdx`
- `apps/ui-library/content/docs/react-router/realtime-cursor.mdx`
- `apps/ui-library/content/docs/tanstack/realtime-cursor.mdx`
- `apps/ui-library/content/docs/vue/realtime-cursor.mdx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced responsive Dual Realtime Cursor component with adaptive layouts for different screen sizes.

* **Improvements**
  * Enhanced responsive design in Dual Realtime Chat and Dual Realtime Monaco components for better mobile support.

* **Documentation**
  * Updated realtime cursor documentation across all framework guides to showcase the new responsive component functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->