### PR TITLE
fix: authenticate vercel deploy status checks

### DIFF
--- a/.github/workflows/authorize-vercel-deploys.yml
+++ b/.github/workflows/authorize-vercel-deploys.yml
@@ -15,6 +15,7 @@ concurrency:
 
 permissions:
   contents: read
+  statuses: read
 
 jobs:
   authorize-vercel-deploys:
@@ -47,5 +48,7 @@ jobs:
           pnpm run authorize-vercel-deploys
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           # The SHA of the commit that triggered the validate-pr workflow
           HEAD_COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}

--- a/scripts/authorizeVercelDeploys.ts
+++ b/scripts/authorizeVercelDeploys.ts
@@ -13,8 +13,8 @@ interface GitHubStatus {
   id: number
   node_id: string
   state: 'success' | 'pending' | 'failure' | 'error'
-  description: string
-  target_url: string
+  description: string | null
+  target_url: string | null
   context: string
   created_at: string
   updated_at: string
@@ -26,21 +26,125 @@ const jobInfoSchema = z.object({
       sha: z.string().min(1, 'SHA is required'),
     }),
     id: z.string().min(1, 'ID is required'),
-    org: z.literal('supabase'),
+    org: z.string().min(1, 'Organization is required'),
     prId: z.number().int().positive('PR ID must be a positive integer'),
-    repo: z.literal('supabase'),
+    repo: z.string().min(1, 'Repository is required'),
   }),
 })
 
 type JobInfo = z.infer<typeof jobInfoSchema>
 
-async function fetchGitHubStatuses(sha: string): Promise<GitHubStatus[]> {
-  const url = `https://api.github.com/repos/supabase/supabase/statuses/${sha}`
-  console.log(`Fetching GitHub statuses for SHA: ${sha}`)
+type GitHubRepository = {
+  owner: string
+  repo: string
+}
 
-  const response = await fetch(url)
+const MAX_ATTEMPTS = 3
+const REQUEST_TIMEOUT_MS = 10_000
+
+function getRequiredEnv(name: string) {
+  const value = process.env[name]
+  if (!value) {
+    throw new Error(`${name} environment variable is required`)
+  }
+
+  return value
+}
+
+function getGitHubRepository(): GitHubRepository {
+  const repository = getRequiredEnv('GITHUB_REPOSITORY')
+  const [owner, repo, ...rest] = repository.split('/')
+
+  if (!owner || !repo || rest.length > 0) {
+    throw new Error(`GITHUB_REPOSITORY must use the "owner/repo" format. Received: ${repository}`)
+  }
+
+  return { owner, repo }
+}
+
+function isRateLimitedResponse(status: number, headers: Headers) {
+  return (
+    status === 403 && (headers.get('x-ratelimit-remaining') === '0' || headers.has('retry-after'))
+  )
+}
+
+function isRetryableStatus(status: number, headers: Headers) {
+  return isRateLimitedResponse(status, headers) || status === 408 || status === 429 || status >= 500
+}
+
+function getRetryDelayMs(attempt: number) {
+  return 500 * 2 ** (attempt - 1)
+}
+
+function sleep(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+async function fetchWithRetry(input: string, init: RequestInit, label: string): Promise<Response> {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
+
+    try {
+      const response = await fetch(input, {
+        ...init,
+        signal: controller.signal,
+      })
+
+      if (
+        response.ok ||
+        !isRetryableStatus(response.status, response.headers) ||
+        attempt === MAX_ATTEMPTS
+      ) {
+        return response
+      }
+
+      lastError = new Error(`${label} failed with ${response.status} ${response.statusText}`)
+    } catch (error) {
+      lastError = error
+
+      if (attempt === MAX_ATTEMPTS) {
+        throw error
+      }
+    } finally {
+      clearTimeout(timeout)
+    }
+
+    const delayMs = getRetryDelayMs(attempt)
+    console.warn(`${label} failed on attempt ${attempt}. Retrying in ${delayMs}ms...`)
+    await sleep(delayMs)
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(`${label} failed`)
+}
+
+async function fetchGitHubStatuses(
+  sha: string,
+  repository: GitHubRepository,
+  githubToken: string
+): Promise<GitHubStatus[]> {
+  const url = `https://api.github.com/repos/${repository.owner}/${repository.repo}/statuses/${sha}`
+  console.log(`Fetching GitHub statuses for ${repository.owner}/${repository.repo}@${sha}`)
+
+  const response = await fetchWithRetry(
+    url,
+    {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        Authorization: `Bearer ${githubToken}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    },
+    'GitHub statuses request'
+  )
+
   if (!response.ok) {
-    throw new Error(`Failed to fetch GitHub statuses: ${response.status} ${response.statusText}`)
+    const errorText = await response.text()
+    throw new Error(
+      `Failed to fetch GitHub statuses: ${response.status} ${response.statusText}\n${errorText}`
+    )
   }
 
   return response.json()
@@ -68,18 +172,30 @@ function extractJobInfoFromTargetUrl(targetUrl: string): JobInfo {
   }
 }
 
+function assertJobMatchesRepository(jobInfo: JobInfo, repository: GitHubRepository) {
+  if (jobInfo.job.org !== repository.owner || jobInfo.job.repo !== repository.repo) {
+    throw new Error(
+      `Refusing to authorize ${jobInfo.job.org}/${jobInfo.job.repo}; expected ${repository.owner}/${repository.repo}`
+    )
+  }
+}
+
 async function authorizeVercelJob(jobInfo: JobInfo, vercelToken: string): Promise<void> {
   const url = 'https://vercel.com/api/v1/integrations/authorize-job'
 
-  const response = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Accept: '*/*',
-      'Content-Type': 'application/json; charset=utf-8',
-      Authorization: `Bearer ${vercelToken}`,
+  const response = await fetchWithRetry(
+    url,
+    {
+      method: 'POST',
+      headers: {
+        Accept: '*/*',
+        'Content-Type': 'application/json; charset=utf-8',
+        Authorization: `Bearer ${vercelToken}`,
+      },
+      body: JSON.stringify(jobInfo),
     },
-    body: JSON.stringify(jobInfo),
-  })
+    `Vercel authorization request for ${jobInfo.job.org}/${jobInfo.job.repo}#${jobInfo.job.prId}`
+  )
 
   if (!response.ok) {
     const errorText = await response.text()
@@ -91,27 +207,26 @@ async function authorizeVercelJob(jobInfo: JobInfo, vercelToken: string): Promis
   console.log('✓ Vercel job authorized successfully!')
 }
 
-async function main() {
-  const sha = process.env.HEAD_COMMIT_SHA
-  if (!sha) {
-    throw new Error('HEAD_COMMIT_SHA environment variable is required')
-  }
+function isAuthorizationRequiredStatus(status: GitHubStatus) {
+  const description = status.description?.toLowerCase() ?? ''
 
-  const vercelToken = process.env.VERCEL_TOKEN
-  if (!vercelToken) {
-    throw new Error('VERCEL_TOKEN environment variable is required')
-  }
+  return status.context.startsWith('Vercel - ') && description.includes('authorization required')
+}
+
+async function main() {
+  const sha = getRequiredEnv('HEAD_COMMIT_SHA')
+  const vercelToken = getRequiredEnv('VERCEL_TOKEN')
+  const githubToken = getRequiredEnv('GITHUB_TOKEN')
+  const repository = getGitHubRepository()
 
   console.log(`Starting authorization process for SHA: ${sha}`)
 
   // Fetch GitHub statuses
-  const statuses = await fetchGitHubStatuses(sha)
+  const statuses = await fetchGitHubStatuses(sha, repository, githubToken)
   console.log(`Found ${statuses.length} statuses`)
 
   // Filter for authorization-required statuses
-  const authRequiredStatuses = statuses.filter(
-    (status) => status.description === 'Authorization required to deploy.'
-  )
+  const authRequiredStatuses = statuses.filter(isAuthorizationRequiredStatus)
 
   if (authRequiredStatuses.length === 0) {
     console.log('No authorization-required statuses found. Nothing to authorize.')
@@ -119,6 +234,9 @@ async function main() {
   }
 
   console.log(`Found ${authRequiredStatuses.length} authorization-required status(es)`)
+
+  let failedCount = 0
+  let skippedCount = 0
 
   // Process each authorization-required status
   for (const status of authRequiredStatuses) {
@@ -129,20 +247,33 @@ async function main() {
 
     try {
       console.log(`\nProcessing status: ${status.context}`)
+
+      if (!status.target_url) {
+        skippedCount++
+        console.warn(`Skipping status ${status.context}: target_url is missing`)
+        continue
+      }
+
       console.log(`Target URL: ${status.target_url}`)
 
       // Extract job info from target URL
       const jobInfo = extractJobInfoFromTargetUrl(status.target_url)
+      assertJobMatchesRepository(jobInfo, repository)
 
       // Authorize the job
       await authorizeVercelJob(jobInfo, vercelToken)
     } catch (error) {
+      failedCount++
       console.error(`Failed to process status ${status.context}:`, error)
       // Continue with other statuses even if one fails
     }
   }
 
-  console.log('\n✓ Authorization process completed!')
+  if (failedCount > 0) {
+    throw new Error(`Failed to authorize ${failedCount} Vercel status(es)`)
+  }
+
+  console.log(`\n✓ Authorization process completed! Skipped ${skippedCount} status(es).`)
 }
 
 main().catch((error) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

  YES

  ## What kind of change does this PR introduce?

  Bug fix

  Fixes #45672

  ## What is the current behavior?

  The Vercel deployment authorization script fetches GitHub commit statuses without authentication. This can hit unauthenticated API rate limits in CI
  and makes the workflow less reliable.

  The script also assumes `target_url` is always present, hardcodes the repository path, and continues successfully even when one or more
  authorization attempts fail.

  ## What is the new behavior?

  The workflow now grants `statuses: read` and passes `GITHUB_TOKEN` plus `GITHUB_REPOSITORY` into the authorization script.

  The script now:
  - Authenticates GitHub Status API requests with `GITHUB_TOKEN`
  - Reads the repository from `GITHUB_REPOSITORY`
  - Adds timeout and retry handling for GitHub and Vercel API calls
  - Handles missing `target_url` safely
  - Treats failed authorization attempts as workflow failures

  ## Additional context

  No visual changes.

  Validation performed:
  - `prettier --check`
  - `git diff --check`
  - TypeScript bundling with `esbuild`
  - Syntax check with `node --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved robustness of Vercel deployment authorization with authenticated status checks, retry/backoff for network calls, and richer error messages.
  * Added repository-consistency validation and safer environment token handling for cross-repo deployments.
  * Enhanced logging, status tracking, skip/failed accounting, and overall resilience of the authorization flow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46136?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->