### PR TITLE
chore: remove storage BYOC

### DIFF
--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -60,7 +60,6 @@ export type FeatureKey =
   | 'storage.cachedEgress'
   | 'storage.cdn'
   | 'storage.transformations'
-  | 'storage.byoc'
   | 'functions.invocations'
   | 'functions.scriptSize'
   | 'functions.numberOfFunctions'
@@ -462,17 +461,6 @@ export const pricing: Pricing = {
           enterprise: 'Custom',
         },
         usage_based: true,
-      },
-      {
-        key: 'storage.byoc',
-        title: 'Bring your own storage provider',
-        plans: {
-          free: false,
-          pro: false,
-          team: false,
-          enterprise: true,
-        },
-        usage_based: false,
       },
     ],
   },


### PR DESCRIPTION
As requested by storage team, was planned back in the day but never executed, so removing this for now as not planned in near future.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Removed Features**
  * The "Bring your own storage provider" pricing option has been removed from the storage pricing catalog and is no longer available.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45769)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->