### PR TITLE
docs: rename Supabase agent plugin to Supabase Plugin for AI coding Agents

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -501,7 +501,7 @@ export const gettingstarted: NavMenuConstant = {
       url: undefined,
       items: [
         {
-          name: 'Supabase Agent Plugin',
+          name: 'Supabase Plugin for AI coding Agents',
           url: '/guides/getting-started/plugins' as `/${string}`,
         },
         {

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -501,7 +501,7 @@ export const gettingstarted: NavMenuConstant = {
       url: undefined,
       items: [
         {
-          name: 'Supabase Plugin for AI coding Agents',
+          name: 'Supabase Plugin for AI Coding Agents',
           url: '/guides/getting-started/plugins' as `/${string}`,
         },
         {

--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -22,7 +22,7 @@ Skills are installed at project scope by default, placing them in your repositor
 
 Add skills for all detected agents at the same time by passing `--all`. See the [skills package](https://github.com/vercel-labs/skills) for more options.
 
-You can also install the agent skills together with the Supabase MCP server using the [Supabase agent plugin](/docs/guides/getting-started/plugins) for an agent-first workflow.
+You can also install the agent skills together with the Supabase MCP server using the [Supabase Plugin for AI coding Agents](/docs/guides/getting-started/plugins) for a combined one-step setup.
 
 ## Available skills
 

--- a/apps/docs/content/guides/getting-started/ai-skills.mdx
+++ b/apps/docs/content/guides/getting-started/ai-skills.mdx
@@ -22,7 +22,7 @@ Skills are installed at project scope by default, placing them in your repositor
 
 Add skills for all detected agents at the same time by passing `--all`. See the [skills package](https://github.com/vercel-labs/skills) for more options.
 
-You can also install the agent skills together with the Supabase MCP server using the [Supabase Plugin for AI coding Agents](/docs/guides/getting-started/plugins) for a combined one-step setup.
+You can also install the agent skills together with the Supabase MCP server using the [Supabase Plugin for AI Coding Agents](/docs/guides/getting-started/plugins) for a combined one-step setup.
 
 ## Available skills
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -30,7 +30,7 @@ To verify the client has access to the MCP server tools, try asking it to query 
 
 For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/docs/guides/getting-started/ai-prompts) collection.
 
-Additionally, you can install Supabase agent skills alongside the MCP server, use the [Supabase Plugin for AI coding Agents](/docs/guides/getting-started/plugins) for a combined one-step setup.
+Additionally, you can install Supabase agent skills alongside the MCP server, use the [Supabase Plugin for AI Coding Agents](/docs/guides/getting-started/plugins) for a combined one-step setup.
 
 ## Available tools
 

--- a/apps/docs/content/guides/getting-started/mcp.mdx
+++ b/apps/docs/content/guides/getting-started/mcp.mdx
@@ -30,7 +30,7 @@ To verify the client has access to the MCP server tools, try asking it to query 
 
 For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/docs/guides/getting-started/ai-prompts) collection.
 
-Additionally, you can install Supabase agent skills alongside the MCP server, use the [Supabase agent plugin](/docs/guides/getting-started/plugins) for a combined one-step setup.
+Additionally, you can install Supabase agent skills alongside the MCP server, use the [Supabase Plugin for AI coding Agents](/docs/guides/getting-started/plugins) for a combined one-step setup.
 
 ## Available tools
 

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -1,12 +1,12 @@
 ---
 id: 'ai-tools-plugins'
-title: 'Supabase Plugin for AI coding Agents'
+title: 'Supabase Plugin for AI Coding Agents'
 subtitle: 'One-click setup for Supabase in your AI coding agent'
 description: 'The Supabase plugin for AI coding agents bundles the MCP server and agent skills into a single install for your AI coding agent.'
-sidebar_label: 'Supabase Plugin for AI coding Agents'
+sidebar_label: 'Supabase Plugin for AI Coding Agents'
 ---
 
-The Supabase Plugin for AI coding Agents is a single install that gives your AI coding agent everything it needs to work with Supabase. It bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) so your agent can query your database, manage migrations, deploy Edge Functions, and follow Supabase and Postgres best practices — without manual configuration.
+The Supabase Plugin for AI Coding Agents is a single install that gives your AI coding agent everything it needs to work with Supabase. It bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) so your agent can query your database, manage migrations, deploy Edge Functions, and follow Supabase and Postgres best practices — without manual configuration.
 
 ## Why use the plugin?
 

--- a/apps/docs/content/guides/getting-started/plugins.mdx
+++ b/apps/docs/content/guides/getting-started/plugins.mdx
@@ -1,16 +1,16 @@
 ---
 id: 'ai-tools-plugins'
-title: 'Supabase Agent Plugin'
+title: 'Supabase Plugin for AI coding Agents'
 subtitle: 'One-click setup for Supabase in your AI coding agent'
-description: 'The Supabase agent plugin bundles the MCP server and agent skills into a single install for your AI coding agent.'
-sidebar_label: 'Supabase Agent Plugin'
+description: 'The Supabase plugin for AI coding agents bundles the MCP server and agent skills into a single install for your AI coding agent.'
+sidebar_label: 'Supabase Plugin for AI coding Agents'
 ---
 
-The Supabase agent plugin is a single install that gives your AI coding agent everything it needs to work with Supabase. It bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) so your agent can query your database, manage migrations, deploy Edge Functions, and follow Supabase and Postgres best practices — without manual configuration.
+The Supabase Plugin for AI coding Agents is a single install that gives your AI coding agent everything it needs to work with Supabase. It bundles the [Supabase MCP server](/docs/guides/getting-started/mcp) and [Supabase agent skills](/docs/guides/getting-started/ai-skills) so your agent can query your database, manage migrations, deploy Edge Functions, and follow Supabase and Postgres best practices — without manual configuration.
 
 ## Why use the plugin?
 
-Agent plugins are packages of AI agent extensions. A single plugin can bundle any combination of:
+Plugins for AI coding agents are packages of AI agent extensions. A single plugin can bundle any combination of:
 
 - **MCP servers** — external tool integrations that let your agent interact with services like Supabase
 - **Skills** — procedural knowledge and context your agent loads on demand to work more accurately


### PR DESCRIPTION
## Summary

Renames the docs page title, sidebar label, description, and body text from **"Supabase Agent Plugin"** to **"Supabase Plugin for AI coding Agents"** across `plugins.mdx`, `ai-skills.mdx`, `mcp.mdx`, and the navigation constants

More context in this [Slack thread](https://supabase.slack.com/archives/C0254JUR2DU/p1778165488699219)

Close [AI-710](https://linear.app/supabase/issue/AI-710/rename-supabase-agent-plugin-docs-title)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed the AI tool throughout docs and navigation to "Supabase Plugin for AI Coding Agents" (previously "Supabase Agent Plugin").
  * Updated getting-started and plugin pages, installation guidance, and sidebar labels to use the new name while preserving existing links and instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->