### PR TITLE
fix(studio): fix database functions table columns overlapping on small viewports

### DIFF
--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx
@@ -104,7 +104,7 @@ const FunctionList = ({
 
         return (
           <TableRow key={x.id}>
-            <TableCell className="truncate">
+            <TableCell className="min-w-[150px] truncate">
               <Button
                 type="text"
                 className="text-link-table-cell text-sm disabled:opacity-100 disabled:no-underline p-0 hover:bg-transparent title"
@@ -115,7 +115,7 @@ const FunctionList = ({
                 {x.name}
               </Button>
             </TableCell>
-            <TableCell className="table-cell">
+            <TableCell className="min-w-[120px]">
               <p
                 title={x.argument_types}
                 className={`truncate ${x.argument_types ? 'text-foreground-light' : 'text-foreground-muted'}`}
@@ -123,7 +123,7 @@ const FunctionList = ({
                 {x.argument_types || '–'}
               </p>
             </TableCell>
-            <TableCell className="table-cell">
+            <TableCell className="min-w-[120px]">
               {x.return_type === 'trigger' ? (
                 <Link
                   href={getDatabaseTriggersHref(projectRef, x.name)}
@@ -138,7 +138,7 @@ const FunctionList = ({
                 </p>
               )}
             </TableCell>
-            <TableCell className="table-cell">
+            <TableCell className="min-w-[100px]">
               <p className="truncate text-foreground-light">
                 {x.security_definer ? 'Definer' : 'Invoker'}
               </p>

--- a/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
+++ b/apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx
@@ -372,18 +372,18 @@ export const FunctionsList = () => {
           </div>
 
           {isSchemaLocked && <ProtectedSchemaWarning schema={selectedSchema} entity="functions" />}
-          <Card>
-            <Table className="table-fixed overflow-x-auto">
+          <Card className="overflow-x-auto">
+            <Table className="min-w-[650px]">
               <TableHeader>
                 <TableRow>
                   <TableHead key="name">Name</TableHead>
-                  <TableHead key="arguments" className="table-cell">
+                  <TableHead key="arguments" className="min-w-[120px]">
                     Arguments
                   </TableHead>
-                  <TableHead key="return_type" className="table-cell">
+                  <TableHead key="return_type" className="min-w-[120px]">
                     Return type
                   </TableHead>
-                  <TableHead key="security" className="table-cell w-[100px]">
+                  <TableHead key="security" className="min-w-[120px]">
                     Security
                   </TableHead>
                   <TableHead key="buttons" className="w-1/6"></TableHead>


### PR DESCRIPTION
## Problem
The Database Functions table at `/database/functions` uses `table-fixed` on the `<Table>` component which forces all columns to share equal width regardless of content. On smaller viewports this causes the column headers (NAME, ARGUMENTS, RETURN TYPE, SECURITY) to overlap and stack on top of each other instead of rendering correctly side by side.

Additionally, `overflow-x-auto` was applied directly on the `<Table>` element which has no effect overflow scroll must be set on the parent wrapper element.

## Fix
- Removed `table-fixed` from `<Table>` and replaced with `min-w-[650px]`  so columns have natural widths
- Moved `overflow-x-auto` from `<Table>` to the `<Card>` wrapper so horizontal scroll works correctly on small screens
- Replaced `className="table-cell"` with proper `min-w` constraints on `<TableHead>` elements in the header row
- Added `min-w` constraints to each `<TableCell>` in the function rows so content doesn't collapse

## Files Changed
`apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionsList.tsx`
`apps/studio/components/interfaces/Database/Functions/FunctionsList/FunctionList.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced the database functions table layout with optimized column sizing for improved readability
  * Improved column width constraints for function names, arguments, and security information
  * Added horizontal scrolling support for better handling of longer content in the functions table

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->