### PR TITLE
docs: scope studio UI patterns skill

### DIFF
--- a/.claude/skills/studio-ui-patterns/SKILL.md
+++ b/.claude/skills/studio-ui-patterns/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: studio-ui-patterns
-description: Design system UI patterns for Supabase Studio. Use when building or updating
-  pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels
-  (sheets). Covers layout selection, component choice, and placement conventions.
+description: Design system UI patterns for the Supabase Studio dashboard codebase
+  (apps/studio). Use when building or updating UI inside apps/studio — including pages,
+  forms, tables, charts, empty states, navigation, cards, alerts, or side panels
+  (sheets) — that should follow the Studio design system. Do not use for external
+  Supabase consumer apps, marketing site work, or unrelated frontend projects.
 ---
 
 # Studio UI Patterns


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation/configuration wording update.

## What is the current behavior?

The `studio-ui-patterns` skill description lists broad UI terms without clearly scoping the trigger to the Supabase Studio codebase, which can cause false-positive skill activation for unrelated frontend work.

Issue: Closes #45347

## What is the new behavior?

The description now explicitly scopes the skill to `apps/studio`, clarifies that it applies to UI that should follow the Studio design system, and adds a negative clause for external consumer apps, marketing site work, and unrelated frontend projects.

## Additional context

This is a one-file frontmatter wording change. I ran `git diff --check`; no build was run because there is no executable code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated UI pattern guidelines documentation to clarify scope and correct usage boundaries.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46128?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->