### PR TITLE
fix(studio): remove Supabase logo from Logs sidebar items

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/SidebarV2/SidebarItem.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/SidebarV2/SidebarItem.tsx
@@ -4,7 +4,7 @@ import { Button, cn, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } fr
 
 type Props = {
   label: string
-  icon: React.ReactNode
+  icon?: React.ReactNode
   dropdownItems?: React.ReactNode
   href: string
   isActive: boolean
@@ -25,7 +25,7 @@ export function LogsSidebarItem({ label, icon, dropdownItems, href, isActive, on
         href={href}
         className={'h-7 flex-1 text-sm px-4 flex items-center gap-2 truncate'}
       >
-        <span>{icon}</span>
+        {icon && <span>{icon}</span>}
         <span className="truncate">{label}</span>
       </Link>
       {dropdownItems && (

--- a/apps/studio/components/interfaces/Settings/Logs/SidebarV2/SidebarItem.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/SidebarV2/SidebarItem.tsx
@@ -1,5 +1,6 @@
 import { MoreHorizontal } from 'lucide-react'
 import Link from 'next/link'
+import { type MouseEventHandler } from 'react'
 import { Button, cn, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from 'ui'
 
 type Props = {
@@ -8,7 +9,7 @@ type Props = {
   dropdownItems?: React.ReactNode
   href: string
   isActive: boolean
-  onClick?: (e: any) => void
+  onClick?: MouseEventHandler<HTMLAnchorElement>
 }
 export function LogsSidebarItem({ label, icon, dropdownItems, href, isActive, onClick }: Props) {
   return (

--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -35,23 +35,6 @@ import { useReplicationSourcesQuery } from '@/data/replication/sources-query'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
-const SupaIcon = ({ className }: { className?: string }) => {
-  return (
-    <svg
-      stroke="currentColor"
-      fill="currentColor"
-      strokeWidth="0"
-      viewBox="0 0 24 24"
-      height="15px"
-      width="15px"
-      className={className}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <path d="M10.9997 2.59833V13.9694H3.90013C3.23055 13.9694 2.83063 13.1846 3.25654 12.6326L10.9997 2.59833ZM12.9997 8.03061V2.33296C12.9997 0.521514 10.7034 -0.291434 9.58194 1.16185L1.67316 11.4108C0.246185 13.26 1.54768 15.9694 3.90013 15.9694H10.9997V21.6671C10.9997 23.4785 13.296 24.2915 14.4175 22.8382L22.3262 12.5892C23.7532 10.74 22.4517 8.03061 20.0993 8.03061H12.9997ZM12.9997 10.0306H20.0993C20.7688 10.0306 21.1688 10.8155 20.7429 11.3674L12.9997 21.4017V10.0306Z"></path>
-    </svg>
-  )
-}
-
 export function SidebarCollapsible({
   children,
   title,
@@ -323,7 +306,6 @@ export function LogsSidebarMenuV2() {
                   key={collection?.key ?? ''}
                   isActive={isItemActive}
                   href={collection?.url ?? ''}
-                  icon={<SupaIcon className="text-foreground-light" />}
                   label={collection?.name ?? ''}
                 />
               )
@@ -338,7 +320,6 @@ export function LogsSidebarMenuV2() {
                     key={collection.key}
                     isActive={isActive(collection.url)}
                     href={collection.url}
-                    icon={<SupaIcon className="text-foreground-light" />}
                     label={collection.name}
                   />
                 ))}


### PR DESCRIPTION
## Summary

- Removes the `SupaIcon` component (inline Supabase SVG logo) from `LogsSidebarMenuV2.tsx`
- Removes the `icon` prop from the Collections and Database operations sidebar items
- Makes `icon` optional in `LogsSidebarItem` so the span is only rendered when an icon is provided

Closes FE-3203

## Test plan

- [ ] Navigate to Logs & Analytics in Studio
- [ ] Confirm Collections and Database operations sidebar items no longer show the Supabase logo
- [ ] Confirm Saved Queries items still show the SQL editor icon (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sidebar items in Logs now render without icons by default, simplifying the navigation appearance.
  * Icon display for log sidebar entries is now optional, reducing visual clutter and making the list cleaner and more consistent.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45787)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->