### PR TITLE
chore: skip auto approve for studio

### DIFF
--- a/scripts/authorizeVercelDeploys.ts
+++ b/scripts/authorizeVercelDeploys.ts
@@ -122,6 +122,11 @@ async function main() {
 
   // Process each authorization-required status
   for (const status of authRequiredStatuses) {
+    if (status.context === 'Vercel - studio') {
+      console.log(`\nSkipping status: ${status.context}`)
+      continue
+    }
+
     try {
       console.log(`\nProcessing status: ${status.context}`)
       console.log(`Target URL: ${status.target_url}`)


### PR DESCRIPTION
Studio builds get skipped in Vercel anyway, but be deliberate in skipping approval. We don't want forks to be able to have a studio deployment approved. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized the deployment authorization process to skip unnecessary status checks, reducing processing overhead and improving deployment pipeline efficiency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45781)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->