### PR TITLE
chore(studio): move short Admonitions to descriptions

### DIFF
--- a/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
+++ b/apps/studio/components/interfaces/Auth/Users/UserOverview.tsx
@@ -181,7 +181,7 @@ export const UserOverview = ({ user, onDeleteSuccess }: UserOverviewProps) => {
         {isBanned ? (
           <Admonition
             type="warning"
-            label={`User banned until ${dayjs(user.banned_until).format(DATE_FORMAT)}`}
+            description={`User banned until ${dayjs(user.banned_until).format(DATE_FORMAT)}`}
             className="border-r-0 border-l-0 rounded-none -mt-px [&_svg]:ml-0.5"
           />
         ) : (

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -79,7 +79,7 @@ export const PublicationsTables = () => {
             <Admonition
               type="note"
               className="w-[500px]"
-              title="You need additional permissions to update database replications"
+              description="You need additional permissions to update database replications"
             />
           )}
         </div>

--- a/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
+++ b/apps/studio/components/interfaces/Database/Publications/PublicationsTables.tsx
@@ -63,27 +63,26 @@ export const PublicationsTables = () => {
 
   return (
     <>
-      <div className="mb-4">
-        <div className="flex items-center justify-between">
-          <Input
-            size="tiny"
-            ref={searchInputRef}
-            icon={<Search />}
-            className="w-48"
-            placeholder="Search for a table"
-            value={filterString}
-            onChange={(e) => setFilterString(e.target.value)}
-            onKeyDown={onSearchInputEscape(filterString, setFilterString)}
-          />
-          {!isLoadingPermissions && !canUpdatePublications && (
-            <Admonition
-              type="note"
-              className="w-[500px]"
-              description="You need additional permissions to update database replications"
-            />
-          )}
-        </div>
+      <div className="flex items-center justify-between mb-4">
+        <Input
+          size="tiny"
+          ref={searchInputRef}
+          icon={<Search />}
+          className="w-48"
+          placeholder="Search for a table"
+          value={filterString}
+          onChange={(e) => setFilterString(e.target.value)}
+          onKeyDown={onSearchInputEscape(filterString, setFilterString)}
+        />
       </div>
+
+      {!isLoadingPermissions && !canUpdatePublications && (
+        <Admonition
+          type="warning"
+          className="mb-4 w-full"
+          description="You need additional permissions to update database replications."
+        />
+      )}
 
       <Card>
         <Table>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
@@ -639,21 +639,26 @@ export const AnalyticsBucketFields = ({
                   </p>
 
                   {isSuccessKeys && keyNoLongerExists && (
-                    <Admonition type="warning" title="Unable to find access key ID in project">
-                      <p className="leading-normal!">
-                        Please select another key or create a new set, as this destination will not
-                        work otherwise. S3 access keys can be managed in your{' '}
-                        <InlineLink href={`/project/${projectRef}/storage/files/settings`}>
-                          storage settings
-                        </InlineLink>
-                      </p>
-                    </Admonition>
+                    <Admonition
+                      type="warning"
+                      title="Unable to find access key ID in project"
+                      description={
+                        <>
+                          Please select another key or create a new set, as this destination will
+                          not work otherwise. S3 access keys can be managed in your{' '}
+                          <InlineLink href={`/project/${projectRef}/storage/files/settings`}>
+                            storage settings
+                          </InlineLink>
+                          .
+                        </>
+                      }
+                    />
                   )}
 
                   {s3AccessKeyId === CREATE_NEW_KEY && (
                     <Admonition
                       type="default"
-                      description="A new set of S3 access keys will be created"
+                      description="A new set of S3 access keys will be created."
                     />
                   )}
                 </div>
@@ -719,7 +724,7 @@ export const AnalyticsBucketFields = ({
                 layout="horizontal"
                 label="S3 Secret Access Key"
                 className="relative"
-                description="The secret key corresponding to your selected access key ID"
+                description="The secret key corresponding to your selected access key ID."
               >
                 <FormControl>
                   <Input

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
@@ -653,7 +653,7 @@ export const AnalyticsBucketFields = ({
                   {s3AccessKeyId === CREATE_NEW_KEY && (
                     <Admonition
                       type="default"
-                      title="A new set of S3 access keys will be created"
+                      description="A new set of S3 access keys will be created"
                     />
                   )}
                 </div>

--- a/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
+++ b/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
@@ -136,7 +136,7 @@ export const RestoreToNewProject = () => {
     return (
       <Admonition
         type="default"
-        description="Restoring to new projects is temporarily not available for AWS (Revamped) projects"
+        description="Restoring to new projects is temporarily not available for AWS (Revamped) projects."
       />
     )
   }

--- a/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
+++ b/apps/studio/components/interfaces/Database/RestoreToNewProject/RestoreToNewProject.tsx
@@ -136,7 +136,7 @@ export const RestoreToNewProject = () => {
     return (
       <Admonition
         type="default"
-        title="Restoring to new projects is temporarily not available for AWS (Revamped) projects"
+        description="Restoring to new projects is temporarily not available for AWS (Revamped) projects"
       />
     )
   }

--- a/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/QueueSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/QueueSettings.tsx
@@ -281,7 +281,7 @@ export const QueueSettings = ({}: QueueSettingsProps) => {
             <Admonition
               type="default"
               className="rounded-none border-x-0 border-t-0"
-              description="Only relevant roles for managing queues via client libraries or PostgREST are shown here"
+              description="Only relevant roles for managing queues via client libraries or PostgREST are shown here."
             />
           )}
           <Table>

--- a/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/QueueSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/SingleQueue/QueueSettings.tsx
@@ -281,7 +281,7 @@ export const QueueSettings = ({}: QueueSettingsProps) => {
             <Admonition
               type="default"
               className="rounded-none border-x-0 border-t-0"
-              title="Only relevant roles for managing queues via client libraries or PostgREST are shown here"
+              description="Only relevant roles for managing queues via client libraries or PostgREST are shown here"
             />
           )}
           <Table>

--- a/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/StripeSyncSettingsPage.tsx
+++ b/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/StripeSyncSettingsPage.tsx
@@ -32,7 +32,7 @@ export const StripeSyncSettingsPage = () => {
     return (
       <PageContainer className="mx-0">
         <PageSection>
-          <Admonition type="default" title="Stripe Sync Engine is not installed" />
+          <Admonition type="default" description="Stripe Sync Engine is not installed" />
         </PageSection>
       </PageContainer>
     )

--- a/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/StripeSyncSettingsPage.tsx
+++ b/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/StripeSyncSettingsPage.tsx
@@ -32,7 +32,7 @@ export const StripeSyncSettingsPage = () => {
     return (
       <PageContainer className="mx-0">
         <PageSection>
-          <Admonition type="default" description="Stripe Sync Engine is not installed" />
+          <Admonition type="default" description="Stripe Sync Engine is not installed." />
         </PageSection>
       </PageContainer>
     )

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -272,7 +272,7 @@ export const PostgrestConfig = () => {
                 </CardContent>
               ) : isError ? (
                 <CardContent>
-                  <Admonition type="destructive" description="Failed to retrieve API settings" />
+                  <Admonition type="destructive" description="Failed to retrieve API settings." />
                 </CardContent>
               ) : (
                 <>

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -272,7 +272,7 @@ export const PostgrestConfig = () => {
                 </CardContent>
               ) : isError ? (
                 <CardContent>
-                  <Admonition type="destructive" title="Failed to retrieve API settings" />
+                  <Admonition type="destructive" description="Failed to retrieve API settings" />
                 </CardContent>
               ) : (
                 <>

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -161,7 +161,7 @@ const IPv4SidePanel = () => {
           {!isAws && (
             <Admonition
               type="default"
-              description="Dedicated IPv4 address is only available for AWS projects"
+              description="Dedicated IPv4 address is only available for AWS projects."
             />
           )}
 

--- a/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
+++ b/apps/studio/components/interfaces/Settings/Addons/IPv4SidePanel.tsx
@@ -161,7 +161,7 @@ const IPv4SidePanel = () => {
           {!isAws && (
             <Admonition
               type="default"
-              title="Dedicated IPv4 address is only available for AWS projects"
+              description="Dedicated IPv4 address is only available for AWS projects"
             />
           )}
 

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessRuleSheet.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessRuleSheet.tsx
@@ -305,7 +305,7 @@ export function JitDbAccessRuleSheet({
                       {grants.length === 0 ? (
                         <Admonition
                           type="note"
-                          description="No assignable roles found"
+                          description="No assignable roles found."
                           className="bg-background"
                         />
                       ) : (

--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessRuleSheet.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessRuleSheet.tsx
@@ -305,7 +305,7 @@ export function JitDbAccessRuleSheet({
                       {grants.length === 0 ? (
                         <Admonition
                           type="note"
-                          title="No assignable roles found"
+                          description="No assignable roles found"
                           className="bg-background"
                         />
                       ) : (

--- a/apps/studio/components/interfaces/Settings/General/DashboardPreferences.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DashboardPreferences.tsx
@@ -96,7 +96,7 @@ export const DashboardPreferences = () => {
         {/* [Joshen] Ideally we're able to persist this for all users in the project, but will need support in our middleware */}
         <Admonition
           type="note"
-          title="These preferences control only your experience in the dashboard. Other members of this project will not be affected"
+          description="These preferences control only your experience in the dashboard. Other members of this project will not be affected"
         />
 
         {isLoading ? (

--- a/apps/studio/components/interfaces/Settings/General/DashboardPreferences.tsx
+++ b/apps/studio/components/interfaces/Settings/General/DashboardPreferences.tsx
@@ -96,7 +96,7 @@ export const DashboardPreferences = () => {
         {/* [Joshen] Ideally we're able to persist this for all users in the project, but will need support in our middleware */}
         <Admonition
           type="note"
-          description="These preferences control only your experience in the dashboard. Other members of this project will not be affected"
+          description="These preferences control only your experience in the dashboard. Other members of this project will not be affected."
         />
 
         {isLoading ? (

--- a/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
+++ b/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
@@ -41,7 +41,7 @@ export function ProjectAndPlanInfo({
       <ProjectRefHighlighted projectRef={projectRef} />
 
       {!hasProjectSelected && (
-        <Admonition type="default" description="No project has been selected" />
+        <Admonition type="default" description="No project has been selected." />
       )}
     </div>
   )

--- a/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
+++ b/apps/studio/components/interfaces/Support/ProjectAndPlanInfo.tsx
@@ -40,7 +40,9 @@ export function ProjectAndPlanInfo({
       <ProjectSelector form={form} orgSlug={orgSlug} projectRef={projectRef} />
       <ProjectRefHighlighted projectRef={projectRef} />
 
-      {!hasProjectSelected && <Admonition type="default" title="No project has been selected" />}
+      {!hasProjectSelected && (
+        <Admonition type="default" description="No project has been selected" />
+      )}
     </div>
   )
 }

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -403,7 +403,10 @@ const SchemaExposureOptions = ({
   return (
     <>
       {isError && (
-        <Admonition type="warning" title="An error occurred while fetching Data API settings." />
+        <Admonition
+          type="warning"
+          description="An error occurred while fetching Data API settings."
+        />
       )}
 
       {isSchemaExposed && apiUrl && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore. Follow-up to DEPR-551, #45302, #45535, and #45618.

## What is the current behaviour?

Some short Studio Admonitions still put their entire message in `title` or legacy `label`, so body-copy callouts render as headings.

## What is the new behaviour?

Moves selected single-message Studio Admonitions to `description`, keeping the follow-up deliberately limited to Studio callsites.

This PR does not touch Docs content, shared Alert styling, ui-patterns, design-system registry/docs, or Tailwind config.

| Before | After |
| --- | --- |
| <img width="1818" height="388" alt="Image" src="https://github.com/user-attachments/assets/283a1853-348a-4d74-a408-013957350e5e" /> | <img width="1380" height="462" alt="Image" src="https://github.com/user-attachments/assets/e5761e8e-3697-423b-805b-45110205099a" /> |
| <img width="1640" height="716" alt="CleanShot 2026-04-28 at 15 17 25@2x" src="https://github.com/user-attachments/assets/a5be4d5f-2bf7-4dc2-b396-56129fe64ec9" /> | <img width="1630" height="716" alt="CleanShot 2026-04-28 at 15 16 00@2x" src="https://github.com/user-attachments/assets/0d589252-aaf8-4efc-9d81-15ec4f99ec61" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined message displays and admonition styling across settings, database, dashboard, and admin interfaces for improved visual consistency and clarity.

* **UI Updates**
  * Updated search input layouts and form element styling in publications tables and other admin pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46049?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->