### PR TITLE
test(studio): cover unified logs BigQuery fallback

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -6,6 +6,12 @@ import {
   getLogsCountQuery,
   getUnifiedLogsQuery,
 } from './UnifiedLogs.queries'
+import {
+  getFacetCountCTE as getFacetCountCTEBq,
+  getLogsChartQuery as getLogsChartQueryBq,
+  getLogsCountQuery as getLogsCountQueryBq,
+  getUnifiedLogsQuery as getUnifiedLogsQueryBq,
+} from './UnifiedLogs.queries.bq'
 
 const baseSearch = {
   date: [new Date('2026-05-08T09:00:00Z'), new Date('2026-05-08T10:00:00Z')],
@@ -131,6 +137,61 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(sql).not.toContain(`log_attributes['request.method'] IN ('GET')`)
       expect(sql).toContain(`log_attributes['response.status_code'] IN ('200')`)
       expect(sql).toContain('GROUP BY value')
+      expect(sql).toContain('LIMIT 20')
+    })
+  })
+})
+
+describe('UnifiedLogs.queries.bq (BigQuery fallback)', () => {
+  describe('getUnifiedLogsQuery', () => {
+    it('defaults to postgres + postgrest log types when none specified', () => {
+      const sql = getUnifiedLogsQueryBq(baseSearch)
+      expect(sql).toContain(`'postgres' as log_type`)
+      expect(sql).toContain(`edge_logs_request.path LIKE '%/rest/%'`)
+      expect(sql).not.toContain(`'storage' as log_type`)
+    })
+
+    it('escapes single quotes in filter values to prevent SQL injection', () => {
+      const sql = getUnifiedLogsQueryBq({
+        ...baseSearch,
+        method: [`G'ET`],
+        pathname: `/customers'; DROP TABLE logs --`,
+      } as any)
+
+      expect(sql).toContain(`method IN ('G''ET')`)
+      expect(sql).toContain(`pathname LIKE '%/customers''; DROP TABLE logs --%'`)
+    })
+  })
+
+  describe('getLogsCountQuery', () => {
+    it('keeps the total count branch aligned with an active log_type filter', () => {
+      const sql = getLogsCountQueryBq({ ...baseSearch, log_type: ['edge'] } as any)
+      const logTypeCountsCte = sql.match(/log_type_counts AS \(\s+SELECT[\s\S]*?FROM unified_logs\s+(.*?)\s+\),/i)
+
+      expect(logTypeCountsCte?.[1]).toContain(`WHERE log_type IN ('edge')`)
+    })
+  })
+
+  describe('getLogsChartQuery', () => {
+    it('uses BigQuery timestamp truncation with hour bucketing for long ranges', () => {
+      const sql = getLogsChartQueryBq({
+        ...baseSearch,
+        date: [new Date('2026-05-08T00:00:00Z'), new Date('2026-05-08T18:00:00Z')],
+      } as any)
+      expect(sql).toContain('TIMESTAMP_TRUNC(timestamp, HOUR)')
+    })
+  })
+
+  describe('getFacetCountCTE', () => {
+    it('excludes the requested facet from the WHERE filters and keeps the other ones', () => {
+      const sql = getFacetCountCTEBq({
+        search: { ...baseSearch, method: ['GET'], status: ['200'] } as any,
+        facet: 'method',
+      })
+
+      expect(sql).not.toContain(`method IN ('GET')`)
+      expect(sql).toContain(`status IN ('200')`)
+      expect(sql).toContain(`GROUP BY method`)
       expect(sql).toContain('LIMIT 20')
     })
   })


### PR DESCRIPTION
﻿## Problem

The Unified Logs fallback BigQuery query builder still exists for projects that are not using the OTEL path, but the test coverage in Studio only exercises the OTEL/flat query path. That leaves the legacy fallback vulnerable to silent regressions in escaping, bucketing, or facet/count behavior.

## Root cause

`UnifiedLogs.queries.test.ts` covered the OTEL query builder only, while `UnifiedLogs.queries.bq.ts` had no focused regression coverage.

## Fix

- extend `UnifiedLogs.queries.test.ts` with a dedicated BigQuery fallback suite
- cover default log-type selection, single-quote escaping, chart bucketing, facet exclusion, and count behavior with an active `log_type` filter
- keep the PR tests-only and avoid production code changes

## Solution sketch

```mermaid
flowchart TD
    A[Unified Logs search params] --> B{useOtel?}
    B -- yes --> C[OTEL query path]
    B -- no --> D[BigQuery fallback path]
    D --> E[assert escaping]
    D --> F[assert bucketing]
    D --> G[assert facet and count semantics]
```

## Duplicate check

- reviewed adjacent open work like `#44917`; it targets self-hosted/Logflare BigQuery behavior, not this Studio fallback query coverage
- did not find an open PR specifically adding tests for `UnifiedLogs.queries.bq.ts`

## Tests

Attempted:

- `pnpm --prefix apps/studio vitest --run apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts`
- `corepack pnpm exec vitest --run components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts`
- `npx vitest --run components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts`

Environment note:

- the local workspace is missing the dependencies needed to execute the Studio Vitest config here (`pnpm`/workspace deps like `@vitejs/plugin-react`, `vite-tsconfig-paths`, `vitest/config`)

## Risk

Low. This is a tests-only PR scoped to one existing test file and meant to protect the legacy BigQuery fallback from regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for BigQuery fallback functionality in unified logs, including default log type selection, SQL escaping, filtering, hour bucketing, and facet semantics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45924)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->