### PR TITLE
Opt to use Code2 icon instead of BookHeart for unified logs postgrest rows

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/components/LogTypeIcon.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/LogTypeIcon.tsx
@@ -1,5 +1,5 @@
 import { Auth, EdgeFunctions, Storage } from 'icons'
-import { BookHeart, Box, Database } from 'lucide-react'
+import { Box, Code2, Database } from 'lucide-react'
 import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import { type LOG_TYPES } from '../UnifiedLogs.constants'
@@ -20,7 +20,7 @@ export const LogTypeIcon = ({
   // [Alaister]: commented out types coming in the future
   const iconMap: Record<(typeof LOG_TYPES)[number], () => React.ReactNode> = {
     // edge: () => <Globe size={size} strokeWidth={strokeWidth} className={className} />,
-    postgrest: () => <BookHeart size={size} strokeWidth={strokeWidth} className={className} />,
+    postgrest: () => <Code2 size={size} strokeWidth={strokeWidth} className={className} />,
     auth: () => <Auth size={size} strokeWidth={strokeWidth} className={className} />,
     'edge function': () => (
       <EdgeFunctions size={size} strokeWidth={strokeWidth} className={className} />


### PR DESCRIPTION
## Context

We use the `Code2` icon for the Data API integration, so opting to use the same icon for Postgrest in unified logs for consistency
<img width="538" height="176" alt="image" src="https://github.com/user-attachments/assets/cd98d781-be60-4d09-9dcb-6f064c58f446" />


### Before
<img width="422" height="87" alt="image" src="https://github.com/user-attachments/assets/4c7024ad-b5a7-48aa-8f27-46bb8cd94b57" />


### After
<img width="434" height="89" alt="image" src="https://github.com/user-attachments/assets/4bc18b10-53ee-4c57-89e3-52f45cc8fc07" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the icon representation for PostgreSQL REST API logs to enhance visual clarity and user recognition.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45916)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->