### PR TITLE
Updated dinner details for NYC Exec Dinner

### DIFF
--- a/apps/www/_go/events/dash-2026/exec-dinner-thank-you.tsx
+++ b/apps/www/_go/events/dash-2026/exec-dinner-thank-you.tsx
@@ -8,12 +8,12 @@ const page: GoPageInput = {
   metadata: {
     title: "You're confirmed | Supabase Executive Dinner",
     description:
-      'Your RSVP for the Supabase executive dinner has been confirmed. Join us at Manhatta Restaurant with cocktails at 6:30 PM and dinner at 7:00 PM.',
+      'Your RSVP for the Supabase executive dinner on June 10, 2026 has been confirmed. Join us at Manhatta Restaurant with cocktails at 7:00 PM and dinner at 7:30 PM.',
   },
   hero: {
     title: "You're confirmed",
     description:
-      "We'll see you at Manhatta Restaurant. Cocktails begin at 6:30 PM and dinner starts at 7:00 PM. We look forward to seeing you.",
+      "We'll see you at Manhatta Restaurant on June 10, 2026. Cocktails begin at 7:00 PM and dinner starts at 7:30 PM. We look forward to seeing you.",
   },
   sections: [
     {

--- a/apps/www/_go/events/dash-2026/exec-dinner-thank-you.tsx
+++ b/apps/www/_go/events/dash-2026/exec-dinner-thank-you.tsx
@@ -8,12 +8,12 @@ const page: GoPageInput = {
   metadata: {
     title: "You're confirmed | Supabase Executive Dinner",
     description:
-      'Your RSVP for the Supabase executive dinner on June 10, 2026 has been confirmed. Join us at Manhatta Restaurant with cocktails at 7:00 PM and dinner at 7:30 PM.',
+      'Your RSVP for the Supabase executive dinner on June 10, 2026 has been confirmed. Join us at Manhatta Restaurant with cocktails at 6:30 PM and dinner at 7:00 PM.',
   },
   hero: {
     title: "You're confirmed",
     description:
-      "We'll see you at Manhatta Restaurant on June 10, 2026. Cocktails begin at 7:00 PM and dinner starts at 7:30 PM. We look forward to seeing you.",
+      "We'll see you at Manhatta Restaurant on June 10, 2026. Cocktails begin at 6:30 PM and dinner starts at 7:00 PM. We look forward to seeing you.",
   },
   sections: [
     {

--- a/apps/www/_go/events/dash-2026/exec-dinner.tsx
+++ b/apps/www/_go/events/dash-2026/exec-dinner.tsx
@@ -11,7 +11,7 @@ const page: GoPageInput = {
   metadata: {
     title: 'Executive Dinner | Supabase',
     description:
-      'Join Supabase leaders for an intimate dinner at Manhatta Restaurant. Cocktails at 6:30 PM, dinner at 7:00 PM.',
+      'Join Supabase leaders for an intimate dinner at Manhatta Restaurant on June 10, 2026. Cocktails at 7:00 PM, dinner at 7:30 PM.',
   },
   hero: {
     title: 'The future of scalable databases',
@@ -38,12 +38,14 @@ const page: GoPageInput = {
       title: 'Details',
       children: (
         <div className="flex flex-col items-center gap-2 text-foreground-light">
-          <p className="text-lg font-medium text-foreground">Location</p>
+          <p className="text-lg font-medium text-foreground">Date</p>
+          <p>June 10, 2026</p>
+          <p className="mt-4 text-lg font-medium text-foreground">Location</p>
           <p>Manhatta Restaurant</p>
           <p>28 Liberty St, 60th Floor</p>
           <p className="mt-4 text-lg font-medium text-foreground">Schedule</p>
-          <p>6:30 PM — Cocktails and introductions</p>
-          <p>7:00 PM — Dinner and discussion</p>
+          <p>7:00 PM — Cocktails and introductions</p>
+          <p>7:30 PM — Dinner and discussion</p>
         </div>
       ),
     },
@@ -119,8 +121,22 @@ const page: GoPageInput = {
           type: 'text',
           name: 'company_name',
           label: 'Company',
-          placeholder: 'Company name',
+          placeholder: 'ACME, Inc.',
           required: true,
+        },
+        {
+          type: 'text',
+          name: 'job_title',
+          label: 'Job Title',
+          placeholder: 'VP of Engineering',
+          required: false,
+        },
+        {
+          type: 'text',
+          name: 'phone_number',
+          label: 'Phone Number',
+          placeholder: '+1 212 555 1212',
+          required: false,
         },
       ],
       submitLabel: 'Confirm RSVP',
@@ -134,7 +150,9 @@ const page: GoPageInput = {
             first_name: 'firstname',
             last_name: 'lastname',
             email_address: 'email',
-            company_name: 'company',
+            company_name: 'name',
+            job_title: 'jobtitle',
+            phone_number: 'phone',
           },
           consent:
             'By submitting this form, I confirm that I have read and understood the Privacy Policy.',
@@ -146,6 +164,8 @@ const page: GoPageInput = {
             last_name: 'Last Name',
             email_address: 'Email',
             company_name: 'Company',
+            job_title: 'Job Title',
+            phone_number: 'Phone Number',
           },
         },
       },

--- a/apps/www/_go/events/dash-2026/exec-dinner.tsx
+++ b/apps/www/_go/events/dash-2026/exec-dinner.tsx
@@ -11,7 +11,7 @@ const page: GoPageInput = {
   metadata: {
     title: 'Executive Dinner | Supabase',
     description:
-      'Join Supabase leaders for an intimate dinner at Manhatta Restaurant on June 10, 2026. Cocktails at 7:00 PM, dinner at 7:30 PM.',
+      'Join Supabase leaders for an intimate dinner at Manhatta Restaurant on June 10, 2026. Cocktails at 6:30 PM, dinner at 7:00 PM.',
   },
   hero: {
     title: 'The future of scalable databases',
@@ -44,8 +44,8 @@ const page: GoPageInput = {
           <p>Manhatta Restaurant</p>
           <p>28 Liberty St, 60th Floor</p>
           <p className="mt-4 text-lg font-medium text-foreground">Schedule</p>
-          <p>7:00 PM — Cocktails and introductions</p>
-          <p>7:30 PM — Dinner and discussion</p>
+          <p>6:30 PM — Cocktails and introductions</p>
+          <p>7:00 PM — Dinner and discussion</p>
         </div>
       ),
     },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updated dinner date and time for NYC dinner go page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Executive Dinner now shows the date (June 10, 2026) and revised times: cocktails at 6:30 PM, dinner at 7:00 PM.

* **New Features**
  * RSVP form adds optional Job Title and Phone Number fields; company placeholder set to “ACME, Inc.”

* **UI**
  * Event details now display a dedicated Date block and show Location after the date.

* **Integrations**
  * RSVP integrations updated to include the new fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45901)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->