### PR TITLE
fix(studio): keep AI assistant panel open when running logs queries FE-3384

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider.tsx
@@ -60,8 +60,10 @@ export const LayoutSidebarProvider = ({ children }: PropsWithChildren) => {
   const sidebarURLParamRef = useLatest(sidebarURLParam)
   const sidebarLocalStorageRef = useLatest(sidebarLocalStorage)
 
-  useRegisterSidebar(SIDEBAR_KEYS.AI_ASSISTANT, () => <AIAssistant />, {}, !!project)
-  useRegisterSidebar(SIDEBAR_KEYS.EDITOR_PANEL, () => <EditorPanel />, {}, !!project)
+  const isProjectRoute = router.pathname.startsWith('/project/')
+
+  useRegisterSidebar(SIDEBAR_KEYS.AI_ASSISTANT, () => <AIAssistant />, {}, isProjectRoute)
+  useRegisterSidebar(SIDEBAR_KEYS.EDITOR_PANEL, () => <EditorPanel />, {}, isProjectRoute)
   useRegisterSidebar(SIDEBAR_KEYS.ADVISOR_PANEL, () => <AdvisorPanel />, {}, true)
   useRegisterSidebar(
     SIDEBAR_KEYS.HELP_PANEL,

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.test.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.test.tsx
@@ -92,28 +92,30 @@ const resetSidebarManagerState = () => {
 
 describe('LayoutSidebar', () => {
   beforeEach(() => {
-    routerMock.setCurrentUrl('/projects/default')
+    routerMock.setCurrentUrl('/project/default')
   })
 
   afterEach(() => {
     resetSidebarManagerState()
     localStorage.clear()
     vi.clearAllMocks()
+    mockProjectData = mockProject
   })
 
-  const renderSidebar = () =>
-    render(
-      <ResizablePanelGroup orientation="horizontal">
-        <ResizablePanel>
-          <div />
-        </ResizablePanel>
-        <LayoutSidebarProvider>
-          <MobileSheetProvider>
-            <LayoutSidebar />
-          </MobileSheetProvider>
-        </LayoutSidebarProvider>
-      </ResizablePanelGroup>
-    )
+  const sidebarTree = () => (
+    <ResizablePanelGroup orientation="horizontal">
+      <ResizablePanel>
+        <div />
+      </ResizablePanel>
+      <LayoutSidebarProvider>
+        <MobileSheetProvider>
+          <LayoutSidebar />
+        </MobileSheetProvider>
+      </LayoutSidebarProvider>
+    </ResizablePanelGroup>
+  )
+
+  const renderSidebar = () => render(sidebarTree())
 
   it('does not render when there is no active sidebar', () => {
     renderSidebar()
@@ -136,16 +138,54 @@ describe('LayoutSidebar', () => {
     expect(sidebar).toBeTruthy()
   })
 
+  it('keeps the active sidebar open when project transiently becomes undefined', async () => {
+    const { rerender } = render(sidebarTree())
+
+    await waitFor(() => {
+      expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.AI_ASSISTANT]).toBeDefined()
+    })
+
+    act(() => {
+      sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+    })
+    expect(await screen.findByTestId('ai-assistant-sidebar')).toBeTruthy()
+
+    mockProjectData = undefined
+    rerender(sidebarTree())
+    expect(screen.queryByTestId('ai-assistant-sidebar')).toBeTruthy()
+
+    mockProjectData = mockProject
+    rerender(sidebarTree())
+    expect(screen.queryByTestId('ai-assistant-sidebar')).toBeTruthy()
+  })
+
+  it('closes project-scoped sidebars when navigating to a non-project route', async () => {
+    const { rerender } = render(sidebarTree())
+
+    await waitFor(() => {
+      expect(sidebarManagerState.sidebars[SIDEBAR_KEYS.AI_ASSISTANT]).toBeDefined()
+    })
+
+    act(() => {
+      sidebarManagerState.toggleSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+    })
+    expect(await screen.findByTestId('ai-assistant-sidebar')).toBeTruthy()
+
+    act(() => {
+      routerMock.setCurrentUrl('/org/default')
+    })
+    rerender(sidebarTree())
+
+    await waitFor(() => {
+      expect(screen.queryByTestId('ai-assistant-sidebar')).toBeNull()
+    })
+  })
+
   describe('at organization level', () => {
     beforeEach(() => {
       routerMock.setCurrentUrl('/org/default')
       // Set project to undefined to simulate org-level (no project)
       mockProjectData = undefined
-    })
-
-    afterEach(() => {
-      // Reset to project data for other tests
-      mockProjectData = mockProject
     })
 
     it('does not register project-related sidebars when no project is available', async () => {


### PR DESCRIPTION
## Problem

On the Logs & Analytics page (Logs Explorer), running a SQL query closed the AI assistant sidebar panel. Users had to reopen it after every run, which breaks the flow of using the assistant to build and refine logs queries (FE-3384).

## Root cause

The Logs Explorer's Run action writes query state to the URL through `nuqs` (`useLogsUrlState`: `s`, `its`, `ite`), which triggers a shallow `router.replace`. During that update, `project` (from `useSelectedProjectQuery`) transiently reads `undefined`, so the `enabled` argument (`!!project`) passed to `useRegisterSidebar` for the AI assistant and editor panels briefly flips to `false`.

`useRegisterSidebar` runs `unregisterSidebar(id)` in its effect cleanup whenever `enabled` changes. `unregisterSidebar` clears the active sidebar (and calls its `onClose`), so the panel closed. When `enabled` returned to `true` the panel re-registered but did not reopen.

The SQL Editor runs queries via local/valtio state and mutations without writing the URL, so `!!project` never flipped there. That is why the assistant already stays open in the SQL Editor and only the Logs page was affected.

## Fix

Gate the AI assistant and editor panels on being on a **project route** (`router.pathname.startsWith('/project/')`) instead of on `!!project`:

```diff
- useRegisterSidebar(SIDEBAR_KEYS.AI_ASSISTANT, () => <AIAssistant />, {}, !!project)
- useRegisterSidebar(SIDEBAR_KEYS.EDITOR_PANEL, () => <EditorPanel />, {}, !!project)
+ const isProjectRoute = router.pathname.startsWith('/project/')
+ useRegisterSidebar(SIDEBAR_KEYS.AI_ASSISTANT, () => <AIAssistant />, {}, isProjectRoute)
+ useRegisterSidebar(SIDEBAR_KEYS.EDITOR_PANEL, () => <EditorPanel />, {}, isProjectRoute)
```

`router.pathname` is the route template and does not change during a shallow `router.replace`, so `enabled` stays stable while a query runs and the panel is no longer torn down. Navigating away from the project (e.g. to an org page, where `pathname` is `/org/[slug]`) still flips `enabled` to `false` and closes the project-scoped panels, so that behaviour is preserved.

This decouples the panels from the transient `project` data blip using a signal that is stable across shallow routing, rather than trying to reopen the panel after it closes. `useRegisterSidebar` itself is unchanged.

### Note on cross-project navigation

Because the gate now keys on the route template rather than on `project` data, these panels also stay open when navigating between two different projects in-app (the template `/project/[ref]/...` is unchanged, only `ref` differs). Previously that was a transient close too. This is intentional; the AI assistant reloads its per-project state when `project.ref` changes, so there is no cross-project state leak.

## Testing

Added two tests to `LayoutSidebar/index.test.tsx`:

- `keeps the active sidebar open when project transiently becomes undefined` — the reported bug. Fails with `enabled={!!project}`, passes with the route-based gate.
- `closes project-scoped sidebars when navigating to a non-project route` — locks in the no-regression behaviour (project-scoped panels close when leaving the project). Also fails if the gate is reverted to `!!project`.

All existing sidebar tests pass (`LayoutSidebar`, `AdvisorSignals`, plus the assistant/error tests that touch `sidebarManagerState`). Prettier clean.

### Manual

- Logs > Explorer, open the AI assistant, run a query (Run or Cmd+Enter): the panel stays open.
- Toggling and closing the panel manually still work.
- SQL Editor behaviour is unchanged.
- Navigating from a project page to an org page still closes the assistant.
