### PR TITLE
docs: fix typo in Ionic Angular user-management README

### DIFF
--- a/examples/user-management/ionic-angular-user-management/README.md
+++ b/examples/user-management/ionic-angular-user-management/README.md
@@ -71,7 +71,7 @@ Run the application: `ionic serve` and the browser will open to `https://localho
 
 This project uses very high-level Authorization using Postgres' Role Level Security.
 When you start a Postgres database on Supabase, we populate it with an `auth` schema, and some helper functions.
-When a user logs in, they are issued a JWT with the role `authenticated` and thier UUID.
+When a user logs in, they are issued a JWT with the role `authenticated` and their UUID.
 We can use these details to provide fine-grained control over what each user can and cannot do.
 
 This is a trimmed-down schema, with the policies:


### PR DESCRIPTION
Fixes a small typo in the Ionic Angular user-management example README (thier → their).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a spelling error in the user management documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->