### PR TITLE
fix(self-hosted): use curl -f in analytics healthcheck

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -480,9 +480,8 @@ services:
     healthcheck:
       test:
         [
-          "CMD",
-          "curl",
-          "http://localhost:4000/health"
+          "CMD-SHELL",
+          "curl -sSfL -o /dev/null http://localhost:4000/health"
         ]
       timeout: 5s
       interval: 5s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -570,9 +570,6 @@ services:
     container_name: supabase-vector
     image: timberio/vector:0.53.0-alpine
     restart: unless-stopped
-    depends_on:
-      analytics:
-        condition: service_healthy
     volumes:
       - ./volumes/logs/vector.yml:/etc/vector/vector.yml:ro,z
       - ${DOCKER_SOCKET_LOCATION}:/var/run/docker.sock:ro,z

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -570,6 +570,9 @@ services:
     container_name: supabase-vector
     image: timberio/vector:0.53.0-alpine
     restart: unless-stopped
+    depends_on:
+      analytics:
+        condition: service_healthy
     volumes:
       - ./volumes/logs/vector.yml:/etc/vector/vector.yml:ro,z
       - ${DOCKER_SOCKET_LOCATION}:/var/run/docker.sock:ro,z


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Use `-f` for `curl` in the healthchecks for analytics/logflare
- Switch to `CMD-SHELL`
- Not adding dependency on analytics for vector (adding it won't help much, will delay vector from starting, but will not prevent losing early logs; the analytics team will see if they could address it differently later on)
- Also added to PR #45327

Closes #45738

---

Update 2026-05-17: See also PR #46038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved healthcheck reliability and error detection for the analytics service.
  * Adjusted startup ordering so the vector service waits for analytics to be healthy before starting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45929)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45929)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->