### PR TITLE
Support dock position

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/ServiceFlowPanelControls.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/ServiceFlowPanelControls.tsx
@@ -1,10 +1,30 @@
-import { ChevronDown, ChevronUp, X } from 'lucide-react'
+import { Check, ChevronDown, ChevronUp, PanelBottom, PanelRight, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo } from 'react'
-import { Button, KeyboardShortcut, Separator, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+  KeyboardShortcut,
+  Separator,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
 
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useDataTable } from '@/components/ui/DataTable/providers/DataTableProvider'
 
-export const ServiceFlowPanelControls = () => {
+interface ServiceFlowPanelControlsProps {
+  dock: 'bottom' | 'right'
+  setDock: (value: 'bottom' | 'right') => void
+}
+
+export const ServiceFlowPanelControls = ({
+  dock = 'bottom',
+  setDock,
+}: ServiceFlowPanelControlsProps) => {
   const { table, rowSelection, isLoading } = useDataTable()
 
   const selectedRowKey = Object.keys(rowSelection)?.[0]
@@ -87,6 +107,7 @@ export const ServiceFlowPanelControls = () => {
           <KeyboardShortcut keys={['ArrowUp']} />
         </TooltipContent>
       </Tooltip>
+
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -103,7 +124,36 @@ export const ServiceFlowPanelControls = () => {
           <KeyboardShortcut keys={['ArrowDown']} />
         </TooltipContent>
       </Tooltip>
+
       <Separator orientation="vertical" className="mx-1 h-4" />
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <ButtonTooltip
+            type="text"
+            className="px-1"
+            icon={dock === 'bottom' ? <PanelBottom /> : <PanelRight />}
+            tooltip={{ content: { side: 'top', text: 'Dock side' } }}
+          />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="w-40" align="end">
+          <DropdownMenuItem className="justify-between" onClick={() => setDock('bottom')}>
+            <div className="flex items-center gap-x-2">
+              <PanelBottom size={14} />
+              <span>Dock to bottom</span>
+            </div>
+            {dock === 'bottom' && <Check size={14} className="text-brand" />}
+          </DropdownMenuItem>
+          <DropdownMenuItem className="justify-between" onClick={() => setDock('right')}>
+            <div className="flex items-center gap-x-2">
+              <PanelRight size={14} />
+              <span>Dock to right</span>
+            </div>
+            {dock === 'right' && <Check size={14} className="text-brand" />}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
       <Tooltip>
         <TooltipTrigger asChild>
           <Button size="tiny" type="text" onClick={onClose} className="px-1" icon={<X />} />

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlowPanel.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlowPanel.tsx
@@ -35,12 +35,16 @@ import {
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
 interface ServiceFlowPanelProps {
+  dock: 'bottom' | 'right'
+  setDock: (value: 'bottom' | 'right') => void
   selectedRow?: ColumnSchema
   selectedRowKey: string
   searchParameters: QuerySearchParamsType
 }
 
 export function ServiceFlowPanel({
+  dock,
+  setDock,
   selectedRow,
   selectedRowKey,
   searchParameters,
@@ -82,9 +86,7 @@ export function ServiceFlowPanel({
       type: serviceFlowType,
       search: searchParameters,
     },
-    {
-      enabled: Boolean(projectRef) && Boolean(selectedRow?.id) && Boolean(serviceFlowType),
-    }
+    { enabled: Boolean(selectedRow?.id) && Boolean(serviceFlowType) }
   )
 
   if (!selectedRowKey || !selectedRow) return null
@@ -138,7 +140,8 @@ export function ServiceFlowPanel({
                   Raw JSON
                 </TabsTrigger>
               </TabsList>
-              <ServiceFlowPanelControls />
+
+              <ServiceFlowPanelControls dock={dock} setDock={setDock} />
             </div>
 
             {shouldShowServiceFlow && (

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -13,7 +13,7 @@ import {
   useReactTable,
   VisibilityState,
 } from '@tanstack/react-table'
-import { useDebounce, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useDebounce, useParams } from 'common'
 import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useQueryStates } from 'nuqs'
 import { useEffect, useMemo, useRef, useState } from 'react'
@@ -110,6 +110,11 @@ export const UnifiedLogs = () => {
   const [sorting, setSorting] = useState<SortingState>(defaultColumnSorting)
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>(defaultColumnFilters)
   const [rowSelection, setRowSelection] = useState<RowSelectionState>(defaultRowSelection)
+
+  const [dock, setDock] = useLocalStorageQuery<'bottom' | 'right'>(
+    LOCAL_STORAGE_KEYS.UNIFIED_LOGS_DOCK,
+    'bottom'
+  )
 
   const [columnVisibility, setColumnVisibility] = useLocalStorageQuery<VisibilityState>(
     'data-table-visibility',
@@ -430,7 +435,11 @@ export const UnifiedLogs = () => {
                 chartConfig={filteredChartConfig}
               />
             </div>
-            <ResizablePanelGroup key="main-logs" orientation="vertical" className="flex-1">
+            <ResizablePanelGroup
+              key="main-logs"
+              className="flex-1"
+              orientation={dock === 'bottom' ? 'vertical' : 'horizontal'}
+            >
               <ResizablePanel
                 defaultSize="100"
                 minSize="10"
@@ -453,13 +462,18 @@ export const UnifiedLogs = () => {
                   />
                 </div>
               </ResizablePanel>
-              <LogsListPanel selectedRow={selectedRow} />
-              {selectedRowKey && (
-                <ServiceFlowPanel
-                  selectedRow={selectedRow?.original}
-                  selectedRowKey={selectedRowKey}
-                  searchParameters={searchParameters}
-                />
+
+              {!!selectedRow && (
+                <>
+                  <LogsListPanel selectedRow={selectedRow} />
+                  <ServiceFlowPanel
+                    dock={dock}
+                    setDock={setDock}
+                    selectedRow={selectedRow?.original}
+                    selectedRowKey={selectedRowKey}
+                    searchParameters={searchParameters}
+                  />
+                </>
               )}
             </ResizablePanelGroup>
           </ResizablePanel>

--- a/apps/studio/components/interfaces/UnifiedLogs/components/LogsListPanel.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/LogsListPanel.tsx
@@ -9,43 +9,41 @@ import { LogsList } from './LogsList'
 export const LogsListPanel = ({ selectedRow }: { selectedRow?: Row<ColumnSchema> }) => {
   const [open, setOpenState] = useState(true)
 
+  const logs = selectedRow?.original?.logs
+  if (!Array.isArray(logs) || logs.length === 0) return null
+
   return (
-    selectedRow?.original?.logs &&
-    selectedRow.original.logs.length > 0 && (
-      <>
-        <ResizableHandle withHandle disabled={!open} />
-        <ResizablePanel
-          defaultSize="1"
-          maxSize="50"
-          minSize={open ? '16' : '12'}
-          className={cn(!open ? 'h-12! max-h-12' : 'h-min-16 h-max-32')}
-        >
-          <div className="h-full flex flex-col overflow-hidden">
-            <div className="min-h-12 flex justify-between items-center px-5">
-              <div className="flex flex-row items-center gap-2">
-                <h3 className="text-sm font-medium">Event logs</h3>
-                <span className="text-muted-foreground text-xs bg-muted rounded-md px-1.5 py-0.5">
-                  {selectedRow?.original?.logs && Array.isArray(selectedRow?.original?.logs)
-                    ? selectedRow?.original?.logs?.length
-                    : 0}
-                </span>
-              </div>
-              <Button
-                type="default"
-                onClick={() => setOpenState(!open)}
-                icon={<ChevronDown className={cn('w-4 h-4', !open ? 'rotate-180' : 'rotate-0')} />}
-              >
-                {open ? 'Close' : 'Open'}
-              </Button>
+    <>
+      <ResizableHandle withHandle disabled={!open} />
+      <ResizablePanel
+        defaultSize="1"
+        maxSize="50"
+        minSize={open ? '16' : '12'}
+        className={cn(!open ? 'h-12! max-h-12' : 'h-min-16 h-max-32')}
+      >
+        <div className="h-full flex flex-col overflow-hidden">
+          <div className="min-h-12 flex justify-between items-center px-5">
+            <div className="flex flex-row items-center gap-2">
+              <h3 className="text-sm font-medium">Event logs</h3>
+              <span className="text-muted-foreground text-xs bg-muted rounded-md px-1.5 py-0.5">
+                {logs.length}
+              </span>
             </div>
-            {open && (
-              <div className="grow overflow-auto border-t">
-                <LogsList logs={selectedRow?.original?.logs} />
-              </div>
-            )}
+            <Button
+              type="default"
+              onClick={() => setOpenState(!open)}
+              icon={<ChevronDown className={cn('w-4 h-4', !open ? 'rotate-180' : 'rotate-0')} />}
+            >
+              {open ? 'Close' : 'Open'}
+            </Button>
           </div>
-        </ResizablePanel>
-      </>
-    )
+          {open && (
+            <div className="grow overflow-auto border-t">
+              <LogsList logs={logs} />
+            </div>
+          )}
+        </div>
+      </ResizablePanel>
+    </>
   )
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -14,6 +14,7 @@ export const LOCAL_STORAGE_KEYS = {
   INCIDENT_BANNER_DISMISSED_IDS: 'incident-banner-dismissed-ids',
   MAINTENANCE_BANNER_DISMISSED: (id: string) => `maintenance-banner-dismissed-${id}`,
   DASHBOARD_PREFERENCES: (ref: string) => `dashboard-preferences-${ref}`,
+  UNIFIED_LOGS_DOCK: 'unified-logs-dock',
 
   UI_TIMEZONE: 'supabase-ui-timezone',
   UI_PREVIEW_CLS: 'supabase-ui-cls',


### PR DESCRIPTION
## Context

Added an option to change dock position when a row is selected in unified logs

Just note that this involves the `LogsListPanel` - i'm not too sure how this will look like tbh as I don't have any logs in my unified logs UI that match the criteria to render the `LogsListPanel` (e.g there could be a scenario where we have 3 panes side by side)

<img width="1452" height="955" alt="image" src="https://github.com/user-attachments/assets/21c1a576-7f63-463f-88bf-04c05691995b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now toggle the service flow panel dock position between bottom and right alignment
  * Dock preference is automatically saved and persists across sessions

* **Bug Fixes**
  * Improved logs data validation in the logs list panel for more reliable rendering

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45919)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->