### PR TITLE
Added PGConf Vancouver back into the go pages

### DIFF
--- a/apps/www/_go/index.tsx
+++ b/apps/www/_go/index.tsx
@@ -6,6 +6,8 @@ import aiEngineerEuropeContestThankYou from './events/ai-engineer-europe-2026/co
 import datadogContest from './events/dash-2026/contest'
 import datadogDinner from './events/dash-2026/exec-dinner'
 import datadogContestThankYou from './events/dash-2026/exec-dinner-thank-you'
+import pgconfDev2026Contest from './events/pgconf-dev-2026/contest'
+import pgconfDev2026ContestThankYou from './events/pgconf-dev-2026/contest-thank-you'
 import postgresconfContest from './events/postgresconf-sjc-2026/contest'
 import postgresconfContestThankYou from './events/postgresconf-sjc-2026/contest-thank-you'
 import startupGrindContest from './events/startup-grind-2026/contest'
@@ -37,6 +39,8 @@ const pages: GoPageInput[] = [
   accentureContest, // remove after May 31, 2026
   postgresconfContest, // remove after May 31, 2026
   postgresconfContestThankYou, // remove after May 31, 2026
+  pgconfDev2026Contest, // remove after May 31, 2026
+  pgconfDev2026ContestThankYou, // remove after May 31, 2026
   datadogContest, // remove after June 30, 2026
   datadogContestThankYou, // remove after June 30, 2026
   datadogDinner, // remove after June 30, 2026


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Accidentally deleted a couple of go pages. Adding them back.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced contest registration and confirmation pages for PGConf Dev 2026, designed as time-limited features with automatic removal scheduled for May 31, 2026.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45943)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->