### PR TITLE
Fix method toggle column in unified logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -437,9 +437,10 @@ export const UnifiedLogs = () => {
                 chartConfig={filteredChartConfig}
               />
             </div>
+
             <ResizablePanelGroup
               key="main-logs"
-              className="flex-1"
+              className="flex-1 border-t"
               orientation={dock === 'bottom' ? 'vertical' : 'horizontal'}
             >
               <ResizablePanel

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -224,13 +224,15 @@ export const UnifiedLogs = () => {
     return generateDynamicColumns(flatData)
   }, [flatData])
 
+  console.log({ columnVisibility, dynamicColumnVisibility })
+
   const table: Table<ColumnSchema> = useReactTable({
     data: flatData,
     columns: dynamicColumns,
     state: {
       columnFilters,
       sorting,
-      columnVisibility: { ...columnVisibility, ...dynamicColumnVisibility },
+      columnVisibility: { ...dynamicColumnVisibility, ...columnVisibility },
       rowSelection,
       columnOrder,
     },

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -224,8 +224,6 @@ export const UnifiedLogs = () => {
     return generateDynamicColumns(flatData)
   }, [flatData])
 
-  console.log({ columnVisibility, dynamicColumnVisibility })
-
   const table: Table<ColumnSchema> = useReactTable({
     data: flatData,
     columns: dynamicColumns,

--- a/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
@@ -70,12 +70,12 @@ export function generateDynamicColumns(data: ColumnSchema[]): {
       filterFn: (_row, _columnId, _filterValue) => true,
       enableResizing: false,
       enableSorting: false,
-      size: 130,
-      minSize: 130,
-      maxSize: 130,
+      size: 140,
+      minSize: 140,
+      maxSize: 140,
       meta: {
-        cellClassName: 'font-mono tracking-tight w-[130px]',
-        headerClassName: 'w-[130px]',
+        cellClassName: 'font-mono tracking-tight w-[140px]',
+        headerClassName: 'w-[140px]',
       },
     },
     // Log type column - always visible

--- a/apps/studio/components/ui/DataTable/DataTableViewOptions.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableViewOptions.tsx
@@ -50,7 +50,12 @@ export function DataTableViewOptions() {
       </PopoverTrigger>
       <PopoverContent id={listboxId} side="bottom" align="end" className="w-[200px] p-0">
         <Command>
-          <CommandInput value={search} onValueChange={setSearch} placeholder="Search columns..." />
+          <CommandInput
+            value={search}
+            onValueChange={setSearch}
+            placeholder="Search columns..."
+            className="text-xs"
+          />
           <CommandList>
             <CommandEmpty>No option found.</CommandEmpty>
             <CommandGroup>


### PR DESCRIPTION
## Context

Addresses the toggling of column visibility not working for dynamic columns (e.g method, status, and event_message)
<img width="293" height="262" alt="image" src="https://github.com/user-attachments/assets/c404c063-d6b2-49bf-86ec-bf91f7e35bd2" />

The main problem was actually just because of this in `UnifiedLogs.tsx`:
<img width="569" height="165" alt="image" src="https://github.com/user-attachments/assets/5ae7be01-a7d6-4f64-99ad-87886dbf75f9" />

`dynamicColumnVisibility` is a fixed value determined by which columns are dynamic from the log data (as the default value)
`columnVisibility` is a dynamic value that we're retrieving and updating with local storage

just need to shift `dynamicColumnVisibility` to be before `columnVisibility` so that `columnVisibility` can override the values correctly from local storage

### Other changes

Other resolves DEBUG-102, adds a border top to the table to better visually anchor the side panel
<img width="1157" height="301" alt="image" src="https://github.com/user-attachments/assets/c0b7a90c-0ccb-4b65-8299-a8380e2a76fa" />

## To test
- [ ] Verify that the toggles work for method, pathname and event_message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted date column width in logs view for improved readability.
  * Updated column visibility handling so the intended columns display consistently.

* **UI Improvements**
  * Added a top border to the main logs panel for clearer visual separation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45965?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->