### PR TITLE
fix: prevent crash in ForeignRowSelector when SelectorGrid renders outside provider context

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
@@ -10,7 +10,7 @@ import {
   ESTIMATED_CHARACTER_PIXEL_WIDTH,
   getColumnDefaultWidth,
 } from '@/components/grid/utils/gridColumns'
-import { useTableEditorTableStateSnapshot } from '@/state/table-editor-table'
+import { useOptionalTableEditorTableStateSnapshot } from '@/state/table-editor-table'
 
 export interface SelectorGridProps {
   rows: SupaRow[]
@@ -59,7 +59,9 @@ const formatter = ({ column, format, row }: { column: string; format: string; ro
 }
 
 const SelectorGrid = ({ rows, onRowSelect }: SelectorGridProps) => {
-  const snap = useTableEditorTableStateSnapshot()
+  const snap = useOptionalTableEditorTableStateSnapshot()
+  if (!snap) return null
+
 
   const columns: Column<SupaRow>[] = snap.table.columns.map((column) => {
     const columnDefaultWidth = getColumnDefaultWidth(column)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
Expanding a row in the Table Editor for tables with foreign key relationships causes an application crash with the error:
`Error: No QueryClient set, use QueryClientProvider to set one`

Fixes #45647

## What is the new behavior?
The ForeignRowSelector sidebar opens correctly without crashing.

The `SelectorGrid` component now uses `useOptionalTableEditorTableStateSnapshot()` instead of `useTableEditorTableStateSnapshot()`, which gracefully returns `null` when rendered outside the `TableEditorTableStateContextProvider` context instead of throwing an error.

This hook was already created specifically for this use case, as noted in its own comment:
> "Use this for components that may render outside the provider (e.g. sidebar)"


**After (working):**

<img width="1909" height="876" alt="brave_screenshot_localhost" src="https://github.com/user-attachments/assets/4a96241c-6874-4801-8b4a-9c259ce99a35" />
<img width="1840" height="861" alt="brave_screenshot_localhost (1)" src="https://github.com/user-attachments/assets/57c850b1-a39f-47e8-8a9d-f8cd67cc1fd7" />
<img width="1917" height="871" alt="brave_screenshot_localhost (2)" src="https://github.com/user-attachments/assets/1c992b47-b7af-4749-b53e-12be91afa9ab" />

## Additional context
File changed: `apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx`
- `useTableEditorTableStateSnapshot` → `useOptionalTableEditorTableStateSnapshot`
- Added early `return null` guard when snap is undefined

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when editing rows in the table grid editor by preventing the grid from attempting to render when required state is unavailable, avoiding potential errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->