### PR TITLE
Fix copy / export large values in table editor

### DIFF
--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -17,11 +17,12 @@ import {
 import { useInitializeFiltersFromUrl, useSyncFiltersToUrl } from '../../hooks/useFilterLifeCycle'
 import { ExportDialog } from './ExportDialog'
 import { FilterPopoverNew } from './filter/FilterPopoverNew'
-import { formatRowsForCSV } from './Header.utils'
+import { formatRowsForCSV, hydrateTruncatedRows } from './Header.utils'
 import { SortPopover } from './sort/SortPopover'
 import { useTableRowOperations } from '@/components/grid/hooks/useTableRowOperations'
 import { useTableSort } from '@/components/grid/hooks/useTableSort'
 import { GridHeaderActions } from '@/components/interfaces/TableGridEditor/GridHeaderActions'
+import { isValueTruncated } from '@/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
 import { formatTableRowsToSQL } from '@/components/interfaces/TableGridEditor/TableEntity.utils'
 import {
   useExportAllRowsAsCsv,
@@ -145,6 +146,7 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   const filters = snap.filters
   const { sorts } = useTableSort()
 
+  const [isCopying, setIsCopying] = useState(false)
   const [isExporting, setIsExporting] = useState(false)
   const [showExportModal, setShowExportModal] = useState(false)
 
@@ -206,22 +208,53 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   }
 
   const onCopyRows = (type: 'csv' | 'json' | 'sql') => {
-    const rows = allRows.filter((x) => snap.selectedRows.has(x.idx))
+    if (!project) return toast.error('Project is required')
 
-    if (type === 'csv') {
-      const csv = formatRowsForCSV({
-        rows,
-        columns: snap.table!.columns.map((column) => column.name),
-      })
-      copyToClipboard(csv)
-    } else if (type === 'sql') {
-      const sqlStatements = formatTableRowsToSQL(snap.table, rows)
-      copyToClipboard(sqlStatements)
-    } else if (type === 'json') {
-      copyToClipboard(JSON.stringify(rows))
+    const selected = allRows.filter((x) => snap.selectedRows.has(x.idx))
+
+    const hasTruncated = selected.some((row) =>
+      Object.values(row).some((v) => typeof v === 'string' && isValueTruncated(v))
+    )
+    if (hasTruncated && (!snap.table.primaryKey || snap.table.primaryKey.length === 0)) {
+      return toast(
+        <div>
+          <p>Unable to copy selected rows</p>
+          <p className="text-foreground-light text-sm">
+            A selected row has a column value that needs to be fetched on demand due to its size,
+            but the table has no primary key.
+          </p>
+        </div>,
+        { duration: 8000 }
+      )
     }
 
-    toast.success('Copied rows to clipboard')
+    setIsCopying(true)
+    const formatted = (async () => {
+      const hydrated = await hydrateTruncatedRows({
+        rows: selected,
+        table: snap.table,
+        projectRef: project.ref,
+        connectionString: project.connectionString ?? null,
+      })
+      if (hydrated.status !== 'ok') {
+        throw new Error('Failed to fetch full values for truncated cells')
+      }
+      const rows = hydrated.rows
+      if (type === 'csv') {
+        return formatRowsForCSV({
+          rows,
+          columns: snap.table!.columns.map((column) => column.name),
+        })
+      } else if (type === 'sql') {
+        return formatTableRowsToSQL(snap.table, rows)
+      } else {
+        return JSON.stringify(rows)
+      }
+    })()
+
+    copyToClipboard(formatted, () => toast.success('Copied rows to clipboard')).finally(() => {
+      setIsCopying(false)
+    })
   }
 
   const exportParams = snap.allRowsSelected
@@ -245,15 +278,10 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
       : { enabled: false }
   )
   const onRowsExportCSV = async () => {
+    if (!project) return toast.error('Project is required')
+
     setIsExporting(true)
-
-    if (!project) {
-      toast.error('Project is required')
-      return setIsExporting(false)
-    }
-
-    exportCsv()
-
+    await exportCsv()
     setIsExporting(false)
   }
 
@@ -269,15 +297,10 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
       : { enabled: false }
   )
   const onRowsExportSQL = async () => {
+    if (!project) return toast.error('Project is required')
+
     setIsExporting(true)
-
-    if (!project) {
-      toast.error('Project is required')
-      return setIsExporting(false)
-    }
-
-    exportSql()
-
+    await exportSql()
     setIsExporting(false)
   }
 
@@ -293,14 +316,10 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
       : { enabled: false }
   )
   const onRowsExportJSON = async () => {
-    if (!project) {
-      return toast.error('Project is required')
-    }
+    if (!project) return toast.error('Project is required')
 
     setIsExporting(true)
-
-    exportJson()
-
+    await exportJson()
     setIsExporting(false)
   }
 
@@ -312,7 +331,78 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
 
   return (
     <>
-      <div className="flex items-center gap-x-2">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-x-2">
+          {!snap.allRowsSelected ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button type="default" size="tiny" iconRight={<ChevronDown />} loading={isCopying}>
+                  Copy
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="w-40">
+                <DropdownMenuItem onClick={() => onCopyRows('csv')}>Copy as CSV</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onCopyRows('sql')}>Copy as SQL</DropdownMenuItem>
+                <DropdownMenuItem onClick={() => onCopyRows('json')}>Copy as JSON</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <ButtonTooltip
+              disabled
+              type="default"
+              tooltip={{
+                content: {
+                  side: 'bottom',
+                  className: 'w-64 text-center',
+                  text: 'Copy to clipboard is not supported while all rows in the table are selected',
+                },
+              }}
+            >
+              Copy
+            </ButtonTooltip>
+          )}
+
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button type="default" size="tiny" iconRight={<ChevronDown />} loading={isExporting}>
+                Export
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className={snap.allRowsSelected ? 'w-52' : 'w-40'}>
+              <DropdownMenuItem onClick={onRowsExportCSV}>Export as CSV</DropdownMenuItem>
+              <DropdownMenuItem onClick={onRowsExportSQL}>Export as SQL</DropdownMenuItem>
+              {snap.allRowsSelected ? (
+                <DropdownMenuItem className="group" onClick={() => setShowExportModal(true)}>
+                  <div>
+                    <p className="group-hover:text-foreground">Export via CLI</p>
+                    <p className="text-foreground-lighter">Recommended for large tables</p>
+                  </div>
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem onClick={onRowsExportJSON}>Export as JSON</DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {snap.selectedRows.size > 0 && totalRows > allRows.length && (
+            <>
+              <div className="h-6 ml-0.5">
+                <Separator orientation="vertical" className="bg-border" />
+              </div>
+              <Shortcut
+                id={SHORTCUT_IDS.TABLE_EDITOR_SELECT_ALL_IN_TABLE}
+                onTrigger={onToggleSelectAllInTable}
+                options={{ registerInCommandMenu: true }}
+                side="bottom"
+              >
+                <Button type="text" onClick={onToggleSelectAllInTable}>
+                  {snap.allRowsSelected ? 'Deselect all rows in table' : 'Select all rows in table'}
+                </Button>
+              </Shortcut>
+            </>
+          )}
+        </div>
+
         {snap.editable && (
           <Shortcut
             id={SHORTCUT_IDS.TABLE_EDITOR_DELETE_SELECTED_ROWS}
@@ -324,7 +414,7 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
             }}
           >
             <ButtonTooltip
-              type="default"
+              type="danger"
               size="tiny"
               icon={<Trash />}
               onClick={onRowsDelete}
@@ -346,87 +436,6 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
                   : `Delete ${snap.selectedRows.size} row`}
             </ButtonTooltip>
           </Shortcut>
-        )}
-
-        {!snap.allRowsSelected ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                type="default"
-                size="tiny"
-                iconRight={<ChevronDown />}
-                loading={isExporting}
-                disabled={isExporting}
-              >
-                Copy
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-40">
-              <DropdownMenuItem onClick={() => onCopyRows('csv')}>Copy as CSV</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => onCopyRows('sql')}>Copy as SQL</DropdownMenuItem>
-              <DropdownMenuItem onClick={() => onCopyRows('json')}>Copy as JSON</DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : (
-          <ButtonTooltip
-            disabled
-            type="default"
-            tooltip={{
-              content: {
-                side: 'bottom',
-                className: 'w-64 text-center',
-                text: 'Copy to clipboard is not supported while all rows in the table are selected',
-              },
-            }}
-          >
-            Copy
-          </ButtonTooltip>
-        )}
-
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="default"
-              size="tiny"
-              iconRight={<ChevronDown />}
-              loading={isExporting}
-              disabled={isExporting}
-            >
-              Export
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start" className={snap.allRowsSelected ? 'w-52' : 'w-40'}>
-            <DropdownMenuItem onClick={onRowsExportCSV}>Export as CSV</DropdownMenuItem>
-            <DropdownMenuItem onClick={onRowsExportSQL}>Export as SQL</DropdownMenuItem>
-            {snap.allRowsSelected ? (
-              <DropdownMenuItem className="group" onClick={() => setShowExportModal(true)}>
-                <div>
-                  <p className="group-hover:text-foreground">Export via CLI</p>
-                  <p className="text-foreground-lighter">Recommended for large tables</p>
-                </div>
-              </DropdownMenuItem>
-            ) : (
-              <DropdownMenuItem onClick={onRowsExportJSON}>Export as JSON</DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {snap.selectedRows.size > 0 && totalRows > allRows.length && (
-          <>
-            <div className="h-6 ml-0.5">
-              <Separator orientation="vertical" className="bg-border" />
-            </div>
-            <Shortcut
-              id={SHORTCUT_IDS.TABLE_EDITOR_SELECT_ALL_IN_TABLE}
-              onTrigger={onToggleSelectAllInTable}
-              options={{ registerInCommandMenu: true }}
-              side="bottom"
-            >
-              <Button type="text" onClick={onToggleSelectAllInTable}>
-                {snap.allRowsSelected ? 'Deselect all rows in table' : 'Select all rows in table'}
-              </Button>
-            </Shortcut>
-          </>
         )}
       </div>
 

--- a/apps/studio/components/grid/components/header/Header.utils.ts
+++ b/apps/studio/components/grid/components/header/Header.utils.ts
@@ -1,5 +1,9 @@
 import Papa from 'papaparse'
 
+import type { SupaTable } from '@/components/grid/types'
+import { isValueTruncated } from '@/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
+import { getCellValue } from '@/data/table-rows/get-cell-value-mutation'
+
 export const formatRowsForCSV = ({ rows, columns }: { rows: any[]; columns: string[] }) => {
   const formattedRows = rows.map((row) => {
     const formattedRow = row
@@ -11,4 +15,70 @@ export const formatRowsForCSV = ({ rows, columns }: { rows: any[]; columns: stri
   })
   const csv = Papa.unparse(formattedRows, { columns })
   return csv
+}
+
+export type HydrateTruncatedRowsResult =
+  | { status: 'ok'; rows: Record<string, unknown>[] }
+  | { status: 'no_primary_key' }
+  | { status: 'fetch_error'; error: unknown }
+
+/**
+ * For each cell whose value was truncated for display (see isValueTruncated),
+ * refetch the full value via getCellValue and return a new array with the
+ * truncated cells replaced. If any row has a truncated cell but the table has
+ * no primary key, returns { status: 'no_primary_key' } so the caller can
+ * surface a clear error instead of silently exporting truncated data.
+ */
+export const hydrateTruncatedRows = async ({
+  rows,
+  table,
+  projectRef,
+  connectionString,
+}: {
+  rows: Record<string, unknown>[]
+  table: SupaTable
+  projectRef: string
+  connectionString: string | null
+}): Promise<HydrateTruncatedRowsResult> => {
+  const jobs: { rowIdx: number; column: string }[] = []
+  rows.forEach((row, rowIdx) => {
+    Object.keys(row).forEach((column) => {
+      const value = row[column]
+      if (typeof value === 'string' && isValueTruncated(value)) {
+        jobs.push({ rowIdx, column })
+      }
+    })
+  })
+
+  if (jobs.length === 0) return { status: 'ok', rows }
+
+  if (!table.primaryKey || table.primaryKey.length === 0) {
+    return { status: 'no_primary_key' }
+  }
+
+  const pkColumns = table.primaryKey
+  const hydrated = rows.map((row) => ({ ...row }))
+
+  try {
+    await Promise.all(
+      jobs.map(async ({ rowIdx, column }) => {
+        const sourceRow = rows[rowIdx]
+        const pkMatch = pkColumns.reduce<Record<string, unknown>>(
+          (acc, pk) => ({ ...acc, [pk]: sourceRow[pk] }),
+          {}
+        )
+        hydrated[rowIdx][column] = await getCellValue({
+          projectRef,
+          connectionString,
+          table: { schema: table.schema ?? 'public', name: table.name },
+          column,
+          pkMatch,
+        })
+      })
+    )
+  } catch (error: unknown) {
+    return { status: 'fetch_error', error }
+  }
+
+  return { status: 'ok', rows: hydrated }
 }

--- a/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.errors.ts
+++ b/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.errors.ts
@@ -91,3 +91,12 @@ export class DownloadSaveError extends ExportAllRowsErrorFamily {
     this.name = 'DownloadSaveError'
   }
 }
+
+export class NoPrimaryKeyForTruncatedRowsError extends ExportAllRowsErrorFamily {
+  constructor(tableName: string) {
+    super(
+      `Cannot export rows with truncated values from "${tableName}" because the table has no primary key.`
+    )
+    this.name = 'NoPrimaryKeyForTruncatedRowsError'
+  }
+}

--- a/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/ExportAllRows.tsx
@@ -10,6 +10,7 @@ import {
   DownloadSaveError,
   FetchRowsError,
   NoConnectionStringError,
+  NoPrimaryKeyForTruncatedRowsError,
   NoRowsToExportError,
   NoTableError,
   OutputConversionError,
@@ -18,6 +19,7 @@ import {
   type ExportAllRowsErrorFamily,
 } from './ExportAllRows.errors'
 import { useProgressToasts } from './ExportAllRows.progress'
+import { hydrateTruncatedRows } from '@/components/grid/components/header/Header.utils'
 import { parseSupaTable } from '@/components/grid/SupabaseGrid.utils'
 import type { Filter, Sort, SupaTable } from '@/components/grid/types'
 import { formatTableRowsToSQL } from '@/components/interfaces/TableGridEditor/TableEntity.utils'
@@ -287,13 +289,37 @@ export const useExportAllRowsGeneric = (
 
       const { projectRef, connectionString, entity, totalRows } = params
 
-      const exportResult =
+      const exportResult: FetchAllRowsReturn =
         params.type === 'provided_rows'
-          ? convertAndDownload(formatRowsForExport(params.rows, params.table), params.table, {
-              convertToOutputFormat,
-              convertToBlob,
-              save,
-            })
+          ? await (async () => {
+              const hydrated = await hydrateTruncatedRows({
+                rows: params.rows,
+                table: params.table,
+                projectRef,
+                connectionString,
+              })
+              if (hydrated.status === 'no_primary_key') {
+                return {
+                  status: 'error' as const,
+                  error: new NoPrimaryKeyForTruncatedRowsError(params.table.name),
+                }
+              }
+              if (hydrated.status === 'fetch_error') {
+                return {
+                  status: 'error' as const,
+                  error: new FetchRowsError(params.table.name, hydrated.error),
+                }
+              }
+              return convertAndDownload(
+                formatRowsForExport(hydrated.rows, params.table),
+                params.table,
+                {
+                  convertToOutputFormat,
+                  convertToBlob,
+                  save,
+                }
+              )
+            })()
           : await fetchAllRows({
               queryClient,
               projectRef: projectRef,
@@ -336,6 +362,9 @@ export const useExportAllRowsGeneric = (
         }
         if (error instanceof TableTooLargeError) {
           return stopTrackerWithError(entity.id, entity.name, MAX_EXPORT_ROW_COUNT_MESSAGE)
+        }
+        if (error instanceof NoPrimaryKeyForTruncatedRowsError) {
+          return stopTrackerWithError(entity.id, entity.name, error.message)
         }
         console.error(
           `Export All Rows > Error: %s%s%s`,


### PR DESCRIPTION
## Context

There's an issue with copying / exporting rows from the table editor with the following conditions:
- Row has a column value that exceeds 10,240 and hence is truncated for performance reasons
  <img width="300" alt="image" src="https://github.com/user-attachments/assets/4639edbb-ece6-4028-89b6-769ac314c3f3" />
- User is trying to copy/export selected rows (not all rows in the table)
  <img width="300" alt="image" src="https://github.com/user-attachments/assets/e7c0da77-051c-4c46-af0d-f9510e0b37c4" />

The copy/export action will return the truncated data which is incorrect (Should return the full data)

## Problem

This is happening as if we're only copying/exporting selected rows, we're just using what's been loaded in the table editor to export (as opposed to if the user is copying/exporting all rows in the table, we'd be fetching the data from the database first before doing so)

Hence am opting to add a data hydration logic, such that if there's a selected row that's been truncated, we'd fetch them on demand first before copying/exporting.

There's limitations to this though - e.g if the table doesn't have a primary key we can't do this (since we need to run a query to fetch the data). This is already an existing behaviour when trying to load the column value in the table editor in the grid so no issues I believe. We'll just show this toast:
<img width="300" alt="image" src="https://github.com/user-attachments/assets/442637bb-4b9b-492d-b202-bbf6e5ae7512" />

## To test
You'll need a column with a really large value - the way I do it is to load the data directly into the DB via TablePlus
- [ ] Verify that copying / exporting selected rows with really large column values copies/exports all the data correctly (there shouldn't be any truncated value)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of truncated cell values during copy and export operations

* **Bug Fixes**
  * Copy and export operations now require an active project selection
  * Fixed data export for tables without primary keys

* **Style**
  * Updated grid header copy and export control layout

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46268?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->