### PR TITLE
feat(studio): add Download as JSON option to SQL Editor results export

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -157,6 +157,12 @@ export const UtilityPanel = ({
                   groups: { project: ref ?? '', organization: org?.slug ?? '' },
                 })
               }
+              onDownloadAsJSON={() =>
+                sendEvent({
+                  action: 'sql_editor_result_download_json_clicked',
+                  groups: { project: ref ?? '', organization: org?.slug ?? '' },
+                })
+              }
               onCopyAsMarkdown={() => {
                 sendEvent({
                   action: 'sql_editor_result_copy_markdown_clicked',

--- a/apps/studio/components/ui/DownloadResultsButton.tsx
+++ b/apps/studio/components/ui/DownloadResultsButton.tsx
@@ -31,6 +31,7 @@ interface DownloadResultsButtonProps {
   results: any[]
   fileName: string
   onDownloadAsCSV?: () => void
+  onDownloadAsJSON?: () => void
   onCopyAsMarkdown?: () => void
   onCopyAsJSON?: () => void
   onCopyAsCSV?: () => void
@@ -44,6 +45,7 @@ export const DownloadResultsButton = ({
   results,
   fileName,
   onDownloadAsCSV,
+  onDownloadAsJSON,
   onCopyAsMarkdown,
   onCopyAsJSON,
   onCopyAsCSV,
@@ -64,6 +66,19 @@ export const DownloadResultsButton = ({
     saveAs(blob, `${fileName}.csv`)
     toast.success('Downloading results as CSV')
     onDownloadAsCSV?.()
+  }
+
+  const downloadAsJSON = () => {
+    const jsonData = convertResultsToJSON(results)
+    if (!jsonData) {
+      toast('Results are empty')
+      return
+    }
+
+    const blob = new Blob([jsonData], { type: 'application/json;charset=utf-8;' })
+    saveAs(blob, `${fileName}.json`)
+    toast.success('Downloading results as JSON')
+    onDownloadAsJSON?.()
   }
 
   const copyAsMarkdown = () => {
@@ -118,6 +133,10 @@ export const DownloadResultsButton = ({
     enabled: !isEmpty,
     registerInCommandMenu: true,
   })
+  useShortcut(SHORTCUT_IDS.RESULTS_DOWNLOAD_JSON, downloadAsJSON, {
+    enabled: !isEmpty,
+    registerInCommandMenu: true,
+  })
 
   return (
     <DropdownMenu>
@@ -167,6 +186,13 @@ export const DownloadResultsButton = ({
           <p>Download CSV</p>
           <span className="ml-auto">
             <KeyboardShortcut keys={['Shift', 'Meta', 'd']} />
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem className="gap-x-2" onClick={() => downloadAsJSON()}>
+          <Download size={14} />
+          <p>Download JSON</p>
+          <span className="ml-auto">
+            <KeyboardShortcut keys={['Shift', 'Meta', 'o']} />
           </span>
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -27,6 +27,7 @@ export const SHORTCUT_IDS = {
   RESULTS_COPY_JSON: 'results.copy-json',
   RESULTS_COPY_CSV: 'results.copy-csv',
   RESULTS_DOWNLOAD_CSV: 'results.download-csv',
+  RESULTS_DOWNLOAD_JSON: 'results.download-json',
   DATA_TABLE_TOGGLE_FILTERS: 'data-table.toggle-filters',
   DATA_TABLE_RESET_FILTERS: 'data-table.reset-filters',
   DATA_TABLE_RESET_COLUMNS: 'data-table.reset-columns',
@@ -139,6 +140,11 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     id: SHORTCUT_IDS.RESULTS_DOWNLOAD_CSV,
     label: 'Download results as CSV',
     sequence: ['Mod+Shift+D'],
+  },
+  [SHORTCUT_IDS.RESULTS_DOWNLOAD_JSON]: {
+    id: SHORTCUT_IDS.RESULTS_DOWNLOAD_JSON,
+    label: 'Download results as JSON',
+    sequence: ['Mod+Shift+O'],
   },
   [SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT]: {
     id: SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT,


### PR DESCRIPTION
The SQL Editor's Export dropdown supports downloading results as CSV, and copying as JSON/Markdown/CSV. However, there is no option to directly download results as a .json file.

What is the new behavior? Added a "Download JSON" option to the Export dropdown. It converts query results to formatted JSON, creates a Blob, and downloads it as a .json file. Includes keyboard shortcut Cmd/Ctrl+Shift+O and telemetry tracking. No new dependencies added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to download SQL query results as JSON format alongside existing CSV export.
  * Introduced keyboard shortcut (Mod+Shift+O) for quick JSON downloads.
  * Added "Download JSON" option to the results download menu.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45750)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->