### PR TITLE
fix(studio): hide incorrect 'last paused' date in project paused state

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -99,16 +99,6 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                         ? 'Upgrade to Pro to prevent pauses and unlock features like branching, compute upgrades, and daily backups.'
                         : 'To prevent future pauses, consider upgrading to Pro.'}
                     </p>
-                    {!!pauseStatus.last_paused_on && (
-                      <p className="text-foreground-lighter text-sm">
-                        Project last paused on{' '}
-                        <TimestampInfo
-                          className="text-sm"
-                          labelFormat="DD MMM YYYY"
-                          utcTimestamp={pauseStatus.last_paused_on}
-                        />
-                      </p>
-                    )}
                   </>
                 ) : (
                   <p className="text-sm">


### PR DESCRIPTION
Hides the 'Project last paused on' date shown in the paused state for free-plan projects, as the date returned by the API is currently incorrect (API team is investigating)

Related ticket: FE-3149

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Removed "last paused on" timestamp from paused project display
  * Updated upgrade messaging for free-plan users with improved clarity on preventing future pauses

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45805)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->