### PR TITLE
chore: Add blockExoticSubdeps to prevent GitHub URLs and tarballs

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,6 +4,8 @@ packages:
   - blocks/*
   - e2e/*
 
+blockExoticSubdeps: true
+
 catalog:
   '@sentry/nextjs': ^10.26.0
   '@supabase/auth-js': 2.105.4
@@ -69,8 +71,8 @@ overrides:
   '@rollup/plugin-terser>serialize-javascript': ^7.0.5
   cacache>tar: ^7.5.11
   dompurify: ^3.3.2
-  express-rate-limit>ip-address: ^10.1.1
   esbuild: ^0.25.2
+  express-rate-limit>ip-address: ^10.1.1
   lodash: 'catalog:'
   lodash-es: 'catalog:'
   node-gyp>tar: ^7.5.11


### PR DESCRIPTION
This pull request introduces a configuration update to the `pnpm-workspace.yaml` file. The most significant change is the addition of the `blockExoticSubdeps: true` setting, which helps prevent the installation of potentially problematic or non-standard subdependencies across the workspace. There is also a minor adjustment in the `overrides` section, but it does not result in any functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced package dependency configuration to prevent exotic subdependencies and improve installation reliability.
  * Reorganized dependency override specifications for consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45817)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->