### PR TITLE
fix(www): fix contributors section overflow on mobile in careers page

### DIFF
--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -331,7 +331,7 @@ const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) =>
                   mission.
                 </p>
               </div>
-              <div className="w-[1080px] h-[370px] mx-auto sm:mt-10 md:mt-16 lg:mt-28 2xl:mt-60">
+              <div className="w-[1080px] h-[370px] mx-auto sm:mt-10 md:mt-16 lg:mt-28 2xl:mt-60 max-w-full overflow-hidden">
                 {contributors.map((contributor, i) => {
                   return (
                     <div

--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -157,7 +157,7 @@ const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) =>
         </SectionContainer>
 
         <div className="py-[1.25px] bg-linear-to-r from-background via-border to-background">
-          <div className="bg-alternative text-clip">
+          <div className="bg-alternative text-clip overflow-hidden">
             <SectionContainer className="md:pt-16! md:grid md:max-h-[500px] grid-cols-1 md:grid-cols-5 md:gap-8">
               <div
                 className="
@@ -331,7 +331,7 @@ const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) =>
                   mission.
                 </p>
               </div>
-              <div className="w-[1080px] h-[370px] mx-auto sm:mt-10 md:mt-16 lg:mt-28 2xl:mt-60 max-w-full overflow-hidden">
+              <div className="w-[1080px] h-[370px] mx-auto sm:mt-10 md:mt-16 lg:mt-28 2xl:mt-60">
                 {contributors.map((contributor, i) => {
                   return (
                     <div


### PR DESCRIPTION
## Problem
The contributors section on /careers has a fixed `w-[1080px]` container with no max-width constraint. On mobile viewports this causes horizontal overflow and breaks the page layout.

## Fix
Added `max-w-full overflow-hidden` to the contributors wrapper  so it caps at 1080px on large screens and fits within the viewport on smaller ones.

## File changed
`apps/www/pages/careers.tsx`

## Screenshots

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/71c2ac3b-e4b8-49cf-801b-90ecb8b41811" width="300" /> | <img src="https://github.com/user-attachments/assets/594465f4-2ca7-4858-89ef-dee71eb37415" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Fixed overflow in the contributors section to prevent content spilling and ensure background clipping.
* Improved layout stability so contributor avatars and content render consistently across screen sizes.
* Resolved visual glitch that could cause unintended scroll or layout shifts within the contributors area.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45923)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->