### PR TITLE
fix(observability): align overview Connections count with details view DEBUG-75

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -169,8 +169,8 @@ export const DatabaseInfrastructureSection = ({
         <Link href={databaseReportUrl} className="block group">
           <MetricCard isLoading={infraLoading}>
             <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-              <MetricCardLabel tooltip="Active database connections (current/max). Monitor to avoid connection exhaustion">
-                Connections
+              <MetricCardLabel tooltip="Highest concurrent database connections observed in the selected window, against the connection limit. Monitor to avoid connection exhaustion.">
+                Peak Connections
               </MetricCardLabel>
             </MetricCardHeader>
             <MetricCardContent>
@@ -178,7 +178,7 @@ export const DatabaseInfrastructureSection = ({
                 <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
               ) : connections.max > 0 ? (
                 <MetricCardValue>
-                  {connections.current}/{connections.max}
+                  {connections.peak}/{connections.max}
                 </MetricCardValue>
               ) : (
                 <MetricCardValue>--</MetricCardValue>

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
@@ -192,101 +192,104 @@ describe('parseInfrastructureMetrics', () => {
 })
 
 describe('parseConnectionsData', () => {
+  const buildResponse = (
+    values: Array<string | number | undefined>
+  ): InfraMonitoringMultiResponse => ({
+    data: values.map((v, i) => ({
+      period_start: `2026-05-22T00:0${i}:00.000Z`,
+      values: { pg_stat_database_num_backends: v as string | undefined },
+    })),
+    series: {
+      pg_stat_database_num_backends: {
+        format: 'number',
+        total: 0,
+        totalAverage: 0,
+        yAxisLimit: 100,
+      },
+    },
+  })
+
   it('returns zeros when data is undefined', () => {
     expect(parseConnectionsData(undefined, undefined)).toEqual({ current: 0, max: 0 })
     expect(parseConnectionsData(undefined, { maxConnections: 100 })).toEqual({
       current: 0,
-      max: 0,
+      max: 100,
     })
   })
 
-  it('parses connections data correctly', () => {
-    const mockInfraData: InfraMonitoringMultiResponse = {
-      data: [],
-      series: {
-        pg_stat_database_num_backends: {
-          format: 'number',
-          total: 150,
-          totalAverage: 25.5,
-          yAxisLimit: 100,
-        },
-      },
-    }
+  it('uses the most recent data point rather than totalAverage', () => {
+    const mockInfraData = buildResponse([10, 8, 6, 5])
+    // totalAverage in series is intentionally a stale 25 to ensure we ignore it
+    mockInfraData.series.pg_stat_database_num_backends.totalAverage = 25
 
-    const mockMaxData = { maxConnections: 100 }
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    const result = parseConnectionsData(mockInfraData, mockMaxData)
-
-    expect(result).toEqual({ current: 26, max: 100 }) // 25.5 rounded to 26
+    expect(result).toEqual({ current: 5, max: 100 })
   })
 
-  it('handles string values for connections', () => {
-    const mockInfraData: InfraMonitoringMultiResponse = {
-      data: [],
-      series: {
-        pg_stat_database_num_backends: {
-          format: 'number',
-          total: 150,
-          totalAverage: '30.7',
-          yAxisLimit: 100,
-        },
-      },
-    }
+  it('rounds the latest value', () => {
+    const mockInfraData = buildResponse([10, 8, 6, 5.6])
 
-    const mockMaxData = { maxConnections: 100 }
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    const result = parseConnectionsData(mockInfraData, mockMaxData)
+    expect(result).toEqual({ current: 6, max: 100 })
+  })
 
-    expect(result).toEqual({ current: 31, max: 100 }) // 30.7 rounded to 31
+  it('handles string values for the latest data point', () => {
+    const mockInfraData = buildResponse(['10', '8', '5.4'])
+
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
+
+    expect(result).toEqual({ current: 5, max: 100 })
+  })
+
+  it('falls back to the previous point when the latest value is missing', () => {
+    const mockInfraData = buildResponse([5, 7, undefined])
+
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
+
+    expect(result).toEqual({ current: 7, max: 100 })
   })
 
   it('returns current connections even when maxConnectionsData is undefined', () => {
-    const mockInfraData: InfraMonitoringMultiResponse = {
-      data: [],
-      series: {
-        pg_stat_database_num_backends: {
-          format: 'number',
-          total: 150,
-          totalAverage: 25,
-          yAxisLimit: 100,
-        },
-      },
-    }
+    const mockInfraData = buildResponse([4])
 
     const result = parseConnectionsData(mockInfraData, undefined)
 
-    expect(result).toEqual({ current: 25, max: 0 })
+    expect(result).toEqual({ current: 4, max: 0 })
   })
 
   it('returns 0 max when maxConnections is missing from data object', () => {
-    const mockInfraData: InfraMonitoringMultiResponse = {
-      data: [],
-      series: {
-        pg_stat_database_num_backends: {
-          format: 'number',
-          total: 150,
-          totalAverage: 25,
-          yAxisLimit: 100,
-        },
-      },
-    }
+    const mockInfraData = buildResponse([4])
 
-    const mockMaxData = {}
+    const result = parseConnectionsData(mockInfraData, {})
 
-    const result = parseConnectionsData(mockInfraData, mockMaxData)
-
-    expect(result).toEqual({ current: 25, max: 0 })
+    expect(result).toEqual({ current: 4, max: 0 })
   })
 
-  it('returns 0 current when connections metric is missing', () => {
+  it('returns 0 current when data array is empty', () => {
     const mockInfraData: InfraMonitoringMultiResponse = {
       data: [],
       series: {},
     }
 
-    const mockMaxData = { maxConnections: 100 }
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    const result = parseConnectionsData(mockInfraData, mockMaxData)
+    expect(result).toEqual({ current: 0, max: 100 })
+  })
+
+  it('returns 0 current when connections metric is missing from data points', () => {
+    const mockInfraData: InfraMonitoringMultiResponse = {
+      data: [
+        {
+          period_start: '2026-05-22T00:00:00.000Z',
+          values: { avg_cpu_usage: '50' },
+        },
+      ],
+      series: {},
+    }
+
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
     expect(result).toEqual({ current: 0, max: 100 })
   })
@@ -300,9 +303,7 @@ describe('parseConnectionsData', () => {
       yAxisLimit: 100,
     }
 
-    const mockMaxData = { maxConnections: 100 }
-
-    const result = parseConnectionsData(mockInfraData, mockMaxData)
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
     expect(result).toEqual({ current: 0, max: 100 })
   })

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
@@ -251,6 +251,14 @@ describe('parseConnectionsData', () => {
     expect(result).toEqual({ current: 7, max: 100 })
   })
 
+  it('treats empty-string values as missing and falls back', () => {
+    const mockInfraData = buildResponse(['5', '7', ''])
+
+    const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
+
+    expect(result).toEqual({ current: 7, max: 100 })
+  })
+
   it('returns current connections even when maxConnectionsData is undefined', () => {
     const mockInfraData = buildResponse([4])
 

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
@@ -210,61 +210,61 @@ describe('parseConnectionsData', () => {
   })
 
   it('returns zeros when data is undefined', () => {
-    expect(parseConnectionsData(undefined, undefined)).toEqual({ current: 0, max: 0 })
+    expect(parseConnectionsData(undefined, undefined)).toEqual({ peak: 0, max: 0 })
     expect(parseConnectionsData(undefined, { maxConnections: 100 })).toEqual({
-      current: 0,
+      peak: 0,
       max: 100,
     })
   })
 
-  it('uses the most recent data point rather than totalAverage', () => {
-    const mockInfraData = buildResponse([10, 8, 6, 5])
-    // totalAverage in series is intentionally a stale 25 to ensure we ignore it
+  it('returns the peak value across the window, not totalAverage', () => {
+    const mockInfraData = buildResponse([4, 4, 6, 4, 5, 4])
+    // totalAverage in series is intentionally stale to ensure we ignore it
     mockInfraData.series.pg_stat_database_num_backends.totalAverage = 25
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 5, max: 100 })
+    expect(result).toEqual({ peak: 6, max: 100 })
   })
 
-  it('rounds the latest value', () => {
-    const mockInfraData = buildResponse([10, 8, 6, 5.6])
+  it('rounds the peak value', () => {
+    const mockInfraData = buildResponse([3, 5.6, 4])
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 6, max: 100 })
+    expect(result).toEqual({ peak: 6, max: 100 })
   })
 
-  it('handles string values for the latest data point', () => {
-    const mockInfraData = buildResponse(['10', '8', '5.4'])
+  it('handles string values when computing peak', () => {
+    const mockInfraData = buildResponse(['4', '7', '5.4'])
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 5, max: 100 })
+    expect(result).toEqual({ peak: 7, max: 100 })
   })
 
-  it('falls back to the previous point when the latest value is missing', () => {
-    const mockInfraData = buildResponse([5, 7, undefined])
+  it('skips missing values when computing peak', () => {
+    const mockInfraData = buildResponse([5, undefined, 7, undefined])
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 7, max: 100 })
+    expect(result).toEqual({ peak: 7, max: 100 })
   })
 
-  it('treats empty-string values as missing and falls back', () => {
-    const mockInfraData = buildResponse(['5', '7', ''])
+  it('skips empty-string values when computing peak', () => {
+    const mockInfraData = buildResponse(['5', '', '7', ''])
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 7, max: 100 })
+    expect(result).toEqual({ peak: 7, max: 100 })
   })
 
-  it('returns current connections even when maxConnectionsData is undefined', () => {
-    const mockInfraData = buildResponse([4])
+  it('returns peak connections even when maxConnectionsData is undefined', () => {
+    const mockInfraData = buildResponse([4, 9, 6])
 
     const result = parseConnectionsData(mockInfraData, undefined)
 
-    expect(result).toEqual({ current: 4, max: 0 })
+    expect(result).toEqual({ peak: 9, max: 0 })
   })
 
   it('returns 0 max when maxConnections is missing from data object', () => {
@@ -272,10 +272,10 @@ describe('parseConnectionsData', () => {
 
     const result = parseConnectionsData(mockInfraData, {})
 
-    expect(result).toEqual({ current: 4, max: 0 })
+    expect(result).toEqual({ peak: 4, max: 0 })
   })
 
-  it('returns 0 current when data array is empty', () => {
+  it('returns 0 peak when data array is empty', () => {
     const mockInfraData: InfraMonitoringMultiResponse = {
       data: [],
       series: {},
@@ -283,10 +283,10 @@ describe('parseConnectionsData', () => {
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 0, max: 100 })
+    expect(result).toEqual({ peak: 0, max: 100 })
   })
 
-  it('returns 0 current when connections metric is missing from data points', () => {
+  it('returns 0 peak when connections metric is missing from data points', () => {
     const mockInfraData: InfraMonitoringMultiResponse = {
       data: [
         {
@@ -299,7 +299,7 @@ describe('parseConnectionsData', () => {
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 0, max: 100 })
+    expect(result).toEqual({ peak: 0, max: 100 })
   })
 
   it('handles single-response format (legacy)', () => {
@@ -313,6 +313,6 @@ describe('parseConnectionsData', () => {
 
     const result = parseConnectionsData(mockInfraData, { maxConnections: 100 })
 
-    expect(result).toEqual({ current: 0, max: 100 })
+    expect(result).toEqual({ peak: 0, max: 100 })
   })
 })

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
@@ -64,7 +64,7 @@ export function parseInfrastructureMetrics(
 }
 
 type ConnectionsData = {
-  current: number
+  peak: number
   max: number
 }
 
@@ -79,24 +79,18 @@ export function parseConnectionsData(
   const max = maxConnectionsData?.maxConnections ?? 0
 
   if (!infraData || !('series' in infraData)) {
-    return { current: 0, max }
+    return { peak: 0, max }
   }
 
-  // Read the most recent data point rather than the window's totalAverage so the
-  // overview matches the details chart, which shows the latest value. Using the
-  // average makes the count vary with bucket granularity (e.g. 1h vs 1m) and
-  // skews towards older samples in the window.
-  const points = infraData.data ?? []
-  let currentVal: string | undefined
-  for (let i = points.length - 1; i >= 0; i--) {
-    const v = points[i]?.values?.pg_stat_database_num_backends
-    if (v !== undefined && v !== '') {
-      currentVal = v
-      break
-    }
+  // Show the highest connection count observed in the selected window rather
+  // than the window's totalAverage. The average varies with bucket granularity
+  // (e.g. 1h vs 1m) and is hard to reason about; peak is interval-stable and
+  // the more actionable signal for headroom against the connection limit.
+  let peak = 0
+  for (const point of infraData.data ?? []) {
+    const n = parseNumericValue(point?.values?.pg_stat_database_num_backends)
+    if (n > peak) peak = n
   }
 
-  const current = Math.round(parseNumericValue(currentVal))
-
-  return { current, max }
+  return { peak: Math.round(peak), max }
 }

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
@@ -76,15 +76,27 @@ export function parseConnectionsData(
   infraData: InfraMonitoringResponse | undefined,
   maxConnectionsData: MaxConnectionsData | undefined
 ): ConnectionsData {
-  if (!infraData) {
-    return { current: 0, max: 0 }
+  const max = maxConnectionsData?.maxConnections || 0
+
+  if (!infraData || !('series' in infraData)) {
+    return { current: 0, max }
   }
 
-  const series = 'series' in infraData ? infraData.series : {}
+  // Read the most recent data point rather than the window's totalAverage so the
+  // overview matches the details chart, which shows the latest value. Using the
+  // average makes the count vary with bucket granularity (e.g. 1h vs 1m) and
+  // skews towards older samples in the window.
+  const points = infraData.data ?? []
+  let currentVal: string | number | undefined
+  for (let i = points.length - 1; i >= 0; i--) {
+    const v = points[i]?.values?.pg_stat_database_num_backends
+    if (v !== undefined && v !== null && v !== '') {
+      currentVal = v
+      break
+    }
+  }
 
-  const currentVal = series.pg_stat_database_num_backends?.totalAverage
   const current = Math.round(parseNumericValue(currentVal))
-  const max = maxConnectionsData?.maxConnections || 0
 
   return { current, max }
 }

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
@@ -76,7 +76,7 @@ export function parseConnectionsData(
   infraData: InfraMonitoringResponse | undefined,
   maxConnectionsData: MaxConnectionsData | undefined
 ): ConnectionsData {
-  const max = maxConnectionsData?.maxConnections || 0
+  const max = maxConnectionsData?.maxConnections ?? 0
 
   if (!infraData || !('series' in infraData)) {
     return { current: 0, max }
@@ -87,10 +87,10 @@ export function parseConnectionsData(
   // average makes the count vary with bucket granularity (e.g. 1h vs 1m) and
   // skews towards older samples in the window.
   const points = infraData.data ?? []
-  let currentVal: string | number | undefined
+  let currentVal: string | undefined
   for (let i = points.length - 1; i >= 0; i--) {
     const v = points[i]?.values?.pg_stat_database_num_backends
-    if (v !== undefined && v !== null && v !== '') {
+    if (v !== undefined && v !== '') {
       currentVal = v
       break
     }

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceNode.tsx
@@ -201,7 +201,7 @@ export const PrimaryNode = ({ data }: NodeProps<Node<PrimaryNodeData>>) => {
                     <>
                       <span className="text-foreground-lighter">·</span>
                       <span className="text-foreground-light">
-                        {connections.current}/{connections.max} conns
+                        {connections.peak}/{connections.max} conns
                       </span>
                     </>
                   )}

--- a/apps/studio/hooks/analytics/useComputeMetrics.ts
+++ b/apps/studio/hooks/analytics/useComputeMetrics.ts
@@ -13,7 +13,7 @@ export type ComputeMetrics = {
   cpu: number
   disk: number
   memory: number
-  connections: { current: number; max: number }
+  connections: { peak: number; max: number }
   isLoading: boolean
   isError: boolean
 }


### PR DESCRIPTION
## Problem

The Overview's Connections card and the Database details chart showed different numbers for the same window. The Overview read `totalAverage`, which varies with bucket interval (`1h` Overview, `1m` details).

## Fix

Rename the card to "Peak Connections" and show the highest value in the selected window. Interval-stable, and a more useful signal for connection-limit headroom.

## How to test

- Open `/project/[ref]/observability`, note Peak Connections
- Open Database details, set range to "Last 60 minutes"
- Card should match the peak of the Database Connections chart across `1hr`, `1day`, `7day`
- `cd apps/studio && pnpm vitest run components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Database connections metric now displays peak (maximum concurrent) connections observed during the selected time window instead of current snapshots. This change applies across the database infrastructure view and infrastructure settings, providing better visibility into connection usage patterns and supporting more informed capacity planning decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->