### PR TITLE
fix(design-system): fix last table cell showing independent hover state

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -493,7 +493,7 @@ export const TableList = ({
                             {!isSchemaLocked && (
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
-                                  <Button type="text" className="px-1" icon={<MoreVertical />} />
+                                  <Button type="default" className="px-1" icon={<MoreVertical />} />
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent side="bottom" align="end" className="w-40">
                                   <DropdownMenuItem

--- a/packages/ui/src/components/ShadowScrollArea/index.tsx
+++ b/packages/ui/src/components/ShadowScrollArea/index.tsx
@@ -60,8 +60,8 @@ const ShadowScrollArea = React.forwardRef<HTMLDivElement, ShadowScrollAreaProps>
               '[&_tr:hover>*:last-child]:bg-transparent',
               '[&_th>*:last-child]:bg-surface-100',
               stickyColumnShadow,
+              hasHorizontalScroll && '[&_tr:hover>td:last-child]:!bg-surface-200',
             ],
-            hasHorizontalScroll && '[&_tr:hover>td:last-child]:!bg-surface-200',
             canScrollRight &&
               '[&_td]:before:opacity-100 [&_tr>*:last-child]:before:opacity-100 [&_th:last-child]:before:opacity-100',
             className

--- a/packages/ui/src/components/shadcn/ui/table.tsx
+++ b/packages/ui/src/components/shadcn/ui/table.tsx
@@ -53,7 +53,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     <tr
       ref={ref}
       className={cn(
-        'border-b transition-colors group data-[state=selected]:bg-muted hover:bg-surface-200',
+        'border-b group data-[state=selected]:bg-muted hover:bg-surface-200',
         className
       )}
       {...props}

--- a/packages/ui/src/components/shadcn/ui/table.tsx
+++ b/packages/ui/src/components/shadcn/ui/table.tsx
@@ -53,7 +53,7 @@ const TableRow = React.forwardRef<HTMLTableRowElement, React.HTMLAttributes<HTML
     <tr
       ref={ref}
       className={cn(
-        'border-b group data-[state=selected]:bg-muted hover:bg-surface-200',
+        'border-b transition-colors group data-[state=selected]:bg-muted hover:bg-surface-200',
         className
       )}
       {...props}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

On pages where the table has horizontal overflow (e.g. Database Tables with its 7 columns), `ShadowScrollArea` unconditionally applies `!bg-surface-200` to `td:last-child` on row hover. Since `TableCell` has `transition-colors`, this gives the last cell an explicit animated background change — making it visually distinct from every other cell, which simply inherit the row's hover bg transparently.

This manifests as the last cell appearing to have its own independent hover state, separate from the row hover.

## What is the new behavior?

The `!bg-surface-200` override on `td:last-child` is moved inside the `stickyLastColumn` block, since that's the only case where an explicit background is actually needed (sticky cells require a solid bg to avoid showing scrolled content behind them). Non-sticky tables no longer get the spurious cell-level hover.

Also reverts the MoreVertical dropdown trigger in `TableList` back to `type="default"` (undoes the workaround from #46247).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed hover styling behavior in horizontally scrollable tables to apply only when appropriate.

* **Style**
  * Updated the visual appearance of the row action dropdown button.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46251?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->