### PR TITLE
fix(studio): validate and encode domain parameter in check-cname API route

### DIFF
--- a/apps/studio/pages/api/check-cname.ts
+++ b/apps/studio/pages/api/check-cname.ts
@@ -2,12 +2,19 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { CheckCNAMERecordResponse } from '@/data/custom-domains/check-cname-mutation'
 
+const DOMAIN_RE = /^[a-zA-Z0-9._-]{1,253}$/
+
 const handler = async (req: NextApiRequest, res: NextApiResponse) => {
-  const { domain } = req.query
+  const raw = req.query.domain
+  const domain = Array.isArray(raw) ? raw[0] : raw
+
+  if (!domain || !DOMAIN_RE.test(domain)) {
+    return res.status(400).json({ message: 'Invalid domain' })
+  }
 
   try {
     const result: CheckCNAMERecordResponse = await fetch(
-      `https://cloudflare-dns.com/dns-query?name=${domain}&type=CNAME`,
+      `https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(domain)}&type=CNAME`,
       {
         method: 'GET',
         headers: { Accept: 'application/dns-json' },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (security hardening)

## What is the current behavior?

The `domain` query parameter in `/api/check-cname` is interpolated directly into the Cloudflare DoH URL without validation or encoding:

```ts
`https://cloudflare-dns.com/dns-query?name=${domain}&type=CNAME`
```

This allows URL parameter injection — for example, a `domain` value of `example.com&type=A` causes the upstream request to include `&type=A`, bypassing the intended CNAME-only constraint. The raw `req.query.domain` value is also typed as `string | string[]`, so the array case was unhandled.

## What is the new behavior?

- Domain is validated against an allowlist regex (`/^[a-zA-Z0-9._-]{1,253}$/`) and returns 400 for invalid input.
- Domain is encoded with `encodeURIComponent` before URL interpolation.
- The `string[]` case from repeated query params is handled explicitly.

```ts
const DOMAIN_RE = /^[a-zA-Z0-9._-]{1,253}$/

const raw = req.query.domain
const domain = Array.isArray(raw) ? raw[0] : raw

if (!domain || !DOMAIN_RE.test(domain)) {
  return res.status(400).json({ message: 'Invalid domain' })
}

`https://cloudflare-dns.com/dns-query?name=${encodeURIComponent(domain)}&type=CNAME`
```

## Additional context

Affects `apps/studio/pages/api/check-cname.ts` line 10. No other call sites are impacted.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced domain input validation with clearer error messaging when invalid or missing domain values are provided
  * Improved robustness of DNS lookups through better handling of special characters in domain names

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46234?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->