### PR TITLE
Fix width of unified logs table to fit viewport, which fixes centering of load more button

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -439,7 +439,16 @@ export const UnifiedLogs = () => {
                   isFetchingButNotPaginating && 'opacity-60 transition-opacity duration-150'
                 )}
               >
-                <div className="h-full [&>div]:h-full [&_thead_tr]:bg-[linear-gradient(to_bottom,hsl(var(--background-default)),hsl(var(--background-surface-75)))]! [&_thead_th]:[border-top:none]! [&_thead_th]:[border-bottom:none]! [&_thead_th]:[box-shadow:inset_0_-1px_0_hsl(var(--border-default))]! [&_thead_tr]:border-b-0! [&_tbody_tr]:border-b-0! [&_thead_tr:hover]:bg-[linear-gradient(to_bottom,hsl(var(--background-default)),hsl(var(--background-surface-75)))]! [&_thead_th]:text-foreground-lighter!">
+                <div
+                  className={cn(
+                    'h-full [&>div]:h-full',
+                    '[&_thead_tr]:bg-[linear-gradient(to_bottom,hsl(var(--background-default)),hsl(var(--background-surface-75)))]!',
+                    '[&_thead_th]:[border-top:none]! [&_thead_th]:[border-bottom:none]!',
+                    '[&_thead_th]:[box-shadow:inset_0_-1px_0_hsl(var(--border-default))]!',
+                    '[&_thead_tr]:border-b-0! [&_tbody_tr]:border-b-0! [&_thead_tr:hover]:bg-[linear-gradient(to_bottom,hsl(var(--background-default)),hsl(var(--background-surface-75)))]!',
+                    '[&_thead_th]:text-foreground-lighter!'
+                  )}
+                >
                   <DataTableInfinite
                     columns={UNIFIED_LOGS_COLUMNS}
                     totalRows={totalDBRowCount}

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -83,7 +83,8 @@ export function DataTableInfinite<TData, TValue, TMeta>({
             return (
               <TableHead
                 key={header.id}
-                className={headerClassName}
+                id={header.id}
+                className={cn('w-full', headerClassName)}
                 aria-sort={sort === 'asc' ? 'ascending' : sort === 'desc' ? 'descending' : 'none'}
               >
                 {header.isPlaceholder

--- a/apps/studio/components/ui/DataTable/Table.tsx
+++ b/apps/studio/components/ui/DataTable/Table.tsx
@@ -20,7 +20,7 @@ export const Table = forwardRef<HTMLTableElement, ComponentPropsWithRef<typeof S
       className={cn(className)}
       containerProps={{
         onScroll,
-        className: 'h-full w-full overflow-auto table-fixed min-w-max caption-bottom text-sm',
+        className: 'h-full w-full overflow-auto caption-bottom text-sm [&>table]:table-fixed',
       }}
     />
   )


### PR DESCRIPTION
## Context

Load more button in unified logs was off center because the `table` element was exceeded the viewport width.
The fix needed was hence to adjust the width of the `table` to only take up the remaining width of the viewport which then fixes the positioning of the load more button.


### Before
<img width="1446" height="204" alt="image" src="https://github.com/user-attachments/assets/fcd99e18-ede8-4454-b612-91b4384fb3e1" />


### After
<img width="1450" height="274" alt="image" src="https://github.com/user-attachments/assets/d5f56383-bdb0-4418-a36f-242e72fe3a5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated table container styling and layout properties for improved rendering.
  * Enhanced table header cell structure with improved styling attributes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45914)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->