### PR TITLE
chore(telemetry): clean up frontend event catalog

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -25,10 +25,9 @@ import { formatForeignKeys } from '@/components/interfaces/TableGridEditor/SideP
 import { useForeignKeyConstraintsQuery } from '@/data/database/foreign-key-constraints-query'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
 import { isTableLike } from '@/data/table-editor/table-editor-types'
-import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
-import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useCsvFileDrop } from '@/hooks/ui/useCsvFileDrop'
+import { useTrack } from '@/lib/telemetry/track'
 import { useTableEditorStateSnapshot } from '@/state/table-editor'
 import { useTableEditorTableStateSnapshot } from '@/state/table-editor-table'
 import { ResponseError } from '@/types'
@@ -69,7 +68,6 @@ export const Grid = memo(
       const snap = useTableEditorTableStateSnapshot()
       const { filters, clearFilters } = useTableFilter()
 
-      const { data: org } = useSelectedOrganizationQuery()
       const { data: project } = useSelectedProjectQuery()
 
       const onRowsChange = useOnRowsChange(rows)
@@ -92,20 +90,12 @@ export const Grid = memo(
       const isForeignTable = tableEntityType === ENTITY_TYPE.FOREIGN_TABLE
       const isTableEmpty = (rows ?? []).length === 0
 
-      const { mutate: sendEvent } = useSendEventMutation()
+      const track = useTrack()
 
       const { isDraggedOver, onDragOver, onFileDrop } = useCsvFileDrop({
         enabled: isTableEmpty && !isForeignTable,
         onFileDropped: (file) => tableEditorSnap.onImportData(valtioRef(file)),
-        onTelemetryEvent: (eventName) => {
-          sendEvent({
-            action: eventName,
-            groups: {
-              project: project?.ref ?? 'Unknown',
-              organization: org?.slug ?? 'Unknown',
-            },
-          })
-        },
+        onTelemetryEvent: (eventName) => track(eventName),
       })
 
       const { data } = useForeignKeyConstraintsQuery({
@@ -339,14 +329,7 @@ export const Grid = memo(
                             className="pointer-events-auto"
                             onClick={() => {
                               tableEditorSnap.onImportData()
-                              sendEvent({
-                                action: 'import_data_button_clicked',
-                                properties: { tableType: 'Existing Table' },
-                                groups: {
-                                  project: project?.ref ?? 'Unknown',
-                                  organization: org?.slug ?? 'Unknown',
-                                },
-                              })
+                              track('import_data_button_clicked', { tableType: 'Existing Table' })
                             }}
                           >
                             Import data from CSV

--- a/apps/studio/components/interfaces/Integrations/CronJobs/DeleteCronJob.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/DeleteCronJob.tsx
@@ -3,17 +3,16 @@ import { useEffect } from 'react'
 import { toast } from 'sonner'
 import { ConfirmationModal } from 'ui-patterns/Dialogs/ConfirmationModal'
 
+import { parseCronJobCommand } from './CronJobs.utils'
 import { useCronJobsData } from './CronJobsTab.useCronJobsData'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useDatabaseCronJobDeleteMutation } from '@/data/database-cron-jobs/database-cron-jobs-delete-mutation'
-import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
-import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { cleanPointerEventsNoneOnBody } from '@/lib/helpers'
+import { useTrack } from '@/lib/telemetry/track'
 
 export const DeleteCronJob = () => {
   const { data: project } = useSelectedProjectQuery()
-  const { data: org } = useSelectedOrganizationQuery()
 
   const [searchQuery] = useQueryState('search', parseAsString.withDefault(''))
   const [cronJobIdForDeletion, setCronJobForDeletion] = useQueryState('delete', parseAsString)
@@ -25,17 +24,17 @@ export const DeleteCronJob = () => {
   })
   const cronJob = grid.rows.find((j) => j.jobid.toString() === cronJobIdForDeletion)
 
-  const { mutate: sendEvent } = useSendEventMutation()
+  const track = useTrack()
   const {
     mutate: deleteDatabaseCronJob,
     isPending,
     isSuccess: isSuccessDelete,
   } = useDatabaseCronJobDeleteMutation({
     onSuccess: () => {
-      sendEvent({
-        action: 'cron_job_removed',
-        groups: { project: project?.ref ?? 'Unknown', organization: org?.slug ?? 'Unknown' },
-      })
+      if (cronJob && project) {
+        const { type } = parseCronJobCommand(cronJob.command, project.ref)
+        track('cron_job_removed', { type })
+      }
       toast.success(`Successfully removed cron job`)
       setCronJobForDeletion(null)
     },

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
@@ -210,7 +210,7 @@ export function LogDrains({
             onConfirm={() => {
               if (selectedLogDrain && ref) {
                 deleteLogDrain({ token: selectedLogDrain.token, projectRef: ref })
-                track('log_drain_deleted', {
+                track('log_drain_removed', {
                   destination: selectedLogDrain.type,
                 })
               }

--- a/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
@@ -210,7 +210,7 @@ export function LogDrains({
             onConfirm={() => {
               if (selectedLogDrain && ref) {
                 deleteLogDrain({ token: selectedLogDrain.token, projectRef: ref })
-                track('log_drain_confirm_button_submitted', {
+                track('log_drain_deleted', {
                   destination: selectedLogDrain.type,
                 })
               }

--- a/apps/studio/components/interfaces/Organization/Documents/DPA.tsx
+++ b/apps/studio/components/interfaces/Organization/Documents/DPA.tsx
@@ -10,9 +10,9 @@ import {
 import { InlineLink } from '@/components/ui/InlineLink'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useDpaRequestMutation } from '@/data/documents/dpa-request-mutation'
-import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useProfile } from '@/lib/profile'
+import { useTrack } from '@/lib/telemetry/track'
 
 export const DPA = () => {
   const { profile } = useProfile()
@@ -21,7 +21,7 @@ export const DPA = () => {
 
   const [isOpen, setIsOpen] = useState(false)
 
-  const { mutate: sendEvent } = useSendEventMutation()
+  const track = useTrack()
   const { mutate: requestDpa, isPending: isRequesting } = useDpaRequestMutation({
     onSuccess: () => {
       toast.success('DPA request sent successfully')
@@ -49,12 +49,7 @@ export const DPA = () => {
               You can review a static PDF version of our latest DPA document{' '}
               <InlineLink
                 href="https://supabase.com/downloads/docs/Supabase+DPA+260317.pdf"
-                onClick={() =>
-                  sendEvent({
-                    action: 'dpa_pdf_opened',
-                    properties: { source: 'studio' },
-                  })
-                }
+                onClick={() => track('dpa_pdf_opened', { source: 'studio' })}
               >
                 here
               </InlineLink>
@@ -67,9 +62,7 @@ export const DPA = () => {
             <Button
               onClick={() => {
                 setIsOpen(true)
-                sendEvent({
-                  action: 'dpa_request_button_clicked',
-                })
+                track('dpa_request_button_clicked')
               }}
               type="default"
             >

--- a/apps/studio/components/interfaces/QueryPerformance/IndexAdvisor/EnableIndexAdvisorButton.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/IndexAdvisor/EnableIndexAdvisorButton.tsx
@@ -28,7 +28,7 @@ export const EnableIndexAdvisorButton = () => {
         type="primary"
         onClick={() => {
           setIsDialogOpen(true)
-          track('index_advisor_banner_enable_button_clicked')
+          track('index_advisor_enable_button_clicked', { origin: 'banner' })
         }}
       >
         Enable
@@ -112,7 +112,7 @@ export const EnableIndexAdvisorDialog = ({
             onClick={(e) => {
               e.preventDefault()
               onEnableIndexAdvisor()
-              track('index_advisor_dialog_enable_button_clicked')
+              track('index_advisor_enable_button_clicked', { origin: 'dialog' })
             }}
             disabled={isEnablingExtension}
           >

--- a/apps/studio/components/layouts/Navigation/LayoutHeader/HeaderUpgradeButton.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/HeaderUpgradeButton.tsx
@@ -4,7 +4,8 @@ import { useTrackExperimentExposure } from '@/hooks/misc/useTrackExperimentExpos
 import { usePHFlag } from '@/hooks/ui/useFlag'
 import { useTrack } from '@/lib/telemetry/track'
 
-const EXPERIMENT_ID = 'headerUpgradeCta'
+const EXPERIMENT_FLAG_KEY = 'headerUpgradeCta'
+const EXPERIMENT_EXPOSURE_NAME = 'header_upgrade_cta'
 type HeaderUpgradeCtaVariant = 'control' | 'test'
 
 interface HeaderUpgradeButtonProps {
@@ -14,15 +15,14 @@ interface HeaderUpgradeButtonProps {
 export const HeaderUpgradeButton = ({ className }: HeaderUpgradeButtonProps) => {
   const track = useTrack()
   const { data: organization } = useSelectedOrganizationQuery()
-  const flagValue = usePHFlag<HeaderUpgradeCtaVariant | false>(EXPERIMENT_ID)
+  const flagValue = usePHFlag<HeaderUpgradeCtaVariant | false>(EXPERIMENT_FLAG_KEY)
 
   const isFreePlan = organization?.plan?.id === 'free'
   const isInExperiment = flagValue === 'control' || flagValue === 'test'
   const showButton = flagValue === 'test'
 
-  // Track experiment exposure for all free-plan users in the experiment (both control and test)
   const variant = isFreePlan && isInExperiment ? (flagValue as string) : undefined
-  useTrackExperimentExposure(EXPERIMENT_ID, variant)
+  useTrackExperimentExposure(EXPERIMENT_EXPOSURE_NAME, variant)
 
   if (!isFreePlan) return null
   if (!showButton) return null
@@ -31,5 +31,7 @@ export const HeaderUpgradeButton = ({ className }: HeaderUpgradeButtonProps) => 
     track('header_upgrade_cta_clicked')
   }
 
-  return <UpgradePlanButton source={EXPERIMENT_ID} className={className} onClick={handleClick} />
+  return (
+    <UpgradePlanButton source={EXPERIMENT_FLAG_KEY} className={className} onClick={handleClick} />
+  )
 }

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
@@ -13,8 +13,10 @@ import { tableKeys } from '@/data/tables/keys'
 import { tryParseJson } from '@/lib/helpers'
 import { ResponseError } from '@/types'
 
+export type MutationCategory = 'functions' | 'rls-policies'
+
 // [Joshen] This is just very basic identification, but possible can extend perhaps
-export const identifyQueryType = (query: string) => {
+export const identifyQueryType = (query: string): MutationCategory | undefined => {
   const formattedQuery = query.toLowerCase().replaceAll('\n', ' ')
   if (
     formattedQuery.includes('create function') ||
@@ -24,6 +26,7 @@ export const identifyQueryType = (query: string) => {
   } else if (formattedQuery.includes('create policy') || formattedQuery.includes('alter policy')) {
     return 'rls-policies'
   }
+  return undefined
 }
 
 // Check for function calls that aren't in the safe list

--- a/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
@@ -14,11 +14,10 @@ import { entityTypeKeys } from '@/data/entity-types/keys'
 import { lintKeys } from '@/data/lint/keys'
 import { usePrimaryDatabase } from '@/data/read-replicas/replicas-query'
 import { useExecuteSqlMutation } from '@/data/sql/execute-sql-mutation'
-import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useChangedSync } from '@/hooks/misc/useChanged'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useProfile } from '@/lib/profile'
+import { useTrack } from '@/lib/telemetry/track'
 
 interface DisplayBlockRendererProps {
   messageId: string
@@ -77,9 +76,8 @@ export const DisplayBlockRenderer = ({
   const router = useRouter()
   const { ref } = useParams()
   const { profile } = useProfile()
-  const { data: org } = useSelectedOrganizationQuery()
 
-  const { mutate: sendEvent } = useSendEventMutation()
+  const track = useTrack()
   const { can: canCreateSQLSnippet } = useAsyncCheckPermissions(
     PermissionAction.CREATE,
     'user_content',
@@ -141,16 +139,11 @@ export const DisplayBlockRenderer = ({
 
     onQueryRun?.(queryType)
 
-    sendEvent({
-      action: 'assistant_suggestion_run_query_clicked',
-      properties: {
-        queryType,
-        ...(queryType === 'mutation' ? { category: identifyQueryType(sqlQuery) ?? 'unknown' } : {}),
-      },
-      groups: {
-        project: ref ?? 'Unknown',
-        organization: org?.slug ?? 'Unknown',
-      },
+    track('assistant_suggestion_run_query_clicked', {
+      queryType,
+      ...(queryType === 'mutation'
+        ? { mutationType: identifyQueryType(sqlQuery) ?? 'unknown' }
+        : {}),
     })
   }
 

--- a/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
@@ -102,31 +102,49 @@ describe('useTrackDefaultPrivilegesExposure', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
     renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true }))
     expect(track).toHaveBeenCalledTimes(1)
-    expect(track).toHaveBeenCalledWith('project_creation_default_privileges_exposed', {
-      surface: 'main',
-      dataApiEnabled: true,
-      dataApiRevokeOnCreateDefaultEnabled: true,
-    })
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      {
+        surface: 'main',
+        dataApiEnabled: true,
+        dataApiRevokeOnCreateDefaultEnabled: true,
+      },
+      undefined
+    )
   })
 
   it('fires once when the flag resolves to false on the main surface', () => {
     vi.mocked(usePHFlag).mockReturnValue(false)
     renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: false }))
     expect(track).toHaveBeenCalledTimes(1)
-    expect(track).toHaveBeenCalledWith('project_creation_default_privileges_exposed', {
-      surface: 'main',
-      dataApiEnabled: false,
-      dataApiRevokeOnCreateDefaultEnabled: false,
-    })
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      {
+        surface: 'main',
+        dataApiEnabled: false,
+        dataApiRevokeOnCreateDefaultEnabled: false,
+      },
+      undefined
+    )
   })
 
   it('omits dataApiEnabled on the vercel surface', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
-    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'vercel' }))
-    expect(track).toHaveBeenCalledWith('project_creation_default_privileges_exposed', {
-      surface: 'vercel',
-      dataApiRevokeOnCreateDefaultEnabled: true,
-    })
+    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'vercel', orgSlug: 'acme-org' }))
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      {
+        surface: 'vercel',
+        dataApiRevokeOnCreateDefaultEnabled: true,
+      },
+      { organization: 'acme-org' }
+    )
+  })
+
+  it('skips emission on vercel surface when orgSlug is missing', () => {
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'vercel', orgSlug: undefined }))
+    expect(track).not.toHaveBeenCalled()
   })
 
   it('deduplicates across re-renders', () => {
@@ -149,7 +167,8 @@ describe('useTrackDefaultPrivilegesExposure', () => {
     expect(track).toHaveBeenCalledTimes(1)
     expect(track).toHaveBeenCalledWith(
       'project_creation_default_privileges_exposed',
-      expect.objectContaining({ dataApiRevokeOnCreateDefaultEnabled: false })
+      expect.objectContaining({ dataApiRevokeOnCreateDefaultEnabled: false }),
+      undefined
     )
   })
 })

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -26,7 +26,7 @@ export const useDataApiRevokeOnCreateDefaultEnabled = (): boolean => {
 
 type DefaultPrivilegesExposureOptions =
   | { surface: 'main'; dataApiEnabled: boolean }
-  | { surface: 'vercel' }
+  | { surface: 'vercel'; orgSlug: string | undefined }
 
 /**
  * Fires `project_creation_default_privileges_exposed` once per mount after both
@@ -47,6 +47,7 @@ export const useTrackDefaultPrivilegesExposure = (options: DefaultPrivilegesExpo
 
   const { surface } = options
   const dataApiEnabled = options.surface === 'main' ? options.dataApiEnabled : null
+  const orgSlug = options.surface === 'vercel' ? options.orgSlug : undefined
 
   // Mark ready once org_count appears on the SDK person. A /flags/ response
   // received after our identify will have included org_count in the evaluation,
@@ -67,11 +68,16 @@ export const useTrackDefaultPrivilegesExposure = (options: DefaultPrivilegesExpo
     if (hasTracked.current) return
     if (flag === undefined) return
     if (!orgCountReady) return
+    if (surface === 'vercel' && !orgSlug) return
     hasTracked.current = true
-    track('project_creation_default_privileges_exposed', {
-      surface,
-      ...(dataApiEnabled !== null && { dataApiEnabled }),
-      dataApiRevokeOnCreateDefaultEnabled: flag,
-    })
-  }, [flag, orgCountReady, track, surface, dataApiEnabled])
+    track(
+      'project_creation_default_privileges_exposed',
+      {
+        surface,
+        ...(dataApiEnabled !== null && { dataApiEnabled }),
+        dataApiRevokeOnCreateDefaultEnabled: flag,
+      },
+      surface === 'vercel' ? { organization: orgSlug } : undefined
+    )
+  }, [flag, orgCountReady, track, surface, dataApiEnabled, orgSlug])
 }

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -1,4 +1,4 @@
-import { type ImportDataFileDroppedEvent } from 'common/telemetry-constants'
+import { type ImportDataFileAddedEvent } from 'common/telemetry-constants'
 import { useCallback, useState, type DragEvent } from 'react'
 
 import { flagInvalidFileImport } from '@/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
@@ -6,7 +6,7 @@ import { flagInvalidFileImport } from '@/components/interfaces/TableGridEditor/S
 interface UseCsvFileDropOptions {
   enabled: boolean
   onFileDropped: (file: File) => void
-  onTelemetryEvent?: (eventName: ImportDataFileDroppedEvent['action']) => void
+  onTelemetryEvent?: (eventName: ImportDataFileAddedEvent['action']) => void
 }
 
 interface UseCsvFileDropReturn {
@@ -58,7 +58,7 @@ export function useCsvFileDrop({
 
       onFileDropped(file)
 
-      onTelemetryEvent?.('import_data_dropzone_file_dropped')
+      onTelemetryEvent?.('import_data_dropzone_file_added')
     },
     [enabled, onDragOver, onFileDropped, onTelemetryEvent]
   )

--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -58,7 +58,7 @@ export function useCsvFileDrop({
 
       onFileDropped(file)
 
-      onTelemetryEvent?.('import_data_dropzone_file_added')
+      onTelemetryEvent?.('import_data_dropzone_file_dropped')
     },
     [enabled, onDragOver, onFileDropped, onTelemetryEvent]
   )

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -87,15 +87,15 @@ const CreateProject = () => {
     !isDataApiRevokeOnCreateDefault
   )
 
-  useTrackDefaultPrivilegesExposure({ surface: 'vercel' })
+  const { slug, next, currentProjectId: foreignProjectId, externalId } = useParams()
+
+  useTrackDefaultPrivilegesExposure({ surface: 'vercel', orgSlug: slug })
 
   async function checkPasswordStrength(value: string) {
     const { message, strength } = await passwordStrength(value)
     setPasswordStrengthScore(strength)
     setPasswordStrengthMessage(message)
   }
-
-  const { slug, next, currentProjectId: foreignProjectId, externalId } = useParams()
 
   const { mutateAsync: createConnections } = useIntegrationVercelConnectionsCreateMutation()
 

--- a/apps/www/components/Pricing/PricingComparisonTable.tsx
+++ b/apps/www/components/Pricing/PricingComparisonTable.tsx
@@ -41,6 +41,7 @@ const MobileHeader = ({
   hasExistingOrganizations?: boolean
 }) => {
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const orgSlug = organizations?.[0]?.slug
 
   const selectedPlan = plans.find((p) => p.name === plan)!
   const isUpgradablePlan = selectedPlan.name === 'Pro' || selectedPlan.name === 'Team'
@@ -74,6 +75,7 @@ const MobileHeader = ({
                 section: 'comparison_table',
                 tableMode: 'mobile',
               },
+              ...(orgSlug && { groups: { organization: orgSlug } }),
             })
           }
           size="medium"
@@ -92,6 +94,7 @@ const MobileHeader = ({
                   section: 'comparison_table',
                   tableMode: 'mobile',
                 },
+                ...(orgSlug && { groups: { organization: orgSlug } }),
               })
             }
           >
@@ -115,6 +118,7 @@ const PricingComparisonTable = ({
   const [activeMobilePlan, setActiveMobilePlan] = useState('Free')
 
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const orgSlug = organizations?.[0]?.slug
 
   return (
     <div
@@ -428,6 +432,7 @@ const PricingComparisonTable = ({
                                   section: 'comparison_table',
                                   tableMode: 'desktop',
                                 },
+                                ...(orgSlug && { groups: { organization: orgSlug } }),
                               })
                             }
                             size="tiny"
@@ -451,6 +456,7 @@ const PricingComparisonTable = ({
                                     section: 'comparison_table',
                                     tableMode: 'desktop',
                                   },
+                                  ...(orgSlug && { groups: { organization: orgSlug } }),
                                 })
                               }
                             >

--- a/apps/www/components/Pricing/PricingPlans.tsx
+++ b/apps/www/components/Pricing/PricingPlans.tsx
@@ -16,6 +16,7 @@ interface PricingPlansProps {
 
 const PricingPlans = ({ organizations, hasExistingOrganizations }: PricingPlansProps) => {
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const orgSlug = organizations?.[0]?.slug
 
   return (
     <div className="mx-auto lg:container lg:px-16 xl:px-12 flex flex-col">
@@ -36,6 +37,7 @@ const PricingPlans = ({ organizations, hasExistingOrganizations }: PricingPlansP
                   showUpgradeText: isUpgradablePlan && hasExistingOrganizations ? true : false,
                   section: 'main',
                 },
+                ...(orgSlug && { groups: { organization: orgSlug } }),
               })
             }
 

--- a/apps/www/pages/events/[slug].tsx
+++ b/apps/www/pages/events/[slug].tsx
@@ -306,7 +306,7 @@ const EventPage = ({ event }: InferGetStaticPropsType<typeof getStaticProps>) =>
                       target={event.main_cta?.target ? event.main_cta?.target : undefined}
                       onClick={() =>
                         sendTelemetryEvent({
-                          action: 'www_pricing_plan_cta_clicked',
+                          action: 'www_event_page_cta_clicked',
                           properties: { eventTitle: event.title },
                         })
                       }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -287,24 +287,6 @@ export interface TimezonePickerClickedEvent {
   groups: TelemetryGroups
 }
 /**
- * User was exposed to the project creation form (exposure event for RLS option experiment).
- *
- * @group Events
- * @source studio
- * @page new/{slug}
- */
-export interface ProjectCreationRlsOptionExperimentExposedEvent {
-  action: 'project_creation_rls_option_experiment_exposed'
-  properties: {
-    /**
-     * Experiment variant: 'control' (checkbox hidden) or 'test' (checkbox shown)
-     */
-    variant: 'control' | 'test'
-  }
-  groups: Omit<TelemetryGroups, 'project'>
-}
-
-/**
  * Top-of-funnel event for the dataApiRevokeOnCreateDefault rollout. Fires once per
  * mount after the flag resolves so cohort attribution is clean — pair with
  * project_creation_simple_version_submitted to measure the flag's impact on
@@ -1913,24 +1895,6 @@ export interface HomeCustomReportBlockRemovedEvent {
 }
 
 /**
- * User was exposed to the HomeV2 experiment (shown the new home page).
- *
- * @group Events
- * @source studio
- * @page /project/{ref}
- */
-export interface HomeNewExperimentExposedEvent {
-  action: 'home_new_experiment_exposed'
-  properties: {
-    /**
-     * The experiment variant shown to the user
-     */
-    variant: string
-  }
-  groups: TelemetryGroups
-}
-
-/**
  * Connect section was shown to the user on the project homepage.
  *
  * @group Events
@@ -2160,68 +2124,6 @@ export interface RLSGeneratedPolicyRemovedEvent {
  */
 export interface RLSGeneratedPoliciesCreatedEvent {
   action: 'rls_generated_policies_created'
-  groups: TelemetryGroups
-}
-
-/**
- * Conversion event for the generate policies experiment.
- * Fires when a user in the experiment creates a new table via table editor.
- * This is separate from TableCreatedEvent to keep experiment tracking isolated.
- *
- * @group Events
- * @source studio
- * @page /dashboard/project/{ref}/editor
- */
-export interface TableCreateGeneratePoliciesExperimentConvertedEvent {
-  action: 'table_create_generate_policies_experiment_converted'
-  properties: {
-    /**
-     * Experiment identifier for tracking
-     */
-    experiment_id: 'tableCreateGeneratePolicies'
-    /**
-     * Experiment variant: 'control' (feature disabled) or 'variation' (feature enabled)
-     */
-    variant: 'control' | 'variation'
-    /**
-     * Whether RLS was enabled on the table
-     */
-    has_rls_enabled: boolean
-    /**
-     * Whether the table was created with any RLS policies (manual or generated)
-     */
-    has_rls_policies: boolean
-    /**
-     * Whether AI-generated policies were used (only possible in variation)
-     */
-    has_generated_policies: boolean
-  }
-  groups: TelemetryGroups
-}
-
-/**
- * User was exposed to the generate policies experiment (shown or not shown the Generate Policies button).
- *
- * @group Events
- * @source studio
- * @page /dashboard/project/{ref}/editor
- */
-export interface TableCreateGeneratePoliciesExperimentExposedEvent {
-  action: 'table_create_generate_policies_experiment_exposed'
-  properties: {
-    /**
-     * Experiment identifier for tracking
-     */
-    experiment_id: 'tableCreateGeneratePolicies'
-    /**
-     * Experiment variant: 'control' (feature disabled) or 'variation' (feature enabled)
-     */
-    variant: 'control' | 'variation'
-    /**
-     * Days since project creation (to segment by new user cohorts)
-     */
-    days_since_project_creation: number
-  }
   groups: TelemetryGroups
 }
 
@@ -3405,7 +3307,6 @@ export type TelemetryEvent =
   | FeaturePreviewEnabledEvent
   | FeaturePreviewDisabledEvent
   | TimezonePickerClickedEvent
-  | ProjectCreationRlsOptionExperimentExposedEvent
   | ProjectCreationDefaultPrivilegesExposedEvent
   | ProjectCreationGithubConnectClickedEvent
   | ProjectCreationSimpleVersionSubmittedEvent
@@ -3501,7 +3402,6 @@ export type TelemetryEvent =
   | BranchSelectorCreateClickedEvent
   | BranchSelectorManageClickedEvent
   | DpaPdfOpenedEvent
-  | HomeNewExperimentExposedEvent
   | HomeConnectSectionExposedEvent
   | HomeConnectActionClickedEvent
   | ConnectSheetOpenedEvent
@@ -3520,8 +3420,6 @@ export type TelemetryEvent =
   | RLSGeneratePoliciesClickedEvent
   | RLSGeneratedPolicyRemovedEvent
   | RLSGeneratedPoliciesCreatedEvent
-  | TableCreateGeneratePoliciesExperimentExposedEvent
-  | TableCreateGeneratePoliciesExperimentConvertedEvent
   | AuthUsersSearchSubmittedEvent
   | CommandMenuOpenedEvent
   | CommandMenuClosedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -886,6 +886,7 @@ export interface WwwPricingPlanCtaClickedEvent {
     section: 'main' | 'comparison_table'
     tableMode?: 'mobile' | 'desktop'
   }
+  groups?: Partial<TelemetryGroups>
 }
 
 /**

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3089,7 +3089,12 @@ export interface ResourceExhaustionBannerAiAssistantClickedEvent {
 export interface UnifiedLogsRowClickedEvent {
   action: 'unified_logs_row_clicked'
   properties: {
-    logType: string
+    /**
+     * Service that produced the log row. Mirrors `LOG_TYPES` in UnifiedLogs.constants.tsx.
+     * Server values are validated against this set by zod (UnifiedLogs.schema.ts) before
+     * reaching the table; anything else is rejected upstream so the union here is exhaustive.
+     */
+    logType: 'postgres' | 'postgrest' | 'auth' | 'storage' | 'edge function'
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -708,7 +708,13 @@ export interface AssistantSuggestionRunQueryClickedEvent {
      * The type of suggestion that was run by the user. Mutate or Select query types only.
      */
     queryType: string
-    category?: string
+    /**
+     * For mutation queries only: the DDL subtype detected from the SQL.
+     * 'functions' for CREATE FUNCTION / CREATE OR REPLACE FUNCTION,
+     * 'rls-policies' for CREATE POLICY / ALTER POLICY,
+     * 'unknown' for any other mutation. Omitted for non-mutation queries.
+     */
+    mutationType?: 'functions' | 'rls-policies' | 'unknown'
   }
   groups: TelemetryGroups
 }

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2428,17 +2428,17 @@ export interface LogDrainSaveButtonClickedEvent {
 }
 
 /**
- * User confirmed addition of log drain destination.
+ * User confirmed deletion of a log drain destination in the delete-confirm modal.
  *
  * @group Events
  * @source studio
- * @page /dashboard/project/{ref}/settings/log-drains (LogDrains)
+ * @page /dashboard/project/{ref}/settings/log-drains
  */
-export interface LogDrainConfirmButtonSubmittedEvent {
-  action: 'log_drain_confirm_button_submitted'
+export interface LogDrainDeletedEvent {
+  action: 'log_drain_deleted'
   properties: {
     /**
-     * Type of the destination confirmed
+     * Type of the destination deleted
      */
     destination:
       | 'postgres'
@@ -3408,7 +3408,7 @@ export type TelemetryEvent =
   | QueueOperationsSettingClickedEvent
   | SidebarOpenedEvent
   | LogDrainSaveButtonClickedEvent
-  | LogDrainConfirmButtonSubmittedEvent
+  | LogDrainDeletedEvent
   | AdvisorDetailOpenedEvent
   | AdvisorAssistantButtonClickedEvent
   | QueryPerformanceAIExplanationButtonClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1104,7 +1104,7 @@ export interface ImportDataButtonClickedEvent {
  * @page /dashboard/project/{ref}/editor
  */
 export interface ImportDataFileDroppedEvent {
-  action: 'import_data_dropzone_file_added'
+  action: 'import_data_dropzone_file_dropped'
   groups: TelemetryGroups
 }
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1015,23 +1015,6 @@ export interface RequestDemoButtonClickedEvent {
 }
 
 /**
- * User clicked the "Register" button in the State of Startups 2025 newsletter form.
- *
- * @group Events
- * @source www
- */
-export interface RegisterStateOfStartups2025NewsletterClicked {
-  action: 'register_for_state_of_startups_newsletter_clicked'
-  properties: {
-    /**
-     * The source of the button click, e.g. homepage hero, cta banner, product page header.
-     * If it states it came from the request demo form, it can come from different pages so refer to path name to determine.
-     */
-    buttonLocation: string
-  }
-}
-
-/**
  * User clicked the sign-in button in various locations described in properties.
  *
  * @group Events
@@ -3351,7 +3334,6 @@ export type TelemetryEvent =
   | StartProjectButtonClickedEvent
   | SeeDocumentationButtonClickedEvent
   | RequestDemoButtonClickedEvent
-  | RegisterStateOfStartups2025NewsletterClicked
   | SignInButtonClickedEvent
   | HelpButtonClickedEvent
   | ExampleProjectCardClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -966,7 +966,7 @@ export interface WwwPricingPlanCtaClickedEvent {
  * @page /events/*
  */
 export interface EventPageCtaClickedEvent {
-  action: 'www_pricing_plan_cta_clicked'
+  action: 'www_event_page_cta_clicked'
   properties: {
     /**
      * The title of the event clicked.

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1210,26 +1210,17 @@ export interface MetricsAPIBannerDismissButtonClickedEvent {
 }
 
 /**
- * Index Advisor banner enable button clicked event.
+ * User clicked the enable button for Index Advisor, either from the banner or the confirmation dialog.
  *
  * @group Events
  * @source studio
  * @page /observability/query-performance
  */
-export interface IndexAdvisorBannerEnableButtonClickedEvent {
-  action: 'index_advisor_banner_enable_button_clicked'
-  groups: TelemetryGroups
-}
-
-/**
- * Index Advisor dialog enable button clicked event.
- *
- * @group Events
- * @source studio
- * @page /observability/query-performance
- */
-export interface IndexAdvisorDialogEnableButtonClickedEvent {
-  action: 'index_advisor_dialog_enable_button_clicked'
+export interface IndexAdvisorEnableButtonClickedEvent {
+  action: 'index_advisor_enable_button_clicked'
+  properties: {
+    origin: 'banner' | 'dialog'
+  }
   groups: TelemetryGroups
 }
 
@@ -3358,9 +3349,8 @@ export type TelemetryEvent =
   | ReportsDatabaseGrafanaBannerClickedEvent
   | MetricsAPIBannerCtaButtonClickedEvent
   | MetricsAPIBannerDismissButtonClickedEvent
-  | IndexAdvisorBannerEnableButtonClickedEvent
+  | IndexAdvisorEnableButtonClickedEvent
   | IndexAdvisorBannerDismissButtonClickedEvent
-  | IndexAdvisorDialogEnableButtonClickedEvent
   | IndexAdvisorTabClickedEvent
   | IndexAdvisorCreateIndexesButtonClickedEvent
   | EdgeFunctionDeployButtonClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1977,6 +1977,7 @@ export interface HomeSectionRowsMovedEvent {
  */
 export interface DpaRequestButtonClickedEvent {
   action: 'dpa_request_button_clicked'
+  groups: Omit<TelemetryGroups, 'project'>
 }
 
 /**

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1106,14 +1106,14 @@ export interface ImportDataButtonClickedEvent {
 }
 
 /**
- * User dropped a file into the import data dropzone on an empty table.
+ * User added a file to the import data dropzone on an empty table.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/editor
  */
-export interface ImportDataFileDroppedEvent {
-  action: 'import_data_dropzone_file_dropped'
+export interface ImportDataFileAddedEvent {
+  action: 'import_data_dropzone_file_added'
   groups: TelemetryGroups
 }
 
@@ -2437,17 +2437,17 @@ export interface LogDrainSaveButtonClickedEvent {
 }
 
 /**
- * User confirmed deletion of a log drain destination in the delete-confirm modal.
+ * User confirmed removal of a log drain destination in the delete-confirm modal.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/settings/log-drains
  */
-export interface LogDrainDeletedEvent {
-  action: 'log_drain_deleted'
+export interface LogDrainRemovedEvent {
+  action: 'log_drain_removed'
   properties: {
     /**
-     * Type of the destination deleted
+     * Type of the destination removed
      */
     destination:
       | 'postgres'
@@ -3349,7 +3349,7 @@ export type TelemetryEvent =
   | HelpButtonClickedEvent
   | ExampleProjectCardClickedEvent
   | ImportDataButtonClickedEvent
-  | ImportDataFileDroppedEvent
+  | ImportDataFileAddedEvent
   | ImportDataAddedEvent
   | SendFeedbackButtonClickedEvent
   | SqlEditorQueryRunButtonClickedEvent
@@ -3422,7 +3422,7 @@ export type TelemetryEvent =
   | QueueOperationsSettingClickedEvent
   | SidebarOpenedEvent
   | LogDrainSaveButtonClickedEvent
-  | LogDrainDeletedEvent
+  | LogDrainRemovedEvent
   | AdvisorDetailOpenedEvent
   | AdvisorAssistantButtonClickedEvent
   | QueryPerformanceAIExplanationButtonClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -454,72 +454,6 @@ export interface TableApiAccessToggleClickedEvent {
 }
 
 /**
- * On the InitialStep.tsx screen, where user can chose to prompt, start blank or migrate, at least 5 characters were typed
- * in the prompt textarea indicating an intention to use the prompt.
- *
- * @group Events
- * @source studio
- * @page new/v2/{slug}
- */
-export interface ProjectCreationInitialStepPromptIntendedEvent {
-  action: 'project_creation_initial_step_prompt_intended'
-  /**
-   * Is this a new prompt (e.g. when following the start blank route where no prompt has been filled in the InitialStep). In other
-   * words, was this not just an edit. In this case, it should always be true.
-   */
-  properties: {
-    isNewPrompt: boolean
-  }
-}
-
-/**
- * First step of project creation was submitted, where the user writes a prompt or select to start blank or to migrate.
- *
- * @group Events
- * @source studio
- * @page new/v2/{slug}
- */
-export interface ProjectCreationInitialStepSubmittedEvent {
-  action: 'project_creation_initial_step_submitted'
-  properties: {
-    /**
-     * Records what the user selected in the first step of project creation.
-     */
-    onboardingPath: 'use_prompt' | 'start_blank' | 'migrate'
-  }
-}
-
-/**
- * After the InitialStep screen, at least 5 characters were typed in the prompt textarea indicating an intention to use the prompt.
- *
- * @group Events
- * @source studio
- * @page new/v2/{slug}
- */
-export interface ProjectCreationSecondStepPromptIntendedEvent {
-  action: 'project_creation_second_step_prompt_intended'
-  properties: {
-    /**
-     * Is this a new prompt (e.g. when following the start blank route where no prompt has been filled in the InitialStep). In other
-     * words, was this not just an edit.
-     */
-    isNewPrompt: boolean
-  }
-}
-
-/**
- * Second and final step of project creation was submitted. More precisely, right after the user clicks on "Create Project". To check,
- * if the project creation was successful, please refer to project_created event.
- *
- * @group Events
- * @source studio
- * @page new/v2/{slug}
- */
-export interface ProjectCreationSecondStepSubmittedEvent {
-  action: 'project_creation_second_step_submitted'
-}
-
-/**
  * User clicked either "Listening to channel" or "Start listening" button after selecting a channel.
  *
  * @group Events
@@ -3477,10 +3411,6 @@ export type TelemetryEvent =
   | ProjectCreationSimpleVersionSubmittedEvent
   | ProjectCreationSimpleVersionConfirmModalOpenedEvent
   | TableApiAccessToggleClickedEvent
-  | ProjectCreationInitialStepPromptIntendedEvent
-  | ProjectCreationInitialStepSubmittedEvent
-  | ProjectCreationSecondStepPromptIntendedEvent
-  | ProjectCreationSecondStepSubmittedEvent
   | RealtimeInspectorListenChannelClickedEvent
   | RealtimeInspectorBroadcastSentEvent
   | RealtimeInspectorMessageClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -175,6 +175,10 @@ export interface CronJobUpdatedEvent {
  */
 export interface CronJobRemovedEvent {
   action: 'cron_job_removed'
+  properties: {
+    /** Cron job classification, parsed from the job's command at deletion time. */
+    type: 'sql_function' | 'sql_snippet' | 'edge_function' | 'http_request'
+  }
   groups: TelemetryGroups
 }
 

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -20,7 +20,11 @@ export const TABLE_EVENT_ACTIONS = {
   TableCreated: 'table_created',
   TableDataAdded: 'table_data_added',
   TableRLSEnabled: 'table_rls_enabled',
-} as const
+} as const satisfies {
+  TableCreated: TableCreatedEvent['action']
+  TableDataAdded: TableDataAddedEvent['action']
+  TableRLSEnabled: TableRLSEnabledEvent['action']
+}
 
 export type TableEventAction = (typeof TABLE_EVENT_ACTIONS)[keyof typeof TABLE_EVENT_ACTIONS]
 


### PR DESCRIPTION
## Summary
Resolves 13 findings (2 HIGH, 5 MEDIUM, 6 LOW) from the frontend telemetry audit: 1 action-string collision, 1 camelCase experiment name, 9 dead events removed, 4 missing org groups attached, 1 ambiguous property renamed, 1 raw-string property narrowed, plus consolidations and a structural tightening on TABLE_EVENT_ACTIONS.

## Changes
### HIGH
- Rename `EventPageCtaClickedEvent.action` to `www_event_page_cta_clicked` so it no longer collides with the pricing CTA event (which had a different schema sharing the same action string)
- Snake_case the header-upgrade experiment exposure name (`headerUpgradeCta_experiment_exposed` → `header_upgrade_cta_experiment_exposed`); PostHog flag key and `?source=` URL param unchanged

### MEDIUM
- Remove 4 dead `ProjectCreation*Step*` events (referenced a v2 route that doesn't exist; 0 emissions)
- Remove 4 dead experiment exposure events: `ProjectCreationRlsOptionExperimentExposed`, `HomeNewExperimentExposed`, `TableCreateGeneratePoliciesExperimentExposed`, `TableCreateGeneratePoliciesExperimentConverted` (0 emissions)
- Attach org group to `dpa_request_button_clicked` (0% had `$group_0` per Hex)
- Delete `RegisterStateOfStartups2025NewsletterClicked` (interface naming outlier, 0 emissions, page renamed to 2026)
- Rename `AssistantSuggestionRunQueryClickedEvent.category` to `mutationType` with tightened literal union (`'functions' | 'rls-policies' | 'unknown'`)
- Attach org group to `project_creation_default_privileges_exposed` on Vercel surface via explicit `groupOverrides` (auto-injection misses because `useSelectedOrganizationQuery` is undefined on that page)

### LOW
- Consolidate `IndexAdvisorBannerEnableButtonClickedEvent` + `IndexAdvisorDialogEnableButtonClickedEvent` into one event with `origin: 'banner' | 'dialog'`
- Rename `ImportDataFileDroppedEvent` → `ImportDataFileAddedEvent` so the interface name matches the action and the verb is on the approved list
- Rename `LogDrainConfirmButtonSubmittedEvent` → `LogDrainRemovedEvent` and action to `log_drain_removed` (fires on delete-confirm modal, matches `CronJobRemovedEvent` pattern)
- Add `type` property to `CronJobRemovedEvent` (parsed from the job's command), matching the create/update event shape
- Tighten `TABLE_EVENT_ACTIONS` values with `satisfies` against the event union so renames in the union fail typecheck here too
- Attach org group to `www_pricing_plan_cta_clicked` at 5 emission sites when an org is available in the page context
- Narrow `unified_logs_row_clicked.logType` from raw `string` to the 5-literal `LOG_TYPES` union (zod already validates server values)

### Bundled refactor
Migrated 5 emission sites from deprecated `useSendEventMutation` to `useTrack` while their containing files were being edited: `DPA.tsx`, `DisplayBlockRenderer.tsx`, `Grid.tsx` (2 events), `DeleteCronJob.tsx`. Full sweep of the remaining ~79 files is a separate follow-up.

## Testing

Mostly just renaming of events

## Linear
- fixes GROWTH-798


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized telemetry to a unified tracking system for more consistent analytics.
  * Simplified experiment exposure reporting for upgrade prompts.

* **New Features**
  * More granular tracking for CSV import, cron job deletions, log drain removals, DPA downloads/requests, and pricing CTAs.
  * Assistant now classifies mutation queries more precisely.

* **Bug Fixes**
  * Improved default-privileges exposure logic on Vercel deployments (skips when org missing).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45964)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->