### PR TITLE
feat: restore a physical backup by id only

### DIFF
--- a/apps/studio/data/database/backup-restore-mutation.ts
+++ b/apps/studio/data/database/backup-restore-mutation.ts
@@ -17,7 +17,7 @@ export async function restoreFromBackup({ ref, backup }: BackupRestoreVariables)
   if (backup.isPhysicalBackup) {
     const { data, error } = await post('/platform/database/{ref}/backups/restore-physical', {
       params: { path: { ref } },
-      body: { id: backup.id, recovery_time_target: backup.inserted_at },
+      body: { id: backup.id },
     })
     if (error) throw error
     return data

--- a/apps/studio/data/marketplace/install-oauth-integration-mutation.ts
+++ b/apps/studio/data/marketplace/install-oauth-integration-mutation.ts
@@ -13,8 +13,8 @@ export async function installOAuthIntegration({
   projectRef,
   id,
 }: OAuthIntegrationInstallVariables) {
-  const { data, error } = await post('/platform/integrations/partners/{ref}/{listing_id}', {
-    params: { path: { ref: projectRef, listing_id: id } },
+  const { data, error } = await post('/platform/integrations/partners/{ref}/{listing_slug}', {
+    params: { path: { ref: projectRef, listing_slug: id } },
   })
 
   if (error) handleError(error)

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -1153,6 +1153,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/v1/projects/{ref}/database/backups/restore': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Restores a physical backup for a database */
+    post: operations['v1-restore-physical-backup']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/v1/projects/{ref}/database/backups/restore-pitr': {
     parameters: {
       query?: never
@@ -4666,6 +4683,7 @@ export interface components {
     }
     V1BackupsResponse: {
       backups: {
+        id: number
         inserted_at: string
         is_physical_backup: boolean
         /** @enum {string} */
@@ -4932,6 +4950,7 @@ export interface components {
             | 'auth.advanced_auth_settings'
             | 'auth.performance_settings'
             | 'auth.password_hibp'
+            | 'auth.custom_oauth.max_providers'
             | 'backup.retention_days'
             | 'backup.restore_to_new_project'
             | 'function.max_count'
@@ -5180,6 +5199,12 @@ export interface components {
     V1ReadOnlyQueryBody: {
       parameters?: unknown[]
       query: string
+    }
+    /** @example {
+     *       "id": 12345
+     *     } */
+    V1RestoreBackupBody: {
+      id: number
     }
     /** @example {
      *       "recovery_time_target_unix": 1740787200
@@ -9594,6 +9619,51 @@ export interface operations {
       }
       /** @description Failed to get backups */
       500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  'v1-restore-physical-backup': {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['V1RestoreBackupBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
         headers: {
           [name: string]: unknown
         }

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -670,7 +670,7 @@ export interface paths {
     patch?: never
     trace?: never
   }
-  '/platform/integrations/partners/{ref}/{listing_id}': {
+  '/platform/integrations/partners/{ref}/{listing_slug}': {
     parameters: {
       query?: never
       header?: never
@@ -1071,6 +1071,23 @@ export interface paths {
     put?: never
     /** Retrieves a list of available Postgres versions available to the organization */
     post: operations['OrganizationSlugController_getAvailableImageVersions']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/organizations/{slug}/billing/credits/balance': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets the current credit balance */
+    get: operations['OrgCreditsController_getBalance']
+    put?: never
+    post?: never
     delete?: never
     options?: never
     head?: never
@@ -2430,6 +2447,24 @@ export interface paths {
     put?: never
     /** Gets project's logs */
     post: operations['LogsController_getProjectLogsViaPost']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/projects/{ref}/analytics/endpoints/logs.all.otel': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Gets project's logs from the ClickHouse-backed endpoint */
+    get: operations['LogsController_getProjectLogsOtelViaGet']
+    put?: never
+    /** Gets project's logs from the ClickHouse-backed endpoint */
+    post: operations['LogsController_getProjectLogsOtelViaPost']
     delete?: never
     options?: never
     head?: never
@@ -4693,7 +4728,32 @@ export interface components {
       role_scoped_projects?: string[]
     }
     AuditLogsResponse: {
-      result: unknown[]
+      result: {
+        action: {
+          metadata?: {
+            [key: string]: unknown
+          }
+          method: string
+          name: string
+          route: string
+          status: number
+        }
+        actor: {
+          app_id?: string
+          app_name?: string
+          email?: string
+          ip?: string
+          oauth_app_id?: string
+          oauth_app_name?: string
+          token_hash?: string
+          token_type: string
+          user_id?: string
+        }
+        organization_slug?: string
+        project_ref?: string
+        request_id: string
+        timestamp: number
+      }[]
       retention_period: number
     }
     AuthBackupAdminLintResponse: {
@@ -5390,6 +5450,7 @@ export interface components {
         }
       }
       data_api_exposed_schemas?: string[]
+      data_api_revoke_default_privileges?: boolean
       data_api_use_api_schema?: boolean
       db_pass: string
       db_pricing_tier_id?: string
@@ -5419,6 +5480,10 @@ export interface components {
         | '48xlarge_optimized_memory'
         | '48xlarge_optimized_cpu'
         | '48xlarge_high_memory'
+      /** @description GitHub App installation ID. Must be provided together with github_repository_id to connect a GitHub repository during project creation. */
+      github_installation_id?: number
+      /** @description GitHub repository ID. Must be provided together with github_installation_id to connect a GitHub repository during project creation. */
+      github_repository_id?: number
       /** @description Whether to enable high availability for the project. */
       high_availability?: boolean
       name: string
@@ -5562,6 +5627,68 @@ export interface components {
               }
             }
           }
+        | {
+            ducklake: {
+              /**
+               * @description DuckLake catalog URL
+               * @example postgres://user:pass@localhost:5432/ducklake_catalog
+               */
+              catalog_url: string
+              /**
+               * @description DuckLake data path
+               * @example s3://<bucket-name>/
+               */
+              data_path: string
+              /**
+               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
+               * @example 7 days
+               */
+              expire_snapshots_older_than?: string
+              /**
+               * @description Schema used for DuckLake metadata tables stored in PostgreSQL
+               * @default ducklake
+               * @example ducklake
+               */
+              metadata_schema?: string
+              /**
+               * @description Number of concurrent DuckDB connections.
+               * @example 4
+               */
+              pool_size?: number
+              /**
+               * @description S3-compatible storage access key ID
+               * @example my-access-key
+               */
+              s3_access_key_id: string
+              /**
+               * @description S3-compatible storage endpoint
+               * @example 127.0.0.1:5000/s3
+               */
+              s3_endpoint: string
+              /**
+               * @description S3-compatible storage region
+               * @example us-east-1
+               */
+              s3_region: string
+              /**
+               * @description S3-compatible storage secret access key
+               * @example my-secret-key
+               */
+              s3_secret_access_key: string
+              /**
+               * @description S3 URL style: `path` (MinIO/Supabase) or `vhost` (AWS)
+               * @example path
+               * @enum {string}
+               */
+              s3_url_style?: 'path' | 'vhost'
+              /**
+               * @description Whether to use SSL for S3-compatible storage
+               * @default true
+               * @example false
+               */
+              s3_use_ssl?: boolean
+            }
+          }
       /**
        * @description Destination name
        * @example bq-analytics
@@ -5636,6 +5763,68 @@ export interface components {
                  */
                 warehouse_name: string
               }
+            }
+          }
+        | {
+            ducklake: {
+              /**
+               * @description DuckLake catalog URL
+               * @example postgres://user:pass@localhost:5432/ducklake_catalog
+               */
+              catalog_url: string
+              /**
+               * @description DuckLake data path
+               * @example s3://<bucket-name>/
+               */
+              data_path: string
+              /**
+               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
+               * @example 7 days
+               */
+              expire_snapshots_older_than?: string
+              /**
+               * @description Schema used for DuckLake metadata tables stored in PostgreSQL
+               * @default ducklake
+               * @example ducklake
+               */
+              metadata_schema?: string
+              /**
+               * @description Number of concurrent DuckDB connections.
+               * @example 4
+               */
+              pool_size?: number
+              /**
+               * @description S3-compatible storage access key ID
+               * @example my-access-key
+               */
+              s3_access_key_id: string
+              /**
+               * @description S3-compatible storage endpoint
+               * @example 127.0.0.1:5000/s3
+               */
+              s3_endpoint: string
+              /**
+               * @description S3-compatible storage region
+               * @example us-east-1
+               */
+              s3_region: string
+              /**
+               * @description S3-compatible storage secret access key
+               * @example my-secret-key
+               */
+              s3_secret_access_key: string
+              /**
+               * @description S3 URL style: `path` (MinIO/Supabase) or `vhost` (AWS)
+               * @example path
+               * @enum {string}
+               */
+              s3_url_style?: 'path' | 'vhost'
+              /**
+               * @description Whether to use SSL for S3-compatible storage
+               * @default true
+               * @example false
+               */
+              s3_use_ssl?: boolean
             }
           }
       /**
@@ -6017,6 +6206,10 @@ export interface components {
       organization_slug: string
       source: string
       teamId?: string
+    }
+    CreditBalanceResponse: {
+      billing_via_partner: boolean
+      total_balance_cents: number
     }
     CreditRedemptionRequest: {
       code: string
@@ -7394,6 +7587,7 @@ export interface components {
             | 'auth.advanced_auth_settings'
             | 'auth.performance_settings'
             | 'auth.password_hibp'
+            | 'auth.custom_oauth.max_providers'
             | 'backup.retention_days'
             | 'backup.restore_to_new_project'
             | 'function.max_count'
@@ -8090,7 +8284,7 @@ export interface components {
         has_address: boolean
         id: string
         is_default: boolean
-        shared_payment_token: {
+        shared_payment_token?: {
           expires_at: number | null
           is_expired: boolean
           last4: string
@@ -9066,6 +9260,68 @@ export interface components {
               }
             }
           }
+        | {
+            ducklake: {
+              /**
+               * @description DuckLake catalog URL
+               * @example postgres://user:pass@localhost:5432/ducklake_catalog
+               */
+              catalog_url: string
+              /**
+               * @description DuckLake data path
+               * @example s3://<bucket-name>/
+               */
+              data_path: string
+              /**
+               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
+               * @example 7 days
+               */
+              expire_snapshots_older_than?: string
+              /**
+               * @description Schema used for DuckLake metadata tables stored in PostgreSQL
+               * @default ducklake
+               * @example ducklake
+               */
+              metadata_schema?: string
+              /**
+               * @description Number of concurrent DuckDB connections.
+               * @example 4
+               */
+              pool_size?: number
+              /**
+               * @description S3-compatible storage access key ID
+               * @example my-access-key
+               */
+              s3_access_key_id: string
+              /**
+               * @description S3-compatible storage endpoint
+               * @example 127.0.0.1:5000/s3
+               */
+              s3_endpoint: string
+              /**
+               * @description S3-compatible storage region
+               * @example us-east-1
+               */
+              s3_region: string
+              /**
+               * @description S3-compatible storage secret access key
+               * @example my-secret-key
+               */
+              s3_secret_access_key: string
+              /**
+               * @description S3 URL style: `path` (MinIO/Supabase) or `vhost` (AWS)
+               * @example path
+               * @enum {string}
+               */
+              s3_url_style?: 'path' | 'vhost'
+              /**
+               * @description Whether to use SSL for S3-compatible storage
+               * @default true
+               * @example false
+               */
+              s3_use_ssl?: boolean
+            }
+          }
       /**
        * @description Destination id
        * @example 2001
@@ -9152,6 +9408,68 @@ export interface components {
                    */
                   warehouse_name: string
                 }
+              }
+            }
+          | {
+              ducklake: {
+                /**
+                 * @description DuckLake catalog URL
+                 * @example postgres://user:pass@localhost:5432/ducklake_catalog
+                 */
+                catalog_url: string
+                /**
+                 * @description DuckLake data path
+                 * @example s3://<bucket-name>/
+                 */
+                data_path: string
+                /**
+                 * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
+                 * @example 7 days
+                 */
+                expire_snapshots_older_than?: string
+                /**
+                 * @description Schema used for DuckLake metadata tables stored in PostgreSQL
+                 * @default ducklake
+                 * @example ducklake
+                 */
+                metadata_schema?: string
+                /**
+                 * @description Number of concurrent DuckDB connections.
+                 * @example 4
+                 */
+                pool_size?: number
+                /**
+                 * @description S3-compatible storage access key ID
+                 * @example my-access-key
+                 */
+                s3_access_key_id: string
+                /**
+                 * @description S3-compatible storage endpoint
+                 * @example 127.0.0.1:5000/s3
+                 */
+                s3_endpoint: string
+                /**
+                 * @description S3-compatible storage region
+                 * @example us-east-1
+                 */
+                s3_region: string
+                /**
+                 * @description S3-compatible storage secret access key
+                 * @example my-secret-key
+                 */
+                s3_secret_access_key: string
+                /**
+                 * @description S3 URL style: `path` (MinIO/Supabase) or `vhost` (AWS)
+                 * @example path
+                 * @enum {string}
+                 */
+                s3_url_style?: 'path' | 'vhost'
+                /**
+                 * @description Whether to use SSL for S3-compatible storage
+                 * @default true
+                 * @example false
+                 */
+                s3_use_ssl?: boolean
               }
             }
         /**
@@ -9596,7 +9914,6 @@ export interface components {
     }
     RestorePhysicalBackupBody: {
       id: number
-      recovery_time_target: string
     }
     RevokeAuthorizedOAuthAppResponse: {
       authorized_at?: string
@@ -9812,7 +10129,7 @@ export interface components {
     SignedUrlsResponse: {
       error: string | null
       path: string | null
-      signedUrl: string
+      signedUrl: string | null
     }
     SignUpBody: {
       /** Format: email */
@@ -10941,6 +11258,68 @@ export interface components {
               }
             }
           }
+        | {
+            ducklake: {
+              /**
+               * @description DuckLake catalog URL
+               * @example postgres://user:pass@localhost:5432/ducklake_catalog
+               */
+              catalog_url: string
+              /**
+               * @description DuckLake data path
+               * @example s3://<bucket-name>/
+               */
+              data_path: string
+              /**
+               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
+               * @example 7 days
+               */
+              expire_snapshots_older_than?: string
+              /**
+               * @description Schema used for DuckLake metadata tables stored in PostgreSQL
+               * @default ducklake
+               * @example ducklake
+               */
+              metadata_schema?: string
+              /**
+               * @description Number of concurrent DuckDB connections.
+               * @example 4
+               */
+              pool_size?: number
+              /**
+               * @description S3-compatible storage access key ID
+               * @example my-access-key
+               */
+              s3_access_key_id: string
+              /**
+               * @description S3-compatible storage endpoint
+               * @example 127.0.0.1:5000/s3
+               */
+              s3_endpoint: string
+              /**
+               * @description S3-compatible storage region
+               * @example us-east-1
+               */
+              s3_region: string
+              /**
+               * @description S3-compatible storage secret access key
+               * @example my-secret-key
+               */
+              s3_secret_access_key: string
+              /**
+               * @description S3 URL style: `path` (MinIO/Supabase) or `vhost` (AWS)
+               * @example path
+               * @enum {string}
+               */
+              s3_url_style?: 'path' | 'vhost'
+              /**
+               * @description Whether to use SSL for S3-compatible storage
+               * @default true
+               * @example false
+               */
+              s3_use_ssl?: boolean
+            }
+          }
       /**
        * @description Destination name
        * @example bq-analytics
@@ -11015,6 +11394,68 @@ export interface components {
                  */
                 warehouse_name: string
               }
+            }
+          }
+        | {
+            ducklake: {
+              /**
+               * @description DuckLake catalog URL
+               * @example postgres://user:pass@localhost:5432/ducklake_catalog
+               */
+              catalog_url: string
+              /**
+               * @description DuckLake data path
+               * @example s3://<bucket-name>/
+               */
+              data_path: string
+              /**
+               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
+               * @example 7 days
+               */
+              expire_snapshots_older_than?: string
+              /**
+               * @description Schema used for DuckLake metadata tables stored in PostgreSQL
+               * @default ducklake
+               * @example ducklake
+               */
+              metadata_schema?: string
+              /**
+               * @description Number of concurrent DuckDB connections.
+               * @example 4
+               */
+              pool_size?: number
+              /**
+               * @description S3-compatible storage access key ID
+               * @example my-access-key
+               */
+              s3_access_key_id: string
+              /**
+               * @description S3-compatible storage endpoint
+               * @example 127.0.0.1:5000/s3
+               */
+              s3_endpoint: string
+              /**
+               * @description S3-compatible storage region
+               * @example us-east-1
+               */
+              s3_region: string
+              /**
+               * @description S3-compatible storage secret access key
+               * @example my-secret-key
+               */
+              s3_secret_access_key: string
+              /**
+               * @description S3 URL style: `path` (MinIO/Supabase) or `vhost` (AWS)
+               * @example path
+               * @enum {string}
+               */
+              s3_url_style?: 'path' | 'vhost'
+              /**
+               * @description Whether to use SSL for S3-compatible storage
+               * @default true
+               * @example false
+               */
+              s3_use_ssl?: boolean
             }
           }
       /**
@@ -11321,7 +11762,32 @@ export interface components {
       visibility: 'user' | 'project' | 'org' | 'public'
     }
     UserAuditLogsResponse: {
-      result: unknown[]
+      result: {
+        action: {
+          metadata?: {
+            [key: string]: unknown
+          }
+          method: string
+          name: string
+          route: string
+          status: number
+        }
+        actor: {
+          app_id?: string
+          app_name?: string
+          email?: string
+          ip?: string
+          oauth_app_id?: string
+          oauth_app_name?: string
+          token_hash?: string
+          token_type: string
+          user_id?: string
+        }
+        organization_slug?: string
+        project_ref?: string
+        request_id: string
+        timestamp: number
+      }[]
       retention_period: number
     }
     UserBody: {
@@ -11477,6 +11943,68 @@ export interface components {
                  */
                 warehouse_name: string
               }
+            }
+          }
+        | {
+            ducklake: {
+              /**
+               * @description DuckLake catalog URL
+               * @example postgres://user:pass@localhost:5432/ducklake_catalog
+               */
+              catalog_url: string
+              /**
+               * @description DuckLake data path
+               * @example s3://<bucket-name>/
+               */
+              data_path: string
+              /**
+               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
+               * @example 7 days
+               */
+              expire_snapshots_older_than?: string
+              /**
+               * @description Schema used for DuckLake metadata tables stored in PostgreSQL
+               * @default ducklake
+               * @example ducklake
+               */
+              metadata_schema?: string
+              /**
+               * @description Number of concurrent DuckDB connections.
+               * @example 4
+               */
+              pool_size?: number
+              /**
+               * @description S3-compatible storage access key ID
+               * @example my-access-key
+               */
+              s3_access_key_id: string
+              /**
+               * @description S3-compatible storage endpoint
+               * @example 127.0.0.1:5000/s3
+               */
+              s3_endpoint: string
+              /**
+               * @description S3-compatible storage region
+               * @example us-east-1
+               */
+              s3_region: string
+              /**
+               * @description S3-compatible storage secret access key
+               * @example my-secret-key
+               */
+              s3_secret_access_key: string
+              /**
+               * @description S3 URL style: `path` (MinIO/Supabase) or `vhost` (AWS)
+               * @example path
+               * @enum {string}
+               */
+              s3_url_style?: 'path' | 'vhost'
+              /**
+               * @description Whether to use SSL for S3-compatible storage
+               * @default true
+               * @example false
+               */
+              s3_use_ssl?: boolean
             }
           }
     }
@@ -13406,8 +13934,8 @@ export interface operations {
       query?: never
       header?: never
       path: {
-        /** @description The id of the listing in the marketplace database */
-        listing_id: string
+        /** @description The slug of the listing in the marketplace database */
+        listing_slug: string
         /** @description Supabase project ref */
         ref: string
       }
@@ -14694,6 +15222,7 @@ export interface operations {
   OrgAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
+        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */
@@ -14793,6 +15322,49 @@ export interface operations {
       }
       /** @description Failed to determine available Postgres versions */
       500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  OrgCreditsController_getBalance: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Organization slug */
+        slug: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['CreditBalanceResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
         headers: {
           [name: string]: unknown
         }
@@ -18639,6 +19211,7 @@ export interface operations {
           | 'auth.advanced_auth_settings'
           | 'auth.performance_settings'
           | 'auth.password_hibp'
+          | 'auth.custom_oauth.max_providers'
           | 'backup.retention_days'
           | 'backup.restore_to_new_project'
           | 'function.max_count'
@@ -18873,6 +19446,7 @@ export interface operations {
   UserAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
+        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */
@@ -19536,6 +20110,115 @@ export interface operations {
     }
   }
   LogsController_getProjectLogsViaPost: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['GetProjectLogsBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AnalyticsResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get project's logs */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  LogsController_getProjectLogsOtelViaGet: {
+    parameters: {
+      query?: {
+        iso_timestamp_end?: string
+        iso_timestamp_start?: string
+        lql?: string
+        sql?: string
+      }
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['AnalyticsResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to get project's logs */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  LogsController_getProjectLogsOtelViaPost: {
     parameters: {
       query?: never
       header?: never


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature / minor refactor.

## What is the current behavior?

When restoring a physical backup, Studio sends both `id` and `recovery_time_target` (the backup's `inserted_at`) in the request body to `POST /v1/projects/{ref}/database/backups/restore-physical`. The `recovery_time_target` field is no longer needed — the backend endpoint already accepts `id` alone and resolves the recovery target server-side. This change is already deployed in production.

## What is the new behavior?

Studio now sends only `{ id: backup.id }` to the restore-physical endpoint, matching the simplified contract that's live in prod.

## Additional context

Single-line change in `apps/studio/data/database/backup-restore-mutation.ts`. No UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for restoring physical backups via a simplified restore flow.
  * Projects can include GitHub integration fields.
  * New DuckLake replication destination type.
  * New org credit/balance endpoint.
  * Marketplace OAuth installs now use listing slugs.

* **Bug Fixes**
  * Backups include numeric identifiers for clearer selection.

* **Behavior**
  * Audit logs return richer structured details and support legacy/v2 formats.
  * Signed download URLs may be absent (now nullable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->