### PR TITLE
fix: in-arrears transition in upcoming invoice

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -12,6 +12,7 @@ import {
   UpcomingInvoiceResponse,
   useOrgUpcomingInvoiceQuery,
 } from '@/data/invoices/org-invoice-upcoming-query'
+import { useOrganizationQuery } from '@/data/organizations/organization-query'
 import { DOCS_URL } from '@/lib/constants'
 import { formatCurrency } from '@/lib/helpers'
 
@@ -57,6 +58,8 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
     isError,
     isSuccess,
   } = useOrgUpcomingInvoiceQuery({ orgSlug: slug })
+
+  const { data: organization } = useOrganizationQuery({ slug })
 
   // For non-platform customers, compute is broken down per project and contains a breakdown array
   const computeItems =
@@ -117,19 +120,21 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
           <div>
             <Table className="w-full text-sm">
               <TableBody>
-                <TableRow>
-                  <TableCell className="py-2! px-0">{planItem?.description}</TableCell>
-                  <TableCell className="text-right py-2 px-0">
-                    {planItem == null ? (
-                      '-'
-                    ) : (
-                      <InvoiceLineItemAmount
-                        amount={planItem.amount}
-                        amountBeforeDiscount={planItem.amount_before_discount}
-                      />
-                    )}
-                  </TableCell>
-                </TableRow>
+                {!(planItem == null && upcomingInvoice.plan_fee_paid_in_advance) && (
+                  <TableRow>
+                    <TableCell className="py-2! px-0">{planItem?.description}</TableCell>
+                    <TableCell className="text-right py-2 px-0">
+                      {planItem == null ? (
+                        '-'
+                      ) : (
+                        <InvoiceLineItemAmount
+                          amount={planItem.amount}
+                          amountBeforeDiscount={planItem.amount_before_discount}
+                        />
+                      )}
+                    </TableCell>
+                  </TableRow>
+                )}
 
                 {/* Compute section */}
                 <ComputeLineItem
@@ -366,6 +371,19 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                           ? upcomingInvoice.tax!.total_amount_including_tax
                           : upcomingInvoice.amount_projected
                       ) ?? '-'}
+                    </TableCell>
+                  </TableRow>
+                )}
+
+                {planItem == null && upcomingInvoice.plan_fee_paid_in_advance && (
+                  <TableRow className="border-0 hover:bg-transparent">
+                    <TableCell
+                      className="pt-2! pb-0! px-0 text-foreground-light text-xs text-right"
+                      colSpan={2}
+                    >
+                      Your {organization?.plan?.name ? `${organization.plan.name} Plan` : 'Plan'}{' '}
+                      fee for this period has already been paid. This invoice will only reflect
+                      usage charges.
                     </TableCell>
                   </TableRow>
                 )}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -103,6 +103,9 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
     upcomingInvoice?.tax_status === 'calculated' && (upcomingInvoice?.tax?.tax_amount ?? 0) > 0
   const taxFailed = upcomingInvoice?.tax_status === 'failed'
 
+  const planFeePaidInAdvance =
+    planItem == null && upcomingInvoice?.fixed_fees_billing_mode === 'in_advance'
+
   return (
     <>
       {isLoading && (
@@ -120,7 +123,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
           <div>
             <Table className="w-full text-sm">
               <TableBody>
-                {!(planItem == null && upcomingInvoice.plan_fee_paid_in_advance) && (
+                {!planFeePaidInAdvance && (
                   <TableRow>
                     <TableCell className="py-2! px-0">{planItem?.description}</TableCell>
                     <TableCell className="text-right py-2 px-0">
@@ -375,7 +378,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   </TableRow>
                 )}
 
-                {planItem == null && upcomingInvoice.plan_fee_paid_in_advance && (
+                {planFeePaidInAdvance && (
                   <TableRow className="border-0 hover:bg-transparent">
                     <TableCell
                       className="pt-2! pb-0! px-0 text-foreground-light text-xs text-right"

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import React from 'react'
 import { Table, TableBody, TableCell, TableFooter, TableRow } from 'ui'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
@@ -104,7 +103,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
   const taxFailed = upcomingInvoice?.tax_status === 'failed'
 
   const planFeePaidInAdvance =
-    planItem == null && upcomingInvoice?.fixed_fees_billing_mode === 'in_advance'
+    !planItem && upcomingInvoice?.fixed_fees_billing_mode === 'in_advance'
 
   return (
     <>
@@ -127,7 +126,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                   <TableRow>
                     <TableCell className="py-2! px-0">{planItem?.description}</TableCell>
                     <TableCell className="text-right py-2 px-0">
-                      {planItem == null ? (
+                      {!planItem ? (
                         '-'
                       ) : (
                         <InvoiceLineItemAmount
@@ -149,12 +148,9 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                       The first project is covered by Compute Credits. Additional projects incur
                       compute costs starting at <span translate="no">$10</span>/month, independent
                       of activity. See{' '}
-                      <Link
-                        href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}
-                        target="_blank"
-                      >
+                      <InlineLink href={`${DOCS_URL}/guides/platform/manage-your-usage/compute`}>
                         docs
-                      </Link>
+                      </InlineLink>
                       .
                     </p>
                   }
@@ -169,12 +165,11 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                       Each Read Replica is a dedicated database. You are charged for its resources:
                       Compute, Disk Size, provisioned Disk IOPS, provisioned Disk Throughput, and
                       IPv4. See{' '}
-                      <Link
+                      <InlineLink
                         href={`${DOCS_URL}/guides/platform/manage-your-usage/read-replicas`}
-                        target="_blank"
                       >
                         docs
-                      </Link>
+                      </InlineLink>
                       .
                     </p>
                   }
@@ -384,9 +379,9 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                       className="pt-2! pb-0! px-0 text-foreground-light text-xs text-right"
                       colSpan={2}
                     >
-                      Your {organization?.plan?.name ? `${organization.plan.name} Plan` : 'Plan'}{' '}
-                      fee for this period has already been paid. This invoice will only reflect
-                      usage charges.
+                      Your {organization?.plan?.name && `${organization.plan.name} `}Plan fee for
+                      this period has already been paid. This invoice will only reflect usage
+                      charges.
                     </TableCell>
                   </TableRow>
                 )}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -103,7 +103,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
   const taxFailed = upcomingInvoice?.tax_status === 'failed'
 
   const planFeePaidInAdvance =
-    !planItem && upcomingInvoice?.fixed_fees_billing_mode === 'in_advance'
+    !planItem && upcomingInvoice?.fixed_fees_billing_mode === 'in_arrears'
 
   return (
     <>

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5444,6 +5444,33 @@ export interface components {
       cloud_provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
       custom_supabase_internal_requests?: {
         ami: {
+          /**
+           * @description Exact AWS instance type to provision (e.g. `t3.nano`, `t4g.nano`). When omitted the default for `desired_instance_size` is used. Only for internal use; rejected for user-facing requests in production.
+           * @enum {string}
+           */
+          instance_type?:
+            | 't4g.nano'
+            | 't3.nano'
+            | 't3a.nano'
+            | 't4g.micro'
+            | 't4g.small'
+            | 't4g.medium'
+            | 'm6g.medium'
+            | 'm6g.large'
+            | 'm6g.xlarge'
+            | 'm6g.2xlarge'
+            | 'm6g.4xlarge'
+            | 'm6g.8xlarge'
+            | 'm6g.12xlarge'
+            | 'm6g.16xlarge'
+            | 'm8g.24xlarge'
+            | 'c8g.24xlarge'
+            | 'r8g.24xlarge'
+            | 'x8g.24xlarge'
+            | 'm8g.48xlarge'
+            | 'c8g.48xlarge'
+            | 'r8g.48xlarge'
+            | 'x8g.48xlarge'
           search_tags?: {
             [key: string]: string
           }
@@ -9914,6 +9941,7 @@ export interface components {
     }
     RestorePhysicalBackupBody: {
       id: number
+      recovery_time_target?: string
     }
     RevokeAuthorizedOAuthAppResponse: {
       authorized_at?: string
@@ -10390,6 +10418,8 @@ export interface components {
       billing_cycle_start: string
       currency: string
       customer_balance: number
+      /** @enum {string} */
+      fixed_fees_billing_mode: 'in_advance' | 'in_arrears'
       lines: {
         amount: number
         amount_before_discount: number
@@ -15222,7 +15252,6 @@ export interface operations {
   OrgAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
-        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */
@@ -19446,7 +19475,6 @@ export interface operations {
   UserAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
-        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -10418,6 +10418,8 @@ export interface components {
       billing_cycle_start: string
       currency: string
       customer_balance: number
+      /** @enum {string} */
+      fixed_fees_billing_mode: 'in_advance' | 'in_arrears'
       lines: {
         amount: number
         amount_before_discount: number
@@ -10536,7 +10538,6 @@ export interface components {
           | 'ACTIVE_COMPUTE_HOURS'
         usage_original?: number
       }[]
-      plan_fee_paid_in_advance: boolean
       subscription_id: string
       tax: {
         currency: string

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5444,6 +5444,33 @@ export interface components {
       cloud_provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
       custom_supabase_internal_requests?: {
         ami: {
+          /**
+           * @description Exact AWS instance type to provision (e.g. `t3.nano`, `t4g.nano`). When omitted the default for `desired_instance_size` is used. Only for internal use; rejected for user-facing requests in production.
+           * @enum {string}
+           */
+          instance_type?:
+            | 't4g.nano'
+            | 't3.nano'
+            | 't3a.nano'
+            | 't4g.micro'
+            | 't4g.small'
+            | 't4g.medium'
+            | 'm6g.medium'
+            | 'm6g.large'
+            | 'm6g.xlarge'
+            | 'm6g.2xlarge'
+            | 'm6g.4xlarge'
+            | 'm6g.8xlarge'
+            | 'm6g.12xlarge'
+            | 'm6g.16xlarge'
+            | 'm8g.24xlarge'
+            | 'c8g.24xlarge'
+            | 'r8g.24xlarge'
+            | 'x8g.24xlarge'
+            | 'm8g.48xlarge'
+            | 'c8g.48xlarge'
+            | 'r8g.48xlarge'
+            | 'x8g.48xlarge'
           search_tags?: {
             [key: string]: string
           }
@@ -9914,6 +9941,7 @@ export interface components {
     }
     RestorePhysicalBackupBody: {
       id: number
+      recovery_time_target?: string
     }
     RevokeAuthorizedOAuthAppResponse: {
       authorized_at?: string
@@ -10508,6 +10536,7 @@ export interface components {
           | 'ACTIVE_COMPUTE_HOURS'
         usage_original?: number
       }[]
+      plan_fee_paid_in_advance: boolean
       subscription_id: string
       tax: {
         currency: string
@@ -15222,7 +15251,6 @@ export interface operations {
   OrgAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
-        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */
@@ -19446,7 +19474,6 @@ export interface operations {
   UserAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
-        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5444,33 +5444,6 @@ export interface components {
       cloud_provider: 'AWS' | 'FLY' | 'AWS_K8S' | 'AWS_NIMBUS'
       custom_supabase_internal_requests?: {
         ami: {
-          /**
-           * @description Exact AWS instance type to provision (e.g. `t3.nano`, `t4g.nano`). When omitted the default for `desired_instance_size` is used. Only for internal use; rejected for user-facing requests in production.
-           * @enum {string}
-           */
-          instance_type?:
-            | 't4g.nano'
-            | 't3.nano'
-            | 't3a.nano'
-            | 't4g.micro'
-            | 't4g.small'
-            | 't4g.medium'
-            | 'm6g.medium'
-            | 'm6g.large'
-            | 'm6g.xlarge'
-            | 'm6g.2xlarge'
-            | 'm6g.4xlarge'
-            | 'm6g.8xlarge'
-            | 'm6g.12xlarge'
-            | 'm6g.16xlarge'
-            | 'm8g.24xlarge'
-            | 'c8g.24xlarge'
-            | 'r8g.24xlarge'
-            | 'x8g.24xlarge'
-            | 'm8g.48xlarge'
-            | 'c8g.48xlarge'
-            | 'r8g.48xlarge'
-            | 'x8g.48xlarge'
           search_tags?: {
             [key: string]: string
           }
@@ -9941,7 +9914,6 @@ export interface components {
     }
     RestorePhysicalBackupBody: {
       id: number
-      recovery_time_target?: string
     }
     RevokeAuthorizedOAuthAppResponse: {
       authorized_at?: string
@@ -10418,8 +10390,6 @@ export interface components {
       billing_cycle_start: string
       currency: string
       customer_balance: number
-      /** @enum {string} */
-      fixed_fees_billing_mode: 'in_advance' | 'in_arrears'
       lines: {
         amount: number
         amount_before_discount: number
@@ -15252,6 +15222,7 @@ export interface operations {
   OrgAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
+        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */
@@ -19475,6 +19446,7 @@ export interface operations {
   UserAuditLogsController_getAuditLogs: {
     parameters: {
       query: {
+        format?: 'legacy' | 'v2'
         /** @description End timestamp */
         iso_timestamp_end: string
         /** @description Start timestamp */


### PR DESCRIPTION
## Show notice when plan fee is prepaid for the upcoming invoice

When a subscription's plan fee has already been billed for the current period (e.g. transitioning to in-arrears billing), the upcoming invoice no longer contains a plan line item. Previously this rendered as an empty plan row with a `-`, which was confusing.

<img width="2178" height="538" alt="image" src="https://github.com/user-attachments/assets/1fa289d9-60ae-48b1-b779-34770bc2c242" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Billing breakdown now detects when the plan fee was already paid upfront, hides the redundant plan line, and notes only usage will be invoiced; shows the organization plan name when available.
  * Backup restoration: added an optional recovery time target for physical backups.
  * Expanded supported AWS instance types for deployments.

* **UI**
  * Compute and Replica Compute docs links now use inline linking for a smoother in-app experience.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45765)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->