### PR TITLE
fix(envoy): reject direct asymmetric JWT access when translation is enabled

### DIFF
--- a/docker/docker-compose.envoy.yml
+++ b/docker/docker-compose.envoy.yml
@@ -16,7 +16,7 @@ services:
   # Envoy API gateway
   api-gw:
     container_name: supabase-envoy
-    image: envoyproxy/envoy:v1.37.2
+    image: envoyproxy/envoy:v1.38.0
     restart: unless-stopped
     ports:
       - ${KONG_HTTP_PORT}:8000/tcp

--- a/docker/volumes/api/envoy/lds.template.yaml
+++ b/docker/volumes/api/envoy/lds.template.yaml
@@ -590,6 +590,78 @@ resources:
                           end
                         end
                       end
+                      
+                # Returns 401 for missing/invalid API keys on protected API routes.
+                - name: envoy.filters.http.lua
+                  typed_config:
+                    '@type': >-
+                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+                    inline_code: |
+                      local ANON_KEY = "${ANON_KEY}"
+                      local SERVICE_ROLE_KEY = "${SERVICE_ROLE_KEY}"
+                      local SUPABASE_PUBLISHABLE_KEY = "${SUPABASE_PUBLISHABLE_KEY}"
+                      local SUPABASE_SECRET_KEY = "${SUPABASE_SECRET_KEY}"
+                      local ANON_KEY_ASYMMETRIC = "${ANON_KEY_ASYMMETRIC}"
+                      local SERVICE_ROLE_KEY_ASYMMETRIC = "${SERVICE_ROLE_KEY_ASYMMETRIC}"
+                      local TRANSLATION_ENABLED = SUPABASE_SECRET_KEY ~= "" and SUPABASE_PUBLISHABLE_KEY ~= "" and SERVICE_ROLE_KEY_ASYMMETRIC ~= "" and ANON_KEY_ASYMMETRIC ~= ""
+
+                      local PROTECTED_ROUTES = {
+                        ["auth-v1-protected"] = true,
+                        ["rest-v1-protected"] = true,
+                        ["graphql-v1-protected"] = true,
+                        ["realtime-v1-api-protected"] = true,
+                        ["realtime-v1-ws-protected"] = true,
+                        ["pg-protected"] = true,
+                      }
+
+                      local function is_protected_route(route_name)
+                        if route_name == nil or route_name == "" then
+                          return false
+                        end
+
+                        return PROTECTED_ROUTES[route_name] == true
+                      end
+
+                      local function is_valid_apikey(apikey)
+                        if apikey == nil or apikey == "" then
+                          return false
+                        end
+
+                        if SERVICE_ROLE_KEY ~= "" and apikey == SERVICE_ROLE_KEY then
+                          return true
+                        end
+
+                        if ANON_KEY ~= "" and apikey == ANON_KEY then
+                          return true
+                        end
+
+                        if TRANSLATION_ENABLED and apikey == SUPABASE_SECRET_KEY then
+                          return true
+                        end
+
+                        if TRANSLATION_ENABLED and apikey == SUPABASE_PUBLISHABLE_KEY then
+                          return true
+                        end
+
+                        return false
+                      end
+
+                      function envoy_on_request(request_handle)
+                        local headers = request_handle:headers()
+                        local route_name = request_handle:streamInfo():routeName()
+                        if not is_protected_route(route_name) then
+                          return
+                        end
+
+                        if is_valid_apikey(headers:get("apikey")) then
+                          return
+                        end
+
+                        request_handle:respond({
+                          [":status"] = "401",
+                          ["content-type"] = "text/plain",
+                        }, "Unauthorized")
+                      end
 
                 # Translates the query parameter apikey into the matching internal JWT and rewrites the URL so only JWTs propagate downstream.
                 - name: envoy.filters.http.lua
@@ -859,78 +931,6 @@ resources:
                         if authorization_value ~= nil then
                           headers:replace("authorization", authorization_value)
                         end
-                      end
-
-                # Returns 401 for missing/invalid API keys on protected API routes.
-                - name: envoy.filters.http.lua
-                  typed_config:
-                    '@type': >-
-                      type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
-                    inline_code: |
-                      local ANON_KEY = "${ANON_KEY}"
-                      local SERVICE_ROLE_KEY = "${SERVICE_ROLE_KEY}"
-                      local SUPABASE_PUBLISHABLE_KEY = "${SUPABASE_PUBLISHABLE_KEY}"
-                      local SUPABASE_SECRET_KEY = "${SUPABASE_SECRET_KEY}"
-                      local ANON_KEY_ASYMMETRIC = "${ANON_KEY_ASYMMETRIC}"
-                      local SERVICE_ROLE_KEY_ASYMMETRIC = "${SERVICE_ROLE_KEY_ASYMMETRIC}"
-                      local TRANSLATION_ENABLED = SUPABASE_SECRET_KEY ~= "" and SUPABASE_PUBLISHABLE_KEY ~= "" and SERVICE_ROLE_KEY_ASYMMETRIC ~= "" and ANON_KEY_ASYMMETRIC ~= ""
-
-                      local PROTECTED_ROUTES = {
-                        ["auth-v1-protected"] = true,
-                        ["rest-v1-protected"] = true,
-                        ["graphql-v1-protected"] = true,
-                        ["realtime-v1-api-protected"] = true,
-                        ["realtime-v1-ws-protected"] = true,
-                        ["pg-protected"] = true,
-                      }
-
-                      local function is_protected_route(route_name)
-                        if route_name == nil or route_name == "" then
-                          return false
-                        end
-
-                        return PROTECTED_ROUTES[route_name] == true
-                      end
-
-                      local function is_valid_apikey(apikey)
-                        if apikey == nil or apikey == "" then
-                          return false
-                        end
-
-                        if SERVICE_ROLE_KEY ~= "" and apikey == SERVICE_ROLE_KEY then
-                          return true
-                        end
-
-                        if ANON_KEY ~= "" and apikey == ANON_KEY then
-                          return true
-                        end
-
-                        if TRANSLATION_ENABLED and apikey == SERVICE_ROLE_KEY_ASYMMETRIC then
-                          return true
-                        end
-
-                        if TRANSLATION_ENABLED and apikey == ANON_KEY_ASYMMETRIC then
-                          return true
-                        end
-
-                        return false
-                      end
-
-                      function envoy_on_request(request_handle)
-                        local headers = request_handle:headers()
-                        local route_name = request_handle:streamInfo():routeName()
-                        if not is_protected_route(route_name) then
-                          return
-                        end
-
-                        if is_valid_apikey(headers:get("apikey")) then
-                          return
-                        end
-
-                        request_handle:respond({
-                          [":status"] = "401",
-                          ["content-type"] = "text/plain",
-                        }, "Unauthorized")
                       end
 
                 - name: envoy.filters.http.rbac


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix + **updating Envoy image**

## What is the current behavior?

When `TRANSLATION` is enabled in the Envoy configuration (`lds.template.yaml`), the Lua API key validator filter was placed **after** the translation filters. As a result, the validator was seeing already-trans lated keys and incorrectly accepting asymmetric JWTs (`SERVICE_ROLE_KEY_ASYMMETRIC` and `ANON_KEY_ASYMMETRIC`) directly from clients.

This meant clients could bypass the intended `sb_` key flow and use the internal asymmetric JWTs directly, which defeats the purpose of the translation layer.

## What is the new behavior?

The Lua validator filter is now placed **before** the translation filters. The validator sees the original client-provided key and enforces the correct policy:

- **When TRANSLATION is enabled**: only accepts `sb_` keys (`SUPABASE_SECRET_KEY`, `SUPABASE_PUBLISHABLE_KEY`) and legacy keys (`SERVICE_ROLE_KEY`, `ANON_KEY`)
- **Rejects direct asymmetric JWT access** with `401 Unauthorized`
- **When TRANSLATION is disabled**: legacy behavior is preserved

The translation filters then convert valid `sb_` keys into internal asymmetric JWTs downstream as intended. No changes to the RBAC filter were needed.

## Additional context

- File changed: `docker/volumes/api/envoy/lds.template.yaml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Enhanced API key validation for protected routes, including route-based allowlist behavior and optional translation-key acceptance.
  * Invalid or missing API keys on protected endpoints now return HTTP 401 with plain-text "Unauthorized" for clearer error handling.
* **Chores**
  * Upgraded the Envoy gateway to a newer minor release.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46023?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->