### PR TITLE
fix(docs): Fix Oauth docs and code to use redirect_url

### DIFF
--- a/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
@@ -238,6 +238,11 @@ export default async function ConsentPage({
     return <div>Error: {error?.message || 'Invalid authorization request'}</div>
   }
 
+  // if no authorization_id returned, user has previously consented, redirect them
+  if (!('authorization_id' in authDetails)) {
+    redirect(authDetails['redirect_url'])
+  }
+
   return (
     <div>
       <h1>Authorize {authDetails.client.name}</h1>
@@ -313,7 +318,7 @@ export async function POST(request: Request) {
     }
 
     // Redirect back to the client with authorization code
-    return NextResponse.redirect(data.redirect_to)
+    return NextResponse.redirect(data.redirect_url)
   } else {
     const { data, error } = await supabase.auth.oauth.denyAuthorization(authorizationId)
 
@@ -322,7 +327,7 @@ export async function POST(request: Request) {
     }
 
     // Redirect back to the client with error
-    return NextResponse.redirect(data.redirect_to)
+    return NextResponse.redirect(data.redirect_url)
   }
 }
 ```
@@ -388,7 +393,7 @@ export function OAuthConsent() {
       setError(error.message)
     } else {
       // Redirect to client app
-      window.location.href = data.redirect_to
+      window.location.href = data.redirect_url
     }
   }
 
@@ -401,7 +406,7 @@ export function OAuthConsent() {
       setError(error.message)
     } else {
       // Redirect to client app with error
-      window.location.href = data.redirect_to
+      window.location.href = data.redirect_url
     }
   }
 
@@ -455,8 +460,8 @@ export function OAuthConsent() {
 6. **Handle decision** - When the user clicks approve/deny:
    - Call `supabase.auth.oauth.approveAuthorization(authorization_id)` or `denyAuthorization(authorization_id)`
    - These methods handle all OAuth logic internally (generating authorization codes, etc.)
-   - They return a `redirect_to` URL
-7. **Redirect back** - Redirect the user to the `redirect_to` URL, which sends them back to the third-party app with either an authorization code (approved) or error (denied)
+   - They return a `redirect_url` URL
+7. **Redirect back** - Redirect the user to the `redirect_url` URL, which sends them back to the third-party app with either an authorization code (approved) or error (denied)
 
 ## Register an OAuth client
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -189,7 +189,7 @@ Your frontend application at the authorization path should:
 5. **Handle user decision** - When the user approves or denies:
    - Call `supabase.auth.oauth.approveAuthorization(authorization_id)` to approve
    - Call `supabase.auth.oauth.denyAuthorization(authorization_id)` to deny
-   - Redirect user to the returned `redirect_to` URL
+   - Redirect user to the returned `redirect_url` URL
 
 This is a **frontend implementation** using `supabase-js`. Supabase Auth handles all the backend OAuth logic (generating authorization codes, validating requests, etc.) after you call the approve/deny methods.
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -56,7 +56,7 @@ Here's a visual representation of the complete authorization code flow:
        │     (code_verifier, code_challenge)                            │
        │                              │                                 │
        │  2. Redirect to /oauth/authorize with code_challenge           │
-       ├────────────────────────────────────────────────────────────────>│
+       ├───────────────────────────────────────────────────────────────>│
        │                              │                                 │
        │                              │  3. Validate params & redirect  │
        │                              │     to authorization_path       │
@@ -79,18 +79,18 @@ Here's a visual representation of the complete authorization code flow:
        │                              │                                 │
        │  8. Exchange code for tokens (POST /oauth/token)               │
        │     with code_verifier                                         │
-       ├────────────────────────────────────────────────────────────────>│
+       ├───────────────────────────────────────────────────────────────>│
        │                              │                                 │
        │  9. Return tokens (access, refresh, ID)                        │
-       │<────────────────────────────────────────────────────────────────┤
+       │<───────────────────────────────────────────────────────────────┤
        │                              │                                 │
        │  10. Access resources with access_token                        │
        │                              │                                 │
        │  11. Refresh tokens (POST /oauth/token with refresh_token)     │
-       ├────────────────────────────────────────────────────────────────>│
+       ├───────────────────────────────────────────────────────────────>│
        │                              │                                 │
        │  12. Return new tokens                                         │
-       │<────────────────────────────────────────────────────────────────┤
+       │<───────────────────────────────────────────────────────────────┤
        │                              │                                 │
 ```
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -71,7 +71,7 @@ Here's a visual representation of the complete authorization code flow:
        │                              │                                 │
        │                              │  6. approveAuthorization()      │
        │                              ├────────────────────────────────>│
-       │                              │  Return redirect_to with code   │
+       │                              │  Return redirect_url with code  │
        │                              │<────────────────────────────────┤
        │                              │                                 │
        │  7. Redirect to client callback with code                      │


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix incorrect reference to `redirect_to` when it should be `redirect_url`
- https://github.com/supabase/supabase-js/blob/1c48755657c5f7aac5e4a7abf3f68f27efc0c746/packages/core/auth-js/src/lib/types.ts#L2561-L2569
- https://github.com/supabase/supabase-js/blob/1c48755657c5f7aac5e4a7abf3f68f27efc0c746/packages/core/auth-js/src/lib/types.ts#L2534-L2537



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced OAuth Server "Getting Started" guide with updated code examples and clearer explanatory steps for implementing authorization flows with accurate field references.
  * Refined OAuth authorization code flow documentation, including updated diagrams and instructions to ensure consistent field references across all redirect and consent handling steps.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45966)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->