### PR TITLE
fix(www): mobile partner form blank panel on submit success

### DIFF
--- a/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
+++ b/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
@@ -1,9 +1,9 @@
-import { FC, useEffect, useState } from 'react'
-import Link from 'next/link'
+import { useSendTelemetryEvent } from '~/lib/telemetry'
 import { CircleAlert } from 'lucide-react'
+import Link from 'next/link'
+import { FC, useEffect, useState } from 'react'
 import { Button, cn, Input_Shadcn_, Label_Shadcn_, Separator, TextArea_Shadcn_ } from 'ui'
 import { Alert } from 'ui/src/components/shadcn/ui/alert'
-import { useSendTelemetryEvent } from '~/lib/telemetry'
 
 interface FormData {
   firstName: string
@@ -190,9 +190,9 @@ const TalkToPartnershipTeamForm: FC<Props> = ({ className }) => {
         className
       )}
     >
-      <div className="border rounded-xl bg-surface-75 p-4 md:p-6 w-full lg:max-w-lg min-h-[200px]">
+      <div className="border rounded-xl bg-surface-75 p-4 md:p-6 w-full lg:max-w-lg min-h-[200px] flex flex-col">
         {success ? (
-          <div className="flex flex-col h-full w-full min-w-[300px] gap-4 items-center justify-center opacity-0 transition-opacity animate-fade-in scale-1">
+          <div className="flex flex-col flex-1 w-full gap-4 items-center justify-center animate-fade-in">
             <p className="text-center text-sm">{success}</p>
             <Button onClick={handleReset}>Reset</Button>
           </div>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On the [AI Builders](https://supabase.com/solutions/ai-builders) page (and any other surface using the Talk to Partnerships form), submitting on mobile rendered a blank square instead of the submission confirmation. Linear: [DEBR-279](https://linear.app/supabase/issue/DEBR-279/mobile-partner-form-submit-state-renders-blank-panel).

## What is the new behavior?

The success state in `TalkToPartnershipTeamForm` now drops `min-w-[300px]` (which overflowed narrow mobile viewports), removes the redundant `opacity-0`/`transition-opacity` pair that occasionally left the panel stuck at opacity 0 on iOS Safari, and removes the invalid `scale-1` class. The parent panel is now `flex flex-col` so the success message can use `flex-1` to center properly within the `min-h-[200px]` panel.

## Additional context

The `animate-fade-in` keyframe already uses `both` fill-mode, so it handles the initial-to-final opacity transition without needing the extra `opacity-0` class.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated success-state container layout and styling with improved flex sizing and spacing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45836)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->