### PR TITLE
fix(telemetry): exposure event captures dataApiDefaultPrivileges + drop race-fix hook

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
@@ -32,10 +32,12 @@ export const SecurityOptions = ({ form, layout = 'horizontal' }: SecurityOptions
     control: form.control,
     name: 'dataApiDefaultPrivileges',
   })
+  const hasUserModified = form.getFieldState('dataApiDefaultPrivileges', form.formState).isDirty
 
   useTrackDefaultPrivilegesExposure({
     surface: 'main',
     dataApiDefaultPrivileges: dataApiDefaultPrivileges ?? true,
+    hasUserModified,
   })
 
   return (

--- a/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/SecurityOptions.tsx
@@ -28,8 +28,15 @@ interface SecurityOptionsProps {
 
 export const SecurityOptions = ({ form, layout = 'horizontal' }: SecurityOptionsProps) => {
   const dataApi = useWatch({ control: form.control, name: 'dataApi' })
+  const dataApiDefaultPrivileges = useWatch({
+    control: form.control,
+    name: 'dataApiDefaultPrivileges',
+  })
 
-  useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: dataApi ?? true })
+  useTrackDefaultPrivilegesExposure({
+    surface: 'main',
+    dataApiDefaultPrivileges: dataApiDefaultPrivileges ?? true,
+  })
 
   return (
     <Panel.Content className="pb-8">

--- a/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
@@ -1,5 +1,4 @@
 import { renderHook } from '@testing-library/react'
-import { posthogClient } from 'common'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
@@ -25,17 +24,6 @@ vi.mock('@/lib/constants', async () => {
 vi.mock('@/lib/telemetry/track', () => ({
   useTrack: vi.fn(),
 }))
-
-vi.mock('common', async () => {
-  const actual = await vi.importActual<typeof import('common')>('common')
-  return {
-    ...actual,
-    posthogClient: {
-      getPersonProperty: vi.fn(),
-      onFeatureFlags: vi.fn(() => () => {}),
-    },
-  }
-})
 
 describe('useDataApiRevokeOnCreateDefaultEnabled', () => {
   afterEach(() => {
@@ -74,11 +62,6 @@ describe('useTrackDefaultPrivilegesExposure', () => {
 
   beforeEach(() => {
     vi.mocked(useTrack).mockReturnValue(track)
-    // Default: org_count is set on the person — most tests want to exercise
-    // the post-targeting-resolution behavior. The gate-blocked case has its
-    // own test below.
-    vi.mocked(posthogClient.getPersonProperty).mockReturnValue(1)
-    vi.mocked(posthogClient.onFeatureFlags).mockReturnValue(() => {})
   })
 
   afterEach(() => {
@@ -87,26 +70,23 @@ describe('useTrackDefaultPrivilegesExposure', () => {
 
   it('does not fire while the flag is undefined', () => {
     vi.mocked(usePHFlag).mockReturnValue(undefined)
-    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true }))
-    expect(track).not.toHaveBeenCalled()
-  })
-
-  it('does not fire while org_count is missing from the SDK person', () => {
-    vi.mocked(usePHFlag).mockReturnValue(true)
-    vi.mocked(posthogClient.getPersonProperty).mockReturnValue(undefined)
-    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true }))
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
+    )
     expect(track).not.toHaveBeenCalled()
   })
 
   it('fires once when the flag resolves to true on the main surface', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
-    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true }))
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: false })
+    )
     expect(track).toHaveBeenCalledTimes(1)
     expect(track).toHaveBeenCalledWith(
       'project_creation_default_privileges_exposed',
       {
         surface: 'main',
-        dataApiEnabled: true,
+        dataApiDefaultPrivileges: false,
         dataApiRevokeOnCreateDefaultEnabled: true,
       },
       undefined
@@ -115,20 +95,22 @@ describe('useTrackDefaultPrivilegesExposure', () => {
 
   it('fires once when the flag resolves to false on the main surface', () => {
     vi.mocked(usePHFlag).mockReturnValue(false)
-    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: false }))
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
+    )
     expect(track).toHaveBeenCalledTimes(1)
     expect(track).toHaveBeenCalledWith(
       'project_creation_default_privileges_exposed',
       {
         surface: 'main',
-        dataApiEnabled: false,
+        dataApiDefaultPrivileges: true,
         dataApiRevokeOnCreateDefaultEnabled: false,
       },
       undefined
     )
   })
 
-  it('omits dataApiEnabled on the vercel surface', () => {
+  it('omits dataApiDefaultPrivileges on the vercel surface', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
     renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'vercel', orgSlug: 'acme-org' }))
     expect(track).toHaveBeenCalledWith(
@@ -150,7 +132,7 @@ describe('useTrackDefaultPrivilegesExposure', () => {
   it('deduplicates across re-renders', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
     const { rerender } = renderHook(() =>
-      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true })
+      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
     )
     rerender()
     rerender()
@@ -160,7 +142,7 @@ describe('useTrackDefaultPrivilegesExposure', () => {
   it('does not re-fire if the flag flips after initial exposure', () => {
     vi.mocked(usePHFlag).mockReturnValue(false)
     const { rerender } = renderHook(() =>
-      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiEnabled: true })
+      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
     )
     vi.mocked(usePHFlag).mockReturnValue(true)
     rerender()

--- a/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
@@ -71,7 +71,11 @@ describe('useTrackDefaultPrivilegesExposure', () => {
   it('does not fire while the flag is undefined', () => {
     vi.mocked(usePHFlag).mockReturnValue(undefined)
     renderHook(() =>
-      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: true,
+        hasUserModified: false,
+      })
     )
     expect(track).not.toHaveBeenCalled()
   })
@@ -79,7 +83,11 @@ describe('useTrackDefaultPrivilegesExposure', () => {
   it('fires once when the flag resolves to true on the main surface', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
     renderHook(() =>
-      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: false })
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: false,
+        hasUserModified: false,
+      })
     )
     expect(track).toHaveBeenCalledTimes(1)
     expect(track).toHaveBeenCalledWith(
@@ -96,7 +104,11 @@ describe('useTrackDefaultPrivilegesExposure', () => {
   it('fires once when the flag resolves to false on the main surface', () => {
     vi.mocked(usePHFlag).mockReturnValue(false)
     renderHook(() =>
-      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: true,
+        hasUserModified: false,
+      })
     )
     expect(track).toHaveBeenCalledTimes(1)
     expect(track).toHaveBeenCalledWith(
@@ -110,13 +122,85 @@ describe('useTrackDefaultPrivilegesExposure', () => {
     )
   })
 
-  it('omits dataApiDefaultPrivileges on the vercel surface', () => {
+  it('does not fire while the form value is stale relative to the flag (waits for sync)', () => {
+    // Race: flag just resolved to true (treatment), but the caller-side sync
+    // useEffect hasn't run yet, so the form value is still the legacy `true`.
+    // Without the convergence gate, exposure would fire with the wrong value.
     vi.mocked(usePHFlag).mockReturnValue(true)
-    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'vercel', orgSlug: 'acme-org' }))
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: true,
+        hasUserModified: false,
+      })
+    )
+    expect(track).not.toHaveBeenCalled()
+  })
+
+  it('fires on the next render after the form syncs to match the flag', () => {
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    const { rerender } = renderHook(
+      ({ dataApiDefaultPrivileges }: { dataApiDefaultPrivileges: boolean }) =>
+        useTrackDefaultPrivilegesExposure({
+          surface: 'main',
+          dataApiDefaultPrivileges,
+          hasUserModified: false,
+        }),
+      { initialProps: { dataApiDefaultPrivileges: true } }
+    )
+    expect(track).not.toHaveBeenCalled()
+
+    // Caller-side sync runs and updates the form value to !flag.
+    rerender({ dataApiDefaultPrivileges: false })
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      expect.objectContaining({
+        dataApiDefaultPrivileges: false,
+        dataApiRevokeOnCreateDefaultEnabled: true,
+      }),
+      undefined
+    )
+  })
+
+  it('fires immediately with the dirty value when the user has modified the field', () => {
+    // User toggled the checkbox before the flag resolved, dirtying the field.
+    // The sync gate is bypassed; exposure fires with the user's explicit value.
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: true, // form value disagrees with !flag=false
+        hasUserModified: true,
+      })
+    )
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      {
+        surface: 'main',
+        dataApiDefaultPrivileges: true,
+        dataApiRevokeOnCreateDefaultEnabled: true,
+      },
+      undefined
+    )
+  })
+
+  it('fires on the vercel surface with the form-flag convergence gate', () => {
+    vi.mocked(usePHFlag).mockReturnValue(true)
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({
+        surface: 'vercel',
+        orgSlug: 'acme-org',
+        dataApiDefaultPrivileges: false,
+        hasUserModified: false,
+      })
+    )
     expect(track).toHaveBeenCalledWith(
       'project_creation_default_privileges_exposed',
       {
         surface: 'vercel',
+        dataApiDefaultPrivileges: false,
         dataApiRevokeOnCreateDefaultEnabled: true,
       },
       { organization: 'acme-org' }
@@ -125,14 +209,25 @@ describe('useTrackDefaultPrivilegesExposure', () => {
 
   it('skips emission on vercel surface when orgSlug is missing', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
-    renderHook(() => useTrackDefaultPrivilegesExposure({ surface: 'vercel', orgSlug: undefined }))
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({
+        surface: 'vercel',
+        orgSlug: undefined,
+        dataApiDefaultPrivileges: false,
+        hasUserModified: false,
+      })
+    )
     expect(track).not.toHaveBeenCalled()
   })
 
   it('deduplicates across re-renders', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
     const { rerender } = renderHook(() =>
-      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: false,
+        hasUserModified: false,
+      })
     )
     rerender()
     rerender()
@@ -142,7 +237,11 @@ describe('useTrackDefaultPrivilegesExposure', () => {
   it('does not re-fire if the flag flips after initial exposure', () => {
     vi.mocked(usePHFlag).mockReturnValue(false)
     const { rerender } = renderHook(() =>
-      useTrackDefaultPrivilegesExposure({ surface: 'main', dataApiDefaultPrivileges: true })
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: true,
+        hasUserModified: false,
+      })
     )
     vi.mocked(usePHFlag).mockReturnValue(true)
     rerender()

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -24,39 +24,51 @@ export const useDataApiRevokeOnCreateDefaultEnabled = (): boolean => {
 }
 
 type DefaultPrivilegesExposureOptions =
-  | { surface: 'main'; dataApiDefaultPrivileges: boolean }
-  | { surface: 'vercel'; orgSlug: string | undefined }
+  | {
+      surface: 'main'
+      dataApiDefaultPrivileges: boolean
+      hasUserModified: boolean
+    }
+  | {
+      surface: 'vercel'
+      orgSlug: string | undefined
+      dataApiDefaultPrivileges: boolean
+      hasUserModified: boolean
+    }
 
 /**
- * Fires `project_creation_default_privileges_exposed` once per mount, once
- * the flag has resolved. On the main surface, the event payload includes
- * `dataApiDefaultPrivileges` — the actual form-field value the experiment
- * controls (true = legacy grants kept, false = revoked on create).
- * Deduplicated via ref so re-renders and mid-session flag flips don't re-fire.
+ * Fires `project_creation_default_privileges_exposed` once per mount, once the
+ * flag has resolved AND the form value is consistent with the flag's expected
+ * default. The convergence gate avoids a render-ordering race: caller-side
+ * sync effects (in /new/[slug] and the Vercel deploy flow) update the form
+ * value when the flag resolves late, but child effects fire before parent
+ * effects in the same commit, so without the gate the exposure would capture
+ * the stale pre-sync value. If the user has dirtied the field, fire
+ * immediately with their explicit value. Deduplicated via ref.
  */
 export const useTrackDefaultPrivilegesExposure = (options: DefaultPrivilegesExposureOptions) => {
   const track = useTrack()
   const flag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
   const hasTracked = useRef(false)
 
-  const { surface } = options
-  const dataApiDefaultPrivileges =
-    options.surface === 'main' ? options.dataApiDefaultPrivileges : null
+  const { surface, dataApiDefaultPrivileges, hasUserModified } = options
   const orgSlug = options.surface === 'vercel' ? options.orgSlug : undefined
 
   useEffect(() => {
     if (hasTracked.current) return
     if (flag === undefined) return
     if (surface === 'vercel' && !orgSlug) return
+    // Gate on form-flag convergence unless the user explicitly dirtied the field.
+    if (!hasUserModified && dataApiDefaultPrivileges !== !flag) return
     hasTracked.current = true
     track(
       'project_creation_default_privileges_exposed',
       {
         surface,
-        ...(dataApiDefaultPrivileges !== null && { dataApiDefaultPrivileges }),
+        dataApiDefaultPrivileges,
         dataApiRevokeOnCreateDefaultEnabled: flag,
       },
       surface === 'vercel' ? { organization: orgSlug } : undefined
     )
-  }, [flag, track, surface, dataApiDefaultPrivileges, orgSlug])
+  }, [flag, track, surface, dataApiDefaultPrivileges, hasUserModified, orgSlug])
 }

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -1,5 +1,4 @@
-import { posthogClient } from 'common'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { usePHFlag } from '../ui/useFlag'
 import { IS_TEST_ENV } from '@/lib/constants'
@@ -25,59 +24,39 @@ export const useDataApiRevokeOnCreateDefaultEnabled = (): boolean => {
 }
 
 type DefaultPrivilegesExposureOptions =
-  | { surface: 'main'; dataApiEnabled: boolean }
+  | { surface: 'main'; dataApiDefaultPrivileges: boolean }
   | { surface: 'vercel'; orgSlug: string | undefined }
 
 /**
- * Fires `project_creation_default_privileges_exposed` once per mount after both
- * the `dataApiRevokeOnCreateDefault` flag resolves AND the `org_count` person
- * property has been set on the PostHog SDK. Waiting for both signals avoids
- * locking in the variant on the initial /flags/ response, which races the
- * org_count identify for brand-new signups — the exposure must reflect the
- * targeting-aware flag value. Deduplicated via ref so re-renders and mid-session
- * flag flips don't re-fire.
+ * Fires `project_creation_default_privileges_exposed` once per mount, once
+ * the flag has resolved. On the main surface, the event payload includes
+ * `dataApiDefaultPrivileges` — the actual form-field value the experiment
+ * controls (true = legacy grants kept, false = revoked on create).
+ * Deduplicated via ref so re-renders and mid-session flag flips don't re-fire.
  */
 export const useTrackDefaultPrivilegesExposure = (options: DefaultPrivilegesExposureOptions) => {
   const track = useTrack()
   const flag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
   const hasTracked = useRef(false)
-  const [orgCountReady, setOrgCountReady] = useState(
-    () => posthogClient.getPersonProperty('org_count') !== undefined
-  )
 
   const { surface } = options
-  const dataApiEnabled = options.surface === 'main' ? options.dataApiEnabled : null
+  const dataApiDefaultPrivileges =
+    options.surface === 'main' ? options.dataApiDefaultPrivileges : null
   const orgSlug = options.surface === 'vercel' ? options.orgSlug : undefined
-
-  // Mark ready once org_count appears on the SDK person. A /flags/ response
-  // received after our identify will have included org_count in the evaluation,
-  // so subscribing via onFeatureFlags is the right signal that the flag store
-  // reflects the targeting-aware value.
-  useEffect(() => {
-    if (orgCountReady) return
-    const check = () => {
-      if (posthogClient.getPersonProperty('org_count') !== undefined) {
-        setOrgCountReady(true)
-      }
-    }
-    check()
-    return posthogClient.onFeatureFlags(check)
-  }, [orgCountReady])
 
   useEffect(() => {
     if (hasTracked.current) return
     if (flag === undefined) return
-    if (!orgCountReady) return
     if (surface === 'vercel' && !orgSlug) return
     hasTracked.current = true
     track(
       'project_creation_default_privileges_exposed',
       {
         surface,
-        ...(dataApiEnabled !== null && { dataApiEnabled }),
+        ...(dataApiDefaultPrivileges !== null && { dataApiDefaultPrivileges }),
         dataApiRevokeOnCreateDefaultEnabled: flag,
       },
       surface === 'vercel' ? { organization: orgSlug } : undefined
     )
-  }, [flag, orgCountReady, track, surface, dataApiEnabled, orgSlug])
+  }, [flag, track, surface, dataApiDefaultPrivileges, orgSlug])
 }

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import { ChangeEvent, useEffect, useState } from 'react'
+import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import { AWS_REGIONS } from 'shared-data'
 import { toast } from 'sonner'
 import {
@@ -86,10 +86,22 @@ const CreateProject = () => {
   const [dataApiDefaultPrivileges, setDataApiDefaultPrivileges] = useState(
     !isDataApiRevokeOnCreateDefault
   )
+  const hasUserModifiedDataApiDefaultPrivileges = useRef(false)
+
+  useEffect(() => {
+    if (dataApiRevokeOnCreateDefaultFlag === undefined) return
+    if (hasUserModifiedDataApiDefaultPrivileges.current) return
+    setDataApiDefaultPrivileges(!dataApiRevokeOnCreateDefaultFlag)
+  }, [dataApiRevokeOnCreateDefaultFlag])
 
   const { slug, next, currentProjectId: foreignProjectId, externalId } = useParams()
 
-  useTrackDefaultPrivilegesExposure({ surface: 'vercel', orgSlug: slug })
+  useTrackDefaultPrivilegesExposure({
+    surface: 'vercel',
+    orgSlug: slug,
+    dataApiDefaultPrivileges,
+    hasUserModified: hasUserModifiedDataApiDefaultPrivileges.current,
+  })
 
   async function checkPasswordStrength(value: string) {
     const { message, strength } = await passwordStrength(value)
@@ -362,7 +374,10 @@ const CreateProject = () => {
             id="dataApiDefaultPrivileges"
             name="dataApiDefaultPrivileges"
             checked={dataApiDefaultPrivileges}
-            onCheckedChange={(checked) => setDataApiDefaultPrivileges(!!checked)}
+            onCheckedChange={(checked) => {
+              hasUserModifiedDataApiDefaultPrivileges.current = true
+              setDataApiDefaultPrivileges(!!checked)
+            }}
           />
           <div className="grid gap-1.5 leading-none">
             <label

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -163,6 +163,14 @@ const Wizard: NextPageWithLayout = () => {
     highAvailability,
   } = useWatch({ control: form.control })
 
+  useEffect(() => {
+    if (dataApiRevokeOnCreateDefaultFlag === undefined) return
+    if (getFieldState('dataApiDefaultPrivileges', form.formState).isDirty) return
+    setValue('dataApiDefaultPrivileges', !dataApiRevokeOnCreateDefaultFlag, {
+      shouldDirty: false,
+    })
+  }, [dataApiRevokeOnCreateDefaultFlag, getFieldState, setValue, form.formState])
+
   // [Charis] Since the form is updated in a useEffect, there is an edge case
   // when switching from free to paid, where canChooseInstanceSize is true for
   // an in-between render, but watchedInstanceSize is still undefined from the

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -315,9 +315,8 @@ export interface ProjectCreationDefaultPrivilegesExposedEvent {
      * field the experiment actually controls.
      * true = default privileges granted (legacy behaviour)
      * false = revoke SQL runs on create (new behaviour, treatment default)
-     * Main flow only; the Vercel surface omits this property.
      */
-    dataApiDefaultPrivileges?: boolean
+    dataApiDefaultPrivileges: boolean
     /**
      * Raw value of the dataApiRevokeOnCreateDefault PostHog flag at exposure time.
      * true = revoke cohort (checkbox defaulted to unchecked)

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -310,10 +310,14 @@ export interface ProjectCreationDefaultPrivilegesExposedEvent {
     /** Where the checkbox was shown. */
     surface: 'main' | 'vercel'
     /**
-     * State of the "Enable Data API" toggle at exposure time. Main flow only —
-     * the Vercel surface has no such toggle, so this is omitted there.
+     * Current state of the "Automatically expose new tables" checkbox
+     * (`dataApiDefaultPrivileges` form field) at exposure time. This is the
+     * field the experiment actually controls.
+     * true = default privileges granted (legacy behaviour)
+     * false = revoke SQL runs on create (new behaviour, treatment default)
+     * Main flow only; the Vercel surface omits this property.
      */
-    dataApiEnabled?: boolean
+    dataApiDefaultPrivileges?: boolean
     /**
      * Raw value of the dataApiRevokeOnCreateDefault PostHog flag at exposure time.
      * true = revoke cohort (checkbox defaulted to unchecked)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

This PR addresses three issues with the implementation of the `dataApiRevokeOnCreateDefault` experiment ([GROWTH-858](https://linear.app/supabase/issue/GROWTH-858)) on the frontend side:

1. The `project_creation_default_privileges_exposed` event payload captures `dataApiEnabled`, which is the parent "Enable Data API" toggle. That value defaults to `true` for everyone in both arms, which doesn't help understand how people are interacting with the form.

2. The hook itself was gating on PostHog JS SDK values rather than our backend server values being sent from `/telemetry/feature-flags`.

3. The form on `/new/[slug]` captures `dataApiDefaultPrivileges` defaults once at mount via react-hook-form's `defaultValues`. If the flag is still loading when the page mounts, `useDataApiRevokeOnCreateDefaultEnabled()` returns `false` (coerced from undefined), and the form locks the field to the legacy default of `true`. The flag later resolving has no effect, and treatment users get the legacy default visually and in the exposure event.

## What is the new behavior?

1. Main-surface payload now sends `dataApiDefaultPrivileges` — the form field the experiment actually controls (`true` = legacy grants kept, `false` = revoked on create). Post-fix data will let us read out whether treatment users actually got the new default.

2. Hook is simplified: drop `orgCountReady`, drop the `onFeatureFlags` subscription, drop the `posthogClient` import. It now fires once when the flag resolves, period. Vercel surface is unchanged (still no `dataApiDefaultPrivileges` since there's no user-facing toggle there). Tests updated.

3. New useEffect in `/new/[slug]` watches the raw flag value and syncs `dataApiDefaultPrivileges` to the correct experiment-driven default when the flag resolves, gated on `getFieldState(...).isDirty` so we don't clobber intentional user input.

## Additional context

Backend half of this fix is at supabase/platform#32933 (passes `org_count` and `signup_timestamp` in `personProperties` so the audience filter actually evaluates correctly). Both PRs are needed for the experiment to bucket at 5% and be measurable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Telemetry now records the selected default-privileges setting (dataApiDefaultPrivileges) in project-creation events; the previous dataApiEnabled field was removed.
  * Project-creation flows apply the experiment-driven default for that setting once the experiment resolves, but they do not overwrite user-edited choices. Vercel new-project flow syncs with the experiment until the user changes the checkbox.

* **Tests**
  * Updated tests to validate tracking, deduplication, and sync/timing behaviors for dataApiDefaultPrivileges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46085?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->