### PR TITLE
fix: display inactivity timeout in human readable format

### DIFF
--- a/apps/studio/components/interfaces/Auth/ProtectionAuthSettingsForm/ProtectionAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/ProtectionAuthSettingsForm/ProtectionAuthSettingsForm.tsx
@@ -49,6 +49,14 @@ const CAPTCHA_PROVIDERS = [
 
 type CaptchaProviders = 'hcaptcha' | 'turnstile'
 
+function secondsToHours(seconds: number): number {
+  return seconds / 3600
+}
+
+function hoursToSeconds(hours: number): number {
+  return Math.round(hours * 3600)
+}
+
 const baseSchema = z.object({
   DISABLE_SIGNUP: z.boolean(),
   EXTERNAL_ANONYMOUS_USERS_ENABLED: z.boolean(),
@@ -167,8 +175,10 @@ export const ProtectionAuthSettingsForm = () => {
           SECURITY_CAPTCHA_ENABLED: authConfig.SECURITY_CAPTCHA_ENABLED,
           SECURITY_CAPTCHA_SECRET: authConfig.SECURITY_CAPTCHA_SECRET || '',
           SECURITY_CAPTCHA_PROVIDER,
-          SESSIONS_TIMEBOX: authConfig.SESSIONS_TIMEBOX || 0,
-          SESSIONS_INACTIVITY_TIMEOUT: authConfig.SESSIONS_INACTIVITY_TIMEOUT || 0,
+          SESSIONS_TIMEBOX: secondsToHours(authConfig.SESSIONS_TIMEBOX || 0),
+          SESSIONS_INACTIVITY_TIMEOUT: secondsToHours(
+            authConfig.SESSIONS_INACTIVITY_TIMEOUT || 0
+          ),
           SESSIONS_SINGLE_PER_USER: authConfig.SESSIONS_SINGLE_PER_USER || false,
           PASSWORD_MIN_LENGTH: authConfig.PASSWORD_MIN_LENGTH || 6,
           PASSWORD_REQUIRED_CHARACTERS:
@@ -184,8 +194,10 @@ export const ProtectionAuthSettingsForm = () => {
           SECURITY_CAPTCHA_ENABLED: authConfig.SECURITY_CAPTCHA_ENABLED,
           SECURITY_CAPTCHA_SECRET: authConfig.SECURITY_CAPTCHA_SECRET || '',
           SECURITY_CAPTCHA_PROVIDER,
-          SESSIONS_TIMEBOX: authConfig.SESSIONS_TIMEBOX || 0,
-          SESSIONS_INACTIVITY_TIMEOUT: authConfig.SESSIONS_INACTIVITY_TIMEOUT || 0,
+          SESSIONS_TIMEBOX: secondsToHours(authConfig.SESSIONS_TIMEBOX || 0),
+          SESSIONS_INACTIVITY_TIMEOUT: secondsToHours(
+            authConfig.SESSIONS_INACTIVITY_TIMEOUT || 0
+          ),
           SESSIONS_SINGLE_PER_USER: authConfig.SESSIONS_SINGLE_PER_USER || false,
           PASSWORD_MIN_LENGTH: authConfig.PASSWORD_MIN_LENGTH || 6,
           PASSWORD_REQUIRED_CHARACTERS:
@@ -197,7 +209,11 @@ export const ProtectionAuthSettingsForm = () => {
   }, [authConfig, isUpdatingConfig])
 
   const onSubmitProtection = (values: any) => {
-    const payload = { ...values }
+    const payload = {
+      ...values,
+      SESSIONS_TIMEBOX: hoursToSeconds(values.SESSIONS_TIMEBOX),
+      SESSIONS_INACTIVITY_TIMEOUT: hoursToSeconds(values.SESSIONS_INACTIVITY_TIMEOUT),
+    }
     payload.DISABLE_SIGNUP = !values.DISABLE_SIGNUP
     // The backend uses empty string to represent no required characters in the password
     if (payload.PASSWORD_REQUIRED_CHARACTERS === NO_REQUIRED_CHARACTERS) {

--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
@@ -48,6 +48,14 @@ function HoursOrNeverText({ value }: { value: number }) {
   }
 }
 
+function secondsToHours(seconds: number): number {
+  return seconds / 3600
+}
+
+function hoursToSeconds(hours: number): number {
+  return Math.round(hours * 3600)
+}
+
 const RefreshTokenSchema = z.object({
   REFRESH_TOKEN_ROTATION_ENABLED: z.boolean(),
   SECURITY_REFRESH_TOKEN_REUSE_INTERVAL: z.coerce.number().min(0, 'Must be a value more than 0'),
@@ -118,8 +126,10 @@ export const SessionsAuthSettingsForm = () => {
 
       if (!isUpdatingUserSessions) {
         userSessionsForm.reset({
-          SESSIONS_TIMEBOX: authConfig.SESSIONS_TIMEBOX || 0,
-          SESSIONS_INACTIVITY_TIMEOUT: authConfig.SESSIONS_INACTIVITY_TIMEOUT || 0,
+          SESSIONS_TIMEBOX: secondsToHours(authConfig.SESSIONS_TIMEBOX || 0),
+          SESSIONS_INACTIVITY_TIMEOUT: secondsToHours(
+            authConfig.SESSIONS_INACTIVITY_TIMEOUT || 0
+          ),
           SESSIONS_SINGLE_PER_USER: authConfig.SESSIONS_SINGLE_PER_USER || false,
         })
       }
@@ -146,7 +156,11 @@ export const SessionsAuthSettingsForm = () => {
   }
 
   const onSubmitUserSessions = (values: any) => {
-    const payload = { ...values }
+    const payload = {
+      ...values,
+      SESSIONS_TIMEBOX: hoursToSeconds(values.SESSIONS_TIMEBOX),
+      SESSIONS_INACTIVITY_TIMEOUT: hoursToSeconds(values.SESSIONS_INACTIVITY_TIMEOUT),
+    }
     setIsUpdatingUserSessions(true)
 
     updateAuthConfig(


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix (UI/display issue)

## What is the current behavior?

Fixes #35990

The `auth.sessions.inactivity_timeout` value is correctly configured in `config.toml` using duration format such as:

```toml
[auth.sessions]
inactivity_timeout = "10h0m0s"
```

During deployment, the backend correctly converts this value internally to seconds (`36000`).

However, in the Supabase Dashboard/Auth Sessions UI, the value is displayed directly as `36000` without clarifying that the unit is seconds. This creates confusion because users expect the configured duration (`10 hours`) rather than the raw converted value.

## What is the new behavior?

This PR improves the handling/display of `inactivity_timeout` in the Dashboard UI by converting the raw seconds value into a human-readable format before rendering.

Example:

* Previous UI display: `36000`
* New UI display: `10`

The conversion back to seconds for API requests is still preserved internally, so backend behavior remains unchanged.

This fix only affects frontend display and conversion handling near the API boundary.

## Additional context

* Backend behavior was already correct.
* The issue was caused by unclear frontend unit representation.
* The fix improves UX and prevents confusion when editing Auth Session settings.

Tested locally by:

1. Running Supabase backend with Docker
2. Launching Studio dashboard locally
3. Navigating to:

```txt
/auth/sessions
```

4. Verifying:

   * Existing values render correctly in hours
   * Saving changes correctly converts values back to seconds for the API
<img width="1422" height="689" alt="Screenshot 2026-05-09 at 3 25 09 AM" src="https://github.com/user-attachments/assets/b682d677-f566-47d2-a0d4-2a88263c89f3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session timeout values in authentication settings now use hours for input, with automatic conversion to seconds for backend compatibility.
  * Simplified session timeout configuration across authentication settings forms for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->