### PR TITLE
Joshen/debug 110 default unified logs search to event message

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.fields.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.fields.tsx
@@ -134,6 +134,23 @@ export const filterFields = [
       )
     },
   },
+  {
+    label: 'Event message',
+    value: 'event_message',
+    type: 'checkbox',
+    defaultOpen: false,
+    options: [],
+    hasDynamicOptions: false,
+    hasAsyncSearch: false,
+    hidden: true,
+    component: (props: Option) => {
+      return (
+        <span className="truncate block w-full text-[0.75rem]" title={props.value as string}>
+          {props.value}
+        </span>
+      )
+    },
+  },
 ] satisfies DataTableFilterField<ColumnSchema>[]
 
 export const sheetFields = [

--- a/apps/studio/components/interfaces/UnifiedLogs/components/LogsFilterBar.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/LogsFilterBar.tsx
@@ -85,6 +85,7 @@ export const LogsFilterBar = () => {
   return (
     <FilterBar
       variant="pill"
+      freeformDefaultProperty="event_message"
       className="bg-transparent border-0 [&>div>div>div>input]:!text-xs"
       filterProperties={filterProperties}
       freeformText={freeformText}

--- a/apps/studio/components/ui/DataTable/DataTable.types.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.types.ts
@@ -54,6 +54,8 @@ export type Base<TData> = {
   commandDisabled?: boolean
   hasDynamicOptions?: boolean
   hasAsyncSearch?: boolean
+  /** Defines if the filter should be present in the filter nav */
+  hidden?: boolean
 }
 
 export type DataTableCheckboxFilterField<TData> = Base<TData> & Checkbox

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterControls.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterControls.tsx
@@ -30,51 +30,53 @@ export function DataTableFilterControls({
         ?.filter(({ defaultOpen }) => defaultOpen)
         ?.map(({ value }) => value as string)}
     >
-      {filterFields?.map((field) => {
-        const value = field.value as string
-        return (
-          <AccordionItem key={value} value={value} className="border-none">
-            <div className="flex items-center gap-2 pr-2">
-              <AccordionTrigger className="flex-1 px-2 py-0 hover:no-underline data-[state=closed]:text-muted-foreground data-open:text-foreground focus-within:data-closed:text-foreground hover:data-closed:text-foreground">
-                <div className="flex items-center gap-2 truncate py-2">
-                  <p className="text-sm">{field.label}</p>
-                </div>
-              </AccordionTrigger>
-              <DataTableFilterResetButton {...field} />
-            </div>
-            <AccordionContent>
-              {/* REMINDER: avoid the focus state to be cut due to overflow-hidden */}
-              {/* REMINDER: need to move within here because of accordion height animation */}
-              <div className="p-1">
-                {(() => {
-                  switch (field.type) {
-                    case 'checkbox': {
-                      // [Joshen] Loader here so that CheckboxAsync can retrieve the data
-                      // immediately to be set in its react query state
-                      if (field.hasDynamicOptions && isLoadingCounts) {
-                        return <DataTableFilterCheckboxLoader />
-                      } else if (field.hasAsyncSearch) {
-                        return <DataTableFilterCheckboxAsync {...field} />
-                      } else {
-                        return <DataTableFilterCheckbox {...field} />
+      {filterFields
+        ?.filter((field) => !field.hidden)
+        .map((field) => {
+          const value = field.value as string
+          return (
+            <AccordionItem key={value} value={value} className="border-none">
+              <div className="flex items-center gap-2 pr-2">
+                <AccordionTrigger className="flex-1 px-2 py-0 hover:no-underline data-[state=closed]:text-muted-foreground data-open:text-foreground focus-within:data-closed:text-foreground hover:data-closed:text-foreground">
+                  <div className="flex items-center gap-2 truncate py-2">
+                    <p className="text-sm">{field.label}</p>
+                  </div>
+                </AccordionTrigger>
+                <DataTableFilterResetButton {...field} />
+              </div>
+              <AccordionContent>
+                {/* REMINDER: avoid the focus state to be cut due to overflow-hidden */}
+                {/* REMINDER: need to move within here because of accordion height animation */}
+                <div className="p-1">
+                  {(() => {
+                    switch (field.type) {
+                      case 'checkbox': {
+                        // [Joshen] Loader here so that CheckboxAsync can retrieve the data
+                        // immediately to be set in its react query state
+                        if (field.hasDynamicOptions && isLoadingCounts) {
+                          return <DataTableFilterCheckboxLoader />
+                        } else if (field.hasAsyncSearch) {
+                          return <DataTableFilterCheckboxAsync {...field} />
+                        } else {
+                          return <DataTableFilterCheckbox {...field} />
+                        }
+                      }
+                      case 'slider': {
+                        return <DataTableFilterSlider {...field} />
+                      }
+                      case 'input': {
+                        return <DataTableFilterInput {...field} />
+                      }
+                      case 'timerange': {
+                        return <DataTableFilterTimerange {...field} />
                       }
                     }
-                    case 'slider': {
-                      return <DataTableFilterSlider {...field} />
-                    }
-                    case 'input': {
-                      return <DataTableFilterInput {...field} />
-                    }
-                    case 'timerange': {
-                      return <DataTableFilterTimerange {...field} />
-                    }
-                  }
-                })()}
-              </div>
-            </AccordionContent>
-          </AccordionItem>
-        )
-      })}
+                  })()}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          )
+        })}
     </Accordion>
   )
 }

--- a/apps/studio/components/ui/DataTable/DataTableSheetRowAction.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableSheetRowAction.tsx
@@ -47,8 +47,12 @@ export function DataTableSheetRowAction<TData, TFields extends DataTableFilterFi
   ...props
 }: DataTableSheetRowActionProps<TData, TFields>) {
   const { copy, isCopied } = useCopyToClipboard()
+
   const field = !!fieldValue ? filterFields.find((f) => f.value === fieldValue) : undefined
-  const column = !!fieldValue ? table.getColumn(fieldValue.toString()) : undefined
+  const column =
+    !!fieldValue && !!field
+      ? table.getAllColumns().find((c) => c.id === fieldValue.toString())
+      : undefined
 
   function renderOptions() {
     if (!field) return null

--- a/apps/studio/components/ui/DataTable/FilterSideBar.tsx
+++ b/apps/studio/components/ui/DataTable/FilterSideBar.tsx
@@ -52,8 +52,9 @@ export function FilterSideBar({
   return (
     <ResizablePanel
       panelRef={panelRef}
-      maxSize={512}
       minSize={256}
+      defaultSize={265}
+      maxSize={512}
       id="panel-left"
       collapsible
       onResize={(size) => {

--- a/apps/studio/components/ui/DataTable/TimelineChart.tsx
+++ b/apps/studio/components/ui/DataTable/TimelineChart.tsx
@@ -81,7 +81,7 @@ export function TimelineChart<TChart extends BaseChartSchema>({
     <ChartContainer
       config={chartConfig}
       className={cn(
-        'aspect-auto h-[60px] w-full',
+        'aspect-auto h-[60px] w-full px-2',
         '[&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted/50', // otherwise same color as 200
         'select-none', // disable text selection
         className
@@ -103,7 +103,7 @@ export function TimelineChart<TChart extends BaseChartSchema>({
           tickLine={false}
           minTickGap={32}
           axisLine={false}
-          // interval="preserveStartEnd"
+          interval="preserveStartEnd"
           tickFormatter={(value) => {
             const date = new Date(value)
             if (isNaN(date.getTime())) return 'N/A'

--- a/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
+++ b/packages/ui-patterns/src/FilterBar/CommandListItem.tsx
@@ -31,9 +31,9 @@ export function CommandListItem({
       )}
       data-testid={`filter-menu-item-${item.value}`}
     >
-      <span className="flex items-center gap-2">
+      <span className="flex items-center gap-2 min-w-0">
         {includeIcon && item.icon}
-        {getActionItemLabel(item)}
+        <span className="truncate">{getActionItemLabel(item)}</span>
       </span>
       {item.operatorSymbol && <OperatorSymbolBadge symbol={item.operatorSymbol} />}
     </div>

--- a/packages/ui-patterns/src/FilterBar/FilterBar.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterBar.tsx
@@ -24,6 +24,14 @@ export type FilterBarProps = {
   supportsOperators?: boolean
   variant?: FilterBarVariant
   icon?: React.ReactNode
+  /**
+   * Name of the property to use when the user commits free text from the root input. Must match
+   * a `name` in `filterProperties`. When set, the dropdown shows a "Search <propertyLabel>: \"...\""
+   * item as the first option while the user is typing. Selecting it (Enter) creates a filter
+   * `{ propertyName, operator: '=', value: typedText }`. If the property has no `=` operator,
+   * the first operator in its list is used instead.
+   */
+  freeformDefaultProperty?: string
   onFilterChange: (filters: FilterGroupType) => void
   /**
    * Fires only on commit boundaries: menu item selected, operator/property/logical-operator
@@ -135,6 +143,7 @@ export const FilterBar = forwardRef<FilterBarHandle, FilterBarProps>(function Fi
     supportsOperators = false,
     variant = 'default',
     icon,
+    freeformDefaultProperty,
   },
   ref
 ) {
@@ -152,6 +161,7 @@ export const FilterBar = forwardRef<FilterBarHandle, FilterBarProps>(function Fi
       supportsOperators={supportsOperators}
       variant={variant}
       icon={icon}
+      freeformDefaultProperty={freeformDefaultProperty}
     >
       <FilterBarContent className={className} />
     </FilterBarRoot>

--- a/packages/ui-patterns/src/FilterBar/FilterBarContext.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterBarContext.tsx
@@ -71,6 +71,7 @@ export type FilterBarContextValue = {
   variant: FilterBarVariant
   actions?: FilterBarAction[]
   icon?: React.ReactNode
+  freeformDefaultProperty?: string
 
   rootRef: React.RefObject<HTMLDivElement | null>
 }
@@ -98,6 +99,7 @@ export type FilterBarRootProps = {
   supportsOperators?: boolean
   variant?: FilterBarVariant
   icon?: React.ReactNode
+  freeformDefaultProperty?: string
 }
 
 export type FilterBarVariant = 'default' | 'pill'
@@ -120,6 +122,7 @@ export const FilterBarRoot = forwardRef<FilterBarHandle, FilterBarRootProps>(fun
     supportsOperators = false,
     variant = 'default',
     icon,
+    freeformDefaultProperty,
   }: FilterBarRootProps,
   ref: React.Ref<FilterBarHandle>
 ) {
@@ -395,6 +398,7 @@ export const FilterBarRoot = forwardRef<FilterBarHandle, FilterBarRootProps>(fun
     variant,
     actions,
     icon,
+    freeformDefaultProperty,
 
     rootRef,
   }

--- a/packages/ui-patterns/src/FilterBar/FilterGroup.tsx
+++ b/packages/ui-patterns/src/FilterBar/FilterGroup.tsx
@@ -25,6 +25,7 @@ export function FilterGroup({ group, path }: FilterGroupProps) {
     actions,
     variant,
     highlightedConditionPath,
+    freeformDefaultProperty,
     handleInputBlur,
     handleGroupFreeformFocus,
     handleGroupFreeformChange,
@@ -86,6 +87,16 @@ export function FilterGroup({ group, path }: FilterGroupProps) {
     return pathsEqual(conditionPath, highlightedConditionPath)
   }
 
+  // Free-text search only applies to the root group's input — nested groups don't synthesize
+  // a "Search <property>" item.
+  const resolvedFreeformDefaultProperty = useMemo(
+    () =>
+      path.length === 0 && freeformDefaultProperty
+        ? filterProperties.find((p) => p.name === freeformDefaultProperty)
+        : undefined,
+    [path.length, freeformDefaultProperty, filterProperties]
+  )
+
   const items = useMemo(
     () =>
       buildPropertyItems({
@@ -93,8 +104,17 @@ export function FilterGroup({ group, path }: FilterGroupProps) {
         inputValue: (isActive ? freeformText : localFreeformValue) || '',
         actions,
         supportsOperators,
+        freeformDefaultProperty: resolvedFreeformDefaultProperty,
       }),
-    [filterProperties, isActive, freeformText, localFreeformValue, actions, supportsOperators]
+    [
+      filterProperties,
+      isActive,
+      freeformText,
+      localFreeformValue,
+      actions,
+      supportsOperators,
+      resolvedFreeformDefaultProperty,
+    ]
   )
 
   const emptyPlaceholder = useMemo(
@@ -220,7 +240,7 @@ export function FilterGroup({ group, path }: FilterGroupProps) {
             )}
           </PopoverAnchor>
           <PopoverContent
-            className="min-w-[220px] p-0"
+            className="min-w-[220px] max-w-[360px] p-0"
             align="start"
             side="bottom"
             onOpenAutoFocus={(e) => e.preventDefault()}

--- a/packages/ui-patterns/src/FilterBar/menuItems.ts
+++ b/packages/ui-patterns/src/FilterBar/menuItems.ts
@@ -70,9 +70,22 @@ export function buildPropertyItems(params: {
   inputValue: string
   supportsOperators?: boolean
   actions?: FilterBarAction[]
+  freeformDefaultProperty?: FilterProperty
 }): MenuItem[] {
-  const { filterProperties, inputValue, supportsOperators, actions } = params
+  const { filterProperties, inputValue, supportsOperators, actions, freeformDefaultProperty } =
+    params
   const items: MenuItem[] = []
+
+  const trimmedInput = inputValue.trim()
+  if (freeformDefaultProperty && trimmedInput.length > 0) {
+    items.push({
+      value: '__freeform_search__',
+      label: `Search ${freeformDefaultProperty.label.toLowerCase()}: "${trimmedInput}"`,
+      isFreeformSearch: true,
+      freeformPropertyName: freeformDefaultProperty.name,
+      freeformValue: trimmedInput,
+    })
+  }
 
   items.push(
     ...filterProperties
@@ -84,7 +97,6 @@ export function buildPropertyItems(params: {
     items.push({ value: 'group', label: 'New Group' })
   }
 
-  const trimmedInput = inputValue.trim()
   if (actions && trimmedInput.length > 0) {
     actions.forEach((action) => {
       items.push({

--- a/packages/ui-patterns/src/FilterBar/types.ts
+++ b/packages/ui-patterns/src/FilterBar/types.ts
@@ -99,6 +99,9 @@ export type MenuItem = {
   operatorSymbol?: string
   isDefaultOperator?: boolean
   defaultValue?: string
+  isFreeformSearch?: boolean
+  freeformPropertyName?: string
+  freeformValue?: string
 }
 
 export type GroupedMenuItem = {

--- a/packages/ui-patterns/src/FilterBar/useCommandHandling.ts
+++ b/packages/ui-patterns/src/FilterBar/useCommandHandling.ts
@@ -146,6 +146,35 @@ export function useCommandHandling({
         return
       }
 
+      if (item.isFreeformSearch && item.freeformPropertyName) {
+        if (!activeInput || activeInput.type !== 'group') return
+        const property = filterProperties.find((p) => p.name === item.freeformPropertyName)
+        if (!property) return
+
+        const currentPath = activeInput.path
+        const group = findGroupByPath(activeFilters, currentPath)
+        if (!group) return
+
+        const operators = property.operators ?? ['=']
+        const defaultOperator =
+          operators.find((op) => (isFilterOperatorObject(op) ? op.value : op) === '=') ??
+          operators[0]
+        const operatorValue = isFilterOperatorObject(defaultOperator)
+          ? defaultOperator.value
+          : defaultOperator
+
+        let updatedFilters = addFilterToGroup(activeFilters, currentPath, property)
+        const newPath = [...currentPath, group.conditions.length]
+        updatedFilters = updateNestedOperator(updatedFilters, newPath, operatorValue)
+        updatedFilters = updateNestedValue(updatedFilters, newPath, item.freeformValue ?? '')
+        commitFilters(updatedFilters)
+        onFreeformTextChange('')
+        setTimeout(() => {
+          setActiveInput({ type: 'group', path: currentPath })
+        }, 0)
+        return
+      }
+
       if (item.value === 'group') {
         handleGroupCommand()
         return
@@ -174,6 +203,8 @@ export function useCommandHandling({
       activeInput,
       activeFilters,
       freeformText,
+      filterProperties,
+      onFreeformTextChange,
       setActiveInput,
       handleGroupCommand,
       handleValueCommand,

--- a/packages/ui-patterns/src/FilterBar/utils.test.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.test.ts
@@ -17,7 +17,6 @@ import {
   isSyncOptionsFunction,
   removeFromGroup,
   resolvePropertyChange,
-  truncateText,
   updateNestedLogicalOperator,
   updateNestedOperator,
   updateNestedPropertyName,
@@ -477,24 +476,6 @@ describe('FilterBar Utils', () => {
     })
   })
 
-  describe('truncateText', () => {
-    it('returns text unchanged if under max length', () => {
-      expect(truncateText('hello', 10)).toBe('hello')
-    })
-
-    it('returns text unchanged if exactly max length', () => {
-      expect(truncateText('hello', 5)).toBe('hello')
-    })
-
-    it('truncates text and adds ellipsis if over max length', () => {
-      expect(truncateText('hello world', 5)).toBe('hello...')
-    })
-
-    it('handles empty string', () => {
-      expect(truncateText('', 10)).toBe('')
-    })
-  })
-
   describe('getActionItemLabel', () => {
     it('returns original label for non-action items', () => {
       const item: MenuItem = { value: 'test', label: 'Test Label' }
@@ -516,14 +497,16 @@ describe('FilterBar Utils', () => {
       expect(getActionItemLabel(item)).toBe('Ask AI: "Find users"')
     })
 
-    it('truncates long input values at 30 characters', () => {
+    it('returns full input value (no truncation — CSS handles overflow)', () => {
       const item: MenuItem = {
         value: 'ai',
         label: 'Filter by AI',
         isAction: true,
         actionInputValue: 'Find all users who registered in the last 30 days',
       }
-      expect(getActionItemLabel(item)).toBe('Ask AI: "Find all users who registered ..."')
+      expect(getActionItemLabel(item)).toBe(
+        'Ask AI: "Find all users who registered in the last 30 days"'
+      )
     })
   })
 

--- a/packages/ui-patterns/src/FilterBar/utils.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.ts
@@ -326,14 +326,9 @@ export function groupMenuItemsByOperator(items: MenuItem[]): MenuItemGroup[] {
   }))
 }
 
-export function truncateText(text: string, maxLength: number): string {
-  if (text.length <= maxLength) return text
-  return text.slice(0, maxLength) + '...'
-}
-
 export function getActionItemLabel(item: MenuItem): string {
   if (item.isAction && item.actionInputValue) {
-    return `Ask AI: "${truncateText(item.actionInputValue, 30)}"`
+    return `Ask AI: "${item.actionInputValue}"`
   }
   return item.label
 }


### PR DESCRIPTION
## Context

Adjusts the filter bar component to accept a `freeformDefaultProperty`, in which entering any text in the filter bar will opt to search against that property by default. (Property must be defined within the `filterProperties` prop too)

Applies to unified logs, which for e.g "Event message" is a valid filter:
<img width="428" height="250" alt="image" src="https://github.com/user-attachments/assets/a08c015c-c9aa-4985-9e15-6429f455ccf0" />

I've set `freeformDefaultProperty` to be `event_message`, and hence typing free text will opt the default action to just filtering against that property
<img width="437" height="135" alt="image" src="https://github.com/user-attachments/assets/ccf6944a-1c5d-4944-acfa-ac82dc20bb10" />

### Demo:

https://github.com/user-attachments/assets/287ee22d-f957-48e5-89b0-1fed159cd86a

### Other changes
- Opt to deprecate `truncateText` util from unified logs -> preference for tailwind instead
- Event message is added as a filter field, but hidden in the side nav (wouldn't make sense since the content is very dynamic, unlike something similar like pathname)
- Fixes some console errors in unified logs because we were using `.getColumn` in `DataTableSheetRowAction`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Event message" filter (hidden by default) and set it as the default target for freeform searches.

* **UI Improvements**
  * Filter sidebar resize constraints tightened.
  * Timeline chart spacing and x-axis tick behavior improved.
  * Action labels and command list items no longer truncate long input values.

* **Bug Fixes**
  * More reliable resolution of target columns for row actions, improving available filter options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46134?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->