### PR TITLE
fix: update link for OAuth client registration documentation

### DIFF
--- a/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/CreateOrUpdateOAuthAppSheet.tsx
@@ -456,7 +456,9 @@ export const CreateOrUpdateOAuthAppSheet = ({
                           flow can be used, particularly beneficial for applications that cannot
                           securely store Client Secrets, such as native and mobile apps. This cannot
                           be changed after creation.{' '}
-                          <InlineLink href={`${DOCS_URL}/guides/auth/oauth/public-oauth-apps`}>
+                          <InlineLink
+                            href={`${DOCS_URL}/guides/auth/oauth-server/getting-started#register-an-oauth-client`}
+                          >
                             Learn more
                           </InlineLink>
                         </>


### PR DESCRIPTION
Updates broken link for OAuth client registration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "Learn more" link in the Public Client field to point to the OAuth server getting-started guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46098?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->