### PR TITLE
fix(unified-logs): wrap facet LIMIT subqueries in parens for UNION ALL compatibility

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -187,9 +187,7 @@ const whereClause = (predicates: SafeLogSqlFragment[]): SafeLogSqlFragment =>
 /**
  * Calculates the chart bucketing level (minute/hour/day) given the date range.
  */
-const calculateChartBucketing = (
-  search: SearchParamsType | Record<string, unknown>
-): 'MINUTE' | 'HOUR' | 'DAY' => {
+const calculateChartBucketing = (search: SearchParamsType | Record<string, unknown>): 'MINUTE' | 'HOUR' | 'DAY' => {
   const dateRange = (search.date as Array<Date | string | number | null | undefined>) || []
 
   const convertToMillis = (timestamp: Date | string | number | null | undefined) => {
@@ -317,11 +315,11 @@ export const getFacetCountQuery = ({
   }
 
   return safeSql`
-SELECT ${lit(facet)} AS dimension, (${facetExpr}) AS value, count() AS count
+(SELECT ${lit(facet)} AS dimension, (${facetExpr}) AS value, count() AS count
 FROM logs
 ${whereClause(predicates)}
 GROUP BY value
-LIMIT ${lit(MAX_FACETS_QUANTITY)}
+LIMIT ${lit(MAX_FACETS_QUANTITY)})
 `
 }
 


### PR DESCRIPTION
## Summary

- `getFacetCountQuery` returns a fragment with a `LIMIT` clause that gets composed into a `UNION ALL` chain in `getLogsCountQuery`
- ClickHouse treats a bare `LIMIT` as an end-of-statement marker, so the next `UNION ALL` token triggers a parse error: *"Expected: end of statement, found: UNION"*
- Fix: wrap each facet `SELECT` in parentheses so the `LIMIT` is scoped to that branch — this is valid across all ClickHouse versions

## Test plan

- [ ] Verify the unified logs count query (facets panel) loads without parse errors in prod
- [ ] Verify facet counts for `method`, `status`, and `pathname` are still correctly limited to 20 entries each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Code structure improvements for better maintainability with no impact to user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45945)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->