### PR TITLE
fix(query-insights): aggregate logs into per-minute buckets for chart

### DIFF
--- a/apps/studio/components/interfaces/QueryInsights/QueryInsights.tsx
+++ b/apps/studio/components/interfaces/QueryInsights/QueryInsights.tsx
@@ -10,6 +10,7 @@ import { QueryInsightsHealth } from './QueryInsightsHealth/QueryInsightsHealth'
 import { QueryInsightsTable } from './QueryInsightsTable/QueryInsightsTable'
 import {
   aggregateLogsByQuery,
+  aggregateLogsToMinuteBuckets,
   filterSystemLogs,
   parseSupamonitorLogs,
   transformLogsToChartData,
@@ -63,7 +64,15 @@ export const QueryInsights = ({ dateRange }: QueryInsightsProps) => {
 
   const parsedLogs = useMemo(() => parseSupamonitorLogs(logData || []), [logData])
   const filteredLogs = useMemo(() => filterSystemLogs(parsedLogs), [parsedLogs])
-  const chartData = useMemo(() => transformLogsToChartData(filteredLogs), [filteredLogs])
+  const chartData = useMemo(
+    () =>
+      aggregateLogsToMinuteBuckets(
+        filteredLogs,
+        new Date(effectiveDateRange.iso_timestamp_start).getTime(),
+        new Date(effectiveDateRange.iso_timestamp_end).getTime()
+      ),
+    [filteredLogs, effectiveDateRange]
+  )
   const selectedChartData = useMemo(
     () =>
       selectedQuery

--- a/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.test.ts
+++ b/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.test.ts
@@ -14,7 +14,7 @@ const makeSampleLog = (overrides: Partial<ParsedLogEntry> = {}): ParsedLogEntry 
   application_name: 'test_app',
   calls: 10,
   database_name: 'test_db',
-  query: 'SELECT 1',
+  query: safeSql`SELECT 1`,
   query_id: 1,
   total_exec_time: 100,
   total_plan_time: 20,
@@ -40,7 +40,7 @@ describe('parseSupamonitorLogs', () => {
 
   it('parses log entries preserving all fields', () => {
     const raw = [makeSampleLog()]
-    const result = parseSupamonitorLogs(raw)
+    const result = parseSupamonitorLogs(raw as any)
 
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({
@@ -68,7 +68,7 @@ describe('parseSupamonitorLogs', () => {
 
   it('handles multiple log entries', () => {
     const raw = [makeSampleLog(), makeSampleLog({ query: safeSql`SELECT 2`, query_id: 2 })]
-    const result = parseSupamonitorLogs(raw)
+    const result = parseSupamonitorLogs(raw as any)
     expect(result).toHaveLength(2)
   })
 })

--- a/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.test.ts
+++ b/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.test.ts
@@ -4,11 +4,12 @@ import { describe, expect, it } from 'vitest'
 import type { ParsedLogEntry } from '../QueryInsights.types'
 import {
   aggregateLogsByQuery,
+  aggregateLogsToMinuteBuckets,
   parseSupamonitorLogs,
   transformLogsToChartData,
 } from './supamonitor.utils'
 
-const makeSampleLog = (overrides: Partial<ParsedLogEntry> = {}): any => ({
+const makeSampleLog = (overrides: Partial = {}): any => ({
   timestamp: '2025-01-01T00:00:00Z',
   application_name: 'test_app',
   calls: 10,
@@ -157,6 +158,113 @@ describe('transformLogsToChartData', () => {
     expect(result[0].timestamp).toBe('2025-01-01T00:00:00Z')
     expect(result[1].timestamp).toBe('2025-01-02T00:00:00Z')
     expect(result[2].timestamp).toBe('2025-01-03T00:00:00Z')
+  })
+})
+
+describe('aggregateLogsToMinuteBuckets', () => {
+  const MIN = 60_000
+  const BASE_MS = new Date('2025-01-01T00:00:00Z').getTime()
+
+  it('returns empty buckets for the full range when logs are empty', () => {
+    const result = aggregateLogsToMinuteBuckets([], BASE_MS, BASE_MS + 2 * MIN)
+    expect(result).toHaveLength(3) // minutes 0, 1, 2
+    result.forEach((pt) => {
+      expect(pt.calls).toBe(0)
+      expect(pt.p50_time).toBe(0)
+      expect(pt.p95_time).toBe(0)
+    })
+  })
+
+  it('produces exactly one bucket per minute across the range', () => {
+    const result = aggregateLogsToMinuteBuckets([], BASE_MS, BASE_MS + 59 * MIN)
+    expect(result).toHaveLength(60)
+    expect(result[0].period_start).toBe(BASE_MS)
+    expect(result[59].period_start).toBe(BASE_MS + 59 * MIN)
+  })
+
+  it('aggregates multiple queries at the same minute into one bucket', () => {
+    const logs: ParsedLogEntry[] = [
+      {
+        timestamp: '2025-01-01T00:00:00Z',
+        calls: 10,
+        p50_exec_time: 8,
+        p50_plan_time: 2,
+        p95_exec_time: 40,
+        p95_plan_time: 10,
+        total_exec_time: 80,
+        total_plan_time: 20,
+        min_exec_time: 1,
+        min_plan_time: 0,
+        max_exec_time: 50,
+        max_plan_time: 5,
+      },
+      {
+        timestamp: '2025-01-01T00:00:30Z', // same minute
+        calls: 5,
+        p50_exec_time: 20,
+        p50_plan_time: 5,
+        p95_exec_time: 80,
+        p95_plan_time: 20,
+        total_exec_time: 100,
+        total_plan_time: 25,
+        min_exec_time: 5,
+        min_plan_time: 1,
+        max_exec_time: 90,
+        max_plan_time: 10,
+      },
+    ]
+
+    const result = aggregateLogsToMinuteBuckets(logs, BASE_MS, BASE_MS)
+    expect(result).toHaveLength(1)
+    const bucket = result[0]
+    expect(bucket.calls).toBe(15) // 10 + 5
+    // weighted p50: (10*10 + 5*25) / 15 = (100 + 125) / 15 = 15
+    expect(bucket.p50_time).toBeCloseTo(15)
+    // weighted p95: (10*50 + 5*100) / 15 = (500 + 500) / 15 ≈ 66.67
+    expect(bucket.p95_time).toBeCloseTo(66.67, 1)
+    expect(bucket.min_time).toBe(1) // min(1+0, 5+1) = 1
+    expect(bucket.max_time).toBe(100) // max(50+5, 90+10) = 100
+  })
+
+  it('fills missing minute buckets with zeros between data points', () => {
+    const logs: ParsedLogEntry[] = [
+      { timestamp: '2025-01-01T00:00:00Z', calls: 5 },
+      { timestamp: '2025-01-01T00:05:00Z', calls: 3 }, // gap at minutes 1-4
+    ]
+
+    const result = aggregateLogsToMinuteBuckets(logs, BASE_MS, BASE_MS + 5 * MIN)
+    expect(result).toHaveLength(6) // minutes 0-5
+    expect(result[0].calls).toBe(5)
+    expect(result[1].calls).toBe(0) // filled
+    expect(result[2].calls).toBe(0) // filled
+    expect(result[3].calls).toBe(0) // filled
+    expect(result[4].calls).toBe(0) // filled
+    expect(result[5].calls).toBe(3)
+  })
+
+  it('data outside the start/end range is ignored', () => {
+    const logs: ParsedLogEntry[] = [
+      { timestamp: '2024-12-31T23:59:00Z', calls: 99 }, // before range
+      { timestamp: '2025-01-01T00:00:00Z', calls: 5 },
+      { timestamp: '2025-01-01T00:02:00Z', calls: 99 }, // after range
+    ]
+
+    const result = aggregateLogsToMinuteBuckets(logs, BASE_MS, BASE_MS + MIN)
+    expect(result).toHaveLength(2)
+    expect(result[0].calls).toBe(5)
+    expect(result[1].calls).toBe(0) // minute 1, no data in range
+  })
+
+  it('skips entries with missing or invalid timestamps', () => {
+    const logs: ParsedLogEntry[] = [
+      { timestamp: undefined, calls: 10 },
+      { timestamp: 'not-a-date', calls: 10 },
+      { timestamp: '2025-01-01T00:00:00Z', calls: 5 },
+    ]
+
+    const result = aggregateLogsToMinuteBuckets(logs, BASE_MS, BASE_MS)
+    expect(result).toHaveLength(1)
+    expect(result[0].calls).toBe(5)
   })
 })
 

--- a/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.test.ts
+++ b/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.test.ts
@@ -9,7 +9,7 @@ import {
   transformLogsToChartData,
 } from './supamonitor.utils'
 
-const makeSampleLog = (overrides: Partial = {}): any => ({
+const makeSampleLog = (overrides: Partial<ParsedLogEntry> = {}): ParsedLogEntry => ({
   timestamp: '2025-01-01T00:00:00Z',
   application_name: 'test_app',
   calls: 10,

--- a/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.ts
+++ b/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.ts
@@ -100,7 +100,7 @@ export function transformLogsToChartData(parsedLogs: ParsedLogEntry[]): ChartDat
         cache_misses: 0,
       }
     })
-    .filter((item): item is NonNullable => item !== null)
+    .filter((item): item is ChartDataPoint => item !== null)
     .sort((a, b) => a.period_start - b.period_start)
 }
 

--- a/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.ts
+++ b/apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.ts
@@ -10,6 +10,8 @@ import {
 } from '../QueryInsights.constants'
 import type { ChartDataPoint, ParsedLogEntry } from '../QueryInsights.types'
 
+const MINUTE_MS = 60_000
+
 export function filterSystemLogs(
   logs: ParsedLogEntry[],
   { includeIntrospection = false }: { includeIntrospection?: boolean } = {}
@@ -98,8 +100,112 @@ export function transformLogsToChartData(parsedLogs: ParsedLogEntry[]): ChartDat
         cache_misses: 0,
       }
     })
-    .filter((item): item is NonNullable<typeof item> => item !== null)
+    .filter((item): item is NonNullable => item !== null)
     .sort((a, b) => a.period_start - b.period_start)
+}
+
+export function aggregateLogsToMinuteBuckets(
+  parsedLogs: ParsedLogEntry[],
+  startMs: number,
+  endMs: number
+): ChartDataPoint[] {
+  type Accumulator = {
+    calls: number
+    weightedP50: number
+    weightedP95: number
+    totalWeight: number
+    minTime: number
+    maxTime: number
+    totalTime: number
+  }
+
+  const buckets = new Map<number, Accumulator>()
+
+  for (const log of parsedLogs) {
+    if (!log.timestamp) continue
+    const ts = new Date(log.timestamp).getTime()
+    if (isNaN(ts)) continue
+
+    const minuteTs = Math.floor(ts / MINUTE_MS) * MINUTE_MS
+    const calls = Math.max(0, parseInt(String(log.calls ?? 0), 10))
+    const p50 =
+      parseFloat(String(log.p50_exec_time ?? 0)) + parseFloat(String(log.p50_plan_time ?? 0))
+    const p95 =
+      parseFloat(String(log.p95_exec_time ?? 0)) + parseFloat(String(log.p95_plan_time ?? 0))
+    const minTime =
+      parseFloat(String(log.min_exec_time ?? 0)) + parseFloat(String(log.min_plan_time ?? 0))
+    const maxTime =
+      parseFloat(String(log.max_exec_time ?? 0)) + parseFloat(String(log.max_plan_time ?? 0))
+    const totalTime =
+      parseFloat(String(log.total_exec_time ?? 0)) + parseFloat(String(log.total_plan_time ?? 0))
+
+    if (!buckets.has(minuteTs)) {
+      buckets.set(minuteTs, {
+        calls: 0,
+        weightedP50: 0,
+        weightedP95: 0,
+        totalWeight: 0,
+        minTime: Infinity,
+        maxTime: -Infinity,
+        totalTime: 0,
+      })
+    }
+
+    const bucket = buckets.get(minuteTs)!
+    bucket.calls += calls
+    bucket.weightedP50 += p50 * calls
+    bucket.weightedP95 += p95 * calls
+    bucket.totalWeight += calls
+    bucket.minTime = Math.min(bucket.minTime, minTime)
+    bucket.maxTime = Math.max(bucket.maxTime, maxTime)
+    bucket.totalTime += totalTime
+  }
+
+  const startMinute = Math.floor(startMs / MINUTE_MS) * MINUTE_MS
+  const endMinute = Math.floor(endMs / MINUTE_MS) * MINUTE_MS
+
+  const result: ChartDataPoint[] = []
+  for (let t = startMinute; t <= endMinute; t += MINUTE_MS) {
+    const bucket = buckets.get(t)
+    if (bucket) {
+      const meanTime = bucket.calls > 0 ? bucket.totalTime / bucket.calls : 0
+      const p50 = bucket.totalWeight > 0 ? bucket.weightedP50 / bucket.totalWeight : 0
+      const p95 = bucket.totalWeight > 0 ? bucket.weightedP95 / bucket.totalWeight : 0
+      result.push({
+        period_start: t,
+        timestamp: new Date(t).toISOString(),
+        query_latency: meanTime,
+        mean_time: meanTime,
+        min_time: bucket.minTime === Infinity ? 0 : bucket.minTime,
+        max_time: bucket.maxTime === -Infinity ? 0 : bucket.maxTime,
+        stddev_time: 0,
+        p50_time: p50,
+        p95_time: p95,
+        calls: bucket.calls,
+        rows_read: 0,
+        cache_hits: 0,
+        cache_misses: 0,
+      })
+    } else {
+      result.push({
+        period_start: t,
+        timestamp: new Date(t).toISOString(),
+        query_latency: 0,
+        mean_time: 0,
+        min_time: 0,
+        max_time: 0,
+        stddev_time: 0,
+        p50_time: 0,
+        p95_time: 0,
+        calls: 0,
+        rows_read: 0,
+        cache_hits: 0,
+        cache_misses: 0,
+      })
+    }
+  }
+
+  return result
 }
 
 function normalizeQuery(query: string): string {


### PR DESCRIPTION
## Summary

- Fixes the Query Insights chart showing only 2 x-axis data points (hourly buckets) instead of 60 minute-level buckets
- Root cause: `transformLogsToChartData` created one `ChartDataPoint` per SQL row; since supamonitor samples at round-hour boundaries, all rows shared 1–2 timestamps
- Adds `aggregateLogsToMinuteBuckets` which (1) groups all per-query rows at the same minute into one weighted-average aggregate bucket, and (2) fills the complete requested time range with zero-value buckets for empty minutes

## Changes

- [`supamonitor.utils.ts`](apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.ts): new `aggregateLogsToMinuteBuckets` export
- [`QueryInsights.tsx`](apps/studio/components/interfaces/QueryInsights/QueryInsights.tsx): switch `chartData` memo to use `aggregateLogsToMinuteBuckets` (per-query `selectedChartData` keeps using `transformLogsToChartData`)
- [`supamonitor.utils.test.ts`](apps/studio/components/interfaces/QueryInsights/utils/supamonitor.utils.test.ts): 5 new unit tests covering empty input, 60-bucket span, multi-query aggregation, gap-filling, and out-of-range data

## Test plan

- [ ] All 18 unit tests pass (`pnpm test:studio`)
- [ ] Query Insights chart renders 60 minute-level buckets for the "Last 60 minutes" preset
- [ ] Empty minutes show as zero-value bars (no gaps in the chart)
- [ ] Selecting a specific query in the table still shows the per-query overlay chart correctly

Fixes DEBUG-95

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate minute-level bucketing for query insights with filled gaps for missing minutes.
  * Refined percentile and weighted-mean latency calculations for clearer performance charts.
  * Better handling of out-of-range or invalid log entries to reduce misleading spikes.

* **Tests**
  * Expanded test coverage for minute buckets, aggregation behavior, gaps/zero-filling, weighted percentiles, and invalid timestamps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45891)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->