### PR TITLE
blog(www): add Saxon Fletcher as author on branching post

### DIFF
--- a/apps/www/_blog/2026-05-04-branching-without-git-is-now-the-default.mdx
+++ b/apps/www/_blog/2026-05-04-branching-without-git-is-now-the-default.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Branching Without Git Is Now The Default'
 description: 'Branching without Git is now the default for all Supabase projects.'
-author: joshenlim, qiao
+author: joshenlim, qiao, saxonf
 imgSocial: 'https://zhfonblqamxferhoguzj.supabase.co/functions/v1/generate-og?template=announcement&layout=horizontal&copy=Branching+Without+Git%0AIs+Now+The+Default&icon=icon-rows.svg'
 imgThumb: 'https://zhfonblqamxferhoguzj.supabase.co/functions/v1/generate-og?template=announcement&layout=vertical&copy=Branching+Without+Git%0AIs+Now+The+Default&icon=icon-rows.svg'
 categories:

--- a/apps/www/data/Authors.json
+++ b/apps/www/data/Authors.json
@@ -1,4 +1,10 @@
 {
+  "saxonf": {
+    "name": "Saxon Fletcher",
+    "job_title": "Design",
+    "username": "SaxonF",
+    "avatar_url": "https://avatars.githubusercontent.com/u/1072756?v=4"
+  },
   "paul_copplestone": {
     "name": "Paul Copplestone",
     "job_title": "CEO and Co-Founder",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Adds Saxon Fletcher as a co-author on the branching without Git blog post
- Adds Saxon Fletcher entry to Authors.json

## What is the current behavior?

The blog post lists joshenlim and qiao as authors only.

## What is the new behavior?

- Saxon Fletcher is added as a third author on the post
- Saxon Fletcher's author profile is added to Authors.json with GitHub username SaxonF

## Additional context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Blog post frontmatter updated to credit an additional contributor.
  * Added a new author profile to the site’s author data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45884)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45884)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->