### PR TITLE
fix(upcomingInvoice): do not manually subtract credits

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -455,7 +455,7 @@ function ComputeLineItem({
 
   const discountedComputeCosts = Math.max(
     0,
-    computeItems.reduce((prev, cur) => prev + (cur.amount ?? 0), 0) + (computeCredits?.amount ?? 0)
+    computeItems.reduce((prev, cur) => prev + (cur.amount ?? 0), 0)
   )
 
   if (!computeItems.length) return null


### PR DESCRIPTION
Once [this](https://github.com/supabase/platform/pull/32924) is merged, `amount` already includes all discounts — if we subtract the compute credits again, we subtract twice 👍


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected invoice billing calculations to properly separate compute credits from line item amounts, preventing calculation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46116?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->