### PR TITLE
chore(docs): adjust billing docs prices to 730-hour month

### DIFF
--- a/apps/docs/content/_partials/billing/pricing/pricing_pitr.mdx
+++ b/apps/docs/content/_partials/billing/pricing/pricing_pitr.mdx
@@ -2,10 +2,10 @@
 
 Pricing depends on the recovery retention period, which determines how many days back you can restore data to any chosen point of up to seconds in granularity.
 
-| Recovery Retention Period in Days | Hourly Price USD        | Monthly Price USD     |
-| --------------------------------- | ----------------------- | --------------------- |
-| 7                                 | <Price price="0.137" /> | <Price price="100" /> |
-| 14                                | <Price price="0.274" /> | <Price price="200" /> |
-| 28                                | <Price price="0.55" />  | <Price price="400" /> |
+| Recovery Retention Period in Days | Hourly Price USD        | Monthly Price USD      |
+| --------------------------------- | ----------------------- | ---------------------- |
+| 7                                 | <Price price="0.137" /> | ~<Price price="100" /> |
+| 14                                | <Price price="0.274" /> | ~<Price price="200" /> |
+| 28                                | <Price price="0.55" />  | ~<Price price="400" /> |
 
 For a detailed breakdown of how charges are calculated, refer to [Manage Point-in-Time Recovery usage](/docs/guides/platform/manage-your-usage/point-in-time-recovery).

--- a/apps/docs/content/_partials/billing/pricing/pricing_storage_size.mdx
+++ b/apps/docs/content/_partials/billing/pricing/pricing_storage_size.mdx
@@ -1,9 +1,9 @@
-<Price price="0.00002919" /> per GB-Hr (<Price price="0.021" /> per GB per month). You are only
+<Price price="0.00002919" /> per GB-Hr (<Price price="0.0213" /> per GB per month). You are only
 charged for usage exceeding your subscription plan's quota.
 
-| Plan       | Quota in GB | Over-Usage per GB       | Quota in GB-Hrs | Over-Usage per GB-Hr         |
-| ---------- | ----------- | ----------------------- | --------------- | ---------------------------- |
-| Free       | 1           | -                       | 744             | -                            |
-| Pro        | 100         | <Price price="0.021" /> | 74,400          | <Price price="0.00002919" /> |
-| Team       | 100         | <Price price="0.021" /> | 74,400          | <Price price="0.00002919" /> |
-| Enterprise | Custom      | Custom                  | Custom          | Custom                       |
+| Plan       | Quota in GB | Over-Usage per GB        | Quota in GB-Hrs | Over-Usage per GB-Hr         |
+| ---------- | ----------- | ------------------------ | --------------- | ---------------------------- |
+| Free       | 1           | -                        | 744             | -                            |
+| Pro        | 100         | <Price price="0.0213" /> | 74,400          | <Price price="0.00002919" /> |
+| Team       | 100         | <Price price="0.0213" /> | 74,400          | <Price price="0.00002919" /> |
+| Enterprise | Custom      | Custom                   | Custom          | Custom                       |

--- a/apps/docs/content/guides/platform/manage-your-usage/advanced-mfa-phone.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/advanced-mfa-phone.mdx
@@ -51,11 +51,11 @@ The project has MFA Phone activated throughout the entire billing cycle.
 | Line Item                     | Hours | Costs                     |
 | ----------------------------- | ----- | ------------------------- |
 | Pro Plan                      | -     | <Price price="25" />      |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />      |
-| MFA Phone Hours               | 744   | <Price price="75" />      |
-| **Subtotal**                  |       | **<Price price="110" />** |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />      |
+| MFA Phone Hours               | 730   | <Price price="75" />      |
+| **Subtotal**                  |       | **<Price price="115" />** |
 | Compute Credits               |       | -<Price price="10" />     |
-| **Total**                     |       | **<Price price="100" />** |
+| **Total**                     |       | **<Price price="105" />** |
 
 ### Multiple projects
 
@@ -65,18 +65,18 @@ All projects have MFA Phone activated throughout the entire billing cycle.
 | ----------------------------- | ----- | ------------------------- |
 | Pro Plan                      | -     | <Price price="25" />      |
 |                               |       |                           |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />      |
-| MFA Phone Hours Project 1     | 744   | <Price price="75" />      |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />      |
+| MFA Phone Hours Project 1     | 730   | <Price price="75" />      |
 |                               |       |                           |
-| Compute Hours Micro Project 2 | 744   | <Price price="10" />      |
-| MFA Phone Hours Project 2     | 744   | <Price price="10" />      |
+| Compute Hours Small Project 2 | 730   | <Price price="15" />      |
+| MFA Phone Hours Project 2     | 730   | <Price price="10" />      |
 |                               |       |                           |
-| Compute Hours Micro Project 3 | 744   | <Price price="10" />      |
-| MFA Phone Hours Project 3     | 744   | <Price price="10" />      |
+| Compute Hours Small Project 3 | 730   | <Price price="15" />      |
+| MFA Phone Hours Project 3     | 730   | <Price price="10" />      |
 |                               |       |                           |
-| **Subtotal**                  |       | **<Price price="150" />** |
+| **Subtotal**                  |       | **<Price price="165" />** |
 | Compute Credits               |       | -<Price price="10" />     |
-| **Total**                     |       | **<Price price="140" />** |
+| **Total**                     |       | **<Price price="155" />** |
 
 ### Add-on disabled after a day
 
@@ -87,9 +87,9 @@ If you remove the MFA Phone add-on, you are no longer billed from the time of re
 | ----------------------------- | ----- | --------------------------- |
 | Pro Plan                      | -     | <Price price="25" />        |
 |                               |       |                             |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />        |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />        |
 | MFA Phone Hours Project 1     | 24    | <Price price="2.46" />      |
 |                               |       |                             |
-| **Subtotal**                  |       | **<Price price="37.46" />** |
+| **Subtotal**                  |       | **<Price price="42.46" />** |
 | Compute Credits               |       | -<Price price="10" />       |
-| **Total**                     |       | **<Price price="27.46" />** |
+| **Total**                     |       | **<Price price="32.46" />** |

--- a/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/compute.mdx
@@ -25,7 +25,7 @@ Each project you launch increases your monthly Compute costs.
 
 ### Example
 
-Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, you switch your project from the Micro Compute size to the Small Compute size. At the end of the billing cycle you are billed for 233 hours of Micro Compute size and 511 hours of Small Compute size.
+Your billing cycle runs from January 1 to January 31. On January 10 at 4:30 PM, you switch your project from the Micro Compute size to the Small Compute size. At the end of the billing cycle you are billed for 233 hours of Micro Compute size and 512 hours of Small Compute size.
 
 | Time Window                                 | Compute Size | Hours Billed | Description         |
 | ------------------------------------------- | ------------ | ------------ | ------------------- |
@@ -50,7 +50,7 @@ Paid plans include <Price price="10" /> in Compute Credits, which cover one proj
 | Micro        | <Price price="0.01344" /> | ~<Price price="10" />                                                                                   |
 | Small        | <Price price="0.0206" />  | ~<Price price="15" />                                                                                   |
 | Medium       | <Price price="0.0822" />  | ~<Price price="60" />                                                                                   |
-| Large        | <Price price="0.1517" />  | ~<Price price="110" />                                                                                  |
+| Large        | <Price price="0.1517" />  | ~<Price price="111" />                                                                                  |
 | XL           | <Price price="0.2877" />  | ~<Price price="210" />                                                                                  |
 | 2XL          | <Price price="0.562" />   | ~<Price price="410" />                                                                                  |
 | 4XL          | <Price price="1.32" />    | ~<Price price="960" />                                                                                  |
@@ -76,10 +76,10 @@ The project runs on the same Compute size throughout the entire billing cycle.
 | Line Item                     | Hours | Costs                    |
 | ----------------------------- | ----- | ------------------------ |
 | Pro Plan                      | -     | <Price price="25"/>      |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />     |
-| **Subtotal**                  |       | **<Price price="35" />** |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />     |
+| **Subtotal**                  |       | **<Price price="40" />** |
 | Compute Credits               |       | -<Price price="10" />    |
-| **Total**                     |       | **<Price price="25" />** |
+| **Total**                     |       | **<Price price="30" />** |
 
 ### Multiple projects
 
@@ -88,25 +88,25 @@ All projects run on the same Compute size throughout the entire billing cycle.
 | Line Item                     | Hours | Costs                    |
 | ----------------------------- | ----- | ------------------------ |
 | Pro Plan                      | -     | <Price price="25" />     |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />     |
-| Compute Hours Micro Project 2 | 744   | <Price price="10" />     |
-| Compute Hours Micro Project 3 | 744   | <Price price="10" />     |
-| **Subtotal**                  |       | **<Price price="55" />** |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />     |
+| Compute Hours Small Project 2 | 730   | <Price price="15" />     |
+| Compute Hours Small Project 3 | 730   | <Price price="15" />     |
+| **Subtotal**                  |       | **<Price price="70" />** |
 | Compute Credits               |       | -<Price price="10" />    |
-| **Total**                     |       | **<Price price="45" />** |
+| **Total**                     |       | **<Price price="60" />** |
 
 ### One project on different Compute sizes
 
 The project's Compute size changes throughout the billing cycle.
 
-| Line Item                     | Hours | Costs                    |
-| ----------------------------- | ----- | ------------------------ |
-| Pro Plan                      | -     | <Price price="25" />     |
-| Compute Hours Micro Project 1 | 233   | <Price price="3" />      |
-| Compute Hours Small Project 1 | 511   | <Price price="11" />     |
-| **Subtotal**                  |       | **<Price price="39" />** |
-| Compute Credits               |       | -<Price price="10" />    |
-| **Total**                     |       | **<Price price="29" />** |
+| Line Item                     | Hours | Costs                       |
+| ----------------------------- | ----- | --------------------------- |
+| Pro Plan                      | -     | <Price price="25" />        |
+| Compute Hours Micro Project 1 | 230   | <Price price="3.09" />      |
+| Compute Hours Small Project 1 | 500   | <Price price="10.30" />     |
+| **Subtotal**                  |       | **<Price price="38.39" />** |
+| Compute Credits               |       | -<Price price="10" />       |
+| **Total**                     |       | **<Price price="28.39" />** |
 
 ### Projects not running for full month
 
@@ -117,12 +117,12 @@ Compute is always billed in arrears when your billing cycle resets.
 | Line Item                     | Hours | Costs                       |
 | ----------------------------- | ----- | --------------------------- |
 | Pro Plan                      | -     | <Price price="25" />        |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />        |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />        |
 | Compute Hours Micro Project 2 | 20    | <Price price="0.27" />      |
 | Compute Hours Micro Project 3 | 70    | <Price price="0.94" />      |
-| **Subtotal**                  |       | **<Price price="36.21" />** |
+| **Subtotal**                  |       | **<Price price="41.21" />** |
 | Compute Credits               |       | -<Price price="10" />       |
-| **Total**                     |       | **<Price price="26.21" />** |
+| **Total**                     |       | **<Price price="31.21" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/custom-domains.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/custom-domains.mdx
@@ -45,11 +45,11 @@ The project has a custom domain activated throughout the entire billing cycle.
 | Line Item                     | Hours | Costs                    |
 | ----------------------------- | ----- | ------------------------ |
 | Pro Plan                      | -     | <Price price="25" />     |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />     |
-| Custom Domain Hours           | 744   | <Price price="10" />     |
-| **Subtotal**                  |       | **<Price price="45" />** |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />     |
+| Custom Domain Hours           | 730   | <Price price="10" />     |
+| **Subtotal**                  |       | **<Price price="50" />** |
 | Compute Credits               |       | -<Price price="10" />    |
-| **Total**                     |       | **<Price price="35" />** |
+| **Total**                     |       | **<Price price="40" />** |
 
 ### Multiple projects
 
@@ -59,15 +59,15 @@ All projects have a custom domain activated throughout the entire billing cycle.
 | ----------------------------- | ----- | ------------------------ |
 | Pro Plan                      | -     | <Price price="25" />     |
 |                               |       |                          |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />     |
-| Custom Domain Hours Project 1 | 744   | <Price price="10" />     |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />     |
+| Custom Domain Hours Project 1 | 730   | <Price price="10" />     |
 |                               |       |                          |
-| Compute Hours Micro Project 2 | 744   | <Price price="10" />     |
-| Custom Domain Hours Project 2 | 744   | <Price price="10" />     |
+| Compute Hours Small Project 2 | 730   | <Price price="15" />     |
+| Custom Domain Hours Project 2 | 730   | <Price price="10" />     |
 |                               |       |                          |
-| **Subtotal**                  |       | **<Price price="65" />** |
+| **Subtotal**                  |       | **<Price price="75" />** |
 | Compute Credits               |       | -<Price price="10" />    |
-| **Total**                     |       | **<Price price="55" />** |
+| **Total**                     |       | **<Price price="65" />** |
 
 ### Add-on disabled after a day
 
@@ -78,12 +78,12 @@ If you remove the custom domain add-on, you are no longer billed from the time o
 | ----------------------------- | ----- | --------------------------- |
 | Pro Plan                      | -     | <Price price="25" />        |
 |                               |       |                             |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />        |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />        |
 | Custom Domain Hours Project 1 | 24    | <Price price="0.33" />      |
 |                               |       |                             |
-| **Subtotal**                  |       | **<Price price="35.33" />** |
+| **Subtotal**                  |       | **<Price price="40.33" />** |
 | Compute Credits               |       | -<Price price="10" />       |
-| **Total**                     |       | **<Price price="25.33" />** |
+| **Total**                     |       | **<Price price="30.33" />** |
 
 ## Optimize usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/disk-iops.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/disk-iops.mdx
@@ -66,15 +66,15 @@ Project 1 doesn't exceed the included IOPS, so no charges for IOPS apply. Projec
 | ----------------------------- | ---------- | ---------------------------- |
 | Pro Plan                      | 1          | <Price price="25" />         |
 |                               |            |                              |
-| Compute Hours Micro Project 1 | 744 hours  | <Price price="10" />         |
+| Compute Hours Small Project 1 | 730 hours  | <Price price="15" />         |
 | Disk IOPS Project 1           | 3,000 IOPS | <Price price="0" />          |
 |                               |            |                              |
-| Compute Hours Large Project 2 | 744 hours  | <Price price="110" />        |
+| Compute Hours Large Project 2 | 730 hours  | <Price price="111" />        |
 | Disk IOPS Project 2           | 3,600 IOPS | <Price price="14.40" />      |
 |                               |            |                              |
-| **Subtotal**                  |            | **<Price price="159.40" />** |
+| **Subtotal**                  |            | **<Price price="165.40" />** |
 | Compute Credits               |            | -<Price price="10" />        |
-| **Total**                     |            | **<Price price="149.40" />** |
+| **Total**                     |            | **<Price price="155.40" />** |
 
 ### Io2
 
@@ -83,8 +83,8 @@ This disk type is billed from the first IOPS provisioned, meaning for 8000 IOPS.
 | Line Item                     | Units      | Costs                       |
 | ----------------------------- | ---------- | --------------------------- |
 | Pro Plan                      | 1          | <Price price="25" />        |
-| Compute Hours Large Project 1 | 744 hours  | <Price price="110" />       |
+| Compute Hours Large Project 1 | 730 hours  | <Price price="111" />       |
 | Disk IOPS Project 1           | 8,000 IOPS | <Price price="952" />       |
-| **Subtotal**                  |            | **<Price price="1" />,087** |
+| **Subtotal**                  |            | **<Price price="1,088" />** |
 | Compute Credits               |            | -<Price price="10" />       |
-| **Total**                     |            | **<Price price="1" />,077** |
+| **Total**                     |            | **<Price price="1,078" />** |

--- a/apps/docs/content/guides/platform/manage-your-usage/disk-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/disk-size.mdx
@@ -65,18 +65,18 @@ Project 1 and 2 don't exceed the included disk size, so no charges for Disk size
 | ----------------------------- | --------- | --------------------------- |
 | Pro Plan                      | 1         | <Price price="25" />        |
 |                               |           |                             |
-| Compute Hours Micro Project 1 | 744 hours | <Price price="10" />        |
+| Compute Hours Small Project 1 | 730 hours | <Price price="15" />        |
 | Disk Size Project 1           | 8 GB      | <Price price="0" />         |
 |                               |           |                             |
-| Compute Hours Micro Project 2 | 744 hours | <Price price="10" />        |
+| Compute Hours Small Project 2 | 730 hours | <Price price="15" />        |
 | Disk Size Project 2           | 8 GB      | <Price price="0" />         |
 |                               |           |                             |
-| Compute Hours Micro Project 3 | 744 hours | <Price price="10" />        |
-| Disk Size Project 3           | 50 GB     | <Price price="5.25" />      |
+| Compute Hours Small Project 3 | 730 hours | <Price price="15" />        |
+| Disk Size Project 3           | 50 GB     | <Price price="5.24" />      |
 |                               |           |                             |
-| **Subtotal**                  |           | **<Price price="50.25" />** |
+| **Subtotal**                  |           | **<Price price="75.24" />** |
 | Compute Credits               |           | -<Price price="10" />       |
-| **Total**                     |           | **<Price price="40.25" />** |
+| **Total**                     |           | **<Price price="65.24" />** |
 
 ### Io2
 
@@ -86,18 +86,18 @@ This disk type is billed from the first byte of provisioned disk, meaning for 66
 | ----------------------------- | --------- | --------------------------- |
 | Pro Plan                      | 1         | <Price price="25" />        |
 |                               |           |                             |
-| Compute Hours Micro Project 1 | 744 hours | <Price price="10" />        |
+| Compute Hours Small Project 1 | 730 hours | <Price price="15" />        |
 | Disk Size Project 1           | 8 GB      | <Price price="1.56" />      |
 |                               |           |                             |
-| Compute Hours Micro Project 2 | 744 hours | <Price price="10" />        |
+| Compute Hours Small Project 2 | 730 hours | <Price price="15" />        |
 | Disk Size Project 2           | 8 GB      | <Price price="1.56" />      |
 |                               |           |                             |
-| Compute Hours Micro Project 3 | 744 hours | <Price price="10" />        |
+| Compute Hours Small Project 3 | 730 hours | <Price price="15" />        |
 | Disk Size Project 3           | 50 GB     | <Price price="9.75" />      |
 |                               |           |                             |
-| **Subtotal**                  |           | **<Price price="67.87" />** |
+| **Subtotal**                  |           | **<Price price="82.87" />** |
 | Compute Credits               |           | -<Price price="10" />       |
-| **Total**                     |           | **<Price price="57.87" />** |
+| **Total**                     |           | **<Price price="72.87" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/disk-throughput.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/disk-throughput.mdx
@@ -57,12 +57,12 @@ There are no charges. Throughput scales with IOPS at no additional cost.
 | ----------------------------- | --------- | ------------------------ |
 | Pro Plan                      | 1         | <Price price="25" />     |
 |                               |           |                          |
-| Compute Hours Micro Project 1 | 744 hours | <Price price="10" />     |
+| Compute Hours Small Project 1 | 730 hours | <Price price="15" />     |
 | Disk Throughput Project 1     | 125 MB/s  | <Price price="0" />      |
 |                               |           |                          |
-| **Subtotal**                  |           | **<Price price="35" />** |
+| **Subtotal**                  |           | **<Price price="40" />** |
 | Compute Credits               |           | -<Price price="10" />    |
-| **Total**                     |           | **<Price price="25" />** |
+| **Total**                     |           | **<Price price="30" />** |
 
 ### Additional throughput configured
 
@@ -70,12 +70,12 @@ There are no charges. Throughput scales with IOPS at no additional cost.
 | ----------------------------- | --------- | ---------------------------- |
 | Pro Plan                      | 1         | <Price price="25" />         |
 |                               |           |                              |
-| Compute Hours Large Project 1 | 744 hours | <Price price="110" />        |
-| Disk Throughput Project 1     | 200 MB/s  | <Price price="7.13" />       |
+| Compute Hours Large Project 1 | 730 hours | <Price price="111" />        |
+| Disk Throughput Project 1     | 200 MB/s  | <Price price="7.12" />       |
 |                               |           |                              |
-| **Subtotal**                  |           | **<Price price="142.13" />** |
+| **Subtotal**                  |           | **<Price price="143.12" />** |
 | Compute Credits               |           | -<Price price="10" />        |
-| **Total**                     |           | **<Price price="132.13" />** |
+| **Total**                     |           | **<Price price="133.12" />** |
 
 ### Additional throughput configured with Read Replica
 
@@ -83,12 +83,12 @@ There are no charges. Throughput scales with IOPS at no additional cost.
 | ----------------------------- | --------- | ---------------------------- |
 | Pro Plan                      | 1         | <Price price="25" />         |
 |                               |           |                              |
-| Compute Hours Large Project 1 | 744 hours | <Price price="110" />        |
-| Disk Throughput Project 1     | 200 MB/s  | <Price price="7.13" />       |
+| Compute Hours Large Project 1 | 730 hours | <Price price="111" />        |
+| Disk Throughput Project 1     | 200 MB/s  | <Price price="7.12" />       |
 |                               |           |                              |
-| Compute Hours Large Replica   | 744 hours | <Price price="110" />        |
-| Disk Throughput Replica       | 200 MB/s  | <Price price="7.13" />       |
+| Compute Hours Large Replica   | 730 hours | <Price price="111" />        |
+| Disk Throughput Replica       | 200 MB/s  | <Price price="7.12" />       |
 |                               |           |                              |
-| **Subtotal**                  |           | **<Price price="259.26" />** |
+| **Subtotal**                  |           | **<Price price="261.24" />** |
 | Compute Credits               |           | -<Price price="10" />        |
-| **Total**                     |           | **<Price price="249.26" />** |
+| **Total**                     |           | **<Price price="251.24" />** |

--- a/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/edge-function-invocations.mdx
@@ -39,11 +39,11 @@ The organization's function invocations are within the quota, so no charges appl
 | Line Item            | Units                 | Costs                    |
 | -------------------- | --------------------- | ------------------------ |
 | Pro Plan             | 1                     | <Price price="25" />     |
-| Compute Hours Micro  | 744 hours             | <Price price="10" />     |
+| Compute Hours Small  | 730 hours             | <Price price="15" />     |
 | Function Invocations | 1,800,000 invocations | <Price price="0" />      |
-| **Subtotal**         |                       | **<Price price="35" />** |
+| **Subtotal**         |                       | **<Price price="40" />** |
 | Compute Credits      |                       | -<Price price="10" />    |
-| **Total**            |                       | **<Price price="25" />** |
+| **Total**            |                       | **<Price price="30" />** |
 
 ### Exceeding quota
 
@@ -52,11 +52,11 @@ The organization's function invocations exceed the quota by 1.4 million, incurri
 | Line Item            | Units                 | Costs                    |
 | -------------------- | --------------------- | ------------------------ |
 | Pro Plan             | 1                     | <Price price="25" />     |
-| Compute Hours Micro  | 744 hours             | <Price price="10" />     |
+| Compute Hours Small  | 730 hours             | <Price price="15" />     |
 | Function Invocations | 3,400,000 invocations | <Price price="4" />      |
-| **Subtotal**         |                       | **<Price price="39" />** |
+| **Subtotal**         |                       | **<Price price="44" />** |
 | Compute Credits      |                       | -<Price price="10" />    |
-| **Total**            |                       | **<Price price="29" />** |
+| **Total**            |                       | **<Price price="34" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
@@ -88,26 +88,26 @@ The organization's Egress usage is within the quota, so no charges for Egress ap
 | Line Item           | Units     | Costs                    |
 | ------------------- | --------- | ------------------------ |
 | Pro Plan            | 1         | <Price price="25" />     |
-| Compute Hours Micro | 744 hours | <Price price="10" />     |
+| Compute Hours Small | 730 hours | <Price price="15" />     |
 | Egress              | 200 GB    | <Price price="0" />      |
 | Cached Egress       | 230 GB    | <Price price="0" />      |
-| **Subtotal**        |           | **<Price price="35" />** |
+| **Subtotal**        |           | **<Price price="40" />** |
 | Compute Credits     |           | -<Price price="10" />    |
-| **Total**           |           | **<Price price="25" />** |
+| **Total**           |           | **<Price price="30" />** |
 
 ### Exceeding quota
 
 The organization's Egress usage exceeds the uncached egress quota by 50 GB and the cached egress quota by 550 GB, incurring charges for this additional usage.
 
-| Line Item           | Units     | Costs                      |
-| ------------------- | --------- | -------------------------- |
-| Pro Plan            | 1         | <Price price="25" />       |
-| Compute Hours Micro | 744 hours | <Price price="10" />       |
-| Egress              | 300 GB    | <Price price="4.5" />      |
-| Cached Egress       | 800 GB    | <Price price="16.5" />     |
-| **Subtotal**        |           | **<Price price="47.5" />** |
-| Compute Credits     |           | -<Price price="10" />      |
-| **Total**           |           | **<Price price="37.5" />** |
+| Line Item           | Units     | Costs                    |
+| ------------------- | --------- | ------------------------ |
+| Pro Plan            | 1         | <Price price="25" />     |
+| Compute Hours Small | 730 hours | <Price price="15" />     |
+| Egress              | 300 GB    | <Price price="4.5" />    |
+| Cached Egress       | 800 GB    | <Price price="16.5" />   |
+| **Subtotal**        |           | **<Price price="61" />** |
+| Compute Credits     |           | -<Price price="10" />    |
+| **Total**           |           | **<Price price="51" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/ipv4.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/ipv4.mdx
@@ -51,11 +51,11 @@ The project has the IPv4 add-on enabled throughout the entire billing cycle.
 | Line Item                     | Hours | Costs                    |
 | ----------------------------- | ----- | ------------------------ |
 | Pro Plan                      | -     | <Price price="25" />     |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />     |
-| IPv4 Hours                    | 744   | <Price price="4" />      |
-| **Subtotal**                  |       | **<Price price="39" />** |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />     |
+| IPv4 Hours                    | 730   | <Price price="4" />      |
+| **Subtotal**                  |       | **<Price price="44" />** |
 | Compute Credits               |       | -<Price price="10" />    |
-| **Total**                     |       | **<Price price="29" />** |
+| **Total**                     |       | **<Price price="34" />** |
 
 ### Multiple projects
 
@@ -65,18 +65,18 @@ All projects have the IPv4 add-on enabled throughout the entire billing cycle.
 | ----------------------------- | ----- | ------------------------ |
 | Pro Plan                      | -     | <Price price="25" />     |
 |                               |       |                          |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />     |
-| IPv4 Hours Project 1          | 744   | <Price price="4" />      |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />     |
+| IPv4 Hours Project 1          | 730   | <Price price="4" />      |
 |                               |       |                          |
-| Compute Hours Micro Project 2 | 744   | <Price price="10" />     |
-| IPv4 Hours Project 2          | 744   | <Price price="4" />      |
+| Compute Hours Small Project 2 | 730   | <Price price="15" />     |
+| IPv4 Hours Project 2          | 730   | <Price price="4" />      |
 |                               |       |                          |
-| Compute Hours Micro Project 3 | 744   | <Price price="10" />     |
-| IPv4 Hours Project 3          | 744   | <Price price="4" />      |
+| Compute Hours Small Project 3 | 730   | <Price price="15" />     |
+| IPv4 Hours Project 3          | 730   | <Price price="4" />      |
 |                               |       |                          |
-| **Subtotal**                  |       | **<Price price="67" />** |
+| **Subtotal**                  |       | **<Price price="82" />** |
 | Compute Credits               |       | -<Price price="10" />    |
-| **Total**                     |       | **<Price price="57" />** |
+| **Total**                     |       | **<Price price="72" />** |
 
 ### One project with Read Replicas
 
@@ -86,14 +86,14 @@ The project has two Read Replicas and the IPv4 add-on enabled throughout the ent
 | ----------------------------- | ----- | ------------------------ |
 | Pro Plan                      | -     | <Price price="25" />     |
 |                               |       |                          |
-| Compute Hours Small Project 1 | 744   | <Price price="15" />     |
-| IPv4 Hours Project 1          | 744   | <Price price="4" />      |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />     |
+| IPv4 Hours Project 1          | 730   | <Price price="4" />      |
 |                               |       |                          |
-| Compute Hours Small Replica 1 | 744   | <Price price="15" />     |
-| IPv4 Hours Replica 1          | 744   | <Price price="4" />      |
+| Compute Hours Small Replica 1 | 730   | <Price price="15" />     |
+| IPv4 Hours Replica 1          | 730   | <Price price="4" />      |
 |                               |       |                          |
-| Compute Hours Small Replica 2 | 744   | <Price price="15" />     |
-| IPv4 Hours Replica 2          | 744   | <Price price="4" />      |
+| Compute Hours Small Replica 2 | 730   | <Price price="15" />     |
+| IPv4 Hours Replica 2          | 730   | <Price price="4" />      |
 |                               |       |                          |
 | **Subtotal**                  |       | **<Price price="82" />** |
 | Compute Credits               |       | -<Price price="10" />    |
@@ -108,12 +108,12 @@ If you remove the IPv4 add-on, you are no longer billed from the time of removal
 | ----------------------------- | ----- | --------------------------- |
 | Pro Plan                      | -     | <Price price="25" />        |
 |                               |       |                             |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />        |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />        |
 | IPv4 Hours Project 1          | 24    | <Price price="0.13" />      |
 |                               |       |                             |
-| **Subtotal**                  |       | **<Price price="35.13" />** |
+| **Subtotal**                  |       | **<Price price="40.13" />** |
 | Compute Credits               |       | -<Price price="10" />       |
-| **Total**                     |       | **<Price price="25.13" />** |
+| **Total**                     |       | **<Price price="30.13" />** |
 
 ## Optimize usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/log-drains.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/log-drains.mdx
@@ -69,19 +69,19 @@ The project has two log drains configured throughout the entire billing cycle wi
 | ----------------------------- | ------------------ | ---------------------------- |
 | Team Plan                     | 1                  | <Price price="599" />        |
 |                               |                    |                              |
-| Compute Hours Micro Project 1 | 744 hours          | <Price price="10" />         |
+| Compute Hours Small Project 1 | 730 hours          | <Price price="15" />         |
 |                               |                    |                              |
-| Log Drain Hours Drain 1       | 744 hours          | <Price price="60" />         |
+| Log Drain Hours Drain 1       | 730 hours          | <Price price="60" />         |
 | Log Drain Events Drain 1      | 800,000 events     | <Price price="0.2" />        |
 | Egress Drain 1                | 2 GB               | <Price price="0.18" />       |
 |                               |                    |                              |
-| Log Drain Hours Drain 2       | 744 hours          | <Price price="60" />         |
+| Log Drain Hours Drain 2       | 730 hours          | <Price price="60" />         |
 | Log Drain Events Drain 2      | 1.6 million events | <Price price="0.4" />        |
 | Egress Drain 2                | 4 GB               | <Price price="0.36" />       |
 |                               |                    |                              |
-| **Subtotal**                  |                    | **<Price price="730.14" />** |
+| **Subtotal**                  |                    | **<Price price="735.14" />** |
 | Compute Credits               |                    | -<Price price="10" />        |
-| **Total**                     |                    | **<Price price="720.14" />** |
+| **Total**                     |                    | **<Price price="725.14" />** |
 
 ### Add-on disabled after a day
 
@@ -92,15 +92,15 @@ If you remove the log drain add-on, you are no longer billed from the time of re
 | ----------------------------- | -------- | --------------------------- |
 | Pro Plan                      | -        | <Price price="25" />        |
 |                               |          |                             |
-| Compute Hours Micro Project 1 | 744      | <Price price="10" />        |
+| Compute Hours Small Project 1 | 730      | <Price price="15" />        |
 |                               |          |                             |
 | Log Drain Hours Drain 1       | 24       | <Price price="1.97" />      |
 | Log Drain Events Drain 1      | 0 events | <Price price="0" />         |
 | Egress Drain 1                | 0 GB     | <Price price="0" />         |
 |                               |          |                             |
-| **Subtotal**                  |          | **<Price price="36.97" />** |
+| **Subtotal**                  |          | **<Price price="41.97" />** |
 | Compute Credits               |          | -<Price price="10" />       |
-| **Total**                     |          | **<Price price="26.97" />** |
+| **Total**                     |          | **<Price price="31.97" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-sso.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-sso.mdx
@@ -95,11 +95,11 @@ The organization's SSO MAU usage for the billing cycle is within the quota, so n
 | Line Item                | Units      | Costs                    |
 | ------------------------ | ---------- | ------------------------ |
 | Pro Plan                 | 1          | <Price price="25" />     |
-| Compute Hours Micro      | 744 hours  | <Price price="10" />     |
+| Compute Hours Small      | 730 hours  | <Price price="15" />     |
 | Monthly Active SSO Users | 37 SSO MAU | <Price price="0" />      |
-| **Subtotal**             |            | **<Price price="35" />** |
+| **Subtotal**             |            | **<Price price="40" />** |
 | Compute Credits          |            | -<Price price="10" />    |
-| **Total**                |            | **<Price price="25" />** |
+| **Total**                |            | **<Price price="30" />** |
 
 ### Exceeding quota
 
@@ -108,11 +108,11 @@ The organization's SSO MAU usage for the billing cycle exceeds the quota by 10, 
 | Line Item                | Units      | Costs                       |
 | ------------------------ | ---------- | --------------------------- |
 | Pro Plan                 | 1          | <Price price="25" />        |
-| Compute Hours Micro      | 744 hours  | <Price price="10" />        |
+| Compute Hours Small      | 730 hours  | <Price price="15" />        |
 | Monthly Active SSO Users | 60 SSO MAU | <Price price="0.15" />      |
-| **Subtotal**             |            | **<Price price="35.15" />** |
+| **Subtotal**             |            | **<Price price="40.15" />** |
 | Compute Credits          |            | -<Price price="10" />       |
-| **Total**                |            | **<Price price="25.15" />** |
+| **Total**                |            | **<Price price="30.15" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-third-party.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users-third-party.mdx
@@ -83,24 +83,24 @@ The organization's Third-Party MAU usage for the billing cycle is within the quo
 | Line Item                        | Units                  | Costs                    |
 | -------------------------------- | ---------------------- | ------------------------ |
 | Pro Plan                         | 1                      | <Price price="25" />     |
-| Compute Hours Micro              | 744 hours              | <Price price="10" />     |
+| Compute Hours Small              | 730 hours              | <Price price="15" />     |
 | Monthly Active Third-Party Users | 37,000 Third-Party MAU | <Price price="0" />      |
-| **Subtotal**                     |                        | **<Price price="35" />** |
+| **Subtotal**                     |                        | **<Price price="40" />** |
 | Compute Credits                  |                        | -<Price price="10" />    |
-| **Total**                        |                        | **<Price price="25" />** |
+| **Total**                        |                        | **<Price price="30" />** |
 
 ### Exceeding quota
 
-The organization's Third-Party MAU usage for the billing cycle exceeds the quota by 4950, incurring charges for this additional usage.
+The organization's Third-Party MAU usage for the billing cycle exceeds the quota by 30,000, incurring charges for this additional usage.
 
 | Line Item                        | Units                   | Costs                        |
 | -------------------------------- | ----------------------- | ---------------------------- |
 | Pro Plan                         | 1                       | <Price price="25" />         |
-| Compute Hours Micro              | 744 hours               | <Price price="10" />         |
+| Compute Hours Small              | 730 hours               | <Price price="15" />         |
 | Monthly Active Third-Party Users | 130,000 Third-Party MAU | <Price price="97.50" />      |
-| **Subtotal**                     |                         | **<Price price="132.50" />** |
+| **Subtotal**                     |                         | **<Price price="137.50" />** |
 | Compute Credits                  |                         | -<Price price="10" />        |
-| **Total**                        |                         | **<Price price="122.50" />** |
+| **Total**                        |                         | **<Price price="127.50" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/monthly-active-users.mdx
@@ -83,11 +83,11 @@ The organization's MAU usage for the billing cycle is within the quota, so no ch
 | Line Item            | Units      | Costs                    |
 | -------------------- | ---------- | ------------------------ |
 | Pro Plan             | 1          | <Price price="25" />     |
-| Compute Hours Micro  | 744 hours  | <Price price="10" />     |
+| Compute Hours Small  | 730 hours  | <Price price="15" />     |
 | Monthly Active Users | 23,000 MAU | <Price price="0" />      |
-| **Subtotal**         |            | **<Price price="35" />** |
+| **Subtotal**         |            | **<Price price="40" />** |
 | Compute Credits      |            | -<Price price="10" />    |
-| **Total**            |            | **<Price price="25" />** |
+| **Total**            |            | **<Price price="30" />** |
 
 ### Exceeding quota
 
@@ -96,11 +96,11 @@ The organization's MAU usage for the billing cycle exceeds the quota by 60,000, 
 | Line Item            | Units       | Costs                     |
 | -------------------- | ----------- | ------------------------- |
 | Pro Plan             | 1           | <Price price="25" />      |
-| Compute Hours Micro  | 744 hours   | <Price price="10" />      |
+| Compute Hours Small  | 730 hours   | <Price price="15" />      |
 | Monthly Active Users | 160,000 MAU | <Price price="195" />     |
-| **Subtotal**         |             | **<Price price="230" />** |
+| **Subtotal**         |             | **<Price price="235" />** |
 | Compute Credits      |             | -<Price price="10" />     |
-| **Total**            |             | **<Price price="220" />** |
+| **Total**            |             | **<Price price="225" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/point-in-time-recovery.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/point-in-time-recovery.mdx
@@ -45,8 +45,8 @@ The project has PITR with a recovery retention period of 7 days activated throug
 | Line Item                     | Hours | Costs                     |
 | ----------------------------- | ----- | ------------------------- |
 | Pro Plan                      | -     | <Price price="25" />      |
-| Compute Hours Small Project 1 | 744   | <Price price="15" />      |
-| 7-day PITR Hours Project 1    | 744   | <Price price="100" />     |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />      |
+| 7-day PITR Hours Project 1    | 730   | <Price price="100" />     |
 | **Subtotal**                  |       | **<Price price="140" />** |
 | Compute Credits               |       | -<Price price="10" />     |
 | **Total**                     |       | **<Price price="130" />** |
@@ -59,11 +59,11 @@ All projects have PITR with a recovery retention period of 14 days activated thr
 | ----------------------------- | ----- | ------------------------- |
 | Pro Plan                      | -     | <Price price="25" />      |
 |                               |       |                           |
-| Compute Hours Small Project 1 | 744   | <Price price="15" />      |
-| 14-day PITR Hours Project 1   | 744   | <Price price="200" />     |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />      |
+| 14-day PITR Hours Project 1   | 730   | <Price price="200" />     |
 |                               |       |                           |
-| Compute Hours Small Project 2 | 744   | <Price price="15" />      |
-| 14-day PITR Hours Project 2   | 744   | <Price price="200" />     |
+| Compute Hours Small Project 2 | 730   | <Price price="15" />      |
+| 14-day PITR Hours Project 2   | 730   | <Price price="200" />     |
 |                               |       |                           |
 | **Subtotal**                  |       | **<Price price="455" />** |
 | Compute Credits               |       | -<Price price="10" />     |
@@ -78,12 +78,12 @@ If you remove the PITR add-on, you are no longer billed from the time of removal
 | ----------------------------- | ----- | --------------------------- |
 | Pro Plan                      | -     | <Price price="25" />        |
 |                               |       |                             |
-| Compute Hours Micro Project 1 | 744   | <Price price="10" />        |
-| 7-day PITR Hours Project 1    | 24    | <Price price="3.23" />      |
+| Compute Hours Small Project 1 | 730   | <Price price="15" />        |
+| 7-day PITR Hours Project 1    | 24    | <Price price="3.29" />      |
 |                               |       |                             |
-| **Subtotal**                  |       | **<Price price="38.23" />** |
+| **Subtotal**                  |       | **<Price price="43.29" />** |
 | Compute Credits               |       | -<Price price="10" />       |
-| **Total**                     |       | **<Price price="28.23" />** |
+| **Total**                     |       | **<Price price="33.29" />** |
 
 ## Optimize usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/read-replicas.mdx
@@ -65,10 +65,10 @@ The project has one Read Replica, no IPv4, and no additional Disk IOPS and Disk 
 | ----------------------------- | --------- | --------------------------- |
 | Pro Plan                      | 1         | <Price price="25" />        |
 |                               |           |                             |
-| Compute Hours Small Project 1 | 744 hours | <Price price="15" />        |
+| Compute Hours Small Project 1 | 730 hours | <Price price="15" />        |
 | Disk Size Project 1           | 8 GB      | <Price price="0" />         |
 |                               |           |                             |
-| Compute Hours Small Replica   | 744 hours | <Price price="15" />        |
+| Compute Hours Small Replica   | 730 hours | <Price price="15" />        |
 | Disk Size Replica             | 10 GB     | <Price price="1.25" />      |
 |                               |           |                             |
 | **Subtotal**                  |           | **<Price price="56.25" />** |
@@ -83,27 +83,27 @@ The project has two Read Replicas, IPv4, and additional Disk IOPS and Disk Throu
 | ----------------------------- | --------- | ---------------------------- |
 | Pro Plan                      | 1         | <Price price="25" />         |
 |                               |           |                              |
-| Compute Hours Large Project 1 | 744 hours | <Price price="110" />        |
+| Compute Hours Large Project 1 | 730 hours | <Price price="111" />        |
 | Disk Size Project 1           | 8 GB      | <Price price="0" />          |
 | Disk IOPS Project 1           | 3600      | <Price price="14.40" />      |
-| Disk Throughput Project 1     | 200 MB/s  | <Price price="7.13" />       |
-| IPv4 Hours Project 1          | 744 hours | <Price price="4" />          |
+| Disk Throughput Project 1     | 200 MB/s  | <Price price="7.12" />       |
+| IPv4 Hours Project 1          | 730 hours | <Price price="4" />          |
 |                               |           |                              |
-| Compute Hours Large Replica 1 | 744 hours | <Price price="110" />        |
+| Compute Hours Large Replica 1 | 730 hours | <Price price="111" />        |
 | Disk Size Replica 1           | 10 GB     | <Price price="1.25" />       |
 | Disk IOPS Replica 1           | 3600      | <Price price="14.40" />      |
-| Disk Throughput Replica 1     | 200 MB/s  | <Price price="7.13" />       |
-| IPv4 Hours Replica 1          | 744 hours | <Price price="4" />          |
+| Disk Throughput Replica 1     | 200 MB/s  | <Price price="7.12" />       |
+| IPv4 Hours Replica 1          | 730 hours | <Price price="4" />          |
 |                               |           |                              |
-| Compute Hours Large Replica 2 | 744 hours | <Price price="110" />        |
+| Compute Hours Large Replica 2 | 730 hours | <Price price="111" />        |
 | Disk Size Replica 2           | 10 GB     | <Price price="1.25" />       |
 | Disk IOPS Replica 2           | 3600      | <Price price="14.40" />      |
-| Disk Throughput Replica 2     | 200 MB/s  | <Price price="7.13" />       |
-| IPv4 Hours Replica 2          | 744 hours | <Price price="4" />          |
+| Disk Throughput Replica 2     | 200 MB/s  | <Price price="7.12" />       |
+| IPv4 Hours Replica 2          | 730 hours | <Price price="4" />          |
 |                               |           |                              |
-| **Subtotal**                  |           | **<Price price="434.09" />** |
+| **Subtotal**                  |           | **<Price price="437.06" />** |
 | Compute Credits               |           | -<Price price="10" />        |
-| **Total**                     |           | **<Price price="424.09" />** |
+| **Total**                     |           | **<Price price="427.06" />** |
 
 ## FAQ
 

--- a/apps/docs/content/guides/platform/manage-your-usage/realtime-messages.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/realtime-messages.mdx
@@ -45,11 +45,11 @@ The organization's Realtime messages are within the quota, so no charges apply.
 | Line Item           | Units                | Costs                    |
 | ------------------- | -------------------- | ------------------------ |
 | Pro Plan            | 1                    | <Price price="25" />     |
-| Compute Hours Micro | 744 hours            | <Price price="10" />     |
+| Compute Hours Small | 730 hours            | <Price price="15" />     |
 | Realtime Messages   | 1.8 million messages | <Price price="0" />      |
-| **Subtotal**        |                      | **<Price price="35" />** |
+| **Subtotal**        |                      | **<Price price="40" />** |
 | Compute Credits     |                      | -<Price price="10" />    |
-| **Total**           |                      | **<Price price="25" />** |
+| **Total**           |                      | **<Price price="30" />** |
 
 ### Exceeding quota
 
@@ -58,11 +58,11 @@ The organization's Realtime messages exceed the quota by 3.5 million, incurring 
 | Line Item           | Units                | Costs                    |
 | ------------------- | -------------------- | ------------------------ |
 | Pro Plan            | 1                    | <Price price="25" />     |
-| Compute Hours Micro | 744 hours            | <Price price="10" />     |
+| Compute Hours Small | 730 hours            | <Price price="15" />     |
 | Realtime Messages   | 8.5 million messages | <Price price="10" />     |
-| **Subtotal**        |                      | **<Price price="45" />** |
+| **Subtotal**        |                      | **<Price price="50" />** |
 | Compute Credits     |                      | -<Price price="10" />    |
-| **Total**           |                      | **<Price price="35" />** |
+| **Total**           |                      | **<Price price="40" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/realtime-peak-connections.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/realtime-peak-connections.mdx
@@ -50,11 +50,11 @@ The organization's connections are within the quota, so no charges apply.
 | Line Item                 | Units           | Costs                    |
 | ------------------------- | --------------- | ------------------------ |
 | Pro Plan                  | 1               | <Price price="25" />     |
-| Compute Hours Micro       | 744 hours       | <Price price="10" />     |
+| Compute Hours Small       | 730 hours       | <Price price="15" />     |
 | Realtime Peak Connections | 350 connections | <Price price="0" />      |
-| **Subtotal**              |                 | **<Price price="35" />** |
+| **Subtotal**              |                 | **<Price price="40" />** |
 | Compute Credits           |                 | -<Price price="10" />    |
-| **Total**                 |                 | **<Price price="25" />** |
+| **Total**                 |                 | **<Price price="30" />** |
 
 ### Exceeding quota
 
@@ -63,11 +63,11 @@ The organization's connections exceed the quota by 1,200, incurring charges for 
 | Line Item                 | Units             | Costs                    |
 | ------------------------- | ----------------- | ------------------------ |
 | Pro Plan                  | 1                 | <Price price="25" />     |
-| Compute Hours Micro       | 744 hours         | <Price price="10" />     |
+| Compute Hours Small       | 730 hours         | <Price price="15" />     |
 | Realtime Peak Connections | 1,700 connections | <Price price="20" />     |
-| **Subtotal**              |                   | **<Price price="45" />** |
+| **Subtotal**              |                   | **<Price price="60" />** |
 | Compute Credits           |                   | -<Price price="10" />    |
-| **Total**                 |                   | **<Price price="35" />** |
+| **Total**                 |                   | **<Price price="50" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-image-transformations.mdx
@@ -77,11 +77,11 @@ The organization's number of origin images for the billing cycle is within the q
 | Line Item             | Units            | Costs                    |
 | --------------------- | ---------------- | ------------------------ |
 | Pro Plan              | 1                | <Price price="25" />     |
-| Compute Hours Micro   | 744 hours        | <Price price="10" />     |
+| Compute Hours Small   | 730 hours        | <Price price="15" />     |
 | Image Transformations | 74 origin images | <Price price="0" />      |
-| **Subtotal**          |                  | **<Price price="35" />** |
+| **Subtotal**          |                  | **<Price price="40" />** |
 | Compute Credits       |                  | -<Price price="10" />    |
-| **Total**             |                  | **<Price price="25" />** |
+| **Total**             |                  | **<Price price="30" />** |
 
 ### Exceeding quota
 
@@ -90,11 +90,11 @@ The organization's number of origin images for the billing cycle exceeds the quo
 | Line Item             | Units             | Costs                    |
 | --------------------- | ----------------- | ------------------------ |
 | Pro Plan              | 1                 | <Price price="25" />     |
-| Compute Hours Micro   | 744 hours         | <Price price="10" />     |
+| Compute Hours Small   | 730 hours         | <Price price="15" />     |
 | Image Transformations | 850 origin images | <Price price="5" />      |
-| **Subtotal**          |                   | **<Price price="40" />** |
+| **Subtotal**          |                   | **<Price price="45" />** |
 | Compute Credits       |                   | -<Price price="10" />    |
-| **Total**             |                   | **<Price price="30" />** |
+| **Total**             |                   | **<Price price="35" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
@@ -29,7 +29,7 @@ The organization's Storage size usage is within the quota, so no charges for Sto
 | Line Item           | Units     | Costs                    |
 | ------------------- | --------- | ------------------------ |
 | Pro Plan            | 1         | <Price price="25" />     |
-| Compute Hours Micro | 744 hours | <Price price="10" />     |
+| Compute Hours Small | 730 hours | <Price price="15" />     |
 | Storage Size        | 85 GB     | <Price price="0" />      |
 | **Subtotal**        |           | **<Price price="35" />** |
 | Compute Credits     |           | -<Price price="10" />    |
@@ -37,16 +37,16 @@ The organization's Storage size usage is within the quota, so no charges for Sto
 
 ### Exceeding quota
 
-The organization's Storage size usage exceeds the quota by 257 GB, incurring charges for this additional usage.
+The organization's Storage size usage exceeds the quota by 188 GB, incurring charges for this additional usage.
 
-| Line Item           | Units     | Costs                      |
-| ------------------- | --------- | -------------------------- |
-| Pro Plan            | 1         | <Price price="25" />       |
-| Compute Hours Micro | 744 hours | <Price price="10" />       |
-| Storage Size        | 357 GB    | <Price price="5.4" />      |
-| **Subtotal**        |           | **<Price price="40.4" />** |
-| Compute Credits     |           | -<Price price="10" />      |
-| **Total**           |           | **<Price price="30.4" />** |
+| Line Item           | Units     | Costs                    |
+| ------------------- | --------- | ------------------------ |
+| Pro Plan            | 1         | <Price price="25" />     |
+| Compute Hours Small | 730 hours | <Price price="15" />     |
+| Storage Size        | 288 GB    | <Price price="4" />      |
+| **Subtotal**        |           | **<Price price="44" />** |
+| Compute Credits     |           | -<Price price="10" />    |
+| **Total**           |           | **<Price price="34" />** |
 
 ## View usage
 

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
@@ -31,9 +31,9 @@ The organization's Storage size usage is within the quota, so no charges for Sto
 | Pro Plan            | 1         | <Price price="25" />     |
 | Compute Hours Small | 730 hours | <Price price="15" />     |
 | Storage Size        | 85 GB     | <Price price="0" />      |
-| **Subtotal**        |           | **<Price price="35" />** |
+| **Subtotal**        |           | **<Price price="40" />** |
 | Compute Credits     |           | -<Price price="10" />    |
-| **Total**           |           | **<Price price="25" />** |
+| **Total**           |           | **<Price price="30" />** |
 
 ### Exceeding quota
 


### PR DESCRIPTION
Most of our monthly prices are based off 730-hour months (yearly average), but our examples are in 744-hour months (31 days).

For example, the Auth MFA Phone add-on costs $0.1027 per hour.
With a 730-hour month, that's $74.97.
With a 744-hour month, that's $76.41.

We advertise $75 for that add-on, so we should compare them in examples using 730-hour months.

Small caveat: the Micro instance is priced such that it only costs $10 in a 744-hour month. For a 730-hour month, it only costs $9.81. So we shift to the Small instance in our examples, which rounds much more nicely to an even $15 (costs $15.03 for 730-hour month).



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated pricing tables and billing examples across platform guides (compute, storage, IPv4, edge, egress, disks, realtime, auth, and more) to use revised example tiers/hours and recalculated subtotals/totals.
  * Adjusted Point-in-Time Recovery pricing display and monthly price formatting.
  * Increased one storage per-GB-per-month rate display for select tiers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46275?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->