### PR TITLE
feat(unified-logs): show feature preview for flag or team/enterprise plan

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewContext.tsx
@@ -14,7 +14,6 @@ import {
 import { useFeaturePreviews } from './useFeaturePreviews'
 import { useIsEnterpriseOrSupabaseOrg } from './useIsEnterpriseOrSupabaseOrg'
 import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
-import { IS_STAGING_OR_LOCAL } from '@/lib/constants'
 import { EMPTY_OBJ } from '@/lib/void'
 
 type FeaturePreviewContextType = {
@@ -94,8 +93,8 @@ export const useUnifiedLogsPreview = () => {
     useIsEnterpriseOrSupabaseOrg()
 
   const isLoading = !flagsHaveLoaded || isOrgLoading
-  const isEligible = unifiedLogsEnabled && (IS_STAGING_OR_LOCAL || isEnterpriseOrSupabaseOrg)
-  const isEnabled = unifiedLogsEnabled && flags[LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS]
+  const isEligible = unifiedLogsEnabled || isEnterpriseOrSupabaseOrg
+  const isEnabled = isEligible && flags[LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS]
 
   const enable = () => onUpdateFlag(LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS, true)
   const disable = () => onUpdateFlag(LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS, false)

--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -1,7 +1,6 @@
 import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
 
 import { useIsEnterpriseOrSupabaseOrg } from './useIsEnterpriseOrSupabaseOrg'
-import { IS_STAGING_OR_LOCAL } from '@/lib/constants'
 
 export type FeaturePreview = {
   key: string
@@ -38,7 +37,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
       key: LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS,
       name: 'New Logs interface',
       discussionsUrl: 'https://github.com/orgs/supabase/discussions/37234',
-      enabled: isUnifiedLogsPreviewAvailable && (IS_STAGING_OR_LOCAL || isEnterpriseOrSupabaseOrg),
+      enabled: isUnifiedLogsPreviewAvailable || isEnterpriseOrSupabaseOrg,
       isNew: false,
       isPlatformOnly: true,
       isDefaultOptIn: false,

--- a/apps/studio/components/interfaces/App/FeaturePreview/useIsEnterpriseOrSupabaseOrg.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useIsEnterpriseOrSupabaseOrg.ts
@@ -13,8 +13,7 @@ export const useIsEnterpriseOrSupabaseOrg = () => {
   })
 
   const isLoading = isProjectLoading || isOrgLoading || (org !== undefined && isSubscriptionLoading)
-  const isEligible =
-    subscription?.plan?.id === 'team' || subscription?.plan?.id === 'enterprise' || org?.id === 1
+  const isEligible = subscription?.plan?.id === 'enterprise' || org?.id === 1
 
   return { isLoading, isEligible }
 }

--- a/apps/studio/components/interfaces/App/FeaturePreview/useIsEnterpriseOrSupabaseOrg.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useIsEnterpriseOrSupabaseOrg.ts
@@ -13,7 +13,8 @@ export const useIsEnterpriseOrSupabaseOrg = () => {
   })
 
   const isLoading = isProjectLoading || isOrgLoading || (org !== undefined && isSubscriptionLoading)
-  const isEligible = subscription?.plan?.id === 'enterprise' || org?.id === 1
+  const isEligible =
+    subscription?.plan?.id === 'team' || subscription?.plan?.id === 'enterprise' || org?.id === 1
 
   return { isLoading, isEligible }
 }


### PR DESCRIPTION
## Problem

The unified logs feature preview was only shown to users with the \`unifiedLogs\` LaunchDarkly flag enabled AND who were either on an enterprise plan or on staging/local. Team plan users were excluded, and the staging escape hatch added noise.

## Fix

Updated the eligibility check to use an OR condition: show the feature preview if the \`unifiedLogs\` flag is on OR the org is on a team or enterprise plan. Also added \`team\` to the \`useIsEnterpriseOrSupabaseOrg\` hook and removed the \`IS_STAGING_OR_LOCAL\` bypass.

## How to test

- Log in as a user on a team plan and verify the "New Logs interface" option appears in the Feature Previews modal
- Log in as a user on an enterprise plan and verify the same
- Log in as a user on a free or pro plan without the \`unifiedLogs\` flag enabled and verify the option does not appear
- Enable the \`unifiedLogs\` LaunchDarkly flag for a free/pro user and verify the option appears

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified logs preview is now more accessible for enterprise and Supabase organizations without requiring additional staging conditions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45937)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->