### PR TITLE
feat: Add a color palette to design-system

### DIFF
--- a/apps/design-system/components/color-palette.tsx
+++ b/apps/design-system/components/color-palette.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useState } from 'react'
+
+const colorNames = [
+  'Gray',
+  'Slate',
+  'Tomato',
+  'Red',
+  'Crimson',
+  'Pink',
+  'Purple',
+  'Violet',
+  'Indigo',
+  'Blue',
+  'Green',
+  'Gold',
+  'Orange',
+  'Amber',
+  'Yellow',
+]
+
+const SCALE_STEPS = Array.from({ length: 12 }, (_, i) => i + 1)
+
+const GRID_COLS = 'grid-cols-[6rem_repeat(12,minmax(0,1fr))]'
+
+const ColorPalette = () => {
+  const [copied, setCopied] = useState<string | null>(null)
+
+  const handleCopy = async (value: string) => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(value)
+      setTimeout(() => setCopied(null), 1500)
+    } catch (err) {
+      console.error('Failed to copy text: ', err)
+    }
+  }
+
+  return (
+    <div className="my-6 w-full overflow-x-auto">
+      <div className="flex min-w-[640px] flex-col gap-1">
+        <div className={`grid gap-1 ${GRID_COLS}`}>
+          <div />
+          {SCALE_STEPS.map((step) => (
+            <div key={step} className="text-center font-mono text-[10px] text-foreground-lighter">
+              {step}
+            </div>
+          ))}
+        </div>
+        {colorNames.map((name) => {
+          const slug = name.toLowerCase()
+          return (
+            <div key={slug} className={`grid items-center gap-1 ${GRID_COLS}`}>
+              <div className="pr-2 text-sm font-medium text-foreground">{name}</div>
+              {SCALE_STEPS.map((step) => {
+                const reference = `var(--colors-${slug}${step})`
+                const isCopied = copied === reference
+                return (
+                  <button
+                    key={step}
+                    type="button"
+                    onClick={() => handleCopy(reference)}
+                    className="group relative flex aspect-square w-full items-center justify-center rounded-sm border border-overlay/40 transition hover:scale-[1.05] focus:outline-none focus-visible:ring-2 focus-visible:ring-foreground"
+                    style={{ backgroundColor: reference }}
+                    title={reference}
+                  >
+                    <span className="rounded-xs bg-surface-100/90 px-1 font-mono text-[10px] text-foreground-light opacity-0 transition group-hover:opacity-100">
+                      {isCopied ? 'Copied!' : step}
+                    </span>
+                  </button>
+                )
+              })}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}
+
+export { ColorPalette }

--- a/apps/design-system/components/color-palette.tsx
+++ b/apps/design-system/components/color-palette.tsx
@@ -3,20 +3,22 @@
 import { useState } from 'react'
 
 const colorNames = [
-  'Gray',
-  'Slate',
-  'Tomato',
-  'Red',
+  'Amber',
+  'Blue',
+  'Brand',
   'Crimson',
+  'Gold',
+  'Gray',
+  'Green',
+  'Indigo',
+  'Orange',
   'Pink',
   'Purple',
+  'Red',
+  'Scale',
+  'Slate',
+  'Tomato',
   'Violet',
-  'Indigo',
-  'Blue',
-  'Green',
-  'Gold',
-  'Orange',
-  'Amber',
   'Yellow',
 ]
 

--- a/apps/design-system/components/color-palette.tsx
+++ b/apps/design-system/components/color-palette.tsx
@@ -40,7 +40,7 @@ const ColorPalette = () => {
   }
 
   return (
-    <div className="my-6 w-full overflow-x-auto">
+    <div className="my-6 w-full">
       <div className="flex min-w-[640px] flex-col gap-1">
         <div className={`grid gap-1 ${GRID_COLS}`}>
           <div />

--- a/apps/design-system/components/mdx-components.tsx
+++ b/apps/design-system/components/mdx-components.tsx
@@ -31,6 +31,7 @@ import { StyleWrapper } from './style-wrapper'
 import { Callout } from '@/components/callout'
 import { CodeBlockWrapper } from '@/components/code-block-wrapper'
 import { CodeFragment } from '@/components/code-fragment'
+import { ColorPalette } from '@/components/color-palette'
 import { Colors } from '@/components/colors'
 import { ComponentExample } from '@/components/component-example'
 import { ComponentPreview } from '@/components/component-preview'
@@ -265,6 +266,7 @@ const components = {
     />
   ),
   Colors,
+  ColorPalette,
   Icons,
   ThemeSettings,
   CodeFragment,

--- a/apps/design-system/content/docs/color-usage.mdx
+++ b/apps/design-system/content/docs/color-usage.mdx
@@ -72,6 +72,7 @@ These can also be accessed with `foreground`. Like `text-foreground-light`.
 
 ## Color palette
 
-Every Radix scale exposed via `--colors-{name}{1..12}`. Click a swatch to copy the CSS variable reference.
+Every Radix scale exposed via `--colors-{name}{1..12}`. Click a swatch to copy the CSS variable reference. The colors are taken
+from `@radix-ui/colors` v0.1.9 except the `Brand` and `Scale` colors.
 
 <ColorPalette />

--- a/apps/design-system/content/docs/color-usage.mdx
+++ b/apps/design-system/content/docs/color-usage.mdx
@@ -69,3 +69,9 @@ This is not to be confused with `Dialogs`, they require to use the same app back
 These can also be accessed with `foreground`. Like `text-foreground-light`.
 
 <Colors definition={'colors'} />
+
+## Color palette
+
+Every Radix scale exposed via `--colors-{name}{1..12}`. Click a swatch to copy the CSS variable reference.
+
+<ColorPalette />


### PR DESCRIPTION
This PR adds a color palette to the Design system for easier reference.

<img width="1325" height="1200" alt="Screenshot 2026-05-08 at 17 18 51" src="https://github.com/user-attachments/assets/7de77c15-f6c6-4691-9875-eea72919ff7d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interactive color palette: displays named colors with 12 scale steps; click a swatch to copy its CSS variable and see brief "Copied!" feedback.

* **Documentation**
  * Added a "Color palette" section to the color usage docs with instructions and an embedded palette for exploring and copying CSS variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->