### PR TITLE
studio: SafeSql stragglers + remaining tests (6/7)

### DIFF
--- a/apps/studio/components/interfaces/Docs/Description.tsx
+++ b/apps/studio/components/interfaces/Docs/Description.tsx
@@ -1,4 +1,4 @@
-import { ident, literal, safeSql } from '@supabase/pg-meta/src/pg-format'
+import { ident, literal, safeSql, type SafeSqlFragment } from '@supabase/pg-meta/src/pg-format'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { noop } from 'lodash'
 import { Loader } from 'lucide-react'
@@ -51,7 +51,7 @@ const Description = ({ content, metadata, onChange = noop }: DescrptionProps) =>
     if (isUpdating || !canUpdateDescription) return false
 
     setIsUpdating(true)
-    let query: string | undefined
+    let query: SafeSqlFragment | undefined
     if (table && column)
       query = safeSql`comment on column ${ident('public')}.${ident(table)}.${ident(column)} is ${literal(value)};`
     if (table && !column)

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet.test.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet.test.tsx
@@ -1,3 +1,4 @@
+import { safeSql } from '@supabase/pg-meta'
 import { fireEvent, screen, waitFor } from '@testing-library/dom'
 import userEvent from '@testing-library/user-event'
 import { mockAnimationsApi } from 'jsdom-testing-mocks'
@@ -43,7 +44,7 @@ vi.mock('@/components/interfaces/Database/Extensions/Extensions.constants', () =
 }))
 
 vi.mock('./IntegrationOverviewTabV2.utils', () => ({
-  getEnableExtensionsSQL: () => 'CREATE EXTENSION IF NOT EXISTS pg_net;',
+  getEnableExtensionsSQL: () => safeSql`CREATE EXTENSION IF NOT EXISTS pg_net;`,
   getExtensionDefaultSchema: () => 'extensions',
 }))
 

--- a/apps/studio/lib/ai/tools/studio-tools.test.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.test.ts
@@ -1,3 +1,4 @@
+import { safeSql } from '@supabase/pg-meta'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { getStudioTools } from './studio-tools'
@@ -101,7 +102,7 @@ describe('ai/tools/studio-tools', () => {
       if ('safeParse' in schema) {
         // Valid input
         const validInput = {
-          sql: 'SELECT * FROM users',
+          sql: safeSql`SELECT * FROM users`,
           label: 'Get users',
           chartConfig: { view: 'table' as const },
           isWriteQuery: false,
@@ -110,7 +111,7 @@ describe('ai/tools/studio-tools', () => {
 
         // Valid chart config
         const validChartInput = {
-          sql: 'SELECT count(*) FROM users',
+          sql: safeSql`SELECT count(*) FROM users`,
           label: 'User count',
           chartConfig: { view: 'chart' as const, xAxis: 'date', yAxis: 'count' },
           isWriteQuery: false,
@@ -119,7 +120,7 @@ describe('ai/tools/studio-tools', () => {
 
         // Missing required field
         const invalidInput = {
-          sql: 'SELECT * FROM users',
+          sql: safeSql`SELECT * FROM users`,
           // missing label, chartConfig, isWriteQuery
         }
         expect(schema.safeParse(invalidInput).success).toBe(false)

--- a/apps/studio/lib/api/generate-v4.test.ts
+++ b/apps/studio/lib/api/generate-v4.test.ts
@@ -1,3 +1,4 @@
+import { safeSql } from '@supabase/pg-meta'
 import { UIMessage } from 'ai'
 import { expect, test, vi } from 'vitest'
 
@@ -24,7 +25,7 @@ test('generateV4 calls the tool sanitizer', async () => {
               type: 'tool-execute_sql',
               state: 'output-available',
               toolCallId: 'test-tool-call-id',
-              input: { sql: 'SELECT * FROM users' },
+              input: { sql: safeSql`SELECT * FROM users` },
               output: [{ id: 1, name: 'test-output' }],
             },
           ],


### PR DESCRIPTION
## Summary

Part 6 of 7 in the SafeSql migration stack. Picks up the few remaining files that didn't fit cleanly into earlier batches:

- `components/Docs/Description.tsx` — comment statements built via `safeSql`.
- `components/Integrations/IntegrationOverviewTabV2/InstallIntegrationSheet.test.tsx` — test fixture updated to `SafeSqlFragment`.
- `lib/ai/tools/studio-tools.test.ts` — test fixture updated.
- `lib/api/generate-v4.test.ts` — test fixture updated.

Sets up PR 7, which flips the `executeSql` signature itself.

## Test plan

- [x] `pnpm typecheck` passes
- [x] Specific Studio unit tests run on top of the stack (`Policies.utils.test.ts`, `SidePanelEditor.utils.createTable.test.ts`, `useQueryInsightsIssues.utils.test.ts`)
- [x] Dev-server smoke: Docs panel renders / accepts edits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suites to reflect internal type definition changes.

* **Refactor**
  * Internal code improvements to enhance type safety and consistency across the codebase.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46006)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->