### PR TITLE
chore: remove `<Toggle>` `_Shadcn_` suffix

### DIFF
--- a/apps/design-system/registry/default/example/toggle-demo.tsx
+++ b/apps/design-system/registry/default/example/toggle-demo.tsx
@@ -1,10 +1,10 @@
 import { Bold } from 'lucide-react'
-import { Toggle_Shadcn_ } from 'ui'
+import { Toggle } from 'ui'
 
 export default function ToggleDemo() {
   return (
-    <Toggle_Shadcn_ aria-label="Toggle bold">
+    <Toggle aria-label="Toggle bold">
       <Bold className="h-4 w-4" />
-    </Toggle_Shadcn_>
+    </Toggle>
   )
 }

--- a/apps/design-system/registry/default/example/toggle-disabled.tsx
+++ b/apps/design-system/registry/default/example/toggle-disabled.tsx
@@ -1,10 +1,10 @@
 import { Underline } from 'lucide-react'
-import { Toggle_Shadcn_ } from 'ui'
+import { Toggle } from 'ui'
 
 export default function ToggleDisabled() {
   return (
-    <Toggle_Shadcn_ aria-label="Toggle underline" disabled>
+    <Toggle aria-label="Toggle underline" disabled>
       <Underline className="h-4 w-4" />
-    </Toggle_Shadcn_>
+    </Toggle>
   )
 }

--- a/apps/design-system/registry/default/example/toggle-lg.tsx
+++ b/apps/design-system/registry/default/example/toggle-lg.tsx
@@ -1,10 +1,10 @@
 import { Italic } from 'lucide-react'
-import { Toggle_Shadcn_ } from 'ui'
+import { Toggle } from 'ui'
 
 export default function ToggleLg() {
   return (
-    <Toggle_Shadcn_ size="lg" aria-label="Toggle italic">
+    <Toggle size="lg" aria-label="Toggle italic">
       <Italic className="h-4 w-4" />
-    </Toggle_Shadcn_>
+    </Toggle>
   )
 }

--- a/apps/design-system/registry/default/example/toggle-outline.tsx
+++ b/apps/design-system/registry/default/example/toggle-outline.tsx
@@ -1,10 +1,10 @@
 import { Italic } from 'lucide-react'
-import { Toggle_Shadcn_ } from 'ui'
+import { Toggle } from 'ui'
 
 export default function ToggleOutline() {
   return (
-    <Toggle_Shadcn_ variant="outline" aria-label="Toggle italic">
+    <Toggle variant="outline" aria-label="Toggle italic">
       <Italic className="h-4 w-4" />
-    </Toggle_Shadcn_>
+    </Toggle>
   )
 }

--- a/apps/design-system/registry/default/example/toggle-sm.tsx
+++ b/apps/design-system/registry/default/example/toggle-sm.tsx
@@ -1,10 +1,10 @@
 import { Italic } from 'lucide-react'
-import { Toggle_Shadcn_ } from 'ui'
+import { Toggle } from 'ui'
 
 export default function ToggleSm() {
   return (
-    <Toggle_Shadcn_ size="sm" aria-label="Toggle italic">
+    <Toggle size="sm" aria-label="Toggle italic">
       <Italic className="h-4 w-4" />
-    </Toggle_Shadcn_>
+    </Toggle>
   )
 }

--- a/apps/design-system/registry/default/example/toggle-with-text.tsx
+++ b/apps/design-system/registry/default/example/toggle-with-text.tsx
@@ -1,11 +1,11 @@
 import { Italic } from 'lucide-react'
-import { Toggle_Shadcn_ } from 'ui'
+import { Toggle } from 'ui'
 
 export default function ToggleWithText() {
   return (
-    <Toggle_Shadcn_ aria-label="Toggle italic">
+    <Toggle aria-label="Toggle italic">
       <Italic className="mr-2 h-4 w-4" />
       Italic
-    </Toggle_Shadcn_>
+    </Toggle>
   )
 }

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -64,9 +64,7 @@ export * from './src/components/shadcn/ui/skeleton'
 export * from './src/components/shadcn/ui/slider'
 export * from './src/components/shadcn/ui/textarea'
 export * from './src/components/shadcn/ui/toggle-group'
-
-export { Toggle as Toggle_Shadcn_ } from './src/components/shadcn/ui/toggle'
-
+export * from './src/components/shadcn/ui/toggle'
 export * from './src/components/shadcn/ui/card'
 
 export {


### PR DESCRIPTION
## Problem

The `_Shadcn_` suffix isn't needed anymore on `<Toggle__Shadcn_>`

## Solution

Remove it. No other changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated Toggle component examples and standardized exports
  * Simplified export structure for improved consistency
  * All existing Toggle component functionality maintained

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45970)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->