### PR TITLE
Improve loading state for unified logs

### DIFF
--- a/apps/studio/components/interfaces/Organization/GeneralSettings/OrganizationDetailsForm.tsx
+++ b/apps/studio/components/interfaces/Organization/GeneralSettings/OrganizationDetailsForm.tsx
@@ -94,7 +94,7 @@ export const OrganizationDetailsForm = () => {
           </CardContent>
           <CardContent>
             <FormItemLayout label="Organization slug" layout="flex-row-reverse">
-              <Input copy disabled id="slug" value={selectedOrganization?.slug ?? ''} />
+              <Input copy readOnly id="slug" value={selectedOrganization?.slug ?? ''} />
             </FormItemLayout>
           </CardContent>
           <CardFooter className="flex justify-end p-4 md:px-8">

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -5,6 +5,7 @@ import { LoaderCircle } from 'lucide-react'
 import { useQueryState } from 'nuqs'
 import { Fragment, ReactNode, UIEvent, useCallback, useRef } from 'react'
 import { Button, cn } from 'ui'
+import { ShimmeringLoader } from 'ui-patterns'
 
 import { formatCompactNumber } from './DataTable.utils'
 import { useDataTable } from './providers/DataTableProvider'
@@ -71,7 +72,13 @@ export function DataTableInfinite<TData, TValue, TMeta>({
   })
 
   return (
-    <Table ref={tableRef} onScroll={onScroll}>
+    <Table
+      ref={tableRef}
+      onScroll={onScroll}
+      className={
+        isLoading ? '[mask-image:linear-gradient(to_bottom,black_70%,transparent_100%)]' : ''
+      }
+    >
       <TableHeader>
         <TableRow className="bg-surface-75">
           {headers.map((header) => {
@@ -105,6 +112,7 @@ export function DataTableInfinite<TData, TValue, TMeta>({
           })}
         </TableRow>
       </TableHeader>
+
       <TableBody
         id="content"
         tabIndex={-1}
@@ -124,25 +132,33 @@ export function DataTableInfinite<TData, TValue, TMeta>({
               />
             </Fragment>
           ))
+        ) : isLoading ? (
+          <Fragment>
+            {new Array(15).fill(0).map((_, x) => (
+              <TableRow
+                key={x}
+                className="h-[30px] hover:!bg-transparent [&>td]:group-hover:!bg-transparent"
+              >
+                {table.getAllLeafColumns().map((col, idx) => (
+                  <TableCell key={col.id}>
+                    <ShimmeringLoader className={cn('py-2', idx % 2 === 0 && 'opacity-50')} />
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+          </Fragment>
         ) : (
           <Fragment>
-            {renderLiveRow?.()}
             <TableRow>
               <TableCell colSpan={columns.length} className="h-[32vh] text-center">
                 <div className="flex flex-col items-center justify-center h-full gap-3">
-                  {isLoading ? (
-                    <>
-                      <LoaderCircle className="h-6 w-6 animate-spin text-foreground-muted" />
-                      <p className="text-foreground-light text-sm">Retrieving logs...</p>
-                    </>
-                  ) : (
-                    <p className="text-foreground-light text-sm">No results found</p>
-                  )}
+                  <p className="text-foreground-light text-sm">No results found</p>
                 </div>
               </TableCell>
             </TableRow>
           </Fragment>
         )}
+
         {/* Only show load more section if we have rows OR if we're not in initial loading state */}
         {(rows.length > 0 || (!isLoading && !rows.length)) && (
           <TableRow className="hover:bg-transparent data-[state=selected]:bg-transparent">


### PR DESCRIPTION
## Context

Improves loading state for unified logs

### Before
<img width="1451" height="957" alt="image" src="https://github.com/user-attachments/assets/97280982-1358-4234-bcf4-d3e6590040b9" />


### After
<img width="1451" height="956" alt="image" src="https://github.com/user-attachments/assets/b28eb3a8-e7eb-4fc9-bd0d-d0c8d40933ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Organization slug field now displays as read-only.
  * Data table loading states now show skeleton rows with shimmer effect instead of spinner.
  * Empty state displays simplified "No results found" message.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45913)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->