### PR TITLE
Fix for AI Assistant query and deploy confirmation 

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -15,7 +15,11 @@ import { ButtonTooltip } from '../ButtonTooltip'
 import { ErrorBoundary } from '../ErrorBoundary/ErrorBoundary'
 import { ASSISTANT_ERRORS } from './AiAssistant.constants'
 import type { SqlSnippet } from './AIAssistant.types'
-import { onErrorChat } from './AIAssistant.utils'
+import {
+  hasPendingToolApproval,
+  onErrorChat,
+  resolvePendingToolApprovalsAsDenied,
+} from './AIAssistant.utils'
 import { AIAssistantHeader } from './AIAssistantHeader'
 import { AIOnboarding } from './AIOnboarding'
 import { AssistantChatForm } from './AssistantChatForm'
@@ -171,6 +175,8 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
   })
 
   const isChatLoading = chatStatus === 'submitted' || chatStatus === 'streaming'
+  const hasPendingApproval = hasPendingToolApproval(chatMessages)
+  const isChatInputDisabled = !isApiKeySet || disablePrompts || isLoadingOrganization
 
   const deleteMessageFromHere = useCallback(
     (messageId: string) => {
@@ -326,6 +332,9 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
 
     snap.clearSqlSnippets()
     lastUserMessageRef.current = payload
+    if (hasPendingApproval && !editingMessageId) {
+      setMessages(resolvePendingToolApprovalsAsDenied(chatMessages))
+    }
     sendMessage(payload, {
       body: {
         schema: currentSchema,
@@ -556,7 +565,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
             )}
             loading={isChatLoading}
             isEditing={!!editingMessageId}
-            disabled={!isApiKeySet || disablePrompts || isLoadingOrganization}
+            disabled={isChatInputDisabled}
             placeholder={
               hasMessages
                 ? 'Ask a follow up question...'

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.test.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.test.ts
@@ -1,6 +1,31 @@
+import type { UIMessage } from 'ai'
 import { describe, expect, test } from 'vitest'
 
-import { isReadOnlySelect } from './AIAssistant.utils'
+import {
+  hasPendingToolApproval,
+  isReadOnlySelect,
+  resolvePendingToolApprovalsAsDenied,
+} from './AIAssistant.utils'
+
+const createMessageWithPart = (
+  part: UIMessage['parts'][number],
+  role: UIMessage['role'] = 'assistant'
+) =>
+  [
+    {
+      id: `${role}-msg-1`,
+      role,
+      parts: [part],
+    },
+  ] as UIMessage[]
+
+const pendingSqlApprovalPart = {
+  type: 'tool-execute_sql',
+  toolCallId: 'call-1',
+  state: 'approval-requested',
+  input: { sql: 'select 1', label: 'Test query' },
+  approval: { id: 'approval-1' },
+} satisfies UIMessage['parts'][number]
 
 describe('AIAssistant.utils.ts:isReadOnlySelect', () => {
   test('Should return true for SQL that only contains SELECT operation', () => {
@@ -60,5 +85,75 @@ describe('AIAssistant.utils.ts:isReadOnlySelect', () => {
     const sql2 = `create schema joshen; select count(select * from countries);`
     const result2 = isReadOnlySelect(sql2)
     expect(result2).toBe(false)
+  })
+})
+
+describe('AIAssistant.utils.ts:hasPendingToolApproval', () => {
+  test('Should return true when an assistant message has a pending tool approval', () => {
+    const messages = createMessageWithPart(pendingSqlApprovalPart)
+
+    expect(hasPendingToolApproval(messages)).toBe(true)
+  })
+
+  test('Should return false when approval has already been answered', () => {
+    const messages = createMessageWithPart({
+      type: 'tool-execute_sql',
+      toolCallId: 'call-1',
+      state: 'approval-responded',
+      input: { sql: 'select 1', label: 'Test query' },
+      approval: { id: 'approval-1', approved: true },
+    })
+
+    expect(hasPendingToolApproval(messages)).toBe(false)
+  })
+
+  test('Should ignore non-assistant messages', () => {
+    const messages = createMessageWithPart(pendingSqlApprovalPart, 'user')
+
+    expect(hasPendingToolApproval(messages)).toBe(false)
+  })
+
+  test('Should return true for dynamic tool approvals', () => {
+    const messages = createMessageWithPart({
+      type: 'dynamic-tool',
+      toolName: 'execute_sql',
+      toolCallId: 'call-1',
+      state: 'approval-requested',
+      input: { sql: 'select 1', label: 'Test query' },
+      approval: { id: 'approval-1' },
+    })
+
+    expect(hasPendingToolApproval(messages)).toBe(true)
+  })
+})
+
+describe('AIAssistant.utils.ts:resolvePendingToolApprovalsAsDenied', () => {
+  test('Should convert pending approvals into denied outputs', () => {
+    const messages = createMessageWithPart(pendingSqlApprovalPart)
+
+    const resolvedMessages = resolvePendingToolApprovalsAsDenied(messages)
+    const [part] = resolvedMessages[0].parts
+
+    expect(part).toMatchObject({
+      state: 'output-denied',
+      approval: {
+        id: 'approval-1',
+        approved: false,
+        reason: 'Skipped because the user sent a follow-up message.',
+      },
+    })
+  })
+
+  test('Should leave completed approvals unchanged', () => {
+    const messages = createMessageWithPart({
+      type: 'tool-execute_sql',
+      toolCallId: 'call-1',
+      state: 'output-available',
+      input: { sql: 'select 1', label: 'Test query' },
+      output: [],
+      approval: { id: 'approval-1', approved: true },
+    })
+
+    expect(resolvePendingToolApprovalsAsDenied(messages)).toEqual(messages)
   })
 })

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
@@ -1,3 +1,4 @@
+import { isToolUIPart, type UIMessage } from 'ai'
 import { toast } from 'sonner'
 
 import { SAFE_FUNCTIONS } from './AiAssistant.constants'
@@ -70,6 +71,36 @@ export const isReadOnlySelect = (query: string): boolean => {
   if (hasUnknownFunction) return false
 
   return true
+}
+
+export const hasPendingToolApproval = (messages: Pick<UIMessage, 'role' | 'parts'>[]) => {
+  return messages.some((message) => {
+    if (message.role !== 'assistant') return false
+
+    return message.parts?.some((part) => isToolUIPart(part) && part.state === 'approval-requested')
+  })
+}
+
+export const resolvePendingToolApprovalsAsDenied = (messages: UIMessage[]): UIMessage[] => {
+  return messages.map((message) => {
+    if (message.role !== 'assistant') return message
+
+    const parts = message.parts?.map((part) => {
+      if (!isToolUIPart(part) || part.state !== 'approval-requested') return part
+
+      return {
+        ...part,
+        state: 'output-denied',
+        approval: {
+          id: part.approval.id,
+          approved: false,
+          reason: 'Skipped because the user sent a follow-up message.',
+        },
+      } as UIMessage['parts'][number]
+    })
+
+    return { ...message, parts } as UIMessage
+  })
 }
 
 const getContextKey = (pathname: string) => {

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
@@ -79,7 +79,7 @@ const AssistantChatFormComponent = forwardRef<HTMLFormElement, FormProps>(
 
     const handleSubmit = (event?: FormEvent<HTMLFormElement>) => {
       if (event) event.preventDefault()
-      if (!value || (loading && !isEditing)) return
+      if (disabled || !value || (loading && !isEditing)) return
 
       let finalMessage = value
       if (includeSnippetsInMessage && sqlSnippets && sqlSnippets.length > 0) {
@@ -99,7 +99,7 @@ const AssistantChatFormComponent = forwardRef<HTMLFormElement, FormProps>(
       }
     }
 
-    const canSubmit = !loading && !!value
+    const canSubmit = !disabled && !loading && !!value
 
     return (
       <div className="w-full">

--- a/apps/studio/components/ui/AIAssistantPanel/ConfirmFooter.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/ConfirmFooter.tsx
@@ -5,6 +5,7 @@ interface ConfirmFooterProps {
   message: string
   cancelLabel?: string
   confirmLabel?: string
+  confirmLabelLoading?: string
   isLoading?: boolean
   onCancel?: () => void | Promise<void>
   onConfirm?: () => void | Promise<void>
@@ -14,6 +15,7 @@ export const ConfirmFooter = ({
   message,
   cancelLabel = 'Cancel',
   confirmLabel = 'Confirm',
+  confirmLabelLoading = 'Working...',
   isLoading = false,
   onCancel,
   onConfirm,
@@ -32,7 +34,7 @@ export const ConfirmFooter = ({
           {cancelLabel}
         </Button>
         <Button size="tiny" type="primary" onClick={onConfirm} disabled={isLoading}>
-          {isLoading ? 'Working...' : confirmLabel}
+          {isLoading ? confirmLabelLoading : confirmLabel}
         </Button>
       </div>
     </div>

--- a/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/DisplayBlockRenderer.tsx
@@ -40,6 +40,7 @@ interface DisplayBlockRendererProps {
   onDeny?: () => void
   /** AI SDK tool state used to show approval UI for pending tool calls. */
   toolState?: ToolUIPart['state']
+  toolApprovalRespondedApproved?: boolean
   isLastPart?: boolean
   isLastMessage?: boolean
   showConfirmFooter?: boolean
@@ -57,6 +58,7 @@ export const DisplayBlockRenderer = ({
   onApprove,
   onDeny,
   toolState,
+  toolApprovalRespondedApproved,
   isLastPart = false,
   isLastMessage = false,
   showConfirmFooter = true,
@@ -223,13 +225,16 @@ export const DisplayBlockRenderer = ({
     )
   }
 
+  const isApprovalRequested = toolState === 'approval-requested'
+  const isApprovalResponded = toolState === 'approval-responded'
+  const isApprovalDenied = isApprovalResponded && toolApprovalRespondedApproved === false
   const shouldShowConfirmFooter =
     showConfirmFooter &&
-    toolState === 'approval-requested' &&
+    (isApprovalRequested || (isApprovalResponded && !isApprovalDenied)) &&
     isLastPart &&
     isLastMessage &&
-    !!onApprove &&
-    !!onDeny
+    (isApprovalResponded || (!!onApprove && !!onDeny))
+  const isRunningApprovedTool = (isApprovalResponded && !isApprovalDenied) || executeSqlLoading
 
   return (
     <div className="display-block w-auto overflow-x-hidden">
@@ -246,7 +251,7 @@ export const DisplayBlockRenderer = ({
           draggable={isDraggableToReports}
           onDragStart={handleDragStart}
           disabled={shouldShowConfirmFooter}
-          isExecuting={executeSqlLoading}
+          isExecuting={isRunningApprovedTool}
         />
       </div>
       {shouldShowConfirmFooter && (
@@ -254,10 +259,11 @@ export const DisplayBlockRenderer = ({
           <ConfirmFooter
             message="Assistant wants to run this query"
             cancelLabel="Skip"
-            confirmLabel={executeSqlLoading ? 'Running...' : 'Run Query'}
-            isLoading={executeSqlLoading}
-            onCancel={onDeny}
-            onConfirm={onApprove}
+            confirmLabel="Run Query"
+            confirmLabelLoading="Running..."
+            isLoading={isApprovalResponded || executeSqlLoading}
+            onCancel={isApprovalRequested ? onDeny : undefined}
+            onConfirm={isApprovalRequested ? onApprove : undefined}
           />
         </div>
       )}

--- a/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/EdgeFunctionRenderer.tsx
@@ -113,7 +113,8 @@ export const EdgeFunctionRenderer = ({
           <ConfirmFooter
             message="Assistant wants to deploy this Edge Function"
             cancelLabel="Skip"
-            confirmLabel={isDeploying ? 'Deploying...' : 'Deploy'}
+            confirmLabel="Deploy"
+            confirmLabelLoading="Deploying..."
             isLoading={isDeploying}
             onCancel={() => onDeny?.()}
             onConfirm={handleDeploy}

--- a/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/Message.Parts.tsx
@@ -123,16 +123,14 @@ function MessagePartExecuteSql({
     return <ToolDisplayExecuteSqlFailure />
   }
 
-  if (state === 'approval-responded') {
-    return <ToolDisplayExecuteSqlLoading label="Running SQL..." />
-  }
-
   const { data: chart, success } = parseExecuteSqlChartResult(input)
   if (!success) return null
 
   if (
     state === 'input-available' ||
     state === 'approval-requested' ||
+    state === 'approval-responded' ||
+    state === 'output-denied' ||
     state === 'output-available'
   ) {
     const approvalId = state === 'approval-requested' ? toolPart.approval?.id : undefined
@@ -151,6 +149,7 @@ function MessagePartExecuteSql({
           }}
           initialResults={output}
           toolState={state}
+          toolApprovalRespondedApproved={toolPart.approval?.approved}
           isLastPart={isLastPart}
           isLastMessage={isLastMessage}
           onApprove={
@@ -175,6 +174,7 @@ const TOOL_DEPLOY_EDGE_FUNCTION_STATES_WITH_INPUT = new Set([
   'input-available',
   'approval-requested',
   'approval-responded',
+  'output-denied',
   'output-available',
 ])
 
@@ -212,7 +212,7 @@ function MessagePartDeployEdgeFunction({ toolPart }: { toolPart: ToolUIPart }) {
       code={parsedInput.data.code}
       functionName={parsedInput.data.functionName}
       showConfirmFooter={state === 'approval-requested'}
-      isDeploying={state === 'approval-responded'}
+      isDeploying={state === 'approval-responded' && toolPart.approval?.approved !== false}
       initialIsDeployed={isInitiallyDeployed}
       onApprove={
         approvalId ? () => addToolApprovalResponse?.({ id: approvalId, approved: true }) : undefined

--- a/apps/studio/lib/ai/generate-assistant-response.ts
+++ b/apps/studio/lib/ai/generate-assistant-response.ts
@@ -73,7 +73,12 @@ export async function generateAssistantResponse({
         const cleanedParts = msg.parts
           .filter((part) => {
             if (isToolUIPart(part)) {
-              const invalidStates = ['input-streaming', 'input-available', 'output-error']
+              const invalidStates = [
+                'input-streaming',
+                'input-available',
+                'approval-requested',
+                'output-error',
+              ]
               return !invalidStates.includes(part.state)
             }
             return true

--- a/apps/studio/lib/ai/tools/studio-tools.test.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.test.ts
@@ -136,8 +136,9 @@ describe('ai/tools/studio-tools', () => {
       expect(tools.execute_sql.needsApproval).toBe(true)
     })
 
-    it('should sanitize execute_sql output without data opt-in', async () => {
-      vi.mocked(executeSql).mockResolvedValue({ result: [{ email: 'test@example.com' }] })
+    it('should return execute_sql rows to the UI and sanitize model output without data opt-in', async () => {
+      const rows = [{ email: 'test@example.com' }]
+      vi.mocked(executeSql).mockResolvedValue({ result: rows })
 
       const tools = getStudioTools({
         projectRef: 'test-project',
@@ -165,7 +166,11 @@ describe('ai/tools/studio-tools', () => {
         undefined,
         undefined
       )
-      expect(result).toBe(NO_DATA_PERMISSIONS)
+      expect(result).toEqual(rows)
+      expect((tools.execute_sql as any).toModelOutput({ output: result })).toEqual({
+        type: 'text',
+        value: NO_DATA_PERMISSIONS,
+      })
     })
 
     it('should return execute_sql rows with data opt-in', async () => {
@@ -199,6 +204,10 @@ describe('ai/tools/studio-tools', () => {
         undefined
       )
       expect(result).toEqual(rows)
+      expect((tools.execute_sql as any).toModelOutput({ output: result })).toEqual({
+        type: 'json',
+        value: rows,
+      })
     })
 
     it('should validate rename_chat input schema correctly', () => {

--- a/apps/studio/lib/ai/tools/studio-tools.ts
+++ b/apps/studio/lib/ai/tools/studio-tools.ts
@@ -77,7 +77,12 @@ export const getStudioTools = (ctx: StudioToolsContext = {}) => {
           undefined,
           authHeaders
         )
-        return aiOptInLevel === 'schema_and_log_and_data' ? result : NO_DATA_PERMISSIONS
+        return result
+      },
+      toModelOutput: ({ output }) => {
+        return aiOptInLevel === 'schema_and_log_and_data'
+          ? { type: 'json', value: output }
+          : { type: 'text', value: NO_DATA_PERMISSIONS }
       },
     }),
     deploy_edge_function: tool({


### PR DESCRIPTION
When Assistant requests confirmation to run a query or deploy an edge function if the user doesn't skip or run and instead sends a follow-up message it errors out. This allows follow-up messages and treats them as "skips" which means adjusting confirmation message state as part of the follow-up. This also uses toModelOutput to cleanse data based on permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced tool approval workflow: pending approvals are now automatically resolved as denied when submitting new messages
  * Improved chat input state management with better handling of approval states
  * Customizable loading messages for tool operations

* **Bug Fixes**
  * Fixed chat input availability during pending tool approval states
  * Improved tool execution feedback during approval workflows

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46052?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->