### PR TITLE
fix(studio): pre-empt React 19 regressions in tests + Support form

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/__tests__/EditSecretModal.test.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/__tests__/EditSecretModal.test.tsx
@@ -79,9 +79,6 @@ describe(`EditSecretModal`, () => {
 
     await screen.findByRole(`dialog`)
 
-    // The decrypted-value query resolves on a separate render tick from the
-    // vault list query that opens the dialog. Wait for the form fields to
-    // replace the skeleton before reading them.
     const nameInput = await screen.findByLabelText(`Name`)
     const descriptionInput = screen.getByLabelText(`Description`)
     const valueInput = screen.getByLabelText(`Secret value`)

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/__tests__/EditSecretModal.test.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/__tests__/EditSecretModal.test.tsx
@@ -79,7 +79,10 @@ describe(`EditSecretModal`, () => {
 
     await screen.findByRole(`dialog`)
 
-    const nameInput = screen.getByLabelText(`Name`)
+    // The decrypted-value query resolves on a separate render tick from the
+    // vault list query that opens the dialog. Wait for the form fields to
+    // replace the skeleton before reading them.
+    const nameInput = await screen.findByLabelText(`Name`)
     const descriptionInput = screen.getByLabelText(`Description`)
     const valueInput = screen.getByLabelText(`Secret value`)
     const togglePasswordButton = screen.getByRole(`button`, { name: `Show secret value` })

--- a/apps/studio/components/interfaces/Support/CategoryAndSeverityInfo.tsx
+++ b/apps/studio/components/interfaces/Support/CategoryAndSeverityInfo.tsx
@@ -74,13 +74,26 @@ function CategorySelector({ form }: CategorySelectorProps) {
       control={form.control}
       render={({ field }) => {
         const { ref: _ref, ...fieldWithoutRef } = field
+        // Radix Select fires `onValueChange('')` when its controlled value
+        // transitions from `undefined` to a defined value whose matching
+        // SelectItem isn't mounted yet (the dropdown is closed, so
+        // SelectContent and the items it portals haven't registered). On
+        // React 19's stricter scheduling this races our `setValue` from
+        // useSupportForm and clobbers the prefilled category. No
+        // SelectItem can have value="" (Radix throws), so `v === ''` is
+        // always the spurious bubble — drop it. See
+        // radix-ui/primitives#3381.
+        const onValueChange = (v: string) => {
+          if (v === '' && field.value) return
+          field.onChange(v)
+        }
         return (
           <FormItemLayout hideMessage layout="vertical" label="What are you having issues with?">
             <FormControl>
               <Select_Shadcn_
                 {...fieldWithoutRef}
                 defaultValue={field.value}
-                onValueChange={field.onChange}
+                onValueChange={onValueChange}
               >
                 <SelectTrigger_Shadcn_ aria-label="Select an issue" className="w-full">
                   <SelectValue_Shadcn_ placeholder="Select an issue">

--- a/apps/studio/components/interfaces/Support/useSupportForm.ts
+++ b/apps/studio/components/interfaces/Support/useSupportForm.ts
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect, useMemo, useRef, type Dispatch } from 'react'
+import { useEffect, useRef, useState, type Dispatch } from 'react'
 import { useForm, useWatch, type DefaultValues, type UseFormReturn } from 'react-hook-form'
 
 import { SupportFormSchema, type SupportFormValues } from './SupportForm.schema'
@@ -16,7 +16,7 @@ import {
 
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 
-const supportFormBaseDefaults: DefaultValues<SupportFormValues> = {
+const supportFormDefaultValues: DefaultValues<SupportFormValues> = {
   organizationSlug: NO_ORG_MARKER,
   projectRef: NO_PROJECT_MARKER,
   severity: 'Low',
@@ -41,33 +41,6 @@ export function useSupportForm(
   dispatch: Dispatch<SupportFormActions>,
   initialParams?: Partial<SupportFormUrlKeys>
 ): UseSupportFormResult {
-  // Seed defaults from the URL synchronously so controlled fields like the
-  // category Select start in their final state. Setting these via a useEffect
-  // setValue makes Radix Select switch from uncontrolled to controlled
-  // mid-mount, which on React 19 spuriously emits onValueChange('') and
-  // clears the field. See radix-ui/primitives#3381.
-  const initialParamsResult = useMemo(() => {
-    return initialParams !== undefined
-      ? loadSupportFormInitialParamsFromObject(initialParams)
-      : loadSupportFormInitialParams(typeof window === 'undefined' ? '' : window.location.search)
-    // Snapshot once; URL/object changes after mount are intentionally ignored.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  const supportFormDefaultValues = useMemo<DefaultValues<SupportFormValues>>(() => {
-    return {
-      ...supportFormBaseDefaults,
-      ...(initialParamsResult.category ? { category: initialParamsResult.category } : {}),
-      ...(typeof initialParamsResult.subject === 'string'
-        ? { subject: initialParamsResult.subject }
-        : {}),
-      ...(typeof initialParamsResult.message === 'string'
-        ? { message: initialParamsResult.message }
-        : {}),
-      ...(initialParamsResult.sid ? { dashboardSentryIssueId: initialParamsResult.sid } : {}),
-    }
-  }, [initialParamsResult])
-
   const form = useForm<SupportFormValues>({
     mode: 'onBlur',
     reValidateMode: 'onBlur',
@@ -75,8 +48,36 @@ export function useSupportForm(
     defaultValues: supportFormDefaultValues,
   })
 
-  const urlParamsRef = useRef<SupportFormUrlKeys | null>(initialParamsResult)
-  const initialError = initialParamsResult.error ?? null
+  const urlParamsRef = useRef<SupportFormUrlKeys | null>(null)
+  const providedInitialParamsRef = useRef(initialParams)
+  const [initialError, setInitialError] = useState<string | null>(null)
+
+  // Load initial values from URL params after mount so SSR/SSG render with
+  // bare defaults (no `window` access) and the client hydrates against the
+  // same HTML. URL-derived values are applied here, post-hydration.
+  useEffect(() => {
+    const params =
+      providedInitialParamsRef.current !== undefined
+        ? loadSupportFormInitialParamsFromObject(providedInitialParamsRef.current)
+        : loadSupportFormInitialParams(window.location.search)
+    urlParamsRef.current = params
+    setInitialError(params.error ?? null)
+
+    if (params.category && !form.getFieldState('category').isDirty) {
+      form.setValue('category', params.category, { shouldDirty: false })
+    }
+    if (typeof params.subject === 'string' && !form.getFieldState('subject').isDirty) {
+      form.setValue('subject', params.subject, { shouldDirty: false })
+    }
+    if (typeof params.message === 'string' && !form.getFieldState('message').isDirty) {
+      form.setValue('message', params.message, { shouldDirty: false })
+    }
+    if (params.sid && !form.getFieldState('dashboardSentryIssueId').isDirty) {
+      form.setValue('dashboardSentryIssueId', params.sid, {
+        shouldDirty: false,
+      })
+    }
+  }, [form])
 
   const hasAppliedOrgProjectRef = useRef(false)
   const { data: organizations, isPending: organizationsLoading } = useOrganizationsQuery()

--- a/apps/studio/components/interfaces/Support/useSupportForm.ts
+++ b/apps/studio/components/interfaces/Support/useSupportForm.ts
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useEffect, useRef, useState, type Dispatch } from 'react'
+import { useEffect, useMemo, useRef, type Dispatch } from 'react'
 import { useForm, useWatch, type DefaultValues, type UseFormReturn } from 'react-hook-form'
 
 import { SupportFormSchema, type SupportFormValues } from './SupportForm.schema'
@@ -16,7 +16,7 @@ import {
 
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 
-const supportFormDefaultValues: DefaultValues<SupportFormValues> = {
+const supportFormBaseDefaults: DefaultValues<SupportFormValues> = {
   organizationSlug: NO_ORG_MARKER,
   projectRef: NO_PROJECT_MARKER,
   severity: 'Low',
@@ -41,6 +41,33 @@ export function useSupportForm(
   dispatch: Dispatch<SupportFormActions>,
   initialParams?: Partial<SupportFormUrlKeys>
 ): UseSupportFormResult {
+  // Seed defaults from the URL synchronously so controlled fields like the
+  // category Select start in their final state. Setting these via a useEffect
+  // setValue makes Radix Select switch from uncontrolled to controlled
+  // mid-mount, which on React 19 spuriously emits onValueChange('') and
+  // clears the field. See radix-ui/primitives#3381.
+  const initialParamsResult = useMemo(() => {
+    return initialParams !== undefined
+      ? loadSupportFormInitialParamsFromObject(initialParams)
+      : loadSupportFormInitialParams(typeof window === 'undefined' ? '' : window.location.search)
+    // Snapshot once; URL/object changes after mount are intentionally ignored.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const supportFormDefaultValues = useMemo<DefaultValues<SupportFormValues>>(() => {
+    return {
+      ...supportFormBaseDefaults,
+      ...(initialParamsResult.category ? { category: initialParamsResult.category } : {}),
+      ...(typeof initialParamsResult.subject === 'string'
+        ? { subject: initialParamsResult.subject }
+        : {}),
+      ...(typeof initialParamsResult.message === 'string'
+        ? { message: initialParamsResult.message }
+        : {}),
+      ...(initialParamsResult.sid ? { dashboardSentryIssueId: initialParamsResult.sid } : {}),
+    }
+  }, [initialParamsResult])
+
   const form = useForm<SupportFormValues>({
     mode: 'onBlur',
     reValidateMode: 'onBlur',
@@ -48,34 +75,8 @@ export function useSupportForm(
     defaultValues: supportFormDefaultValues,
   })
 
-  const urlParamsRef = useRef<SupportFormUrlKeys | null>(null)
-  const providedInitialParamsRef = useRef(initialParams)
-  const [initialError, setInitialError] = useState<string | null>(null)
-
-  // Load initial values from URL params
-  useEffect(() => {
-    const params =
-      providedInitialParamsRef.current !== undefined
-        ? loadSupportFormInitialParamsFromObject(providedInitialParamsRef.current)
-        : loadSupportFormInitialParams(window.location.search)
-    urlParamsRef.current = params
-    setInitialError(params.error ?? null)
-
-    if (params.category && !form.getFieldState('category').isDirty) {
-      form.setValue('category', params.category, { shouldDirty: false })
-    }
-    if (typeof params.subject === 'string' && !form.getFieldState('subject').isDirty) {
-      form.setValue('subject', params.subject, { shouldDirty: false })
-    }
-    if (typeof params.message === 'string' && !form.getFieldState('message').isDirty) {
-      form.setValue('message', params.message, { shouldDirty: false })
-    }
-    if (params.sid && !form.getFieldState('dashboardSentryIssueId').isDirty) {
-      form.setValue('dashboardSentryIssueId', params.sid, {
-        shouldDirty: false,
-      })
-    }
-  }, [form])
+  const urlParamsRef = useRef<SupportFormUrlKeys | null>(initialParamsResult)
+  const initialError = initialParamsResult.error ?? null
 
   const hasAppliedOrgProjectRef = useRef(false)
   const { data: organizations, isPending: organizationsLoading } = useOrganizationsQuery()

--- a/apps/studio/hooks/misc/useStateTransition.ts
+++ b/apps/studio/hooks/misc/useStateTransition.ts
@@ -6,7 +6,10 @@ export function useStateTransition<
   NewType extends State['type'],
 >(
   state: State,
-  prevTest: PrevType,
+  // Kept in the signature for documentation / type-narrowing of `cb`'s first
+  // arg, but the entry-detection logic below no longer uses it. See the
+  // comment in the effect for why.
+  _prevTest: PrevType,
   newTest: NewType,
   cb: (
     prevState: Extract<State, { type: PrevType }>,
@@ -18,7 +21,16 @@ export function useStateTransition<
   useEffect(() => {
     const savedPrevState = prevState.current
 
-    if (savedPrevState.type === prevTest && state.type === newTest) {
+    // Fire when entering newTest from any other state. React 18+ auto-batches
+    // dispatches across awaits (e.g. dispatch SUBMIT → await → mutation
+    // onError dispatch ERROR), which collapses `prevTest → newTest` into a
+    // single render where the intermediate `prevTest` state is never observed.
+    // Treat prevTest as advisory only: as long as the previous state was *not*
+    // already `newTest`, fire the callback.
+    if (savedPrevState.type !== newTest && state.type === newTest) {
+      // Pass the previous state through even if it doesn't match prevTest —
+      // callers shouldn't rely on it being prevTest in batched flows. Cast is
+      // safe at the type level because callers only consume `currState`.
       cb(
         savedPrevState as Extract<State, { type: PrevType }>,
         state as Extract<State, { type: NewType }>
@@ -26,5 +38,7 @@ export function useStateTransition<
     }
 
     prevState.current = state
-  }, [cb, newTest, prevTest, state])
+    // prevTest is kept in the signature for documentation but intentionally
+    // not depended on — the entry-detection logic doesn't use it.
+  }, [cb, newTest, state])
 }

--- a/apps/studio/hooks/misc/useStateTransition.ts
+++ b/apps/studio/hooks/misc/useStateTransition.ts
@@ -6,13 +6,17 @@ export function useStateTransition<
   NewType extends State['type'],
 >(
   state: State,
-  // Kept in the signature for documentation / type-narrowing of `cb`'s first
-  // arg, but the entry-detection logic below no longer uses it. See the
-  // comment in the effect for why.
+  // Documentary only — the entry-detection logic below intentionally does not
+  // require `savedPrevState.type === prevTest`. React 18+ auto-batches
+  // dispatches across awaits (e.g. dispatch SUBMIT → await → mutation
+  // onError dispatch ERROR), which collapses `prevTest → newTest` into a
+  // single render where the intermediate `prevTest` state is never observed,
+  // so the previous state may be any variant other than `newTest`. `cb`'s
+  // first parameter is typed accordingly.
   _prevTest: PrevType,
   newTest: NewType,
   cb: (
-    prevState: Extract<State, { type: PrevType }>,
+    prevState: Exclude<State, { type: NewType }>,
     currState: Extract<State, { type: NewType }>
   ) => void
 ): void {
@@ -21,24 +25,13 @@ export function useStateTransition<
   useEffect(() => {
     const savedPrevState = prevState.current
 
-    // Fire when entering newTest from any other state. React 18+ auto-batches
-    // dispatches across awaits (e.g. dispatch SUBMIT → await → mutation
-    // onError dispatch ERROR), which collapses `prevTest → newTest` into a
-    // single render where the intermediate `prevTest` state is never observed.
-    // Treat prevTest as advisory only: as long as the previous state was *not*
-    // already `newTest`, fire the callback.
     if (savedPrevState.type !== newTest && state.type === newTest) {
-      // Pass the previous state through even if it doesn't match prevTest —
-      // callers shouldn't rely on it being prevTest in batched flows. Cast is
-      // safe at the type level because callers only consume `currState`.
       cb(
-        savedPrevState as Extract<State, { type: PrevType }>,
+        savedPrevState as Exclude<State, { type: NewType }>,
         state as Extract<State, { type: NewType }>
       )
     }
 
     prevState.current = state
-    // prevTest is kept in the signature for documentation but intentionally
-    // not depended on — the entry-detection logic doesn't use it.
   }, [cb, newTest, state])
 }

--- a/apps/studio/tests/features/logs/LogsPreviewer.test.tsx
+++ b/apps/studio/tests/features/logs/LogsPreviewer.test.tsx
@@ -132,11 +132,16 @@ test('can click load older', async () => {
     { timeout: 10000 }
   )
 
-  loadOlder.onclick = vi.fn()
+  // React 19 reassigns `.onclick` on managed elements as part of its event
+  // wiring, so a direct `loadOlder.onclick = vi.fn()` spy gets clobbered
+  // before the assertion runs. addEventListener is unaffected and gives us a
+  // clean way to confirm the click reached the button.
+  const handleClick = vi.fn()
+  loadOlder.addEventListener('click', handleClick)
 
   await userEvent.click(loadOlder)
 
-  expect(loadOlder.onclick).toHaveBeenCalled()
+  expect(handleClick).toHaveBeenCalled()
 })
 
 describe('calculateBarClickTimeRange', () => {

--- a/apps/studio/tests/features/logs/LogsPreviewer.test.tsx
+++ b/apps/studio/tests/features/logs/LogsPreviewer.test.tsx
@@ -132,10 +132,6 @@ test('can click load older', async () => {
     { timeout: 10000 }
   )
 
-  // React 19 reassigns `.onclick` on managed elements as part of its event
-  // wiring, so a direct `loadOlder.onclick = vi.fn()` spy gets clobbered
-  // before the assertion runs. addEventListener is unaffected and gives us a
-  // clean way to confirm the click reached the button.
   const handleClick = vi.fn()
   loadOlder.addEventListener('click', handleClick)
 


### PR DESCRIPTION
Four React-19-sensitive patterns that pass on React 18 today but break under React 19 (verified on the in-flight TanStack Start branch). Landing on master now so the eventual React 19 upgrade is a no-op for tests, instead of a separate cleanup pass under upgrade pressure.

Each fix is a strict superset / less-fragile equivalent of the existing pattern, so master (React 18) stays green.

**Changed:**
- `hooks/misc/useStateTransition.ts` — fire on entry into `newTest` from any state other than `newTest`, instead of requiring exactly `prevTest → newTest`. React 18+ auto-batches dispatches across awaits (e.g. `dispatch SUBMIT` in the handler, `dispatch ERROR` in `onError`), collapsing `editing → submitting → error` into a single render where the intermediate `submitting` tick is never observed. Strict superset of the old check for our reducers — `success`/`error` are only reachable from `submitting`.
- `Support/CategoryAndSeverityInfo.tsx` — guard `onValueChange` against Radix Select's spurious `''` emission. When the controlled value transitions from `undefined` to a defined value whose `SelectItem` isn't mounted yet (dropdown closed → items haven't registered), Radix's hidden `BubbleSelect` fires `onValueChange('')` and clobbers the field. No `SelectItem` can have `value=""` (Radix throws), so any `''` is guaranteed spurious — drop it before calling `field.onChange`. ([radix-ui/primitives#3381](https://github.com/radix-ui/primitives/issues/3381))
- `EditSecretModal.test.tsx` — `getByLabelText` → `findByLabelText`. Under React 19's scheduling, the decrypted-value query resolves on a separate render tick, so form fields appear one tick after the skeleton.
- `LogsPreviewer.test.tsx` — `addEventListener('click', spy)` instead of `loadOlder.onclick = vi.fn()`. React 19 reassigns `.onclick` on managed elements as part of its event wiring, clobbering the direct-property spy.

## To test

### Unit tests
- `pnpm --filter studio test` — all unit tests pass on master (React 18)

### Support form URL prefill (Radix Select guard)
- `/support/new?category=Problem` → category dropdown reads "APIs and client libraries" on first paint
- `/support/new?category=dashboard_bug` → "Dashboard bug" (case-insensitive match)
- `/support/new?category=invalid_garbage` → falls back to "Select an issue" placeholder, no crash
- `/support/new?subject=My%20issue&message=Details%20here` → subject and message inputs are prefilled
- `/support/new?projectRef=<your-ref>&category=Problem` → both project selector and category set, library selector appears
- With a prefilled URL, click the category dropdown and pick a different option — the new value sticks (this is the path that surfaced the Radix bug, want to confirm we didn't break user selection)
- DevTools console on first load should be clean — no React hydration mismatch warning

### Support form submit (`useStateTransition` success + error branches)
- Submit a valid support form → green toast "Support request sent" appears **once**, view swaps to the success screen, one `POST /platform/feedback/send` in the network panel
- Block `POST /platform/feedback/send` in DevTools → submit → red error toast appears **once** (not twice — if you see two toasts the relaxed transition is firing more than it should), form stays editable with all inputs preserved
- Unblock and submit again → success path runs cleanly

### Sidebar support form (same reducer + `useStateTransition`, separate component)
- Open the support widget in the side nav (`SupportSidebarForm`)
- Repeat the success and error paths — should behave identically

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed category selector to prevent selected values from being unexpectedly cleared during form interactions.

* **Tests**
  * Improved test reliability for modal field rendering and event handling assertions.

* **Chores**
  * Clarified internal comments for form initialization logic.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45784)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->