### PR TITLE
chore(studio): clarify advisor scope on project home

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/AdvisorSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/AdvisorSection.tsx
@@ -58,8 +58,8 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
   const hiddenIssuesCount = totalIssues - visibleAdvisorItems.length
 
   const titleContent = useMemo(() => {
-    if (totalIssues === 0) return <h2>No critical issues found</h2>
-    const issuesText = totalIssues === 1 ? 'critical issue' : 'critical issues'
+    if (totalIssues === 0) return <h2>No high-priority issues found</h2>
+    const issuesText = totalIssues === 1 ? 'high-priority issue' : 'high-priority issues'
     const numberDisplay = totalIssues.toString()
     return (
       <h2>
@@ -130,7 +130,7 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
                 href={`/project/${projectRef}/advisors/security`}
                 className="text-sm text-foreground-light hover:text-foreground"
               >
-                View all in Advisors
+                See warnings and info in Advisors
               </Link>
             )}
           </div>
@@ -258,7 +258,7 @@ function EmptyState({ projectRef }: { projectRef?: string }) {
       <CardContent className="flex flex-col items-center justify-center gap-2 p-16 h-full">
         <Shield size={20} strokeWidth={1.5} className="text-foreground-muted" />
         <p className="text-sm text-foreground-light text-center">
-          No critical (error-level) security or performance issues found.
+          No high-priority security or performance issues found.
         </p>
         {projectRef && (
           <p className="text-sm text-foreground-lighter text-center">

--- a/apps/studio/components/interfaces/ProjectHome/AdvisorSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/AdvisorSection.tsx
@@ -1,5 +1,6 @@
 import { useParams } from 'common'
 import { BarChart, Shield } from 'lucide-react'
+import Link from 'next/link'
 import { useCallback, useMemo } from 'react'
 import { AiIconAnimation, Badge, Button, Card, CardContent, CardHeader, CardTitle, cn } from 'ui'
 import { Row } from 'ui-patterns'
@@ -57,8 +58,8 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
   const hiddenIssuesCount = totalIssues - visibleAdvisorItems.length
 
   const titleContent = useMemo(() => {
-    if (totalIssues === 0) return <h2>Advisor found no issues</h2>
-    const issuesText = totalIssues === 1 ? 'issue' : 'issues'
+    if (totalIssues === 0) return <h2>No critical issues found</h2>
+    const issuesText = totalIssues === 1 ? 'critical issue' : 'critical issues'
     const numberDisplay = totalIssues.toString()
     return (
       <h2>
@@ -110,7 +111,7 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
   )
 
   if (showEmptyState) {
-    return <EmptyState />
+    return <EmptyState projectRef={projectRef} />
   }
 
   // [Joshen] Note that we're intentionally (for now) not waiting for advisor signals to load
@@ -122,7 +123,17 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
         <ShimmeringLoader className="w-96 mb-6" />
       ) : (
         <div className="flex justify-between items-center mb-6">
-          {titleContent}
+          <div className="flex items-baseline gap-x-3">
+            {titleContent}
+            {projectRef && (
+              <Link
+                href={`/project/${projectRef}/advisors/security`}
+                className="text-sm text-foreground-light hover:text-foreground"
+              >
+                View all in Advisors
+              </Link>
+            )}
+          </div>
           <Button type="default" icon={<AiIconAnimation />} onClick={handleAskAssistant}>
             Ask Assistant
           </Button>
@@ -229,26 +240,45 @@ export const AdvisorSection = ({ showEmptyState = false }: { showEmptyState?: bo
           {hiddenIssuesCount > 0 && (
             <div className="mt-4 flex justify-end">
               <Button type="text" onClick={() => openSidebar(SIDEBAR_KEYS.ADVISOR_PANEL)}>
-                View {hiddenIssuesCount} more issue{hiddenIssuesCount !== 1 ? 's' : ''} in Advisor
+                View {hiddenIssuesCount} more issue{hiddenIssuesCount !== 1 ? 's' : ''} in Advisors
               </Button>
             </div>
           )}
         </>
       ) : (
-        <EmptyState />
+        <EmptyState projectRef={projectRef} />
       )}
     </div>
   )
 }
 
-function EmptyState() {
+function EmptyState({ projectRef }: { projectRef?: string }) {
   return (
     <Card className="bg-transparent h-64">
       <CardContent className="flex flex-col items-center justify-center gap-2 p-16 h-full">
         <Shield size={20} strokeWidth={1.5} className="text-foreground-muted" />
         <p className="text-sm text-foreground-light text-center">
-          No security or performance issues found
+          No critical (error-level) security or performance issues found.
         </p>
+        {projectRef && (
+          <p className="text-sm text-foreground-lighter text-center">
+            Warnings and informational findings are shown in the{' '}
+            <Link
+              href={`/project/${projectRef}/advisors/security`}
+              className="text-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Security
+            </Link>{' '}
+            and{' '}
+            <Link
+              href={`/project/${projectRef}/advisors/performance`}
+              className="text-foreground underline underline-offset-2 hover:text-foreground"
+            >
+              Performance
+            </Link>{' '}
+            advisor pages.
+          </p>
+        )}
       </CardContent>
     </Card>
   )

--- a/apps/studio/components/ui/AdvisorPanel/AdvisorSignals.integration.test.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorSignals.integration.test.tsx
@@ -159,7 +159,7 @@ describe('Advisor signals integration', () => {
       </>
     )
 
-    expect(screen.getByText('Advisor found 2 issues')).toBeInTheDocument()
+    expect(screen.getByText('Advisor found 2 high-priority issues')).toBeInTheDocument()
     expect(screen.getByText('Banned IP address')).toBeInTheDocument()
     expect(screen.getAllByText('Critical lint detail').length).toBeGreaterThan(0)
     expect(
@@ -255,8 +255,10 @@ describe('Advisor signals integration', () => {
 
     render(<AdvisorSection />)
 
-    expect(screen.getByText('Advisor found 5 issues')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: 'View 1 more issue in Advisor' })).toBeInTheDocument()
+    expect(screen.getByText('Advisor found 5 high-priority issues')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'View 1 more issue in Advisors' })
+    ).toBeInTheDocument()
     expect(screen.queryByText('Banned IP address')).not.toBeInTheDocument()
   })
 
@@ -275,6 +277,6 @@ describe('Advisor signals integration', () => {
     render(<AdvisorSection />)
 
     // Lints have loaded — homepage renders without being blocked by signal loading
-    expect(screen.getByText('Advisor found no issues')).toBeInTheDocument()
+    expect(screen.getByText('No high-priority issues found')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Improve clarity of the Advisor section on the project home page:

The home page Advisor card only surfaces a subset of findings (error-level lints + signals), but the surrounding copy didn't make that scope obvious. Users might wonder why warning-level issues they could see in Advisors.

Changes:

- Title: `Advisor found N issues` / `Advisor found no issues` → `Advisor found N high-priority issues` / `No high-priority issues found`. "High-priority" is meant to cover both error-level lints (that are "critical") and signal items, where "critical" would have been wrong for the latter.
- Empty-state body: aligned to the same "high-priority" wording.
- Added a `See warnings and info in Advisors` link next to the title, and Security/Performance links in the empty state, so users have a clear path to the full list.
- Minor: `Advisor` → `Advisors` in the "View N more" button to match the destination page name.
