### PR TITLE
fix(www): add max-w-full to realtime hero image to fix mobile overflow

### DIFF
--- a/apps/www/pages/realtime.tsx
+++ b/apps/www/pages/realtime.tsx
@@ -98,7 +98,7 @@ function RealtimePage() {
           h1={[<span key={'authentication-h1'}>Build modern web and mobile applications</span>]}
           subheader={['Sync client state globally over WebSockets in Realtime']}
           image={[
-            <div className="bg-surface-100 border-default relative flex h-[372px] w-[560px] items-center justify-center overflow-hidden rounded-sm border drop-shadow-md">
+            <div className="bg-surface-100 border-default relative flex h-[372px] w-[560px] max-w-full items-center justify-center overflow-hidden rounded-sm border drop-shadow-md">
               <div
                 className={[
                   'border-brand-300 relative h-12 w-48 bg-brand',


### PR DESCRIPTION
## Problem
The realtime page hero section has a fixed `w-[560px]` container for the interactive cursor demo. On viewports smaller than 560px this causes horizontal overflow and breaks the mobile layout.

## Fix
Added `max-w-full` to the image container so it caps at 560px on desktop and shrinks to fit on smaller screens. The existing `overflow-hidden` on the same element cleanly clips internal absolutely positioned cursors.

## File changed
`apps/www/pages/realtime.tsx`

## Screenshots

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/ae04cde1-e65c-4077-8c01-2a2fbb2b9392" width="300" /> | <img src="https://github.com/user-attachments/assets/f5992e26-200d-4ec7-800b-78f2b851bcf7" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Enhanced responsive design for the Realtime page's hero image container, improving its display consistency across different screen sizes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45736)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->