### PR TITLE
chore(docs): add Claudiu Dragalina-Paraipan to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -58,6 +58,7 @@ Chris Martin
 Chris Stockton
 Chris Ward
 Christian Funkhouser
+Claudiu Dragalina-Paraipan
 Clayton Kast
 Colin Goodheart-Smithe
 Colin Murray


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add **Claudiu Dragalina-Paraipan** to `humans.txt`

## What is the current behavior?

After a thorough investigation it has been discovered that **Claudiu Dragalina-Paraipan** is not in `humans.txt`, even though he is human.

## What is the new behavior?

**Claudiu Dragalina-Paraipan** is now present in `humans.txt`

## Additional context

**Claudiu Dragalina-Paraipan** has been recognized officially as a human, after passing many `I-am-not-a-robot` tests with flying colors.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new team member entry to the public team information file.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46200?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->