### PR TITLE
fix(studio): selected status bg colour unified logs

### DIFF
--- a/apps/studio/components/ui/DataTable/DataTable.utils.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.utils.ts
@@ -63,8 +63,8 @@ export function getLevelColor(
     case 'success':
       return {
         text: 'text-muted',
-        bg: 'bg-muted',
-        border: 'border-muted',
+        bg: 'bg-muted group-data-[state=selected]/row:bg-foreground-lighter',
+        border: 'border-muted group-data-[state=selected]/row:border-foreground-lighter',
       }
     case 'warning':
       return {

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -1,11 +1,5 @@
 import { type FetchNextPageOptions } from '@tanstack/react-query'
-import type {
-  ColumnDef,
-  Row,
-  RowData,
-  Table as TTable,
-  VisibilityState,
-} from '@tanstack/react-table'
+import type { ColumnDef, Row, Table as TTable, VisibilityState } from '@tanstack/react-table'
 import { flexRender } from '@tanstack/react-table'
 import { LoaderCircle } from 'lucide-react'
 import { useQueryState } from 'nuqs'
@@ -19,18 +13,6 @@ import { useDataTable } from './providers/DataTableProvider'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './Table'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
-
-declare module '@tanstack/react-table' {
-  interface TableMeta<TData extends RowData> {
-    getRowClassName?: (row: Row<TData>) => string
-    [key: string]: unknown
-  }
-  interface ColumnMeta<TData extends RowData, TValue> {
-    headerClassName?: string
-    cellClassName?: string
-    [key: string]: unknown
-  }
-}
 
 // TODO: add a possible chartGroupBy
 export interface DataTableInfiniteProps<TData, TValue, _TMeta> {
@@ -103,7 +85,7 @@ export function DataTableInfinite<TData, TValue, TMeta>({
             const sort = header.column.getIsSorted()
             const canResize = header.column.getCanResize()
             const onResize = header.getResizeHandler()
-            const headerClassName = header.column.columnDef.meta?.headerClassName
+            const headerClassName = (header.column.columnDef.meta as any)?.headerClassName
 
             return (
               <TableHead
@@ -254,7 +236,7 @@ function DataTableRow<TData>({
   searchParamsParser: any
 }) {
   useQueryState('live', searchParamsParser.live)
-  const rowClassName = cn('group/row', table.options.meta?.getRowClassName?.(row))
+  const rowClassName = cn('group/row', (table.options.meta as any)?.getRowClassName?.(row))
   const cells = row.getVisibleCells()
 
   return (
@@ -272,7 +254,7 @@ function DataTableRow<TData>({
       className={cn(rowClassName)}
     >
       {cells.map((cell) => {
-        const cellClassName = cell.column.columnDef.meta?.cellClassName
+        const cellClassName = (cell.column.columnDef.meta as any)?.cellClassName
         return (
           <TableCell key={cell.id} className={cn(cellClassName)}>
             {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -1,5 +1,11 @@
 import { type FetchNextPageOptions } from '@tanstack/react-query'
-import type { ColumnDef, Row, Table as TTable, VisibilityState } from '@tanstack/react-table'
+import type {
+  ColumnDef,
+  Row,
+  RowData,
+  Table as TTable,
+  VisibilityState,
+} from '@tanstack/react-table'
 import { flexRender } from '@tanstack/react-table'
 import { LoaderCircle } from 'lucide-react'
 import { useQueryState } from 'nuqs'
@@ -13,6 +19,16 @@ import { useDataTable } from './providers/DataTableProvider'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from './Table'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
+
+declare module '@tanstack/react-table' {
+  interface TableMeta<TData extends RowData> {
+    getRowClassName?: (row: Row<TData>) => string
+  }
+  interface ColumnMeta<TData extends RowData, TValue> {
+    headerClassName?: string
+    cellClassName?: string
+  }
+}
 
 // TODO: add a possible chartGroupBy
 export interface DataTableInfiniteProps<TData, TValue, _TMeta> {
@@ -85,7 +101,7 @@ export function DataTableInfinite<TData, TValue, TMeta>({
             const sort = header.column.getIsSorted()
             const canResize = header.column.getCanResize()
             const onResize = header.getResizeHandler()
-            const headerClassName = (header.column.columnDef.meta as any)?.headerClassName
+            const headerClassName = header.column.columnDef.meta?.headerClassName
 
             return (
               <TableHead
@@ -236,7 +252,7 @@ function DataTableRow<TData>({
   searchParamsParser: any
 }) {
   useQueryState('live', searchParamsParser.live)
-  const rowClassName = (table.options.meta as any)?.getRowClassName?.(row)
+  const rowClassName = cn('group/row', table.options.meta?.getRowClassName?.(row))
   const cells = row.getVisibleCells()
 
   return (
@@ -254,7 +270,7 @@ function DataTableRow<TData>({
       className={cn(rowClassName)}
     >
       {cells.map((cell) => {
-        const cellClassName = (cell.column.columnDef.meta as any)?.cellClassName
+        const cellClassName = cell.column.columnDef.meta?.cellClassName
         return (
           <TableCell key={cell.id} className={cn(cellClassName)}>
             {flexRender(cell.column.columnDef.cell, cell.getContext())}

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -23,10 +23,12 @@ import { useShortcut } from '@/state/shortcuts/useShortcut'
 declare module '@tanstack/react-table' {
   interface TableMeta<TData extends RowData> {
     getRowClassName?: (row: Row<TData>) => string
+    [key: string]: unknown
   }
   interface ColumnMeta<TData extends RowData, TValue> {
     headerClassName?: string
     cellClassName?: string
+    [key: string]: unknown
   }
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Small visual gremlin where the status dot was blending in with the selected state background colour. See image below.

Appreciate there's probably another PR to go in with the row select before this goes in.

| Before | After |
|--------|--------|
| <img width="97" height="84" alt="Screenshot 2026-05-20 at 09 34 10" src="https://github.com/user-attachments/assets/7f21d415-e551-4686-a7e8-a6c7260ecab3" /> | <img width="173" height="67" alt="Screenshot 2026-05-20 at 12 51 14" src="https://github.com/user-attachments/assets/439b4c73-bd82-4bca-9d93-69c833da60bc" /> | 




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated visual styling for successful rows in data tables to use the selected-row variant, improving highlight consistency for selected/successful rows.

* **Refactor**
  * Standardized row class composition so each table row reliably includes the base row grouping class alongside any custom row classes from table metadata, reducing UI regressions and improving consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46152?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->