### PR TITLE
fix(studio): make cron log query backend-agnostic

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -323,10 +323,7 @@ const calcChartStart = (
   return [its.add(-extendValue, trunc), trunc]
 }
 
-// TODO(qiao): workaround for self-hosted cron logs error until logflare is fixed
-const basePgCronWhere = IS_PLATFORM
-  ? `where ( parsed.application_name = 'pg_cron' or regexp_contains(event_message, 'cron job') )`
-  : `where ( parsed.application_name = 'pg_cron' or event_message::text LIKE '%cron job%' )`
+const basePgCronWhere = `where ( parsed.application_name = 'pg_cron' or event_message LIKE '%cron job%' )`
 /**
  *
  * generates log event chart query

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -675,6 +675,8 @@ function getWarningCondition(table: LogsTableName): string {
       return 'response.status_code >= 400 AND response.status_code < 500'
     case 'function_logs':
       return "metadata.level IN ('warning')"
+    case 'pg_cron_logs':
+      return "parsed.error_severity IN ('WARNING')"
     default:
       return 'false'
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Self-hosted Supabase users running Logflare with the BigQuery analytics backend see a syntax error on the Cron logs tab:

> Syntax error: Expected "," but got ":" at [1:5196]

The Cron query's `WHERE` clause is branched on `IS_PLATFORM`, but `IS_PLATFORM` reflects hosted vs. self-hosted, not which analytics backend is in use. The self-hosted branch uses Postgres cast syntax (`event_message::text`) which BigQuery rejects. Studio has no way to detect the analytics backend (no env var is plumbed through), so the only viable fix is a backend-agnostic query.

Collapse both branches into a single `LIKE` clause that works on Postgres and BigQuery alike:

```ts
const basePgCronWhere =
  `where ( parsed.application_name = 'pg_cron' or event_message LIKE '%cron job%' )`
```

`LIKE` is standard SQL, `event_message` is `text`/`STRING` in both backends, and `LIKE '%cron job%'` is functionally equivalent to the existing `regexp_contains(event_message, 'cron job')` (both are case-sensitive substring matches with no anchors). No behavior change on the hosted path; fixes the syntax error on self-hosted+BigQuery.

**This requires a fix in Logflare.** (See https://github.com/Logflare/logflare/pull/3488/changes/09d31e3b2dac22c0d003bef8f24a59be9da3ac76)

Refs supabase#44104, logflare/logflare#3488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the filtering logic for pg_cron logs to use consistent behavior across all platform configurations. This ensures that pg_cron logs are queried and displayed uniformly, regardless of the deployment environment.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46037?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->