### PR TITLE
chore(www): add Default.com snippet to contact sales page

### DIFF
--- a/apps/www/pages/contact/sales.tsx
+++ b/apps/www/pages/contact/sales.tsx
@@ -1,12 +1,12 @@
-import Image from 'next/image'
-import { useRouter } from 'next/router'
-import { NextSeo } from 'next-seo'
-import { cn } from 'ui'
-
-import DefaultLayout from '~/components/Layouts/Default'
-import SectionContainer from '~/components/Layouts/SectionContainer'
 import EnterpriseFormQuotes from '~/components/EnterpriseFormQuotes'
 import RequestADemoForm from '~/components/Forms/RequestADemoForm'
+import DefaultLayout from '~/components/Layouts/Default'
+import SectionContainer from '~/components/Layouts/SectionContainer'
+import { NextSeo } from 'next-seo'
+import Head from 'next/head'
+import Image from 'next/image'
+import { useRouter } from 'next/router'
+import { cn } from 'ui'
 
 const data = {
   meta_title: 'Contact Sales & Request a Demo | Supabase',
@@ -27,6 +27,14 @@ const ContactSales = () => {
           url: `https://supabase.com/${router.pathname}`,
         }}
       />
+      {/* Default.com snippet — enriches HubSpot enterprise form submissions and routes them to instant call scheduling for Sales. */}
+      <Head>
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `!function(e,t){var _=0;e.__default__=e.__default__||{},e.__default__.form_id=299973,e.__default__.team_id=715,e.__default__.listenToIds=["hsForm_de9a785a-fb65-4164-bd7d-000ae6eff219_5037","de9a785a-fb65-4164-bd7d-000ae6eff219_5037"],function e(){var o=t.createElement("script");o.async=!0,o.src="https://import-cdn.default.com",o.onload=function(){!0,console.info("[Default.com] Powered by Default.com")},o.onerror=function(){++_<=3&&setTimeout(e,1e3*_)},t.head.appendChild(o)}()}(window,document);`,
+          }}
+        />
+      </Head>
       <DefaultLayout className="min-h-fit!">
         <SectionContainer className="text grid gap-8 lg:gap-12 md:grid-cols-2">
           <div className="md:px-4 lg:pb-8 md:h-full w-full flex flex-col justify-between gap-2">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature — adds a third-party script.

## What is the current behavior?

The `/contact/sales` page submits the HubSpot enterprise form but has no integration with Default.com for instant enrichment and call scheduling. Linked issue: FE-3244.

## What is the new behavior?

Injects the Default.com snippet into the `<head>` of `/contact/sales`. Default.com listens to the HubSpot form submission, enriches the lead, and routes qualified prospects to instant call scheduling for Sales.

## Additional context

The other form mentioned in the issue (`forms.supabase.com/enterprise`) lives on a separate subdomain outside this monorepo and will need a separate change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contact sales form now includes integrated form enrichment functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->