### PR TITLE
fix: omit billing fields when using a saved payment method

### DIFF
--- a/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/PaymentMethods/NewPaymentMethodElement.tsx
@@ -72,6 +72,7 @@ export type PaymentMethodElementRef = {
         address: CustomerAddress | null
         customerName: string | null
         taxId: CustomerTaxId | null
+        isNewPaymentMethod: boolean
       }
     | undefined
   >
@@ -200,6 +201,7 @@ export const NewPaymentMethodElement = forwardRef(
         },
         customerName: addressElement.value.name,
         taxId: getConfiguredTaxId(),
+        isNewPaymentMethod: true,
       }
     }
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -198,9 +198,13 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
         amount,
         payment_method_id: paymentMethodResult.paymentMethod.id,
         hcaptchaToken: token,
-        address: paymentMethodResult.address,
-        tax_id: paymentMethodResult.taxId ?? undefined,
-        billing_name: paymentMethodResult.customerName,
+        ...(paymentMethodResult.isNewPaymentMethod
+          ? {
+              address: paymentMethodResult.address,
+              tax_id: paymentMethodResult.taxId ?? undefined,
+              billing_name: paymentMethodResult.customerName,
+            }
+          : {}),
       },
       {
         onSuccess: (data) => {

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
@@ -237,7 +237,6 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
     return true
   }
 
-  // If createPaymentMethod already exists, use it. Otherwise, define it here.
   const createPaymentMethod = async (): ReturnType<
     PaymentMethodElementRef['createPaymentMethod']
   > => {
@@ -251,6 +250,7 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
         customerName: useAsDefaultBillingAddress ? paymentResult.customerName : null,
         address: useAsDefaultBillingAddress ? paymentResult.address : null,
         taxId: useAsDefaultBillingAddress ? paymentResult.taxId : null,
+        isNewPaymentMethod: true,
       }
     } else {
       return {
@@ -258,6 +258,7 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
         customerName: useAsDefaultBillingAddress ? customerProfile?.billing_name || '' : null,
         address: useAsDefaultBillingAddress ? (customerProfile?.address ?? null) : null,
         taxId: useAsDefaultBillingAddress ? (taxId ?? null) : null,
+        isNewPaymentMethod: false,
       }
     }
   }

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -213,9 +213,13 @@ export const SubscriptionPlanUpdateDialog = ({
       slug: selectedOrganization?.slug,
       tier,
       paymentMethod: result?.paymentMethod?.id,
-      address: result?.address,
-      tax_id: result?.taxId ?? undefined,
-      billing_name: result?.customerName ?? undefined,
+      ...(result?.isNewPaymentMethod
+        ? {
+            address: result.address,
+            tax_id: result.taxId ?? undefined,
+            billing_name: result.customerName ?? undefined,
+          }
+        : {}),
     })
   }
 


### PR DESCRIPTION
## Summary

When updating a subscription or topping up credits with a **saved** payment method, omit `address`, `tax_id`, and `billing_name` from the request. The backend treats the presence of these fields as an update signal, so echoing back the existing customer profile would update it.

## Manual testing

### Subscription update — saved payment method
- [ ] Go to Organization → Billing and start a plan change.
- [ ] In the payment method step, keep an existing saved card selected (do **not** add a new one).
- [ ] Confirm the update and verify the request payload to the subscription update endpoint does **not** include `address`, `tax_id`, or `billing_name`.
- [ ] Verify the customer's billing address / tax ID / billing name in Stripe remain unchanged after the update.

### Subscription update — new payment method
- [ ] Repeat the flow above, this time adding a new card.
- [ ] Toggle "Use as default billing address" on and submit. Confirm the payload includes `address`, `tax_id`, and `billing_name`, and the values are persisted.
- [ ] Toggle "Use as default billing address" off and submit. Confirm those fields are `null`/absent.

### Credit top-up
- [ ] Top up credits using a saved payment method. Verify the payload does **not** include `address`, `tax_id`, or `billing_name`, and the customer profile is unchanged.
- [ ] Top up credits using a newly entered card. Verify the payload includes the billing fields as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved billing data handling in payment workflows. Billing profile information (address, name, tax ID) is now conditionally included only when creating a new payment method, optimizing data transmission for subscription updates and credit top-ups.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45902)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->