### PR TITLE
chore: migrate project settings `Modal` to `Dialog`

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert.tsx
@@ -12,10 +12,16 @@ import {
   AlertTitle,
   Badge,
   Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
   Form,
   FormControl,
   FormField,
-  Modal,
   Select,
   SelectContent,
   SelectGroup,
@@ -140,153 +146,152 @@ export const ProjectUpgradeAlert = () => {
         </AlertDescription>
       </Alert>
 
-      <Modal
-        hideFooter
-        size="small"
-        visible={showUpgradeModal}
-        onCancel={() => setShowUpgradeModal(false)}
-        header="Confirm to upgrade Postgres version"
-      >
-        <Form {...form}>
-          <form onSubmit={form.handleSubmit(onConfirmUpgrade)}>
-            <Admonition
-              type="warning"
-              className="border-x-0 border-t-0 rounded-none"
-              title={`Your project will be offline for up to ${durationEstimateHours} hour${durationEstimateHours === 1 ? '' : 's'}`}
-              description="It is advised to upgrade at a time when there will be minimal impact for your application."
-            />
-            <Modal.Content>
-              <div className="space-y-4">
-                <p className="text-sm">
-                  All services will be offline and you will not be able to downgrade back to
-                  Postgres {currentPgVersion}.
-                </p>
-                {isDiskSizeUpdated && (
-                  <Markdown
-                    extLinks
-                    className="text-foreground"
-                    content={`Your current disk size of ${diskAttributes?.attributes.size_gb}GB will also be
+      <Dialog open={showUpgradeModal} onOpenChange={(open) => setShowUpgradeModal(open)}>
+        <DialogContent size="small">
+          <DialogHeader>
+            <DialogTitle>Confirm to upgrade Postgres version</DialogTitle>
+          </DialogHeader>
+          <DialogSectionSeparator />
+          <Form {...form}>
+            <form onSubmit={form.handleSubmit(onConfirmUpgrade)}>
+              <Admonition
+                type="warning"
+                className="border-x-0 border-t-0 rounded-none"
+                title={`Your project will be offline for up to ${durationEstimateHours} hour${durationEstimateHours === 1 ? '' : 's'}`}
+                description="It is advised to upgrade at a time when there will be minimal impact for your application."
+              />
+              <DialogSection>
+                <div className="space-y-4">
+                  <p className="text-sm">
+                    All services will be offline and you will not be able to downgrade back to
+                    Postgres {currentPgVersion}.
+                  </p>
+                  {isDiskSizeUpdated && (
+                    <Markdown
+                      extLinks
+                      className="text-foreground"
+                      content={`Your current disk size of ${diskAttributes?.attributes.size_gb}GB will also be
                     [right-sized](${DOCS_URL}/guides/platform/upgrading#disk-sizing) with the upgrade.`}
-                  />
-                )}
-                {/* @ts-ignore */}
-                {(data?.potential_breaking_changes ?? []).length > 0 && (
-                  <Alert variant="destructive" title="Breaking changes">
-                    <AlertCircle className="h-4 w-4" strokeWidth={2} />
-                    <AlertTitle>Breaking changes</AlertTitle>
-                    <AlertDescription className="flex flex-col gap-3">
-                      <p>
-                        Your project will be upgraded across major versions of Postgres. This may
-                        involve breaking changes.
-                      </p>
-
-                      <div>
-                        <Button size="tiny" type="default" asChild>
-                          <Link
-                            href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            View docs
-                          </Link>
-                        </Button>
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                )}
-                {legacyAuthCustomRoles.length > 0 && (
-                  <Alert
-                    variant="warning"
-                    title="Custom Postgres roles using md5 authentication have been detected"
-                  >
-                    <AlertTriangle className="h-4 w-4" strokeWidth={2} />
-                    <AlertTitle>
-                      Custom Postgres roles will not work automatically after upgrade
-                    </AlertTitle>
-                    <AlertDescription className="flex flex-col gap-3">
-                      <p>You must run a series of commands after upgrading.</p>
-                      <p>
-                        This is because new Postgres versions use scram-sha-256 authentication by
-                        default and do not support md5, as it has been deprecated.
-                      </p>
-                      <div>
-                        <p className="mb-1">Run the following commands after the upgrade:</p>
-                        <div className="flex items-baseline gap-2">
-                          <code className="text-xs">
-                            {legacyAuthCustomRoles.map((role) => (
-                              <div key={role} className="pb-1">
-                                ALTER ROLE <span className="text-brand">{role}</span> WITH PASSWORD
-                                '<span className="text-brand">newpassword</span>';
-                              </div>
-                            ))}
-                          </code>
-                        </div>
-                      </div>
-                      <div>
-                        <Button size="tiny" type="default" asChild>
-                          <Link
-                            href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            View docs
-                          </Link>
-                        </Button>
-                      </div>
-                    </AlertDescription>
-                  </Alert>
-                )}
-                <FormField
-                  control={form.control}
-                  name="postgresVersionSelection"
-                  render={({ field }) => (
-                    <FormItemLayout label="Select the version of Postgres to upgrade to">
-                      <FormControl>
-                        <Select value={field.value} onValueChange={field.onChange}>
-                          <SelectTrigger>
-                            <SelectValue placeholder="Select a Postgres version" />
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectGroup>
-                              {(data?.target_upgrade_versions || [])?.map((value) => {
-                                const postgresVersion =
-                                  value.app_version.split('supabase-postgres-')[1]
-                                return (
-                                  <SelectItem key={formatValue(value)} value={formatValue(value)}>
-                                    <div className="flex items-center gap-3">
-                                      <span className="text-foreground">{postgresVersion}</span>
-                                      {value.release_channel !== 'ga' && (
-                                        <Badge variant="warning">{value.release_channel}</Badge>
-                                      )}
-                                    </div>
-                                  </SelectItem>
-                                )
-                              })}
-                            </SelectGroup>
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                    </FormItemLayout>
+                    />
                   )}
-                />
-              </div>
-            </Modal.Content>
-            <Modal.Separator />
-            <Modal.Content className="flex items-center space-x-2 justify-end">
-              <Button
-                type="default"
-                onClick={() => setShowUpgradeModal(false)}
-                disabled={isUpgrading}
-              >
-                Cancel
-              </Button>
-              <Button htmlType="submit" disabled={isUpgrading} loading={isUpgrading}>
-                Confirm upgrade
-              </Button>
-            </Modal.Content>
-          </form>
-        </Form>
-      </Modal>
+                  {/* @ts-ignore */}
+                  {(data?.potential_breaking_changes ?? []).length > 0 && (
+                    <Alert variant="destructive" title="Breaking changes">
+                      <AlertCircle className="h-4 w-4" strokeWidth={2} />
+                      <AlertTitle>Breaking changes</AlertTitle>
+                      <AlertDescription className="flex flex-col gap-3">
+                        <p>
+                          Your project will be upgraded across major versions of Postgres. This may
+                          involve breaking changes.
+                        </p>
+
+                        <div>
+                          <Button size="tiny" type="default" asChild>
+                            <Link
+                              href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              View docs
+                            </Link>
+                          </Button>
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                  {legacyAuthCustomRoles.length > 0 && (
+                    <Alert
+                      variant="warning"
+                      title="Custom Postgres roles using md5 authentication have been detected"
+                    >
+                      <AlertTriangle className="h-4 w-4" strokeWidth={2} />
+                      <AlertTitle>
+                        Custom Postgres roles will not work automatically after upgrade
+                      </AlertTitle>
+                      <AlertDescription className="flex flex-col gap-3">
+                        <p>You must run a series of commands after upgrading.</p>
+                        <p>
+                          This is because new Postgres versions use scram-sha-256 authentication by
+                          default and do not support md5, as it has been deprecated.
+                        </p>
+                        <div>
+                          <p className="mb-1">Run the following commands after the upgrade:</p>
+                          <div className="flex items-baseline gap-2">
+                            <code className="text-xs">
+                              {legacyAuthCustomRoles.map((role) => (
+                                <div key={role} className="pb-1">
+                                  ALTER ROLE <span className="text-brand">{role}</span> WITH
+                                  PASSWORD '<span className="text-brand">newpassword</span>';
+                                </div>
+                              ))}
+                            </code>
+                          </div>
+                        </div>
+                        <div>
+                          <Button size="tiny" type="default" asChild>
+                            <Link
+                              href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              View docs
+                            </Link>
+                          </Button>
+                        </div>
+                      </AlertDescription>
+                    </Alert>
+                  )}
+                  <FormField
+                    control={form.control}
+                    name="postgresVersionSelection"
+                    render={({ field }) => (
+                      <FormItemLayout label="Select the version of Postgres to upgrade to">
+                        <FormControl>
+                          <Select value={field.value} onValueChange={field.onChange}>
+                            <SelectTrigger>
+                              <SelectValue placeholder="Select a Postgres version" />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectGroup>
+                                {(data?.target_upgrade_versions || [])?.map((value) => {
+                                  const postgresVersion =
+                                    value.app_version.split('supabase-postgres-')[1]
+                                  return (
+                                    <SelectItem key={formatValue(value)} value={formatValue(value)}>
+                                      <div className="flex items-center gap-3">
+                                        <span className="text-foreground">{postgresVersion}</span>
+                                        {value.release_channel !== 'ga' && (
+                                          <Badge variant="warning">{value.release_channel}</Badge>
+                                        )}
+                                      </div>
+                                    </SelectItem>
+                                  )
+                                })}
+                              </SelectGroup>
+                            </SelectContent>
+                          </Select>
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                </div>
+              </DialogSection>
+              <DialogFooter>
+                <Button
+                  type="default"
+                  onClick={() => setShowUpgradeModal(false)}
+                  disabled={isUpgrading}
+                >
+                  Cancel
+                </Button>
+                <Button htmlType="submit" disabled={isUpgrading} loading={isUpgrading}>
+                  Confirm upgrade
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/ProjectUpgradeAlert.tsx
@@ -19,6 +19,7 @@ import {
   DialogSection,
   DialogSectionSeparator,
   DialogTitle,
+  DialogTrigger,
   Form,
   FormControl,
   FormField,
@@ -28,9 +29,6 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -39,6 +37,7 @@ import { z } from 'zod'
 import { PLAN_DETAILS } from '@/components/interfaces/DiskManagement/ui/DiskManagement.constants'
 import { Markdown } from '@/components/interfaces/Markdown'
 import { extractPostgresVersionDetails } from '@/components/interfaces/ProjectCreation/PostgresVersionSelector'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useDiskAttributesQuery } from '@/data/config/disk-attributes-query'
 import {
   ProjectUpgradeTargetVersion,
@@ -120,178 +119,179 @@ export const ProjectUpgradeAlert = () => {
   }, [data, form])
 
   return (
-    <>
-      <Alert title="Your project can be upgraded to the latest version of Postgres">
-        <AlertTitle>Your project can be upgraded to the latest version of Postgres</AlertTitle>
-        <AlertDescription>
-          <p>The latest version of Postgres ({latestPgVersion}) is available for your project.</p>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                size="tiny"
-                type="primary"
-                className="mt-2"
-                onClick={() => setShowUpgradeModal(true)}
-                disabled={projectUpgradeDisabled}
-              >
-                Upgrade project
-              </Button>
-            </TooltipTrigger>
-            {projectUpgradeDisabled && (
-              <TooltipContent side="bottom" align="center">
-                Project upgrade is currently disabled
-              </TooltipContent>
-            )}
-          </Tooltip>
-        </AlertDescription>
-      </Alert>
-
-      <Dialog open={showUpgradeModal} onOpenChange={(open) => setShowUpgradeModal(open)}>
-        <DialogContent size="small">
-          <DialogHeader>
-            <DialogTitle>Confirm to upgrade Postgres version</DialogTitle>
-          </DialogHeader>
-          <DialogSectionSeparator />
-          <Form {...form}>
-            <form onSubmit={form.handleSubmit(onConfirmUpgrade)}>
-              <Admonition
-                type="warning"
-                className="border-x-0 border-t-0 rounded-none"
-                title={`Your project will be offline for up to ${durationEstimateHours} hour${durationEstimateHours === 1 ? '' : 's'}`}
-                description="It is advised to upgrade at a time when there will be minimal impact for your application."
-              />
-              <DialogSection>
-                <div className="space-y-4">
-                  <p className="text-sm">
-                    All services will be offline and you will not be able to downgrade back to
-                    Postgres {currentPgVersion}.
-                  </p>
-                  {isDiskSizeUpdated && (
-                    <Markdown
-                      extLinks
-                      className="text-foreground"
-                      content={`Your current disk size of ${diskAttributes?.attributes.size_gb}GB will also be
-                    [right-sized](${DOCS_URL}/guides/platform/upgrading#disk-sizing) with the upgrade.`}
-                    />
-                  )}
-                  {/* @ts-ignore */}
-                  {(data?.potential_breaking_changes ?? []).length > 0 && (
-                    <Alert variant="destructive" title="Breaking changes">
-                      <AlertCircle className="h-4 w-4" strokeWidth={2} />
-                      <AlertTitle>Breaking changes</AlertTitle>
-                      <AlertDescription className="flex flex-col gap-3">
-                        <p>
-                          Your project will be upgraded across major versions of Postgres. This may
-                          involve breaking changes.
-                        </p>
-
-                        <div>
-                          <Button size="tiny" type="default" asChild>
-                            <Link
-                              href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              View docs
-                            </Link>
-                          </Button>
-                        </div>
-                      </AlertDescription>
-                    </Alert>
-                  )}
-                  {legacyAuthCustomRoles.length > 0 && (
-                    <Alert
-                      variant="warning"
-                      title="Custom Postgres roles using md5 authentication have been detected"
-                    >
-                      <AlertTriangle className="h-4 w-4" strokeWidth={2} />
-                      <AlertTitle>
-                        Custom Postgres roles will not work automatically after upgrade
-                      </AlertTitle>
-                      <AlertDescription className="flex flex-col gap-3">
-                        <p>You must run a series of commands after upgrading.</p>
-                        <p>
-                          This is because new Postgres versions use scram-sha-256 authentication by
-                          default and do not support md5, as it has been deprecated.
-                        </p>
-                        <div>
-                          <p className="mb-1">Run the following commands after the upgrade:</p>
-                          <div className="flex items-baseline gap-2">
-                            <code className="text-xs">
-                              {legacyAuthCustomRoles.map((role) => (
-                                <div key={role} className="pb-1">
-                                  ALTER ROLE <span className="text-brand">{role}</span> WITH
-                                  PASSWORD '<span className="text-brand">newpassword</span>';
-                                </div>
-                              ))}
-                            </code>
-                          </div>
-                        </div>
-                        <div>
-                          <Button size="tiny" type="default" asChild>
-                            <Link
-                              href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              View docs
-                            </Link>
-                          </Button>
-                        </div>
-                      </AlertDescription>
-                    </Alert>
-                  )}
-                  <FormField
-                    control={form.control}
-                    name="postgresVersionSelection"
-                    render={({ field }) => (
-                      <FormItemLayout label="Select the version of Postgres to upgrade to">
-                        <FormControl>
-                          <Select value={field.value} onValueChange={field.onChange}>
-                            <SelectTrigger>
-                              <SelectValue placeholder="Select a Postgres version" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectGroup>
-                                {(data?.target_upgrade_versions || [])?.map((value) => {
-                                  const postgresVersion =
-                                    value.app_version.split('supabase-postgres-')[1]
-                                  return (
-                                    <SelectItem key={formatValue(value)} value={formatValue(value)}>
-                                      <div className="flex items-center gap-3">
-                                        <span className="text-foreground">{postgresVersion}</span>
-                                        {value.release_channel !== 'ga' && (
-                                          <Badge variant="warning">{value.release_channel}</Badge>
-                                        )}
-                                      </div>
-                                    </SelectItem>
-                                  )
-                                })}
-                              </SelectGroup>
-                            </SelectContent>
-                          </Select>
-                        </FormControl>
-                      </FormItemLayout>
+    <Alert title="Your project can be upgraded to the latest version of Postgres">
+      <AlertTitle>Your project can be upgraded to the latest version of Postgres</AlertTitle>
+      <AlertDescription>
+        <p>The latest version of Postgres ({latestPgVersion}) is available for your project.</p>
+        <Dialog open={showUpgradeModal} onOpenChange={(open) => setShowUpgradeModal(open)}>
+          <DialogTrigger asChild>
+            <ButtonTooltip
+              size="tiny"
+              type="primary"
+              className="mt-2"
+              disabled={projectUpgradeDisabled}
+              tooltip={{
+                content: {
+                  side: 'bottom',
+                  align: 'center',
+                  text: projectUpgradeDisabled
+                    ? 'Project upgrade is currently disabled'
+                    : undefined,
+                },
+              }}
+            >
+              Upgrade project
+            </ButtonTooltip>
+          </DialogTrigger>
+          <DialogContent size="small">
+            <DialogHeader>
+              <DialogTitle>Confirm to upgrade Postgres version</DialogTitle>
+            </DialogHeader>
+            <DialogSectionSeparator />
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onConfirmUpgrade)}>
+                <Admonition
+                  type="warning"
+                  className="border-x-0 border-t-0 rounded-none"
+                  title={`Your project will be offline for up to ${durationEstimateHours} hour${durationEstimateHours === 1 ? '' : 's'}`}
+                  description="It is advised to upgrade at a time when there will be minimal impact for your application."
+                />
+                <DialogSection>
+                  <div className="space-y-4">
+                    <p className="text-sm">
+                      All services will be offline and you will not be able to downgrade back to
+                      Postgres {currentPgVersion}.
+                    </p>
+                    {isDiskSizeUpdated && (
+                      <Markdown
+                        extLinks
+                        className="text-foreground"
+                        content={`Your current disk size of ${diskAttributes?.attributes.size_gb}GB will also be
+                      [right-sized](${DOCS_URL}/guides/platform/upgrading#disk-sizing) with the upgrade.`}
+                      />
                     )}
-                  />
-                </div>
-              </DialogSection>
-              <DialogFooter>
-                <Button
-                  type="default"
-                  onClick={() => setShowUpgradeModal(false)}
-                  disabled={isUpgrading}
-                >
-                  Cancel
-                </Button>
-                <Button htmlType="submit" disabled={isUpgrading} loading={isUpgrading}>
-                  Confirm upgrade
-                </Button>
-              </DialogFooter>
-            </form>
-          </Form>
-        </DialogContent>
-      </Dialog>
-    </>
+                    {/* @ts-ignore */}
+                    {(data?.potential_breaking_changes ?? []).length > 0 && (
+                      <Alert variant="destructive" title="Breaking changes">
+                        <AlertCircle className="h-4 w-4" strokeWidth={2} />
+                        <AlertTitle>Breaking changes</AlertTitle>
+                        <AlertDescription className="flex flex-col gap-3">
+                          <p>
+                            Your project will be upgraded across major versions of Postgres. This
+                            may involve breaking changes.
+                          </p>
+
+                          <div>
+                            <Button size="tiny" type="default" asChild>
+                              <Link
+                                href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                View docs
+                              </Link>
+                            </Button>
+                          </div>
+                        </AlertDescription>
+                      </Alert>
+                    )}
+                    {legacyAuthCustomRoles.length > 0 && (
+                      <Alert
+                        variant="warning"
+                        title="Custom Postgres roles using md5 authentication have been detected"
+                      >
+                        <AlertTriangle className="h-4 w-4" strokeWidth={2} />
+                        <AlertTitle>
+                          Custom Postgres roles will not work automatically after upgrade
+                        </AlertTitle>
+                        <AlertDescription className="flex flex-col gap-3">
+                          <p>You must run a series of commands after upgrading.</p>
+                          <p>
+                            This is because new Postgres versions use scram-sha-256 authentication
+                            by default and do not support md5, as it has been deprecated.
+                          </p>
+                          <div>
+                            <p className="mb-1">Run the following commands after the upgrade:</p>
+                            <div className="flex items-baseline gap-2">
+                              <code className="text-xs">
+                                {legacyAuthCustomRoles.map((role) => (
+                                  <div key={role} className="pb-1">
+                                    ALTER ROLE <span className="text-brand">{role}</span> WITH
+                                    PASSWORD '<span className="text-brand">newpassword</span>';
+                                  </div>
+                                ))}
+                              </code>
+                            </div>
+                          </div>
+                          <div>
+                            <Button size="tiny" type="default" asChild>
+                              <Link
+                                href={`${DOCS_URL}/guides/platform/migrating-and-upgrading-projects#caveats`}
+                                target="_blank"
+                                rel="noreferrer"
+                              >
+                                View docs
+                              </Link>
+                            </Button>
+                          </div>
+                        </AlertDescription>
+                      </Alert>
+                    )}
+                    <FormField
+                      control={form.control}
+                      name="postgresVersionSelection"
+                      render={({ field }) => (
+                        <FormItemLayout label="Select the version of Postgres to upgrade to">
+                          <FormControl>
+                            <Select value={field.value} onValueChange={field.onChange}>
+                              <SelectTrigger>
+                                <SelectValue placeholder="Select a Postgres version" />
+                              </SelectTrigger>
+                              <SelectContent>
+                                <SelectGroup>
+                                  {(data?.target_upgrade_versions || [])?.map((value) => {
+                                    const postgresVersion =
+                                      value.app_version.split('supabase-postgres-')[1]
+                                    return (
+                                      <SelectItem
+                                        key={formatValue(value)}
+                                        value={formatValue(value)}
+                                      >
+                                        <div className="flex items-center gap-3">
+                                          <span className="text-foreground">{postgresVersion}</span>
+                                          {value.release_channel !== 'ga' && (
+                                            <Badge variant="warning">{value.release_channel}</Badge>
+                                          )}
+                                        </div>
+                                      </SelectItem>
+                                    )
+                                  })}
+                                </SelectGroup>
+                              </SelectContent>
+                            </Select>
+                          </FormControl>
+                        </FormItemLayout>
+                      )}
+                    />
+                  </div>
+                </DialogSection>
+                <DialogFooter>
+                  <Button
+                    type="default"
+                    onClick={() => setShowUpgradeModal(false)}
+                    disabled={isUpgrading}
+                  >
+                    Cancel
+                  </Button>
+                  <Button htmlType="submit" disabled={isUpgrading} loading={isUpgrading}>
+                    Confirm upgrade
+                  </Button>
+                </DialogFooter>
+              </form>
+            </Form>
+          </DialogContent>
+        </Dialog>
+      </AlertDescription>
+    </Alert>
   )
 }

--- a/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
+++ b/apps/studio/components/interfaces/Settings/General/TransferProjectPanel/TransferProjectButton.tsx
@@ -6,9 +6,16 @@ import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  DialogTrigger,
   InfoIcon,
   Loading,
-  Modal,
   Select,
   SelectContent,
   SelectItem,
@@ -81,10 +88,6 @@ export const TransferProjectButton = () => {
     'organizations'
   )
 
-  const toggle = () => {
-    setIsOpen(!isOpen)
-  }
-
   async function handleTransferProject() {
     if (project === undefined) return
     if (selectedOrg === undefined) return
@@ -92,48 +95,31 @@ export const TransferProjectButton = () => {
   }
 
   return (
-    <>
-      <ButtonTooltip
-        type="default"
-        onClick={toggle}
-        disabled={!canTransferProject || disableProjectTransfer}
-        tooltip={{
-          content: {
-            side: 'bottom',
-            text: !canTransferProject
-              ? 'You need additional permissions to transfer this project'
-              : disableProjectTransfer
-                ? 'Project transfers are temporarily disabled, please try again later.'
-                : undefined,
-          },
-        }}
-      >
-        Transfer project
-      </ButtonTooltip>
-
-      <Modal
-        onCancel={() => toggle()}
-        visible={isOpen}
-        loading={isTransferring}
-        size={'xlarge'}
-        header={`Transfer project ${project?.name}`}
-        customFooter={
-          <div className="flex items-center space-x-2 justify-end">
-            <Button type="default" onClick={() => setIsOpen(false)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => handleTransferProject()}
-              disabled={
-                !transferPreviewData || !transferPreviewData.valid || isTransferring || !selectedOrg
-              }
-            >
-              Transfer Project
-            </Button>
-          </div>
-        }
-      >
-        <Modal.Content className="text-foreground-light">
+    <Dialog onOpenChange={(open) => setIsOpen(open)} open={isOpen}>
+      <DialogTrigger asChild>
+        <ButtonTooltip
+          type="default"
+          disabled={!canTransferProject || disableProjectTransfer}
+          tooltip={{
+            content: {
+              side: 'bottom',
+              text: !canTransferProject
+                ? 'You need additional permissions to transfer this project'
+                : disableProjectTransfer
+                  ? 'Project transfers are temporarily disabled, please try again later.'
+                  : undefined,
+            },
+          }}
+        >
+          Transfer project
+        </ButtonTooltip>
+      </DialogTrigger>
+      <DialogContent size="xlarge">
+        <DialogHeader>
+          <DialogTitle>{`Transfer project ${project?.name}`}</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection className="text-foreground-light">
           <p className="text-sm">
             To transfer projects, the owner must be a member of both the source and target
             organizations. Consider the following before transferring your project:
@@ -185,11 +171,11 @@ export const TransferProjectButton = () => {
             className="mt-6"
             href={`${DOCS_URL}/guides/platform/project-transfer`}
           />
-        </Modal.Content>
+        </DialogSection>
 
-        <Modal.Separator />
+        <DialogSectionSeparator />
 
-        <Modal.Content>
+        <DialogSection>
           {organizations && (
             <div className="space-y-2">
               {organizations.length === 0 ? (
@@ -221,11 +207,11 @@ export const TransferProjectButton = () => {
               )}
             </div>
           )}
-        </Modal.Content>
+        </DialogSection>
 
         {selectedOrg !== undefined && (
           <Loading active={selectedOrg !== undefined && transferPreviewIsLoading}>
-            <Modal.Content>
+            <DialogSection>
               <div className="space-y-2">
                 {transferPreviewData && transferPreviewData.errors.length > 0 && (
                   <Admonition type="danger" title="Project cannot be transferred">
@@ -293,10 +279,23 @@ export const TransferProjectButton = () => {
                   />
                 )}
               </div>
-            </Modal.Content>
+            </DialogSection>
           </Loading>
         )}
-      </Modal>
-    </>
+        <DialogFooter>
+          <Button type="default" onClick={() => setIsOpen(false)}>
+            Cancel
+          </Button>
+          <Button
+            onClick={() => handleTransferProject()}
+            disabled={
+              !transferPreviewData || !transferPreviewData.valid || isTransferring || !selectedOrg
+            }
+          >
+            Transfer Project
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Problem

Project settings still uses the deprecated `Modal` for:
- transferring a project
- upgrading Postgres in _Infrastructure_

## Solution

- use `Dialog` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Migrated project upgrade confirmation and project transfer flows to a unified dialog-based UI for improved consistency and accessibility. Visual structure (headers, sections, footers) and action placement were standardized; existing functionality, validation, and user workflows remain unchanged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46265?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->