### PR TITLE
chore(docs): add Julian Domke to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -144,6 +144,7 @@ Jordan McQueen
 Jordi Enric
 José Luis Ledesma
 Joshen Lim
+Julian Domke
 Julien Goux
 Kai M
 Kalleby Santos


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes!

## What kind of change does this PR introduce?

Adds Julian Domke to the humans.txt

## What is the current behavior?

There's no Julian Domke in the humans.txt

## What is the new behavior?

There is a Julian Domke in the humans.txt!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team credits with an additional contributor.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45815)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->