### PR TITLE
chore(pricing-www): adjust storage prices

### DIFF
--- a/packages/shared-data/plans.ts
+++ b/packages/shared-data/plans.ts
@@ -58,7 +58,7 @@ export const plans: PricingInformation[] = [
       ['8 GB disk size per project', 'then $0.125 per GB'],
       ['250 GB egress', 'then $0.09 per GB'],
       ['250 GB cached egress', 'then $0.03 per GB'],
-      ['100 GB file storage', 'then $0.021 per GB'],
+      ['100 GB file storage', 'then $0.0213 per GB'],
       'Email support',
       'Daily backups stored for 7 days',
       '7-day log retention',

--- a/packages/shared-data/pricing.ts
+++ b/packages/shared-data/pricing.ts
@@ -401,8 +401,8 @@ export const pricing: Pricing = {
         title: 'Storage',
         plans: {
           free: '1 GB included',
-          pro: ['100 GB included', 'then $0.021 per GB'],
-          team: ['100 GB included', 'then $0.021 per GB'],
+          pro: ['100 GB included', 'then $0.0213 per GB'],
+          team: ['100 GB included', 'then $0.0213 per GB'],
           enterprise: 'Custom',
         },
         usage_based: true,


### PR DESCRIPTION
We bill $0.00002919 per GB/hour, which is a monthly price of $0.0217 for a 744-hour month and $0.00213 for a 730-hour month. 

Since that's a difference of ~1.5%, the billing team felt this is worthy to change 🙌🏻 

<img width="351" height="867" alt="Screenshot 2026-05-22 at 16 22 56" src="https://github.com/user-attachments/assets/46b8da91-02f8-46b0-b8be-dc9c060bf4eb" />
<img width="1349" height="168" alt="Screenshot 2026-05-22 at 16 23 01" src="https://github.com/user-attachments/assets/9ec2d44f-2583-4b53-8431-a5ea1c226e7c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Pricing Updates**
  * Updated file storage overage rates for Pro and Team plans to $0.0213 per GB.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46276?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->