### PR TITLE
feat(self-hosted): do not require openssl or node for new auth

### DIFF
--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -19,22 +19,33 @@
 
 set -e
 
-# Resolve how to run node: local install preferred, docker fallback.
+# Resolve how to run node: local install (>= 16) preferred, docker fallback.
+node_runner=""
 if command -v node >/dev/null 2>&1; then
-    node_runner="node"
-elif command -v docker >/dev/null 2>&1; then
-    if ! docker info >/dev/null 2>&1; then
-        echo "Error: docker is installed but the daemon is not running."
+    node_version=$(node --version 2>/dev/null)
+    node_major=$(printf '%s' "$node_version" | sed -n 's/^v\([0-9][0-9]*\).*/\1/p')
+    if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
+        node_runner="node"
+    elif [ -n "$node_major" ]; then
+        echo "Local node $node_version is too old (need >= 16), falling back to docker."
+    fi
+fi
+
+if [ -z "$node_runner" ]; then
+    if command -v docker >/dev/null 2>&1; then
+        if ! docker info >/dev/null 2>&1; then
+            echo "Error: docker is installed but the daemon is not running."
+            exit 1
+        fi
+        if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
+            echo "Pulling node:22-alpine (first-run only)..."
+            docker pull node:22-alpine
+        fi
+        node_runner="docker run --rm node:22-alpine node"
+    else
+        echo "Error: requires either node (>= 16) or docker."
         exit 1
     fi
-    if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
-        echo "Pulling node:22-alpine (first-run only)..."
-        docker pull node:22-alpine
-    fi
-    node_runner="docker run --rm node:22-alpine node"
-else
-    echo "Error: requires either node (>= 16) or docker."
-    exit 1
 fi
 
 # Read JWT_SECRET from .env

--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -19,33 +19,32 @@
 
 set -e
 
-# Resolve how to run node: local install (>= 16) preferred, docker fallback.
-node_runner=""
-if command -v node >/dev/null 2>&1; then
-    node_version=$(node --version 2>/dev/null)
-    node_major=$(printf '%s' "$node_version" | sed -n 's/^v\([0-9][0-9]*\).*/\1/p')
-    if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
-        node_runner="node"
-    elif [ -n "$node_major" ]; then
-        echo "Local node $node_version is too old (need >= 16), falling back to docker."
-    fi
-fi
+node_ok() {
+    command -v node >/dev/null 2>&1 || return 1
+    major=$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)
+    [ -n "$major" ] && [ "$major" -ge 16 ] 2>/dev/null
+}
 
-if [ -z "$node_runner" ]; then
-    if command -v docker >/dev/null 2>&1; then
-        if ! docker info >/dev/null 2>&1; then
-            echo "Error: docker is installed but the daemon is not running."
-            exit 1
-        fi
-        if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
-            echo "Pulling node:22-alpine (first-run only)..."
-            docker pull node:22-alpine
-        fi
-        node_runner="docker run --rm node:22-alpine node"
-    else
+# Resolve how to run node: local install (>= 16) preferred, docker fallback.
+if node_ok; then
+    node_runner="node"
+else
+    if command -v node >/dev/null 2>&1; then
+        echo "Local node $(node -v) is too old (need >= 16), falling back to docker."
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
         echo "Error: requires either node (>= 16) or docker."
         exit 1
     fi
+    if ! docker info >/dev/null 2>&1; then
+        echo "Error: docker is installed but the daemon is not running."
+        exit 1
+    fi
+    if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
+        echo "Pulling node:22-alpine (first-run only)..."
+        docker pull node:22-alpine
+    fi
+    node_runner="docker run --rm node:22-alpine node"
 fi
 
 # Read JWT_SECRET from .env

--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -14,19 +14,26 @@
 #
 # Prerequisites:
 #   - .env file with JWT_SECRET set (run generate-keys.sh first)
-#   - openssl
-#   - node >= 16
+#   - node (>= 16) or docker
 #
 
 set -e
 
-if ! command -v openssl >/dev/null 2>&1; then
-    echo "Error: openssl is required but not found."
-    exit 1
-fi
-
-if ! command -v node >/dev/null 2>&1; then
-    echo "Error: node (>= 16) is required but not found."
+# Resolve how to run node: local install preferred, docker fallback.
+if command -v node >/dev/null 2>&1; then
+    node_runner="node"
+elif command -v docker >/dev/null 2>&1; then
+    if ! docker info >/dev/null 2>&1; then
+        echo "Error: docker is installed but the daemon is not running."
+        exit 1
+    fi
+    if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
+        echo "Pulling node:22-alpine (first-run only)..."
+        docker pull node:22-alpine
+    fi
+    node_runner="docker run --rm node:22-alpine node"
+else
+    echo "Error: requires either node (>= 16) or docker."
     exit 1
 fi
 
@@ -36,7 +43,7 @@ if [ ! -f .env ]; then
     exit 1
 fi
 
-jwt_secret=$(grep '^JWT_SECRET=' .env | cut -d= -f2-)
+jwt_secret=$(grep '^JWT_SECRET=' .env | cut -d= -f2- | tr -d '\r')
 if [ -z "$jwt_secret" ]; then
     echo "Error: JWT_SECRET not found in .env. Run generate-keys.sh first."
     exit 1
@@ -45,23 +52,18 @@ fi
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-# Generate EC P-256 private key
-openssl ecparam -name prime256v1 -genkey -noout -out "$tmpdir/ec_private.pem" 2>/dev/null
-
 # Node.js does the crypto-heavy work:
-#   - PEM -> JWK conversion
+#   - EC P-256 keypair generation
 #   - JWKS construction (with symmetric key included)
 #   - ES256 JWT signing
 #   - Opaque API key generation with checksum
-node -e '
+$node_runner -e '
 const crypto = require("crypto");
-const fs = require("fs");
 
-const pem = fs.readFileSync(process.argv[1]);
-const jwtSecret = process.argv[2];
+const jwtSecret = process.argv[1];
 
-// EC key -> JWK
-const privateKey = crypto.createPrivateKey(pem);
+// Generate EC P-256 keypair and export as JWK
+const { privateKey } = crypto.generateKeyPairSync("ec", { namedCurve: "P-256" });
 const jwkPrivate = privateKey.export({ format: "jwk" });
 
 const kid = crypto.randomUUID();
@@ -129,7 +131,7 @@ console.log("ANON_KEY_ASYMMETRIC=" + anonJwt);
 console.log("SERVICE_ROLE_KEY_ASYMMETRIC=" + serviceJwt);
 console.log("JWT_KEYS=" + JSON.stringify(jwksKeypair.keys));
 console.log("JWT_JWKS=" + JSON.stringify(jwksPublic));
-' "$tmpdir/ec_private.pem" "$jwt_secret" > "$tmpdir/output"
+' "$jwt_secret" > "$tmpdir/output"
 
 # Read generated values
 SUPABASE_PUBLISHABLE_KEY=$(grep '^SUPABASE_PUBLISHABLE_KEY=' "$tmpdir/output" | cut -d= -f2-)

--- a/docker/utils/add-new-auth-keys.sh
+++ b/docker/utils/add-new-auth-keys.sh
@@ -32,18 +32,22 @@ else
     if command -v node >/dev/null 2>&1; then
         echo "Local node $(node -v) is too old (need >= 16), falling back to docker."
     fi
+
     if ! command -v docker >/dev/null 2>&1; then
         echo "Error: requires either node (>= 16) or docker."
         exit 1
     fi
+
     if ! docker info >/dev/null 2>&1; then
         echo "Error: docker is installed but the daemon is not running."
         exit 1
     fi
+
     if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
         echo "Pulling node:22-alpine (first-run only)..."
         docker pull node:22-alpine
     fi
+
     node_runner="docker run --rm node:22-alpine node"
 fi
 

--- a/docker/utils/rotate-new-api-keys.sh
+++ b/docker/utils/rotate-new-api-keys.sh
@@ -17,33 +17,32 @@
 
 set -e
 
-# Resolve how to run node: local install (>= 16) preferred, docker fallback.
-node_runner=""
-if command -v node >/dev/null 2>&1; then
-    node_version=$(node --version 2>/dev/null)
-    node_major=$(printf '%s' "$node_version" | sed -n 's/^v\([0-9][0-9]*\).*/\1/p')
-    if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
-        node_runner="node"
-    elif [ -n "$node_major" ]; then
-        echo "Local node $node_version is too old (need >= 16), falling back to docker."
-    fi
-fi
+node_ok() {
+    command -v node >/dev/null 2>&1 || return 1
+    major=$(node -v 2>/dev/null | sed 's/^v//' | cut -d. -f1)
+    [ -n "$major" ] && [ "$major" -ge 16 ] 2>/dev/null
+}
 
-if [ -z "$node_runner" ]; then
-    if command -v docker >/dev/null 2>&1; then
-        if ! docker info >/dev/null 2>&1; then
-            echo "Error: docker is installed but the daemon is not running."
-            exit 1
-        fi
-        if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
-            echo "Pulling node:22-alpine (first-run only)..."
-            docker pull node:22-alpine
-        fi
-        node_runner="docker run --rm node:22-alpine node"
-    else
+# Resolve how to run node: local install (>= 16) preferred, docker fallback.
+if node_ok; then
+    node_runner="node"
+else
+    if command -v node >/dev/null 2>&1; then
+        echo "Local node $(node -v) is too old (need >= 16), falling back to docker."
+    fi
+    if ! command -v docker >/dev/null 2>&1; then
         echo "Error: requires either node (>= 16) or docker."
         exit 1
     fi
+    if ! docker info >/dev/null 2>&1; then
+        echo "Error: docker is installed but the daemon is not running."
+        exit 1
+    fi
+    if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
+        echo "Pulling node:22-alpine (first-run only)..."
+        docker pull node:22-alpine
+    fi
+    node_runner="docker run --rm node:22-alpine node"
 fi
 
 if [ ! -f .env ]; then

--- a/docker/utils/rotate-new-api-keys.sh
+++ b/docker/utils/rotate-new-api-keys.sh
@@ -12,13 +12,26 @@
 #
 # Prerequisites:
 #   - .env file (run generate-keys.sh and add-new-auth-keys.sh first)
-#   - node >= 16
+#   - node (>= 16) or docker
 #
 
 set -e
 
-if ! command -v node >/dev/null 2>&1; then
-    echo "Error: node (>= 16) is required but not found."
+# Resolve how to run node: local install preferred, docker fallback.
+if command -v node >/dev/null 2>&1; then
+    node_runner="node"
+elif command -v docker >/dev/null 2>&1; then
+    if ! docker info >/dev/null 2>&1; then
+        echo "Error: docker is installed but the daemon is not running."
+        exit 1
+    fi
+    if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
+        echo "Pulling node:22-alpine (first-run only)..."
+        docker pull node:22-alpine
+    fi
+    node_runner="docker run --rm node:22-alpine node"
+else
+    echo "Error: requires either node (>= 16) or docker."
     exit 1
 fi
 
@@ -30,7 +43,7 @@ fi
 tmpdir=$(mktemp -d)
 trap 'rm -rf "$tmpdir"' EXIT
 
-node -e '
+$node_runner -e '
 const crypto = require("crypto");
 
 const PROJECT_REF = "supabase-self-hosted";

--- a/docker/utils/rotate-new-api-keys.sh
+++ b/docker/utils/rotate-new-api-keys.sh
@@ -30,18 +30,22 @@ else
     if command -v node >/dev/null 2>&1; then
         echo "Local node $(node -v) is too old (need >= 16), falling back to docker."
     fi
+
     if ! command -v docker >/dev/null 2>&1; then
         echo "Error: requires either node (>= 16) or docker."
         exit 1
     fi
+
     if ! docker info >/dev/null 2>&1; then
         echo "Error: docker is installed but the daemon is not running."
         exit 1
     fi
+
     if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
         echo "Pulling node:22-alpine (first-run only)..."
         docker pull node:22-alpine
     fi
+
     node_runner="docker run --rm node:22-alpine node"
 fi
 

--- a/docker/utils/rotate-new-api-keys.sh
+++ b/docker/utils/rotate-new-api-keys.sh
@@ -17,22 +17,33 @@
 
 set -e
 
-# Resolve how to run node: local install preferred, docker fallback.
+# Resolve how to run node: local install (>= 16) preferred, docker fallback.
+node_runner=""
 if command -v node >/dev/null 2>&1; then
-    node_runner="node"
-elif command -v docker >/dev/null 2>&1; then
-    if ! docker info >/dev/null 2>&1; then
-        echo "Error: docker is installed but the daemon is not running."
+    node_version=$(node --version 2>/dev/null)
+    node_major=$(printf '%s' "$node_version" | sed -n 's/^v\([0-9][0-9]*\).*/\1/p')
+    if [ -n "$node_major" ] && [ "$node_major" -ge 16 ]; then
+        node_runner="node"
+    elif [ -n "$node_major" ]; then
+        echo "Local node $node_version is too old (need >= 16), falling back to docker."
+    fi
+fi
+
+if [ -z "$node_runner" ]; then
+    if command -v docker >/dev/null 2>&1; then
+        if ! docker info >/dev/null 2>&1; then
+            echo "Error: docker is installed but the daemon is not running."
+            exit 1
+        fi
+        if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
+            echo "Pulling node:22-alpine (first-run only)..."
+            docker pull node:22-alpine
+        fi
+        node_runner="docker run --rm node:22-alpine node"
+    else
+        echo "Error: requires either node (>= 16) or docker."
         exit 1
     fi
-    if ! docker image inspect node:22-alpine >/dev/null 2>&1; then
-        echo "Pulling node:22-alpine (first-run only)..."
-        docker pull node:22-alpine
-    fi
-    node_runner="docker run --rm node:22-alpine node"
-else
-    echo "Error: requires either node (>= 16) or docker."
-    exit 1
 fi
 
 if [ ! -f .env ]; then


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Drop node and openssl pre-requisites for self-hosted new auth / new api key utility scripts:

- **Drop `openssl` requirement.** Moved EC P-256 keypair generation into the Node script via `crypto.generateKeyPairSync("ec", { namedCurve: "P-256" })`
- **Make `node` optional.** Both scripts now auto-detect: local `node` if available, else fall back to `docker run --rm node:22-alpine node`
- **First-run UX:** on the Docker path, scripts print `Pulling node:22-alpine (first-run only)...` and pre-pull the image
- **CRLF safety:** `add-new-auth-keys.sh` now strips `\r` when reading `JWT_SECRET` from `.env` for better compat with Windows-environments
- **No behavior change** to the generated keys as compared to the previous scripts' versions

Closes #45802

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JWT secret handling on Windows to prevent line-ending issues.

* **Chores**
  * Updated auth and API key rotation scripts to support local Node (>=16) or Docker fallback for more reliable key generation.
  * Switched key generation to a unified Node-based flow for consistent JWT and API key outputs across environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45941)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->