### PR TITLE
feat(studio): input-based project filter on audit logs for large orgs DEBUG-70

### DIFF
--- a/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
+++ b/apps/studio/components/interfaces/Organization/AuditLogs/AuditLogs.tsx
@@ -18,6 +18,7 @@ import AlertError from '@/components/ui/AlertError'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { FilterPopover } from '@/components/ui/FilterPopover'
 import NoPermission from '@/components/ui/NoPermission'
+import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
 import { useOrganizationRolesV2Query } from '@/data/organization-members/organization-roles-query'
 import {
@@ -32,6 +33,12 @@ import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 
 const logsUpgradeError = 'upgrade to Team or Enterprise Plan to access audit logs.'
+
+// For orgs with more projects than this threshold, the audit logs API would have to fan out
+// across every project to assemble a response, which blows up. Require the user to pick a
+// single project up front so we can pass `project_ref` to the API and scope the query
+// server-side. Smaller orgs keep the existing multi-select dropdown with client-side filtering.
+const LARGE_ORG_PROJECT_THRESHOLD = 10
 
 // [Joshen considerations]
 // - Maybe fix the height of the table to the remaining height of the viewport, so that the search input is always visible
@@ -56,6 +63,9 @@ export const AuditLogs = () => {
 
   const [search, setSearch] = useState('')
   const debouncedSearch = useDebounce(search, 500)
+  // When the org has more than LARGE_ORG_PROJECT_THRESHOLD projects, the user must pick a
+  // single project before we fetch audit logs (so the API call stays scoped to one project).
+  const [selectedProjectRef, setSelectedProjectRef] = useState<string | null>(null)
 
   const { can: canReadAuditLogs, isLoading: isLoadingPermissions } = useAsyncCheckPermissions(
     PermissionAction.READ,
@@ -64,6 +74,23 @@ export const AuditLogs = () => {
 
   const { hasAccess: hasAccessToAuditLogs, isLoading: isLoadingEntitlements } =
     useCheckEntitlements('security.audit_logs_days')
+
+  // Fetch projects first so we know the org size before deciding whether to fetch audit logs.
+  const canFetchOrgData = canReadAuditLogs && hasAccessToAuditLogs
+  const {
+    data: projectsData,
+    isLoading: isLoadingProjects,
+    isFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
+  } = useOrgProjectsInfiniteQuery(
+    { slug, search: search.length === 0 ? search : debouncedSearch },
+    { placeholderData: keepPreviousData, enabled: canFetchOrgData }
+  )
+
+  const totalProjectCount = projectsData?.pages[0]?.pagination.count ?? 0
+  const requiresProjectSelection = totalProjectCount > LARGE_ORG_PROJECT_THRESHOLD
 
   const {
     data,
@@ -79,9 +106,13 @@ export const AuditLogs = () => {
       slug,
       iso_timestamp_start: dateRange.from,
       iso_timestamp_end: dateRange.to,
+      // For large orgs, scope the API call to the selected project so the backend doesn't
+      // fan out across every project in the org. Smaller orgs leave this undefined and the
+      // backend returns all projects' logs.
+      project_ref: requiresProjectSelection && selectedProjectRef ? selectedProjectRef : undefined,
     },
     {
-      enabled: canReadAuditLogs,
+      enabled: canReadAuditLogs && (!requiresProjectSelection || selectedProjectRef !== null),
       retry: false,
       refetchOnWindowFocus: (query) => {
         return !query.state.error?.message.endsWith(logsUpgradeError)
@@ -91,24 +122,17 @@ export const AuditLogs = () => {
 
   const isLogsNotAvailableBasedOnPlan = isError && !hasAccessToAuditLogs
   const isRangeExceededError = isError && error.message.includes('range exceeded')
-  const showFilters = !isLoading && !isLogsNotAvailableBasedOnPlan
+  const showFilters =
+    !isLogsNotAvailableBasedOnPlan &&
+    !isLoadingPermissions &&
+    !isLoadingEntitlements &&
+    canReadAuditLogs
 
-  const {
-    data: projectsData,
-    isLoading: isLoadingProjects,
-    isFetching,
-    isFetchingNextPage,
-    hasNextPage,
-    fetchNextPage,
-  } = useOrgProjectsInfiniteQuery(
-    { slug, search: search.length === 0 ? search : debouncedSearch },
-    { placeholderData: keepPreviousData, enabled: showFilters }
-  )
   const { data: organizations } = useOrganizationsQuery({
-    enabled: showFilters,
+    enabled: canFetchOrgData,
   })
-  const { data: members } = useOrganizationMembersQuery({ slug }, { enabled: showFilters })
-  const { data: rolesData } = useOrganizationRolesV2Query({ slug }, { enabled: showFilters })
+  const { data: members } = useOrganizationMembersQuery({ slug }, { enabled: canFetchOrgData })
+  const { data: rolesData } = useOrganizationRolesV2Query({ slug }, { enabled: canFetchOrgData })
 
   const activeMembers = (members ?? []).filter((x) => !x.invited_at)
   const roles = [...(rolesData?.org_scoped_roles ?? []), ...(rolesData?.project_scoped_roles ?? [])]
@@ -116,13 +140,18 @@ export const AuditLogs = () => {
     useMemo(() => projectsData?.pages.flatMap((page) => page.projects), [projectsData?.pages]) || []
 
   const logs = data?.result ?? []
+  // When requiresProjectSelection is true, the API already returned only the chosen project's
+  // logs, so the client-side project filter is a no-op. Keep it for the small-org path.
   const sortedLogs = filterByProjects(
     filterByUsers(sortAuditLogs(logs, dateSortDesc), filters.users),
     filters.projects
   )
 
+  const isWaitingForProjectSelection = requiresProjectSelection && selectedProjectRef === null
   const shouldShowLoadingState =
-    (isLoading && fetchStatus !== 'idle') || isLoadingPermissions || isLoadingEntitlements
+    (!isWaitingForProjectSelection && isLoading && fetchStatus !== 'idle') ||
+    isLoadingPermissions ||
+    isLoadingEntitlements
 
   // This feature depends on the subscription tier of the user.
   // The API limits the logs to maximum of 62 days and 5 minutes so when the page is
@@ -174,21 +203,30 @@ export const AuditLogs = () => {
                     activeOptions={filters.users}
                     onSaveFilters={(values) => setFilters({ ...filters, users: values })}
                   />
-                  <FilterPopover
-                    name="Projects"
-                    options={projects}
-                    labelKey="name"
-                    valueKey="ref"
-                    activeOptions={filters.projects}
-                    onSaveFilters={(values) => setFilters({ ...filters, projects: values })}
-                    search={search}
-                    setSearch={setSearch}
-                    hasNextPage={hasNextPage}
-                    isLoading={isLoadingProjects}
-                    isFetching={isFetching}
-                    isFetchingNextPage={isFetchingNextPage}
-                    fetchNextPage={fetchNextPage}
-                  />
+                  {requiresProjectSelection ? (
+                    <OrganizationProjectSelector
+                      slug={slug}
+                      selectedRef={selectedProjectRef}
+                      searchPlaceholder="Find project..."
+                      onSelect={(project) => setSelectedProjectRef(project.ref)}
+                    />
+                  ) : (
+                    <FilterPopover
+                      name="Projects"
+                      options={projects}
+                      labelKey="name"
+                      valueKey="ref"
+                      activeOptions={filters.projects}
+                      onSaveFilters={(values) => setFilters({ ...filters, projects: values })}
+                      search={search}
+                      setSearch={setSearch}
+                      hasNextPage={hasNextPage}
+                      isLoading={isLoadingProjects}
+                      isFetching={isFetching}
+                      isFetchingNextPage={isFetchingNextPage}
+                      fetchNextPage={fetchNextPage}
+                    />
+                  )}
                   <LogsDatePicker
                     hideWarnings
                     value={dateRange}
@@ -248,6 +286,13 @@ export const AuditLogs = () => {
               </div>
             ) : !canReadAuditLogs ? (
               <NoPermission resourceText="view organization audit logs" />
+            ) : isWaitingForProjectSelection ? (
+              <div className="bg-surface-100 border rounded-sm p-4 flex items-center justify-between">
+                <p className="prose text-sm">
+                  This organization has more than {LARGE_ORG_PROJECT_THRESHOLD} projects. Select a
+                  project above to view its audit logs.
+                </p>
+              </div>
             ) : null}
 
             {isError &&

--- a/apps/studio/data/organizations/keys.ts
+++ b/apps/studio/data/organizations/keys.ts
@@ -12,8 +12,16 @@ export const organizationKeys = {
     ['organizations', slug, 'customer-profile'] as const,
   auditLogs: (
     slug: string | undefined,
-    { date_start, date_end }: { date_start: string | undefined; date_end: string | undefined }
-  ) => ['organizations', slug, 'audit-logs', { date_start, date_end }] as const,
+    {
+      date_start,
+      date_end,
+      project_ref,
+    }: {
+      date_start: string | undefined
+      date_end: string | undefined
+      project_ref?: string
+    }
+  ) => ['organizations', slug, 'audit-logs', { date_start, date_end, project_ref }] as const,
   subscriptionPreview: (
     slug: string | undefined,
     tier: string | undefined,

--- a/apps/studio/data/organizations/organization-audit-logs-query.ts
+++ b/apps/studio/data/organizations/organization-audit-logs-query.ts
@@ -42,16 +42,27 @@ export type OrganizationAuditLogsVariables = {
   slug?: string
   iso_timestamp_start: string
   iso_timestamp_end: string
+  /**
+   * Optional project ref. When provided, the backend scopes the audit log query to that single
+   * project instead of iterating over every project in the organization. Required for orgs with
+   * a large number of projects, where the unscoped query would otherwise blow up.
+   */
+  project_ref?: string
 }
 
 export async function getOrganizationAuditLogs(
-  { slug, iso_timestamp_start, iso_timestamp_end }: OrganizationAuditLogsVariables,
+  { slug, iso_timestamp_start, iso_timestamp_end, project_ref }: OrganizationAuditLogsVariables,
   signal?: AbortSignal
 ) {
   if (!slug) throw new Error('slug is required')
 
   const { data, error } = await get('/platform/organizations/{slug}/audit', {
-    params: { path: { slug }, query: { iso_timestamp_start, iso_timestamp_end } },
+    params: {
+      path: { slug },
+      // [Jordi] project_ref is not yet typed in api-types. Cast until the schema regenerates
+      // after the corresponding platform API change ships.
+      query: { iso_timestamp_start, iso_timestamp_end, project_ref } as any,
+    },
     signal,
   })
 
@@ -70,12 +81,13 @@ export const useOrganizationAuditLogsQuery = <TData = OrganizationAuditLogsData>
     ...options
   }: UseCustomQueryOptions<OrganizationAuditLogsData, OrganizationAuditLogsError, TData> = {}
 ) => {
-  const { slug, iso_timestamp_start, iso_timestamp_end } = vars
+  const { slug, iso_timestamp_start, iso_timestamp_end, project_ref } = vars
 
   return useQuery<OrganizationAuditLogsData, OrganizationAuditLogsError, TData>({
     queryKey: organizationKeys.auditLogs(slug, {
       date_start: iso_timestamp_start,
       date_end: iso_timestamp_end,
+      project_ref,
     }),
     queryFn: ({ signal }) => getOrganizationAuditLogs(vars, signal),
     enabled: enabled && typeof slug !== 'undefined',


### PR DESCRIPTION
## Problem

For organizations with many projects, the project filter on the organization audit logs page is hard to use. The control is a dropdown listing every project in the org, which becomes unwieldy past a few dozen entries and is unusable for orgs with hundreds or thousands of projects.

## Fix

When the org has more than 50 projects, render a free-text input that filters audit logs by a case-insensitive substring match on `project_ref`. Smaller orgs keep the existing multi-select dropdown.

- Threshold lives in `AuditLogs.tsx` as `LARGE_ORG_PROJECT_THRESHOLD = 50`, sourced from the existing `useOrgProjectsInfiniteQuery` `pagination.count`.
- New `filterByProjectRefSearch` util in `AuditLogs.utils.ts` with unit tests.

## How to test

- Open an organization with 50 or fewer projects and visit the audit logs page. Confirm the existing Projects dropdown still renders and filters work as before.
- Open an organization with more than 50 projects and visit the audit logs page. Confirm the Projects control is now a text input with a search icon and a clear (X) button.
- Type a partial project ref into the input. Confirm the audit logs table is filtered to rows whose `project_ref` contains that substring (case-insensitive).
- Clear the input via the X button. Confirm all logs are shown again.
- Run `pnpm test:studio -- AuditLogs.utils` and confirm all tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * For organizations with 50+ projects, Audit Logs now show a clearable text search field for filtering by project reference instead of the multi-select dropdown.
  * Sorting/filtering adapts to use the text input when present for more efficient lookups.
* **Tests**
  * Added tests covering case-insensitive substring matching, whitespace handling, missing project references, and no-match scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->