### PR TITLE
fix(studio): tighten Version column width in Extensions table FE-3204

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
@@ -39,7 +39,7 @@ export const ExtensionRow = ({ extension }: ExtensionRowProps) => {
   const extensionMeta = extensions.find((item) => item.name === extension.name)
   const docsUrl = extensionMeta?.link.startsWith('/guides')
     ? `${DOCS_URL}${extensionMeta?.link}`
-    : extensionMeta?.link ?? undefined
+    : (extensionMeta?.link ?? undefined)
 
   const { mutate: disableExtension, isPending: isDisabling } = useDatabaseExtensionDisableMutation({
     onSuccess: () => {

--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
@@ -39,7 +39,7 @@ export const ExtensionRow = ({ extension }: ExtensionRowProps) => {
   const extensionMeta = extensions.find((item) => item.name === extension.name)
   const docsUrl = extensionMeta?.link.startsWith('/guides')
     ? `${DOCS_URL}${extensionMeta?.link}`
-    : (extensionMeta?.link ?? undefined)
+    : extensionMeta?.link ?? undefined
 
   const { mutate: disableExtension, isPending: isDisabling } = useDatabaseExtensionDisableMutation({
     onSuccess: () => {
@@ -83,7 +83,7 @@ export const ExtensionRow = ({ extension }: ExtensionRowProps) => {
           </div>
         </TableCell>
 
-        <TableCell className="font-mono tracking-tighter">
+        <TableCell className="w-28 font-mono tracking-tighter">
           {extension?.installed_version ?? extension.default_version}
         </TableCell>
 

--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
@@ -39,7 +39,7 @@ export const ExtensionRow = ({ extension }: ExtensionRowProps) => {
   const extensionMeta = extensions.find((item) => item.name === extension.name)
   const docsUrl = extensionMeta?.link.startsWith('/guides')
     ? `${DOCS_URL}${extensionMeta?.link}`
-    : (extensionMeta?.link ?? undefined)
+    : extensionMeta?.link ?? undefined
 
   const { mutate: disableExtension, isPending: isDisabling } = useDatabaseExtensionDisableMutation({
     onSuccess: () => {
@@ -90,7 +90,7 @@ export const ExtensionRow = ({ extension }: ExtensionRowProps) => {
         <TableCell className="truncate">{isOn ? extension.schema : '-'}</TableCell>
 
         <TableCell className="text-foreground-light">
-          <p className="block max-w-96" title={extension.comment ?? undefined}>
+          <p className="block" title={extension.comment ?? undefined}>
             {extension.comment}
           </p>
         </TableCell>

--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -112,7 +112,9 @@ export const Extensions = () => {
               <TableHeader>
                 <TableRow>
                   <TableHead key="name">Name</TableHead>
-                  <TableHead key="version">Version</TableHead>
+                  <TableHead key="version" className="w-28">
+                    Version
+                  </TableHead>
                   <TableHead key="schema">Schema</TableHead>
                   <TableHead key="description">Description</TableHead>
                   <TableHead key="used-by">Used by</TableHead>

--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -116,7 +116,9 @@ export const Extensions = () => {
                     Version
                   </TableHead>
                   <TableHead key="schema">Schema</TableHead>
-                  <TableHead key="description">Description</TableHead>
+                  <TableHead key="description" className="min-w-80">
+                    Description
+                  </TableHead>
                   <TableHead key="used-by">Used by</TableHead>
                   <TableHead key="links">Links</TableHead>
                   {/*


### PR DESCRIPTION
## Problem

On the Database Extensions page, the Version column takes up disproportionate horizontal space compared to the Description column, making the table harder to read.

## Fix

Added `w-28` to the Version `TableHead` and its corresponding `TableCell` in `ExtensionRow`. This constrains the column to a width appropriate for short version strings and gives the Description column more room.

## How to test

1. Open a project in Studio and navigate to Database > Extensions.
2. Confirm the Version column is now narrow and the Description column has proportionally more space.
3. Verify all version strings are still fully visible (e.g. `1.4.8`, `2.5.2`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Fixed the "Version" column and its cells to a consistent width for improved table alignment.
  * Preserved monospace styling and spacing in version cells for readability.
  * Removed the max-width limit on comment text cells so comments can use more space while retaining hover tooltips for full text.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45786)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->