### PR TITLE
studio: add column sorting to Database Tables list

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -25,6 +25,7 @@ import {
   TableFooter,
   TableHead,
   TableHeader,
+  TableHeadSort,
   TableRow,
   Tooltip,
   TooltipContent,
@@ -34,7 +35,14 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { ProtectedSchemaWarning } from '../ProtectedSchemaWarning'
-import { formatAllEntities } from './Tables.utils'
+import {
+  DEFAULT_TABLE_LIST_SORT,
+  formatAllEntities,
+  handleTableListSortChange,
+  isTableListSort,
+  sortEntities,
+  type TableListSort,
+} from './Tables.utils'
 import { buildTableEditorUrl } from '@/components/grid/SupabaseGrid.utils'
 import AlertError from '@/components/ui/AlertError'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -80,6 +88,14 @@ export const TableList = ({
   const { selectedSchema, setSelectedSchema } = useQuerySchemaState()
 
   const [filterString, setFilterString] = useQueryState('search', parseAsString.withDefault(''))
+  const [sort, setSort] = useQueryState(
+    'sort',
+    parseAsString.withDefault(DEFAULT_TABLE_LIST_SORT)
+  )
+  const activeSort: TableListSort = isTableListSort(sort) ? sort : DEFAULT_TABLE_LIST_SORT
+  const onSortChange = (column: string) =>
+    handleTableListSortChange(activeSort, column, (next) => setSort(next))
+
   const [visibleTypes, setVisibleTypes] = useState<string[]>(Object.values(ENTITY_TYPE))
   const [schemaSelectorOpen, setSchemaSelectorOpen] = useState(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -187,8 +203,18 @@ export const TableList = ({
     (publication) => publication.name === 'supabase_realtime'
   )
 
-  const entities = formatAllEntities({ tables, views, materializedViews, foreignTables }).filter(
-    (x) => visibleTypes.includes(x.type)
+  const realtimeEnabledIds = new Set(
+    (realtimePublication?.tables ?? [])
+      .map((table) => table.id)
+      .filter((id): id is number => typeof id === 'number')
+  )
+
+  const entities = sortEntities(
+    formatAllEntities({ tables, views, materializedViews, foreignTables }).filter((x) =>
+      visibleTypes.includes(x.type)
+    ),
+    activeSort,
+    realtimeEnabledIds
   )
 
   const { isSchemaLocked } = useIsProtectedSchema({ schema: selectedSchema })
@@ -207,6 +233,7 @@ export const TableList = ({
   useShortcut(SHORTCUT_IDS.LIST_PAGE_RESET_FILTERS, () => {
     setVisibleTypes(Object.values(ENTITY_TYPE))
     setFilterString('')
+    setSort(DEFAULT_TABLE_LIST_SORT)
   })
 
   const error = tablesError || viewsError || materializedViewsError || foreignTablesError
@@ -350,12 +377,50 @@ export const TableList = ({
                 <TableRow>
                   <TableHead key="icon" className="w-0 px-0!" />
                   <TableHead key="name" className="max-w-[160px] sm:max-w-[280px]">
-                    Name
+                    <TableHeadSort
+                      column="name"
+                      currentSort={activeSort}
+                      onSortChange={onSortChange}
+                    >
+                      Name
+                    </TableHeadSort>
                   </TableHead>
-                  <TableHead key="columns">Columns</TableHead>
-                  <TableHead key="rows">Rows (Estimated)</TableHead>
-                  <TableHead key="size">Size (Estimated)</TableHead>
-                  <TableHead key="realtime">Realtime</TableHead>
+                  <TableHead key="columns">
+                    <TableHeadSort
+                      column="columns"
+                      currentSort={activeSort}
+                      onSortChange={onSortChange}
+                    >
+                      Columns
+                    </TableHeadSort>
+                  </TableHead>
+                  <TableHead key="rows">
+                    <TableHeadSort
+                      column="rows"
+                      currentSort={activeSort}
+                      onSortChange={onSortChange}
+                    >
+                      Rows (Estimated)
+                    </TableHeadSort>
+                  </TableHead>
+                  <TableHead key="size">
+                    <TableHeadSort
+                      column="size"
+                      currentSort={activeSort}
+                      onSortChange={onSortChange}
+                    >
+                      Size (Estimated)
+                    </TableHeadSort>
+                  </TableHead>
+                  <TableHead key="realtime">
+                    <TableHeadSort
+                      column="realtime"
+                      currentSort={activeSort}
+                      onSortChange={onSortChange}
+                    >
+                      Realtime
+                    </TableHeadSort>
+                  </TableHead>
                   <TableHead key="buttons"></TableHead>
                 </TableRow>
               </TableHeader>

--- a/apps/studio/components/interfaces/Database/Tables/Tables.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Tables/Tables.utils.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+
+import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
+import {
+  DEFAULT_TABLE_LIST_SORT,
+  handleTableListSortChange,
+  isTableListSort,
+  sortEntities,
+  type FormattedEntity,
+} from './Tables.utils'
+
+const makeEntity = (overrides: Partial<FormattedEntity> & { id: number; name: string }) =>
+  ({
+    type: ENTITY_TYPE.TABLE,
+    schema: 'public',
+    comment: null,
+    columns: [],
+    rows: 0,
+    size: '0 bytes',
+    bytes: 0,
+    ...overrides,
+  }) as unknown as FormattedEntity
+
+const realtimeEnabledIds = new Set<number>()
+
+describe('Tables.utils', () => {
+  describe('isTableListSort', () => {
+    it('accepts every supported column / direction combination', () => {
+      expect(isTableListSort('name:asc')).toBe(true)
+      expect(isTableListSort('columns:desc')).toBe(true)
+      expect(isTableListSort('rows:asc')).toBe(true)
+      expect(isTableListSort('size:desc')).toBe(true)
+      expect(isTableListSort('realtime:asc')).toBe(true)
+    })
+
+    it('rejects unknown columns and directions', () => {
+      expect(isTableListSort('schema:asc')).toBe(false)
+      expect(isTableListSort('name:sideways')).toBe(false)
+      expect(isTableListSort('')).toBe(false)
+    })
+  })
+
+  describe('handleTableListSortChange', () => {
+    it('toggles direction when the same column is reselected', () => {
+      let next = ''
+      handleTableListSortChange('rows:desc', 'rows', (s) => (next = s))
+      expect(next).toBe('rows:asc')
+    })
+
+    it('defaults numeric columns to descending on first selection', () => {
+      let next = ''
+      handleTableListSortChange(DEFAULT_TABLE_LIST_SORT, 'size', (s) => (next = s))
+      expect(next).toBe('size:desc')
+    })
+
+    it('defaults name and realtime to ascending on first selection', () => {
+      let next = ''
+      handleTableListSortChange('rows:desc', 'name', (s) => (next = s))
+      expect(next).toBe('name:asc')
+      handleTableListSortChange('rows:desc', 'realtime', (s) => (next = s))
+      expect(next).toBe('realtime:asc')
+    })
+  })
+
+  describe('sortEntities', () => {
+    const entities = [
+      makeEntity({ id: 1, name: 'orders', bytes: 1024, rows: 10 }),
+      makeEntity({ id: 2, name: 'Customers', bytes: 4096, rows: 100 }),
+      makeEntity({ id: 3, name: 'audit_log', bytes: 16, rows: 0 }),
+    ]
+
+    it('sorts by name ascending case-insensitively', () => {
+      const sorted = sortEntities(entities, 'name:asc', realtimeEnabledIds)
+      expect(sorted.map((x) => x.name)).toEqual(['audit_log', 'Customers', 'orders'])
+    })
+
+    it('sorts by size descending using the numeric bytes field', () => {
+      const sorted = sortEntities(entities, 'size:desc', realtimeEnabledIds)
+      expect(sorted.map((x) => x.name)).toEqual(['Customers', 'orders', 'audit_log'])
+    })
+
+    it('sorts empty tables to the top when sorting rows ascending', () => {
+      const sorted = sortEntities(entities, 'rows:asc', realtimeEnabledIds)
+      expect(sorted[0].name).toBe('audit_log')
+    })
+
+    it('keeps entities with undefined size at the bottom regardless of direction', () => {
+      const mixed = [
+        ...entities,
+        makeEntity({ id: 4, name: 'public_view', bytes: undefined as unknown as number, type: ENTITY_TYPE.VIEW as any, size: undefined as any }),
+      ]
+      const asc = sortEntities(mixed as FormattedEntity[], 'size:asc', realtimeEnabledIds)
+      const desc = sortEntities(mixed as FormattedEntity[], 'size:desc', realtimeEnabledIds)
+      expect(asc[asc.length - 1].name).toBe('public_view')
+      expect(desc[desc.length - 1].name).toBe('public_view')
+    })
+
+    it('sorts realtime-enabled entities ahead when descending', () => {
+      const enabled = new Set<number>([2])
+      const sorted = sortEntities(entities, 'realtime:desc', enabled)
+      expect(sorted[0].id).toBe(2)
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Database/Tables/Tables.utils.ts
+++ b/apps/studio/components/interfaces/Database/Tables/Tables.utils.ts
@@ -34,6 +34,7 @@ export const formatAllEntities = ({
       schema: x.schema,
       rows: undefined,
       size: undefined,
+      bytes: undefined,
       columns: x.columns ?? [],
     }
   })
@@ -47,6 +48,7 @@ export const formatAllEntities = ({
       schema: x.schema,
       rows: undefined,
       size: undefined,
+      bytes: undefined,
       columns: x.columns ?? [],
     }
   })
@@ -60,6 +62,7 @@ export const formatAllEntities = ({
       schema: x.schema,
       rows: undefined,
       size: undefined,
+      bytes: undefined,
       columns: x.columns ?? [],
     }
   })
@@ -69,5 +72,92 @@ export const formatAllEntities = ({
     ...formattedViews,
     ...formattedMaterializedViews,
     ...formattedForeignTables,
-  ].sort((a, b) => a.name.localeCompare(b.name))
+  ]
+}
+
+export type FormattedEntity = ReturnType<typeof formatAllEntities>[number]
+
+export const TABLE_LIST_SORT_COLUMNS = [
+  'name',
+  'columns',
+  'rows',
+  'size',
+  'realtime',
+] as const
+
+export type TableListSortColumn = (typeof TABLE_LIST_SORT_COLUMNS)[number]
+export type TableListSortDirection = 'asc' | 'desc'
+export type TableListSort = `${TableListSortColumn}:${TableListSortDirection}`
+
+export const DEFAULT_TABLE_LIST_SORT: TableListSort = 'name:asc'
+
+export const isTableListSort = (value: string): value is TableListSort => {
+  const [column, direction] = value.split(':')
+  return (
+    TABLE_LIST_SORT_COLUMNS.includes(column as TableListSortColumn) &&
+    (direction === 'asc' || direction === 'desc')
+  )
+}
+
+export const handleTableListSortChange = (
+  currentSort: TableListSort,
+  column: string,
+  setSort: (s: TableListSort) => void
+) => {
+  const [currentCol, currentOrder] = currentSort.split(':')
+  if (currentCol === column) {
+    setSort(`${column}:${currentOrder === 'asc' ? 'desc' : 'asc'}` as TableListSort)
+  } else {
+    // First click defaults to descending for numeric columns so the largest values
+    // surface first, otherwise ascending alphabetical/boolean order is more useful.
+    const defaultOrder: TableListSortDirection =
+      column === 'name' || column === 'realtime' ? 'asc' : 'desc'
+    setSort(`${column}:${defaultOrder}` as TableListSort)
+  }
+}
+
+/**
+ * Stable sort that places nullish values last regardless of direction so empty
+ * rows/size cells (views, foreign tables) never crowd out tables the user is
+ * actually trying to compare.
+ */
+export const sortEntities = (
+  entities: FormattedEntity[],
+  sort: TableListSort,
+  realtimeEnabledIds: Set<number>
+): FormattedEntity[] => {
+  const [column, direction] = sort.split(':') as [TableListSortColumn, TableListSortDirection]
+  const multiplier = direction === 'asc' ? 1 : -1
+
+  const getValue = (entity: FormattedEntity): string | number | undefined => {
+    switch (column) {
+      case 'name':
+        return entity.name.toLowerCase()
+      case 'columns':
+        return entity.columns.length
+      case 'rows':
+        return entity.rows
+      case 'size':
+        return entity.bytes
+      case 'realtime':
+        return realtimeEnabledIds.has(entity.id) ? 1 : 0
+    }
+  }
+
+  return [...entities].sort((a, b) => {
+    const aValue = getValue(a)
+    const bValue = getValue(b)
+
+    if (aValue === undefined && bValue === undefined) return a.name.localeCompare(b.name)
+    if (aValue === undefined) return 1
+    if (bValue === undefined) return -1
+
+    if (typeof aValue === 'string' && typeof bValue === 'string') {
+      const cmp = aValue.localeCompare(bValue)
+      return cmp === 0 ? a.name.localeCompare(b.name) : cmp * multiplier
+    }
+
+    if (aValue === bValue) return a.name.localeCompare(b.name)
+    return (aValue < bValue ? -1 : 1) * multiplier
+  })
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature (UX improvement in Studio).

## What is the current behavior?

The Database → Tables list (`/project/{ref}/database/tables`) renders columns for **Name**, **Columns**, **Rows (Estimated)**, **Size (Estimated)**, and **Realtime**, but none of them are sortable. The list comes back in a fixed alphabetical order, so:

- It's hard to spot the largest tables on a project (you have to eyeball the size column).
- Finding empty tables to clean up requires manually scanning every row.
- Seeing which tables have Realtime enabled means scrolling through everything.

The only existing controls are a free-text name search and an entity-type filter.

## What is the new behavior?

Every data column in the table list (`Name`, `Columns`, `Rows (Estimated)`, `Size (Estimated)`, `Realtime`) is now a `TableHeadSort` button — same component already used on the Apps / OAuth / Webhooks / Custom Auth Providers lists, so the affordance is consistent with the rest of Studio.

- Default sort is `name:asc` (matches the previous behavior).
- Numeric columns (`columns`, `rows`, `size`) default to **descending** on first click so the largest values surface first; `name` and `realtime` default to ascending.
- Size sorts on the numeric `bytes` field that pg-meta already returns alongside the `pg_size_pretty` string, so ordering is correct (no string-comparing "8192 bytes" against "1 MB").
- Sort state is persisted in the URL via the existing `nuqs` pattern (`?sort=size:desc`), so the view is shareable and survives reloads — parity with the existing `?search=` filter.
- Views, materialized views, and foreign tables don't have `rows` / `size`, so they're always pushed to the bottom when sorting on those columns regardless of direction. This avoids them crowding out comparable tables in the middle of the result set.
- The existing "reset filters" shortcut now also resets the sort.

Includes unit coverage for the sort helpers (`Tables.utils.test.ts`).

## Additional context

- No changes to data fetching, API surface, or feature flags — purely client-side rendering / state.
- `formatAllEntities` previously sorted alphabetically inside the helper; that sort moved into the component so the helper is now data-only. `formatAllEntities` is only consumed by `TableList.tsx`, so no other callers are affected.
- This came up while reviewing tables on my own project — without sortable headers it was hard to find candidates for cleanup or to compare table sizes. Happy to convert this to a Discussion first if the team would prefer to design the affordance more carefully (e.g. add a secondary sort, persist per-project, or expose more columns like RLS status), but the change is minimal and reuses an existing component so I opened the PR directly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Database table list columns are now sortable (Name, Columns, Rows, Size, Realtime) with persistent sort preferences saved in the URL.

* **Tests**
  * Added comprehensive test coverage for table sorting functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46000)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->