### PR TITLE
chore: migrate observability `Modal` to `Dialog`

### DIFF
--- a/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
+++ b/apps/studio/components/interfaces/Reports/CreateReportModal.tsx
@@ -3,7 +3,21 @@ import { useRouter } from 'next/router'
 import { useMemo } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import { Button, Form, FormControl, FormField, Input, Modal, Textarea } from 'ui'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  Input,
+  Textarea,
+} from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
@@ -99,58 +113,57 @@ export const CreateReportModal = ({ visible, onCancel, afterSubmit }: CreateRepo
   const { isDirty } = form.formState
 
   return (
-    <Modal
-      visible={visible}
-      onCancel={handleCancel}
-      hideFooter
-      header="Create a custom report"
-      size="small"
-    >
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(createCustomReport)} noValidate>
-          <Modal.Content>
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItemLayout name="name" layout="vertical" label="Name">
-                  <FormControl>
-                    <Input {...field} id="name" />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-          </Modal.Content>
-          <Modal.Content>
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItemLayout name="description" layout="vertical" label="Description">
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      id="description"
-                      rows={4}
-                      placeholder="Describe your custom report"
-                      className="resize-none"
-                    />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-          </Modal.Content>
-          <Modal.Separator />
-          <Modal.Content className="flex items-center justify-end gap-2">
-            <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isCreating}>
-              Cancel
-            </Button>
-            <Button htmlType="submit" loading={isCreating} disabled={isCreating || !isDirty}>
-              Create report
-            </Button>
-          </Modal.Content>
-        </form>
-      </Form>
-    </Modal>
+    <Dialog open={visible} onOpenChange={handleCancel}>
+      <DialogContent size="small">
+        <DialogHeader>
+          <DialogTitle>Create a custom report</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(createCustomReport)} noValidate>
+            <DialogSection>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItemLayout name="name" layout="vertical" label="Name">
+                    <FormControl>
+                      <Input {...field} id="name" />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+            <DialogSection>
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItemLayout name="description" layout="vertical" label="Description">
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        id="description"
+                        rows={4}
+                        placeholder="Describe your custom report"
+                        className="resize-none"
+                      />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+            <DialogFooter>
+              <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isCreating}>
+                Cancel
+              </Button>
+              <Button htmlType="submit" loading={isCreating} disabled={isCreating || !isDirty}>
+                Create report
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Reports/UpdateModal.tsx
+++ b/apps/studio/components/interfaces/Reports/UpdateModal.tsx
@@ -3,7 +3,21 @@ import { useParams } from 'common'
 import { useEffect } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
 import { toast } from 'sonner'
-import { Button, Form, FormControl, FormField, Input, Modal, Textarea } from 'ui'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Form,
+  FormControl,
+  FormField,
+  Input,
+  Textarea,
+} from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
@@ -76,58 +90,57 @@ export const UpdateCustomReportModal = ({
   }, [initialValues, isDirty, reset])
 
   return (
-    <Modal
-      visible={selectedReport !== undefined}
-      onCancel={handleCancel}
-      hideFooter
-      header="Update custom report"
-      size="small"
-    >
-      <Form {...form}>
-        <form onSubmit={form.handleSubmit(onConfirmUpdateReport)} noValidate>
-          <Modal.Content>
-            <FormField
-              control={form.control}
-              name="name"
-              render={({ field }) => (
-                <FormItemLayout name="name" layout="vertical" label="Name">
-                  <FormControl>
-                    <Input {...field} id="name" />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-          </Modal.Content>
-          <Modal.Content>
-            <FormField
-              control={form.control}
-              name="description"
-              render={({ field }) => (
-                <FormItemLayout name="description" layout="vertical" label="Description">
-                  <FormControl>
-                    <Textarea
-                      {...field}
-                      id="description"
-                      rows={4}
-                      placeholder="Describe your custom report"
-                      className="resize-none"
-                    />
-                  </FormControl>
-                </FormItemLayout>
-              )}
-            />
-          </Modal.Content>
-          <Modal.Separator />
-          <Modal.Content className="flex items-center justify-end gap-2">
-            <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isUpdating}>
-              Cancel
-            </Button>
-            <Button htmlType="submit" loading={isUpdating} disabled={isUpdating || !isDirty}>
-              Save custom report
-            </Button>
-          </Modal.Content>
-        </form>
-      </Form>
-    </Modal>
+    <Dialog open={selectedReport !== undefined} onOpenChange={handleCancel}>
+      <DialogContent size="small">
+        <DialogHeader>
+          <DialogTitle>Update custom report</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onConfirmUpdateReport)} noValidate>
+            <DialogSection>
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItemLayout name="name" layout="vertical" label="Name">
+                    <FormControl>
+                      <Input {...field} id="name" />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+            <DialogSection>
+              <FormField
+                control={form.control}
+                name="description"
+                render={({ field }) => (
+                  <FormItemLayout name="description" layout="vertical" label="Description">
+                    <FormControl>
+                      <Textarea
+                        {...field}
+                        id="description"
+                        rows={4}
+                        placeholder="Describe your custom report"
+                        className="resize-none"
+                      />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </DialogSection>
+            <DialogFooter>
+              <Button htmlType="reset" type="default" onClick={handleCancel} disabled={isUpdating}>
+                Cancel
+              </Button>
+              <Button htmlType="submit" loading={isUpdating} disabled={isUpdating || !isDirty}>
+                Save custom report
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
   )
 }


### PR DESCRIPTION
## Problem

Observability still uses the deprecated `Modal` for:
- creating a new report
- updating a report

## Solution

- use `Dialog` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated report creation and editing dialogs with refreshed component styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46281?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->