### PR TITLE
chore: remove NoticeBanner2

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -4,12 +4,11 @@ import { PropsWithChildren } from 'react'
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 import { ClockSkewBanner } from '@/components/layouts/AppLayout/ClockSkewBanner'
 import { FlyDeprecationBanner } from '@/components/layouts/AppLayout/FlyDeprecationBanner'
-import { NoticeBanner, NoticeBanner2 } from '@/components/layouts/AppLayout/NoticeBanner'
+import { NoticeBanner } from '@/components/layouts/AppLayout/NoticeBanner'
 import { StatusPageBanner } from '@/components/layouts/AppLayout/StatusPageBanner'
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
   const showNoticeBanner = useFlag('showNoticeBanner')
-  const showNoticeBanner2 = useFlag('showNoticeBanner2')
   const clockSkewBanner = useFlag('clockSkewBanner')
 
   return (
@@ -17,7 +16,6 @@ export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
       <div className="shrink-0">
         <StatusPageBanner />
         {showNoticeBanner && <NoticeBanner />}
-        {showNoticeBanner2 && <NoticeBanner2 />}
         <FlyDeprecationBanner />
         <OrganizationResourceBanner />
         {/* Disabled until reintroduced or removed altogether. */}

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -1,4 +1,3 @@
-import { useQueries } from '@tanstack/react-query'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { useRouter } from 'next/router'
 import {
@@ -18,12 +17,6 @@ import {
 
 import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
 import { InlineLink, InlineLinkClassName } from '@/components/ui/InlineLink'
-import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
-import { projectKeys } from '@/data/projects/keys'
-import {
-  getOrganizationProjects,
-  type OrgProject,
-} from '@/data/projects/org-projects-infinite-query'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 // Update this whenever the banner content below changes so old client bundles
@@ -55,77 +48,6 @@ export const NoticeBanner = () => {
       variant="note"
       title="We've updated our Terms of Service"
       description={<UpdatedTermsOfServiceDialog onDismiss={() => setBannerAcknowledged(true)} />}
-      onDismiss={() => setBannerAcknowledged(true)}
-    />
-  )
-}
-
-const MAINTENANCE_REGIONS = new Set(['ap-southeast-1', 'sa-east-1'])
-
-export const NoticeBanner2 = () => {
-  const id = 'maintenance-2026-05-13'
-  const expiry = new Date('2026-05-14T23:59:00Z')
-  const isExpired = new Date() > expiry
-
-  const router = useRouter()
-
-  const [bannerAcknowledged, setBannerAcknowledged, { isSuccess }] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.MAINTENANCE_BANNER_DISMISSED(id),
-    false
-  )
-
-  const shouldEvaluate =
-    !router.pathname.includes('sign-in') && isSuccess && !bannerAcknowledged && !isExpired
-
-  const { data: organizations } = useOrganizationsQuery({ enabled: shouldEvaluate })
-  const orgProjectsQueries = useQueries({
-    queries: (organizations ?? []).map((org) => ({
-      queryKey: projectKeys.bannerProjectsByOrg(org.slug),
-      queryFn: () => getOrganizationProjects({ slug: org.slug, limit: 100 }),
-      staleTime: 30 * 60 * 1000,
-      enabled: shouldEvaluate,
-    })),
-  })
-
-  const isProjectsFetched =
-    organizations !== undefined &&
-    (organizations.length === 0 || orgProjectsQueries.every((q) => q.isFetched))
-
-  const hasMaintenanceRegionProject = orgProjectsQueries
-    .flatMap((q) => q.data?.projects ?? [])
-    .some((project: OrgProject) =>
-      project.databases.some((db) => MAINTENANCE_REGIONS.has(db.region))
-    )
-
-  if (!shouldEvaluate || !isProjectsFetched || !hasMaintenanceRegionProject) {
-    return null
-  }
-
-  return (
-    <HeaderBanner
-      variant="note"
-      title="Upcoming maintenance"
-      description={
-        <>
-          Shared pooler maintenance in{' '}
-          <a
-            target="_blank"
-            rel="noopener referrer"
-            href="https://status.supabase.com/incidents/hxf8876zl69x"
-          >
-            ap-southeast-1
-          </a>{' '}
-          and{' '}
-          <a
-            target="_blank"
-            rel="noopener noreferrer"
-            href="https://status.supabase.com/incidents/jqsj3pb3mnx7"
-          >
-            sa-east-1
-          </a>{' '}
-          on May 13-14.
-        </>
-      }
       onDismiss={() => setBannerAcknowledged(true)}
     />
   )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Chore / cleanup.

## What is the current behavior?

`NoticeBanner2` displayed a maintenance notice for `ap-southeast-1` and `sa-east-1` on May 13-14. The window has passed and the banner is no longer needed.

## What is the new behavior?

`NoticeBanner2`, its `showNoticeBanner2` flag wiring in `AppBannerWrapper`, and its now-unused imports (`useQueries`, `useOrganizationsQuery`, `projectKeys`, `getOrganizationProjects`, `OrgProject`, `MAINTENANCE_REGIONS`) are removed. Shared utilities still used elsewhere (`projectKeys.bannerProjectsByOrg`, `getOrganizationProjects`/`OrgProject`, `LOCAL_STORAGE_KEYS.MAINTENANCE_BANNER_DISMISSED`) are kept.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Terms of Service update notification banner that expires on July 4, 2026, with options to view details or dismiss.

* **Chores**
  * Removed deprecated maintenance banner notification.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46074?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->