### PR TITLE
fix(docs): add `RedirectTo` and `Data` variables to email templates

### DIFF
--- a/apps/docs/content/guides/local-development/customizing-email-templates.mdx
+++ b/apps/docs/content/guides/local-development/customizing-email-templates.mdx
@@ -207,6 +207,28 @@ Contains your application's Site URL. This can be configured in your project's [
 <p>Visit <a href="{{ .SiteURL }}">here</a> to log in.</p>
 ```
 
+### `RedirectTo`
+
+Contains the redirect URL passed as the `redirectTo` option in the auth method call.
+
+**Usage**
+
+```html
+<a href="{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email&next={{ .RedirectTo }}">
+  Confirm your email
+</a>
+```
+
+### `Data`
+
+Contains metadata from `auth.users.user_metadata`. Use this to personalize the email message.
+
+**Usage**
+
+```html
+<p>Hello {{ .Data.first_name }}, please confirm your signup.</p>
+```
+
 ### `Email`
 
 Contains the user's email address.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated email template customization guide to document two additional template variables: `RedirectTo` (auth method redirect destination accessible via the `next` query parameter) and `Data` (user metadata) for local development templates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45799)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->