### PR TITLE
feat(www): surface on-demand webinars and rework /events hero CTAs

### DIFF
--- a/apps/www/app/events/context.tsx
+++ b/apps/www/app/events/context.tsx
@@ -6,6 +6,7 @@ import { createContext, ReactNode, useContext, useEffect, useMemo, useState } fr
 interface EventsContextValue {
   allEvents: SupabaseEvent[]
   filteredEvents: SupabaseEvent[]
+  pastWebinars: SupabaseEvent[]
   featuredEvent: SupabaseEvent | undefined
   isLoading: boolean
   searchQuery: string
@@ -96,22 +97,44 @@ export function EventsProvider({ children, notionEvents, mdxEvents }: EventsProv
     fetchLumaEvents()
   }, [])
 
-  // Merge Notion (server) + mdx (server) + Luma (client) events, showing only today and future.
-  const allEvents = useMemo(() => {
+  // Merge Notion (server) + mdx (server) + Luma (client) events.
+  const allEvents = useMemo(
+    () => [...notionEvents, ...mdxEvents, ...lumaEvents],
+    [notionEvents, mdxEvents, lumaEvents]
+  )
+
+  const startOfToday = useMemo(() => {
     const now = new Date()
-    const startOfToday = new Date(
-      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
-    )
-    return [...notionEvents, ...mdxEvents, ...lumaEvents].filter((event) => {
-      const eventDate = new Date(event.end_date || event.date)
-      return eventDate >= startOfToday
-    })
-  }, [notionEvents, mdxEvents, lumaEvents])
+    return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  }, [])
+
+  // Today-or-future events drive the main listing, filters, and hero.
+  const upcomingEvents = useMemo(
+    () =>
+      allEvents.filter((event) => {
+        const eventDate = new Date(event.end_date || event.date)
+        return eventDate >= startOfToday
+      }),
+    [allEvents, startOfToday]
+  )
+
+  // Past webinars become on-demand content. Sort newest first.
+  const pastWebinars = useMemo(
+    () =>
+      allEvents
+        .filter((event) => {
+          const eventDate = new Date(event.end_date || event.date)
+          if (eventDate >= startOfToday) return false
+          return event.type === 'webinar' || event.categories?.includes('webinar')
+        })
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()),
+    [allEvents, startOfToday]
+  )
 
   const categories = useMemo(() => {
     const counts: { [key: string]: number } = { all: 0 }
 
-    allEvents.forEach((event) => {
+    upcomingEvents.forEach((event) => {
       counts.all += 1
       event.categories?.forEach((category) => {
         counts[category] = (counts[category] || 0) + 1
@@ -119,7 +142,7 @@ export function EventsProvider({ children, notionEvents, mdxEvents }: EventsProv
     })
 
     return counts
-  }, [allEvents])
+  }, [upcomingEvents])
 
   const toggleCategory = (category: string) => {
     if (category === 'all') {
@@ -140,7 +163,7 @@ export function EventsProvider({ children, notionEvents, mdxEvents }: EventsProv
   }
 
   const filteredEvents = useMemo(() => {
-    let filtered = allEvents
+    let filtered = upcomingEvents
 
     if (!selectedCategories.includes('all')) {
       filtered = filtered.filter((event) =>
@@ -165,17 +188,20 @@ export function EventsProvider({ children, notionEvents, mdxEvents }: EventsProv
       const dateB = new Date(b.date).getTime()
       return dateA - dateB
     })
-  }, [allEvents, selectedCategories, searchQuery])
+  }, [upcomingEvents, selectedCategories, searchQuery])
 
   const featuredEvent = useMemo(() => {
-    if (allEvents.length === 0) return undefined
+    if (upcomingEvents.length === 0) return undefined
 
-    return [...allEvents].sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())[0]
-  }, [allEvents])
+    return [...upcomingEvents].sort(
+      (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime()
+    )[0]
+  }, [upcomingEvents])
 
   const value: EventsContextValue = {
     allEvents,
     filteredEvents,
+    pastWebinars,
     featuredEvent,
     isLoading,
     searchQuery,

--- a/apps/www/components/Events/new/EventBanner.tsx
+++ b/apps/www/components/Events/new/EventBanner.tsx
@@ -15,13 +15,40 @@ export function EventBanner() {
 
   if (!featuredEvent) return null
 
+  const isWebinar =
+    featuredEvent.type === 'webinar' || featuredEvent.categories?.includes('webinar')
+  const internalPath = featuredEvent.path
+  const hasInternalLanding = !!internalPath
+  const externalLink = featuredEvent.link
+  const externalIsRegistration = !!externalLink && externalLink.href !== internalPath
+  const showDualWebinarCtas = isWebinar && hasInternalLanding && externalIsRegistration
+
+  // Title link: prefer internal landing page, otherwise external link.
+  const titleHref = internalPath || externalLink?.href
+  const titleTarget: '_blank' | '_self' | undefined = internalPath ? '_self' : externalLink?.target
+
+  const TitleHeading = (
+    <h2 className="text-2xl font-medium lg:line-clamp-2">{featuredEvent.title}</h2>
+  )
+
   return (
     <section className="flex flex-col gap-6 rounded-lg py-6">
       <article className="flex flex-col md:flex-row md:items-stretch gap-8 lg:py-2">
         <div className="flex flex-col gap-6 flex-1">
           <div className="flex flex-col">
             <div className="flex items-center gap-4">
-              <h2 className="text-2xl font-medium lg:line-clamp-2">{featuredEvent.title}</h2>
+              {titleHref ? (
+                <Link
+                  href={titleHref}
+                  target={titleTarget}
+                  rel={titleTarget === '_blank' ? 'noopener noreferrer' : undefined}
+                  className="hover:text-foreground-light transition-colors"
+                >
+                  {TitleHeading}
+                </Link>
+              ) : (
+                TitleHeading
+              )}
               {featuredEvent.isSpeaking && (
                 <Badge variant="success" className="flex items-center gap-1 shrink-0">
                   Speaking
@@ -49,7 +76,7 @@ export function EventBanner() {
             <LocationWidget location={featuredEvent.location} />
           </div>
 
-          <div className="flex items-center md:justify-end gap-2">
+          <div className="flex items-center md:justify-end gap-2 flex-wrap">
             {featuredEvent.meetingLink && (
               <Button type="secondary" size="medium" asChild>
                 <Link href={featuredEvent.meetingLink} target="_blank" rel="noopener noreferrer">
@@ -57,16 +84,33 @@ export function EventBanner() {
                 </Link>
               </Button>
             )}
-            {featuredEvent.link && (
-              <Button size="medium" asChild iconRight={<ArrowRightIcon size={14} />}>
-                <Link
-                  href={featuredEvent.link.href}
-                  target={featuredEvent.link.target}
-                  rel="noopener noreferrer"
-                >
-                  Register
-                </Link>
-              </Button>
+            {showDualWebinarCtas ? (
+              <>
+                <Button type="secondary" size="medium" asChild>
+                  <Link href={internalPath}>Learn more</Link>
+                </Button>
+                <Button size="medium" asChild iconRight={<ArrowRightIcon size={14} />}>
+                  <Link
+                    href={externalLink!.href}
+                    target={externalLink!.target}
+                    rel="noopener noreferrer"
+                  >
+                    {externalLink!.label || 'Register now'}
+                  </Link>
+                </Button>
+              </>
+            ) : (
+              externalLink && (
+                <Button size="medium" asChild iconRight={<ArrowRightIcon size={14} />}>
+                  <Link
+                    href={externalLink.href}
+                    target={externalLink.target}
+                    rel="noopener noreferrer"
+                  >
+                    {externalLink.label || (isWebinar ? 'Register' : 'Learn more')}
+                  </Link>
+                </Button>
+              )
             )}
           </div>
         </div>

--- a/apps/www/components/Events/new/EventClientRenderer.tsx
+++ b/apps/www/components/Events/new/EventClientRenderer.tsx
@@ -4,18 +4,68 @@ import { EventsProvider, useEvents } from '~/app/events/context'
 import { EventBanner } from '~/components/Events/new/EventBanner'
 import DefaultLayout from '~/components/Layouts/Default'
 import { SupabaseEvent } from '~/lib/eventsTypes'
+import { ArrowRightIcon } from 'lucide-react'
+import Link from 'next/link'
+import { Button } from 'ui'
 
 import { EventGallery } from './EventGallery'
 import { EventsContainer } from './EventsContainer'
+import { OnDemandWebinars } from './OnDemandWebinars'
 
 function EventBannerSection() {
-  const { isLoading, featuredEvent } = useEvents()
-  if (!isLoading && !featuredEvent) return null
+  const { isLoading, featuredEvent, pastWebinars } = useEvents()
+  if (isLoading) {
+    return (
+      <EventsContainer className="border-x border-b flex-1 py-8 bg-surface-200">
+        <EventBanner />
+      </EventsContainer>
+    )
+  }
+  if (featuredEvent) {
+    return (
+      <EventsContainer className="border-x border-b flex-1 py-8 bg-surface-200">
+        <EventBanner />
+      </EventsContainer>
+    )
+  }
 
+  // Fallback hero when there are no upcoming events.
   return (
     <EventsContainer className="border-x border-b flex-1 py-8 bg-surface-200">
-      <EventBanner />
+      <section className="flex flex-col md:flex-row md:items-center md:justify-between gap-6 py-6">
+        <div className="flex flex-col gap-2 max-w-xl">
+          <h2 className="text-2xl font-medium">No upcoming events right now</h2>
+          <p className="text-foreground-light">
+            We're between events at the moment. In the meantime, catch up on our on-demand webinars
+            below.
+          </p>
+        </div>
+        {pastWebinars.length > 0 && (
+          <Button size="medium" asChild iconRight={<ArrowRightIcon size={14} />}>
+            <Link href="#on-demand-webinars">Watch on-demand</Link>
+          </Button>
+        )}
+      </section>
     </EventsContainer>
+  )
+}
+
+function OnDemandWebinarsSection() {
+  const { pastWebinars, isLoading } = useEvents()
+  if (isLoading || pastWebinars.length === 0) return null
+
+  return (
+    <>
+      <EventsContainer className="border-x border-b py-8" id="on-demand-webinars">
+        <h2 className="h3 p-0! m-0!">On-demand webinars</h2>
+        <p className="text-foreground-light">
+          Catch up on past webinars and recorded sessions, available to watch any time.
+        </p>
+      </EventsContainer>
+      <EventsContainer className="border-x border-b py-8">
+        <OnDemandWebinars />
+      </EventsContainer>
+    </>
   )
 }
 
@@ -38,9 +88,11 @@ export function EventClientRenderer({
 
         <EventBannerSection />
 
-        <EventsContainer className="border-x flex-1 py-8">
+        <EventsContainer className="border-x border-b flex-1 py-8 min-h-[600px] flex flex-col">
           <EventGallery />
         </EventsContainer>
+
+        <OnDemandWebinarsSection />
       </DefaultLayout>
     </EventsProvider>
   )

--- a/apps/www/components/Events/new/EventGallery.tsx
+++ b/apps/www/components/Events/new/EventGallery.tsx
@@ -1,11 +1,12 @@
 import { cn } from 'ui'
+
 import { EventGalleryFilters } from './EventGalleryFilters'
 import { EventList } from './EventList'
 import { EventTimeline } from './EventTimeline'
 
 export function EventGallery() {
   return (
-    <section className={cn('grid md:grid-cols-[minmax(320px,35%)_16px_1fr] gap-12')}>
+    <section className={cn('grid md:grid-cols-[minmax(320px,35%)_16px_1fr] gap-12 flex-1')}>
       <div className="sticky top-16 md:top-24 py-4 bg-background self-start z-10">
         <EventGalleryFilters />
       </div>

--- a/apps/www/components/Events/new/EventsContainer.tsx
+++ b/apps/www/components/Events/new/EventsContainer.tsx
@@ -3,11 +3,15 @@ import { cn } from 'ui'
 interface EventsContainerProps {
   children: React.ReactNode
   className?: string
+  id?: string
 }
 
-export function EventsContainer({ children, className }: EventsContainerProps) {
+export function EventsContainer({ children, className, id }: EventsContainerProps) {
   return (
-    <div className={cn('relative mx-auto w-full max-w-5xl px-4 lg:px-10 xl:px-14', className)}>
+    <div
+      id={id}
+      className={cn('relative mx-auto w-full max-w-5xl px-4 lg:px-10 xl:px-14', className)}
+    >
       {children}
     </div>
   )

--- a/apps/www/components/Events/new/OnDemandWebinars.tsx
+++ b/apps/www/components/Events/new/OnDemandWebinars.tsx
@@ -1,0 +1,77 @@
+'use client'
+
+import { useEvents } from '~/app/events/context'
+import Link from 'next/link'
+import { Badge } from 'ui'
+
+export function OnDemandWebinars() {
+  const { pastWebinars } = useEvents()
+
+  if (pastWebinars.length === 0) return null
+
+  return (
+    <section className="flex flex-col gap-6">
+      <ul className="grid gap-4 sm:grid-cols-2">
+        {pastWebinars.map((event) => {
+          const internalPath = event.path
+          const externalLink = event.link
+          const watchHref = internalPath || externalLink?.href
+          const watchTarget: '_blank' | '_self' | undefined = internalPath
+            ? '_self'
+            : externalLink?.target
+
+          const eventDate = new Date(event.date).toLocaleDateString('en-US', {
+            month: 'short',
+            day: 'numeric',
+            year: 'numeric',
+          })
+
+          return (
+            <li
+              key={`${event.source}-${event.slug}-${event.date}`}
+              className="bg-surface-100 border rounded-md p-4 flex flex-col gap-4 relative hover:border-stronger transition-colors"
+            >
+              {watchHref && (
+                <Link
+                  className="absolute inset-0"
+                  href={watchHref}
+                  target={watchTarget}
+                  rel={watchTarget === '_blank' ? 'noopener noreferrer' : undefined}
+                  aria-label={`Watch ${event.title}`}
+                />
+              )}
+
+              <div className="flex items-start justify-between gap-2">
+                <Badge>Webinar</Badge>
+                <span className="text-xs text-foreground-light">{eventDate}</span>
+              </div>
+
+              <h3 className="text-base font-medium leading-snug line-clamp-2">{event.title}</h3>
+
+              {event.description && (
+                <p className="text-sm text-foreground-light line-clamp-3 flex-1">
+                  {event.description}
+                </p>
+              )}
+
+              {event.hosts.length > 0 && (
+                <div className="flex gap-2 items-center text-xs text-foreground-light">
+                  <div className="size-5 rounded-full border bg-linear-to-br from-background-surface-100 to-background-surface-200 relative overflow-hidden">
+                    {event.hosts[0]?.avatar_url && (
+                      <img
+                        src={event.hosts[0].avatar_url}
+                        alt={event.hosts[0].name || 'Host image'}
+                        className="absolute inset-0 w-full h-full object-cover"
+                      />
+                    )}
+                  </div>
+                  {event.hosts[0]?.name || 'Supabase'}
+                </div>
+              )}
+            </li>
+          )
+        })}
+      </ul>
+    </section>
+  )
+}

--- a/apps/www/lib/events.ts
+++ b/apps/www/lib/events.ts
@@ -202,8 +202,8 @@ function startOfTodayUtc(): Date {
 }
 
 /**
- * Read all events under `_events/` and return today-and-future events.
- * Past events are excluded (by end_date when present, otherwise start date).
+ * Read all events under `_events/` and return today-and-future events,
+ * plus past webinars (which remain useful as on-demand content).
  */
 export const getMdxEvents = (): SupabaseEvent[] => {
   const postDirectory = path.join(process.cwd(), EVENTS_DIRECTORY)
@@ -228,13 +228,15 @@ export const getMdxEvents = (): SupabaseEvent[] => {
 
         if (!data.title || !data.date) return null
 
-        const eventEnd = new Date(data.end_date ?? data.date)
-        if (eventEnd < today) return null
-
         const slug = mdxSlugFromFilename(filename)
         const categories = data.categories ?? (data.type ? [data.type] : [])
         // Webinars don't show a "Hosted by" line — drop hosts entirely.
         const isWebinar = data.type === 'webinar' || categories.includes('webinar')
+
+        const eventEnd = new Date(data.end_date ?? data.date)
+        // Past non-webinars are dropped; past webinars stay so they can be
+        // listed in the on-demand section.
+        if (eventEnd < today && !isWebinar) return null
         const rawCtaUrl = data.main_cta?.url ?? ''
         const isExternalCta = /^https?:\/\//i.test(rawCtaUrl)
         const safeExternalCta = isExternalCta && isSafeHttpUrl(rawCtaUrl) ? rawCtaUrl : ''


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature / UX improvement on the marketing \`/events\` page.

## What is the current behavior?

Past webinars were filtered out of the listing entirely, so on-demand recordings were unreachable. The hero (featured upcoming event) wasn't clickable, only had a single \"Register\" CTA, and the section disappeared completely when nothing was upcoming. The timeline guideline collapsed when there were only a few events. Closes [DEBR-167](https://linear.app/supabase/issue/DEBR-167).

## What is the new behavior?

- \`getMdxEvents\` keeps past webinars; \`EventsProvider\` exposes \`pastWebinars\` separately from \`upcomingEvents\`.
- New \`OnDemandWebinars\` section renders a 2-column card grid below the upcoming gallery, with header styling matching the page hero. Whole card is clickable; muted Webinar badge.
- Hero title is now a \`<Link>\` (to internal landing page when available, otherwise external). Webinars with both an internal page and an external registration URL render dual CTAs: \"Learn more\" (secondary) + \"Register now\" (brand).
- Fallback hero appears when there are no upcoming events, with a CTA jumping to the on-demand section.
- Gallery container is \`flex flex-col min-h-[600px]\` and the gallery itself is \`flex-1\`, so the timeline dashed line fills the full container height.

## Additional context

No data-model changes; everything keys off existing mdx frontmatter (\`type: webinar\`, \`onDemand\`, \`main_cta\`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced on-demand webinars section displaying past webinar recordings in a responsive gallery
  * Enhanced webinar event detail pages with improved call-to-action buttons for registration and additional information
  * Added fallback messaging when no upcoming events are scheduled

<!-- end of auto-generated comment: release notes by coderabbit.ai -->