### PR TITLE
docs: add note to direct to correct doc for self-hosted configuration

### DIFF
--- a/apps/docs/content/guides/local-development/customizing-email-templates.mdx
+++ b/apps/docs/content/guides/local-development/customizing-email-templates.mdx
@@ -6,6 +6,12 @@ subtitle: 'Customize local email templates via the config file.'
 
 You can customize the email templates for local development by [editing the `config.toml` file](/docs/guides/local-development/cli/config#auth-config).
 
+<Admonition type="note">
+
+For configuring a self-hosted Supabase instance, see [Custom Email Templates](/docs/guides/self-hosting/custom-email-templates)
+
+</Admonition>
+
 ## Configuring templates
 
 You should provide a relative URL to the `content_path` parameter, pointing to an HTML file which contains the template. For example:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Received feedback that guide for customizing email templates for local development was not helpful. Referenced variable that caused friction is a variable related to self-hosted configuration.

## What is the new behavior?

Admonition added to direct users to correct guide for self-hosted configuration.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a note in the local development guide directing users to self-hosting documentation for information about custom email templates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46122?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->