### PR TITLE
fix(studio): preserve newlines in SMS and MFA phone templates

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -14,7 +14,7 @@ export interface Provider {
   properties: {
     [x: string]: {
       title: string
-      type: 'boolean' | 'string' | 'select' | 'number'
+      type: 'boolean' | 'string' | 'multiline-string' | 'select' | 'number' | 'datetime'
       enum: Enum[]
       show: {
         key: string

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -36,6 +36,11 @@ import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
 import { useHasEntitlementAccess } from '@/hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import {
+  isSmsTemplateConfigKey,
+  normalizeSmsTemplateFieldsInPayload,
+  normalizeSmsTemplateNewlines,
+} from '@/lib/auth-sms-template'
 import { BASE_PATH } from '@/lib/constants'
 
 interface ProviderFormProps {
@@ -102,11 +107,15 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
             values[key] = !(config as any)[key]
           } else {
             const configValue = (config as any)[key]
-            values[key] = configValue
-              ? configValue
-              : provider.properties[key].type === 'boolean'
-                ? false
-                : ''
+            if (isSmsTemplateConfigKey(key) && typeof configValue === 'string') {
+              values[key] = normalizeSmsTemplateNewlines(configValue)
+            } else {
+              values[key] = configValue
+                ? configValue
+                : provider.properties[key].type === 'boolean'
+                  ? false
+                  : ''
+            }
           }
         }
       })
@@ -135,8 +144,10 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       payload.PASSWORD_REQUIRED_CHARACTERS = ''
     }
 
+    const configPayload = normalizeSmsTemplateFieldsInPayload(payload)
+
     updateAuthConfig(
-      { projectRef: projectRef!, config: payload },
+      { projectRef: projectRef!, config: configPayload },
       {
         onSuccess: (newValues) => {
           setOpen(false)

--- a/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
@@ -15,7 +15,6 @@ import {
   FormControl,
   FormField,
   FormInputGroupInput,
-  Input,
   InputGroup,
   InputGroupAddon,
   InputGroupText,
@@ -25,6 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
   Switch,
+  Textarea,
   WarningIcon,
 } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
@@ -47,6 +47,10 @@ import { useAuthConfigQuery } from '@/data/auth/auth-config-query'
 import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-mutation'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import {
+  normalizeSmsTemplateFieldsInPayload,
+  readSmsTemplateFromConfig,
+} from '@/lib/auth-sms-template'
 import { IS_PLATFORM } from '@/lib/constants'
 
 function determineMFAStatus(verifyEnabled: boolean, enrollEnabled: boolean) {
@@ -200,7 +204,10 @@ export const MfaAuthSettingsForm = () => {
               authConfig?.MFA_PHONE_ENROLL_ENABLED || false
             ) || 'Disabled',
           MFA_PHONE_OTP_LENGTH: authConfig?.MFA_PHONE_OTP_LENGTH || 6,
-          MFA_PHONE_TEMPLATE: authConfig?.MFA_PHONE_TEMPLATE || 'Your code is {{ .Code }}',
+          MFA_PHONE_TEMPLATE: readSmsTemplateFromConfig(
+            authConfig?.MFA_PHONE_TEMPLATE,
+            'Your code is {{ .Code }}'
+          ),
         })
       }
 
@@ -282,10 +289,12 @@ export const MfaAuthSettingsForm = () => {
       }
     }
 
+    const configPayload = normalizeSmsTemplateFieldsInPayload(payload)
+
     setIsUpdatingPhoneForm(true)
 
     updateAuthConfig(
-      { projectRef: projectRef!, config: payload },
+      { projectRef: projectRef!, config: configPayload },
       {
         onError: (error) => {
           toast.error(`Failed to update phone MFA settings: ${error?.message}`)
@@ -542,9 +551,10 @@ export const MfaAuthSettingsForm = () => {
                         description="To format the OTP code use `{{ .Code }}`"
                       >
                         <FormControl>
-                          <Input
-                            type="text"
+                          <Textarea
                             {...field}
+                            rows={4}
+                            className="resize-none"
                             disabled={!canUpdateConfig || !hasAccessToMFA}
                             data-1p-ignore // 1Password
                             data-lpignore="true" // LastPass

--- a/apps/studio/lib/auth-sms-template.test.ts
+++ b/apps/studio/lib/auth-sms-template.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isSmsTemplateConfigKey,
+  normalizeSmsTemplateFieldsInPayload,
+  normalizeSmsTemplateNewlines,
+  readSmsTemplateFromConfig,
+  SMS_TEMPLATE_CONFIG_KEYS,
+} from './auth-sms-template'
+
+describe('isSmsTemplateConfigKey', () => {
+  it('identifies known SMS template config keys', () => {
+    expect(isSmsTemplateConfigKey('SMS_TEMPLATE')).toBe(true)
+    expect(isSmsTemplateConfigKey('MFA_PHONE_TEMPLATE')).toBe(true)
+  })
+
+  it('rejects unrelated config keys', () => {
+    expect(isSmsTemplateConfigKey('SMS_OTP_LENGTH')).toBe(false)
+    expect(isSmsTemplateConfigKey('OTHER_FIELD')).toBe(false)
+  })
+})
+
+describe('normalizeSmsTemplateNewlines', () => {
+  it('returns empty string for null, undefined, and empty input', () => {
+    expect(normalizeSmsTemplateNewlines(null)).toBe('')
+    expect(normalizeSmsTemplateNewlines(undefined)).toBe('')
+    expect(normalizeSmsTemplateNewlines('')).toBe('')
+  })
+
+  it('converts literal \\n to newlines', () => {
+    expect(normalizeSmsTemplateNewlines('{{ .Code }}\\n@example.com #{{ .Code }}')).toBe(
+      '{{ .Code }}\n@example.com #{{ .Code }}'
+    )
+  })
+
+  it('converts literal \\r\\n to newlines', () => {
+    expect(normalizeSmsTemplateNewlines('{{ .Code }}\\r\\n@example.com')).toBe(
+      '{{ .Code }}\n@example.com'
+    )
+  })
+
+  it('converts multiple literal \\n sequences', () => {
+    expect(normalizeSmsTemplateNewlines('a\\nb\\nc')).toBe('a\nb\nc')
+  })
+
+  it('leaves templates unchanged when they only contain real newlines', () => {
+    const template = '{{ .Code }}\n@example.com #{{ .Code }}'
+    expect(normalizeSmsTemplateNewlines(template)).toBe(template)
+  })
+
+  it('converts literal \\n even when real newlines are already present', () => {
+    expect(normalizeSmsTemplateNewlines('line1\nline2\\nline3')).toBe('line1\nline2\nline3')
+  })
+
+  it('is idempotent', () => {
+    const once = normalizeSmsTemplateNewlines('{{ .Code }}\\n@example.com')
+    const twice = normalizeSmsTemplateNewlines(once)
+    expect(twice).toBe('{{ .Code }}\n@example.com')
+    expect(twice).toBe(once)
+  })
+
+  it('does not modify templates without escape sequences', () => {
+    expect(normalizeSmsTemplateNewlines('Your code is {{ .Code }}')).toBe(
+      'Your code is {{ .Code }}'
+    )
+  })
+
+  it('supports common WebOTP-style formatting', () => {
+    const input = 'Your code is {{ .Code }}\\n@myapp.com #{{ .Code }}'
+    const expected = 'Your code is {{ .Code }}\n@myapp.com #{{ .Code }}'
+    expect(normalizeSmsTemplateNewlines(input)).toBe(expected)
+  })
+})
+
+describe('readSmsTemplateFromConfig', () => {
+  it('normalizes stored templates', () => {
+    expect(readSmsTemplateFromConfig('code\\n@app.com')).toBe('code\n@app.com')
+  })
+
+  it('uses the fallback when the config value is nullish', () => {
+    expect(readSmsTemplateFromConfig(null, 'Your code is {{ .Code }}')).toBe(
+      'Your code is {{ .Code }}'
+    )
+    expect(readSmsTemplateFromConfig(undefined, 'fallback\\nline')).toBe('fallback\nline')
+  })
+})
+
+describe('normalizeSmsTemplateFieldsInPayload', () => {
+  it('normalizes known SMS template keys only', () => {
+    expect(SMS_TEMPLATE_CONFIG_KEYS).toEqual(['SMS_TEMPLATE', 'MFA_PHONE_TEMPLATE'])
+
+    const payload = {
+      SMS_TEMPLATE: 'otp\\n@app.com',
+      MFA_PHONE_TEMPLATE: 'code\\r\\n@app.com',
+      SMS_OTP_LENGTH: 6,
+      OTHER_FIELD: 'keep\\nme',
+    }
+
+    expect(normalizeSmsTemplateFieldsInPayload(payload)).toEqual({
+      SMS_TEMPLATE: 'otp\n@app.com',
+      MFA_PHONE_TEMPLATE: 'code\n@app.com',
+      SMS_OTP_LENGTH: 6,
+      OTHER_FIELD: 'keep\\nme',
+    })
+  })
+
+  it('does not mutate the original payload object', () => {
+    const payload = { SMS_TEMPLATE: 'a\\nb' }
+    const normalized = normalizeSmsTemplateFieldsInPayload(payload)
+
+    expect(normalized).toEqual({ SMS_TEMPLATE: 'a\nb' })
+    expect(payload).toEqual({ SMS_TEMPLATE: 'a\\nb' })
+    expect(normalized).not.toBe(payload)
+  })
+
+  it('ignores non-string template values', () => {
+    const payload = { SMS_TEMPLATE: null, MFA_PHONE_TEMPLATE: undefined }
+    expect(normalizeSmsTemplateFieldsInPayload(payload)).toEqual(payload)
+  })
+})

--- a/apps/studio/lib/auth-sms-template.ts
+++ b/apps/studio/lib/auth-sms-template.ts
@@ -1,0 +1,67 @@
+/** Config keys that store user-editable SMS body templates in GoTrue. */
+export const SMS_TEMPLATE_CONFIG_KEYS = ['SMS_TEMPLATE', 'MFA_PHONE_TEMPLATE'] as const
+
+/** Auth config property name for an SMS or MFA phone message template. */
+export type SmsTemplateConfigKey = (typeof SMS_TEMPLATE_CONFIG_KEYS)[number]
+
+const SMS_TEMPLATE_CONFIG_KEY_SET = new Set<string>(SMS_TEMPLATE_CONFIG_KEYS)
+
+/**
+ * @param key - Auth config field name from a form or API payload.
+ * @returns Whether the key stores an SMS/MFA phone message template.
+ */
+export function isSmsTemplateConfigKey(key: string): key is SmsTemplateConfigKey {
+  return SMS_TEMPLATE_CONFIG_KEY_SET.has(key)
+}
+
+/**
+ * Converts literal `\\n` and `\\r\\n` sequences in SMS templates to real line breaks.
+ *
+ * Older Studio configs stored escaped newlines from single-line inputs. WebOTP
+ * expects an actual newline after the OTP line.
+ *
+ * @param template - Raw template from auth config or form state.
+ * @returns The template with escaped line breaks replaced, or an empty string for nullish input.
+ */
+export function normalizeSmsTemplateNewlines(template: string | null | undefined): string {
+  if (template == null || template === '') {
+    return template ?? ''
+  }
+
+  return template.replace(/\\r\\n/g, '\n').replace(/\\n/g, '\n')
+}
+
+/**
+ * Reads an SMS template from auth config, applying newline normalization and an optional fallback.
+ *
+ * @param template - Raw template from auth config.
+ * @param fallback - Value used when `template` is nullish.
+ * @returns Normalized template text for form display.
+ */
+export function readSmsTemplateFromConfig(
+  template: string | null | undefined,
+  fallback = ''
+): string {
+  return normalizeSmsTemplateNewlines(template ?? fallback)
+}
+
+/**
+ * Normalizes SMS template fields in an auth config payload before persisting.
+ *
+ * @param payload - Auth config object being saved to the API.
+ * @returns A shallow copy of the payload with SMS template fields normalized.
+ */
+export function normalizeSmsTemplateFieldsInPayload<T extends Record<string, unknown>>(
+  payload: T
+): T {
+  const normalized: Record<string, unknown> = { ...payload }
+
+  for (const key of SMS_TEMPLATE_CONFIG_KEYS) {
+    const value = normalized[key]
+    if (typeof value === 'string') {
+      normalized[key] = normalizeSmsTemplateNewlines(value)
+    }
+  }
+
+  return normalized as T
+}


### PR DESCRIPTION
Fixes #6435

## Summary

Studio already renders `SMS_TEMPLATE` as a multiline field, but users can still see literal `\n` in sent SMS messages when configs were saved from older single-line inputs. MFA phone templates had the same gap (single-line input, no normalization).

This PR normalizes SMS template fields on **load and save** for both `SMS_TEMPLATE` and `MFA_PHONE_TEMPLATE`, and switches the MFA phone template UI to a multiline `Textarea` (matching the phone provider form).

## What changed

- **`auth-sms-template` helper** — converts legacy escaped `\\n` / `\\r\\n` to real line breaks (including mixed real + escaped newlines)
- **`ProviderForm`** — normalizes template keys via a shared type guard (not hard-coded to `SMS_TEMPLATE` only)
- **`MfaAuthSettingsForm`** — multiline `Textarea` + normalization on load/save
- **Types** — add `multiline-string` / `datetime` to provider field union (already used in validation)
- **Tests** — Vitest coverage for normalization, payload scoping, idempotency, and immutability

## Test plan

- [x] `pnpm --filter studio test auth-sms-template` (run locally before merge)
- [ ] Auth → Phone provider: save `SMS_TEMPLATE` with multiple lines; reload and confirm line breaks persist (no visible `\n`)
- [ ] Auth → MFA → Phone: same check for `MFA_PHONE_TEMPLATE`
- [ ] Optional: verify WebOTP-style body (`code` line, blank line, `@origin #code`) in a test SMS

## Notes

- Vercel Studio checks on fork PRs may show **authorization required**; maintainer preview/CI is appreciated.
- Related open PRs (#41956, #43079, #44607) overlap partially; this change set covers SMS + MFA normalization and tests in one place.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for multiline-string and datetime field types in authentication provider configuration
  * SMS phone verification messages now accept multi-line input

* **Bug Fixes**
  * SMS template newlines are consistently normalized on load and save for reliable rendering

* **Tests**
  * Expanded unit tests covering SMS template detection, newline normalization, reading from config, and payload normalization

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->