### PR TITLE
fix: align grace-period banner copy on org usage page

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
@@ -107,7 +107,7 @@ export const Restriction = () => {
           <AlertTitle_Shadcn_>Your grace period has started.</AlertTitle_Shadcn_>
           <AlertDescription_Shadcn_>
             <p className="leading-tight">
-              Your organization is over its quota
+              Your organization went over its quota in the previous billing cycle
               {violationLabels && ` ${violationLabels}`}. You can continue with your projects until
               your grace period ends on{' '}
               <span className="text-foreground">

--- a/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/TotalUsage.tsx
@@ -16,6 +16,7 @@ import {
 import type { OrgSubscription } from '@/data/subscriptions/types'
 import { useOrgUsageQuery } from '@/data/usage/org-usage-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { DOCS_URL } from '@/lib/constants'
 
 export interface ComputeProps {
@@ -50,6 +51,8 @@ export const TotalUsage = ({
   const isMobile = useBreakpoint('md')
   const isUsageBillingEnabled = subscription?.usage_billing_enabled
   const { billingAll } = useIsFeatureEnabled(['billing:all'])
+  const { data: org } = useSelectedOrganizationQuery()
+  const hasActiveRestriction = Boolean(org?.restriction_status)
 
   const {
     data: usage,
@@ -154,7 +157,7 @@ export const TotalUsage = ({
 
         {isSuccessUsage && subscription && (
           <div>
-            {showRelationToSubscription && !isOnHigherPlan && (
+            {showRelationToSubscription && !isOnHigherPlan && !hasActiveRestriction && (
               <p className="text-sm">
                 {!hasExceededAnyLimits ? (
                   <span>

--- a/apps/studio/components/interfaces/Organization/restriction.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.tsx
@@ -1,16 +1,22 @@
+import dayjs from 'dayjs'
 import { type ReactNode } from 'react'
+import { TimestampInfo } from 'ui-patterns'
 
 import { InlineLink } from '@/components/ui/InlineLink'
 
 export const RESTRICTION_MESSAGES = {
   GRACE_PERIOD: {
     title: 'Organization exceeded its quota in the previous billing cycle',
-    description: (date: string, slug: string): ReactNode => (
-      <>
-        You have a grace period until {date} to bring usage back under quota.{' '}
-        <InlineLink href={`/org/${slug}/usage`}>Review usage</InlineLink>
-      </>
-    ),
+    description: (date: string, slug: string): ReactNode => {
+      const label = dayjs(date).format('DD MMM, YYYY')
+      return (
+        <>
+          You have a grace period until{' '}
+          <TimestampInfo className="text-sm" utcTimestamp={date} label={label} /> to bring usage
+          back under quota. <InlineLink href={`/org/${slug}/usage`}>Review usage</InlineLink>
+        </>
+      )
+    },
   },
   GRACE_PERIOD_OVER: {
     title: 'Grace period is over',

--- a/apps/studio/components/interfaces/Organization/restriction.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.tsx
@@ -4,10 +4,10 @@ import { InlineLink } from '@/components/ui/InlineLink'
 
 export const RESTRICTION_MESSAGES = {
   GRACE_PERIOD: {
-    title: 'Organization plan has exceeded its quota',
+    title: 'Organization exceeded its quota in the previous billing cycle',
     description: (date: string, slug: string): ReactNode => (
       <>
-        You have been given a grace period until {date}.{' '}
+        You have a grace period until {date} to bring usage back under quota.{' '}
         <InlineLink href={`/org/${slug}/usage`}>Review usage</InlineLink>
       </>
     ),

--- a/apps/studio/hooks/misc/useOrganizationRestrictions.ts
+++ b/apps/studio/hooks/misc/useOrganizationRestrictions.ts
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs'
 import type { ReactNode } from 'react'
 
 import { useIsFeatureEnabled } from './useIsFeatureEnabled'
@@ -69,7 +68,7 @@ export function useOrganizationRestrictions() {
       variant: 'warning',
       title: RESTRICTION_MESSAGES.GRACE_PERIOD.title,
       description: RESTRICTION_MESSAGES.GRACE_PERIOD.description(
-        dayjs(org?.restriction_data?.['grace_period_end']).format('DD MMM, YYYY'),
+        org?.restriction_data?.['grace_period_end'] ?? '',
         org.slug
       ),
     })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix — copy + visibility logic on the org Usage page.

## What is the current behavior?

On `/org/<slug>/usage` during a grace period, customers see two banners that read as contradictory:

1. *"Organization plan has exceeded its quota — grace period until {date}."*
2. *"You have not exceeded your Pro Plan quota in this billing cycle."*

<img width="1680" height="372" alt="image" src="https://github.com/user-attachments/assets/13826260-55dd-4b55-a3dc-5afc51e6436e" />

Both are individually correct. The first is sticky from the previous cycle's overage (`org.restriction_status`); the second is a live scan over the current cycle. Neither anchors to which cycle it's talking about, so together they read like the dashboard contradicting itself. Surfaced by support off SU-368527 and SU-368395.

## What is the new behavior?

- Top chrome banner copy: *"Organization exceeded its quota in the previous billing cycle / You have a grace period until {date} to bring usage back under quota."*
- Inline `<Restriction />` grace-period alert switches from "is over its quota" to "went over its quota in the previous billing cycle." Same temporal anchor.
- The "…in this billing cycle" summary line in `<TotalUsage>` is hidden whenever `restriction_status` is set. Mirrors the precedence rule `<Restriction />` already applies internally — backend status flag wins over the live cycle scan.

<img width="1678" height="937" alt="CleanShot 2026-05-06 at 12 58 02" src="https://github.com/user-attachments/assets/df55eaed-1029-4f39-bea0-df77bcc5151e" />


## Additional context

Left the `gracePeriodOver` copy alone on purpose — it doesn't make a current-overage claim, so there's nothing to contradict, and adding "previous cycle" would muddy which cycle "previous" refers to.

**Verified**
- Lint and typecheck pass on `apps/studio`.

**Before merge**
- [ ] Load a grace-period org locally: confirm new copy on top banner and inline `<Restriction />`, and that the "not exceeded in this billing cycle" line is gone.
- [ ] Copy review with support — happy to workshop wording.

GROWTH-823

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated grace period alert messaging to clarify organization quota status
  * Refined date formatting in billing restriction notifications
  * Modified usage display to conditionally hide certain information when account restrictions are active

<!-- end of auto-generated comment: release notes by coderabbit.ai -->