### PR TITLE
fix(studio): storage policy warning spacing

### DIFF
--- a/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
+++ b/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
@@ -199,8 +199,8 @@ function PublicBucketWarningView(props: PublicBucketWarningViewProps): ReactNode
         <div className="flex flex-col gap-3">
           <p className="text-sm text-foreground-light">
             This will drop {hasMultiplePolicies ? 'one' : 'the'}{' '}
-            <code className="text-code-inline">SELECT</code> policy that makes the bucket&apos;s
-            contents listable. Object URLs will continue to work.
+            <code className="text-code-inline">SELECT</code>{' '}
+            policy that makes the bucket’s contents listable. Object URLs will continue to work.
             {hasMultiplePolicies
               ? ` ${policyCount - 1} matching ${
                   policyCount - 1 === 1 ? 'policy' : 'policies'

--- a/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
+++ b/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
@@ -199,8 +199,10 @@ function PublicBucketWarningView(props: PublicBucketWarningViewProps): ReactNode
         <div className="flex flex-col gap-3">
           <p className="text-sm text-foreground-light">
             This will drop {hasMultiplePolicies ? 'one' : 'the'}{' '}
-            <code className="text-code-inline">SELECT</code>{' '}
-            policy that makes the bucket’s contents listable. Object URLs will continue to work.
+            <code className="text-code-inline">SELECT</code>
+            {
+              ' policy that makes the bucket’s contents listable. Object URLs will continue to work.'
+            }
             {hasMultiplePolicies
               ? ` ${policyCount - 1} matching ${
                   policyCount - 1 === 1 ? 'policy' : 'policies'

--- a/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
+++ b/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
@@ -198,8 +198,9 @@ function PublicBucketWarningView(props: PublicBucketWarningViewProps): ReactNode
       >
         <div className="flex flex-col gap-3">
           <p className="text-sm text-foreground-light">
-            This will drop {hasMultiplePolicies ? 'one' : 'the'} <code>SELECT</code> policy that
-            makes the bucket&apos;s contents listable. Object URLs will continue to work.
+            This will drop {hasMultiplePolicies ? 'one' : 'the'} <code>SELECT</code>{' '}
+            policy that makes the bucket&apos;s contents listable. Object URLs will continue to
+            work.
             {hasMultiplePolicies
               ? ` ${policyCount - 1} matching ${
                   policyCount - 1 === 1 ? 'policy' : 'policies'

--- a/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
+++ b/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
@@ -198,9 +198,9 @@ function PublicBucketWarningView(props: PublicBucketWarningViewProps): ReactNode
       >
         <div className="flex flex-col gap-3">
           <p className="text-sm text-foreground-light">
-            This will drop {hasMultiplePolicies ? 'one' : 'the'} <code>SELECT</code>{' '}
-            policy that makes the bucket&apos;s contents listable. Object URLs will continue to
-            work.
+            This will drop {hasMultiplePolicies ? 'one' : 'the'}{' '}
+            <code className="text-code-inline">SELECT</code> policy that makes the bucket&apos;s
+            contents listable. Object URLs will continue to work.
             {hasMultiplePolicies
               ? ` ${policyCount - 1} matching ${
                   policyCount - 1 === 1 ? 'policy' : 'policies'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The Storage public bucket warning confirmation modal can render `SELECTpolicy` without a space. The source relied on implicit JSX whitespace after an inline `<code>` element, and that whitespace can be normalised away when React renders the sentence.

## What is the new behavior?

The modal now renders an explicit JSX space after the `SELECT` code element, so the sentence reads `SELECT policy`.

| Before | After |
| --- | --- |
| <img width="860" height="666" alt="CleanShot 2026-05-14 at 14 31 36@2x-2B492E39-5CB4-4D4D-A409-0F0AF268E108" src="https://github.com/user-attachments/assets/683cc8c7-c112-411e-9569-de3be2a1d906" /> | <img width="858" height="668" alt="CleanShot 2026-05-14 at 15 08 08@2x" src="https://github.com/user-attachments/assets/e9a28bb0-9977-4da9-aecb-d4fa56dff368" /> |

## Additional context

Testing instructions:

1. Open the staging link.
2. Open the SQL Editor and run:

```sql
insert into storage.buckets (id, name, public)
values ('public-warning-repro', 'public-warning-repro', true)
on conflict (id) do update set public = true;

drop policy if exists "public warning broad select repro" on storage.objects;

create policy "public warning broad select repro"
on storage.objects
for select
to anon, authenticated
using (bucket_id = 'public-warning-repro');
```

3. Navigate to Storage > `public-warning-repro`.
4. Click `Remove policy` on the warning banner.
5. Confirm the modal says `This will drop the SELECT policy...`, not `SELECTpolicy`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved wording and inline code styling in the public bucket destructive confirmation modal for clearer, more readable messaging; visual presentation updated without changing behavior or confirmation logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45910)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45910)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->