### PR TITLE
self-hosted(ci): expand self host smoke tests

### DIFF
--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [default, envoy]
+        config: [default, envoy, s3]
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -35,6 +35,16 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
+
+      - name: Install AWS CLI v2
+        if: matrix.config == 's3'
+        run: |
+          set -euo pipefail
+          curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
+          unzip -q awscliv2.zip
+          sudo ./aws/install --update
+          rm -rf aws awscliv2.zip
+          aws --version
 
       - name: Generate keys
         shell: bash
@@ -54,6 +64,8 @@ jobs:
           yq -i '.services.supavisor.environment.RLIMIT_NOFILE=1024' docker-compose.yml
           if [ "${{ matrix.config }}" = "envoy" ]; then
             docker compose -f docker-compose.yml -f docker-compose.envoy.yml up --quiet-pull --wait --wait-timeout 180
+          elif [ "${{ matrix.config }}" = "s3" ]; then
+            docker compose -f docker-compose.yml -f docker-compose.s3.yml -f tests/docker-compose.s3.test.yml up --quiet-pull --wait --wait-timeout 180
           else
             docker compose up --quiet-pull --wait --wait-timeout 180
           fi
@@ -78,3 +90,19 @@ jobs:
           set -euo pipefail
           cd docker
           sh tests/test-auth-keys.sh
+
+      - name: Run S3 protocol tests
+        if: matrix.config == 's3'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-s3.sh
+
+      - name: Run S3 backend tests
+        if: matrix.config == 's3'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-s3-backend.sh

--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -17,18 +17,64 @@ permissions:
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [default, envoy]
 
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           sparse-checkout: |
             docker/
-      - name: Run docker-compose up
+
+      - name: Install jq
+        run: sudo apt-get update && sudo apt-get install -y jq
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22'
+
+      - name: Generate keys
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          cp .env.example .env
+          sh utils/generate-keys.sh --update-env
+          sh utils/add-new-auth-keys.sh --update-env
+
+      - name: Run docker compose up
         shell: bash
         # Ensure all services can be started and healthy with default config
         run: |
           set -euo pipefail
           cd docker
-          cp .env.example .env
           yq -i '.services.supavisor.environment.RLIMIT_NOFILE=1024' docker-compose.yml
-          docker compose up --quiet-pull --wait --wait-timeout 180
+          if [ "${{ matrix.config }}" = "envoy" ]; then
+            docker compose -f docker-compose.yml -f docker-compose.envoy.yml up --quiet-pull --wait --wait-timeout 180
+          else
+            docker compose up --quiet-pull --wait --wait-timeout 180
+          fi
+
+      - name: Run container log tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-container-logs.sh
+
+      - name: Run self-hosted smoke tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-self-hosted.sh
+
+      - name: Run auth keys tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-auth-keys.sh

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -444,11 +444,6 @@ services:
     depends_on:
       kong:
         condition: service_healthy
-    healthcheck:
-      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/127.0.0.1/9000'"]
-      interval: 5s
-      timeout: 5s
-      retries: 3
     environment:
       # Legacy symmetric HS256 key
       JWT_SECRET: ${JWT_SECRET}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -444,6 +444,11 @@ services:
     depends_on:
       kong:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/127.0.0.1/9000'"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     environment:
       # Legacy symmetric HS256 key
       JWT_SECRET: ${JWT_SECRET}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

CI update

## What is the current behavior?

The self-host smoke test workflow (`.github/workflows/self-host-tests-smoke.yml`) only verifies that Docker Compose containers start and reach a healthy state. It does not execute any of the functional test scripts located in `docker/tests/`.

## What is the new behavior?

- Expands the CI matrix to test three configurations in parallel: **default** (Kong), **envoy**, and **s3**.
- Generates dynamic secrets and API keys using `docker/utils/generate-keys.sh` and `docker/utils/add-new-auth-keys.sh` instead of relying on hardcoded values from `.env.example`.
- Installs `jq` and `node` dependencies required by the test scripts.
- Installs AWS CLI v2 (S3 job only) to support S3 protocol testing.
- Adds functional test execution after the stack is healthy:
    - `test-container-logs.sh` — verifies service startup log patterns
    - `test-self-hosted.sh` — end-to-end smoke tests (Auth, Storage, REST, GraphQL, Edge Functions, Realtime)
    - `test-auth-keys.sh` — validates legacy and asymmetric/opaque API keys
    - `test-s3.sh` — tests Storage S3-compatible protocol (S3 job only)
    - `test-s3-backend.sh` — tests MinIO S3 backend directly (S3 job only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded automated smoke tests into a multi-configuration matrix (default, envoy, s3), including S3 protocol and backend validation.
* **Chores**
  * CI now prepares environment per-configuration, runs configuration-aware startup, and enforces startup health/wait timeouts.
* **Infrastructure**
  * Added a service healthcheck to improve startup reliability and faster detection of failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46024?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->