### PR TITLE
fix(www): fix broken vector link in MagnifiedProducts component

### DIFF
--- a/apps/www/components/MagnifiedProducts.tsx
+++ b/apps/www/components/MagnifiedProducts.tsx
@@ -174,7 +174,7 @@ const products = {
     description: 'Integrate your favorite ML-models to store, index and search vector embeddings.',
     description_short: '',
     label: '',
-    url: '/vector',
+    url: '/modules/vector',
   },
 }
 


### PR DESCRIPTION
## Problem
The Vector product link in the MagnifiedProducts component points to `/vector` which returns a 404. The correct URL is `/modules/vector`.

## Fix
Updated the url field for the vector product from `/vector` to `/modules/vector`.

## File changed
`apps/www/components/MagnifiedProducts.tsx`

## Steps to reproduce
1. Go to any page that renders MagnifiedProducts (e.g. supabase.com/edge-functions)
2. Click the Vector icon
3. Gets a 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated module path structure for product assets to improve organization and navigation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45737)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->