### PR TITLE
Fix count query for unified logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -59,7 +59,10 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
         pathname: '/customers',
       } as any)
       expect(sql).toContain(`log_attributes['request.method'] IN ('GET')`)
-      expect(sql).toContain(`log_attributes['response.status_code'] IN ('401')`)
+      // Status filter wraps the CASE that picks HTTP code or Postgres SQLSTATE
+      // so e.g. '00000' matches postgres success rows.
+      expect(sql).toContain(`log_attributes['parsed.sql_state_code']`)
+      expect(sql).toMatch(/END\) IN \('401'\)/)
       expect(sql).toContain(`log_attributes['request.path'] LIKE '%/customers%'`)
     })
 
@@ -128,9 +131,12 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
         search: { ...baseSearch, method: ['GET'], status: ['200'] } as any,
         facet: 'method',
       })
-      // Filtered facet is excluded from WHERE; other filters still applied
+      // Filtered facet is excluded from WHERE; other filters still applied.
+      // For facet='method' the SELECT projection doesn't include STATUS_EXPR,
+      // so SQLSTATE/IN ('200') must come from the WHERE clause.
       expect(sql).not.toContain(`log_attributes['request.method'] IN ('GET')`)
-      expect(sql).toContain(`log_attributes['response.status_code'] IN ('200')`)
+      expect(sql).toContain(`log_attributes['parsed.sql_state_code']`)
+      expect(sql).toMatch(/END\) IN \('200'\)/)
       expect(sql).toContain('GROUP BY value')
       expect(sql).toContain('LIMIT 20')
     })

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -371,8 +371,8 @@ WHERE ${baseFiltersFor('level')}
   )
 
   const facetBranches = joinSqlFragments(
-    (['method', 'status', 'pathname'] as const).map((facet) =>
-      getFacetCountQuery({ search, facet })
+    (['method', 'status', 'pathname'] as const).map(
+      (facet) => safeSql`(${getFacetCountQuery({ search, facet })})`
     ),
     ' UNION ALL '
   )

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -128,10 +128,13 @@ const translateFilter = (key: string, value: unknown): SafeLogSqlFragment | null
       return arr
         ? safeSql`${ATTR.method} IN ${inList(arr)}`
         : safeSql`${ATTR.method} = ${lit(String(value))}`
-    case 'status':
-      return arr
-        ? safeSql`${ATTR.status} IN ${inList(arr)}`
-        : safeSql`${ATTR.status} = ${lit(String(value))}`
+    case 'status': {
+      // Match the displayed status: HTTP response code for gateway rows,
+      // Postgres SQLSTATE for postgres rows. Inline STATUS_EXPR so e.g.
+      // filtering on '00000' picks up postgres success rows.
+      const statuses = arr ?? [value]
+      return safeSql`(${STATUS_EXPR}) IN ${inList(statuses.map((v) => String(v)))}`
+    }
     case 'pathname':
       return arr
         ? safeSql`(${joinSqlFragments(

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -16,6 +16,7 @@ import {
   checkForWithClause,
 } from '@/components/interfaces/Settings/Logs/Logs.utils'
 import { get } from '@/data/fetchers'
+import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { DOCS_URL } from '@/lib/constants'
 
@@ -75,10 +76,7 @@ export const useLogsQuery = (
   } = useQuery({
     queryKey: ['projects', projectRef, 'logs', params, { otel: useOtel }],
     queryFn: async ({ signal }) => {
-      const endpoint = useOtel
-        ? (`/platform/projects/{ref}/analytics/endpoints/logs.all.otel` as const)
-        : (`/platform/projects/{ref}/analytics/endpoints/logs.all` as const)
-      const { data, error } = await get(endpoint, {
+      const { data, error } = await get(logsAllEndpointUrl(useOtel), {
         params: {
           path: { ref: projectRef },
           query: params,


### PR DESCRIPTION
## Context

The query to retrieve counts in unified logs have been error-ing out with this
`sql parser error: Expected: end of statement, found: UNION at Line: 71, Column: 2`

This PR fixes that - can verify visually as the status filters are now populated correctly
<img width="365" height="148" alt="image" src="https://github.com/user-attachments/assets/9397cca1-0519-4fe1-9397-c37d399c4b44" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved status-based log filtering so single-value and multi-value filters return more accurate results across all log sources.
  * Made facet count calculations (method, status, pathname) more robust for consistent counts.

* **Bug Fixes**
  * Standardized log endpoint resolution so log retrieval behaves consistently when telemetry mode changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46093?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->