### PR TITLE
fix(www): compute pricing badge wraps incorrectly on mobile viewports <=443px

### DIFF
--- a/apps/www/components/Pricing/PricingComputeSection.tsx
+++ b/apps/www/components/Pricing/PricingComputeSection.tsx
@@ -116,7 +116,7 @@ const PricingComputeSection = () => {
       </div>
       <hr className="border-0 border-t" />
       <div className="flex flex-col">
-        <div className="flex gap-2 p-6 justify-between items-center mt-2">
+        <div className="flex max-[444px]:flex-wrap gap-2 p-6 justify-between items-center mt-2">
           <div className="grid gap-2">
             <p>
               <span className="border bg-alternative px-3 py-0.5 text-foreground text-sm rounded-full">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What does this PR do?

Fixes the "Starts from $10/month" badge on the pricing page breaking into 2 lines at viewport widths ≤443px. The badge is designed to be a single-line pill but the text inside it wraps at narrow widths, breaking the layout. Works fine at 444px and above.

## What's the fix?

Added `max-[444px]:flex-wrap` to the parent flex container in `PricingComputeSection.tsx` so the wrap behaviour is scoped precisely to ≤443px, allowing the badge to take its own full-width row at narrow viewports without affecting the layout at any wider screen size.

```diff
- <div className="flex gap-2 p-6 justify-between items-center mt-2">
+ <div className="flex max-[444px]:flex-wrap gap-2 p-6 justify-between items-center mt-2">
```

## File changed

```
apps/www/components/Pricing/PricingComputeSection.tsx
```

## What was tried before landing on this fix?

`flex-wrap` fixes the badge but stacks elements vertically from 640px downward, breaking the layout on screen sizes where the badge wasn't even breaking in the first place.

`whitespace-nowrap` keeps the badge on one line but causes it to bleed into the parent's right padding at narrow widths.

`Font size reduction` compromises readability of pricing info which isn't a good tradeoff for a layout fix.

## Visual behaviour after fix

At ≤443px the badge and price stack vertically, giving the badge enough space to fit on a single line as designed. Tested on real device viewports Samsung Galaxy S8+ (360px) and iPhone 14 Pro Max (430px) both render the badge correctly with no layout issues. At 444px and above the horizontal layout is completely unchanged.

## Screenshots

| Before: broken at ≤443px | After: fixed at ≤443px |
|---|---|
| <img width="350" alt="443px" src="https://github.com/user-attachments/assets/87767f98-5d9e-4cac-a466-837682765a34" /> | <img width="350" alt="after 443px" src="https://github.com/user-attachments/assets/11730742-5e1f-4841-9b75-74c42dfbfb84" /> |

| Samsung Galaxy S8+ (360px) | iPhone 14 Pro Max (430px) | ≥444px unchanged |
|---|---|---|
| <img width="250" alt="samsung galaxy s8+" src="https://github.com/user-attachments/assets/236dd667-6e93-4242-bd6f-97bd8ae7c973" /> | <img width="250" alt="iphone 14pro max" src="https://github.com/user-attachments/assets/ad1de0d4-566f-4ef8-8f07-1ef22257d829" /> | <img width="250" alt="444px" src="https://github.com/user-attachments/assets/d2f82d91-f2c8-4733-ac0e-b818bde0f9a0" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced responsive design for the pricing section to wrap layout on very narrow screens for improved mobile display.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45760)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->