### PR TITLE
docs: link storage example app

### DIFF
--- a/apps/www/_blog/2021-03-30-supabase-storage.mdx
+++ b/apps/www/_blog/2021-03-30-supabase-storage.mdx
@@ -157,7 +157,7 @@ We have intentionally kept the API surface for the storage backend very small, i
 
 ### Client libraries
 
-You may be itching to get started tinkering around with our new Supabase storage - we have an example app prepared for you which simulates a simple context of setting an avatar image for a user. This will help you to get a high level overview of how to use your project's storage with our client library. For greater detail, refer to our storage API documentation [here](/docs/reference/javascript/storage-createbucket).
+You may be itching to get started tinkering around with our new Supabase storage - we have an [example app](https://github.com/supabase/supabase-js/tree/master/examples/next-storage) prepared for you which simulates a simple context of setting an avatar image for a user. This will help you to get a high level overview of how to use your project's storage with our client library. For greater detail, refer to our storage API documentation [here](/docs/reference/javascript/storage-createbucket).
 
 ![Example app 1](/images/blog/storage/ph-7.png)
 


### PR DESCRIPTION
## I have read CONTRIBUTING.md

Yes.

## What kind of change does this PR introduce?

Documentation update.

## Current behavior

The Supabase Storage launch blog post pointed readers at a generic example app reference instead of the specific Next.js storage example.

Fixes supabase/storage#557.

## New behavior

Updates the Client libraries section to link directly to `supabase-js/examples/next-storage`.

## Additional context

Verification:

- `git diff --check`