### PR TITLE
docs: update to reflect changes with rotating legacy secret

### DIFF
--- a/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
+++ b/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
@@ -26,12 +26,8 @@ If you haven’t migrated to asymmetric JWT signing keys:
 
 {/* supa-mdx-lint-disable Rule004ExcludeWords */}
 
-1. Go to [**Project Settings** → **JWT Keys**](/dashboard/project/_/settings/jwt) in the Supabase Dashboard
-2. Navigate to the **Legacy JWT Secret** tab
-3. Click on **Change Legacy Secret**
-   - Click on **Generate a random secret** to let Supabase decide the JWT secret.
-   - Click on **Create my own secret** to enter a custom JWT secret
-4. You will see a Confirmation dialog. Read it through and confirm to proceed.
+We recommend that you migrate to asymmetric JWT signing keys and publishable/secret API keys as it is no longer possible to rotate the legacy anon, service and JWT secrets.
+You can view this [**Get Started guide**](/docs/guides/auth/signing-keys#getting-started) for steps to migrate to asymmetric JWT signing keys.
 
 If you have migrated to new symmetric JWT signing keys:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Update to troubleshooting guide to reflect changes with legacy JWT secret. As we are no longer supporting rotation of legacy secret, guide has been updated to direct users to migrate to new JWT signing key and new API keys.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guide for JWT secret management. Now recommends migrating to asymmetric JWT signing keys instead of rotating legacy anon, service, and JWT secrets, with a reference to the migration guide.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45855)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->