### PR TITLE
Fix curl command for API key handling

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.constants.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionDetails.constants.ts
@@ -23,7 +23,8 @@ export const INVOCATION_TABS: InvocationTab[] = [
       const keyValue = showKey ? apiKey : obfuscatedName
 
       return `curl -L -X POST '${functionUrl}' \\
-  -H 'Authorization: Bearer ${keyValue}' \\${apiKey.includes('publishable') ? `\n  -H 'apikey: ${keyValue}' \\` : ''}
+  // Or skip the Authorization header with verify_jwt=false (in config.toml)
+  -H 'Authorization: Bearer <JWT-TOKEN>' \\${apiKey.includes('publishable') ? `\n  -H 'apikey: ${keyValue}' \\` : ''}
   -H 'Content-Type: application/json' \\
   --data '{"name":"Functions"}'`
     },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update - fixes https://github.com/supabase/supabase/issues/45993

## What is the current behavior?

https://github.com/supabase/supabase/issues/45993 Following the instructions results in an invalid JWT error.

## What is the new behavior?

Informs the user about JWT configuration.

## Additional context

I have no experience with React and I have not tested these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Edge Function invocation example with clearer guidance on JWT token authentication and how to bypass verification when needed through configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45995)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->