### PR TITLE
fix(docs): Update Edge Function error code from WORKER_LIMIT to WORKER_RESOURCE_LIMIT

### DIFF
--- a/apps/docs/content/guides/functions/status-codes.mdx
+++ b/apps/docs/content/guides/functions/status-codes.mdx
@@ -109,7 +109,7 @@ You can see the output in the [Edge Function Logs](/docs/guides/functions/loggin
 
 ### 546 Resource Limit (Custom Error Code)
 
-**Cause:** Your Edge Function execution was stopped due to exceeding resource limits (`WORKER_LIMIT`). Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.
+**Cause:** Your Edge Function execution was stopped due to exceeding resource limits (`WORKER_RESOURCE_LIMIT` and prevously it was `WORKER_LIMIT`). Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.
 
 **Common causes:**
 

--- a/apps/docs/content/guides/functions/status-codes.mdx
+++ b/apps/docs/content/guides/functions/status-codes.mdx
@@ -109,7 +109,7 @@ You can see the output in the [Edge Function Logs](/docs/guides/functions/loggin
 
 ### 546 Resource Limit (Custom Error Code)
 
-**Cause:** Your Edge Function execution was stopped due to exceeding resource limits (`WORKER_RESOURCE_LIMIT` and prevously it was `WORKER_LIMIT`). Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.
+**Cause:** Your Edge Function execution was stopped due to exceeding resource limits (`WORKER_RESOURCE_LIMIT`, previously it was `WORKER_LIMIT`). Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.
 
 **Common causes:**
 

--- a/apps/docs/content/troubleshooting/edge-function-546-error-response.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-546-error-response.mdx
@@ -1,12 +1,12 @@
 ---
-title = "546 - WORKER_LIMIT Exceeded"
+title = "546 - WORKER_RESOURCE_LIMIT Exceeded"
 topics = [ "functions" ]
 keywords = [ "546", "error", "resource", "memory", "cpu", "event loop", "edge function" ]
 database_id = "4e6ff2e4-2abb-4fba-8233-5883b3d56fb0"
 
 [[errors]]
 http_status_code = 546
-message = "WORKER_LIMIT"
+message = "WORKER_RESOURCE_LIMIT"
 ---
 
 A 546 error indicates that an edge function used more resources (CPU or Memory) than it was allocated.
@@ -37,7 +37,7 @@ When an edge function fails due to internal CPU or memory limits, it will return
 
 ```json
 {
-  "code": "WORKER_LIMIT",
+  "code": "WORKER_RESOURCE_LIMIT",
   "message": "Function failed due to not having enough compute resources (please check logs)"
 }
 ```

--- a/apps/docs/content/troubleshooting/edge-function-546-error-response.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-546-error-response.mdx
@@ -1,5 +1,5 @@
 ---
-title = "546 - WORKER_RESOURCE_LIMIT Exceeded"
+title = "546 - WORKER_RESOURCE_LIMIT Exceeded / WORKER_LIMIT Exceeded"
 topics = [ "functions" ]
 keywords = [ "546", "error", "resource", "memory", "cpu", "event loop", "edge function" ]
 database_id = "4e6ff2e4-2abb-4fba-8233-5883b3d56fb0"
@@ -7,9 +7,13 @@ database_id = "4e6ff2e4-2abb-4fba-8233-5883b3d56fb0"
 [[errors]]
 http_status_code = 546
 message = "WORKER_RESOURCE_LIMIT"
+
+[[errors]]
+http_status_code = 546
+message = "WORKER_LIMIT"
 ---
 
-A 546 error indicates that an edge function used more resources (CPU or Memory) than it was allocated.
+A 546 error indicates that an edge function used more resources (CPU or Memory) than it was allocated. Previously it was `WORKER_LIMIT`.
 
 ## Context for the error
 

--- a/apps/docs/content/troubleshooting/http-status-codes.mdx
+++ b/apps/docs/content/troubleshooting/http-status-codes.mdx
@@ -70,4 +70,4 @@ The timeout limit is set to prevent long-running queries which can cause perform
 
 #### 546 Edge Functions resource limit
 
-Applies only to Edge Functions. Function execution was stopped due to a resource limit (`WORKER_LIMIT`). Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.
+Applies only to Edge Functions. Function execution was stopped due to a resource limit (`WORKER_RESOURCE_LIMIT`). Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updating to the current status code



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
* Updated docs for HTTP status code 546 to reference the correct resource limit identifier: WORKER_RESOURCE_LIMIT.
* Added a note that the limit was previously named WORKER_LIMIT for clarity.
* Revised troubleshooting guidance and examples to reflect the new identifier and to include both WORKER_RESOURCE_LIMIT and the prior WORKER_LIMIT naming where relevant.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46051?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->