### PR TITLE
fix(studio): duplicated words in OrgNotFound/organizations message

### DIFF
--- a/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.tsx
@@ -28,7 +28,7 @@ export const OrgNotFound = ({ slug }: { slug?: string }) => {
               ) : (
                 <>This organization </>
               )}
-              does not exist or you do not have permission to access to it. Contact the the owner if
+              does not exist or you do not have permission to access it. Contact the owner if
               you believe this is a mistake.
             </>
           }

--- a/apps/studio/pages/organizations.tsx
+++ b/apps/studio/pages/organizations.tsx
@@ -73,7 +73,7 @@ const OrganizationsPage: NextPageWithLayout = () => {
               description={
                 <>
                   The organization <code className="text-code-inline">{orgSlug}</code> does not
-                  exist or you do not have permission to access to it. Contact the the owner if you
+                  exist or you do not have permission to access it. Contact the owner if you
                   believe this is a mistake.
                 </>
               }


### PR DESCRIPTION
Two one-line typo fixes for duplicated words in the same user-visible message in two files:
- `apps/studio/pages/organizations.tsx` — "permission to access to it. Contact the the owner" → "permission to access it. Contact the owner"
- `apps/studio/components/interfaces/Organization/OrgNotFound.tsx` — same fix

The message currently says "permission to access **to** it" (extra "to") and "Contact **the the** owner" (duplicated "the"). This PR removes both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed typos and improved clarity in "Organization not found" error messages displayed to users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45911)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->