### PR TITLE
docs: update Prisma Quickstart Guide for Prisma v7

### DIFF
--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -171,11 +171,13 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
                     In your schema.prisma file, edit your `datasource db` configs to reference your DIRECT_URL
                     ```text schema.prisma
                     datasource db {
-                      provider  = "postgresql"
-                      url       = env("DATABASE_URL")
-                      directUrl = env("DIRECT_URL")
+                      provider = "postgresql"
                     }
                     ```
+                     > **Note:** If you're using Prisma v6 or earlier, keep the
+                     > `url = env("DATABASE_URL")` and `directUrl = env("DIRECT_URL")`
+                     > fields in your `datasource db` configuration. The simplified format
+                     > above applies to Prisma v7 and later.
 
 
                 </TabPanel>

--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -168,7 +168,8 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
                     postgres://prisma.[PROJECT-REF]...
                     ```
 
-                    In your schema.prisma file, edit your `datasource db` configs to reference your DIRECT_URL
+                    In your schema.prisma file, update your `datasource db` config. In Prisma v7, 
+                    `DATABASE_URL` and `DIRECT_URL` are no longer required in the datasource block:
                     ```text schema.prisma
                     datasource db {
                       provider = "postgresql"


### PR DESCRIPTION
**What kind of change does this PR introduce?**
docs

**What is the current behavior?**
Fixes supabase#45843 — The Prisma Quickstart Guide documents the deprecated 
`datasource db {}` format with `DATABASE_URL` and `DIRECT_URL` for serverless 
deployments, which is no longer required in Prisma v7.

**What is the new behavior?**
Documentation now reflects the Prisma v7 `datasource db {}` format and includes 
a migration note for users on Prisma v6 or earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Prisma quickstart: simplified datasource guidance for Prisma v7+ (streamlined provider-only configuration) and added an explicit note for Prisma v6 and earlier to retain the connection URL fields.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->