### PR TITLE
chore(upcoming invoice): min amount / no plan fee

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -231,7 +231,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                               {item.item_name === 'minimum_amount' && (
                                 <p className="mb-2" translate="no">
                                   Minimum Fee - If your cost is below the minimum fee, you will be
-                                  charged the difference as a floor fee'
+                                  charged the difference as a floor fee
                                 </p>
                               )}
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -122,7 +122,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
           <div>
             <Table className="w-full text-sm">
               <TableBody>
-                {!planFeePaidInAdvance && (
+                {planItem && !planFeePaidInAdvance && (
                   <TableRow>
                     <TableCell className="py-2! px-0">{planItem?.description}</TableCell>
                     <TableCell className="text-right py-2 px-0">
@@ -228,6 +228,13 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                           <span>{item.description ?? 'Unknown'}</span>
                           {(sortedBreakdown.length > 0 || item.usage_metric !== null) && (
                             <InfoTooltip className="max-w-sm">
+                              {item.item_name === 'minimum_amount' && (
+                                <p className="mb-2" translate="no">
+                                  Minimum Fee - If your cost is below the minimum fee, you will be
+                                  charged the difference as a floor fee'
+                                </p>
+                              )}
+
                               {item.unit_price_desc && (
                                 <p className="mb-2" translate="no">
                                   Pricing: {item.unit_price_desc}


### PR DESCRIPTION
Prep work for new platform plan
<img width="733" height="120" alt="Screenshot 2026-05-13 at 8 25 29 PM" src="https://github.com/user-attachments/assets/5667bb86-e317-44f7-86ac-07a8c5cc1994" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed plan fee visibility in upcoming invoices so the plan row appears only when a plan item exists and the invoice isn't marked as paid in advance.
  * Enhanced invoice line-item tooltips to include a “Minimum Fee” explanatory paragraph when applicable, placed before the existing unit pricing and breakdown details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45877)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->