### PR TITLE
feat: pass subscription plan to ConfigCat for tier-based feature flags

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -86,10 +86,7 @@ const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
   ? [{ id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> }]
   : []
 
-const FeatureFlagProviderWithOrgContext = ({
-  children,
-  ...props
-}: ComponentProps<typeof FeatureFlagProvider>) => {
+const FeatureFlagProviderWithOrgContext = ({ children, ...props }: ComponentProps<typeof FeatureFlagProvider>) => {
   const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
 
   return (
@@ -150,13 +147,16 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
   const isNonProdEnv = (IS_PLATFORM && process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod') || isCLI
 
   const cloudProvider = useDefaultProvider()
+  const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
 
   const getConfigCatFlags = useCallback(
     (userEmail?: string) => {
-      const customAttributes = cloudProvider ? { cloud_provider: cloudProvider } : undefined
+      const customAttributes: Record<string, string> = {}
+      if (cloudProvider) customAttributes.cloud_provider = cloudProvider
+      if (selectedOrganization?.plan?.id) customAttributes.plan = selectedOrganization.plan.id
       return getFlags(userEmail, customAttributes)
     },
-    [cloudProvider]
+    [cloudProvider, selectedOrganization?.plan?.id]
   )
 
   const checkCliEnvironment = async () => {

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -91,9 +91,24 @@ const FeatureFlagProviderWithOrgContext = ({
   ...props
 }: ComponentProps<typeof FeatureFlagProvider>) => {
   const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
+  const cloudProvider = useDefaultProvider()
+
+  const getConfigCatFlags = useCallback(
+    (userEmail?: string) => {
+      const customAttributes: Record<string, string> = {}
+      if (cloudProvider) customAttributes.cloud_provider = cloudProvider
+      if (selectedOrganization?.plan?.id) customAttributes.plan = selectedOrganization.plan.id
+      return getFlags(userEmail, customAttributes)
+    },
+    [cloudProvider, selectedOrganization?.plan?.id]
+  )
 
   return (
-    <FeatureFlagProvider {...props} organizationSlug={selectedOrganization?.slug ?? undefined}>
+    <FeatureFlagProvider
+      {...props}
+      getConfigCatFlags={getConfigCatFlags}
+      organizationSlug={selectedOrganization?.slug ?? undefined}
+    >
       {children}
     </FeatureFlagProvider>
   )
@@ -149,19 +164,6 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
   // [Joshen] Should target hosted staging, local dev, and local CLI only
   const isNonProdEnv = (IS_PLATFORM && process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod') || isCLI
 
-  const cloudProvider = useDefaultProvider()
-  const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
-
-  const getConfigCatFlags = useCallback(
-    (userEmail?: string) => {
-      const customAttributes: Record<string, string> = {}
-      if (cloudProvider) customAttributes.cloud_provider = cloudProvider
-      if (selectedOrganization?.plan?.id) customAttributes.plan = selectedOrganization.plan.id
-      return getFlags(userEmail, customAttributes)
-    },
-    [cloudProvider, selectedOrganization?.plan?.id]
-  )
-
   const checkCliEnvironment = async () => {
     const data = await getCLIReleaseVersion()
     if (!!data.current) setIsCLI(true)
@@ -180,7 +182,6 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
               <FeatureFlagProviderWithOrgContext
                 API_URL={API_URL}
                 enabled={IS_PLATFORM}
-                getConfigCatFlags={getConfigCatFlags}
               >
                 <ProfileProvider>
                   <TimezoneProvider>

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -179,10 +179,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
         <NuqsAdapter>
           <HydrationBoundary state={pageProps.dehydratedState}>
             <AuthProvider>
-              <FeatureFlagProviderWithOrgContext
-                API_URL={API_URL}
-                enabled={IS_PLATFORM}
-              >
+              <FeatureFlagProviderWithOrgContext API_URL={API_URL} enabled={IS_PLATFORM}>
                 <ProfileProvider>
                   <TimezoneProvider>
                     <TimestampInfoTimezoneBridge>

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -86,7 +86,10 @@ const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
   ? [{ id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> }]
   : []
 
-const FeatureFlagProviderWithOrgContext = ({ children, ...props }: ComponentProps<typeof FeatureFlagProvider>) => {
+const FeatureFlagProviderWithOrgContext = ({
+  children,
+  ...props
+}: ComponentProps<typeof FeatureFlagProvider>) => {
   const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
 
   return (


### PR DESCRIPTION
## Summary

- Adds the organization's `plan` (e.g. `free`, `pro`, `team`, `enterprise`) as a custom attribute in the ConfigCat `User` object
- Uses the existing `useSelectedOrganizationQuery` — already called inside `FeatureFlagProviderWithOrgContext`, so no extra network request (React Query deduplicates)
- Refactors `customAttributes` construction from a conditional assignment to an incremental object build, making it easy to add more attributes in the future

## Why

This unlocks tier-based percentage rollouts in the ConfigCat dashboard. For example, to roll out a feature to 25% of Pro accounts:

1. Add a Targeting Rule: `IF plan = "pro"`
2. Set the THEN clause to Percentage Options: `25% ON / 75% OFF`

The split is deterministic per user email (or switch to `org_id` as the percentage evaluation attribute for per-org cohesion).

## Test plan

- [ ] Log in as a user on a paid plan and verify `plan` appears as a custom attribute in ConfigCat's evaluation logs / targeting debugger
- [ ] Log in as a free-tier user and confirm `plan = "free"` is sent
- [ ] Confirm unauthenticated / org-less sessions don't break (attribute is omitted when `selectedOrganization?.plan?.id` is undefined)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced feature flag configuration to account for organization and subscription plan information, ensuring more accurate feature availability based on user context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46063?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->