### PR TITLE
fix(studio): use measured node heights for instance diagram layout

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants.ts
@@ -45,8 +45,19 @@ export type EdgeData = {
 
 // ReactFlow is scaling everything by the factor of 2
 export const NODE_WIDTH = 660
-export const NODE_ROW_HEIGHT = 50
 export const NODE_SEP = 20
+
+// The region wrapper is a static, non-measured sibling node with a fixed size.
+export const REGION_NODE_HEIGHT = 162
+
+// First-paint fallback heights for the dagre layout, only used before React
+// Flow has measured the real nodes. Subsequent layouts use node.measured.height.
+export const NODE_HEIGHT_FALLBACKS: Record<string, number> = {
+  LOAD_BALANCER: 64,
+  PRIMARY: 140,
+  READ_REPLICA: 140,
+  REGION: REGION_NODE_HEIGHT,
+}
 
 export const REPLICA_STATUS: {
   [key: string]: components['schemas']['DatabaseStatusResponse']['status']

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
@@ -5,6 +5,7 @@ import {
   Edge,
   ReactFlow,
   ReactFlowProvider,
+  useNodesInitialized,
   useReactFlow,
 } from '@xyflow/react'
 import { partition } from 'lodash'
@@ -50,6 +51,7 @@ import {
   useIsOrioleDb,
   useSelectedProjectQuery,
 } from '@/hooks/misc/useSelectedProject'
+import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 import { timeout } from '@/lib/helpers'
 
 interface InstanceConfigurationUIProps {
@@ -210,8 +212,17 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
     []
   )
 
-  const setReactFlow = async () => {
-    const graph = getDagreGraphLayout(nodes, edges)
+  const nodesInitialized = useNodesInitialized()
+  const [hasMeasuredLayout, setHasMeasuredLayout] = useState(false)
+
+  const setReactFlow = async ({ measured }: { measured: boolean }) => {
+    // Merge in React Flow's measured dimensions (if any) so dagre can use real
+    // heights instead of the first-paint fallbacks.
+    const measuredNodes = nodes.map((node) => {
+      const existing = reactFlow.getNode(node.id)
+      return existing?.measured ? { ...node, measured: existing.measured } : node
+    })
+    const graph = getDagreGraphLayout(measuredNodes, edges)
     const { nodes: updatedNodes } = addRegionNodes(graph.nodes, graph.edges)
     reactFlow.setNodes(updatedNodes)
     reactFlow.setEdges(graph.edges)
@@ -219,15 +230,31 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
     // [Joshen] Odd fix to ensure that react flow snaps back to center when adding nodes
     await timeout(1)
     reactFlow.fitView({ maxZoom: 0.9, minZoom: 0.9 })
+    if (measured) setHasMeasuredLayout(true)
   }
 
+  // First pass: lay out using fallback heights for any not-yet-measured nodes.
+  // The diagram is kept invisible until the measured pass below has run, so the
+  // user never sees the fallback positions.
   // [Joshen] Just FYI this block is oddly triggering whenever we refocus on the viewport
   // even if I change the dependency array to just data. Not blocker, just an area to optimize
   useEffect(() => {
     if (isSuccessReplicas && isSuccessLoadBalancers && nodes.length > 0 && view === 'flow') {
-      setReactFlow()
+      setReactFlow({ measured: false })
     }
   }, [isSuccessReplicas, isSuccessLoadBalancers, nodes, edges, view])
+
+  // Second pass: once React Flow has measured the nodes, re-run the layout so
+  // dagre uses real heights. Only `nodesInitialized` going true should trigger
+  // this — the first-pass effect above handles node/view changes.
+  const runMeasuredLayout = useStaticEffectEvent(() => {
+    if (nodesInitialized && nodes.length > 0 && view === 'flow') {
+      setReactFlow({ measured: true })
+    }
+  })
+  useEffect(() => {
+    runMeasuredLayout()
+  }, [nodesInitialized, runMeasuredLayout])
 
   return (
     <div className={cn('nowheel', diagramOnly ? 'h-full' : 'border-y')}>
@@ -314,7 +341,12 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
                 colorMode={'' as unknown as ColorMode}
                 fitView
                 fitViewOptions={{ minZoom: 0.9, maxZoom: 0.9 }}
-                className="instance-configuration"
+                // Keep the diagram invisible (but laid out, so nodes can be
+                // measured) until the measured-height layout pass has run.
+                className={cn(
+                  'instance-configuration transition-opacity duration-150',
+                  hasMeasuredLayout ? 'opacity-100' : 'opacity-0'
+                )}
                 zoomOnPinch={false}
                 zoomOnScroll={false}
                 nodesDraggable={false}

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.utils.ts
@@ -6,7 +6,7 @@ import { AWS_REGIONS, AWS_REGIONS_KEYS } from 'shared-data'
 import {
   AVAILABLE_REPLICA_REGIONS,
   AWS_REGIONS_COORDINATES,
-  NODE_ROW_HEIGHT,
+  NODE_HEIGHT_FALLBACKS,
   NODE_SEP,
   NODE_WIDTH,
   ReplicaNodeData,
@@ -123,15 +123,20 @@ export const generateNodes = ({
   ]
 }
 
+const getDagreNodeHeight = (node: Node) => {
+  if (node.measured?.height) return node.measured.height
+  return NODE_HEIGHT_FALLBACKS[node.type ?? ''] ?? 100
+}
+
 export const getDagreGraphLayout = (nodes: Node[], edges: Edge[]) => {
   const dagreGraph = new dagre.graphlib.Graph()
   dagreGraph.setDefaultEdgeLabel(() => ({}))
-  dagreGraph.setGraph({ rankdir: 'TB', ranksep: 160, nodesep: NODE_SEP })
+  dagreGraph.setGraph({ rankdir: 'TB', ranksep: 60, nodesep: NODE_SEP })
 
   nodes.forEach((node) => {
     dagreGraph.setNode(node.id, {
       width: NODE_WIDTH / 2,
-      height: node.id === 'load-balancer' ? -70 : NODE_ROW_HEIGHT / 2,
+      height: getDagreNodeHeight(node),
     })
   })
 

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -28,6 +28,7 @@ import {
   NODE_SEP,
   NODE_WIDTH,
   PrimaryNodeData,
+  REGION_NODE_HEIGHT,
   REPLICA_STATUS,
   ReplicaNodeData,
 } from './InstanceConfiguration.constants'
@@ -435,7 +436,7 @@ export const RegionNode = ({ data }: any) => {
   return (
     <div
       className="relative flex justify-between rounded-sm bg-black/10 border border-default border-white/10 border-2 p-3"
-      style={{ width: regionNodeWidth, height: 162 }}
+      style={{ width: regionNodeWidth, height: REGION_NODE_HEIGHT }}
     >
       <div className="absolute bottom-2 flex items-center justify-between gap-x-2">
         <img


### PR DESCRIPTION
## Summary

The homepage instance diagram looks visually off when a project has read replicas — see [FE-3390](https://linear.app/supabase/issue/FE-3390/adjust-homepage-diagram-spacing-for-read-replicas).

Root cause: the dagre layout in `InstanceConfiguration.utils.ts` was passing a fake `height: 25` (and a `-70` hack for the load balancer) for every node, regardless of how tall the rendered node actually is. When the Primary card grew taller after #45274 added the compute-metrics row, the gap between the Primary node and the Read Replica node became visually tight while the gap between the Load Balancer and Primary stayed loose — the diagram looked lopsided.

## Fix

- Pass the **real measured height** of each node to dagre, sourced from React Flow's internal measurement (`node.measured.height`).
- Run the layout in two passes:
  1. First pass uses small per-type fallback heights so React Flow has something to render and measure against.
  2. Once `useNodesInitialized()` flips true, re-run dagre with the measured heights and fitView.
- Keep the diagram at `opacity-0` until the measured pass completes, so the fallback positions are never visible to the user. Subsequent data refetches don't re-hide the diagram — once measured, it stays visible.
- Drop `NODE_ROW_HEIGHT` and the load-balancer `-70` hack. Replaced with a small `NODE_HEIGHT_FALLBACKS` table used only on first paint.
- `ranksep` reduced from 160 → 60 since dagre now knows real heights.

Closes FE-3390.

## Test plan

- [x] Open the project homepage for a project with no read replicas — diagram renders centered, single Primary node.
- [x] Open the project homepage for a project **with** a read replica — Load Balancer → Primary → Replica spacing is visually balanced; no flash of fallback positions on initial render; the diagram fades in once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More accurate infrastructure diagram layout with better node sizing and spacing for initial and measured renders.
  * Introduced fallback heights so diagrams render correctly on first paint before measurements are available.
  * Region containers now use a consistent fixed height for stable layout.
  * Smoother, visually consistent diagram initialization with improved opacity transition during layout setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46075?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->