### PR TITLE
chore: migrate storage `Modal` to `Dialog`

### DIFF
--- a/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
+++ b/apps/studio/components/interfaces/Storage/ImportForeignSchemaDialog.tsx
@@ -4,7 +4,20 @@ import { uniq } from 'lodash'
 import { useEffect, useState } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import { Button, Form, FormField, Input, Modal, Separator } from 'ui'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Form,
+  FormField,
+  Input,
+  Separator,
+} from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import z from 'zod'
 
@@ -158,56 +171,55 @@ export const ImportForeignSchemaDialog = ({
   }, [visible, form, bucketName, namespace])
 
   return (
-    <Modal
-      hideFooter
-      visible={visible}
-      size="medium"
-      header={<span>Create target schema</span>}
-      onCancel={() => onClose()}
-    >
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)}>
-          <Modal.Content className="flex flex-col gap-y-4">
-            <p className="text-sm">
-              Namespace “<strong>{namespace}</strong>”{' '}
-              {circumstance === 'fresh'
-                ? 'must be linked to a new schema before tables can be paired.'
-                : 'clashes with an existing database schema. Create a new schema to use as the destination for this data.'}
-            </p>
-            <Separator />
-            <FormField
-              control={form.control}
-              name="targetSchema"
-              render={({ field }) => (
-                <FormItemLayout
-                  layout="vertical"
-                  label="Target schema"
-                  description="Where your analytics tables will be stored."
-                >
-                  <Input {...field} placeholder="Enter schema name" />
-                </FormItemLayout>
-              )}
-            />
-          </Modal.Content>
-          <Modal.Separator />
-          <Modal.Content className="flex items-center space-x-2 justify-end">
-            <Button type="default" htmlType="button" disabled={loading} onClick={onClose}>
-              Cancel
-            </Button>
-            <Button type="primary" htmlType="submit" loading={loading}>
-              Create
-            </Button>
-          </Modal.Content>
-        </form>
-      </Form>
-      <SchemaEditor
-        visible={createSchemaSheetOpen}
-        closePanel={() => setCreateSchemaSheetOpen(false)}
-        onSuccess={(schema) => {
-          form.setValue('targetSchema', schema)
-          setCreateSchemaSheetOpen(false)
-        }}
-      />
-    </Modal>
+    <Dialog open={visible} onOpenChange={onClose}>
+      <DialogContent size="medium">
+        <DialogHeader>
+          <DialogTitle>Create target schema</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)}>
+            <DialogSection className="flex flex-col gap-y-4">
+              <p className="text-sm">
+                Namespace “<strong>{namespace}</strong>”{' '}
+                {circumstance === 'fresh'
+                  ? 'must be linked to a new schema before tables can be paired.'
+                  : 'clashes with an existing database schema. Create a new schema to use as the destination for this data.'}
+              </p>
+              <Separator />
+              <FormField
+                control={form.control}
+                name="targetSchema"
+                render={({ field }) => (
+                  <FormItemLayout
+                    layout="vertical"
+                    label="Target schema"
+                    description="Where your analytics tables will be stored."
+                  >
+                    <Input {...field} placeholder="Enter schema name" />
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+            <DialogFooter className="flex items-center space-x-2 justify-end">
+              <Button type="default" htmlType="button" disabled={loading} onClick={onClose}>
+                Cancel
+              </Button>
+              <Button type="primary" htmlType="submit" loading={loading}>
+                Create
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+        <SchemaEditor
+          visible={createSchemaSheetOpen}
+          closePanel={() => setCreateSchemaSheetOpen(false)}
+          onSuccess={(schema) => {
+            form.setValue('targetSchema', schema)
+            setCreateSchemaSheetOpen(false)
+          }}
+        />
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
@@ -3,11 +3,17 @@ import dayjs from 'dayjs'
 import { SubmitHandler, useForm, useWatch } from 'react-hook-form'
 import {
   Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
   Form,
   FormControl,
   FormField,
   Input,
-  Modal,
   Select,
   SelectContent,
   SelectItem,
@@ -72,93 +78,91 @@ export const CustomExpiryModal = () => {
   })
 
   return (
-    <Modal
-      hideFooter
-      size="small"
-      header="Custom expiry for signed URL"
-      visible={visible}
-      alignFooter="right"
-      confirmText="Get URL"
-      onCancel={handleClose}
-    >
-      <Form {...form}>
-        <Modal.Content>
-          <p className="text-sm text-foreground-light mb-4">
-            Enter the duration for which the URL will be valid for:
-          </p>
-          <form
-            id={formId}
-            onSubmit={form.handleSubmit(handleSubmit)}
-            noValidate
-            className="flex items-start space-x-2"
-          >
-            <div className="grow">
-              <FormField
-                control={form.control}
-                name="expiresIn"
-                render={({ field }) => (
-                  <FormItemLayout layout="vertical" label="Duration">
-                    <FormControl>
-                      <Input
-                        {...field}
-                        type="number"
-                        onChange={(e) => {
-                          field.onChange(
-                            isNaN(e.target.valueAsNumber) ? '' : e.target.valueAsNumber
-                          )
-                        }}
-                      />
-                    </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-            </div>
-            <div>
-              <FormField
-                control={form.control}
-                name="units"
-                render={({ field }) => (
-                  <FormItemLayout layout="vertical" label="Units">
-                    <FormControl>
-                      <Select value={field.value} onValueChange={field.onChange}>
-                        <SelectTrigger>
-                          <SelectValue aria-label="Units" placeholder="Select an option" />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="days">days</SelectItem>
-                          <SelectItem value="weeks">weeks</SelectItem>
-                          <SelectItem value="months">months</SelectItem>
-                          <SelectItem value="years">years</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-            </div>
-          </form>
-          {isDirty && isValid && (
-            <p className="text-sm text-foreground-light mt-2">
-              URL will expire on {dayjs().add(expiresIn, units).format(DATETIME_FORMAT)}
+    <Dialog open={visible} onOpenChange={handleClose}>
+      <DialogContent size="small">
+        <DialogHeader>
+          <DialogTitle>Custom expiry for signed URL</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <Form {...form}>
+          <DialogSection>
+            <p className="text-sm text-foreground-light mb-4">
+              Enter the duration for which the URL will be valid for:
             </p>
-          )}
-        </Modal.Content>
-        <Modal.Separator />
-        <Modal.Content className="flex items-center justify-end space-x-2">
-          <Button type="default" onClick={handleClose}>
-            Cancel
-          </Button>
-          <Button
-            form={formId}
-            disabled={!isDirty || isSubmitting}
-            loading={isSubmitting}
-            htmlType="submit"
-            type="primary"
-          >
-            Get signed URL
-          </Button>
-        </Modal.Content>
-      </Form>
-    </Modal>
+            <form
+              id={formId}
+              onSubmit={form.handleSubmit(handleSubmit)}
+              noValidate
+              className="flex items-start space-x-2"
+            >
+              <div className="grow">
+                <FormField
+                  control={form.control}
+                  name="expiresIn"
+                  render={({ field }) => (
+                    <FormItemLayout layout="vertical" label="Duration">
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type="number"
+                          onChange={(e) => {
+                            field.onChange(
+                              isNaN(e.target.valueAsNumber) ? '' : e.target.valueAsNumber
+                            )
+                          }}
+                        />
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
+              </div>
+              <div>
+                <FormField
+                  control={form.control}
+                  name="units"
+                  render={({ field }) => (
+                    <FormItemLayout layout="vertical" label="Units">
+                      <FormControl>
+                        <Select value={field.value} onValueChange={field.onChange}>
+                          <SelectTrigger>
+                            <SelectValue aria-label="Units" placeholder="Select an option" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="days">days</SelectItem>
+                            <SelectItem value="weeks">weeks</SelectItem>
+                            <SelectItem value="months">months</SelectItem>
+                            <SelectItem value="years">years</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
+              </div>
+            </form>
+            {isDirty && isValid && (
+              <p className="text-sm text-foreground-light mt-2">
+                URL will expire on {dayjs().add(expiresIn, units).format(DATETIME_FORMAT)}
+              </p>
+            )}
+          </DialogSection>
+          <DialogSectionSeparator />
+          <DialogFooter>
+            <Button type="default" onClick={handleClose}>
+              Cancel
+            </Button>
+            <Button
+              form={formId}
+              disabled={!isDirty || isSubmitting}
+              loading={isSubmitting}
+              htmlType="submit"
+              type="primary"
+            >
+              Get signed URL
+            </Button>
+          </DialogFooter>
+        </Form>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/CustomExpiryModal.tsx
@@ -146,7 +146,6 @@ export const CustomExpiryModal = () => {
               </p>
             )}
           </DialogSection>
-          <DialogSectionSeparator />
           <DialogFooter>
             <Button type="default" onClick={handleClose}>
               Cancel

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/MoveItemsModal.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/MoveItemsModal.tsx
@@ -1,6 +1,17 @@
 import { noop } from 'lodash'
 import { useEffect, useState } from 'react'
-import { Button, Input, Modal } from 'ui'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Input,
+} from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { StorageItemWithColumn } from '../Storage.types'
@@ -50,43 +61,42 @@ export const MoveItemsModal = ({
   }
 
   return (
-    <Modal
-      visible={visible}
-      header={title}
-      description={description}
-      size="medium"
-      onCancel={onSelectCancel}
-      customFooter={
-        <div className="flex items-center gap-2">
+    <Dialog open={visible} onOpenChange={onSelectCancel}>
+      <DialogContent size="medium">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection>
+          <form>
+            <FormItemLayout
+              label={`Path to new directory in ${bucketName}`}
+              description="Leave blank to move items to the root of the bucket"
+              layout="vertical"
+              isReactForm={false}
+            >
+              <Input
+                autoFocus
+                type="text"
+                placeholder="e.g folder1/subfolder2"
+                value={newPath}
+                onChange={(event) => setNewPath(event.target.value)}
+              />
+            </FormItemLayout>
+
+            <button className="hidden" type="submit" onClick={onConfirmMove} />
+          </form>
+        </DialogSection>
+        <DialogFooter>
           <Button type="default" onClick={onSelectCancel}>
             Cancel
           </Button>
           <Button type="primary" loading={moving} onClick={onConfirmMove}>
             {moving ? 'Moving files' : 'Move files'}
           </Button>
-        </div>
-      }
-    >
-      <Modal.Content>
-        <form>
-          <FormItemLayout
-            label={`Path to new directory in ${bucketName}`}
-            description="Leave blank to move items to the root of the bucket"
-            layout="vertical"
-            isReactForm={false}
-          >
-            <Input
-              autoFocus
-              type="text"
-              placeholder="e.g folder1/subfolder2"
-              value={newPath}
-              onChange={(event) => setNewPath(event.target.value)}
-            />
-          </FormItemLayout>
-
-          <button className="hidden" type="submit" onClick={onConfirmMove} />
-        </form>
-      </Modal.Content>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Problem

Storage still uses the deprecated `Modal` for:
- custom expiry
- moving items
- analytics bucket namespaces

## Solution

- use `Dialog` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated dialog component implementations across Storage features for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46227?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->