### PR TITLE
chore: remove `<Accordion>` `_Shadcn_` suffix

### DIFF
--- a/apps/design-system/components/mdx-components.tsx
+++ b/apps/design-system/components/mdx-components.tsx
@@ -7,10 +7,10 @@ import * as React from 'react'
 // import { NpmCommands } from 'types/unist'
 // import { Event } from '@/lib/events'
 import {
-  Accordion_Shadcn_ as Accordion,
-  AccordionContent_Shadcn_ as AccordionContent,
-  AccordionItem_Shadcn_ as AccordionItem,
-  AccordionTrigger_Shadcn_ as AccordionTrigger,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Alert,
   AlertDescription,
   AlertTitle,

--- a/apps/design-system/registry/default/example/accordion-demo.tsx
+++ b/apps/design-system/registry/default/example/accordion-demo.tsx
@@ -1,31 +1,24 @@
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from 'ui'
 
 export default function AccordionDemo() {
   return (
-    <Accordion_Shadcn_ type="single" collapsible className="w-full">
-      <AccordionItem_Shadcn_ value="item-1">
-        <AccordionTrigger_Shadcn_>Is it accessible?</AccordionTrigger_Shadcn_>
-        <AccordionContent_Shadcn_>
-          Yes. It adheres to the WAI-ARIA design pattern.
-        </AccordionContent_Shadcn_>
-      </AccordionItem_Shadcn_>
-      <AccordionItem_Shadcn_ value="item-2">
-        <AccordionTrigger_Shadcn_>Is it styled?</AccordionTrigger_Shadcn_>
-        <AccordionContent_Shadcn_>
+    <Accordion type="single" collapsible className="w-full">
+      <AccordionItem value="item-1">
+        <AccordionTrigger>Is it accessible?</AccordionTrigger>
+        <AccordionContent>Yes. It adheres to the WAI-ARIA design pattern.</AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-2">
+        <AccordionTrigger>Is it styled?</AccordionTrigger>
+        <AccordionContent>
           Yes. It comes with default styles that matches the other components&apos; aesthetic.
-        </AccordionContent_Shadcn_>
-      </AccordionItem_Shadcn_>
-      <AccordionItem_Shadcn_ value="item-3">
-        <AccordionTrigger_Shadcn_>Is it animated?</AccordionTrigger_Shadcn_>
-        <AccordionContent_Shadcn_>
+        </AccordionContent>
+      </AccordionItem>
+      <AccordionItem value="item-3">
+        <AccordionTrigger>Is it animated?</AccordionTrigger>
+        <AccordionContent>
           Yes. Its animated by default, but you can disable it if you prefer.
-        </AccordionContent_Shadcn_>
-      </AccordionItem_Shadcn_>
-    </Accordion_Shadcn_>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   )
 }

--- a/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/GlobalMobileMenu.tsx
@@ -7,14 +7,7 @@ import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { Dispatch, Fragment, SetStateAction, useEffect } from 'react'
 import { useKey } from 'react-use'
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-  Button,
-  cn,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button, cn } from 'ui'
 import { ThemeToggle } from 'ui-patterns/ThemeToggle'
 
 import type { DropdownMenuItem } from '../Navigation.types'
@@ -42,7 +35,7 @@ const AccordionMenuItem = ({ section }: { section: DropdownMenuItem[] }) => {
   const activeLabel = useActiveMenuLabel(GLOBAL_MENU_ITEMS)
 
   return section[0].menuItems ? (
-    <AccordionItem_Shadcn_
+    <AccordionItem
       value={section[0].label}
       className={cn(
         'relative',
@@ -50,8 +43,8 @@ const AccordionMenuItem = ({ section }: { section: DropdownMenuItem[] }) => {
         itemClassName
       )}
     >
-      <AccordionTrigger_Shadcn_ className="py-1">{section[0].label}</AccordionTrigger_Shadcn_>
-      <AccordionContent_Shadcn_>
+      <AccordionTrigger className="py-1">{section[0].label}</AccordionTrigger>
+      <AccordionContent>
         {section[0].menuItems?.map((menuItem, menuItemIndex) => (
           <Fragment key={`desktop-docs-menu-section-${menuItemIndex}`}>
             {menuItem
@@ -76,8 +69,8 @@ const AccordionMenuItem = ({ section }: { section: DropdownMenuItem[] }) => {
               )}
           </Fragment>
         ))}
-      </AccordionContent_Shadcn_>
-    </AccordionItem_Shadcn_>
+      </AccordionContent>
+    </AccordionItem>
   ) : (
     <Link
       href={section[0].href || '#'}
@@ -89,11 +82,11 @@ const AccordionMenuItem = ({ section }: { section: DropdownMenuItem[] }) => {
 }
 
 const Menu = () => (
-  <Accordion_Shadcn_ type="multiple" className="space-y-1 mt-2.5">
+  <Accordion type="multiple" className="space-y-1 mt-2.5">
     {GLOBAL_MENU_ITEMS.filter((section) => section[0].enabled !== false).map((section, index) => (
       <AccordionMenuItem key={index} section={section} />
     ))}
-  </Accordion_Shadcn_>
+  </Accordion>
 )
 interface Props {
   open: boolean

--- a/apps/docs/features/ui/Accordion.tsx
+++ b/apps/docs/features/ui/Accordion.tsx
@@ -2,17 +2,17 @@
 
 import React, { ComponentProps, useState } from 'react'
 import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
+  AccordionContent,
+  AccordionTrigger,
+  Accordion as BaseAccordion,
+  AccordionItem as BaseAccordionItem,
   cn,
 } from 'ui'
 
 type Type = 'default' | 'bordered'
 type Align = 'left' | 'right'
 
-type BaseAccordionProps = ComponentProps<typeof Accordion_Shadcn_>
+type BaseAccordionProps = ComponentProps<typeof Accordion>
 
 export interface AccordionProps {
   children?: React.ReactNode
@@ -39,14 +39,14 @@ export function Accordion({
 }: AccordionProps) {
   return (
     // @ts-expect-error: This is because the Radix component has 2 interfaces discriminated by its type prop. Safe to ignore
-    <Accordion_Shadcn_
+    <BaseAccordion
       type={openBehaviour}
       onValueChange={onChange}
       defaultValue={defaultValue}
       className={className}
     >
       {children}
-    </Accordion_Shadcn_>
+    </BaseAccordion>
   )
 }
 
@@ -63,7 +63,7 @@ export function AccordionItem({ children, className, header, id, disabled }: Ite
   const [open, setOpen] = useState(false)
 
   return (
-    <AccordionItem_Shadcn_
+    <BaseAccordionItem
       value={id}
       // my-0 is required to avoid issues with the prose classes
       className={cn('*:my-0', className)}
@@ -72,8 +72,8 @@ export function AccordionItem({ children, className, header, id, disabled }: Ite
         setOpen(!open)
       }}
     >
-      <AccordionTrigger_Shadcn_ className="text-sm">{header}</AccordionTrigger_Shadcn_>
-      <AccordionContent_Shadcn_>{children}</AccordionContent_Shadcn_>
-    </AccordionItem_Shadcn_>
+      <AccordionTrigger className="text-sm">{header}</AccordionTrigger>
+      <AccordionContent>{children}</AccordionContent>
+    </BaseAccordionItem>
   )
 }

--- a/apps/learn/components/mdx-components.tsx
+++ b/apps/learn/components/mdx-components.tsx
@@ -1,13 +1,7 @@
 import { useMDXComponent } from 'next-contentlayer2/hooks'
 import Link from 'next/link'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, cn } from 'ui'
 
-import {
-  Accordion_Shadcn_ as Accordion,
-  AccordionContent_Shadcn_ as AccordionContent,
-  AccordionItem_Shadcn_ as AccordionItem,
-  AccordionTrigger_Shadcn_ as AccordionTrigger,
-  cn,
-} from 'ui'
 import { Callout } from './callout'
 import { CopyButton } from './copy-button'
 import TanStackBeta from './tanstack-beta'

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AdvancedSettings.tsx
@@ -1,10 +1,10 @@
 import type { ChangeEvent } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Badge,
   FormControl,
   FormField,
@@ -37,17 +37,17 @@ export const AdvancedSettings = ({
 
   return (
     <div className="px-5">
-      <Accordion_Shadcn_ type="single" collapsible>
-        <AccordionItem_Shadcn_ value="item-1" className="border-none">
-          <AccordionTrigger_Shadcn_ className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
+      <Accordion type="single" collapsible>
+        <AccordionItem value="item-1" className="border-none">
+          <AccordionTrigger className="font-normal gap-2 justify-between text-sm py-3 hover:no-underline">
             <div className="flex flex-col items-start gap-0.5">
               <span className="text-sm font-medium">Advanced settings</span>
               <span className="text-sm text-foreground-lighter font-normal">
                 Optional performance tuning
               </span>
             </div>
-          </AccordionTrigger_Shadcn_>
-          <AccordionContent_Shadcn_ className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
+          </AccordionTrigger>
+          <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
             {/* Batch wait time - applies to all destinations */}
             <FormField
               control={form.control}
@@ -275,9 +275,9 @@ export const AdvancedSettings = ({
                 />
               </>
             )}
-          </AccordionContent_Shadcn_>
-        </AccordionItem_Shadcn_>
-      </Accordion_Shadcn_>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationFailuresSection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationFailuresSection.tsx
@@ -1,11 +1,4 @@
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-  Badge,
-  Card,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge, Card } from 'ui'
 import { Admonition } from 'ui-patterns'
 
 import type { ValidationFailure } from '@/data/replication/validate-destination-mutation'
@@ -45,27 +38,23 @@ export const ValidationFailuresSection = ({
           : 'The following issues were identified, although you may still proceed to create the destination.'}
       </p>
       <Card>
-        <Accordion_Shadcn_ type="multiple">
+        <Accordion type="multiple">
           {validationIssues.map((failure, idx) => (
-            <AccordionItem_Shadcn_
-              key={idx}
-              value={`${failure.name}+${idx}`}
-              className="last:border-b-0"
-            >
-              <AccordionTrigger_Shadcn_ className="text-sm px-3 text-foreground decoration-foreground-lighter">
+            <AccordionItem key={idx} value={`${failure.name}+${idx}`} className="last:border-b-0">
+              <AccordionTrigger className="text-sm px-3 text-foreground decoration-foreground-lighter">
                 <p className="flex items-center gap-x-2">
                   {failure.name}
                   {failure.failure_type === 'critical' && <Badge variant="warning">Required</Badge>}
                 </p>
-              </AccordionTrigger_Shadcn_>
-              <AccordionContent_Shadcn_ className="px-3">
+              </AccordionTrigger>
+              <AccordionContent className="px-3">
                 <p className="whitespace-pre-wrap text-sm">
                   {failure.reason.replaceAll('\n\n', '\n')}
                 </p>
-              </AccordionContent_Shadcn_>
-            </AccordionItem_Shadcn_>
+              </AccordionContent>
+            </AccordionItem>
           ))}
-        </Accordion_Shadcn_>
+        </Accordion>
       </Card>
     </Admonition>
   )

--- a/apps/studio/components/interfaces/Database/Triggers/ChooseFunctionForm.tsx
+++ b/apps/studio/components/interfaces/Database/Triggers/ChooseFunctionForm.tsx
@@ -3,14 +3,7 @@ import { map as lodashMap, uniqBy } from 'lodash'
 import { HelpCircle, Terminal } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-  Button,
-  SidePanel,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button, SidePanel } from 'ui'
 
 import ProductEmptyState from '@/components/to-be-cleaned/ProductEmptyState'
 import InformationBox from '@/components/ui/InformationBox'
@@ -152,8 +145,8 @@ export interface FunctionProps {
 const Function = ({ id, completeStatement, name, onClick }: FunctionProps) => {
   return (
     <div className="cursor-pointer rounded-sm p-3 px-6 hover:bg-studio" onClick={() => onClick(id)}>
-      <Accordion_Shadcn_ type="single" collapsible>
-        <AccordionItem_Shadcn_ value="definition" className="border-none">
+      <Accordion type="single" collapsible>
+        <AccordionItem value="definition" className="border-none">
           <div className="flex items-center justify-between space-x-3">
             <div className="flex items-center space-x-3">
               <div className="flex items-center justify-center rounded-sm bg-foreground p-1 text-background">
@@ -161,20 +154,20 @@ const Function = ({ id, completeStatement, name, onClick }: FunctionProps) => {
               </div>
               <p className="mb-0 text-sm">{name}</p>
             </div>
-            <AccordionTrigger_Shadcn_
+            <AccordionTrigger
               onClick={(e) => e.stopPropagation()}
               className="py-0 text-xs font-normal text-foreground-light hover:no-underline"
             >
               View definition
-            </AccordionTrigger_Shadcn_>
+            </AccordionTrigger>
           </div>
-          <AccordionContent_Shadcn_ className="[&>div]:pb-0" onClick={(e) => e.stopPropagation()}>
+          <AccordionContent className="[&>div]:pb-0" onClick={(e) => e.stopPropagation()}>
             <div className="mt-4 h-64 border border-default">
               <SqlEditor defaultValue={completeStatement} readOnly={true} contextmenu={false} />
             </div>
-          </AccordionContent_Shadcn_>
-        </AccordionItem_Shadcn_>
-      </Accordion_Shadcn_>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/ErrorHandling/TroubleshootingAccordion.tsx
+++ b/apps/studio/components/interfaces/ErrorHandling/TroubleshootingAccordion.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { ReactNode } from 'react'
-import { Accordion_Shadcn_ as Accordion, cn } from 'ui'
+import { Accordion, cn } from 'ui'
 
 import { useTrack } from '@/lib/telemetry/track'
 

--- a/apps/studio/components/interfaces/ErrorHandling/TroubleshootingSections.tsx
+++ b/apps/studio/components/interfaces/ErrorHandling/TroubleshootingSections.tsx
@@ -2,12 +2,7 @@
 
 import { ExternalLink } from 'lucide-react'
 import { useState } from 'react'
-import {
-  AccordionContent_Shadcn_ as AccordionContent,
-  AccordionItem_Shadcn_ as AccordionItem,
-  AccordionTrigger_Shadcn_ as AccordionTrigger,
-  Button,
-} from 'ui'
+import { AccordionContent, AccordionItem, AccordionTrigger, Button } from 'ui'
 
 import { RestartProjectDialog } from './RestartProjectDialog'
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CronJobScheduleSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CreateCronJobSheet/CronJobScheduleSection.tsx
@@ -2,10 +2,10 @@ import { motion } from 'framer-motion'
 import { useEffect, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Button,
   cn,
   FormControl,
@@ -148,16 +148,16 @@ export const CronJobScheduleSection = ({ form, supportsSeconds }: CronJobSchedul
                     </li>
                   ))}
                 </ul>
-                <Accordion_Shadcn_ type="single" collapsible>
-                  <AccordionItem_Shadcn_ value="item-1" className="border-none">
-                    <AccordionTrigger_Shadcn_ className="text-xs text-foreground-light font-normal gap-2 justify-start py-1 ">
+                <Accordion type="single" collapsible>
+                  <AccordionItem value="item-1" className="border-none">
+                    <AccordionTrigger className="text-xs text-foreground-light font-normal gap-2 justify-start py-1 ">
                       View syntax chart
-                    </AccordionTrigger_Shadcn_>
-                    <AccordionContent_Shadcn_ asChild className="pb-0!">
+                    </AccordionTrigger>
+                    <AccordionContent asChild className="pb-0!">
                       <CronSyntaxChart />
-                    </AccordionContent_Shadcn_>
-                  </AccordionItem_Shadcn_>
-                </Accordion_Shadcn_>
+                    </AccordionContent>
+                  </AccordionItem>
+                </Accordion>
               </div>
               <div className="bg-surface-100 p-4 rounded-sm grid gap-y-4 border">
                 <h4 className="text-sm text-foreground">

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
@@ -1,9 +1,9 @@
 import { type Dispatch, type SetStateAction } from 'react'
 import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Badge,
   Select,
   SelectContent,
@@ -54,12 +54,12 @@ export const AdvancedSettings = ({
 
   return (
     <SheetSection>
-      <Accordion_Shadcn_ type="single" collapsible>
-        <AccordionItem_Shadcn_ value="advanced-settings" className="border-none">
-          <AccordionTrigger_Shadcn_ className="font-normal gap-2 py-0 justify-between text-sm hover:no-underline">
+      <Accordion type="single" collapsible>
+        <AccordionItem value="advanced-settings" className="border-none">
+          <AccordionTrigger className="font-normal gap-2 py-0 justify-between text-sm hover:no-underline">
             Advanced settings
-          </AccordionTrigger_Shadcn_>
-          <AccordionContent_Shadcn_ className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
+          </AccordionTrigger>
+          <AccordionContent className="pb-0! pt-3 [&>div]:flex [&>div]:flex-col [&>div]:gap-y-4">
             <p className="text-foreground-light">
               Select which schemas to install the database extensions under
             </p>
@@ -161,9 +161,9 @@ export const AdvancedSettings = ({
                 </FormItemLayout>
               )
             })}
-          </AccordionContent_Shadcn_>
-        </AccordionItem_Shadcn_>
-      </Accordion_Shadcn_>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </SheetSection>
   )
 }

--- a/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
+++ b/apps/studio/components/interfaces/Platform/Webhooks/PlatformWebhooksEndpointSheet.tsx
@@ -3,10 +3,10 @@ import { ChevronDown } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import {
-  Accordion_Shadcn_ as Accordion,
-  AccordionContent_Shadcn_ as AccordionContent,
-  AccordionItem_Shadcn_ as AccordionItem,
-  AccordionTrigger_Shadcn_ as AccordionTrigger,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Button,
   Checkbox,
   cn,

--- a/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
@@ -2,9 +2,9 @@ import { AccordionTrigger } from '@ui/components/shadcn/ui/accordion'
 import { Check, Lightbulb, Table2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
   Alert,
   AlertDescription,
   AlertTitle,
@@ -389,22 +389,22 @@ export const QueryIndexes = ({
           <QueryPanelSection className="py-6 border-t">
             <div className="flex flex-col gap-y-2">
               <h4 className="mb-2">FAQ</h4>
-              <Accordion_Shadcn_ collapsible type="single" className="border rounded-md">
-                <AccordionItem_Shadcn_ value="1">
+              <Accordion collapsible type="single" className="border rounded-md">
+                <AccordionItem value="1">
                   <AccordionTrigger className="px-4 py-3 text-sm font-normal text-foreground-light hover:text-foreground transition data-open:text-foreground">
                     What units are cost in?
                   </AccordionTrigger>
-                  <AccordionContent_Shadcn_ className="px-4 text-foreground-light">
+                  <AccordionContent className="px-4 text-foreground-light">
                     Costs are in an arbitrary unit, and do not represent a unit of time. The units
                     are anchored (by default) to a single sequential page read costing 1.0 units.
                     They do, however, serve as a predictor of higher execution times.
-                  </AccordionContent_Shadcn_>
-                </AccordionItem_Shadcn_>
-                <AccordionItem_Shadcn_ value="2" className="border-b-0">
+                  </AccordionContent>
+                </AccordionItem>
+                <AccordionItem value="2" className="border-b-0">
                   <AccordionTrigger className="px-4 py-3 text-sm font-normal text-foreground-light hover:text-foreground transition data-open:text-foreground">
                     How should I prioritize start up and total cost?
                   </AccordionTrigger>
-                  <AccordionContent_Shadcn_ className="px-4 text-foreground-light [&>div]:space-y-2">
+                  <AccordionContent className="px-4 text-foreground-light [&>div]:space-y-2">
                     <p>This depends on the expected size of the result set from the query.</p>
                     <p>
                       For queries that return a small number or rows, the startup cost is more
@@ -416,9 +416,9 @@ export const QueryIndexes = ({
                       important, and optimizing it will help in efficiently using resources and
                       reducing overall query execution time.
                     </p>
-                  </AccordionContent_Shadcn_>
-                </AccordionItem_Shadcn_>
-              </Accordion_Shadcn_>
+                  </AccordionContent>
+                </AccordionItem>
+              </Accordion>
             </div>
           </QueryPanelSection>
         </>

--- a/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/ResourcesExceededErrorRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogsErrorRenderers/ResourcesExceededErrorRenderer.tsx
@@ -1,9 +1,9 @@
 import { useState } from 'react'
 import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   copyToClipboard,
   InputGroup,
   InputGroupAddon,
@@ -27,10 +27,10 @@ const ResourcesExceededErrorRenderer: React.FC<ErrorRendererProps> = ({ error, i
         </p>
         {!isCustomQuery && <p>Please contact support if this error persists.</p>}
       </div>
-      <Accordion_Shadcn_ className="text-sm" type="single">
-        <AccordionItem_Shadcn_ value="1">
-          <AccordionTrigger_Shadcn_>Full error message</AccordionTrigger_Shadcn_>
-          <AccordionContent_Shadcn_>
+      <Accordion className="text-sm" type="single">
+        <AccordionItem value="1">
+          <AccordionTrigger>Full error message</AccordionTrigger>
+          <AccordionContent>
             <InputGroup>
               <InputGroupTextarea value={errorAsJson} className="font-mono" rows={5} />
               <InputGroupAddon align="block-end">
@@ -50,9 +50,9 @@ const ResourcesExceededErrorRenderer: React.FC<ErrorRendererProps> = ({ error, i
                 </InputGroupButton>
               </InputGroupAddon>
             </InputGroup>
-          </AccordionContent_Shadcn_>
-        </AccordionItem_Shadcn_>
-      </Accordion_Shadcn_>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableInstructions.tsx
+++ b/apps/studio/components/interfaces/Storage/AnalyticsBuckets/AnalyticsBucketDetails/CreateTable/CreateTableInstructions.tsx
@@ -2,10 +2,10 @@ import { useParams } from 'common'
 import { Eye, EyeOff } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
   Card,
   CardFooter,
   CardHeader,
@@ -111,9 +111,9 @@ export const CreateTableInstructions = ({
         </CardHeader>
       )}
 
-      <Accordion_Shadcn_ defaultValue={['step-1']} type="multiple">
-        <AccordionItem_Shadcn_ value="step-1">
-          <AccordionTrigger_Shadcn_ className="px-6 py-3 text-sm">
+      <Accordion defaultValue={['step-1']} type="multiple">
+        <AccordionItem value="step-1">
+          <AccordionTrigger className="px-6 py-3 text-sm">
             <div className="flex items-center gap-x-4">
               <div className="w-6 h-6 rounded-full border flex items-center justify-center text-xs font-mono">
                 1
@@ -122,8 +122,8 @@ export const CreateTableInstructions = ({
                 Set up Python project with <code>uv</code>
               </p>
             </div>
-          </AccordionTrigger_Shadcn_>
-          <AccordionContent_Shadcn_ className="border-0 px-6 pt-1">
+          </AccordionTrigger>
+          <AccordionContent className="border-0 px-6 pt-1">
             <CommandRender
               commands={[
                 {
@@ -143,11 +143,11 @@ export const CreateTableInstructions = ({
                 },
               ]}
             />
-          </AccordionContent_Shadcn_>
-        </AccordionItem_Shadcn_>
+          </AccordionContent>
+        </AccordionItem>
 
-        <AccordionItem_Shadcn_ value="step-2">
-          <AccordionTrigger_Shadcn_ className="px-6 py-3 text-sm">
+        <AccordionItem value="step-2">
+          <AccordionTrigger className="px-6 py-3 text-sm">
             <div className="flex items-center gap-x-4">
               <div className="w-6 h-6 rounded-full border flex items-center justify-center text-xs font-mono">
                 2
@@ -156,8 +156,8 @@ export const CreateTableInstructions = ({
                 Replace <code>main.py</code> with the following snippet
               </p>
             </div>
-          </AccordionTrigger_Shadcn_>
-          <AccordionContent_Shadcn_ className="border-0 px-6 pt-2">
+          </AccordionTrigger>
+          <AccordionContent className="border-0 px-6 pt-2">
             <p className="text-foreground mb-3 prose max-w-full text-sm">
               The following snippet creates a namespace <code>default</code>, then creates a sample
               table
@@ -226,19 +226,19 @@ export const CreateTableInstructions = ({
                 />
               </div>
             </div>
-          </AccordionContent_Shadcn_>
-        </AccordionItem_Shadcn_>
+          </AccordionContent>
+        </AccordionItem>
 
-        <AccordionItem_Shadcn_ value="step-3">
-          <AccordionTrigger_Shadcn_ className="px-6 py-3 text-sm">
+        <AccordionItem value="step-3">
+          <AccordionTrigger className="px-6 py-3 text-sm">
             <div className="flex items-center gap-x-4">
               <div className="w-6 h-6 rounded-full border flex items-center justify-center text-xs font-mono">
                 3
               </div>
               <p className="prose text-sm font-normal">Run the Python script</p>
             </div>
-          </AccordionTrigger_Shadcn_>
-          <AccordionContent_Shadcn_ className="border-0 px-6 pt-2">
+          </AccordionTrigger>
+          <AccordionContent className="border-0 px-6 pt-2">
             <CommandRender
               commands={[
                 {
@@ -248,9 +248,9 @@ export const CreateTableInstructions = ({
                 },
               ]}
             />
-          </AccordionContent_Shadcn_>
-        </AccordionItem_Shadcn_>
-      </Accordion_Shadcn_>
+          </AccordionContent>
+        </AccordionItem>
+      </Accordion>
 
       <CardFooter className="bg">
         <p className="text-xs text-foreground-light">

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterControls.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterControls.tsx
@@ -1,9 +1,4 @@
-import {
-  Accordion_Shadcn_ as Accordion,
-  AccordionContent_Shadcn_ as AccordionContent,
-  AccordionItem_Shadcn_ as AccordionItem,
-  AccordionTrigger_Shadcn_ as AccordionTrigger,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from 'ui'
 
 import { DateRangeDisabled } from '../DataTable.types'
 import { useDataTable } from '../providers/DataTableProvider'

--- a/apps/ui-library/components/mdx-components.tsx
+++ b/apps/ui-library/components/mdx-components.tsx
@@ -1,12 +1,6 @@
 import { useMDXComponent } from 'next-contentlayer2/hooks'
 import Link from 'next/link'
-import {
-  Accordion_Shadcn_ as Accordion,
-  AccordionContent_Shadcn_ as AccordionContent,
-  AccordionItem_Shadcn_ as AccordionItem,
-  AccordionTrigger_Shadcn_ as AccordionTrigger,
-  cn,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, cn } from 'ui'
 
 import { BlockItem } from './block-item'
 import { BlockPreview } from './block-preview'

--- a/apps/www/components/LaunchWeek/7/Releases/index.tsx
+++ b/apps/www/components/LaunchWeek/7/Releases/index.tsx
@@ -4,12 +4,7 @@ import { useBreakpoint } from 'common/hooks/useBreakpoint'
 import { motion } from 'framer-motion'
 import Image from 'next/image'
 import { useEffect } from 'react'
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from 'ui'
 
 import {
   AccordionHeader,
@@ -249,21 +244,21 @@ export default function LW7Releases() {
         </div>
       </SectionContainer>
       <SectionContainer className="pt-0! w-full! px-0! max-w-none!">
-        <Accordion_Shadcn_ type="multiple" className="text-white" defaultValue={publishedSections}>
-          <AccordionItem_Shadcn_
+        <Accordion type="multiple" className="text-white" defaultValue={publishedSections}>
+          <AccordionItem
             key={preRelease.dd}
             disabled={!prereleaseShipped}
             value={preRelease.d.toString()}
           >
-            <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+            <AccordionTrigger className="py-8 font-normal hover:no-underline">
               <AccordionHeader
                 date={preRelease.date}
                 day={preRelease.dd}
                 title={preRelease.title}
                 shipped={prereleaseShipped}
               />
-            </AccordionTrigger_Shadcn_>
-            <AccordionContent_Shadcn_>
+            </AccordionTrigger>
+            <AccordionContent>
               {preRelease.steps.length > 0 && (
                 <div className="h-[800px] lg:h-[400px] flex flex-col gap-5 lg:flex-row">
                   <motion.div
@@ -367,18 +362,18 @@ export default function LW7Releases() {
                   </motion.div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_ disabled={!day1Shipped} value={day1.d.toString()}>
-            <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem disabled={!day1Shipped} value={day1.d.toString()}>
+            <AccordionTrigger className="py-8 font-normal hover:no-underline">
               <AccordionHeader
                 date={day1.date}
                 day={day1.dd}
                 title={day1.title}
                 shipped={day1Shipped}
               />
-            </AccordionTrigger_Shadcn_>
-            <AccordionContent_Shadcn_>
+            </AccordionTrigger>
+            <AccordionContent>
               {day1.steps.length > 0 && (
                 <div className="h-[400px] flex flex-col gap-5 lg:flex-row">
                   <motion.div
@@ -437,18 +432,18 @@ export default function LW7Releases() {
                   </motion.div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_ disabled={!day2Shipped} value={day2.d.toString()}>
-            <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem disabled={!day2Shipped} value={day2.d.toString()}>
+            <AccordionTrigger className="py-8 font-normal hover:no-underline">
               <AccordionHeader
                 date={day2.date}
                 day={day2.dd}
                 title={day2.title}
                 shipped={day2Shipped}
               />
-            </AccordionTrigger_Shadcn_>
-            <AccordionContent_Shadcn_>
+            </AccordionTrigger>
+            <AccordionContent>
               {day2.steps.length > 0 && (
                 <div className="h-[400px] flex flex-col gap-5 lg:flex-row">
                   <motion.div
@@ -507,18 +502,18 @@ export default function LW7Releases() {
                   </motion.div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_ disabled={!day3Shipped} value={day3.d.toString()}>
-            <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem disabled={!day3Shipped} value={day3.d.toString()}>
+            <AccordionTrigger className="py-8 font-normal hover:no-underline">
               <AccordionHeader
                 date={day3.date}
                 day={day3.dd}
                 title={day3.title}
                 shipped={day3Shipped}
               />
-            </AccordionTrigger_Shadcn_>
-            <AccordionContent_Shadcn_>
+            </AccordionTrigger>
+            <AccordionContent>
               {day3.steps.length > 0 && (
                 <div className="h-[400px] flex flex-col gap-5 lg:flex-row">
                   <motion.div
@@ -577,18 +572,18 @@ export default function LW7Releases() {
                   </motion.div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_ disabled={!day4Shipped} value={day4.d.toString()}>
-            <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem disabled={!day4Shipped} value={day4.d.toString()}>
+            <AccordionTrigger className="py-8 font-normal hover:no-underline">
               <AccordionHeader
                 date={day4.date}
                 day={day4.dd}
                 title={day4.title}
                 shipped={day4Shipped}
               />
-            </AccordionTrigger_Shadcn_>
-            <AccordionContent_Shadcn_>
+            </AccordionTrigger>
+            <AccordionContent>
               {day4.steps.length > 0 && (
                 <div className="h-[400px] flex flex-col gap-5 lg:flex-row">
                   <motion.div
@@ -645,22 +640,22 @@ export default function LW7Releases() {
                   </motion.div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_ disabled={!day5Shipped} value={day5.d.toString()}>
-            <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem disabled={!day5Shipped} value={day5.d.toString()}>
+            <AccordionTrigger className="py-8 font-normal hover:no-underline">
               <AccordionHeader
                 date={day5.date}
                 day={day5.dd}
                 title={day5.title}
                 shipped={day5Shipped}
               />
-            </AccordionTrigger_Shadcn_>
-            <AccordionContent_Shadcn_>
+            </AccordionTrigger>
+            <AccordionContent>
               <Day5 day={day5} />
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-        </Accordion_Shadcn_>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </SectionContainer>
     </>
   )

--- a/apps/www/components/LaunchWeek/8/Releases/index.tsx
+++ b/apps/www/components/LaunchWeek/8/Releases/index.tsx
@@ -2,13 +2,7 @@ import SectionContainer from '~/components/Layouts/SectionContainer'
 import { useBreakpoint } from 'common/hooks/useBreakpoint'
 import Image from 'next/image'
 import Link from 'next/link'
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-  cn,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, cn } from 'ui'
 
 import {
   AccordionHeader,
@@ -34,13 +28,13 @@ function LW8Releases() {
   return (
     <>
       <SectionContainer className="pt-0! w-full! px-0! max-w-none!">
-        <Accordion_Shadcn_ type="multiple" className="text-white" defaultValue={publishedSections}>
-          <AccordionItem_Shadcn_
+        <Accordion type="multiple" className="text-white" defaultValue={publishedSections}>
+          <AccordionItem
             key={preRelease.dd}
             value={preRelease.d.toString()}
             className="border-[#111718]"
           >
-            <AccordionTrigger_Shadcn_ className="py-2 font-normal hover:no-underline">
+            <AccordionTrigger className="py-2 font-normal hover:no-underline">
               <AccordionHeader
                 date={preRelease.date}
                 day={preRelease.d}
@@ -50,8 +44,8 @@ function LW8Releases() {
                 shippable={false}
                 publishedAt={preRelease.publishedAt}
               />
-            </AccordionTrigger_Shadcn_>
-            <AccordionContent_Shadcn_>
+            </AccordionTrigger>
+            <AccordionContent>
               {preRelease.steps.length > 0 && (
                 <div className="flex flex-col gap-5 lg:flex-row pb-4">
                   <div
@@ -192,13 +186,9 @@ function LW8Releases() {
                   </div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_
-            key={day1.dd}
-            value={day1.d.toString()}
-            className="border-[#111718]"
-          >
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem key={day1.dd} value={day1.d.toString()} className="border-[#111718]">
             <AccordionHeader
               date={day1.date}
               day={day1.d}
@@ -209,7 +199,7 @@ function LW8Releases() {
               youtube_id={day1.youtube_id}
               videoThumbnail={day1.videoThumbnail}
             />
-            <AccordionContent_Shadcn_>
+            <AccordionContent>
               {day1.steps.length > 0 && (
                 <div className="flex flex-col gap-5 lg:flex-row pb-4">
                   <div
@@ -265,13 +255,9 @@ function LW8Releases() {
                   </div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_
-            key={day2.dd}
-            value={day2.d.toString()}
-            className="border-[#111718]"
-          >
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem key={day2.dd} value={day2.d.toString()} className="border-[#111718]">
             <AccordionHeader
               date={day2.date}
               day={day2.d}
@@ -282,7 +268,7 @@ function LW8Releases() {
               youtube_id={day2.youtube_id}
               videoThumbnail={day2.videoThumbnail}
             />
-            <AccordionContent_Shadcn_>
+            <AccordionContent>
               {day2.steps.length > 0 && (
                 <div className="flex flex-col gap-5 lg:flex-row pb-4">
                   <div
@@ -335,13 +321,9 @@ function LW8Releases() {
                   </div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_
-            key={day3.dd}
-            value={day3.d.toString()}
-            className="border-[#111718]"
-          >
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem key={day3.dd} value={day3.d.toString()} className="border-[#111718]">
             <AccordionHeader
               date={day3.date}
               day={day3.d}
@@ -352,7 +334,7 @@ function LW8Releases() {
               youtube_id={day3.youtube_id}
               videoThumbnail={day3.videoThumbnail}
             />
-            <AccordionContent_Shadcn_>
+            <AccordionContent>
               {day3.steps.length > 0 && (
                 <div className="flex flex-col gap-5 lg:flex-row pb-4">
                   <div
@@ -417,13 +399,9 @@ function LW8Releases() {
                   </div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_
-            key={day4.dd}
-            value={day4.d.toString()}
-            className="border-[#111718]"
-          >
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem key={day4.dd} value={day4.d.toString()} className="border-[#111718]">
             <AccordionHeader
               date={day4.date}
               day={day4.d}
@@ -434,7 +412,7 @@ function LW8Releases() {
               youtube_id={day4.youtube_id}
               videoThumbnail={day4.videoThumbnail}
             />
-            <AccordionContent_Shadcn_>
+            <AccordionContent>
               {day4.steps.length > 0 && (
                 <div className="flex flex-col gap-5 lg:flex-row pb-4">
                   <div
@@ -527,13 +505,9 @@ function LW8Releases() {
                   </div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-          <AccordionItem_Shadcn_
-            key={day5.dd}
-            value={day5.d.toString()}
-            className="border-[#111718]"
-          >
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem key={day5.dd} value={day5.d.toString()} className="border-[#111718]">
             <AccordionHeader
               date={day5.date}
               day={day5.d}
@@ -544,7 +518,7 @@ function LW8Releases() {
               youtube_id={day5.youtube_id}
               videoThumbnail={day5.videoThumbnail}
             />
-            <AccordionContent_Shadcn_>
+            <AccordionContent>
               {day5.steps.length > 0 && (
                 <div className="flex flex-col pb-4">
                   <div
@@ -689,9 +663,9 @@ function LW8Releases() {
                   </div>
                 </div>
               )}
-            </AccordionContent_Shadcn_>
-          </AccordionItem_Shadcn_>
-        </Accordion_Shadcn_>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
       </SectionContainer>
     </>
   )

--- a/apps/www/components/Nav/MobileMenu.tsx
+++ b/apps/www/components/Nav/MobileMenu.tsx
@@ -6,13 +6,7 @@ import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-  Button,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button } from 'ui'
 import { TextLink } from 'ui-patterns/TextLink'
 
 import MenuItem from './MenuItem'
@@ -57,7 +51,7 @@ const MobileMenu = ({ open, setOpen, menu }: Props) => {
   }, [setOpen])
 
   const AccordionMenuItem = ({ menuItem }: any) => (
-    <AccordionContent_Shadcn_ className="p-0">
+    <AccordionContent className="p-0">
       {menuItem.title === 'Product' ? (
         <>
           {Object.values(menuItem.subMenu)?.map((component: any) => (
@@ -171,24 +165,20 @@ const MobileMenu = ({ open, setOpen, menu }: Props) => {
           ))}
         </div>
       ) : null}
-    </AccordionContent_Shadcn_>
+    </AccordionContent>
   )
 
   const Menu = () => (
-    <Accordion_Shadcn_ type="multiple" className="px-0">
+    <Accordion type="multiple" className="px-0">
       {menu.primaryNav.map((menuItem: any) => (
         <m.div variants={listItem} className="border-b [&>div]:rounded-none!">
           {menuItem.hasDropdown ? (
-            <AccordionItem_Shadcn_
-              id={menuItem.title}
-              value={menuItem.title}
-              className="border-none"
-            >
-              <AccordionTrigger_Shadcn_ className="py-2 pl-2 pr-4 text-base font-medium text-foreground hover:bg-surface-200">
+            <AccordionItem id={menuItem.title} value={menuItem.title} className="border-none">
+              <AccordionTrigger className="py-2 pl-2 pr-4 text-base font-medium text-foreground hover:bg-surface-200">
                 {menuItem.title}
-              </AccordionTrigger_Shadcn_>
+              </AccordionTrigger>
               <AccordionMenuItem menuItem={menuItem} />
-            </AccordionItem_Shadcn_>
+            </AccordionItem>
           ) : (
             <Link
               href={menuItem.url}
@@ -199,7 +189,7 @@ const MobileMenu = ({ open, setOpen, menu }: Props) => {
           )}
         </m.div>
       ))}
-    </Accordion_Shadcn_>
+    </Accordion>
   )
 
   return (

--- a/apps/www/components/Pricing/PricingFAQs.tsx
+++ b/apps/www/components/Pricing/PricingFAQs.tsx
@@ -3,12 +3,7 @@
 import pricingFaq from '~/data/PricingFAQ.json'
 import React from 'react'
 import ReactMarkdown from 'react-markdown'
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from 'ui'
 
 const PricingFAQs = () => {
   return (
@@ -16,24 +11,24 @@ const PricingFAQs = () => {
       <div className="sm:py-18 mx-auto px-6 py-16 md:py-24 lg:px-16 lg:py-24 xl:px-20">
         <h2 className="h3 text-center">Frequently asked questions</h2>
         <div className="my-16">
-          <Accordion_Shadcn_ type="multiple" className="text-foreground-light">
+          <Accordion type="multiple" className="text-foreground-light">
             {pricingFaq.map((faq, i) => {
               return (
                 <div className="border-b py-2" key={i}>
-                  <AccordionItem_Shadcn_ value={`faq--${i.toString()}`} className="border-none">
-                    <AccordionTrigger_Shadcn_>
+                  <AccordionItem value={`faq--${i.toString()}`} className="border-none">
+                    <AccordionTrigger>
                       <span className="text-foreground">{faq.question}</span>
-                    </AccordionTrigger_Shadcn_>
-                    <AccordionContent_Shadcn_>
+                    </AccordionTrigger>
+                    <AccordionContent>
                       <div className="prose text-foreground-lighter">
                         <ReactMarkdown>{faq.answer}</ReactMarkdown>
                       </div>
-                    </AccordionContent_Shadcn_>
-                  </AccordionItem_Shadcn_>
+                    </AccordionContent>
+                  </AccordionItem>
                 </div>
               )
             })}
-          </Accordion_Shadcn_>
+          </Accordion>
         </div>
         <p className="p text-center">
           Can&apos;t find the answer to your question?{' '}

--- a/apps/www/pages/launch-week/6/index.tsx
+++ b/apps/www/pages/launch-week/6/index.tsx
@@ -13,13 +13,7 @@ import { useTheme } from 'next-themes'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
 import { useEffect, useState } from 'react'
-import {
-  Accordion_Shadcn_,
-  AccordionContent_Shadcn_,
-  AccordionItem_Shadcn_,
-  AccordionTrigger_Shadcn_,
-  Badge,
-} from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge } from 'ui'
 
 import styles from './styles/launchWeek6.module.css'
 import styleUtils from './styles/utils6.module.css'
@@ -272,7 +266,7 @@ export default function launchweek() {
           </div>
         </SectionContainer>
         <SectionContainer className="pt-0!">
-          <Accordion_Shadcn_
+          <Accordion
             type="multiple"
             className="text-white"
             defaultValue={[
@@ -283,16 +277,16 @@ export default function launchweek() {
               day5.d?.toString(),
             ]}
           >
-            <AccordionItem_Shadcn_ key={day1.dd} disabled={!day1.shipped} value={day1.d.toString()}>
-              <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+            <AccordionItem key={day1.dd} disabled={!day1.shipped} value={day1.d.toString()}>
+              <AccordionTrigger className="py-8 font-normal hover:no-underline">
                 <AccordionHeader
                   date={day1.date}
                   day={day1.dd}
                   title={day1.title}
                   shipped={day1.shipped}
                 />
-              </AccordionTrigger_Shadcn_>
-              <AccordionContent_Shadcn_>
+              </AccordionTrigger>
+              <AccordionContent>
                 {day1.steps.length > 0 && (
                   <div className="h-[400px] flex flex-col lg:flex-row group/day1 relative overflow-hidden">
                     <div
@@ -318,18 +312,18 @@ export default function launchweek() {
                     </div>
                   </div>
                 )}
-              </AccordionContent_Shadcn_>
-            </AccordionItem_Shadcn_>
-            <AccordionItem_Shadcn_ key={day2.dd} disabled={!day2.shipped} value={day2.d.toString()}>
-              <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem key={day2.dd} disabled={!day2.shipped} value={day2.d.toString()}>
+              <AccordionTrigger className="py-8 font-normal hover:no-underline">
                 <AccordionHeader
                   date={day2.date}
                   day={day2.dd}
                   title={day2.title}
                   shipped={day2.shipped}
                 />
-              </AccordionTrigger_Shadcn_>
-              <AccordionContent_Shadcn_>
+              </AccordionTrigger>
+              <AccordionContent>
                 {day2.steps.length > 0 && (
                   <div className="h-[800px] lg:h-[400px] flex flex-col gap-5 lg:flex-row">
                     <div
@@ -369,18 +363,18 @@ export default function launchweek() {
                     </div>
                   </div>
                 )}
-              </AccordionContent_Shadcn_>
-            </AccordionItem_Shadcn_>
-            <AccordionItem_Shadcn_ key={day3.dd} disabled={!day3.shipped} value={day3.d.toString()}>
-              <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem key={day3.dd} disabled={!day3.shipped} value={day3.d.toString()}>
+              <AccordionTrigger className="py-8 font-normal hover:no-underline">
                 <AccordionHeader
                   date={day3.date}
                   day={day3.dd}
                   title={day3.title}
                   shipped={day3.shipped}
                 />
-              </AccordionTrigger_Shadcn_>
-              <AccordionContent_Shadcn_>
+              </AccordionTrigger>
+              <AccordionContent>
                 {day3.steps.length > 0 && (
                   <div className="h-[400px] flex gap-5 group">
                     <div
@@ -414,18 +408,18 @@ export default function launchweek() {
                     </div>
                   </div>
                 )}
-              </AccordionContent_Shadcn_>
-            </AccordionItem_Shadcn_>
-            <AccordionItem_Shadcn_ key={day4.dd} disabled={!day4.shipped} value={day4.d.toString()}>
-              <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem key={day4.dd} disabled={!day4.shipped} value={day4.d.toString()}>
+              <AccordionTrigger className="py-8 font-normal hover:no-underline">
                 <AccordionHeader
                   date={day4.date}
                   day={day4.dd}
                   title={day4.title}
                   shipped={day4.shipped}
                 />
-              </AccordionTrigger_Shadcn_>
-              <AccordionContent_Shadcn_>
+              </AccordionTrigger>
+              <AccordionContent>
                 {day4.steps.length > 0 && (
                   <div className="h-[400px]  flex flex-col gap-5 lg:flex-row group/day4 relative overflow-hidden">
                     <div
@@ -466,18 +460,18 @@ export default function launchweek() {
                     </div>
                   </div>
                 )}
-              </AccordionContent_Shadcn_>
-            </AccordionItem_Shadcn_>
-            <AccordionItem_Shadcn_ key={day5.dd} disabled={!day5.shipped} value={day5.d.toString()}>
-              <AccordionTrigger_Shadcn_ className="py-8 font-normal hover:no-underline">
+              </AccordionContent>
+            </AccordionItem>
+            <AccordionItem key={day5.dd} disabled={!day5.shipped} value={day5.d.toString()}>
+              <AccordionTrigger className="py-8 font-normal hover:no-underline">
                 <AccordionHeader
                   date={day5.date}
                   day={day5.dd}
                   title={day5.title}
                   shipped={day5.shipped}
                 />
-              </AccordionTrigger_Shadcn_>
-              <AccordionContent_Shadcn_>
+              </AccordionTrigger>
+              <AccordionContent>
                 {day5.steps.length > 0 && (
                   <>
                     <div className="h-[800px] lg:h-[400px]  flex flex-col gap-5 lg:flex-row">
@@ -844,9 +838,9 @@ export default function launchweek() {
                     </div>
                   </>
                 )}
-              </AccordionContent_Shadcn_>
-            </AccordionItem_Shadcn_>
-          </Accordion_Shadcn_>
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
         </SectionContainer>
 
         <SectionContainer className="py-20! sm:pb-40! sm:pt-10!"></SectionContainer>

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -87,12 +87,7 @@ export * from './src/components/shadcn/ui/form'
 
 export * from './src/components/shadcn/ui/popover'
 
-export {
-  Accordion as Accordion_Shadcn_,
-  AccordionItem as AccordionItem_Shadcn_,
-  AccordionTrigger as AccordionTrigger_Shadcn_,
-  AccordionContent as AccordionContent_Shadcn_,
-} from './src/components/shadcn/ui/accordion'
+export * from './src/components/shadcn/ui/accordion'
 
 export * from './src/components/shadcn/ui/select'
 


### PR DESCRIPTION
## Problem

The `_Shadcn_` suffix isn't needed anymore on Accordion components

## Solution

- Remove the `_Shadcn_` suffix
- Simplify UI package exports
- Apply prettier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated accordion component exports and imports to use unified naming conventions across the codebase, improving consistency for developers using the UI library.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46107?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->