### PR TITLE
fix: authenticate GitHub Status API in Vercel deployment auth script

### DIFF
--- a/scripts/authorizeVercelDeploys.ts
+++ b/scripts/authorizeVercelDeploys.ts
@@ -38,7 +38,13 @@ async function fetchGitHubStatuses(sha: string): Promise<GitHubStatus[]> {
   const url = `https://api.github.com/repos/supabase/supabase/statuses/${sha}`
   console.log(`Fetching GitHub statuses for SHA: ${sha}`)
 
-  const response = await fetch(url)
+  const headers: Record<string, string> = {}
+  
+  if (process.env.GITHUB_TOKEN) {
+    headers['Authorization'] = `token ${process.env.GITHUB_TOKEN}`
+  }
+
+  const response = await fetch(url, { headers })
   if (!response.ok) {
     throw new Error(`Failed to fetch GitHub statuses: ${response.status} ${response.statusText}`)
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Vercel deployment authorization script (`scripts/authorizeVercelDeploys.ts`) calls the GitHub Status API without authentication. Because it relies on public, unauthenticated `fetch` requests, it makes the CI/CD pipeline vulnerable to strict GitHub API rate limits which can cause unexpected Vercel deployment authorization failures.

Fixes #45672 

## What is the new behavior?

The `fetchGitHubStatuses` function has been updated to securely check for the `GITHUB_TOKEN` environment variable. If the token is available, it is now safely attached to the `Authorization` header as a bearer token (`token ${process.env.GITHUB_TOKEN}`). This prevents the script from hitting unauthenticated API rate limits while retaining backwards compatibility if the token is omitted.

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of deployment status checks by conditionally authenticating with GitHub when credentials are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->