### PR TITLE
Fix the Connect button to show the text.

### DIFF
--- a/apps/studio/components/interfaces/ConnectButton/ConnectButton.tsx
+++ b/apps/studio/components/interfaces/ConnectButton/ConnectButton.tsx
@@ -47,7 +47,7 @@ export const ConnectButton = ({
         },
       }}
     >
-      <span className={cn({ 'sr-only': !iconOnly })}>Connect</span>
+      <span className={cn({ 'sr-only': iconOnly })}>Connect</span>
     </ButtonTooltip>
   )
 }

--- a/apps/studio/components/ui/ButtonTooltip.tsx
+++ b/apps/studio/components/ui/ButtonTooltip.tsx
@@ -10,16 +10,16 @@ export const ButtonTooltip = forwardRef<
       }
     }
   }
->(({ ...props }, ref) => {
+>(({ tooltip, className, ...props }, ref) => {
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <Button ref={ref} {...props} className={cn(props.className, 'pointer-events-auto')}>
+        <Button ref={ref} {...props} className={cn(className, 'pointer-events-auto')}>
           {props.children}
         </Button>
       </TooltipTrigger>
-      {props.tooltip.content.text !== undefined && (
-        <TooltipContent {...props.tooltip.content}>{props.tooltip.content.text}</TooltipContent>
+      {tooltip.content.text !== undefined && (
+        <TooltipContent {...tooltip.content}>{tooltip.content.text}</TooltipContent>
       )}
     </Tooltip>
   )


### PR DESCRIPTION
The connect button was missing its text
Before:
<img width="833" height="244" alt="Screenshot 2026-05-06 at 17 46 23" src="https://github.com/user-attachments/assets/c03e972f-bef6-4bd7-8819-dd51509c58eb" />

After:
<img width="678" height="208" alt="Screenshot 2026-05-06 at 17 46 58" src="https://github.com/user-attachments/assets/5b020017-133e-47c3-8138-925c27299665" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screen-reader behavior for the Connect button so its label visibility correctly reflects the button's display mode.

* **Refactor**
  * Internal tooltip handling simplified for more consistent rendering; no change to user-facing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->