### PR TITLE
chore(docs): migrate Admonition labels to titles

### DIFF
--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -172,7 +172,7 @@ Choose the appropriate `type` for your admonition:
 - `note` for anything else
 
 ```
-<Admonition type="note" title="Optional label displays as title">
+<Admonition type="note" title="Optional title">
 
 Your content here
 

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -172,7 +172,7 @@ Choose the appropriate `type` for your admonition:
 - `note` for anything else
 
 ```
-<Admonition type="note" label="Optional label displays as title">
+<Admonition type="note" title="Optional label displays as title">
 
 Your content here
 

--- a/apps/docs/content/guides/auth/auth-anonymous.mdx
+++ b/apps/docs/content/guides/auth/auth-anonymous.mdx
@@ -6,7 +6,7 @@ subtitle: 'Create and use anonymous users to authenticate with Supabase'
 
 [Enable Anonymous Sign-Ins](/dashboard/project/_/auth/providers) to build apps which provide users an authenticated experience without requiring users to enter an email address, password, use an OAuth provider or provide any other PII (Personally Identifiable Information). Later, when ready, the user can link an authentication method to their account.
 
-<Admonition type="note" label="Anonymous user vs the anon key">
+<Admonition type="note" title="Anonymous user vs the anon key">
 
 Calling `signInAnonymously()` creates an anonymous user. It's just like a permanent user, except the user can't access their account if they sign out, clear browsing data, or use another device.
 
@@ -30,13 +30,13 @@ See the [Access control section](#access-control) for more details.
 
 </Admonition>
 
-<Admonition type="caution" label="Use Dynamic Rendering with Next.js">
+<Admonition type="caution" title="Use Dynamic Rendering with Next.js">
 
 The Supabase team has received reports of user metadata being cached across unique anonymous users as a result of Next.js static page rendering. For the best user experience, utilize dynamic page rendering.
 
 </Admonition>
 
-<Admonition type="note" label="Self hosting and local development">
+<Admonition type="note" title="Self hosting and local development">
 
 For self-hosting, you can update your project configuration using the files and environment variables provided. See the [local development docs](/docs/guides/cli/config) for more details.
 
@@ -293,7 +293,7 @@ to authenticated
 using ( true );
 ```
 
-<Admonition type="note" label="Use restrictive policies">
+<Admonition type="note" title="Use restrictive policies">
 
 RLS policies are permissive by default, which means that they are combined using an "OR" operator when multiple policies are applied. It is important to construct restrictive policies to ensure that the checks for an anonymous user are always enforced when combined with other policies.
 Be aware that a single 'restrictive' RLS policy alone will fail unless combined with another policy that returns true, ensuring the combined condition is met.

--- a/apps/docs/content/guides/auth/redirect-urls.mdx
+++ b/apps/docs/content/guides/auth/redirect-urls.mdx
@@ -42,7 +42,7 @@ Supabase allows you to specify wildcards when adding redirect URLs to the [allow
 
 The separator characters in a URL are defined as `.` and `/`. Use [this tool](https://www.digitalocean.com/community/tools/glob?comments=true&glob=http%3A%2F%2Flocalhost%3A3000%2F%2A%2A&matches=false&tests=http%3A%2F%2Flocalhost%3A3000&tests=http%3A%2F%2Flocalhost%3A3000%2F&tests=http%3A%2F%2Flocalhost%3A3000%2F%3Ftest%3Dtest&tests=http%3A%2F%2Flocalhost%3A3000%2Ftest-test%3Ftest%3Dtest&tests=http%3A%2F%2Flocalhost%3A3000%2Ftest%2Ftest%3Ftest%3Dtest) to test your patterns.
 
-<Admonition type="note" label="Recommendation">
+<Admonition type="note" title="Recommendation">
 
 While the "globstar" (`**`) is useful for local development and preview URLs, we recommend setting the exact redirect URL path for your site URL in production.
 

--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -22,7 +22,7 @@ In some cases you're able to use the OAuth flow within web-based native apps suc
 
 When developing with Expo, you can test Sign in with Apple via the Expo Go app, in all other cases you will need to obtain an [Apple Developer](https://developer.apple.com) account to enable the capability.
 
-<Admonition type="caution" label="Secret Key Rotation Required">
+<Admonition type="caution" title="Secret Key Rotation Required">
 
 If you're using the OAuth flow (web, Flutter web, Kotlin non-iOS platforms), Apple requires you to generate a new secret key every 6 months using the signing key (`.p8` file). This is a critical maintenance task that will cause authentication failures if missed.
 
@@ -35,7 +35,7 @@ This requirement only applies if you're configuring OAuth settings (Services ID,
 
 </Admonition>
 
-<Admonition type="caution" label="Apple Does Not Provide Full Name in Identity Token">
+<Admonition type="caution" title="Apple Does Not Provide Full Name in Identity Token">
 
 Apple's identity token does not include the user's full name in its claims. This means the Supabase Auth server cannot automatically populate the user's name metadata when users sign in with Apple.
 
@@ -97,7 +97,7 @@ The platform-specific examples below demonstrate how to implement this pattern f
 
     This call takes the user to Apple's consent screen. Once the flow ends, the user's profile information is exchanged and validated with Supabase Auth before it redirects back to your web application with an access and refresh token representing the user's session.
 
-    <Admonition type="note" label="Full Name Not Available in OAuth Flow">
+    <Admonition type="note" title="Full Name Not Available in OAuth Flow">
 
     When using the OAuth flow, the user's full name is not accessible from Apple's response. Apple only provides the full name through native authentication methods (Sign in with Apple JS, or native iOS/macOS SDKs) during the first sign-in.
 
@@ -371,7 +371,7 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
     }
     ```
 
-    <Admonition type="note" label="Android Implementation Notes">
+    <Admonition type="note" title="Android Implementation Notes">
 
     - Sign in with Apple is not natively available on Android devices
     - The OAuth flow opens a browser window for authentication

--- a/apps/docs/content/guides/database/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/database/custom-postgres-config.mdx
@@ -208,7 +208,7 @@ select pg_postmaster_start_time();
 
 You can also pass the `--no-restart` flag to attempt a reload-only apply. If the parameter cannot be reloaded, the change stays pending until the next restart.
 
-<Admonition type="note" label="Read Replicas and Custom Config">
+<Admonition type="note" title="Read Replicas and Custom Config">
 
 Postgres requires several parameters to be synchronized between the Primary cluster and [Read Replicas](/docs/guides/platform/read-replicas).
 

--- a/apps/docs/content/guides/database/extensions/pg_net.mdx
+++ b/apps/docs/content/guides/database/extensions/pg_net.mdx
@@ -309,7 +309,7 @@ order by "created" desc;
 
 ## Configuration
 
-<Admonition type="note" label="Must be on pg_net v0.12.0 or above to reconfigure ">
+<Admonition type="note" title="Must be on pg_net v0.12.0 or above to reconfigure ">
 
 Supabase supports reconfiguring pg*net starting from v0.12.0+. For the latest release, initiate a Postgres upgrade in the [Infrastructure Settings](/dashboard/project/*/settings/infrastructure).
 

--- a/apps/docs/content/guides/database/metabase.mdx
+++ b/apps/docs/content/guides/database/metabase.mdx
@@ -43,7 +43,7 @@ hideToc: true
     - On your project dashboard, click [Connect](/dashboard/project/_?showConnect=true)
     - View parameters under "Session pooler"
 
-    <Admonition type="note" label="connection notice">
+    <Admonition type="note" title="connection notice">
 
             If you're in an [IPv6 environment](/docs/guides/platform/ipv4-address#checking-your-network-ipv6-support) or have the [IPv4 Add-On](/docs/guides/platform/ipv4-address#understanding-ip-addresses), you can use the direct connection string instead of Supavisor in Session mode.
 

--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -107,7 +107,7 @@ EXECUTE FUNCTION rls_auto_enable();
 
 Note that this applies to tables created after the trigger is installed. Existing tables still need RLS enabled manually.
 
-<Admonition type="caution" label="`auth.uid()` Returns `null` When Unauthenticated">
+<Admonition type="caution" title="`auth.uid()` Returns `null` When Unauthenticated">
 
 When a request is made without an authenticated user (e.g., no access token is provided or the session has expired), `auth.uid()` returns `null`.
 
@@ -156,7 +156,7 @@ to authenticated
 using ( true );
 ```
 
-<Admonition type="note" label="Anonymous user vs the anon key">
+<Admonition type="note" title="Anonymous user vs the anon key">
 
 Using the `anon` Postgres role is different from an [anonymous user](/docs/guides/auth/auth-anonymous) in Supabase Auth. An anonymous user assumes the `authenticated` role to access the database and can be differentiated from a permanent user by checking the `is_anonymous` claim in the JWT.
 

--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -19,7 +19,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
     <StepHikeCompact.Details title="Create a custom user for Prisma">
       - In the [SQL Editor](/dashboard/project/_/sql/new), create a Prisma DB user with full privileges on the public schema.
       - This gives you better control over Prisma's access and makes it easier to monitor using Supabase tools like the [Query Performance Dashboard](/dashboard/project/_/advisors/query-performance) and [Log Explorer](/dashboard/project/_/logs/explorer).
-      <Admonition type="note" label="password manager">
+      <Admonition type="note" title="password manager">
 
         For security, consider using a [password generator](https://bitwarden.com/password-generator/) for the Prisma role.
 
@@ -283,7 +283,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="tip" label="conflict management">
+            <Admonition type="tip" title="conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
@@ -311,7 +311,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="note" label="conflict management">
+            <Admonition type="note" title="conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
@@ -339,7 +339,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="note" label="conflict management">
+            <Admonition type="note" title="conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
@@ -367,7 +367,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="note" label="conflict management">
+            <Admonition type="note" title="conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma-troubleshooting) for more details
 

--- a/apps/docs/content/guides/database/replication.mdx
+++ b/apps/docs/content/guides/database/replication.mdx
@@ -28,7 +28,7 @@ Read replicas are additional Supabase Postgres databases kept in sync with your 
 
 ### External replication
 
-<Admonition type="caution" label="Private Alpha">
+<Admonition type="caution" title="Private Alpha">
 
 External replication is currently in private alpha. Access is limited and features may change.
 

--- a/apps/docs/content/guides/database/replication/bigquery.mdx
+++ b/apps/docs/content/guides/database/replication/bigquery.mdx
@@ -6,7 +6,7 @@ subtitle: 'Replicate Supabase Postgres tables to BigQuery.'
 sidebar_label: 'BigQuery'
 ---
 
-<Admonition type="caution" label="Private Alpha">
+<Admonition type="caution" title="Private Alpha">
 
 External replication is currently in private alpha. Access is limited and features may change.
 

--- a/apps/docs/content/guides/database/replication/external-replication-faq.mdx
+++ b/apps/docs/content/guides/database/replication/external-replication-faq.mdx
@@ -6,7 +6,7 @@ subtitle: 'Common questions and answers about external replication.'
 sidebar_label: 'FAQ'
 ---
 
-<Admonition type="caution" label="Private Alpha">
+<Admonition type="caution" title="Private Alpha">
 
 External replication is currently in private alpha. Access is limited and features may change.
 

--- a/apps/docs/content/guides/database/replication/external-replication-monitoring.mdx
+++ b/apps/docs/content/guides/database/replication/external-replication-monitoring.mdx
@@ -6,7 +6,7 @@ subtitle: 'Track replication status, view logs, and troubleshoot issues.'
 sidebar_label: 'Monitoring'
 ---
 
-<Admonition type="caution" label="Private Alpha">
+<Admonition type="caution" title="Private Alpha">
 
 External replication is currently in private alpha. Access is limited and features may change.
 

--- a/apps/docs/content/guides/database/replication/external-replication-setup.mdx
+++ b/apps/docs/content/guides/database/replication/external-replication-setup.mdx
@@ -6,7 +6,7 @@ subtitle: 'Configure publications and destinations for external replication.'
 sidebar_label: 'Setting up'
 ---
 
-<Admonition type="caution" label="Private Alpha">
+<Admonition type="caution" title="Private Alpha">
 
 External replication is currently in private alpha. Access is limited and features may change.
 

--- a/apps/docs/content/guides/database/secure-data.mdx
+++ b/apps/docs/content/guides/database/secure-data.mdx
@@ -32,7 +32,7 @@ Your publishable key is safe to expose with RLS enabled, because row access perm
 
 Older projects may also show an `anon` key. Treat it like a publishable key: it can identify your project, but it is not a secret and must be paired with RLS and least-privilege grants.
 
-<Admonition type="danger" label="Never expose your service role or secret keys on the frontend">
+<Admonition type="danger" title="Never expose your service role or secret keys on the frontend">
 
 Unlike your publishable key, your secret and service role keys are **never** safe to expose because they bypass RLS. Only use your secret and service role keys on the backend. Treat them as secrets (for example, import them as sensitive environment variables instead of hardcoding them).
 

--- a/apps/docs/content/guides/deployment/branching/configuration.mdx
+++ b/apps/docs/content/guides/deployment/branching/configuration.mdx
@@ -95,7 +95,7 @@ user = "env(SMTP_USER)"
 password = "env(SMTP_PASSWORD)"
 ```
 
-<Admonition type="note" label="Secrets are branch-specific">
+<Admonition type="note" title="Secrets are branch-specific">
 
 Secrets set for one branch are not automatically available in other branches. You'll need to set them separately for each branch that needs them.
 
@@ -152,7 +152,7 @@ client_id = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_CLIENT_ID)"
 secret = "env(SUPABASE_AUTH_EXTERNAL_GITHUB_SECRET)"
 ```
 
-<Admonition type="note" label="Secret fields">
+<Admonition type="note" title="Secret fields">
 
 The `encrypted:` syntax only works for designated "secret" fields in the configuration. Using encrypted values in other fields will not be automatically decrypted and may cause issues. For non-secret fields, use environment variables with the `env()` syntax instead.
 

--- a/apps/docs/content/guides/deployment/branching/dashboard.mdx
+++ b/apps/docs/content/guides/deployment/branching/dashboard.mdx
@@ -5,7 +5,7 @@ subtitle: 'Create, manage, review, and merge branches directly in the dashboard'
 
 You can create, manage, review, and merge Supabase branches directly via the dashboard. This is useful for quick testing, prototyping, or when you prefer to work in a no-code way. You can also connect a Supabase branch to a GitHub branch at a later time if needed.
 
-<Admonition type="note" label="Public Alpha">
+<Admonition type="note" title="Public Alpha">
 
 Branch management via the dashboard is currently in public alpha. Features and functionality may change.
 

--- a/apps/docs/content/guides/deployment/branching/integrations.mdx
+++ b/apps/docs/content/guides/deployment/branching/integrations.mdx
@@ -17,7 +17,7 @@ Install the Vercel integration:
 - From the [Vercel marketplace](https://vercel.com/integrations/supabase) or
 - By clicking the blue `Deploy` button in a Supabase example app's `README` file
 
-<Admonition type="note" label="Vercel GitHub integration also required.">
+<Admonition type="note" title="Vercel GitHub integration also required.">
 
 For branching to work with Vercel, you also need the [Vercel GitHub integration](https://vercel.com/docs/deployments/git/vercel-for-github).
 

--- a/apps/docs/content/guides/deployment/going-into-prod.mdx
+++ b/apps/docs/content/guides/deployment/going-into-prod.mdx
@@ -76,7 +76,7 @@ Check and review issues in your database using [Performance Advisor](/dashboard/
 
 ## Rate limiting, resource allocation, & abuse prevention
 
-<Admonition type="caution" label="Shared Responsibility Model">
+<Admonition type="caution" title="Shared Responsibility Model">
 
 Running databases is a shared responsibility between you and Supabase. There are some things that we can take care of for you, and some things that you are responsible for.
 

--- a/apps/docs/content/guides/functions/deploy.mdx
+++ b/apps/docs/content/guides/functions/deploy.mdx
@@ -34,7 +34,7 @@ Get the project ID associated with your function:
 supabase projects list
 ```
 
-<Admonition type="tip" label="Need a new project?">
+<Admonition type="tip" title="Need a new project?">
 
 If you haven't yet created a Supabase project, you can do so by visiting [database.new](https://database.new).
 

--- a/apps/docs/content/guides/functions/development-tips.mdx
+++ b/apps/docs/content/guides/functions/development-tips.mdx
@@ -11,7 +11,7 @@ Here are a few recommendations when you first start developing Edge Functions.
 
 Edge Functions support `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, and `OPTIONS`. A Function can be designed to perform different actions based on a request's HTTP method. See the [example on building a RESTful service](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/restful-tasks) to learn how to handle different HTTP methods in your Function.
 
-<Admonition type="caution" label="HTML not supported">
+<Admonition type="caution" title="HTML not supported">
 
 HTML content is not supported. `GET` requests that return `text/html` will be rewritten to `text/plain`.
 

--- a/apps/docs/content/guides/functions/quickstart-dashboard.mdx
+++ b/apps/docs/content/guides/functions/quickstart-dashboard.mdx
@@ -9,13 +9,13 @@ Supabase allows you to create Supabase Edge Functions directly from the Supabase
 
 This guide will walk you through creating, testing, and deploying your first Edge Function using the Supabase Dashboard. You'll have a working function running globally in under 10 minutes.
 
-<Admonition type="tip" label="Prefer using the CLI?">
+<Admonition type="tip" title="Prefer using the CLI?">
 
 You can also create and deploy functions using the Supabase CLI. Check out our [CLI Quickstart guide](/docs/guides/functions/quickstart).
 
 </Admonition>
 
-<Admonition type="note" label="New to Supabase?">
+<Admonition type="note" title="New to Supabase?">
 
 You'll need a Supabase project to get started. If you don't have one yet, create a new project at [database.new](https://database.new/).
 
@@ -50,7 +50,7 @@ width={2338}
 height={926}
 />
 
-<Admonition type="note" label="Pre-built templates">
+<Admonition type="note" title="Pre-built templates">
 
 The dashboard offers several pre-built templates for common use cases, such as Stripe Webhooks, OpenAI proxying, uploading files to Supabase Storage, and sending emails.
 
@@ -139,7 +139,7 @@ To invoke this Edge Function from within your application, you'll need API keys.
 
 If you’d like to update the deployed function code, click on the function you want to edit, modify the code as needed, then click Deploy updates. This will overwrite the existing deployment with the newly edited function code.
 
-<Admonition type="caution" label="No version control">
+<Admonition type="caution" title="No version control">
 
 There is currently **no version control** for edits! The Dashboard's Edge Function editor currently does not support version control, versioning, or rollbacks. We recommend using it only for quick testing and prototypes.
 
@@ -241,7 +241,7 @@ Now that your function is deployed, you can access it from your local developmen
 
 ### CLI
 
-<Admonition type="note" label="CLI not installed?">
+<Admonition type="note" title="CLI not installed?">
 
 Before getting started, make sure you have the **Supabase CLI installed**. Check out the [CLI installation guide](/docs/guides/cli) for installation methods and troubleshooting.
 

--- a/apps/docs/content/guides/functions/quickstart.mdx
+++ b/apps/docs/content/guides/functions/quickstart.mdx
@@ -53,7 +53,7 @@ supabase functions new hello-world
 
 {/* TODO: Link to parameter documentation */}
 
-<Admonition type="tip" label="Secure your function with Supabase Auth">
+<Admonition type="tip" title="Secure your function with Supabase Auth">
 
 When an HTTP request is sent to Edge Functions, you can use Supabase Auth to secure endpoints. By default, the `supabase functions new` command adds handling a valid publishable or secret key to the basic template. However, you can change this behavior with the `--auth` flag when creating a new function.
 
@@ -132,7 +132,7 @@ After this step, you should have successfully tested your Edge Function locally 
 
 To deploy your function globally, you need to connect your local project to a Supabase project.
 
-<Admonition type="tip" label="Need to create a new Supabase project?">
+<Admonition type="tip" title="Need to create a new Supabase project?">
 
 Create one at [database.new](https://database.new/).
 
@@ -176,7 +176,7 @@ If you want to deploy all functions, run the `deploy` command without specifying
 supabase functions deploy
 ```
 
-<Admonition type="note" label="Docker not required">
+<Admonition type="note" title="Docker not required">
 
 The CLI automatically falls back to API-based deployment if Docker isn't available. You can also explicitly use API deployment with the `--use-api` flag:
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-angular.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-angular.mdx
@@ -58,7 +58,7 @@ Optionally, update `src/styles.css` to style the app. You can find the full cont
 
 You need an Angular component to manage logins and sign ups. The component uses [Magic Links](/docs/guides/auth/auth-email-passwordless#with-magic-link), so users can sign in with their email without using passwords.
 
-<Admonition type="tip" label="Did you know?">
+<Admonition type="tip" title="Did you know?">
 
 You can customize other emails sent out to new users, including the email's looks, content, and query parameters from [the **Authentication > Email**](/dashboard/project/_/auth/templates) section of the Dashboard.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
@@ -182,7 +182,7 @@ Before proceeding, change the email template to support a server-side authentica
 - Select the **Confirm signup** template.
 - Change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email`.
 
-<Admonition type="tip" label="Did you know?">
+<Admonition type="tip" title="Did you know?">
 
 You can customize other emails sent out to new users, including the email's looks, content, and query parameters from [the **Authentication > Email**](/dashboard/project/_/auth/templates) section of the Dashboard.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-react.mdx
@@ -62,7 +62,7 @@ You can find the full contents of this file [in the example repository](https://
 
 You need a React component to manage logins and sign-ups. It uses [Magic Links](/docs/guides/auth/auth-email-passwordless#with-magic-link), so users can sign in with their email without using passwords.
 
-<Admonition type="tip" label="Did you know?">
+<Admonition type="tip" title="Did you know?">
 
 You can customize other emails sent out to new users, including the email's looks, content, and query parameters from [the **Authentication > Email**](/dashboard/project/_/auth/templates) section of the Dashboard.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -169,7 +169,7 @@ Before proceeding, change the email template to support sending a token hash:
 - Change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email`.
 - Repeat the previous step for **Magic link** template.
 
-<Admonition type="tip" label="Did you know?">
+<Admonition type="tip" title="Did you know?">
 
 You can also customize emails sent out to new users, including the email's looks, content, and query parameters. Check out the [settings of your project](/dashboard/project/_/auth/templates).
 

--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -234,7 +234,7 @@ npm update supabase@beta --save-dev
 
 If you have any Supabase containers running locally, stop them and delete their data volumes before proceeding with the upgrade. This ensures that Supabase managed services can apply new migrations on a clean state of the local database.
 
-<Admonition type="tip" label="Backup and stop running containers">
+<Admonition type="tip" title="Backup and stop running containers">
 
 Remember to save any local schema and data changes before stopping because the `--no-backup` flag will delete them.
 

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -17,7 +17,7 @@ When you delete a project, we permanently remove all associated data, including 
 
 Database backups can be categorized into two types: **logical** and **physical**. You can learn more about them [in this blog post](/blog/postgresql-physical-logical-backups).
 
-<Admonition type="note" label="Physical backups are now enabled by default">
+<Admonition type="note" title="Physical backups are now enabled by default">
 
 All projects on Postgres `15.8.1.079` and newer use the newer physical backup process.
 

--- a/apps/docs/content/guides/platform/clone-project.mdx
+++ b/apps/docs/content/guides/platform/clone-project.mdx
@@ -3,7 +3,7 @@ title: Restore to a new project
 subtitle: How to clone your existing Supabase project
 ---
 
-<Admonition type="note" label="Beta Version">
+<Admonition type="note" title="Beta Version">
 
 You can clone your Supabase project by restoring your data from an existing project into a completely new one. This process creates a database-only copy and requires manual reconfiguration to fully replicate your original project.
 

--- a/apps/docs/content/guides/platform/compute-and-disk.mdx
+++ b/apps/docs/content/guides/platform/compute-and-disk.mdx
@@ -10,7 +10,7 @@ Every project on the Supabase Platform comes with its own dedicated Postgres ins
 
 The following table describes the base instances, Nano (free plan) and Micro (paid plans), with additional compute instance sizes available if you need extra performance when scaling up.
 
-<Admonition type="note" label="Nano instances in paid plan organizations">
+<Admonition type="note" title="Nano instances in paid plan organizations">
 
 In paid organizations, Nano Compute are billed at the same price as Micro Compute. It is recommended to upgrade your Project from Nano Compute to Micro Compute when it's convenient for you. Compute sizes are not auto-upgraded because of the downtime incurred. See [Supabase Pricing](/pricing) for more information. You cannot launch Nano instances on paid plans, only Micro and above - but you might have Nano instances after upgrading from Free Plan.
 

--- a/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
@@ -61,7 +61,7 @@ Paid plans include <Price price="10" /> in Compute Credits, which cover one proj
 
 [^1]: Compute resources on the Free Plan are subject to change.
 
-<Admonition type="note" label="Nano Compute size in paid plan organizations">
+<Admonition type="note" title="Nano Compute size in paid plan organizations">
 
 In paid organizations, Nano Compute are billed at the same price as Micro Compute. It is recommended to upgrade your Project from Nano Compute to Micro Compute when it's convenient for you. Compute sizes are not auto-upgraded because of the downtime incurred. See [Supabase Pricing](/pricing) for more information. You cannot launch Nano instances on paid plans, only Micro and above - but you might have Nano instances after upgrading from Free Plan.
 

--- a/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
@@ -90,7 +90,7 @@ Migrate existing users to Supabase Auth. This requires two main steps: first, ch
     })
     ```
 
-    <Admonition type="note" label="Supported password hashing algorithms">
+    <Admonition type="note" title="Supported password hashing algorithms">
 
     Supabase supports bcrypt and Argon2 password hashes.
 

--- a/apps/docs/content/guides/platform/sso.mdx
+++ b/apps/docs/content/guides/platform/sso.mdx
@@ -29,7 +29,7 @@ Once configured, you can update your settings anytime from [the **SSO** section]
 
 ![SSO Example](/docs/img/sso-dashboard-enabled-idp.png)
 
-<Admonition type="tip" label="Testing your SSO configuration">
+<Admonition type="tip" title="Testing your SSO configuration">
 
 After configuring your SSO provider, thorough testing is essential. See our [SSO Testing and Best Practices](/docs/guides/platform/sso/testing-best-practices) guide for:
 
@@ -100,13 +100,13 @@ When SSO is enabled for an organization:
 6. Thoroughly test using our [SSO Testing and Best Practices](/docs/guides/platform/sso/testing-best-practices) guide
 7. Invite users to the organization or let them auto-join on login
 
-<Admonition type="note" label="Account linking">
+<Admonition type="note" title="Account linking">
 
 If a user is already a member of the organization under a non-SSO account, they will need to be removed and invited again with an SSO-required invitation to join under their SSO account. SSO and non-SSO accounts with the same email are treated as separate accounts.
 
 </Admonition>
 
-<Admonition type="note" label="No automatic linking">
+<Admonition type="note" title="No automatic linking">
 
 Each user account verified using a SSO identity provider will not be automatically linked to existing user accounts in the system. That is, if a user `valid.email@supabase.io` had signed up with a password, and then uses their company SSO login with your project, there will be two `valid.email@supabase.io` user accounts in the system.
 
@@ -118,7 +118,7 @@ Users will need to ensure they are logged in with the correct account when accep
 
 If you disable or delete the SSO provider for an organization, **all SSO users will immediately be unable to sign in**.
 
-<Admonition type="caution" label="Safety requirement">
+<Admonition type="caution" title="Safety requirement">
 
 The system requires at least one non-SSO owner account before allowing SSO provider deletion. This prevents complete organization lockout. When you delete an SSO provider, all SSO members are automatically removed from the organization.
 

--- a/apps/docs/content/guides/platform/sso/azure.mdx
+++ b/apps/docs/content/guides/platform/sso/azure.mdx
@@ -164,7 +164,7 @@ Before rolling out SSO to your organization, we strongly recommend thorough test
 - Security best practices
 - Pre-launch checklist
 
-<Admonition type="note" label="Testing in Azure sandbox">
+<Admonition type="note" title="Testing in Azure sandbox">
 
 If your organization has an Azure sandbox or test tenant, consider testing your SSO configuration there first before applying to production.
 

--- a/apps/docs/content/guides/platform/sso/choosing-login-flow.mdx
+++ b/apps/docs/content/guides/platform/sso/choosing-login-flow.mdx
@@ -240,7 +240,7 @@ Do users need to start login at supabase.com?
 4. Use **non-SSO invitations** for contractors
 5. Consider disabling auto-join to control membership
 
-<Admonition type="caution" label="Account linking caution">
+<Admonition type="caution" title="Account linking caution">
 
 SSO and non-SSO accounts with the same email are treated as separate accounts. An employee with `alice@company.com` will have two accounts if they:
 
@@ -306,7 +306,7 @@ If you're uncertain which configuration to use:
 4. Enable SP-initiated if users request it
 5. Monitor usage to see which flow is preferred
 
-<Admonition type="tip" label="Support available">
+<Admonition type="tip" title="Support available">
 
 If you need help choosing the right configuration for your organization, contact Supabase support with details about your use case. We're happy to provide personalized recommendations.
 

--- a/apps/docs/content/guides/platform/sso/login-flows.mdx
+++ b/apps/docs/content/guides/platform/sso/login-flows.mdx
@@ -5,7 +5,7 @@ description: 'Learn about IdP-initiated and SP-initiated SSO login flows and whe
 
 When configuring SSO for your organization, you can choose between two different login flows: **identity provider (IdP)-initiated** and **service provider (SP)-initiated**. Understanding the difference helps you provide the best experience for your users.
 
-<Admonition type="tip" label="Quick decision guide">
+<Admonition type="tip" title="Quick decision guide">
 
 Most enterprises use IdP-initiated flow for its simplicity and better user experience. Enable SP-initiated only if you need users to start their login journey at supabase.com.
 
@@ -107,7 +107,7 @@ IdP-initiated flow is automatically enabled when you configure SSO. No additiona
 
 Users can now access Supabase through your IdP's app catalog.
 
-<Admonition type="note" label="Domain configuration optional">
+<Admonition type="note" title="Domain configuration optional">
 
 With IdP-initiated flow, you don't need to configure email domains. Your identity provider handles all authentication routing.
 
@@ -131,7 +131,7 @@ To enable SP-initiated flow, you need to configure email domains:
 - Multiple domains supported (e.g., `company.com`, `subsidiary.com`)
 - Users with matching email domains will be routed to your IdP
 
-<Admonition type="caution" label="Domain restrictions apply">
+<Admonition type="caution" title="Domain restrictions apply">
 
 Only users with email addresses matching your configured domains can use SP-initiated login. Users with other domains cannot sign in via SSO at supabase.com (but can still use IdP-initiated flow if you configure it in your IdP).
 

--- a/apps/docs/content/guides/platform/sso/multiple-providers.mdx
+++ b/apps/docs/content/guides/platform/sso/multiple-providers.mdx
@@ -21,7 +21,7 @@ The traditional challenge with multiple SAML apps is domain conflicts. With SP-i
 
 **Solution:** Use identity provider (IdP)-initiated flow, which doesn't require domain configuration. You can create unlimited SAML apps under the same domain.
 
-<Admonition type="tip" label="Recommended pattern">
+<Admonition type="tip" title="Recommended pattern">
 
 Configure each environment as IdP-initiated only (no domains). Users access each environment through different app tiles in your identity provider.
 
@@ -126,7 +126,7 @@ Configure both organizations with SP-initiated enabled using the same domain:
 - System routes based on org membership (first match wins)
 - Also provide IDP tiles for explicit routing
 
-<Admonition type="caution" label="SP-initiated routing with multiple providers">
+<Admonition type="caution" title="SP-initiated routing with multiple providers">
 
 When multiple organizations use SP-initiated with the same domain, the first provider where the user is a member will be used. This can cause confusion. **IDP-initiated is recommended** for clarity.
 

--- a/apps/docs/content/guides/realtime/limits.mdx
+++ b/apps/docs/content/guides/realtime/limits.mdx
@@ -35,7 +35,7 @@ When you exceed a limit, errors will appear in the backend logs and client-side 
 - **Logs**: check the [Realtime logs](/dashboard/project/_/database/realtime-logs) inside your project Dashboard.
 - **WebSocket errors**: Use your browser's developer tools to find the WebSocket initiation request and view individual messages.
 
-<Admonition type="tip" label="Realtime Inspector">
+<Admonition type="tip" title="Realtime Inspector">
 
 You can use the [Realtime Inspector](https://realtime.supabase.com/inspector/new) to reproduce an error and share those connection details with Supabase support.
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -172,7 +172,7 @@ Review and change URL configuration variables:
 - `API_EXTERNAL_URL`: used by the Auth service to configure callback URLs, e.g., `http://example.com:8000`
 - `SITE_URL`: default [redirect URL](/docs/guides/auth/redirect-urls) for Auth, e.g., `http://example.com:3000`
 
-<Admonition type="note" label="What your-domain means in the docs">
+<Admonition type="note" title="What your-domain means in the docs">
 
   Throughout the self-hosting guides, `<your-domain>` stands for the host where your Supabase instance is reachable: your domain name, your server's IP, or `localhost`, depending on your setup.
 
@@ -236,7 +236,7 @@ To stop Supabase, use:
 docker compose down
 ```
 
-<Admonition type="caution" label="Windows: CRLF line endings">
+<Admonition type="caution" title="Windows: CRLF line endings">
 
   If the API gateway (Kong) fails to start with an entrypoint error, your local files may have been checked out with CRLF line endings instead of LF. Re-clone the repository, or normalize everything in the `docker/` directory to LF, then restart Supabase. Fresh clones should already use LF because of `.gitattributes`.
 

--- a/apps/docs/content/guides/self-hosting/postgres-upgrade-17.mdx
+++ b/apps/docs/content/guides/self-hosting/postgres-upgrade-17.mdx
@@ -58,7 +58,7 @@ Upgrading an existing deployment uses `pg_upgrade` to migrate data in place. The
 
 ### Create a backup
 
-<Admonition type="danger" label="Back up your data before upgrading">
+<Admonition type="danger" title="Back up your data before upgrading">
 
 You should create your own independent backup in case of disk failure or other issues.
 

--- a/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
@@ -18,7 +18,7 @@ You need:
 
 Below are two options for adding a reverse proxy with automatic HTTPS in front of your self-hosted Supabase: **Caddy** (simpler, zero-config TLS) and **Nginx + Let's Encrypt** (more control over proxy settings). Both sit in front of the API gateway and terminate TLS, so internal traffic stays on HTTP.
 
-<Admonition type="tip" label="Using a different reverse proxy?">
+<Admonition type="tip" title="Using a different reverse proxy?">
 
 If you already run [HAProxy](https://www.haproxy.com/), [Traefik](https://traefik.io/), [Nginx Proxy Manager](https://nginxproxymanager.com/), or another reverse proxy for your infrastructure, you can use it instead of Caddy or Nginx above. The key requirements are:
 
@@ -31,7 +31,7 @@ If you already run [HAProxy](https://www.haproxy.com/), [Traefik](https://traefi
 
 </Admonition>
 
-<Admonition type="note" label="Using Envoy instead of Kong?">
+<Admonition type="note" title="Using Envoy instead of Kong?">
 
 Envoy is an optional [API gateway](/docs/guides/self-hosting/self-hosted-envoy), enabled via the `docker-compose.envoy.yml` override. If you already run Envoy instead of Kong, edit `docker-compose.caddy.yml` or `docker-compose.nginx.yml` to comment out the `kong:` block and uncomment the `api-gw:` block (and the matching `depends_on` entry) so the reverse proxy sits in front of Envoy.
 

--- a/apps/docs/content/guides/storage/s3/authentication.mdx
+++ b/apps/docs/content/guides/storage/s3/authentication.mdx
@@ -13,7 +13,7 @@ You have two options to authenticate with Supabase Storage S3:
 
 ## S3 access keys
 
-<Admonition type="danger" label="Keep these credentials secure">
+<Admonition type="danger" title="Keep these credentials secure">
 
 S3 access keys provide full access to all S3 operations across all buckets and bypass RLS policies. These are meant to be used only on the server.
 

--- a/apps/docs/docs/ref/self-hosting-analytics/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-analytics/introduction.mdx
@@ -18,7 +18,7 @@ The Supabase Analytics server is a Logflare self-hostable instance that manages 
 When self-hosting the Analytics server, the full logging experience matching that of the Supabase Platform is available in the Studio instance, allowing for an integrated and enhanced development experience.
 However, it's important to note that certain [differences](#differences) may arise due to the platform's infrastructure.
 
-<Admonition type="note" label="Logflare Technical Docs">
+<Admonition type="note" title="Logflare Technical Docs">
 
 All Logflare technical documentation is available at https://docs.logflare.app.
 

--- a/apps/docs/docs/ref/self-hosting-functions/introduction.mdx
+++ b/apps/docs/docs/ref/self-hosting-functions/introduction.mdx
@@ -21,7 +21,7 @@ You can use it to:
 - Locally test and self-host Supabase's Edge Functions (or any Deno Edge Function)
 - As a programmable HTTP Proxy: You can intercept / route HTTP requests
 
-<Admonition type="note" label="Beta Version">
+<Admonition type="note" title="Beta Version">
 
 Self hosted Edge functions are in beta. There will be breaking changes to APIs / Configuration Options.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update. Related to DEPR-551.

## What is the current behavior?

Docs MDX still uses the legacy `label` prop for Admonitions, even though #45618 added `title` and kept `label` only as a backwards-compatible alias after #45302 was reverted in #45535.

## What is the new behavior?

Migrates Docs-owned Admonitions from `label=` to `title=` without changing rendered copy, component APIs, Studio callsites, design-system examples, or the legacy `label` alias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized admonition headings across the docs by switching how admonition headings are provided (preserving all visible guidance and examples). Content and instructions remain unchanged; this ensures consistent rendering of callouts and improves uniformity across guides and reference pages.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46053?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->