### PR TITLE
fix(self-hosted): add depends_on analytics for vector

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -586,6 +586,9 @@ services:
       timeout: 5s
       interval: 5s
       retries: 3
+    depends_on:
+      analytics:
+        condition: service_healthy
     environment:
       LOGFLARE_PUBLIC_ACCESS_TOKEN: ${LOGFLARE_PUBLIC_ACCESS_TOKEN}
     command:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add "depends_on analytics" for Vector. This ensures a more stable configuration when using Logflare with the BigQuery backend.

(A follow-up to PRs #45929, #46037, and logflare/logflare#3488. Also re: #44104.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized service initialization to ensure proper dependency resolution during startup, improving overall system reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46038?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->