### PR TITLE
studio(chore): reuse org details fields in AWS marketplace flow

### DIFF
--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/AwsMarketplaceOnboarding.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/AwsMarketplaceOnboarding.tsx
@@ -18,7 +18,7 @@ import {
   useCloudMarketplaceOnboardingInfoQuery,
   type CloudMarketplaceOnboardingInfo,
 } from '@/components/interfaces/Organization/CloudMarketplace/cloud-marketplace-query'
-import NewAwsMarketplaceOrgModal from '@/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal'
+import { NewAwsMarketplaceOrgModal } from '@/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal'
 import { InterstitialAccountRow } from '@/components/layouts/InterstitialLayout'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useOrganizationLinkAwsMarketplaceMutation } from '@/data/organizations/organization-link-aws-marketplace-mutation'

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm.tsx
@@ -1,38 +1,14 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useForm } from 'react-hook-form'
+import { Form } from 'ui'
+
 import {
-  Form,
-  FormControl,
-  FormField,
-  Input,
-  Label,
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from 'ui'
-import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
-import { z } from 'zod'
-
-const ORG_KIND_TYPES = {
-  PERSONAL: 'Personal',
-  EDUCATIONAL: 'Educational',
-  STARTUP: 'Startup',
-  AGENCY: 'Agency',
-  COMPANY: 'Company',
-  UNDISCLOSED: 'N/A',
-}
-
-const ORG_KIND_DEFAULT = 'PERSONAL'
-
-const ORG_SIZE_TYPES = {
-  '1': '1 - 10',
-  '10': '10 - 49',
-  '50': '50 - 99',
-  '100': '100 - 299',
-  '300': 'More than 300',
-}
+  ORG_KIND_DEFAULT,
+  ORG_SIZE_DEFAULT,
+  OrganizationDetailsFields,
+  organizationDetailsSchema,
+  type OrganizationDetailsFormValues,
+} from '../NewOrg/OrganizationDetailsFields'
 
 interface Props {
   onSubmit: (values: NewMarketplaceOrgForm) => void
@@ -40,20 +16,15 @@ interface Props {
 
 export const CREATE_AWS_MANAGED_ORG_FORM_ID = 'create-aws-managed-org-form'
 
-const FormSchema = z.object({
-  name: z.string().trim().min(1, 'Please provide an organization name'),
-  kind: z.string(),
-  size: z.string().optional(),
-})
-
-export type NewMarketplaceOrgForm = z.infer<typeof FormSchema>
+export type NewMarketplaceOrgForm = OrganizationDetailsFormValues
 
 const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
   const form = useForm<NewMarketplaceOrgForm>({
-    resolver: zodResolver(FormSchema),
+    resolver: zodResolver(organizationDetailsSchema),
     defaultValues: {
       name: '',
       kind: ORG_KIND_DEFAULT,
+      size: ORG_SIZE_DEFAULT,
     },
   })
 
@@ -62,94 +33,8 @@ const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
   return (
     <Form {...form}>
       <form id={CREATE_AWS_MANAGED_ORG_FORM_ID} onSubmit={form.handleSubmit(onSubmit)}>
-        <div className="flex flex-col gap-4">
-          <FormField
-            control={form.control}
-            name="name"
-            render={({ field }) => (
-              <FormItemLayout label="Name" layout="horizontal">
-                <FormControl>
-                  <>
-                    <Input {...field} placeholder="Organization name" />
-                    <div className="mt-1">
-                      <Label
-                        htmlFor="name"
-                        className="text-foreground-lighter leading-normal text-sm"
-                      >
-                        What's the name of your company or team?
-                      </Label>
-                    </div>
-                  </>
-                </FormControl>
-              </FormItemLayout>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="kind"
-            render={({ field }) => (
-              <FormItemLayout label="Type" layout="horizontal">
-                <FormControl>
-                  <>
-                    <Select value={field.value} onValueChange={field.onChange}>
-                      <SelectTrigger>
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {Object.entries(ORG_KIND_TYPES).map(([k, v]) => (
-                          <SelectItem key={k} value={k}>
-                            {v}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                    <div className="mt-1">
-                      <Label
-                        htmlFor="kind"
-                        className="text-foreground-lighter leading-normal text-sm"
-                      >
-                        What would best describe your organization?
-                      </Label>
-                    </div>
-                  </>
-                </FormControl>
-              </FormItemLayout>
-            )}
-          />
-          {kind == 'COMPANY' && (
-            <FormField
-              control={form.control}
-              name="size"
-              render={({ field }) => (
-                <FormItemLayout label="Company size" layout="horizontal">
-                  <FormControl>
-                    <>
-                      <Select value={field.value} onValueChange={field.onChange}>
-                        <SelectTrigger>
-                          <SelectValue placeholder="How many people are in your company?" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          {Object.entries(ORG_SIZE_TYPES).map(([k, v]) => (
-                            <SelectItem key={k} value={k}>
-                              {v}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                      <div className="mt-1">
-                        <Label
-                          htmlFor="size"
-                          className="text-foreground-lighter leading-normal text-sm"
-                        >
-                          How many people are in your company?
-                        </Label>
-                      </div>
-                    </>
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-          )}
+        <div className="flex flex-col gap-6">
+          <OrganizationDetailsFields control={form.control} kind={kind} />
         </div>
       </form>
     </Form>

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm.tsx
@@ -18,7 +18,7 @@ export const CREATE_AWS_MANAGED_ORG_FORM_ID = 'create-aws-managed-org-form'
 
 export type NewMarketplaceOrgForm = OrganizationDetailsFormValues
 
-const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
+export const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
   const form = useForm<NewMarketplaceOrgForm>({
     resolver: zodResolver(organizationDetailsSchema),
     defaultValues: {
@@ -40,5 +40,3 @@ const NewAwsMarketplaceOrgForm = ({ onSubmit }: Props) => {
     </Form>
   )
 }
-
-export default NewAwsMarketplaceOrgForm

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
@@ -58,7 +58,7 @@ export const NewAwsMarketplaceOrgModal = ({ buyerId, visible, onSuccess, onClose
   )
 }
 
-export const AwsMarketplaceOrgCreationDialog = ({
+const AwsMarketplaceOrgCreationDialog = ({
   visible,
   onClose,
   onSubmit,

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
@@ -14,7 +14,7 @@ import { Button } from 'ui'
 
 import NewAwsMarketplaceOrgForm, {
   CREATE_AWS_MANAGED_ORG_FORM_ID,
-  NewMarketplaceOrgForm,
+  type NewMarketplaceOrgForm,
 } from './NewAwsMarketplaceOrgForm'
 import { useAwsManagedOrganizationCreateMutation } from '@/data/organizations/organization-create-mutation'
 
@@ -25,7 +25,7 @@ interface Props {
   onClose: () => void
 }
 
-const NewAwsMarketplaceOrgModal = ({ buyerId, visible, onSuccess, onClose }: Props) => {
+export const NewAwsMarketplaceOrgModal = ({ buyerId, visible, onSuccess, onClose }: Props) => {
   const { mutate: createOrganization, isPending: isCreatingOrganization } =
     useAwsManagedOrganizationCreateMutation({
       onSuccess: (org) => {
@@ -40,32 +40,65 @@ const NewAwsMarketplaceOrgModal = ({ buyerId, visible, onSuccess, onClose }: Pro
     })
 
   const onSubmit: SubmitHandler<NewMarketplaceOrgForm> = async (values) => {
-    createOrganization({ ...values, buyerId })
+    createOrganization({
+      name: values.name,
+      kind: values.kind,
+      buyerId,
+      ...(values.kind === 'COMPANY' ? { size: values.size } : {}),
+    })
+  }
+
+  return (
+    <AwsMarketplaceOrgCreationDialog
+      visible={visible}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      isCreatingOrganization={isCreatingOrganization}
+    />
+  )
+}
+
+export const AwsMarketplaceOrgCreationDialog = ({
+  visible,
+  onClose,
+  onSubmit,
+  isCreatingOrganization = false,
+}: {
+  visible: boolean
+  onClose: () => void
+  onSubmit: SubmitHandler<NewMarketplaceOrgForm>
+  isCreatingOrganization?: boolean
+}) => {
+  const handleClose = () => {
+    if (!isCreatingOrganization) onClose()
   }
 
   return (
     <Dialog
       open={visible}
       onOpenChange={(open) => {
-        if (!open) onClose()
+        if (!open) handleClose()
       }}
     >
       <DialogContent
         onOpenAutoFocus={(event) => event.preventDefault()}
-        size="xlarge"
-        onEscapeKeyDown={(e) => (isCreatingOrganization ? e.preventDefault() : onClose())}
-        onPointerDownOutside={(e) => (isCreatingOrganization ? e.preventDefault() : onClose())}
-        className="p-2"
+        size="medium"
+        onEscapeKeyDown={(e) => {
+          if (isCreatingOrganization) e.preventDefault()
+        }}
+        onPointerDownOutside={(e) => {
+          if (isCreatingOrganization) e.preventDefault()
+        }}
       >
         <DialogHeader>
-          <DialogTitle>Create a new organization</DialogTitle>
-          <DialogDescription>
+          <DialogTitle>Create and link organization</DialogTitle>
+          <DialogDescription className="text-balance">
             A new organization will be created and linked to your AWS Marketplace subscription
           </DialogDescription>
         </DialogHeader>
         <DialogSectionSeparator />
         <DialogSection>
-          <NewAwsMarketplaceOrgForm onSubmit={onSubmit}></NewAwsMarketplaceOrgForm>
+          <NewAwsMarketplaceOrgForm onSubmit={onSubmit} />
         </DialogSection>
         <DialogFooter>
           <Button
@@ -81,5 +114,3 @@ const NewAwsMarketplaceOrgModal = ({ buyerId, visible, onSuccess, onClose }: Pro
     </Dialog>
   )
 }
-
-export default NewAwsMarketplaceOrgModal

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
@@ -12,8 +12,9 @@ import { SubmitHandler } from 'react-hook-form'
 import { toast } from 'sonner'
 import { Button } from 'ui'
 
-import NewAwsMarketplaceOrgForm, {
+import {
   CREATE_AWS_MANAGED_ORG_FORM_ID,
+  NewAwsMarketplaceOrgForm,
   type NewMarketplaceOrgForm,
 } from './NewAwsMarketplaceOrgForm'
 import { useAwsManagedOrganizationCreateMutation } from '@/data/organizations/organization-create-mutation'

--- a/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
+++ b/apps/studio/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgModal.tsx
@@ -105,7 +105,6 @@ export const AwsMarketplaceOrgCreationDialog = ({
             form={CREATE_AWS_MANAGED_ORG_FORM_ID}
             htmlType="submit"
             loading={isCreatingOrganization}
-            size="medium"
           >
             Create and link organization
           </Button>

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -17,7 +17,6 @@ import {
   Form,
   FormControl,
   FormField,
-  Input,
   Select,
   SelectContent,
   SelectItem,
@@ -29,6 +28,14 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { z } from 'zod'
 
+import {
+  ORG_KIND_DEFAULT,
+  ORG_SIZE_DEFAULT,
+  OrganizationDetailsFields,
+  organizationDetailsSchema,
+  type OrgKind,
+  type OrgSize,
+} from './OrganizationDetailsFields'
 import { UpgradeExistingOrganizationCallout } from './UpgradeExistingOrganizationCallout'
 import { ChargeBreakdown } from '@/components/interfaces/Billing/ChargeBreakdown'
 import { getStripeElementsAppearanceOptions } from '@/components/interfaces/Billing/Payment/Payment.utils'
@@ -52,25 +59,6 @@ import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { PRICING_TIER_LABELS_ORG, STRIPE_PUBLIC_KEY } from '@/lib/constants'
 import { useProfile } from '@/lib/profile'
 
-const ORG_KIND_TYPES = {
-  PERSONAL: 'Personal',
-  EDUCATIONAL: 'Educational',
-  STARTUP: 'Startup',
-  AGENCY: 'Agency',
-  COMPANY: 'Company',
-  UNDISCLOSED: 'N/A',
-}
-const ORG_KIND_DEFAULT = 'PERSONAL'
-
-const ORG_SIZE_TYPES = {
-  '1': '1 - 10',
-  '10': '10 - 49',
-  '50': '50 - 99',
-  '100': '100 - 299',
-  '300': 'More than 300',
-}
-const ORG_SIZE_DEFAULT = '1'
-
 interface NewOrgFormProps {
   onPaymentMethodReset: () => void
   setupIntent?: SetupIntentResponse
@@ -79,19 +67,11 @@ interface NewOrgFormProps {
 
 const plans = ['FREE', 'PRO', 'TEAM'] as const
 
-const formSchema = z.object({
+const formSchema = organizationDetailsSchema.extend({
   plan: z
     .string()
     .transform((val) => val.toUpperCase())
     .pipe(z.enum(plans)),
-  name: z.string().min(1, 'Organization name is required'),
-  kind: z
-    .string()
-    .transform((val) => val.toUpperCase())
-    .pipe(
-      z.enum(['PERSONAL', 'EDUCATIONAL', 'STARTUP', 'AGENCY', 'COMPANY', 'UNDISCLOSED'] as const)
-    ),
-  size: z.enum(['1', '10', '50', '100', '300'] as const),
   spend_cap: z.boolean(),
 })
 
@@ -164,8 +144,8 @@ export const NewOrgForm = ({
     defaultValues: {
       plan: defaultValues.plan.toUpperCase() as (typeof plans)[number],
       name: defaultValues.name,
-      kind: defaultValues.kind as typeof ORG_KIND_DEFAULT,
-      size: defaultValues.size as keyof typeof ORG_SIZE_TYPES,
+      kind: defaultValues.kind as OrgKind,
+      size: defaultValues.size as OrgSize,
       spend_cap: defaultValues.spend_cap,
     },
   })
@@ -174,8 +154,8 @@ export const NewOrgForm = ({
     form.reset({
       plan: defaultValues.plan.toUpperCase() as (typeof plans)[number],
       name: defaultValues.name,
-      kind: defaultValues.kind as typeof ORG_KIND_DEFAULT,
-      size: defaultValues.size as keyof typeof ORG_SIZE_TYPES,
+      kind: defaultValues.kind as OrgKind,
+      size: defaultValues.size as OrgSize,
       spend_cap: defaultValues.spend_cap,
     })
   }, [defaultValues, form])
@@ -420,93 +400,13 @@ export const NewOrgForm = ({
           footerClasses="rounded-b-md"
         >
           <div className="divide-y divide-border-muted">
-            <Panel.Content>
-              <FormField
-                control={form.control}
-                name="name"
-                render={({ field }) => (
-                  <FormItemLayout
-                    label="Name"
-                    layout="horizontal"
-                    description="What's the name of your company or team? You can change this later."
-                  >
-                    <FormControl>
-                      <Input
-                        autoFocus
-                        type="text"
-                        placeholder="Organization name"
-                        data-1p-ignore
-                        data-lpignore="true"
-                        data-form-type="other"
-                        data-bwignore
-                        {...field}
-                      />
-                    </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-            </Panel.Content>
-            <Panel.Content>
-              <FormField
-                control={form.control}
-                name="kind"
-                render={({ field }) => (
-                  <FormItemLayout
-                    label="Type"
-                    layout="horizontal"
-                    description="What best describes your organization?"
-                  >
-                    <FormControl>
-                      <Select value={field.value} onValueChange={field.onChange}>
-                        <SelectTrigger className="w-full">
-                          <SelectValue />
-                        </SelectTrigger>
-
-                        <SelectContent>
-                          {Object.entries(ORG_KIND_TYPES).map(([k, v]) => (
-                            <SelectItem key={k} value={k}>
-                              {v}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-            </Panel.Content>
-
-            {form.watch('kind') == 'COMPANY' && (
-              <Panel.Content>
-                <FormField
-                  control={form.control}
-                  name="size"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      label="Company size"
-                      layout="horizontal"
-                      description="How many people are in your company?"
-                    >
-                      <FormControl>
-                        <Select value={field.value} onValueChange={field.onChange}>
-                          <SelectTrigger className="w-full">
-                            <SelectValue />
-                          </SelectTrigger>
-
-                          <SelectContent>
-                            {Object.entries(ORG_SIZE_TYPES).map(([k, v]) => (
-                              <SelectItem key={k} value={k}>
-                                {v}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
-              </Panel.Content>
-            )}
+            <OrganizationDetailsFields
+              control={form.control}
+              kind={form.watch('kind')}
+              renderFieldWrapper={(children, field) => (
+                <Panel.Content key={field}>{children}</Panel.Content>
+              )}
+            />
 
             {isBillingEnabled && (
               <Panel.Content>

--- a/apps/studio/components/interfaces/Organization/NewOrg/OrganizationDetailsFields.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/OrganizationDetailsFields.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from 'react'
+import type { Control, FieldPath, FieldValues } from 'react-hook-form'
+import {
+  FormControl,
+  FormField,
+  Input,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from 'ui'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { z } from 'zod'
+
+export const ORG_KIND_TYPES = {
+  PERSONAL: 'Personal',
+  EDUCATIONAL: 'Educational',
+  STARTUP: 'Startup',
+  AGENCY: 'Agency',
+  COMPANY: 'Company',
+  UNDISCLOSED: 'N/A',
+}
+
+export const ORG_KIND_DEFAULT = 'PERSONAL'
+
+export const ORG_SIZE_TYPES = {
+  '1': '1 - 10',
+  '10': '10 - 49',
+  '50': '50 - 99',
+  '100': '100 - 299',
+  '300': 'More than 300',
+}
+
+export const ORG_SIZE_DEFAULT = '1'
+
+export type OrgKind = keyof typeof ORG_KIND_TYPES
+export type OrgSize = keyof typeof ORG_SIZE_TYPES
+
+const orgKindValues = [
+  'PERSONAL',
+  'EDUCATIONAL',
+  'STARTUP',
+  'AGENCY',
+  'COMPANY',
+  'UNDISCLOSED',
+] as const
+
+const orgSizeValues = ['1', '10', '50', '100', '300'] as const
+
+export const organizationDetailsSchema = z.object({
+  name: z.string().trim().min(1, 'Organization name is required'),
+  kind: z
+    .string()
+    .transform((val) => val.toUpperCase())
+    .pipe(z.enum(orgKindValues)),
+  size: z.enum(orgSizeValues),
+})
+
+export type OrganizationDetailsFormValues = z.infer<typeof organizationDetailsSchema>
+
+interface OrganizationDetailsFieldsProps<TFieldValues extends FieldValues> {
+  control: Control<TFieldValues>
+  kind: string
+  nameField?: FieldPath<TFieldValues>
+  kindField?: FieldPath<TFieldValues>
+  sizeField?: FieldPath<TFieldValues>
+  renderFieldWrapper?: (children: ReactNode, field: 'name' | 'kind' | 'size') => ReactNode
+}
+
+export const OrganizationDetailsFields = <TFieldValues extends FieldValues>({
+  control,
+  kind,
+  nameField = 'name' as FieldPath<TFieldValues>,
+  kindField = 'kind' as FieldPath<TFieldValues>,
+  sizeField = 'size' as FieldPath<TFieldValues>,
+  renderFieldWrapper = (children) => children,
+}: OrganizationDetailsFieldsProps<TFieldValues>) => (
+  <>
+    {renderFieldWrapper(
+      <FormField
+        control={control}
+        name={nameField}
+        render={({ field }) => (
+          <FormItemLayout
+            label="Name"
+            layout="horizontal"
+            description="What's the name of your company or team? You can change this later."
+          >
+            <FormControl>
+              <Input
+                autoFocus
+                type="text"
+                placeholder="Organization name"
+                data-1p-ignore
+                data-lpignore="true"
+                data-form-type="other"
+                data-bwignore
+                {...field}
+              />
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />,
+      'name'
+    )}
+    {renderFieldWrapper(
+      <FormField
+        control={control}
+        name={kindField}
+        render={({ field }) => (
+          <FormItemLayout
+            label="Type"
+            layout="horizontal"
+            description="What best describes your organization?"
+          >
+            <FormControl>
+              <Select value={field.value} onValueChange={field.onChange}>
+                <SelectTrigger className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+
+                <SelectContent>
+                  {Object.entries(ORG_KIND_TYPES).map(([key, label]) => (
+                    <SelectItem key={key} value={key}>
+                      {label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />,
+      'kind'
+    )}
+
+    {kind === 'COMPANY' &&
+      renderFieldWrapper(
+        <FormField
+          control={control}
+          name={sizeField}
+          render={({ field }) => (
+            <FormItemLayout
+              label="Company size"
+              layout="horizontal"
+              description="How many people are in your company?"
+            >
+              <FormControl>
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+
+                  <SelectContent>
+                    {Object.entries(ORG_SIZE_TYPES).map(([key, label]) => (
+                      <SelectItem key={key} value={key}>
+                        {label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />,
+        'size'
+      )}
+  </>
+)

--- a/apps/studio/tests/pages/aws-marketplace-onboarding.test.tsx
+++ b/apps/studio/tests/pages/aws-marketplace-onboarding.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { http, HttpResponse } from 'msw'
@@ -9,6 +9,7 @@ import type {
   CloudMarketplaceContractLinkingEligibility,
   CloudMarketplaceOnboardingInfo,
 } from '@/components/interfaces/Organization/CloudMarketplace/cloud-marketplace-query'
+import { CREATE_AWS_MANAGED_ORG_FORM_ID } from '@/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm'
 import { API_URL } from '@/lib/constants'
 import type { ProfileContextType } from '@/lib/profile'
 import { createMockOrganization } from '@/tests/helpers'
@@ -165,6 +166,44 @@ describe('AwsMarketplaceOnboardingScreen', () => {
       })
     })
     await screen.findByText('Organization linked')
+  })
+
+  test('creates an AWS-managed organization with buyerId and returns to linked state', async () => {
+    const user = userEvent.setup()
+    let createRequest: unknown
+
+    mockAwsEndpoints({
+      organizations: [],
+      onboardingInfo: createOnboardingInfo({ organizations: [] }),
+    })
+    mswServer.use(
+      http.post(`${API_URL}/platform/organizations/cloud-marketplace`, async ({ request }) => {
+        createRequest = await request.json()
+        return HttpResponse.json(
+          createMockOrganization({
+            id: 3,
+            name: 'Mock Marketplace Org',
+            slug: 'mock-marketplace-org',
+            billing_partner: 'aws_marketplace',
+          })
+        )
+      })
+    )
+
+    renderScreen()
+
+    await user.click(await screen.findByRole('button', { name: 'Create organization' }))
+    await user.type(screen.getByPlaceholderText('Organization name'), 'Mock Marketplace Org')
+    fireEvent.submit(document.getElementById(CREATE_AWS_MANAGED_ORG_FORM_ID)!)
+
+    await waitFor(() => {
+      expect(createRequest).toEqual({
+        name: 'Mock Marketplace Org',
+        kind: 'PERSONAL',
+        buyer_id: 'buyer-test',
+      })
+    })
+    expect(await screen.findByText('Organization linked')).toBeInTheDocument()
   })
 
   test('renders setup unavailable when the buyer ID is missing', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Refactor. Resolves FE-3216.

## What is the current behavior?

The AWS Marketplace create-organisation dialog owns its own copy of the organisation name, type, and company-size form fields. It’s duplicative and has drifted from the normal `/new` organisation form, making the AWS flow harder to keep aligned.

This is stacked on #46058.

## What is the new behavior?

- Extracts the shared organisation details schema, defaults, option constants, and fields from the normal `NewOrgForm`
- Reuses those shared fields in both the full organisation creation form and the AWS Marketplace create-and-link dialog
- Keeps the AWS Marketplace flow anchored in the onboarding interstitial rather than routing through `/new`
- Keeps the AWS-specific buyer ID, AWS-managed organisation endpoint, create-and-link success state, and modal dismissal behaviour

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="Link AWS Marketplace  Supabase-3742FEDF-53BD-4E80-926D-498B2EA94773" src="https://github.com/user-attachments/assets/617ee422-1cf0-4858-801b-a4ee5ee402c9" /> | <img width="1024" height="759" alt="Link AWS Marketplace  Supabase-0FEE2292-CB9F-43AA-B131-B6A549890970" src="https://github.com/user-attachments/assets/ff017468-f8ac-469a-bb17-eea07842306f" /> |

## Additional context

The shared field extraction is intentionally limited to organisation details. Billing, plan selection, spend cap, Stripe, captcha, and the `/new/[slug]` redirect behaviour stay owned by `NewOrgForm`; AWS Marketplace keeps its separate create-and-link container because AWS owns the billing contract.

## Validation

- `pnpm --filter studio exec vitest --run tests/pages/aws-marketplace-onboarding.test.tsx`
- `pnpm --filter studio lint:ratchet --rule no-restricted-exports`
- `git diff --check`

Full Studio typecheck was also run, but it currently fails on existing unrelated repo-wide React/implicit-any errors outside this diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AWS Marketplace organization creation dialog to prevent accidental closure while the creation process is in progress.

* **Improvements**
  * Standardized organization details form handling across different organization creation flows for improved consistency and user experience.

* **Tests**
  * Added comprehensive test coverage for the AWS Marketplace organization creation workflow, including form submission, validation, and state transitions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46087?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->