### PR TITLE
fix(telemetry): pass signup_timestamp on org_count identify

### DIFF
--- a/apps/studio/lib/telemetry.test.tsx
+++ b/apps/studio/lib/telemetry.test.tsx
@@ -1,0 +1,148 @@
+import { render, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { Telemetry } from './telemetry'
+
+const mocks = vi.hoisted(() => ({
+  identify: vi.fn(),
+  useUser: vi.fn(),
+  useOrganizationsQuery: vi.fn(),
+}))
+
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return {
+    ...actual,
+    posthogClient: {
+      identify: mocks.identify,
+    },
+    useUser: () => mocks.useUser(),
+    PageTelemetry: () => null,
+  }
+})
+
+vi.mock('ui-patterns/consent', () => ({
+  useConsentToast: () => ({ hasAcceptedConsent: true }),
+}))
+
+vi.mock('@/data/organizations/organizations-query', () => ({
+  useOrganizationsQuery: () => mocks.useOrganizationsQuery(),
+}))
+
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: () => ({ data: undefined }),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  setUser: vi.fn(),
+}))
+
+const USER_ID = 'user-abc-123'
+const CREATED_AT = '2026-05-14T22:30:00.000Z'
+
+const orgs = (count: number) =>
+  Array.from({ length: count }, (_, i) => ({ id: i, slug: `org-${i}` }))
+
+describe('Telemetry — posthog identify mirroring', () => {
+  beforeEach(() => {
+    mocks.identify.mockReset()
+    mocks.useUser.mockReset()
+    mocks.useOrganizationsQuery.mockReset()
+  })
+
+  it('fires identify with both org_count and signup_timestamp when user and orgs are loaded', async () => {
+    mocks.useUser.mockReturnValue({ id: USER_ID, created_at: CREATED_AT })
+    mocks.useOrganizationsQuery.mockReturnValue({ data: orgs(1) })
+
+    render(<Telemetry />)
+
+    await waitFor(() => {
+      expect(mocks.identify).toHaveBeenCalledWith(USER_ID, {
+        org_count: 1,
+        signup_timestamp: CREATED_AT,
+      })
+    })
+  })
+
+  it('omits signup_timestamp when created_at is missing', async () => {
+    mocks.useUser.mockReturnValue({ id: USER_ID, created_at: undefined })
+    mocks.useOrganizationsQuery.mockReturnValue({ data: orgs(1) })
+
+    render(<Telemetry />)
+
+    await waitFor(() => {
+      expect(mocks.identify).toHaveBeenCalledWith(USER_ID, { org_count: 1 })
+    })
+  })
+
+  it('dedupes when nothing has changed', async () => {
+    mocks.useUser.mockReturnValue({ id: USER_ID, created_at: CREATED_AT })
+    mocks.useOrganizationsQuery.mockReturnValue({ data: orgs(1) })
+
+    const { rerender } = render(<Telemetry />)
+    await waitFor(() => expect(mocks.identify).toHaveBeenCalledTimes(1))
+
+    rerender(<Telemetry />)
+    rerender(<Telemetry />)
+
+    // Still only one identify — same user, same orgCount, same signupTimestamp.
+    expect(mocks.identify).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-fires identify when created_at arrives after the first effect run (CodeRabbit regression)', async () => {
+    // Initial render: user.id is set, but created_at is still undefined (e.g. partial session parse).
+    mocks.useUser.mockReturnValue({ id: USER_ID, created_at: undefined })
+    mocks.useOrganizationsQuery.mockReturnValue({ data: orgs(1) })
+
+    const { rerender } = render(<Telemetry />)
+    await waitFor(() => expect(mocks.identify).toHaveBeenCalledTimes(1))
+    expect(mocks.identify).toHaveBeenLastCalledWith(USER_ID, { org_count: 1 })
+
+    // created_at lands later. The dedup ref must track signupTimestamp,
+    // and the effect deps must include user.created_at, or the second
+    // identify gets silently skipped — which is exactly the race we shipped
+    // the original fix to close.
+    mocks.useUser.mockReturnValue({ id: USER_ID, created_at: CREATED_AT })
+    rerender(<Telemetry />)
+
+    await waitFor(() => expect(mocks.identify).toHaveBeenCalledTimes(2))
+    expect(mocks.identify).toHaveBeenLastCalledWith(USER_ID, {
+      org_count: 1,
+      signup_timestamp: CREATED_AT,
+    })
+  })
+
+  it('re-fires identify when org_count changes', async () => {
+    mocks.useUser.mockReturnValue({ id: USER_ID, created_at: CREATED_AT })
+    mocks.useOrganizationsQuery.mockReturnValue({ data: orgs(1) })
+
+    const { rerender } = render(<Telemetry />)
+    await waitFor(() => expect(mocks.identify).toHaveBeenCalledTimes(1))
+
+    mocks.useOrganizationsQuery.mockReturnValue({ data: orgs(2) })
+    rerender(<Telemetry />)
+
+    await waitFor(() => expect(mocks.identify).toHaveBeenCalledTimes(2))
+    expect(mocks.identify).toHaveBeenLastCalledWith(USER_ID, {
+      org_count: 2,
+      signup_timestamp: CREATED_AT,
+    })
+  })
+
+  it('does not fire identify when user or orgs are missing', async () => {
+    // user missing
+    mocks.useUser.mockReturnValue(null)
+    mocks.useOrganizationsQuery.mockReturnValue({ data: orgs(1) })
+    const first = render(<Telemetry />)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(mocks.identify).not.toHaveBeenCalled()
+    first.unmount()
+
+    // user present but orgs not loaded
+    mocks.useUser.mockReturnValue({ id: USER_ID, created_at: CREATED_AT })
+    mocks.useOrganizationsQuery.mockReturnValue({ data: undefined })
+    render(<Telemetry />)
+    await new Promise((r) => setTimeout(r, 10))
+    expect(mocks.identify).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/lib/telemetry.tsx
+++ b/apps/studio/lib/telemetry.tsx
@@ -30,19 +30,33 @@ export function Telemetry() {
   const user = useUser()
 
   // Mirror the user's org-list length into a PostHog person property so feature
-  // flags and analytics can segment by current org membership (e.g. "users in
-  // exactly one org") without behavioral-cohort lag. Only fires when the value
-  // changes.
+  // flags and analytics can segment by current org membership. signup_timestamp
+  // is set on the same identify so flag audiences requiring both properties see
+  // them together on /decide. Only fires when the value changes.
   const { data: organizations } = useOrganizationsQuery()
-  const lastSentRef = useRef<{ userId: string; orgCount: number } | null>(null)
+  const lastSentRef = useRef<{
+    userId: string
+    orgCount: number
+    signupTimestamp?: string
+  } | null>(null)
   useEffect(() => {
     if (!user?.id || !organizations) return
     const orgCount = organizations.length
+    const signupTimestamp = user.created_at ?? undefined
     const last = lastSentRef.current
-    if (last?.userId === user.id && last.orgCount === orgCount) return
-    lastSentRef.current = { userId: user.id, orgCount }
-    posthogClient.identify(user.id, { org_count: orgCount })
-  }, [user?.id, organizations])
+    if (
+      last?.userId === user.id &&
+      last.orgCount === orgCount &&
+      last.signupTimestamp === signupTimestamp
+    ) {
+      return
+    }
+    lastSentRef.current = { userId: user.id, orgCount, signupTimestamp }
+    posthogClient.identify(user.id, {
+      org_count: orgCount,
+      ...(signupTimestamp && { signup_timestamp: signupTimestamp }),
+    })
+  }, [user?.id, user?.created_at, organizations])
 
   useEffect(() => {
     // don't set the sentry user id if the user hasn't logged in (so that Sentry errors show null user id instead of anonymous id)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The `dataApiRevokeOnCreateDefault` experiment ([GROWTH-853](https://linear.app/supabase/issue/GROWTH-853)) flipped to 5% rollout on 2026-05-14 22:59 UTC. First-day diagnostic on cohort-filtered exposures showed treatment share at 0.87%, well below the 5% target — about 5× under-bucketed.

Diagnosis: the two audience properties (`org_count` and `signup_timestamp`) were being set on two separate `posthog.identify` calls. Identify #2's `/decide` request body only carried `org_count`. The server-side person record didn't yet have `signup_timestamp` persisted from identify #1 (ingestion is async), so the audience filter failed and the flag returned `false` by default. About 74% of cohort users hit this race.

Pinned down by isolating filters: `org_count = 1` alone vs `org_count = 1 AND signup_timestamp >= rollout` gives the same treatment count (188 vs 190) but the control count halves (28,626 → 14,075). Same numerator, smaller denominator → confirms ~14,500 users had `org_count` matched at flag-evaluation time but `signup_timestamp` not yet landed server-side.

## What is the new behavior?

The studio `Telemetry` component's `org_count` identify now also passes `signup_timestamp` (sourced from `user.created_at`). That makes the `/decide` request body self-sufficient for the audience filter — the server can match `org_count = 1 AND signup_timestamp >= rollout` against request `person_properties` regardless of whether the previous identify's `$set` has been persisted yet.

Kept the existing `signup_timestamp` set in `useTelemetryIdentify` in `packages/common/`. That hook runs in non-studio apps too (www, docs, cms) and they still need `signup_timestamp` set for cross-app analytics.

## Additional context

Validation plan: rerun the cohort-filtered exposure-by-variant query in PostHog 24h post-deploy, filtered to users who signed up after the deploy timestamp. Treatment share should approach 5% vs 0.87% pre-fix. If it doesn't, the assumption about `/decide` honoring request-body `person_properties` is wrong and we need to dig further.

Tracking ticket: [GROWTH-858](https://linear.app/supabase/issue/GROWTH-858).
Live PostHog readout: https://eu.posthog.com/project/34344/insights/fBk4AZ1K.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Telemetry now records organization count and user signup timestamp together; user identification is re-sent only when those values change to improve analytics accuracy and audience matching.
* **Tests**
  * Added tests validating telemetry identification behavior, deduping across renders, and edge cases when signup timestamp or organization data are missing or become available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46005)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->