### PR TITLE
fix(security): validate RLS policy expressions to prevent SQL injecti…

### DIFF
--- a/packages/pg-meta/src/pg-meta-policies.ts
+++ b/packages/pg-meta/src/pg-meta-policies.ts
@@ -102,6 +102,30 @@ type PolicyCreateParams = {
   roles?: string[]
 }
 
+/**
+ * Validates a policy SQL expression to prevent injection via stacked queries or
+ * dangerous DDL/DCL statements. Policy expressions should only contain boolean
+ * expressions (SELECT-level SQL), not DDL or DCL commands.
+ */
+function validatePolicyExpression(expression: string, context: string): void {
+  // Block semicolons which enable stacked queries
+  if (expression.includes(';')) {
+    throw new Error(
+      `Invalid ${context} expression: semicolons are not allowed in policy expressions`
+    )
+  }
+
+  // Block dangerous DDL/DCL keywords that should never appear in a policy expression
+  const DANGEROUS_KEYWORDS =
+    /\b(DROP|TRUNCATE|CREATE\s+ROLE|ALTER\s+ROLE|GRANT|REVOKE|COPY|pg_read_file|pg_write_file|lo_import|lo_export)\b/i
+  if (DANGEROUS_KEYWORDS.test(expression)) {
+    throw new Error(
+      `Invalid ${context} expression: contains disallowed keyword. ` +
+        `Policy expressions should only contain boolean conditions.`
+    )
+  }
+}
+
 function create({
   name,
   schema = 'public',
@@ -112,6 +136,14 @@ function create({
   command = 'ALL',
   roles = ['public'],
 }: PolicyCreateParams): { sql: string } {
+  // Validate SQL expressions to prevent injection via stacked queries
+  if (definition) {
+    validatePolicyExpression(definition, 'USING')
+  }
+  if (check) {
+    validatePolicyExpression(check, 'WITH CHECK')
+  }
+
   const sql = `
 create policy ${ident(name)} on ${ident(schema)}.${ident(table)}
   as ${action}
@@ -134,6 +166,14 @@ function update(
   params: PolicyUpdateParams
 ): { sql: string } {
   const { name, definition, check, roles } = params
+
+  // Validate SQL expressions to prevent injection via stacked queries
+  if (definition) {
+    validatePolicyExpression(definition, 'USING')
+  }
+  if (check) {
+    validatePolicyExpression(check, 'WITH CHECK')
+  }
 
   const alter = `ALTER POLICY ${ident(identifier.name)} ON ${ident(identifier.schema)}.${ident(identifier.table)}`
   const nameSql = name === undefined ? '' : `${alter} RENAME TO ${ident(name)};`


### PR DESCRIPTION
### Description

**What this fixes:**
The `create()` and `update()` functions in `packages/pg-meta/src/pg-meta-policies.ts` interpolate the `definition` (USING clause) and `check` (WITH CHECK clause) parameters directly into SQL without any validation. While these are intentionally SQL expressions, there is no guard against:
- Stacked queries via semicolons: `true); DROP TABLE users; --`
- Dangerous DDL/DCL commands: `true); GRANT pg_read_all_data TO anon; --`

**Change:**
Added a `validatePolicyExpression()` function that:
1. Rejects expressions containing semicolons (prevents stacked queries)
2. Rejects expressions containing dangerous DDL/DCL keywords (DROP, TRUNCATE, CREATE ROLE, ALTER ROLE, GRANT, REVOKE, COPY, pg_read_file, etc.)

**What this does NOT block:**
- Legitimate policy expressions like `auth.uid() = user_id`
- Subqueries in expressions like `(SELECT count(*) FROM ...) > 0`
- Function calls like `current_setting('request.jwt.claims')::json->>'sub'`

**Testing:**
- `auth.uid() = user_id` → passes validation ✓
- `true); DROP TABLE users; --` → rejected (semicolon) ✓
- `true); GRANT pg_read_all_data TO anon; --` → rejected (semicolon + GRANT) ✓
- `(SELECT pg_read_file('/etc/passwd'))::boolean` → rejected (pg_read_file) ✓

**Security impact:** HIGH — prevents SQL injection in policy editor (CWE-89)

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added server-side validation for policy SQL expressions during creation and updates to prevent potentially dangerous SQL patterns, including those containing semicolons and disallowed SQL/DCL keywords.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45894)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->