### PR TITLE
debug: log ConfigCat user attributes to console

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -86,10 +86,7 @@ const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
   ? [{ id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> }]
   : []
 
-const FeatureFlagProviderWithOrgContext = ({
-  children,
-  ...props
-}: ComponentProps<typeof FeatureFlagProvider>) => {
+const FeatureFlagProviderWithOrgContext = ({ children, ...props }: ComponentProps<typeof FeatureFlagProvider>) => {
   const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
   const cloudProvider = useDefaultProvider()
 

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -86,7 +86,10 @@ const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
   ? [{ id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> }]
   : []
 
-const FeatureFlagProviderWithOrgContext = ({ children, ...props }: ComponentProps<typeof FeatureFlagProvider>) => {
+const FeatureFlagProviderWithOrgContext = ({
+  children,
+  ...props
+}: ComponentProps<typeof FeatureFlagProvider>) => {
   const { data: selectedOrganization } = useSelectedOrganizationQuery({ enabled: IS_PLATFORM })
   const cloudProvider = useDefaultProvider()
 

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -98,6 +98,7 @@ const FeatureFlagProviderWithOrgContext = ({
       const customAttributes: Record<string, string> = {}
       if (cloudProvider) customAttributes.cloud_provider = cloudProvider
       if (selectedOrganization?.plan?.id) customAttributes.plan = selectedOrganization.plan.id
+      console.log('[ConfigCat] user attributes', { userEmail, ...customAttributes })
       return getFlags(userEmail, customAttributes)
     },
     [cloudProvider, selectedOrganization?.plan?.id]


### PR DESCRIPTION
Temporary `console.log` to verify the `plan` attribute is being passed to ConfigCat correctly. Check the browser console in staging — you should see:

```
[ConfigCat] user attributes { userEmail: "...", cloud_provider: "AWS", plan: "pro" }
```

Close this PR once confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)