### PR TITLE
fix(studio): preserve unsaved columns in table editor across refetches

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -1,5 +1,5 @@
 import { isEmpty, noop } from 'lodash'
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Badge, Checkbox, Input, SidePanel } from 'ui'
 import { Admonition } from 'ui-patterns'
@@ -89,6 +89,10 @@ export const TableEditor = ({
   const [errors, setErrors] = useState<PlainObject>({})
   const [tableFields, setTableFields] = useState<TableField>()
   const [fkRelations, setFkRelations] = useState<ForeignKey[]>([])
+  // Tracks whether tableFields has been initialized with fully-loaded server data
+  // for the current panel session. Prevents background refetches from resetting
+  // local edits (e.g. unsaved newly-added columns) while the panel is open.
+  const hasInitializedRef = useRef(false)
 
   const [isDuplicateRows, setIsDuplicateRows] = useState<boolean>(false)
   const [importContent, setImportContent] = useState<ImportContent>()
@@ -290,6 +294,7 @@ export const TableEditor = ({
           setTableFields(tableFields)
         }
         setFkRelations([])
+        hasInitializedRef.current = true
       } else {
         const tableFields = generateTableFieldFromPGTable(
           table,
@@ -298,7 +303,12 @@ export const TableEditor = ({
           isRealtimeEnabled
         )
         setTableFields(tableFields)
+        // Only mark fully initialized once FK meta has loaded — otherwise we'll
+        // re-init below when it arrives.
+        hasInitializedRef.current = isSuccessForeignKeyMeta
       }
+    } else if (visibleChanged && !visible) {
+      hasInitializedRef.current = false
     }
   }, [
     visible,
@@ -309,10 +319,14 @@ export const TableEditor = ({
     isDuplicating,
     table,
     visibleChanged,
+    isSuccessForeignKeyMeta,
   ])
 
   useEffect(() => {
-    if (!isNewRecord) {
+    // Re-init tableFields once if foreignKeyMeta arrives after the panel opened.
+    // After this fires (or after the panel-open effect above sets it true),
+    // subsequent background refetches must not clobber the user's local edits.
+    if (!isNewRecord && visible && isSuccessForeignKeyMeta && !hasInitializedRef.current) {
       const tableFields = generateTableFieldFromPGTable(
         table,
         foreignKeyMeta ?? [],
@@ -320,8 +334,17 @@ export const TableEditor = ({
         isRealtimeEnabled
       )
       setTableFields(tableFields)
+      hasInitializedRef.current = true
     }
-  }, [isNewRecord, table, foreignKeyMeta, isDuplicating, isRealtimeEnabled])
+  }, [
+    isNewRecord,
+    visible,
+    isSuccessForeignKeyMeta,
+    table,
+    foreignKeyMeta,
+    isDuplicating,
+    isRealtimeEnabled,
+  ])
 
   useEffect(() => {
     if (isSuccessForeignKeyMeta) setFkRelations(formatForeignKeys(foreignKeys))

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -23,6 +23,7 @@ import {
   formatImportedContentToColumnFields,
   generateTableField,
   generateTableFieldFromPGTable,
+  mergeForeignKeyMeta,
   validateFields,
 } from './TableEditor.utils'
 import { DocsButton } from '@/components/ui/DocsButton'
@@ -93,6 +94,10 @@ export const TableEditor = ({
   // for the current panel session. Prevents background refetches from resetting
   // local edits (e.g. unsaved newly-added columns) while the panel is open.
   const hasInitializedRef = useRef(false)
+  // Set true the moment the user makes any field change within the panel session.
+  // Used to switch the late FK-hydration paths from wholesale replace → merge so
+  // unsaved edits (e.g. a column added before foreignKeyMeta resolves) survive.
+  const hasUserEditsRef = useRef(false)
 
   const [isDuplicateRows, setIsDuplicateRows] = useState<boolean>(false)
   const [importContent, setImportContent] = useState<ImportContent>()
@@ -153,6 +158,7 @@ export const TableEditor = ({
     const updatedTableFields = { ...tableFields, ...changes } as TableField
     setTableFields(updatedTableFields)
     updateEditorDirty()
+    hasUserEditsRef.current = true
 
     const updatedErrors = { ...errors }
     for (const key of Object.keys(changes)) {
@@ -194,6 +200,7 @@ export const TableEditor = ({
         }),
       }
       setTableFields(updatedTableFields)
+      hasUserEditsRef.current = true
     }
     setFkRelations(relations)
   }
@@ -296,19 +303,27 @@ export const TableEditor = ({
         setFkRelations([])
         hasInitializedRef.current = true
       } else {
-        const tableFields = generateTableFieldFromPGTable(
+        const serverTableFields = generateTableFieldFromPGTable(
           table,
           foreignKeyMeta ?? [],
           isDuplicating,
           isRealtimeEnabled
         )
-        setTableFields(tableFields)
+        // Defensive: if a prior session somehow left edits in place, merge
+        // FK metadata in instead of clobbering. In normal flow this branch is
+        // pristine because the close handler resets hasUserEditsRef.
+        setTableFields((current) =>
+          hasUserEditsRef.current && current !== undefined
+            ? mergeForeignKeyMeta(current, serverTableFields)
+            : serverTableFields
+        )
         // Only mark fully initialized once FK meta has loaded — otherwise we'll
         // re-init below when it arrives.
         hasInitializedRef.current = isSuccessForeignKeyMeta
       }
     } else if (visibleChanged && !visible) {
       hasInitializedRef.current = false
+      hasUserEditsRef.current = false
     }
   }, [
     visible,
@@ -327,13 +342,20 @@ export const TableEditor = ({
     // After this fires (or after the panel-open effect above sets it true),
     // subsequent background refetches must not clobber the user's local edits.
     if (!isNewRecord && visible && isSuccessForeignKeyMeta && !hasInitializedRef.current) {
-      const tableFields = generateTableFieldFromPGTable(
+      const serverTableFields = generateTableFieldFromPGTable(
         table,
         foreignKeyMeta ?? [],
         isDuplicating,
         isRealtimeEnabled
       )
-      setTableFields(tableFields)
+      // If the user has already started editing before FK meta resolved, only
+      // merge FK metadata in — never replace, or we'd lose their work
+      // (e.g. a column added while the FK section was still loading).
+      setTableFields((current) =>
+        hasUserEditsRef.current && current !== undefined
+          ? mergeForeignKeyMeta(current, serverTableFields)
+          : serverTableFields
+      )
       hasInitializedRef.current = true
     }
   }, [

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.utils.ts
@@ -58,6 +58,24 @@ export const generateTableFieldFromPGTable = (
   }
 }
 
+// Merges only foreign-key metadata from a freshly server-derived TableField into
+// the existing (possibly user-edited) one. Preserves user-added columns and any
+// edits to existing columns; only injects `foreignKey` onto matching server-
+// originated columns. Used when foreignKeyMeta resolves after the user has
+// already started editing the panel.
+export const mergeForeignKeyMeta = (existing: TableField, fromServer: TableField): TableField => {
+  const serverColumnsById = new Map(fromServer.columns.map((col) => [col.id, col]))
+  return {
+    ...existing,
+    columns: existing.columns.map((col) => {
+      if (col.isNewColumn) return col
+      const serverCol = serverColumnsById.get(col.id)
+      if (!serverCol) return col
+      return { ...col, foreignKey: serverCol.foreignKey }
+    }),
+  }
+}
+
 export const formatImportedContentToColumnFields = (importContent: ImportContent) => {
   const { headers, selectedHeaders, columnTypeMap } = importContent
   const columnFields = headers


### PR DESCRIPTION
## Summary
- Fixes FE-3386: columns added via the Table Editor side panel vanished when components auto-refreshed.
- Root cause: a `useEffect` re-initialized `tableFields` from server data on every `table` / `foreignKeyMeta` refetch, clobbering unsaved local edits.
- Fix (initial): `hasInitializedRef` gates the late-init path so it runs at most once per panel session (to incorporate late-arriving `foreignKeyMeta`) and resets on panel close.
- Fix (follow-up): handle the race where the user starts editing *before* `foreignKeyMeta` resolves. Added `hasUserEditsRef` (flipped on user edits, reset on panel close) and a `mergeForeignKeyMeta` utility. Both late-init paths now merge FK metadata into existing `tableFields` instead of wholesale-replacing when the user has unsaved edits — `foreignKey` is only injected onto matching server-originated columns, so user-added columns and other in-progress edits survive.

Linear: FE-3386

## Test plan
- [ ] Open the Table Editor on an existing table.
- [ ] Add one or more new columns via the side panel.
- [ ] Watch the foreign key section flash / resolve its loading state.
- [ ] Confirm the newly-added columns are NOT removed when the FK section resolves.