### PR TITLE
docs: clarify PostGIS TIGER geocoder data loading

### DIFF
--- a/apps/docs/content/guides/database/extensions.mdx
+++ b/apps/docs/content/guides/database/extensions.mdx
@@ -48,7 +48,9 @@ Most extensions are installed under the `extensions` schema, which is accessible
 
 If you need to restrict user access to tables managed by extensions, we recommend creating a separate schema for installing that specific extension.
 
-Some extensions can only be created under a specific schema, for example, `postgis_tiger_geocoder` extension creates a schema named `tiger`. Before enabling such extensions, make sure you have not created a conflicting schema with the same name.
+Some extensions can only be created under a specific schema. For example, the `postgis_tiger_geocoder` extension creates a schema named `tiger`. Before enabling such extensions, make sure you have not created a conflicting schema with the same name.
+
+Enabling `postgis_tiger_geocoder` does not load TIGER census data into the `tiger_data` schema. See the [PostGIS guide](/docs/guides/database/extensions/postgis#use-the-tiger-geocoder) for details.
 
 In addition to the pre-configured extensions, you can also install your own SQL extensions directly in the database using Supabase's SQL editor. The SQL code for the extensions, including plpgsql extensions, can be added through the SQL editor.
 

--- a/apps/docs/content/guides/database/extensions/postgis.mdx
+++ b/apps/docs/content/guides/database/extensions/postgis.mdx
@@ -45,6 +45,18 @@ drop extension if exists postgis;
 </TabPanel>
 </Tabs>
 
+{/* supa-mdx-lint-disable Rule003Spelling */}
+
+## Use the TIGER geocoder
+
+The `postgis_tiger_geocoder` extension adds geocoding functions, but it does not include TIGER census data by itself. The official PostGIS TIGER geocoder setup generates command-line loader scripts that download and load data into the `tiger_data` schema.
+
+Enabling `postgis_tiger_geocoder` in a hosted Supabase project creates the extension objects, but it does not run those loader scripts or populate `tiger_data`. Enabling `address_standardizer_data_us` adds data for address standardization; it does not add the census data required by `tiger.geocode`.
+
+If you need TIGER geocoding, use a self-hosted Postgres environment where you can run the [PostGIS TIGER data loader](https://postgis.net/docs/postgis_installation.html#install_tiger_geocoder_extension), or store geocoded coordinates in your own tables before querying them with PostGIS.
+
+{/* supa-mdx-lint-enable Rule003Spelling */}
+
 ## Examples
 
 Now that we are ready to get started with PostGIS, let’s create a table and see how we can utilize PostGIS for some typical use cases. Let’s imagine we are creating a simple restaurant-searching app.


### PR DESCRIPTION
Fixes #1318.

## What changed

- Clarifies that enabling postgis_tiger_geocoder creates extension objects but does not populate TIGER census data.
- Notes that address_standardizer_data_us is separate from the TIGER data required by tiger.geocode.
- Links from the extensions overview to the PostGIS guide note.

## Verification

- pnpm exec prettier --config prettier.config.mjs --check apps/docs/content/guides/database/extensions.mdx apps/docs/content/guides/database/extensions/postgis.mdx
- volta run --node 22.14.0 pnpm run lint:mdx
