### PR TITLE
fix(experiment): make dataApiRevokeOnCreateDefault flag reads shape-agnostic

### DIFF
--- a/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  isInDataApiRevokeTreatment,
   useDataApiRevokeOnCreateDefaultEnabled,
   useTrackDefaultPrivilegesExposure,
 } from '../useDataApiRevokeOnCreateDefault'
@@ -25,6 +26,33 @@ vi.mock('@/lib/telemetry/track', () => ({
   useTrack: vi.fn(),
 }))
 
+describe('isInDataApiRevokeTreatment', () => {
+  it('returns true for boolean true (current rollout shape)', () => {
+    expect(isInDataApiRevokeTreatment(true)).toBe(true)
+  })
+
+  it("returns true for the 'test' variant (future multivariate shape)", () => {
+    expect(isInDataApiRevokeTreatment('test')).toBe(true)
+  })
+
+  it('returns false for boolean false', () => {
+    expect(isInDataApiRevokeTreatment(false)).toBe(false)
+  })
+
+  it("returns false for the 'control' variant", () => {
+    expect(isInDataApiRevokeTreatment('control')).toBe(false)
+  })
+
+  it('returns false for undefined (flag not resolved)', () => {
+    expect(isInDataApiRevokeTreatment(undefined)).toBe(false)
+  })
+
+  it('returns false for unrelated string values', () => {
+    expect(isInDataApiRevokeTreatment('something-else')).toBe(false)
+    expect(isInDataApiRevokeTreatment('')).toBe(false)
+  })
+})
+
 describe('useDataApiRevokeOnCreateDefaultEnabled', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -47,6 +75,18 @@ describe('useDataApiRevokeOnCreateDefaultEnabled', () => {
     vi.mocked(usePHFlag).mockReturnValue(true)
     const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
     expect(result.current).toBe(true)
+  })
+
+  it("returns true when the PostHog flag is the 'test' variant string", () => {
+    vi.mocked(usePHFlag).mockReturnValue('test')
+    const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
+    expect(result.current).toBe(true)
+  })
+
+  it("returns false when the PostHog flag is the 'control' variant string", () => {
+    vi.mocked(usePHFlag).mockReturnValue('control')
+    const { result } = renderHook(() => useDataApiRevokeOnCreateDefaultEnabled())
+    expect(result.current).toBe(false)
   })
 
   it('returns false in test env regardless of flag value', () => {
@@ -249,6 +289,55 @@ describe('useTrackDefaultPrivilegesExposure', () => {
     expect(track).toHaveBeenCalledWith(
       'project_creation_default_privileges_exposed',
       expect.objectContaining({ dataApiRevokeOnCreateDefaultEnabled: false }),
+      undefined
+    )
+  })
+
+  // The next two tests cover the future multivariate flag shape (GROWTH-877).
+  // Today the flag returns boolean true/false; post-migration it returns the
+  // variant string. The convergence gate must derive the expected default from
+  // the variant, not from `!flag` directly — `!'control'` is false (truthy
+  // string negation), which would have set the wrong expected default and
+  // either skipped or mis-fired the exposure for control-arm users.
+
+  it("fires for the 'test' variant with the correct convergence default (treatment)", () => {
+    vi.mocked(usePHFlag).mockReturnValue('test')
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: false, // expected default for treatment
+        hasUserModified: false,
+      })
+    )
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      {
+        surface: 'main',
+        dataApiDefaultPrivileges: false,
+        dataApiRevokeOnCreateDefaultEnabled: 'test',
+      },
+      undefined
+    )
+  })
+
+  it("fires for the 'control' variant with the correct convergence default (legacy)", () => {
+    vi.mocked(usePHFlag).mockReturnValue('control')
+    renderHook(() =>
+      useTrackDefaultPrivilegesExposure({
+        surface: 'main',
+        dataApiDefaultPrivileges: true, // expected default for non-treatment
+        hasUserModified: false,
+      })
+    )
+    expect(track).toHaveBeenCalledTimes(1)
+    expect(track).toHaveBeenCalledWith(
+      'project_creation_default_privileges_exposed',
+      {
+        surface: 'main',
+        dataApiDefaultPrivileges: true,
+        dataApiRevokeOnCreateDefaultEnabled: 'control',
+      },
       undefined
     )
   })

--- a/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
+++ b/apps/studio/hooks/misc/useDataApiRevokeOnCreateDefault.ts
@@ -5,13 +5,33 @@ import { IS_TEST_ENV } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
 
 /**
+ * Returns true iff the user is assigned to the treatment arm of the
+ * dataApiRevokeOnCreateDefault experiment. Shape-agnostic across the current
+ * boolean rollout config and a future multivariate experiment with named
+ * variants. See GROWTH-877 for the migration plan.
+ *
+ * Accepts:
+ *   - `true`     → treatment (current boolean shape)
+ *   - `'test'`   → treatment (future multivariate shape)
+ *   - anything else (`false`, `'control'`, `null`, `undefined`) → not treatment
+ *
+ * Use this everywhere the flag's value is read so the PostHog config can
+ * migrate to multivariate without a coordinated frontend deploy.
+ */
+export const isInDataApiRevokeTreatment = (flag: boolean | string | undefined): boolean => {
+  if (flag === true) return true
+  if (flag === 'test') return true
+  return false
+}
+
+/**
  * Controls the default state of the "Automatically expose new tables"
  * checkbox at project creation. When the flag is on, the checkbox defaults
  * to unchecked (i.e. revoke SQL runs). When off/absent, the checkbox defaults
  * to checked (current behaviour — default grants remain).
  */
 export const useDataApiRevokeOnCreateDefaultEnabled = (): boolean => {
-  const flag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
+  const flag = usePHFlag<boolean | string>('dataApiRevokeOnCreateDefault')
 
   // Preserve current behaviour (default grants remain) in tests so existing
   // E2E flows don't change silently. Tests that need the revoke-default path
@@ -20,7 +40,7 @@ export const useDataApiRevokeOnCreateDefaultEnabled = (): boolean => {
     return false
   }
 
-  return !!flag
+  return isInDataApiRevokeTreatment(flag)
 }
 
 type DefaultPrivilegesExposureOptions =
@@ -48,7 +68,7 @@ type DefaultPrivilegesExposureOptions =
  */
 export const useTrackDefaultPrivilegesExposure = (options: DefaultPrivilegesExposureOptions) => {
   const track = useTrack()
-  const flag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
+  const flag = usePHFlag<boolean | string>('dataApiRevokeOnCreateDefault')
   const hasTracked = useRef(false)
 
   const { surface, dataApiDefaultPrivileges, hasUserModified } = options
@@ -59,7 +79,8 @@ export const useTrackDefaultPrivilegesExposure = (options: DefaultPrivilegesExpo
     if (flag === undefined) return
     if (surface === 'vercel' && !orgSlug) return
     // Gate on form-flag convergence unless the user explicitly dirtied the field.
-    if (!hasUserModified && dataApiDefaultPrivileges !== !flag) return
+    const expectedDefault = !isInDataApiRevokeTreatment(flag)
+    if (!hasUserModified && dataApiDefaultPrivileges !== expectedDefault) return
     hasTracked.current = true
     track(
       'project_creation_default_privileges_exposed',

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -28,6 +28,7 @@ import { useVercelProjectsQuery } from '@/data/integrations/integrations-vercel-
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useProjectCreateMutation } from '@/data/projects/project-create-mutation'
 import {
+  isInDataApiRevokeTreatment,
   useDataApiRevokeOnCreateDefaultEnabled,
   useTrackDefaultPrivilegesExposure,
 } from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
@@ -82,7 +83,9 @@ const CreateProject = () => {
   const track = useTrack()
   const snapshot = useIntegrationInstallationSnapshot()
   const isDataApiRevokeOnCreateDefault = useDataApiRevokeOnCreateDefaultEnabled()
-  const dataApiRevokeOnCreateDefaultFlag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
+  const dataApiRevokeOnCreateDefaultFlag = usePHFlag<boolean | string>(
+    'dataApiRevokeOnCreateDefault'
+  )
   const [dataApiDefaultPrivileges, setDataApiDefaultPrivileges] = useState(
     !isDataApiRevokeOnCreateDefault
   )
@@ -91,7 +94,7 @@ const CreateProject = () => {
   useEffect(() => {
     if (dataApiRevokeOnCreateDefaultFlag === undefined) return
     if (hasUserModifiedDataApiDefaultPrivileges.current) return
-    setDataApiDefaultPrivileges(!dataApiRevokeOnCreateDefaultFlag)
+    setDataApiDefaultPrivileges(!isInDataApiRevokeTreatment(dataApiRevokeOnCreateDefaultFlag))
   }, [dataApiRevokeOnCreateDefaultFlag])
 
   const { slug, next, currentProjectId: foreignProjectId, externalId } = useParams()

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -58,7 +58,10 @@ import {
 import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { useDataApiRevokeOnCreateDefaultEnabled } from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
+import {
+  isInDataApiRevokeTreatment,
+  useDataApiRevokeOnCreateDefaultEnabled,
+} from '@/hooks/misc/useDataApiRevokeOnCreateDefault'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -108,8 +111,11 @@ const Wizard: NextPageWithLayout = () => {
 
   // Read the raw flag for telemetry — coerce-undefined-to-false would record false for
   // users whose flags haven't loaded yet. The raw value preserves undefined (omitted from
-  // PostHog) so we only record true/false when the flag is resolved.
-  const dataApiRevokeOnCreateDefaultFlag = usePHFlag<boolean>('dataApiRevokeOnCreateDefault')
+  // PostHog) so we only record an actual value (boolean true/false, or a variant string
+  // like 'test'/'control' post-multivariate migration) once the flag has resolved.
+  const dataApiRevokeOnCreateDefaultFlag = usePHFlag<boolean | string>(
+    'dataApiRevokeOnCreateDefault'
+  )
   const isDataApiRevokeOnCreateDefault = useDataApiRevokeOnCreateDefaultEnabled()
 
   const isNotOnHigherPlan = !['team', 'enterprise', 'platform'].includes(currentOrg?.plan.id ?? '')
@@ -174,9 +180,13 @@ const Wizard: NextPageWithLayout = () => {
   useEffect(() => {
     if (dataApiRevokeOnCreateDefaultFlag === undefined) return
     if (isDataApiDefaultPrivilegesDirty) return
-    setValue('dataApiDefaultPrivileges', !dataApiRevokeOnCreateDefaultFlag, {
-      shouldDirty: false,
-    })
+    setValue(
+      'dataApiDefaultPrivileges',
+      !isInDataApiRevokeTreatment(dataApiRevokeOnCreateDefaultFlag),
+      {
+        shouldDirty: false,
+      }
+    )
   }, [dataApiRevokeOnCreateDefaultFlag, isDataApiDefaultPrivilegesDirty, setValue])
 
   // [Charis] Since the form is updated in a useEffect, there is an edge case

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -319,10 +319,13 @@ export interface ProjectCreationDefaultPrivilegesExposedEvent {
     dataApiDefaultPrivileges: boolean
     /**
      * Raw value of the dataApiRevokeOnCreateDefault PostHog flag at exposure time.
-     * true = revoke cohort (checkbox defaulted to unchecked)
-     * false = control cohort (checkbox defaulted to checked)
+     * Accepts boolean (current rollout shape) or string (post-multivariate-migration
+     * variant name, e.g. 'test' / 'control'). See GROWTH-877 for the migration plan.
+     * true | 'test' = revoke cohort (checkbox defaulted to unchecked)
+     * false = outside the rollout (checkbox defaulted to checked)
+     * 'control' = in-experiment control arm (checkbox defaulted to checked)
      */
-    dataApiRevokeOnCreateDefaultEnabled: boolean
+    dataApiRevokeOnCreateDefaultEnabled: boolean | string
   }
   groups: Omit<TelemetryGroups, 'project'>
 }
@@ -381,14 +384,17 @@ export interface ProjectCreationSimpleVersionSubmittedEvent {
      */
     dataApiDefaultPrivilegesGranted?: boolean
     /**
-     * Whether the dataApiRevokeOnCreateDefault PostHog flag was enabled for this user.
+     * Raw value of the dataApiRevokeOnCreateDefault PostHog flag at submission time.
      * Controls only the default checkbox state of "Automatically expose new tables and functions"
      * at project creation. Tracking it lets us correlate flag cohort with user choice.
-     * true = user is in the staged rollout cohort (checkbox defaulted to unchecked)
+     * Accepts boolean (current rollout shape) or string (post-multivariate-migration
+     * variant name, e.g. 'test' / 'control'). See GROWTH-877 for the migration plan.
+     * true | 'test' = user is in the treatment arm (checkbox defaulted to unchecked)
      * false = user is outside the rollout (checkbox defaulted to checked)
+     * 'control' = in-experiment control arm (checkbox defaulted to checked)
      * omitted = PostHog flags had not loaded at the time of project creation
      */
-    dataApiRevokeOnCreateDefaultEnabled?: boolean
+    dataApiRevokeOnCreateDefaultEnabled?: boolean | string
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / experiment prep.

## What is the current behavior?

The `data-api-revoke-on-create-default` PostHog flag is configured as a boolean rollout, not a multivariate experiment. Confirmed via Hex on 2026-05-22: bucketing math reconciles (treatment share 2.56%, expected 2.5%), but in-experiment control users are indistinguishable from non-cohort users in the event data — both return `false`. Any control-arm signal is diluted across the ~95% of users who never entered the experiment.

The fix is reconfiguring the flag as multivariate with `control` / `test` string variants ([GROWTH-877](https://linear.app/supabase/issue/GROWTH-877)). But the boolean and string return shapes can't coexist cleanly — whichever side ships first breaks the experiment in the gap:

- PostHog config first → frontend sees `'test'`; strings are truthy, so `if (flag)` evaluates true for both arms.
- Frontend first → frontend strict-equals `'test'` while PostHog still returns boolean `true`; nobody gets treatment.

## What is the new behavior?

Exported helper that accepts both shapes:

```ts
export const isInDataApiRevokeTreatment = (flag: boolean | string | undefined): boolean => {
  if (flag === true) return true   // current boolean shape
  if (flag === 'test') return true // future multivariate shape
  return false                     // false, 'control', null, undefined
}
```

Routes the enabled-hook, both page surfaces (`/new/[slug]` and the Vercel deploy button), and the convergence gate in the exposure hook through it. No behavioral change on the boolean flag today. After the PostHog config flip lands, the same code picks up the variant string automatically — no coordinated deploy needed.

Pre-fixes a latent bug along the way: the previous code computed the form's expected default as `!flag`, which evaluates false for any truthy string including `'control'`. That would have defaulted control-arm users to the revoke checkbox on day one of the migration. The helper-based derivation correctly treats `'control'` as not-treatment.

Telemetry contract for `project_creation_default_privileges_exposed` and `project_creation_simple_version_submitted` widened from `boolean` to `boolean | string`. Payload keeps sending the raw flag value (not the derived boolean) so BQ analysis can distinguish control from non-cohort once multivariate lands.

## Testing

- `pnpm --filter studio exec vitest run hooks/misc/__tests__/useDataApiRevokeOnCreateDefault.test.ts` — 24/24 pass (16 existing + 8 new covering both variant strings)
- Existing boolean-shape tests pass unmodified
- Two new exposure tests assert the convergence gate fires correctly for both `'test'` (treatment, expected default false) and `'control'` (not treatment, expected default true) — these document the latent bug fix

## Additional context

Migration sequence after this lands is in [GROWTH-877](https://linear.app/supabase/issue/GROWTH-877). BQ-side query updates to read the variant string are flagged as a followup on the ticket — they don't block this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced feature flag handling for data API default privileges configuration to support both current and future flag variations across project creation flows.

* **Tests**
  * Added test coverage for multivariate flag shape handling in data API revoke-on-create default scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46289?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->