### PR TITLE
fix(design-system): improve responsiveness of copywriting components

### DIFF
--- a/apps/design-system/components/component-preview.tsx
+++ b/apps/design-system/components/component-preview.tsx
@@ -69,7 +69,7 @@ export function ComponentPreview({
         <div
           className={cn(
             'preview flex min-h-[256px] w-full justify-center',
-            padded && 'p-10',
+            padded && 'p-4 sm:p-10',
             {
               'items-center': align === 'center',
               'items-start': align === 'start',

--- a/apps/design-system/registry/default/example/copy-button-verbs.tsx
+++ b/apps/design-system/registry/default/example/copy-button-verbs.tsx
@@ -4,7 +4,7 @@ import { Button } from 'ui'
 
 export default function CopyButtonVerbs() {
   return (
-    <div className="flex flex-row gap-16">
+    <div className="flex flex-row flex-wrap gap-8 sm:gap-16">
       <div className="flex flex-col gap-4">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <Button variant="primary">Table creation</Button>

--- a/apps/design-system/registry/default/example/copy-confirmations.tsx
+++ b/apps/design-system/registry/default/example/copy-confirmations.tsx
@@ -5,8 +5,8 @@ import { Button } from 'ui'
 
 export default function CopyConfirmations() {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-4 w-[400px]">
+    <div className="flex flex-col gap-8 w-full max-w-[400px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <div className="flex flex-col gap-5 border border-border rounded-md p-4 bg-surface-100">
           <div className="flex flex-row items-start gap-4">
@@ -27,7 +27,7 @@ export default function CopyConfirmations() {
           </div>
         </div>
       </div>
-      <div className="flex flex-col gap-4 w-[400px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Good Example</span>
         <div className="flex flex-col gap-5 border border-border rounded-md p-4 bg-surface-100">
           <div className="flex flex-row items-start gap-4">

--- a/apps/design-system/registry/default/example/copy-error-messages.tsx
+++ b/apps/design-system/registry/default/example/copy-error-messages.tsx
@@ -4,18 +4,18 @@ import { CircleAlert } from 'lucide-react'
 
 export default function CopyErrorMessages() {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-4 w-[400px]">
+    <div className="flex flex-col gap-8 w-full max-w-[400px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <div className="flex flex-row items-center gap-2 border border-destructive-500 rounded-md px-4 py-2 bg-destructive-200 text-destructive shadow-md">
-          <CircleAlert size={16} strokeWidth={1.5} />
+          <CircleAlert size={16} strokeWidth={1.5} className="shrink-0" />
           <p className="text-sm">Something went wrong. Please try again.</p>
         </div>
       </div>
-      <div className="flex flex-col gap-4 w-[400px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Good Example</span>
         <div className="flex flex-row items-center gap-2 border border-destructive-500 rounded-md px-4 py-2 bg-destructive-200 text-destructive shadow-md">
-          <CircleAlert size={16} strokeWidth={1.5} />
+          <CircleAlert size={16} strokeWidth={1.5} className="shrink-0" />
           <p className="text-sm">Invalid API key. Check your project settings.</p>
         </div>
       </div>

--- a/apps/design-system/registry/default/example/copy-form-labels.tsx
+++ b/apps/design-system/registry/default/example/copy-form-labels.tsx
@@ -4,8 +4,8 @@ import { Input, Label } from 'ui'
 
 export default function CopyFormLabels() {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-4 w-[300px]">
+    <div className="flex flex-col gap-8 w-full max-w-[300px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <div className="grid w-full items-center gap-1.5">
           <Label htmlFor="table-name-bad">Name your table</Label>
@@ -16,7 +16,7 @@ export default function CopyFormLabels() {
           </p>
         </div>
       </div>
-      <div className="flex flex-col gap-4 w-[300px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Good Example</span>
         <div className="grid w-full items-center gap-1.5">
           <Label htmlFor="table-name-good">Table name</Label>

--- a/apps/design-system/registry/default/example/copy-loading-states.tsx
+++ b/apps/design-system/registry/default/example/copy-loading-states.tsx
@@ -4,7 +4,7 @@ import { Button } from 'ui'
 
 export default function CopyLoadingStates() {
   return (
-    <div className="flex flex-row gap-16">
+    <div className="flex flex-row flex-wrap gap-8 sm:gap-16">
       <div className="flex flex-col gap-4">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <div className="flex flex-col gap-4">

--- a/apps/design-system/registry/default/example/copy-success-messages.tsx
+++ b/apps/design-system/registry/default/example/copy-success-messages.tsx
@@ -4,18 +4,18 @@ import { CheckCircle } from 'lucide-react'
 
 export default function CopySuccessMessages() {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-4 w-[400px]">
+    <div className="flex flex-col gap-8 w-full max-w-[400px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <div className="flex flex-row items-center gap-2 border border-brand-500 rounded-md px-4 py-2 bg-brand-300 text-brand-600 shadow-md">
-          <CheckCircle size={16} strokeWidth={1.5} />
+          <CheckCircle size={16} strokeWidth={1.5} className="shrink-0" />
           <p className="text-sm">Success!</p>
         </div>
       </div>
-      <div className="flex flex-col gap-4 w-[400px]">
+      <div className="flex flex-col gap-4 w-full">
         <span className="text-xs text-foreground-muted">Good Example</span>
         <div className="flex flex-row items-center gap-2 border border-brand-500 rounded-md px-4 py-2 bg-brand-300 text-brand-600 shadow-md">
-          <CheckCircle size={16} strokeWidth={1.5} />
+          <CheckCircle size={16} strokeWidth={1.5} className="shrink-0" />
           <p className="text-sm">Table created successfully</p>
         </div>
       </div>

--- a/apps/design-system/registry/default/example/copy-tooltips.tsx
+++ b/apps/design-system/registry/default/example/copy-tooltips.tsx
@@ -5,7 +5,7 @@ import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from
 
 export default function CopyTooltips() {
   return (
-    <div className="flex flex-row gap-20">
+    <div className="flex flex-row flex-wrap gap-8 sm:gap-20">
       <div className="flex flex-col gap-4">
         <span className="text-xs text-foreground-muted">Bad Example</span>
         <div className="flex flex-row gap-8 items-center">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On mobile devices, the component previews in the Design System documentation site (`/apps/design-system`) overflow horizontally and clip off the screen. This is caused by rigid `p-10` padding on the preview container and hardcoded widths (`w-[400px]`, `w-[300px]`) and inflexible flex layouts (`flex-row gap-16`) within the example components.

## What is the new behavior?

The component previews are now fully responsive and render correctly on mobile viewports:
- Updated the main preview container padding to be responsive (`p-4 sm:p-10`) in `component-preview.tsx` to maximize available space on mobile.
- Replaced fixed widths with fluid max-widths (`w-full max-w-[400px]`) in various copywriting component examples.
- Updated flex layouts that previously forced single rows to wrap (`flex-wrap`) and scale down gaps on smaller screens (`gap-8 sm:gap-16`).
- Added `shrink-0` to icons in alerts to prevent them from squishing when text wraps on narrow screens.

Affected components:
- `component-preview.tsx`
- `copy-button-verbs.tsx`
- `copy-confirmations.tsx`
- `copy-error-messages.tsx`
- `copy-form-labels.tsx`
- `copy-loading-states.tsx`
- `copy-success-messages.tsx`
- `copy-tooltips.tsx`

## Screenshots
### Mobile (Layout Bug - Before)
<!-- Add your broken mobile layout screenshot here -->
<img width="383" height="673" alt="Image" src="https://github.com/user-attachments/assets/faeba844-c137-4ab2-aa2c-2299e5ae5bf0" />

<img width="377" height="667" alt="Image" src="https://github.com/user-attachments/assets/e995289c-8c4c-4ba2-8fac-f36bfe869cd7" />

<img width="376" height="671" alt="Image" src="https://github.com/user-attachments/assets/b08afcfc-cc03-4087-9bdc-6082ed4a0c0a" />

### Mobile (Responsive - After)
<!-- Add your fixed mobile layout screenshot here -->
<img width="375" height="672" alt="Image" src="https://github.com/user-attachments/assets/54f68165-1e42-4f96-b9b8-cc6928909cbf" />

<img width="378" height="673" alt="Image" src="https://github.com/user-attachments/assets/816e7103-3184-4593-9847-896e3e4736ff" />

<img width="372" height="665" alt="Image" src="https://github.com/user-attachments/assets/97ba8f70-5340-4d15-92ee-1a032ee7d935" />

## Additional context

This addresses the layout bugs on the Design System Copywriting documentation page.

Fixes #46033


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved responsiveness across the design system with updated layout and spacing utilities.
  * Replaced several fixed-width examples with flexible full-width containers constrained by max-widths for consistent sizing.
  * Adjusted preview padding to use responsive values for better mobile presentation.
  * Enabled flex wrapping and refined gap sizes for multi-row layouts.
  * Prevented icons from shrinking in flex rows to preserve alignment and visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46034?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->