### PR TITLE
fix(studio): refine organisation invite state helpers

### DIFF
--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
@@ -6,6 +6,10 @@ import { toast } from 'sonner'
 import { Button, Card, CardContent } from 'ui'
 import { Admonition, ShimmeringLoader } from 'ui-patterns'
 
+import {
+  getOrganizationInviteContent,
+  getOrganizationInviteStatus,
+} from './OrganizationInvite.utils'
 import { OrganizationInviteError } from './OrganizationInviteError'
 import {
   InterstitialAccountRow,
@@ -40,50 +44,27 @@ export const OrganizationInvite = () => {
       enabled: !!profile && !!slug && !!token,
     }
   )
-  const inviteIsNoLongerValid =
-    error?.code === 401 && error?.message.includes('Failed to retrieve organization')
-  const inviteIsInvalid =
-    (isSuccessInvitation && !!data?.token_does_not_exist) ||
-    (isErrorInvitation && error?.code === 404)
-  const hasError =
-    isErrorInvitation ||
-    (isSuccessInvitation && (data.token_does_not_exist || data.expired_token || !data.email_match))
-
-  const isWrongAccount = isSuccessInvitation && !!data && !data.email_match
-  const showOrganizationHeader =
-    isSuccessInvitation &&
-    !!data &&
-    !data.token_does_not_exist &&
-    !data.expired_token &&
-    !isWrongAccount
-  const organizationName = data?.organization_name ?? 'an organization'
-  const isSignedOut = !isLoggedIn || (!profile && !isLoadingProfile)
-  const isInvitationLoading =
-    !isSignedOut && (isLoadingProfile || isLoadingInvitation || !router.isReady)
+  const inviteStatus = getOrganizationInviteStatus({
+    data,
+    error,
+    isErrorInvitation,
+    isLoadingInvitation,
+    isLoadingProfile,
+    isLoggedIn,
+    isRouterReady: router.isReady,
+    isSuccessInvitation,
+    profileExists: !!profile,
+  })
+  const isSignedOut = inviteStatus === 'signed-out'
+  const isInvitationLoading = inviteStatus === 'loading'
+  const inviteContent = getOrganizationInviteContent({
+    data,
+    isSignUpEnabled,
+    status: inviteStatus,
+  })
+  const hasError = ['wrong-account', 'expired', 'invalid', 'error'].includes(inviteStatus)
   const loginRedirectLink = `/sign-in?returnTo=${encodeURIComponent(`/join?token=${token}&slug=${slug}`)}`
   const signupRedirectLink = `/sign-up?returnTo=${encodeURIComponent(`/join?token=${token}&slug=${slug}`)}`
-  const interstitialTitle = inviteIsNoLongerValid
-    ? 'Invite no longer available'
-    : isSignedOut
-      ? 'View invitation'
-      : isWrongAccount
-        ? 'Wrong account'
-        : inviteIsInvalid
-          ? 'Invite invalid'
-          : isErrorInvitation
-            ? 'Unable to load invitation'
-            : data?.expired_token
-              ? 'Invite expired'
-              : showOrganizationHeader
-                ? `Join ${organizationName}`
-                : undefined
-  const interstitialDescription = showOrganizationHeader
-    ? isSignedOut
-      ? `Sign in${isSignUpEnabled ? ' or create an account' : ''} to view this invitation`
-      : 'You have been invited to join this Supabase organization'
-    : isSignedOut
-      ? `Sign in${isSignUpEnabled ? ' or create an account' : ''} to view this invitation`
-      : undefined
 
   const { mutate: joinOrganization, isPending: isJoining } =
     useOrganizationAcceptInvitationMutation({
@@ -107,15 +88,15 @@ export const OrganizationInvite = () => {
       title={
         isInvitationLoading ? (
           <ShimmeringLoader className="mx-auto h-7 w-36 max-w-full py-0" />
-        ) : interstitialTitle ? (
-          interstitialTitle
+        ) : inviteContent.title ? (
+          inviteContent.title
         ) : undefined
       }
       description={
         isInvitationLoading ? (
           <ShimmeringLoader className="mx-auto h-4 w-48 max-w-full py-0" />
-        ) : interstitialDescription ? (
-          interstitialDescription
+        ) : inviteContent.description ? (
+          inviteContent.description
         ) : undefined
       }
       titleClassName="text-xl"
@@ -159,7 +140,7 @@ export const OrganizationInvite = () => {
     )
   }
 
-  if (inviteIsNoLongerValid) {
+  if (inviteStatus === 'no-longer-valid') {
     return withLayout(
       <div className="flex flex-col gap-3">
         <Admonition
@@ -179,7 +160,7 @@ export const OrganizationInvite = () => {
         data={data}
         error={error}
         isError={isErrorInvitation}
-        isInvalidInvite={inviteIsInvalid}
+        isInvalidInvite={inviteStatus === 'invalid'}
       />
     )
   }

--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.utils.ts
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.utils.ts
@@ -1,0 +1,96 @@
+import type { OrganizationInviteByToken } from '@/data/organization-members/organization-invitation-token-query'
+import type { ResponseError } from '@/types'
+
+type OrganizationInviteStatusVariables = {
+  data?: OrganizationInviteByToken
+  error?: ResponseError | null
+  isErrorInvitation: boolean
+  isLoadingInvitation: boolean
+  isLoadingProfile: boolean
+  isLoggedIn: boolean
+  isRouterReady: boolean
+  isSuccessInvitation: boolean
+  profileExists: boolean
+}
+
+type OrganizationInviteContentVariables = {
+  data?: OrganizationInviteByToken
+  isSignUpEnabled: boolean
+  status: OrganizationInviteStatus
+}
+
+export type OrganizationInviteStatus =
+  | 'signed-out'
+  | 'loading'
+  | 'ready'
+  | 'wrong-account'
+  | 'expired'
+  | 'invalid'
+  | 'no-longer-valid'
+  | 'error'
+
+export function getOrganizationInviteStatus({
+  data,
+  error,
+  isErrorInvitation,
+  isLoadingInvitation,
+  isLoadingProfile,
+  isLoggedIn,
+  isRouterReady,
+  isSuccessInvitation,
+  profileExists,
+}: OrganizationInviteStatusVariables): OrganizationInviteStatus {
+  const isSignedOut = !isLoggedIn || (!profileExists && !isLoadingProfile)
+
+  if (isSignedOut) return 'signed-out'
+  if (isLoadingProfile || isLoadingInvitation || !isRouterReady) return 'loading'
+
+  if (error?.code === 401 && error?.message.includes('Failed to retrieve organization')) {
+    return 'no-longer-valid'
+  }
+
+  if (
+    (isSuccessInvitation && !!data?.token_does_not_exist) ||
+    (isErrorInvitation && error?.code === 404)
+  ) {
+    return 'invalid'
+  }
+
+  if (isErrorInvitation) return 'error'
+  if (isSuccessInvitation && !!data?.expired_token) return 'expired'
+  if (isSuccessInvitation && !!data && !data.email_match) return 'wrong-account'
+
+  return 'ready'
+}
+
+export function getOrganizationInviteContent({
+  data,
+  isSignUpEnabled,
+  status,
+}: OrganizationInviteContentVariables) {
+  const signedOutDescription = `Sign in${
+    isSignUpEnabled ? ' or create an account' : ''
+  } to view this invitation`
+
+  if (status === 'signed-out') {
+    return {
+      title: 'View invitation',
+      description: signedOutDescription,
+    }
+  }
+
+  if (status === 'ready') {
+    return {
+      title: `Join ${data?.organization_name ?? 'an organization'}`,
+      description: 'You have been invited to join this Supabase organization',
+    }
+  }
+
+  if (status === 'wrong-account') return { title: 'Wrong account' }
+  if (status === 'expired') return { title: 'Invite expired' }
+  if (status === 'invalid') return { title: 'Invite invalid' }
+  if (status === 'no-longer-valid') return { title: 'Invite no longer available' }
+  if (status === 'error') return { title: 'Unable to load invitation' }
+
+  return {}
+}

--- a/apps/studio/tests/components/OrganizationInvite.test.tsx
+++ b/apps/studio/tests/components/OrganizationInvite.test.tsx
@@ -198,40 +198,6 @@ describe('OrganizationInvite', () => {
     expect(mocks.routerReload).toHaveBeenCalled()
   })
 
-  test('renders expired and invalid invite states', () => {
-    mocks.useInvitationQuery.mockReturnValueOnce({
-      data: { ...READY_INVITE, expired_token: true },
-      error: null,
-      isSuccess: true,
-      isError: false,
-      isPending: false,
-    })
-
-    const { rerender } = render(<OrganizationInvite />)
-
-    expect(screen.getByText('Invite expired')).toBeInTheDocument()
-    expect(
-      screen.getByText('Ask the organization owner to send you a new invite.')
-    ).toBeInTheDocument()
-
-    mocks.useInvitationQuery.mockReturnValueOnce({
-      data: { ...READY_INVITE, token_does_not_exist: true },
-      error: null,
-      isSuccess: true,
-      isError: false,
-      isPending: false,
-    })
-
-    rerender(<OrganizationInvite />)
-
-    expect(screen.getByText('Invite invalid')).toBeInTheDocument()
-    expect(
-      screen.getByText(
-        'Open the full invite link again, or ask the organization owner for a new invite.'
-      )
-    ).toBeInTheDocument()
-  })
-
   test('renders no-longer-valid, invalid lookup, and generic error states', () => {
     mocks.useInvitationQuery.mockReturnValueOnce({
       data: undefined,

--- a/apps/studio/tests/components/OrganizationInvite.utils.test.ts
+++ b/apps/studio/tests/components/OrganizationInvite.utils.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  getOrganizationInviteContent,
+  getOrganizationInviteStatus,
+  type OrganizationInviteStatus,
+} from '@/components/interfaces/OrganizationInvite/OrganizationInvite.utils'
+import type { OrganizationInviteByToken } from '@/data/organization-members/organization-invitation-token-query'
+import type { ResponseError } from '@/types'
+
+const READY_INVITE: OrganizationInviteByToken = {
+  authorized_user: true,
+  email_match: true,
+  expired_token: false,
+  invite_id: 42,
+  organization_name: 'Acme Corp',
+  sso_mismatch: false,
+  token_does_not_exist: false,
+}
+
+const responseError = (message: string, code = 500) => ({ message, code }) as ResponseError
+type StatusOverrides = Partial<Parameters<typeof getOrganizationInviteStatus>[0]>
+
+const getStatus = (overrides: StatusOverrides = {}) =>
+  getOrganizationInviteStatus({
+    data: READY_INVITE,
+    error: null,
+    isErrorInvitation: false,
+    isLoadingInvitation: false,
+    isLoadingProfile: false,
+    isLoggedIn: true,
+    isRouterReady: true,
+    isSuccessInvitation: true,
+    profileExists: true,
+    ...overrides,
+  })
+
+describe('OrganizationInvite utils', () => {
+  test.each<[string, OrganizationInviteStatus, StatusOverrides]>([
+    ['signed out when there is no current user', 'signed-out', { isLoggedIn: false }],
+    ['loading while the profile is loading', 'loading', { isLoadingProfile: true }],
+    ['loading while the invite is loading', 'loading', { isLoadingInvitation: true }],
+    [
+      'no longer valid for accepted or declined invites',
+      'no-longer-valid',
+      {
+        data: undefined,
+        error: responseError('Failed to retrieve organization', 401),
+        isErrorInvitation: true,
+        isSuccessInvitation: false,
+      },
+    ],
+    [
+      'invalid when the API returns a missing token response',
+      'invalid',
+      {
+        data: { ...READY_INVITE, token_does_not_exist: true },
+      },
+    ],
+    [
+      'invalid when the invite lookup 404s',
+      'invalid',
+      {
+        data: undefined,
+        error: responseError('Not Found', 404),
+        isErrorInvitation: true,
+        isSuccessInvitation: false,
+      },
+    ],
+    [
+      'error for other API failures',
+      'error',
+      {
+        data: undefined,
+        error: responseError('Failed to retrieve token', 500),
+        isErrorInvitation: true,
+        isSuccessInvitation: false,
+      },
+    ],
+    [
+      'expired when the token has expired',
+      'expired',
+      {
+        data: { ...READY_INVITE, expired_token: true },
+      },
+    ],
+    [
+      'wrong account when the invite email does not match',
+      'wrong-account',
+      {
+        data: { ...READY_INVITE, email_match: false },
+      },
+    ],
+    ['ready when the invite can be accepted', 'ready', {}],
+  ])('returns %s', (_name, expected, overrides) => {
+    expect(getStatus(overrides)).toBe(expected)
+  })
+
+  test.each<[OrganizationInviteStatus, string, string | undefined]>([
+    ['signed-out', 'View invitation', 'Sign in or create an account to view this invitation'],
+    ['ready', 'Join Acme Corp', 'You have been invited to join this Supabase organization'],
+    ['wrong-account', 'Wrong account', undefined],
+    ['expired', 'Invite expired', undefined],
+    ['invalid', 'Invite invalid', undefined],
+    ['no-longer-valid', 'Invite no longer available', undefined],
+    ['error', 'Unable to load invitation', undefined],
+  ])('returns content for %s', (status, title, description) => {
+    expect(
+      getOrganizationInviteContent({
+        data: READY_INVITE,
+        isSignUpEnabled: true,
+        status,
+      })
+    ).toEqual({ title, ...(description ? { description } : {}) })
+  })
+
+  test('omits sign-up copy when sign-up is disabled', () => {
+    expect(
+      getOrganizationInviteContent({
+        data: READY_INVITE,
+        isSignUpEnabled: false,
+        status: 'signed-out',
+      }).description
+    ).toBe('Sign in to view this invitation')
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Code cleanup. Follow-up to #45774.

## What is the current behavior?

The organisation invite interstitial derives invite states, titles, and descriptions from nested conditional logic in the component. That makes the component harder to scan and pushes too much state coverage into render tests.

## What is the new behavior?

See #45774 for screenshots of the general UI before-and-after (which this one builds upon). That PR also contains testing instructions.

Extracts the invite status and content decisions into small pure helpers, then covers those helpers with focused unit tests. 

The component keeps the user-facing render and interaction coverage, including the invalid lookup regression where a 404 should render the invalid invite state instead of raw backend copy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved organization invite flow with enhanced error state handling for expired, invalid, and wrong-account scenarios.
  * Better consistency in error messages and user guidance throughout the invite process.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45813)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->