### PR TITLE
studio: flip executeSql signature to SafeSqlFragment (7/7)

### DIFF
--- a/apps/studio/data/sql/execute-sql-query.ts
+++ b/apps/studio/data/sql/execute-sql-query.ts
@@ -1,4 +1,8 @@
-import { ROLE_IMPERSONATION_NO_RESULTS, ROLE_IMPERSONATION_SQL_LINE_COUNT } from '@supabase/pg-meta'
+import {
+  ROLE_IMPERSONATION_NO_RESULTS,
+  ROLE_IMPERSONATION_SQL_LINE_COUNT,
+  SafeSqlFragment,
+} from '@supabase/pg-meta'
 import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
 import { QueryKey, useQuery } from '@tanstack/react-query'
 
@@ -24,7 +28,7 @@ export const COST_THRESHOLD_ERROR = 'Query cost exceeds threshold'
 export type ExecuteSqlVariables = {
   projectRef?: string
   connectionString?: string | null
-  sql: string
+  sql: SafeSqlFragment
   queryKey?: QueryKey
   handleError?: (error: ResponseError) => { result: any }
   isRoleImpersonationEnabled?: boolean

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -1,3 +1,4 @@
+import { acceptUntrustedSql, untrustedSql } from '@supabase/pg-meta'
 import { tool } from 'ai'
 import { z } from 'zod'
 
@@ -68,8 +69,11 @@ export const getStudioTools = (ctx: StudioToolsContext = {}) => {
       inputSchema: executeSqlInputSchema,
       needsApproval: true,
       execute: async ({ sql }) => {
+        // The `needsApproval: true` gate on this tool means the user has
+        // explicitly approved this AI-generated SQL before execute runs —
+        // that approval is the user gesture that promotes untrusted to safe.
         const { result } = await executeSql(
-          { projectRef, connectionString, sql },
+          { projectRef, connectionString, sql: acceptUntrustedSql(untrustedSql(sql)) },
           undefined,
           authHeaders
         )


### PR DESCRIPTION
## Summary

Final PR in the SafeSql migration stack. Stacked on top of #46006.

Tightens `executeSql`'s `sql` parameter from `string` to `SafeSqlFragment`. Any future raw-string caller is now a compile error — the SafeSql safety property becomes structural rather than convention-based.

Also adapts the AI `execute_sql` tool to promote AI-generated SQL via `acceptUntrustedSql(untrustedSql(sql))` inside the `execute` callback. The tool's existing \`needsApproval: true\` gate ensures `execute` only runs after the user has explicitly approved — that approval is the gesture that promotes untrusted to safe.

## Test plan

- [x] `pnpm typecheck` passes
- [x] Grep for any remaining raw-string `executeSql` calls in `apps/studio` returns nothing
- [x] Dev-server smoke: AI tool approval flow executes SQL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SQL query execution with improved safety validation. Queries now undergo an approval verification process before execution to strengthen security and prevent unintended operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46007)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->