### PR TITLE
docs: clarify queues read visibility timeout

### DIFF
--- a/apps/docs/content/guides/queues/api.mdx
+++ b/apps/docs/content/guides/queues/api.mdx
@@ -55,8 +55,10 @@ Permanently deletes a Message from the specified Queue.
 
 ### `pgmq_public.read(queue_name, sleep_seconds, n)`
 
-Reads up to "n" Messages from the specified Queue with an optional "sleep_seconds" (visibility timeout).
+Reads up to `n` Messages from the specified Queue. `sleep_seconds` is required and sets the visibility timeout: while the timeout is active, Messages returned by this call are hidden from other consumers. If a Message is not deleted or archived before the timeout expires, it can be read again.
 
 - `queue_name` (`text`): Queue name
-- `sleep_seconds` (`integer`): Visibility timeout in seconds
+- `sleep_seconds` (`integer`): Required visibility timeout in seconds. Set this long enough for the consumer to process and delete or archive the Messages.
 - `n` (`integer`): Maximum number of Messages to read
+
+Use `pgmq_public.pop(queue_name)` instead if you want to read and delete a single Message immediately.


### PR DESCRIPTION
- Issue: Refs https://github.com/supabase/supabase/issues/32306. The Queues API page lists `pgmq_public.read(queue_name, sleep_seconds, n)`, but the description still called `sleep_seconds` optional, which contradicts the required RPC signature and can lead to failed Data API calls when users omit it.

- Fix: Clarify that `sleep_seconds` is required for `pgmq_public.read`, explain that it is the visibility timeout for returned messages, and point users to `pgmq_public.pop(queue_name)` when they want to read and immediately delete a single message. This is intentionally limited to the docs clarification and leaves the batch-delete feature request out of scope.

- Tests:
  - `volta run --node 22.14.0 pnpm exec prettier --config prettier.config.mjs --check apps/docs/content/guides/queues/api.mdx`
  - `volta run --node 22.14.0 pnpm run lint:mdx` from `apps/docs`

- Risk: One MDX docs file changed. No generated files or navigation entries were touched. Remaining risk is limited to wording accuracy for the Queues API reference.
