### PR TITLE
chore: remove slider shadcn suffix

### DIFF
--- a/apps/www/components/Pricing/ComputePricingCalculator.tsx
+++ b/apps/www/components/Pricing/ComputePricingCalculator.tsx
@@ -2,7 +2,7 @@ import pricingAddOn from '~/data/PricingAddOnTable.json'
 import { Plus, Trash2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { plans as allPlans } from 'shared-data/plans'
-import { Button, cn, Slider_Shadcn_ } from 'ui'
+import { Button, cn, Slider } from 'ui'
 import { ComputeBadge } from 'ui-patterns/ComputeBadge'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
 import { ToggleGroup, ToggleGroupItem } from 'ui/src/components/shadcn/ui/toggle-group'
@@ -193,7 +193,7 @@ const ComputePricingCalculator = ({
                     Drag to adjust
                   </label>
                 )}
-                <Slider_Shadcn_
+                <Slider
                   onValueChange={(value) => handleUpdateInstance(activeInstance.position, value)}
                   value={findSliderComputeValue(activeInstance)}
                   min={1}

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -105,7 +105,7 @@ export * from './src/components/shadcn/ui/input'
 
 export { Button as Button_Shadcn_ } from './src/components/shadcn/ui/button'
 
-export { ButtonGroup, ButtonGroupItem } from './src/components/shadcn/ui/button-group'
+export * from './src/components/shadcn/ui/button-group'
 
 export * from './src/components/shadcn/ui/breadcrumb'
 
@@ -137,21 +137,15 @@ export {
   TabsTrigger as TabsTrigger_Shadcn_,
 } from './src/components/shadcn/ui/tabs'
 
-export {
-  TooltipProvider,
-  Tooltip,
-  TooltipTrigger,
-  TooltipContent,
-  TooltipPortal,
-} from './src/components/shadcn/ui/tooltip'
+export * from './src/components/shadcn/ui/tooltip'
 
 export * from './src/components/shadcn/ui/hover-card'
 
 export * from './src/components/shadcn/ui/calendar'
 
-export { ScrollArea, ScrollBar, ScrollViewport } from './src/components/shadcn/ui/scroll-area'
+export * from './src/components/shadcn/ui/scroll-area'
 
-export { Separator } from './src/components/shadcn/ui/separator'
+export * from './src/components/shadcn/ui/separator'
 
 export * from './src/components/shadcn/ui/resizable'
 

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -99,7 +99,7 @@ export * from './src/components/shadcn/ui/select'
 
 export * from './src/components/shadcn/ui/radio-group'
 
-export { Slider as Slider_Shadcn_ } from './src/components/shadcn/ui/slider'
+export * from './src/components/shadcn/ui/slider'
 
 export * from './src/components/shadcn/ui/input'
 


### PR DESCRIPTION
## Problem

The `_Shadcn_` suffix isn't needed anymore on slider components

## Solution

- Remove the `_Shadcn_` suffix
- Simplify UI package exports

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal component export structure and import organization for better code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45992)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->