### PR TITLE
feat(studio): rename 'Replication' to 'Manage Read Replicas' in command menu

### DIFF
--- a/apps/studio/components/layouts/DatabaseLayout/Database.Commands.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/Database.Commands.tsx
@@ -82,8 +82,8 @@ export function useDatabaseGotoCommands(options?: CommandOptions) {
         ? [
             {
               id: 'nav-database-replication',
-              name: 'Replication',
-              value: 'Database: Replication',
+              name: 'Manage Read Replicas',
+              value: 'Database: Manage Read Replicas',
               route: `/project/${ref}/database/replication`,
               defaultHidden: true,
             } as IRouteCommand,

--- a/apps/studio/state/shortcuts/registry/database-nav.ts
+++ b/apps/studio/state/shortcuts/registry/database-nav.ts
@@ -124,7 +124,7 @@ export const databaseNavRegistry: RegistryDefinations<DatabaseNavShortcutId> = {
   },
   [DATABASE_NAV_SHORTCUT_IDS.NAV_DATABASE_REPLICATION]: {
     id: DATABASE_NAV_SHORTCUT_IDS.NAV_DATABASE_REPLICATION,
-    label: 'Go to Replication',
+    label: 'Manage Read Replicas',
     sequence: ['D', 'L'],
     showInSettings: false,
     referenceGroup: SHORTCUT_REFERENCE_GROUPS.NAVIGATION_DATABASE,


### PR DESCRIPTION
## Problem

Searching for "read replica" in the Studio command menu (cmd+K) returns no results. The existing entry is labeled "Replication", which does not match how users think about the feature.

## Fix

Renamed the command menu entry and keyboard shortcut label from "Replication" to "Manage Read Replicas". The route (`/database/replication`) is unchanged.

## How to test

1. Open Studio and press cmd+K to open the command menu.
2. Type "read replica".
3. Expected result: the "Manage Read Replicas" entry appears and navigates to the replication page on selection.
4. Also verify the keyboard chord D then L still navigates to the same page and displays the updated label "Manage Read Replicas" in shortcut settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated database replication feature labels to "Manage Read Replicas" in command menu and navigation shortcuts for improved clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45785)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->