### PR TITLE
Adjust Data API exposed schema

### DIFF
--- a/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
@@ -1,4 +1,4 @@
-import { AlertCircle, Check, ChevronsUpDown, HelpCircle } from 'lucide-react'
+import { Check, ChevronsUpDown } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import {
   Button,
@@ -13,9 +13,6 @@ import {
   PopoverContent,
   PopoverTrigger,
   ScrollArea,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -28,7 +25,7 @@ import { pluralize } from '@/lib/helpers'
  * [Joshen] This would only affect graphql_public and pgmq_public, given that they're intended
  * to be public, we can let users expose them via the API, but not let them adjust the schema via the dashboard
  * */
-const internalSchemasCannotExpose = INTERNAL_SCHEMAS.filter((x) => !x.endsWith('_public'))
+export const internalSchemasCannotExpose = INTERNAL_SCHEMAS.filter((x) => !x.endsWith('_public'))
 
 interface ExposedSchemaSelectorProps {
   disabled?: boolean

--- a/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
@@ -1,4 +1,4 @@
-import { Check, ChevronsUpDown } from 'lucide-react'
+import { AlertCircle, Check, ChevronsUpDown, HelpCircle } from 'lucide-react'
 import { useMemo, useState } from 'react'
 import {
   Button,
@@ -13,6 +13,9 @@ import {
   PopoverContent,
   PopoverTrigger,
   ScrollArea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -20,6 +23,12 @@ import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
 import { pluralize } from '@/lib/helpers'
+
+/**
+ * [Joshen] This would only affect graphql_public and pgmq_public, given that they're intended
+ * to be public, we can let users expose them via the API, but not let them adjust the schema via the dashboard
+ * */
+const internalSchemasCannotExpose = INTERNAL_SCHEMAS.filter((x) => !x.endsWith('_public'))
 
 interface ExposedSchemaSelectorProps {
   disabled?: boolean
@@ -49,10 +58,7 @@ export const ExposedSchemaSelector = ({
   const schemas = useMemo(
     () =>
       (allSchemas ?? [])
-        .filter((s) => {
-          if (s.name === 'graphql_public') return true
-          return !INTERNAL_SCHEMAS.includes(s.name)
-        })
+        .filter((s) => !internalSchemasCannotExpose.includes(s.name))
         .sort((a, b) => a.name.localeCompare(b.name)),
     [allSchemas]
   )
@@ -129,9 +135,15 @@ export const ExposedSchemaSelector = ({
                             <Check size={16} className="text-brand shrink-0" />
                             <span className="truncate">{schema}</span>
                           </div>
-                          <span className="pl-6 text-destructive text-[11px]">
-                            This schema does not exist
-                          </span>
+                          {internalSchemasCannotExpose.includes(schema) ? (
+                            <span className="pl-6 text-warning text-xs tracking-tight">
+                              This schema is protected and should not be exposed
+                            </span>
+                          ) : (
+                            <span className="pl-6 text-foreground-lighter text-xs tracking-tight">
+                              This schema does not exist and can be safely removed
+                            </span>
+                          )}
                         </div>
                       </CommandItem>
                     ))}

--- a/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
@@ -25,7 +25,9 @@ import { pluralize } from '@/lib/helpers'
  * [Joshen] This would only affect graphql_public and pgmq_public, given that they're intended
  * to be public, we can let users expose them via the API, but not let them adjust the schema via the dashboard
  * */
-export const internalSchemasCannotExpose = INTERNAL_SCHEMAS.filter((x) => !x.endsWith('_public'))
+export const internalSchemasCannotExpose = new Set(
+  INTERNAL_SCHEMAS.filter((x) => !x.endsWith('_public'))
+)
 
 interface ExposedSchemaSelectorProps {
   disabled?: boolean
@@ -55,7 +57,7 @@ export const ExposedSchemaSelector = ({
   const schemas = useMemo(
     () =>
       (allSchemas ?? [])
-        .filter((s) => !internalSchemasCannotExpose.includes(s.name))
+        .filter((s) => !internalSchemasCannotExpose.has(s.name))
         .sort((a, b) => a.name.localeCompare(b.name)),
     [allSchemas]
   )
@@ -132,7 +134,7 @@ export const ExposedSchemaSelector = ({
                             <Check size={16} className="text-brand shrink-0" />
                             <span className="truncate">{schema}</span>
                           </div>
-                          {internalSchemasCannotExpose.includes(schema) ? (
+                          {internalSchemasCannotExpose.has(schema) ? (
                             <span className="pl-6 text-warning text-xs tracking-tight">
                               This schema is protected and should not be exposed
                             </span>

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -35,7 +35,7 @@ import {
 } from 'ui-patterns/multi-select'
 import { z } from 'zod'
 
-import { ExposedSchemaSelector } from './ExposedSchemaSelector'
+import { ExposedSchemaSelector, internalSchemasCannotExpose } from './ExposedSchemaSelector'
 import { HardenAPIModal } from './HardenAPIModal'
 import { ExposedFunctionSelector } from '@/components/interfaces/Settings/API/ExposedFunctionSelector'
 import { ExposedTableSelector } from '@/components/interfaces/Settings/API/ExposedTableSelector'
@@ -264,6 +264,10 @@ export const PostgrestConfig = () => {
     () => watchedDbSchema.filter((schema) => !allSchemas.some((s) => s.name === schema)),
     [allSchemas, watchedDbSchema]
   )
+  const protectedSchemasExposed = useMemo(
+    () => watchedDbSchema.filter((schema) => internalSchemasCannotExpose.includes(schema)),
+    [watchedDbSchema]
+  )
 
   return (
     <PageSection id="postgrest-config" className="first:pt-0">
@@ -306,7 +310,13 @@ export const PostgrestConfig = () => {
                           }
                         }}
                       />
-                      {missingExposedSchema.length > 0 ? (
+                      {protectedSchemasExposed.length > 0 ? (
+                        <p className="mt-1 text-sm text-warning">
+                          {protectedSchemasExposed.length} protected schema
+                          {protectedSchemasExposed.length > 1 ? 's' : ''} is currently exposed and
+                          should be removed
+                        </p>
+                      ) : missingExposedSchema.length > 0 ? (
                         <p className="mt-1 text-sm text-foreground-lighter">
                           {missingExposedSchema.length} exposed schema
                           {missingExposedSchema.length > 1 ? 's' : ''} does not exist — safe to

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -287,9 +287,6 @@ export const PostgrestConfig = () => {
                       layout="flex-row-reverse"
                       label="Exposed schemas"
                       description="Select schemas to include in the Data API. Schemas must be included before tables can be exposed."
-                      error={
-                        missingExposedSchema.length > 0 ? 'Some exposed schemas are missing' : null
-                      }
                     >
                       <ExposedSchemaSelector
                         selectedSchemas={watchedDbSchema}
@@ -309,6 +306,13 @@ export const PostgrestConfig = () => {
                           }
                         }}
                       />
+                      {missingExposedSchema.length > 0 ? (
+                        <p className="mt-1 text-sm text-foreground-lighter">
+                          {missingExposedSchema.length} exposed schema
+                          {missingExposedSchema.length > 1 ? 's' : ''} does not exist — safe to
+                          remove
+                        </p>
+                      ) : null}
                     </FormItemLayout>
 
                     <FormItemLayout

--- a/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/API/PostgrestConfig.tsx
@@ -265,7 +265,7 @@ export const PostgrestConfig = () => {
     [allSchemas, watchedDbSchema]
   )
   const protectedSchemasExposed = useMemo(
-    () => watchedDbSchema.filter((schema) => internalSchemasCannotExpose.includes(schema)),
+    () => watchedDbSchema.filter((schema) => internalSchemasCannotExpose.has(schema)),
     [watchedDbSchema]
   )
 


### PR DESCRIPTION
## Context

Builds on top of the work done previously here: https://github.com/supabase/supabase/pull/46169

In the Data API settings, only non-protected schemas are allowed to be exposed - in which `pgmq_public` was labelled as protected, resulting in an odd situation whereby if users expose the `pgmq_public` schema via the queue settings, they'll see this UI message
<img width="762" height="238" alt="image" src="https://github.com/user-attachments/assets/1ccac832-9524-40a9-956d-bbbda8a7e136" />

The `pgmq_public` schema was intended to be public, much like how `graphql_public` schema was, hence we're exposing that schema to be selectable in the Data API exposed schemas dropdown.

Am also making a couple of changes to adjust the UI a little
- Change missing schema text to be less alarming (reserve red for destructive actions - otherwise the visual signal is inaccurate and might cause unnecessary distress)
<img width="465" height="113" alt="image" src="https://github.com/user-attachments/assets/bdc30d9c-7898-4b25-9c4b-bc5aafa22076" />
<img width="488" height="112" alt="image" src="https://github.com/user-attachments/assets/f3e4459c-c670-4321-9f42-93e7abe69a00" />

- Highlight if a protected schema is being exposed with warning colors 
<img width="501" height="105" alt="image" src="https://github.com/user-attachments/assets/b8bff3b8-9635-4e57-96d2-80b5ad33f53f" />

- Adjust text of missing schema in dropdown to text-foreground-lighter instead of red (It's not necessarily a problem, just a clean up so again just a visual signal thing)
<img width="461" height="249" alt="image" src="https://github.com/user-attachments/assets/7f0632df-bee5-4911-bd3c-8a1cd6fb2f1f" />
<img width="442" height="207" alt="image" src="https://github.com/user-attachments/assets/bad266aa-84bf-4de7-b62a-4362f85b9481" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Inline help text now surfaces schema exposure status directly in the configuration UI.

* **Bug Fixes**
  * Improved filtering of internal schemas considered exposable.
  * Messaging updated to show counts and distinct styling: protected internal schemas render a warning and should be removed, while missing/nonexistent schemas show a lighter "safe to remove" note.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46260?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->