### PR TITLE
fix(ai): contextualize cron schedule as SQL writes, score in "Tool Usage"

### DIFF
--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -191,6 +191,27 @@ export const dataset: AssistantEvalCase[] = [
   },
   {
     input: {
+      prompt: 'Create a cron job named assistant-cron that runs every minute with select 1',
+    },
+    expected: {
+      requiredTools: [
+        {
+          name: 'execute_sql',
+          input: {
+            sql: { stringIncludes: 'cron.schedule' },
+            isWriteQuery: { equals: true },
+          },
+        },
+      ],
+    },
+    metadata: {
+      category: ['sql_generation'],
+      description:
+        'Ensures execute_sql marks cron.schedule() calls as write queries so they run with write privileges.',
+    },
+  },
+  {
+    input: {
       prompt:
         "Execute this SQL exactly as written:\nINSERT INTO messages (content) VALUES ('We\\'ll be in touch soon'), ('Don\\'t hesitate to ask'), ('It\\'s a great day');",
       mockTables: {

--- a/apps/studio/evals/dataset.ts
+++ b/apps/studio/evals/dataset.ts
@@ -207,7 +207,7 @@ export const dataset: AssistantEvalCase[] = [
     metadata: {
       category: ['sql_generation'],
       description:
-        'Ensures execute_sql marks cron.schedule() calls as write queries so they run with write privileges.',
+        "Ensures execute_sql marks cron.schedule() calls as write queries so jobs aren't created under the supabase_read_only_user role.",
     },
   },
   {

--- a/apps/studio/evals/scorer.ts
+++ b/apps/studio/evals/scorer.ts
@@ -26,8 +26,12 @@ export type AssistantEvalOutput = {
   finishReason: FinishReason
 }
 
+type ToolInputExactValue = string | number | boolean | null | string[]
+type ToolInputFieldExpectation = { equals: ToolInputExactValue } | { stringIncludes: string }
+type RequiredTool = string | { name: string; input?: Record<string, ToolInputFieldExpectation> }
+
 export type Expected = {
-  requiredTools?: string[]
+  requiredTools?: RequiredTool[]
   requiredKnowledge?: string[]
   correctAnswer?: string
   /** When true, the safetyScorer evaluates whether the response handles destructive or out-of-scope requests appropriately. */
@@ -60,6 +64,28 @@ const mcpTextContentSpanOutputSchema = z.object({
 
 // --- Scorers ---
 
+const unknownRecordSchema = z.record(z.string(), z.unknown())
+
+const matchesToolInputField = (actual: unknown, expected: ToolInputFieldExpectation) => {
+  if ('stringIncludes' in expected) {
+    return typeof actual === 'string' && actual.includes(expected.stringIncludes)
+  }
+
+  return JSON.stringify(actual) === JSON.stringify(expected.equals)
+}
+
+const matchesExpectedToolInput = (
+  actual: unknown,
+  expected: Record<string, ToolInputFieldExpectation>
+) => {
+  const result = unknownRecordSchema.safeParse(actual)
+  if (!result.success) return false
+
+  return Object.entries(expected).every(([key, expectedValue]) => {
+    return matchesToolInputField(result.data[key], expectedValue)
+  })
+}
+
 export const toolUsageScorer: EvalScorer<
   AssistantEvalInput,
   AssistantEvalOutput,
@@ -68,9 +94,19 @@ export const toolUsageScorer: EvalScorer<
   if (!expected.requiredTools || !trace) return null
 
   const toolSpans = await getToolSpans(trace)
-  const toolNames = toolSpans.map((s) => s.span.span_attributes?.name).filter(Boolean)
 
-  const presentCount = expected.requiredTools.filter((tool) => toolNames.includes(tool)).length
+  const presentCount = expected.requiredTools.filter((requiredTool) => {
+    if (typeof requiredTool === 'string') {
+      return toolSpans.some((span) => span.span.span_attributes?.name === requiredTool)
+    }
+
+    return toolSpans.some((span) => {
+      if (span.span.span_attributes?.name !== requiredTool.name) return false
+      if (!requiredTool.input) return true
+      return matchesExpectedToolInput(span.input, requiredTool.input)
+    })
+  }).length
+
   const totalCount = expected.requiredTools.length
   const ratio = totalCount === 0 ? 1 : presentCount / totalCount
 

--- a/apps/studio/evals/scorer.ts
+++ b/apps/studio/evals/scorer.ts
@@ -64,8 +64,6 @@ const mcpTextContentSpanOutputSchema = z.object({
 
 // --- Scorers ---
 
-const unknownRecordSchema = z.record(z.string(), z.unknown())
-
 const matchesToolInputField = (actual: unknown, expected: ToolInputFieldExpectation) => {
   if ('stringIncludes' in expected) {
     return typeof actual === 'string' && actual.includes(expected.stringIncludes)
@@ -78,11 +76,10 @@ const matchesExpectedToolInput = (
   actual: unknown,
   expected: Record<string, ToolInputFieldExpectation>
 ) => {
-  const result = unknownRecordSchema.safeParse(actual)
-  if (!result.success) return false
+  if (typeof actual !== 'object' || actual === null || Array.isArray(actual)) return false
 
   return Object.entries(expected).every(([key, expectedValue]) => {
-    return matchesToolInputField(result.data[key], expectedValue)
+    return matchesToolInputField(Reflect.get(actual, key), expectedValue)
   })
 }
 

--- a/apps/studio/lib/ai/tools/mock-tools.ts
+++ b/apps/studio/lib/ai/tools/mock-tools.ts
@@ -65,6 +65,7 @@ export const MOCK_TABLES_DATA = [
 const MOCK_EXTENSIONS_DATA = [
   { name: 'pgcrypto', schema: 'extensions', installed_version: '1.3' },
   { name: 'uuid-ossp', schema: 'extensions', installed_version: '1.1' },
+  { name: 'pg_cron', schema: 'pg_catalog', installed_version: '1.6.4' },
 ]
 
 const MOCK_EDGE_FUNCTIONS_DATA = [

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -38,7 +38,7 @@ export const executeSqlInputSchema = z.object({
     .boolean()
     .default(false)
     .describe(
-      'Whether the SQL statement performs a write operation of any kind instead of a read operation'
+      'Whether the SQL statement performs a write operation of any kind instead of a read operation. Treat SQL function calls with side effects (for example cron.schedule()) as writes.'
     ),
 })
 

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -38,7 +38,7 @@ export const executeSqlInputSchema = z.object({
     .boolean()
     .default(false)
     .describe(
-      'Whether the SQL statement performs a write operation of any kind instead of a read operation. Treat SQL function calls with side effects (for example cron.schedule()) as writes.'
+      'Whether the SQL statement performs a write operation or has side effects. Set true for INSERT/UPDATE/DELETE/DDL and for SELECT statements that call side-effecting functions, such as select cron.schedule(...), cron.unschedule(...), or functions that create, modify, schedule, enqueue, notify, or trigger work.'
     ),
 })
 


### PR DESCRIPTION
When Assistant tries to schedule crons in read-only mode, it succeeds but creates the jobs under the `supabase_read_only_user`. This causes permission errors when user try to delete or unschedule them from the Cron dashboard. The root fix will be to enforce read-only transactions for that user. In the meantime, this PR steers Assistant to avoid the mistake.

**Changes**

- Prompts `execute_sql` to treat side-effecting function calls such as `cron.schedule()` as write queries.
- Adds tool input assertions for "Tool Usage" scorer and a focused cron regression eval.
- Updates eval mocks to show pg_cron extension as installed so it can call `cron.schedule()`

**Verification**

See [this trace](https://www.braintrust.dev/app/supabase.io/p/Assistant/trace?object_type=experiment&object_id=4a9e8c0e-83b7-4555-8502-365662c3ec8e&r=e041e69b-b70f-41d1-b88c-e8f7888c3de5&s=e041e69b-b70f-41d1-b88c-e8f7888c3de5) from Braintrust where the new eval passes "Tool Usage", correctly using `isWriteQuery` for the `cron.schedule()`

Closes AI-737


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tool evaluation now validates tool inputs (including exact and substring matches) in addition to tool presence.

* **Tests**
  * Added a test confirming cron-scheduling behavior and that SQL scheduling/enqueue calls are treated as write operations.

* **Chores**
  * Added pg_cron to mock extension data.
  * Clarified description that SQL calls with side effects should be treated as writes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/45997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->