### PR TITLE
chore: migrate SQL editor `Modal` to `Dialog`

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/DownloadSnippetModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/DownloadSnippetModal.tsx
@@ -1,9 +1,18 @@
-import type { ModalProps } from '@ui/components/Modal/Modal'
 import { snakeCase } from 'lodash'
 import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import { useState } from 'react'
-import { Button, Modal, Tabs } from 'ui'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Tabs,
+  type DialogProps,
+} from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import { Markdown } from '../Markdown'
@@ -16,7 +25,7 @@ import { TwoOptionToggle } from '@/components/ui/TwoOptionToggle'
 import { DOCS_URL } from '@/lib/constants'
 import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
 
-export interface DownloadSnippetModalProps extends ModalProps {
+export interface DownloadSnippetModalProps extends DialogProps {
   id: string
 }
 
@@ -57,19 +66,17 @@ const DownloadSnippetModal = ({ id, ...props }: DownloadSnippetModalProps) => {
   ]
 
   return (
-    <Modal
-      hideFooter
-      showCloseButton
-      size="xlarge"
-      header={<p>Download snippet as local migration file via the Supabase CLI.</p>}
-      {...props}
-    >
-      <div className="flex flex-col items-start justify-between gap-4 relative pt-2">
-        <Tabs type="underlined" listClassNames="pl-5">
+    <Dialog {...props}>
+      <DialogContent size="xlarge">
+        <DialogHeader>
+          <DialogTitle>Download snippet as local migration file via the Supabase CLI</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <Tabs type="underlined" listClassNames="pl-5 pt-2">
           {SNIPPETS.map((snippet) => {
             return (
               <Tabs.Panel key={snippet.id} id={snippet.id} label={snippet.label}>
-                <Modal.Content className="py-0!">
+                <DialogSection>
                   <div className="flex items-center justify-between mb-3">
                     <div className="flex flex-col gap-y-1">
                       <p className="text-base">{snippet.title}</p>
@@ -96,12 +103,12 @@ const DownloadSnippetModal = ({ id, ...props }: DownloadSnippetModalProps) => {
                       {selectedView === 'CLI' ? snippet.cli : snippet.npm}
                     </CodeBlock>
                   </pre>
-                </Modal.Content>
+                </DialogSection>
               </Tabs.Panel>
             )
           })}
         </Tabs>
-        <Modal.Content className="w-full flex items-center justify-between pt-0">
+        <DialogSection className="flex items-center justify-between">
           <p className="text-xs text-lighter">Run this command from your project directory</p>
           <div className="flex justify-between items-center gap-x-2">
             <Button asChild type="default" icon={<ExternalLink strokeWidth={1.5} />}>
@@ -124,9 +131,9 @@ const DownloadSnippetModal = ({ id, ...props }: DownloadSnippetModalProps) => {
               </Link>
             </Button>
           </div>
-        </Modal.Content>
-      </div>
-    </Modal>
+        </DialogSection>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
@@ -4,7 +4,22 @@ import { useRouter } from 'next/router'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import { AiIconAnimation, Button, Form, FormControl, FormField, Input, Modal, Textarea } from 'ui'
+import {
+  AiIconAnimation,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  Input,
+  Textarea,
+} from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
@@ -163,78 +178,86 @@ const RenameQueryModal = ({
   }
 
   return (
-    <Modal visible={visible} onCancel={handleCancel} hideFooter header="Rename" size="small">
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
-          <Modal.Content className="space-y-4">
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItemLayout name="name" layout="vertical" label="Name">
-                  <FormControl>
-                    <Input {...field} id="name" />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-            <div className="flex w-full justify-end mt-2">
-              {!hasHipaaAddon && (
-                <ButtonTooltip
-                  type="default"
-                  onClick={() => generateTitle()}
-                  size="tiny"
-                  disabled={isTitleGenerationLoading || !isApiKeySet}
-                  tooltip={{
-                    content: {
-                      side: 'bottom',
-                      text: isApiKeySet
-                        ? undefined
-                        : 'Add your "OPENAI_API_KEY" to your environment variables to use this feature.',
-                    },
-                  }}
-                >
-                  <div className="flex items-center gap-1">
-                    <div className="scale-75">
-                      <AiIconAnimation loading={isTitleGenerationLoading} />
+    <Dialog open={visible} onOpenChange={handleCancel}>
+      <DialogContent size="small">
+        <DialogHeader>
+          <DialogTitle>Rename</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} noValidate>
+            <DialogSection className="space-y-4">
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItemLayout name="name" layout="vertical" label="Name">
+                    <FormControl>
+                      <Input {...field} id="name" />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+              <div className="flex w-full justify-end mt-2">
+                {!hasHipaaAddon && (
+                  <ButtonTooltip
+                    type="default"
+                    onClick={() => generateTitle()}
+                    size="tiny"
+                    disabled={isTitleGenerationLoading || !isApiKeySet}
+                    tooltip={{
+                      content: {
+                        side: 'bottom',
+                        text: isApiKeySet
+                          ? undefined
+                          : 'Add your "OPENAI_API_KEY" to your environment variables to use this feature.',
+                      },
+                    }}
+                  >
+                    <div className="flex items-center gap-1">
+                      <div className="scale-75">
+                        <AiIconAnimation loading={isTitleGenerationLoading} />
+                      </div>
+                      <span>Rename with Supabase AI</span>
                     </div>
-                    <span>Rename with Supabase AI</span>
-                  </div>
-                </ButtonTooltip>
-              )}
-            </div>
-          </Modal.Content>
-          <Modal.Content>
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItemLayout name="description" layout="vertical" label="Description">
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      id="description"
-                      rows={4}
-                      placeholder="Describe query"
-                      className="resize-none"
-                    />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-          </Modal.Content>
-          <Modal.Separator />
-          <Modal.Content className="flex items-center justify-end gap-2">
-            <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isSubmitting}>
-              Cancel
-            </Button>
-            <Button htmlType="submit" loading={isSubmitting} disabled={isSubmitting || !isDirty}>
-              Rename query
-            </Button>
-          </Modal.Content>
-        </form>
-      </Form>
-    </Modal>
+                  </ButtonTooltip>
+                )}
+              </div>
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItemLayout name="description" layout="vertical" label="Description">
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        id="description"
+                        rows={4}
+                        placeholder="Describe query"
+                        className="resize-none"
+                      />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+            <DialogFooter>
+              <Button
+                htmlType="reset"
+                type="default"
+                onClick={handleCancel}
+                disabled={isSubmitting}
+              >
+                Cancel
+              </Button>
+              <Button htmlType="submit" loading={isSubmitting} disabled={isSubmitting || !isDirty}>
+                Rename query
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -772,8 +772,8 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
 
       <DownloadSnippetModal
         id={selectedSnippetToDownload?.id ?? ''}
-        visible={selectedSnippetToDownload !== undefined}
-        onCancel={() => setSelectedSnippetToDownload(undefined)}
+        open={selectedSnippetToDownload !== undefined}
+        onOpenChange={() => setSelectedSnippetToDownload(undefined)}
       />
 
       <ShareSnippetModal

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SearchList.tsx
@@ -161,8 +161,8 @@ export const SearchList = ({ search }: SearchListProps) => {
 
       <DownloadSnippetModal
         id={selectedSnippetToDownload?.id ?? ''}
-        visible={selectedSnippetToDownload !== undefined}
-        onCancel={() => setSelectedSnippetToDownload(undefined)}
+        open={selectedSnippetToDownload !== undefined}
+        onOpenChange={() => setSelectedSnippetToDownload(undefined)}
       />
 
       <RenameQueryModal


### PR DESCRIPTION
## Problem

SQL Editor still uses the deprecated `Modal` for:
- renaming queries
- downloading snippet

## Solution

- use `Dialog` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated modal dialog implementations across the SQL Editor to use modern UI standards, improving code quality and maintainability.
  * Refined state management for query-related modal operations including downloads and renaming to ensure consistent and reliable user interactions.
  * Streamlined dialog structure and behavior patterns to reduce code complexity and improve overall consistency in the SQL Editor interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46228?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->