### PR TITLE
fix(billing): block downgrade plan requests

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -308,7 +308,10 @@ export const PlanUpdateSidePanel = () => {
                         Current plan
                       </Button>
                     ) : !canUpdateSubscription ? (
-                      <RequestUpgradeToBillingOwners block plan={plan.name as 'Pro' | 'Team'} />
+                      <RequestUpgradeToBillingOwners
+                        block
+                        plan={plan.name as 'Free' | 'Pro' | 'Team'}
+                      />
                     ) : (
                       <ButtonTooltip
                         block

--- a/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
+++ b/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
@@ -25,12 +25,15 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import z from 'zod'
 
+import { getPlanChangeType } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useOrganizationRolesV2Query } from '@/data/organization-members/organization-roles-query'
 import { useOrganizationMembersQuery } from '@/data/organizations/organization-members-query'
 import {
   PlanRequest,
   useSendUpgradeRequestMutation,
 } from '@/data/organizations/request-upgrade-mutation'
+import type { PlanId } from '@/data/subscriptions/types'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useTrack } from '@/lib/telemetry/track'
@@ -41,9 +44,11 @@ const FormSchema = z.object({
 
 const formId = 'request-upgrade-form'
 
+type DisplayPlan = 'Free' | PlanRequest
+
 interface RequestUpgradeToBillingOwnersProps {
   block?: boolean
-  plan?: PlanRequest
+  plan?: DisplayPlan
   addon?: 'pitr' | 'customDomain' | 'ipv4' | 'spendCap' | 'computeSize'
   /** Used in the default message template, e.g: "Upgrade to ..." */
   featureProposition?: string
@@ -68,6 +73,10 @@ export const RequestUpgradeToBillingOwners = ({
   const currentPlan = organization?.plan?.id
   const isFreePlan = currentPlan === 'free'
 
+  const requestedPlanId = plan.toLowerCase() as PlanId
+  const planChange = !addon ? getPlanChangeType(currentPlan, requestedPlanId) : 'upgrade'
+  const isInvalidDirection = planChange === 'downgrade' || planChange === 'none'
+
   const { data: members = [] } = useOrganizationMembersQuery({ slug: organization?.slug })
   const { data: roles } = useOrganizationRolesV2Query({ slug: organization?.slug })
   const orgRoles = roles?.org_scoped_roles ?? []
@@ -75,7 +84,7 @@ export const RequestUpgradeToBillingOwners = ({
   const { mutate: sendUpgradeRequest, isPending: isSubmitting } = useSendUpgradeRequestMutation({
     onSuccess: () => {
       track('request_upgrade_submitted', {
-        requestedPlan: plan,
+        requestedPlan: plan as PlanRequest,
         addon,
         currentPlan,
       })
@@ -144,19 +153,38 @@ export const RequestUpgradeToBillingOwners = ({
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
     if (!slug) return console.error('Slug is required')
-    sendUpgradeRequest({ slug, plan, note: values.note })
+    sendUpgradeRequest({ slug, plan: plan as PlanRequest, note: values.note })
   }
 
   const handleOpenChange = (isOpen: boolean) => {
     if (isOpen) {
       track('request_upgrade_modal_opened', {
-        requestedPlan: plan,
+        requestedPlan: plan as PlanRequest,
         addon,
         currentPlan,
         featureProposition,
       })
     }
     setOpen(isOpen)
+  }
+
+  if (isInvalidDirection) {
+    return (
+      <ButtonTooltip
+        block={block}
+        disabled
+        type="default"
+        className={className}
+        tooltip={{
+          content: {
+            side: 'bottom',
+            text: 'Downgrades cannot be requested. Ask a billing owner to change the plan directly.',
+          },
+        }}
+      >
+        Not available
+      </ButtonTooltip>
+    )
   }
 
   return (

--- a/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
+++ b/apps/studio/components/ui/RequestUpgradeToBillingOwners.tsx
@@ -74,7 +74,8 @@ export const RequestUpgradeToBillingOwners = ({
   const isFreePlan = currentPlan === 'free'
 
   const requestedPlanId = plan.toLowerCase() as PlanId
-  const planChange = !addon ? getPlanChangeType(currentPlan, requestedPlanId) : 'upgrade'
+  const planChange =
+    !addon && currentPlan ? getPlanChangeType(currentPlan, requestedPlanId) : 'upgrade'
   const isInvalidDirection = planChange === 'downgrade' || planChange === 'none'
 
   const { data: members = [] } = useOrganizationMembersQuery({ slug: organization?.slug })
@@ -153,7 +154,8 @@ export const RequestUpgradeToBillingOwners = ({
 
   const onSubmit: SubmitHandler<z.infer<typeof FormSchema>> = async (values) => {
     if (!slug) return console.error('Slug is required')
-    sendUpgradeRequest({ slug, plan: plan as PlanRequest, note: values.note })
+    if (plan === 'Free') return console.error('Cannot request a downgrade to the Free plan')
+    sendUpgradeRequest({ slug, plan, note: values.note })
   }
 
   const handleOpenChange = (isOpen: boolean) => {


### PR DESCRIPTION
## Summary
Blocks the frontend from submitting downgrade or no-op plan-change requests to billing owners. `RequestUpgradeToBillingOwners` now checks the requested plan against the viewer's current plan and renders a disabled "Not available" state when the request would be a downgrade or a no-op, so the backend `requested_plan` enum (Pro/Team/Enterprise only) never sees a Free submission. Centralising the guard inside the component also catches three pre-existing wrong-tier surfaces (log-drains empty state, billing-metric paywall, custom-auth-providers fallback) where higher-tier members were seeing "Request upgrade to Pro" buttons.

## Changes
- Added a plan-direction guard inside `RequestUpgradeToBillingOwners` that renders a disabled `ButtonTooltip` when the requested plan is not an upgrade from the current plan
- Skipped the guard for addon-flavored requests (compute size, PITR, custom domain, IPv4, spend cap) since they target feature add-ons, not plan tiers
- Widened the `plan` prop type to include `'Free'` so the plan-switcher can pass it honestly; cast back to `PlanRequest` at the submission and telemetry call sites where the guard ensures safety
- Updated the `PlanUpdateSidePanel` callsite to pass the wider literal union

## Testing
Still verifying on the Vercel preview — unchecked items below are pending. Reviewers, please leave the PR un-merged until the boxes are checked:
- [x] Plan switcher as a non-billing-owner on Pro: Free card shows "Not available" + tooltip, Pro shows "Current plan", Team shows "Request upgrade to Team"
- [x] Plan switcher as a non-billing-owner on Team: Free and Pro both show "Not available", Team shows "Current plan"
- [x] Network tab: zero POSTs to `/platform/organizations/{slug}/billing/upgrade-request` when interacting with the disabled state
- [x] Hover the "Not available" button: tooltip appears with the "Ask a billing owner to change the plan directly" copy

If the tooltip does not fire on hover, Radix is blocking pointer events on the disabled trigger. Fix by wrapping the disabled button with `<span className="inline-flex w-full">` inside `ButtonTooltip`.

## Linear
- fixes GROWTH-833
