### PR TITLE
fix(studio): suppress stale notice banner on old client bundles

### DIFF
--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -19,6 +19,10 @@ import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
 import { InlineLink, InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
+// Update this whenever the banner content below changes so old client bundles
+// stop displaying outdated notices after the relevant date passes.
+const BANNER_EXPIRES_AT = new Date('2026-07-04T00:00:00Z')
+
 /**
  * Used to display urgent notices that apply for all users, such as maintenance windows.
  */
@@ -30,7 +34,12 @@ export const NoticeBanner = () => {
     false
   )
 
-  if (router.pathname.includes('sign-in') || !isSuccess || bannerAcknowledged) {
+  if (
+    Date.now() >= BANNER_EXPIRES_AT.getTime() ||
+    router.pathname.includes('sign-in') ||
+    !isSuccess ||
+    bannerAcknowledged
+  ) {
     return null
   }
 


### PR DESCRIPTION
## Summary

- Adds a hardcoded `BANNER_EXPIRES_AT` constant to `NoticeBanner` so long-lived tabs running an old client bundle stop displaying outdated notices once the relevant date passes.
- Self-suppresses on every bundle that ever shipped — no server-side flag flip, no refresh, no over-suppression on unrelated deploys.
- The existing `showNoticeBanner` ConfigCat boolean stays in place as the emergency kill-switch.

For future banners, set `BANNER_EXPIRES_AT` to the time the notice should stop rendering (e.g. end of a maintenance window, or a generous tail after a TOS effective date).

Closes [FE-3175](https://linear.app/supabase/issue/FE-3175/suppress-stale-maintenance-banner-on-old-client-bundles).

## Test plan

- [x] Locally set `BANNER_EXPIRES_AT` to a past date and confirm the banner does not render.
- [x] Set it to a future date and confirm the banner renders as before.
- [x] Confirm flipping `showNoticeBanner` off in ConfigCat still hides the banner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic expiration for notice banners, ensuring outdated notices no longer display after a specified date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->