### PR TITLE
feat(logs): gate CH/otel toggle in log explorer behind feature flag

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -38,7 +38,8 @@ import { DatePickerValue, LogsDatePicker } from './Logs.DatePickers'
 import { LogsWarning, LogTemplate } from './Logs.types'
 import Table from '@/components/to-be-cleaned/Table'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import { DOCS_URL, IS_STAGING_OR_LOCAL } from '@/lib/constants'
+import { usePHFlag } from '@/hooks/ui/useFlag'
+import { DOCS_URL } from '@/lib/constants'
 
 export interface LogsQueryPanelProps {
   templates?: LogTemplate[]
@@ -72,9 +73,8 @@ const LogsQueryPanel = ({
 }: LogsQueryPanelProps) => {
   const [showReference, setShowReference] = useState(false)
   const { logsTemplates } = useIsFeatureEnabled(['logs:templates'])
-  // Staff-only debugging affordance: only show on staging/local, never to
-  // enterprise customers running against production.
-  const otelToggleEnabled = IS_STAGING_OR_LOCAL && !!onUseOtelChange
+  const showChToggleInLogExplorer = usePHFlag('showChToggleInLogExplorer')
+  const otelToggleEnabled = !!showChToggleInLogExplorer && !!onUseOtelChange
 
   const {
     projectAuthAll: authEnabled,

--- a/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -1,4 +1,4 @@
-import { IS_PLATFORM } from 'common'
+import { IS_PLATFORM, useFlag } from 'common'
 import { BookOpen, Check, ChevronDown, ChevronsUpDown, Copy, ExternalLink, X } from 'lucide-react'
 import Link from 'next/link'
 import { ReactNode, useEffect, useState } from 'react'
@@ -38,7 +38,6 @@ import { DatePickerValue, LogsDatePicker } from './Logs.DatePickers'
 import { LogsWarning, LogTemplate } from './Logs.types'
 import Table from '@/components/to-be-cleaned/Table'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import { usePHFlag } from '@/hooks/ui/useFlag'
 import { DOCS_URL } from '@/lib/constants'
 
 export interface LogsQueryPanelProps {
@@ -73,7 +72,7 @@ const LogsQueryPanel = ({
 }: LogsQueryPanelProps) => {
   const [showReference, setShowReference] = useState(false)
   const { logsTemplates } = useIsFeatureEnabled(['logs:templates'])
-  const showChToggleInLogExplorer = usePHFlag('showChToggleInLogExplorer')
+  const showChToggleInLogExplorer = useFlag('showChToggleInLogExplorer')
   const otelToggleEnabled = !!showChToggleInLogExplorer && !!onUseOtelChange
 
   const {


### PR DESCRIPTION
## Problem

The CH/otel queries toggle in log explorer was only shown on staging and local environments, controlled by the hardcoded `IS_STAGING_OR_LOCAL` check. This made it impossible to enable for specific users or teams in production via a feature flag.

## Fix

Replaced the `IS_STAGING_OR_LOCAL` check with `useFlag('showChToggleInLogExplorer')` from `common`, so the toggle visibility is controlled by the PostHog feature flag instead of the environment.

## How to test

1. Open log explorer on a project.
2. Without the `showChToggleInLogExplorer` flag enabled, confirm the CH/otel toggle is not visible.
3. Enable the `showChToggleInLogExplorer` flag in PostHog for your user.
4. Reload log explorer and confirm the CH/otel toggle appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal feature gating mechanism for the OTEL toggle in Logs settings from environment-based to flag-based configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45944)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->