### PR TITLE
Joshen/fe 3213 make rls tester feedback callout more obvious

### DIFF
--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@ui/components/shadcn/ui/select'
-import { LOCAL_STORAGE_KEYS } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { Code, ExternalLink } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -42,6 +42,7 @@ import type { Policy } from '@/components/interfaces/Auth/Policies/PolicyTableRo
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
 import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
+import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
@@ -51,9 +52,12 @@ interface RLSTesterSheetProps {
 }
 
 export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) => {
+  const { ref } = useParams()
   const aiSnap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
   const { setRole } = useRoleImpersonationStateSnapshot()
+
+  const { mutate: sendEvent } = useSendEventMutation()
 
   const [open, setOpen] = useState(false)
   const [selectedOption, setSelectedOption] = useState<'anon' | 'authenticated'>('anon')
@@ -103,8 +107,18 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
     if (format === 'lib') {
       if (!inferredSQL) return
       await testQuery({ value: acceptUntrustedSql(inferredSQL), ...executionCallbacks })
+      sendEvent({
+        action: 'rls_tester_query_ran',
+        properties: { type: 'inferred' },
+        groups: { project: ref ?? 'Unknown' },
+      })
     } else {
       await testQuery({ value, ...executionCallbacks })
+      sendEvent({
+        action: 'rls_tester_query_ran',
+        properties: { type: 'raw' },
+        groups: { project: ref ?? 'Unknown' },
+      })
     }
   }
 

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -14,7 +14,7 @@ import {
   SelectValue,
 } from '@ui/components/shadcn/ui/select'
 import { LOCAL_STORAGE_KEYS } from 'common'
-import { Code } from 'lucide-react'
+import { Code, ExternalLink } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import {
   Button,
@@ -272,11 +272,10 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
         </div>
 
         <SheetFooter className="sm:justify-between">
-          <Button asChild type="text">
+          <Button asChild type="default" icon={<ExternalLink />}>
             <a
               target="_blank"
               rel="noopener noreferrer"
-              className="text-foreground-light hover:text-foreground"
               href="https://github.com/orgs/supabase/discussions/45233"
             >
               Give feedback

--- a/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/RLSTester/RLSTesterSheet.tsx
@@ -13,7 +13,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@ui/components/shadcn/ui/select'
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { Code, ExternalLink } from 'lucide-react'
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -42,7 +42,7 @@ import type { Policy } from '@/components/interfaces/Auth/Policies/PolicyTableRo
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
 import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
-import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
+import { useTrack } from '@/lib/telemetry/track'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
@@ -52,12 +52,10 @@ interface RLSTesterSheetProps {
 }
 
 export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) => {
-  const { ref } = useParams()
+  const track = useTrack()
   const aiSnap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
   const { setRole } = useRoleImpersonationStateSnapshot()
-
-  const { mutate: sendEvent } = useSendEventMutation()
 
   const [open, setOpen] = useState(false)
   const [selectedOption, setSelectedOption] = useState<'anon' | 'authenticated'>('anon')
@@ -107,18 +105,10 @@ export const RLSTesterSheet = ({ handleSelectEditPolicy }: RLSTesterSheetProps) 
     if (format === 'lib') {
       if (!inferredSQL) return
       await testQuery({ value: acceptUntrustedSql(inferredSQL), ...executionCallbacks })
-      sendEvent({
-        action: 'rls_tester_query_ran',
-        properties: { type: 'inferred' },
-        groups: { project: ref ?? 'Unknown' },
-      })
+      track('rls_tester_run_query_clicked', { type: 'inferred' })
     } else {
       await testQuery({ value, ...executionCallbacks })
-      sendEvent({
-        action: 'rls_tester_query_ran',
-        properties: { type: 'raw' },
-        groups: { project: ref ?? 'Unknown' },
-      })
+      track('rls_tester_run_query_clicked', { type: 'raw' })
     }
   }
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3440,6 +3440,18 @@ export interface HeaderLocalVersionPopoverOpenedEvent {
 }
 
 /**
+ * User ran a query in the RLS tester feature preview.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface RLSTesterQueryRanEvent {
+  action: 'rls_tester_query_ran'
+  properties: { type: 'raw' | 'inferred' }
+  groups: Partial<TelemetryGroups>
+}
+
+/**
  * @hidden
  */
 export type TelemetryEvent =
@@ -3638,3 +3650,4 @@ export type TelemetryEvent =
   | HeaderUserDropdownOpenedEvent
   | HeaderLocalDropdownOpenedEvent
   | HeaderLocalVersionPopoverOpenedEvent
+  | RLSTesterQueryRanEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3445,8 +3445,8 @@ export interface HeaderLocalVersionPopoverOpenedEvent {
  * @group Events
  * @source studio
  */
-export interface RLSTesterQueryRanEvent {
-  action: 'rls_tester_query_ran'
+export interface RLSTesterRunQueryClickedEvent {
+  action: 'rls_tester_run_query_clicked'
   properties: { type: 'raw' | 'inferred' }
   groups: Partial<TelemetryGroups>
 }
@@ -3650,4 +3650,4 @@ export type TelemetryEvent =
   | HeaderUserDropdownOpenedEvent
   | HeaderLocalDropdownOpenedEvent
   | HeaderLocalVersionPopoverOpenedEvent
-  | RLSTesterQueryRanEvent
+  | RLSTesterRunQueryClickedEvent


### PR DESCRIPTION
## Context

Minor nit to adjust the "Give feedback" button at the bottom to use default type + external link icon
<img width="612" height="68" alt="image" src="https://github.com/user-attachments/assets/e74370cb-d284-4552-a69d-8c838f565af7" />

Also added telemetry for the "Run query" button

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added analytics tracking for RLS Tester query runs to better understand how the feature is used.

* **Style**
  * Updated the "Give feedback" button in the RLS Tester to use the default button style and display an external-link icon for clarity.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45820)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->