### PR TITLE
fix: show maintenance banners only for affected project regions

### DIFF
--- a/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
+++ b/apps/studio/components/interfaces/App/AppBannerWrapper.tsx
@@ -1,14 +1,41 @@
-import { useFlag } from 'common'
-import { PropsWithChildren } from 'react'
+import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
+import { PropsWithChildren, useEffect } from 'react'
 
 import { OrganizationResourceBanner } from '../Organization/HeaderBanner'
 import { ClockSkewBanner } from '@/components/layouts/AppLayout/ClockSkewBanner'
 import { NoticeBanner } from '@/components/layouts/AppLayout/NoticeBanner'
 import { StatusPageBanner } from '@/components/layouts/AppLayout/StatusPageBanner'
+import { BannerTOSUpdate } from '@/components/ui/BannerStack/Banners/BannerTOSUpdate'
+import { useBannerStack } from '@/components/ui/BannerStack/BannerStackProvider'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+
+const TOSUpdateExpiry = new Date('2026-07-04T00:00:00Z')
 
 export const AppBannerWrapper = ({ children }: PropsWithChildren<{}>) => {
   const showNoticeBanner = useFlag('showNoticeBanner')
   const clockSkewBanner = useFlag('clockSkewBanner')
+
+  const { addBanner, dismissBanner } = useBannerStack()
+
+  const [TOSUpdateAcknowledged, , { isSuccess }] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.TERMS_OF_SERVICE_UPDATE,
+    false
+  )
+
+  useEffect(() => {
+    if (Date.now() >= TOSUpdateExpiry.getTime()) return
+
+    if (isSuccess && !TOSUpdateAcknowledged) {
+      addBanner({
+        id: 'tos-update-banner',
+        isDismissed: false,
+        content: <BannerTOSUpdate />,
+        priority: 2,
+      })
+    } else {
+      dismissBanner('tos-update-banner')
+    }
+  }, [TOSUpdateAcknowledged, isSuccess, addBanner, dismissBanner])
 
   return (
     <div className="flex flex-col">

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -1,41 +1,84 @@
-import { LOCAL_STORAGE_KEYS } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import dayjs from 'dayjs'
 import { useRouter } from 'next/router'
 import { TimestampInfo } from 'ui-patterns'
 
 import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
-import { InlineLink } from '@/components/ui/InlineLink'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+
+// Update this whenever the banner content below changes so old client bundles
+// stop displaying outdated notices after the relevant date passes.
+const BANNER_EXPIRES_AT = new Date('2026-06-01T15:00:00Z')
+
+const SUPAVISOR_UPDATE_REGIONS = {
+  'eu-central-1': {
+    start: Date.UTC(2026, 4, 26, 13, 0, 0),
+    end: Date.UTC(2026, 4, 26, 15, 0, 0),
+    url: 'https://status.supabase.com/incidents/jy1tm4wfs68t',
+  },
+  'eu-west-1': {
+    start: Date.UTC(2026, 4, 27, 13, 0, 0),
+    end: Date.UTC(2026, 4, 27, 15, 0, 0),
+    url: 'https://status.supabase.com/incidents/3t293hpd545z',
+  },
+  'us-west-1': {
+    start: Date.UTC(2026, 4, 28, 13, 0, 0),
+    end: Date.UTC(2026, 4, 28, 15, 0, 0),
+    url: 'https://status.supabase.com/incidents/8f72bnv3xs8r',
+  },
+  'us-east-1': {
+    start: Date.UTC(2026, 5, 1, 13, 0, 0),
+    end: Date.UTC(2026, 5, 1, 15, 0, 0),
+    url: 'https://status.supabase.com/incidents/7zgmgh2p343n',
+  },
+}
 
 /**
  * Used to display urgent notices that apply for all users, such as maintenance windows.
  */
 export const NoticeBanner = () => {
   const router = useRouter()
+  const { ref } = useParams()
+  const { data: project } = useSelectedProjectQuery()
 
   const [bannerAcknowledged, setBannerAcknowledged, { isSuccess }] = useLocalStorageQuery(
-    LOCAL_STORAGE_KEYS.MAINTENANCE_WINDOW_BANNER,
+    LOCAL_STORAGE_KEYS.SUPAVISOR_MAINTENANCE(ref ?? ''),
     false
   )
 
-  if (router.pathname.includes('sign-in') || !isSuccess || bannerAcknowledged) {
+  const region = project?.region ?? ''
+  const maintenanceWindow =
+    SUPAVISOR_UPDATE_REGIONS[region as keyof typeof SUPAVISOR_UPDATE_REGIONS]
+
+  if (
+    Date.now() >= BANNER_EXPIRES_AT.getTime() ||
+    router.pathname.includes('sign-in') ||
+    !isSuccess ||
+    !project ||
+    !maintenanceWindow ||
+    bannerAcknowledged
+  ) {
     return null
   }
 
   return (
     <HeaderBanner
-      variant="warning"
-      title="Upcoming Dashboard and Management API maintenance"
+      variant="note"
+      title="Upcoming maintenance"
       description={
         <>
+          Shared pooler maintenance in{' '}
+          <a target="_blank" rel="noopener referrer" href={maintenanceWindow.url}>
+            {project.region}
+          </a>{' '}
+          on{' '}
           <TimestampInfo
             className="text-sm"
-            utcTimestamp={1768530600000}
-            label="02:30 UTC on Jan 16, 2026"
+            utcTimestamp={maintenanceWindow.start}
+            label={dayjs(maintenanceWindow.start).format('DD MMM, HH:mm')}
           />
-          .{' '}
-          <InlineLink href="https://status.supabase.com/incidents/lg4j8mcn50zb">
-            Learn more
-          </InlineLink>
+          .
         </>
       }
       onDismiss={() => setBannerAcknowledged(true)}

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
@@ -7,6 +7,7 @@ export const BANNER_ID = {
   RLS_EVENT_TRIGGER: 'rls-event-trigger-banner',
   RLS_TESTER: 'rls-tester-banner',
   FREE_MICRO_UPGRADE: 'free-micro-upgrade-banner',
+  TOS_UPDATE: 'tos-update-banner',
 } as const
 
 export type BannerId = (typeof BANNER_ID)[keyof typeof BANNER_ID]

--- a/apps/studio/components/ui/BannerStack/Banners/BannerTOSUpdate.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerTOSUpdate.tsx
@@ -1,0 +1,123 @@
+import { LOCAL_STORAGE_KEYS } from 'common'
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
+} from 'ui'
+
+import { InlineLink } from '../../InlineLink'
+import { BannerCard } from '../BannerCard'
+import { useBannerStack } from '../BannerStackProvider'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
+
+/**
+ * [Joshen] TOS update takes place from 6th June onwards, can remove from 4th July onwards as
+ * previously stated in the NoticeBanner
+ */
+
+export const BannerTOSUpdate = () => {
+  const { dismissBanner } = useBannerStack()
+  const [, setTOSUpdateAcknowledged] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.TERMS_OF_SERVICE_UPDATE,
+    false
+  )
+
+  return (
+    <BannerCard
+      onDismiss={() => {
+        setTOSUpdateAcknowledged(true)
+        dismissBanner('tos-update-banner')
+      }}
+    >
+      <div className="flex flex-col gap-y-2">
+        <Badge variant="default" className="w-min -ml-0.5 uppercase inline-flex items-center mb-2">
+          Notice
+        </Badge>
+
+        <div className="flex flex-col gap-y-1 mb-2">
+          <p className="text-sm font-medium">We've updated our Terms of Service</p>
+          <p className="text-xs text-foreground-lighter text-balance">
+            Updates define the responsibilities of both you and Supabase in the use of AI.
+          </p>
+        </div>
+        <UpdatedTermsOfServiceDialog />
+      </div>
+    </BannerCard>
+  )
+}
+
+const UpdatedTermsOfServiceDialog = () => {
+  const [, setTOSUpdateAcknowledged] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.TERMS_OF_SERVICE_UPDATE,
+    false
+  )
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="default" className="w-min">
+          Learn more
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Terms of Service update</DialogTitle>
+          <DialogDescription>
+            We've updated our Terms of Service to better define the responsibilities of both you and
+            Supabase in the use of AI.
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogSectionSeparator />
+
+        <DialogSection className="text-sm flex flex-col gap-y-2">
+          <p>
+            We've clarified how we use AI in our customer support tooling, introduced guidelines for
+            the responsible use of AI by our users, and updated our indemnification terms to clarify
+            the allocation of responsibility for claims arising from AI-generated inputs and
+            outputs.
+          </p>
+
+          <p>
+            Additionally, we've made an explicit commitment that Supabase will never use the data
+            you submit to the Supabase services to train or improve any AI without your prior
+            written consent.
+          </p>
+
+          <p>
+            The updated Terms (Version 2) will take effect on June 6, 2026. By continuing to use the
+            Services after that date, you agree to the updated Terms. You can review the changes{' '}
+            <InlineLink href="https://supabase.com/terms">here</InlineLink>.
+          </p>
+
+          <p>
+            This notice applies to users on Supabase's standard Terms of Service only. If you are on
+            an Enterprise plan or with a separately negotiated agreement, your existing terms
+            continue to govern your use of the Services.
+          </p>
+        </DialogSection>
+
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button
+              type="default"
+              className="opacity-100"
+              onClick={() => setTOSUpdateAcknowledged(true)}
+            >
+              Understood
+            </Button>
+          </DialogClose>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilters.utils.ts
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilters.utils.ts
@@ -2,7 +2,7 @@ import { ColumnFiltersState } from '@tanstack/react-table'
 import { ParserBuilder } from 'nuqs'
 
 import { ARRAY_DELIMITER, RANGE_DELIMITER, SLIDER_DELIMITER } from '../DataTable.constants'
-import type { DataTableFilterField } from '../DataTable.types'
+import type { DataTableFilterField, Option } from '../DataTable.types'
 import { isArrayOfDates } from '../DataTable.utils'
 
 /**
@@ -34,7 +34,7 @@ export function replaceInputByFieldType<TData>({
 }: {
   prev: string
   currentWord: string
-  optionValue?: string | number | boolean | undefined // FIXME: use DataTableFilterField<TData>["options"][number];
+  optionValue?: Option['value'];
   value: string
   field: DataTableFilterField<TData>
 }) {

--- a/apps/studio/data/integrations/github-authorization-query.ts
+++ b/apps/studio/data/integrations/github-authorization-query.ts
@@ -4,7 +4,6 @@ import { integrationKeys } from './keys'
 import { get } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
-// FIXME(kamil): Do not retry, a single check is fine.
 export async function getGitHubAuthorization(signal?: AbortSignal) {
   const { data, error } = await get('/platform/integrations/github/authorization', {
     signal,
@@ -25,8 +24,9 @@ export const useGitHubAuthorizationQuery = <TData = GitHubAuthorizationData>({
   return useQuery<GitHubAuthorizationData, GitHubAuthorizationError, TData>({
     queryKey: integrationKeys.githubAuthorization(),
     queryFn: ({ signal }) => getGitHubAuthorization(signal),
-    enabled,
+enabled,
     staleTime: 0,
+    retry: false,
     ...options,
   })
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -5,29 +5,23 @@ export const LOCAL_STORAGE_KEYS = {
   AI_ASSISTANT_STATE: (projectRef: string | undefined) =>
     `supabase-ai-assistant-state-${projectRef}`,
   SIDEBAR_BEHAVIOR: 'supabase-sidebar-behavior',
-  EDITOR_PANEL_STATE: 'supabase-editor-panel-state',
   PROJECTS_VIEW: 'projects-view',
   PROJECTS_FILTER: 'projects-filter',
   PROJECTS_SORT: 'projects-sort',
   FEEDBACK_WIDGET_CONTENT: 'feedback-widget-content',
   FEEDBACK_WIDGET_SCREENSHOT: 'feedback-widget-screenshot',
   INCIDENT_BANNER_DISMISSED_IDS: 'incident-banner-dismissed-ids',
-  MAINTENANCE_BANNER_DISMISSED: (id: string) => `maintenance-banner-dismissed-${id}`,
   DASHBOARD_PREFERENCES: (ref: string) => `dashboard-preferences-${ref}`,
 
   UI_PREVIEW_CLS: 'supabase-ui-cls',
   UI_PREVIEW_INLINE_EDITOR: 'supabase-ui-preview-inline-editor',
   UI_PREVIEW_UNIFIED_LOGS: 'supabase-ui-preview-unified-logs',
-  UI_ONBOARDING_NEW_PAGE_SHOWN: 'supabase-ui-onboarding-new-page-shown',
   UI_PREVIEW_ADVISOR_RULES: 'supabase-ui-advisor-rules',
   UI_PREVIEW_QUEUE_OPERATIONS: 'supabase-ui-queue-operations',
   UI_PREVIEW_PG_DELTA_DIFF: 'supabase-ui-pg-delta-diff',
   UI_PREVIEW_PLATFORM_WEBHOOKS: 'supabase-ui-platform-webhooks',
   UI_PREVIEW_JIT_DB_ACCESS: 'supabase-ui-jit-db-access',
   UI_PREVIEW_RLS_TESTER: 'supabase-ui-rls-tester',
-
-  NEW_LAYOUT_NOTICE_ACKNOWLEDGED: 'new-layout-notice-acknowledge',
-  TABS_INTERFACE_ACKNOWLEDGED: 'tabs-interface-acknowledge',
   AI_ASSISTANT_MCP_OPT_IN: 'ai-assistant-mcp-opt-in',
 
   DASHBOARD_HISTORY: (ref: string) => `dashboard-history-${ref}`,
@@ -50,7 +44,6 @@ export const LOCAL_STORAGE_KEYS = {
   SQL_EDITOR_SORT: (ref: string) => `sql-editor-sort-${ref}`,
 
   LOG_EXPLORER_SPLIT_SIZE: 'supabase_log-explorer-split-size',
-  GRAPHIQL_RLS_BYPASS_WARNING: 'graphiql-rls-bypass-warning-dismissed',
   CLS_DIFF_WARNING: 'cls-diff-warning-dismissed',
   CLS_SELECT_STAR_WARNING: 'cls-select-star-warning-dismissed',
   QUERY_PERF_SHOW_BOTTOM_SECTION: 'supabase-query-perf-show-bottom-section',
@@ -73,6 +66,8 @@ export const LOCAL_STORAGE_KEYS = {
   FLY_POSTGRES_DEPRECATION_WARNING: 'fly-postgres-deprecation-warning-dismissed',
   API_KEYS_FEEDBACK_DISMISSED: (ref: string) => `supabase-api-keys-feedback-dismissed-${ref}`,
   MAINTENANCE_WINDOW_BANNER: 'maintenance-window-banner-2026-01-16',
+  TERMS_OF_SERVICE_UPDATE: 'terms-of-service-update-2026-06-06',
+  SUPAVISOR_MAINTENANCE: (ref: string) => `supavisor-maintenance-2026-05-21-${ref}`,
   REPORT_DATERANGE: 'supabase-report-daterange',
   PROJECT_PAUSING_STARTED_AT: (ref: string) => `supabase-project-pausing-started-at-${ref}`,
   PROJECT_RESTORING_STARTED_AT: (ref: string) => `supabase-project-restoring-started-at-${ref}`,
@@ -117,7 +112,6 @@ export const LOCAL_STORAGE_KEYS = {
     `free-micro-upgrade-banner-dismissed-${ref}`,
   STORAGE_PUBLIC_BUCKET_SELECT_POLICY_WARNING_DISMISSED: (ref: string, bucketId: string) =>
     `storage-public-bucket-select-policy-warning-dismissed-${ref}-${bucketId}`,
-  PRIVACY_NOTICE_ACKNOWLEDGED: 'privacy-notice-acknowledged-2026-03',
 
   /**
    * COMMON


### PR DESCRIPTION
Applying changes from upstream PR #46191 by @joshenlim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Terms of Service update notification banner with option to learn more and acknowledge.
  * Enhanced maintenance alerts to display region-specific information based on selected project.

* **Improvements**
  * Maintenance notifications now link to relevant Supabase status page incidents.
  * Dismissed banners remain dismissed across sessions.
  * Banners automatically expire after configured cutoff dates.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46197?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->