### PR TITLE
fix(studio): work around Vercel build OOM

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportSidebarForm.tsx
+++ b/apps/studio/components/interfaces/Support/SupportSidebarForm.tsx
@@ -1,6 +1,7 @@
 import * as Sentry from '@sentry/nextjs'
 import { useFlag } from 'common'
 import { Loader2 } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useCallback, useReducer } from 'react'
 import { toast } from 'sonner'
@@ -9,7 +10,6 @@ import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { IncidentAdmonition } from './IncidentAdmonition'
 import { Success } from './Success'
 import type { ExtendedSupportCategories } from './Support.constants'
-import { SupportAssistantSuccessCard } from './SupportAssistantSuccessCard'
 import { createInitialSupportFormState, supportFormReducer } from './SupportForm.state'
 import { NO_PROJECT_MARKER, type SupportFormUrlKeys } from './SupportForm.utils'
 import { SupportFormV3 } from './SupportFormV3'
@@ -17,6 +17,10 @@ import { useSupportForm } from './useSupportForm'
 import { useIncidentStatusQuery } from '@/data/platform/incident-status-query'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useStateTransition } from '@/hooks/misc/useStateTransition'
+
+const SupportAssistantSuccessCard = dynamic(() =>
+  import('./SupportAssistantSuccessCard').then((m) => m.SupportAssistantSuccessCard)
+)
 
 function useSupportFormTelemetry() {
   const { mutate: sendEvent } = useSendEventMutation()

--- a/apps/studio/next.config.ts
+++ b/apps/studio/next.config.ts
@@ -642,11 +642,14 @@ export default process.env.NEXT_PUBLIC_IS_PLATFORM === 'true' && process.env.VER
       // https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
       // Upload a larger set of source maps for prettier stack traces (increases build time)
-      widenClientFileUpload: true,
+      // Disabled: builds were OOMing on Vercel; re-enable once we lift the build memory ceiling.
+      widenClientFileUpload: false,
 
       // Automatically annotate React components to show their full name in breadcrumbs and session replay
+      // Disabled: this walks every component AST at build time and was the primary contributor to
+      // OOMs on Vercel. Re-enable once we lift the build memory ceiling.
       reactComponentAnnotation: {
-        enabled: true,
+        enabled: false,
       },
 
       // Automatically tree-shake Sentry logger statements to reduce bundle size


### PR DESCRIPTION
Studio builds on Vercel started OOMing around #45861. Sometimes the build crashed in ~3min, sometimes ran for ~35min before crashing.

## What's actually going on

Two things going on together:

1. **Sentry's `reactComponentAnnotation` is the primary memory hog.** It walks every React component AST at build time to add component-name annotations to bundles. It's gated by `process.env.VERCEL === '1'` in `next.config.ts`, which is exactly why **local builds succeed (peak ~15GB) but Vercel builds OOM** — the annotation pass never runs locally. `widenClientFileUpload: true` compounds it by widening the sourcemap upload scope. As studio's component count grows, this pass approaches Vercel's container memory ceiling.

2. **#45861 was the straw that broke it.** That PR added the new `SupportAssistantSuccessCard` (and its dependency on the AI Assistant `Message` graph) as a *static* import from `SupportSidebarForm`. `SupportSidebarForm` is reachable from `LayoutSidebarProvider` (mounted in `DefaultLayout`), so this re-introduced the heavy `@ai-sdk/react` + `AIAssistantPanel/Message` subgraph through a second dynamic-chunk root (`HelpPanel`) on top of the existing `AIAssistant` dynamic root. Webpack ends up hoisting/recomputing a large shared chunk, which both bloats the module graph and gives Sentry's annotation pass more work to do.

The variable 3min vs 35min OOM timing fits: ~3min is OOM during webpack/Sentry annotation, ~35min is OOM later during static page generation / sourcemap upload.

## Changes

1. **`apps/studio/next.config.ts`** — disable Sentry's most expensive build-time features:
   - `reactComponentAnnotation.enabled: false` — biggest memory win. Loses component names in Sentry breadcrumbs/replay; stack traces still work.
   - `widenClientFileUpload: false` — narrower sourcemap upload, smaller memory footprint.
2. **`apps/studio/components/interfaces/Support/SupportSidebarForm.tsx`** — `SupportAssistantSuccessCard` is now loaded via `next/dynamic`. Card is gated by the `supportAssistantFollowUp` flag and only renders after submit, so paying the static-import cost was never justified. Net bundle/perf improvement even though it didn't fix the OOM on its own.

## How to verify

- Watch the Vercel preview build — should complete without OOM.
- Open `/support/new`, submit a ticket with the `supportAssistantFollowUp` flag enabled, and confirm the success card still renders correctly.
- Submit a ticket with the flag disabled and confirm the regular `Success` view still renders.

## Follow-ups

- Re-enable `reactComponentAnnotation` / `widenClientFileUpload` once we raise the Vercel build memory ceiling (`NODE_OPTIONS=--max-old-space-size=…`) or upgrade `@sentry/nextjs` past any known memory regressions.
- If OOM persists, next move is `experimental.workerThreads: false` in `next.config.ts` to serialize static page generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Support UI component loading switched to lazy/dynamic loading to improve initial load performance.
* **Chores**
  * Updated monitoring/telemetry configuration to change client-side upload and annotation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->