### PR TITLE
fix: improve loading state when changing log filters in unified logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -307,7 +307,7 @@ export const UnifiedLogs = () => {
     setSearch(search)
   }
 
-  const debouncedApplyFilterSearch = useDebounce(applyFilterSearch, 1000)
+  const debouncedApplyFilterSearch = useDebounce(applyFilterSearch, 250)
 
   useEffect(() => {
     debouncedApplyFilterSearch()

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCommand.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCommand.tsx
@@ -39,7 +39,7 @@ export function DataTableFilterCommand({
   searchParamsParser,
   placeholder = 'Search data table...',
 }: DataTableFilterCommandProps) {
-  const { table, isLoading, filterFields: _filterFields, getFacetedUniqueValues } = useDataTable()
+  const { table, isFetching, filterFields: _filterFields, getFacetedUniqueValues } = useDataTable()
   const columnFilters = table.getState().columnFilters
   const inputRef = useRef<HTMLInputElement>(null)
   const [open, setOpen] = useState<boolean>(false)
@@ -120,7 +120,7 @@ export function DataTableFilterCommand({
         )}
         onClick={() => setOpen(true)}
       >
-        {isLoading ? (
+        {isFetching ? (
           <LoaderCircle className="mr-2 h-4 w-4 shrink-0 animate-spin text-muted-foreground opacity-50 group-hover:text-popover-foreground" />
         ) : (
           <Search className="mr-2 h-4 w-4 shrink-0 text-muted-foreground opacity-50 group-hover:text-popover-foreground" />


### PR DESCRIPTION
## Problem

When changing filters, while the query is running the loading state is not clear, its only shown in the "Load more" button at the bottom which can be missed if you got a lot of logs, we should improve the filters loading state.

That's actually due to two things:
- we rely on the `isLoading` state instead of `isFetching`
- we debounce filters changes by a second

## Solution

- use `isFetching` to determine whether to display the loading spinner in the top filter bar
- reduce the debounce delay to `250ms` as users can't filter by typing anyway (what they type must be validated with Enter to select a filter, no fuzzy filtering)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized unified logs filter response time, applying filter changes more quickly.

* **Bug Fixes**
  * Enhanced loading indicator behavior in data tables to accurately reflect active data fetching operations, providing clearer visual feedback during interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46070?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->