### PR TITLE
fix: guard profile image src

### DIFF
--- a/apps/studio/components/ui/ProfileImage.test.tsx
+++ b/apps/studio/components/ui/ProfileImage.test.tsx
@@ -1,0 +1,37 @@
+import { render, screen } from '@testing-library/react'
+import type { ComponentProps } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { ProfileImage } from './ProfileImage'
+
+vi.mock('next/image', () => ({
+  default: ({ alt, src, ...props }: ComponentProps<'img'>) => (
+    <img alt={alt} src={src} {...props} />
+  ),
+}))
+
+describe('ProfileImage', () => {
+  it('renders an image for a string src', () => {
+    render(<ProfileImage alt="Profile" src="https://avatars.githubusercontent.com/u/1" />)
+
+    expect(screen.getByRole('img', { name: 'Profile' })).toHaveAttribute(
+      'src',
+      'https://avatars.githubusercontent.com/u/1'
+    )
+  })
+
+  it('falls back when src is not a string at runtime', () => {
+    const invalidSrc = { url: 'https://avatars.githubusercontent.com/u/1' }
+
+    const { container } = render(
+      <ProfileImage
+        alt="Profile"
+        src={invalidSrc as unknown as string}
+        placeholder={<span data-testid="fallback-avatar" />}
+      />
+    )
+
+    expect(screen.getByTestId('fallback-avatar')).toBeInTheDocument()
+    expect(container.querySelector('img')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/ui/ProfileImage.tsx
+++ b/apps/studio/components/ui/ProfileImage.tsx
@@ -12,8 +12,9 @@ interface ProfileImageProps {
 
 export const ProfileImage = ({ alt, src, placeholder, className }: ProfileImageProps) => {
   const [hasInvalidImg, setHasInvalidImg] = useState(false)
+  const hasValidSrc = typeof src === 'string' && src.length > 0
 
-  return !!src && !hasInvalidImg ? (
+  return hasValidSrc && !hasInvalidImg ? (
     <Image
       alt={alt ?? ''}
       src={src}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`ProfileImage` checks whether `src` is truthy before passing it to Next Image. If malformed API/profile data passes a non-string value through at runtime, Next Image can still receive that value and crash while reading string methods such as `startsWith`.

Fixes #39654.

## What is the new behavior?

`ProfileImage` now renders the image only when `src` is a non-empty string. Otherwise it falls back to the existing placeholder behavior.

## Additional context

This keeps the change limited to the shared profile image component and adds a regression test for a non-string runtime payload.

## Tests

- `volta run --node 22.14.0 pnpm --dir apps/studio exec vitest --run components/ui/ProfileImage.test.tsx`
- `volta run --node 22.14.0 pnpm exec prettier --check apps/studio/components/ui/ProfileImage.tsx apps/studio/components/ui/ProfileImage.test.tsx`
- `volta run --node 22.14.0 pnpm --dir apps/studio exec eslint components/ui/ProfileImage.tsx components/ui/ProfileImage.test.tsx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image source validation in ProfileImage component to more reliably detect and handle invalid image sources with proper placeholder fallback.

* **Tests**
  * Added comprehensive test coverage for ProfileImage component, verifying correct rendering with valid sources and proper placeholder display when sources are invalid.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46188?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->