### PR TITLE
Use font mono for unified log rows

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
@@ -74,7 +74,7 @@ export function generateDynamicColumns(data: ColumnSchema[]): {
       minSize: 130,
       maxSize: 130,
       meta: {
-        cellClassName: 'font-mono w-[130px]',
+        cellClassName: 'font-mono tracking-tight w-[130px]',
         headerClassName: 'w-[130px]',
       },
     },
@@ -168,7 +168,7 @@ export function generateDynamicColumns(data: ColumnSchema[]): {
       minSize: 70,
       maxSize: 70,
       meta: {
-        cellClassName: 'w-[70px]',
+        cellClassName: 'font-mono tracking-tight w-[70px]',
         headerClassName: 'w-[70px]',
       },
     },
@@ -186,7 +186,7 @@ export function generateDynamicColumns(data: ColumnSchema[]): {
       minSize: 200,
       maxSize: 200,
       meta: {
-        cellClassName: 'max-w-[320px]',
+        cellClassName: 'font-mono tracking-tight max-w-[320px]',
         headerClassName: 'max-w-[320px]',
       },
     },
@@ -225,6 +225,9 @@ export function generateDynamicColumns(data: ColumnSchema[]): {
       size: 200,
       minSize: 200,
       maxSize: 400,
+      meta: {
+        cellClassName: 'font-mono tracking-tight',
+      },
     },
   ]
 


### PR DESCRIPTION
## Context

Opting to use `font-mono` and `tracking-tight` for all the data within the unified logs table to improve readability

### Before
<img width="1451" height="956" alt="image" src="https://github.com/user-attachments/assets/8c3f51b8-40bb-4e84-b1b3-af4d69e92224" />


### After
<img width="1450" height="959" alt="image" src="https://github.com/user-attachments/assets/5cb64864-fdf8-4c97-8caf-a440aa405b3d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual styling of the Unified Logs table columns for improved readability, including updated typography and letter spacing for the Date, Method, Pathname, and Event message columns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45917)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->