### PR TITLE
chore(self-hosted): update prerequisites and example in docs

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -38,7 +38,7 @@ You need the following installed on your system:
   - **macOS**: Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/)
   - **Windows**: Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/)
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-- OpenSSL and Node.js 16+ (when switching to the [new API keys](/docs/guides/self-hosting/self-hosted-auth-keys) and new auth)
+- OpenSSL
 
 
 ## System requirements
@@ -63,7 +63,9 @@ size="small"
 type="underlined"
 defaultActiveId="general"
 
-> <TabPanel id="general" label="General">
+>
+
+<TabPanel id="general" label="General">
 
 ```sh
 # Get the code
@@ -91,13 +93,16 @@ docker compose pull
 ```
 
 </TabPanel>
+
 <TabPanel id="advanced" label="Advanced">
 
 ```sh
 # Get the code using git sparse checkout
-git clone --filter=blob:none --no-checkout https://github.com/supabase/supabase
+git clone --filter=blob:none --no-checkout --depth=1 --quiet https://github.com/supabase/supabase
 cd supabase
-git sparse-checkout set --cone docker && git checkout master
+git sparse-checkout init --cone
+git sparse-checkout set docker
+git checkout --quiet
 cd ..
 
 # Make your new supabase project directory
@@ -122,6 +127,7 @@ docker compose pull
 ```
 
 </TabPanel>
+
 </Tabs>
 
 <Admonition type="tip">

--- a/apps/docs/content/guides/self-hosting/self-hosted-auth-keys.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-auth-keys.mdx
@@ -10,7 +10,6 @@ You can configure self-hosted Supabase to use the [new API keys](/docs/guides/ge
 
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
 
-- Ensure OpenSSL and Node.js 16+ are available on the machine where you will generate new keys
 - Complete the [Docker setup guide](/docs/guides/self-hosting/docker), including running `generate-keys.sh` so that `JWT_SECRET`, `ANON_KEY`, and `SERVICE_ROLE_KEY` are set in your `.env` file
 - If you are upgrading an existing self-hosted Supabase environment, make sure to check the [changelog](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md) and add/update the following files:
   - `.env.example` (merge new sections into your `.env` file)
@@ -36,13 +35,18 @@ The script reads `JWT_SECRET` from `.env` and includes it as a symmetric key ins
 
 </Admonition>
 
-After updating `.env`, enable new authentication by uncommenting these lines in `docker-compose.yml`:
+The following configuration should be uncommented in the `.env` file for the new authentication to work correctly:
 
 ```yaml name=docker-compose.yml
 auth:
   environment:
     # JSON array of signing JWKs (EC private + legacy symmetric)
     GOTRUE_JWT_KEYS: ${JWT_KEYS:-[]}
+
+rest:
+  environment:
+    # PostgREST accepts a plain-text symmetric secret, a single JWK, or a JWKS.
+    PGRST_JWT_SECRET: ${JWT_JWKS:-${JWT_SECRET}}
 
 realtime:
   environment:
@@ -54,8 +58,6 @@ storage:
     # JWKS for token verification (EC public + legacy symmetric)
     JWT_JWKS: ${JWT_JWKS:-{"keys":[]}}
 ```
-
-PostgREST does not need uncommenting - it already uses `PGRST_JWT_SECRET: ${JWT_JWKS:-${JWT_SECRET}}` which automatically picks up `JWT_JWKS` when set.
 
 <Admonition type="caution">
 
@@ -84,14 +86,14 @@ Test with the new publishable key:
 
 ```sh
 curl http://<your-domain>/rest/v1/ \
--H "apikey: your-supabase-publishable-key"
+-H "apikey: your-supabase-secret-key"
 ```
 
 You should receive a valid response from PostgREST. Then verify that the legacy key still works:
 
 ```sh
 curl http://<your-domain>/rest/v1/ \
--H "apikey: your-anon-key"
+-H "apikey: your-service-role-key"
 ```
 
 Both should work and return the same result.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Remove the pre-requisite to have Node.js (not needed after PR #45941)
- Update "advanced" checkout instructions to work universally across different Linux distros
- Minor edits re: new auth configuration
- Update an example using `/rest/v1` with anon key


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Updated self-hosting Docker guide with simplified prerequisites and revised setup commands
* Updated self-hosted authentication keys guide with clarified Docker environment configuration and verification steps

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45948)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->