### PR TITLE
fix(studio): hide burst-credit disk IO metrics from Custom Reports picker

### DIFF
--- a/apps/studio/components/interfaces/Reports/MetricOptions.tsx
+++ b/apps/studio/components/interfaces/Reports/MetricOptions.tsx
@@ -17,12 +17,17 @@ import {
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
-import { DEPRECATED_REPORTS, HIDDEN_REPORT_METRICS } from './Reports.constants'
+import {
+  computeSizeSupportsIoBalance,
+  DEPRECATED_REPORTS,
+  IO_BALANCE_DEPENDENT_METRICS,
+} from './Reports.constants'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { useContentQuery } from '@/data/content/content-query'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { Metric, METRIC_CATEGORIES, METRICS } from '@/lib/constants/metrics'
 import { editorPanelState } from '@/state/editor-panel-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
@@ -42,8 +47,11 @@ interface MetricOptionsProps {
 export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsProps) => {
   const { ref: projectRef } = useParams()
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
+  const { data: selectedProject } = useSelectedProjectQuery()
   const { openSidebar } = useSidebarManagerSnapshot()
   const [search, setSearch] = useState('')
+
+  const supportsIoBalance = computeSizeSupportsIoBalance(selectedProject?.infra_compute_size)
 
   const { projectAuthAll: authEnabled, projectStorageAll: storageEnabled } = useIsFeatureEnabled([
     'project_auth:all',
@@ -84,7 +92,7 @@ export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsPro
                 {METRICS.filter(
                   (metric) =>
                     !DEPRECATED_REPORTS.includes(metric.key) &&
-                    !HIDDEN_REPORT_METRICS.includes(metric.key) &&
+                    !(IO_BALANCE_DEPENDENT_METRICS.includes(metric.key) && !supportsIoBalance) &&
                     metric?.category?.key === cat.key
                 ).map((metric) => {
                   return (

--- a/apps/studio/components/interfaces/Reports/MetricOptions.tsx
+++ b/apps/studio/components/interfaces/Reports/MetricOptions.tsx
@@ -17,7 +17,7 @@ import {
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
-import { DEPRECATED_REPORTS } from './Reports.constants'
+import { DEPRECATED_REPORTS, HIDDEN_REPORT_METRICS } from './Reports.constants'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { useContentQuery } from '@/data/content/content-query'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
@@ -83,7 +83,9 @@ export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsPro
               <DropdownMenuSubContent>
                 {METRICS.filter(
                   (metric) =>
-                    !DEPRECATED_REPORTS.includes(metric.key) && metric?.category?.key === cat.key
+                    !DEPRECATED_REPORTS.includes(metric.key) &&
+                    !HIDDEN_REPORT_METRICS.includes(metric.key) &&
+                    metric?.category?.key === cat.key
                 ).map((metric) => {
                   return (
                     <DropdownMenuCheckboxItem

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -5,7 +5,7 @@ import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
 import { ChartContainer, ChartTooltip, ChartTooltipContent, WarningIcon } from 'ui'
 
-import { HIDDEN_REPORT_METRICS } from '../Reports.constants'
+import { computeSizeSupportsIoBalance, IO_BALANCE_DEPENDENT_METRICS } from '../Reports.constants'
 import { METRIC_THRESHOLDS } from './ReportBlock.constants'
 import { ReportBlockContainer } from './ReportBlockContainer'
 import { ChartConfig } from '@/components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
@@ -28,6 +28,7 @@ import {
   ProjectDailyStatsAttribute,
   useProjectDailyStatsQuery,
 } from '@/data/analytics/project-daily-stats-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { METRICS } from '@/lib/constants/metrics'
 import { useFormatDateTime } from '@/lib/datetime'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
@@ -72,6 +73,10 @@ export const ChartBlock = ({
   const { ref } = router.query
 
   const state = useDatabaseSelectorStateSnapshot()
+  const { data: selectedProject } = useSelectedProjectQuery()
+  const isIoBalanceUnavailable =
+    IO_BALANCE_DEPENDENT_METRICS.includes(attribute) &&
+    !computeSizeSupportsIoBalance(selectedProject?.infra_compute_size)
   const [chartStyle, setChartStyle] = useState<string>(defaultChartStyle)
   const logScale = useMemo(() => defaultLogScale, [defaultLogScale])
   const [latestValue, setLatestValue] = useState<string | undefined>()
@@ -281,8 +286,8 @@ export const ChartBlock = ({
             size="small"
             className="border-0"
             description={
-              HIDDEN_REPORT_METRICS.includes(attribute)
-                ? 'This metric may not be available for your instance or disk configuration.'
+              isIoBalanceUnavailable
+                ? 'Not available for 4XL and larger compute sizes'
                 : 'It may take up to 24 hours for data to refresh'
             }
           />

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ChartBlock.tsx
@@ -5,6 +5,7 @@ import { ReactNode, useCallback, useEffect, useMemo, useState } from 'react'
 import { Bar, BarChart, CartesianGrid, Line, LineChart, XAxis, YAxis } from 'recharts'
 import { ChartContainer, ChartTooltip, ChartTooltipContent, WarningIcon } from 'ui'
 
+import { HIDDEN_REPORT_METRICS } from '../Reports.constants'
 import { METRIC_THRESHOLDS } from './ReportBlock.constants'
 import { ReportBlockContainer } from './ReportBlockContainer'
 import { ChartConfig } from '@/components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
@@ -279,7 +280,11 @@ export const ChartBlock = ({
           <NoDataPlaceholder
             size="small"
             className="border-0"
-            description="It may take up to 24 hours for data to refresh"
+            description={
+              HIDDEN_REPORT_METRICS.includes(attribute)
+                ? 'This metric may not be available for your instance or disk configuration.'
+                : 'It may take up to 24 hours for data to refresh'
+            }
           />
         </div>
       ) : (

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -1,6 +1,7 @@
 import { literal, safeSql, type SafeSqlFragment } from '@supabase/pg-meta'
 import dayjs from 'dayjs'
 
+import type { InfraInstanceSize } from '../DiskManagement/DiskManagement.types'
 import type { DatetimeHelper } from '../Settings/Logs/Logs.types'
 import { PresetConfig, Presets, ReportFilterItem } from './Reports.types'
 import { PlanId } from '@/data/subscriptions/types'
@@ -730,12 +731,24 @@ SELECT
   },
 }
 
-// Metrics hidden from the Custom Reports picker because the underlying data is
-// not available for a large slice of customers (e.g. derived from EC2
-// EBS-bandwidth burst credits, which are not published on larger,
-// non-burstable instance sizes). Saved reports that already reference these
-// keys still render the chart block with an explanatory empty state.
-export const HIDDEN_REPORT_METRICS = ['disk_io_consumption', 'disk_io_budget']
+// Metrics derived from EC2 EBS IO/byte balance percent CloudWatch series.
+// AWS only publishes those series on instances smaller than 4XL, so these
+// metrics are structurally unavailable on 4XL and larger compute sizes.
+export const IO_BALANCE_DEPENDENT_METRICS = ['disk_io_consumption', 'disk_io_budget']
+
+const INSTANCE_SIZES_WITH_IO_BALANCE: InfraInstanceSize[] = [
+  'pico',
+  'nano',
+  'micro',
+  'small',
+  'medium',
+  'large',
+  'xlarge',
+  '2xlarge',
+]
+
+export const computeSizeSupportsIoBalance = (computeSize?: InfraInstanceSize | null): boolean =>
+  computeSize != null && INSTANCE_SIZES_WITH_IO_BALANCE.includes(computeSize)
 
 export const DEPRECATED_REPORTS = [
   'total_realtime_ingress',

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -730,6 +730,13 @@ SELECT
   },
 }
 
+// Metrics hidden from the Custom Reports picker because the underlying data is
+// not available for a large slice of customers (e.g. derived from EC2
+// EBS-bandwidth burst credits, which are not published on larger,
+// non-burstable instance sizes). Saved reports that already reference these
+// keys still render the chart block with an explanatory empty state.
+export const HIDDEN_REPORT_METRICS = ['disk_io_consumption', 'disk_io_budget']
+
 export const DEPRECATED_REPORTS = [
   'total_realtime_ingress',
   'total_rest_options_requests',


### PR DESCRIPTION
Two disk IO metrics (`disk_io_consumption`, `disk_io_budget`) return no data for a large share of customers. The dashboard shows the generic 24-hour refresh message indefinitely.

These were already removed from the Infrastructure Activity page ([c82d5db](https://github.com/supabase/supabase/commit/c82d5db2e8)) — this PR removes them from Custom Reports too.

**Changes:**
- Hide both metrics from the Custom Reports picker (`MetricOptions.tsx`)
- For already-saved reports that reference them, show `"This metric may not be available for your instance or disk configuration."` instead of the 24-hour copy

**Test plan:**
- [ ] Open a Custom Report → "Add chart" → confirm both disk IO metrics are absent from the picker
- [ ] Open an existing report with those charts → confirm the updated empty-state copy
- [ ] Confirm other empty charts still show the original 24-hour message