### PR TITLE
Add missing hover bg color on table row

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -493,7 +493,7 @@ export const TableList = ({
                             {!isSchemaLocked && (
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
-                                  <Button type="default" className="px-1" icon={<MoreVertical />} />
+                                  <Button type="text" className="px-1" icon={<MoreVertical />} />
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent side="bottom" align="end" className="w-40">
                                   <DropdownMenuItem

--- a/packages/ui/src/components/shadcn/ui/table.tsx
+++ b/packages/ui/src/components/shadcn/ui/table.tsx
@@ -52,7 +52,10 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
   ({ className, ...props }, ref) => (
     <tr
       ref={ref}
-      className={cn('border-b group data-[state=selected]:bg-muted', className)}
+      className={cn(
+        'border-b group data-[state=selected]:bg-muted hover:bg-surface-200',
+        className
+      )}
       {...props}
     />
   )


### PR DESCRIPTION
## Context

Previously removed the group hover background color for TableCell in this PR [here](https://github.com/supabase/supabase/pull/45933/changes#diff-6eac0b6bc77e68de6a37e675290a8e0634b53493470a9d9843a047fe5fa4202d) with the intention to apply the background color on the TableRow instead, but totally forgot to add that behaviour on the TableRow 🤦 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Table rows now display enhanced hover and background states for clearer interaction feedback.
  * Action menu buttons updated to a text-style appearance for a cleaner, less prominent visual presentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46246?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->