### PR TITLE
fix: SQL Editor private queries empty state CSS bug

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/PrivateSqlSnippetEmpty.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/PrivateSqlSnippetEmpty.tsx
@@ -8,8 +8,8 @@ export const EmptyPrivateQueriesPanel = () => (
     description="Queries will be automatically saved once you start writing in the editor"
     className="mx-4"
   >
-    <div className="top-0 left-6 flex flex-col opacity-50 cursor-not-allowed bg-dash-sidebar h-content -mb-7 pointer-events-none scale-75">
-      <div className="relative h-content">
+    <div className="top-0 left-6 flex flex-col opacity-50 cursor-not-allowed bg-dash-sidebar -mb-7 pointer-events-none scale-75">
+      <div className="relative">
         <div className="absolute inset-0 pointer-events-none z-10">
           <div className="absolute inset-0 bg-linear-to-t from-transparent from-80% to-100% to-background-surface-100 dark:to-background-surface-75" />
           <div className="absolute inset-0 bg-linear-to-r from-transparent from-50% to-100% to-background-surface-100 dark:to-background-surface-75" />


### PR DESCRIPTION
## Screenshots

Before:
<img width="258" height="312" alt="image" src="https://github.com/user-attachments/assets/998609fa-bf39-4ff9-a9c5-9b7018d6a5a3" />

After:
<img width="258" height="381" alt="image" src="https://github.com/user-attachments/assets/23d7d8f7-e3ab-4737-8c3f-25f5995c1880" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the layout and spacing of the empty private queries sidebar placeholder in the SQL editor.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45963)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->