### PR TITLE
feat(studio): visually separate user and system schemas in SchemaSele…

### DIFF
--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -23,6 +23,13 @@ import {
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
+
+/** Schemas that are part of PostgreSQL itself or Supabase internals */
+const isSystemSchema = (name: string): boolean =>
+  INTERNAL_SCHEMAS.includes(name) ||
+  name.startsWith('pg_') ||
+  name === 'information_schema'
 
 type SchemaSelectorProps = Omit<ComponentPropsWithoutRef<'div'>, 'onSelect'> & {
   disabled?: boolean
@@ -89,6 +96,9 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
     const schemas = (data || [])
       .filter((schema) => !excludedSchemas.includes(schema.name))
       .sort((a, b) => a.name.localeCompare(b.name))
+
+    const userSchemas = schemas.filter((s) => !isSystemSchema(s.name))
+    const systemSchemas = schemas.filter((s) => isSystemSchema(s.name))
 
     return (
       <div ref={ref} className={className} {...rest}>
@@ -176,7 +186,7 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
                           )}
                         </CommandItem>
                       )}
-                      {schemas.map((schema) => (
+                      {userSchemas.map((schema) => (
                         <CommandItem
                           key={schema.id}
                           className="cursor-pointer flex items-center justify-between space-x-2 w-full"
@@ -195,6 +205,33 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
                           )}
                         </CommandItem>
                       ))}
+                      {systemSchemas.length > 0 && (
+                        <>
+                          <CommandSeparator className="my-1" />
+                          <p className="px-2 py-1.5 text-xs text-foreground-lighter">
+                            System schemas
+                          </p>
+                          {systemSchemas.map((schema) => (
+                            <CommandItem
+                              key={schema.id}
+                              className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                              onSelect={() => {
+                                onSelectSchema(schema.name)
+                                setOpen(false)
+                              }}
+                              onClick={() => {
+                                onSelectSchema(schema.name)
+                                setOpen(false)
+                              }}
+                            >
+                              <span className="text-foreground-lighter">{schema.name}</span>
+                              {selectedSchemaName === schema.name && (
+                                <Check className="text-brand" strokeWidth={2} size={16} />
+                              )}
+                            </CommandItem>
+                          ))}
+                        </>
+                      )}
                     </ScrollArea>
                   </CommandGroup>
                   {onSelectCreateSchema !== undefined && canCreateSchemas && (


### PR DESCRIPTION
Group schemas into user-defined schemas (shown first) and system/internal schemas (shown below a separator with a 'System schemas' label and muted text). This reduces cognitive noise when users only need their custom schemas.

Reuses the existing INTERNAL_SCHEMAS constant from useProtectedSchemas and additionally classifies any schema starting with 'pg_' as a system schema.

Closes https://github.com/orgs/supabase/discussions/46065

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature — visually group user vs system schemas in the SchemaSelector dropdown

## What is the current behavior?

All schemas (user-defined and system/internal) are displayed in a single flat alphabetical list, making it cognitively noisy to find custom schemas.

Related: https://github.com/orgs/supabase/discussions/46065

## What is the new behavior?

- User-defined schemas appear at the top of the dropdown
- A "System schemas" separator and label divides the two groups
- System schema names render in muted text for visual distinction
- System schemas are identified via the existing `INTERNAL_SCHEMAS` constant plus any schema prefixed with `pg_`

## Additional context

Only one file changed: `apps/studio/components/ui/SchemaSelector.tsx` (38 additions, 1 deletion). No breaking changes — all existing props and behavior are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Schema selector now organizes schemas by type, displaying user schemas in the main list and system schemas in a separate grouped section with visual separation for better clarity and navigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46186?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->