### PR TITLE
fix(studio): reports table footer overflow

### DIFF
--- a/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -181,6 +181,7 @@ export const TopApiRoutesRenderer = (
     <>
       <Table
         className="rounded-t-none"
+        containerClassName="overflow-x-auto"
         head={
           <>
             <Table.th className={headerClasses}>Request</Table.th>
@@ -206,11 +207,11 @@ export const TopApiRoutesRenderer = (
                       <Table.td className={[cellClasses].join(' ')}>
                         <RouteTdContent {...datum} />
                       </Table.td>
-                      <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                      <Table.td className={[cellClasses, 'text-right'].join(' ')}>
                         {datum.count}
                       </Table.td>
                       {props.data[0].avg !== undefined && (
-                        <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                        <Table.td className={[cellClasses, 'text-right'].join(' ')}>
                           {Number(datum.avg).toFixed(2)}ms
                         </Table.td>
                       )}

--- a/apps/studio/components/interfaces/Reports/renderers/StorageRenderers.tsx
+++ b/apps/studio/components/interfaces/Reports/renderers/StorageRenderers.tsx
@@ -53,6 +53,7 @@ export const TopCacheMissesRenderer = (
     <>
       <h3 className="py-4 px-6">Top Cache Misses</h3>
       <Table
+        containerClassName="overflow-x-auto"
         head={
           <>
             <Table.th className={headerClasses}>Request</Table.th>
@@ -73,7 +74,7 @@ export const TopCacheMissesRenderer = (
                       />
                     </div>
                   </Table.td>
-                  <Table.td className={[cellClasses, 'text-right align-top'].join(' ')}>
+                  <Table.td className={[cellClasses, 'text-right'].join(' ')}>
                     {datum.count}
                   </Table.td>
                 </Table.tr>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

A small bug that was causing the overflow of chart table footers to break on smaller viewports. Now fixed along with cell horizontal spacing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced table layouts in the Reports section by enabling horizontal scrolling for API Routes and Cache Misses tables, ensuring all data is visible on various screen sizes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45885)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->