### PR TITLE
fix: policy urls

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -318,7 +318,7 @@ export const EntityListItem = ({
                   <DropdownMenuItem key="view-policies" className="space-x-2" asChild>
                     <Link
                       key="view-policies"
-                      href={`/project/${projectRef}/auth/policies?schema=${selectedSchema}&search=${entity.id}`}
+                      href={`/project/${projectRef}/auth/policies?schema=${encodeURIComponent(selectedSchema ?? '')}&search=${encodeURIComponent(String(entity.id))}`}
                     >
                       <Lock size={12} />
                       <span>View policies</span>


### PR DESCRIPTION
## TL;DR

fixes `Table Editor -> View policies` for schema names with special characters

tested with schema `sales&ops` :

## ex: 

| b4 url: `schema=sales&ops` | after url: `schema=sales%26ops` |
| --- | --- |
| <img width="394" height="63" alt="image" src="https://github.com/user-attachments/assets/fe5bea94-e364-493e-a2de-e9493bf17ef2" /> | <img width="544" height="67" alt="image" src="https://github.com/user-attachments/assets/23f5d648-d7f0-49b9-95de-ef0207d5839c" /> |

## ref

- closes #46061


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL handling for the "View policies" link to ensure proper encoding and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46064?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->