### PR TITLE
fix: unified logs time range active filter has invalid applid filter count

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
@@ -76,6 +76,7 @@ export function generateDynamicColumns(data: ColumnSchema[]): {
       meta: {
         cellClassName: 'font-mono tracking-tight w-[140px]',
         headerClassName: 'w-[140px]',
+        dataType: 'date',
       },
     },
     // Log type column - always visible

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterResetButton.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterResetButton.tsx
@@ -29,7 +29,7 @@ export function DataTableFilterResetButton<TData>({ value: _value }: DataTableFi
         }
       }}
     >
-      {filters.length}
+      {column?.id === 'date' ? 1 : filters.length}
     </Button>
   )
 }

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterResetButton.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterResetButton.tsx
@@ -29,7 +29,7 @@ export function DataTableFilterResetButton<TData>({ value: _value }: DataTableFi
         }
       }}
     >
-      {column?.id === 'date' ? 1 : filters.length}
+      {(column?.columnDef.meta as Record<string, string>)?.dataType === 'date' ? 1 : filters.length}
     </Button>
   )
 }


### PR DESCRIPTION
## Problem

After selecting a time range filter value, users see that `2` filters are applied which is technically correct (begin/end of the time range) but weird as you have only one filter made of two values.

## Solution

~~Not great, but check the filter column id and display `1` if it is the _Date_ column~~
Better: rely on column definition metadata

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data table filter reset button display for date columns: date-based filters now show a consistent single indicator, while other columns continue to display their actual filter counts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46060?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->