### PR TITLE
docs: clarify JavaScript CDN usage

### DIFF
--- a/apps/docs/docs/ref/javascript/installing.mdx
+++ b/apps/docs/docs/ref/javascript/installing.mdx
@@ -54,15 +54,22 @@ custom_edit_url: https://github.com/supabase/supabase/edit/master/web/spec/supab
   <RefSubLayout.Details>
     
     You can install @supabase/supabase-js via CDN links.
+    The CDN build exposes a `supabase` global on `window`.
+    If you want to use an `import { createClient } from '@supabase/supabase-js'` statement, install the package with a package manager instead.
 
   </RefSubLayout.Details>
 
   <RefSubLayout.Examples>
 
-    ```js
+    ```html
     <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-    //or
-    <script src="https://unpkg.com/@supabase/supabase-js@2"></script>
+    <!-- Or: <script src="https://unpkg.com/@supabase/supabase-js@2"></script> -->
+
+    <script>
+      const supabaseUrl = 'https://your-project-id.supabase.co'
+      const supabaseKey = 'sb_publishable_...'
+      const supabase = window.supabase.createClient(supabaseUrl, supabaseKey)
+    </script>
     ```
 
   </RefSubLayout.Examples>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The JavaScript reference shows script-tag CDN URLs but does not show how to initialize the client from the CDN build. Readers can reasonably try to combine that script-tag install with an `import { createClient } from '@supabase/supabase-js'` statement, which does not match the CDN global usage.

## What is the new behavior?

- Clarifies that the CDN build exposes `window.supabase`.
- Shows `window.supabase.createClient(...)` after loading a CDN script.
- Points package-style `import` usage back to package manager installation.

Refs #21261.

## Additional context

This handles only the documentation gap from the latest issue comment. It does not try to resolve the broader package/runtime analysis in #21261.

## Tests

- `volta run --node 22.14.0 pnpm exec prettier --config prettier.config.mjs --check apps/docs/docs/ref/javascript/installing.mdx`
- `volta run --node 22.14.0 pnpm run lint:mdx` (from `apps/docs`)

Note: `volta run --node 22.14.0 pnpm --dir apps/docs exec eslint docs/ref/javascript/installing.mdx` exits successfully but reports the file is ignored by the current ESLint config.
