### PR TITLE
fix(studio): export metric banner logos overflow

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/AnimatedLogos.tsx
+++ b/apps/studio/components/interfaces/LogDrains/AnimatedLogos.tsx
@@ -1,31 +1,35 @@
 import { AnimatePresence, motion } from 'framer-motion'
-import { Datadog, Grafana, Sentry } from 'icons'
-import { BracesIcon } from 'lucide-react'
+import { Axiom, Datadog, Grafana, Last9, Otlp, Sentry } from 'icons'
+import { BracesIcon, Cloud, Server } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { cn } from 'ui'
 
-export const AnimatedLogos = () => {
+interface AnimatedLogosProps {
+  iconSize?: number
+  className?: string
+}
+
+export const AnimatedLogos = ({ iconSize = 36, className }: AnimatedLogosProps) => {
   const [currIndex, setCurrIndex] = useState(0)
   const timer = 2500
-  const iconSize = 36
+
+  const centerWrapperSize = Math.round(iconSize * 2.67)
+  const sideWrapperSize = Math.round(iconSize * 2.22)
+  const containerW = Math.round(iconSize * 5.33)
+  const containerH = Math.round(iconSize * 3.56)
+  const sideOffset = Math.round(iconSize * 2.22)
+  const hiddenOffset = Math.round(iconSize * 3.33)
 
   const logos = [
-    {
-      id: 'datadog',
-      name: 'Datadog',
-      icon: <Datadog fill="currentColor" size={iconSize} />,
-    },
-    {
-      id: 'loki',
-      name: 'Loki',
-      icon: <Grafana fill="currentColor" size={iconSize} />,
-    },
-    { id: 'https', name: 'HTTPS', icon: <BracesIcon size={iconSize} /> },
-    {
-      id: 'sentry',
-      name: 'Sentry',
-      icon: <Sentry fill="currentColor" size={iconSize} />,
-    },
+    { id: 'webhook', name: 'Custom Endpoint', icon: <BracesIcon size={iconSize} /> },
+    { id: 'otlp', name: 'OTLP', icon: <Otlp fill="currentColor" size={iconSize} /> },
+    { id: 'datadog', name: 'Datadog', icon: <Datadog fill="currentColor" size={iconSize} /> },
+    { id: 'loki', name: 'Loki', icon: <Grafana fill="currentColor" size={iconSize} /> },
+    { id: 's3', name: 'Amazon S3', icon: <Cloud size={iconSize} /> },
+    { id: 'sentry', name: 'Sentry', icon: <Sentry fill="currentColor" size={iconSize} /> },
+    { id: 'axiom', name: 'Axiom', icon: <Axiom fill="currentColor" size={iconSize} /> },
+    { id: 'last9', name: 'Last9', icon: <Last9 fill="currentColor" size={iconSize} /> },
+    { id: 'syslog', name: 'Syslog', icon: <Server size={iconSize} /> },
   ]
 
   useEffect(() => {
@@ -47,14 +51,14 @@ export const AnimatedLogos = () => {
 
   const logoVariants = {
     hidden: {
-      x: 'calc(-50% + 120px)',
+      x: `calc(-50% + ${hiddenOffset}px)`,
       y: '-50%',
       scale: 0.6,
       opacity: 0,
       filter: 'blur(1px)',
     },
     right: {
-      x: 'calc(-50% + 80px)',
+      x: `calc(-50% + ${sideOffset}px)`,
       y: '-50%',
       scale: 0.8,
       opacity: 0.5,
@@ -70,7 +74,7 @@ export const AnimatedLogos = () => {
       filter: 'blur(0px)',
     },
     left: {
-      x: 'calc(-50% - 80px)',
+      x: `calc(-50% - ${sideOffset}px)`,
       y: '-50%',
       scale: 0.8,
       opacity: 0.5,
@@ -78,7 +82,7 @@ export const AnimatedLogos = () => {
       filter: 'blur(1px)',
     },
     exit: {
-      x: 'calc(-50% - 120px)',
+      x: `calc(-50% - ${hiddenOffset}px)`,
       y: '-50%',
       scale: 0.6,
       opacity: 0,
@@ -89,21 +93,23 @@ export const AnimatedLogos = () => {
   const visibleIndices = [getPreviousIndex(), currIndex, getNextIndex()]
 
   return (
-    <div className="relative w-48 h-32 mx-auto mb-8 overflow-hidden">
+    <div
+      className={cn('relative overflow-hidden', className ?? 'mx-auto mb-8')}
+      style={{ width: containerW, height: containerH }}
+    >
       <AnimatePresence initial={false}>
         {logos.map((logo, index) => {
           if (!visibleIndices.includes(index)) return null
 
           const position = getPosition(index)
           const isCenter = index === currIndex
+          const wrapperSize = isCenter ? centerWrapperSize : sideWrapperSize
 
           return (
             <motion.div
               key={logo.id}
-              className={cn(
-                'absolute top-1/2 left-1/2 flex items-center justify-center rounded-lg',
-                isCenter ? 'w-24 h-24' : 'w-20 h-20'
-              )}
+              className="absolute top-1/2 left-1/2 flex items-center justify-center rounded-lg"
+              style={{ width: wrapperSize, height: wrapperSize }}
               variants={logoVariants}
               initial="hidden"
               animate={position}

--- a/apps/studio/components/ui/BannerStack/Banners/BannerMetricsAPI.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerMetricsAPI.tsx
@@ -1,12 +1,11 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { useParams } from 'common/hooks'
 import Link from 'next/link'
-import React from 'react'
 import { Badge, Button } from 'ui'
 
 import { BannerCard } from '../BannerCard'
 import { useBannerStack } from '../BannerStackProvider'
-import { LOG_DRAIN_TYPES } from '@/components/interfaces/LogDrains/LogDrains.constants'
+import { AnimatedLogos } from '@/components/interfaces/LogDrains/AnimatedLogos'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { DOCS_URL } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
@@ -32,13 +31,7 @@ export const BannerMetricsAPI = () => {
           <Badge variant="success" className="-ml-0.5 uppercase inline-flex items-center mb-2">
             Beta
           </Badge>
-          <div className="flex items-center gap-4">
-            {LOG_DRAIN_TYPES.filter((type) => type.value !== 'sentry').map((type) => (
-              <React.Fragment key={type.value}>
-                {React.cloneElement(type.icon, { height: 20, width: 20 })}
-              </React.Fragment>
-            ))}
-          </div>
+          <AnimatedLogos iconSize={20} className="h-[22px]!" />
         </div>
         <div className="flex flex-col gap-y-1 mb-2">
           <p className="text-sm font-medium">Export Metrics to your dashboards</p>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

These logos began to overflow the more log drains we've added. Imported the animated logos from the empty state of log drains settings on free accounts.

| Before | After |
|--------|--------|
| <img width="317" height="256" alt="Screenshot 2026-05-13 at 13 38 11" src="https://github.com/user-attachments/assets/46f04abc-fe33-48f2-8c1f-7d543c85b5a8" /> | <img width="638" height="540" alt="CleanShot 2026-05-13 at 13 47 11" src="https://github.com/user-attachments/assets/e49a9123-f486-45d8-9714-ef41402762d6" /> | 





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded support for additional telemetry and service integrations including OTLP, Amazon S3, Axiom, Last9, and Syslog in the Log Drains interface.

* **Refactor**
  * Updated animated logo component to support flexible sizing and styling options, improving layout consistency across the metrics API banner.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45879)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->