### PR TITLE
Joshen/debug 76 fix sticky hover state on log rows

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlowPanel.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlowPanel.tsx
@@ -113,7 +113,7 @@ export function ServiceFlowPanel({
       <ResizablePanel
         id="log-sidepanel"
         defaultSize={400}
-        minSize={300}
+        minSize={dock === 'bottom' ? 300 : 400}
         className="bg-dash-sidebar"
       >
         <div className="flex h-full flex-col overflow-hidden">

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
@@ -81,13 +81,13 @@ export function getLevelRowClassName(value: (typeof LEVELS)[number]): string {
       return ''
     case 'warning':
       return cn(
-        'bg-warning/5 [&>td]:group-hover:bg-warning/10',
+        'bg-warning/5 hover:bg-warning/10',
         'data-[state=selected]:bg-warning/20 focus-visible:bg-warning/10',
         'dark:bg-warning/10 dark:hover:bg-warning/20 dark:data-[state=selected]:bg-warning/30 dark:focus-visible:bg-warning/20'
       )
     case 'error':
       return cn(
-        'bg-destructive/5 [&>td]:group-hover:bg-destructive/10',
+        'bg-destructive/5 hover:bg-destructive/10',
         'data-[state=selected]:bg-destructive/20 focus-visible:bg-destructive/10',
         'dark:bg-error/10 dark:hover:bg-destructive/20 dark:data-[state=selected]:bg-destructive/30 dark:focus-visible:bg-destructive/20'
       )

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -3,7 +3,7 @@ import type { ColumnDef, Row, Table as TTable, VisibilityState } from '@tanstack
 import { flexRender } from '@tanstack/react-table'
 import { LoaderCircle } from 'lucide-react'
 import { useQueryState } from 'nuqs'
-import { Fragment, ReactNode, UIEvent, useCallback, useRef } from 'react'
+import { Fragment, UIEvent, useCallback, useRef } from 'react'
 import { Button, cn } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns'
 
@@ -24,7 +24,6 @@ export interface DataTableInfiniteProps<TData, TValue, _TMeta> {
   isLoading?: boolean
   hasNextPage?: boolean
   fetchNextPage: (options?: FetchNextPageOptions | undefined) => Promise<unknown>
-  renderLiveRow?: (props?: { row: Row<TData> }) => ReactNode
   setColumnOrder: (columnOrder: string[]) => void
   setColumnVisibility: (columnVisibility: VisibilityState) => void
 
@@ -41,7 +40,6 @@ export function DataTableInfinite<TData, TValue, TMeta>({
   totalRows = 0,
   filterRows = 0,
   totalRowsFetched = 0,
-  renderLiveRow,
   setColumnOrder,
   setColumnVisibility,
   searchParamsParser,
@@ -123,15 +121,13 @@ export function DataTableInfinite<TData, TValue, TMeta>({
         {rows.length ? (
           rows.map((row) => (
             // REMINDER: if we want to add arrow navigation https://github.com/TanStack/table/discussions/2752#discussioncomment-192558
-            <Fragment key={row.id}>
-              {renderLiveRow?.({ row: row as any })}
-              <DataTableRow
-                row={row}
-                table={table}
-                searchParamsParser={searchParamsParser}
-                selected={row.getIsSelected()}
-              />
-            </Fragment>
+            <DataTableRow
+              key={row.id}
+              row={row}
+              table={table}
+              searchParamsParser={searchParamsParser}
+              selected={row.getIsSelected()}
+            />
           ))
         ) : isLoading ? (
           <Fragment>

--- a/packages/ui/src/components/shadcn/ui/table.tsx
+++ b/packages/ui/src/components/shadcn/ui/table.tsx
@@ -148,10 +148,7 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn(
-      'transition-colors p-4 align-middle group-hover:bg-surface-200 [&:has([role=checkbox])]:pr-0',
-      className
-    )}
+    className={cn('transition-colors p-4 align-middle [&:has([role=checkbox])]:pr-0', className)}
     {...props}
   />
 ))


### PR DESCRIPTION
## Context

The original problem was that some log rows remain in the hover state after the cursor moves away

I was just cleaning up some of the styles and noticed that it doesn't seem to happen anymore so thinking this might have fixed it haha 😅 

## Changes involved
- Remove `group-hover` background color change behaviour in `TableCell` in `ui`
  - `TableRow` should handle the background color instead, hence the changes in `UnifiedLogs.utils` too
- Remove unnecessary `renderLiveRows` in `DataTableInfinite` -> the prop isn't being passed anywhere

## To test
- [ ] The sticky hover state happens when you hover over the rows very quickly, so just make sure there's no "stale" hover state in any row eg:
<img width="400" alt="image" src="https://github.com/user-attachments/assets/b4a91bc6-d269-4ee6-b222-b0476b9feffa" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized hover styling for log rows and table cells to use direct hover rules for more consistent visual feedback.
  * Adjusted table cell hover/transition behavior to simplify styling while preserving layout and checkbox spacing.
  * Streamlined the data table API by removing the custom live-row rendering override.
  * Made the resizable panel’s minimum size dynamic based on dock position.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45933)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->