### PR TITLE
chore(studio): pass integration listing by slug when installing

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -75,8 +75,8 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
     if (!integration || !projectRef) return
 
     if (integration.installUrlType === 'post') {
-      if (!integration.listingId) return toast.error('Listing ID is required')
-      installOAuthIntegration({ projectRef, id: integration.listingId })
+      if (!integration.id) return toast.error('Listing ID is required')
+      installOAuthIntegration({ projectRef, listingSlug: integration.id })
     } else {
       let redirectUrl = '/'
 

--- a/apps/studio/data/marketplace/install-oauth-integration-mutation.ts
+++ b/apps/studio/data/marketplace/install-oauth-integration-mutation.ts
@@ -6,15 +6,15 @@ import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
 export type OAuthIntegrationInstallVariables = {
   projectRef: string
-  id: string
+  listingSlug: string
 }
 
 export async function installOAuthIntegration({
   projectRef,
-  id,
+  listingSlug,
 }: OAuthIntegrationInstallVariables) {
   const { data, error } = await post('/platform/integrations/partners/{ref}/{listing_slug}', {
-    params: { path: { ref: projectRef, listing_slug: id } },
+    params: { path: { ref: projectRef, listing_slug: listingSlug } },
   })
 
   if (error) handleError(error)


### PR DESCRIPTION
Passes listings by slug instead of UUID when getting an installation URL. This is already supported in the Platform API in a backwards compatible way.

Toward INT-109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced the OAuth integration installation process to ensure reliable identification and validation of integrations during installation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46119?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->