### PR TITLE
fix(security): add auth to MCP endpoint and default read_only to true

### DIFF
--- a/apps/studio/pages/api/mcp/index.ts
+++ b/apps/studio/pages/api/mcp/index.ts
@@ -9,6 +9,7 @@ import {
   fromNodeHeaders,
   zBooleanString,
 } from '@/lib/api/apiHelpers'
+import apiWrapper from '@/lib/api/apiWrapper'
 import {
   getDatabaseOperations,
   getDebuggingOperations,
@@ -32,13 +33,13 @@ const mcpQuerySchema = z.object({
     )
     .pipe(z.array(supportedFeatureGroupSchema).optional()),
   read_only: zBooleanString()
-    .default('false')
+    .default('true')
     .describe(
-      'Indicates whether or not the MCP server should operate in read-only mode. This prevents write operations on any of your databases by executing SQL as a read-only Postgres user.'
+      'Indicates whether or not the MCP server should operate in read-only mode. Defaults to true for safety. Set to false to enable write operations.'
     ),
 })
 
-const handler = async (req: NextApiRequest, res: NextApiResponse) => {
+async function handler(req: NextApiRequest, res: NextApiResponse) {
   switch (req.method) {
     case 'POST':
       return handlePost(req, res)
@@ -47,6 +48,9 @@ const handler = async (req: NextApiRequest, res: NextApiResponse) => {
       return res.status(405).json({ error: { message: `Method ${req.method} Not Allowed` } })
   }
 }
+
+export default (req: NextApiRequest, res: NextApiResponse) =>
+  apiWrapper(req, res, handler, { withAuth: true })
 
 async function handlePost(req: NextApiRequest, res: NextApiResponse) {
   const { error, data } = mcpQuerySchema.safeParse(req.query)
@@ -89,5 +93,3 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     return res.status(500).json({ error: 'Unable to process MCP request', cause: error })
   }
 }
-
-export default handler


### PR DESCRIPTION
### Description

**What this fixes:**
The `/api/mcp` endpoint had no authentication check it was not wrapped with `apiWrapper({ withAuth: true })`. In self-hosted deployments (where `IS_PLATFORM` is false), this meant anyone with network access could execute arbitrary SQL, apply migrations, and access debugging operations via the MCP protocol.

Additionally, the `read_only` parameter defaulted to `false`, meaning unauthenticated callers had full write access by default.

**Changes:**
1. Wrapped the handler with `apiWrapper(req, res, handler, { withAuth: true })` requires authentication on the platform
2. Changed `read_only` default from `'false'` to `'true'` safe default, opt-in for writes

**Note on self-hosted:**
Due to the `IS_PLATFORM` gate in `apiWrapper` (Finding 1), this fix only enforces auth on the hosted platform. Self-hosted deployments should additionally restrict network access to the Studio port. A comprehensive fix for the self-hosted auth model is tracked separately.

**Testing:**
- Unauthenticated POST to `/api/mcp` on platform → 401 Unauthorized
- Authenticated POST with valid features → works as before
- `read_only` defaults to true. Write operations require explicit `?read_only=false`

**Security impact:** CRITICAL prevents unauthenticated arbitrary SQL execution via MCP (CWE-306)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * MCP API now requires authentication on all incoming requests, ensuring secure and properly verified access to your critical API operations.

* **Improvements**
  * Query operations default to read-only mode to protect your data from inadvertent changes and unintended modifications. Write operations require explicit enablement for safer operation defaults and better control.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45893)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->