### PR TITLE
fix(studio): change shortcuts reference hotkey from Cmd+/ to ?

### DIFF
--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -392,6 +392,9 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
   [SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE]: {
     id: SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE,
     label: 'Show all keyboard shortcuts',
+    // '?' isn't yet in @tanstack/hotkeys' PunctuationKey union (TanStack/hotkeys#19),
+    // but matches correctly at runtime — event.key === '?' regardless of layout.
+    // @ts-expect-error — remove this once upstream adds '?' to PunctuationKey.
     sequence: ['Shift+?'],
     showInSettings: false,
     options: { ignoreInputs: true },

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -392,7 +392,7 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
   [SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE]: {
     id: SHORTCUT_IDS.SHORTCUTS_OPEN_REFERENCE,
     label: 'Show all keyboard shortcuts',
-    sequence: ['Mod+/'],
+    sequence: ['Shift+?'],
     showInSettings: false,
     options: { ignoreInputs: true },
   },


### PR DESCRIPTION
## Why this happens

- `@tanstack/hotkeys` matches `Mod+/` against `event.key`, then falls back to `event.code` via `PUNCTUATION_CODE_MAP` (the library's macOS Option+punctuation workaround).
- On Spanish/Italian ISO keyboards, the physical key at the `Slash` position produces `-`/`_`, so `Cmd+-` (browser zoom out) reports `event.key='-'` and `event.code='Slash'`.
- The fallback maps `Slash → '/'`, the match succeeds, and the shortcuts drawer opens. US/Canada layouts report `event.code='Minus'` and are unaffected.

## Fix

- Change the hotkey to `Shift+?`. The shift-modifier check fails before the punctuation `event.code` fallback runs, so no misfire.
- Matches the `?`-for-help convention used by GitHub, Linear, Notion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated keyboard shortcut for opening the keyboard shortcuts reference from Mod+/ to Shift+?, so the reference can be opened with Shift+? on supported keyboards. This aligns the trigger with the expected key label and improves discoverability. No other user-facing behavior changed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->