### PR TITLE
feat(studio): Fly.io deprecation banner

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -3,6 +3,7 @@ import { PropsWithChildren } from 'react'
 
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 import { ClockSkewBanner } from '@/components/layouts/AppLayout/ClockSkewBanner'
+import { FlyDeprecationBanner } from '@/components/layouts/AppLayout/FlyDeprecationBanner'
 import { NoticeBanner, NoticeBanner2 } from '@/components/layouts/AppLayout/NoticeBanner'
 import { StatusPageBanner } from '@/components/layouts/AppLayout/StatusPageBanner'
 
@@ -17,6 +18,7 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
         <StatusPageBanner />
         {showNoticeBanner && <NoticeBanner />}
         {showNoticeBanner2 && <NoticeBanner2 />}
+        <FlyDeprecationBanner />
         <OrganizationResourceBanner />
         {/* Disabled until reintroduced or removed altogether. */}
         {/* <TaxIdBanner /> */}

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -26,9 +26,12 @@ import {
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 const BANNER_EXPIRES_AT = new Date('2026-06-01T00:00:00Z')
-const MIGRATION_GUIDE_URL =
+const BACKUP_RESTORE_CLI_URL =
   'https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore'
-const SUPPORT_URL = 'https://supabase.com/dashboard/support/new'
+const DASHBOARD_RESTORE_URL =
+  'https://supabase.com/docs/guides/platform/migrating-within-supabase/dashboard-restore'
+const BRANCHING_DASHBOARD_URL = 'https://supabase.com/docs/guides/deployment/branching/dashboard'
+const SUPPORT_EMAIL = 'success@supabase.io'
 
 export const FlyDeprecationBanner = () => {
   const router = useRouter()
@@ -85,10 +88,10 @@ export const FlyDeprecationBanner = () => {
 
   const title =
     primaries.length > 0 && branches.length > 0
-      ? 'Action required: Fly.io projects and branches will be suspended May 31'
+      ? 'Action required: Fly.io project and branch suspensions begin May 31'
       : primaries.length > 0
-        ? 'Action required: Fly.io projects will be suspended May 31'
-        : 'Action required: Fly.io branches will be suspended May 31'
+        ? 'Action required: Fly.io project suspensions begin May 31'
+        : 'Action required: Fly.io branch suspensions begin May 31'
 
   return (
     <HeaderBanner
@@ -114,10 +117,10 @@ const FlyDeprecationDialog = ({
       </DialogTrigger>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Fly.io deprecation: May 31, 2026</DialogTitle>
+          <DialogTitle>Fly.io deprecation: suspensions begin May 31, 2026</DialogTitle>
           <DialogDescription>
-            Supabase is sunsetting Fly.io infrastructure. Projects and branches still running on
-            Fly.io will be suspended on May 31, 2026.
+            Supabase will begin suspending projects and branches still running on Fly.io
+            infrastructure on May 31, 2026.
           </DialogDescription>
         </DialogHeader>
 
@@ -128,9 +131,18 @@ const FlyDeprecationDialog = ({
           items={primaries}
           note={
             <>
-              To preserve your data, follow the{' '}
-              <InlineLink href={MIGRATION_GUIDE_URL}>migration guide</InlineLink> to back up and
-              restore onto Supabase's general infrastructure.
+              <p>
+                To preserve your data, migrate each project to Supabase's general infrastructure:
+              </p>
+              <ol className="list-decimal pl-5 space-y-1">
+                <li>
+                  Back up your database using the{' '}
+                  <InlineLink href={BACKUP_RESTORE_CLI_URL}>Supabase CLI</InlineLink> (or take a{' '}
+                  <InlineLink href={DASHBOARD_RESTORE_URL}>Dashboard backup</InlineLink>).
+                </li>
+                <li>Create a new project on Supabase's general infrastructure.</li>
+                <li>Restore the backup into the new project.</li>
+              </ol>
             </>
           }
         />
@@ -140,17 +152,34 @@ const FlyDeprecationDialog = ({
           items={branches}
           note={
             <>
-              Merge preview branches before May 31. For persistent branches, take a{' '}
-              <InlineLink href={MIGRATION_GUIDE_URL}>snapshot</InlineLink>, then deploy a new branch
-              and restore your data.
+              <p>Merge preview branches before May 31. For persistent branches:</p>
+              <ol className="list-decimal pl-5 space-y-1">
+                <li>
+                  Take a{' '}
+                  <InlineLink href={BACKUP_RESTORE_CLI_URL}>
+                    snapshot of the branch database
+                  </InlineLink>{' '}
+                  before shutting it down.
+                </li>
+                <li>
+                  <InlineLink href={BRANCHING_DASHBOARD_URL}>
+                    Deploy a new persistent branch
+                  </InlineLink>{' '}
+                  on Supabase's general infrastructure.
+                </li>
+                <li>Restore your data manually from the snapshot.</li>
+              </ol>
             </>
           }
         />
 
         <DialogSection className="text-sm">
           <p>
-            Questions or need an extension?{' '}
-            <InlineLink href={SUPPORT_URL}>File a support ticket</InlineLink>.
+            Questions or need an extension? Email{' '}
+            <a className={InlineLinkClassName} href={`mailto:${SUPPORT_EMAIL}`}>
+              {SUPPORT_EMAIL}
+            </a>
+            .
           </p>
         </DialogSection>
 
@@ -186,7 +215,7 @@ const ProjectList = ({
           </li>
         ))}
       </ul>
-      <p>{note}</p>
+      {note}
     </DialogSection>
   )
 }

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -179,6 +179,8 @@ const FlyDeprecationDialog = ({
   )
 }
 
+const MAX_LISTED = 5
+
 const ProjectList = ({
   label,
   items,
@@ -189,6 +191,8 @@ const ProjectList = ({
   instructions: ReactNode
 }) => {
   if (items.length === 0) return null
+  const visible = items.slice(0, MAX_LISTED)
+  const remaining = items.length - visible.length
   return (
     <>
       <DialogSection className="text-sm flex flex-col gap-y-2">
@@ -201,11 +205,14 @@ const ProjectList = ({
           </p>
         ) : (
           <ul className="list-disc pl-5 space-y-1">
-            {items.map((p) => (
+            {visible.map((p) => (
               <li key={p.ref}>
                 {p.name} <span className="text-foreground-muted">({p.orgName})</span>
               </li>
             ))}
+            {remaining > 0 && (
+              <li className="text-foreground-muted list-none -ml-5">…and {remaining} more.</li>
+            )}
           </ul>
         )}
       </DialogSection>

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -173,6 +173,8 @@ const FlyDeprecationDialog = ({
           }
         />
 
+        <DialogSectionSeparator />
+
         <DialogSection className="text-sm">
           <p>
             Questions or need an extension? Email{' '}
@@ -208,13 +210,19 @@ const ProjectList = ({
       <p className="font-medium">
         {label} ({items.length})
       </p>
-      <ul className="list-disc pl-5 space-y-1 text-foreground-light">
-        {items.map((p) => (
-          <li key={p.ref}>
-            {p.name} <span className="text-foreground-muted">— {p.orgName}</span>
-          </li>
-        ))}
-      </ul>
+      {items.length === 1 ? (
+        <p>
+          {items[0].name} <span className="text-foreground-muted">({items[0].orgName})</span>
+        </p>
+      ) : (
+        <ul className="list-disc pl-5 space-y-1">
+          {items.map((p) => (
+            <li key={p.ref}>
+              {p.name} <span className="text-foreground-muted">({p.orgName})</span>
+            </li>
+          ))}
+        </ul>
+      )}
       {note}
     </DialogSection>
   )

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/hooks/misc/useFlyDeprecationProjects'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
-const BANNER_EXPIRES_AT = new Date('2026-06-15T00:00:00Z')
+const BANNER_EXPIRES_AT = new Date('2026-06-01T00:00:00Z')
 const MIGRATION_GUIDE_URL =
   'https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore'
 const SUPPORT_URL = 'https://supabase.com/dashboard/support/new'

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -1,0 +1,175 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import { useRouter } from 'next/router'
+import { useEffect, useRef } from 'react'
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
+
+import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
+import { InlineLink, InlineLinkClassName } from '@/components/ui/InlineLink'
+import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
+import {
+  useFlyDeprecationProjects,
+  type FlyDeprecationProject,
+} from '@/hooks/misc/useFlyDeprecationProjects'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+
+const BANNER_EXPIRES_AT = new Date('2026-06-15T00:00:00Z')
+const MIGRATION_GUIDE_URL =
+  'https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore'
+const SUPPORT_URL = 'https://supabase.com/dashboard/support/new'
+
+export const FlyDeprecationBanner = () => {
+  const router = useRouter()
+
+  const [acknowledged, setAcknowledged, { isSuccess }] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.FLY_DEPRECATION_2026_05_31,
+    false
+  )
+
+  const isExpired = Date.now() >= BANNER_EXPIRES_AT.getTime()
+  const onSignIn = router.pathname.includes('sign-in')
+
+  const shouldEvaluate = !isExpired && !onSignIn && isSuccess && !acknowledged
+
+  const { isReady, primaries, branches } = useFlyDeprecationProjects({ enabled: shouldEvaluate })
+
+  const hasFlyResources = primaries.length > 0 || branches.length > 0
+  const firstOrgSlug = primaries[0]?.orgSlug ?? branches[0]?.orgSlug ?? ''
+  const firstProjectRef = primaries[0]?.ref ?? branches[0]?.ref ?? ''
+
+  const { mutate: sendEvent } = useSendEventMutation()
+
+  const viewedRef = useRef(false)
+  useEffect(() => {
+    if (!shouldEvaluate || !isReady || !hasFlyResources || viewedRef.current) return
+    viewedRef.current = true
+    sendEvent({
+      action: 'fly_deprecation_banner_viewed',
+      properties: { primaryCount: primaries.length, branchCount: branches.length },
+      groups: { project: firstProjectRef, organization: firstOrgSlug },
+    })
+  }, [
+    shouldEvaluate,
+    isReady,
+    hasFlyResources,
+    primaries.length,
+    branches.length,
+    firstProjectRef,
+    firstOrgSlug,
+    sendEvent,
+  ])
+
+  if (!shouldEvaluate || !isReady || !hasFlyResources) return null
+
+  const onDismiss = () => {
+    sendEvent({
+      action: 'fly_deprecation_banner_dismissed',
+      properties: { primaryCount: primaries.length, branchCount: branches.length },
+      groups: { project: firstProjectRef, organization: firstOrgSlug },
+    })
+    setAcknowledged(true)
+  }
+
+  const title =
+    primaries.length > 0 && branches.length > 0
+      ? 'Action required: Fly.io projects and branches will be suspended May 31'
+      : primaries.length > 0
+        ? 'Action required: Fly.io projects will be suspended May 31'
+        : 'Action required: Fly.io branches will be suspended May 31'
+
+  return (
+    <HeaderBanner
+      variant="warning"
+      title={title}
+      description={<FlyDeprecationDialog primaries={primaries} branches={branches} />}
+      onDismiss={onDismiss}
+    />
+  )
+}
+
+interface FlyDeprecationDialogProps {
+  primaries: FlyDeprecationProject[]
+  branches: FlyDeprecationProject[]
+}
+
+const FlyDeprecationDialog = ({ primaries, branches }: FlyDeprecationDialogProps) => {
+  return (
+    <Dialog>
+      <DialogTrigger className={cn(InlineLinkClassName, 'cursor-pointer')}>
+        View affected projects
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Fly.io deprecation: May 31, 2026</DialogTitle>
+          <DialogDescription>
+            Supabase is sunsetting Fly.io infrastructure. Projects and branches still running on
+            Fly.io will be suspended on May 31, 2026.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogSectionSeparator />
+
+        {primaries.length > 0 && (
+          <DialogSection className="text-sm flex flex-col gap-y-2">
+            <p className="font-medium">Projects on Fly.io ({primaries.length})</p>
+            <ul className="list-disc pl-5 space-y-1 text-foreground-light">
+              {primaries.map((p) => (
+                <li key={p.ref}>
+                  {p.name} <span className="text-foreground-muted">— {p.orgName}</span>
+                </li>
+              ))}
+            </ul>
+            <p>
+              To preserve your data, follow the{' '}
+              <InlineLink href={MIGRATION_GUIDE_URL}>migration guide</InlineLink> to back up and
+              restore onto Supabase's general infrastructure.
+            </p>
+          </DialogSection>
+        )}
+
+        {branches.length > 0 && (
+          <DialogSection className="text-sm flex flex-col gap-y-2">
+            <p className="font-medium">Branches on Fly.io ({branches.length})</p>
+            <ul className="list-disc pl-5 space-y-1 text-foreground-light">
+              {branches.map((b) => (
+                <li key={b.ref}>
+                  {b.name} <span className="text-foreground-muted">— {b.orgName}</span>
+                </li>
+              ))}
+            </ul>
+            <p>
+              Merge preview branches before May 31. For persistent branches, take a{' '}
+              <InlineLink href={MIGRATION_GUIDE_URL}>snapshot</InlineLink>, then deploy a new branch
+              and restore your data.
+            </p>
+          </DialogSection>
+        )}
+
+        <DialogSection className="text-sm">
+          <p>
+            Questions or need an extension?{' '}
+            <InlineLink href={SUPPORT_URL}>File a support ticket</InlineLink>.
+          </p>
+        </DialogSection>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button type="default">Close</Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -18,12 +18,12 @@ import {
 
 import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
 import { InlineLink, InlineLinkClassName } from '@/components/ui/InlineLink'
-import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import {
   useFlyDeprecationProjects,
   type FlyDeprecationProject,
 } from '@/hooks/misc/useFlyDeprecationProjects'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+import { useTrack } from '@/lib/telemetry/track'
 
 const BANNER_EXPIRES_AT = new Date('2026-06-01T00:00:00Z')
 const BACKUP_RESTORE_CLI_URL =
@@ -49,39 +49,25 @@ export const FlyDeprecationBanner = () => {
   const { isReady, primaries, branches } = useFlyDeprecationProjects({ enabled: shouldEvaluate })
 
   const hasFlyResources = primaries.length > 0 || branches.length > 0
-  const firstProject = primaries[0] ?? branches[0]
-  const firstOrgSlug = firstProject?.orgSlug ?? ''
-  const firstProjectRef = firstProject?.ref ?? ''
 
-  const { mutate: sendEvent } = useSendEventMutation()
+  const track = useTrack()
 
-  const viewedRef = useRef(false)
+  const exposedRef = useRef(false)
   useEffect(() => {
-    if (!shouldEvaluate || !isReady || !hasFlyResources || viewedRef.current) return
-    viewedRef.current = true
-    sendEvent({
-      action: 'fly_deprecation_banner_viewed',
-      properties: { primaryCount: primaries.length, branchCount: branches.length },
-      groups: { project: firstProjectRef, organization: firstOrgSlug },
+    if (!shouldEvaluate || !isReady || !hasFlyResources || exposedRef.current) return
+    exposedRef.current = true
+    track('fly_deprecation_banner_exposed', {
+      primaryCount: primaries.length,
+      branchCount: branches.length,
     })
-  }, [
-    shouldEvaluate,
-    isReady,
-    hasFlyResources,
-    primaries.length,
-    branches.length,
-    firstProjectRef,
-    firstOrgSlug,
-    sendEvent,
-  ])
+  }, [shouldEvaluate, isReady, hasFlyResources, primaries.length, branches.length, track])
 
   if (!shouldEvaluate || !isReady || !hasFlyResources) return null
 
   const onDismiss = () => {
-    sendEvent({
-      action: 'fly_deprecation_banner_dismissed',
-      properties: { primaryCount: primaries.length, branchCount: branches.length },
-      groups: { project: firstProjectRef, organization: firstOrgSlug },
+    track('fly_deprecation_banner_dismissed', {
+      primaryCount: primaries.length,
+      branchCount: branches.length,
     })
     setAcknowledged(true)
   }

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -42,7 +42,7 @@ export const FlyDeprecationBanner = () => {
   )
 
   const isExpired = Date.now() >= BANNER_EXPIRES_AT.getTime()
-  const onSignIn = router.pathname.includes('sign-in')
+  const onSignIn = router.pathname.startsWith('/sign-in')
 
   const shouldEvaluate = !isExpired && !onSignIn && isSuccess && !acknowledged
 

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -1,6 +1,6 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { useRouter } from 'next/router'
-import { useEffect, useRef } from 'react'
+import { useEffect, useRef, type ReactNode } from 'react'
 import {
   Button,
   cn,
@@ -46,8 +46,9 @@ export const FlyDeprecationBanner = () => {
   const { isReady, primaries, branches } = useFlyDeprecationProjects({ enabled: shouldEvaluate })
 
   const hasFlyResources = primaries.length > 0 || branches.length > 0
-  const firstOrgSlug = primaries[0]?.orgSlug ?? branches[0]?.orgSlug ?? ''
-  const firstProjectRef = primaries[0]?.ref ?? branches[0]?.ref ?? ''
+  const firstProject = primaries[0] ?? branches[0]
+  const firstOrgSlug = firstProject?.orgSlug ?? ''
+  const firstProjectRef = firstProject?.ref ?? ''
 
   const { mutate: sendEvent } = useSendEventMutation()
 
@@ -99,12 +100,13 @@ export const FlyDeprecationBanner = () => {
   )
 }
 
-interface FlyDeprecationDialogProps {
+const FlyDeprecationDialog = ({
+  primaries,
+  branches,
+}: {
   primaries: FlyDeprecationProject[]
   branches: FlyDeprecationProject[]
-}
-
-const FlyDeprecationDialog = ({ primaries, branches }: FlyDeprecationDialogProps) => {
+}) => {
   return (
     <Dialog>
       <DialogTrigger className={cn(InlineLinkClassName, 'cursor-pointer')}>
@@ -121,41 +123,29 @@ const FlyDeprecationDialog = ({ primaries, branches }: FlyDeprecationDialogProps
 
         <DialogSectionSeparator />
 
-        {primaries.length > 0 && (
-          <DialogSection className="text-sm flex flex-col gap-y-2">
-            <p className="font-medium">Projects on Fly.io ({primaries.length})</p>
-            <ul className="list-disc pl-5 space-y-1 text-foreground-light">
-              {primaries.map((p) => (
-                <li key={p.ref}>
-                  {p.name} <span className="text-foreground-muted">— {p.orgName}</span>
-                </li>
-              ))}
-            </ul>
-            <p>
+        <ProjectList
+          label="Projects on Fly.io"
+          items={primaries}
+          note={
+            <>
               To preserve your data, follow the{' '}
               <InlineLink href={MIGRATION_GUIDE_URL}>migration guide</InlineLink> to back up and
               restore onto Supabase's general infrastructure.
-            </p>
-          </DialogSection>
-        )}
+            </>
+          }
+        />
 
-        {branches.length > 0 && (
-          <DialogSection className="text-sm flex flex-col gap-y-2">
-            <p className="font-medium">Branches on Fly.io ({branches.length})</p>
-            <ul className="list-disc pl-5 space-y-1 text-foreground-light">
-              {branches.map((b) => (
-                <li key={b.ref}>
-                  {b.name} <span className="text-foreground-muted">— {b.orgName}</span>
-                </li>
-              ))}
-            </ul>
-            <p>
+        <ProjectList
+          label="Branches on Fly.io"
+          items={branches}
+          note={
+            <>
               Merge preview branches before May 31. For persistent branches, take a{' '}
               <InlineLink href={MIGRATION_GUIDE_URL}>snapshot</InlineLink>, then deploy a new branch
               and restore your data.
-            </p>
-          </DialogSection>
-        )}
+            </>
+          }
+        />
 
         <DialogSection className="text-sm">
           <p>
@@ -171,5 +161,32 @@ const FlyDeprecationDialog = ({ primaries, branches }: FlyDeprecationDialogProps
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  )
+}
+
+const ProjectList = ({
+  label,
+  items,
+  note,
+}: {
+  label: string
+  items: FlyDeprecationProject[]
+  note: ReactNode
+}) => {
+  if (items.length === 0) return null
+  return (
+    <DialogSection className="text-sm flex flex-col gap-y-2">
+      <p className="font-medium">
+        {label} ({items.length})
+      </p>
+      <ul className="list-disc pl-5 space-y-1 text-foreground-light">
+        {items.map((p) => (
+          <li key={p.ref}>
+            {p.name} <span className="text-foreground-muted">— {p.orgName}</span>
+          </li>
+        ))}
+      </ul>
+      <p>{note}</p>
+    </DialogSection>
   )
 }

--- a/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/FlyDeprecationBanner.tsx
@@ -129,7 +129,7 @@ const FlyDeprecationDialog = ({
         <ProjectList
           label="Projects on Fly.io"
           items={primaries}
-          note={
+          instructions={
             <>
               <p>
                 To preserve your data, migrate each project to Supabase's general infrastructure:
@@ -150,7 +150,7 @@ const FlyDeprecationDialog = ({
         <ProjectList
           label="Branches on Fly.io"
           items={branches}
-          note={
+          instructions={
             <>
               <p>Merge preview branches before May 31. For persistent branches:</p>
               <ol className="list-decimal pl-5 space-y-1">
@@ -172,8 +172,6 @@ const FlyDeprecationDialog = ({
             </>
           }
         />
-
-        <DialogSectionSeparator />
 
         <DialogSection className="text-sm">
           <p>
@@ -198,32 +196,34 @@ const FlyDeprecationDialog = ({
 const ProjectList = ({
   label,
   items,
-  note,
+  instructions,
 }: {
   label: string
   items: FlyDeprecationProject[]
-  note: ReactNode
+  instructions: ReactNode
 }) => {
   if (items.length === 0) return null
   return (
-    <DialogSection className="text-sm flex flex-col gap-y-2">
-      <p className="font-medium">
-        {label} ({items.length})
-      </p>
-      {items.length === 1 ? (
-        <p>
-          {items[0].name} <span className="text-foreground-muted">({items[0].orgName})</span>
+    <>
+      <DialogSection className="text-sm flex flex-col gap-y-2">
+        <p className="font-medium">
+          {label} ({items.length})
         </p>
-      ) : (
-        <ul className="list-disc pl-5 space-y-1">
-          {items.map((p) => (
-            <li key={p.ref}>
-              {p.name} <span className="text-foreground-muted">({p.orgName})</span>
-            </li>
-          ))}
-        </ul>
-      )}
-      {note}
-    </DialogSection>
+        {items.length === 1 ? (
+          <p>
+            {items[0].name} <span className="text-foreground-muted">({items[0].orgName})</span>
+          </p>
+        ) : (
+          <ul className="list-disc pl-5 space-y-1">
+            {items.map((p) => (
+              <li key={p.ref}>
+                {p.name} <span className="text-foreground-muted">({p.orgName})</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </DialogSection>
+      <DialogSection className="text-sm flex flex-col gap-y-2">{instructions}</DialogSection>
+    </>
   )
 }

--- a/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
+++ b/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
@@ -2,10 +2,7 @@ import { useQueries } from '@tanstack/react-query'
 
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { projectKeys } from '@/data/projects/keys'
-import {
-  getOrganizationProjects,
-  type OrgProject,
-} from '@/data/projects/org-projects-infinite-query'
+import { getOrganizationProjects } from '@/data/projects/org-projects-infinite-query'
 import { PROVIDERS } from '@/lib/constants/infrastructure'
 
 export interface FlyDeprecationProject {
@@ -13,20 +10,9 @@ export interface FlyDeprecationProject {
   name: string
   orgSlug: string
   orgName: string
-  isBranch: boolean
 }
 
-export interface FlyDeprecationProjectsResult {
-  isReady: boolean
-  primaries: FlyDeprecationProject[]
-  branches: FlyDeprecationProject[]
-}
-
-export function useFlyDeprecationProjects({
-  enabled,
-}: {
-  enabled: boolean
-}): FlyDeprecationProjectsResult {
+export function useFlyDeprecationProjects({ enabled }: { enabled: boolean }) {
   const { data: organizations } = useOrganizationsQuery({ enabled })
 
   const orgProjectsQueries = useQueries({
@@ -43,24 +29,21 @@ export function useFlyDeprecationProjects({
     organizations !== undefined &&
     (organizations.length === 0 || orgProjectsQueries.every((q) => q.isFetched))
 
-  const flyProjects: FlyDeprecationProject[] = orgProjectsQueries.flatMap((query, idx) => {
-    const org = (organizations ?? [])[idx]
-    if (!org) return []
-    const projects = query.data?.projects ?? []
-    return projects
-      .filter((p: OrgProject) => p.cloud_provider === PROVIDERS.FLY.id)
-      .map((p: OrgProject) => ({
-        ref: p.ref,
-        name: p.name,
-        orgSlug: org.slug,
-        orgName: org.name,
-        isBranch: p.is_branch,
-      }))
-  })
+  const { primaries, branches } = (organizations ?? []).reduce<{
+    primaries: FlyDeprecationProject[]
+    branches: FlyDeprecationProject[]
+  }>(
+    (acc, org, idx) => {
+      const projects = orgProjectsQueries[idx]?.data?.projects ?? []
+      for (const p of projects) {
+        if (p.cloud_provider !== PROVIDERS.FLY.id) continue
+        const bucket = p.is_branch ? acc.branches : acc.primaries
+        bucket.push({ ref: p.ref, name: p.name, orgSlug: org.slug, orgName: org.name })
+      }
+      return acc
+    },
+    { primaries: [], branches: [] }
+  )
 
-  return {
-    isReady,
-    primaries: flyProjects.filter((p) => !p.isBranch),
-    branches: flyProjects.filter((p) => p.isBranch),
-  }
+  return { isReady, primaries, branches }
 }

--- a/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
+++ b/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
@@ -15,14 +15,16 @@ export function useFlyDeprecationProjects({ enabled }: { enabled: boolean }) {
   const { data: selectedOrg } = useSelectedOrganizationQuery()
 
   const orgSlug = selectedOrg?.slug
-  const orgName = selectedOrg?.name ?? orgSlug ?? ''
+  const orgName = selectedOrg?.name ?? ''
 
   const { data: orgProjectsData, isFetched } = useOrgProjectsInfiniteQuery(
     { slug: orgSlug },
     { enabled: enabled && Boolean(orgSlug), staleTime: 30 * 60 * 1000 }
   )
 
-  const isReady = !enabled || !orgSlug || isFetched
+  if (!enabled || !orgSlug) {
+    return { isReady: false, primaries: [], branches: [] }
+  }
 
   const byRef = new Map<string, FlyDeprecationProject & { isBranch: boolean }>()
 
@@ -30,7 +32,7 @@ export function useFlyDeprecationProjects({ enabled }: { enabled: boolean }) {
     byRef.set(selectedProject.ref, {
       ref: selectedProject.ref,
       name: selectedProject.name,
-      orgSlug: orgSlug ?? '',
+      orgSlug,
       orgName,
       isBranch: Boolean(selectedProject.parent_project_ref),
     })
@@ -43,7 +45,7 @@ export function useFlyDeprecationProjects({ enabled }: { enabled: boolean }) {
     byRef.set(p.ref, {
       ref: p.ref,
       name: p.name,
-      orgSlug: orgSlug ?? '',
+      orgSlug,
       orgName,
       isBranch: Boolean(p.is_branch),
     })
@@ -56,5 +58,5 @@ export function useFlyDeprecationProjects({ enabled }: { enabled: boolean }) {
     ;(isBranch ? branches : primaries).push(rest)
   }
 
-  return { isReady, primaries, branches }
+  return { isReady: isFetched, primaries, branches }
 }

--- a/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
+++ b/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
@@ -1,0 +1,66 @@
+import { useQueries } from '@tanstack/react-query'
+
+import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
+import { projectKeys } from '@/data/projects/keys'
+import {
+  getOrganizationProjects,
+  type OrgProject,
+} from '@/data/projects/org-projects-infinite-query'
+import { PROVIDERS } from '@/lib/constants/infrastructure'
+
+export interface FlyDeprecationProject {
+  ref: string
+  name: string
+  orgSlug: string
+  orgName: string
+  isBranch: boolean
+}
+
+export interface FlyDeprecationProjectsResult {
+  isReady: boolean
+  primaries: FlyDeprecationProject[]
+  branches: FlyDeprecationProject[]
+}
+
+export function useFlyDeprecationProjects({
+  enabled,
+}: {
+  enabled: boolean
+}): FlyDeprecationProjectsResult {
+  const { data: organizations } = useOrganizationsQuery({ enabled })
+
+  const orgProjectsQueries = useQueries({
+    queries: (organizations ?? []).map((org) => ({
+      queryKey: projectKeys.bannerProjectsByOrg(org.slug),
+      queryFn: () => getOrganizationProjects({ slug: org.slug, limit: 100 }),
+      staleTime: 30 * 60 * 1000,
+      enabled,
+    })),
+  })
+
+  const isReady =
+    enabled &&
+    organizations !== undefined &&
+    (organizations.length === 0 || orgProjectsQueries.every((q) => q.isFetched))
+
+  const flyProjects: FlyDeprecationProject[] = orgProjectsQueries.flatMap((query, idx) => {
+    const org = (organizations ?? [])[idx]
+    if (!org) return []
+    const projects = query.data?.projects ?? []
+    return projects
+      .filter((p: OrgProject) => p.cloud_provider === PROVIDERS.FLY.id)
+      .map((p: OrgProject) => ({
+        ref: p.ref,
+        name: p.name,
+        orgSlug: org.slug,
+        orgName: org.name,
+        isBranch: p.is_branch,
+      }))
+  })
+
+  return {
+    isReady,
+    primaries: flyProjects.filter((p) => !p.isBranch),
+    branches: flyProjects.filter((p) => p.isBranch),
+  }
+}

--- a/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
+++ b/apps/studio/hooks/misc/useFlyDeprecationProjects.ts
@@ -1,8 +1,6 @@
-import { useQueries } from '@tanstack/react-query'
-
-import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
-import { projectKeys } from '@/data/projects/keys'
-import { getOrganizationProjects } from '@/data/projects/org-projects-infinite-query'
+import { useOrgProjectsInfiniteQuery } from '@/data/projects/org-projects-infinite-query'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { PROVIDERS } from '@/lib/constants/infrastructure'
 
 export interface FlyDeprecationProject {
@@ -13,37 +11,50 @@ export interface FlyDeprecationProject {
 }
 
 export function useFlyDeprecationProjects({ enabled }: { enabled: boolean }) {
-  const { data: organizations } = useOrganizationsQuery({ enabled })
+  const { data: selectedProject } = useSelectedProjectQuery()
+  const { data: selectedOrg } = useSelectedOrganizationQuery()
 
-  const orgProjectsQueries = useQueries({
-    queries: (organizations ?? []).map((org) => ({
-      queryKey: projectKeys.bannerProjectsByOrg(org.slug),
-      queryFn: () => getOrganizationProjects({ slug: org.slug, limit: 100 }),
-      staleTime: 30 * 60 * 1000,
-      enabled,
-    })),
-  })
+  const orgSlug = selectedOrg?.slug
+  const orgName = selectedOrg?.name ?? orgSlug ?? ''
 
-  const isReady =
-    enabled &&
-    organizations !== undefined &&
-    (organizations.length === 0 || orgProjectsQueries.every((q) => q.isFetched))
-
-  const { primaries, branches } = (organizations ?? []).reduce<{
-    primaries: FlyDeprecationProject[]
-    branches: FlyDeprecationProject[]
-  }>(
-    (acc, org, idx) => {
-      const projects = orgProjectsQueries[idx]?.data?.projects ?? []
-      for (const p of projects) {
-        if (p.cloud_provider !== PROVIDERS.FLY.id) continue
-        const bucket = p.is_branch ? acc.branches : acc.primaries
-        bucket.push({ ref: p.ref, name: p.name, orgSlug: org.slug, orgName: org.name })
-      }
-      return acc
-    },
-    { primaries: [], branches: [] }
+  const { data: orgProjectsData, isFetched } = useOrgProjectsInfiniteQuery(
+    { slug: orgSlug },
+    { enabled: enabled && Boolean(orgSlug), staleTime: 30 * 60 * 1000 }
   )
+
+  const isReady = !enabled || !orgSlug || isFetched
+
+  const byRef = new Map<string, FlyDeprecationProject & { isBranch: boolean }>()
+
+  if (selectedProject?.cloud_provider === PROVIDERS.FLY.id) {
+    byRef.set(selectedProject.ref, {
+      ref: selectedProject.ref,
+      name: selectedProject.name,
+      orgSlug: orgSlug ?? '',
+      orgName,
+      isBranch: Boolean(selectedProject.parent_project_ref),
+    })
+  }
+
+  const orgProjects = orgProjectsData?.pages.flatMap((page) => page.projects) ?? []
+  for (const p of orgProjects) {
+    if (p.cloud_provider !== PROVIDERS.FLY.id) continue
+    if (byRef.has(p.ref)) continue
+    byRef.set(p.ref, {
+      ref: p.ref,
+      name: p.name,
+      orgSlug: orgSlug ?? '',
+      orgName,
+      isBranch: Boolean(p.is_branch),
+    })
+  }
+
+  const all = Array.from(byRef.values())
+  const primaries: FlyDeprecationProject[] = []
+  const branches: FlyDeprecationProject[] = []
+  for (const { isBranch, ...rest } of all) {
+    ;(isBranch ? branches : primaries).push(rest)
+  }
 
   return { isReady, primaries, branches }
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -71,7 +71,7 @@ export const LOCAL_STORAGE_KEYS = {
   EXPAND_NAVIGATION_PANEL: 'supabase-expand-navigation-panel',
   GITHUB_AUTHORIZATION_STATE: 'supabase-github-authorization-state',
   // Notice banner keys
-  FLY_POSTGRES_DEPRECATION_WARNING: 'fly-postgres-deprecation-warning-dismissed',
+  FLY_DEPRECATION_2026_05_31: 'fly-deprecation-2026-05-31-dismissed',
   API_KEYS_FEEDBACK_DISMISSED: (ref: string) => `supabase-api-keys-feedback-dismissed-${ref}`,
   TERMS_OF_SERVICE_UPDATE: 'terms-of-service-update-2026-06-06',
   REPORT_DATERANGE: 'supabase-report-daterange',

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3073,6 +3073,36 @@ export interface ComputeBadgeUpgradeClickedEvent {
 }
 
 /**
+ * Fly.io deprecation banner rendered for a user with at least one Fly.io project or branch.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface FlyDeprecationBannerViewedEvent {
+  action: 'fly_deprecation_banner_viewed'
+  groups: TelemetryGroups
+  properties: {
+    primaryCount: number
+    branchCount: number
+  }
+}
+
+/**
+ * User dismissed the Fly.io deprecation banner.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface FlyDeprecationBannerDismissedEvent {
+  action: 'fly_deprecation_banner_dismissed'
+  groups: TelemetryGroups
+  properties: {
+    primaryCount: number
+    branchCount: number
+  }
+}
+
+/**
  * User dismissed the free Micro upgrade banner.
  *
  * @group Events
@@ -3583,6 +3613,8 @@ export type TelemetryEvent =
   | OrgMenuBackClickedEvent
   | OrgMenuItemClickedEvent
   | ComputeBadgeUpgradeClickedEvent
+  | FlyDeprecationBannerViewedEvent
+  | FlyDeprecationBannerDismissedEvent
   | FreeMicroUpgradeBannerDismissedEvent
   | FreeMicroUpgradeBannerCtaClickedEvent
   | HeaderUpgradeCtaClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3078,8 +3078,8 @@ export interface ComputeBadgeUpgradeClickedEvent {
  * @group Events
  * @source studio
  */
-export interface FlyDeprecationBannerViewedEvent {
-  action: 'fly_deprecation_banner_viewed'
+export interface FlyDeprecationBannerExposedEvent {
+  action: 'fly_deprecation_banner_exposed'
   groups: TelemetryGroups
   properties: {
     primaryCount: number
@@ -3613,7 +3613,7 @@ export type TelemetryEvent =
   | OrgMenuBackClickedEvent
   | OrgMenuItemClickedEvent
   | ComputeBadgeUpgradeClickedEvent
-  | FlyDeprecationBannerViewedEvent
+  | FlyDeprecationBannerExposedEvent
   | FlyDeprecationBannerDismissedEvent
   | FreeMicroUpgradeBannerDismissedEvent
   | FreeMicroUpgradeBannerCtaClickedEvent


### PR DESCRIPTION
## Summary

Adding an in-dashboard banner for the Fly.io May 31 suspension. Banner targets users on a Fly project (or with a Fly project in their currently-selected org) and surfaces a per-project breakdown of what's affected in a dialog. Detection is self-correcting: as soon as the user migrates off Fly, the banner disappears with no follow-up.

<img width="557" height="502" alt="Screenshot 2026-05-11 at 5 08 22 PM" src="https://github.com/user-attachments/assets/7bafb712-3490-4555-9667-66e9909f1b1a" />
<img width="1675" height="536" alt="Screenshot 2026-05-11 at 3 55 06 PM" src="https://github.com/user-attachments/assets/6c1bf9d1-4dcc-4aac-a679-2ed477d2ed1c" />


## Changes

- **Detection hook** (`useFlyDeprecationProjects`): reads only from already-cached data — `useSelectedProjectQuery` for the current project, plus `useOrgProjectsInfiniteQuery` scoped to the selected org. Zero cross-org fan-out: worst case is one paginated query per session (the same one the project list page already makes).
- **Banner component** (`FlyDeprecationBanner.tsx`): mounted in `AppBannerWrapper`. Dynamic title (primaries / branches / both), dialog lists affected projects with org name, numbered migration steps, links to backup/restore CLI + Dashboard backup + branching docs. List truncates to 5 entries with "…and N more." tail when more are affected.
- **Telemetry**: `fly_deprecation_banner_exposed` and `fly_deprecation_banner_dismissed` events emitted via `useTrack` (auto-injects project + org groups). Properties: `primaryCount`, `branchCount`. CTA click tracking intentionally omitted — migration outcome is measured via warehouse `cloud_provider = 'FLY'` decay.
- **LocalStorage**: dated dismissal key `FLY_DEPRECATION_2026_05_31`; orphan `FLY_POSTGRES_DEPRECATION_WARNING` from PR #33510 removed in the same change so users who dismissed the Feb 2025 banner still see this one.
- **Support contact**: email `success@supabase.io` only (no support ticket link), per Brian's outreach copy in the Linear issues.

## Coverage trade-off

Banner renders on project pages (selected-project check) and pages where the selected org's projects list is cached (org overview, project list). It does **not** render on `/dashboard` home or other pages without org context. Email outreach from GROWTH-817 / GROWTH-819 handles those users. This was a deliberate trade-off to avoid cross-org fan-out load.

## Lifecycle

Banner expires `2026-06-01T00:00:00Z` (right after the May 31 deadline). Stale client bundles stop rendering it without a redeploy. Cleanup PR planned post-deadline to remove the component, hook, localStorage key, and telemetry events.

## Testing

Tested on the Vercel preview with React Query cache overrides to mock a Fly project:

- [x] Banner renders for a user with at least one project where `cloud_provider === 'FLY'`
- [x] Banner does **not** render for a user with no Fly projects
- [x] Banner does **not** render on `/sign-in`
- [x] Title varies by primaries-only / branches-only / both
- [x] Dialog lists affected projects with org name in parens
- [x] Dialog list truncates to 5 with "…and N more." for larger sets
- [x] Migration guide / Dashboard backup / branching links open in a new tab
- [x] Dismiss (×) closes the banner and persists across hard reload (localStorage `fly-deprecation-2026-05-31-dismissed`)
- [x] PostHog receives one `fly_deprecation_banner_exposed` per mount with `primaryCount` + `branchCount` and `$groups.organization` populated
- [x] PostHog receives one `fly_deprecation_banner_dismissed` on close with the same property shape

## Linear

- fixes GROWTH-817
- fixes GROWTH-819
