### PR TITLE
fix(www): fix sticky events filter overlapped by event cards on scroll

### DIFF
--- a/apps/www/components/Events/new/EventGallery.tsx
+++ b/apps/www/components/Events/new/EventGallery.tsx
@@ -6,7 +6,7 @@ import { EventTimeline } from './EventTimeline'
 export function EventGallery() {
   return (
     <section className={cn('grid md:grid-cols-[minmax(320px,35%)_16px_1fr] gap-12')}>
-      <div className="sticky top-16 md:top-24 py-4 bg-background self-start z-10">
+      <div className="sticky top-16 md:top-24 py-4 bg-background self-start z-20">
         <EventGalleryFilters />
       </div>
       <EventTimeline />


### PR DESCRIPTION
## Problem
The sticky filter sidebar on /events has `z-10`. Event list cards contain elements with `relative z-10` which creates a stacking 
context that overlaps the sticky filter when scrolling, causing filter badges and the search bar to be covered by event content.

## Fix
Increased the sticky filter wrapper from `z-10` to `z-20` in `EventGallery.tsx` so it always renders above event card content.

## File changed
`apps/www/components/Events/new/EventGallery.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined element layering to improve visual presentation and accessibility of filtering controls on the Events page.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45758)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->