### PR TITLE
[INC-475] fix(studio): show incident banner on sign-in page

### DIFF
--- a/apps/studio/components/layouts/AppLayout/StatusPageBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/StatusPageBanner.tsx
@@ -1,4 +1,7 @@
-import { useStatusPageBannerVisibility } from './useStatusPageBannerVisibility'
+import {
+  useStatusPageBannerVisibility,
+  type UseStatusPageBannerVisibilityOptions,
+} from './useStatusPageBannerVisibility'
 import { HeaderBanner } from '@/components/interfaces/Organization/HeaderBanner'
 import { InlineLink } from '@/components/ui/InlineLink'
 
@@ -11,8 +14,10 @@ const BANNER_DESCRIPTION = (
 /**
  * Used to display ongoing incidents
  */
-export const StatusPageBanner = () => {
-  const banner = useStatusPageBannerVisibility()
+export const StatusPageBanner = ({
+  assumeNoProjects,
+}: UseStatusPageBannerVisibilityOptions = {}) => {
+  const banner = useStatusPageBannerVisibility({ assumeNoProjects })
 
   if (!banner) return null
 

--- a/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
+++ b/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
@@ -14,7 +14,18 @@ import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 export type StatusPageBannerData = { title: string; dismiss?: () => void }
 
-export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
+export type UseStatusPageBannerVisibilityOptions = {
+  /**
+   * Skip the org/projects queries (which require an authenticated session) and
+   * evaluate the smart targeting as if the viewer has no projects. Use on
+   * signed-out surfaces like the sign-in page.
+   */
+  assumeNoProjects?: boolean
+}
+
+export function useStatusPageBannerVisibility({
+  assumeNoProjects = false,
+}: UseStatusPageBannerVisibilityOptions = {}): StatusPageBannerData | null {
   const showIncidentBannerOverride =
     useFlag('ongoingIncident') || process.env.NEXT_PUBLIC_ONGOING_INCIDENT === 'true'
 
@@ -24,8 +35,11 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
   const incidents = bannerItems.map((i) => ({ id: i.id, cache: i.metadata }))
   const hasActiveIncidents = incidents.length > 0
 
+  const shouldFetchUserContext =
+    !assumeNoProjects && !showIncidentBannerOverride && hasActiveIncidents
+
   const { data: organizations } = useOrganizationsQuery({
-    enabled: !showIncidentBannerOverride && hasActiveIncidents,
+    enabled: shouldFetchUserContext,
   })
 
   const orgProjectsQueries = useQueries({
@@ -33,26 +47,31 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
       queryKey: projectKeys.bannerProjectsByOrg(org.slug),
       queryFn: () => getOrganizationProjects({ slug: org.slug, limit: 100 }),
       staleTime: 5 * 60 * 1000,
-      enabled: !showIncidentBannerOverride && hasActiveIncidents,
+      enabled: shouldFetchUserContext,
     })),
   })
 
   const isProjectsFetched =
-    organizations !== undefined &&
-    (organizations.length === 0 || orgProjectsQueries.every((q) => q.isFetched))
+    assumeNoProjects ||
+    (organizations !== undefined &&
+      (organizations.length === 0 || orgProjectsQueries.every((q) => q.isFetched)))
 
   const allProjects = orgProjectsQueries.flatMap((q) => q.data?.projects ?? [])
-  const hasProjects = allProjects.length > 0
+  const hasProjects = !assumeNoProjects && allProjects.length > 0
   const userRegions = useMemo(
     () =>
-      new Set(
-        allProjects.flatMap((project: OrgProject) => project.databases.map((db) => db.region))
-      ),
-    [allProjects]
+      assumeNoProjects
+        ? new Set<string>()
+        : new Set(
+            allProjects.flatMap((project: OrgProject) => project.databases.map((db) => db.region))
+          ),
+    [allProjects, assumeNoProjects]
   )
-  const hasUnknownRegions = orgProjectsQueries.some(
-    (q) => q.isError || (q.data !== undefined && q.data.pagination.count > q.data.projects.length)
-  )
+  const hasUnknownRegions =
+    !assumeNoProjects &&
+    orgProjectsQueries.some(
+      (q) => q.isError || (q.data !== undefined && q.data.pagination.count > q.data.projects.length)
+    )
 
   const [dismissedIds, setDismissedIds, { isSuccess: isDismissedLoaded }] = useLocalStorageQuery<
     Array<string>

--- a/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
+++ b/apps/studio/components/layouts/SignInLayout/SignInLayout.tsx
@@ -1,11 +1,13 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { getAccessToken, useFlag } from 'common'
+import { getAccessToken } from 'common'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { PropsWithChildren, useEffect, useState } from 'react'
 import { tweets } from 'shared-data'
 
+import { StatusPageBanner } from '@/components/layouts/AppLayout/StatusPageBanner'
+import { useStatusPageBannerVisibility } from '@/components/layouts/AppLayout/useStatusPageBannerVisibility'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { BASE_PATH, DOCS_URL } from '@/lib/constants'
@@ -28,7 +30,8 @@ const SignInLayout = ({
   const router = useRouter()
   const queryClient = useQueryClient()
   const { resolvedTheme } = useTheme()
-  const ongoingIncident = useFlag('ongoingIncident')
+  const incidentBanner = useStatusPageBannerVisibility({ assumeNoProjects: true })
+  const showIncidentBanner = incidentBanner !== null
 
   const {
     dashboardAuthShowTestimonial: showTestimonial,
@@ -109,9 +112,10 @@ const SignInLayout = ({
   return (
     <>
       <div className="relative flex flex-col bg-alternative min-h-screen">
+        <StatusPageBanner assumeNoProjects />
         <div
           className={`absolute top-0 w-full px-8 mx-auto sm:px-6 lg:px-8 ${
-            ongoingIncident ? 'mt-14' : 'mt-6'
+            showIncidentBanner ? 'mt-14' : 'mt-6'
           }`}
         >
           <nav className="relative flex items-center justify-between sm:h-10">


### PR DESCRIPTION
The status-page incident banner was never rendered on `/sign-in` (and other auth pages using `SignInLayout`), so signed-out users couldn't see ongoing incidents — the `SignInLayout` only read the `ongoingIncident` flag to shift the nav margin, but never mounted a banner. This wires up the existing `StatusPageBanner` so it renders there too.

**Changed:**
- `useStatusPageBannerVisibility` accepts an `assumeNoProjects` option that skips the auth-gated `useOrganizationsQuery` / org-projects queries and evaluates smart targeting as if the viewer has no projects.
- `StatusPageBanner` accepts and forwards the same option.
- `SignInLayout` mounts `<StatusPageBanner assumeNoProjects />` above the layout and drives the nav's `mt-14`/`mt-6` shift off actual banner visibility (instead of the override-only `ongoingIncident` flag).

## To test

- Set `NEXT_PUBLIC_ONGOING_INCIDENT=true` locally and visit `/sign-in` — banner should render at the top and the logo should sit below it without overlap.
- Without the override, hit `/sign-in` with an active incident that has `affects_project_creation = true` and no region targeting — banner should show.
- Without the override, region-only incidents should stay hidden on `/sign-in` (matches existing no-projects behavior).
- Confirm authed pages (`DefaultLayout`/`AuthenticationLayout`) still show the banner exactly as before.

Closes INC-475

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Status page incident banner now displays on the sign-in page to keep users informed during service incidents.

* **Refactor**
  * Enhanced incident banner visibility system for consistent display across the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->