### PR TITLE
Add project region info in settings and vector buckets + make region clickable in home page instance config

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/General.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.tsx
@@ -58,7 +58,7 @@ export const General = () => {
   })
 
   const regionLabel = AVAILABLE_REPLICA_REGIONS.find((region) =>
-    project?.region.includes(region.region)
+    project?.region?.includes(region.region)
   )
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {

--- a/apps/studio/components/interfaces/Settings/General/General.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.tsx
@@ -25,6 +25,7 @@ import {
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import * as z from 'zod'
 
+import { AVAILABLE_REPLICA_REGIONS } from '../Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { ProjectAccessSection } from './ProjectAccessSection'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useProjectUpdateMutation } from '@/data/projects/project-update-mutation'
@@ -55,6 +56,10 @@ export const General = () => {
     mode: 'onSubmit',
     reValidateMode: 'onBlur',
   })
+
+  const regionLabel = AVAILABLE_REPLICA_REGIONS.find((region) =>
+    project?.region.includes(region.region)
+  )
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     if (!project?.ref) return console.error('Ref is required')
@@ -126,6 +131,7 @@ export const General = () => {
                       )}
                     />
                   </CardContent>
+
                   <CardContent>
                     <FormItemLayout
                       layout="flex-row-reverse"
@@ -134,10 +140,24 @@ export const General = () => {
                       className="[&>div]:md:w-1/2 [&>div>div]:md:w-full"
                     >
                       <FormControl>
-                        <Input copy readOnly size="small" value={project?.ref ?? ''} />
+                        <Input copy readOnly size="small" value={project.ref} />
                       </FormControl>
                     </FormItemLayout>
                   </CardContent>
+
+                  <CardContent>
+                    <FormItemLayout
+                      layout="flex-row-reverse"
+                      label="Project region"
+                      description={regionLabel?.name}
+                      className="[&>div]:md:w-1/2 [&>div>div]:md:w-full"
+                    >
+                      <FormControl>
+                        <Input copy readOnly size="small" value={project.region} />
+                      </FormControl>
+                    </FormItemLayout>
+                  </CardContent>
+
                   <CardFooter className="justify-end space-x-2">
                     {form.formState.isDirty && (
                       <Button

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -4,10 +4,12 @@ import dayjs from 'dayjs'
 import { Database, DatabaseBackup, HelpCircle, Loader2, MoreVertical } from 'lucide-react'
 import Link from 'next/link'
 import { parseAsBoolean, parseAsString, useQueryStates } from 'nuqs'
+import { toast } from 'sonner'
 import {
   Badge,
   Button,
   cn,
+  copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -17,6 +19,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from 'ui'
+import { TimestampInfo } from 'ui-patterns'
 
 import {
   ERROR_STATES,
@@ -129,7 +132,19 @@ export const PrimaryNode = ({ data }: NodeProps<Node<PrimaryNodeData>>) => {
                 <span className="text-sm text-foreground-light">{region.name}</span>
               </p>
               <p className="flex items-center gap-x-1">
-                <span className="text-sm text-foreground-light">{region.region}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="text-sm transition text-foreground-light hover:text-foreground"
+                      onClick={async () =>
+                        await copyToClipboard(region.region, () => toast('Copied project region'))
+                      }
+                    >
+                      {region.region}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Click to copy</TooltipContent>
+                </Tooltip>
                 {projectHomepageShowInstanceSize && (
                   <>
                     <span className="text-sm text-foreground-lighter">·</span>
@@ -318,7 +333,19 @@ export const ReplicaNode = ({ data }: NodeProps<Node<ReplicaNodeData>>) => {
             <div className="my-0.5">
               <p className="text-sm text-foreground-light">{region.name}</p>
               <p className="flex text-sm text-foreground-light items-center gap-x-1">
-                <span>{region.region}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span
+                      className="text-sm transition text-foreground-light hover:text-foreground"
+                      onClick={async () =>
+                        await copyToClipboard(region.region, () => toast('Copied replica region'))
+                      }
+                    >
+                      {region.region}
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">Click to copy</TooltipContent>
+                </Tooltip>
                 {projectHomepageShowInstanceSize && !!computeSize && (
                   <>
                     <span className="text-foreground-lighter">·</span>
@@ -366,7 +393,10 @@ export const ReplicaNode = ({ data }: NodeProps<Node<ReplicaNodeData>>) => {
                 Error: {ERROR_STATES[error as keyof typeof ERROR_STATES]}
               </p>
             ) : (
-              <p className="text-sm text-foreground-light">Created: {created}</p>
+              <p className="text-sm text-foreground-light">
+                Created:{' '}
+                <TimestampInfo className="text-sm" utcTimestamp={inserted_at} label={created} />
+              </p>
             )}
           </div>
         </div>

--- a/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
@@ -8,7 +8,9 @@ import {
   PageSection,
   PageSectionContent,
 } from 'ui-patterns'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
 
+import { AVAILABLE_REPLICA_REGIONS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { BucketsUpgradePlan } from '@/components/interfaces/Storage/BucketsUpgradePlan'
 import { VectorsBuckets } from '@/components/interfaces/Storage/VectorBuckets'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
@@ -32,6 +34,9 @@ const StorageVectorsPage: NextPageWithLayout = () => {
 
   // [Joshen] We're actively looking into lifting this restriction so can remove once done
   const isAvailableInProjectRegion = AVAILABLE_REGIONS.includes(project?.region ?? '')
+  const regionLabel = AVAILABLE_REPLICA_REGIONS.find((region) =>
+    project?.region.includes(region.region)
+  )
 
   if (!isAvailableInProjectRegion) {
     return (
@@ -44,24 +49,32 @@ const StorageVectorsPage: NextPageWithLayout = () => {
             />
             <EmptyStatePresentational
               icon={VectorBucket}
+              className="[&>div>div>h3]:flex [&>div>div>h3]:items-center [&>div>div>h3]:gap-x-2"
               title="Coming soon to your project's region"
               description={
                 <p>
-                  Vector buckets are currently only available for projects created in{' '}
+                  Your project is in{' '}
                   <Tooltip>
-                    <TooltipTrigger className={InlineLinkClassName}>some regions</TooltipTrigger>
+                    <TooltipTrigger className={InlineLinkClassName}>
+                      {regionLabel?.name}
+                    </TooltipTrigger>
+                    <TooltipContent side="bottom">{regionLabel?.region}</TooltipContent>
+                  </Tooltip>
+                  , but Vector buckets are only available for{' '}
+                  <Tooltip>
+                    <TooltipTrigger className={InlineLinkClassName}>certain regions</TooltipTrigger>
                     <TooltipContent side="bottom">
                       <ul>
                         {AVAILABLE_REGIONS.map((x) => (
                           <li key={x}>
                             <span>{getRegionNameFromCode(x)}</span>
-                            <span className="text-foreground-lighter ml-2">{x}</span>
+                            <span className="text-foreground-light ml-2">{x}</span>
                           </li>
                         ))}
                       </ul>
                     </TooltipContent>
-                  </Tooltip>{' '}
-                  and we're actively looking to expand that soon.
+                  </Tooltip>
+                  . We're actively looking to expand that soon.
                 </p>
               }
             />

--- a/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
@@ -34,7 +34,7 @@ const StorageVectorsPage: NextPageWithLayout = () => {
   // [Joshen] We're actively looking into lifting this restriction so can remove once done
   const isAvailableInProjectRegion = AVAILABLE_REGIONS.includes(project?.region ?? '')
   const regionLabel = AVAILABLE_REPLICA_REGIONS.find((region) =>
-    project?.region.includes(region.region)
+    project?.region?.includes(region.region)
   )
 
   if (!isAvailableInProjectRegion) {

--- a/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
@@ -8,7 +8,6 @@ import {
   PageSection,
   PageSectionContent,
 } from 'ui-patterns'
-import { InfoTooltip } from 'ui-patterns/info-tooltip'
 
 import { AVAILABLE_REPLICA_REGIONS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { BucketsUpgradePlan } from '@/components/interfaces/Storage/BucketsUpgradePlan'


### PR DESCRIPTION
## Context

Resolves FE-2985

As per PR title

- Add project region info in project settings page for convenience
<img width="722" height="375" alt="image" src="https://github.com/user-attachments/assets/b32e80ed-42bd-4b12-b9b4-a3e696646335" />

- Add project region info in vector buckets empty state
<img width="1110" height="215" alt="image" src="https://github.com/user-attachments/assets/60bfde97-c3e3-4c10-8b86-98ecd0437ad5" />

- Make DB region copyable by clicking in instance config chart on home page
<img width="419" height="298" alt="image" src="https://github.com/user-attachments/assets/269b9517-d0eb-42b9-9648-386c59d53842" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project region is now shown as a read-only field with a descriptive region label in Settings.
  * Region identifiers are clickable to copy to clipboard, with a “Click to copy” tooltip and success toast.
  * Storage/empty-state messaging updated to show clearer, region-specific text and tooltip details.
  * Replica creation time now uses an enhanced timestamp display.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->