### PR TITLE
docs: clarify password field behavior for main branch in CLI

### DIFF
--- a/apps/docs/spec/cli_v1_commands.yaml
+++ b/apps/docs/spec/cli_v1_commands.yaml
@@ -3907,7 +3907,10 @@ commands:
   - id: supabase-branches-get
     title: supabase branches get
     summary: Retrieve details of a preview branch
-    description: Retrieve details of the specified preview branch.
+    description: |
+      Retrieve details of the specified preview branch.
+
+      **Note:** For the main branch, password-dependent fields (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`) are not populated because production database credentials are not retrievable via API.
     tags: []
     links: []
     usage: supabase branches get [name]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The `supabase branches get` command documentation does not explain why certain password-dependent fields may not be populated when retrieving details for the main branch.

## What is the new behavior?

Added a clarifying note to the `supabase branches get` command documentation explaining that for the main branch, password-dependent fields (`POSTGRES_URL`, `POSTGRES_URL_NON_POOLING`) are not populated because production database credentials are not retrievable via API.

## Additional context

This documentation update helps users understand expected behavior when using the CLI to retrieve branch details, particularly for the main production branch where sensitive credentials are intentionally restricted from API access.

Fixes CLI-1450

https://claude.ai/code/session_01Qwq7TBwMiKidMFUQKkwkTr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the `branches get` command behavior: password-dependent database credential fields are not populated for the main branch.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45789)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->