### PR TITLE
docs: redirect legacy Stripe wrapper integration link

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -61,6 +61,11 @@ module.exports = [
   },
   {
     permanent: true,
+    source: '/partners/integrations/supabase_wrapper_stripe',
+    destination: '/partners/integrations/stripe-wrapper',
+  },
+  {
+    permanent: true,
     source: '/docs/guides/storage/access-control',
     destination: 'docs/guides/storage/security/access-control',
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation/website redirect fix.

## What is the current behavior?

The legacy Stripe wrapper integration URL `/partners/integrations/supabase_wrapper_stripe` returns a 404.

Closes #46127

## What is the new behavior?

Adds a permanent redirect from `/partners/integrations/supabase_wrapper_stripe` to the current Stripe Wrapper integration page at `/partners/integrations/stripe-wrapper`.

## Additional context

Validation run:

- `git diff --check`
- `node -e "const redirects=require('./apps/www/lib/redirects.js'); const r=redirects.find(x=>x.source==='/partners/integrations/supabase_wrapper_stripe'); if(!r||r.destination!=='/partners/integrations/stripe-wrapper') process.exit(1); console.log('redirect_ok')"`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated redirect for the Stripe integration documentation path to ensure users accessing the previous URL are automatically directed to the current location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46129?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->