### PR TITLE
docs: fix Swift example links and redirect config

### DIFF
--- a/examples/user-management/swift-user-management/README.md
+++ b/examples/user-management/swift-user-management/README.md
@@ -1,18 +1,18 @@
 # Supabase Swift User Management
 
-This repo is a quick sample of how you can get started building apps using Swift and Supabase. You can find a step by step guide of how to build out this app in the [Quickstart: Swift guide](https://supabase.com/docs/guides/getting-started/quickstarts/ios-swiftui).
+This repo is a quick sample of how you can get started building apps using Swift and Supabase. You can find a step by step guide of how to build out this app in the [Swift user management tutorial](https://supabase.com/docs/guides/getting-started/tutorials/with-swift).
 
 This repo will demonstrate how to:
 
-- Sign users in with Supabase Auth using [magic link](https://supabase.com/docs/reference/dart/auth-signinwithotp)
-- Store and retrieve data with [Supabase database](https://supabase.io/docs/guides/database)
-- Store image files in [Supabase storage](https://supabase.io/docs/guides/storage)
+- Sign users in with Supabase Auth using [magic link](https://supabase.com/docs/reference/swift/auth-signinwithotp)
+- Store and retrieve data with [Supabase database](https://supabase.com/docs/guides/database)
+- Store image files in [Supabase storage](https://supabase.com/docs/guides/storage)
 
 ![Supabase User Management example](supabase-swift-demo.png)
 
 ## Getting Started
 
-Run `cp .env.example .env` and fill in [your credentials](https://supabase.io/docs/guides/with-flutter#get-the-api-keys).
+Run `cp .env.example .env` and fill in [your credentials](https://supabase.com/docs/guides/getting-started/tutorials/with-swift#get-api-details).
 
 Run the application in a device or simulator using Xcode.
 

--- a/examples/user-management/swift-user-management/supabase/config.toml
+++ b/examples/user-management/swift-user-management/supabase/config.toml
@@ -73,7 +73,10 @@ enabled = true
 # in emails.
 site_url = "http://127.0.0.1:3000"
 # A list of *exact* URLs that auth providers are permitted to redirect to post authentication.
-additional_redirect_urls = ["https://127.0.0.1:3000"]
+additional_redirect_urls = [
+  "https://127.0.0.1:3000",
+  "io.supabase.user-management://login-callback",
+]
 # How long tokens are valid for, in seconds. Defaults to 3600 (1 hour), maximum 604,800 (1 week).
 jwt_expiry = 3600
 # If disabled, the refresh token will never expire.


### PR DESCRIPTION
Issue: Refs #34214. The Swift user-management example README still linked to the Dart magic-link reference, old `supabase.io` pages, and Flutter credential docs. The local Supabase config also did not allow the custom `io.supabase.user-management://login-callback` URL used by `AuthView.swift`.

Fix: Update the README links to current Swift, database, storage, and Swift tutorial targets. Add the Swift app callback URL to `additional_redirect_urls` while keeping the existing localhost redirect entry.

Tests:
- `volta run --node 22.14.0 pnpm exec prettier --config prettier.config.mjs --check examples/user-management/swift-user-management/README.md`
- `python3 -c "import tomllib; tomllib.load(open('examples/user-management/swift-user-management/supabase/config.toml','rb'))"`
- `git diff --check`

Risk: Docs/example-config only. No generated files. I did not run the Xcode app, so runtime validation is limited to matching the configured redirect allow-list to the callback URL used by the sample code.
