### PR TITLE
experiment(studio): expanded onboarding survey

### DIFF
--- a/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurvey.constants.ts
+++ b/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurvey.constants.ts
@@ -1,0 +1,138 @@
+export const HEARD_FROM_OPTIONS = [
+  { value: 'search_engine', label: 'Search engine' },
+  { value: 'social_media', label: 'Social media' },
+  { value: 'ai_tool', label: 'AI tool' },
+  { value: 'friend_colleague', label: 'Friend or colleague' },
+  { value: 'youtube', label: 'YouTube' },
+  { value: 'blog_article', label: 'Blog or article' },
+  { value: 'conference', label: 'Conference' },
+  { value: 'podcast', label: 'Podcast' },
+  { value: 'other', label: 'Other' },
+] as const
+
+export type HeardFromOptionValue = (typeof HEARD_FROM_OPTIONS)[number]['value']
+
+export const HEARD_FROM_OTHER_VALUE = 'other'
+
+export const HEARD_FROM_FOLLOW_UP_BY_VALUE: Record<
+  string,
+  { label: string; placeholder: string } | undefined
+> = {
+  social_media: {
+    label: 'Which platform?',
+    placeholder: 'e.g. X, Reddit, LinkedIn',
+  },
+  ai_tool: {
+    label: 'Which AI tool?',
+    placeholder: 'e.g. ChatGPT, Claude, Cursor',
+  },
+  youtube: {
+    label: 'Which channel or video?',
+    placeholder: 'e.g. Supabase, Fireship, KRAZAM',
+  },
+  blog_article: {
+    label: 'Which blog or article?',
+    placeholder: 'Paste a title, site, or link',
+  },
+  conference: {
+    label: 'Which conference?',
+    placeholder: 'e.g. Launch Week, PostgresConf, local meetup',
+  },
+  podcast: {
+    label: 'Which podcast?',
+    placeholder: 'e.g. Syntax, Changelog, Software Engineering Daily',
+  },
+  other: {
+    label: 'Tell us where',
+    placeholder: 'Tell us where',
+  },
+}
+
+export function formatHeardFromAnswer(value?: string, detail?: string) {
+  const trimmedValue = value?.trim()
+  const trimmedDetail = detail?.trim()
+
+  if (!trimmedValue) return trimmedDetail
+  if (!trimmedDetail) return trimmedValue
+  if (trimmedValue === HEARD_FROM_OTHER_VALUE) return trimmedDetail
+
+  return `${trimmedValue}: ${trimmedDetail}`
+}
+
+export const BUILDING_MAX_LENGTH = 500
+
+export const BUILDING_PLACEHOLDER =
+  'e.g. realtime collaboration, an AI support workflow, or an operations dashboard'
+
+export {
+  ORG_KIND_DEFAULT,
+  ORG_KIND_TYPES,
+  ORG_SIZE_DEFAULT,
+  ORG_SIZE_TYPES,
+} from '../Organization/NewOrg/OrganizationDetailsFields'
+
+export const ONBOARDING_SURVEY_EXPERIMENT_ID = 'onboardingSurveyPlacement'
+
+export const ONBOARDING_SURVEY_VARIANTS = [
+  'control',
+  'org_form_collapsed',
+  'org_form_expanded',
+  'dialog',
+  'toast',
+] as const
+
+export type OnboardingSurveyVariant = (typeof ONBOARDING_SURVEY_VARIANTS)[number]
+
+export type OnboardingSurveySurface = 'org_form' | 'project_home'
+
+const ORG_FORM_VARIANTS: ReadonlySet<OnboardingSurveyVariant> = new Set([
+  'org_form_collapsed',
+  'org_form_expanded',
+])
+
+const PROJECT_HOME_VARIANTS: ReadonlySet<OnboardingSurveyVariant> = new Set(['dialog', 'toast'])
+
+export function isOnboardingSurveyVariant(value: unknown): value is OnboardingSurveyVariant {
+  return (
+    typeof value === 'string' && (ONBOARDING_SURVEY_VARIANTS as readonly string[]).includes(value)
+  )
+}
+
+export function isOrgFormVariant(variant?: OnboardingSurveyVariant) {
+  return !!variant && ORG_FORM_VARIANTS.has(variant)
+}
+
+export function variantMatchesSurface(
+  variant: OnboardingSurveyVariant | undefined,
+  surface: OnboardingSurveySurface
+) {
+  if (!variant) return false
+  if (surface === 'org_form') return ORG_FORM_VARIANTS.has(variant)
+  if (surface === 'project_home') return PROJECT_HOME_VARIANTS.has(variant)
+  return false
+}
+
+export type OnboardingSurveyAnswers = {
+  heard_from?: string
+  building?: string
+}
+
+export function buildOnboardingSurveyAnswers({
+  heardFrom,
+  building,
+}: {
+  heardFrom?: string
+  building?: string
+}): OnboardingSurveyAnswers {
+  return {
+    heard_from: heardFrom,
+    building,
+  }
+}
+
+export type OnboardingSurveyPromptStatus = 'submitted' | 'dismissed'
+
+export type OnboardingSurveyPromptState = {
+  status: OnboardingSurveyPromptStatus
+  updatedAt: string
+}

--- a/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyDialog.test.tsx
+++ b/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyDialog.test.tsx
@@ -1,0 +1,153 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import type { ComponentProps, ReactNode } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { BUILDING_MAX_LENGTH } from './OnboardingSurvey.constants'
+import { OnboardingSurveyDialog } from './OnboardingSurveyDialog'
+
+type ButtonMockProps = ComponentProps<'button'> & { loading?: boolean }
+type SelectMockProps = {
+  children: ReactNode
+  onValueChange: (value: string) => void
+}
+
+vi.mock('ui', () => ({
+  Button: ({ children, loading, ...props }: ButtonMockProps) => (
+    <button {...props} disabled={props.disabled || loading}>
+      {children}
+    </button>
+  ),
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div role="dialog">{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogSection: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogSectionSeparator: () => <hr />,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  Input: (props: ComponentProps<'input'>) => <input {...props} />,
+  Label: ({ children, ...props }: ComponentProps<'label'>) => <label {...props}>{children}</label>,
+  Select: ({ children, onValueChange }: SelectMockProps) => (
+    <div>
+      {children}
+      <button type="button" onClick={() => onValueChange('ai_tool')}>
+        AI tool
+      </button>
+      <button type="button" onClick={() => onValueChange('conference')}>
+        Conference
+      </button>
+      <button type="button" onClick={() => onValueChange('other')}>
+        Other
+      </button>
+    </div>
+  ),
+  SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  Textarea: (props: ComponentProps<'textarea'>) => <textarea {...props} />,
+}))
+
+describe('OnboardingSurveyDialog', () => {
+  it('submits optional answers', async () => {
+    const onSubmit = vi.fn()
+
+    render(
+      <OnboardingSurveyDialog
+        open
+        onDismiss={vi.fn()}
+        onOpenChange={vi.fn()}
+        onSkip={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'AI tool' }))
+    await userEvent.type(screen.getByLabelText('What are you building?'), 'A SaaS app')
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      heard_from: 'ai_tool',
+      building: 'A SaaS app',
+    })
+  })
+
+  it('limits building input to 500 characters', async () => {
+    render(
+      <OnboardingSurveyDialog
+        open
+        onDismiss={vi.fn()}
+        onOpenChange={vi.fn()}
+        onSkip={vi.fn()}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    const input = screen.getByLabelText('What are you building?')
+    expect(input).toHaveAttribute('maxLength', String(BUILDING_MAX_LENGTH))
+  })
+
+  it('submits source details when a follow-up option is selected', async () => {
+    const onSubmit = vi.fn()
+
+    render(
+      <OnboardingSurveyDialog
+        open
+        onDismiss={vi.fn()}
+        onOpenChange={vi.fn()}
+        onSkip={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Conference' }))
+    await userEvent.type(screen.getByLabelText('Which conference?'), 'Launch Week')
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      heard_from: 'conference: Launch Week',
+      building: '',
+    })
+  })
+
+  it('submits custom details when other is selected', async () => {
+    const onSubmit = vi.fn()
+
+    render(
+      <OnboardingSurveyDialog
+        open
+        onDismiss={vi.fn()}
+        onOpenChange={vi.fn()}
+        onSkip={vi.fn()}
+        onSubmit={onSubmit}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Other' }))
+    await userEvent.type(screen.getByLabelText('Tell us where'), 'Launch Week')
+    await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      heard_from: 'Launch Week',
+      building: '',
+    })
+  })
+
+  it('allows the user to skip', async () => {
+    const onSkip = vi.fn()
+
+    render(
+      <OnboardingSurveyDialog
+        open
+        onDismiss={vi.fn()}
+        onOpenChange={vi.fn()}
+        onSkip={onSkip}
+        onSubmit={vi.fn()}
+      />
+    )
+
+    await userEvent.click(screen.getByRole('button', { name: 'Skip' }))
+    expect(onSkip).toHaveBeenCalled()
+  })
+})

--- a/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyDialog.tsx
+++ b/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyDialog.tsx
@@ -1,0 +1,145 @@
+import { useState } from 'react'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from 'ui'
+
+import {
+  BUILDING_MAX_LENGTH,
+  BUILDING_PLACEHOLDER,
+  buildOnboardingSurveyAnswers,
+  formatHeardFromAnswer,
+  HEARD_FROM_FOLLOW_UP_BY_VALUE,
+  HEARD_FROM_OPTIONS,
+  type OnboardingSurveyAnswers,
+} from './OnboardingSurvey.constants'
+
+type OnboardingSurveyDialogProps = {
+  open: boolean
+  description?: string
+  isSubmitting?: boolean
+  onDismiss: () => void
+  onOpenChange: (open: boolean) => void
+  onSkip: () => void
+  onSubmit: (values: OnboardingSurveyAnswers) => Promise<unknown> | unknown
+  title?: string
+}
+
+export function OnboardingSurveyDialog({
+  open,
+  description = 'Answer two optional questions about how you found Supabase and what you are building.',
+  isSubmitting = false,
+  onDismiss,
+  onOpenChange,
+  onSkip,
+  onSubmit,
+  title = 'Help improve Supabase',
+}: OnboardingSurveyDialogProps) {
+  const [heardFrom, setHeardFrom] = useState('')
+  const [heardFromDetail, setHeardFromDetail] = useState('')
+  const [building, setBuilding] = useState('')
+  const heardFromFollowUp = HEARD_FROM_FOLLOW_UP_BY_VALUE[heardFrom]
+
+  const handleOpenChange = (nextOpen: boolean) => {
+    if (!nextOpen && open && !isSubmitting) {
+      onDismiss()
+      return
+    }
+
+    onOpenChange(nextOpen)
+  }
+
+  const handleSubmit = async () => {
+    await onSubmit(
+      buildOnboardingSurveyAnswers({
+        heardFrom: formatHeardFromAnswer(heardFrom, heardFromDetail),
+        building,
+      })
+    )
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent size="small" aria-describedby={undefined}>
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection className="flex flex-col gap-y-6 pt-4.5 pb-5">
+          <p className="text-sm text-foreground-light">{description}</p>
+
+          <div className="flex flex-col gap-y-2">
+            <Label htmlFor="onboarding-survey-heard-from">Where did you hear about us?</Label>
+            <Select
+              value={heardFrom}
+              onValueChange={(value) => {
+                setHeardFrom(value)
+                if (!HEARD_FROM_FOLLOW_UP_BY_VALUE[value]) setHeardFromDetail('')
+              }}
+            >
+              <SelectTrigger id="onboarding-survey-heard-from" className="w-full">
+                <SelectValue placeholder="Select an option" />
+              </SelectTrigger>
+              <SelectContent>
+                {HEARD_FROM_OPTIONS.map((option) => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {heardFromFollowUp && (
+              <Input
+                aria-label={heardFromFollowUp.label}
+                value={heardFromDetail}
+                placeholder={heardFromFollowUp.placeholder}
+                onChange={(event) => setHeardFromDetail(event.target.value)}
+              />
+            )}
+          </div>
+
+          <div className="flex flex-col gap-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor="onboarding-survey-building">What are you building?</Label>
+              <span className="text-xs text-foreground-lighter">
+                {building.length}/{BUILDING_MAX_LENGTH}
+              </span>
+            </div>
+            <Textarea
+              id="onboarding-survey-building"
+              value={building}
+              rows={3}
+              maxLength={BUILDING_MAX_LENGTH}
+              placeholder={BUILDING_PLACEHOLDER}
+              className="resize-none"
+              onChange={(event) => setBuilding(event.target.value)}
+            />
+          </div>
+        </DialogSection>
+
+        <DialogFooter className="px-5 py-4">
+          <Button type="default" disabled={isSubmitting} onClick={onSkip}>
+            Skip
+          </Button>
+          <Button loading={isSubmitting} onClick={handleSubmit}>
+            Submit
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyToastPrompt.test.tsx
+++ b/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyToastPrompt.test.tsx
@@ -1,0 +1,110 @@
+import { render, screen } from '@testing-library/react'
+import type { ComponentProps, ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { OnboardingSurveyToastPrompt } from './OnboardingSurveyToastPrompt'
+
+type ButtonMockProps = ComponentProps<'button'> & { loading?: boolean }
+
+const { mockAddBanner, mockDismissBanner, mockOpenDialog, promptState } = vi.hoisted(() => ({
+  mockAddBanner: vi.fn(),
+  mockDismissBanner: vi.fn(),
+  mockOpenDialog: vi.fn(),
+  promptState: {
+    current: {
+      dismissPrompt: vi.fn(),
+      isSubmitting: false,
+      open: false,
+      openDialog: vi.fn(),
+      setOpen: vi.fn(),
+      shouldShowPrompt: true,
+      submitSurvey: vi.fn(),
+    },
+  },
+}))
+
+vi.mock('@/lib/telemetry/track', () => ({
+  useTrack: () => vi.fn(),
+}))
+
+vi.mock('@/components/ui/BannerStack/BannerCard', () => ({
+  BannerCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/BannerStack/BannerStackProvider', () => ({
+  BANNER_ID: {
+    ONBOARDING_SURVEY: 'onboarding-survey-banner',
+  },
+  useBannerStack: () => ({
+    addBanner: mockAddBanner,
+    dismissBanner: mockDismissBanner,
+  }),
+}))
+
+vi.mock('ui', () => ({
+  Button: ({ children, loading, ...props }: ButtonMockProps) => (
+    <button {...props} disabled={props.disabled || loading}>
+      {children}
+    </button>
+  ),
+  Dialog: ({ children, open }: { children: ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div role="dialog">{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogSection: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogSectionSeparator: () => <hr />,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+  Label: ({ children, ...props }: ComponentProps<'label'>) => <label {...props}>{children}</label>,
+  Select: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  SelectValue: ({ placeholder }: { placeholder?: string }) => <span>{placeholder}</span>,
+  Textarea: (props: ComponentProps<'textarea'>) => <textarea {...props} />,
+}))
+
+vi.mock('./useOnboardingSurveyPrompt', () => ({
+  useOnboardingSurveyPrompt: () => ({
+    ...promptState.current,
+    openDialog: mockOpenDialog,
+  }),
+}))
+
+describe('OnboardingSurveyToastPrompt', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+    promptState.current.open = false
+    promptState.current.shouldShowPrompt = true
+  })
+
+  it('adds the bottom-right banner stack card for the fallback prompt', () => {
+    render(<OnboardingSurveyToastPrompt />)
+
+    expect(mockAddBanner).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'onboarding-survey-banner',
+        isDismissed: false,
+      })
+    )
+  })
+
+  it('auto-opens the welcome dialog when requested', () => {
+    render(<OnboardingSurveyToastPrompt autoOpen />)
+
+    expect(mockOpenDialog).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses welcome copy for the auto-open dialog', () => {
+    promptState.current.open = true
+
+    render(<OnboardingSurveyToastPrompt autoOpen />)
+
+    expect(screen.getByText('Welcome to Supabase')).toBeTruthy()
+    expect(
+      screen.getByText(
+        'Answer two optional questions about how you found Supabase and what you are building.'
+      )
+    ).toBeTruthy()
+  })
+})

--- a/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyToastPrompt.tsx
+++ b/apps/studio/components/interfaces/OnboardingSurvey/OnboardingSurveyToastPrompt.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef } from 'react'
+import { Button } from 'ui'
+
+import { OnboardingSurveyDialog } from './OnboardingSurveyDialog'
+import { useOnboardingSurveyPrompt } from './useOnboardingSurveyPrompt'
+import { BannerCard } from '@/components/ui/BannerStack/BannerCard'
+import { BANNER_ID, useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
+import { useTrack } from '@/lib/telemetry/track'
+
+type OnboardingSurveyToastPromptProps = {
+  autoOpen?: boolean
+}
+
+const WELCOME_TITLE = 'Welcome to Supabase'
+
+const WELCOME_DESCRIPTION =
+  'Answer two optional questions about how you found Supabase and what you are building.'
+
+export function OnboardingSurveyToastPrompt({
+  autoOpen = false,
+}: OnboardingSurveyToastPromptProps) {
+  const track = useTrack()
+  const prompt = useOnboardingSurveyPrompt({ surface: 'project_home' })
+  const { addBanner, dismissBanner } = useBannerStack()
+  const hasAutoOpened = useRef(false)
+  const hasTrackedOpened = useRef(false)
+  const { dismissPrompt, openDialog, shouldShowPrompt } = prompt
+
+  useEffect(() => {
+    if (!shouldShowPrompt || hasTrackedOpened.current) return
+    hasTrackedOpened.current = true
+    track('onboarding_survey_prompt_opened', { surface: 'project_home' })
+  }, [shouldShowPrompt, track])
+
+  useEffect(() => {
+    if (!autoOpen || !shouldShowPrompt || hasAutoOpened.current) return
+
+    hasAutoOpened.current = true
+    openDialog()
+  }, [autoOpen, openDialog, shouldShowPrompt])
+
+  useEffect(() => {
+    if (autoOpen || !shouldShowPrompt) {
+      dismissBanner(BANNER_ID.ONBOARDING_SURVEY)
+      return
+    }
+
+    addBanner({
+      id: BANNER_ID.ONBOARDING_SURVEY,
+      isDismissed: false,
+      priority: 1,
+      content: (
+        <BannerCard
+          onDismiss={() => {
+            dismissBanner(BANNER_ID.ONBOARDING_SURVEY)
+            dismissPrompt('toast_skip')
+          }}
+        >
+          <div className="flex flex-col gap-y-4">
+            <div className="flex flex-col gap-y-1 mb-2">
+              <p className="text-sm font-medium">Help improve Supabase</p>
+              <p className="text-xs text-foreground-lighter text-balance">
+                Answer two optional questions about how you found Supabase and what you are
+                building.
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                type="primary"
+                size="tiny"
+                onClick={() => {
+                  dismissBanner(BANNER_ID.ONBOARDING_SURVEY)
+                  track('onboarding_survey_answer_button_clicked', { surface: 'project_home' })
+                  openDialog()
+                }}
+              >
+                Answer
+              </Button>
+              <Button
+                type="default"
+                size="tiny"
+                onClick={() => {
+                  dismissBanner(BANNER_ID.ONBOARDING_SURVEY)
+                  dismissPrompt('toast_skip')
+                }}
+              >
+                Skip
+              </Button>
+            </div>
+          </div>
+        </BannerCard>
+      ),
+    })
+
+    return () => {
+      dismissBanner(BANNER_ID.ONBOARDING_SURVEY)
+    }
+  }, [addBanner, autoOpen, dismissBanner, dismissPrompt, openDialog, shouldShowPrompt, track])
+
+  return (
+    <OnboardingSurveyDialog
+      open={prompt.open}
+      title={autoOpen ? WELCOME_TITLE : undefined}
+      description={autoOpen ? WELCOME_DESCRIPTION : undefined}
+      isSubmitting={prompt.isSubmitting}
+      onDismiss={() => prompt.dismissPrompt('dialog_dismissed')}
+      onOpenChange={prompt.setOpen}
+      onSkip={() => prompt.dismissPrompt('skip_button')}
+      onSubmit={prompt.submitSurvey}
+    />
+  )
+}

--- a/apps/studio/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt.test.tsx
+++ b/apps/studio/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt.test.tsx
@@ -1,0 +1,210 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { OnboardingSurveyVariant } from './OnboardingSurvey.constants'
+import { useOnboardingSurveyPrompt } from './useOnboardingSurveyPrompt'
+
+type PromptState = {
+  status: 'submitted' | 'dismissed'
+  updatedAt: string
+} | null
+type OrganizationState = { slug: string } | undefined
+type ProfileState = { gotrue_id?: string; id?: number } | undefined
+type ProjectState = { ref: string } | undefined
+
+const {
+  flagState,
+  localStorageState,
+  mockMutateAsync,
+  mockSetLocalStorageState,
+  mockTrack,
+  mockTrackExperimentExposure,
+  organizationState,
+  profileState,
+  projectState,
+} = vi.hoisted(() => ({
+  flagState: {
+    current: 'org_form_collapsed' as OnboardingSurveyVariant | false | undefined,
+  },
+  localStorageState: { current: null as PromptState },
+  mockMutateAsync: vi.fn(),
+  mockSetLocalStorageState: vi.fn((value: PromptState | ((state: PromptState) => PromptState)) => {
+    localStorageState.current = value instanceof Function ? value(localStorageState.current) : value
+  }),
+  mockTrack: vi.fn(),
+  mockTrackExperimentExposure: vi.fn(),
+  organizationState: { current: { slug: 'test-org' } as OrganizationState },
+  profileState: { current: { gotrue_id: 'user-1', id: 1 } as ProfileState },
+  projectState: { current: { ref: 'project-ref' } as ProjectState },
+}))
+
+vi.mock('common', () => ({
+  LOCAL_STORAGE_KEYS: {
+    ONBOARDING_SURVEY_PROMPT_STATE: (profileId: string, orgSlug: string) =>
+      `survey-${profileId}-${orgSlug}`,
+  },
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}))
+
+vi.mock('@/data/organizations/onboarding-survey-mutation', () => ({
+  useOnboardingSurveyMutation: () => ({
+    isPending: false,
+    mutateAsync: mockMutateAsync,
+  }),
+}))
+
+vi.mock('@/hooks/misc/useLocalStorage', () => ({
+  useLocalStorageQuery: () => [
+    localStorageState.current,
+    mockSetLocalStorageState,
+    { isSuccess: true },
+  ],
+}))
+
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: () => ({ data: organizationState.current }),
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({ data: projectState.current }),
+}))
+
+vi.mock('@/hooks/misc/useTrackExperimentExposure', () => ({
+  useTrackExperimentExposure: (id: string, variant: string | undefined) =>
+    mockTrackExperimentExposure(id, variant),
+}))
+
+vi.mock('@/hooks/ui/useFlag', () => ({
+  usePHFlag: () => flagState.current,
+}))
+
+vi.mock('@/lib/profile', () => ({
+  useProfile: () => ({ profile: profileState.current }),
+}))
+
+vi.mock('@/lib/telemetry/track', () => ({
+  useTrack: () => mockTrack,
+}))
+
+describe('useOnboardingSurveyPrompt', () => {
+  beforeEach(() => {
+    flagState.current = 'org_form_collapsed'
+    localStorageState.current = null
+    organizationState.current = { slug: 'test-org' }
+    profileState.current = { gotrue_id: 'user-1', id: 1 }
+    projectState.current = { ref: 'project-ref' }
+    mockMutateAsync.mockResolvedValue(undefined)
+    mockTrackExperimentExposure.mockReset()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not show the prompt for the control variant on any surface', () => {
+    flagState.current = 'control'
+    const { result } = renderHook(() => useOnboardingSurveyPrompt({ surface: 'org_form' }))
+
+    expect(result.current.shouldShowPrompt).toBe(false)
+    expect(result.current.variant).toBe('control')
+  })
+
+  it('shows the prompt when the variant matches the surface', () => {
+    flagState.current = 'org_form_collapsed'
+    const { result } = renderHook(() => useOnboardingSurveyPrompt({ surface: 'org_form' }))
+
+    expect(result.current.shouldShowPrompt).toBe(true)
+  })
+
+  it('does not show the prompt when the variant does not match the surface', () => {
+    flagState.current = 'org_form_collapsed'
+    const { result } = renderHook(() => useOnboardingSurveyPrompt({ surface: 'project_home' }))
+
+    expect(result.current.shouldShowPrompt).toBe(false)
+  })
+
+  it('shows the prompt for project_home surface with toast and dialog variants', () => {
+    flagState.current = 'toast'
+    const toastResult = renderHook(() =>
+      useOnboardingSurveyPrompt({ surface: 'project_home' })
+    ).result
+    expect(toastResult.current.shouldShowPrompt).toBe(true)
+
+    flagState.current = 'dialog'
+    const dialogResult = renderHook(() =>
+      useOnboardingSurveyPrompt({ surface: 'project_home' })
+    ).result
+    expect(dialogResult.current.shouldShowPrompt).toBe(true)
+  })
+
+  it('fires experiment exposure with the variant on mount', async () => {
+    flagState.current = 'org_form_expanded'
+    renderHook(() => useOnboardingSurveyPrompt({ surface: 'org_form' }))
+
+    await waitFor(() =>
+      expect(mockTrackExperimentExposure).toHaveBeenCalledWith(
+        'onboardingSurveyPlacement',
+        'org_form_expanded'
+      )
+    )
+  })
+
+  it('does not fire experiment exposure when the flag is still loading', () => {
+    flagState.current = undefined
+    renderHook(() => useOnboardingSurveyPrompt({ surface: 'org_form' }))
+
+    expect(mockTrackExperimentExposure).toHaveBeenCalledWith('onboardingSurveyPlacement', undefined)
+  })
+
+  it('does not show after the user has dismissed or submitted', () => {
+    flagState.current = 'org_form_collapsed'
+    localStorageState.current = {
+      status: 'submitted',
+      updatedAt: '2026-05-07T00:00:00.000Z',
+    }
+
+    const { result } = renderHook(() => useOnboardingSurveyPrompt({ surface: 'org_form' }))
+
+    expect(result.current.shouldShowPrompt).toBe(false)
+  })
+
+  it('records dismissal when user skips', () => {
+    flagState.current = 'toast'
+    const { result } = renderHook(() => useOnboardingSurveyPrompt({ surface: 'project_home' }))
+
+    act(() => result.current.dismissPrompt('skip_button'))
+
+    expect(mockSetLocalStorageState).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'dismissed' })
+    )
+  })
+
+  it('submits the survey payload and records completion', async () => {
+    flagState.current = 'dialog'
+    const { result } = renderHook(() => useOnboardingSurveyPrompt({ surface: 'project_home' }))
+
+    await act(async () => {
+      await result.current.submitSurvey({
+        heard_from: 'ai_tool',
+        building: 'SaaS app',
+      })
+    })
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      slug: 'test-org',
+      kind: 'PERSONAL',
+      size: '1',
+      heard_from: 'ai_tool',
+      building: 'SaaS app',
+    })
+    expect(mockSetLocalStorageState).toHaveBeenCalledWith(
+      expect.objectContaining({ status: 'submitted' })
+    )
+  })
+})

--- a/apps/studio/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt.ts
+++ b/apps/studio/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt.ts
@@ -1,0 +1,180 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { useCallback, useMemo, useRef, useState } from 'react'
+import { toast } from 'sonner'
+
+import type {
+  OnboardingSurveyPromptState,
+  OnboardingSurveySurface,
+  OnboardingSurveyVariant,
+} from './OnboardingSurvey.constants'
+import {
+  ONBOARDING_SURVEY_EXPERIMENT_ID,
+  ORG_KIND_DEFAULT,
+  ORG_SIZE_DEFAULT,
+  variantMatchesSurface,
+} from './OnboardingSurvey.constants'
+import { useOnboardingSurveyMutation } from '@/data/organizations/onboarding-survey-mutation'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useTrackExperimentExposure } from '@/hooks/misc/useTrackExperimentExposure'
+import { usePHFlag } from '@/hooks/ui/useFlag'
+import { useProfile } from '@/lib/profile'
+import { useTrack } from '@/lib/telemetry/track'
+
+type SurveyValues = {
+  heard_from?: string
+  building?: string
+}
+
+type SubmitSurveyOptions = {
+  showSuccessToast?: boolean
+}
+
+type DismissReason =
+  | 'skip_button'
+  | 'dialog_dismissed'
+  | 'toast_skip'
+  | 'org_form_blank'
+  | 'close_button'
+
+export const getOnboardingSurveyPromptStorageKey = ({
+  orgSlug,
+  profileId,
+}: {
+  orgSlug?: string
+  profileId?: string | number
+}) => {
+  if (!orgSlug || profileId === undefined || profileId === null) {
+    return 'supabase-onboarding-survey-unknown'
+  }
+
+  return LOCAL_STORAGE_KEYS.ONBOARDING_SURVEY_PROMPT_STATE(String(profileId), orgSlug)
+}
+
+export function useOnboardingSurveyPrompt({ surface }: { surface: OnboardingSurveySurface }) {
+  const track = useTrack()
+  const { profile } = useProfile()
+  const { data: organization } = useSelectedOrganizationQuery()
+  const { data: project } = useSelectedProjectQuery()
+  const [open, setOpen] = useState(false)
+
+  const flagValue = usePHFlag<OnboardingSurveyVariant | false>(ONBOARDING_SURVEY_EXPERIMENT_ID)
+  const variant: OnboardingSurveyVariant | undefined =
+    typeof flagValue === 'string' ? flagValue : undefined
+
+  useTrackExperimentExposure(ONBOARDING_SURVEY_EXPERIMENT_ID, variant)
+
+  const profileId = profile?.gotrue_id ?? profile?.id
+  const orgSlug = organization?.slug
+  const projectRef = project?.ref
+
+  const storageKey = useMemo(
+    () => getOnboardingSurveyPromptStorageKey({ orgSlug, profileId }),
+    [orgSlug, profileId]
+  )
+
+  const [promptState, setPromptState, { isSuccess: isPromptStateLoaded }] =
+    useLocalStorageQuery<OnboardingSurveyPromptState | null>(storageKey, null)
+
+  const mutation = useOnboardingSurveyMutation()
+  const hasFiredMutationRef = useRef(false)
+
+  const shouldShowPrompt =
+    isPromptStateLoaded &&
+    !!orgSlug &&
+    !!projectRef &&
+    !!profileId &&
+    promptState === null &&
+    variantMatchesSurface(variant, surface)
+
+  const openDialog = useCallback(() => {
+    if (!shouldShowPrompt) return
+    setOpen(true)
+  }, [shouldShowPrompt])
+
+  // On project_home surfaces (dialog/toast) the org-creation backend side-effect
+  // is skipped, so dismissing without answering would leave no survey row at all.
+  // Fire the mutation with default kind/size so the row exists. Single-fire
+  // guarded by hasFiredMutationRef.
+  const fireDefaultSurvey = useCallback(async () => {
+    if (hasFiredMutationRef.current || !orgSlug) return
+    hasFiredMutationRef.current = true
+    try {
+      await mutation.mutateAsync({
+        slug: orgSlug,
+        kind: ORG_KIND_DEFAULT,
+        size: ORG_SIZE_DEFAULT,
+      })
+    } catch {
+      hasFiredMutationRef.current = false
+    }
+  }, [mutation, orgSlug])
+
+  const dismissPrompt = useCallback(
+    (reason: DismissReason = 'dialog_dismissed') => {
+      if (!shouldShowPrompt) {
+        setOpen(false)
+        return
+      }
+
+      setPromptState({
+        status: 'dismissed',
+        updatedAt: new Date().toISOString(),
+      })
+      setOpen(false)
+      track('onboarding_survey_dismissed', { surface, reason })
+
+      if (surface === 'project_home') {
+        void fireDefaultSurvey()
+      }
+    },
+    [fireDefaultSurvey, setPromptState, shouldShowPrompt, surface, track]
+  )
+
+  const submitSurvey = useCallback(
+    async (
+      { heard_from, building }: SurveyValues,
+      { showSuccessToast = true }: SubmitSurveyOptions = {}
+    ) => {
+      if (!orgSlug) return false
+
+      const hasHeardFrom = !!heard_from?.trim()
+      const hasBuilding = !!building?.trim()
+
+      track('onboarding_survey_submit_button_clicked', { surface, hasHeardFrom, hasBuilding })
+
+      try {
+        hasFiredMutationRef.current = true
+        await mutation.mutateAsync({
+          slug: orgSlug,
+          kind: ORG_KIND_DEFAULT,
+          size: ORG_SIZE_DEFAULT,
+          heard_from,
+          building,
+        })
+        setPromptState({ status: 'submitted', updatedAt: new Date().toISOString() })
+        setOpen(false)
+        if (showSuccessToast) toast.success('Thanks for sharing')
+        return true
+      } catch {
+        hasFiredMutationRef.current = false
+        track('onboarding_survey_submit_failed', { surface, hasHeardFrom, hasBuilding })
+        toast.error('Failed to submit. Please try again.')
+        return false
+      }
+    },
+    [mutation, orgSlug, setPromptState, surface, track]
+  )
+
+  return {
+    dismissPrompt,
+    isSubmitting: mutation.isPending,
+    open,
+    openDialog,
+    setOpen,
+    shouldShowPrompt,
+    submitSurvey,
+    variant,
+  }
+}

--- a/apps/studio/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt.ts
+++ b/apps/studio/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt.ts
@@ -83,7 +83,7 @@ export function useOnboardingSurveyPrompt({ surface }: { surface: OnboardingSurv
   const shouldShowPrompt =
     isPromptStateLoaded &&
     !!orgSlug &&
-    !!projectRef &&
+    (surface !== 'project_home' || !!projectRef) &&
     !!profileId &&
     promptState === null &&
     variantMatchesSurface(variant, surface)

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -17,25 +17,21 @@ import {
   Form,
   FormControl,
   FormField,
+  Input,
   Select,
   SelectContent,
   SelectItem,
   SelectTrigger,
   SelectValue,
   Switch,
+  Textarea,
 } from 'ui'
+import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { z } from 'zod'
 
-import {
-  ORG_KIND_DEFAULT,
-  ORG_SIZE_DEFAULT,
-  OrganizationDetailsFields,
-  organizationDetailsSchema,
-  type OrgKind,
-  type OrgSize,
-} from './OrganizationDetailsFields'
+import { organizationDetailsSchema, type OrgKind, type OrgSize } from './OrganizationDetailsFields'
 import { UpgradeExistingOrganizationCallout } from './UpgradeExistingOrganizationCallout'
 import { ChargeBreakdown } from '@/components/interfaces/Billing/ChargeBreakdown'
 import { getStripeElementsAppearanceOptions } from '@/components/interfaces/Billing/Payment/Payment.utils'
@@ -45,8 +41,22 @@ import {
   type PaymentMethodElementRef,
 } from '@/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement'
 import SpendCapModal from '@/components/interfaces/Billing/SpendCapModal'
+import {
+  BUILDING_MAX_LENGTH,
+  BUILDING_PLACEHOLDER,
+  formatHeardFromAnswer,
+  HEARD_FROM_FOLLOW_UP_BY_VALUE,
+  HEARD_FROM_OPTIONS,
+  isOrgFormVariant,
+  ORG_KIND_DEFAULT,
+  ORG_KIND_TYPES,
+  ORG_SIZE_DEFAULT,
+  ORG_SIZE_TYPES,
+} from '@/components/interfaces/OnboardingSurvey/OnboardingSurvey.constants'
+import { useOnboardingSurveyPrompt } from '@/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt'
 import { InlineLink } from '@/components/ui/InlineLink'
 import Panel from '@/components/ui/Panel'
+import { useOnboardingSurveyMutation } from '@/data/organizations/onboarding-survey-mutation'
 import { useOrganizationCreateMutation } from '@/data/organizations/organization-create-mutation'
 import { useOrganizationCreationPreview } from '@/data/organizations/organization-creation-preview'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
@@ -58,6 +68,7 @@ import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { PRICING_TIER_LABELS_ORG, STRIPE_PUBLIC_KEY } from '@/lib/constants'
 import { useProfile } from '@/lib/profile'
+import { useTrack } from '@/lib/telemetry/track'
 
 interface NewOrgFormProps {
   onPaymentMethodReset: () => void
@@ -73,6 +84,9 @@ const formSchema = organizationDetailsSchema.extend({
     .transform((val) => val.toUpperCase())
     .pipe(z.enum(plans)),
   spend_cap: z.boolean(),
+  heard_from: z.string().optional(),
+  heard_from_detail: z.string().optional(),
+  building: z.string().max(BUILDING_MAX_LENGTH).optional(),
 })
 
 type FormState = z.infer<typeof formSchema>
@@ -92,7 +106,9 @@ export const NewOrgForm = ({
 }: NewOrgFormProps) => {
   const router = useRouter()
   const user = useProfile()
+  const track = useTrack()
   const { resolvedTheme } = useTheme()
+  const hasTrackedSurveyOpened = useRef(false)
 
   const isBillingEnabled = useIsFeatureEnabled('billing:all')
 
@@ -147,8 +163,32 @@ export const NewOrgForm = ({
       kind: defaultValues.kind as OrgKind,
       size: defaultValues.size as OrgSize,
       spend_cap: defaultValues.spend_cap,
+      heard_from: '',
+      heard_from_detail: '',
+      building: '',
     },
   })
+
+  const { variant: onboardingSurveyVariant } = useOnboardingSurveyPrompt({
+    surface: 'org_form',
+  })
+  const showOnboardingSurveyInOrgForm = isOrgFormVariant(onboardingSurveyVariant)
+  const showOnboardingSurveyExpanded = onboardingSurveyVariant === 'org_form_expanded'
+  // Skip kind/size on org creation for any variant that will later fire the
+  // survey endpoint — sendOrgCreationSurvey dedupes on (user, org_slug) at the
+  // parent row, so letting both paths fire would swallow the later call.
+  const omitKindFromOrgCreation =
+    onboardingSurveyVariant !== undefined && onboardingSurveyVariant !== 'control'
+
+  useEffect(() => {
+    if (!showOnboardingSurveyInOrgForm) return
+    if (hasTrackedSurveyOpened.current) return
+
+    hasTrackedSurveyOpened.current = true
+    track('onboarding_survey_prompt_opened', {
+      surface: 'org_form',
+    })
+  }, [showOnboardingSurveyInOrgForm, track])
 
   useEffect(() => {
     form.reset({
@@ -157,6 +197,9 @@ export const NewOrgForm = ({
       kind: defaultValues.kind as OrgKind,
       size: defaultValues.size as OrgSize,
       spend_cap: defaultValues.spend_cap,
+      heard_from: form.getValues('heard_from'),
+      heard_from_detail: form.getValues('heard_from_detail'),
+      building: form.getValues('building'),
     })
   }, [defaultValues, form])
 
@@ -191,6 +234,12 @@ export const NewOrgForm = ({
 
   const selectedPlan = form.watch('plan')
   const selectedSpendCap = form.watch('spend_cap')
+  const selectedOrgKind = form.watch('kind')
+  const selectedHeardFrom = form.watch('heard_from')
+  const selectedHeardFromDetail = form.watch('heard_from_detail')
+  const heardFromFollowUp = selectedHeardFrom
+    ? HEARD_FROM_FOLLOW_UP_BY_VALUE[selectedHeardFrom]
+    : undefined
 
   useEffect(() => {
     if (selectedPlan === 'FREE' || !setupIntent) {
@@ -235,7 +284,7 @@ export const NewOrgForm = ({
       if ('pending_payment_intent_secret' in org && org.pending_payment_intent_secret) {
         setPaymentIntentSecret(org.pending_payment_intent_secret)
       } else {
-        onOrganizationCreated(org as { slug: string })
+        await onOrganizationCreated(org as { slug: string })
       }
     },
     onError: (data) => {
@@ -243,11 +292,62 @@ export const NewOrgForm = ({
       setNewOrgLoading(false)
     },
   })
+  const { mutateAsync: submitOnboardingSurvey } = useOnboardingSurveyMutation()
+
+  const submitOrganizationSurvey = useCallback(
+    async (slug: string) => {
+      if (!showOnboardingSurveyInOrgForm) return
+
+      const heardFrom = formatHeardFromAnswer(
+        form.getValues('heard_from'),
+        form.getValues('heard_from_detail')
+      )
+      const building = form.getValues('building')?.trim()
+      const kind = form.getValues('kind')
+      const size = kind === 'COMPANY' ? form.getValues('size') : undefined
+      const hasHeardFrom = !!heardFrom
+      const hasBuilding = !!building
+
+      const groupOverrides = { organization: slug }
+
+      if (!hasHeardFrom && !hasBuilding) {
+        track(
+          'onboarding_survey_dismissed',
+          { surface: 'org_form', reason: 'org_form_blank' },
+          groupOverrides
+        )
+        return
+      }
+
+      track(
+        'onboarding_survey_submit_button_clicked',
+        { surface: 'org_form', hasHeardFrom, hasBuilding },
+        groupOverrides
+      )
+
+      try {
+        await submitOnboardingSurvey({
+          slug,
+          kind,
+          size,
+          heard_from: heardFrom,
+          building,
+        })
+      } catch {
+        track(
+          'onboarding_survey_submit_failed',
+          { surface: 'org_form', hasHeardFrom, hasBuilding },
+          groupOverrides
+        )
+      }
+    },
+    [form, showOnboardingSurveyInOrgForm, submitOnboardingSurvey, track]
+  )
 
   const { mutate: confirmPendingSubscriptionChange } = useConfirmPendingSubscriptionCreateMutation({
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       if (data && 'slug' in data) {
-        onOrganizationCreated({ slug: data.slug })
+        await onOrganizationCreated({ slug: data.slug })
       }
     },
   })
@@ -260,8 +360,12 @@ export const NewOrgForm = ({
       await confirmPendingSubscriptionChange({
         payment_intent_id: paymentIntentConfirmation.paymentIntent.id,
         name: form.getValues('name'),
-        kind: form.getValues('kind'),
-        size: form.getValues('size'),
+        ...(omitKindFromOrgCreation
+          ? {}
+          : {
+              kind: form.getValues('kind'),
+              size: form.getValues('size'),
+            }),
       })
     } else {
       // If the payment intent is not successful, we reset the payment method and show an error
@@ -273,7 +377,9 @@ export const NewOrgForm = ({
     }
   }
 
-  const onOrganizationCreated = (org: { slug: string }) => {
+  const onOrganizationCreated = async (org: { slug: string }) => {
+    await submitOrganizationSurvey(org.slug)
+
     const prefilledProjectName = user.profile?.username
       ? user.profile.username + `'s Project`
       : 'My Project'
@@ -313,13 +419,17 @@ export const NewOrgForm = ({
 
     createOrganization({
       name: formValues.name,
-      kind: formValues.kind,
+      ...(omitKindFromOrgCreation
+        ? {}
+        : {
+            kind: formValues.kind,
+            ...(formValues.kind == 'COMPANY' ? { size: formValues.size } : {}),
+          }),
       tier: ('tier_' + dbTier.toLowerCase()) as
         | 'tier_payg'
         | 'tier_pro'
         | 'tier_free'
         | 'tier_team',
-      ...(formValues.kind == 'COMPANY' ? { size: formValues.size } : {}),
       payment_method: paymentMethodId,
       billing_name: dbTier === 'FREE' ? undefined : customerData?.billing_name,
       address: dbTier === 'FREE' ? null : customerData?.address,
@@ -355,6 +465,152 @@ export const NewOrgForm = ({
     setPaymentMethod(undefined)
     return onPaymentMethodReset()
   }
+
+  const buildingPlaceholder = BUILDING_PLACEHOLDER
+
+  const orgKindField = (
+    <FormField
+      control={form.control}
+      name="kind"
+      render={({ field }) => (
+        <FormItemLayout
+          label={showOnboardingSurveyInOrgForm ? 'Who is this org for?' : 'Type'}
+          layout="horizontal"
+          description={
+            showOnboardingSurveyInOrgForm ? undefined : 'What best describes your organization?'
+          }
+        >
+          <FormControl>
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+
+              <SelectContent>
+                {Object.entries(ORG_KIND_TYPES).map(([k, v]) => (
+                  <SelectItem key={k} value={k}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormControl>
+        </FormItemLayout>
+      )}
+    />
+  )
+
+  const orgSizeField = selectedOrgKind == 'COMPANY' && (
+    <FormField
+      control={form.control}
+      name="size"
+      render={({ field }) => (
+        <FormItemLayout label="How many people?" layout="horizontal">
+          <FormControl>
+            <Select value={field.value} onValueChange={field.onChange}>
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+
+              <SelectContent>
+                {Object.entries(ORG_SIZE_TYPES).map(([k, v]) => (
+                  <SelectItem key={k} value={k}>
+                    {v}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </FormControl>
+        </FormItemLayout>
+      )}
+    />
+  )
+
+  const heardFromField = (
+    <FormField
+      control={form.control}
+      name="heard_from"
+      render={({ field }) => (
+        <FormItemLayout label="Where did you hear about us?" layout="horizontal">
+          <FormControl>
+            <div className="flex flex-col gap-y-2">
+              <Select
+                value={field.value}
+                onValueChange={(value) => {
+                  field.onChange(value)
+                  if (!HEARD_FROM_FOLLOW_UP_BY_VALUE[value]) {
+                    form.setValue('heard_from_detail', '', {
+                      shouldDirty: true,
+                    })
+                  }
+                }}
+              >
+                <SelectTrigger className="w-full">
+                  <SelectValue placeholder="Select an option" />
+                </SelectTrigger>
+
+                <SelectContent>
+                  {HEARD_FROM_OPTIONS.map((option) => (
+                    <SelectItem key={option.value} value={option.value}>
+                      {option.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {heardFromFollowUp && (
+                <Input
+                  aria-label={heardFromFollowUp.label}
+                  value={selectedHeardFromDetail ?? ''}
+                  placeholder={heardFromFollowUp.placeholder}
+                  onChange={(event) =>
+                    form.setValue('heard_from_detail', event.target.value, {
+                      shouldDirty: true,
+                    })
+                  }
+                />
+              )}
+            </div>
+          </FormControl>
+        </FormItemLayout>
+      )}
+    />
+  )
+
+  const buildingField = (
+    <FormField
+      control={form.control}
+      name="building"
+      render={({ field }) => (
+        <FormItemLayout label="What are you building?" layout="horizontal">
+          <FormControl>
+            <div className="relative">
+              <Textarea
+                {...field}
+                value={field.value ?? ''}
+                rows={3}
+                maxLength={BUILDING_MAX_LENGTH}
+                placeholder={buildingPlaceholder}
+                className="resize-none pb-6"
+              />
+              <span className="pointer-events-none absolute bottom-1.5 right-2 text-xs text-foreground-lighter">
+                {(field.value ?? '').length}/{BUILDING_MAX_LENGTH}
+              </span>
+            </div>
+          </FormControl>
+        </FormItemLayout>
+      )}
+    />
+  )
+
+  const onboardingSurveyFields = (
+    <div className="flex flex-col gap-y-5">
+      {orgKindField}
+      {orgSizeField}
+      {heardFromField}
+      {buildingField}
+    </div>
+  )
 
   return (
     <Form {...form}>
@@ -400,13 +656,32 @@ export const NewOrgForm = ({
           footerClasses="rounded-b-md"
         >
           <div className="divide-y divide-border-muted">
-            <OrganizationDetailsFields
-              control={form.control}
-              kind={form.watch('kind')}
-              renderFieldWrapper={(children, field) => (
-                <Panel.Content key={field}>{children}</Panel.Content>
-              )}
-            />
+            <Panel.Content>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItemLayout
+                    label="Name"
+                    layout="horizontal"
+                    description="What's the name of your company or team? You can change this later."
+                  >
+                    <FormControl>
+                      <Input
+                        autoFocus
+                        type="text"
+                        placeholder="Organization name"
+                        data-1p-ignore
+                        data-lpignore="true"
+                        data-form-type="other"
+                        data-bwignore
+                        {...field}
+                      />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </Panel.Content>
 
             {isBillingEnabled && (
               <Panel.Content>
@@ -537,6 +812,23 @@ export const NewOrgForm = ({
 
             {hasFreeOrgWithProjects && form.getValues('plan') !== 'FREE' && (
               <UpgradeExistingOrganizationCallout />
+            )}
+
+            {showOnboardingSurveyInOrgForm ? (
+              <Panel.Content>
+                <CollapsibleCardSection
+                  title="Help improve Supabase"
+                  description="Optional questions to help improve the Supabase experience"
+                  defaultOpen={showOnboardingSurveyExpanded}
+                >
+                  {onboardingSurveyFields}
+                </CollapsibleCardSection>
+              </Panel.Content>
+            ) : (
+              <>
+                <Panel.Content>{orgKindField}</Panel.Content>
+                {orgSizeField && <Panel.Content>{orgSizeField}</Panel.Content>}
+              </>
             )}
           </div>
         </Panel>

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -316,22 +316,23 @@ export const NewOrgForm = ({
           { surface: 'org_form', reason: 'org_form_blank' },
           groupOverrides
         )
-        return
+      } else {
+        track(
+          'onboarding_survey_submit_button_clicked',
+          { surface: 'org_form', hasHeardFrom, hasBuilding },
+          groupOverrides
+        )
       }
 
-      track(
-        'onboarding_survey_submit_button_clicked',
-        { surface: 'org_form', hasHeardFrom, hasBuilding },
-        groupOverrides
-      )
-
+      // Always persist kind/size: omitKindFromOrgCreation removes them from the
+      // org creation payload for survey variants, so this is the only save path.
       try {
         await submitOnboardingSurvey({
           slug,
           kind,
           size,
-          heard_from: heardFrom,
-          building,
+          heard_from: heardFrom || undefined,
+          building: building || undefined,
         })
       } catch {
         track(

--- a/apps/studio/components/interfaces/ProjectHome/Home.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/Home.tsx
@@ -11,6 +11,8 @@ import { CustomReportSection } from './CustomReportSection'
 import { DEFAULT_SECTION_ORDER, mergeSectionOrder } from './Home.utils'
 import { ProjectUsageSection as ProjectUsageSectionV2 } from './ProjectUsageSection'
 import { ProjectUsageSection as ProjectUsageSectionV1 } from '@/components/interfaces/Home/ProjectUsageSection'
+import { OnboardingSurveyToastPrompt } from '@/components/interfaces/OnboardingSurvey/OnboardingSurveyToastPrompt'
+import { useOnboardingSurveyPrompt } from '@/components/interfaces/OnboardingSurvey/useOnboardingSurveyPrompt'
 import { SortableSection } from '@/components/interfaces/ProjectHome/SortableSection'
 import { TopSection } from '@/components/interfaces/ProjectHome/TopSection'
 import { ProjectNeedsSecuring } from '@/components/layouts/ProjectNeedsSecuring/ProjectNeedsSecuring'
@@ -34,6 +36,21 @@ export const ProjectHome = () => {
   const hasShownEnableBranchingModalRef = useRef(false)
   const isPaused = project?.status === PROJECT_STATUS.INACTIVE
   const isComingUp = project?.status === PROJECT_STATUS.COMING_UP
+  const { variant: onboardingSurveyVariant } = useOnboardingSurveyPrompt({
+    surface: 'project_home',
+  })
+  // Platform's `inserted_at` is UTC but lacks a `Z` suffix, so we parse it explicitly as UTC.
+  const isRecentlyCreatedProject =
+    !!project?.inserted_at &&
+    dayjs.utc(project.inserted_at).isAfter(dayjs.utc().subtract(1, 'hour'))
+  const inProvisioningWindow = isComingUp || isRecentlyCreatedProject
+
+  const showOnboardingSurveyToast =
+    !!project &&
+    !isPaused &&
+    inProvisioningWindow &&
+    (onboardingSurveyVariant === 'toast' || onboardingSurveyVariant === 'dialog')
+  const shouldAutoOpenOnboardingSurveyDialog = isComingUp && onboardingSurveyVariant === 'dialog'
 
   const [sectionOrder, setSectionOrder] = useLocalStorage<string[]>(
     `home-section-order-${project?.ref || 'default'}`,
@@ -82,6 +99,9 @@ export const ProjectHome = () => {
 
   return (
     <ProjectNeedsSecuring>
+      {showOnboardingSurveyToast && (
+        <OnboardingSurveyToastPrompt autoOpen={shouldAutoOpenOnboardingSurveyDialog} />
+      )}
       <div className="w-full h-full">
         <ScaffoldContainer size="large" className={cn(isPaused && 'h-full')}>
           <ScaffoldSection

--- a/apps/studio/components/interfaces/ProjectHome/Home.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/Home.tsx
@@ -31,7 +31,7 @@ export const ProjectHome = () => {
 
   const showHomepageUsageV2 = useFlag('newHomepageUsageV2')
 
-  const isMatureProject = dayjs(project?.inserted_at).isBefore(dayjs().subtract(10, 'day'))
+  const isMatureProject = dayjs.utc(project?.inserted_at).isBefore(dayjs.utc().subtract(10, 'day'))
 
   const hasShownEnableBranchingModalRef = useRef(false)
   const isPaused = project?.status === PROJECT_STATUS.INACTIVE

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.test.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.test.tsx
@@ -1,0 +1,61 @@
+import { act, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { BANNER_ID, BannerStackProvider, useBannerStack } from './BannerStackProvider'
+
+function BannerStackTestConsumer() {
+  const { addBanner, banners, dismissBanner } = useBannerStack()
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          addBanner({
+            id: BANNER_ID.ONBOARDING_SURVEY,
+            isDismissed: false,
+            content: <span>Survey</span>,
+          })
+        }
+      >
+        Add banner
+      </button>
+      <button type="button" onClick={() => dismissBanner(BANNER_ID.ONBOARDING_SURVEY)}>
+        Dismiss banner
+      </button>
+      <div data-testid="banner-state">
+        {banners.map((banner) => `${banner.id}:${banner.isDismissed ? 'dismissed' : 'active'}`)}
+      </div>
+    </>
+  )
+}
+
+describe('BannerStackProvider', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('revives an existing dismissed banner when it is re-added before removal', () => {
+    vi.useFakeTimers()
+
+    render(
+      <BannerStackProvider>
+        <BannerStackTestConsumer />
+      </BannerStackProvider>
+    )
+
+    act(() => screen.getByText('Add banner').click())
+    expect(screen.getByTestId('banner-state').textContent).toBe('onboarding-survey-banner:active')
+
+    act(() => screen.getByText('Dismiss banner').click())
+    expect(screen.getByTestId('banner-state').textContent).toBe(
+      'onboarding-survey-banner:dismissed'
+    )
+
+    act(() => screen.getByText('Add banner').click())
+    expect(screen.getByTestId('banner-state').textContent).toBe('onboarding-survey-banner:active')
+
+    act(() => vi.advanceTimersByTime(300))
+    expect(screen.getByTestId('banner-state').textContent).toBe('onboarding-survey-banner:active')
+  })
+})

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useState } from 'react'
+import { createContext, useCallback, useContext, useRef, useState } from 'react'
 
 export const BANNER_ID = {
   METRICS_API: 'metrics-api-banner',
@@ -7,6 +7,7 @@ export const BANNER_ID = {
   RLS_EVENT_TRIGGER: 'rls-event-trigger-banner',
   RLS_TESTER: 'rls-tester-banner',
   FREE_MICRO_UPGRADE: 'free-micro-upgrade-banner',
+  ONBOARDING_SURVEY: 'onboarding-survey-banner',
 } as const
 
 export type BannerId = (typeof BANNER_ID)[keyof typeof BANNER_ID]
@@ -29,20 +30,35 @@ const BannerStackContext = createContext<BannerStackContextType | undefined>(und
 
 export const BannerStackProvider = ({ children }: { children: React.ReactNode }) => {
   const [banners, setBanners] = useState<Banner[]>([])
+  const dismissTimeoutsRef = useRef<Partial<Record<BannerId, ReturnType<typeof setTimeout>>>>({})
 
   const addBanner = useCallback((banner: Banner) => {
+    const dismissTimeout = dismissTimeoutsRef.current[banner.id]
+
+    if (dismissTimeout) {
+      clearTimeout(dismissTimeout)
+      delete dismissTimeoutsRef.current[banner.id]
+    }
+
     setBanners((prev) => {
       const exists = prev.some((b) => b.id === banner.id)
-      if (exists) return prev
-      const newBanners = [...prev, banner]
+      const newBanners = exists
+        ? prev.map((b) => (b.id === banner.id ? banner : b))
+        : [...prev, banner]
+
       return newBanners.sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0))
     })
   }, [])
 
-  const dismissBanner = useCallback((id: string) => {
+  const dismissBanner = useCallback((id: BannerId) => {
+    const existingTimeout = dismissTimeoutsRef.current[id]
+
+    if (existingTimeout) clearTimeout(existingTimeout)
+
     setBanners((prev) => prev.map((b) => (b.id === id ? { ...b, isDismissed: true } : b)))
-    setTimeout(() => {
+    dismissTimeoutsRef.current[id] = setTimeout(() => {
       setBanners((prev) => prev.filter((b) => b.id !== id))
+      delete dismissTimeoutsRef.current[id]
     }, 300)
   }, [])
 

--- a/apps/studio/data/organizations/onboarding-survey-mutation.test.ts
+++ b/apps/studio/data/organizations/onboarding-survey-mutation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { buildOnboardingSurveyPayload, submitOnboardingSurvey } from './onboarding-survey-mutation'
+
+const postMock = vi.fn()
+
+vi.mock('@/data/fetchers', () => ({
+  post: (...args: unknown[]) => postMock(...args),
+  handleError: (error: unknown) => {
+    throw error
+  },
+}))
+
+describe('buildOnboardingSurveyPayload', () => {
+  it('matches the onboarding survey API body shape', () => {
+    expect(
+      buildOnboardingSurveyPayload({
+        slug: 'test-org',
+        heard_from: ' ai_tool ',
+        building: ' a mobile game backend ',
+      })
+    ).toEqual({
+      slug: 'test-org',
+      heard_from: 'ai_tool',
+      building: 'a mobile game backend',
+    })
+  })
+
+  it('omits empty optional values', () => {
+    expect(
+      buildOnboardingSurveyPayload({
+        slug: 'test-org',
+        heard_from: ' ',
+        building: '',
+      })
+    ).toEqual({ slug: 'test-org' })
+  })
+
+  it('includes kind and size when present', () => {
+    expect(
+      buildOnboardingSurveyPayload({
+        slug: 'test-org',
+        kind: '  STARTUP  ',
+        size: '10',
+        heard_from: 'twitter',
+        building: 'a saas',
+      })
+    ).toEqual({
+      slug: 'test-org',
+      kind: 'STARTUP',
+      size: '10',
+      heard_from: 'twitter',
+      building: 'a saas',
+    })
+  })
+})
+
+describe('submitOnboardingSurvey', () => {
+  it('posts to the platform endpoint with the typed payload', async () => {
+    postMock.mockReset()
+    postMock.mockResolvedValue({ error: undefined })
+
+    await submitOnboardingSurvey({
+      slug: 'acme',
+      kind: 'COMPANY',
+      size: '10',
+      heard_from: 'search_engine',
+      building: 'a saas',
+    })
+
+    expect(postMock).toHaveBeenCalledWith('/platform/organizations/onboarding-survey', {
+      body: {
+        slug: 'acme',
+        kind: 'COMPANY',
+        size: '10',
+        heard_from: 'search_engine',
+        building: 'a saas',
+      },
+    })
+  })
+
+  it('throws when the slug is missing', async () => {
+    await expect(submitOnboardingSurvey({ slug: '' })).rejects.toThrow(
+      'Organization slug is required'
+    )
+  })
+})

--- a/apps/studio/data/organizations/onboarding-survey-mutation.ts
+++ b/apps/studio/data/organizations/onboarding-survey-mutation.ts
@@ -1,0 +1,61 @@
+import { useMutation } from '@tanstack/react-query'
+import type { components } from 'api-types'
+
+import { handleError, post } from '@/data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from '@/types'
+
+export type OnboardingSurveyBody = components['schemas']['OnboardingSurveyBody']
+
+export type OnboardingSurveyVariables = {
+  slug: string
+  kind?: string
+  size?: string
+  heard_from?: string
+  building?: string
+}
+
+const trim = (v?: string) => v?.trim() || undefined
+
+export function buildOnboardingSurveyPayload({
+  slug,
+  kind,
+  size,
+  heard_from,
+  building,
+}: OnboardingSurveyVariables): OnboardingSurveyBody {
+  return {
+    slug,
+    kind: trim(kind),
+    size: trim(size),
+    heard_from: trim(heard_from),
+    building: trim(building),
+  }
+}
+
+export async function submitOnboardingSurvey(variables: OnboardingSurveyVariables) {
+  const payload = buildOnboardingSurveyPayload(variables)
+
+  if (!payload.slug) {
+    throw new Error('Organization slug is required')
+  }
+
+  const { error } = await post('/platform/organizations/onboarding-survey', {
+    body: payload,
+  })
+
+  if (error) handleError(error)
+}
+
+type SubmitOnboardingSurveyData = Awaited<ReturnType<typeof submitOnboardingSurvey>>
+
+export const useOnboardingSurveyMutation = ({
+  ...options
+}: Omit<
+  UseCustomMutationOptions<SubmitOnboardingSurveyData, ResponseError, OnboardingSurveyVariables>,
+  'mutationFn'
+> = {}) => {
+  return useMutation<SubmitOnboardingSurveyData, ResponseError, OnboardingSurveyVariables>({
+    mutationFn: (vars) => submitOnboardingSurvey(vars),
+    ...options,
+  })
+}

--- a/apps/studio/hooks/misc/useTrackExperimentExposure.ts
+++ b/apps/studio/hooks/misc/useTrackExperimentExposure.ts
@@ -1,8 +1,15 @@
 import { hasConsented, posthogClient } from 'common'
+import { EXPERIMENTS, type ExperimentKey } from 'common/telemetry-constants'
 import { useEffect } from 'react'
 
+/**
+ * Captures a PostHog experiment exposure. Looks up the exposure event name
+ * from the EXPERIMENTS registry and emits `${exposureName}_experiment_exposed`.
+ * Register new experiments in `packages/common/telemetry-constants.ts`
+ * before calling this hook.
+ */
 export function useTrackExperimentExposure(
-  experimentId: string,
+  experimentKey: ExperimentKey,
   variant: string | undefined,
   extraProperties?: Record<string, any>
 ) {
@@ -10,9 +17,9 @@ export function useTrackExperimentExposure(
     if (!variant) return
 
     posthogClient.captureExperimentExposure(
-      experimentId,
+      EXPERIMENTS[experimentKey],
       { variant, ...extraProperties },
       hasConsented()
     )
-  }, [experimentId, variant])
+  }, [experimentKey, variant])
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -119,6 +119,8 @@ export const LOCAL_STORAGE_KEYS = {
     `free-micro-upgrade-banner-dismissed-${ref}`,
   STORAGE_PUBLIC_BUCKET_SELECT_POLICY_WARNING_DISMISSED: (ref: string, bucketId: string) =>
     `storage-public-bucket-select-policy-warning-dismissed-${ref}-${bucketId}`,
+  ONBOARDING_SURVEY_PROMPT_STATE: (profileId: string, orgSlug: string) =>
+    `supabase-onboarding-survey-prompt-${profileId}-${orgSlug}`,
   PRIVACY_NOTICE_ACKNOWLEDGED: 'privacy-notice-acknowledged-2026-03',
 
   /**

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -31,6 +31,17 @@ export type TableEventAction = (typeof TABLE_EVENT_ACTIONS)[keyof typeof TABLE_E
 export const TABLE_EVENT_VALUES: TableEventAction[] = Object.values(TABLE_EVENT_ACTIONS)
 
 /**
+ * Maps PostHog flag key → exposure event-name base. Emitted event becomes
+ * `${value}_experiment_exposed`. Snake_case the value for new experiments;
+ * legacy camelCase values are kept to avoid breaking saved insights.
+ */
+export const EXPERIMENTS = {
+  onboardingSurveyPlacement: 'onboarding_survey_placement',
+} as const
+
+export type ExperimentKey = keyof typeof EXPERIMENTS
+
+/**
  * Triggered when a user signs up. When signing up with Email and Password, this is only triggered once user confirms their email.
  *
  * @group Events
@@ -421,6 +432,81 @@ export interface ProjectCreationSimpleVersionConfirmModalOpenedEvent {
     instanceSize?: string
   }
   groups: Omit<TelemetryGroups, 'project'>
+}
+
+type OnboardingSurveySurface = 'org_form' | 'project_home'
+
+/**
+ * Onboarding survey prompt UI became visible.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface OnboardingSurveyPromptOpenedEvent {
+  action: 'onboarding_survey_prompt_opened'
+  properties: { surface: OnboardingSurveySurface }
+  groups: Partial<TelemetryGroups>
+}
+
+/**
+ * User clicked the Answer button on the toast banner. Toast variant only.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface OnboardingSurveyAnswerButtonClickedEvent {
+  action: 'onboarding_survey_answer_button_clicked'
+  properties: { surface: OnboardingSurveySurface }
+  groups: Partial<TelemetryGroups>
+}
+
+/**
+ * User clicked Submit. Fires before the backend mutation; pair with
+ * OnboardingSurveySubmitFailedEvent for failure rate. The platform's own
+ * `onboarding_survey_submitted` event tracks actual completions.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface OnboardingSurveySubmitButtonClickedEvent {
+  action: 'onboarding_survey_submit_button_clicked'
+  properties: {
+    surface: OnboardingSurveySurface
+    hasHeardFrom: boolean
+    hasBuilding: boolean
+  }
+  groups: Partial<TelemetryGroups>
+}
+
+/**
+ * User dismissed the onboarding survey.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface OnboardingSurveyDismissedEvent {
+  action: 'onboarding_survey_dismissed'
+  properties: {
+    surface: OnboardingSurveySurface
+    reason: 'skip_button' | 'dialog_dismissed' | 'toast_skip' | 'org_form_blank' | 'close_button'
+  }
+  groups: Partial<TelemetryGroups>
+}
+
+/**
+ * Onboarding survey submit failed.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface OnboardingSurveySubmitFailedEvent {
+  action: 'onboarding_survey_submit_failed'
+  properties: {
+    surface: OnboardingSurveySurface
+    hasHeardFrom: boolean
+    hasBuilding: boolean
+  }
+  groups: Partial<TelemetryGroups>
 }
 
 /**
@@ -3297,6 +3383,11 @@ export type TelemetryEvent =
   | ProjectCreationGithubConnectClickedEvent
   | ProjectCreationSimpleVersionSubmittedEvent
   | ProjectCreationSimpleVersionConfirmModalOpenedEvent
+  | OnboardingSurveyPromptOpenedEvent
+  | OnboardingSurveyAnswerButtonClickedEvent
+  | OnboardingSurveySubmitButtonClickedEvent
+  | OnboardingSurveyDismissedEvent
+  | OnboardingSurveySubmitFailedEvent
   | TableApiAccessToggleClickedEvent
   | RealtimeInspectorListenChannelClickedEvent
   | RealtimeInspectorBroadcastSentEvent


### PR DESCRIPTION
## What kind of change does this PR introduce?

Experiment. Resolves GROWTH-771.

## What is the current behavior?

Studio does not ask new users the onboarding attribution/building questions during organisation or project creation.

## What is the new behavior?

Adds a Studio onboarding survey experiment with multiple placements for comparison:

- New organisation form placements. The answers are collected during the form, then submitted through the onboarding survey endpoint after org creation succeeds, without adding the survey fields to the org creation request body.
- Project-home placements after project creation. When the project is still `COMING_UP`, the `dialog` arm auto-opens the welcome dialog. The `toast` arm shows a bottom-right pinned `BannerStack` card; users open the dialog by clicking `Answer`.

The project-home `dialog` and `toast` arms share the same survey dialog. The `toast` arm never auto-opens it; it is only the fallback CTA entry point.

The prompt state is localStorage-scoped by org slug and user id for the prototype. Typed telemetry covers prompt opened, answer clicked, submitted, dismissed, and submit-failed behaviour with surface metadata.

| After |
| --- |
| <img width="1430" height="902" alt="CleanShot 2026-05-20 at 15 31 58@2x" src="https://github.com/user-attachments/assets/ce151081-dd75-4209-b262-522973dbd02c" /> |
| `org_form_collapsed` |
| <img width="1432" height="1402" alt="CleanShot 2026-05-20 at 15 32 04@2x-E094096E-E50E-4976-A5F8-37A7A6CDD02B" src="https://github.com/user-attachments/assets/b620088e-35f8-4da6-aa06-69a9c6a18e07" /> |
| `org_form_expanded` |
| <img width="690" height="424" alt="CleanShot 2026-05-20 at 15 32 38@2x-88E89B35-12A4-4E79-B988-436989E60CFE" src="https://github.com/user-attachments/assets/dd0d6e67-3c4c-4e9a-9f19-85d86a3724d8" /> |
| `toast` |
| <img width="908" height="916" alt="CleanShot 2026-05-20 at 15 32 45@2x" src="https://github.com/user-attachments/assets/dd20e579-a30f-454c-a604-56c9fe85d07c" /> |
| `dialog` (also reachable via `toast`) |

## Experiment wiring

Experiment assignment uses the PostHog feature flag `onboardingSurveyPlacement` with five arms:

- `control`: no survey prompt. The normal org type field remains `Type` with `What best describes your organization?`.
- `org_form_collapsed`: shows `Help improve Supabase` as a collapsible section after Plan, closed by default. It contains `Who is this org for?`, `How many people?` when the org is for a company, `Where did you hear about us?`, and `What are you building?`.
- `org_form_expanded`: the same collapsible org-form section, open by default.
- `dialog`: project-home welcome dialog arm. Auto-opens only while the project is `COMING_UP`.
- `toast`: project-home bottom-right `BannerStack` card. The user must click `Answer` to open the survey dialog.

Variant assignment happens per user via `usePHFlag`; intent-to-treat exposure fires for every assigned arm including control. The exposure event is registered in the `EXPERIMENTS` table in `packages/common/telemetry-constants.ts` and emits `onboarding_survey_placement_experiment_exposed`.

The survey mutation posts to `POST /platform/organizations/onboarding-survey` (platform#31538) carrying `slug`, `kind`, `size`, `heard_from`, and `building`. `kind` and `size` are sent from the new-org form variants; the project-home variants submit the default org type/size when they need to create the survey row.

## Local testing

In local Studio, call `devTelemetry()` in the browser console, open the dev toolbar, then use Flags -> PostHog to override `onboardingSurveyPlacement` to one of the five arm names above. Reload after changing the override.

For project-home arms, use a project that is `COMING_UP` or was created within the last hour; otherwise the project-home prompt is intentionally suppressed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added onboarding survey that collects feedback on how users heard about the product and what they're building
  * Survey appears as a dismissible dialog or banner during organization creation and on recently created projects
  * Users can submit survey responses or skip the prompt

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45707?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
