### PR TITLE
fix: link redirect

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2430,6 +2430,11 @@ module.exports = [
   },
   {
     permanent: true,
+    source: '/partners/integrations/refine_dev',
+    destination: '/partners/integrations/refine',
+  },
+  {
+    permanent: true,
     source: '/docs/guides/integrations/sequin',
     destination: '/partners/integrations/sequin',
   },

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2435,6 +2435,11 @@ module.exports = [
   },
   {
     permanent: true,
+    source: '/partners/integrations/supabase_wrapper_stripe',
+    destination: '/partners/integrations/stripe-wrapper',
+  },
+  {
+    permanent: true,
     source: '/docs/guides/integrations/sequin',
     destination: '/partners/integrations/sequin',
   },


### PR DESCRIPTION
- closes https://github.com/supabase/supabase/issues/46236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a permanent redirect so requests to the old guide URL /docs/guides/integrations/refine_dev now automatically route to the new /partners/integrations/refine location, ensuring users following outdated links land on the updated integration documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->