### PR TITLE
docs: clarify scheduled function Vault key usage

### DIFF
--- a/apps/docs/content/guides/functions/schedule-functions.mdx
+++ b/apps/docs/content/guides/functions/schedule-functions.mdx
@@ -34,6 +34,11 @@ select vault.create_secret('https://project-ref.supabase.co', 'project_url');
 select vault.create_secret('YOUR_SUPABASE_PUBLISHABLE_KEY', 'publishable_key');
 ```
 
+Run the Vault setup once before creating the cron job. The cron job reads the
+same `publishable_key` secret from Vault and sends it as the bearer token when
+it invokes your Edge Function, so the key is not hard-coded in the scheduled
+job definition.
+
 Make a POST request to a Supabase Edge Function every minute:
 
 ```sql


### PR DESCRIPTION
## I have read CONTRIBUTING.md

Yes.

## What kind of change does this PR introduce?

Documentation update.

## Current behavior

The scheduled functions guide did not clearly state when Vault setup runs or how the cron job reads the `publishable_key` secret for the Edge Function bearer token.

Fixes #42398.

## New behavior

Clarifies that Vault setup runs once before creating the cron job, that the scheduled job reads the same `publishable_key` secret from Vault, and that the key is not hard-coded in the cron job definition.

## Additional context

Verification:

- `git diff --check`