### PR TITLE
feat(ui-patterns): add CollapsibleCardSection component

### DIFF
--- a/apps/design-system/__registry__/index.tsx
+++ b/apps/design-system/__registry__/index.tsx
@@ -5,6 +5,17 @@ import * as React from "react"
 
 export const Index: Record<string, any> = {
   "default": {
+    "CollapsibleCardSection": {
+      name: "CollapsibleCardSection",
+      type: "components:fragment",
+      registryDependencies: undefined,
+      component: React.lazy(() => import("@/../../packages/ui-patterns/src/CollapsibleCardSection")),
+      source: "",
+      files: ["registry/default//CollapsibleCardSection.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
     "ConfirmationModal": {
       name: "ConfirmationModal",
       type: "components:fragment",
@@ -221,6 +232,17 @@ export const Index: Record<string, any> = {
       component: React.lazy(() => import("@/registry/default/example/collapsible-alert-demo")),
       source: "",
       files: ["registry/default/example/collapsible-alert-demo.tsx"],
+      category: "undefined",
+      subcategory: "undefined",
+      chunks: []
+    },
+    "collapsible-card-section-demo": {
+      name: "collapsible-card-section-demo",
+      type: "components:example",
+      registryDependencies: ["collapsible-card-section"],
+      component: React.lazy(() => import("@/registry/default/example/collapsible-card-section-demo")),
+      source: "",
+      files: ["registry/default/example/collapsible-card-section-demo.tsx"],
       category: "undefined",
       subcategory: "undefined",
       chunks: []

--- a/apps/design-system/config/docs.ts
+++ b/apps/design-system/config/docs.ts
@@ -123,6 +123,11 @@ export const docsConfig: DocsConfig = {
           items: [],
         },
         {
+          title: 'Collapsible Card Section',
+          href: '/docs/fragments/collapsible-card-section',
+          items: [],
+        },
+        {
           title: 'Assistant Chat',
           href: '/docs/fragments/assistant-chat',
           items: [],

--- a/apps/design-system/content/docs/fragments/collapsible-card-section.mdx
+++ b/apps/design-system/content/docs/fragments/collapsible-card-section.mdx
@@ -1,0 +1,40 @@
+---
+title: Collapsible Card Section
+description: A mono-uppercase collapsible trigger for hiding optional or advanced settings inside a card or panel.
+fragment: true
+---
+
+Use `CollapsibleCardSection` to progressively disclose optional or advanced fields inside a card or panel form. The trigger is styled mono-uppercase to blend with card section headings; content animates in and out on toggle.
+
+<ComponentPreview name="collapsible-card-section-demo" peekCode wide />
+
+## Usage
+
+```tsx
+import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
+```
+
+```tsx
+<CollapsibleCardSection title="Advanced settings">{/* form fields */}</CollapsibleCardSection>
+```
+
+### With description
+
+Use `description` to add a short qualifier below the title, only when the content needs context that the title alone doesn't provide.
+
+```tsx
+<CollapsibleCardSection
+  title="Advanced settings"
+  description="These settings cannot be changed after creation"
+>
+  {/* form fields */}
+</CollapsibleCardSection>
+```
+
+### Default open
+
+```tsx
+<CollapsibleCardSection title="Advanced settings" defaultOpen>
+  {/* form fields */}
+</CollapsibleCardSection>
+```

--- a/apps/design-system/registry/default/example/collapsible-card-section-demo.tsx
+++ b/apps/design-system/registry/default/example/collapsible-card-section-demo.tsx
@@ -1,0 +1,23 @@
+import { Input } from 'ui'
+import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+
+export default function CollapsibleCardSectionDemo() {
+  return (
+    <div className="border rounded-lg px-6 py-4 w-full max-w-lg">
+      <CollapsibleCardSection
+        title="Advanced settings"
+        description="These settings cannot be changed after creation"
+      >
+        <FormItemLayout
+          isReactForm={false}
+          layout="flex-row-reverse"
+          label="OIDC Issuer"
+          description="The OIDC issuer URL of your identity provider."
+        >
+          <Input placeholder="https://your-org.okta.com" />
+        </FormItemLayout>
+      </CollapsibleCardSection>
+    </div>
+  )
+}

--- a/apps/design-system/registry/examples.ts
+++ b/apps/design-system/registry/examples.ts
@@ -68,6 +68,12 @@ export const examples: Registry = [
     files: ['example/collapsible-alert-demo.tsx'],
   },
   {
+    name: 'collapsible-card-section-demo',
+    type: 'components:example',
+    registryDependencies: ['collapsible-card-section'],
+    files: ['example/collapsible-card-section-demo.tsx'],
+  },
+  {
     name: 'alert-dialog-demo',
     type: 'components:example',
     registryDependencies: ['alert-dialog', 'button'],

--- a/apps/design-system/registry/fragments.ts
+++ b/apps/design-system/registry/fragments.ts
@@ -2,6 +2,12 @@ import { Registry } from '@/registry/schema'
 
 export const fragments: Registry = [
   {
+    name: 'CollapsibleCardSection',
+    type: 'components:fragment',
+    files: ['/CollapsibleCardSection.tsx'],
+    optionalPath: '',
+  },
+  {
     name: 'ConfirmationModal',
     type: 'components:fragment',
     files: ['/Dialogs/ConfirmationModal.tsx'],

--- a/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
@@ -1,12 +1,8 @@
 import { useFlag } from 'common'
-import { ChevronRight } from 'lucide-react'
 import { UseFormReturn } from 'react-hook-form'
 import {
   Badge,
   cn,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
   FormControl,
   FormField,
   FormItem,
@@ -17,6 +13,7 @@ import {
   TooltipTrigger,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
+import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CreateProjectForm } from './ProjectCreation.schema'
@@ -33,104 +30,90 @@ export const AdvancedConfiguration = ({ form }: AdvancedConfigurationProps) => {
 
   return (
     <Panel.Content>
-      <Collapsible>
-        <CollapsibleTrigger className="group/advanced-trigger font-mono uppercase tracking-widest text-xs flex items-center gap-1 text-foreground-lighter/75 hover:text-foreground-light transition data-open:text-foreground-light">
-          Advanced Configuration
-          <ChevronRight
-            size={16}
-            strokeWidth={1}
-            className="mr-2 group-data-open/advanced-trigger:rotate-90 group-hover/advanced-trigger:text-foreground-light transition"
-          />
-        </CollapsibleTrigger>
-        <CollapsibleContent
-          className={cn(
-            'pt-2 data-closed:animate-collapsible-up data-open:animate-collapsible-down'
+      <CollapsibleCardSection
+        title="Advanced Configuration"
+        description="These settings cannot be changed after the project is created"
+      >
+        <FormField
+          name="useOrioleDb"
+          control={form.control}
+          render={({ field }) => (
+            <>
+              <FormItemLayout
+                layout="horizontal"
+                label="Postgres Type"
+                className="[&>div>label]:break-normal!"
+              >
+                <FormControl>
+                  <RadioGroupStacked
+                    // Due to radio group not supporting boolean values
+                    // value is converted to boolean
+                    onValueChange={(value) => field.onChange(value === 'true')}
+                    defaultValue={field.value.toString()}
+                  >
+                    <FormItem asChild>
+                      <FormControl>
+                        <RadioGroupStackedItem
+                          value="false"
+                          // @ts-ignore
+                          label={
+                            <>
+                              Postgres
+                              <Badge>Default</Badge>
+                            </>
+                          }
+                          description="Recommended for production workloads"
+                          className="[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2"
+                        />
+                      </FormControl>
+                    </FormItem>
+                    <FormItem asChild>
+                      <FormControl>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <RadioGroupStackedItem
+                              value="true"
+                              // @ts-ignore
+                              label={
+                                <>
+                                  Postgres with OrioleDB
+                                  <Badge variant="warning">Alpha</Badge>
+                                </>
+                              }
+                              description="Not recommended for production workloads"
+                              className={cn(
+                                '[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2',
+                                form.getValues('useOrioleDb') ? 'rounded-b-none!' : ''
+                              )}
+                              disabled={disableOrioleProjectCreation}
+                            />
+                          </TooltipTrigger>
+                          {disableOrioleProjectCreation && (
+                            <TooltipContent side="right" className="w-60 text-center">
+                              OrioleDB is temporarily disabled for new projects. Please try again
+                              later.
+                            </TooltipContent>
+                          )}
+                        </Tooltip>
+                      </FormControl>
+                    </FormItem>
+                  </RadioGroupStacked>
+                </FormControl>
+                {form.getValues('useOrioleDb') && (
+                  <Admonition
+                    type="warning"
+                    className="rounded-t-none [&>div]:text-xs"
+                    title="OrioleDB is not production ready"
+                    description="Postgres with OrioleDB extension is currently in Public Alpha and not recommended for production usage yet."
+                  >
+                    <DocsButton className="mt-2" href={`${DOCS_URL}/guides/database/orioledb`} />
+                  </Admonition>
+                )}
+              </FormItemLayout>
+            </>
           )}
-        >
-          <p className="text-xs text-foreground-lighter mb-6">
-            These settings cannot be changed after the project is created
-          </p>
-          <FormField
-            name="useOrioleDb"
-            control={form.control}
-            render={({ field }) => (
-              <>
-                <FormItemLayout
-                  layout="horizontal"
-                  label="Postgres Type"
-                  className="[&>div>label]:break-normal!"
-                >
-                  <FormControl>
-                    <RadioGroupStacked
-                      // Due to radio group not supporting boolean values
-                      // value is converted to boolean
-                      onValueChange={(value) => field.onChange(value === 'true')}
-                      defaultValue={field.value.toString()}
-                    >
-                      <FormItem asChild>
-                        <FormControl>
-                          <RadioGroupStackedItem
-                            value="false"
-                            // @ts-ignore
-                            label={
-                              <>
-                                Postgres
-                                <Badge>Default</Badge>
-                              </>
-                            }
-                            description="Recommended for production workloads"
-                            className="[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2"
-                          />
-                        </FormControl>
-                      </FormItem>
-                      <FormItem asChild>
-                        <FormControl>
-                          <Tooltip>
-                            <TooltipTrigger asChild>
-                              <RadioGroupStackedItem
-                                value="true"
-                                // @ts-ignore
-                                label={
-                                  <>
-                                    Postgres with OrioleDB
-                                    <Badge variant="warning">Alpha</Badge>
-                                  </>
-                                }
-                                description="Not recommended for production workloads"
-                                className={cn(
-                                  '[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2',
-                                  form.getValues('useOrioleDb') ? 'rounded-b-none!' : ''
-                                )}
-                                disabled={disableOrioleProjectCreation}
-                              />
-                            </TooltipTrigger>
-                            {disableOrioleProjectCreation && (
-                              <TooltipContent side="right" className="w-60 text-center">
-                                OrioleDB is temporarily disabled for new projects. Please try again
-                                later.
-                              </TooltipContent>
-                            )}
-                          </Tooltip>
-                        </FormControl>
-                      </FormItem>
-                    </RadioGroupStacked>
-                  </FormControl>
-                  {form.getValues('useOrioleDb') && (
-                    <Admonition
-                      type="warning"
-                      className="rounded-t-none [&>div]:text-xs"
-                      title="OrioleDB is not production ready"
-                      description="Postgres with OrioleDB extension is currently in Public Alpha and not recommended for production usage yet."
-                    >
-                      <DocsButton className="mt-2" href={`${DOCS_URL}/guides/database/orioledb`} />
-                    </Admonition>
-                  )}
-                </FormItemLayout>
-              </>
-            )}
-          />
-        </CollapsibleContent>
-      </Collapsible>
+        />
+      </CollapsibleCardSection>
     </Panel.Content>
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/AdvancedConfiguration.tsx
@@ -2,6 +2,8 @@ import { useFlag } from 'common'
 import { UseFormReturn } from 'react-hook-form'
 import {
   Badge,
+  Card,
+  CardContent,
   cn,
   FormControl,
   FormField,
@@ -18,7 +20,6 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CreateProjectForm } from './ProjectCreation.schema'
 import { DocsButton } from '@/components/ui/DocsButton'
-import Panel from '@/components/ui/Panel'
 import { DOCS_URL } from '@/lib/constants'
 
 interface AdvancedConfigurationProps {
@@ -29,91 +30,93 @@ export const AdvancedConfiguration = ({ form }: AdvancedConfigurationProps) => {
   const disableOrioleProjectCreation = useFlag('disableOrioleProjectCreation')
 
   return (
-    <Panel.Content>
-      <CollapsibleCardSection
-        title="Advanced Configuration"
-        description="These settings cannot be changed after the project is created"
-      >
-        <FormField
-          name="useOrioleDb"
-          control={form.control}
-          render={({ field }) => (
-            <>
-              <FormItemLayout
-                layout="horizontal"
-                label="Postgres Type"
-                className="[&>div>label]:break-normal!"
-              >
-                <FormControl>
-                  <RadioGroupStacked
-                    // Due to radio group not supporting boolean values
-                    // value is converted to boolean
-                    onValueChange={(value) => field.onChange(value === 'true')}
-                    defaultValue={field.value.toString()}
-                  >
-                    <FormItem asChild>
-                      <FormControl>
-                        <RadioGroupStackedItem
-                          value="false"
-                          // @ts-ignore
-                          label={
-                            <>
-                              Postgres
-                              <Badge>Default</Badge>
-                            </>
-                          }
-                          description="Recommended for production workloads"
-                          className="[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2"
-                        />
-                      </FormControl>
-                    </FormItem>
-                    <FormItem asChild>
-                      <FormControl>
-                        <Tooltip>
-                          <TooltipTrigger asChild>
-                            <RadioGroupStackedItem
-                              value="true"
-                              // @ts-ignore
-                              label={
-                                <>
-                                  Postgres with OrioleDB
-                                  <Badge variant="warning">Alpha</Badge>
-                                </>
-                              }
-                              description="Not recommended for production workloads"
-                              className={cn(
-                                '[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2',
-                                form.getValues('useOrioleDb') ? 'rounded-b-none!' : ''
-                              )}
-                              disabled={disableOrioleProjectCreation}
-                            />
-                          </TooltipTrigger>
-                          {disableOrioleProjectCreation && (
-                            <TooltipContent side="right" className="w-60 text-center">
-                              OrioleDB is temporarily disabled for new projects. Please try again
-                              later.
-                            </TooltipContent>
-                          )}
-                        </Tooltip>
-                      </FormControl>
-                    </FormItem>
-                  </RadioGroupStacked>
-                </FormControl>
-                {form.getValues('useOrioleDb') && (
-                  <Admonition
-                    type="warning"
-                    className="rounded-t-none [&>div]:text-xs"
-                    title="OrioleDB is not production ready"
-                    description="Postgres with OrioleDB extension is currently in Public Alpha and not recommended for production usage yet."
-                  >
-                    <DocsButton className="mt-2" href={`${DOCS_URL}/guides/database/orioledb`} />
-                  </Admonition>
-                )}
-              </FormItemLayout>
-            </>
-          )}
-        />
-      </CollapsibleCardSection>
-    </Panel.Content>
+    <Card className="border-0 border-b rounded-none">
+      <CardContent>
+        <CollapsibleCardSection
+          title="Advanced Configuration"
+          description="These settings cannot be changed after the project is created"
+        >
+          <FormField
+            name="useOrioleDb"
+            control={form.control}
+            render={({ field }) => (
+              <>
+                <FormItemLayout
+                  layout="horizontal"
+                  label="Postgres Type"
+                  className="[&>div>label]:break-normal!"
+                >
+                  <FormControl>
+                    <RadioGroupStacked
+                      // Due to radio group not supporting boolean values
+                      // value is converted to boolean
+                      onValueChange={(value) => field.onChange(value === 'true')}
+                      defaultValue={field.value.toString()}
+                    >
+                      <FormItem asChild>
+                        <FormControl>
+                          <RadioGroupStackedItem
+                            value="false"
+                            // @ts-ignore
+                            label={
+                              <>
+                                Postgres
+                                <Badge>Default</Badge>
+                              </>
+                            }
+                            description="Recommended for production workloads"
+                            className="[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2"
+                          />
+                        </FormControl>
+                      </FormItem>
+                      <FormItem asChild>
+                        <FormControl>
+                          <Tooltip>
+                            <TooltipTrigger asChild>
+                              <RadioGroupStackedItem
+                                value="true"
+                                // @ts-ignore
+                                label={
+                                  <>
+                                    Postgres with OrioleDB
+                                    <Badge variant="warning">Alpha</Badge>
+                                  </>
+                                }
+                                description="Not recommended for production workloads"
+                                className={cn(
+                                  '[&>div>div>p]:text-left [&>div>div>p]:text-xs [&>div>div>label]:flex [&>div>div>label]:items-center [&>div>div>label]:gap-x-2',
+                                  form.getValues('useOrioleDb') ? 'rounded-b-none!' : ''
+                                )}
+                                disabled={disableOrioleProjectCreation}
+                              />
+                            </TooltipTrigger>
+                            {disableOrioleProjectCreation && (
+                              <TooltipContent side="right" className="w-60 text-center">
+                                OrioleDB is temporarily disabled for new projects. Please try again
+                                later.
+                              </TooltipContent>
+                            )}
+                          </Tooltip>
+                        </FormControl>
+                      </FormItem>
+                    </RadioGroupStacked>
+                  </FormControl>
+                  {form.getValues('useOrioleDb') && (
+                    <Admonition
+                      type="warning"
+                      className="rounded-t-none [&>div]:text-xs"
+                      title="OrioleDB is not production ready"
+                      description="Postgres with OrioleDB extension is currently in Public Alpha and not recommended for production usage yet."
+                    >
+                      <DocsButton className="mt-2" href={`${DOCS_URL}/guides/database/orioledb`} />
+                    </Admonition>
+                  )}
+                </FormItemLayout>
+              </>
+            )}
+          />
+        </CollapsibleCardSection>
+      </CardContent>
+    </Card>
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'common'
 import { UseFormReturn } from 'react-hook-form'
 import { type CloudProvider } from 'shared-data'
-import { FormControl, FormField, Input } from 'ui'
+import { Card, CardContent, FormControl, FormField, Input } from 'ui'
 import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
@@ -9,7 +9,6 @@ import { CloudProviderSelector } from './CloudProviderSelector'
 import { HighAvailabilityInput } from './HighAvailabilityInput'
 import { PostgresVersionSelector } from './PostgresVersionSelector'
 import { CreateProjectForm } from './ProjectCreation.schema'
-import Panel from '@/components/ui/Panel'
 
 interface InternalOnlyConfigurationProps {
   form: UseFormReturn<CreateProjectForm>
@@ -20,13 +19,13 @@ export const InternalOnlyConfiguration = ({ form }: InternalOnlyConfigurationPro
   const showNonProdFields = process.env.NEXT_PUBLIC_ENVIRONMENT !== 'prod'
 
   return (
-    <Panel.Content>
-      <CollapsibleCardSection title="Internal-only Configuration">
-        <div className="flex flex-col gap-y-6">
-          <div>
-            <p className="text-xs text-foreground-lighter mb-6">
-              These settings are only visible to internal staff
-            </p>
+    <Card className="border-0 border-b rounded-none">
+      <CardContent>
+        <CollapsibleCardSection
+          title="Internal-only Configuration"
+          description="These settings are only visible to internal staff"
+        >
+          <div className="flex flex-col gap-y-6">
             <div className="flex flex-col gap-y-4">
               <FormField
                 control={form.control}
@@ -44,52 +43,52 @@ export const InternalOnlyConfiguration = ({ form }: InternalOnlyConfigurationPro
 
               <HighAvailabilityInput form={form} />
             </div>
-          </div>
 
-          {showNonProdFields && (
-            <div>
-              <p className="text-xs text-foreground-lighter mb-6">
-                The settings below are only applicable for local/staging projects
-              </p>
-              <div className="flex flex-col gap-y-4">
-                <CloudProviderSelector form={form} />
+            {showNonProdFields && (
+              <div>
+                <p className="text-xs text-foreground-lighter mb-6">
+                  The settings below are only applicable for local/staging projects
+                </p>
+                <div className="flex flex-col gap-y-4">
+                  <CloudProviderSelector form={form} />
 
-                <FormField
-                  control={form.control}
-                  name="postgresVersion"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      label="Custom Postgres version"
-                      layout="horizontal"
-                      description="Specify a custom version of Postgres (defaults to the latest)."
-                    >
-                      <FormControl>
-                        <Input placeholder="e.g 17.6.1.104" {...field} autoComplete="off" />
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
+                  <FormField
+                    control={form.control}
+                    name="postgresVersion"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        label="Custom Postgres version"
+                        layout="horizontal"
+                        description="Specify a custom version of Postgres (defaults to the latest)."
+                      >
+                        <FormControl>
+                          <Input placeholder="e.g 17.6.1.104" {...field} autoComplete="off" />
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
 
-                <FormField
-                  control={form.control}
-                  name="instanceType"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      label="Custom instance type"
-                      layout="horizontal"
-                      description="Specify a custom instance type."
-                    >
-                      <FormControl>
-                        <Input placeholder="e.g t3.nano" {...field} autoComplete="off" />
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
+                  <FormField
+                    control={form.control}
+                    name="instanceType"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        label="Custom instance type"
+                        layout="horizontal"
+                        description="Specify a custom instance type."
+                      >
+                        <FormControl>
+                          <Input placeholder="e.g t3.nano" {...field} autoComplete="off" />
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                </div>
               </div>
-            </div>
-          )}
-        </div>
-      </CollapsibleCardSection>
-    </Panel.Content>
+            )}
+          </div>
+        </CollapsibleCardSection>
+      </CardContent>
+    </Card>
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
@@ -1,15 +1,8 @@
 import { useParams } from 'common'
-import { ChevronRight } from 'lucide-react'
 import { UseFormReturn } from 'react-hook-form'
 import { type CloudProvider } from 'shared-data'
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  FormControl,
-  FormField,
-  Input,
-} from 'ui'
+import { FormControl, FormField, Input } from 'ui'
+import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CloudProviderSelector } from './CloudProviderSelector'
@@ -28,16 +21,8 @@ export const InternalOnlyConfiguration = ({ form }: InternalOnlyConfigurationPro
 
   return (
     <Panel.Content>
-      <Collapsible>
-        <CollapsibleTrigger className="group/advanced-trigger font-mono uppercase tracking-widest text-xs flex items-center gap-1 text-foreground-lighter/75 hover:text-foreground-light transition data-open:text-foreground-light">
-          Internal-only Configuration
-          <ChevronRight
-            size={16}
-            strokeWidth={1}
-            className="mr-2 group-data-open/advanced-trigger:rotate-90 group-hover/advanced-trigger:text-foreground-light transition"
-          />
-        </CollapsibleTrigger>
-        <CollapsibleContent className="pt-2 data-closed:animate-collapsible-up data-open:animate-collapsible-down flex flex-col gap-y-6">
+      <CollapsibleCardSection title="Internal-only Configuration">
+        <div className="flex flex-col gap-y-6">
           <div>
             <p className="text-xs text-foreground-lighter mb-6">
               These settings are only visible to internal staff
@@ -103,8 +88,8 @@ export const InternalOnlyConfiguration = ({ form }: InternalOnlyConfigurationPro
               </div>
             </div>
           )}
-        </CollapsibleContent>
-      </Collapsible>
+        </div>
+      </CollapsibleCardSection>
     </Panel.Content>
   )
 }

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -78,6 +78,10 @@
       "import": "./src/CodeBlock/index.tsx",
       "types": "./src/CodeBlock/index.tsx"
     },
+    "./CollapsibleCardSection": {
+      "import": "./src/CollapsibleCardSection.tsx",
+      "types": "./src/CollapsibleCardSection.tsx"
+    },
     "./CommandMenu/api/Badges": {
       "import": "./src/CommandMenu/api/Badges.tsx",
       "types": "./src/CommandMenu/api/Badges.tsx"

--- a/packages/ui-patterns/src/CollapsibleCardSection.tsx
+++ b/packages/ui-patterns/src/CollapsibleCardSection.tsx
@@ -1,0 +1,35 @@
+import { ChevronRight } from 'lucide-react'
+import type { PropsWithChildren, ReactNode } from 'react'
+import { cn, Collapsible, CollapsibleContent, CollapsibleTrigger } from 'ui'
+
+type CollapsibleCardSectionProps = PropsWithChildren<{
+  title: string
+  description?: ReactNode
+  defaultOpen?: boolean
+}>
+
+export const CollapsibleCardSection = ({
+  title,
+  description,
+  defaultOpen = false,
+  children,
+}: CollapsibleCardSectionProps) => (
+  <Collapsible defaultOpen={defaultOpen}>
+    <CollapsibleTrigger className="group/trigger font-mono uppercase tracking-widest text-xs flex items-center gap-1 text-foreground-lighter/75 hover:text-foreground-light transition data-open:text-foreground-light">
+      {title}
+      <ChevronRight
+        size={16}
+        strokeWidth={1}
+        className="mr-2 group-data-open/trigger:rotate-90 group-hover/trigger:text-foreground-light transition"
+      />
+    </CollapsibleTrigger>
+    <CollapsibleContent
+      className={cn(
+        '[overflow-y:clip] pt-2 data-closed:animate-collapsible-up data-open:animate-collapsible-down'
+      )}
+    >
+      {description && <p className="text-xs text-foreground-lighter mb-6">{description}</p>}
+      {children}
+    </CollapsibleContent>
+  </Collapsible>
+)


### PR DESCRIPTION
## What kind of change does this PR introduce?

New shared component + docs.

## What is the current behavior?

`AdvancedConfiguration` and `InternalOnlyConfiguration` in the New Project form each contain bespoke `<Collapsible>` markup. There's no reusable collapsible section component available to other card/panel forms.

## What is the new behavior?

- Extracts a shared `CollapsibleCardSection` into `packages/ui-patterns`, exported via `ui-patterns/CollapsibleCardSection`
- Refactors `AdvancedConfiguration` and `InternalOnlyConfiguration` to use it
- Adds design system docs with a live demo at `/docs/fragments/collapsible-card-section`

This is a prereq for #45707 and #46187, which both consume this component.

| Example Usage |
| --- |
| <img width="1464" height="500" alt="CleanShot 2026-05-22 at 15 20 38@2x" src="https://github.com/user-attachments/assets/5b88ef8d-3f9a-4454-b246-5bbaf53e027a" /> |

## To test

- [ ] Check that [the Design System page](https://design-system-git-dnywh-collapsible-card-section-supabase.vercel.app/design-system/docs/fragments/collapsible-card-section) makes sense
- [ ] Check that the [new project form](https://studio-staging-git-dnywh-collapsible-card-section-supabase.vercel.app/dashboard/new/) collapsible sections work as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced CollapsibleCardSection component as a reusable UI pattern for collapsible card-based content with customizable title, description, and open state.
  * Refactored project configuration interfaces to use the new component for improved visual consistency.

* **Documentation**
  * Added comprehensive documentation with interactive examples and multiple usage patterns for CollapsibleCardSection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46250?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->