### PR TITLE
fix: cron regression

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -235,6 +235,22 @@ describe('parseCronJobCommand', () => {
     })
   })
 
+  it('should return an HTTP request config with POST method, escape-string headers and body with backslashes', () => {
+    const command = String.raw`select net.http_post( url:='https://example.com/api/endpoint', headers:=E'{"Content-Type":"application/json","X-Regex":"^\\\\d+$"}'::jsonb,body:=E'{"path":"C:\\\\tmp","regex":"^\\\\d+$"}',timeout_milliseconds:=1000);`
+    expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({
+      endpoint: 'https://example.com/api/endpoint',
+      method: 'POST',
+      httpHeaders: [
+        { name: 'Content-Type', value: 'application/json' },
+        { name: 'X-Regex', value: String.raw`^\d+$` },
+      ],
+      httpBody: String.raw`{"path":"C:\\tmp","regex":"^\\d+$"}`,
+      timeoutMs: 1000,
+      type: 'http_request',
+      snippet: command,
+    })
+  })
+
   it('should parse a POST body without swallowing later quoted arguments', () => {
     const command = `select net.http_post( url:='https://example.com/api/endpoint', body:='{"payload":"ok"}'::jsonb, headers:='{"Authorization":"Bearer demo"}'::jsonb, timeout_milliseconds:=5000 );`
     expect(parseCronJobCommand(command, 'random_project_ref')).toStrictEqual({

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
@@ -8,7 +8,10 @@ import { CRON_TABLE_COLUMNS, HTTPHeader, secondsPattern } from './CronJobs.const
 import { CronJobTableCell } from './CronJobTableCell'
 import { CronJob } from '@/data/database-cron-jobs/database-cron-jobs-infinite-query'
 
-const unescapeSqlLiteral = (value = '') => value.replaceAll("''", "'")
+const unescapeSqlLiteral = (value = '', isEscapeString = false) => {
+  const unescaped = value.replaceAll("''", "'")
+  return isEscapeString ? unescaped.replaceAll('\\\\', '\\') : unescaped
+}
 
 export function buildCronQuery(name: string, schedule: string, command: string): SafeSqlFragment {
   return safeSql`select cron.schedule(${literal(name)}, ${literal(schedule)}, ${literal(command)});`
@@ -51,11 +54,11 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
     const methodMatch = command.match(/select\s+net\.([^']+)\(\s*url:=/i)
     const method = methodMatch?.[1] || ''
 
-    const urlMatch = command.match(/url:='((?:''|[^'])*)'/i)
-    const url = unescapeSqlLiteral(urlMatch?.[1])
+    const urlMatch = command.match(/url:=(E)?'((?:''|[^'])*)'/i)
+    const url = unescapeSqlLiteral(urlMatch?.[2], Boolean(urlMatch?.[1]))
 
-    const bodyMatch = command.match(/body:='((?:''|[^'])*)'/i)
-    const body = unescapeSqlLiteral(bodyMatch?.[1])
+    const bodyMatch = command.match(/body:=(E)?'((?:''|[^'])*)'/i)
+    const body = unescapeSqlLiteral(bodyMatch?.[2], Boolean(bodyMatch?.[1]))
 
     const timeoutMatch = command.match(/timeout_milliseconds:=(\d+)/i)
     const timeout = timeoutMatch?.[1] || ''
@@ -75,8 +78,9 @@ export const parseCronJobCommand = (originalCommand: string, projectRef: string)
         }
       }
     } else {
-      const headersStringMatch = command.match(/headers:='((?:''|[^'])*)'/i)
-      const headersString = unescapeSqlLiteral(headersStringMatch?.[1]) || '{}'
+      const headersStringMatch = command.match(/headers:=(E)?'((?:''|[^'])*)'/i)
+      const headersString =
+        unescapeSqlLiteral(headersStringMatch?.[2], Boolean(headersStringMatch?.[1])) || '{}'
       try {
         const parsedHeaders = JSON.parse(headersString)
         headersObjs = Object.entries(parsedHeaders).map(([name, value]) => ({


### PR DESCRIPTION
## TL;DR

fixes cron losing http body/headers when values contain backslashes, broken by: 
- #45560

parser now handles escape-string literals (`E'...'`) emitted by `literal()`

## ex:

Before:


https://github.com/user-attachments/assets/9f7c3c13-5c49-448d-aac1-b64e27e269f4

After:

https://github.com/user-attachments/assets/2c517c4d-9eaa-412f-9b40-5eaacc2c2b2d

## ref:
- closes https://github.com/supabase/supabase/issues/45674
- broken by / adds upto: #45560



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of cron job HTTP POST request parsing when using special characters and escape sequences in headers and body parameters.
  * Enhanced support for extracting headers from cron job commands configured with escaped SQL literals.

* **Tests**
  * Added test coverage for HTTP cron job command parsing with escaped SQL string literals and special character handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->