### PR TITLE
studio: clarify storage bucket upgrade message for Pro users on Nano compute

### DIFF
--- a/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
@@ -62,13 +62,11 @@ export const BucketsUpgradePlan = ({ type }: { type: 'analytics' | 'vector' }) =
                 : `Upgrade to Pro to use ${type} buckets for your project`
             }
           >
-            <div className="flex items-center gap-x-2">
-              <UpgradePlanButton
-                source={`${type}Buckets`}
-                featureProposition={`use ${type} buckets`}
-                addon={requiresComputeUpgrade ? 'computeSize' : undefined}
-              />
-            </div>
+            <UpgradePlanButton
+              source={`${type}Buckets`}
+              featureProposition={`use ${type} buckets`}
+              addon={requiresComputeUpgrade ? 'computeSize' : undefined}
+            />
           </EmptyStatePresentational>
         </PageSectionContent>
       </PageSection>

--- a/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
@@ -6,8 +6,19 @@ import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 import { BUCKET_TYPES } from './Storage.constants'
 import { AlphaNotice } from '@/components/ui/AlphaNotice'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 export const BucketsUpgradePlan = ({ type }: { type: 'analytics' | 'vector' }) => {
+  const { data: organization } = useSelectedOrganizationQuery()
+  const { data: project } = useSelectedProjectQuery()
+
+  const isFreePlan = organization?.plan?.id === 'free'
+  const isNanoCompute = project?.infra_compute_size === 'nano'
+  // On a paid plan with the smallest compute, the feature is gated by compute
+  // size rather than plan tier, so we surface the compute upgrade path instead.
+  const requiresComputeUpgrade = !!organization && !isFreePlan && isNanoCompute
+
   return (
     <PageContainer>
       <PageSection>
@@ -27,12 +38,17 @@ export const BucketsUpgradePlan = ({ type }: { type: 'analytics' | 'vector' }) =
                 ? BUCKET_TYPES.analytics.valueProp
                 : BUCKET_TYPES.vectors.valueProp
             }
-            description={`Upgrade to Pro to use ${type} buckets for your project`}
+            description={
+              requiresComputeUpgrade
+                ? `Upgrade your project's compute size to Micro or larger to use ${type} buckets`
+                : `Upgrade to Pro to use ${type} buckets for your project`
+            }
           >
             <div className="flex items-center gap-x-2">
               <UpgradePlanButton
                 source={`${type}Buckets`}
                 featureProposition={`use ${type} buckets`}
+                addon={requiresComputeUpgrade ? 'computeSize' : undefined}
               />
             </div>
           </EmptyStatePresentational>

--- a/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
+++ b/apps/studio/components/interfaces/Storage/BucketsUpgradePlan.tsx
@@ -1,23 +1,41 @@
+import { useParams } from 'common'
 import { AnalyticsBucket as AnalyticsBucketIcon, VectorBucket as VectorBucketIcon } from 'icons'
 import { EmptyStatePresentational } from 'ui-patterns'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
+import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { BUCKET_TYPES } from './Storage.constants'
 import { AlphaNotice } from '@/components/ui/AlphaNotice'
 import { UpgradePlanButton } from '@/components/ui/UpgradePlanButton'
+import { useProjectStorageConfigQuery } from '@/data/config/project-storage-config-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 export const BucketsUpgradePlan = ({ type }: { type: 'analytics' | 'vector' }) => {
-  const { data: organization } = useSelectedOrganizationQuery()
-  const { data: project } = useSelectedProjectQuery()
+  const { ref: projectRef } = useParams()
+  const { isLoading: isLoadingStorageConfig } = useProjectStorageConfigQuery({ projectRef })
+  const { data: organization, isLoading: isLoadingOrganization } = useSelectedOrganizationQuery()
+  const { data: project, isLoading: isLoadingProject } = useSelectedProjectQuery()
 
-  const isFreePlan = organization?.plan?.id === 'free'
-  const isNanoCompute = project?.infra_compute_size === 'nano'
-  // On a paid plan with the smallest compute, the feature is gated by compute
-  // size rather than plan tier, so we surface the compute upgrade path instead.
-  const requiresComputeUpgrade = !!organization && !isFreePlan && isNanoCompute
+  const isLoading =
+    isLoadingStorageConfig || isLoadingOrganization || isLoadingProject || !organization || !project
+
+  if (isLoading) {
+    return (
+      <PageContainer>
+        <PageSection>
+          <PageSectionContent className="flex flex-col gap-y-8">
+            <GenericSkeletonLoader />
+          </PageSectionContent>
+        </PageSection>
+      </PageContainer>
+    )
+  }
+
+  const isFreePlan = organization.plan?.id === 'free'
+  const isNanoCompute = project.infra_compute_size === 'nano'
+  const requiresComputeUpgrade = !isFreePlan && isNanoCompute
 
   return (
     <PageContainer>

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/RegionLimitation.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/RegionLimitation.tsx
@@ -1,0 +1,77 @@
+import { VectorBucket } from 'icons'
+import { AWS_REGIONS } from 'shared-data'
+import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import {
+  EmptyStatePresentational,
+  PageContainer,
+  PageSection,
+  PageSectionContent,
+} from 'ui-patterns'
+
+import { AVAILABLE_REPLICA_REGIONS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
+import { AlphaNotice } from '@/components/ui/AlphaNotice'
+import { InlineLinkClassName } from '@/components/ui/InlineLink'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+
+export const VECTOR_BUCKETS_AVAILABLE_REGIONS = [
+  'us-east-1',
+  'us-east-2',
+  'us-west-2',
+  'eu-central-1',
+  'ap-southeast-2',
+]
+
+const getRegionNameFromCode = (code: string) =>
+  Object.values(AWS_REGIONS).find((x) => x.code === code)?.displayName
+
+export const RegionLimitation = () => {
+  const { data: project } = useSelectedProjectQuery()
+
+  const regionLabel = AVAILABLE_REPLICA_REGIONS.find((region) =>
+    project?.region?.includes(region.region)
+  )
+
+  return (
+    <PageContainer>
+      <PageSection>
+        <PageSectionContent className="flex flex-col gap-y-8">
+          <AlphaNotice
+            entity="Vector buckets"
+            feedbackUrl="https://github.com/orgs/supabase/discussions/40815"
+          />
+          <EmptyStatePresentational
+            icon={VectorBucket}
+            className="[&>div>div>h3]:flex [&>div>div>h3]:items-center [&>div>div>h3]:gap-x-2"
+            title="Coming soon to your project's region"
+            description={
+              <p>
+                Your project is in{' '}
+                <Tooltip>
+                  <TooltipTrigger className={InlineLinkClassName}>
+                    {regionLabel?.name}
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{regionLabel?.region}</TooltipContent>
+                </Tooltip>
+                , but Vector buckets are only available for{' '}
+                <Tooltip>
+                  <TooltipTrigger className={InlineLinkClassName}>certain regions</TooltipTrigger>
+                  <TooltipContent side="bottom">
+                    <ul>
+                      {VECTOR_BUCKETS_AVAILABLE_REGIONS.map((x) => (
+                        <li key={x}>
+                          <span>{getRegionNameFromCode(x)}</span>
+                          <span className="text-foreground-light ml-2">{x}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </TooltipContent>
+                </Tooltip>
+                . We're actively looking to expand that soon.
+              </p>
+            }
+          />
+        </PageSectionContent>
+      </PageSection>
+    </PageContainer>
+  )
+}

--- a/apps/studio/components/interfaces/Storage/VectorBuckets/RegionLimitation.tsx
+++ b/apps/studio/components/interfaces/Storage/VectorBuckets/RegionLimitation.tsx
@@ -44,7 +44,7 @@ export const RegionLimitation = () => {
             className="[&>div>div>h3]:flex [&>div>div>h3]:items-center [&>div>div>h3]:gap-x-2"
             title="Coming soon to your project's region"
             description={
-              <p>
+              <>
                 Your project is in{' '}
                 <Tooltip>
                   <TooltipTrigger className={InlineLinkClassName}>
@@ -67,7 +67,7 @@ export const RegionLimitation = () => {
                   </TooltipContent>
                 </Tooltip>
                 . We're actively looking to expand that soon.
-              </p>
+              </>
             }
           />
         </PageSectionContent>

--- a/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
+++ b/apps/studio/pages/project/[ref]/storage/vectors/index.tsx
@@ -1,30 +1,17 @@
 import { useParams } from 'common'
-import { VectorBucket } from 'icons'
-import { AWS_REGIONS } from 'shared-data'
-import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
-import {
-  EmptyStatePresentational,
-  PageContainer,
-  PageSection,
-  PageSectionContent,
-} from 'ui-patterns'
 
-import { AVAILABLE_REPLICA_REGIONS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { BucketsUpgradePlan } from '@/components/interfaces/Storage/BucketsUpgradePlan'
 import { VectorsBuckets } from '@/components/interfaces/Storage/VectorBuckets'
+import {
+  RegionLimitation,
+  VECTOR_BUCKETS_AVAILABLE_REGIONS,
+} from '@/components/interfaces/Storage/VectorBuckets/RegionLimitation'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { StorageBucketsLayout } from '@/components/layouts/StorageLayout/StorageBucketsLayout'
 import StorageLayout from '@/components/layouts/StorageLayout/StorageLayout'
-import { AlphaNotice } from '@/components/ui/AlphaNotice'
-import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useIsVectorBucketsEnabled } from '@/data/config/project-storage-config-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import type { NextPageWithLayout } from '@/types'
-
-const AVAILABLE_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-central-1', 'ap-southeast-2']
-
-const getRegionNameFromCode = (code: string) =>
-  Object.values(AWS_REGIONS).find((x) => x.code === code)?.displayName
 
 const StorageVectorsPage: NextPageWithLayout = () => {
   const { ref: projectRef } = useParams()
@@ -32,55 +19,12 @@ const StorageVectorsPage: NextPageWithLayout = () => {
   const isVectorBucketsEnabled = useIsVectorBucketsEnabled({ projectRef })
 
   // [Joshen] We're actively looking into lifting this restriction so can remove once done
-  const isAvailableInProjectRegion = AVAILABLE_REGIONS.includes(project?.region ?? '')
-  const regionLabel = AVAILABLE_REPLICA_REGIONS.find((region) =>
-    project?.region?.includes(region.region)
+  const isAvailableInProjectRegion = VECTOR_BUCKETS_AVAILABLE_REGIONS.includes(
+    project?.region ?? ''
   )
 
   if (!isAvailableInProjectRegion) {
-    return (
-      <PageContainer>
-        <PageSection>
-          <PageSectionContent className="flex flex-col gap-y-8">
-            <AlphaNotice
-              entity="Vector buckets"
-              feedbackUrl="https://github.com/orgs/supabase/discussions/40815"
-            />
-            <EmptyStatePresentational
-              icon={VectorBucket}
-              className="[&>div>div>h3]:flex [&>div>div>h3]:items-center [&>div>div>h3]:gap-x-2"
-              title="Coming soon to your project's region"
-              description={
-                <p>
-                  Your project is in{' '}
-                  <Tooltip>
-                    <TooltipTrigger className={InlineLinkClassName}>
-                      {regionLabel?.name}
-                    </TooltipTrigger>
-                    <TooltipContent side="bottom">{regionLabel?.region}</TooltipContent>
-                  </Tooltip>
-                  , but Vector buckets are only available for{' '}
-                  <Tooltip>
-                    <TooltipTrigger className={InlineLinkClassName}>certain regions</TooltipTrigger>
-                    <TooltipContent side="bottom">
-                      <ul>
-                        {AVAILABLE_REGIONS.map((x) => (
-                          <li key={x}>
-                            <span>{getRegionNameFromCode(x)}</span>
-                            <span className="text-foreground-light ml-2">{x}</span>
-                          </li>
-                        ))}
-                      </ul>
-                    </TooltipContent>
-                  </Tooltip>
-                  . We're actively looking to expand that soon.
-                </p>
-              }
-            />
-          </PageSectionContent>
-        </PageSection>
-      </PageContainer>
-    )
+    return <RegionLimitation />
   } else if (!isVectorBucketsEnabled) {
     return <BucketsUpgradePlan type="vector" />
   } else {


### PR DESCRIPTION
## Summary

Vector and analytics bucket access is gated by both the org's plan tier and the project's compute size, but the storage config API only returns a single `enabled: false` flag. The empty state always told users to "Upgrade to Pro" — including users who were already on Pro with Nano compute, leaving them no obvious path forward.

`BucketsUpgradePlan` now reads the org plan and the project's `infra_compute_size`. When the user is on a paid plan but still on Nano compute, the message becomes "Upgrade your project's compute size to Micro or larger…" and the button is wired through `UpgradePlanButton`'s existing `addon='computeSize'` route to `/settings/compute-and-disk`. Free plan users keep the existing copy and upgrade flow.

Closes FE-3383.

## Test plan

- [ ] Free org, Nano compute, navigate to `/storage/vectors`: still shows "Upgrade to Pro" with the billing link
- [ ] Pro org, Nano compute, navigate to `/storage/vectors`: shows the compute-size message and the button navigates to compute-and-disk settings
- [ ] Pro org, Micro+ compute: page renders the actual Vector buckets UI (unchanged)
- [ ] Same flows on `/storage/analytics`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a regional limitation notice for Vector Buckets with an informational "Coming soon" empty state, alpha notice, and tooltip listing available regions.

* **Bug Fixes**
  * Storage bucket upgrade prompts now show context-aware messaging (including compute-size guidance) and conditionally adjust the upgrade action.

* **Refactor**
  * Region-gating UI logic consolidated into a shared component for clearer messaging and easier maintenance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->