### PR TITLE
docs: clarify path to database password reset in dashboard

### DIFF
--- a/apps/docs/content/troubleshooting/how-do-i-reset-my-supabase-database-password-oTs5sB.mdx
+++ b/apps/docs/content/troubleshooting/how-do-i-reset-my-supabase-database-password-oTs5sB.mdx
@@ -7,4 +7,4 @@ keywords = [ "password", "reset" ]
 database_id = "6e4a515c-5e70-4b92-808c-f076d47d4e35"
 ---
 
-You can reset your database password from the [Database Settings page](/dashboard/project/_/database/settings) on the project dashboard.
+You can reset your database password by navigating to [Database > Settings](/dashboard/project/_/database/settings) from the project dashboard.

--- a/apps/docs/content/troubleshooting/how-do-i-reset-my-supabase-database-password-oTs5sB.mdx
+++ b/apps/docs/content/troubleshooting/how-do-i-reset-my-supabase-database-password-oTs5sB.mdx
@@ -7,4 +7,4 @@ keywords = [ "password", "reset" ]
 database_id = "6e4a515c-5e70-4b92-808c-f076d47d4e35"
 ---
 
-You can reset your database password by navigating to [Database > Settings](/dashboard/project/_/database/settings) from the project dashboard.
+You can reset your database password from the [**Database > Settings**](/dashboard/project/_/database/settings) section of the Dashboard.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This small change updates directions for changing database password to highlight path to database settings page for more clarity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified troubleshooting instructions for resetting a database password: now directs users to use the project dashboard navigation (Database > Settings) to perform the reset, replacing the previous phrasing. This improves discoverability and reduces confusion when locating the password reset option.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45853)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->