### PR TITLE
Fix useParams hook destructuring in ProjectSelector

### DIFF
--- a/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
+++ b/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
@@ -52,7 +52,7 @@ interface ProjectSelectorProps {
 }
 
 function ProjectSelector({ form, orgSlug, projectRef }: ProjectSelectorProps) {
-  const { projectRef: urlProjectRef } = useParams()
+  const { ref: urlProjectRef } = useParams()
 
   return (
     <FormField


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The `ProjectSelector` component in `apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx` is attempting to destructure `projectRef` from the `useParams()` hook, but the actual parameter name in the route is `ref`.

This causes `urlProjectRef` to be `undefined`, which may lead to incorrect behavior when the component tries to use this value.

## What is the new behavior?

Updated the destructuring to use the correct parameter name `ref` instead of `projectRef`, ensuring that the URL parameter is properly captured and assigned to `urlProjectRef`.

## Additional context

This is a straightforward parameter name correction to match the actual route parameter definition.

https://claude.ai/code/session_01GN1WNTabtxfHUhkkENoKTK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed project selection initialization when accessing the studio via URL parameters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45835)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->