### PR TITLE
docs: update Prisma Quickstart Guide for Prisma v7 datasource format

### DIFF
--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -168,14 +168,26 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
                     postgres://prisma.[PROJECT-REF]...
                     ```
 
-                    In your schema.prisma file, edit your `datasource db` configs to reference your DIRECT_URL
+                    In your schema.prisma file, edit your `datasource db` configs to reference your database provider
                     ```text schema.prisma
                     datasource db {
-                      provider  = "postgresql"
-                      url       = env("DATABASE_URL")
-                      directUrl = env("DIRECT_URL")
+                      provider = "postgresql"
                     }
                     ```
+
+                    <Admonition type="note" label="Prisma v6 and earlier">
+
+                      If you're using Prisma v6 or earlier, you still need to include the `url` and `directUrl` fields in your `schema.prisma` file. In Prisma v7, database connection URLs are configured outside of the schema file:
+
+                      ```text schema.prisma
+                      datasource db {
+                        provider  = "postgresql"
+                        url       = env("DATABASE_URL")
+                        directUrl = env("DIRECT_URL")
+                      }
+                      ```
+
+                    </Admonition>
 
 
                 </TabPanel>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The Prisma Quickstart Guide documentation shows the deprecated `datasource db` format for serverless deployments in Step 3, which includes `url` and `directUrl` fields. This format is no longer required in Prisma v7.

Closes #45843

## What is the new behavior?

- Updated Step 3 (serverless deployments tab) to reflect the Prisma v7 `datasource db` format:
  ```prisma
  datasource db {
    provider = "postgresql"
  }
  ```
- Added a backward compatibility note for users still on Prisma v6 or earlier, showing the old format with `url` and `directUrl`.

## Additional context

As per [Prisma v7 documentation](https://www.prisma.io/docs/orm/prisma-schema/overview#accessing-environment-variables-from-the-schema), the `datasource db` block no longer requires `url` and `directUrl` fields. This change aligns the Supabase Prisma Quickstart Guide with the latest Prisma standards while maintaining compatibility documentation for older versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated Prisma serverless deployment guide with refined `datasource db` configuration instructions and environment variable requirements.
* Added version-specific guidance for Prisma v6 and earlier regarding required environment variable setup for database connections.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46015?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->