### PR TITLE
fix(security): validate domain parameter in check-cname to prevent SSRF/URL injection

### DIFF
--- a/apps/studio/pages/api/check-cname.ts
+++ b/apps/studio/pages/api/check-cname.ts
@@ -2,17 +2,27 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { CheckCNAMERecordResponse } from '@/data/custom-domains/check-cname-mutation'
 
+// Only allow valid public hostnames — prevents URL injection and SSRF
+const VALID_HOSTNAME_RE =
+  /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  const { domain } = req.query
+  const rawDomain = req.query.domain
+  const domain = Array.isArray(rawDomain) ? rawDomain[0] : rawDomain
+
+  if (!domain || !VALID_HOSTNAME_RE.test(domain)) {
+    return res.status(400).json({ message: 'Invalid domain name' })
+  }
 
   try {
-    const result: CheckCNAMERecordResponse = await fetch(
-      `https://cloudflare-dns.com/dns-query?name=${domain}&type=CNAME`,
-      {
-        method: 'GET',
-        headers: { Accept: 'application/dns-json' },
-      }
-    ).then((res) => res.json())
+    const url = new URL('https://cloudflare-dns.com/dns-query')
+    url.searchParams.set('name', domain)
+    url.searchParams.set('type', 'CNAME')
+
+    const result: CheckCNAMERecordResponse = await fetch(url.toString(), {
+      method: 'GET',
+      headers: { Accept: 'application/dns-json' },
+    }).then((res) => res.json())
     return res.status(200).json(result)
   } catch (error: any) {
     return res.status(400).json({ message: error.message })


### PR DESCRIPTION
### Description

**What this fixes:**
The `/api/check-cname` endpoint interpolates the user-supplied `domain` query parameter directly into a URL string without any validation or encoding. This allows URL injection and can be used as a DNS oracle to probe internal network hostnames.

**Before (vulnerable):**
```typescript
const { domain } = req.query
fetch(`https://cloudflare-dns.com/dns-query?name=${domain}&type=CNAME`)
```

**After (fixed):**
```typescript
const VALID_HOSTNAME_RE = /^(?:[a-zA-Z0-9](?:[a-zA-Z0-9\-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,63}$/

if (!domain || !VALID_HOSTNAME_RE.test(domain)) {
  return res.status(400).json({ message: 'Invalid domain name' })
}

const url = new URL('https://cloudflare-dns.com/dns-query')
url.searchParams.set('name', domain)
url.searchParams.set('type', 'CNAME')
```

**Changes:**
- Added strict hostname regex validation before processing
- Replaced raw string interpolation with `URL` + `searchParams.set()` (safe encoding)
- Returns 400 for invalid domain names

**Testing:**
- Valid domains like `example.com`, `sub.domain.co.uk` still work
- Injection attempts like `evil.com&type=A&name=internal` are rejected
- Fragment injection `evil.com#fragment` is rejected
- Empty/missing domain returns 400

**Security impact:** HIGH prevents SSRF/URL injection (CWE-918)

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Strengthened domain name validation to reject invalid entries earlier
* Improved error handling with consistent error messaging for invalid domain submissions
* Optimized DNS request construction for better reliability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45890)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->