### PR TITLE
chore(docs): clarify Postgres connection options and IPv4/IPv6 support

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -19,8 +19,8 @@ The table below summarizes each mode, its host and port, IP version support per 
 | Mode                              | Host:Port                                 | Free | Paid | Paid + IPv4 add-on | Best for                                   |
 | --------------------------------- | ----------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
 | Direct                            | `db.[project-id].supabase.co:5432`        | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
-| Shared session (Supavisor)        | `aws-0-[region].pooler.supabase.com:5432` | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
-| Shared transaction (Supavisor)    | `aws-0-[region].pooler.supabase.com:6543` | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
+| Shared session (Supavisor)        | `aws-[region].pooler.supabase.com:5432` | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
+| Shared transaction (Supavisor)    | `aws-[region].pooler.supabase.com:6543` | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
 | Dedicated transaction (PgBouncer) | `db.[project-id].supabase.co:6543`        | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
 
 <Admonition type="caution">
@@ -105,7 +105,7 @@ The session mode connection string connects to your Postgres instance via the Sh
 The connection string looks like this:
 
 ```
-postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-0-[REGION].pooler.supabase.com:5432/postgres
+postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-[REGION].pooler.supabase.com:5432/postgres
 ```
 
 Get your project's Session pooler connection string from your project dashboard by clicking [Connect](/dashboard/project/_?showConnect=true&method=session).
@@ -123,7 +123,7 @@ Transaction mode does not support [prepared statements](https://postgresql.org/d
 The connection string looks like this:
 
 ```
-postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres
+postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-[REGION].pooler.supabase.com:6543/postgres
 ```
 
 Get your project's Transaction pooler connection string from your project dashboard by clicking [Connect](/dashboard/project/_?showConnect=true&method=transaction).

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -18,7 +18,7 @@ The table below summarizes each mode, its host and port, IP version support per 
 
 | Mode                                            | Host:Port                               | Free | Paid | Paid + IPv4 add-on | Best for                                   |
 | ----------------------------------------------- | --------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
-| Direct                                          | `db.[project-id].supabase.co:5432`      | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
+| Direct connection                               | `db.[project-id].supabase.co:5432`      | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
 | Shared pooler (Supavisor) - session mode        | `aws-[region].pooler.supabase.com:5432` | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
 | Shared pooler (Supavisor) - transaction mode    | `aws-[region].pooler.supabase.com:6543` | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
 | Dedicated pooler (PgBouncer) - transaction mode | `db.[project-id].supabase.co:6543`      | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -11,8 +11,19 @@ How you connect to your database depends on where you're connecting from:
 - For frontend applications, use the [Data API](#data-apis-and-client-libraries)
 - For Postgres clients, use a connection string
   - For single sessions (for example, database GUIs) or Postgres native commands (for example, using client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external)) use the [direct connection string](#direct-connection) if your environment supports IPv6. IPv4 available as [Add-on](/docs/guides/platform/ipv4-address).
-  - For application traffic from persistent clients, and support for both IPv4 and IPv6, use [pooler session mode](#pooler-session-mode)
+  - For application traffic from persistent clients on IPv4-only networks, use [pooler session mode](#pooler-session-mode)
   - For application traffic from temporary clients (for example, serverless or edge functions) use [pooler transaction mode](#pooler-transaction-mode)
+
+The table below summarizes each mode, its host and port, IP version support per project tier, and what it's best used for:
+
+| Mode                              | Host:Port                                 | Free | Paid | Paid + IPv4 add-on | Best for                                   |
+| --------------------------------- | ----------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
+| Direct                            | `db.[id].supabase.co:5432`                | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
+| Shared session (Supavisor)        | `aws-0-[region].pooler.supabase.com:5432` | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
+| Shared transaction (Supavisor)    | `aws-0-[region].pooler.supabase.com:6543` | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
+| Dedicated transaction (PgBouncer) | `db.[id].supabase.co:6543`                | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
+
+The IPv4 add-on swaps the project's IPv6 connectivity for IPv4 - it does not add IPv4 alongside IPv6.
 
 ## Quickstarts
 
@@ -67,7 +78,7 @@ The direct connection string connects directly to your Postgres instance. It is 
 
 <Admonition type="caution">
 
-Direct connections use IPv6 by default. If your environment doesn't support IPv6, use [Supavisor session mode](#supavisor-session-mode) or get the [IPv4 add-on](/docs/guides/platform/ipv4-address).
+Direct connections use IPv6 by default. If your environment doesn't support IPv6, use [pooler session mode](#pooler-session-mode) or get the [IPv4 add-on](/docs/guides/platform/ipv4-address), which swaps your project's IPv6 connectivity for IPv4.
 
 </Admonition>
 
@@ -81,11 +92,11 @@ Get your project's direct connection string from your project dashboard by click
 
 ## Poolers
 
-Every Supabase project includes a connection pooler. This is ideal for persistent servers when IPv6 is not supported.
+Supabase offers two poolers. The **Shared Pooler** ([Supavisor](https://github.com/supabase/supavisor)) is multi-tenant, available on every project, and accepts IPv4 connections only. The **Dedicated Pooler** ([PgBouncer](https://www.pgbouncer.org/)) is available on paid plans, co-located with your Postgres instance, and accepts IPv6 connections (or IPv4 with the [add-on](/docs/guides/platform/ipv4-address)).
 
 ### Pooler session mode
 
-The session mode connection string connects to your Postgres instance via a proxy. This is only recommended as an alternative to a Direct Connection, when connecting via an IPv4 network.
+The session mode connection string connects to your Postgres instance via the Shared Pooler (Supavisor). This is only recommended as an alternative to a Direct Connection when connecting from an IPv4-only network.
 
 The connection string looks like this:
 
@@ -97,7 +108,7 @@ Get your project's Session pooler connection string from your project dashboard 
 
 ### Pooler transaction mode
 
-The transaction mode connection string connects to your Postgres instance via a proxy which serves as a connection pooler. This is ideal for serverless or edge functions, which require many transient connections.
+The transaction mode connection string connects to your Postgres instance via the Shared Pooler (Supavisor) in transaction-pooling mode. This is ideal for serverless or edge functions, which require many transient connections.
 
 <Admonition type="caution">
 
@@ -108,14 +119,20 @@ Transaction mode does not support [prepared statements](https://postgresql.org/d
 The connection string looks like this:
 
 ```
-postgres://postgres:[YOUR-PASSWORD]@db.abcdefghijklmnopqrst.supabase.co:6543/postgres
+postgres://postgres.apbkobhfnmcqqzqeeqss:[YOUR-PASSWORD]@aws-0-[REGION].pooler.supabase.com:6543/postgres
 ```
 
 Get your project's Transaction pooler connection string from your project dashboard by clicking [Connect](/dashboard/project/_?showConnect=true&method=transaction).
 
 ## Dedicated pooler
 
-For paying customers, we provision a Dedicated Pooler ([PgBouncer](https://www.pgbouncer.org/)) that's co-located with your Postgres database. This will require you to connect with IPv6 or, if that's not an option, you can use the [IPv4 add-on](/docs/guides/platform/ipv4-address).
+For paying customers, we provision a Dedicated Pooler ([PgBouncer](https://www.pgbouncer.org/)) that's co-located with your Postgres database. The Dedicated Pooler runs in transaction mode only - for session mode, use the [Shared Pooler](#pooler-session-mode). It requires IPv6, or the [IPv4 add-on](/docs/guides/platform/ipv4-address) if your network is IPv4-only.
+
+The connection string looks like this:
+
+```
+postgres://postgres:[YOUR-PASSWORD]@db.abcdefghijklmnopqrst.supabase.co:6543/postgres
+```
 
 The Dedicated Pooler ensures best performance and latency, while using up more of your project's compute resources. If your network supports IPv6 or you have the IPv4 add-on, we encourage you to use the Dedicated Pooler over the Shared Pooler.
 
@@ -131,11 +148,11 @@ You can use an application-side pooler or a server-side pooler (Supabase automat
 
 Application-side poolers are built into connection libraries and API servers, such as Prisma, SQLAlchemy, and PostgREST. They maintain several active connections with Postgres or a server-side pooler, reducing the overhead of establishing connections between queries. When deploying to static architecture, such as long-standing containers or VMs, application-side poolers are satisfactory on their own.
 
-### Serverside poolers
+### Server-side poolers
 
 Postgres connections are like a WebSocket. Once established, they are preserved until the client (application server) disconnects. A server might only make a single 10 ms query, but needlessly reserve its database connection for seconds or longer.
 
-Serverside-poolers, such as Supabase's [Supavisor](https://github.com/supabase/supavisor) in transaction mode, sit between clients and the database and can be thought of as load balancers for Postgres connections.
+Server-side poolers, such as Supabase's [Supavisor](https://github.com/supabase/supavisor) in transaction mode, sit between clients and the database and can be thought of as load balancers for Postgres connections.
 
 <Image
   alt="New migration files trigger migrations on the preview instance."
@@ -180,7 +197,7 @@ This error occurs when your credentials are incorrect. Double-check your usernam
 
 ### How do you connect using IPv4?
 
-Supabase’s default direct connection supports IPv6 only. To connect over IPv4, consider using the Supavisor session or transaction modes, or a connection pooler (shared or dedicated), which support both IPv4 and IPv6.
+Supabase's direct connection uses IPv6 by default. To connect over IPv4, use the Shared Pooler (Supavisor) in either session or transaction mode - it is IPv4-only on every project tier. Alternatively, add the [IPv4 add-on](/docs/guides/platform/ipv4-address) to your project, which swaps the project's IPv6 connectivity (direct and Dedicated Pooler) for IPv4.
 
 ### Where is the Postgres connection string in Supabase?
 
@@ -259,10 +276,10 @@ Even if your application isn’t making queries, some Supabase services keep per
 
 Different modes use different ports:
 
-- Direct connection: `5432` (database server)
-- PgBouncer: `6543` (database server)
-- Supavisor transaction mode: `6543` (separate server)
-- Supavisor session mode: `5432` (separate server)
+- Direct connection: `5432` (Postgres on your project instance)
+- Dedicated pooler, transaction mode: `6543` (PgBouncer on your project instance)
+- Shared pooler, transaction mode: `6543` (Supavisor, multi-tenant)
+- Shared pooler, session mode: `5432` (Supavisor, multi-tenant)
 
 The port helps route the connection to the right pooler/mode.
 
@@ -278,20 +295,21 @@ Because the dedicated pooler is hosted on the same machine as your database, it 
 - Use for migrations, pg_dump, backup and management tools
 - Limitation: IPv6 only by default. IPv4 available as [Add-on](/docs/guides/platform/ipv4-address).
 
-**Shared pooler:**
+**Shared pooler (Supavisor):**
 
-- Best for: general-purpose connections (supports IPv4 and IPv6)
-  - Supavisor session mode → persistent backend that require IPv4
+- Best for: IPv4-only environments and serverless workloads (IPv4-only on every tier)
+  - Supavisor session mode → persistent backends on IPv4 networks
   - Supavisor transaction mode → serverless functions or short-lived tasks
 - Use for application runtime traffic (queries, writes)
 
-**Dedicated pooler (paid tier):**
+**Dedicated pooler (PgBouncer, paid tier):**
 
 - Best for: high-performance apps that need dedicated resources
 - Use for application runtime traffic (queries, writes)
-- Uses PgBouncer
+- Transaction mode only - use the Shared Pooler if you need session mode
+- IPv6 by default, IPv4 with the add-on
 
-You can follow the decision flow in the connection method diagram to quickly choose the right option for your environment.
+See the [connection method matrix](#how-to-connect-to-your-postgres-databases) at the top of this page for a quick reference, or follow the decision flow in the diagram below to choose the right option for your environment.
 
 <Image
   alt="Decision tree diagram showing when to connect directly to Postgres or use a connection pooler."

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -11,7 +11,7 @@ How you connect to your database depends on where you're connecting from:
 - For frontend applications, use the [Data API](#data-apis-and-client-libraries)
 - For Postgres clients, use a connection string
   - **Use the [direct connection string](#direct-connection) for single sessions or Postgres native commands**. For example, database GUIs,  client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external). The direct endpoint is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
-  - For application traffic from persistent clients on IPv4-only networks, use [pooler session mode](#pooler-session-mode)
+  - **Use [pooler session mode](#pooler-session-mode)** for application traffic from persistent clients on IPv4-only networks, 
   - For application traffic from temporary clients (for example, serverless or edge functions) use [pooler transaction mode](#pooler-transaction-mode)
 
 The table below summarizes each mode, its host and port, IP version support per project tier, and what it's best used for:

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -297,8 +297,8 @@ Because the dedicated pooler is hosted on the same machine as your database, it 
 
 **Shared pooler (Supavisor):**
 
-- Best for: IPv4-only environments and serverless workloads (IPv4-only on every tier)
-  - Supavisor session mode → persistent backends on IPv4 networks
+- Best for: connections from IPv4 networks (IPv4-only on every tier)
+  - Supavisor session mode → persistent backend on IPv4 networks
   - Supavisor transaction mode → serverless functions or short-lived tasks
 - Use for application runtime traffic (queries, writes)
 

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -12,7 +12,7 @@ How you connect to your database depends on where you're connecting from:
 - For Postgres clients, use a connection string
   - **Use the [direct connection string](#direct-connection) for single sessions or Postgres native commands**. For example, database GUIs,  client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external). The direct endpoint is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
   - **Use [pooler session mode](#pooler-session-mode)** for application traffic from persistent clients on IPv4-only networks, 
-  - For application traffic from temporary clients (for example, serverless or edge functions) use [pooler transaction mode](#pooler-transaction-mode)
+  - **Use [pooler transaction mode](#pooler-transaction-mode)** for application traffic from temporary clients (for example, serverless or edge functions).
 
 The table below summarizes each mode, its host and port, IP version support per project tier, and what it's best used for:
 

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -16,12 +16,12 @@ How you connect to your database depends on where you're connecting from:
 
 The table below summarizes each mode, its host and port, IP version support per project tier, and what it's best used for:
 
-| Mode                                            | Host:Port                                 | Free | Paid | Paid + IPv4 add-on | Best for                                   |
-| ----------------------------------------------- | ----------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
-| Direct                                          | `db.[project-id].supabase.co:5432`        | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
-| Shared pooler (Supavisor) - session mode        | `aws-[region].pooler.supabase.com:5432`   | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
-| Shared pooler (Supavisor) - transaction mode    | `aws-[region].pooler.supabase.com:6543`   | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
-| Dedicated pooler (PgBouncer) - transaction mode | `db.[project-id].supabase.co:6543`        | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
+| Mode                                            | Host:Port                               | Free | Paid | Paid + IPv4 add-on | Best for                                   |
+| ----------------------------------------------- | --------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
+| Direct                                          | `db.[project-id].supabase.co:5432`      | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
+| Shared pooler (Supavisor) - session mode        | `aws-[region].pooler.supabase.com:5432` | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
+| Shared pooler (Supavisor) - transaction mode    | `aws-[region].pooler.supabase.com:6543` | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
+| Dedicated pooler (PgBouncer) - transaction mode | `db.[project-id].supabase.co:6543`      | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
 
 <Admonition type="caution">
 

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -18,12 +18,16 @@ The table below summarizes each mode, its host and port, IP version support per 
 
 | Mode                              | Host:Port                                 | Free | Paid | Paid + IPv4 add-on | Best for                                   |
 | --------------------------------- | ----------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
-| Direct                            | `db.[id].supabase.co:5432`                | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
+| Direct                            | `db.[project-id].supabase.co:5432`        | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
 | Shared session (Supavisor)        | `aws-0-[region].pooler.supabase.com:5432` | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
 | Shared transaction (Supavisor)    | `aws-0-[region].pooler.supabase.com:6543` | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
-| Dedicated transaction (PgBouncer) | `db.[id].supabase.co:6543`                | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
+| Dedicated transaction (PgBouncer) | `db.[project-id].supabase.co:6543`        | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
 
-The IPv4 add-on swaps the project's IPv6 connectivity for IPv4 - it does not add IPv4 alongside IPv6.
+<Admonition type="caution">
+
+The IPv4 add-on is not dual-stack: enabling it swaps the project's IPv6 (AAAA) DNS record for an IPv4 (A) record, so the project endpoint becomes reachable only over IPv4.
+
+</Admonition>
 
 ## Quickstarts
 
@@ -126,7 +130,7 @@ Get your project's Transaction pooler connection string from your project dashbo
 
 ## Dedicated pooler
 
-For paying customers, we provision a Dedicated Pooler ([PgBouncer](https://www.pgbouncer.org/)) that's co-located with your Postgres database. The Dedicated Pooler runs in transaction mode only - for session mode, use the [Shared Pooler](#pooler-session-mode). It requires IPv6, or the [IPv4 add-on](/docs/guides/platform/ipv4-address) if your network is IPv4-only.
+For paying customers, we provision a Dedicated Pooler ([PgBouncer](https://www.pgbouncer.org/)) that's co-located with your Postgres database. The Dedicated Pooler runs in transaction mode only - for session mode, use the [Shared Pooler](#pooler-session-mode). It is reachable over IPv6, or over IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
 
 The connection string looks like this:
 
@@ -197,7 +201,7 @@ This error occurs when your credentials are incorrect. Double-check your usernam
 
 ### How do you connect using IPv4?
 
-Supabase's direct connection uses IPv6 by default. To connect over IPv4, use the Shared Pooler (Supavisor) in either session or transaction mode - it is IPv4-only on every project tier. Alternatively, add the [IPv4 add-on](/docs/guides/platform/ipv4-address) to your project, which swaps the project's IPv6 connectivity (direct and Dedicated Pooler) for IPv4.
+You have two options. The Shared Pooler (Supavisor) is IPv4-only on every project tier - use it in either session or transaction mode. Alternatively, add the [IPv4 add-on](/docs/guides/platform/ipv4-address) to your project, which makes the direct connection and Dedicated Pooler reachable over IPv4 instead of IPv6.
 
 ### Where is the Postgres connection string in Supabase?
 
@@ -293,7 +297,7 @@ Because the dedicated pooler is hosted on the same machine as your database, it 
 
 - Best for: persistent backend services
 - Use for migrations, pg_dump, backup and management tools
-- Limitation: IPv6 only by default. IPv4 available as [Add-on](/docs/guides/platform/ipv4-address).
+- Network: reachable over IPv6, or over IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
 
 **Shared pooler (Supavisor):**
 
@@ -307,7 +311,7 @@ Because the dedicated pooler is hosted on the same machine as your database, it 
 - Best for: high-performance apps that need dedicated resources
 - Use for application runtime traffic (queries, writes)
 - Transaction mode only - use the Shared Pooler if you need session mode
-- IPv6 by default, IPv4 with the add-on
+- Network: reachable over IPv6, or over IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address)
 
 See the [connection method matrix](#how-to-connect-to-your-postgres-databases) at the top of this page for a quick reference, or follow the decision flow in the diagram below to choose the right option for your environment.
 

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -16,12 +16,12 @@ How you connect to your database depends on where you're connecting from:
 
 The table below summarizes each mode, its host and port, IP version support per project tier, and what it's best used for:
 
-| Mode                              | Host:Port                                 | Free | Paid | Paid + IPv4 add-on | Best for                                   |
-| --------------------------------- | ----------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
-| Direct                            | `db.[project-id].supabase.co:5432`        | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
-| Shared session (Supavisor)        | `aws-[region].pooler.supabase.com:5432` | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
-| Shared transaction (Supavisor)    | `aws-[region].pooler.supabase.com:6543` | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
-| Dedicated transaction (PgBouncer) | `db.[project-id].supabase.co:6543`        | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
+| Mode                                            | Host:Port                                 | Free | Paid | Paid + IPv4 add-on | Best for                                   |
+| ----------------------------------------------- | ----------------------------------------- | ---- | ---- | ------------------ | ------------------------------------------ |
+| Direct                                          | `db.[project-id].supabase.co:5432`        | IPv6 | IPv6 | IPv4               | Migrations, `pg_dump`, long-lived backend  |
+| Shared pooler (Supavisor) - session mode        | `aws-[region].pooler.supabase.com:5432`   | IPv4 | IPv4 | IPv4               | Persistent backend on IPv4-only networks   |
+| Shared pooler (Supavisor) - transaction mode    | `aws-[region].pooler.supabase.com:6543`   | IPv4 | IPv4 | IPv4               | Serverless and edge functions              |
+| Dedicated pooler (PgBouncer) - transaction mode | `db.[project-id].supabase.co:6543`        | -    | IPv6 | IPv4               | High-performance app traffic on paid tiers |
 
 <Admonition type="caution">
 

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -10,7 +10,7 @@ How you connect to your database depends on where you're connecting from:
 
 - For frontend applications, use the [Data API](#data-apis-and-client-libraries)
 - For Postgres clients, use a connection string
-  - For single sessions (for example, database GUIs) or Postgres native commands (for example, using client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external)), use the [direct connection string](#direct-connection). The direct endpoint is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
+  - **Use the [direct connection string](#direct-connection) for single sessions or Postgres native commands**. For example, database GUIs,  client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external). The direct endpoint is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
   - For application traffic from persistent clients on IPv4-only networks, use [pooler session mode](#pooler-session-mode)
   - For application traffic from temporary clients (for example, serverless or edge functions) use [pooler transaction mode](#pooler-transaction-mode)
 

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -10,7 +10,7 @@ How you connect to your database depends on where you're connecting from:
 
 - For frontend applications, use the [Data API](#data-apis-and-client-libraries)
 - For Postgres clients, use a connection string
-  - For single sessions (for example, database GUIs) or Postgres native commands (for example, using client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external)) use the [direct connection string](#direct-connection) if your environment supports IPv6. IPv4 available as [Add-on](/docs/guides/platform/ipv4-address).
+  - For single sessions (for example, database GUIs) or Postgres native commands (for example, using client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external)), use the [direct connection string](#direct-connection). The direct endpoint is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
   - For application traffic from persistent clients on IPv4-only networks, use [pooler session mode](#pooler-session-mode)
   - For application traffic from temporary clients (for example, serverless or edge functions) use [pooler transaction mode](#pooler-transaction-mode)
 
@@ -78,7 +78,7 @@ The direct connection string connects directly to your Postgres instance. It is 
 
 <Admonition type="caution">
 
-Direct connections use IPv6 by default. If your environment doesn't support IPv6, use [pooler session mode](#pooler-session-mode) or get the [IPv4 add-on](/docs/guides/platform/ipv4-address), which swaps your project's IPv6 connectivity for IPv4.
+Direct connections are on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address). If your network is IPv4-only and you don't have the add-on, use [pooler session mode](#pooler-session-mode) instead.
 
 </Admonition>
 
@@ -92,7 +92,7 @@ Get your project's direct connection string from your project dashboard by click
 
 ## Poolers
 
-Supabase offers two poolers. The **Shared Pooler** ([Supavisor](https://github.com/supabase/supavisor)) is multi-tenant, available on every project, and accepts IPv4 connections only. The **Dedicated Pooler** ([PgBouncer](https://www.pgbouncer.org/)) is available on paid plans, co-located with your Postgres instance, and accepts IPv6 connections (or IPv4 with the [add-on](/docs/guides/platform/ipv4-address)).
+Supabase offers two poolers. The **Shared Pooler** ([Supavisor](https://github.com/supabase/supavisor)) is multi-tenant, available on every project, and IPv4-only. The **Dedicated Pooler** ([PgBouncer](https://www.pgbouncer.org/)) is available on paid plans and co-located with your Postgres instance; like the direct connection, it is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
 
 ### Pooler session mode
 

--- a/apps/docs/content/guides/database/connecting-to-postgres.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres.mdx
@@ -10,8 +10,8 @@ How you connect to your database depends on where you're connecting from:
 
 - For frontend applications, use the [Data API](#data-apis-and-client-libraries)
 - For Postgres clients, use a connection string
-  - **Use the [direct connection string](#direct-connection) for single sessions or Postgres native commands**. For example, database GUIs,  client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external). The direct endpoint is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
-  - **Use [pooler session mode](#pooler-session-mode)** for application traffic from persistent clients on IPv4-only networks, 
+  - **Use the [direct connection string](#direct-connection) for single sessions or Postgres native commands**. For example, database GUIs, client applications like [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html), [migrations](/docs/guides/deployment/database-migrations), [backup-restore](/docs/guides/platform/migrating-within-supabase/backup-restore), or specifying connections for [replication](/docs/guides/database/postgres/setup-replication-external). The direct endpoint is on IPv6, or on IPv4 if the project has the [IPv4 add-on](/docs/guides/platform/ipv4-address).
+  - **Use [pooler session mode](#pooler-session-mode)** for application traffic from persistent clients on IPv4-only networks,
   - **Use [pooler transaction mode](#pooler-transaction-mode)** for application traffic from temporary clients (for example, serverless or edge functions).
 
 The table below summarizes each mode, its host and port, IP version support per project tier, and what it's best used for:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Corrects several confusing statements about pooler IP support, and improves the "what should I use?" hints.

- Adds a matrix near the top showing host/port, IPv4/IPv6 support per project tier (Free / Paid / Paid + IPv4 add-on), and what each mode is best for.
- Corrects the IP support claims: Shared Pooler (Supavisor) is **IPv4-only** on every tier (the doc previously said dual-stack). The IPv4 add-on **swaps** IPv6 for IPv4 project-wide rather than adding it alongside.
- Clarifies that the Dedicated Pooler (PgBouncer) is **transaction mode only**; session mode is always Shared Pooler.
- Fixes the transaction-mode example, which used the direct-host URL instead of the shared-pooler URL.
- Makes the Supavisor=Shared / PgBouncer=Dedicated equivalence explicit throughout.
- Fixes a broken anchor (`#supavisor-session-mode` → `#pooler-session-mode`) and a typo ("Serverside" → "Server-side").

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked guidance for choosing IPv6 vs IPv4 connection methods and added a mode summary table with host/port and best‑use recommendations.
  * Explained that the IPv4 add‑on is not dual‑stack, how it swaps DNS records, and its impact on reachability.
  * Updated pooler descriptions: Supavisor is multi‑tenant IPv4‑only; PgBouncer available on paid plans and reachable over IPv6 or IPv4 with the add‑on.
  * Clarified session vs transaction modes, port mappings, connection strings, and IPv4 troubleshooting guidance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46294?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->