### PR TITLE
chore: extract common cell formatter from SelectorGrid

### DIFF
--- a/apps/studio/components/grid/components/formatter/SelectGridCellFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/SelectGridCellFormatter.tsx
@@ -1,0 +1,30 @@
+import { NullValue } from '../common/NullValue'
+import { SupaRow } from '@/components/grid/types'
+import { convertByteaToHex } from '@/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
+
+interface SelectGridCellFormatterProps {
+  row: SupaRow
+  column: string
+  format: string
+}
+
+export const SelectGridCellFormatter = ({ row, column, format }: SelectGridCellFormatterProps) => {
+  const formattedValue =
+    format === 'bytea'
+      ? convertByteaToHex(row[column])
+      : row[column] === null
+        ? null
+        : typeof row[column] === 'object'
+          ? JSON.stringify(row[column])
+          : row[column]
+
+  return (
+    <div className="group sb-grid-select-cell__formatter overflow-hidden">
+      {formattedValue === null ? (
+        <NullValue />
+      ) : (
+        <span className="text-sm truncate">{formattedValue}</span>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/SelectorGrid.tsx
@@ -2,8 +2,7 @@ import { Key } from 'lucide-react'
 import DataGrid, { Column } from 'react-data-grid'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
-import { convertByteaToHex } from '../RowEditor.utils'
-import { NullValue } from '@/components/grid/components/common/NullValue'
+import { SelectGridCellFormatter } from '@/components/grid/components/formatter/SelectGridCellFormatter'
 import { COLUMN_MIN_WIDTH } from '@/components/grid/constants'
 import type { SupaRow } from '@/components/grid/types'
 import {
@@ -36,28 +35,6 @@ const columnRender = (name: string, isPrimaryKey = false) => {
   )
 }
 
-// TODO: move this formatter out to a common component
-const formatter = ({ column, format, row }: { column: string; format: string; row: SupaRow }) => {
-  const formattedValue =
-    format === 'bytea'
-      ? convertByteaToHex(row[column])
-      : row[column] === null
-        ? null
-        : typeof row[column] === 'object'
-          ? JSON.stringify(row[column])
-          : row[column]
-
-  return (
-    <div className="group sb-grid-select-cell__formatter overflow-hidden">
-      {formattedValue === null ? (
-        <NullValue />
-      ) : (
-        <span className="text-sm truncate">{formattedValue}</span>
-      )}
-    </div>
-  )
-}
-
 const SelectorGrid = ({ rows, onRowSelect }: SelectorGridProps) => {
   const snap = useTableEditorTableStateSnapshot()
 
@@ -71,8 +48,9 @@ const SelectorGrid = ({ rows, onRowSelect }: SelectorGridProps) => {
     const result: Column<SupaRow> = {
       key: column.name,
       name: column.name,
-      renderCell: (props) =>
-        formatter({ column: column.name, format: column.format, row: props.row }),
+      renderCell: (props) => (
+        <SelectGridCellFormatter column={column.name} format={column.format} row={props.row} />
+      ),
       renderHeaderCell: () => columnRender(column.name, column.isPrimaryKey),
       resizable: true,
       width: columnWidth,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

chore (refactoring)

## What is the current behavior?

The `SelectorGrid` component used a local `formatter` function for data display, which was marked with a `TODO` for extraction.

Fixes #45739

## What is the new behavior?

The formatting logic has been moved to a new shared component: `apps/studio/components/grid/components/formatter/SelectGridCellFormatter.tsx`. 

- `SelectorGrid.tsx` now imports and uses this common formatter.
- Logic for handling `bytea`, `null`, and `object` (JSON) types remains identical to ensure no regressions.
- Code duplication is reduced and the component is now more modular.

## Additional context

- Successfully ran `pnpm turbo run typecheck --filter=studio` to ensure type safety.
- Verified that the `sb-grid-select-cell__formatter` styles are correctly applied.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored grid cell rendering in studio to improve code organization. Extracted data formatting logic into a reusable component that handles rendering of various data types including binary data, null values, and complex objects, reducing code duplication across different grid interfaces.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45740)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->