### PR TITLE
studio: change configcat prefetch to head request

### DIFF
--- a/packages/common/configcat.ts
+++ b/packages/common/configcat.ts
@@ -35,7 +35,9 @@ async function getClient() {
   }
 
   try {
-    const response = await fetchHandler(process.env.NEXT_PUBLIC_CONFIGCAT_PROXY_URL + endpoint)
+    const response = await fetchHandler(process.env.NEXT_PUBLIC_CONFIGCAT_PROXY_URL + endpoint, {
+      method: 'HEAD',
+    })
     const options = { pollIntervalSeconds: 7 * 60 } // 7 minutes
 
     if (response.status !== 200) {


### PR DESCRIPTION
We run an experimental fetch of the ConfigCat proxy to test whether we can reach it before initializing the ConfigCat client with either the proxy or the fallback URL. The prefetch can be a HEAD request instead of a full fetch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  - Optimized proxy endpoint availability detection with more efficient request handling
  - Enhanced system resilience with improved fallback behavior when proxy services are unavailable

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45896)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->