### PR TITLE
fix(studio): encode special characters in trigger/function cross-link search params

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -14,6 +14,7 @@ import {
   TableRow,
 } from 'ui'
 
+import { getDatabaseTriggersHref } from './FunctionList.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import type { DatabaseFunction } from '@/data/database-functions/database-functions-query'
@@ -125,7 +126,7 @@ const FunctionList = ({
             <TableCell className="table-cell">
               {x.return_type === 'trigger' ? (
                 <Link
-                  href={`/project/${projectRef}/database/triggers?search=${x.name}`}
+                  href={getDatabaseTriggersHref(projectRef, x.name)}
                   className="truncate text-link"
                   title={x.return_type}
                 >

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDatabaseTriggersHref } from './FunctionList.utils'
+
+describe('FunctionList.utils: getDatabaseTriggersHref', () => {
+  it('builds the triggers href with a plain function name', () => {
+    expect(getDatabaseTriggersHref('abc', 'on_insert')).toBe(
+      '/project/abc/database/triggers?search=on_insert'
+    )
+  })
+
+  it('preserves special characters in the function name', () => {
+    const href = getDatabaseTriggersHref('abc', 'on_insert&schema=secret')
+    const parsed = new URL(href, 'http://example.com')
+    expect(parsed.searchParams.get('search')).toBe('on_insert&schema=secret')
+    expect(parsed.searchParams.get('schema')).toBeNull()
+  })
+
+  it('preserves spaces and plus signs in the function name', () => {
+    const href = getDatabaseTriggersHref('abc', 'a name+x')
+    const parsed = new URL(href, 'http://example.com')
+    expect(parsed.searchParams.get('search')).toBe('a name+x')
+  })
+
+  it('falls back to empty strings for undefined inputs', () => {
+    expect(getDatabaseTriggersHref(undefined, undefined)).toBe(
+      '/project//database/triggers?search='
+    )
+  })
+})

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.utils.ts
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.utils.ts
@@ -1,0 +1,6 @@
+export const getDatabaseTriggersHref = (
+  projectRef: string | null | undefined,
+  name: string | null | undefined
+): string => {
+  return `/project/${projectRef ?? ''}/database/triggers?search=${encodeURIComponent(name ?? '')}`
+}

--- a/apps/studio/components/interfaces/Database/Triggers/EventTriggersList/EventTriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/EventTriggersList/EventTriggerList.tsx
@@ -17,6 +17,7 @@ import {
 
 import type { EventTrigger } from './EventTriggerList.utils'
 import { SUPABASE_ROLES } from '@/components/interfaces/Database/Roles/Roles.constants'
+import { getDatabaseFunctionsHref } from '@/components/interfaces/Database/Triggers/TriggersList/TriggerList.utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 
 interface EventTriggerListProps {
@@ -126,7 +127,11 @@ export const EventTriggerList = ({
             <TableCell className="space-x-2">
               {trigger.function_name ? (
                 <Link
-                  href={`/project/${projectRef}/database/functions?search=${trigger.function_name}&schema=${trigger.function_schema}`}
+                  href={getDatabaseFunctionsHref(
+                    projectRef,
+                    trigger.function_schema,
+                    trigger.function_name
+                  )}
                   className="text-link-table-cell block max-w-40 text-foreground-light"
                 >
                   {trigger.function_name}

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.tsx
@@ -16,7 +16,11 @@ import {
   TableRow,
 } from 'ui'
 
-import { generateTriggerCreateSQL, type PostgresTrigger } from './TriggerList.utils'
+import {
+  generateTriggerCreateSQL,
+  getDatabaseFunctionsHref,
+  type PostgresTrigger,
+} from './TriggerList.utils'
 import { selectFilterSchema } from '@/components/interfaces/Reports/v2/ReportsSelectFilter'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -131,7 +135,7 @@ export const TriggerList = ({ editTrigger, duplicateTrigger, deleteTrigger }: Tr
           <TableCell className="space-x-2">
             {x.function_name ? (
               <Link
-                href={`/project/${projectRef}/database/functions?search=${x.function_name}&schema=${x.function_schema}`}
+                href={getDatabaseFunctionsHref(projectRef, x.function_schema, x.function_name)}
                 className="text-link-table-cell block max-w-40 text-foreground-light"
               >
                 {x.function_name}

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { getDatabaseFunctionsHref } from './TriggerList.utils'
+
+describe('TriggerList.utils: getDatabaseFunctionsHref', () => {
+  it('builds the functions href with plain values', () => {
+    expect(getDatabaseFunctionsHref('abc', 'public', 'do_thing')).toBe(
+      '/project/abc/database/functions?search=do_thing&schema=public'
+    )
+  })
+
+  it('preserves special characters in the function name', () => {
+    const href = getDatabaseFunctionsHref('abc', 'public', 'do_thing&secret=1')
+    const parsed = new URL(href, 'http://example.com')
+    expect(parsed.searchParams.get('search')).toBe('do_thing&secret=1')
+    expect(parsed.searchParams.get('schema')).toBe('public')
+  })
+
+  it('preserves special characters in the schema', () => {
+    const href = getDatabaseFunctionsHref('abc', 'my schema+x', 'do_thing')
+    const parsed = new URL(href, 'http://example.com')
+    expect(parsed.searchParams.get('schema')).toBe('my schema+x')
+    expect(parsed.searchParams.get('search')).toBe('do_thing')
+  })
+
+  it('encodes both name and schema together', () => {
+    const href = getDatabaseFunctionsHref('abc', 'a&b=c', 'd e+f')
+    const parsed = new URL(href, 'http://example.com')
+    expect(parsed.searchParams.get('schema')).toBe('a&b=c')
+    expect(parsed.searchParams.get('search')).toBe('d e+f')
+  })
+
+  it('falls back to empty strings for undefined inputs', () => {
+    expect(getDatabaseFunctionsHref(undefined, undefined, undefined)).toBe(
+      '/project//database/functions?search=&schema='
+    )
+  })
+})

--- a/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.utils.ts
+++ b/apps/studio/components/interfaces/Database/Triggers/TriggersList/TriggerList.utils.ts
@@ -37,3 +37,13 @@ FOR EACH ${keyword(trigger.orientation)}
 
   return sql
 }
+
+export const getDatabaseFunctionsHref = (
+  projectRef: string | null | undefined,
+  schema: string | null | undefined,
+  name: string | null | undefined
+): string => {
+  return `/project/${projectRef ?? ''}/database/functions?search=${encodeURIComponent(
+    name ?? ''
+  )}&schema=${encodeURIComponent(schema ?? '')}`
+}


### PR DESCRIPTION
Closes #45850.

## Summary

`TriggerList`, `EventTriggerList`, and `FunctionList` built cross-links between the database triggers and functions pages by interpolating user-controlled identifiers directly into the URL query string. A function or schema name containing `&`, `=`, `+`, or `#` corrupted the destination filter and routed users to the wrong row.

Adds `getDatabaseFunctionsHref` to `TriggerList.utils` (used by both `TriggerList` and `EventTriggerList`) and a new `getDatabaseTriggersHref` in `FunctionList.utils`, both with `encodeURIComponent` wraps. Replaces the three inline interpolations.

`FunctionList` only has a single search param (no schema) because the link filters by function name only, so its helper takes one less argument.

Same pattern as #45385.

## Test plan

Added `TriggerList.utils.test.ts` covering `getDatabaseFunctionsHref` (plain, special chars in name, special chars in schema, both, undefined inputs) and `FunctionList.utils.test.ts` covering `getDatabaseTriggersHref` (plain, special chars in name, plus signs and spaces, undefined inputs). Nine tests total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved database navigation links for functions and triggers by standardizing link generation through centralized utility functions. This ensures consistent URL encoding and parameter handling across the application.

* **Tests**
  * Added comprehensive test coverage for database navigation link utilities, including edge cases with special characters and empty parameters.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45851)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->