### PR TITLE
fix(www): fix table overflow on mobile in MDX pages

### DIFF
--- a/apps/www/lib/mdx/mdxComponents.tsx
+++ b/apps/www/lib/mdx/mdxComponents.tsx
@@ -132,6 +132,11 @@ export default function mdxComponents(type?: 'blog' | 'lp' | undefined) {
     ),
     Admonition,
     Mermaid,
+    table: (props: any) => (
+      <div className="w-full overflow-x-auto">
+        <table {...props} />
+      </div>
+    ),
   }
 
   return components as any


### PR DESCRIPTION
## Problem
Markdown tables in MDX pages (e.g. /privacy) have no overflow handling. On small screens wide tables overflow horizontally 
breaking the layout and making content unreadable.

## Fix
Added a `table` component override in `mdxComponents.tsx` that wraps every rendered table in a `div` with `overflow-x-auto`, 
allowing horizontal scrolling on small viewports.

## File changed
`apps/www/lib/mdx/mdxComponents.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved table rendering to prevent horizontal overflow. Tables now display in a horizontally scrollable container on smaller screens, enhancing readability and layout consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45757)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->