### PR TITLE
feat(studio): move CLI login to connect interstitial

### DIFF
--- a/apps/studio/components/layouts/InterstitialLayout.tsx
+++ b/apps/studio/components/layouts/InterstitialLayout.tsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion'
+import { ArrowRightLeft } from 'lucide-react'
 import type { PropsWithChildren, ReactNode } from 'react'
 import { Card, CardContent, CardHeader, cn } from 'ui'
 
@@ -85,6 +86,14 @@ export const LogoBox = ({ children, className }: { children: ReactNode; classNam
     )}
   >
     {children}
+  </div>
+)
+
+export const LogoPair = ({ left, right }: { left: ReactNode; right: ReactNode }) => (
+  <div className="flex items-center justify-center gap-2.5">
+    {left}
+    <ArrowRightLeft className="size-4 text-foreground-muted" />
+    {right}
   </div>
 )
 

--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -31,6 +31,9 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
       onClick,
       copyLabel = 'Copy',
       copiedLabel = 'Copied',
+      type = 'primary',
+      icon,
+      className,
       ...props
     },
     ref
@@ -53,9 +56,17 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
           onClick?.(e)
         }}
         {...props}
-        className={cn({ 'px-1': iconOnly }, props.className)}
+        type={type}
+        className={cn({ 'px-1': iconOnly }, className)}
         icon={
-          showCopied ? <Check strokeWidth={2} className="text-brand" /> : (props.icon ?? <Copy />)
+          showCopied ? (
+            <Check
+              strokeWidth={2}
+              className={cn(type === 'primary' ? 'text-inherit' : 'text-brand')}
+            />
+          ) : (
+            (icon ?? <Copy />)
+          )
         }
       >
         {!iconOnly && <>{children ?? (showCopied ? copiedLabel : copyLabel)}</>}

--- a/apps/studio/pages/cli/login.tsx
+++ b/apps/studio/pages/cli/login.tsx
@@ -30,6 +30,24 @@ const CliLogo = () => (
   </LogoBox>
 )
 
+const CliLoginInterstitial = ({
+  title,
+  description,
+  children,
+}: {
+  title: ReactNode
+  description?: ReactNode
+  children: ReactNode
+}) => (
+  <InterstitialLayout
+    logo={<LogoPair left={<CliLogo />} right={<SupabaseLogo />} />}
+    title={title}
+    description={description}
+  >
+    <div className="px-6 pb-6">{children}</div>
+  </InterstitialLayout>
+)
+
 const CliLoginPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { session_id, public_key, token_name, device_code } = useParams()
@@ -129,29 +147,12 @@ export const CliLoginScreen = ({
     }
   }, [deviceCode, isLoggedIn, navigate, publicKey, routerReady, sessionId, tokenName])
 
-  const withInterstitial = ({
-    title,
-    description,
-    children,
-  }: {
-    title: ReactNode
-    description?: ReactNode
-    children: ReactNode
-  }) => (
-    <InterstitialLayout
-      logo={<LogoPair left={<CliLogo />} right={<SupabaseLogo />} />}
-      title={title}
-      description={description}
-    >
-      <div className="px-6 pb-6">{children}</div>
-    </InterstitialLayout>
-  )
-
   if (status._tag === 'loading') {
-    return withInterstitial({
-      title: <ShimmeringLoader className="mx-auto h-7 w-32 max-w-full py-0" />,
-      description: <ShimmeringLoader className="mx-auto h-4 w-56 max-w-full py-0" />,
-      children: (
+    return (
+      <CliLoginInterstitial
+        title={<ShimmeringLoader className="mx-auto h-7 w-32 max-w-full py-0" />}
+        description={<ShimmeringLoader className="mx-auto h-4 w-56 max-w-full py-0" />}
+      >
         <div className="flex flex-col gap-5">
           <Card className="shadow-none">
             <CardContent className="flex items-center gap-3 border-none px-4 py-3">
@@ -164,17 +165,18 @@ export const CliLoginScreen = ({
           </Card>
           <ShimmeringLoader className="h-20 w-full rounded-lg py-0" />
         </div>
-      ),
-    })
+      </CliLoginInterstitial>
+    )
   }
 
   if (status._tag === 'missing-params') {
     const isPlural = status.missingParameters.length > 1
 
-    return withInterstitial({
-      title: 'Missing sign-in parameters',
-      description: 'This Supabase CLI sign-in request cannot be authorized',
-      children: (
+    return (
+      <CliLoginInterstitial
+        title="Missing sign-in parameters"
+        description="This Supabase CLI sign-in request cannot be authorized"
+      >
         <div className="flex flex-col gap-3">
           <Admonition
             type="warning"
@@ -186,15 +188,16 @@ export const CliLoginScreen = ({
             <Link href="/organizations">Back to dashboard</Link>
           </Button>
         </div>
-      ),
-    })
+      </CliLoginInterstitial>
+    )
   }
 
   if (status._tag === 'error') {
-    return withInterstitial({
-      title: 'Unable to create CLI sign-in',
-      description: 'Retry the sign-in command from Supabase CLI',
-      children: (
+    return (
+      <CliLoginInterstitial
+        title="Unable to create CLI sign-in"
+        description="Retry the sign-in command from Supabase CLI"
+      >
         <div className="flex flex-col gap-3">
           <Admonition
             type="warning"
@@ -213,14 +216,15 @@ export const CliLoginScreen = ({
             <Link href="/organizations">Back to dashboard</Link>
           </Button>
         </div>
-      ),
-    })
+      </CliLoginInterstitial>
+    )
   }
 
-  return withInterstitial({
-    title: 'Authorize Supabase CLI',
-    description: 'Enter this verification code in Supabase CLI to finish signing in',
-    children: (
+  return (
+    <CliLoginInterstitial
+      title="Authorize Supabase CLI"
+      description="Enter this verification code in Supabase CLI to finish signing in"
+    >
       <div className="flex flex-col gap-5">
         <div className="flex flex-col items-center gap-3">
           <div
@@ -257,8 +261,8 @@ export const CliLoginScreen = ({
           <InlineLink href="/account/tokens">Access Tokens</InlineLink>.
         </p>
       </div>
-    ),
-  })
+    </CliLoginInterstitial>
+  )
 }
 
 export default withAuth(CliLoginPage)

--- a/apps/studio/pages/cli/login.tsx
+++ b/apps/studio/pages/cli/login.tsx
@@ -1,88 +1,264 @@
 import { useIsLoggedIn, useParams } from 'common'
+import { Terminal } from 'lucide-react'
 import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
-import { toast } from 'sonner'
-import { InputOTP, InputOTPGroup, InputOTPSlot, LogoLoader } from 'ui'
-import { Admonition } from 'ui-patterns'
+import { useEffect, useState, type ReactNode } from 'react'
+import { Button, Card, CardContent } from 'ui'
+import { Admonition, ShimmeringLoader } from 'ui-patterns'
 
-import { APIAuthorizationLayout } from '@/components/layouts/APIAuthorizationLayout'
+import {
+  InterstitialAccountRow,
+  InterstitialLayout,
+  LogoBox,
+  LogoPair,
+  SupabaseLogo,
+} from '@/components/layouts/InterstitialLayout'
 import CopyButton from '@/components/ui/CopyButton'
+import { InlineLink } from '@/components/ui/InlineLink'
 import { createCliLoginSession } from '@/data/cli/login'
 import { withAuth } from '@/hooks/misc/withAuth'
+import { buildStudioPageTitle } from '@/lib/page-title'
+import { useProfile } from '@/lib/profile'
 import type { NextPageWithLayout } from '@/types'
+
+const PAGE_TITLE = buildStudioPageTitle({ section: 'Authorize CLI', brand: 'Supabase' })
+
+const CliLogo = () => (
+  <LogoBox className="bg-black">
+    <Terminal className="size-6 text-white" strokeWidth={2} />
+  </LogoBox>
+)
 
 const CliLoginPage: NextPageWithLayout = () => {
   const router = useRouter()
   const { session_id, public_key, token_name, device_code } = useParams()
   const isLoggedIn = useIsLoggedIn()
 
+  if (!router.isReady) return null
+
+  return (
+    <>
+      <Head>
+        <title>{PAGE_TITLE}</title>
+      </Head>
+      <CliLoginScreen
+        isLoggedIn={isLoggedIn}
+        routerReady={router.isReady}
+        sessionId={session_id}
+        publicKey={public_key}
+        tokenName={token_name}
+        deviceCode={device_code}
+        navigate={(destination) => router.push(destination)}
+      />
+    </>
+  )
+}
+
+type CliLoginStatus =
+  | { _tag: 'loading' }
+  | { _tag: 'ready'; deviceCode: string }
+  | { _tag: 'missing-params'; missingParameters: string[] }
+  | { _tag: 'error'; message?: string }
+
+export const CliLoginScreen = ({
+  isLoggedIn,
+  routerReady,
+  sessionId,
+  publicKey,
+  tokenName,
+  deviceCode,
+  navigate,
+}: {
+  isLoggedIn: boolean
+  routerReady: boolean
+  sessionId?: string
+  publicKey?: string
+  tokenName?: string
+  deviceCode?: string
+  navigate: (destination: string) => void
+}) => {
+  const { profile } = useProfile()
+  const [status, setStatus] = useState<CliLoginStatus>({ _tag: 'loading' })
+  const displayName = profile?.primary_email ?? profile?.username
+
   useEffect(() => {
-    if (!isLoggedIn || !router.isReady || device_code) {
+    if (!isLoggedIn || !routerReady) return
+    if (deviceCode) {
+      setStatus({ _tag: 'ready', deviceCode })
       return
     }
 
-    async function createSession() {
-      if (!session_id || !public_key) {
-        router.push('/404')
-        return
-      }
+    const missingParameters = [
+      !sessionId ? 'session_id' : undefined,
+      !publicKey ? 'public_key' : undefined,
+    ].filter(Boolean) as string[]
 
+    if (missingParameters.length > 0) {
+      setStatus({ _tag: 'missing-params', missingParameters })
+      return
+    }
+
+    let isActive = true
+    setStatus({ _tag: 'loading' })
+
+    async function createSession() {
       try {
-        const { nonce } = await createCliLoginSession(session_id, public_key, token_name)
+        const { nonce } = await createCliLoginSession(sessionId!, publicKey!, tokenName)
+
+        if (!isActive) return
 
         if (nonce) {
-          router.push(`/cli/login?device_code=${nonce.substring(0, 8)}`)
+          navigate(`/cli/login?device_code=${nonce.substring(0, 8)}`)
         } else {
-          router.push(`/404`)
+          setStatus({ _tag: 'error', message: 'The CLI sign-in session did not return a code.' })
         }
-      } catch (error: any) {
-        toast.error(`Failed to create login session: ${error.message}`)
-        router.push(`/500`)
+      } catch (error: unknown) {
+        if (!isActive) return
+        setStatus({
+          _tag: 'error',
+          message: error instanceof Error ? error.message : 'Unknown error',
+        })
       }
     }
 
     createSession()
-  }, [isLoggedIn, router, router.isReady, session_id, public_key, token_name, device_code])
 
-  return (
-    <APIAuthorizationLayout HeadProvider={Head}>
-      <div className={`flex flex-col items-center justify-center h-full`}>
-        {device_code ? (
-          <>
-            <h2 className="py-2">Your Supabase account is being used to login on Supabase CLI</h2>
-            <p>Enter this verification code on Supabase CLI to authorize login.</p>
-            <div className="flex flex-row gap-2 py-10">
-              <InputOTP maxLength={8} value={device_code} disabled>
-                <InputOTPGroup>
-                  {Array.from({ length: 8 }, (_, i) => (
-                    <InputOTPSlot key={i} className="text-xl" index={i} />
-                  ))}
-                </InputOTPGroup>
-              </InputOTP>
-              <CopyButton iconOnly size="large" type="text" className="px-2" text={device_code} />
-            </div>
-            <p>After authorizing the login attempt, you can close this window.</p>
-            <p>
-              If you ever want to remove your new token, go to{' '}
-              <Link href="/account/tokens" className="underline">
-                Access Tokens
-              </Link>{' '}
-              page.
-            </p>
-            <Admonition
-              type="tip"
-              title="Browser login flow requires Supabase CLI version 1.219.0 and above."
-              className="mt-16"
-            />
-          </>
-        ) : (
-          <LogoLoader />
-        )}
-      </div>
-    </APIAuthorizationLayout>
+    return () => {
+      isActive = false
+    }
+  }, [deviceCode, isLoggedIn, navigate, publicKey, routerReady, sessionId, tokenName])
+
+  const withInterstitial = ({
+    title,
+    description,
+    children,
+  }: {
+    title: ReactNode
+    description?: ReactNode
+    children: ReactNode
+  }) => (
+    <InterstitialLayout
+      logo={<LogoPair left={<CliLogo />} right={<SupabaseLogo />} />}
+      title={title}
+      description={description}
+    >
+      <div className="px-6 pb-6">{children}</div>
+    </InterstitialLayout>
   )
+
+  if (status._tag === 'loading') {
+    return withInterstitial({
+      title: <ShimmeringLoader className="mx-auto h-7 w-32 max-w-full py-0" />,
+      description: <ShimmeringLoader className="mx-auto h-4 w-56 max-w-full py-0" />,
+      children: (
+        <div className="flex flex-col gap-5">
+          <Card className="shadow-none">
+            <CardContent className="flex items-center gap-3 border-none px-4 py-3">
+              <ShimmeringLoader className="size-8 flex-shrink-0 rounded-full py-0" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <ShimmeringLoader className="h-3 w-20 py-0" />
+                <ShimmeringLoader className="h-4 w-40 max-w-full py-0" />
+              </div>
+            </CardContent>
+          </Card>
+          <ShimmeringLoader className="h-20 w-full rounded-lg py-0" />
+        </div>
+      ),
+    })
+  }
+
+  if (status._tag === 'missing-params') {
+    const isPlural = status.missingParameters.length > 1
+
+    return withInterstitial({
+      title: 'Missing sign-in parameters',
+      description: 'This Supabase CLI sign-in request cannot be authorized',
+      children: (
+        <div className="flex flex-col gap-3">
+          <Admonition
+            type="warning"
+            description={`Open the browser sign-in flow from Supabase CLI again. The URL is missing parameter${
+              isPlural ? 's' : ''
+            }: ${status.missingParameters.join(', ')}.`}
+          />
+          <Button type="default" block asChild>
+            <Link href="/organizations">Back to dashboard</Link>
+          </Button>
+        </div>
+      ),
+    })
+  }
+
+  if (status._tag === 'error') {
+    return withInterstitial({
+      title: 'Unable to create CLI sign-in',
+      description: 'Retry the sign-in command from Supabase CLI',
+      children: (
+        <div className="flex flex-col gap-3">
+          <Admonition
+            type="warning"
+            description={
+              <>
+                Supabase could not create the CLI sign-in session.
+                {status.message && (
+                  <span className="mt-1 block text-foreground-lighter">
+                    Error: {status.message}
+                  </span>
+                )}
+              </>
+            }
+          />
+          <Button type="default" block asChild>
+            <Link href="/organizations">Back to dashboard</Link>
+          </Button>
+        </div>
+      ),
+    })
+  }
+
+  return withInterstitial({
+    title: 'Authorize Supabase CLI',
+    description: 'Enter this verification code in Supabase CLI to finish signing in',
+    children: (
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col items-center gap-3">
+          <div
+            aria-label={`Verification code ${status.deviceCode}`}
+            className="flex w-full select-text items-center font-sans text-xl text-foreground"
+            onCopy={(event) => {
+              event.preventDefault()
+              event.clipboardData.setData('text/plain', status.deviceCode)
+            }}
+          >
+            {Array.from(status.deviceCode.padEnd(8, ' ')).map((character, index) => (
+              <span
+                key={index}
+                className="flex h-11 flex-1 cursor-text select-text items-center justify-center border-y border-r border-input first:rounded-l-md first:border-l last:rounded-r-md"
+              >
+                {character}
+              </span>
+            ))}
+          </div>
+          <CopyButton
+            text={status.deviceCode}
+            copyLabel="Copy code"
+            copiedLabel="Copied"
+            type="primary"
+            size="tiny"
+            className="w-full"
+          />
+        </div>
+
+        <InterstitialAccountRow displayName={displayName} />
+
+        <p className="text-center text-xs text-foreground-lighter text-balance">
+          After authorizing, you can close this tab or manage tokens like this one in{' '}
+          <InlineLink href="/account/tokens">Access Tokens</InlineLink>.
+        </p>
+      </div>
+    ),
+  })
 }
 
 export default withAuth(CliLoginPage)

--- a/apps/studio/tests/components/CopyButton.test.tsx
+++ b/apps/studio/tests/components/CopyButton.test.tsx
@@ -12,3 +12,14 @@ test('shows copied text', async () => {
   await screen.findByText('Copied')
   expect(callback).toBeCalled()
 })
+
+test('does not show a green copied icon for primary buttons', async () => {
+  const { container } = render(<CopyButton text="some text" type="primary" />)
+
+  await userEvent.click(await screen.findByText('Copy'))
+  await screen.findByText('Copied')
+
+  const icon = container.querySelector('svg')
+  expect(icon).toHaveClass('text-inherit')
+  expect(icon).not.toHaveClass('text-brand')
+})

--- a/apps/studio/tests/pages/cli-login.test.tsx
+++ b/apps/studio/tests/pages/cli-login.test.tsx
@@ -1,0 +1,122 @@
+import { screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import type { ProfileContextType } from '@/lib/profile'
+import { CliLoginScreen } from '@/pages/cli/login'
+import { customRender } from '@/tests/lib/custom-render'
+
+const { createCliLoginSessionMock } = vi.hoisted(() => ({
+  createCliLoginSessionMock: vi.fn(),
+}))
+
+vi.mock('@/data/cli/login', () => ({
+  createCliLoginSession: createCliLoginSessionMock,
+}))
+
+const DEFAULT_PROFILE_CONTEXT: ProfileContextType = {
+  profile: {
+    id: 1,
+    auth0_id: 'auth0|test',
+    gotrue_id: 'gotrue-test',
+    username: 'testuser',
+    primary_email: 'test@example.com',
+    first_name: null,
+    last_name: null,
+    mobile: null,
+    is_alpha_user: false,
+    is_sso_user: false,
+    disabled_features: [],
+    free_project_limit: null,
+  },
+  error: null,
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+}
+
+function renderScreen(props: Partial<Parameters<typeof CliLoginScreen>[0]> = {}) {
+  const navigate = vi.fn()
+  const result = customRender(
+    <CliLoginScreen
+      isLoggedIn
+      routerReady
+      sessionId="session-test"
+      publicKey="public-key-test"
+      tokenName="local-dev"
+      navigate={navigate}
+      {...props}
+    />,
+    { profileContext: DEFAULT_PROFILE_CONTEXT }
+  )
+  return { ...result, navigate }
+}
+
+describe('CliLoginScreen', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  test('creates a session and routes to the device code', async () => {
+    createCliLoginSessionMock.mockResolvedValue({ nonce: 'ABCDEFGH12345678' })
+    const { navigate } = renderScreen()
+
+    await waitFor(() => {
+      expect(createCliLoginSessionMock).toHaveBeenCalledWith(
+        'session-test',
+        'public-key-test',
+        'local-dev'
+      )
+    })
+    await waitFor(() => {
+      expect(navigate).toHaveBeenCalledWith('/cli/login?device_code=ABCDEFGH')
+    })
+  })
+
+  test('renders ready state with verification code and copy control', async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn()
+    vi.spyOn(window.document, 'hasFocus').mockReturnValue(true)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+
+    const { container } = renderScreen({ deviceCode: 'ZXCV9876' })
+
+    expect(container).toHaveTextContent('ZXCV9876')
+    await user.click(screen.getByRole('button', { name: 'Copy code' }))
+    expect(await screen.findByRole('button', { name: 'Copied' })).toBeInTheDocument()
+    expect(writeText).toHaveBeenCalledWith('ZXCV9876')
+  })
+
+  test('copies selected verification code as a single string', () => {
+    renderScreen({ deviceCode: 'ZXCV9876' })
+
+    const clipboardData = { setData: vi.fn() }
+    const code = screen.getByLabelText('Verification code ZXCV9876')
+    const copyEvent = new Event('copy', { bubbles: true })
+
+    Object.defineProperty(copyEvent, 'clipboardData', {
+      value: clipboardData,
+    })
+    code.dispatchEvent(copyEvent)
+
+    expect(clipboardData.setData).toHaveBeenCalledWith('text/plain', 'ZXCV9876')
+  })
+
+  test('renders missing-params state without redirecting away', () => {
+    renderScreen({ sessionId: undefined })
+
+    expect(screen.getByText('Missing sign-in parameters')).toBeInTheDocument()
+    expect(screen.getByText(/session_id/)).toBeInTheDocument()
+  })
+
+  test('renders creation error state in the card', async () => {
+    createCliLoginSessionMock.mockRejectedValue(new Error('Session expired'))
+    renderScreen()
+
+    expect(await screen.findByText('Unable to create CLI sign-in')).toBeInTheDocument()
+    expect(screen.getByText(/Session expired/)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature / UI refactor

## What is the current behaviour?

The CLI browser login route still uses the older API authorisation layout and redirects missing or failed sign-in session states to generic 404/500 pages.

## What is the new behaviour?

Moves `/cli/login` onto the shared connect interstitial layout as the next small stacked slice after the organisation invite work.

This keeps the real CLI login contract intact while updating the surface:
- creates the CLI login session from `session_id`, `public_key`, and optional `token_name`
- redirects to the generated `device_code`
- renders missing-parameter and session-creation failures in-card instead of redirecting away
- keeps the 8-character verification code selectable and copyable as a single string
- uses a full-width primary `Copy code` action

This also adds the small shared interstitial helpers needed by this surface and adjusts `CopyButton` so the copied check icon inherits the primary button colour instead of turning green.

This also removes the CLI version admonition:

> Browser login flow requires Supabase CLI version 1.219.0 and above.

I checked with our stats and the CLI team. The vast majority of users are on a newer version.

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="Authorize API access  Supabase-D1E3CF26-BD59-4BB2-B457-B552EE47E3DA" src="https://github.com/user-attachments/assets/c89b8b13-fa98-41b7-8093-e59d15b2aa9e" /> | <img width="1024" height="759" alt="Authorize CLI  Supabase-C9977F21-88B8-441B-8A2C-09A9515935B0" src="https://github.com/user-attachments/assets/ca13b65a-3875-425c-b73b-8f2101c1e406" /> |
| <img width="1024" height="759" alt="Supabase-F42FBEAF-F74D-4920-8A51-7C25004F66D5" src="https://github.com/user-attachments/assets/51adb1e6-a2fb-41fb-b36f-0ae466fe60e2" /> | <img width="1024" height="759" alt="Authorize CLI  Supabase-8159A1B1-2594-4183-AC35-FEF1EFD4EA37" src="https://github.com/user-attachments/assets/6f143218-795d-41c9-a8e1-52e529a6b988" />
| <img width="1024" height="759" alt="Supabase-2506E468-9F42-44B9-A5B7-BC4D3777F552" src="https://github.com/user-attachments/assets/a304fca5-cf26-4ae7-abe9-77cdbc21fba5" /> | <img width="1024" height="759" alt="Authorize CLI  Supabase-A0EE1239-A345-427C-9CF7-997037A8FC0E" src="https://github.com/user-attachments/assets/33118777-35f3-49d6-bc1e-30e7124b3677" /> |
| <img width="1024" height="759" alt="Authorize API access  Supabase-A7B84CA6-D230-4C3E-9227-DE21CE35375C" src="https://github.com/user-attachments/assets/78eb6296-035a-4201-b254-b97eda44443c" /> | <img width="1024" height="759" alt="Authorize CLI  Supabase-F55E26B2-609B-449C-9C64-08AA90AE3D1E" src="https://github.com/user-attachments/assets/ff7b3b4e-729c-4681-844d-2d5d94bfc084" /> |

## Testing instructions

Use the Vercel preview URL for this PR once it is available. The examples below use `<preview-origin>` as a placeholder, for example `https://studio-git-dnywh-feat-cli-login-interstitial-supabase.vercel.app`.

You need to be signed in to Studio to see these states because `/cli/login` is still behind `withAuth`.

Ready state:
- Open `<preview-origin>/cli/login?device_code=ABCD1234`
- Check the page title is `Authorize CLI | Supabase`
- Check the card title is `Authorize Supabase CLI`
- Check the code fills the width, uses the normal sans font, and can be selected
- Drag-select the code and copy it; the clipboard should contain `ABCD1234`, not one character per line
- Click `Copy code`; the button should show the usual copied success state without a green check icon on the primary button

Missing parameters state:
- Open `<preview-origin>/cli/login`
- Check the card says `Missing sign-in parameters` and names the missing `session_id` and `public_key` parameters
- Open `<preview-origin>/cli/login?session_id=session-test`
- Check it still stays in-card and names the missing `public_key` parameter instead of redirecting to `/404`

Creation error state:
- Open `<preview-origin>/cli/login?session_id=not-real&public_key=not-real&token_name=local-dev`
- Check it stays in-card with `Unable to create CLI sign-in` instead of redirecting to `/500`
- The exact error detail can vary by environment; the important bit is that the failure is shown inside the interstitial card

Loading state:
- This is transient because there are no production mocks in this slice
- To inspect it manually, throttle the browser network before opening a session-creation URL such as `<preview-origin>/cli/login?session_id=not-real&public_key=not-real`

Real CLI flow:
- Run the browser login flow from Supabase CLI as usual
- When the CLI opens a Studio URL, keep the path and query string but replace the origin with the PR preview origin
- The page should create the login session and then route to `/cli/login?device_code=<8 character code>`
- Enter that 8-character code back in the CLI prompt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned CLI login flow with clearer state-driven screens and improved verification UI.
  * Added a small paired-logo component for centered logo pairs with a connector icon.

* **Improvements**
  * Copy button behavior and styling refined for consistent visual feedback across variants.

* **Tests**
  * New unit tests covering copy-button behavior and multiple CLI login UI flows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45814)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->