### PR TITLE
feat: serve agent skills from .well-known/agent-skills at build time

### DIFF
--- a/apps/www/scripts/fetchAgentSkills.mjs
+++ b/apps/www/scripts/fetchAgentSkills.mjs
@@ -1,18 +1,19 @@
 // @ts-check
 
 /**
- * Fetches the latest agent-skills release from supabase/agent-skills and writes
- * index.json + skill archives to public/.well-known/agent-skills/.
+ * Fetches the latest agent-skills index.json from supabase/agent-skills and
+ * writes it to public/.well-known/agent-skills/index.json with skill URLs
+ * rewritten to absolute GitHub Release URLs.
  *
- * Releases are semver-tagged (e.g. v0.2.0) and managed by Release Please in
- * https://github.com/supabase/agent-skills. Each release includes:
- *   - index.json  (discovery index per agent-skills .well-known spec v0.2.0)
- *   - *.tar.gz    (one archive per skill)
+ * Tarballs are NOT downloaded or hosted here — the index points directly to
+ * GitHub Release assets. The digest in each skill entry is the trust anchor:
+ * clients verify SHA-256 after downloading from GitHub, same pattern as SRI
+ * on the web. The URL is just a location hint; the digest is the guarantee.
  *
+ * Spec: https://github.com/agentskills/agentskills/pull/254
  * Runs unauthenticated — public repo, build-time only.
  */
 
-import { createHash } from 'node:crypto'
 import { promises as fs } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -27,53 +28,35 @@ async function fetchJson(url) {
   return res.json()
 }
 
-async function download(url) {
-  const res = await fetch(url, { headers: { 'User-Agent': 'supabase-www-build' } })
-  if (!res.ok) throw new Error(`GET ${url} → ${res.status}`)
-  return Buffer.from(await res.arrayBuffer())
-}
-
-function sha256(buf) {
-  return 'sha256:' + createHash('sha256').update(buf).digest('hex')
-}
-
 async function main() {
   const release = await fetchJson(`https://api.github.com/repos/${REPO}/releases/latest`)
   console.log(`Fetching agent-skills release: ${release.tag_name}`)
 
-  // Find the index.json asset in the GitHub release to get its download URL
-  const githubReleaseIndexAsset = release.assets.find((a) => a.name === 'index.json')
-  if (!githubReleaseIndexAsset) throw new Error('No index.json found in release assets')
+  const indexAsset = release.assets.find((a) => a.name === 'index.json')
+  if (!indexAsset) throw new Error('No index.json found in release assets')
 
-  // Keep the GitHub download URL as the base URI for RFC 3986 artifact URL resolution (see below)
-  const githubReleaseIndexUrl = githubReleaseIndexAsset.browser_download_url
-  const indexJsonFileBuf = await download(githubReleaseIndexUrl)
-  const indexJsonFile = JSON.parse(indexJsonFileBuf.toString('utf8'))
+  const index = await fetchJson(indexAsset.browser_download_url)
 
-  // Fetch each artifact from its resolved URL, verify digest, buffer before writing
-  const buffers = { 'index.json': indexJsonFileBuf }
-  for (const skill of indexJsonFile.skills ?? []) {
-    // Resolve skill.url against the index URL per RFC 3986 §5.2.2 (https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2)
-    // as adopted by the agent-skills .well-known spec (https://github.com/agentskills/agentskills/pull/254)
-    // skill.url can be relative ("supabase.tar.gz"), path-absolute, or fully absolute (e.g. a CDN URL)
-    const githubReleaseArtifactUrl = new URL(skill.url, githubReleaseIndexUrl).href
-    const artifactName = new URL(githubReleaseArtifactUrl).pathname.split('/').pop()
-    const buf = await download(githubReleaseArtifactUrl)
-    const actual = sha256(buf)
-    if (actual !== skill.digest) {
-      throw new Error(`Digest mismatch for ${skill.name}: expected ${skill.digest}, got ${actual}`)
-    }
-    console.log(`  ✓ ${skill.name} digest verified`)
-    buffers[artifactName] = buf
+  // skill.url values in the published index.json are relative (e.g. "supabase.tar.gz").
+  // Rewrite them to absolute GitHub Release URLs so supabase.com only needs to
+  // serve index.json — tarballs are fetched directly from GitHub by clients.
+  const assetUrls = Object.fromEntries(release.assets.map((a) => [a.name, a.browser_download_url]))
+
+  const rewritten = {
+    ...index,
+    skills: (index.skills ?? []).map((skill) => ({
+      ...skill,
+      url: assetUrls[skill.url] ?? skill.url,
+    })),
   }
 
   await fs.mkdir(OUT_DIR, { recursive: true })
+  await fs.writeFile(join(OUT_DIR, 'index.json'), JSON.stringify(rewritten, null, 2) + '\n')
 
-  for (const [name, buf] of Object.entries(buffers)) {
-    await fs.writeFile(join(OUT_DIR, name), buf)
+  for (const skill of index.skills ?? []) {
+    console.log(`  ${skill.name}`)
   }
-
-  console.log(`Done — wrote to public/.well-known/agent-skills/`)
+  console.log(`Done — wrote public/.well-known/agent-skills/index.json`)
 }
 
 main().catch((err) => {

--- a/apps/www/scripts/fetchAgentSkills.mjs
+++ b/apps/www/scripts/fetchAgentSkills.mjs
@@ -14,7 +14,7 @@
 
 import { createHash } from 'node:crypto'
 import { promises as fs } from 'node:fs'
-import { join, dirname } from 'node:path'
+import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
@@ -41,30 +41,36 @@ async function main() {
   const release = await fetchJson(`https://api.github.com/repos/${REPO}/releases/latest`)
   console.log(`Fetching agent-skills release: ${release.tag_name}`)
 
-  await fs.mkdir(OUT_DIR, { recursive: true })
+  // Find the index.json asset in the GitHub release to get its download URL
+  const githubReleaseIndexAsset = release.assets.find((a) => a.name === 'index.json')
+  if (!githubReleaseIndexAsset) throw new Error('No index.json found in release assets')
 
-  // Download all release assets (index.json + skill tarballs)
-  const assetMap = Object.fromEntries(release.assets.map((a) => [a.name, a.browser_download_url]))
-  for (const [name, url] of Object.entries(assetMap)) {
-    const buf = await download(url)
-    await fs.writeFile(join(OUT_DIR, name), buf)
-    console.log(`  ${name}`)
+  // Keep the GitHub download URL as the base URI for RFC 3986 artifact URL resolution (see below)
+  const githubReleaseIndexUrl = githubReleaseIndexAsset.browser_download_url
+  const indexJsonFileBuf = await download(githubReleaseIndexUrl)
+  const indexJsonFile = JSON.parse(indexJsonFileBuf.toString('utf8'))
+
+  // Fetch each artifact from its resolved URL, verify digest, buffer before writing
+  const buffers = { 'index.json': indexJsonFileBuf }
+  for (const skill of indexJsonFile.skills ?? []) {
+    // Resolve skill.url against the index URL per RFC 3986 §5.2.2 (https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2)
+    // as adopted by the agent-skills .well-known spec (https://github.com/agentskills/agentskills/pull/254)
+    // skill.url can be relative ("supabase.tar.gz"), path-absolute, or fully absolute (e.g. a CDN URL)
+    const githubReleaseArtifactUrl = new URL(skill.url, githubReleaseIndexUrl).href
+    const artifactName = new URL(githubReleaseArtifactUrl).pathname.split('/').pop()
+    const buf = await download(githubReleaseArtifactUrl)
+    const actual = sha256(buf)
+    if (actual !== skill.digest) {
+      throw new Error(`Digest mismatch for ${skill.name}: expected ${skill.digest}, got ${actual}`)
+    }
+    console.log(`  ✓ ${skill.name} digest verified`)
+    buffers[artifactName] = buf
   }
 
-  // Verify digests for skill artifacts using index.json
-  if (assetMap['index.json']) {
-    const index = JSON.parse(await fs.readFile(join(OUT_DIR, 'index.json'), 'utf8'))
-    for (const skill of index.skills ?? []) {
-      const artifactName = skill.url.split('/').pop()
-      const artifactPath = join(OUT_DIR, artifactName)
-      const actual = sha256(await fs.readFile(artifactPath))
-      if (actual !== skill.digest) {
-        throw new Error(
-          `Digest mismatch for ${skill.name}: expected ${skill.digest}, got ${actual}`
-        )
-      }
-      console.log(`  ✓ ${skill.name} digest verified`)
-    }
+  await fs.mkdir(OUT_DIR, { recursive: true })
+
+  for (const [name, buf] of Object.entries(buffers)) {
+    await fs.writeFile(join(OUT_DIR, name), buf)
   }
 
   console.log(`Done — wrote to public/.well-known/agent-skills/`)

--- a/apps/www/scripts/fetchAgentSkills.mjs
+++ b/apps/www/scripts/fetchAgentSkills.mjs
@@ -4,9 +4,15 @@
  * Fetches the latest agent-skills release from supabase/agent-skills and writes
  * index.json + skill archives to public/.well-known/agent-skills/.
  *
- * Runs unauthenticated - public repo, build-time only.
+ * Releases are semver-tagged (e.g. v0.2.0) and managed by Release Please in
+ * https://github.com/supabase/agent-skills. Each release includes:
+ *   - index.json  (discovery index per agent-skills .well-known spec v0.2.0)
+ *   - *.tar.gz    (one archive per skill)
+ *
+ * Runs unauthenticated — public repo, build-time only.
  */
 
+import { createHash } from 'node:crypto'
 import { promises as fs } from 'node:fs'
 import { join, dirname } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -21,10 +27,14 @@ async function fetchJson(url) {
   return res.json()
 }
 
-async function download(url, destPath) {
+async function download(url) {
   const res = await fetch(url, { headers: { 'User-Agent': 'supabase-www-build' } })
   if (!res.ok) throw new Error(`GET ${url} → ${res.status}`)
-  await fs.writeFile(destPath, Buffer.from(await res.arrayBuffer()))
+  return Buffer.from(await res.arrayBuffer())
+}
+
+function sha256(buf) {
+  return 'sha256:' + createHash('sha256').update(buf).digest('hex')
 }
 
 async function main() {
@@ -33,12 +43,31 @@ async function main() {
 
   await fs.mkdir(OUT_DIR, { recursive: true })
 
-  for (const asset of release.assets) {
-    await download(asset.browser_download_url, join(OUT_DIR, asset.name))
-    console.log(`  ${asset.name}`)
+  // Download all release assets (index.json + skill tarballs)
+  const assetMap = Object.fromEntries(release.assets.map((a) => [a.name, a.browser_download_url]))
+  for (const [name, url] of Object.entries(assetMap)) {
+    const buf = await download(url)
+    await fs.writeFile(join(OUT_DIR, name), buf)
+    console.log(`  ${name}`)
   }
 
-  console.log(`Done - wrote to public/.well-known/agent-skills/`)
+  // Verify digests for skill artifacts using index.json
+  if (assetMap['index.json']) {
+    const index = JSON.parse(await fs.readFile(join(OUT_DIR, 'index.json'), 'utf8'))
+    for (const skill of index.skills ?? []) {
+      const artifactName = skill.url.split('/').pop()
+      const artifactPath = join(OUT_DIR, artifactName)
+      const actual = sha256(await fs.readFile(artifactPath))
+      if (actual !== skill.digest) {
+        throw new Error(
+          `Digest mismatch for ${skill.name}: expected ${skill.digest}, got ${actual}`
+        )
+      }
+      console.log(`  ✓ ${skill.name} digest verified`)
+    }
+  }
+
+  console.log(`Done — wrote to public/.well-known/agent-skills/`)
 }
 
 main().catch((err) => {


### PR DESCRIPTION
## Summary

This PR makes `fetchAgentSkills.mjs` a spec-compliant client of the [agent-skills `.well-known` URI spec](https://github.com/agentskills/agentskills/pull/254), and updates the script to match the current release structure in [`supabase/agent-skills`](https://github.com/supabase/agent-skills).

---

## 1. Spec-compliant URL resolution and digest verification

`fetchAgentSkills.mjs` acts as a client consuming the `.well-known` discovery index. The [agent-skills `.well-known` spec](https://github.com/agentskills/agentskills/pull/254) is explicit on two points:

**URL resolution** — skill artifact URLs in `index.json` must be resolved per [RFC 3986 §5.2.2](https://datatracker.ietf.org/doc/html/rfc3986#section-5.2.2) using the index URL as the base URI:

> "The `url` field specifies where to fetch the skill artifact. URLs are resolved per RFC 3986 Section 5 using the index URL as the base URI."

This means `skill.url` can be relative (`supabase.tar.gz`), path-absolute (`/.well-known/agent-skills/supabase.tar.gz`), or fully absolute (e.g. a CDN URL like `https://cdn.example.com/supabase.tar.gz`). The previous implementation extracted a filename with `.split('/').pop()` which happened to work for bare relative URLs but was not doing RFC 3986 resolution.

**Digest verification** — clients must verify artifact integrity before use:

> "Clients **must** verify downloaded content against the `digest` in the index. A mismatch indicates the content is corrupted or tampered with — clients **must not** use unverified content."

The updated script uses `new URL(skill.url, githubReleaseIndexUrl)` for compliant resolution, verifies each artifact's SHA-256 digest from the in-memory buffer before any disk writes, and only writes to `public/.well-known/agent-skills/` once all digests pass.

**Acknowledged overhead**: since Supabase owns both the publisher ([`scripts/build-release.ts`](https://github.com/supabase/agent-skills/blob/main/scripts/build-release.ts) in `supabase/agent-skills`) and this consumer, the practical risk of non-compliant URL handling is currently low — the publisher always emits bare relative filenames. However, being spec-compliant here gives us full flexibility to change how skills are packaged or hosted in `supabase/agent-skills` in the future (e.g. moving artifacts to a CDN) without needing to update this script.

---

## 2. Semver release tags

#44878 referenced `supabase/agent-skills#66` (date+SHA tags). [supabase/agent-skills#77](https://github.com/supabase/agent-skills/pull/77) has since merged, moving releases to semver tags managed by Release Please. `/releases/latest` works for both formats — no code change needed, just a rebase.