### PR TITLE
perf(studio): virtualize rendering, memoize nodes/edges, and O(1) FK lookup in Schema Visualizer

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/DefaultEdge.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/DefaultEdge.tsx
@@ -8,7 +8,7 @@ import {
   useReactFlow,
 } from '@xyflow/react'
 import { ArrowLeft, ArrowRight } from 'lucide-react'
-import { useState } from 'react'
+import { memo, useState } from 'react'
 import { Badge, cn } from 'ui'
 
 import { useSchemaGraphContext } from './SchemaGraphContext'
@@ -16,7 +16,7 @@ import { EdgeData } from './Schemas.constants'
 import { useQuerySchemaState } from '@/hooks/misc/useSchemaQueryState'
 import { useStaticEffectEvent } from '@/hooks/useStaticEffectEvent'
 
-export const DefaultEdge = ({
+const DefaultEdgeComponent = ({
   id,
   animated,
   data,
@@ -72,6 +72,8 @@ export const DefaultEdge = ({
     </>
   )
 }
+
+export const DefaultEdge = memo(DefaultEdgeComponent)
 
 const EdgeRelationInfo = ({
   data,

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -187,14 +187,17 @@ export const SchemaGraph = () => {
       }
 
       const selectedNodeIds = new Set(params.nodes.map((n) => n.id))
-      reactFlowInstance.setEdges(
-        reactFlowInstance.getEdges().map((edge) => ({
-          ...edge,
-          animated:
-            selectedNodeIds.size > 0 &&
-            (selectedNodeIds.has(edge.source) || selectedNodeIds.has(edge.target)),
-        }))
-      )
+      const currentEdges = reactFlowInstance.getEdges()
+      let hasChanges = false
+      const nextEdges = currentEdges.map((edge) => {
+        const shouldAnimate =
+          selectedNodeIds.size > 0 &&
+          (selectedNodeIds.has(edge.source) || selectedNodeIds.has(edge.target))
+        if (edge.animated === shouldAnimate) return edge
+        hasChanges = true
+        return { ...edge, animated: shouldAnimate }
+      })
+      if (hasChanges) reactFlowInstance.setEdges(nextEdges)
     }
   )
 
@@ -253,16 +256,7 @@ export const SchemaGraph = () => {
         }
       })
     }
-  }, [
-    isSuccessTables,
-    isSuccessSchemas,
-    tables,
-    reactFlowInstance,
-    ref,
-    resolvedTheme,
-    schemas,
-    selectedSchema,
-  ])
+  }, [isSuccessTables, isSuccessSchemas, tables, reactFlowInstance, ref, schemas, selectedSchema])
 
   const schemaGraphContext = useMemo<SchemaGraphContextType>(
     () => ({
@@ -470,6 +464,7 @@ export const SchemaGraph = () => {
                   fitView
                   minZoom={0.8}
                   maxZoom={1.8}
+                  onlyRenderVisibleElements
                   proOptions={{ hideAttribution: true }}
                   onNodeDragStop={saveNodePositions}
                   onSelectionChange={handleSelectionChange}

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaTableNode.tsx
@@ -13,6 +13,7 @@ import {
   Table2,
 } from 'lucide-react'
 import { useRouter } from 'next/router'
+import { memo } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
@@ -41,13 +42,15 @@ import { formatSql } from '@/lib/formatSql'
 export const TABLE_NODE_WIDTH = 320
 export const TABLE_NODE_ROW_HEIGHT = 40
 
-export const TableNode = ({
+type TableNodeOwnProps = NodeProps<Node<TableNodeData>> & { placeholder?: boolean }
+
+const TableNodeComponent = ({
   id,
   data,
   targetPosition,
   sourcePosition,
   placeholder,
-}: NodeProps<Node<TableNodeData>> & { placeholder?: boolean }) => {
+}: TableNodeOwnProps) => {
   // Important styles is a nasty hack to use Handles (required for edges calculations), but do not show them in the UI.
   // ref: https://github.com/wbkd/react-flow/discussions/2698
   const hiddenNodeConnector = 'h-px! w-px! min-w-0! min-h-0! cursor-grab! border-0! opacity-0!'
@@ -358,3 +361,17 @@ export const TableNode = ({
     </article>
   )
 }
+
+// Custom comparator: xyflow re-renders nodes on selection/drag with new prop
+// objects; only the listed props affect rendered output. Selection-driven styling
+// (highlighted edges) is read from context inside the component, so we can safely
+// ignore xyflow's `selected`/`dragging`/etc. here.
+export const TableNode = memo(
+  TableNodeComponent,
+  (prev, next) =>
+    prev.id === next.id &&
+    prev.data === next.data &&
+    prev.targetPosition === next.targetPosition &&
+    prev.sourcePosition === next.sourcePosition &&
+    prev.placeholder === next.placeholder
+)

--- a/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
+++ b/apps/studio/components/interfaces/Database/Schemas/Schemas.utils.ts
@@ -66,6 +66,25 @@ export async function getGraphDataFromTables(
     'id'
   )
 
+  // Precompute name → { tableId, columnsByName } lookup so each relationship
+  // resolves its source/target handles in O(1) instead of scanning every table+column.
+  const tablesByName = new Map<string, { tableId: number; columnsByName: Map<string, string> }>()
+  for (const table of tables) {
+    const columnsByName = new Map<string, string>()
+    for (const column of table.columns || []) {
+      columnsByName.set(column.name, column.id)
+    }
+    tablesByName.set(table.name, { tableId: table.id, columnsByName })
+  }
+
+  const findHandleIds = (tableName: string, columnName: string): [string?, string?] => {
+    const entry = tablesByName.get(tableName)
+    if (!entry) return []
+    const columnId = entry.columnsByName.get(columnName)
+    if (columnId === undefined) return []
+    return [String(entry.tableId), columnId]
+  }
+
   for (const rel of uniqueRelationships) {
     // TODO: Support [external->this] relationship?
     if (rel.source_schema !== currentSchema) {
@@ -96,11 +115,7 @@ export async function getGraphDataFromTables(
         })
       }
 
-      const [source, sourceHandle] = findTablesHandleIds(
-        tables,
-        rel.source_table_name,
-        rel.source_column_name
-      )
+      const [source, sourceHandle] = findHandleIds(rel.source_table_name, rel.source_column_name)
 
       if (source) {
         edges.push({
@@ -124,16 +139,8 @@ export async function getGraphDataFromTables(
       continue
     }
 
-    const [source, sourceHandle] = findTablesHandleIds(
-      tables,
-      rel.source_table_name,
-      rel.source_column_name
-    )
-    const [target, targetHandle] = findTablesHandleIds(
-      tables,
-      rel.target_table_name,
-      rel.target_column_name
-    )
+    const [source, sourceHandle] = findHandleIds(rel.source_table_name, rel.source_column_name)
+    const [target, targetHandle] = findHandleIds(rel.target_table_name, rel.target_column_name)
 
     // We do not support [external->this] flow currently.
     if (source && target) {
@@ -163,24 +170,6 @@ export async function getGraphDataFromTables(
   return !!savedPositions
     ? getLayoutedElementsViaLocalStorage(nodes, edges, savedPositions)
     : getLayoutedElementsViaDagre(nodes, edges)
-}
-
-function findTablesHandleIds(
-  tables: PGTable[],
-  table_name: string,
-  column_name: string
-): [string?, string?] {
-  for (const table of tables) {
-    if (table_name !== table.name) continue
-
-    for (const column of table.columns || []) {
-      if (column_name !== column.name) continue
-
-      return [String(table.id), column.id]
-    }
-  }
-
-  return []
 }
 
 export const getLayoutedElementsViaDagre = (nodes: Node<TableNodeData>[], edges: Edge[]) => {


### PR DESCRIPTION
Towards [FE-3428](https://linear.app/supabase/issue/FE-3428).

## Summary

Cheap render-cost fixes so the Schema Visualizer stays responsive at 400+ tables. No data-layer or API changes — pure render-side work, isolated to the Schema Visualizer.

- Enable `onlyRenderVisibleElements` on `<ReactFlow>` so xyflow skips mounting nodes and edges outside the viewport.
- Memoize `TableNode` (custom comparator) and `DefaultEdge` so they don't re-render on unrelated state changes (pan/zoom, theme toggle, parent re-renders).
- Drop `resolvedTheme` from the layout effect deps — theme is purely visual; toggling it no longer re-runs Dagre and replaces every node/edge.
- `handleSelectionChange` now (a) skips `setEdges` entirely when no edge's `animated` flipped, and (b) preserves the object reference for untouched edges so memoized edges don't re-render.
- Precompute a `Map<tableName, …>` lookup in `getGraphDataFromTables` so FK handle resolution is O(1) per relationship instead of scanning every table+column.

A follow-up PR will add a `useInfiniteTablesQuery` and switch both the Schema Visualizer and Database > Tables list onto it for progressive loading and infinite scroll.

## Caveats

- `TableNode` reads `selectedEdge` from context, so selecting an edge still re-renders all visible `TableNode`s via context propagation. The memo guards against props-driven re-renders (pan/zoom/theme).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized database schema graph rendering with improved component caching and efficient relationship lookups.
  * Enhanced visual element rendering to reduce unnecessary re-renders for large schemas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->