### PR TITLE
chore: fix e2e flaky Supabase CLI start

### DIFF
--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -83,9 +83,21 @@ jobs:
         if: steps.filter.outputs.studio == 'true'
         run: rm -rf supabase && pnpm exec supabase init && mkdir supabase/functions
 
+      - name: Pre-start diagnostics
+        run: |
+          docker ps -a
+          sudo ss -tlnp | grep 5432 || echo "5432 free"
+
       - name: Start supabase
         if: steps.filter.outputs.studio == 'true'
         run: SKIP_ASSET_UPLOAD=1 pnpm run e2e:setup:cli
+
+      - name: Failure diagnostics
+        if: failure()
+        run: |
+          docker ps -a
+          sudo ss -tlnp | grep 5432
+          docker logs $(docker ps -aq) 2>&1 || true
 
       - name: Build studio
         if: steps.filter.outputs.studio == 'true'

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ui-patterns": "turbo run test --filter=ui-patterns",
     "test:studio": "turbo run test --filter=studio",
     "test:studio:watch": "turbo run test --filter=studio -- watch",
-    "e2e:setup:cli": "supabase stop --all --no-backup ; supabase start --exclude studio && if [ -z \"${CI}\" ]; then supabase db reset; fi && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
+    "e2e:setup:cli": "supabase stop --all --no-backup ; supabase start --exclude studio,mailpit && if [ -z \"${CI}\" ]; then supabase db reset; fi && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
     "e2e:setup:selfhosted": "SKIP_ASSET_UPLOAD=1 pnpm e2e:setup:cli && NODE_ENV=test NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm run build:studio && NODE_ENV=test pnpm --prefix ./apps/studio start",
     "e2e:setup:selfhosted:start-studio": "SKIP_ASSET_UPLOAD=1 NODE_ENV=test pnpm --prefix ./apps/studio start",
     "e2e:setup:platform": "SKIP_ASSET_UPLOAD=1 NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm run build:studio && pnpm --prefix ./apps/studio start",
@@ -67,6 +67,13 @@
     "pnpm": "10.24",
     "node": ">=22"
   },
-  "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
+  "keywords": [
+    "postgres",
+    "firebase",
+    "storage",
+    "functions",
+    "database",
+    "auth"
+  ],
   "packageManager": "pnpm@10.24.0"
 }


### PR DESCRIPTION
## Problem

The Supabase CLI sometimes fails to start because the postgres port is already used:
> failed to start docker container: Error response from daemon: failed to set up container networking: driver failed programming external connectivity on endpoint supabase_db_supabase (10587f26e7287c8086fd27db12be7aac4afe1f3fc521c9d7a8dfe109993c995d): failed to bind host port for 0.0.0.0:54322:172.18.0.2:5432/tcp: address already in use

## Solution

None yet, debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end test workflow with added pre-start and failure diagnostics for better observability and troubleshooting of test runs.
  * Updated the e2e setup CLI script to skip certain local services by default and clarify script formatting for maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->