### PR TITLE
Set default size for filter side bar unified logs

### DIFF
--- a/apps/studio/components/ui/DataTable/FilterSideBar.tsx
+++ b/apps/studio/components/ui/DataTable/FilterSideBar.tsx
@@ -52,8 +52,9 @@ export function FilterSideBar({
   return (
     <ResizablePanel
       panelRef={panelRef}
-      maxSize={512}
       minSize={256}
+      defaultSize={265}
+      maxSize={512}
       id="panel-left"
       collapsible
       onResize={(size) => {


### PR DESCRIPTION
## Context

Width of filter side bar of unified logs was getting defaulted to the max value because the default value isn't set
<img width="1449" height="646" alt="image" src="https://github.com/user-attachments/assets/15e336b5-ca0b-43f9-93eb-4c5c52694f4e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the filter sidebar's default width initialization to ensure consistent visual appearance upon loading.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->