### PR TITLE
Update maintenance windows

### DIFF
--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -18,18 +18,18 @@ const SUPAVISOR_UPDATE_REGIONS = {
     url: 'https://status.supabase.com/incidents/jy1tm4wfs68t',
   },
   'eu-west-1': {
-    start: Date.UTC(2026, 4, 27, 13, 0, 0),
-    end: Date.UTC(2026, 4, 27, 15, 0, 0),
+    start: Date.UTC(2026, 5, 1, 13, 0, 0),
+    end: Date.UTC(2026, 5, 1, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/3t293hpd545z',
   },
   'us-west-1': {
-    start: Date.UTC(2026, 4, 28, 13, 0, 0),
-    end: Date.UTC(2026, 4, 28, 15, 0, 0),
+    start: Date.UTC(2026, 5, 2, 16, 0, 0),
+    end: Date.UTC(2026, 5, 2, 18, 0, 0),
     url: 'https://status.supabase.com/incidents/8f72bnv3xs8r',
   },
   'us-east-1': {
-    start: Date.UTC(2026, 5, 1, 13, 0, 0),
-    end: Date.UTC(2026, 5, 1, 15, 0, 0),
+    start: Date.UTC(2026, 5, 3, 13, 0, 0),
+    end: Date.UTC(2026, 5, 3, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/7zgmgh2p343n',
   },
 }

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -9,7 +9,7 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 // Update this whenever the banner content below changes so old client bundles
 // stop displaying outdated notices after the relevant date passes.
-const BANNER_EXPIRES_AT = new Date('2026-06-01T15:00:00Z')
+const BANNER_EXPIRES_AT = new Date('2026-06-03T15:00:00Z')
 
 const SUPAVISOR_UPDATE_REGIONS = {
   'eu-central-1': {


### PR DESCRIPTION
## Context

Updating the shared pooler notice banner a little as we're shifting the maintenance windows a bit

- eu-central-1: 2026-05-26, 13:00-15:00 UTC
- eu-west-1: 2026-06-01, 13:00-15:00 UTC
- us-west-1: 2026-06-02, 16:00-18:00 UTC
- us-east-1: 2026-06-03, 13:00-15:00 UTC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended the notice banner expiry to remain visible for an additional two days.
  * Updated regional maintenance window schedules and related incident info for system notices.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46280?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->