### PR TITLE
chore: migrate realtime `Modal` to `Dialog`

### DIFF
--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover.tsx
@@ -11,7 +11,6 @@ import {
   FormField,
   FormItem,
   FormLabel,
-  Input,
   InputGroup,
   InputGroupAddon,
   InputGroupButton,

--- a/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/ChooseChannelPopover.tsx
@@ -12,6 +12,10 @@ import {
   FormItem,
   FormLabel,
   Input,
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupInput,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -140,25 +144,25 @@ export const ChooseChannelPopover = ({
                       <FormItem className="flex flex-col gap-y-2">
                         <div className="flex flex-col gap-y-1">
                           <label className="text-foreground text-xs">Name of channel</label>
-                          <div className="flex flex-row">
+                          <InputGroup>
                             <FormControl>
-                              <Input
+                              <InputGroupInput
                                 {...field}
                                 autoComplete="off"
                                 className="rounded-r-none text-xs px-2.5 py-1 h-auto"
                                 placeholder="Enter a channel name"
                               />
                             </FormControl>
-
-                            <Button
-                              type="primary"
-                              className="rounded-l-none"
-                              disabled={form.getValues().channel.length === 0}
-                              onClick={() => onSubmit()}
-                            >
-                              Listen to channel
-                            </Button>
-                          </div>
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupButton
+                                type="primary"
+                                disabled={form.getValues().channel.length === 0}
+                                onClick={() => onSubmit()}
+                              >
+                                Listen to channel
+                              </InputGroupButton>
+                            </InputGroupAddon>
+                          </InputGroup>
                         </div>
                         <FormDescription className="text-xs text-foreground-lighter">
                           The channel you initialize with the Supabase Realtime client. Learn more

--- a/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
@@ -1,5 +1,15 @@
 import { useEffect, useState } from 'react'
-import { Input } from 'ui'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  Input,
+} from 'ui'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
@@ -33,9 +43,9 @@ export const SendMessageModal = ({
   }, [visible])
 
   return (
-    <ConfirmationModal
-      visible={visible}
-      onCancel={onSelectCancel}
+    <Dialog
+      open={visible}
+      onOpenChange={onSelectCancel}
       onConfirm={() => {
         const payload = tryParseJson(values.payload)
         if (payload === undefined) {
@@ -44,34 +54,59 @@ export const SendMessageModal = ({
           onSelectConfirm({ ...values, payload })
         }
       }}
-      title="Broadcast a message to all clients"
       confirmLabel="Confirm"
     >
-      <div className="flex flex-col gap-y-4">
-        <FormItemLayout label="Message name" layout="vertical" isReactForm={false}>
-          <Input
-            size="small"
-            value={values.message}
-            onChange={(v) => setValues({ ...values, message: v.target.value })}
-          />
-        </FormItemLayout>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Broadcast a message to all clients</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection>
+          <div className="flex flex-col gap-y-4">
+            <FormItemLayout label="Message name" layout="vertical" isReactForm={false}>
+              <Input
+                size="small"
+                value={values.message}
+                onChange={(v) => setValues({ ...values, message: v.target.value })}
+              />
+            </FormItemLayout>
 
-        <div className="flex flex-col gap-y-2">
-          <FormItemLayout label="Message payload" layout="vertical" isReactForm={false}>
-            <CodeEditor
-              id="message-payload"
-              language="json"
-              className="mb-0! h-32 overflow-hidden rounded-sm border"
-              onInputChange={(e: string | undefined) =>
-                setValues({ ...values, payload: e ?? '{}' })
+            <div className="flex flex-col gap-y-2">
+              <FormItemLayout label="Message payload" layout="vertical" isReactForm={false}>
+                <CodeEditor
+                  id="message-payload"
+                  language="json"
+                  className="mb-0! h-32 overflow-hidden rounded-sm border"
+                  onInputChange={(e: string | undefined) =>
+                    setValues({ ...values, payload: e ?? '{}' })
+                  }
+                  options={{ wordWrap: 'off', contextmenu: false }}
+                  value={values.payload}
+                />
+                {error !== undefined && <p className="text-sm text-red-900">{error}</p>}
+              </FormItemLayout>
+            </div>
+          </div>
+        </DialogSection>
+        <DialogFooter>
+          <Button onClick={onSelectCancel} type="default">
+            Cancel
+          </Button>
+          <Button
+            onClick={() => {
+              const payload = tryParseJson(values.payload)
+              if (payload === undefined) {
+                setError('Please provide a valid JSON')
+              } else {
+                onSelectConfirm({ ...values, payload })
               }
-              options={{ wordWrap: 'off', contextmenu: false }}
-              value={values.payload}
-            />
-            {error !== undefined && <p className="text-sm text-red-900">{error}</p>}
-          </FormItemLayout>
-        </div>
-      </div>
-    </ConfirmationModal>
+            }}
+            type="primary"
+          >
+            Confirm
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
@@ -45,6 +45,7 @@ export const SendMessageModal = ({
         }
       }}
       title="Broadcast a message to all clients"
+      confirmLabel="Confirm"
     >
       <div className="flex flex-col gap-y-4">
         <FormItemLayout label="Message name" layout="vertical" isReactForm={false}>

--- a/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
-import { Input, Modal } from 'ui'
+import { Input } from 'ui'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import CodeEditor from '@/components/ui/CodeEditor/CodeEditor'
@@ -32,12 +33,8 @@ export const SendMessageModal = ({
   }, [visible])
 
   return (
-    <Modal
-      size="medium"
-      alignFooter="right"
-      header="Broadcast a message to all clients"
+    <ConfirmationModal
       visible={visible}
-      loading={false}
       onCancel={onSelectCancel}
       onConfirm={() => {
         const payload = tryParseJson(values.payload)
@@ -47,8 +44,9 @@ export const SendMessageModal = ({
           onSelectConfirm({ ...values, payload })
         }
       }}
+      title="Broadcast a message to all clients"
     >
-      <Modal.Content className="flex flex-col gap-y-4">
+      <div className="flex flex-col gap-y-4">
         <FormItemLayout label="Message name" layout="vertical" isReactForm={false}>
           <Input
             size="small"
@@ -72,7 +70,7 @@ export const SendMessageModal = ({
             {error !== undefined && <p className="text-sm text-red-900">{error}</p>}
           </FormItemLayout>
         </div>
-      </Modal.Content>
-    </Modal>
+      </div>
+    </ConfirmationModal>
   )
 }

--- a/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
+++ b/apps/studio/components/interfaces/Realtime/Inspector/SendMessageModal.tsx
@@ -10,7 +10,6 @@ import {
   DialogTitle,
   Input,
 } from 'ui'
-import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import CodeEditor from '@/components/ui/CodeEditor/CodeEditor'
@@ -43,19 +42,7 @@ export const SendMessageModal = ({
   }, [visible])
 
   return (
-    <Dialog
-      open={visible}
-      onOpenChange={onSelectCancel}
-      onConfirm={() => {
-        const payload = tryParseJson(values.payload)
-        if (payload === undefined) {
-          setError('Please provide a valid JSON')
-        } else {
-          onSelectConfirm({ ...values, payload })
-        }
-      }}
-      confirmLabel="Confirm"
-    >
+    <Dialog open={visible} onOpenChange={onSelectCancel}>
       <DialogContent>
         <DialogHeader>
           <DialogTitle>Broadcast a message to all clients</DialogTitle>


### PR DESCRIPTION
## Problem

Realtime still uses the deprecated `Modal` for:
- sending a message

## Solution

- use `Dialog` instead
- Fix `ChooseChannelPopover`

## Screenshots
Before:
<img width="379" height="289" alt="image" src="https://github.com/user-attachments/assets/d0389aef-e00e-463d-b994-3ef495ff2baa" />

After:
<img width="340" height="289" alt="image" src="https://github.com/user-attachments/assets/75e5d982-6f26-4e92-beea-dcc136a75bd1" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Message-sending modal redesigned to use a dialog layout with a clear header, body and footer; confirm/cancel actions and inline JSON validation behave as before.
  * Channel-join form updated to a compact grouped input-and-button layout for more consistent, space-efficient entry.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46284?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->