### PR TITLE
docs(monitoring): add self-hosted monitoring guide

### DIFF
--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -2,4 +2,5 @@ volumes/db/data
 volumes/storage
 .env
 test.http
-docker-compose.override.yml
+/docker-compose.override.yml
+/docker-compose.metrics.yml

--- a/docker/.gitignore
+++ b/docker/.gitignore
@@ -1,5 +1,6 @@
 volumes/db/data
 volumes/storage
+volumes/monitoring/
 .env
 test.http
 /docker-compose.override.yml

--- a/docker/docs/monitoring/README.md
+++ b/docker/docs/monitoring/README.md
@@ -1,0 +1,240 @@
+# Monitoring Self-Hosted Supabase
+
+The [Supabase Metrics API](https://supabase.com/docs/guides/telemetry/metrics)
+is not available in self-hosted deployments. Each service exposes metrics
+independently — some are on by default, others require explicit activation.
+
+This guide documents what is available, how to enable it, and how to wire
+everything into a working observability stack. All endpoints were verified
+against the source code of each service and tested against a live self-hosted
+instance.
+
+---
+
+## Prerequisites
+
+This guide assumes you already have a self-hosted Supabase instance running
+via Docker Compose. If you haven't set that up yet:
+→ [Self-Hosting with Docker](https://supabase.com/docs/guides/self-hosting/docker)
+
+---
+
+## How it works
+
+Unlike Supabase Cloud, self-hosted Supabase has no single unified metrics
+endpoint. Each service exposes telemetry differently — some via the Prometheus
+client library, others via the OpenTelemetry SDK. Services fall into two
+categories:
+
+```
+┌──────────────────────────────────────────────────────────────────────┐
+│                     PROMETHEUS PULL                                  │
+│                                                                      │
+│  VictoriaMetrics ──scrapes──► Supavisor   supabase-pooler:4000       │
+│                  ──scrapes──► Realtime    realtime-dev.*:4000        │
+│                  ──scrapes──► Auth        supabase-auth:9100         │
+│                  ──scrapes──► Postgres    postgres-exporter:9187     │
+│                  ──scrapes──► Kong        supabase-kong:8001         │
+│                  ──scrapes──► Vector      supabase-vector:9598       │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+
+┌──────────────────────────────────────────────────────────────────────┐
+│                          OTEL PUSH                                   │
+│                                                                      │
+│  Storage ──pushes──► OTel Collector ──► VictoriaMetrics              │
+│                                                                      │
+│  Storage's /metrics route is only active in multi-tenant mode        │
+│  (Supabase Cloud internal). In standard self-hosted deployments,     │
+│  Storage metrics are collected via OTel push.                        │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Quick reference
+
+| Service | Repo | Endpoint | On by default | Auth |
+|---------|------|----------|---------------|------|
+| Supavisor | [supabase/supavisor](https://github.com/supabase/supavisor) | `:4000/metrics` | ✅ Yes | Bearer JWT (`ANON_KEY`) |
+| Realtime | [supabase/realtime](https://github.com/supabase/realtime) | `:4000/metrics` | ✅ Yes | Bearer JWT (`ANON_KEY`) |
+| Auth (GoTrue) | [supabase/auth](https://github.com/supabase/auth) | `:9100/` | ❌ Env vars needed | None |
+| PostgreSQL | [postgres_exporter](https://github.com/prometheus-community/postgres_exporter) | `:9187/metrics` | ❌ Sidecar needed | None |
+| Kong | [Kong/kong](https://github.com/Kong/kong) | `:8001/metrics` | ❌ Plugin + env var needed | None |
+| Storage | [supabase/storage](https://github.com/supabase/storage) | OTel push only | ❌ Env vars needed | — |
+| Vector | [vectordotdev/vector](https://github.com/vectordotdev/vector) | `:9598/metrics` | ❌ Config file needed | None |
+
+> **Note:** Supavisor and Realtime both use port `4000` but run in separate
+> containers — no conflict. Address them by container name:
+> `supabase-pooler:4000` and `realtime-dev.supabase-realtime:4000`.
+
+> **Note:** Kong's Admin API binds to `127.0.0.1` by default — unlike other
+> services which bind to `0.0.0.0`. Setting `KONG_ADMIN_LISTEN: "0.0.0.0:8001"`
+> opens it to the Docker network so VictoriaMetrics can reach it. Port `8001`
+> is not mapped to the host in the default `docker-compose.yml`.
+
+---
+
+## What's included
+
+### `examples/docker-compose.override.yml`
+
+Auth, Kong, Vector, and Storage do not expose metrics by default. This file
+adds the environment variables needed to activate them without modifying the
+original `docker-compose.yml`. Docker Compose automatically merges override
+files.
+
+- **Auth** — activates a Prometheus exporter on `:9100` via
+  `GOTRUE_METRICS_ENABLED=true`.
+- **Kong** — adds `prometheus` to `KONG_PLUGINS` and sets
+  `KONG_ADMIN_LISTEN: "0.0.0.0:8001"` to open the Admin API to the Docker
+  network.
+- **Vector** — mounts a second config file (`vector/metrics.yml`) alongside
+  the original `vector.yml` to add an internal metrics exporter on `:9598`.
+- **Storage** — enables OTel push via `OTEL_METRICS_ENABLED=true` and points
+  it at the OTel Collector.
+
+### `examples/vector/metrics.yml`
+
+A standalone Vector config that adds an `internal_metrics` source and a
+`prometheus_exporter` sink on `:9598`.
+
+### `examples/docker-compose.metrics.yml`
+
+Adds the monitoring stack:
+
+- **VictoriaMetrics** — Prometheus-compatible time series database. Scrapes
+  all six pull endpoints and stores them for querying via PromQL.
+- **postgres_exporter** — Postgres does not expose Prometheus metrics
+  natively. This sidecar connects to the Supabase Postgres container and
+  exposes metrics at `:9187/metrics`.
+- **OTel Collector** — receives Storage metrics via OTLP gRPC and forwards
+  them to VictoriaMetrics via Prometheus remote write.
+
+### `examples/victoriametrics/scrape.yml`
+
+VictoriaMetrics scrape configuration covering all six pull-based services.
+Uses `ANON_KEY` from your `.env` file for Bearer authentication on Supavisor
+and Realtime.
+
+### `examples/otelcol/config.yml`
+
+OTel Collector configuration. Sets up an OTLP gRPC receiver on `:4317` to
+accept Storage push and a Prometheus remote write exporter to forward metrics
+to VictoriaMetrics.
+
+---
+
+## Getting started
+
+**Step 1 — Stage runtime files**
+
+The example files in `docs/monitoring/examples/` are documentation. Copy them
+to the locations Docker Compose expects, alongside `docker-compose.yml`:
+
+```bash
+cd docker
+
+# Copy override and metrics compose files to the project root
+cp docs/monitoring/examples/docker-compose.override.yml .
+cp docs/monitoring/examples/docker-compose.metrics.yml .
+
+# Copy Vector metrics config alongside the existing vector.yml
+cp docs/monitoring/examples/vector/metrics.yml volumes/logs/vector.metrics.yml
+
+# Set up the monitoring volume with scrape config, OTel config, and JWT token
+mkdir -p volumes/monitoring/otelcol
+cp docs/monitoring/examples/victoriametrics/scrape.yml volumes/monitoring/
+cp docs/monitoring/examples/otelcol/config.yml volumes/monitoring/otelcol/
+grep '^ANON_KEY=' .env | cut -d= -f2 > volumes/monitoring/jwt
+```
+
+**Step 2 — Enable metrics endpoints**
+
+Apply the override file to activate metrics on Auth, Kong, Vector, and Storage:
+
+```bash
+docker compose up -d auth kong vector storage
+```
+
+**Step 3 — Verify each endpoint responds (1st check)**
+
+Confirm the endpoints are reachable inside the Docker network:
+
+```bash
+ANON_KEY=$(grep '^ANON_KEY=' .env | cut -d= -f2)
+
+# Supavisor — on by default, requires Bearer JWT
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s -H "Authorization: Bearer $ANON_KEY" \
+  http://supabase-pooler:4000/metrics | head -3
+
+# Realtime — on by default, requires Bearer JWT
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s -H "Authorization: Bearer $ANON_KEY" \
+  http://realtime-dev.supabase-realtime:4000/metrics | head -3
+
+# Auth — enabled by docker-compose.override.yml
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-auth:9100/ | head -3
+
+# Kong — enabled by docker-compose.override.yml
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-kong:8001/metrics | head -3
+
+# Vector — enabled by docker-compose.override.yml
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-vector:9598/metrics | head -3
+```
+
+**Step 4 — Bring up VictoriaMetrics, postgres_exporter, and OTel Collector**
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.override.yml \
+               -f docker-compose.metrics.yml up -d
+```
+
+**Step 5 — Verify all services are being scraped (2nd check)**
+
+Open `http://localhost:8428/targets` — all six targets should show state `UP`
+with zero errors.
+
+For Storage (which pushes via OTel rather than being scraped), confirm metrics
+arrived in VictoriaMetrics:
+
+```bash
+curl -s "http://localhost:8428/api/v1/label/__name__/values" | \
+  python3 -m json.tool | grep -E "nodejs|cache_entries|db_connections"
+```
+
+**Step 6 — Explore metrics**
+
+Open `http://localhost:8428/vmui` and try a query like
+`supavisor_prom_ex_cluster_size` or `kong_datastore_reachable`.
+
+---
+
+## Guides
+
+- **[Prometheus pull →](./prometheus-pull.md)** Source code references,
+  environment variables, key metrics, and scrape config for each pull-based
+  service.
+
+- **[OTel push →](./otel-push.md)** How Storage pushes metrics via the
+  OpenTelemetry SDK and how the OTel Collector forwards them to
+  VictoriaMetrics.
+
+---
+
+## Related
+
+- [Supabase Metrics API (cloud only)](https://supabase.com/docs/guides/telemetry/metrics)
+- [Self-hosting with Docker](https://supabase.com/docs/guides/self-hosting/docker)
+- [Supavisor metrics documentation](https://supabase.github.io/supavisor/monitoring/metrics/)
+- [postgres_exporter](https://github.com/prometheus-community/postgres_exporter)
+- [Kong Prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/)
+- [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)
+- [Vector internal_metrics](https://vector.dev/docs/reference/configuration/sources/internal_metrics/)
+- [VictoriaMetrics](https://victoriametrics.com/)

--- a/docker/docs/monitoring/README.md
+++ b/docker/docs/monitoring/README.md
@@ -1,31 +1,32 @@
-# Monitoring Self-Hosted Supabase
 
+# Monitoring Self-Hosted Supabase
+ 
 The [Supabase Metrics API](https://supabase.com/docs/guides/telemetry/metrics)
 is not available in self-hosted deployments. Each service exposes metrics
 independently — some are on by default, others require explicit activation.
-
+ 
 This guide documents what is available, how to enable it, and how to wire
 everything into a working observability stack. All endpoints were verified
 against the source code of each service and tested against a live self-hosted
 instance.
-
+ 
 ---
-
+ 
 ## Prerequisites
-
+ 
 This guide assumes you already have a self-hosted Supabase instance running
 via Docker Compose. If you haven't set that up yet:
 → [Self-Hosting with Docker](https://supabase.com/docs/guides/self-hosting/docker)
-
+ 
 ---
-
+ 
 ## How it works
-
+ 
 Unlike Supabase Cloud, self-hosted Supabase has no single unified metrics
 endpoint. Each service exposes telemetry differently — some via the Prometheus
 client library, others via the OpenTelemetry SDK. Services fall into two
 categories:
-
+ 
 ```
 ┌──────────────────────────────────────────────────────────────────────┐
 │                     PROMETHEUS PULL                                  │
@@ -34,11 +35,13 @@ categories:
 │                  ──scrapes──► Realtime    realtime-dev.*:4000        │
 │                  ──scrapes──► Auth        supabase-auth:9100         │
 │                  ──scrapes──► Postgres    postgres-exporter:9187     │
-│                  ──scrapes──► Kong        supabase-kong:8001         │
+│                  ──scrapes──► Kong        supabase-kong:8001  (↓)    │
+│                  ──scrapes──► Envoy       supabase-envoy:9901        │
 │                  ──scrapes──► Vector      supabase-vector:9598       │
 │                                                                      │
+│  (↓) Kong will be deprecated soon. Envoy is its replacement.         │
 └──────────────────────────────────────────────────────────────────────┘
-
+ 
 ┌──────────────────────────────────────────────────────────────────────┐
 │                          OTEL PUSH                                   │
 │                                                                      │
@@ -50,191 +53,257 @@ categories:
 │                                                                      │
 └──────────────────────────────────────────────────────────────────────┘
 ```
-
+ 
 ---
-
+ 
 ## Quick reference
-
+ 
 | Service | Repo | Endpoint | On by default | Auth |
 |---------|------|----------|---------------|------|
 | Supavisor | [supabase/supavisor](https://github.com/supabase/supavisor) | `:4000/metrics` | ✅ Yes | Bearer JWT (`ANON_KEY`) |
 | Realtime | [supabase/realtime](https://github.com/supabase/realtime) | `:4000/metrics` | ✅ Yes | Bearer JWT (`ANON_KEY`) |
 | Auth (GoTrue) | [supabase/auth](https://github.com/supabase/auth) | `:9100/` | ❌ Env vars needed | None |
 | PostgreSQL | [postgres_exporter](https://github.com/prometheus-community/postgres_exporter) | `:9187/metrics` | ❌ Sidecar needed | None |
-| Kong | [Kong/kong](https://github.com/Kong/kong) | `:8001/metrics` | ❌ Plugin + env var needed | None |
+| Kong *(deprecation pending)* | [Kong/kong](https://github.com/Kong/kong) | `:8001/metrics` | ❌ Plugin + env var needed | None |
+| Envoy | [envoyproxy/envoy](https://github.com/envoyproxy/envoy) | `:9901/stats/prometheus` | ❌ Admin bind address needed | None |
 | Storage | [supabase/storage](https://github.com/supabase/storage) | OTel push only | ❌ Env vars needed | — |
 | Vector | [vectordotdev/vector](https://github.com/vectordotdev/vector) | `:9598/metrics` | ❌ Config file needed | None |
-
+ 
 > **Note:** Supavisor and Realtime both use port `4000` but run in separate
 > containers — no conflict. Address them by container name:
 > `supabase-pooler:4000` and `realtime-dev.supabase-realtime:4000`.
-
-> **Note:** Kong's Admin API binds to `127.0.0.1` by default — unlike other
-> services which bind to `0.0.0.0`. Setting `KONG_ADMIN_LISTEN: "0.0.0.0:8001"`
-> opens it to the Docker network so VictoriaMetrics can reach it. Port `8001`
-> is not mapped to the host in the default `docker-compose.yml`.
-
+ 
+> **Note:** Kong will be deprecated soon in the self-hosted stack. The optional
+> [Envoy gateway](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy)
+> (`docker-compose.envoy.yml`) is its replacement.
+ 
+> **Note:** Both Kong (`:8001`) and Envoy (`:9901`) expose admin APIs that go
+> beyond metrics — Kong's Admin API can modify routes and plugins; Envoy's
+> `/config_dump` exposes API keys and JWTs in plaintext. Keep these ports
+> internal to the Docker network — do not map them to the host.
+> See [Kong security guide](https://developer.konghq.com/gateway/secure-the-admin-api/)
+> and [Envoy security hardening](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#security-hardening).
+ 
 ---
-
+ 
 ## What's included
-
+ 
 ### `examples/docker-compose.override.yml`
-
+ 
 Auth, Kong, Vector, and Storage do not expose metrics by default. This file
 adds the environment variables needed to activate them without modifying the
 original `docker-compose.yml`. Docker Compose automatically merges override
 files.
-
+ 
 - **Auth** — activates a Prometheus exporter on `:9100` via
   `GOTRUE_METRICS_ENABLED=true`.
-- **Kong** — adds `prometheus` to `KONG_PLUGINS` and sets
+- **Kong** *(deprecation pending)* — adds `prometheus` to `KONG_PLUGINS` and sets
   `KONG_ADMIN_LISTEN: "0.0.0.0:8001"` to open the Admin API to the Docker
-  network.
+  network. If you are using Envoy instead, this section can be omitted.
 - **Vector** — mounts a second config file (`vector/metrics.yml`) alongside
   the original `vector.yml` to add an internal metrics exporter on `:9598`.
 - **Storage** — enables OTel push via `OTEL_METRICS_ENABLED=true` and points
   it at the OTel Collector.
-
 ### `examples/vector/metrics.yml`
-
+ 
 A standalone Vector config that adds an `internal_metrics` source and a
 `prometheus_exporter` sink on `:9598`.
-
+ 
 ### `examples/docker-compose.metrics.yml`
-
+ 
 Adds the monitoring stack:
-
+ 
 - **VictoriaMetrics** — Prometheus-compatible time series database. Scrapes
-  all six pull endpoints and stores them for querying via PromQL.
+  all pull endpoints and stores them for querying via PromQL.
 - **postgres_exporter** — Postgres does not expose Prometheus metrics
   natively. This sidecar connects to the Supabase Postgres container and
   exposes metrics at `:9187/metrics`.
 - **OTel Collector** — receives Storage metrics via OTLP gRPC and forwards
   them to VictoriaMetrics via Prometheus remote write.
-
 ### `examples/victoriametrics/scrape.yml`
-
-VictoriaMetrics scrape configuration covering all six pull-based services.
+ 
+VictoriaMetrics scrape configuration covering all pull-based services.
 Uses `ANON_KEY` from your `.env` file for Bearer authentication on Supavisor
-and Realtime.
-
+and Realtime. Includes both Kong and Envoy scrape jobs — enable whichever
+gateway you are running.
+ 
 ### `examples/otelcol/config.yml`
-
+ 
 OTel Collector configuration. Sets up an OTLP gRPC receiver on `:4317` to
 accept Storage push and a Prometheus remote write exporter to forward metrics
 to VictoriaMetrics.
-
+ 
 ---
-
+ 
 ## Getting started
-
+ 
 **Step 1 — Stage runtime files**
-
+ 
 The example files in `docs/monitoring/examples/` are documentation. Copy them
 to the locations Docker Compose expects, alongside `docker-compose.yml`:
-
+ 
 ```bash
 cd docker
-
+ 
 # Copy override and metrics compose files to the project root
 cp docs/monitoring/examples/docker-compose.override.yml .
 cp docs/monitoring/examples/docker-compose.metrics.yml .
-
+ 
 # Copy Vector metrics config alongside the existing vector.yml
 cp docs/monitoring/examples/vector/metrics.yml volumes/logs/vector.metrics.yml
-
+ 
 # Set up the monitoring volume with scrape config, OTel config, and JWT token
 mkdir -p volumes/monitoring/otelcol
 cp docs/monitoring/examples/victoriametrics/scrape.yml volumes/monitoring/
 cp docs/monitoring/examples/otelcol/config.yml volumes/monitoring/otelcol/
 grep '^ANON_KEY=' .env | cut -d= -f2 > volumes/monitoring/jwt
 ```
-
+ 
 **Step 2 — Enable metrics endpoints**
-
-Apply the override file to activate metrics on Auth, Kong, Vector, and Storage:
-
+ 
+> **Note:** This step assumes the full Supabase stack is already running. If
+> you haven't started it yet, follow the [Self-Hosting with Docker](https://supabase.com/docs/guides/self-hosting/docker)
+> guide first, then return here.
+ 
+Activate metrics on Auth, Vector, and Storage (required regardless of which gateway you use):
+ 
 ```bash
-docker compose up -d auth kong vector storage
+docker compose up -d auth vector storage
 ```
-
+ 
+_Gateway (choose one):_
+ 
+_Option A — Kong (default)_
+ 
+```bash
+docker compose up -d kong
+```
+ 
+_Option B — Envoy_
+ 
+Change the admin bind address in `volumes/api/envoy/envoy.yaml`:
+ 
+```yaml
+# volumes/api/envoy/envoy.yaml
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0  # changed from 127.0.0.1
+      port_value: 9901
+```
+ 
+> **Note:** This is a direct edit to `volumes/api/envoy/envoy.yaml`. Unlike
+> other services in this guide, Envoy does not support overriding the admin
+> bind address via environment variables — editing the config file directly
+> is the only option.
+>
+> This opens the admin interface to the Docker network so VictoriaMetrics can
+> scrape it. See [Metrics Security →](./security.md#envoy) for what this
+> exposes and how to keep it safe.
+ 
+Then stop Kong (both gateways bind to host port 8000 and cannot run simultaneously)
+and start Envoy:
+ 
+```bash
+docker compose stop kong
+docker compose -f docker-compose.yml -f docker-compose.envoy.yml up -d api-gw
+```
+ 
 **Step 3 — Verify each endpoint responds (1st check)**
-
+ 
 Confirm the endpoints are reachable inside the Docker network:
-
+ 
 ```bash
 ANON_KEY=$(grep '^ANON_KEY=' .env | cut -d= -f2)
-
+ 
 # Supavisor — on by default, requires Bearer JWT
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s -H "Authorization: Bearer $ANON_KEY" \
   http://supabase-pooler:4000/metrics | head -3
-
+ 
 # Realtime — on by default, requires Bearer JWT
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s -H "Authorization: Bearer $ANON_KEY" \
   http://realtime-dev.supabase-realtime:4000/metrics | head -3
-
-# Auth — enabled by docker-compose.override.yml
+ 
+# Auth
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-auth:9100/ | head -3
-
-# Kong — enabled by docker-compose.override.yml
+ 
+# Option A — Kong
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-kong:8001/metrics | head -3
-
-# Vector — enabled by docker-compose.override.yml
+ 
+# Option B — Envoy
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-envoy:9901/stats/prometheus | head -3
+ 
+# Vector
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-vector:9598/metrics | head -3
 ```
-
+ 
 **Step 4 — Bring up VictoriaMetrics, postgres_exporter, and OTel Collector**
-
+ 
+_Option A — Kong_
+ 
 ```bash
 docker compose -f docker-compose.yml \
                -f docker-compose.override.yml \
                -f docker-compose.metrics.yml up -d
 ```
-
+ 
+_Option B — Envoy_
+ 
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.metrics.yml up -d
+```
+ 
 **Step 5 — Verify all services are being scraped (2nd check)**
-
-Open `http://localhost:8428/targets` — all six targets should show state `UP`
+ 
+Open `http://localhost:8428/targets` — all active targets should show state `UP`
 with zero errors.
-
+ 
 For Storage (which pushes via OTel rather than being scraped), confirm metrics
 arrived in VictoriaMetrics:
-
+ 
 ```bash
 curl -s "http://localhost:8428/api/v1/label/__name__/values" | \
   python3 -m json.tool | grep -E "nodejs|cache_entries|db_connections"
 ```
-
+ 
 **Step 6 — Explore metrics**
-
+ 
 Open `http://localhost:8428/vmui` and try a query like
-`supavisor_prom_ex_cluster_size` or `kong_datastore_reachable`.
-
+`supavisor_prom_ex_cluster_size`, `envoy_cluster_upstream_rq_total`, or
+`vector_component_received_events_total`.
+ 
 ---
-
+ 
 ## Guides
-
+ 
 - **[Prometheus pull →](./prometheus-pull.md)** Source code references,
   environment variables, key metrics, and scrape config for each pull-based
   service.
-
 - **[OTel push →](./otel-push.md)** How Storage pushes metrics via the
   OpenTelemetry SDK and how the OTel Collector forwards them to
   VictoriaMetrics.
-
+- **[Security →](./security.md)** Security properties of each metrics
+  endpoint, admin API exposure risks, and production hardening recommendations.
 ---
-
+ 
 ## Related
-
+ 
 - [Supabase Metrics API (cloud only)](https://supabase.com/docs/guides/telemetry/metrics)
 - [Self-hosting with Docker](https://supabase.com/docs/guides/self-hosting/docker)
+- [Envoy API Gateway (self-hosted)](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy)
 - [Supavisor metrics documentation](https://supabase.github.io/supavisor/monitoring/metrics/)
 - [postgres_exporter](https://github.com/prometheus-community/postgres_exporter)
-- [Kong Prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/)
+- [Kong Prometheus plugin](https://developer.konghq.com/plugins/prometheus/)
+- [Envoy Admin API](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
 - [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)
 - [Vector internal_metrics](https://vector.dev/docs/reference/configuration/sources/internal_metrics/)
 - [VictoriaMetrics](https://victoriametrics.com/)
+- [Security reference](./security.md)
+ 

--- a/docker/docs/monitoring/README.md
+++ b/docker/docs/monitoring/README.md
@@ -37,6 +37,8 @@ categories:
 │                  ──scrapes──► Postgres    postgres-exporter:9187     │
 │                  ──scrapes──► Kong        supabase-kong:8001  (↓)    │
 │                  ──scrapes──► Envoy       supabase-envoy:9901        │
+│                  ──scrapes──► PostgREST   supabase-rest:3001         │
+│                  ──scrapes──► imgproxy    supabase-imgproxy:8081     │
 │                  ──scrapes──► Vector      supabase-vector:9598       │
 │                                                                      │
 │  (↓) Kong will be deprecated soon. Envoy is its replacement.         │
@@ -66,6 +68,8 @@ categories:
 | PostgreSQL | [postgres_exporter](https://github.com/prometheus-community/postgres_exporter) | `:9187/metrics` | ❌ Sidecar needed | None |
 | Kong *(deprecation pending)* | [Kong/kong](https://github.com/Kong/kong) | `:8001/metrics` | ❌ Plugin + env var needed | None |
 | Envoy | [envoyproxy/envoy](https://github.com/envoyproxy/envoy) | `:9901/stats/prometheus` | ❌ Admin bind address needed | None |
+| PostgREST | [PostgREST/postgrest](https://github.com/PostgREST/postgrest) | `:3001/metrics` | ❌ Env var needed | None |
+| imgproxy | [imgproxy/imgproxy](https://github.com/imgproxy/imgproxy) | `:8081/metrics` | ❌ Env var needed | None |
 | Storage | [supabase/storage](https://github.com/supabase/storage) | OTel push only | ❌ Env vars needed | — |
 | Vector | [vectordotdev/vector](https://github.com/vectordotdev/vector) | `:9598/metrics` | ❌ Config file needed | None |
  
@@ -100,6 +104,8 @@ files.
 - **Kong** *(deprecation pending)* — adds `prometheus` to `KONG_PLUGINS` and sets
   `KONG_ADMIN_LISTEN: "0.0.0.0:8001"` to open the Admin API to the Docker
   network. If you are using Envoy instead, this section can be omitted.
+- **PostgREST** — enables the admin server on `:3001` via `PGRST_ADMIN_SERVER_PORT`.
+- **imgproxy** — enables the Prometheus metrics server on `:8081` via `IMGPROXY_PROMETHEUS_BIND`.
 - **Vector** — mounts a second config file (`vector/metrics.yml`) alongside
   the original `vector.yml` to add an internal metrics exporter on `:9598`.
 - **Storage** — enables OTel push via `OTEL_METRICS_ENABLED=true` and points
@@ -171,15 +177,18 @@ Activate metrics on Auth, Vector, and Storage (required regardless of which gate
 docker compose up -d auth vector storage
 ```
  
-_Gateway (choose one):_
+**Gateway — choose one:**
  
-_Option A — Kong (default)_
+> ⚠️ Kong and Envoy both bind to host port `8000` and cannot run simultaneously.
+> If you are switching gateways, stop the currently running one first.
+ 
+### *Option A — Kong (default)*
  
 ```bash
 docker compose up -d kong
 ```
  
-_Option B — Envoy_
+### *Option B — Envoy*
  
 Change the admin bind address in `volumes/api/envoy/envoy.yaml`:
  
@@ -201,14 +210,15 @@ admin:
 > scrape it. See [Metrics Security →](./security.md#envoy) for what this
 > exposes and how to keep it safe.
  
-Then stop Kong (both gateways bind to host port 8000 and cannot run simultaneously)
-and start Envoy:
- 
 ```bash
-docker compose stop kong
 docker compose -f docker-compose.yml -f docker-compose.envoy.yml up -d api-gw
 ```
- 
+
+> If Envoy cannot reach other services after starting, re-run with `--force-recreate`:
+> ```bash
+> docker compose -f docker-compose.yml -f docker-compose.envoy.yml up -d api-gw --force-recreate
+> ```
+
 **Step 3 — Verify each endpoint responds (1st check)**
  
 Confirm the endpoints are reachable inside the Docker network:
@@ -238,6 +248,14 @@ docker run --rm --network supabase_default curlimages/curl:latest \
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-envoy:9901/stats/prometheus | head -3
  
+# PostgREST
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-rest:3001/metrics | head -3
+ 
+# imgproxy
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-imgproxy:8081/metrics | head -3
+ 
 # Vector
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-vector:9598/metrics | head -3
@@ -245,7 +263,7 @@ docker run --rm --network supabase_default curlimages/curl:latest \
  
 **Step 4 — Bring up VictoriaMetrics, postgres_exporter, and OTel Collector**
  
-_Option A — Kong_
+### *Option A — Kong*
  
 ```bash
 docker compose -f docker-compose.yml \
@@ -253,7 +271,7 @@ docker compose -f docker-compose.yml \
                -f docker-compose.metrics.yml up -d
 ```
  
-_Option B — Envoy_
+### *Option B — Envoy*
  
 ```bash
 docker compose -f docker-compose.yml \

--- a/docker/docs/monitoring/examples/docker-compose.metrics.yml
+++ b/docker/docs/monitoring/examples/docker-compose.metrics.yml
@@ -1,0 +1,85 @@
+# docker-compose.metrics.yml
+#
+# Adds VictoriaMetrics, postgres_exporter, and OTel Collector to your
+# existing self-hosted Supabase stack.
+#
+# Usage:
+#   Copy this file to docker/ alongside docker-compose.yml. Then:
+#
+#     docker compose -f docker-compose.yml \
+#                    -f docker-compose.override.yml \
+#                    -f docker-compose.metrics.yml up -d
+#
+# See docs/monitoring/README.md for the full setup guide.
+
+services:
+
+  # ---------------------------------------------------------------------------
+  # VictoriaMetrics — metrics storage and scraping
+  #
+  # Prometheus-compatible time series database. Scrapes all Supabase pull
+  # endpoints and accepts Storage metrics forwarded by the OTel Collector.
+  #
+  # Targets page: http://localhost:8428/targets
+  # Query UI:     http://localhost:8428/vmui
+  # ---------------------------------------------------------------------------
+  victoriametrics:
+    image: victoriametrics/victoria-metrics:v1.122.0
+    container_name: supabase-victoriametrics
+    restart: unless-stopped
+    ports:
+      - "8428:8428"
+    volumes:
+      - ./volumes/monitoring/victoriametrics:/victoria-metrics-data
+      - ./volumes/monitoring/scrape.yml:/scrape.yml:ro
+      - ./volumes/monitoring/jwt:/etc/vm/jwt:ro
+    command:
+      - -storageDataPath=/victoria-metrics-data
+      - -retentionPeriod=30d
+      - -promscrape.config=/scrape.yml
+      - -httpListenAddr=:8428
+    networks:
+      - default
+    depends_on:
+      db:
+        condition: service_healthy
+
+  # ---------------------------------------------------------------------------
+  # postgres_exporter — Postgres metrics sidecar
+  #
+  # Postgres does not expose Prometheus metrics natively. This sidecar
+  # connects to the Supabase Postgres container and exposes metrics at
+  # :9187/metrics for VictoriaMetrics to scrape.
+  # ---------------------------------------------------------------------------
+  postgres-exporter:
+    image: quay.io/prometheuscommunity/postgres-exporter:v0.19.1
+    container_name: supabase-postgres-exporter
+    restart: unless-stopped
+    environment:
+      DATA_SOURCE_NAME: "postgresql://postgres:${POSTGRES_PASSWORD}@db:5432/postgres?sslmode=disable"
+    networks:
+      - default
+    depends_on:
+      db:
+        condition: service_healthy
+
+  # ---------------------------------------------------------------------------
+  # OTel Collector — receives Storage metrics
+  #
+  # Storage uses the OpenTelemetry SDK and pushes metrics via gRPC every 60s.
+  # The Collector receives them on :4317 and forwards to VictoriaMetrics via
+  # Prometheus remote write. See docs/monitoring/otel-push.md.
+  # ---------------------------------------------------------------------------
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.152.0
+    container_name: supabase-otel-collector
+    restart: unless-stopped
+    volumes:
+      - ./volumes/monitoring/otelcol/config.yml:/etc/otelcol-contrib/config.yaml:ro
+    networks:
+      - default
+
+networks:
+  default:
+    name: ${COMPOSE_PROJECT_NAME:-supabase}_default
+    external: true

--- a/docker/docs/monitoring/examples/docker-compose.override.yml
+++ b/docker/docs/monitoring/examples/docker-compose.override.yml
@@ -1,0 +1,52 @@
+# docker-compose.override.yml
+#
+# Enables Prometheus metrics on Auth, Kong, and Vector, and OTel push
+# on Storage. These services do not expose metrics in the default self-hosted
+# configuration.
+#
+# Usage:
+#   Copy this file to docker/ alongside docker-compose.yml.
+#   Docker Compose automatically merges override files.
+#
+#     cp docs/monitoring/examples/docker-compose.override.yml .
+#     docker compose up -d auth kong vector storage
+#
+# See docs/monitoring/README.md for the full setup guide.
+
+services:
+  auth:
+    environment:
+      # OTel SDK with Prometheus exporter — exposes /metrics on :9100
+      # See: internal/conf/metrics.go in supabase/auth
+      GOTRUE_METRICS_ENABLED: "true"
+      GOTRUE_METRICS_EXPORTER: "prometheus"
+      OTEL_EXPORTER_PROMETHEUS_HOST: "0.0.0.0"
+      OTEL_EXPORTER_PROMETHEUS_PORT: "9100"
+
+  kong:
+    environment:
+      # Add prometheus plugin to the default Supabase plugin list
+      KONG_PLUGINS: >-
+        request-transformer,cors,key-auth,acl,basic-auth,
+        request-termination,ip-restriction,post-function,prometheus
+      # Kong Admin API binds to 127.0.0.1 by default; this opens it to the Docker network
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+
+  vector:
+    # Mount the metrics config alongside the original vector.yml without modifying it
+    volumes:
+      - ./volumes/logs/vector.yml:/etc/vector/vector.yml:ro,z
+      - ./volumes/logs/vector.metrics.yml:/etc/vector/vector.metrics.yml:ro,z
+      - ${DOCKER_SOCKET_LOCATION}:/var/run/docker.sock:ro,z
+    command:
+      - "--config"
+      - "/etc/vector/vector.yml"
+      - "--config"
+      - "/etc/vector/vector.metrics.yml"
+
+  storage:
+    environment:
+      # Storage uses OTel push (not Prometheus pull) for metrics in self-hosted mode.
+      # The OTel Collector is defined in docker-compose.metrics.yml.
+      OTEL_METRICS_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"

--- a/docker/docs/monitoring/examples/docker-compose.override.yml
+++ b/docker/docs/monitoring/examples/docker-compose.override.yml
@@ -1,8 +1,8 @@
 # docker-compose.override.yml
 #
-# Enables Prometheus metrics on Auth, Kong, and Vector, and OTel push
-# on Storage. These services do not expose metrics in the default self-hosted
-# configuration.
+# Enables Prometheus metrics on Auth, Kong, PostgREST, imgproxy, and Vector,
+# and OTel push on Storage. These services do not expose metrics in the default
+# self-hosted configuration.
 #
 # Usage:
 #   Copy this file to docker/ alongside docker-compose.yml.
@@ -31,6 +31,19 @@ services:
         request-termination,ip-restriction,post-function,prometheus
       # Kong Admin API binds to 127.0.0.1 by default; this opens it to the Docker network
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"
+
+  rest:
+    environment:
+      # Enables the PostgREST admin server — exposes /metrics on :3001
+      # See: https://docs.postgrest.org/en/v14/references/admin_server.html
+      PGRST_ADMIN_SERVER_PORT: "3001"
+
+  imgproxy:
+    environment:
+      # Enables the imgproxy Prometheus metrics server on :8081
+      # Must differ from the main imgproxy port (8080)
+      # See: https://docs.imgproxy.net/monitoring/prometheus
+      IMGPROXY_PROMETHEUS_BIND: ":8081"
 
   vector:
     # Mount the metrics config alongside the original vector.yml without modifying it

--- a/docker/docs/monitoring/examples/otelcol/config.yml
+++ b/docker/docs/monitoring/examples/otelcol/config.yml
@@ -1,0 +1,25 @@
+# OTel Collector config for receiving Storage metrics.
+#
+# - Storage pushes metrics via OTLP gRPC every 60s
+# - Collector forwards them to VictoriaMetrics via Prometheus remote write
+# - debug exporter logs received metrics (useful for verification)
+#
+# See docs/monitoring/otel-push.md for the full setup guide.
+
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  debug:
+    verbosity: detailed
+  prometheusremotewrite:
+    endpoint: http://supabase-victoriametrics:8428/api/v1/write
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug, prometheusremotewrite]

--- a/docker/docs/monitoring/examples/vector/metrics.yml
+++ b/docker/docs/monitoring/examples/vector/metrics.yml
@@ -1,0 +1,20 @@
+# Vector internal metrics config.
+#
+# Mounted alongside the original vector.yml (not modifying it) to add a
+# Prometheus exporter for Vector's own operational metrics.
+#
+# Exposes Vector internal metrics at :9598/metrics including:
+# - Events received/sent per component
+# - Component errors
+# - Buffer utilization
+
+sources:
+  internal_metrics:
+    type: internal_metrics
+
+sinks:
+  prometheus_exporter:
+    type: prometheus_exporter
+    inputs:
+      - internal_metrics
+    address: "0.0.0.0:9598"

--- a/docker/docs/monitoring/examples/victoriametrics/scrape.yml
+++ b/docker/docs/monitoring/examples/victoriametrics/scrape.yml
@@ -1,0 +1,70 @@
+# VictoriaMetrics scrape configuration for self-hosted Supabase.
+#
+# Mounted into the VictoriaMetrics container by docker-compose.metrics.yml.
+#
+# Bearer JWT for Supavisor and Realtime: ANON_KEY from your .env file.
+# Generate the jwt file with:
+#   grep '^ANON_KEY=' .env | cut -d= -f2 > volumes/monitoring/jwt
+
+global:
+  scrape_interval: 60s
+
+scrape_configs:
+
+  # Supavisor — connection pooler, on by default, requires Bearer JWT
+  - job_name: supabase-supavisor
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials_file: /etc/vm/jwt
+    static_configs:
+      - targets: ["supabase-pooler:4000"]
+        labels:
+          service: supavisor
+
+  # Realtime — on by default, requires Bearer JWT
+  - job_name: supabase-realtime
+    metrics_path: /metrics
+    authorization:
+      type: Bearer
+      credentials_file: /etc/vm/jwt
+    static_configs:
+      - targets: ["realtime-dev.supabase-realtime:4000"]
+        labels:
+          service: realtime
+
+  # Auth (GoTrue) — requires GOTRUE_METRICS_ENABLED=true
+  # (see docker-compose.override.yml)
+  - job_name: supabase-auth
+    metrics_path: /
+    static_configs:
+      - targets: ["supabase-auth:9100"]
+        labels:
+          service: auth
+
+  # PostgreSQL — via postgres_exporter sidecar
+  # (added by docker-compose.metrics.yml)
+  - job_name: supabase-postgres
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["postgres-exporter:9187"]
+        labels:
+          service: postgres
+
+  # Kong — requires prometheus plugin + KONG_ADMIN_LISTEN=0.0.0.0:8001
+  # (see docker-compose.override.yml)
+  - job_name: supabase-kong
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["supabase-kong:8001"]
+        labels:
+          service: kong
+
+  # Vector — requires vector.metrics.yml mounted alongside vector.yml
+  # (see docker-compose.override.yml)
+  - job_name: supabase-vector
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["supabase-vector:9598"]
+        labels:
+          service: vector

--- a/docker/docs/monitoring/examples/victoriametrics/scrape.yml
+++ b/docker/docs/monitoring/examples/victoriametrics/scrape.yml
@@ -5,6 +5,10 @@
 # Bearer JWT for Supavisor and Realtime: ANON_KEY from your .env file.
 # Generate the jwt file with:
 #   grep '^ANON_KEY=' .env | cut -d= -f2 > volumes/monitoring/jwt
+#
+# API gateway: Supabase ships with Kong (default) and Envoy (optional).
+# Kong will be deprecated soon — Envoy is its replacement.
+# Enable the scrape job that matches your active gateway.
 
 global:
   scrape_interval: 60s
@@ -51,7 +55,8 @@ scrape_configs:
         labels:
           service: postgres
 
-  # Kong — requires prometheus plugin + KONG_ADMIN_LISTEN=0.0.0.0:8001
+  # Kong API Gateway (deprecation pending — use Envoy job below if on Envoy)
+  # Requires prometheus plugin + KONG_ADMIN_LISTEN=0.0.0.0:8001
   # (see docker-compose.override.yml)
   - job_name: supabase-kong
     metrics_path: /metrics
@@ -60,7 +65,20 @@ scrape_configs:
         labels:
           service: kong
 
-  # Vector — requires vector.metrics.yml mounted alongside vector.yml
+  # Envoy API Gateway (replaces Kong)
+  # Requires admin address set to 0.0.0.0 in volumes/api/envoy/envoy.yaml
+  # Only applies when running with docker-compose.envoy.yml
+  # ⚠️ Keep port 9901 internal to the Docker network — do not map to host.
+  #    See: https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#security-hardening
+  - job_name: supabase-envoy
+    metrics_path: /stats/prometheus
+    static_configs:
+      - targets: ["supabase-envoy:9901"]
+        labels:
+          service: envoy
+
+  # Vector (log pipeline)
+  # Requires vector.metrics.yml mounted alongside vector.yml
   # (see docker-compose.override.yml)
   - job_name: supabase-vector
     metrics_path: /metrics

--- a/docker/docs/monitoring/examples/victoriametrics/scrape.yml
+++ b/docker/docs/monitoring/examples/victoriametrics/scrape.yml
@@ -77,6 +77,24 @@ scrape_configs:
         labels:
           service: envoy
 
+  # PostgREST — requires PGRST_ADMIN_SERVER_PORT=3001
+  # (see docker-compose.override.yml)
+  - job_name: supabase-rest
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["supabase-rest:3001"]
+        labels:
+          service: rest
+
+  # imgproxy — requires IMGPROXY_PROMETHEUS_BIND=:8081
+  # (see docker-compose.override.yml)
+  - job_name: supabase-imgproxy
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["supabase-imgproxy:8081"]
+        labels:
+          service: imgproxy
+
   # Vector (log pipeline)
   # Requires vector.metrics.yml mounted alongside vector.yml
   # (see docker-compose.override.yml)

--- a/docker/docs/monitoring/otel-push.md
+++ b/docker/docs/monitoring/otel-push.md
@@ -146,7 +146,7 @@ curl -s "http://localhost:8428/api/v1/label/__name__/values" | \
 ## Related
 
 - [Overview → Full service reference and getting started guide](./README.md)
-- [Prometheus pull → Supavisor, Realtime, Auth, Postgres, Kong, Vector](./prometheus-pull.md)
+- [Prometheus pull → Supavisor, Realtime, Auth, Postgres, Kong, Envoy, Vector](./prometheus-pull.md)
 - [docker-compose.override.yml → Enables Storage OTel push](./examples/docker-compose.override.yml)
 - [docker-compose.metrics.yml → Defines OTel Collector and VictoriaMetrics](./examples/docker-compose.metrics.yml)
 - [otelcol/config.yml → OTel Collector configuration](./examples/otelcol/config.yml)

--- a/docker/docs/monitoring/otel-push.md
+++ b/docker/docs/monitoring/otel-push.md
@@ -1,0 +1,155 @@
+# OTel Push — Storage Metrics
+
+Storage is the only service in the self-hosted Supabase stack that does not
+expose a Prometheus pull endpoint. Instead, it uses the OpenTelemetry SDK to
+push metrics to an OTel Collector.
+
+This is a deliberate design choice in the Storage source code — the `/metrics`
+HTTP route only activates in multi-tenant mode, which is internal to Supabase
+Cloud. In single-tenant (self-hosted) deployments, OTel push is the only way
+to collect Storage metrics.
+
+**Source:**
+[src/internal/monitoring/otel-metrics.ts](https://github.com/supabase/storage/blob/master/src/internal/monitoring/otel-metrics.ts) ·
+[src/start/server.ts](https://github.com/supabase/storage/blob/master/src/start/server.ts)
+
+---
+
+## How it works
+
+```
+Storage (Node.js)
+    │
+    │  OTel gRPC push (every 60s)
+    │  OTEL_EXPORTER_OTLP_ENDPOINT
+    ▼
+OTel Collector
+    │
+    │  Prometheus remote write
+    ▼
+VictoriaMetrics
+```
+
+Storage pushes metrics every 60 seconds via gRPC to the OTel Collector. The
+Collector forwards them to VictoriaMetrics via Prometheus remote write.
+
+---
+
+## Setup
+
+### 1. OTel Collector config
+
+[`examples/otelcol/config.yml`](./examples/otelcol/config.yml) is included in
+this repository. It configures:
+
+- an OTLP gRPC receiver on `:4317` to accept Storage push
+- a debug exporter to log received metrics (useful for verification)
+- a Prometheus remote write exporter to forward metrics to VictoriaMetrics
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  debug:
+    verbosity: detailed
+  prometheusremotewrite:
+    endpoint: http://supabase-victoriametrics:8428/api/v1/write
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      exporters: [debug, prometheusremotewrite]
+```
+
+### 2. Enable Storage OTel push
+
+Add to `docker-compose.override.yml` (already included):
+
+```yaml
+services:
+  storage:
+    environment:
+      OTEL_METRICS_ENABLED: "true"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4317"
+```
+
+The OTel Collector itself is defined in `docker-compose.metrics.yml` alongside
+VictoriaMetrics.
+
+### 3. Apply
+
+```bash
+docker compose -f docker-compose.yml \
+               -f docker-compose.override.yml \
+               -f docker-compose.metrics.yml up -d
+```
+
+---
+
+## Verify
+
+**Step 1 — Storage is pushing to OTel Collector:**
+
+```bash
+docker logs supabase-storage 2>&1 | grep -i "otel"
+```
+
+Expected output:
+```
+[OTel Metrics] Initializing
+[OTel Metrics] OTLP exporter configured
+[OTel Metrics] Initialized
+```
+
+**Step 2 — OTel Collector is receiving metrics:**
+
+Wait 60 seconds for the first push, then:
+
+```bash
+docker logs supabase-otel-collector 2>&1 | grep "resource metrics"
+```
+
+Expected output:
+```
+resource metrics: 1, metrics: 37, data points: 96
+```
+
+**Step 3 — Metrics are in VictoriaMetrics:**
+
+```bash
+curl -s "http://localhost:8428/api/v1/label/__name__/values" | \
+  python3 -m json.tool | grep -E "nodejs|cache_entries|db_connections"
+```
+
+---
+
+## Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `cache_entries` | Number of entries in the Storage cache |
+| `cache_size_bytes` | Total size of the Storage cache |
+| `db_connections` | Total database connections |
+| `db_connections_in_use` | Active database connections |
+| `db_active_local_pools` | Active local connection pools |
+| `http_status_codes_total` | HTTP requests by status code |
+| `nodejs_eventloop_utilization_ratio` | Node.js event loop utilization |
+| `nodejs_eventloop_delay_p99_seconds` | P99 event loop delay |
+
+---
+
+## Related
+
+- [Overview → Full service reference and getting started guide](./README.md)
+- [Prometheus pull → Supavisor, Realtime, Auth, Postgres, Kong, Vector](./prometheus-pull.md)
+- [docker-compose.override.yml → Enables Storage OTel push](./examples/docker-compose.override.yml)
+- [docker-compose.metrics.yml → Defines OTel Collector and VictoriaMetrics](./examples/docker-compose.metrics.yml)
+- [otelcol/config.yml → OTel Collector configuration](./examples/otelcol/config.yml)
+- [OTel Collector docs](https://opentelemetry.io/docs/collector/)
+- [Storage otel-metrics.ts → Source code for Storage metrics implementation](https://github.com/supabase/storage/blob/master/src/internal/monitoring/otel-metrics.ts)
+- [Storage server.ts → isMultitenant condition that disables pull endpoint](https://github.com/supabase/storage/blob/master/src/start/server.ts)

--- a/docker/docs/monitoring/prometheus-pull.md
+++ b/docker/docs/monitoring/prometheus-pull.md
@@ -1,0 +1,320 @@
+# Prometheus Pull — Self-Hosted Supabase
+
+This guide covers enabling and scraping Prometheus-compatible metrics from
+each pull-based service in the self-hosted Supabase stack. All endpoints were
+verified against source code and tested against a live self-hosted instance.
+
+For a quick overview of which services expose metrics and how, see
+[README.md](./README.md).
+
+---
+
+## Bearer JWT
+
+Supavisor and Realtime authenticate scrape requests with a Bearer JWT.
+The `ANON_KEY` in your `.env` file works directly as the scrape token:
+
+```bash
+ANON_KEY=$(grep '^ANON_KEY=' .env | cut -d= -f2)
+```
+
+> Both services use `METRICS_JWT_SECRET=${JWT_SECRET}` from `docker-compose.yml`.
+> `ANON_KEY` is signed with `JWT_SECRET`, so it satisfies the metrics endpoint
+> auth check.
+
+---
+
+## 1. Supavisor
+
+[Source](https://github.com/supabase/supavisor) ·
+[prom_ex.ex](https://github.com/supabase/supavisor/blob/main/lib/supavisor/monitoring/prom_ex.ex) ·
+[Metrics docs](https://supabase.github.io/supavisor/monitoring/metrics/)
+
+Supavisor exposes Prometheus metrics at `/metrics` on port `4000` out of the
+box. No additional configuration required.
+
+### Verify
+
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s -H "Authorization: Bearer $ANON_KEY" \
+  http://supabase-pooler:4000/metrics | head -5
+```
+
+### Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `supavisor_prom_ex_beam_memory_allocated_bytes` | Total memory allocated to the BEAM VM |
+| `supavisor_prom_ex_osmon_memory_system_total` | Total system memory |
+| `supavisor_prom_ex_cluster_size` | Number of nodes in the Supavisor cluster |
+| `supavisor_prom_ex_phoenix_http_request_duration_milliseconds` | HTTP request latency histogram |
+
+### Scrape config
+
+```yaml
+- job_name: supabase-supavisor
+  metrics_path: /metrics
+  authorization:
+    type: Bearer
+    credentials_file: /etc/vm/jwt
+  static_configs:
+    - targets: ["supabase-pooler:4000"]
+      labels:
+        service: supavisor
+```
+
+---
+
+## 2. Realtime
+
+[Source](https://github.com/supabase/realtime) ·
+[router.ex](https://github.com/supabase/realtime/blob/main/lib/realtime_web/router.ex) ·
+[prom_ex plugins](https://github.com/supabase/realtime/tree/main/lib/realtime/monitoring/prom_ex/plugins)
+
+Realtime exposes Prometheus metrics at `/metrics` on port `4000` using the
+same Bearer JWT as Supavisor. Container name is `realtime-dev.supabase-realtime`.
+
+### Verify
+
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s -H "Authorization: Bearer $ANON_KEY" \
+  http://realtime-dev.supabase-realtime:4000/metrics | head -5
+```
+
+### Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `realtime_tenants_connected` | Number of connected tenants |
+| `beam_memory_ets_total_bytes` | Memory allocated to ETS tables |
+| `osmon_cpu_avg15` | 15-minute CPU load average |
+
+### Scrape config
+
+```yaml
+- job_name: supabase-realtime
+  metrics_path: /metrics
+  authorization:
+    type: Bearer
+    credentials_file: /etc/vm/jwt
+  static_configs:
+    - targets: ["realtime-dev.supabase-realtime:4000"]
+      labels:
+        service: realtime
+```
+
+---
+
+## 3. Auth (GoTrue)
+
+[Source](https://github.com/supabase/auth) ·
+[internal/conf/metrics.go](https://github.com/supabase/auth/blob/master/internal/conf/metrics.go) ·
+[internal/observability/metrics.go](https://github.com/supabase/auth/blob/master/internal/observability/metrics.go)
+
+Auth metrics are off by default. The Prometheus exporter is only started when
+`GOTRUE_METRICS_ENABLED=true` is set.
+
+Enable via `docker-compose.override.yml` (already included in this repository):
+
+```yaml
+services:
+  auth:
+    environment:
+      GOTRUE_METRICS_ENABLED: "true"
+      GOTRUE_METRICS_EXPORTER: "prometheus"
+      OTEL_EXPORTER_PROMETHEUS_HOST: "0.0.0.0"
+      OTEL_EXPORTER_PROMETHEUS_PORT: "9100"
+```
+
+> **Note:** Auth uses the OpenTelemetry SDK internally.
+> `GOTRUE_METRICS_EXPORTER: "prometheus"` tells the OTel SDK to expose a
+> Prometheus pull endpoint instead of pushing to an OTel Collector.
+> `OTEL_EXPORTER_PROMETHEUS_HOST/PORT` configure where that endpoint listens.
+
+### Verify
+
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-auth:9100/ | head -5
+```
+
+### Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `db_sql_connection_open` | Open database connections (idle + in-use) |
+| `db_sql_connection_wait_total` | Total connections waited for |
+| `gotrue_running` | Always 1 — confirms Auth is up |
+
+### Scrape config
+
+```yaml
+- job_name: supabase-auth
+  metrics_path: /
+  static_configs:
+    - targets: ["supabase-auth:9100"]
+      labels:
+        service: auth
+```
+
+---
+
+## 4. PostgreSQL
+
+[Source](https://github.com/prometheus-community/postgres_exporter)
+
+Postgres does not expose Prometheus metrics natively. `postgres_exporter` is
+added as a sidecar via
+[`examples/docker-compose.metrics.yml`](./examples/docker-compose.metrics.yml).
+It connects to the Supabase Postgres container and exposes metrics at
+`:9187/metrics`.
+
+### Verify
+
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://postgres-exporter:9187/metrics | grep "^pg_" | head -5
+```
+
+### Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `pg_database_size_bytes` | Database size per database |
+| `pg_locks_count` | Lock contention by mode |
+| `pg_stat_database_numbackends` | Active connections per database |
+| `pg_replication_lag` | Replication lag in seconds |
+
+### Scrape config
+
+```yaml
+- job_name: supabase-postgres
+  metrics_path: /metrics
+  static_configs:
+    - targets: ["postgres-exporter:9187"]
+      labels:
+        service: postgres
+```
+
+---
+
+## 5. Kong
+
+[Source](https://github.com/Kong/kong) ·
+[Prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/)
+
+Two changes are required, both included in
+[`examples/docker-compose.override.yml`](./examples/docker-compose.override.yml):
+
+**1. Enable the Prometheus plugin** in `volumes/api/kong.yml`:
+
+```yaml
+plugins:
+  - name: prometheus
+    config:
+      status_code_metrics: true
+      latency_metrics: true
+      bandwidth_metrics: true
+      upstream_health_metrics: true
+```
+
+**2. Open the Admin API to the Docker network:**
+
+```yaml
+services:
+  kong:
+    environment:
+      KONG_PLUGINS: >-
+        request-transformer,cors,key-auth,acl,basic-auth,
+        request-termination,ip-restriction,post-function,prometheus
+      KONG_ADMIN_LISTEN: "0.0.0.0:8001"  # Kong Admin API binds to 127.0.0.1 by default; this opens it to the Docker network
+```
+
+### Verify
+
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-kong:8001/metrics | head -5
+```
+
+### Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `kong_datastore_reachable` | 1 if datastore is reachable, 0 if not |
+| `kong_http_requests_total` | Total requests by service, route, and status code |
+| `kong_request_latency_ms` | End-to-end request latency histogram |
+| `kong_memory_lua_shared_dict_bytes` | Lua shared memory usage |
+
+### Scrape config
+
+```yaml
+- job_name: supabase-kong
+  metrics_path: /metrics
+  static_configs:
+    - targets: ["supabase-kong:8001"]
+      labels:
+        service: kong
+```
+
+---
+
+## 6. Vector
+
+[Source](https://github.com/vectordotdev/vector) ·
+[internal_metrics](https://vector.dev/docs/reference/configuration/sources/internal_metrics/)
+
+Vector's own operational metrics are off by default. Enabling them requires
+adding a second config file alongside the original `vector.yml` — without
+modifying it. Vector supports loading multiple config files simultaneously.
+
+[`examples/vector/metrics.yml`](./examples/vector/metrics.yml) adds an
+`internal_metrics` source and a `prometheus_exporter` sink on `:9598`.
+[`examples/docker-compose.override.yml`](./examples/docker-compose.override.yml)
+mounts it alongside the original `vector.yml`.
+
+### Verify
+
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-vector:9598/metrics | head -5
+```
+
+### Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `vector_component_received_events_total` | Events received per component |
+| `vector_component_sent_events_total` | Events sent per component |
+| `vector_component_errors_total` | Errors per component |
+
+### Scrape config
+
+```yaml
+- job_name: supabase-vector
+  metrics_path: /metrics
+  static_configs:
+    - targets: ["supabase-vector:9598"]
+      labels:
+        service: vector
+```
+
+---
+
+## Complete scrape config
+
+A complete VictoriaMetrics scrape config for all six services is available at
+[`examples/victoriametrics/scrape.yml`](./examples/victoriametrics/scrape.yml).
+
+---
+
+## Related
+
+- [Overview → Full service reference and getting started guide](./README.md)
+- [OTel push → Storage metrics via OpenTelemetry Collector](./otel-push.md)
+- [victoriametrics/scrape.yml → Complete VictoriaMetrics scrape config](./examples/victoriametrics/scrape.yml)
+- [docker-compose.override.yml → Enables Auth, Kong, Vector, Storage metrics](./examples/docker-compose.override.yml)
+- [docker-compose.metrics.yml → Adds VictoriaMetrics, postgres_exporter, and OTel Collector](./examples/docker-compose.metrics.yml)
+- [vector/metrics.yml → Vector internal metrics config](./examples/vector/metrics.yml)

--- a/docker/docs/monitoring/prometheus-pull.md
+++ b/docker/docs/monitoring/prometheus-pull.md
@@ -1,57 +1,58 @@
-# Prometheus Pull — Self-Hosted Supabase
 
+# Prometheus Pull — Self-Hosted Supabase
+ 
 This guide covers enabling and scraping Prometheus-compatible metrics from
 each pull-based service in the self-hosted Supabase stack. All endpoints were
 verified against source code and tested against a live self-hosted instance.
-
+ 
 For a quick overview of which services expose metrics and how, see
 [README.md](./README.md).
-
+ 
 ---
-
+ 
 ## Bearer JWT
-
+ 
 Supavisor and Realtime authenticate scrape requests with a Bearer JWT.
 The `ANON_KEY` in your `.env` file works directly as the scrape token:
-
+ 
 ```bash
 ANON_KEY=$(grep '^ANON_KEY=' .env | cut -d= -f2)
 ```
-
+ 
 > Both services use `METRICS_JWT_SECRET=${JWT_SECRET}` from `docker-compose.yml`.
 > `ANON_KEY` is signed with `JWT_SECRET`, so it satisfies the metrics endpoint
 > auth check.
-
+ 
 ---
-
+ 
 ## 1. Supavisor
-
+ 
 [Source](https://github.com/supabase/supavisor) ·
 [prom_ex.ex](https://github.com/supabase/supavisor/blob/main/lib/supavisor/monitoring/prom_ex.ex) ·
 [Metrics docs](https://supabase.github.io/supavisor/monitoring/metrics/)
-
+ 
 Supavisor exposes Prometheus metrics at `/metrics` on port `4000` out of the
 box. No additional configuration required.
-
+ 
 ### Verify
-
+ 
 ```bash
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s -H "Authorization: Bearer $ANON_KEY" \
   http://supabase-pooler:4000/metrics | head -5
 ```
-
+ 
 ### Key metrics
-
+ 
 | Metric | Description |
 |--------|-------------|
 | `supavisor_prom_ex_beam_memory_allocated_bytes` | Total memory allocated to the BEAM VM |
 | `supavisor_prom_ex_osmon_memory_system_total` | Total system memory |
 | `supavisor_prom_ex_cluster_size` | Number of nodes in the Supavisor cluster |
 | `supavisor_prom_ex_phoenix_http_request_duration_milliseconds` | HTTP request latency histogram |
-
+ 
 ### Scrape config
-
+ 
 ```yaml
 - job_name: supabase-supavisor
   metrics_path: /metrics
@@ -63,36 +64,36 @@ docker run --rm --network supabase_default curlimages/curl:latest \
       labels:
         service: supavisor
 ```
-
+ 
 ---
-
+ 
 ## 2. Realtime
-
+ 
 [Source](https://github.com/supabase/realtime) ·
 [router.ex](https://github.com/supabase/realtime/blob/main/lib/realtime_web/router.ex) ·
 [prom_ex plugins](https://github.com/supabase/realtime/tree/main/lib/realtime/monitoring/prom_ex/plugins)
-
+ 
 Realtime exposes Prometheus metrics at `/metrics` on port `4000` using the
 same Bearer JWT as Supavisor. Container name is `realtime-dev.supabase-realtime`.
-
+ 
 ### Verify
-
+ 
 ```bash
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s -H "Authorization: Bearer $ANON_KEY" \
   http://realtime-dev.supabase-realtime:4000/metrics | head -5
 ```
-
+ 
 ### Key metrics
-
+ 
 | Metric | Description |
 |--------|-------------|
 | `realtime_tenants_connected` | Number of connected tenants |
 | `beam_memory_ets_total_bytes` | Memory allocated to ETS tables |
 | `osmon_cpu_avg15` | 15-minute CPU load average |
-
+ 
 ### Scrape config
-
+ 
 ```yaml
 - job_name: supabase-realtime
   metrics_path: /metrics
@@ -104,20 +105,20 @@ docker run --rm --network supabase_default curlimages/curl:latest \
       labels:
         service: realtime
 ```
-
+ 
 ---
-
+ 
 ## 3. Auth (GoTrue)
-
+ 
 [Source](https://github.com/supabase/auth) ·
 [internal/conf/metrics.go](https://github.com/supabase/auth/blob/master/internal/conf/metrics.go) ·
 [internal/observability/metrics.go](https://github.com/supabase/auth/blob/master/internal/observability/metrics.go)
-
+ 
 Auth metrics are off by default. The Prometheus exporter is only started when
 `GOTRUE_METRICS_ENABLED=true` is set.
-
+ 
 Enable via `docker-compose.override.yml` (already included in this repository):
-
+ 
 ```yaml
 services:
   auth:
@@ -127,29 +128,29 @@ services:
       OTEL_EXPORTER_PROMETHEUS_HOST: "0.0.0.0"
       OTEL_EXPORTER_PROMETHEUS_PORT: "9100"
 ```
-
+ 
 > **Note:** Auth uses the OpenTelemetry SDK internally.
 > `GOTRUE_METRICS_EXPORTER: "prometheus"` tells the OTel SDK to expose a
 > Prometheus pull endpoint instead of pushing to an OTel Collector.
 > `OTEL_EXPORTER_PROMETHEUS_HOST/PORT` configure where that endpoint listens.
-
+ 
 ### Verify
-
+ 
 ```bash
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-auth:9100/ | head -5
 ```
-
+ 
 ### Key metrics
-
+ 
 | Metric | Description |
 |--------|-------------|
 | `db_sql_connection_open` | Open database connections (idle + in-use) |
 | `db_sql_connection_wait_total` | Total connections waited for |
 | `gotrue_running` | Always 1 — confirms Auth is up |
-
+ 
 ### Scrape config
-
+ 
 ```yaml
 - job_name: supabase-auth
   metrics_path: /
@@ -158,37 +159,37 @@ docker run --rm --network supabase_default curlimages/curl:latest \
       labels:
         service: auth
 ```
-
+ 
 ---
-
+ 
 ## 4. PostgreSQL
-
+ 
 [Source](https://github.com/prometheus-community/postgres_exporter)
-
+ 
 Postgres does not expose Prometheus metrics natively. `postgres_exporter` is
 added as a sidecar via
 [`examples/docker-compose.metrics.yml`](./examples/docker-compose.metrics.yml).
 It connects to the Supabase Postgres container and exposes metrics at
 `:9187/metrics`.
-
+ 
 ### Verify
-
+ 
 ```bash
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://postgres-exporter:9187/metrics | grep "^pg_" | head -5
 ```
-
+ 
 ### Key metrics
-
+ 
 | Metric | Description |
 |--------|-------------|
 | `pg_database_size_bytes` | Database size per database |
 | `pg_locks_count` | Lock contention by mode |
 | `pg_stat_database_numbackends` | Active connections per database |
-| `pg_replication_lag` | Replication lag in seconds |
-
+| `pg_replication_lag_seconds` | Replication lag in seconds |
+ 
 ### Scrape config
-
+ 
 ```yaml
 - job_name: supabase-postgres
   metrics_path: /metrics
@@ -197,24 +198,24 @@ docker run --rm --network supabase_default curlimages/curl:latest \
       labels:
         service: postgres
 ```
-
+ 
 ---
-
+ 
 ## 5. Kong *(deprecation pending)*
-
+ 
 > **Note:** Kong will be deprecated soon in the self-hosted stack. The optional
 > [Envoy gateway](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy)
 > (`docker-compose.envoy.yml`) is its replacement. See [Envoy →](#6-envoy) below
 > for how to collect metrics from the Envoy gateway.
-
+ 
 [Source](https://github.com/Kong/kong) ·
 [Prometheus plugin](https://developer.konghq.com/plugins/prometheus/)
-
+ 
 Two changes are required, both included in
 [`examples/docker-compose.override.yml`](./examples/docker-compose.override.yml):
-
+ 
 **1. Enable the Prometheus plugin** in `volumes/api/kong.yml`:
-
+ 
 ```yaml
 plugins:
   - name: prometheus
@@ -224,9 +225,9 @@ plugins:
       bandwidth_metrics: true
       upstream_health_metrics: true
 ```
-
+ 
 **2. Open the Admin API to the Docker network:**
-
+ 
 ```yaml
 services:
   kong:
@@ -236,30 +237,31 @@ services:
         request-termination,ip-restriction,post-function,prometheus
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"  # Kong Admin API binds to 127.0.0.1 by default; this opens it to the Docker network
 ```
-
+ 
 > ⚠️ Kong's Admin API (`:8001`) exposes management endpoints beyond just
 > metrics — including routes, plugins, and consumers. Keep port `8001`
 > internal to the Docker network — do not map it to the host.
 > See [Kong's security guide](https://developer.konghq.com/gateway/secure-the-admin-api/).
-
+ 
 ### Verify
-
+ 
 ```bash
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-kong:8001/metrics | head -5
 ```
-
+ 
 ### Key metrics
-
+ 
 | Metric | Description |
 |--------|-------------|
 | `kong_datastore_reachable` | 1 if datastore is reachable, 0 if not |
-| `kong_http_requests_total` | Total requests by service, route, and status code |
-| `kong_request_latency_ms` | End-to-end request latency histogram |
-| `kong_memory_lua_shared_dict_bytes` | Lua shared memory usage |
-
+| `kong_nginx_requests_total` | Total requests handled by Nginx |
+| `kong_nginx_connections_total` | Total Nginx connections by state |
+| `kong_memory_lua_shared_dict_bytes` | Lua shared memory usage per dictionary |
+| `kong_memory_lua_shared_dict_total_bytes` | Total Lua shared memory allocated |
+ 
 ### Scrape config
-
+ 
 ```yaml
 - job_name: supabase-kong
   metrics_path: /metrics
@@ -268,24 +270,24 @@ docker run --rm --network supabase_default curlimages/curl:latest \
       labels:
         service: kong
 ```
-
+ 
 ---
-
+ 
 ## 6. Envoy
-
+ 
 [Source](https://github.com/envoyproxy/envoy) ·
 [Supabase Envoy docs](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy) ·
 [Admin API docs](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
-
+ 
 Envoy is the replacement for Kong as the self-hosted API gateway, available via
 `docker-compose.envoy.yml`. Envoy exposes Prometheus-compatible metrics at
 `:9901/stats/prometheus` through its admin interface.
-
+ 
 By default, the admin interface binds to `127.0.0.1:9901` — accessible only
 from within the container itself. To allow a metrics collector running in the
 same Docker network to scrape it, change the bind address in
 `volumes/api/envoy/envoy.yaml`:
-
+ 
 ```yaml
 admin:
   address:
@@ -293,37 +295,37 @@ admin:
       address: 0.0.0.0  # changed from 127.0.0.1
       port_value: 9901
 ```
-
+ 
 Apply the change:
-
+ 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.envoy.yml up -d api-gw
 ```
-
+ 
 > ⚠️ Envoy's admin endpoint (`:9901`) exposes `/config_dump` which includes
 > API keys, JWTs, and the dashboard basic auth hash in plaintext. Keep port
 > `9901` internal to the Docker network — do not map it to the host.
 > See the [Envoy security hardening guide](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#security-hardening).
-
+ 
 ### Verify
-
+ 
 ```bash
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-envoy:9901/stats/prometheus | head -5
 ```
-
+ 
 ### Key metrics
-
+ 
 | Metric | Description |
 |--------|-------------|
 | `envoy_cluster_upstream_rq_total` | Total requests forwarded per upstream cluster (auth, rest, realtime, storage, functions, meta, studio) |
-| `envoy_cluster_upstream_rq_time` | Request latency histogram per upstream cluster |
+| `envoy_cluster_upstream_cx_length_ms` | Connection length histogram per upstream cluster |
 | `envoy_http_downstream_rq_total` | Total requests received from downstream clients |
 | `envoy_server_memory_allocated` | Envoy process memory usage |
 | `envoy_cluster_assignment_stale` | CDS assignment staleness counter per cluster |
-
+ 
 ### Scrape config
-
+ 
 ```yaml
 - job_name: supabase-envoy
   metrics_path: /stats/prometheus
@@ -332,40 +334,140 @@ docker run --rm --network supabase_default curlimages/curl:latest \
       labels:
         service: envoy
 ```
-
+ 
 ---
-
-## 7. Vector
-
+ 
+## 7. PostgREST
+ 
+[Source](https://github.com/PostgREST/postgrest) ·
+[Observability docs](https://docs.postgrest.org/en/v14/references/observability.html) ·
+[Admin Server docs](https://docs.postgrest.org/en/v14/references/admin_server.html)
+ 
+PostgREST exposes Prometheus metrics via its admin server on a separate port.
+The admin server is off by default — enable it by setting `PGRST_ADMIN_SERVER_PORT`
+in `docker-compose.override.yml` (already included in this repository):
+ 
+```yaml
+services:
+  rest:
+    environment:
+      PGRST_ADMIN_SERVER_PORT: "3001"
+```
+ 
+Metrics are available at `:{PGRST_ADMIN_SERVER_PORT}/metrics`.
+ 
+### Verify
+ 
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-rest:3001/metrics | head -5
+```
+ 
+### Key metrics
+ 
+| Metric | Description |
+|--------|-------------|
+| `pgrst_db_pool_available` | Available connections in the pool |
+| `pgrst_db_pool_waiting` | Requests waiting to acquire a pool connection |
+| `pgrst_db_pool_timeouts_total` | Total pool connection timeouts |
+| `pgrst_schema_cache_loads_total` | Total number of schema cache loads |
+| `pgrst_jwt_cache_hits_total` | JWT cache hits (when JWT caching is enabled) |
+ 
+### Scrape config
+ 
+```yaml
+- job_name: supabase-rest
+  metrics_path: /metrics
+  static_configs:
+    - targets: ["supabase-rest:3001"]
+      labels:
+        service: rest
+```
+ 
+---
+ 
+## 8. imgproxy
+ 
+[Source](https://github.com/imgproxy/imgproxy) ·
+[Prometheus docs](https://docs.imgproxy.net/monitoring/prometheus)
+ 
+imgproxy exposes Prometheus metrics on a separate port. The metrics server is
+off by default — enable it by setting `IMGPROXY_PROMETHEUS_BIND` in
+`docker-compose.override.yml` (already included in this repository):
+ 
+```yaml
+services:
+  imgproxy:
+    environment:
+      IMGPROXY_PROMETHEUS_BIND: ":8081"
+```
+ 
+Metrics are available at `:{IMGPROXY_PROMETHEUS_BIND}/metrics`. Note that
+this port must differ from the main imgproxy server port (`8080`).
+ 
+### Verify
+ 
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-imgproxy:8081/metrics | head -5
+```
+ 
+### Key metrics
+ 
+| Metric | Description |
+|--------|-------------|
+| `requests_total` | Total number of image processing requests |
+| `requests_in_progress` | Currently active requests |
+| `download_duration_seconds` | Source image download latency histogram |
+| `processing_duration_seconds` | Image processing latency histogram |
+| `images_in_progress` | Number of images currently being processed |
+| `vips_memory_bytes` | libvips memory usage |
+| `workers_utilization` | Worker utilization ratio |
+ 
+### Scrape config
+ 
+```yaml
+- job_name: supabase-imgproxy
+  metrics_path: /metrics
+  static_configs:
+    - targets: ["supabase-imgproxy:8081"]
+      labels:
+        service: imgproxy
+```
+ 
+---
+ 
+## 9. Vector
+ 
 [Source](https://github.com/vectordotdev/vector) ·
 [internal_metrics](https://vector.dev/docs/reference/configuration/sources/internal_metrics/)
-
+ 
 Vector's own operational metrics are off by default. Enabling them requires
 adding a second config file alongside the original `vector.yml` — without
 modifying it. Vector supports loading multiple config files simultaneously.
-
+ 
 [`examples/vector/metrics.yml`](./examples/vector/metrics.yml) adds an
 `internal_metrics` source and a `prometheus_exporter` sink on `:9598`.
 [`examples/docker-compose.override.yml`](./examples/docker-compose.override.yml)
 mounts it alongside the original `vector.yml`.
-
+ 
 ### Verify
-
+ 
 ```bash
 docker run --rm --network supabase_default curlimages/curl:latest \
   curl -s http://supabase-vector:9598/metrics | head -5
 ```
-
+ 
 ### Key metrics
-
+ 
 | Metric | Description |
 |--------|-------------|
 | `vector_component_received_events_total` | Events received per component |
 | `vector_component_sent_events_total` | Events sent per component |
 | `vector_component_errors_total` | Errors per component |
-
+ 
 ### Scrape config
-
+ 
 ```yaml
 - job_name: supabase-vector
   metrics_path: /metrics
@@ -374,20 +476,34 @@ docker run --rm --network supabase_default curlimages/curl:latest \
       labels:
         service: vector
 ```
-
+ 
 ---
-
+ 
+## Services without metrics endpoints
+ 
+The following services in the default self-hosted stack do not expose
+Prometheus-compatible metrics endpoints:
+ 
+| Service | Reason |
+|---------|--------|
+| `supabase-analytics` (Logflare) | Log ingestion and query pipeline — no metrics endpoint implemented |
+| `supabase-meta` (postgres-meta) | PostgreSQL management REST API — no metrics endpoint implemented |
+| `supabase-studio` | Next.js web UI — no metrics endpoint |
+| `supabase-edge-functions` (edge-runtime) | Metrics endpoint not yet implemented — [feature request open](https://github.com/orgs/supabase/discussions/17269) |
+ 
+---
+ 
 ## Complete scrape config
-
+ 
 A complete VictoriaMetrics scrape config for all services — including both Kong
 and Envoy scrape jobs — is available at
 [`examples/victoriametrics/scrape.yml`](./examples/victoriametrics/scrape.yml).
 Enable the job that matches your active gateway.
-
+ 
 ---
-
+ 
 ## Related
-
+ 
 - [Overview → Full service reference and getting started guide](./README.md)
 - [OTel push → Storage metrics via OpenTelemetry Collector](./otel-push.md)
 - [Security → Endpoint exposure risks and hardening recommendations](./security.md)
@@ -396,3 +512,4 @@ Enable the job that matches your active gateway.
 - [docker-compose.override.yml → Enables Auth, Kong, Vector, Storage metrics](./examples/docker-compose.override.yml)
 - [docker-compose.metrics.yml → Adds VictoriaMetrics, postgres_exporter, and OTel Collector](./examples/docker-compose.metrics.yml)
 - [vector/metrics.yml → Vector internal metrics config](./examples/vector/metrics.yml)
+ 

--- a/docker/docs/monitoring/prometheus-pull.md
+++ b/docker/docs/monitoring/prometheus-pull.md
@@ -200,10 +200,15 @@ docker run --rm --network supabase_default curlimages/curl:latest \
 
 ---
 
-## 5. Kong
+## 5. Kong *(deprecation pending)*
+
+> **Note:** Kong will be deprecated soon in the self-hosted stack. The optional
+> [Envoy gateway](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy)
+> (`docker-compose.envoy.yml`) is its replacement. See [Envoy →](#6-envoy) below
+> for how to collect metrics from the Envoy gateway.
 
 [Source](https://github.com/Kong/kong) ·
-[Prometheus plugin](https://docs.konghq.com/hub/kong-inc/prometheus/)
+[Prometheus plugin](https://developer.konghq.com/plugins/prometheus/)
 
 Two changes are required, both included in
 [`examples/docker-compose.override.yml`](./examples/docker-compose.override.yml):
@@ -231,6 +236,11 @@ services:
         request-termination,ip-restriction,post-function,prometheus
       KONG_ADMIN_LISTEN: "0.0.0.0:8001"  # Kong Admin API binds to 127.0.0.1 by default; this opens it to the Docker network
 ```
+
+> ⚠️ Kong's Admin API (`:8001`) exposes management endpoints beyond just
+> metrics — including routes, plugins, and consumers. Keep port `8001`
+> internal to the Docker network — do not map it to the host.
+> See [Kong's security guide](https://developer.konghq.com/gateway/secure-the-admin-api/).
 
 ### Verify
 
@@ -261,7 +271,71 @@ docker run --rm --network supabase_default curlimages/curl:latest \
 
 ---
 
-## 6. Vector
+## 6. Envoy
+
+[Source](https://github.com/envoyproxy/envoy) ·
+[Supabase Envoy docs](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy) ·
+[Admin API docs](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
+
+Envoy is the replacement for Kong as the self-hosted API gateway, available via
+`docker-compose.envoy.yml`. Envoy exposes Prometheus-compatible metrics at
+`:9901/stats/prometheus` through its admin interface.
+
+By default, the admin interface binds to `127.0.0.1:9901` — accessible only
+from within the container itself. To allow a metrics collector running in the
+same Docker network to scrape it, change the bind address in
+`volumes/api/envoy/envoy.yaml`:
+
+```yaml
+admin:
+  address:
+    socket_address:
+      address: 0.0.0.0  # changed from 127.0.0.1
+      port_value: 9901
+```
+
+Apply the change:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.envoy.yml up -d api-gw
+```
+
+> ⚠️ Envoy's admin endpoint (`:9901`) exposes `/config_dump` which includes
+> API keys, JWTs, and the dashboard basic auth hash in plaintext. Keep port
+> `9901` internal to the Docker network — do not map it to the host.
+> See the [Envoy security hardening guide](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#security-hardening).
+
+### Verify
+
+```bash
+docker run --rm --network supabase_default curlimages/curl:latest \
+  curl -s http://supabase-envoy:9901/stats/prometheus | head -5
+```
+
+### Key metrics
+
+| Metric | Description |
+|--------|-------------|
+| `envoy_cluster_upstream_rq_total` | Total requests forwarded per upstream cluster (auth, rest, realtime, storage, functions, meta, studio) |
+| `envoy_cluster_upstream_rq_time` | Request latency histogram per upstream cluster |
+| `envoy_http_downstream_rq_total` | Total requests received from downstream clients |
+| `envoy_server_memory_allocated` | Envoy process memory usage |
+| `envoy_cluster_assignment_stale` | CDS assignment staleness counter per cluster |
+
+### Scrape config
+
+```yaml
+- job_name: supabase-envoy
+  metrics_path: /stats/prometheus
+  static_configs:
+    - targets: ["supabase-envoy:9901"]
+      labels:
+        service: envoy
+```
+
+---
+
+## 7. Vector
 
 [Source](https://github.com/vectordotdev/vector) ·
 [internal_metrics](https://vector.dev/docs/reference/configuration/sources/internal_metrics/)
@@ -305,8 +379,10 @@ docker run --rm --network supabase_default curlimages/curl:latest \
 
 ## Complete scrape config
 
-A complete VictoriaMetrics scrape config for all six services is available at
+A complete VictoriaMetrics scrape config for all services — including both Kong
+and Envoy scrape jobs — is available at
 [`examples/victoriametrics/scrape.yml`](./examples/victoriametrics/scrape.yml).
+Enable the job that matches your active gateway.
 
 ---
 
@@ -314,6 +390,8 @@ A complete VictoriaMetrics scrape config for all six services is available at
 
 - [Overview → Full service reference and getting started guide](./README.md)
 - [OTel push → Storage metrics via OpenTelemetry Collector](./otel-push.md)
+- [Security → Endpoint exposure risks and hardening recommendations](./security.md)
+- [Supabase Envoy gateway docs](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy)
 - [victoriametrics/scrape.yml → Complete VictoriaMetrics scrape config](./examples/victoriametrics/scrape.yml)
 - [docker-compose.override.yml → Enables Auth, Kong, Vector, Storage metrics](./examples/docker-compose.override.yml)
 - [docker-compose.metrics.yml → Adds VictoriaMetrics, postgres_exporter, and OTel Collector](./examples/docker-compose.metrics.yml)

--- a/docker/docs/monitoring/security.md
+++ b/docker/docs/monitoring/security.md
@@ -1,0 +1,120 @@
+# Metrics Security Reference
+
+This guide covers the security properties of each metrics endpoint in the
+self-hosted Supabase stack and how to keep them safe.
+
+---
+
+## Isolated metrics endpoints
+
+The following services expose metrics on a **dedicated port** that serves only
+Prometheus-formatted metric lines — no management functions, no sensitive data.
+
+| Service | Endpoint | Exposed data |
+|---------|----------|--------------|
+| Supavisor | `:4000/metrics` | Runtime counters, connection pool stats |
+| Realtime | `:4000/metrics` | Tenant counts, BEAM VM stats |
+| Auth | `:9100/` | DB connection pool, request counters |
+| Storage | OTel push to `:4317` | Cache, DB connections, HTTP status codes |
+| Vector | `:9598/metrics` | Pipeline event counts, component errors |
+| postgres_exporter | `:9187/metrics` | Postgres query stats, lock counts, replication lag |
+
+**Supavisor and Realtime** require a Bearer JWT on every scrape request.
+The `ANON_KEY` in your `.env` file is the correct token — it is signed with
+`JWT_SECRET`, which both services use as `METRICS_JWT_SECRET`. No additional
+token management is needed.
+
+**Auth, Storage, Vector, and postgres_exporter** expose metrics without
+authentication. They rely entirely on network isolation — keep them inside
+the Docker network and do not publish their ports to the host unless you
+control who can reach those ports.
+
+---
+
+## Shared admin endpoints
+
+Kong and Envoy both expose metrics through an **admin interface** that also
+serves management and introspection endpoints beyond metrics. These require
+extra care.
+
+### Kong *(deprecation pending)*
+
+Kong's Admin API runs on `:8001`. The Prometheus plugin exposes metrics at
+`:8001/metrics`, but the same port also handles:
+
+- Route and plugin configuration (`/config`)
+- Consumer and credential management (`/consumers`)
+- Health check data and node information
+
+**The Admin API must not be published to the host.** Keep port `8001` inside
+the Docker network. Do not add `- "8001:8001"` to the `kong` service in
+`docker-compose.yml`.
+
+→ [Kong Admin API security guide](https://developer.konghq.com/gateway/secure-the-admin-api/)
+
+> **Note:** Kong will be deprecated soon in the self-hosted stack. Envoy is
+> its replacement.
+
+### Envoy
+
+Envoy's admin interface runs on `:9901`. Prometheus-compatible metrics are
+available at `:9901/stats/prometheus`, but the same port also exposes:
+
+- `/config_dump` — full runtime configuration including **API keys, JWTs, and
+  the dashboard basic auth hash in plaintext**
+- `/clusters` — upstream cluster membership and health state
+- `/listeners` — active listener configuration
+
+**The admin interface must not be published to the host.** Keep port `9901`
+inside the Docker network. Do not add `- "9901:9901"` to the `api-gw` service
+in `docker-compose.envoy.yml`.
+
+By default, Envoy's admin interface binds to `127.0.0.1:9901` — accessible
+only from within the container itself. The setup guide changes this to
+`0.0.0.0` so that VictoriaMetrics (running in the same Docker network) can
+reach it. This is intentional and safe as long as the port is not published
+to the host.
+
+→ [Envoy Admin API reference](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
+→ [Supabase Envoy security hardening](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#security-hardening)
+
+---
+
+## General recommendations
+
+**Keep scrapers in the same Docker network.**
+VictoriaMetrics and the OTel Collector are defined in
+`docker-compose.metrics.yml` with `network: default` (the Supabase compose
+network). All scrape targets are addressed by container name over this
+internal network — no host-level port exposure required.
+
+**Do not publish admin ports to the host.**
+Neither Kong's `:8001` nor Envoy's `:9901` should appear in a `ports:` block.
+Only publish ports that need to be reachable from outside Docker — typically
+the API gateway's public port (`8000` for Kong, `8443` for Envoy).
+
+**Restrict access to VictoriaMetrics.**
+VictoriaMetrics is published on `:8428` by default (for local access to
+`/vmui` and `/targets`). In production, either remove the `ports:` entry and
+access it through a reverse proxy with authentication, or restrict the bind
+address to `127.0.0.1:8428`.
+
+**Rotate `ANON_KEY` if metrics are exposed externally.**
+If Supavisor or Realtime metrics are scraped from outside the Docker network
+(for example, by a remote Grafana Cloud agent), the Bearer token is your only
+access control. Treat `ANON_KEY` as a scrape credential and rotate it if
+compromised.
+
+**For production environments**, review the upstream hardening guides:
+
+- [Kong Admin API security](https://developer.konghq.com/gateway/secure-the-admin-api/)
+- [Envoy security hardening (Supabase)](https://supabase.com/docs/guides/self-hosting/self-hosted-envoy#security-hardening)
+- [Envoy Admin API reference](https://www.envoyproxy.io/docs/envoy/latest/operations/admin)
+
+---
+
+## Related
+
+- [Overview → Full service reference and getting started guide](./README.md)
+- [Prometheus pull → Per-service setup and scrape config](./prometheus-pull.md)
+- [OTel push → Storage metrics via OpenTelemetry Collector](./otel-push.md)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
 
YES
 
## What kind of change does this PR introduce?
 
Docs addition.
 
## What is the current behavior?
 
`docker/` has no documentation on how to enable or scrape metrics from the self-hosted services. The Cloud [Metrics API](https://supabase.com/docs/guides/telemetry/metrics) is not available in self-hosted, and each service exposes metrics differently — some are on by default, others require env vars, Storage uses OTel push only.
 
## What is the new behavior?
 
Adds `docker/docs/monitoring/`:
 
```
docker/docs/monitoring/
├── README.md                                    # overview, service reference, getting started
├── prometheus-pull.md                           # per-service detail for pull-based services
├── otel-push.md                                 # Storage metrics via OTel SDK
├── security.md                                  # admin endpoint risks and hardening
└── examples/
    ├── docker-compose.override.yml              # enables Auth/Kong/PostgREST/imgproxy/Vector/Storage metrics
    ├── docker-compose.metrics.yml               # VictoriaMetrics + postgres_exporter + OTel Collector
    ├── otelcol/config.yml                       # OTel Collector config
    ├── vector/metrics.yml                       # Vector internal metrics config
    └── victoriametrics/scrape.yml               # scrape config for all pull services (Kong + Envoy jobs included)
```
 
**Services covered:**
 
| Service | Method | Endpoint | On by default |
|---------|--------|----------|---------------|
| Supavisor | Prometheus pull | `:4000/metrics` | ✅ |
| Realtime | Prometheus pull | `:4000/metrics` | ✅ |
| Auth (GoTrue) | Prometheus pull | `:9100/` | ❌ env vars needed |
| PostgreSQL | Prometheus pull | `:9187/metrics` | ❌ sidecar needed |
| Kong *(deprecation pending)* | Prometheus pull | `:8001/metrics` | ❌ plugin + env var needed |
| Envoy | Prometheus pull | `:9901/stats/prometheus` | ❌ admin bind address needed |
| PostgREST | Prometheus pull | `:3001/metrics` | ❌ env var needed |
| imgproxy | Prometheus pull | `:8081/metrics` | ❌ env var needed |
| Storage | OTel push | gRPC `:4317` | ❌ env vars needed |
| Vector | Prometheus pull | `:9598/metrics` | ❌ config file needed |
 
Services confirmed to have no metrics endpoint: `supabase-analytics` (Logflare), `supabase-meta` (postgres-meta), `supabase-studio`, `supabase-edge-functions` — documented in `prometheus-pull.md`.
 
**Verification:**
 
All endpoints verified by reading the source code of each service and tested end-to-end against the default `docker-compose.yml`:
 
- Each pull endpoint responds with `curl` (1st check)
- All active pull targets show `UP` with zero errors on VictoriaMetrics `/targets` (2nd check)
- Storage OTel push confirmed end-to-end: Storage → OTel Collector → VictoriaMetrics (`nodejs_*`, `cache_entries`, `db_connections` metrics visible)
Tested against:
- Postgres `15.8.1.085`
- Kong `3.9.1`
- Auth `2.186.0`
- Storage `1.48.26`
- Supavisor `2.7.4`
- Realtime `2.76.5`
- Vector `0.53.0`
- Envoy `1.37.2`
- PostgREST `v14.8`
- imgproxy `v3.30.1`
- VictoriaMetrics `1.122.0`
- OTel Collector Contrib `0.152.0`
- postgres_exporter `0.19.1`
 
## Additional context
Discussion: [#46304](https://github.com/orgs/supabase/discussions/46304)

<img width="1139" height="983" alt="vmui_query" src="https://github.com/user-attachments/assets/c8acbbfd-5e22-47e1-990d-4ce8cd2e39bc" />


<img width="1141" height="914" alt="vmui Cardinality" src="https://github.com/user-attachments/assets/e6949961-13d4-4756-8ed6-527de6fac67a" />


<img width="1168" height="891" alt="supabase-victoriametrics-targets-kong" src="https://github.com/user-attachments/assets/8d229cbd-7893-43dc-9d7a-69fcea29783e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive self-hosted monitoring guide with Prometheus pull and OpenTelemetry push workflows, security guidance, step‑by‑step setup, verification steps, key metrics, and related references
  * Included multiple example configurations for a metrics stack, OTLP collector, VictoriaMetrics scrape, Vector metrics, and per-service telemetry guidance

* **Chores**
  * Updated ignore rules to exclude monitoring volumes and compose override/metrics files using absolute-path patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46310?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->