### PR TITLE
fix(studio): use per-tier baseline throughput in disk IO banner copy

### DIFF
--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
@@ -55,13 +55,13 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
       warning: {
         title: 'Your project is about to deplete its Disk IO Budget',
         description:
-          'Once exhausted, disk throughput will be throttled to {baseline} until the budget resets. Upgrade your compute or use the AI Assistant to identify and optimize disk-intensive queries.',
+          'Once exhausted, disk throughput will return to its baseline of {baseline} until the budget resets. Upgrade your compute or use the AI Assistant to identify and optimize disk-intensive queries.',
       },
       critical: {
         title:
-          'Your project has depleted its Disk IO Budget. Disk throughput is throttled to {baseline}',
+          'Your project has depleted its Disk IO Budget. Disk throughput is at its baseline of {baseline}',
         description:
-          'Throughput will stay throttled until the budget resets. Upgrade your compute to restore full performance, or use the AI Assistant to identify and optimize disk-intensive queries.',
+          'Throughput will stay at baseline until the budget resets. Upgrade your compute to sustain higher throughput, or use the AI Assistant to identify and optimize disk-intensive queries.',
       },
     },
     cardContent: {

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.constants.ts
@@ -55,11 +55,11 @@ export const RESOURCE_WARNING_MESSAGES: ResourceWarningMessages = {
       warning: {
         title: 'Your project is about to deplete its Disk IO Budget',
         description:
-          'Once exhausted, disk throughput will be throttled to 5 MB/s until the budget resets. Upgrade your compute or use the AI Assistant to identify and optimize disk-intensive queries.',
+          'Once exhausted, disk throughput will be throttled to {baseline} until the budget resets. Upgrade your compute or use the AI Assistant to identify and optimize disk-intensive queries.',
       },
       critical: {
         title:
-          'Your project has depleted its Disk IO Budget. Disk throughput is throttled to 5 MB/s',
+          'Your project has depleted its Disk IO Budget. Disk throughput is throttled to {baseline}',
         description:
           'Throughput will stay throttled until the budget resets. Upgrade your compute to restore full performance, or use the AI Assistant to identify and optimize disk-intensive queries.',
       },

--- a/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
+++ b/apps/studio/components/ui/ResourceExhaustionWarningBanner/ResourceExhaustionWarningBanner.tsx
@@ -2,6 +2,7 @@ import { useParams } from 'common'
 import { AlertTriangle, BookOpen, ChevronDown, Sparkles, Wrench } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
+import { COMPUTE_DISK } from 'shared-data'
 import {
   Alert_Shadcn_,
   AlertDescription_Shadcn_,
@@ -16,9 +17,11 @@ import {
 
 import { RESOURCE_WARNING_MESSAGES } from './ResourceExhaustionWarningBanner.constants'
 import { getWarningContent } from './ResourceExhaustionWarningBanner.utils'
+import { mapComputeSizeNameToAddonVariantId } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { useResourceWarningsQuery } from '@/data/usage/resource-warnings-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useTrack } from '@/lib/telemetry/track'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
@@ -34,6 +37,14 @@ export const ResourceExhaustionWarningBanner = () => {
   const { ref } = useParams()
   const router = useRouter()
   const { data: organization, isLoading: isOrgLoading } = useSelectedOrganizationQuery()
+  const { data: project } = useSelectedProjectQuery()
+  const diskIoBaselineLabel = (() => {
+    const variant = mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)
+    const baseline = COMPUTE_DISK[variant]?.baselineThroughputMBps
+    return typeof baseline === 'number' ? `${baseline} MB/s` : 'its baseline'
+  })()
+  const applyDiskIoBaseline = (text?: string) =>
+    text ? text.replace(/\{baseline\}/g, diskIoBaselineLabel) : text
   const { openSidebar } = useSidebarManagerSnapshot()
   const aiSnap = useAiAssistantStateSnapshot()
   const track = useTrack()
@@ -69,19 +80,21 @@ export const ResourceExhaustionWarningBanner = () => {
       ? getWarningContent(projectResourceWarnings, activeWarnings[0], 'bannerContent')
       : undefined
 
-  const title =
+  const title = applyDiskIoBaseline(
     activeWarnings.length > 1
       ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.bannerContent[
           hasCriticalWarning ? 'critical' : 'warning'
         ].title
       : warningContent?.title
+  )
 
-  const description =
+  const description = applyDiskIoBaseline(
     activeWarnings.length > 1
       ? RESOURCE_WARNING_MESSAGES.multiple_resource_warnings.bannerContent[
           hasCriticalWarning ? 'critical' : 'warning'
         ].description
       : warningContent?.description
+  )
 
   const learnMoreUrl =
     activeWarnings.length > 1


### PR DESCRIPTION
## Problem

The disk IO exhaustion banner copy added in #45514 hardcoded the throttle floor as **5 MB/s**, but that's only correct for nano. Every burstable compute tier has its own baseline, since `baselineThroughputMBps` in [`packages/shared-data/compute-disk-limits.ts`](packages/shared-data/compute-disk-limits.ts) is `toMBps(43)` for nano (which rounds to 5), `toMBps(87) = 11` for micro, and so on:

| Tier | Throttle floor |
|------|---------------|
| nano | 5 MB/s |
| micro | 11 MB/s |
| small | 22 MB/s |
| medium | 43 MB/s |
| large | 79 MB/s |
| xlarge | 148 MB/s |
| 2xlarge | 297 MB/s |

Caught during review of the equivalent change in #45516.

## Fix

- Replace the hardcoded `5 MB/s` in `ResourceExhaustionWarningBanner.constants.ts` with a `{baseline}` placeholder in the `disk_io_exhaustion` banner copy.
- In `ResourceExhaustionWarningBanner.tsx`, read the selected project's compute variant, look up `baselineThroughputMBps` in `COMPUTE_DISK`, and substitute the placeholder in both the title and description. Falls back to `'its baseline'` if the variant isn't in the map.

`cardContent` for `disk_io_exhaustion` doesn't mention the floor, so no changes there.

## Test plan

- [ ] use dev toolbar to toggle the disk io banner, should see different throttle floors based on instance 
- [ ] on micro: "...throttled to 11 MB/s..."
- [ ] on medium: "...throttled to 43 MB/s..."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Disk I/O exhaustion warnings now display dynamic baseline values tailored to each project's configuration instead of a fixed threshold.
  * Warning and critical messages have been updated to reference the project-specific baseline and clarify that throughput returns to that baseline until the budget resets, improving clarity about throttling behavior and its duration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45833)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->