### PR TITLE
Refactor auth email template variables

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
@@ -1,6 +1,84 @@
 import * as z from 'zod'
 
-import type { AuthTemplate } from './EmailTemplates.types'
+import type { AuthTemplate, TemplateVariable, TemplateVariableName } from './EmailTemplates.types'
+import { InlineLink } from '@/components/ui/InlineLink'
+
+const TemplateVariables: Record<TemplateVariableName, TemplateVariable> = {
+  ConfirmationURL: {
+    name: 'ConfirmationURL',
+    value: '{{ .ConfirmationURL }}',
+    description: 'URL to confirm the email address for the new account',
+  },
+  Token: {
+    name: 'Token',
+    value: '{{ .Token }}',
+    description: 'The 6-digit numeric email OTP.',
+  },
+  TokenHash: {
+    name: 'TokenHash',
+    value: '{{ .TokenHash }}',
+    description: 'The hashed token used in the URL, useful for constructing your own email link.',
+  },
+  SiteURL: {
+    name: 'SiteURL',
+    value: '{{ .SiteURL }}',
+    description: 'The URL of the site.',
+  },
+  Email: {
+    name: 'Email',
+    value: '{{ .Email }}',
+    description: "The user's email address",
+  },
+  NewEmail: {
+    name: 'NewEmail',
+    value: '{{ .NewEmail }}',
+    description: "Contains the new user's email address.",
+  },
+  OldEmail: {
+    name: 'OldEmail',
+    value: '{{ .OldEmail }}',
+    description: "Contains the user's old email address.",
+  },
+  Phone: {
+    name: 'Phone',
+    value: '{{ .Phone }}',
+    description: "The user's new phone number",
+  },
+  OldPhone: {
+    name: 'OldPhone',
+    value: '{{ .OldPhone }}',
+    description: "The user's old phone number",
+  },
+  Provider: {
+    name: 'Provider',
+    value: '{{ .Provider }}',
+    description: 'The provider of the newly linked/unlinked identity',
+  },
+  FactorType: {
+    name: 'FactorType',
+    value: '{{ .FactorType }}',
+    description: 'The type of the newly enrolled/unenrolled MFA factor',
+  },
+  Data: {
+    name: 'Data',
+    value: '{{ .Data }}',
+    description: (
+      <>
+        The user's <code className="text-code-inline">user_metadata</code>
+      </>
+    ),
+  },
+  // [Joshen] To check if this is deprecated - no longer in the docs
+  RedirectTo: {
+    name: 'RedirectTo',
+    value: '{{ .RedirectTo }}',
+    description: (
+      <>
+        The URL of <code className="text-code-inline">emailRedirectTo</code> passed in options
+      </>
+    ),
+  },
+}
 
 const CONFIRMATION: AuthTemplate = {
   id: 'CONFIRMATION',
@@ -8,25 +86,18 @@ const CONFIRMATION: AuthTemplate = {
   title: 'Confirm sign up',
   purpose: 'Ask users to confirm their email address after signing up',
   properties: {
-    MAILER_SUBJECTS_CONFIRMATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_CONFIRMATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .ConfirmationURL }}\` : URL to confirm the email address for the new account
-- \`{{ .Token }}\` : The 6-digit numeric email OTP
-- \`{{ .TokenHash }}\` : The hashed token used in the URL
-- \`{{ .SiteURL }}\` : The URL of the site
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-- \`{{ .RedirectTo }}\` : The URL of \`emailRedirectTo\` passed in options
-`,
-    },
+    MAILER_SUBJECTS_CONFIRMATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_CONFIRMATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [
+    TemplateVariables.ConfirmationURL,
+    TemplateVariables.Token,
+    TemplateVariables.TokenHash,
+    TemplateVariables.SiteURL,
+    TemplateVariables.Email,
+    TemplateVariables.Data,
+    TemplateVariables.RedirectTo,
+  ],
   validationSchema: z.object({
     MAILER_SUBJECTS_CONFIRMATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -41,25 +112,18 @@ const INVITE: AuthTemplate = {
   title: 'Invite user',
   purpose: "Invite users who don't yet have an account to sign up",
   properties: {
-    MAILER_SUBJECTS_INVITE: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_INVITE_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .ConfirmationURL }}\` : URL to accept the invitation to create an account
-- \`{{ .Token }}\` : The 6-digit numeric email OTP
-- \`{{ .TokenHash }}\` : The hashed token used in the URL
-- \`{{ .SiteURL }}\` : The URL of the site
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-- \`{{ .RedirectTo }}\` : The URL of \`redirectTo\` passed in options
-`,
-    },
+    MAILER_SUBJECTS_INVITE: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_INVITE_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [
+    TemplateVariables.ConfirmationURL,
+    TemplateVariables.Token,
+    TemplateVariables.TokenHash,
+    TemplateVariables.SiteURL,
+    TemplateVariables.Email,
+    TemplateVariables.Data,
+    TemplateVariables.RedirectTo,
+  ],
   validationSchema: z.object({
     MAILER_SUBJECTS_INVITE: z.string().min(1, 'Subject is required.'),
   }),
@@ -74,25 +138,18 @@ const MAGIC_LINK: AuthTemplate = {
   title: 'Magic link',
   purpose: 'Allow users to sign in via a one-time link sent to their email',
   properties: {
-    MAILER_SUBJECTS_MAGIC_LINK: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_MAGIC_LINK_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .ConfirmationURL }}\` : URL for a one-time login to the user's account
-- \`{{ .Token }}\` : The 6-digit numeric email OTP
-- \`{{ .TokenHash }}\` : The hashed token used in the URL
-- \`{{ .SiteURL }}\` : The URL of the site
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-- \`{{ .RedirectTo }}\` : The URL of \`emailRedirectTo\` passed in options
-`,
-    },
+    MAILER_SUBJECTS_MAGIC_LINK: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_MAGIC_LINK_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [
+    TemplateVariables.ConfirmationURL,
+    TemplateVariables.Token,
+    TemplateVariables.TokenHash,
+    TemplateVariables.SiteURL,
+    TemplateVariables.Email,
+    TemplateVariables.Data,
+    TemplateVariables.RedirectTo,
+  ],
   validationSchema: z.object({
     MAILER_SUBJECTS_MAGIC_LINK: z.string().min(1, 'Subject is required.'),
   }),
@@ -107,26 +164,19 @@ const EMAIL_CHANGE: AuthTemplate = {
   title: 'Change email address',
   purpose: 'Ask users to verify their new email address after changing it',
   properties: {
-    MAILER_SUBJECTS_EMAIL_CHANGE: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .ConfirmationURL }}\` : URL to confirm the email change
-- \`{{ .Token }}\` : The 6-digit numeric email OTP
-- \`{{ .TokenHash }}\` : The hashed token used in the URL
-- \`{{ .SiteURL }}\` : The URL of the site
-- \`{{ .Email }}\` : The original user's email address
-- \`{{ .NewEmail }}\` : The user's new email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-- \`{{ .RedirectTo }}\` : The URL of \`emailRedirectTo\` passed in options
-`,
-    },
+    MAILER_SUBJECTS_EMAIL_CHANGE: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [
+    TemplateVariables.ConfirmationURL,
+    TemplateVariables.Token,
+    TemplateVariables.TokenHash,
+    TemplateVariables.SiteURL,
+    TemplateVariables.Email,
+    TemplateVariables.NewEmail,
+    TemplateVariables.Data,
+    TemplateVariables.RedirectTo,
+  ],
   validationSchema: z.object({
     MAILER_SUBJECTS_EMAIL_CHANGE: z.string().min(1, 'Subject is required.'),
   }),
@@ -141,25 +191,18 @@ const RECOVERY: AuthTemplate = {
   title: 'Reset password',
   purpose: 'Allow users to reset their password if they forget it',
   properties: {
-    MAILER_SUBJECTS_RECOVERY: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_RECOVERY_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .ConfirmationURL }}\` : URL to confirm the password reset
-- \`{{ .Token }}\` : The 6-digit numeric email OTP
-- \`{{ .TokenHash }}\` : The hashed token used in the URL
-- \`{{ .SiteURL }}\` : The URL of the site
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-- \`{{ .RedirectTo }}\` : The URL of \`redirectTo\` passed in options
-`,
-    },
+    MAILER_SUBJECTS_RECOVERY: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_RECOVERY_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [
+    TemplateVariables.ConfirmationURL,
+    TemplateVariables.Token,
+    TemplateVariables.TokenHash,
+    TemplateVariables.SiteURL,
+    TemplateVariables.Email,
+    TemplateVariables.Data,
+    TemplateVariables.RedirectTo,
+  ],
   validationSchema: z.object({
     MAILER_SUBJECTS_RECOVERY: z.string().min(1, 'Subject is required.'),
   }),
@@ -174,22 +217,15 @@ const REAUTHENTICATION: AuthTemplate = {
   title: 'Reauthentication',
   purpose: 'Ask users to re-authenticate before performing a sensitive action',
   properties: {
-    MAILER_SUBJECTS_REAUTHENTICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_REAUTHENTICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Token }}\` : The 6-digit numeric email OTP
-- \`{{ .SiteURL }}\` : The URL of the site
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_REAUTHENTICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_REAUTHENTICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [
+    TemplateVariables.Token,
+    TemplateVariables.SiteURL,
+    TemplateVariables.Email,
+    TemplateVariables.Data,
+  ],
   validationSchema: z.object({
     MAILER_SUBJECTS_REAUTHENTICATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -205,20 +241,10 @@ const PASSWORD_CHANGED_NOTIFICATION: AuthTemplate = {
   title: 'Password changed',
   purpose: 'Notify users when their password has changed',
   properties: {
-    MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_PASSWORD_CHANGED_NOTIFICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_PASSWORD_CHANGED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [TemplateVariables.Email, TemplateVariables.Data],
   validationSchema: z.object({
     MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -233,21 +259,10 @@ const EMAIL_CHANGED_NOTIFICATION: AuthTemplate = {
   title: 'Email address changed',
   purpose: 'Notify users when their email address has changed',
   properties: {
-    MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_EMAIL_CHANGED_NOTIFICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Email }}\` : The user's new email address
-- \`{{ .OldEmail }}\` : The user's old email address
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_EMAIL_CHANGED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [TemplateVariables.Email, TemplateVariables.OldEmail, TemplateVariables.Data],
   validationSchema: z.object({
     MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -262,22 +277,15 @@ const PHONE_CHANGED_NOTIFICATION: AuthTemplate = {
   title: 'Phone number changed',
   purpose: 'Notify users when their phone number has changed',
   properties: {
-    MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_PHONE_CHANGED_NOTIFICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Phone }}\` : The user's new phone number
-- \`{{ .OldPhone }}\` : The user's old phone number
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_PHONE_CHANGED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [
+    TemplateVariables.Email,
+    TemplateVariables.Phone,
+    TemplateVariables.OldPhone,
+    TemplateVariables.Data,
+  ],
   validationSchema: z.object({
     MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -292,21 +300,10 @@ const IDENTITY_LINKED_NOTIFICATION: AuthTemplate = {
   title: 'Identity linked',
   purpose: 'Notify users when a new identity has been linked to their account',
   properties: {
-    MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_IDENTITY_LINKED_NOTIFICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Provider }}\` : The provider of the linked identity
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_IDENTITY_LINKED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [TemplateVariables.Email, TemplateVariables.Provider, TemplateVariables.Data],
   validationSchema: z.object({
     MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -321,21 +318,10 @@ const IDENTITY_UNLINKED_NOTIFICATION: AuthTemplate = {
   title: 'Identity unlinked',
   purpose: 'Notify users when an identity has been unlinked from their account',
   properties: {
-    MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_IDENTITY_UNLINKED_NOTIFICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .Provider }}\` : The provider of the unlinked identity
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_IDENTITY_UNLINKED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [TemplateVariables.Email, TemplateVariables.Provider, TemplateVariables.Data],
   validationSchema: z.object({
     MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -350,21 +336,10 @@ const MFA_FACTOR_ENROLLED_NOTIFICATION: AuthTemplate = {
   title: 'MFA method added',
   purpose: 'Notify users when an MFA method has been added to their account',
   properties: {
-    MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_MFA_FACTOR_ENROLLED_NOTIFICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .FactorType }}\` : The type of verification method that was added
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_MFA_FACTOR_ENROLLED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [TemplateVariables.Email, TemplateVariables.FactorType, TemplateVariables.Data],
   validationSchema: z.object({
     MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
   }),
@@ -379,21 +354,10 @@ const MFA_FACTOR_UNENROLLED_NOTIFICATION: AuthTemplate = {
   title: 'MFA method removed',
   purpose: 'Notify users when an MFA method has been removed from their account',
   properties: {
-    MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION: {
-      title: 'Subject',
-      type: 'string',
-    },
-    MAILER_TEMPLATES_MFA_FACTOR_UNENROLLED_NOTIFICATION_CONTENT: {
-      title: 'Body',
-      descriptionOptional: 'HTML body of your email',
-      type: 'code',
-      description: `
-- \`{{ .Email }}\` : The user's email address
-- \`{{ .FactorType }}\` : The type of the newly enrolled MFA factor
-- \`{{ .Data }}\` : The user's \`user_metadata\`
-`,
-    },
+    MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION: { title: 'Subject', type: 'string' },
+    MAILER_TEMPLATES_MFA_FACTOR_UNENROLLED_NOTIFICATION_CONTENT: { title: 'Body', type: 'code' },
   },
+  variables: [TemplateVariables.Email, TemplateVariables.FactorType, TemplateVariables.Data],
   validationSchema: z.object({
     MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION: z.string().min(1, 'Subject is required.'),
   }),

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
@@ -11,59 +11,59 @@ const TemplateVariables: Record<TemplateVariableName, TemplateVariable> = {
   Token: {
     name: 'Token',
     value: '{{ .Token }}',
-    description: 'The 6-digit numeric email OTP',
+    description: '6-digit numeric email OTP',
   },
   TokenHash: {
     name: 'TokenHash',
     value: '{{ .TokenHash }}',
-    description: 'The hashed token used in the URL, useful for constructing your own email link',
+    description: 'Hashed token used in the URL, useful for constructing your own email link',
   },
   SiteURL: {
     name: 'SiteURL',
     value: '{{ .SiteURL }}',
-    description: "This project's redirect URL",
+    description: 'Redirect URL',
   },
   Email: {
     name: 'Email',
     value: '{{ .Email }}',
-    description: "The user's current email address",
+    description: "User's current email address",
   },
   NewEmail: {
     name: 'NewEmail',
     value: '{{ .NewEmail }}',
-    description: "The user's new email address",
+    description: "User's new email address",
   },
   OldEmail: {
     name: 'OldEmail',
     value: '{{ .OldEmail }}',
-    description: "The user's old email address",
+    description: "User's old email address",
   },
   Phone: {
     name: 'Phone',
     value: '{{ .Phone }}',
-    description: "The user's new phone number",
+    description: "User's new phone number",
   },
   OldPhone: {
     name: 'OldPhone',
     value: '{{ .OldPhone }}',
-    description: "The user's old phone number",
+    description: "User's old phone number",
   },
   Provider: {
     name: 'Provider',
     value: '{{ .Provider }}',
-    description: 'The provider of the newly linked/unlinked identity',
+    description: 'Provider of newly linked/unlinked identity',
   },
   FactorType: {
     name: 'FactorType',
     value: '{{ .FactorType }}',
-    description: 'The type of the newly enrolled/unenrolled MFA factor',
+    description: 'Type of newly enrolled/unenrolled MFA factor',
   },
   Data: {
     name: 'Data',
     value: '{{ .Data }}',
     description: (
       <>
-        The user's <code className="text-code-inline">user_metadata</code>
+        User's <code className="text-code-inline">user_metadata</code>
       </>
     ),
   },
@@ -73,7 +73,7 @@ const TemplateVariables: Record<TemplateVariableName, TemplateVariable> = {
     value: '{{ .RedirectTo }}',
     description: (
       <>
-        The URL of <code className="text-code-inline">emailRedirectTo</code> passed in options
+        URL of <code className="text-code-inline">emailRedirectTo</code> passed in options
       </>
     ),
   },

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
@@ -1,7 +1,6 @@
 import * as z from 'zod'
 
 import type { AuthTemplate, TemplateVariable, TemplateVariableName } from './EmailTemplates.types'
-import { InlineLink } from '@/components/ui/InlineLink'
 
 const TemplateVariables: Record<TemplateVariableName, TemplateVariable> = {
   ConfirmationURL: {

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation.tsx
@@ -11,32 +11,32 @@ const TemplateVariables: Record<TemplateVariableName, TemplateVariable> = {
   Token: {
     name: 'Token',
     value: '{{ .Token }}',
-    description: 'The 6-digit numeric email OTP.',
+    description: 'The 6-digit numeric email OTP',
   },
   TokenHash: {
     name: 'TokenHash',
     value: '{{ .TokenHash }}',
-    description: 'The hashed token used in the URL, useful for constructing your own email link.',
+    description: 'The hashed token used in the URL, useful for constructing your own email link',
   },
   SiteURL: {
     name: 'SiteURL',
     value: '{{ .SiteURL }}',
-    description: 'The URL of the site.',
+    description: "This project's redirect URL",
   },
   Email: {
     name: 'Email',
     value: '{{ .Email }}',
-    description: "The user's email address",
+    description: "The user's current email address",
   },
   NewEmail: {
     name: 'NewEmail',
     value: '{{ .NewEmail }}',
-    description: "Contains the new user's email address.",
+    description: "The user's new email address",
   },
   OldEmail: {
     name: 'OldEmail',
     value: '{{ .OldEmail }}',
-    description: "Contains the user's old email address.",
+    description: "The user's old email address",
   },
   Phone: {
     name: 'Phone',

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.types.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.types.ts
@@ -1,3 +1,4 @@
+import { ReactNode } from 'react'
 import z from 'zod'
 
 export type KebabCase<S extends string> = S extends `${infer A}_${infer B}`
@@ -23,6 +24,27 @@ const AUTH_TEMPLATE_TYPES = [
 export type AuthTemplateType = (typeof AUTH_TEMPLATE_TYPES)[number]
 export type AuthTemplateResetType = KebabCase<AuthTemplateType>
 
+export type TemplateVariableName =
+  | 'ConfirmationURL'
+  | 'Token'
+  | 'TokenHash'
+  | 'SiteURL'
+  | 'Email'
+  | 'NewEmail'
+  | 'OldEmail'
+  | 'Phone'
+  | 'OldPhone'
+  | 'Provider'
+  | 'FactorType'
+  | 'Data'
+  | 'RedirectTo'
+
+export type TemplateVariable = {
+  name: TemplateVariableName
+  value: string
+  description: string | ReactNode
+}
+
 export interface AuthTemplate {
   id: AuthTemplateType
   type: 'object'
@@ -32,10 +54,9 @@ export interface AuthTemplate {
     [x: string]: {
       title: string
       type: 'boolean' | 'string' | 'select' | 'number' | 'code'
-      description?: string
-      descriptionOptional?: string
     }
   }
+  variables: TemplateVariable[]
   validationSchema: z.AnyZodObject
   misc: { emailTemplateType: 'authentication' | 'security' }
 }

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import { Book } from 'lucide-react'
+import { Book, BookOpen } from 'lucide-react'
 import type { editor } from 'monaco-editor'
 import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -295,7 +295,7 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                         asChild
                         type="text"
                         className="w-7"
-                        icon={<Book />}
+                        icon={<BookOpen />}
                         tooltip={{
                           content: {
                             side: 'right',

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -1,10 +1,11 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
+import { Book } from 'lucide-react'
 import type { editor } from 'monaco-editor'
+import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
-import ReactMarkdown from 'react-markdown'
 import { toast } from 'sonner'
 import {
   Button,
@@ -27,13 +28,16 @@ import type { AuthTemplate } from './EmailTemplates.types'
 import { ResetTemplateDialog } from './ResetTemplateDialog'
 import { SpamValidation } from './SpamValidation'
 import { PreventNavigationOnUnsavedChanges } from '@/components/ui-patterns/Dialogs/PreventNavigationOnUnsavedChanges'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { CodeEditor } from '@/components/ui/CodeEditor/CodeEditor'
+import { InlineLink } from '@/components/ui/InlineLink'
 import { TwoOptionToggle } from '@/components/ui/TwoOptionToggle'
 import type { AuthConfigResponse } from '@/data/auth/auth-config-query'
 import { useAuthConfigQuery } from '@/data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-mutation'
 import { useValidateSpamMutation, ValidateSpamResponse } from '@/data/auth/validate-spam-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { DOCS_URL } from '@/lib/constants'
 
 interface TemplateEditorProps {
   template: AuthTemplate
@@ -161,29 +165,6 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
     )
   }
 
-  // Single useMemo hook to parse and prepare message variables
-  const messageVariables = useMemo(() => {
-    if (!messageProperty?.description) return []
-
-    // Parse bullet point format: - `{{ .Variable }}` : Description
-    const lines = messageProperty.description.split('\n')
-    const variables: { variable: string; description: string }[] = []
-
-    for (const line of lines) {
-      // Match lines that start with a bullet point followed by a variable in the format {{ .Variable }}
-      // Handle variations in formatting (with or without backticks, different spacing)
-      const match = line.match(/-\s*`?({{\s*\.\w+\s*}})`?\s*(?::|-)?\s*(.+)/)
-      if (match && match[1] && match[2]) {
-        variables.push({
-          variable: match[1].replace(/`/g, '').trim(),
-          description: match[2].trim(),
-        })
-      }
-    }
-
-    return variables
-  }, [messageProperty?.description])
-
   // Check if form values have changed
   const formValues = form.watch()
   const baselineValues = INITIAL_VALUES
@@ -263,25 +244,7 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                   control={form.control}
                   name={x}
                   render={({ field }) => (
-                    <FormItemLayout
-                      className="gap-y-3"
-                      layout="vertical"
-                      label={property.title}
-                      description={
-                        property.description ? (
-                          <ReactMarkdown unwrapDisallowed disallowedElements={['p']}>
-                            {property.description}
-                          </ReactMarkdown>
-                        ) : null
-                      }
-                      labelOptional={
-                        property.descriptionOptional ? (
-                          <ReactMarkdown unwrapDisallowed disallowedElements={['p']}>
-                            {property.descriptionOptional}
-                          </ReactMarkdown>
-                        ) : null
-                      }
-                    >
+                    <FormItemLayout className="gap-y-3" layout="vertical" label={property.title}>
                       <FormControl>
                         <Input_Shadcn_ id={x} {...field} disabled={!canUpdateConfig} />
                       </FormControl>
@@ -324,27 +287,68 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                       editorRef={editorRef}
                     />
                   </div>
-                  {messageVariables.length > 0 && (
-                    <div className="flex flex-wrap gap-1">
-                      {messageVariables.map(({ variable, description }) => (
-                        <Tooltip key={variable}>
+
+                  <div className="flex flex-col gap-y-1">
+                    <div className="flex items-center gap-x-1">
+                      <p className="text-sm">Template variables</p>
+                      <ButtonTooltip
+                        asChild
+                        type="text"
+                        className="w-7"
+                        icon={<Book />}
+                        tooltip={{
+                          content: {
+                            side: 'right',
+                            text: 'Documentation',
+                          },
+                        }}
+                      >
+                        <Link
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          href={`${DOCS_URL}/guides/local-development/customizing-email-templates#template-variables`}
+                        />
+                      </ButtonTooltip>
+                    </div>
+                    <div className="flex flex-wrap gap-x-1">
+                      {template.variables.map((variable) => (
+                        <Tooltip key={variable.value}>
                           <TooltipTrigger asChild>
                             <Button
                               type="outline"
                               size="tiny"
                               className="rounded-full"
-                              onClick={() => insertTextAtCursor(variable)}
+                              onClick={() => insertTextAtCursor(variable.value)}
                             >
-                              {variable}
+                              {variable.value}
                             </Button>
                           </TooltipTrigger>
-                          <TooltipContent side="top">
-                            <p>{description || 'Variable description not available'}</p>
+                          <TooltipContent side="bottom">
+                            {variable.description}
+
+                            {variable.name === 'Token' &&
+                              template.variables.some((x) => x.name === 'ConfirmationURL') && (
+                                <>
+                                  {' '}
+                                  Can be used instead of{' '}
+                                  <code className="text-code-inline">ConfirmationURL</code>
+                                </>
+                              )}
+
+                            {variable.name === 'SiteURL' && (
+                              <>
+                                {' '}
+                                Configurable in your project's{' '}
+                                <InlineLink href={`/project/${projectRef}/auth/url-configuration`}>
+                                  authentication settings
+                                </InlineLink>
+                              </>
+                            )}
                           </TooltipContent>
                         </Tooltip>
                       ))}
                     </div>
-                  )}
+                  </div>
                 </>
               ) : (
                 <>

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -338,9 +338,9 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                             {variable.name === 'SiteURL' && (
                               <>
                                 {' '}
-                                Configurable in your project's{' '}
+                                as defined in{' '}
                                 <InlineLink href={`/project/${projectRef}/auth/url-configuration`}>
-                                  authentication settings
+                                  URL Configuration
                                 </InlineLink>
                               </>
                             )}

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -316,7 +316,8 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                             {variable.name === 'Token' &&
                               template.variables.some((x) => x.name === 'ConfirmationURL') && (
                                 <>
-                                  , which can be used instead of{' '}
+                                  {' '}
+                                  which can be used instead of{' '}
                                   <code className="text-code-inline">ConfirmationURL</code>
                                 </>
                               )}

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -289,7 +289,7 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                     <div className="flex flex-col">
                       <p className="text-sm">Template variables</p>
                       <p className="text-sm text-foreground-lighter">
-                        Data placeholders that can be inserted in the subject line or email body.{' '}
+                        Data placeholders that can be inserted into the subject or body.{' '}
                         <InlineLink
                           href={`${DOCS_URL}/guides/local-development/customizing-email-templates#template-variables`}
                         >

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -329,8 +329,7 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                             {variable.name === 'Token' &&
                               template.variables.some((x) => x.name === 'ConfirmationURL') && (
                                 <>
-                                  {' '}
-                                  Can be used instead of{' '}
+                                  , which can be used instead of{' '}
                                   <code className="text-code-inline">ConfirmationURL</code>
                                 </>
                               )}

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -1,9 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import { Book, BookOpen } from 'lucide-react'
 import type { editor } from 'monaco-editor'
-import Link from 'next/link'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
@@ -28,7 +26,6 @@ import type { AuthTemplate } from './EmailTemplates.types'
 import { ResetTemplateDialog } from './ResetTemplateDialog'
 import { SpamValidation } from './SpamValidation'
 import { PreventNavigationOnUnsavedChanges } from '@/components/ui-patterns/Dialogs/PreventNavigationOnUnsavedChanges'
-import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { CodeEditor } from '@/components/ui/CodeEditor/CodeEditor'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { TwoOptionToggle } from '@/components/ui/TwoOptionToggle'
@@ -288,27 +285,17 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
                     />
                   </div>
 
-                  <div className="flex flex-col gap-y-1">
-                    <div className="flex items-center gap-x-1">
+                  <div className="flex flex-col gap-y-2">
+                    <div className="flex flex-col">
                       <p className="text-sm">Template variables</p>
-                      <ButtonTooltip
-                        asChild
-                        type="text"
-                        className="w-7"
-                        icon={<BookOpen />}
-                        tooltip={{
-                          content: {
-                            side: 'right',
-                            text: 'Documentation',
-                          },
-                        }}
-                      >
-                        <Link
-                          target="_blank"
-                          rel="noopener noreferrer"
+                      <p className="text-sm text-foreground-lighter">
+                        Data placeholders that can be inserted in the subject line or email body.{' '}
+                        <InlineLink
                           href={`${DOCS_URL}/guides/local-development/customizing-email-templates#template-variables`}
-                        />
-                      </ButtonTooltip>
+                        >
+                          Learn more
+                        </InlineLink>
+                      </p>
                     </div>
                     <div className="flex flex-wrap gap-x-1">
                       {template.variables.map((variable) => (

--- a/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
+++ b/apps/studio/components/layouts/AuthLayout/AuthEmailsLayout.tsx
@@ -23,7 +23,7 @@ export const AuthEmailsLayout = ({ children }: PropsWithChildren<{}>) => {
   ]
 
   return (
-    <AuthLayout title="Email">
+    <AuthLayout title="Emails">
       {showEmails ? (
         <PageLayout
           title="Emails"

--- a/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.test.ts
+++ b/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.test.ts
@@ -52,7 +52,7 @@ describe('generateAuthMenu', () => {
     expect(names).toContain('Overview')
     expect(names).toContain('Users')
     expect(names).toContain('OAuth Apps')
-    expect(names).toContain('Email')
+    expect(names).toContain('Emails')
     expect(names).toContain('Sign In / Providers')
     expect(names).toContain('OAuth Server')
     expect(names).toContain('Passkeys')
@@ -81,7 +81,7 @@ describe('generateAuthMenu', () => {
     expect(names).toContain('Audit Logs')
 
     expect(names).not.toContain('Overview')
-    expect(names).not.toContain('Email')
+    expect(names).not.toContain('Emails')
     expect(names).not.toContain('Sign In / Providers')
     expect(names).not.toContain('Rate Limits')
     expect(names).not.toContain('Multi-Factor')
@@ -119,7 +119,7 @@ describe('generateAuthMenu', () => {
   it.each([
     ['signInProviders', 'Sign In / Providers'],
     ['rateLimits', 'Rate Limits'],
-    ['emails', 'Email'],
+    ['emails', 'Emails'],
     ['multiFactor', 'Multi-Factor'],
     ['attackProtection', 'Attack Protection'],
     ['performance', 'Performance'],

--- a/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
+++ b/apps/studio/components/layouts/AuthLayout/AuthLayout.utils.ts
@@ -52,7 +52,7 @@ export function generateAuthMenu(options: GenerateAuthMenuOptions): ProductMenuG
               ...(features.emails
                 ? [
                     {
-                      name: 'Email',
+                      name: 'Emails',
                       key: 'email',
                       pages: ['templates', 'smtp'],
                       url: `${baseUrl}/templates`,


### PR DESCRIPTION
## Context

Reworks the template variables section of an email template a little
- Add a section header with docs button
  <img width="1112" height="133" alt="image" src="https://github.com/user-attachments/assets/34f27c81-a7d7-430c-b23b-f95bf6572c8c" />
- Refactor `AuthTemplatesValidation` to remove unnecessary description parsing logic in `TemplateEditor`
- Update tooltip content to match [docs](https://supabase.com/docs/guides/local-development/customizing-email-templates#template-variables)
  - e.g `SiteURL`: Add inline link for configuration
    <img width="480" height="96" alt="image" src="https://github.com/user-attachments/assets/731312bd-e46b-4cd2-81e9-85a67c9e318e" />
  - e.g `Token`: Mention that its swappable with `ConfirmationURL` if both parameters are available for use in the template (Counter example is the reauthentication template which there's only `Token` variable available)
    <img width="462" height="93" alt="image" src="https://github.com/user-attachments/assets/63017f28-3d84-4840-8217-ba113646b63b" />
    <img width="262" height="122" alt="image" src="https://github.com/user-attachments/assets/e3450eb8-7ff5-4eec-920f-77bb5fd4f367" />



