### PR TITLE
chore: migrate storage policies `Modal` to `Dialog`

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicySelection.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicySelection.tsx
@@ -1,6 +1,6 @@
 import { noop } from 'lodash'
 import { Edit, ExternalLink, FlaskConical, Grid } from 'lucide-react'
-import { Alert, AlertDescription, AlertTitle, Button, Modal } from 'ui'
+import { Alert, AlertDescription, AlertTitle, Button, DialogSection } from 'ui'
 
 import CardButton from '@/components/ui/CardButton'
 
@@ -20,7 +20,7 @@ const PolicySelection = ({
   onToggleFeaturePreviewModal,
 }: PolicySelectionProps) => {
   return (
-    <Modal.Content className="space-y-4 py-4">
+    <DialogSection>
       <div className="flex flex-col gap-y-2">
         <p className="text-sm text-foreground-light">{description}</p>
         <div className="grid grid-cols-1 gap-2 lg:grid-cols-1">
@@ -86,7 +86,7 @@ const PolicySelection = ({
           </div>
         </Alert>
       )}
-    </Modal.Content>
+    </DialogSection>
   )
 }
 

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyTemplates/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyTemplates/index.tsx
@@ -1,6 +1,6 @@
 import { isEmpty, noop } from 'lodash'
 import { useState } from 'react'
-import { Button } from 'ui'
+import { Button, DialogSectionSeparator } from 'ui'
 
 import { PolicyTemplate } from './PolicyTemplates.constants'
 import TemplatePreview from './TemplatePreview'
@@ -20,7 +20,7 @@ const PolicyTemplates = ({
   const [selectedTemplate, setSelectedTemplate] = useState<PolicyTemplate>(templates[0])
   return (
     <div>
-      <div className="flex flex-col md:flex-row justify-between border-t border-default">
+      <div className="flex flex-col md:flex-row justify-between">
         <TemplatesList
           templatesNote={templatesNote}
           templates={templates}
@@ -29,7 +29,8 @@ const PolicyTemplates = ({
         />
         <TemplatePreview selectedTemplate={selectedTemplate} />
       </div>
-      <div className="flex w-full items-center justify-end gap-3 border-t px-6 py-4 border-default">
+      <DialogSectionSeparator />
+      <div className="flex w-full items-center justify-end gap-3 px-6 py-4">
         <span className="text-sm text-foreground-lighter">
           This will override any existing code you've written
         </span>

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditPolicyModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditPolicyModal.tsx
@@ -1,8 +1,7 @@
-import { noop, pull } from 'lodash'
-import { ChevronLeft } from 'lucide-react'
+import { pull } from 'lodash'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { Modal } from 'ui'
+import { Dialog, DialogContent, DialogHeader, DialogSectionSeparator, DialogTitle } from 'ui'
 
 import {
   applyBucketIdToTemplateDefinition,
@@ -12,11 +11,10 @@ import {
 import { STORAGE_POLICY_TEMPLATES } from './StoragePolicies.constants'
 import StoragePoliciesEditor from './StoragePoliciesEditor'
 import StoragePoliciesReview from './StoragePoliciesReview'
+import { StoragePolicyEditorModalTitle } from './StoragePolicyEditorModalTitle'
 import { POLICY_MODAL_VIEWS } from '@/components/interfaces/Auth/Policies/Policies.constants'
 import PolicySelection from '@/components/interfaces/Auth/Policies/PolicySelection'
 import PolicyTemplates from '@/components/interfaces/Auth/Policies/PolicyTemplates'
-import { DocsButton } from '@/components/ui/DocsButton'
-import { DOCS_URL } from '@/lib/constants'
 
 const newPolicyTemplate: any = {
   name: '',
@@ -168,62 +166,22 @@ export const StoragePoliciesEditPolicyModal = ({
     }
   }
 
-  /* Misc components */
-
-  const StoragePolicyEditorModalTitle = ({
-    view,
-    bucketName,
-    onSelectBackFromTemplates = noop,
-  }: any) => {
-    const getTitle = () => {
-      if (view === POLICY_MODAL_VIEWS.EDITOR || view === POLICY_MODAL_VIEWS.SELECTION) {
-        return `Adding new policy to ${bucketName}`
-      }
-      if (view === POLICY_MODAL_VIEWS.REVIEW) {
-        return `Reviewing policies to be created for ${bucketName}`
-      }
-    }
-    if (view === POLICY_MODAL_VIEWS.TEMPLATES) {
-      return (
-        <div>
-          <div className="flex items-center space-x-3">
-            <span
-              onClick={onSelectBackFromTemplates}
-              className="cursor-pointer text-foreground-lighter transition-colors hover:text-foreground"
-            >
-              <ChevronLeft strokeWidth={2} size={14} />
-            </span>
-            <h4 className="textlg m-0">Select a template to use for your new policy</h4>
-          </div>
-        </div>
-      )
-    }
-    return (
-      <div className="w-full flex items-center justify-between gap-x-2 pr-6">
-        <h4 className="m-0 truncate">{getTitle()}</h4>
-        <DocsButton href={`${DOCS_URL}/learn/auth-deep-dive/auth-policies`} />
-      </div>
-    )
-  }
-
   return (
-    <Modal
-      hideFooter
-      className="[&>div:first-child]:py-3"
-      size={view === POLICY_MODAL_VIEWS.SELECTION ? 'medium' : 'xxlarge'}
-      visible={visible}
-      contentStyle={{ padding: 0 }}
-      header={[
-        <StoragePolicyEditorModalTitle
-          key="0"
-          view={view}
-          bucketName={bucketName}
-          onSelectBackFromTemplates={onSelectBackFromTemplates}
-        />,
-      ]}
-      onCancel={onSelectCancel}
-    >
-      <div className="w-full">
+    <Dialog open={visible} onOpenChange={() => onSelectCancel()}>
+      <DialogContent
+        size={view === POLICY_MODAL_VIEWS.SELECTION ? 'medium' : 'xxlarge'}
+        hideClose={view !== POLICY_MODAL_VIEWS.TEMPLATES}
+      >
+        <DialogHeader>
+          <DialogTitle>
+            <StoragePolicyEditorModalTitle
+              view={view}
+              bucketName={bucketName}
+              onSelectBackFromTemplates={onSelectBackFromTemplates}
+            />
+          </DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
         {view === POLICY_MODAL_VIEWS.SELECTION ? (
           <PolicySelection
             description="PostgreSQL policies control access to your files and folders"
@@ -256,7 +214,7 @@ export const StoragePoliciesEditPolicyModal = ({
         ) : (
           <div />
         )}
-      </div>
-    </Modal>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesEditor.tsx
@@ -1,5 +1,5 @@
 import { noop } from 'lodash'
-import { Button, Checkbox, cn, Modal } from 'ui'
+import { Button, Checkbox, cn, DialogSection, DialogSectionSeparator } from 'ui'
 
 import { STORAGE_CLIENT_LIBRARY_MAPPINGS } from '../Storage.constants'
 import { deriveAllowedClientLibraryMethods } from '../Storage.utils'
@@ -160,31 +160,31 @@ const StoragePoliciesEditor = ({
   return (
     <>
       <div className="space-y-4 py-4">
-        <Modal.Content>
+        <DialogSection>
           <PolicyName
             name={policyFormFields.name}
             limit={50}
             onUpdatePolicyName={onUpdatePolicyName}
           />
-        </Modal.Content>
-        <Modal.Separator />
-        <Modal.Content>
+        </DialogSection>
+        <DialogSectionSeparator />
+        <DialogSection>
           <PolicyAllowedOperations
             allowedOperations={policyFormFields.allowedOperations}
             onToggleOperation={onToggleOperation}
           />
-        </Modal.Content>
-        <Modal.Separator />
-        <Modal.Content>
+        </DialogSection>
+        <DialogSectionSeparator />
+        <DialogSection>
           <PolicyRoles selectedRoles={selectedRoles} onUpdateSelectedRoles={onUpdatePolicyRoles} />
-        </Modal.Content>
-        <Modal.Separator />
-        <Modal.Content>
+        </DialogSection>
+        <DialogSectionSeparator />
+        <DialogSection>
           <PolicyDefinition
             definition={definition}
             onUpdatePolicyDefinition={onUpdatePolicyDefinition}
           />
-        </Modal.Content>
+        </DialogSection>
       </div>
       <PolicyEditorFooter onViewTemplates={onViewTemplates} onReviewPolicy={onReviewPolicy} />
     </>

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesReview.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePoliciesReview.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Button, Modal } from 'ui'
+import { Button, DialogFooter, DialogSection, DialogSectionSeparator } from 'ui'
 
 import SqlEditor from '@/components/ui/SqlEditor'
 
@@ -30,7 +30,7 @@ const StoragePoliciesReview = ({
 
   return (
     <>
-      <Modal.Content className="space-y-6">
+      <DialogSection className="space-y-6">
         <div className="flex items-center justify-between space-y-8 space-x-4">
           <div className="flex flex-col">
             <p className="text-sm text-foreground-light">
@@ -54,9 +54,9 @@ const StoragePoliciesReview = ({
             )
           })}
         </div>
-      </Modal.Content>
-      <Modal.Separator />
-      <Modal.Content className="flex w-full items-center justify-end gap-2">
+      </DialogSection>
+      <DialogSectionSeparator />
+      <DialogFooter>
         <Button type="default" onClick={onSelectBack}>
           Back to edit
         </Button>
@@ -65,7 +65,7 @@ const StoragePoliciesReview = ({
             Save policy
           </Button>
         )}
-      </Modal.Content>
+      </DialogFooter>
     </>
   )
 }

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicyEditorModalTitle.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicyEditorModalTitle.tsx
@@ -36,6 +36,7 @@ export const StoragePolicyEditorModalTitle = ({
             )}
           >
             <ChevronLeft strokeWidth={2} size={14} />
+            <span className="sr-only">Back</span>
           </button>
           <span>Select a template to use for your new policy</span>
         </div>

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicyEditorModalTitle.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicyEditorModalTitle.tsx
@@ -1,0 +1,61 @@
+import { noop } from 'lodash'
+import { ChevronLeft, X } from 'lucide-react'
+import { Dialog as DialogPrimitive } from 'radix-ui'
+import { cn } from 'ui'
+
+import { POLICY_MODAL_VIEWS } from '@/components/interfaces/Auth/Policies/Policies.constants'
+import { DocsButton } from '@/components/ui/DocsButton'
+import { DOCS_URL } from '@/lib/constants'
+
+export const StoragePolicyEditorModalTitle = ({
+  view,
+  bucketName,
+  onSelectBackFromTemplates = noop,
+}: {
+  view: string
+  bucketName: string
+  onSelectBackFromTemplates: () => void
+}) => {
+  const getTitle = () => {
+    if (view === POLICY_MODAL_VIEWS.EDITOR || view === POLICY_MODAL_VIEWS.SELECTION) {
+      return `Adding new policy to ${bucketName}`
+    }
+    if (view === POLICY_MODAL_VIEWS.REVIEW) {
+      return `Reviewing policies to be created for ${bucketName}`
+    }
+  }
+  if (view === POLICY_MODAL_VIEWS.TEMPLATES) {
+    return (
+      <div>
+        <div className="flex items-center space-x-3">
+          <button
+            onClick={onSelectBackFromTemplates}
+            className={cn(
+              'cursor-pointer rounded-xs opacity-20 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-foreground-muted',
+              'hit-area-6'
+            )}
+          >
+            <ChevronLeft strokeWidth={2} size={14} />
+          </button>
+          <span>Select a template to use for your new policy</span>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-x-2 pr-6">
+      <span className="truncate">{getTitle()}</span>
+      <DocsButton href={`${DOCS_URL}/learn/auth-deep-dive/auth-policies`} />
+      <DialogPrimitive.Close
+        className={cn(
+          'absolute p-0.5 right-3.5 top-4.5 rounded-xs opacity-20 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-foreground-muted',
+          'hit-area-6'
+        )}
+      >
+        <X size={16} />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </div>
+  )
+}


### PR DESCRIPTION
## Problem

Storage policies edition still uses the deprecated `Modal`

## Solution

- use `Dialog` instead
- improve accessibility of the templates selection _back_ button
- extract the dialog title component in its own file

## Screenshots

The only difference is the title font which is larger with `Dialog`

Before:
<img width="542" height="504" alt="image" src="https://github.com/user-attachments/assets/46a078da-db77-4a14-a7f7-fad20f5b45e5" />

After:
<img width="550" height="523" alt="image" src="https://github.com/user-attachments/assets/80c9c6ec-25cd-445a-ad65-f9b659cdfd72" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized policy editing interfaces with updated dialog structure and consistent section separation across policy selection, templates, editor, and review flows for clearer layout and spacing.
* **New Features**
  * Added a unified, context-aware modal header that adapts titles, back action, docs link, and close controls for different policy workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46222?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->