### PR TITLE
docs(telemetry): add swap usage to database reports docs DOCS-950

### DIFF
--- a/apps/docs/content/guides/telemetry/reports.mdx
+++ b/apps/docs/content/guides/telemetry/reports.mdx
@@ -84,6 +84,7 @@ The following charts are available for Free and Pro plans:
 | Chart                        | Available Plans | Description                                  | Key Insights                                                   |
 | ---------------------------- | --------------- | -------------------------------------------- | -------------------------------------------------------------- |
 | Memory usage                 | Free, Pro       | RAM usage percentage by the database         | Memory pressure and resource utilization                       |
+| Swap usage                   | Free, Pro       | Swap space in use by the operating system    | Memory pressure detection when RAM is exhausted                |
 | CPU usage                    | Free, Pro       | Average CPU usage percentage                 | CPU-intensive query identification                             |
 | Disk IOPS                    | Free, Pro       | Read/write operations per second with limits | IO bottleneck detection and workload analysis                  |
 | Database connections         | Free, Pro       | Number of pooler connections to the database | Connection pool monitoring                                     |
@@ -136,6 +137,29 @@ Actions you can take:
 | [Optimize queries](/docs/content/guides/database/query-optimization)        | Reduce memory consumption of expensive queries |
 | [Tune Postgres configuration](https://pgtune.leopard.in.ua)                 | Improve memory management settings             |
 | Implement application caching                                               | Add query result caching to reduce memory load |
+
+### Swap usage
+
+This chart shows swap space currently in use by the operating system. Every Supabase compute instance is provisioned with 1 GB of swap regardless of compute size. The y-axis always spans at least 0 to 1 GB so that low swap usage appears correctly at the bottom of the chart.
+
+| Component | Description                                                                                          |
+| --------- | ---------------------------------------------------------------------------------------------------- |
+| **Swap**  | Disk space used as overflow when RAM is exhausted. Sustained usage slows the database significantly. |
+
+How it helps debug issues:
+
+| Issue                     | Description                                                            |
+| ------------------------- | ---------------------------------------------------------------------- |
+| Memory pressure detection | Identify when the database is spilling to disk due to insufficient RAM |
+| Performance degradation   | Correlate swap usage spikes with query slowdowns                       |
+
+Actions you can take:
+
+| Action                                                                      | Description                                              |
+| --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| [Upgrade compute size](/docs/guides/platform/compute-and-disk#compute-size) | Increase available RAM to eliminate swap usage           |
+| [Optimize queries](/docs/content/guides/database/query-optimization)        | Reduce memory consumption of expensive queries           |
+| [Tune Postgres configuration](https://pgtune.leopard.in.ua)                 | Lower `work_mem` or `shared_buffers` to reduce RAM usage |
 
 ### CPU usage
 

--- a/apps/docs/content/guides/telemetry/reports.mdx
+++ b/apps/docs/content/guides/telemetry/reports.mdx
@@ -84,7 +84,7 @@ The following charts are available for Free and Pro plans:
 | Chart                        | Available Plans | Description                                  | Key Insights                                                   |
 | ---------------------------- | --------------- | -------------------------------------------- | -------------------------------------------------------------- |
 | Memory usage                 | Free, Pro       | RAM usage percentage by the database         | Memory pressure and resource utilization                       |
-| Swap usage                   | Free, Pro       | Swap space in use by the operating system    | Memory pressure detection when RAM is exhausted                |
+| Swap usage                   | Free, Pro       | Swap space in use by the operating system    | Swap utilization over time                                     |
 | CPU usage                    | Free, Pro       | Average CPU usage percentage                 | CPU-intensive query identification                             |
 | Disk IOPS                    | Free, Pro       | Read/write operations per second with limits | IO bottleneck detection and workload analysis                  |
 | Database connections         | Free, Pro       | Number of pooler connections to the database | Connection pool monitoring                                     |

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -105,7 +105,7 @@ export const getReportAttributesV2: (
     {
       id: 'swap-usage',
       label: 'Swap usage',
-      docsUrl: `${DOCS_URL}/guides/telemetry/reports#memory-usage`,
+      docsUrl: `${DOCS_URL}/guides/telemetry/reports#swap-usage`,
       hide: false,
       showTooltip: true,
       showLegend: false,


### PR DESCRIPTION
## Problem

The telemetry reports documentation did not mention swap usage, even though the Database report in Studio includes a swap usage chart. Users had no reference explaining what the chart shows or how to act on it.

## Fix

- Added swap usage to the database report summary table in `reports.mdx`
- Added a dedicated `### Swap usage` section explaining the 1 GB fixed swap allocation, chart components, debugging guidance, and recommended actions
- Corrected the `docsUrl` in the swap chart config (`database-charts.ts`) from `#memory-usage` to `#swap-usage` so the docs link in Studio opens the right section

## How to test

- Open the [telemetry reports docs page](https://supabase.com/docs/guides/telemetry/reports)
- Verify the Database section summary table includes a "Swap usage" row
- Verify a "Swap usage" section appears after "Memory usage" in the detailed chart descriptions
- In Studio, open Database Reports and click the docs icon on the Swap usage chart
- Expected result: the link navigates to the `#swap-usage` anchor on the reports docs page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive "Swap usage" guide with a component table, troubleshooting tips, and actionable recommendations for compute sizing, query optimization, and Postgres tuning.
* **Bug Fixes**
  * Updated chart links so the database charts now point to the correct Swap usage documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46067?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->