### PR TITLE
docs: scope studio-ui-patterns skill description to apps/studio

### DIFF
--- a/.claude/skills/studio-ui-patterns/SKILL.md
+++ b/.claude/skills/studio-ui-patterns/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: studio-ui-patterns
-description: Design system UI patterns for Supabase Studio. Use when building or updating
-  pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels
-  (sheets). Covers layout selection, component choice, and placement conventions.
+description: Design system UI patterns for the Supabase Studio dashboard codebase
+  (apps/studio). Use when building or updating UI inside apps/studio — including pages,
+  forms, tables, charts, empty states, navigation, cards, alerts, or side panels (sheets)
+  — that should follow the Studio design system. Do not use for external Supabase consumer
+  apps, marketing site work, or unrelated frontend projects.
 ---
 
 # Studio UI Patterns


### PR DESCRIPTION
Fixes #45347

## What changed

Tightened the `description` field in `.claude/skills/studio-ui-patterns/SKILL.md` to explicitly scope the skill to the `apps/studio` codebase and add a negative clause for when it should not trigger.

**Before:**
```yaml
description: Design system UI patterns for Supabase Studio. Use when building or updating
  pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels
  (sheets). Covers layout selection, component choice, and placement conventions.
```

**After:**
```yaml
description: Design system UI patterns for the Supabase Studio dashboard codebase
  (apps/studio). Use when building or updating UI inside apps/studio — including pages,
  forms, tables, charts, empty states, navigation, cards, alerts, or side panels (sheets)
  — that should follow the Studio design system. Do not use for external Supabase consumer
  apps, marketing site work, or unrelated frontend projects.
```

## Why

The previous description listed generic UI nouns without scoping them to a specific codebase path. This caused false-positive skill triggers in unrelated frontend projects, pushing Studio-specific conventions (`FormItemLayout`, `PageContainer`, Shadcn imports, etc.) onto code that should not follow them. The skill body was already correctly scoped to `apps/design-system/...` paths, but by the time that context is read, the skill has already loaded — too late to prevent the wrong trigger.

Key changes:
- Adds the concrete path signal (`apps/studio`) as an unambiguous anchor
- Names the actual constraint ("should follow the Studio design system")
- Adds an explicit negative clause covering the most likely false-positive cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified scope and usage guidelines for UI pattern documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45927)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->