### PR TITLE
fix(studio): prevent infinite render loop in new-project form

### DIFF
--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -163,13 +163,21 @@ const Wizard: NextPageWithLayout = () => {
     highAvailability,
   } = useWatch({ control: form.control })
 
+  // Read dirty state during render rather than depending on form.formState in the
+  // effect — form.formState is a Proxy that gets a new reference every render, which
+  // would re-fire this effect after each setValue and trigger an infinite loop.
+  const isDataApiDefaultPrivilegesDirty = getFieldState(
+    'dataApiDefaultPrivileges',
+    form.formState
+  ).isDirty
+
   useEffect(() => {
     if (dataApiRevokeOnCreateDefaultFlag === undefined) return
-    if (getFieldState('dataApiDefaultPrivileges', form.formState).isDirty) return
+    if (isDataApiDefaultPrivilegesDirty) return
     setValue('dataApiDefaultPrivileges', !dataApiRevokeOnCreateDefaultFlag, {
       shouldDirty: false,
     })
-  }, [dataApiRevokeOnCreateDefaultFlag, getFieldState, setValue, form.formState])
+  }, [dataApiRevokeOnCreateDefaultFlag, isDataApiDefaultPrivilegesDirty, setValue])
 
   // [Charis] Since the form is updated in a useEffect, there is an edge case
   // when switching from free to paid, where canChooseInstanceSize is true for


### PR DESCRIPTION
Fixes a "Maximum update depth exceeded" infinite render loop on `/new/[slug]` introduced by #46085. The symptom showed up on the internal-only configuration dropdown, but the entire form was looping.

## Root cause

The new `useEffect` that syncs `dataApiDefaultPrivileges` to the experiment-driven default had `form.formState` in its deps. `form.formState` is a react-hook-form Proxy that returns a new reference on every render, so the effect refired after every render → `setValue` → render → effect → loop.

## Fix

Pull the dirty check out of the effect into a stable boolean computed during render, and drop `form.formState` from the deps. Semantics unchanged — still syncs on flag resolve, still skips when the user has touched the field.

## To test

- Hard-reload `/new/[slug]` and confirm there's no "Maximum update depth exceeded" error in the console
- Open the configuration dropdown (internal-only) and confirm it interacts normally
- With the `data-api-revoke-on-create-default` flag off, confirm `dataApiDefaultPrivileges` defaults to `true`; with it on, defaults to `false`
- Manually toggle the dataApiDefaultPrivileges field, then confirm the effect no longer overwrites your choice when the flag resolves

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data API default privileges synchronization to prevent unnecessary updates and improve application stability during configuration changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46131?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->