### PR TITLE
Open advanced settings + scroll to that collapsible if submitting has an error

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -349,10 +349,13 @@ export function DiskManagementForm() {
         fieldErrors.includes('maxSizeGb')
       ) {
         setAdvancedSettingsOpenState(true)
+
         // [Joshen] The timeout is to let the collapsible open prior to scrolling
-        setTimeout(() => {
+        const timeoutId = setTimeout(() => {
           advancedSettingsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
         }, 100)
+
+        return () => clearTimeout(timeoutId)
       }
     }
   }, [errors])

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -3,7 +3,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
 import { ChevronRight } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { CloudProvider } from 'shared-data'
 import { toast } from 'sonner'
@@ -13,6 +13,7 @@ import {
   Collapsible_Shadcn_,
   CollapsibleContent_Shadcn_,
   CollapsibleTrigger_Shadcn_,
+  DialogSectionSeparator,
   Form,
   Separator,
 } from 'ui'
@@ -76,6 +77,8 @@ export function DiskManagementForm() {
   const { data: project, isPending: isProjectPending } = useSelectedProjectQuery()
   const { data: org } = useSelectedOrganizationQuery()
   const { setProjectStatus } = useSetProjectStatus()
+
+  const advancedSettingsRef = useRef<HTMLDivElement>(null)
 
   const isSpendCapEnabled =
     org?.plan.id !== 'free' && !org?.usage_billing_enabled && project?.cloud_provider !== 'FLY'
@@ -163,42 +166,7 @@ export function DiskManagementForm() {
     reValidateMode: 'onChange',
   })
 
-  useEffect(() => {
-    if (!isDiskAttributesSuccess) return
-    // @ts-ignore
-    const { type, iops, throughput_mbps, size_gb } = data?.attributes ?? { size_gb: 0 }
-    const formValues = {
-      storageType: type,
-      provisionedIOPS: iops,
-      throughput: throughput_mbps,
-      totalSize: size_gb,
-      computeSize: form.getValues('computeSize'),
-    }
-
-    if (!('requested_modification' in data)) {
-      if (refetchInterval !== false) {
-        form.reset(formValues)
-        setRefetchInterval(false)
-        toast.success('Disk configuration changes have been successfully applied!')
-      }
-    } else {
-      setRefetchInterval(2000)
-    }
-  }, [data, isDiskAttributesSuccess, form, refetchInterval])
-
   const { computeSize: modifiedComputeSize } = form.watch()
-
-  // We only support disk configurations for >=Large instances
-  // If a customer downgrades back to <Large, we should reset the storage settings to avoid incurring unnecessary costs
-  useEffect(() => {
-    if (modifiedComputeSize && project?.infra_compute_size && isDialogOpen) {
-      if (RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3.includes(modifiedComputeSize)) {
-        form.setValue('storageType', DiskType.GP3)
-        form.setValue('throughput', DISK_LIMITS['gp3'].minThroughput)
-        form.setValue('provisionedIOPS', DISK_LIMITS['gp3'].minIops)
-      }
-    }
-  }, [modifiedComputeSize, isDialogOpen, project])
 
   const isSuccess =
     isAddonsSuccess &&
@@ -213,6 +181,7 @@ export function DiskManagementForm() {
   const isPlanUpgradeRequired = !hasAccess
 
   const { formState } = form
+  const errors = formState.errors
   const usedSize = Math.round(((diskUtil?.metrics.fs_used_bytes ?? 0) / GB) * 100) / 100
   const totalSize = formState.defaultValues?.totalSize || 0
   const usedPercentage = (usedSize / totalSize) * 100
@@ -329,12 +298,64 @@ export function DiskManagementForm() {
   }
 
   useEffect(() => {
+    if (!isDiskAttributesSuccess) return
+    // @ts-ignore
+    const { type, iops, throughput_mbps, size_gb } = data?.attributes ?? { size_gb: 0 }
+    const formValues = {
+      storageType: type,
+      provisionedIOPS: iops,
+      throughput: throughput_mbps,
+      totalSize: size_gb,
+      computeSize: form.getValues('computeSize'),
+    }
+
+    if (!('requested_modification' in data)) {
+      if (refetchInterval !== false) {
+        form.reset(formValues)
+        setRefetchInterval(false)
+        toast.success('Disk configuration changes have been successfully applied!')
+      }
+    } else {
+      setRefetchInterval(2000)
+    }
+  }, [data, isDiskAttributesSuccess, form, refetchInterval])
+
+  // We only support disk configurations for >=Large instances
+  // If a customer downgrades back to <Large, we should reset the storage settings to avoid incurring unnecessary costs
+  useEffect(() => {
+    if (modifiedComputeSize && project?.infra_compute_size && isDialogOpen) {
+      if (RESTRICTED_COMPUTE_FOR_THROUGHPUT_ON_GP3.includes(modifiedComputeSize)) {
+        form.setValue('storageType', DiskType.GP3)
+        form.setValue('throughput', DISK_LIMITS['gp3'].minThroughput)
+        form.setValue('provisionedIOPS', DISK_LIMITS['gp3'].minIops)
+      }
+    }
+  }, [modifiedComputeSize, isDialogOpen, project])
+
+  useEffect(() => {
     // Initialize field values properly when data has been loaded, preserving any user changes
     if (isDiskAttributesSuccess || isSuccess) {
       form.reset(defaultValues, {})
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isSuccess, isDiskAttributesSuccess])
+
+  useEffect(() => {
+    const fieldErrors = Object.keys(errors)
+    if (fieldErrors.length > 0) {
+      if (
+        fieldErrors.includes('throughput') ||
+        fieldErrors.includes('provisionedIOPS') ||
+        fieldErrors.includes('maxSizeGb')
+      ) {
+        setAdvancedSettingsOpenState(true)
+        // [Joshen] The timeout is to let the collapsible open prior to scrolling
+        setTimeout(() => {
+          advancedSettingsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+        }, 100)
+      }
+    }
+  }, [errors])
 
   return (
     <>
@@ -447,8 +468,6 @@ export function DiskManagementForm() {
                 <Separator />
 
                 <Collapsible_Shadcn_
-                  // TO DO: wrap component into pattern
-                  className="-space-y-px"
                   open={advancedSettingsOpen}
                   onOpenChange={() => setAdvancedSettingsOpenState((prev) => !prev)}
                 >
@@ -467,16 +486,17 @@ export function DiskManagementForm() {
                     />
                   </CollapsibleTrigger_Shadcn_>
                   <CollapsibleContent_Shadcn_
+                    ref={advancedSettingsRef}
                     className={cn(
                       'transition-all rounded-b',
-                      'data-open:border data-closed:animate-collapsible-up data-open:animate-collapsible-down'
+                      'border border-t-0 data-closed:animate-collapsible-up data-open:animate-collapsible-down'
                     )}
                   >
                     <div className="flex flex-col gap-y-8 py-8">
                       <div className="px-card flex flex-col gap-y-8">
                         <AutoScaleFields form={form} />
                       </div>
-                      <Separator />
+                      <DialogSectionSeparator />
                       <div className="px-card flex flex-col gap-y-8">
                         <NoticeBar
                           type="default"

--- a/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DeleteProjectPanel/DeleteProjectModal.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { TextArea_Shadcn_ as TextArea } from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CANCELLATION_REASONS } from '@/components/interfaces/Billing/Billing.constants'
 import { LogicalBackupCliInstructions } from '@/components/layouts/ProjectLayout/LogicalBackupCliInstructions'
@@ -141,17 +142,18 @@ export const DeleteProjectModal = ({
     >
       <div className="space-y-6">
         <LogicalBackupCliInstructions enabled={visible} showResetPassword={false} />
+
         {/*
           [Joshen] This is basically ExitSurvey.tsx, ideally we have one shared component but the one
           in ExitSurvey has a Form wrapped around it already. Will probably need some effort to refactor
           but leaving that for the future.
         */}
         {!isFree && (
-          <>
-            <div className="space-y-1">
-              <h4 className="text-base">What made you decide to delete your project?</h4>
-            </div>
-            <div className="space-y-4 pt-4">
+          <div className="flex flex-col gap-y-6">
+            <FormItemLayout
+              isReactForm={false}
+              label="What made you decide to delete your project?"
+            >
               <div className="flex flex-wrap gap-2" data-toggle="buttons">
                 {shuffledReasons.map((option) => {
                   const active = selectedReason[0] === option.value
@@ -181,19 +183,17 @@ export const DeleteProjectModal = ({
                   )
                 })}
               </div>
-              <div className="text-area-text-sm flex flex-col gap-y-2">
-                <label htmlFor="message" className="text-sm whitespace-pre-line wrap-break-word">
-                  {textareaLabel}
-                </label>
-                <TextArea
-                  name="message"
-                  rows={3}
-                  value={message}
-                  onChange={(event) => setMessage(event.target.value)}
-                />
-              </div>
-            </div>
-          </>
+            </FormItemLayout>
+
+            <FormItemLayout isReactForm={false} label={textareaLabel}>
+              <TextArea
+                name="message"
+                rows={3}
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+              />
+            </FormItemLayout>
+          </div>
         )}
       </div>
     </TextConfirmModal>


### PR DESCRIPTION
## Context

Compute and Disk page: There's an odd scenario whereby down sizing the compute might involve some validation errors in the advanced settings, in which case because the advanced settings is in a collapsible and requires the user to scroll down, there's hence no visual indication of where the error is until the user opens the advanced settings to see the inline error.

Am hence opting to open the advanced settings + scroll to it for this particular scenario, if submitting the form causes a validation issue on either IOPS, throughput or max disk size field inputs (the rest in this section do not have validation checks on that afaict and hence wouldn't be applicable to this scenario)

## To test

Can be tested locally
- Upsize compute to 8XL + change throughput to 750
- Once completed, try to down size to XL and hit "review changes"
- It should be clear from a UX POV if there are any errors

Also added an unrelated nit tidy up for ExitSurveyModal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Advanced disk settings now auto-open and scroll into view (with a brief delay) when validation errors occur for throughput, IOPS, or size, improving error visibility.

* **User Interface**
  * Improved advanced settings panel animation and separators for clearer visual boundaries.
  * Updated project deletion layout for the reason chooser and message input, providing a more consistent form appearance.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45818)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->