### PR TITLE
fix(studio): encode special characters in table editor policy links

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -31,7 +31,10 @@ import { SecurityDefinerViewPopover } from './SecurityDefinerViewPopover'
 import { ViewEntityAutofixSecurityModal } from './ViewEntityAutofixSecurityModal'
 import { RefreshButton } from '@/components/grid/components/header/RefreshButton'
 import { useTableIndexAdvisor } from '@/components/grid/context/TableIndexAdvisorContext'
-import { getEntityLintDetails } from '@/components/interfaces/TableGridEditor/TableEntity.utils'
+import {
+  getEntityLintDetails,
+  getTablePoliciesUrl,
+} from '@/components/interfaces/TableGridEditor/TableEntity.utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useIsTableRealtimeEnabled } from '@/data/database-publications/database-publications-query'
@@ -228,10 +231,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
                       },
                     }}
                   >
-                    <Link
-                      passHref
-                      href={`/project/${projectRef}/auth/policies?search=${table.name}&schema=${table.schema}`}
-                    >
+                    <Link passHref href={getTablePoliciesUrl(projectRef, table.schema, table.name)}>
                       Add RLS policy
                     </Link>
                   </ButtonTooltip>
@@ -258,10 +258,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
                       )
                     }
                   >
-                    <Link
-                      passHref
-                      href={`/project/${projectRef}/auth/policies?search=${table.name}&schema=${table.schema}`}
-                    >
+                    <Link passHref href={getTablePoliciesUrl(projectRef, table.schema, table.name)}>
                       RLS {policies.length > 1 ? 'policies' : 'policy'}
                     </Link>
                   </Button>

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { formatTableRowsToSQL } from './TableEntity.utils'
+import { formatTableRowsToSQL, getTablePoliciesUrl } from './TableEntity.utils'
 import type { SupaTable } from '@/components/grid/types'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
 
@@ -175,5 +175,34 @@ describe('TableEntity.utils: formatTableRowsToSQL', () => {
     const result = formatTableRowsToSQL(table, rows)
     const expected = `INSERT INTO "public"."people" ("id", "name") VALUES (1, 'Person 1'), (2, 'Person 2');`
     expect(result).toBe(expected)
+  })
+})
+
+describe('TableEntity.utils: getTablePoliciesUrl', () => {
+  it('builds the policies url for plain schema and name values', () => {
+    expect(getTablePoliciesUrl('abc', 'public', 'users')).toBe(
+      '/project/abc/auth/policies?search=users&schema=public'
+    )
+  })
+
+  it('preserves special characters in the table name', () => {
+    const url = getTablePoliciesUrl('abc', 'public', 'user_data&secret=1')
+    const parsed = new URL(url, 'http://example.com')
+    expect(parsed.searchParams.get('search')).toBe('user_data&secret=1')
+    expect(parsed.searchParams.get('schema')).toBe('public')
+  })
+
+  it('preserves special characters in the schema', () => {
+    const url = getTablePoliciesUrl('abc', 'my schema+x', 'users')
+    const parsed = new URL(url, 'http://example.com')
+    expect(parsed.searchParams.get('schema')).toBe('my schema+x')
+    expect(parsed.searchParams.get('search')).toBe('users')
+  })
+
+  it('encodes both the table name and schema together', () => {
+    const url = getTablePoliciesUrl('abc', 'a&b=c', 'd e+f')
+    const parsed = new URL(url, 'http://example.com')
+    expect(parsed.searchParams.get('search')).toBe('d e+f')
+    expect(parsed.searchParams.get('schema')).toBe('a&b=c')
   })
 })

--- a/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/TableEntity.utils.ts
@@ -24,6 +24,16 @@ export const getEntityLintDetails = (
   }
 }
 
+export const getTablePoliciesUrl = (
+  projectRef: string | undefined,
+  schema: string | undefined,
+  name: string | undefined
+): string => {
+  return `/project/${projectRef ?? ''}/auth/policies?search=${encodeURIComponent(
+    name ?? ''
+  )}&schema=${encodeURIComponent(schema ?? '')}`
+}
+
 export const formatTableRowsToSQL = (table: SupaTable, rows: any[]) => {
   if (rows.length === 0) return ''
 


### PR DESCRIPTION
Closes #45845.

## Summary

`GridHeaderActions.tsx` interpolated `table.name` and `table.schema` directly into the policies URL at two `<Link href>` builders. A table or schema containing `&`, `=`, `+`, or `#` corrupted the destination and routed users to the wrong policies filter.

Extracts the URL into `getTablePoliciesUrl` in `TableEntity.utils.ts` with `encodeURIComponent` wraps, and replaces both inline interpolations. Same pattern as #45385 (Linter shortcut links).

## Test plan

Added four `getTablePoliciesUrl` cases in `TableEntity.utils.test.ts`: plain values, special chars in name, special chars in schema, special chars in both. Existing seven tests in the same file still pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved Row-Level Security (RLS) policy URL handling in the table editor using a shared utility function for consistent URL building and proper parameter encoding.

* **Tests**
  * Added test coverage for RLS policy URL generation with various parameter combinations and special character handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45846)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->