### PR TITLE
Update Supabase client configuration options

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/expo-react-native.mdx
@@ -99,8 +99,6 @@ hideToc: true
       export const supabase = createClient(supabaseUrl, supabasePublishableKey, {
         auth: {
           storage: localStorage,
-          autoRefreshToken: true,
-          persistSession: true,
           detectSessionInUrl: false,
         },
       })


### PR DESCRIPTION
Removed autoRefreshToken and persistSession options from Supabase client configuration as they default to: true

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

The React Native/Expo example explicitly configures autoRefreshToken: true and persistSession: true.

## What is the new behavior?

Those options are omitted because they are already the default values. This is only a documentation cleanup


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the Supabase client configuration example in the Expo React Native quickstart guide.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46176?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->