### PR TITLE
fix: run format step in separate low-privilege job

### DIFF
--- a/.github/workflows/autofix_linters.yml
+++ b/.github/workflows/autofix_linters.yml
@@ -112,7 +112,7 @@ jobs:
             exit 0
           fi
 
-          git config --local user.name "kevcodez"
-          git config --local user.email "k.grueneberg1994@gmail.com"
+          git config --local user.name "supabase-autofix-bot"
+          git config --local user.email "noreply@supabase.com"
           git commit -m "ci: Autofix updates from GitHub workflow"
           git -c credential.helper= push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${TARGET_BRANCH}"

--- a/.github/workflows/autofix_linters.yml
+++ b/.github/workflows/autofix_linters.yml
@@ -5,33 +5,31 @@ on:
     types:
       - labeled
 
+permissions:
+  contents: read
+
 # Cancel old builds on new commit for same workflow + branch/PR
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  autofix:
+  format:
+    name: Format PR without write credentials
     runs-on: blacksmith-2vcpu-ubuntu-2404
-    permissions:
-      contents: write
     if: ${{ github.event_name == 'pull_request' && (github.event.label.name == 'autofix') }}
+    outputs:
+      changed: ${{ steps.create-patch.outputs.changed }}
+
     steps:
       - name: Calculate number of commits
         run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
 
-      - name: Generate token
-        id: app-token
-        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
-        with:
-          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
-          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
-          permission-contents: write
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
-          ref: ${{ github.head_ref }}
-          token: ${{ steps.app-token.outputs.token }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
           fetch-depth: ${{ env.PR_FETCH_DEPTH }}
           sparse-checkout: |
             packages
@@ -52,9 +50,69 @@ jobs:
       - name: Run Prettier in fix mode
         run: pnpm run format
 
-      - name: Commit changes and push to existing branch
-        uses: stefanzweifel/git-auto-commit-action@b863ae1933cb653a53c021fe36dbb774e1fb9403 # v5.2.0
+      - name: Create autofix patch
+        id: create-patch
+        run: |
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          git diff --binary > autofix.patch
+
+      - name: Upload autofix patch
+        if: steps.create-patch.outputs.changed == 'true'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          commit_message: 'ci: Autofix updates from GitHub workflow'
-          commit_user_name: 'kevcodez'
-          commit_user_email: 'k.grueneberg1994@gmail.com'
+          name: autofix-linters-patch
+          path: autofix.patch
+          retention-days: 1
+
+  push:
+    name: Commit autofix updates
+    needs: format
+    runs-on: blacksmith-2vcpu-ubuntu-2404
+    if: >-
+      ${{
+        needs.format.outputs.changed == 'true' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      }}
+    steps:
+      - name: Generate token
+        id: app-token
+        uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
+        with:
+          app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
+          private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
+          permission-contents: write
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+          sparse-checkout: |
+            packages
+            apps
+            patches
+
+      - name: Download autofix patch
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: autofix-linters-patch
+
+      - name: Commit changes and push to existing branch
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+          TARGET_BRANCH: ${{ github.head_ref }}
+        run: |
+          git apply --index autofix.patch
+
+          if git diff --cached --quiet; then
+            exit 0
+          fi
+
+          git config --local user.name "kevcodez"
+          git config --local user.email "k.grueneberg1994@gmail.com"
+          git commit -m "ci: Autofix updates from GitHub workflow"
+          git -c credential.helper= push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${TARGET_BRANCH}"


### PR DESCRIPTION
Out of an abundance of caution, running the format step in a strictly read-only context.
Added explicit validations on pushes instead of relying on an implicit lack of pull_request_target

Resolves PRODSEC-118

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reworked automated autofix workflow into a two-step format-and-apply flow, reduced top-level permissions, and moved from an auto-commit action to a manual apply/commit/push process for more controlled automated fixes.
  * No user-facing features or functionality changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46090?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->