### PR TITLE
fix(studio): add warning banner for exposed schemas and hardening desync

### DIFF
--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -246,7 +246,12 @@ export const PostgrestConfig = () => {
   }, [isReady])
 
   const watchedDbSchema = useWatch({ control: form.control, name: 'dbSchema' })
+  const watchedDbExtraSearchPath = useWatch({ control: form.control, name: 'dbExtraSearchPath' })
   const watchedTableIdsToAdd = useWatch({ control: form.control, name: 'tableIdsToAdd' })
+
+  const missingSchemas =
+    watchedDbExtraSearchPath?.filter((schema) => !watchedDbSchema.includes(schema)) ?? []
+  const hasSchemaDesync = missingSchemas.length > 0
   const watchedTableIdsToRemove = useWatch({
     control: form.control,
     name: 'tableIdsToRemove',
@@ -283,24 +288,33 @@ export const PostgrestConfig = () => {
                       label="Exposed schemas"
                       description="Select schemas to include in the Data API. Schemas must be included before tables can be exposed."
                     >
-                      <ExposedSchemaSelector
-                        selectedSchemas={watchedDbSchema}
-                        disabled={!canUpdatePostgrestConfig}
-                        onToggleSchema={(schema) => {
-                          const current = form.getValues('dbSchema')
-                          if (current.includes(schema)) {
-                            form.setValue(
-                              'dbSchema',
-                              current.filter((x) => x !== schema),
-                              { shouldDirty: true }
-                            )
-                          } else {
-                            form.setValue('dbSchema', [...current, schema], {
-                              shouldDirty: true,
-                            })
-                          }
-                        }}
-                      />
+                      <div className="flex flex-col gap-y-4 w-full">
+                        {hasSchemaDesync && (
+                          <Admonition
+                            type="warning"
+                            title="Configuration mismatch"
+                            description="Warning: You have schemas active in your Data API Hardening settings that are not listed here. This may cause PostgREST to fail. Please ensure both settings match."
+                          />
+                        )}
+                        <ExposedSchemaSelector
+                          selectedSchemas={watchedDbSchema}
+                          disabled={!canUpdatePostgrestConfig}
+                          onToggleSchema={(schema) => {
+                            const current = form.getValues('dbSchema')
+                            if (current.includes(schema)) {
+                              form.setValue(
+                                'dbSchema',
+                                current.filter((x) => x !== schema),
+                                { shouldDirty: true }
+                              )
+                            } else {
+                              form.setValue('dbSchema', [...current, schema], {
+                                shouldDirty: true,
+                              })
+                            }
+                          }}
+                        />
+                      </div>
                     </FormItemLayout>
 
                     <FormItemLayout


### PR DESCRIPTION
### What kind of change does this PR introduce?
[x] Bug fix (non-breaking change which fixes an issue)
[ ] New feature (non-breaking change which adds functionality)

### What is the current behavior?
In the Dashboard, the `Data API > Settings > Exposed schemas` UI and the `Data API > Hardening` UI can easily become desynchronized. If a user removes a schema (like `public`) from the Exposed Schemas list but it remains active in the Hardening extra search path, PostgREST will fail to load the schema cache and return 500s. 

Because the Settings page looks correct (the schema is removed from the input), users are left confused as to why the Data API is failing.

Fixes #45904

### What is the new behavior?
This PR adds a real-time validation check using `react-hook-form`'s `useWatch`. It diffs the `dbSchema` array against the `dbExtraSearchPath` array. 

If a schema is detected in the Hardening settings that is *not* present in the Exposed Schemas list, it renders a warning `Admonition` component directly above the Exposed Schema selector. This explicitly warns the user of the configuration mismatch before they save, preventing the PostgREST backend crash.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation checks to PostgreSQL hardening configuration settings. Users are now alerted with a warning when active hardening schemas are not properly aligned with Data API settings, helping prevent configuration inconsistencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45907)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->