### PR TITLE
fix(studio): hide Database Tables row actions until row hover

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -493,7 +493,7 @@ export const TableList = ({
                             {!isSchemaLocked && (
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
-                                  <Button type="default" className="px-1" icon={<MoreVertical />} />
+                                  <Button type="text" className="px-1" icon={<MoreVertical />} />
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent side="bottom" align="end" className="w-40">
                                   <DropdownMenuItem


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix. Stacked on top of #46246.

## What is the current behavior?

The `MoreVertical` dropdown trigger in the Database Tables last cell uses `type="default"`, giving it its own `bg-alternative dark:bg-muted` static background. Once #46246 restores `hover:bg-surface-200` on `TableRow`, this button creates a second visible hover layer on the last cell — unlike equivalent icon buttons on other list pages (e.g. Indexes) which correctly use `type="text"` (transparent background).

## What is the new behavior?

One-word change: `type="default"` → `type="text"` on the `MoreVertical` trigger. The button is now transparent and inherits the row's hover background cleanly, consistent with the established pattern.

## Additional context

No extra class names needed — aligning with the existing convention is sufficient.