### PR TITLE
Fix table editor editing a row, setting a timestamptz column to NULL doesn't work

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/index.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/DateTimeInput/index.tsx
@@ -19,7 +19,7 @@ interface DateTimeInputProps {
   value: string
   isNullable: boolean
   description: string | ReactNode
-  onChange: (value: string) => void
+  onChange: (value: string | null) => void
   disabled?: boolean
 }
 
@@ -65,7 +65,7 @@ export const DateTimeInput = ({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-28 pointer-events-auto">
               {isNullable && (
-                <DropdownMenuItem onClick={() => onChange('')}>Set to NULL</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onChange(null)}>Set to NULL</DropdownMenuItem>
               )}
               <DropdownMenuItem
                 onClick={() =>

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/InputField.tsx
@@ -276,7 +276,7 @@ export const InputField = ({
             {field.comment && <p>{field.comment}</p>}
           </>
         }
-        onChange={(value: any) => onUpdateField({ [field.name]: value })}
+        onChange={(value: string | null) => onUpdateField({ [field.name]: value })}
         disabled={!isEditable}
       />
     )


### PR DESCRIPTION
## Context

There's a bug atm with the Table Editor whereby hitting "Set to NULL" on a date time format column, doesn't set it to `null` but rather an empty string - which then causes an error when trying to update the row, so this PR addresses that
<img width="703" height="252" alt="image" src="https://github.com/user-attachments/assets/bdb7e73e-de85-44ea-9852-eeaef2faee4d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date/time input field handling to properly support NULL value assignment. The "Set to NULL" action now correctly applies NULL values instead of empty strings in the table editor.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45824)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->