### PR TITLE
fix(studio): query performance detail panel metadata 

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -139,7 +139,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
         </div>
       </QueryPanelSection>
       <QueryPanelSection className="pb-3 pt-6">
-        <h4 className="mb-2">Metadata</h4>
+        <h4 className="mb-4">Metadata</h4>
         <ul className="flex flex-col gap-y-3 divide-y divide-dashed">
           {report
             .filter((x) => x.id !== 'query')
@@ -160,7 +160,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
                 const totalTime = selectedRow?.total_time || 0
 
                 return (
-                  <li key={x.id} className="flex justify-between pt-3 text-sm">
+                  <li key={x.id} className="flex justify-between pb-3 text-sm">
                     <p className="text-foreground-light">{x.name}</p>
                     {percentage && totalTime ? (
                       <p className="flex items-center gap-x-1.5">
@@ -191,7 +191,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
 
               if (x.id == 'rows_read') {
                 return (
-                  <li key={x.id} className="flex justify-between pt-3 text-sm">
+                  <li key={x.id} className="flex justify-between pb-3 text-sm">
                     <p className="text-foreground-light">{x.name}</p>
                     {typeof rawValue === 'number' && !isNaN(rawValue) && isFinite(rawValue) ? (
                       <p
@@ -213,7 +213,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
 
               if (x.id === 'cache_hit_rate') {
                 return (
-                  <li key={x.id} className="flex justify-between pt-3 text-sm">
+                  <li key={x.id} className="flex justify-between pb-3 text-sm">
                     <p className="text-foreground-light">{x.name}</p>
                     {typeof rawValue === 'string' || typeof rawValue === 'number' ? (
                       <p
@@ -236,7 +236,7 @@ export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: Que
               }
 
               return (
-                <li key={x.id} className="flex justify-between pt-3 text-sm">
+                <li key={x.id} className="flex justify-between pb-3 text-sm">
                   <p className="text-foreground-light">{x.name}</p>
                   <p className={cn('tabular-nums', x.id === 'rolname' && 'font-mono')}>
                     {formattedValue}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Tailwind 4 applies `divide` a little bit differently, so a small fix applied here to get it back to how it looked.

| Header | Header |
|--------|--------|
| <img width="485" height="488" alt="Screenshot 2026-05-07 at 16 41 18" src="https://github.com/user-attachments/assets/d7f678fb-1179-4153-99fa-bfbe247fe519" /> | <img width="485" height="487" alt="Screenshot 2026-05-07 at 16 41 24" src="https://github.com/user-attachments/assets/a2ce53d4-5296-475c-a4d8-38b0820e820c" /> | 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted metadata header spacing and list item padding in the Query Performance interface for improved visual consistency and layout alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->