### PR TITLE
docs: fix CPU time limit documentation

### DIFF
--- a/apps/docs/content/troubleshooting/edge-function-shutdown-reasons-explained.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-shutdown-reasons-explained.mdx
@@ -51,7 +51,7 @@ These events are surfaced through logs and observability tools, allowing you to 
 
 ### CPUTime
 
-**What it means:** The worker consumed more CPU time than allowed. CPU time measures actual processing cycles used by your code, excluding time spent waiting for I/O or sleeping. Currently limited to 200 milliseconds.
+**What it means:** The worker consumed more CPU time than allowed. CPU time measures actual processing cycles used by your code, excluding time spent waiting for I/O or sleeping. Currently limited to 2000 milliseconds.
 
 **When it happens:** Your function is performing too much computation. This includes complex calculations, data processing, encryption, or other CPU-intensive operations.
 


### PR DESCRIPTION
Updates the documented CPU time limit from 200ms to the correct value of 2000ms (2 seconds) for Edge Functions in the shutdown guide.

**References:**
- Source: https://github.com/supabase/edge-runtime/blob/main/.cargo/config.toml#L7
- Docs: https://supabase.com/docs/guides/functions/limits#runtime-limits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated edge function shutdown reasons documentation to reflect an increased CPU time limit of 2000 milliseconds (previously 200 milliseconds).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->