### PR TITLE
fix(docker): handle optional services and compose overrides in test-container-logs

### DIFF
--- a/docker/tests/test-container-logs.sh
+++ b/docker/tests/test-container-logs.sh
@@ -13,6 +13,7 @@ set -e
 
 pass=0
 fail=0
+project_name="${COMPOSE_PROJECT_NAME:-supabase}"
 
 fail_msg() {
     fail=$((fail + 1))
@@ -24,12 +25,56 @@ pass_msg() {
     echo "  PASS: $1"
 }
 
+# The `docker ps` fallback in the helpers below exists because the script
+# doesn't know which compose `-f` flags the user ran `up` with. `docker compose
+# ps` only sees services defined in the currently loaded compose files, but
+# compose stamps `com.docker.compose.{project,service}` labels at `up` time -
+# so a label-based lookup finds the container regardless of which override
+# files are active in this shell.
+
+is_service_running() {
+    service="$1"
+    if docker compose ps --services --status running 2>/dev/null | grep -q "^$service$"; then
+        return 0
+    fi
+
+    docker ps --filter "label=com.docker.compose.project=$project_name" \
+        --filter "label=com.docker.compose.service=$service" \
+        --filter "status=running" \
+        --quiet | grep -q '.'
+}
+
+get_container_id() {
+    service="$1"
+
+    container_id=$(docker compose ps -q "$service" 2>/dev/null || true)
+    if [ -n "$container_id" ]; then
+        printf '%s' "$container_id"
+        return
+    fi
+
+    container_id=$(docker ps -a \
+        --filter "label=com.docker.compose.project=$project_name" \
+        --filter "label=com.docker.compose.service=$service" \
+        --quiet)
+
+    set -- $container_id
+    printf '%s' "$1"
+}
+
 # Check that a service's logs contain all expected patterns
 check_logs() {
     service="$1"
     shift
 
-    logs=$(docker compose logs "$service" 2>/dev/null)
+    logs=$(docker compose logs "$service" 2>/dev/null || true)
+    if [ -z "$logs" ]; then
+        container_id=$(get_container_id "$service")
+        if [ -n "$container_id" ]; then
+            logs=$(docker logs "$container_id" 2>&1 || true)
+        fi
+    fi
+
     if [ -z "$logs" ]; then
         fail_msg "$service (no logs found)"
         return
@@ -45,6 +90,17 @@ check_logs() {
     pass_msg "$service"
 }
 
+check_logs_if_running() {
+    service="$1"
+    shift
+
+    if is_service_running "$service"; then
+        check_logs "$service" "$@"
+    else
+        pass_msg "$service (skipped: service not running)"
+    fi
+}
+
 echo ""
 echo "=== Checking service startup logs ==="
 echo ""
@@ -55,8 +111,12 @@ check_logs db \
 check_logs auth \
     'db worker started'
 
-check_logs kong \
+check_logs_if_running kong \
     'init.lua.*declarative config loaded'
+
+check_logs_if_running api-gw \
+     'Envoy configuration generated successfully' \
+     'Starting Envoy...'
 
 check_logs rest \
     'Schema cache loaded in.*milliseconds'
@@ -79,7 +139,7 @@ check_logs meta \
 check_logs functions \
     'main function started'
 
-check_logs analytics \
+check_logs_if_running analytics \
     'Access LogflareWeb.Endpoint at http://localhost:4000' \
     'Executing startup tasks' \
     'Ensuring single tenant user is seeded'
@@ -88,7 +148,7 @@ check_logs supavisor \
     'Connected to Postgres database' \
     'HEAD /api/health$'
 
-check_logs vector \
+check_logs_if_running vector \
     'Vector has started'
 
 check_logs imgproxy \


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

 `docker/tests/test-container-logs.sh` fails or produces false negatives in two scenarios:

  1. **Compose file mismatch:** If the stack was started with a different set of compose override files (e.g. `docker compose -f docker-compose.yml -f docker-compose.envoy.yml up`) than what the test shell has loaded, `docker compose ps` and `docker compose logs` cannot see the containers, causing all log checks to fail with "no logs found".
  2. **Optional services not running:** The script hard-fails for optional services such as `kong`, `analytics`, and `vector` when they are disabled or not running.

## What is the new behavior?

- Introduces `is_service_running()` and `get_container_id()` helpers that fall back to `docker ps` filters on `com.docker.compose.project` and `com.docker.compose.service` labels. This finds containers regardless of which `-f` flags were used during `up`.
- Updates `check_logs()` to fall back to `docker logs <container_id>` when `docker compose logs` returns empty.
- Adds `check_logs_if_running()` to gracefully skip log verification for optional services instead of failing.
- Applies the conditional check to `kong`, `api-gw`, `analytics`, and `vector`.
- Adds log pattern checks for the new `api-gw` (Envoy) service.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved container log collection reliability in test infrastructure by implementing fallback mechanisms for unavailable Docker Compose log output.
  * Enhanced service status detection to conditionally run log pattern checks only for active services.
  * Optimized container identification process to work even when standard CLI output is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46099?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->