### PR TITLE
Shift internal only fields on new project form into a collapsible

### DIFF
--- a/apps/studio/components/interfaces/Project/ResumeProjectButton.tsx
+++ b/apps/studio/components/interfaces/Project/ResumeProjectButton.tsx
@@ -58,7 +58,7 @@ export const ResumeProjectButton = ({
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const { setProjectStatus } = useSetProjectStatus()
 
-  const showPostgresVersionSelector = useFlag('showPostgresVersionSelector')
+  const newProjectInternalOnlyConfiguration = useFlag('newProjectInternalOnlyConfiguration')
   const region = Object.values(AWS_REGIONS).find((x) => x.code === project?.region)
   const orgSlug = selectedOrganization?.slug
   const isFreePlan = selectedOrganization?.plan?.id === 'free'
@@ -125,7 +125,7 @@ export const ResumeProjectButton = ({
       return toast.error('Unable to restore: project is required')
     }
 
-    if (!showPostgresVersionSelector) {
+    if (!newProjectInternalOnlyConfiguration) {
       return restoreProject({ ref: project.ref })
     }
 
@@ -186,7 +186,7 @@ export const ResumeProjectButton = ({
         confirmLabelLoading="Resuming"
         cancelLabel="Cancel"
       >
-        <div className={cn(showPostgresVersionSelector && 'flex flex-col gap-y-4')}>
+        <div className={cn(newProjectInternalOnlyConfiguration && 'flex flex-col gap-y-4')}>
           <p className="text-sm">
             {isFreePlan
               ? 'Your project’s data will be restored to when it was initially paused.'
@@ -194,7 +194,7 @@ export const ResumeProjectButton = ({
           </p>
           <Form {...form}>
             <form onSubmit={form.handleSubmit(onConfirmRestore)}>
-              {showPostgresVersionSelector && (
+              {newProjectInternalOnlyConfiguration && (
                 <div className="space-y-2">
                   <FormField
                     control={form.control}

--- a/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/CloudProviderSelector.tsx
@@ -13,7 +13,6 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CreateProjectForm } from './ProjectCreation.schema'
-import Panel from '@/components/ui/Panel'
 import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
 import { PROVIDERS } from '@/lib/constants'
 
@@ -28,52 +27,50 @@ export const CloudProviderSelector = ({ form }: CloudProviderSelectorProps) => {
   const highAvailability = useWatch({ control: form.control, name: 'highAvailability' })
 
   return (
-    <Panel.Content>
-      <FormField
-        control={form.control}
-        name="cloudProvider"
-        render={({ field }) => (
-          <FormItemLayout
-            label="Cloud provider"
-            layout="horizontal"
-            description={
-              highAvailability ? (
-                <p className="text-warning">
-                  High availability is only supported on AWS (Revamped)
-                </p>
-              ) : undefined
-            }
+    <FormField
+      control={form.control}
+      name="cloudProvider"
+      render={({ field }) => (
+        <FormItemLayout
+          label="Cloud provider"
+          layout="horizontal"
+          description={
+            highAvailability ? (
+              <p className="text-warning">High availability is only supported on AWS (Revamped)</p>
+            ) : (
+              'Select which cloud provider to spin up project from'
+            )
+          }
+        >
+          <Select_Shadcn_
+            onValueChange={(value) => field.onChange(value)}
+            defaultValue={field.value}
+            value={field.value}
           >
-            <Select_Shadcn_
-              onValueChange={(value) => field.onChange(value)}
-              defaultValue={field.value}
-              value={field.value}
-            >
-              <FormControl>
-                <SelectTrigger_Shadcn_>
-                  <SelectValue_Shadcn_ placeholder="Select a cloud provider" />
-                </SelectTrigger_Shadcn_>
-              </FormControl>
-              <SelectContent_Shadcn_>
-                <SelectGroup_Shadcn_>
-                  {Object.values(PROVIDERS)
-                    .filter((provider) => validCloudProviders?.includes(provider.id) ?? true)
-                    .map((providerObj) => {
-                      const label = providerObj['name']
-                      const value = providerObj['id']
-                      const isDisabled = highAvailability && !HA_SUPPORTED_PROVIDERS.includes(value)
-                      return (
-                        <SelectItem_Shadcn_ key={value} value={value} disabled={isDisabled}>
-                          {label}
-                        </SelectItem_Shadcn_>
-                      )
-                    })}
-                </SelectGroup_Shadcn_>
-              </SelectContent_Shadcn_>
-            </Select_Shadcn_>
-          </FormItemLayout>
-        )}
-      />
-    </Panel.Content>
+            <FormControl>
+              <SelectTrigger_Shadcn_>
+                <SelectValue_Shadcn_ placeholder="Select a cloud provider" />
+              </SelectTrigger_Shadcn_>
+            </FormControl>
+            <SelectContent_Shadcn_>
+              <SelectGroup_Shadcn_>
+                {Object.values(PROVIDERS)
+                  .filter((provider) => validCloudProviders?.includes(provider.id) ?? true)
+                  .map((providerObj) => {
+                    const label = providerObj['name']
+                    const value = providerObj['id']
+                    const isDisabled = highAvailability && !HA_SUPPORTED_PROVIDERS.includes(value)
+                    return (
+                      <SelectItem_Shadcn_ key={value} value={value} disabled={isDisabled}>
+                        {label}
+                      </SelectItem_Shadcn_>
+                    )
+                  })}
+              </SelectGroup_Shadcn_>
+            </SelectContent_Shadcn_>
+          </Select_Shadcn_>
+        </FormItemLayout>
+      )}
+    />
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
@@ -4,7 +4,6 @@ import { FormControl, FormField, Switch } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CreateProjectForm } from './ProjectCreation.schema'
-import Panel from '@/components/ui/Panel'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 
 interface HighAvailabilityInputProps {
@@ -17,31 +16,29 @@ export const HighAvailabilityInput = ({ form }: HighAvailabilityInputProps) => {
   if (!hasAccess) return null
 
   return (
-    <Panel.Content>
-      <FormField
-        control={form.control}
-        name="highAvailability"
-        render={({ field }) => (
-          <FormItemLayout
-            label="High Availability"
-            description={
-              <>
-                Powered by{' '}
-                <Link href="https://multigres.com/" target="_blank" className="text-link">
-                  Multigres
-                </Link>
-                : horizontally scalable Postgres for multi-tenant, highly available, globally
-                distributed deployments while staying true to standard Postgres.
-              </>
-            }
-            layout="horizontal"
-          >
-            <FormControl>
-              <Switch checked={field.value} onCheckedChange={field.onChange} />
-            </FormControl>
-          </FormItemLayout>
-        )}
-      />
-    </Panel.Content>
+    <FormField
+      control={form.control}
+      name="highAvailability"
+      render={({ field }) => (
+        <FormItemLayout
+          label="High Availability"
+          description={
+            <>
+              Powered by{' '}
+              <Link href="https://multigres.com/" target="_blank" className="text-link">
+                Multigres
+              </Link>
+              : horizontally scalable Postgres for multi-tenant, highly available, globally
+              distributed deployments while staying true to standard Postgres.
+            </>
+          }
+          layout="horizontal"
+        >
+          <FormControl>
+            <Switch checked={field.value} onCheckedChange={field.onChange} />
+          </FormControl>
+        </FormItemLayout>
+      )}
+    />
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
@@ -1,5 +1,7 @@
+import { useParams } from 'common'
 import { ChevronRight } from 'lucide-react'
 import { UseFormReturn } from 'react-hook-form'
+import { type CloudProvider } from 'shared-data'
 import {
   Collapsible_Shadcn_,
   CollapsibleContent_Shadcn_,
@@ -10,6 +12,9 @@ import {
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
+import { CloudProviderSelector } from './CloudProviderSelector'
+import { HighAvailabilityInput } from './HighAvailabilityInput'
+import { PostgresVersionSelector } from './PostgresVersionSelector'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import Panel from '@/components/ui/Panel'
 
@@ -18,6 +23,9 @@ interface InternalOnlyConfigurationProps {
 }
 
 export const InternalOnlyConfiguration = ({ form }: InternalOnlyConfigurationProps) => {
+  const { slug } = useParams()
+  const showNonProdFields = process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod'
+
   return (
     <Panel.Content>
       <Collapsible_Shadcn_>
@@ -29,43 +37,72 @@ export const InternalOnlyConfiguration = ({ form }: InternalOnlyConfigurationPro
             className="mr-2 group-data-open/advanced-trigger:rotate-90 group-hover/advanced-trigger:text-foreground-light transition"
           />
         </CollapsibleTrigger_Shadcn_>
-        <CollapsibleContent_Shadcn_ className="pt-2 data-closed:animate-collapsible-up data-open:animate-collapsible-down">
-          <p className="text-xs text-foreground-lighter mb-6">
-            These settings are only applicable for local/staging projects
-          </p>
-          <div className="flex flex-col gap-y-4">
-            <FormField
-              control={form.control}
-              name="postgresVersion"
-              render={({ field }) => (
-                <FormItemLayout
-                  label="Custom Postgres version"
-                  layout="horizontal"
-                  description="Specify a custom version of Postgres (defaults to the latest)."
-                >
-                  <FormControl>
-                    <Input_Shadcn_ placeholder="e.g 17.6.1.104" {...field} autoComplete="off" />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
+        <CollapsibleContent_Shadcn_ className="pt-2 data-closed:animate-collapsible-up data-open:animate-collapsible-down flex flex-col gap-y-6">
+          <div>
+            <p className="text-xs text-foreground-lighter mb-6">
+              These settings are only visible to internal staff
+            </p>
+            <div className="flex flex-col gap-y-4">
+              <FormField
+                control={form.control}
+                name="postgresVersionSelection"
+                render={({ field }) => (
+                  <PostgresVersionSelector
+                    field={field}
+                    form={form}
+                    cloudProvider={form.getValues('cloudProvider') as CloudProvider}
+                    organizationSlug={slug}
+                    dbRegion={form.getValues('dbRegion')}
+                  />
+                )}
+              />
 
-            <FormField
-              control={form.control}
-              name="instanceType"
-              render={({ field }) => (
-                <FormItemLayout
-                  label="Custom instance type"
-                  layout="horizontal"
-                  description="Specify a custom instance type."
-                >
-                  <FormControl>
-                    <Input_Shadcn_ placeholder="e.g t3.nano" {...field} autoComplete="off" />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
+              <HighAvailabilityInput form={form} />
+            </div>
           </div>
+
+          {showNonProdFields && (
+            <div>
+              <p className="text-xs text-foreground-lighter mb-6">
+                The settings below are only applicable for local/staging projects
+              </p>
+              <div className="flex flex-col gap-y-4">
+                <CloudProviderSelector form={form} />
+
+                <FormField
+                  control={form.control}
+                  name="postgresVersion"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      label="Custom Postgres version"
+                      layout="horizontal"
+                      description="Specify a custom version of Postgres (defaults to the latest)."
+                    >
+                      <FormControl>
+                        <Input_Shadcn_ placeholder="e.g 17.6.1.104" {...field} autoComplete="off" />
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="instanceType"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      label="Custom instance type"
+                      layout="horizontal"
+                      description="Specify a custom instance type."
+                    >
+                      <FormControl>
+                        <Input_Shadcn_ placeholder="e.g t3.nano" {...field} autoComplete="off" />
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
+              </div>
+            </div>
+          )}
         </CollapsibleContent_Shadcn_>
       </Collapsible_Shadcn_>
     </Panel.Content>

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -8,25 +8,20 @@ import { PropsWithChildren, useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { AWS_REGIONS, type CloudProvider } from 'shared-data'
 import { toast } from 'sonner'
-import { Button, Form, FormField, useWatch } from 'ui'
+import { Button, Form, useWatch } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { z } from 'zod'
 
 import { AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL } from '@/components/interfaces/Database/Triggers/EventTriggersList/EventTriggers.constants'
 import { AdvancedConfiguration } from '@/components/interfaces/ProjectCreation/AdvancedConfiguration'
-import { CloudProviderSelector } from '@/components/interfaces/ProjectCreation/CloudProviderSelector'
 import { ComputeSizeSelector } from '@/components/interfaces/ProjectCreation/ComputeSizeSelector'
 import { DatabasePasswordInput } from '@/components/interfaces/ProjectCreation/DatabasePasswordInput'
 import { DisabledWarningDueToIncident } from '@/components/interfaces/ProjectCreation/DisabledWarningDueToIncident'
 import { FreeProjectLimitWarning } from '@/components/interfaces/ProjectCreation/FreeProjectLimitWarning'
-import { HighAvailabilityInput } from '@/components/interfaces/ProjectCreation/HighAvailabilityInput'
 import { InternalOnlyConfiguration } from '@/components/interfaces/ProjectCreation/InternalOnlyConfiguration'
 import { OrganizationSelector } from '@/components/interfaces/ProjectCreation/OrganizationSelector'
-import {
-  extractPostgresVersionDetails,
-  PostgresVersionSelector,
-} from '@/components/interfaces/ProjectCreation/PostgresVersionSelector'
+import { extractPostgresVersionDetails } from '@/components/interfaces/ProjectCreation/PostgresVersionSelector'
 import { sizes } from '@/components/interfaces/ProjectCreation/ProjectCreation.constants'
 import { FormSchema } from '@/components/interfaces/ProjectCreation/ProjectCreation.schema'
 import {
@@ -109,8 +104,7 @@ const Wizard: NextPageWithLayout = () => {
 
   const smartRegionEnabled = useFlag('enableSmartRegion')
   const projectCreationDisabled = useFlag('disableProjectCreationAndUpdate')
-  const showPostgresVersionSelector = useFlag('showPostgresVersionSelector')
-  const cloudProviderEnabled = useFlag('enableFlyCloudProvider')
+  const showInternalOnlyConfiguration = useFlag('newProjectInternalOnlyConfiguration')
 
   // Read the raw flag for telemetry — coerce-undefined-to-false would record false for
   // users whose flags haven't loaded yet. The raw value preserves undefined (omitted from
@@ -118,7 +112,6 @@ const Wizard: NextPageWithLayout = () => {
   const dataApiRevokeOnCreateDefaultFlag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
   const isDataApiRevokeOnCreateDefault = useDataApiRevokeOnCreateDefaultEnabled()
 
-  const showNonProdFields = process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod'
   const isNotOnHigherPlan = !['team', 'enterprise', 'platform'].includes(currentOrg?.plan.id ?? '')
 
   // This is to make the database.new redirect work correctly. The database.new redirect should be set to supabase.com/dashboard/new/last-visited-org
@@ -550,11 +543,6 @@ const Wizard: NextPageWithLayout = () => {
                         </Panel.Content>
                       )}
                       <ProjectNameInput form={form} />
-                      <HighAvailabilityInput form={form} />
-
-                      {cloudProviderEnabled && showNonProdFields && (
-                        <CloudProviderSelector form={form} />
-                      )}
 
                       {canChooseInstanceSize && <ComputeSizeSelector form={form} />}
 
@@ -565,31 +553,13 @@ const Wizard: NextPageWithLayout = () => {
                         instanceSize={instanceSize as DesiredInstanceSize}
                       />
 
-                      {showPostgresVersionSelector && (
-                        <Panel.Content>
-                          <FormField
-                            control={form.control}
-                            name="postgresVersionSelection"
-                            render={({ field }) => (
-                              <PostgresVersionSelector
-                                field={field}
-                                form={form}
-                                cloudProvider={form.getValues('cloudProvider') as CloudProvider}
-                                organizationSlug={slug}
-                                dbRegion={form.getValues('dbRegion')}
-                              />
-                            )}
-                          />
-                        </Panel.Content>
-                      )}
-
                       <SecurityOptions form={form} />
+
+                      {showInternalOnlyConfiguration && <InternalOnlyConfiguration form={form} />}
 
                       {showAdvancedConfig && !!availableOrioleVersion && (
                         <AdvancedConfiguration form={form} />
                       )}
-
-                      {showNonProdFields && <InternalOnlyConfiguration form={form} />}
 
                       {shouldShowFreeProjectInfo ? (
                         <Admonition


### PR DESCRIPTION
## Context

Changes here aren't public facing - we're just shifting some internal only fields on the new project page to consolidate them into the "internal-only" collapsible

Mainly to improve clarity from our POV RE what fields do users see and the general look of the new project form
<img width="727" height="558" alt="image" src="https://github.com/user-attachments/assets/7d8f2915-3a81-4d9d-a067-cd45c1725726" />

So everything that's not within the collapsible are essentially fields that users will see on prod. The changes here also subsequently deprecates the use of 2 feature flags on the new project page:
- `showPostgresVersionSelector` -> replaced by new flag `newProjectInternalOnlyConfiguration`
- `enableFlyCloudProvider` -> was used to control the visibility of the cloud provider field, now replaced by `newProjectInternalOnlyConfiguration`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized project creation form layout and field ordering for improved structure.
  * Updated project resume flow with refined confirmation modal UI.
  * Simplified cloud provider selection interface.
  * Streamlined high-availability configuration presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45873)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->