### PR TITLE
feat(reports): add network throughput chart to database report

### DIFF
--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -166,6 +166,38 @@ export const getReportAttributesV2: (
       ],
     },
     {
+      id: 'network-throughput',
+      label: 'Network throughput',
+      syncId: 'database-reports',
+      hide: false,
+      showTooltip: true,
+      format: 'bytes-per-second',
+      valuePrecision: 1,
+      showLegend: true,
+      showMaxValue: false,
+      hideChartType: false,
+      showGrid: true,
+      YAxisProps: {
+        width: 70,
+        tickFormatter: (value: any) => `${formatBytes(value, 1)}/s`,
+      },
+      defaultChartStyle: 'stackedAreaLine',
+      attributes: [
+        {
+          attribute: 'network_receive_bytes',
+          provider: 'infra-monitoring',
+          label: 'Network in',
+          tooltip: 'Inbound network throughput (bytes per second)',
+        },
+        {
+          attribute: 'network_transmit_bytes',
+          provider: 'infra-monitoring',
+          label: 'Network out',
+          tooltip: 'Outbound network throughput (bytes per second)',
+        },
+      ],
+    },
+    {
       id: 'disk-iops',
       label: 'Disk Input/Output operations per second (IOPS)',
       docsUrl: `${DOCS_URL}/guides/telemetry/reports#disk-inputoutput-operations-per-second-iops`,


### PR DESCRIPTION
## Problem

The Database report in Observability has no view of network traffic. Inbound/outbound throughput is useful for spotting saturation, large unexpected egress, or correlating spikes with disk I/O.

Closes [FE-3193](https://linear.app/supabase/issue/FE-3193/add-network-in-and-out-charts).

## Fix

Add a new \`network-throughput\` chart entry to \`getReportAttributesV2\` in [apps/studio/data/reports/database-charts.ts](apps/studio/data/reports/database-charts.ts), placed right before \`disk-iops\`. Uses the existing \`network_receive_bytes\` and \`network_transmit_bytes\` infra-monitoring attributes (series already exist, no backend work needed). Pattern mirrors the \`disk-throughput\` chart: bytes-per-second Y-axis, \`stackedAreaLine\` default, same \`syncId\`.

\`showMaxValue\` is \`false\` because there is no provisioned network max to render as a reference line.

## Test plan

- [ ] Open \`/project/<ref>/observability/database\` and confirm a "Network throughput" chart renders with two series (Network in / Network out) and a \`bytes/s\` Y-axis.
- [ ] Switch the date range and confirm the chart respects it (auto-wired via \`REPORT_ATTRIBUTES.flatMap\`).
- [ ] Use the global refresh button and confirm both series invalidate with the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a network throughput chart that visualizes inbound and outbound network throughput metrics with real-time speed data visualization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45747)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->