### PR TITLE
Fix jwxs format

### DIFF
--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
@@ -7,7 +7,7 @@ import {
   DialogSection,
   DialogSectionSeparator,
   DialogTitle,
-  Input_Shadcn_ as Input,
+  Input,
   Label_Shadcn_,
   Textarea,
 } from 'ui'
@@ -24,7 +24,7 @@ export function KeyDetailsDialog({
   onClose: () => void
 }) {
   const jwksURL = useMemo(() => new URL('/auth/v1/.well-known/jwks.json', restURL), [restURL])
-  const jwk = useMemo(() => JSON.stringify(selectedKey.public_jwk, null, 2), [selectedKey])
+  const jwks = useMemo(() => JSON.stringify({ keys: [selectedKey.public_jwk]}, null, 2), [selectedKey])
 
   return (
     <>
@@ -46,7 +46,7 @@ export function KeyDetailsDialog({
             <FileKey className="size-4 text-foreground-light" />
             Public Key (JSON Web Key format)
           </Label_Shadcn_>
-          <Textarea className="font-mono text-sm" rows={8} value={jwk} readOnly />
+          <Textarea className="font-mono text-sm" rows={8} value={jwks} readOnly />
         </div>
       </DialogSection>
       <DialogFooter>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
@@ -1,4 +1,4 @@
-import CopyButton from 'components/ui/CopyButton'
+import CopyButton from '@/components/ui/CopyButton'
 import { FileKey } from 'lucide-react'
 import { useMemo } from 'react'
 import {
@@ -48,7 +48,7 @@ export function KeyDetailsDialog({
         <div className="flex flex-col gap-2">
           <Label_Shadcn_ htmlFor="jwk" className="flex flex-row gap-2 items-center">
             <FileKey className="size-4 text-foreground-light" />
-            Public Key Set (JSON Web Key Set format)
+            Public Key (JSON Web Key format)
           </Label_Shadcn_>
           <div className="relative">
             <Textarea className="font-mono text-sm pr-10" rows={8} value={jwks} readOnly />

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
@@ -1,3 +1,4 @@
+import CopyButton from 'components/ui/CopyButton'
 import { FileKey } from 'lucide-react'
 import { useMemo } from 'react'
 import {
@@ -24,7 +25,10 @@ export function KeyDetailsDialog({
   onClose: () => void
 }) {
   const jwksURL = useMemo(() => new URL('/auth/v1/.well-known/jwks.json', restURL), [restURL])
-  const jwks = useMemo(() => JSON.stringify({ keys: [selectedKey.public_jwk]}, null, 2), [selectedKey])
+  const jwks = useMemo(
+    () => JSON.stringify({ keys: [selectedKey.public_jwk] }, null, 2),
+    [selectedKey]
+  )
 
   return (
     <>
@@ -44,9 +48,18 @@ export function KeyDetailsDialog({
         <div className="flex flex-col gap-2">
           <Label_Shadcn_ htmlFor="jwk" className="flex flex-row gap-2 items-center">
             <FileKey className="size-4 text-foreground-light" />
-            Public Key (JSON Web Key format)
+            Public Key Set (JSON Web Key Set format)
           </Label_Shadcn_>
-          <Textarea className="font-mono text-sm" rows={8} value={jwks} readOnly />
+          <div className="relative">
+            <Textarea className="font-mono text-sm pr-10" rows={8} value={jwks} readOnly />
+            <CopyButton
+              type="default"
+              iconOnly
+              text={jwks}
+              className="absolute top-2 right-2"
+              copyLabel="Copy JWKS"
+            />
+          </div>
         </div>
       </DialogSection>
       <DialogFooter>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
@@ -1,4 +1,3 @@
-import CopyButton from '@/components/ui/CopyButton'
 import { FileKey } from 'lucide-react'
 import { useMemo } from 'react'
 import {
@@ -13,6 +12,7 @@ import {
   Textarea,
 } from 'ui'
 
+import CopyButton from '@/components/ui/CopyButton'
 import { JWTSigningKey } from '@/data/jwt-signing-keys/jwt-signing-keys-query'
 
 export function KeyDetailsDialog({

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
@@ -48,7 +48,7 @@ export function KeyDetailsDialog({
         <div className="flex flex-col gap-2">
           <Label_Shadcn_ htmlFor="jwk" className="flex flex-row gap-2 items-center">
             <FileKey className="size-4 text-foreground-light" />
-            Public Key (JSON Web Key format)
+            Public key set (JSON Web Key Set format)
           </Label_Shadcn_>
           <div className="relative">
             <Textarea className="font-mono text-sm pr-10" rows={8} value={jwks} readOnly />


### PR DESCRIPTION
<img width="1244" height="1146" alt="CleanShot 2026-05-07 at 17 07 32" src="https://github.com/user-attachments/assets/475cce46-a066-4a8b-a0e0-82261e1e4e73" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Public key display in JWT key details now shows a pretty-printed JWKS (JSON Web Key Set) with updated JWKS-oriented labeling.
  * The key textarea is wrapped in a positioned container for improved layout and readability.

* **New Features**
  * Added an overlaid Copy button labeled “Copy JWKS” to copy the displayed JWKS directly from the key details view.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->