### PR TITLE
feat(reports): add swap usage chart to database report

### DIFF
--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -75,6 +75,33 @@ export const getReportAttributesV2: (
       ],
     },
     {
+      id: 'swap-usage',
+      label: 'Swap usage',
+      docsUrl: `${DOCS_URL}/guides/telemetry/reports#memory-usage`,
+      hide: false,
+      showTooltip: true,
+      showLegend: false,
+      hideChartType: false,
+      defaultChartStyle: 'bar',
+      showMaxValue: false,
+      showGrid: true,
+      syncId: 'database-reports',
+      valuePrecision: 2,
+      YAxisProps: {
+        width: 75,
+        tickFormatter: (value: any) => formatBytes(value, 2),
+      },
+      attributes: [
+        {
+          attribute: 'swap_usage',
+          provider: 'infra-monitoring',
+          label: 'Swap',
+          tooltip:
+            'Swap space in use by the operating system. Sustained swap usage indicates memory pressure and may degrade database performance',
+        },
+      ],
+    },
+    {
       id: 'cpu-usage',
       label: 'CPU usage',
       docsUrl: `${DOCS_URL}/guides/telemetry/reports#cpu-usage`,


### PR DESCRIPTION
## Problem

The Database report in Observability surfaces memory, CPU, disk and connections but not swap usage. Sustained swap is a strong signal of memory pressure and one of the metrics Support typically asks for when investigating instability.

Closes [FE-3192](https://linear.app/supabase/issue/FE-3192/add-swap-usage-to-the-database-report).

## Fix

Add a new \`swap-usage\` chart entry to \`getReportAttributesV2\` in [apps/studio/data/reports/database-charts.ts](apps/studio/data/reports/database-charts.ts), placed right after the existing memory chart so the two read together. Uses the existing \`swap_usage\` infra-monitoring attribute (the series already exists, no backend work needed). Pattern mirrors the \`ram-usage\` chart: \`formatBytes\` Y-axis, bar default, same \`syncId\`.

## Test plan

- [ ] Open \`/project/<ref>/observability/database\` and confirm a "Swap usage" chart renders under the Memory chart with bytes on the Y-axis.
- [ ] Switch the date range and confirm the chart respects it (it auto-wires through \`REPORT_ATTRIBUTES.flatMap\`).
- [ ] Use the global refresh button and confirm the swap series invalidates with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Swap usage monitoring metric to the reports dashboard, enabling visibility into memory swap utilization alongside existing RAM and CPU usage metrics.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45746)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->