### PR TITLE
fix(table-editor): wait for filter value before applying

### DIFF
--- a/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterPopoverNew.tsx
@@ -186,6 +186,15 @@ export const FilterPopoverNew = ({
 
   const handleApply = useCallback(
     (newFilterGroup: FilterGroup) => {
+      const isValid = newFilterGroup.conditions.every(
+        (condition) =>
+          isGroup(condition) ||
+          (!!condition.propertyName &&
+            !!condition.operator &&
+            condition.value !== '' &&
+            condition.value != null)
+      )
+      if (!isValid) return
       setFilters(filterGroupToFilters(newFilterGroup))
     },
     [setFilters]

--- a/e2e/studio/features/filter-bar.spec.ts
+++ b/e2e/studio/features/filter-bar.spec.ts
@@ -52,6 +52,54 @@ test.describe('Filter Bar', () => {
       }
     })
 
+    test('selecting a column without a value does not trigger a row request', async ({
+      page,
+      ref,
+    }) => {
+      const tableName = `${tableNamePrefix}_no_value_no_req`
+      const columnName = 'name'
+
+      await createTable(tableName, columnName, [{ name: 'Alice' }, { name: 'Bob' }])
+
+      try {
+        await setupFilterBarPage(page, ref, toUrl(`/project/${ref}/editor?schema=public`))
+        await navigateToTable(page, ref, tableName)
+
+        await expect(page.getByRole('gridcell', { name: 'Alice' })).toBeVisible()
+        await expect(page.getByRole('gridcell', { name: 'Bob' })).toBeVisible()
+
+        // Count any new table-rows requests fired after the column/operator are picked.
+        // A request here means the filter applied before a value was entered — the regression.
+        let tableRowsRequests = 0
+        const rowsListener = (request: { url: () => string }) => {
+          if (request.url().includes('query?key=table-rows-')) tableRowsRequests++
+        }
+        page.on('request', rowsListener)
+
+        try {
+          await selectColumnFilter(page, columnName)
+          await expect(page.getByTestId(`filter-condition-${columnName}`)).toBeVisible()
+
+          await selectOperator(page, columnName, '=')
+
+          // Allow any debounced request to fire before we assert.
+          await page.waitForTimeout(500)
+
+          expect(
+            tableRowsRequests,
+            'No table-rows request should fire until a filter value is entered'
+          ).toBe(0)
+
+          await expect(page.getByRole('gridcell', { name: 'Alice' })).toBeVisible()
+          await expect(page.getByRole('gridcell', { name: 'Bob' })).toBeVisible()
+        } finally {
+          page.off('request', rowsListener)
+        }
+      } finally {
+        await dropTable(tableName)
+      }
+    })
+
     test('entering value filters the grid', async ({ page, ref }) => {
       const tableName = `${tableNamePrefix}_val_filt`
       const columnName = 'name'


### PR DESCRIPTION
## Summary

- Closes [FE-3399](https://linear.app/supabase/issue/FE-3399/make-table-editor-filter-bar-wait-for-a-value)
- Table editor's filter bar was firing a row request as soon as a property was selected, before any operator/value was set. This regressed after #46071 unified the table editor and unified logs onto the shared `FilterBar`.
- `LogsFilterBar` already validates that each condition has a propertyName, operator, and non-empty value before applying. `FilterPopoverNew.handleApply` did not — it called `setFilters` unconditionally on every `onApply` from the shared bar (property change, operator change, blur, etc.). This PR mirrors the `LogsFilterBar` validation so the table editor stops requesting rows until the condition is complete.

## Test plan

- [ ] Open the table editor on any table
- [ ] Click the filter bar, pick a column → no network request fires, no toast, grid unchanged
- [ ] Pick an operator → still no request
- [ ] Type a value and hit Enter → row request fires, grid filters
- [ ] Remove the filter → grid refetches with no filter
- [ ] New e2e test: `pnpm --prefix e2e/studio run e2e -- features/filter-bar.spec.ts --grep "does not trigger a row request"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Filter validation now prevents incomplete filter conditions from being applied, ensuring only fully-specified filters affect table data.

* **Tests**
  * Added end-to-end test coverage for filter bar operations to verify expected behavior during filter setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46113?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->