### PR TITLE
Support optionally remove custom domain addon when deleting custom domain after activated

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/CreateUserModal.tsx
@@ -144,7 +144,7 @@ const CreateUserModal = ({ visible, setVisible }: CreateUserModalProps) => {
                       onCheckedChange={(value) => field.onChange(value)}
                     />
                   </FormControl>
-                  <FormLabel>Auto Confirm User?</FormLabel>
+                  <FormLabel>Auto confirm user?</FormLabel>
                 </FormItem>
               )}
             />

--- a/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/Addons.tsx
@@ -3,7 +3,6 @@ import { useFlag, useParams } from 'common'
 import { Lock } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Image from 'next/image'
-import Link from 'next/link'
 import {
   Alert_Shadcn_,
   AlertDescription_Shadcn_,
@@ -268,15 +267,13 @@ export const Addons = () => {
                   <p className="m-0 text-foreground-light text-sm">
                     Reserve a dedicated IPv4 address for your project.
                   </p>
-                  <Link
+                  <InlineLink
+                    className="text-foreground-light"
                     href={`${DOCS_URL}/guides/platform/ipv4-address`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-link text-sm"
-                    onClick={(event) => event.stopPropagation()}
+                    onClick={(e) => e.stopPropagation()}
                   >
                     About IPv4 deprecation
-                  </Link>
+                  </InlineLink>
                 </div>
               </ResourceItem>
             )}
@@ -320,15 +317,13 @@ export const Addons = () => {
                 <p className="m-0 text-foreground-light text-sm">
                   Restore your database to a specific moment in the past.
                 </p>
-                <Link
+                <InlineLink
                   href={`${DOCS_URL}/guides/platform/backups#point-in-time-recovery`}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-link text-sm"
-                  onClick={(event) => event.stopPropagation()}
+                  className="text-foreground-light"
+                  onClick={(e) => e.stopPropagation()}
                 >
                   About PITR backups
-                </Link>
+                </InlineLink>
               </div>
             </ResourceItem>
 
@@ -378,15 +373,13 @@ export const Addons = () => {
                   <p className="m-0 text-foreground-light text-sm">
                     Serve your project on your own domain name.
                   </p>
-                  <Link
+                  <InlineLink
                     href={`${DOCS_URL}/guides/platform/custom-domains`}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="text-link text-sm"
-                    onClick={(event) => event.stopPropagation()}
+                    className="text-foreground-light"
+                    onClick={(e) => e.stopPropagation()}
                   >
                     About custom domains
-                  </Link>
+                  </InlineLink>
                 </div>
               </ResourceItem>
             )}

--- a/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/CustomDomainSidePanel.tsx
@@ -1,7 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useFlag, useParams } from 'common'
 import { AlertCircle } from 'lucide-react'
-import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -16,6 +15,7 @@ import {
 
 import { TaxDisclaimer } from '@/components/interfaces/Billing/TaxDisclaimer'
 import { DocsButton } from '@/components/ui/DocsButton'
+import { InlineLink } from '@/components/ui/InlineLink'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
 import { useProjectAddonRemoveMutation } from '@/data/subscriptions/project-addon-remove-mutation'
 import { useProjectAddonUpdateMutation } from '@/data/subscriptions/project-addon-update-mutation'
@@ -144,9 +144,9 @@ const CustomDomainSidePanel = () => {
           <p className="text-sm">
             Custom domains allow you to present a branded experience to your users. You may set up
             your custom domain in the{' '}
-            <Link href={`/project/${projectRef}/settings/general`} className="text-brand">
+            <InlineLink href={`/project/${projectRef}/settings/general#custom-domains`}>
               General Settings
-            </Link>{' '}
+            </InlineLink>{' '}
             page after enabling the add-on.
           </p>
 

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainDelete.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainDelete.tsx
@@ -1,8 +1,9 @@
 import { Trash } from 'lucide-react'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { Button } from 'ui'
+import { Button, Checkbox } from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { DocsButton } from '@/components/ui/DocsButton'
 import Panel from '@/components/ui/Panel'
@@ -16,7 +17,9 @@ export type CustomDomainDeleteProps = {
 }
 
 export const CustomDomainDelete = ({ projectRef, customDomain }: CustomDomainDeleteProps) => {
+  const [removeCustomDomain, setRemoveCustomDomain] = useState(false)
   const [isDeleteConfirmModalVisible, setIsDeleteConfirmModalVisible] = useState(false)
+
   const { mutate: deleteCustomDomain, isPending: isDeletingCustomDomain } =
     useCustomDomainDeleteMutation({
       onSuccess: () => {
@@ -29,8 +32,12 @@ export const CustomDomainDelete = ({ projectRef, customDomain }: CustomDomainDel
 
   const onDeleteCustomDomain = async () => {
     if (!projectRef) return console.error('Project ref is required')
-    deleteCustomDomain({ projectRef })
+    deleteCustomDomain({ projectRef, removeAddon: removeCustomDomain })
   }
+
+  useEffect(() => {
+    if (!isDeleteConfirmModalVisible) setRemoveCustomDomain(false)
+  }, [isDeleteConfirmModalVisible])
 
   return (
     <>
@@ -76,11 +83,25 @@ export const CustomDomainDelete = ({ projectRef, customDomain }: CustomDomainDel
         onCancel={() => setIsDeleteConfirmModalVisible(false)}
         onConfirm={onDeleteCustomDomain}
       >
-        <p className="text-sm">
+        <p className="text-sm mb-4">
           Are you sure you want to delete the custom domain{' '}
           <code className="text-code-inline break-normal!">{customDomain.hostname}</code> for your
           project? You will need to re-verify this domain if you want to use it again.
         </p>
+
+        <FormItemLayout
+          isReactForm={false}
+          layout="flex"
+          name="removeCustomDomain"
+          label="Also remove custom domain add-on"
+          description="Stops the monthly add-on charge for this project"
+          className="[&>div:first-child>button]:translate-y-0.5"
+        >
+          <Checkbox
+            checked={removeCustomDomain}
+            onCheckedChange={(value) => setRemoveCustomDomain(!!value)}
+          />
+        </FormItemLayout>
       </ConfirmationModal>
     </>
   )

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainVerify.tsx
@@ -11,7 +11,7 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
-import DNSRecord from './DNSRecord'
+import { DNSRecord } from './DNSRecord'
 import { DNSTableHeaders } from './DNSTableHeaders'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLink } from '@/components/ui/InlineLink'
@@ -88,10 +88,8 @@ export const CustomDomainVerify = () => {
           </h4>
           <p className="text-sm text-foreground-light">
             Set the following TXT record(s) in your DNS provider, then click verify to confirm your
-            control over the domain.
-          </p>
-          <p className="text-sm text-foreground-light">
-            Records which have been successfully verified will be removed from this list below.
+            control over the domain. Records which have been successfully verified will be removed
+            from this list below.
           </p>
           {!isValidating && (
             <div className="mt-4 mb-2">

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/DNSRecord.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/DNSRecord.tsx
@@ -6,29 +6,15 @@ export type DNSRecordProps = {
   value: string
 }
 
-const DNSRecord = ({ type, name, value }: DNSRecordProps) => {
+export const DNSRecord = ({ type, name, value }: DNSRecordProps) => {
   return (
     <div className="flex gap-4 items-center">
       <div className="w-[50px]">
         <p className="font-mono text-base">{type.toUpperCase()}</p>
       </div>
 
-      <Input
-        readOnly
-        copy
-        disabled
-        containerClassName="flex-1"
-        className="font-mono"
-        value={name}
-      />
-      <Input
-        readOnly
-        copy
-        disabled
-        containerClassName="flex-1"
-        className="font-mono"
-        value={value}
-      />
+      <Input readOnly copy containerClassName="flex-1" className="font-mono" value={name} />
+      <Input readOnly copy containerClassName="flex-1" className="font-mono" value={value} />
     </div>
   )
 }

--- a/apps/studio/components/ui/InlineLink.tsx
+++ b/apps/studio/components/ui/InlineLink.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link'
-import { PropsWithChildren } from 'react'
+import { type MouseEvent, type PropsWithChildren } from 'react'
 import { cn } from 'ui'
 
 interface InlineLinkProps {
@@ -8,7 +8,7 @@ interface InlineLinkProps {
   target?: string
   rel?: string
   title?: string
-  onClick?: () => void
+  onClick?: (e: MouseEvent<HTMLAnchorElement>) => void
 }
 
 export const InlineLinkClassName =

--- a/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
+++ b/apps/studio/data/custom-domains/custom-domains-delete-mutation.ts
@@ -8,12 +8,17 @@ import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
 export type CustomDomainDeleteVariables = {
   projectRef: string
+  removeAddon?: boolean
 }
 
-export async function deleteCustomDomain({ projectRef }: CustomDomainDeleteVariables) {
+export async function deleteCustomDomain({
+  projectRef,
+  removeAddon = false,
+}: CustomDomainDeleteVariables) {
   const { data, error } = await del(`/v1/projects/{ref}/custom-hostname`, {
     params: {
       path: { ref: projectRef },
+      query: { remove_addon: removeAddon },
     },
   })
 
@@ -36,7 +41,7 @@ export const useCustomDomainDeleteMutation = ({
   return useMutation<CustomDomainDeleteData, ResponseError, CustomDomainDeleteVariables>({
     mutationFn: (vars) => deleteCustomDomain(vars),
     async onSuccess(data, variables, context) {
-      const { projectRef } = variables
+      const { projectRef, removeAddon } = variables
 
       // we manually setQueriesData here instead of using
       // the standard invalidateQueries is the custom domains
@@ -48,8 +53,10 @@ export const useCustomDomainDeleteMutation = ({
         }
       })
 
-      // Invalidate addons cache since the backend removes the addon when deleting the domain
-      await queryClient.invalidateQueries({ queryKey: subscriptionKeys.addons(projectRef) })
+      if (removeAddon) {
+        // Invalidate addons cache since if removing addon too when deleting the domain
+        await queryClient.invalidateQueries({ queryKey: subscriptionKeys.addons(projectRef) })
+      }
 
       await onSuccess?.(data, variables, context)
     },

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -3123,6 +3123,7 @@ export interface components {
             cidr: string
           }[]
         }
+        branches_only?: boolean
         expires_at?: number
         role: string
       }[]
@@ -3139,6 +3140,7 @@ export interface components {
             cidr: string
           }[]
         }
+        branches_only?: boolean
         expires_at?: number
         role: string
       }
@@ -3156,6 +3158,7 @@ export interface components {
               cidr: string
             }[]
           }
+          branches_only?: boolean
           expires_at?: number
           role: string
         }[]
@@ -4434,7 +4437,8 @@ export interface components {
      *                 "cidr": "203.0.113.0/24"
      *               }
      *             ]
-     *           }
+     *           },
+     *           "branches_only": false
      *         }
      *       ]
      *     } */
@@ -4448,6 +4452,7 @@ export interface components {
             cidr: string
           }[]
         }
+        branches_only?: boolean
         expires_at?: number
         role: string
       }[]
@@ -9376,7 +9381,10 @@ export interface operations {
   }
   'v1-Delete hostname config': {
     parameters: {
-      query?: never
+      query?: {
+        /** @description If true, also removes the custom domain add-on from the project subscription. */
+        remove_addon?: boolean
+      }
       header?: never
       path: {
         /** @description Project ref */

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -124,6 +124,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/auth/{ref}/templates/{template}/reset': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Resets Auth template */
+    post: operations['TemplateController_resetTemplate']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/auth/{ref}/users': {
     parameters: {
       query?: never
@@ -7313,6 +7330,21 @@ export interface components {
       MAILER_OTP_LENGTH: number
       MAILER_SECURE_EMAIL_CHANGE_ENABLED: boolean
       MAILER_SUBJECTS_CONFIRMATION: string
+      MAILER_SUBJECTS_CUSTOM_CONTENTS: {
+        MAILER_SUBJECTS_CONFIRMATION: boolean
+        MAILER_SUBJECTS_EMAIL_CHANGE: boolean
+        MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: boolean
+        MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: boolean
+        MAILER_SUBJECTS_IDENTITY_UNLINKED_NOTIFICATION: boolean
+        MAILER_SUBJECTS_INVITE: boolean
+        MAILER_SUBJECTS_MAGIC_LINK: boolean
+        MAILER_SUBJECTS_MFA_FACTOR_ENROLLED_NOTIFICATION: boolean
+        MAILER_SUBJECTS_MFA_FACTOR_UNENROLLED_NOTIFICATION: boolean
+        MAILER_SUBJECTS_PASSWORD_CHANGED_NOTIFICATION: boolean
+        MAILER_SUBJECTS_PHONE_CHANGED_NOTIFICATION: boolean
+        MAILER_SUBJECTS_REAUTHENTICATION: boolean
+        MAILER_SUBJECTS_RECOVERY: boolean
+      }
       MAILER_SUBJECTS_EMAIL_CHANGE: string
       MAILER_SUBJECTS_EMAIL_CHANGED_NOTIFICATION: string
       MAILER_SUBJECTS_IDENTITY_LINKED_NOTIFICATION: string
@@ -7326,6 +7358,21 @@ export interface components {
       MAILER_SUBJECTS_REAUTHENTICATION: string
       MAILER_SUBJECTS_RECOVERY: string
       MAILER_TEMPLATES_CONFIRMATION_CONTENT: string
+      MAILER_TEMPLATES_CUSTOM_CONTENTS: {
+        MAILER_TEMPLATES_CONFIRMATION_CONTENT: boolean
+        MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT: boolean
+        MAILER_TEMPLATES_EMAIL_CHANGED_NOTIFICATION_CONTENT: boolean
+        MAILER_TEMPLATES_IDENTITY_LINKED_NOTIFICATION_CONTENT: boolean
+        MAILER_TEMPLATES_IDENTITY_UNLINKED_NOTIFICATION_CONTENT: boolean
+        MAILER_TEMPLATES_INVITE_CONTENT: boolean
+        MAILER_TEMPLATES_MAGIC_LINK_CONTENT: boolean
+        MAILER_TEMPLATES_MFA_FACTOR_ENROLLED_NOTIFICATION_CONTENT: boolean
+        MAILER_TEMPLATES_MFA_FACTOR_UNENROLLED_NOTIFICATION_CONTENT: boolean
+        MAILER_TEMPLATES_PASSWORD_CHANGED_NOTIFICATION_CONTENT: boolean
+        MAILER_TEMPLATES_PHONE_CHANGED_NOTIFICATION_CONTENT: boolean
+        MAILER_TEMPLATES_REAUTHENTICATION_CONTENT: boolean
+        MAILER_TEMPLATES_RECOVERY_CONTENT: boolean
+      }
       MAILER_TEMPLATES_EMAIL_CHANGE_CONTENT: string
       MAILER_TEMPLATES_EMAIL_CHANGED_NOTIFICATION_CONTENT: string
       MAILER_TEMPLATES_IDENTITY_LINKED_NOTIFICATION_CONTENT: string
@@ -10195,8 +10242,7 @@ export interface components {
       name: string
       owner: string
       public: boolean
-      /** @enum {string} */
-      type?: 'STANDARD' | 'ANALYTICS'
+      type?: ('STANDARD' | 'ANALYTICS') | string
       updated_at: string
     }
     StorageConfigResponse: {
@@ -10267,8 +10313,7 @@ export interface components {
         name: string
         owner: string
         public: boolean
-        /** @enum {string} */
-        type?: 'STANDARD' | 'ANALYTICS'
+        type?: ('STANDARD' | 'ANALYTICS') | string
         updated_at: string
       }
       created_at: string | null
@@ -10284,11 +10329,9 @@ export interface components {
     StorageVectorBucketListIndexesResponse: {
       indexes: {
         creationTime?: number
-        /** @enum {string} */
-        dataType: 'float32'
+        dataType: 'float32' | string
         dimension: number
-        /** @enum {string} */
-        distanceMetric: 'cosine' | 'euclidean' | 'dotproduct'
+        distanceMetric: ('cosine' | 'euclidean' | 'dotproduct') | string
         indexName: string
         metadataConfiguration?: {
           nonFilterableMetadataKeys?: string[]
@@ -12509,6 +12552,69 @@ export interface operations {
         content?: never
       }
       /** @description Failed to retrieve Auth template */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  TemplateController_resetTemplate: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        ref: string
+        template:
+          | 'confirmation'
+          | 'email-change'
+          | 'invite'
+          | 'magic-link'
+          | 'recovery'
+          | 'reauthentication'
+          | 'password-changed-notification'
+          | 'email-changed-notification'
+          | 'phone-changed-notification'
+          | 'mfa-factor-enrolled-notification'
+          | 'mfa-factor-unenrolled-notification'
+          | 'identity-linked-notification'
+          | 'identity-unlinked-notification'
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['GoTrueConfigResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to reset Auth template */
       500: {
         headers: {
           [name: string]: unknown


### PR DESCRIPTION
## Context

Related BE PR: https://github.com/supabase/platform/pull/32693

Add support to remove the custom domain add-on when deleting a custom domain after the custom domain is activated.

<img width="411" height="310" alt="image" src="https://github.com/user-attachments/assets/23d57fc0-f760-42d4-8383-480ff2b2ec5a" />

We previously had this behaviour by default to address some customer feedback RE confusion that they were still being charged for custom domain add-on despite deleting the custom domain, but not removing the add-on.

However this was a bit of confusing UX (RE deleting the add-on implicitly), so this makes the deleting of the custom domain add-on an explicit action instead.

## To test

- [ ] Set up custom domain on a project
- [ ] Trying deleting the custom domain after activating _without_ removing the add-on
- [ ] Trying deleting the custom domain after activating _with_ removing the add-on