### PR TITLE
chore: update leaked password button in attack protection

### DIFF
--- a/apps/studio/components/interfaces/Auth/ProtectionAuthSettingsForm/ProtectionAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/ProtectionAuthSettingsForm/ProtectionAuthSettingsForm.tsx
@@ -358,7 +358,7 @@ export const ProtectionAuthSettingsForm = () => {
                           {field.value ? 'Enabled' : 'Disabled'}
                         </Badge>
                         <Link href={`/project/${projectRef}/auth/providers?provider=Email`}>
-                          <Button type="default">Configure email provider</Button>
+                          <Button type="default">Configure in email provider</Button>
                         </Link>
                       </div>
                     </FormItemLayout>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Frontend improvement

## What is the current behavior?
"Configure email provider" button in the Authentication > Attack Protection: the title doesn't change, only the label on the left depending on whether it's enabled or disabled.
 
<img width="1512" height="148" alt="CleanShot 2026-05-15 at 12 15 57@2x" src="https://github.com/user-attachments/assets/b2069333-6f1a-4503-9b3b-d75c005e4522" />

## What is the new behavior?
"Configure in email provider" - to clarify that this feature is managed in the email provider settings, and not refer to the whole email provider setup. 
<img width="1668" height="172" alt="CleanShot 2026-05-15 at 12 19 10@2x" src="https://github.com/user-attachments/assets/35fd5b35-8b31-4912-875d-cc9fc7b1968e" />

## Additional context
Relevant ticket where the button title was confusing for the customer: https://supabase.frontapp.com/open/cnv_1mtka5ni?key=-r6o8zPz-3XzuiQ7eh5FfCZBjTuKg78n