### PR TITLE
fix(pg-meta): tighten pg-format keyword() against control-phrase injection

### DIFF
--- a/packages/pg-meta/src/pg-format/index.ts
+++ b/packages/pg-meta/src/pg-format/index.ts
@@ -212,18 +212,28 @@ export function literal(value?: unknown): SafeSqlFragment {
   return quoted as SafeSqlFragment
 }
 
+// Multi-word SQL keyword phrases callers are allowed to pass to `keyword()`.
+// Compared case-insensitively. Any phrase not listed here must be expressed as
+// separate single-word `keyword()` calls composed via `safeSql`, so that
+// arbitrary control phrases (e.g. "DROP TABLE") can't slip through.
+const ALLOWED_MULTI_WORD_KEYWORDS = new Set(['INSTEAD OF', 'BY DEFAULT'])
+
 /**
- * Marks SQL keywords (e.g., 'BEFORE', 'instead of') as safe for interpolation.
- * Only letters, numbers, underscores, and spaces are allowed, to prevent
- * injection.
+ * Marks SQL keywords (e.g., 'BEFORE', 'INSTEAD OF') as safe for interpolation.
+ * Accepts either a single word matching [A-Za-z][A-Za-z0-9_]*, or a
+ * multi-word phrase from `ALLOWED_MULTI_WORD_KEYWORDS`. Any other input —
+ * including arbitrary space-separated tokens like "DROP TABLE" — is rejected.
  */
 export function keyword(value: string): SafeSqlFragment {
-  if (!/^[A-Za-z][A-Za-z0-9_ ]*$/.test(value)) {
-    throw new Error(
-      `Not a valid keyword: "${value}". Only letters, numbers, underscores, and spaces are permitted.`
-    )
+  if (/^[A-Za-z][A-Za-z0-9_]*$/.test(value)) {
+    return value as SafeSqlFragment
   }
-  return value as SafeSqlFragment
+  if (ALLOWED_MULTI_WORD_KEYWORDS.has(value.toUpperCase())) {
+    return value as SafeSqlFragment
+  }
+  throw new Error(
+    `Not a valid keyword: "${value}". Must be a single word matching [A-Za-z][A-Za-z0-9_]*, or one of: ${[...ALLOWED_MULTI_WORD_KEYWORDS].join(', ')}.`
+  )
 }
 
 type Stringifyable =

--- a/packages/pg-meta/test/pg-format.test.ts
+++ b/packages/pg-meta/test/pg-format.test.ts
@@ -147,9 +147,14 @@ describe('pg-format', () => {
       expect(keyword('ROW')).toBe('ROW')
     })
 
-    test('accepts lowercase and mixed case', () => {
+    test('accepts allow-listed multi-word keywords', () => {
+      expect(keyword('INSTEAD OF')).toBe('INSTEAD OF')
+      expect(keyword('BY DEFAULT')).toBe('BY DEFAULT')
+    })
+
+    test('multi-word allow-list is case-insensitive', () => {
       expect(keyword('instead of')).toBe('instead of')
-      expect(keyword('Each Row')).toBe('Each Row')
+      expect(keyword('By Default')).toBe('By Default')
     })
 
     test('accepts words with underscores and digits', () => {
@@ -179,6 +184,12 @@ describe('pg-format', () => {
 
     test('rejects strings with parentheses', () => {
       expect(() => keyword('fn()')).toThrow('Not a valid keyword')
+    })
+
+    test('rejects arbitrary multi-word phrases not on the allow-list', () => {
+      expect(() => keyword('DROP TABLE')).toThrow('Not a valid keyword')
+      expect(() => keyword('DELETE FROM users')).toThrow('Not a valid keyword')
+      expect(() => keyword('Each Row')).toThrow('Not a valid keyword')
     })
   })
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (sanitization hardening).

## What is the current behavior?

`pg-format`'s `keyword()` helper validates with `/^[A-Za-z][A-Za-z0-9_ ]*$/`, which allows any space-separated word sequence. Phrases like `'DROP TABLE'` or `'DELETE FROM users'` pass validation and can be interpolated into queries.

## What is the new behavior?

`keyword()` accepts either a single word matching `[A-Za-z][A-Za-z0-9_]*` (no spaces) or a phrase from a small case-insensitive allow-list (`'INSTEAD OF'`, `'BY DEFAULT'`) — which covers every multi-word value real callers actually produce (trigger activation, identity generation). Arbitrary multi-word phrases now throw. Tests updated accordingly.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reinforced SQL keyword validation with stricter security controls to prevent unsafe keyword usage. The system now only permits single-word identifiers or specific pre-approved multi-word keyword phrases. Previously accepted multi-word inputs that don't match the curated allowlist are now properly rejected with improved error messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46076?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->