### PR TITLE
fix: guard GraphiQL against invalid enum values

### DIFF
--- a/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx
@@ -14,6 +14,7 @@ import { LogoLoader } from 'ui'
 
 import { DEFAULT_INTROSPECTION_SCHEMA } from './constants'
 import styles from './graphiql.module.css'
+import { sanitizeIntrospectionResponse } from './GraphiQLTab.utils'
 import { IntrospectionDisabledNotice } from './IntrospectionDisabledNotice'
 import { IntrospectionEnabledNotice } from './IntrospectionEnabledNotice'
 import { usePgGraphqlIntrospectionStatus } from './usePgGraphqlIntrospectionStatus'
@@ -92,10 +93,23 @@ export const GraphiQLTab = () => {
   )
 
   const fetcher = useMemo(() => {
+    const graphqlUrl = `${API_URL}${IS_PLATFORM ? '' : '/platform'}/projects/${projectRef}/api/graphql`
     const fetcherFn = createGraphiQLFetcher({
       // [Joshen] Opting to hard code /platform for local to match the routes, so that it's clear what's happening
-      url: `${API_URL}${IS_PLATFORM ? '' : '/platform'}/projects/${projectRef}/api/graphql`,
+      url: graphqlUrl,
       fetch,
+      schemaFetcher: async (graphqlParams, opts) => {
+        const response = await fetch(graphqlUrl, {
+          method: 'POST',
+          body: JSON.stringify(graphqlParams),
+          headers: {
+            'content-type': 'application/json',
+            ...opts?.headers,
+          },
+        })
+
+        return sanitizeIntrospectionResponse(await response.json())
+      },
     })
     const customFetcher: Fetcher = async (graphqlParams, opts) => {
       let userAuthorization: string | undefined
@@ -110,8 +124,9 @@ export const GraphiQLTab = () => {
         try {
           const token = await getRoleImpersonationJWT(projectRef, jwtSecret, role)
           userAuthorization = 'Bearer ' + token
-        } catch (err: any) {
-          toast.error(`Failed to get JWT for role: ${err.message}`)
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err)
+          toast.error(`Failed to get JWT for role: ${message}`)
         }
       }
 

--- a/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+
+import { isValidGraphQLEnumValueName, sanitizeIntrospectionResponse } from './GraphiQLTab.utils'
+
+describe('isValidGraphQLEnumValueName', () => {
+  it('matches GraphQL enum value naming rules', () => {
+    expect(isValidGraphQLEnumValueName('a')).toBe(true)
+    expect(isValidGraphQLEnumValueName('_private')).toBe(true)
+    expect(isValidGraphQLEnumValueName('VALUE_1')).toBe(true)
+    expect(isValidGraphQLEnumValueName('c and d')).toBe(false)
+    expect(isValidGraphQLEnumValueName('1_value')).toBe(false)
+    expect(isValidGraphQLEnumValueName('true')).toBe(false)
+    expect(isValidGraphQLEnumValueName(null)).toBe(false)
+  })
+})
+
+describe('sanitizeIntrospectionResponse', () => {
+  it('removes enum values that cannot be represented in a GraphQL schema', () => {
+    const response = {
+      data: {
+        __schema: {
+          types: [
+            {
+              kind: 'ENUM',
+              name: 'Status',
+              enumValues: [
+                { name: 'a' },
+                { name: 'b' },
+                { name: 'c and d' },
+                { name: '1_value' },
+                { name: 'null' },
+              ],
+            },
+            {
+              kind: 'OBJECT',
+              name: 'Query',
+              fields: [],
+            },
+          ],
+        },
+      },
+    }
+
+    const sanitized = sanitizeIntrospectionResponse(response)
+    const sanitizedStatusType = sanitized.data.__schema.types[0] as {
+      enumValues: Array<{ name: string }>
+    }
+    const originalStatusType = response.data.__schema.types[0] as {
+      enumValues: Array<{ name: string }>
+    }
+
+    expect(sanitizedStatusType.enumValues.map(({ name }) => name)).toEqual(['a', 'b'])
+    expect(originalStatusType.enumValues.map(({ name }) => name)).toEqual([
+      'a',
+      'b',
+      'c and d',
+      '1_value',
+      'null',
+    ])
+  })
+
+  it('returns the original response when no enum values are removed', () => {
+    const response = {
+      data: {
+        __schema: {
+          types: [
+            {
+              kind: 'ENUM',
+              name: 'Status',
+              enumValues: [{ name: 'a' }, { name: 'VALUE_1' }],
+            },
+          ],
+        },
+      },
+    }
+
+    expect(sanitizeIntrospectionResponse(response)).toBe(response)
+  })
+
+  it('leaves non-introspection responses unchanged', () => {
+    const response = { data: { project: { ref: 'default' } } }
+
+    expect(sanitizeIntrospectionResponse(response)).toBe(response)
+  })
+})

--- a/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.ts
@@ -1,0 +1,49 @@
+const GRAPHQL_ENUM_VALUE_NAME_REGEX = /^[_A-Za-z][_0-9A-Za-z]*$/
+const RESERVED_GRAPHQL_ENUM_VALUE_NAMES = new Set(['true', 'false', 'null'])
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null
+
+export const isValidGraphQLEnumValueName = (name: unknown): name is string =>
+  typeof name === 'string' &&
+  GRAPHQL_ENUM_VALUE_NAME_REGEX.test(name) &&
+  !RESERVED_GRAPHQL_ENUM_VALUE_NAMES.has(name)
+
+const hasValidEnumValueName = (
+  enumValue: unknown
+): enumValue is Record<string, unknown> & { name: string } =>
+  isRecord(enumValue) && isValidGraphQLEnumValueName(enumValue.name)
+
+export const sanitizeIntrospectionResponse = <T>(response: T): T => {
+  if (!isRecord(response) || !isRecord(response.data)) return response
+  if (!isRecord(response.data.__schema) || !Array.isArray(response.data.__schema.types)) {
+    return response
+  }
+
+  let hasChanges = false
+
+  const types = response.data.__schema.types.map((type) => {
+    if (!isRecord(type) || type.kind !== 'ENUM' || !Array.isArray(type.enumValues)) {
+      return type
+    }
+
+    const enumValues = type.enumValues.filter(hasValidEnumValueName)
+    if (enumValues.length === type.enumValues.length) return type
+
+    hasChanges = true
+    return { ...type, enumValues }
+  })
+
+  if (!hasChanges) return response
+
+  return {
+    ...response,
+    data: {
+      ...response.data,
+      __schema: {
+        ...response.data.__schema,
+        types,
+      },
+    },
+  } as T
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

GraphiQL can fail to load the schema when an introspection response contains enum values that GraphQL.js rejects as enum names, such as values with whitespace. This is reported in #31068.

## What is the new behavior?

GraphiQL uses a schema-specific fetcher for introspection requests and sanitizes only the introspection payload by removing enum values that cannot be represented as GraphQL enum names. Normal GraphQL operations continue to use the existing fetcher path.

## Additional context

The sanitizer preserves the original response object when no invalid enum values are found and includes focused coverage for whitespace, digit-prefixed, and reserved enum value names.

Fixes #31068

## Tests

- volta run --node 22.14.0 pnpm exec prettier --check apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.ts apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.test.ts
- volta run --node 22.14.0 pnpm --dir apps/studio exec eslint components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.ts components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.test.ts
- volta run --node 22.14.0 pnpm --dir apps/studio exec vitest --run components/interfaces/Integrations/GraphQL/GraphiQLTab.utils.test.ts
- volta run --node 22.14.0 pnpm --dir apps/studio run typecheck