### PR TITLE
chore: remove `<Label>` `_Shadcn_` suffix

### DIFF
--- a/apps/design-system/content/docs/components/label.mdx
+++ b/apps/design-system/content/docs/components/label.mdx
@@ -24,9 +24,9 @@ Please use [FormLabel](/design-system/docs/components/form#anatomy) if you are u
 ## Usage
 
 ```tsx
-import { Label_Shadcn_ } from '@/components/ui/label'
+import { Label } from '@/components/ui/label'
 ```
 
 ```tsx
-<Label_Shadcn_ htmlFor="email">Your email address</Label_Shadcn_>
+<Label htmlFor="email">Your email address</Label>
 ```

--- a/apps/design-system/registry/default/example/copy-form-labels.tsx
+++ b/apps/design-system/registry/default/example/copy-form-labels.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Input, Label_Shadcn_ } from 'ui'
+import { Input, Label } from 'ui'
 
 export default function CopyFormLabels() {
   return (
@@ -8,7 +8,7 @@ export default function CopyFormLabels() {
       <div className="flex flex-col gap-4 w-[300px]">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <div className="grid w-full items-center gap-1.5">
-          <Label_Shadcn_ htmlFor="table-name-bad">Name your table</Label_Shadcn_>
+          <Label htmlFor="table-name-bad">Name your table</Label>
           <Input id="table-name-bad" placeholder="my_table" />
           <p className="text-sm text-muted-foreground">
             This field allows you to specify a name for your table using letters, numbers, and
@@ -19,7 +19,7 @@ export default function CopyFormLabels() {
       <div className="flex flex-col gap-4 w-[300px]">
         <span className="text-xs text-foreground-muted">Good Example</span>
         <div className="grid w-full items-center gap-1.5">
-          <Label_Shadcn_ htmlFor="table-name-good">Table name</Label_Shadcn_>
+          <Label htmlFor="table-name-good">Table name</Label>
           <Input id="table-name-good" placeholder="my_table" />
           <p className="text-sm text-muted-foreground">Letters, numbers, and underscores only</p>
         </div>

--- a/apps/design-system/registry/default/example/dialog-centered-off.tsx
+++ b/apps/design-system/registry/default/example/dialog-centered-off.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle,
   DialogTrigger,
   Input,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 
 export default function DialogDemo() {
@@ -27,15 +27,15 @@ export default function DialogDemo() {
         <DialogSectionSeparator />
         <DialogSection className="space-y-4">
           <div>
-            <Label_Shadcn_ htmlFor="name" className="text-right">
+            <Label htmlFor="name" className="text-right">
               Name
-            </Label_Shadcn_>
+            </Label>
             <Input id="name" defaultValue="Pedro Duarte" className="col-span-3" />
           </div>
           <div>
-            <Label_Shadcn_ htmlFor="username" className="text-right">
+            <Label htmlFor="username" className="text-right">
               Username
-            </Label_Shadcn_>
+            </Label>
             <Input id="username" defaultValue="@peduarte" className="col-span-3" />
           </div>
         </DialogSection>

--- a/apps/design-system/registry/default/example/dialog-close-button.tsx
+++ b/apps/design-system/registry/default/example/dialog-close-button.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
   DialogTrigger,
   Input,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 
 export default function DialogCloseButton() {
@@ -30,9 +30,9 @@ export default function DialogCloseButton() {
         <DialogSection>
           <div className="flex items-center space-x-2">
             <div className="grid flex-1 gap-2">
-              <Label_Shadcn_ htmlFor="link" className="sr-only">
+              <Label htmlFor="link" className="sr-only">
                 Link
-              </Label_Shadcn_>
+              </Label>
               <Input id="link" defaultValue="https://ui.shadcn.com/docs/installation" readOnly />
             </div>
             <Button htmlType="submit" size="small" type="secondary" className="px-3">

--- a/apps/design-system/registry/default/example/dialog-demo.tsx
+++ b/apps/design-system/registry/default/example/dialog-demo.tsx
@@ -10,7 +10,7 @@ import {
   DialogTitle,
   DialogTrigger,
   Input,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 
 export default function DialogDemo() {
@@ -27,11 +27,11 @@ export default function DialogDemo() {
         <DialogSectionSeparator />
         <DialogSection className="space-y-4">
           <div>
-            <Label_Shadcn_ htmlFor="name">Name</Label_Shadcn_>
+            <Label htmlFor="name">Name</Label>
             <Input id="name" defaultValue="Pedro Duarte" />
           </div>
           <div>
-            <Label_Shadcn_ htmlFor="username">Username</Label_Shadcn_>
+            <Label htmlFor="username">Username</Label>
             <Input id="username" defaultValue="@peduarte" />
           </div>
         </DialogSection>

--- a/apps/design-system/registry/default/example/drawer-dialog.tsx
+++ b/apps/design-system/registry/default/example/drawer-dialog.tsx
@@ -18,7 +18,7 @@ import {
   DrawerTitle,
   DrawerTrigger,
   Input,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 
 import { useMediaQuery } from '@/hooks/use-media-query'
@@ -74,11 +74,11 @@ function ProfileForm({ className }: React.ComponentProps<'form'>) {
   return (
     <form className={cn('grid items-start gap-4', className)}>
       <div className="grid gap-2">
-        <Label_Shadcn_ htmlFor="email">Email</Label_Shadcn_>
+        <Label htmlFor="email">Email</Label>
         <Input type="email" id="email" defaultValue="shadcn@example.com" />
       </div>
       <div className="grid gap-2">
-        <Label_Shadcn_ htmlFor="username">Username</Label_Shadcn_>
+        <Label htmlFor="username">Username</Label>
         <Input id="username" defaultValue="@shadcn" />
       </div>
       <Button htmlType="submit">Save changes</Button>

--- a/apps/design-system/registry/default/example/input-file.tsx
+++ b/apps/design-system/registry/default/example/input-file.tsx
@@ -1,9 +1,9 @@
-import { Input, Label_Shadcn_ } from 'ui'
+import { Input, Label } from 'ui'
 
 export default function InputFile() {
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
-      <Label_Shadcn_ htmlFor="picture">Picture</Label_Shadcn_>
+      <Label htmlFor="picture">Picture</Label>
       <Input id="picture" type="file" />
     </div>
   )

--- a/apps/design-system/registry/default/example/input-with-label.tsx
+++ b/apps/design-system/registry/default/example/input-with-label.tsx
@@ -1,9 +1,9 @@
-import { Input, Label_Shadcn_ } from 'ui'
+import { Input, Label } from 'ui'
 
 export default function InputWithLabel() {
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
-      <Label_Shadcn_ htmlFor="email">Email</Label_Shadcn_>
+      <Label htmlFor="email">Email</Label>
       <Input type="email" id="email" placeholder="Email" />
     </div>
   )

--- a/apps/design-system/registry/default/example/input-with-text.tsx
+++ b/apps/design-system/registry/default/example/input-with-text.tsx
@@ -1,9 +1,9 @@
-import { Input, Label_Shadcn_ } from 'ui'
+import { Input, Label } from 'ui'
 
 export default function InputWithText() {
   return (
     <div className="grid w-full max-w-sm items-center gap-1.5">
-      <Label_Shadcn_ htmlFor="email-2">Email</Label_Shadcn_>
+      <Label htmlFor="email-2">Email</Label>
       <Input type="email" id="email-2" placeholder="Email" />
       <p className="text-sm text-muted-foreground">Enter your email address.</p>
     </div>

--- a/apps/design-system/registry/default/example/label-demo.tsx
+++ b/apps/design-system/registry/default/example/label-demo.tsx
@@ -1,11 +1,11 @@
-import { Checkbox, Label_Shadcn_ } from 'ui'
+import { Checkbox, Label } from 'ui'
 
 export default function LabelDemo() {
   return (
     <div>
       <div className="flex items-center space-x-2">
         <Checkbox id="terms" />
-        <Label_Shadcn_ htmlFor="terms">Accept terms and conditions</Label_Shadcn_>
+        <Label htmlFor="terms">Accept terms and conditions</Label>
       </div>
     </div>
   )

--- a/apps/design-system/registry/default/example/multi-select-in-dialog.tsx
+++ b/apps/design-system/registry/default/example/multi-select-in-dialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogSectionSeparator,
   DialogTitle,
   DialogTrigger,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 import {
   MultiSelector,
@@ -47,7 +47,7 @@ export default function MultiSelectDemo() {
         <DialogSectionSeparator />
         <DialogSection className="space-y-4">
           <div>
-            <Label_Shadcn_ htmlFor="fruits">Fruits</Label_Shadcn_>
+            <Label htmlFor="fruits">Fruits</Label>
             <MultiSelector id="fruits" values={selectedValues} onValuesChange={setSelectedValues}>
               <MultiSelectorTrigger label="Select fruits" badgeLimit="wrap" showIcon={false} />
               <MultiSelectorContent>

--- a/apps/design-system/registry/default/example/popover-demo.tsx
+++ b/apps/design-system/registry/default/example/popover-demo.tsx
@@ -1,4 +1,4 @@
-import { Button, Input, Label_Shadcn_, Popover, PopoverContent, PopoverTrigger } from 'ui'
+import { Button, Input, Label, Popover, PopoverContent, PopoverTrigger } from 'ui'
 
 export default function PopoverDemo() {
   return (
@@ -14,19 +14,19 @@ export default function PopoverDemo() {
           </div>
           <div className="grid gap-2">
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label_Shadcn_ htmlFor="width">Width</Label_Shadcn_>
+              <Label htmlFor="width">Width</Label>
               <Input id="width" defaultValue="100%" className="col-span-2 h-8" />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label_Shadcn_ htmlFor="maxWidth">Max. width</Label_Shadcn_>
+              <Label htmlFor="maxWidth">Max. width</Label>
               <Input id="maxWidth" defaultValue="300px" className="col-span-2 h-8" />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label_Shadcn_ htmlFor="height">Height</Label_Shadcn_>
+              <Label htmlFor="height">Height</Label>
               <Input id="height" defaultValue="25px" className="col-span-2 h-8" />
             </div>
             <div className="grid grid-cols-3 items-center gap-4">
-              <Label_Shadcn_ htmlFor="maxHeight">Max. height</Label_Shadcn_>
+              <Label htmlFor="maxHeight">Max. height</Label>
               <Input id="maxHeight" defaultValue="none" className="col-span-2 h-8" />
             </div>
           </div>

--- a/apps/design-system/registry/default/example/radio-group-demo.tsx
+++ b/apps/design-system/registry/default/example/radio-group-demo.tsx
@@ -1,19 +1,19 @@
-import { Label_Shadcn_, RadioGroup, RadioGroupItem } from 'ui'
+import { Label, RadioGroup, RadioGroupItem } from 'ui'
 
 export default function RadioGroupDemo() {
   return (
     <RadioGroup defaultValue="comfortable">
       <div className="flex items-center space-x-2">
         <RadioGroupItem value="default" id="r1" />
-        <Label_Shadcn_ htmlFor="r1">Default</Label_Shadcn_>
+        <Label htmlFor="r1">Default</Label>
       </div>
       <div className="flex items-center space-x-2">
         <RadioGroupItem value="comfortable" id="r2" />
-        <Label_Shadcn_ htmlFor="r2">Comfortable</Label_Shadcn_>
+        <Label htmlFor="r2">Comfortable</Label>
       </div>
       <div className="flex items-center space-x-2">
         <RadioGroupItem value="compact" id="r3" />
-        <Label_Shadcn_ htmlFor="r3">Compact</Label_Shadcn_>
+        <Label htmlFor="r3">Compact</Label>
       </div>
     </RadioGroup>
   )

--- a/apps/design-system/registry/default/example/sheet-confirm-on-close-demo.tsx
+++ b/apps/design-system/registry/default/example/sheet-confirm-on-close-demo.tsx
@@ -10,7 +10,7 @@ import {
   AlertDialogTitle,
   Button,
   Input,
-  Label_Shadcn_ as Label,
+  Label as Label,
   Separator,
   Sheet,
   SheetContent,

--- a/apps/design-system/registry/default/example/sheet-demo.tsx
+++ b/apps/design-system/registry/default/example/sheet-demo.tsx
@@ -1,7 +1,7 @@
 import {
   Button,
   Input,
-  Label_Shadcn_,
+  Label,
   Sheet,
   SheetClose,
   SheetContent,
@@ -28,15 +28,15 @@ export default function SheetDemo() {
           <SheetSection>
             <div className="grid gap-4 py-4">
               <div className="grid grid-cols-4 items-center gap-4">
-                <Label_Shadcn_ htmlFor="name" className="text-right">
+                <Label htmlFor="name" className="text-right">
                   Name
-                </Label_Shadcn_>
+                </Label>
                 <Input id="name" value="Pedro Duarte" className="col-span-3" readOnly />
               </div>
               <div className="grid grid-cols-4 items-center gap-4">
-                <Label_Shadcn_ htmlFor="username" className="text-right">
+                <Label htmlFor="username" className="text-right">
                   Username
-                </Label_Shadcn_>
+                </Label>
                 <Input id="username" value="@peduarte" className="col-span-3" readOnly />
               </div>
             </div>

--- a/apps/design-system/registry/default/example/sheet-side.tsx
+++ b/apps/design-system/registry/default/example/sheet-side.tsx
@@ -3,7 +3,7 @@
 import {
   Button,
   Input,
-  Label_Shadcn_,
+  Label,
   Sheet,
   SheetClose,
   SheetContent,
@@ -35,15 +35,15 @@ export default function SheetSide() {
             </SheetHeader>
             <div className="grid gap-4 py-4">
               <div className="grid grid-cols-4 items-center gap-4">
-                <Label_Shadcn_ htmlFor="name" className="text-right">
+                <Label htmlFor="name" className="text-right">
                   Name
-                </Label_Shadcn_>
+                </Label>
                 <Input id="name" value="Pedro Duarte" className="col-span-3" />
               </div>
               <div className="grid grid-cols-4 items-center gap-4">
-                <Label_Shadcn_ htmlFor="username" className="text-right">
+                <Label htmlFor="username" className="text-right">
                   Username
-                </Label_Shadcn_>
+                </Label>
                 <Input id="username" value="@peduarte" className="col-span-3" />
               </div>
             </div>

--- a/apps/design-system/registry/default/example/switch-demo.tsx
+++ b/apps/design-system/registry/default/example/switch-demo.tsx
@@ -1,10 +1,10 @@
-import { Label_Shadcn_, Switch } from 'ui'
+import { Label, Switch } from 'ui'
 
 export default function SwitchDemo() {
   return (
     <div className="flex items-center space-x-2">
       <Switch id="airplane-mode" />
-      <Label_Shadcn_ htmlFor="airplane-mode">Airplane Mode</Label_Shadcn_>
+      <Label htmlFor="airplane-mode">Airplane Mode</Label>
     </div>
   )
 }

--- a/apps/design-system/registry/default/example/tabs-demo.tsx
+++ b/apps/design-system/registry/default/example/tabs-demo.tsx
@@ -7,7 +7,7 @@ import {
   CardHeader,
   CardTitle,
   Input,
-  Label_Shadcn_,
+  Label,
   Tabs_Shadcn_,
   TabsContent_Shadcn_,
   TabsList_Shadcn_,
@@ -31,11 +31,11 @@ export default function TabsDemo() {
           </CardHeader>
           <CardContent className="space-y-2">
             <div className="space-y-1">
-              <Label_Shadcn_ htmlFor="name">Name</Label_Shadcn_>
+              <Label htmlFor="name">Name</Label>
               <Input id="name" defaultValue="Pedro Duarte" />
             </div>
             <div className="space-y-1">
-              <Label_Shadcn_ htmlFor="username">Username</Label_Shadcn_>
+              <Label htmlFor="username">Username</Label>
               <Input id="username" defaultValue="@peduarte" />
             </div>
           </CardContent>
@@ -54,11 +54,11 @@ export default function TabsDemo() {
           </CardHeader>
           <CardContent className="space-y-2">
             <div className="space-y-1">
-              <Label_Shadcn_ htmlFor="current">Current password</Label_Shadcn_>
+              <Label htmlFor="current">Current password</Label>
               <Input id="current" type="password" />
             </div>
             <div className="space-y-1">
-              <Label_Shadcn_ htmlFor="new">New password</Label_Shadcn_>
+              <Label htmlFor="new">New password</Label>
               <Input id="new" type="password" />
             </div>
           </CardContent>

--- a/apps/design-system/registry/default/example/textarea-with-label.tsx
+++ b/apps/design-system/registry/default/example/textarea-with-label.tsx
@@ -1,9 +1,9 @@
-import { Label_Shadcn_, Textarea } from 'ui'
+import { Label, Textarea } from 'ui'
 
 export default function TextareaWithLabel() {
   return (
     <div className="grid w-full gap-1.5">
-      <Label_Shadcn_ htmlFor="message">Your message</Label_Shadcn_>
+      <Label htmlFor="message">Your message</Label>
       <Textarea placeholder="Type your message here." id="message" />
     </div>
   )

--- a/apps/design-system/registry/default/example/textarea-with-text.tsx
+++ b/apps/design-system/registry/default/example/textarea-with-text.tsx
@@ -1,9 +1,9 @@
-import { Label_Shadcn_, Textarea } from 'ui'
+import { Label, Textarea } from 'ui'
 
 export default function TextareaWithText() {
   return (
     <div className="grid w-full gap-1.5">
-      <Label_Shadcn_ htmlFor="message-2">Your Message</Label_Shadcn_>
+      <Label htmlFor="message-2">Your Message</Label>
       <Textarea placeholder="Type your message here." id="message-2" />
       <p className="text-sm text-muted-foreground">
         Your message will be copied to the support team.

--- a/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.tsx
+++ b/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.tsx
@@ -6,7 +6,7 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  Label_Shadcn_,
+  Label,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectItem_Shadcn_,
@@ -65,7 +65,7 @@ export default function RealtimeLimitsEstimater({}) {
       <h4>Set your expected parameters</h4>
       <div className="grid mb-8 gap-y-8 gap-x-8 grid-cols-2 xl:grid-cols-4">
         <div>
-          <Label_Shadcn_ htmlFor="computeAddOn">Compute:</Label_Shadcn_>
+          <Label htmlFor="computeAddOn">Compute:</Label>
           <Select_Shadcn_ onValueChange={handleComputeAddOnSelection} value={computeAddOn}>
             <SelectTrigger_Shadcn_ id="computeAddOn">
               <SelectValue_Shadcn_ className="font-mono" />
@@ -78,7 +78,7 @@ export default function RealtimeLimitsEstimater({}) {
           </Select_Shadcn_>
         </div>
         <div>
-          <Label_Shadcn_ htmlFor="filters">Filters:</Label_Shadcn_>
+          <Label htmlFor="filters">Filters:</Label>
           <Select_Shadcn_
             onValueChange={handleFiltersSelection}
             value={filters.toString()}
@@ -94,7 +94,7 @@ export default function RealtimeLimitsEstimater({}) {
           </Select_Shadcn_>
         </div>
         <div>
-          <Label_Shadcn_ htmlFor="rls">RLS:</Label_Shadcn_>
+          <Label htmlFor="rls">RLS:</Label>
           <Select_Shadcn_ onValueChange={handleRLSSelection} value={rls.toString()}>
             <SelectTrigger_Shadcn_ id="rls">
               <SelectValue_Shadcn_ className="font-mono" />
@@ -106,7 +106,7 @@ export default function RealtimeLimitsEstimater({}) {
           </Select_Shadcn_>
         </div>
         <div>
-          <Label_Shadcn_ htmlFor="concurrency">Connected clients:</Label_Shadcn_>
+          <Label htmlFor="concurrency">Connected clients:</Label>
           <Select_Shadcn_ onValueChange={handleConcurrencySelection} value={concurrency.toString()}>
             <SelectTrigger_Shadcn_ id="concurrency">
               <SelectValue_Shadcn_ className="font-mono" />

--- a/apps/lite-studio/app/routes/projects.$ref.tsx
+++ b/apps/lite-studio/app/routes/projects.$ref.tsx
@@ -6,7 +6,7 @@ import {
   Card,
   Checkbox,
   Input,
-  Label_Shadcn_ as Label,
+  Label,
   Separator,
   Switch,
   Tabs_Shadcn_ as Tabs,

--- a/apps/studio/components/interfaces/Account/Preferences/ThemeSettings.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/ThemeSettings.tsx
@@ -5,7 +5,7 @@ import SVG from 'react-inlinesvg'
 import {
   Card,
   CardContent,
-  Label_Shadcn_,
+  Label,
   RadioGroup,
   RadioGroupLargeItem,
   Select_Shadcn_,
@@ -86,9 +86,9 @@ export const ThemeSettings = () => {
         <Card>
           <CardContent className="grid grid-cols-12 gap-6">
             <div className="col-span-full md:col-span-4 flex flex-col gap-2">
-              <Label_Shadcn_ htmlFor="theme" className="text-foreground">
+              <Label htmlFor="theme" className="text-foreground">
                 Theme mode
-              </Label_Shadcn_>
+              </Label>
               <p className="text-sm text-foreground-light">
                 Choose how Supabase looks to you. Select a single theme, or sync with your system.
               </p>

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/TemplateEditor.tsx
@@ -14,7 +14,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_,
+  Label,
   Tooltip,
   TooltipContent,
   TooltipTrigger,
@@ -274,7 +274,7 @@ export const TemplateEditor = ({ template }: TemplateEditorProps) => {
           <>
             <CardContent className="flex flex-col gap-4">
               <div className="flex items-center justify-between gap-2">
-                <Label_Shadcn_>Body</Label_Shadcn_>
+                <Label>Body</Label>
                 <TwoOptionToggle
                   width={60}
                   options={['preview', 'source']}

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorPanel/index.tsx
@@ -21,7 +21,7 @@ import {
   Checkbox,
   cn,
   Form,
-  Label_Shadcn_,
+  Label,
   ScrollArea,
   Sheet,
   SheetContent,
@@ -506,9 +506,9 @@ export const PolicyEditorPanel = memo(function ({
                             setShowCheckBlock(!showCheckBlock)
                           }}
                         />
-                        <Label_Shadcn_ className="text-xs cursor-pointer" htmlFor="use-check">
+                        <Label className="text-xs cursor-pointer" htmlFor="use-check">
                           Use check expression
-                        </Label_Shadcn_>
+                        </Label>
                       </div>
                     )}
                   </div>

--- a/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
@@ -1,7 +1,7 @@
 import { useQueryClient } from '@tanstack/react-query'
 import { useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { Button, Checkbox, Label_Shadcn_, Modal } from 'ui'
+import { Button, Checkbox, Label, Modal } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import {
@@ -214,9 +214,9 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
               }
             }}
           />
-          <Label_Shadcn_ htmlFor="save-as-default" className="text-foreground-light">
+          <Label htmlFor="save-as-default" className="text-foreground-light">
             Save as default payment method
-          </Label_Shadcn_>
+          </Label>
         </div>
 
         <div className="flex items-center gap-x-2 mt-4 mb-2">
@@ -229,9 +229,9 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
               }
             }}
           />
-          <Label_Shadcn_ htmlFor="is-primary-billing-address" className="text-foreground-light">
+          <Label htmlFor="is-primary-billing-address" className="text-foreground-light">
             Use the billing address as my organization's primary address
-          </Label_Shadcn_>
+          </Label>
         </div>
       </Modal.Content>
       <Modal.Separator />

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -25,7 +25,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label as Label,
+  Label,
   Switch,
   Tooltip,
   TooltipContent,

--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -25,7 +25,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_ as Label,
+  Label as Label,
   Switch,
   Tooltip,
   TooltipContent,

--- a/apps/studio/components/interfaces/BranchManagement/EditBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/EditBranchModal.tsx
@@ -21,7 +21,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label as Label,
+  Label,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'

--- a/apps/studio/components/interfaces/BranchManagement/EditBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/EditBranchModal.tsx
@@ -21,7 +21,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_ as Label,
+  Label as Label,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'

--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -9,7 +9,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_,
+  Label,
   RadioGroupStacked,
   RadioGroupStackedItem,
   Select_Shadcn_,
@@ -193,12 +193,12 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
                         }}
                       />
                       <div className="grid gap-1.5 leading-none">
-                        <Label_Shadcn_
+                        <Label
                           htmlFor={`event-${event.value}`}
                           className="text-sm font-normal cursor-pointer"
                         >
                           {event.label}
-                        </Label_Shadcn_>
+                        </Label>
                         <p className="text-xs text-foreground-lighter">{event.description}</p>
                       </div>
                     </div>

--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -15,7 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -275,9 +275,9 @@ export const TableList = ({
                             }
                           }}
                         />
-                        <Label_Shadcn_ htmlFor={key} className="capitalize text-xs">
+                        <Label htmlFor={key} className="capitalize text-xs">
                           {key.toLowerCase().replace('_', ' ')}
-                        </Label_Shadcn_>
+                        </Label>
                       </div>
                       <Button
                         size="tiny"

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -11,7 +11,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_ as Label,
+  Label,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
@@ -115,9 +115,7 @@ const WrapperTableEditor = ({
       <SidePanel.Content>
         <div className="my-4 flex flex-col gap-y-6">
           <div className="flex flex-col gap-y-2">
-            <Label className="text-foreground-light">
-              Select a target the table will point to
-            </Label>
+            <Label className="text-foreground-light">Select a target the table will point to</Label>
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild>
                 <Button

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
@@ -22,7 +22,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -115,9 +115,9 @@ const WrapperTableEditor = ({
       <SidePanel.Content>
         <div className="my-4 flex flex-col gap-y-6">
           <div className="flex flex-col gap-y-2">
-            <Label_Shadcn_ className="text-foreground-light">
+            <Label className="text-foreground-light">
               Select a target the table will point to
-            </Label_Shadcn_>
+            </Label>
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild>
                 <Button

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/create-key-dialog.tsx
@@ -10,7 +10,7 @@ import {
   DialogSection,
   DialogSectionSeparator,
   DialogTitle,
-  Label_Shadcn_,
+  Label,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectItem_Shadcn_,
@@ -164,7 +164,7 @@ export const CreateKeyDialog = ({
       <DialogSectionSeparator />
       <DialogSection className="flex flex-col gap-4">
         <div className="flex flex-col gap-4">
-          <Label_Shadcn_ htmlFor="algorithm">Choose signing algorithm:</Label_Shadcn_>
+          <Label htmlFor="algorithm">Choose signing algorithm:</Label>
           <Select_Shadcn_
             name="algorithm"
             value={newKeyAlgorithm}
@@ -186,12 +186,12 @@ export const CreateKeyDialog = ({
           </Select_Shadcn_>
         </div>
         <div className="flex flex-col gap-4">
-          <Label_Shadcn_ htmlFor="byok" className="flex items-center gap-x-2">
+          <Label htmlFor="byok" className="flex items-center gap-x-2">
             <Checkbox id="byok" checked={isBYOK} onCheckedChange={(value) => setBYOK(!!value)} />
             {newKeyAlgorithm === 'HS256'
               ? 'Import an existing secret'
               : 'Import an existing private key'}
-          </Label_Shadcn_>
+          </Label>
           {isBYOK && (
             <div className="flex flex-col gap-2">
               <Textarea
@@ -215,14 +215,14 @@ export const CreateKeyDialog = ({
           )}
           {isBYOK && newKeyAlgorithm === 'HS256' && (
             <>
-              <Label_Shadcn_ htmlFor="base64" className="flex items-center gap-x-2">
+              <Label htmlFor="base64" className="flex items-center gap-x-2">
                 <Checkbox
                   id="base64"
                   checked={isBase64}
                   onCheckedChange={(value) => setBase64(!!value)}
                 />
                 Secret is already Base64 encoded
-              </Label_Shadcn_>
+              </Label>
             </>
           )}
         </div>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/key-details-dialog.tsx
@@ -8,7 +8,7 @@ import {
   DialogSectionSeparator,
   DialogTitle,
   Input,
-  Label_Shadcn_,
+  Label,
   Textarea,
 } from 'ui'
 
@@ -38,18 +38,18 @@ export function KeyDetailsDialog({
       <DialogSectionSeparator />
       <DialogSection className="flex flex-col gap-6">
         <div className="flex flex-col gap-2">
-          <Label_Shadcn_ htmlFor="key-id">Key ID</Label_Shadcn_>
+          <Label htmlFor="key-id">Key ID</Label>
           <Input id="key-id" value={selectedKey.id} readOnly />
         </div>
         <div className="flex flex-col gap-2">
-          <Label_Shadcn_ htmlFor="discovery-url">Discovery URL</Label_Shadcn_>
+          <Label htmlFor="discovery-url">Discovery URL</Label>
           <Input id="discovery-url" value={jwksURL.href} readOnly />
         </div>
         <div className="flex flex-col gap-2">
-          <Label_Shadcn_ htmlFor="jwk" className="flex flex-row gap-2 items-center">
+          <Label htmlFor="jwk" className="flex flex-row gap-2 items-center">
             <FileKey className="size-4 text-foreground-light" />
             Public key set (JSON Web Key Set format)
-          </Label_Shadcn_>
+          </Label>
           <div className="relative">
             <Textarea className="font-mono text-sm pr-10" rows={8} value={jwks} readOnly />
             <CopyButton

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/rotate-key-dialog.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-secret-keys-table/rotate-key-dialog.tsx
@@ -12,7 +12,7 @@ import {
   DialogSection,
   DialogSectionSeparator,
   DialogTitle,
-  Label_Shadcn_,
+  Label,
   Skeleton,
 } from 'ui'
 
@@ -138,7 +138,7 @@ export function RotateKeyDialog({
           <>
             <div className="text-sm">To proceed please confirm:</div>
 
-            <Label_Shadcn_
+            <Label
               htmlFor="understands-standby"
               className="flex items-top gap-4 text-sm leading-none"
             >
@@ -172,9 +172,9 @@ export function RotateKeyDialog({
                   },
                 }}
               />
-            </Label_Shadcn_>
+            </Label>
 
-            <Label_Shadcn_
+            <Label
               htmlFor="understands-previously-used"
               className="flex items-top gap-4 text-sm leading-none"
             >
@@ -211,10 +211,10 @@ export function RotateKeyDialog({
                   },
                 }}
               />
-            </Label_Shadcn_>
+            </Label>
 
             {verifyJWTEdgeFunctions.length > 0 && (
-              <Label_Shadcn_ htmlFor="edge-functions-verify-jwt" className="flex gap-4 text-sm">
+              <Label htmlFor="edge-functions-verify-jwt" className="flex gap-4 text-sm">
                 <Checkbox
                   id="edge-functions-verify-jwt"
                   className="mt-0.5"
@@ -268,7 +268,7 @@ export function RotateKeyDialog({
                     },
                   }}
                 />
-              </Label_Shadcn_>
+              </Label>
             )}
           </>
         )}

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm.tsx
@@ -5,7 +5,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_,
+  Label,
   Select_Shadcn_,
   SelectContent_Shadcn_,
   SelectItem_Shadcn_,
@@ -72,12 +72,12 @@ const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
                   <>
                     <Input {...field} placeholder="Organization name" />
                     <div className="mt-1">
-                      <Label_Shadcn_
+                      <Label
                         htmlFor="name"
                         className="text-foreground-lighter leading-normal text-sm"
                       >
                         What's the name of your company or team?
-                      </Label_Shadcn_>
+                      </Label>
                     </div>
                   </>
                 </FormControl>
@@ -104,12 +104,12 @@ const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
                       </SelectContent_Shadcn_>
                     </Select_Shadcn_>
                     <div className="mt-1">
-                      <Label_Shadcn_
+                      <Label
                         htmlFor="kind"
                         className="text-foreground-lighter leading-normal text-sm"
                       >
                         What would best describe your organization?
-                      </Label_Shadcn_>
+                      </Label>
                     </div>
                   </>
                 </FormControl>
@@ -137,12 +137,12 @@ const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
                         </SelectContent_Shadcn_>
                       </Select_Shadcn_>
                       <div className="mt-1">
-                        <Label_Shadcn_
+                        <Label
                           htmlFor="size"
                           className="text-foreground-lighter leading-normal text-sm"
                         >
                           How many people are in your company?
-                        </Label_Shadcn_>
+                        </Label>
                       </div>
                     </>
                   </FormControl>

--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
@@ -14,7 +14,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label as Label,
+  Label,
   Separator,
   Sheet,
   SheetContent,

--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
@@ -14,7 +14,7 @@ import {
   FormControl,
   FormField,
   Input,
-  Label_Shadcn_ as Label,
+  Label as Label,
   Separator,
   Sheet,
   SheetContent,

--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksPage.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksPage.tsx
@@ -19,7 +19,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -483,7 +483,7 @@ export const PlatformWebhooksPage = ({ scope, endpointId }: PlatformWebhooksPage
           {/* Content */}
           <div className="space-y-4 mx-5 pb-5">
             <div className="space-y-1">
-              <Label_Shadcn_>Signing secret</Label_Shadcn_>
+              <Label>Signing secret</Label>
               <Input
                 copy
                 readOnly

--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -29,7 +29,7 @@ import {
   FormLabel,
   FormMessage,
   Input,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -229,7 +229,7 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
 
             <DialogSection className="py-5 flex flex-col gap-y-4">
               <div className="flex flex-col gap-y-2">
-                <Label_Shadcn_ className="text-foreground-light">Select a folder</Label_Shadcn_>
+                <Label className="text-foreground-light">Select a folder</Label>
                 <Popover open={open} onOpenChange={setOpen} modal={false}>
                   <PopoverTrigger asChild>
                     <Button

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
@@ -7,7 +7,7 @@ import {
   Badge,
   Button,
   Checkbox,
-  Label_Shadcn_,
+  Label,
   ResizableHandle,
   ResizablePanel,
   ResizablePanelGroup,
@@ -227,7 +227,7 @@ export const ChartConfig = ({
         )}
 
         <div>
-          <Label_Shadcn_ className="text-xs text-foreground-light">X Axis</Label_Shadcn_>
+          <Label className="text-xs text-foreground-light">X Axis</Label>
           <Select_Shadcn_
             value={config.xKey}
             onValueChange={(value) => {
@@ -248,7 +248,7 @@ export const ChartConfig = ({
         </div>
 
         <div>
-          <Label_Shadcn_ className="text-xs text-foreground-light">Y Axis</Label_Shadcn_>
+          <Label className="text-xs text-foreground-light">Y Axis</Label>
           <Select_Shadcn_
             value={config.yKey}
             onValueChange={(value) => {
@@ -268,7 +268,7 @@ export const ChartConfig = ({
           </Select_Shadcn_>
         </div>
         <div className="*:flex *:gap-2 *:items-center grid gap-2 *:text-foreground-light *:p-1.5 *:pl-0">
-          <Label_Shadcn_ className="" htmlFor="cumulative">
+          <Label className="" htmlFor="cumulative">
             <Checkbox
               id="cumulative"
               name="cumulative"
@@ -276,9 +276,9 @@ export const ChartConfig = ({
               onClick={() => onConfigChange({ ...config, cumulative: !config.cumulative })}
             />
             Cumulative
-          </Label_Shadcn_>
+          </Label>
 
-          <Label_Shadcn_ htmlFor="showLabels">
+          <Label htmlFor="showLabels">
             <Checkbox
               id="showLabels"
               name="showLabels"
@@ -286,9 +286,9 @@ export const ChartConfig = ({
               onClick={() => onConfigChange({ ...config, showLabels: !config.showLabels })}
             />
             Show labels
-          </Label_Shadcn_>
+          </Label>
 
-          <Label_Shadcn_ htmlFor="showGrid">
+          <Label htmlFor="showGrid">
             <Checkbox
               id="showGrid"
               name="showGrid"
@@ -296,7 +296,7 @@ export const ChartConfig = ({
               onClick={() => onConfigChange({ ...config, showGrid: !config.showGrid })}
             />
             Show grid
-          </Label_Shadcn_>
+          </Label>
         </div>
       </ResizablePanel>
     </ResizablePanelGroup>

--- a/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsQueryPanel.tsx
@@ -18,7 +18,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -169,12 +169,12 @@ const LogsQueryPanel = ({
                       checked={useOtel}
                       onCheckedChange={(checked) => onUseOtelChange?.(checked)}
                     />
-                    <Label_Shadcn_
+                    <Label
                       htmlFor="logs-explorer-otel-toggle"
                       className="text-xs text-foreground-light cursor-pointer"
                     >
                       OTEL endpoint
-                    </Label_Shadcn_>
+                    </Label>
                   </div>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="max-w-xs">

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/FileExplorerHeader.tsx
@@ -40,7 +40,7 @@ import {
   DropdownMenuSubTrigger,
   DropdownMenuTrigger,
   FieldDescription,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 
@@ -101,7 +101,7 @@ const NavigateDialog = ({
           </DialogDescription>
         </DialogHeader>
         <DialogSection className="flex flex-col gap-y-2">
-          <Label_Shadcn_ htmlFor={inputId}>Path</Label_Shadcn_>
+          <Label htmlFor={inputId}>Path</Label>
           <Input
             id={inputId}
             autoFocus

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ColumnEditor/ColumnType.tsx
@@ -29,7 +29,7 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupInput,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -185,7 +185,7 @@ const ColumnType = ({
 
   return (
     <div className={cn('flex flex-col gap-y-2', className)}>
-      {showLabel && <Label_Shadcn_ className="text-foreground-light">Type</Label_Shadcn_>}
+      {showLabel && <Label className="text-foreground-light">Type</Label>}
       <Popover modal open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.tsx
@@ -1,7 +1,7 @@
 import type { PGTable } from '@supabase/pg-meta'
 import { isEmpty, noop, partition } from 'lodash'
 import { useEffect, useMemo, useState } from 'react'
-import { Label_Shadcn_, SidePanel, Switch } from 'ui'
+import { Label, SidePanel, Switch } from 'ui'
 
 import { ActionBar } from '../ActionBar'
 import { formatForeignKeys } from '../ForeignKeySelector/ForeignKeySelector.utils'
@@ -199,7 +199,7 @@ export const RowEditor = ({
                 checked={createMore}
                 onCheckedChange={(checked) => setCreateMore(checked)}
               />
-              <Label_Shadcn_ htmlFor="create-more">Create more</Label_Shadcn_>
+              <Label htmlFor="create-more">Create more</Label>
             </div>
           )}
         </ActionBar>

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -3,7 +3,7 @@ import { keepPreviousData } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { Filter, Plus } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Button, Checkbox, Label_Shadcn_, Popover, PopoverContent, PopoverTrigger } from 'ui'
+import { Button, Checkbox, Label, Popover, PopoverContent, PopoverTrigger } from 'ui'
 import {
   InnerSideBarEmptyPanel,
   InnerSideBarFilters,
@@ -244,9 +244,9 @@ export const TableEditorMenu = () => {
                               }
                             }}
                           />
-                          <Label_Shadcn_ htmlFor={key} className="capitalize text-xs">
+                          <Label htmlFor={key} className="capitalize text-xs">
                             {key.toLowerCase().replace('_', ' ')}
-                          </Label_Shadcn_>
+                          </Label>
                         </div>
                         <Button
                           size="tiny"

--- a/apps/studio/components/ui/Charts/ReportSettings.tsx
+++ b/apps/studio/components/ui/Charts/ReportSettings.tsx
@@ -1,13 +1,6 @@
 import { Settings } from 'lucide-react'
 import { useState } from 'react'
-import {
-  cn,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuTrigger,
-  Label,
-  Switch,
-} from 'ui'
+import { cn, DropdownMenu, DropdownMenuContent, DropdownMenuTrigger, Label, Switch } from 'ui'
 
 import { useChartHoverState } from './useChartHoverState'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'

--- a/apps/studio/components/ui/Charts/ReportSettings.tsx
+++ b/apps/studio/components/ui/Charts/ReportSettings.tsx
@@ -5,7 +5,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
-  Label_Shadcn_,
+  Label,
   Switch,
 } from 'ui'
 
@@ -32,7 +32,7 @@ export const ReportSettings = ({ chartId }: ReportSettingsProps) => {
       </DropdownMenuTrigger>
       <DropdownMenuContent align="start" side="bottom" className="w-64 p-3">
         <div className="space-y-4">
-          <Label_Shadcn_ htmlFor="sync-hover" className="text-sm font-normal">
+          <Label htmlFor="sync-hover" className="text-sm font-normal">
             <div className="flex items-center justify-between space-x-2">
               Sync chart headers
               <Switch id="sync-hover" checked={syncHover} onCheckedChange={setSyncHover} />
@@ -40,9 +40,9 @@ export const ReportSettings = ({ chartId }: ReportSettingsProps) => {
             <p className="text-xs text-foreground-light mt-1">
               When enabled, hovering over any chart will update headers across all charts
             </p>
-          </Label_Shadcn_>
+          </Label>
 
-          <Label_Shadcn_ htmlFor="sync-tooltips" className="text-sm font-normal flex flex-col">
+          <Label htmlFor="sync-tooltips" className="text-sm font-normal flex flex-col">
             <div className="flex items-center justify-between space-x-2">
               Sync tooltips
               <Switch
@@ -58,7 +58,7 @@ export const ReportSettings = ({ chartId }: ReportSettingsProps) => {
                 Requires header sync.
               </span>
             </p>
-          </Label_Shadcn_>
+          </Label>
         </div>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
@@ -1,6 +1,6 @@
 import { Search } from 'lucide-react'
 import { useState } from 'react'
-import { Checkbox, cn, Label_Shadcn_ as Label, Skeleton } from 'ui'
+import { Checkbox, cn, Label as Label, Skeleton } from 'ui'
 
 import type { DataTableCheckboxFilterField } from '../DataTable.types'
 import { formatCompactNumber } from '../DataTable.utils'

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
@@ -1,6 +1,6 @@
 import { Search } from 'lucide-react'
 import { useState } from 'react'
-import { Checkbox, cn, Label as Label, Skeleton } from 'ui'
+import { Checkbox, cn, Label, Skeleton } from 'ui'
 
 import type { DataTableCheckboxFilterField } from '../DataTable.types'
 import { formatCompactNumber } from '../DataTable.utils'

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
@@ -3,7 +3,7 @@ import { useDebounce } from '@uidotdev/usehooks'
 import { useParams } from 'common'
 import { Loader2, Search } from 'lucide-react'
 import { useState } from 'react'
-import { Checkbox, cn, Label_Shadcn_ as Label, Skeleton } from 'ui'
+import { Checkbox, cn, Label, Skeleton } from 'ui'
 
 import type { DataTableCheckboxFilterField } from '../DataTable.types'
 import { formatCompactNumber } from '../DataTable.utils'

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterInput.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterInput.tsx
@@ -1,6 +1,6 @@
 import { Search } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { Label as Label } from 'ui'
+import { Label } from 'ui'
 
 import type { DataTableInputFilterField } from '../DataTable.types'
 import { useDebounce } from '../hooks/useDebounce'

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterInput.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterInput.tsx
@@ -1,6 +1,6 @@
 import { Search } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import { Label_Shadcn_ as Label } from 'ui'
+import { Label as Label } from 'ui'
 
 import type { DataTableInputFilterField } from '../DataTable.types'
 import { useDebounce } from '../hooks/useDebounce'

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterSlider.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterSlider.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Label_Shadcn_ as Label } from 'ui'
+import { Label as Label } from 'ui'
 
 import type { DataTableSliderFilterField } from '../DataTable.types'
 import { isArrayOfNumbers } from '../DataTable.utils'

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterSlider.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterSlider.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { Label as Label } from 'ui'
+import { Label } from 'ui'
 
 import type { DataTableSliderFilterField } from '../DataTable.types'
 import { isArrayOfNumbers } from '../DataTable.utils'

--- a/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
+++ b/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
@@ -12,7 +12,7 @@ import {
   DialogSectionSeparator,
   DialogTitle,
   Input,
-  Label_Shadcn_,
+  Label,
 } from 'ui'
 
 import { subscriptionHasHipaaAddon } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
@@ -72,7 +72,7 @@ export const SaveSnippetDialog = ({ open, sql, onOpenChange, onSave }: SaveSnipp
         <DialogSectionSeparator />
         <DialogSection className="flex flex-col gap-y-4 py-5">
           <div className="flex flex-col gap-y-2">
-            <Label_Shadcn_ htmlFor="snippet-name">Name</Label_Shadcn_>
+            <Label htmlFor="snippet-name">Name</Label>
             <Input
               id="snippet-name"
               autoFocus

--- a/apps/studio/components/ui/FilterPopover.tsx
+++ b/apps/studio/components/ui/FilterPopover.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   Checkbox,
   cn,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -92,7 +92,7 @@ export const FilterPopover = <T extends Record<string, any>>({
     const icon = iconKey ? option[iconKey] : undefined
 
     const defaultLabel = (
-      <Label_Shadcn_
+      <Label
         htmlFor={option[valueKey]}
         className={cn('flex items-center gap-x-2 text-xs cursor-pointer', labelClass)}
       >
@@ -100,7 +100,7 @@ export const FilterPopover = <T extends Record<string, any>>({
           <img src={icon} alt={option[labelKey]} className={cn('w-4 h-4', option.iconClass)} />
         )}
         <span>{option[labelKey]}</span>
-      </Label_Shadcn_>
+      </Label>
     )
 
     const label = renderLabel ? renderLabel(option, value) : defaultLabel

--- a/apps/studio/components/ui/QueryBlock/BlockViewConfiguration.tsx
+++ b/apps/studio/components/ui/QueryBlock/BlockViewConfiguration.tsx
@@ -1,7 +1,7 @@
 import { BarChart2, Settings2, Table } from 'lucide-react'
 import {
   Checkbox,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -108,7 +108,7 @@ export const BlockViewConfiguration = ({
               </Select_Shadcn_>
 
               <div className="*:flex *:gap-2 *:items-center grid gap-2 *:text-foreground-light *:p-1.5 *:pl-0">
-                <Label_Shadcn_ htmlFor="cumulative">
+                <Label htmlFor="cumulative">
                   <Checkbox
                     id="cumulative"
                     checked={chartConfig?.cumulative}
@@ -120,8 +120,8 @@ export const BlockViewConfiguration = ({
                     }
                   />
                   Cumulative
-                </Label_Shadcn_>
-                <Label_Shadcn_ htmlFor="logScale">
+                </Label>
+                <Label htmlFor="logScale">
                   <Checkbox
                     id="logScale"
                     checked={chartConfig?.logScale}
@@ -133,7 +133,7 @@ export const BlockViewConfiguration = ({
                     }
                   />
                   Log scale
-                </Label_Shadcn_>
+                </Label>
               </div>
             </>
           )}

--- a/apps/studio/pages/project/[ref]/functions/new.tsx
+++ b/apps/studio/pages/project/[ref]/functions/new.tsx
@@ -21,7 +21,7 @@ import {
   FormField,
   FormItem,
   Input,
-  Label_Shadcn_,
+  Label,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -380,7 +380,7 @@ const NewFunctionPage = () => {
           className="flex items-center bg-background-muted justify-end p-4 border-t bg-surface-100 gap-3"
         >
           <div className="flex items-center gap-3">
-            <Label_Shadcn_ htmlFor="functionName">Function name</Label_Shadcn_>
+            <Label htmlFor="functionName">Function name</Label>
             <FormField
               control={form.control}
               name="functionName"

--- a/apps/ui-library/registry/default/examples/realtime-avatar-stack-demo.tsx
+++ b/apps/ui-library/registry/default/examples/realtime-avatar-stack-demo.tsx
@@ -3,7 +3,7 @@
 import { REALTIME_SUBSCRIBE_STATES } from '@supabase/supabase-js'
 import { useUser } from 'common'
 import { useEffect, useMemo, useState } from 'react'
-import { Label_Shadcn_, Switch } from 'ui'
+import { Label, Switch } from 'ui'
 
 import { getRandomUser } from './utils'
 import { AvatarStack } from '@/registry/default/blocks/realtime-avatar-stack/components/avatar-stack'
@@ -97,7 +97,7 @@ const RealtimeAvatarStackDemo = () => {
       ) : user ? (
         <div className="flex items-center space-x-2">
           <Switch id="current-user" checked={dashboardUser} onCheckedChange={setDashboardUser} />
-          <Label_Shadcn_ htmlFor="current-user">Use my supabase.com account instead</Label_Shadcn_>
+          <Label htmlFor="current-user">Use my supabase.com account instead</Label>
         </div>
       ) : (
         <span className="text-sm text-foreground-light">

--- a/apps/www/components/Contribute/SimilarSolvedThreads.tsx
+++ b/apps/www/components/Contribute/SimilarSolvedThreads.tsx
@@ -24,7 +24,7 @@ import {
   DialogSection,
   DialogSectionSeparator,
   DialogTitle,
-  Label_Shadcn_,
+  Label,
   TextArea,
   Tooltip,
   TooltipContent,
@@ -284,9 +284,9 @@ export const SimilarSolvedThreads = ({ threads, parentThreadId }: SimilarSolvedT
               </div>
             </fieldset>
             <div className="space-y-1">
-              <Label_Shadcn_ htmlFor="feedback">
+              <Label htmlFor="feedback">
                 Additional feedback <span className="text-foreground-muted">(optional)</span>
-              </Label_Shadcn_>
+              </Label>
               <TextArea
                 id="feedback"
                 placeholder="What was helpful or missing?"

--- a/apps/www/components/Forms/RequestADemoForm.tsx
+++ b/apps/www/components/Forms/RequestADemoForm.tsx
@@ -220,10 +220,7 @@ const RequestADemoForm: FC<Props> = ({ className }) => {
                   key={key}
                   className={cn('flex flex-col col-span-full gap-y-2', fieldValue.className)}
                 >
-                  <Label
-                    htmlFor={fieldKey}
-                    className="text-foreground-light flex justify-between"
-                  >
+                  <Label htmlFor={fieldKey} className="text-foreground-light flex justify-between">
                     {fieldValue.label}
                     <div
                       className={cn(

--- a/apps/www/components/Forms/RequestADemoForm.tsx
+++ b/apps/www/components/Forms/RequestADemoForm.tsx
@@ -2,7 +2,7 @@ import { useSendTelemetryEvent } from '~/lib/telemetry'
 import { CircleAlert } from 'lucide-react'
 import Link from 'next/link'
 import { FC, useEffect, useState } from 'react'
-import { Button, cn, Input, Label_Shadcn_, Separator, TextArea } from 'ui'
+import { Button, cn, Input, Label, Separator, TextArea } from 'ui'
 import { Alert } from 'ui/src/components/shadcn/ui/alert'
 
 interface FormData {
@@ -220,7 +220,7 @@ const RequestADemoForm: FC<Props> = ({ className }) => {
                   key={key}
                   className={cn('flex flex-col col-span-full gap-y-2', fieldValue.className)}
                 >
-                  <Label_Shadcn_
+                  <Label
                     htmlFor={fieldKey}
                     className="text-foreground-light flex justify-between"
                   >
@@ -233,7 +233,7 @@ const RequestADemoForm: FC<Props> = ({ className }) => {
                     >
                       {errors[fieldKey]}
                     </div>
-                  </Label_Shadcn_>
+                  </Label>
                   <Component
                     type="text"
                     id={fieldKey}

--- a/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
+++ b/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
@@ -210,10 +210,7 @@ const TalkToPartnershipTeamForm: FC<Props> = ({ className }) => {
                   key={key}
                   className={cn('flex flex-col col-span-full gap-y-2', fieldValue.className)}
                 >
-                  <Label
-                    htmlFor={fieldKey}
-                    className="text-foreground-light flex justify-between"
-                  >
+                  <Label htmlFor={fieldKey} className="text-foreground-light flex justify-between">
                     {fieldValue.label}
                     <div
                       className={cn(

--- a/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
+++ b/apps/www/components/Forms/TalkToPartnershipTeamForm.tsx
@@ -2,7 +2,7 @@ import { useSendTelemetryEvent } from '~/lib/telemetry'
 import { CircleAlert } from 'lucide-react'
 import Link from 'next/link'
 import { FC, useEffect, useState } from 'react'
-import { Button, cn, Input, Label_Shadcn_, Separator, TextArea } from 'ui'
+import { Button, cn, Input, Label, Separator, TextArea } from 'ui'
 import { Alert } from 'ui/src/components/shadcn/ui/alert'
 
 interface FormData {
@@ -210,7 +210,7 @@ const TalkToPartnershipTeamForm: FC<Props> = ({ className }) => {
                   key={key}
                   className={cn('flex flex-col col-span-full gap-y-2', fieldValue.className)}
                 >
-                  <Label_Shadcn_
+                  <Label
                     htmlFor={fieldKey}
                     className="text-foreground-light flex justify-between"
                   >
@@ -223,7 +223,7 @@ const TalkToPartnershipTeamForm: FC<Props> = ({ className }) => {
                     >
                       {errors[fieldKey]}
                     </div>
-                  </Label_Shadcn_>
+                  </Label>
                   <Component
                     type="text"
                     id={fieldKey}

--- a/apps/www/components/SecurityNewsletterForm.tsx
+++ b/apps/www/components/SecurityNewsletterForm.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button, Input, Label_Shadcn_ } from 'ui'
+import { Button, Input, Label } from 'ui'
 
 const isValidEmail = (email: string): boolean => {
   const emailPattern = /^[\w-\.+]+@([\w-]+\.)+[\w-]{2,8}$/
@@ -66,7 +66,7 @@ const SecurityNewsletterForm = () => {
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="flex flex-col gap-2">
-                <Label_Shadcn_ htmlFor="security-first-name">First Name</Label_Shadcn_>
+                <Label htmlFor="security-first-name">First Name</Label>
                 <Input
                   id="security-first-name"
                   type="text"
@@ -77,7 +77,7 @@ const SecurityNewsletterForm = () => {
                 />
               </div>
               <div className="flex flex-col gap-2">
-                <Label_Shadcn_ htmlFor="security-last-name">Last Name</Label_Shadcn_>
+                <Label htmlFor="security-last-name">Last Name</Label>
                 <Input
                   id="security-last-name"
                   type="text"
@@ -89,7 +89,7 @@ const SecurityNewsletterForm = () => {
               </div>
             </div>
             <div className="flex flex-col gap-2">
-              <Label_Shadcn_ htmlFor="security-email">Email Address</Label_Shadcn_>
+              <Label htmlFor="security-email">Email Address</Label>
               <Input
                 id="security-email"
                 type="email"

--- a/packages/ui-patterns/src/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/src/PrivacySettings/index.tsx
@@ -3,7 +3,7 @@
 import { useConsentState } from 'common'
 import Link from 'next/link'
 import { PropsWithChildren, useState } from 'react'
-import { Label_Shadcn_, Modal, Switch } from 'ui'
+import { Label, Modal, Switch } from 'ui'
 
 import { Admonition } from '../admonition'
 
@@ -137,9 +137,9 @@ function Category({
     <Modal.Content key={category.slug}>
       <div className="flex flex-row items-center justify-between gap-4">
         <div className="space-y-0.5">
-          <Label_Shadcn_ className="text-base" htmlFor={category.slug}>
+          <Label className="text-base" htmlFor={category.slug}>
             {category.label}
-          </Label_Shadcn_>
+          </Label>
           <div className="text-sm text-foreground-light" id={`${category.slug}-description`}>
             {category.description}
             <br />

--- a/packages/ui-patterns/src/form/Layout/FormLayout.tsx
+++ b/packages/ui-patterns/src/form/Layout/FormLayout.tsx
@@ -1,6 +1,6 @@
 import { cva } from 'class-variance-authority'
 import React from 'react'
-import { cn, FormDescription, FormLabel, FormMessage, Label_Shadcn_ } from 'ui'
+import { cn, FormDescription, FormLabel, FormMessage, Label } from 'ui'
 import { SIZE } from 'ui/src/lib/constants'
 
 type Props = {
@@ -377,13 +377,13 @@ export const FormLayout = React.forwardRef<
                   <LabelContents />
                 </FormLabel>
               ) : (
-                <Label_Shadcn_
+                <Label
                   className="text-foreground flex gap-2 items-center wrap-break-word leading-normal"
                   data-formlayout-id="label"
                   htmlFor={props.name || id}
                 >
                   <LabelContents />
-                </Label_Shadcn_>
+                </Label>
               )}
               {labelOptional && (
                 <span

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -130,7 +130,7 @@ export {
 
 export * from './src/components/shadcn/ui/text-area'
 
-export { Label as Label_Shadcn_ } from './src/components/shadcn/ui/label'
+export * from './src/components/shadcn/ui/label'
 
 export * from './src/components/shadcn/ui/input-group'
 


### PR DESCRIPTION
## Problem

The `_Shadcn_` suffix isn't needed anymore on label component

## Solution

Remove it. No other changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized Label usage across the codebase by removing the legacy alias and using the direct Label export from the UI package consistently.
* **Documentation**
  * Updated component examples and docs to use the standardized Label component in usage snippets and demos.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45986)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->