### PR TITLE
Fix chat name truncation causing action icons to disappear

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
@@ -161,9 +161,7 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
                               snap.activeChatId === id ? 'opacity-100' : 'opacity-0'
                             )}
                           />
-                          <span className="truncate flex-1 min-w-0 overflow-hidden">
-                            {chat.name}
-                          </span>
+                          <span className="truncate flex-1 w-0">{chat.name}</span>
                         </>
                       )}
                     </div>


### PR DESCRIPTION
Fixes issue #46002

## Description
If the chat name is too long, it wont get truncated properly, which caused the edit and delete icons to be pushed out of view. (see problem in #46002)


## Screenshots
https://github.com/user-attachments/assets/7c664ff2-15da-47e0-88f0-39d8d3063686



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated text truncation and overflow styling for chat names in the AI Assistant Chat Selector.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46003)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->