### PR TITLE
feat(reports): explain hazardous memory patterns in database reports

### DIFF
--- a/apps/studio/components/interfaces/Reports/MemoryPatternCallout.tsx
+++ b/apps/studio/components/interfaces/Reports/MemoryPatternCallout.tsx
@@ -39,5 +39,4 @@ const MemoryPatternCallout = () => {
   )
 }
 
-export default MemoryPatternCallout
 export { MemoryPatternCallout }

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -56,6 +56,8 @@ export const getReportAttributesV2: (
     {
       id: 'ram-usage',
       label: 'Memory usage',
+      titleTooltip:
+        'Watch for three hazardous patterns: (1) Used memory approaching or spiking past the Total RAM line — the database may go offline. (2) Steady linear growth over time — likely a memory leak or workload outgrowing the current compute size. (3) Shrinking Cache + Buffers under sustained load — Postgres has less buffer pool available, increasing disk reads and degrading query performance.',
       docsUrl: `${DOCS_URL}/guides/telemetry/reports#memory-usage`,
       hide: false,
       showTooltip: true,

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -57,7 +57,7 @@ export const getReportAttributesV2: (
       id: 'ram-usage',
       label: 'Memory usage',
       titleTooltip:
-        'Watch for three hazardous patterns: (1) Used memory approaching or spiking past the Total RAM line — the database may go offline. (2) Steady linear growth over time — likely a memory leak or workload outgrowing the current compute size. (3) Shrinking Cache + Buffers under sustained load — Postgres has less buffer pool available, increasing disk reads and degrading query performance.',
+        'Watch for three hazardous patterns: (1) Used memory approaching or spiking past the Total RAM line - the database may go offline. (2) Steady linear growth over time - likely a memory leak or workload outgrowing the current compute size. (3) Shrinking Cache + Buffers under sustained load - Postgres has less buffer pool available, increasing disk reads and degrading query performance.',
       docsUrl: `${DOCS_URL}/guides/telemetry/reports#memory-usage`,
       hide: false,
       showTooltip: true,

--- a/apps/studio/pages/project/[ref]/observability/MemoryPatternCallout.tsx
+++ b/apps/studio/pages/project/[ref]/observability/MemoryPatternCallout.tsx
@@ -1,0 +1,42 @@
+import { Admonition } from 'ui-patterns'
+
+const MemoryPatternCallout = () => {
+  return (
+    <Admonition type="default" title="What to look for in memory charts">
+      <ul className="mt-1 space-y-2 text-sm text-foreground-light list-none">
+        <li>
+          <span className="font-medium text-foreground">Overcommitment with memory spikes</span>
+          {' - '}
+          If Used memory approaches or briefly exceeds Total RAM, the database is at risk of going
+          offline. Even short spikes above the commit limit can trigger an out-of-memory event.
+          Upgrade compute or reduce workload before the next spike.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">Gradual linear growth over time</span>
+          {' - '}A steady upward trend in Used memory that does not level off is a strong signal of
+          a memory leak or a workload that has outgrown the current compute size. Monitor over a
+          longer window (hours to days) to confirm the trend.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">
+            Shrinking Cache + Buffers at low Postgres hit rates
+          </span>
+          {' - '}
+          Cache + Buffers penalties become significant when the Postgres hit rate falls below 95%.
+          When Used memory is high, the OS shrinks Cache + Buffers to compensate, forcing more
+          queries to read from disk and slowing down the database. Check the cache hit rate in the
+          Query Performance report if you see this pattern.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">Other fluctuations</span>
+          {' - '}
+          Occasional bumps or periodic cycles in memory are generally normal and can be safely
+          ignored unless they coincide with visible database degradation (slow queries, connection
+          errors, or downtime).
+        </li>
+      </ul>
+    </Admonition>
+  )
+}
+
+export { MemoryPatternCallout }

--- a/apps/studio/pages/project/[ref]/observability/MemoryPatternCallout.tsx
+++ b/apps/studio/pages/project/[ref]/observability/MemoryPatternCallout.tsx
@@ -39,4 +39,5 @@ const MemoryPatternCallout = () => {
   )
 }
 
+export default MemoryPatternCallout
 export { MemoryPatternCallout }

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -7,7 +7,6 @@ import Link from 'next/link'
 import { Fragment, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Alert, AlertDescription, Button } from 'ui'
-import { Admonition } from 'ui-patterns'
 
 import ReportHeader from '@/components/interfaces/Reports/ReportHeader'
 import ReportPadding from '@/components/interfaces/Reports/ReportPadding'
@@ -45,6 +44,7 @@ import { DOCS_URL } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import type { NextPageWithLayout } from '@/types'
+import { MemoryPatternCallout } from './MemoryPatternCallout'
 
 const DatabaseReport: NextPageWithLayout = () => {
   return (
@@ -291,7 +291,7 @@ const DatabaseUsage = () => {
             return (
               <Fragment key={chart.id}>
                 {chartElement}
-                {chart.id === 'swap-usage' && <MemoryPatternCallout />}
+                {chart.id === 'ram-usage' && <MemoryPatternCallout />}
               </Fragment>
             )
           })}
@@ -447,41 +447,3 @@ const DatabaseUsage = () => {
   )
 }
 
-const MemoryPatternCallout = () => {
-  return (
-    <Admonition type="default" title="What to look for in memory charts">
-      <ul className="mt-1 space-y-2 text-sm text-foreground-light list-none">
-        <li>
-          <span className="font-medium text-foreground">Overcommitment with memory spikes</span>
-          {' — '}
-          If Used memory approaches or briefly exceeds Total RAM, the database is at risk of going
-          offline. Even short spikes above the commit limit can trigger an out-of-memory event.
-          Upgrade compute or reduce workload before the next spike.
-        </li>
-        <li>
-          <span className="font-medium text-foreground">Gradual linear growth over time</span>
-          {' — '}A steady upward trend in Used memory that does not level off is a strong signal of
-          a memory leak or a workload that has outgrown the current compute size. Monitor over a
-          longer window (hours to days) to confirm the trend.
-        </li>
-        <li>
-          <span className="font-medium text-foreground">
-            Shrinking cache at low Postgres hit rates
-          </span>
-          {' — '}
-          Cache penalties become significant when the Postgres buffer cache hit rate falls below
-          95%. When Used memory is high, the OS shrinks the page cache to compensate, forcing more
-          queries to read from disk and slowing down the database. Check the cache hit rate in the
-          Query Performance report if you see this pattern.
-        </li>
-        <li>
-          <span className="font-medium text-foreground">Other fluctuations</span>
-          {' — '}
-          Occasional bumps or periodic cycles in memory are generally normal and can be safely
-          ignored unless they coincide with visible database degradation (slow queries, connection
-          errors, or downtime).
-        </li>
-      </ul>
-    </Admonition>
-  )
-}

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -42,7 +42,7 @@ import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganizati
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
-import { MemoryPatternCallout } from './MemoryPatternCallout'
+import { MemoryPatternCallout } from '@/components/interfaces/Reports/MemoryPatternCallout'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import type { NextPageWithLayout } from '@/types'
 

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -4,9 +4,10 @@ import { useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import { ArrowRight, ExternalLink, RefreshCw } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Alert, AlertDescription, Button } from 'ui'
+import { Admonition } from 'ui-patterns'
 
 import ReportHeader from '@/components/interfaces/Reports/ReportHeader'
 import ReportPadding from '@/components/interfaces/Reports/ReportPadding'
@@ -263,9 +264,8 @@ const DatabaseUsage = () => {
               !chart.entitlement ||
               isEntitlementLoading ||
               entitledFeatures.includes(chart.entitlement)
-            return chartAvailable ? (
+            const chartElement = chartAvailable ? (
               <LazyComposedChartHandler
-                key={chart.id}
                 {...chart}
                 attributes={chart.attributes as MultiAttribute[]}
                 interval={selectedDateRange.interval}
@@ -284,10 +284,15 @@ const DatabaseUsage = () => {
               />
             ) : (
               <ReportChartUpsell
-                key={chart.id}
                 report={{ label: chart.label, requiredPlan: chart.requiredPlan }}
                 orgSlug={org?.slug ?? ''}
               />
+            )
+            return (
+              <Fragment key={chart.id}>
+                {chartElement}
+                {chart.id === 'swap-usage' && <MemoryPatternCallout />}
+              </Fragment>
             )
           })}
         {selectedDateRange && isReplicaSelected && (
@@ -439,5 +444,44 @@ const DatabaseUsage = () => {
         <ObservabilityLink />
       </div>
     </>
+  )
+}
+
+const MemoryPatternCallout = () => {
+  return (
+    <Admonition type="default" title="What to look for in memory charts">
+      <ul className="mt-1 space-y-2 text-sm text-foreground-light list-none">
+        <li>
+          <span className="font-medium text-foreground">Overcommitment with memory spikes</span>
+          {' — '}
+          If Used memory approaches or briefly exceeds Total RAM, the database is at risk of going
+          offline. Even short spikes above the commit limit can trigger an out-of-memory event.
+          Upgrade compute or reduce workload before the next spike.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">Gradual linear growth over time</span>
+          {' — '}A steady upward trend in Used memory that does not level off is a strong signal of
+          a memory leak or a workload that has outgrown the current compute size. Monitor over a
+          longer window (hours to days) to confirm the trend.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">
+            Shrinking cache at low Postgres hit rates
+          </span>
+          {' — '}
+          Cache penalties become significant when the Postgres buffer cache hit rate falls below
+          95%. When Used memory is high, the OS shrinks the page cache to compensate, forcing more
+          queries to read from disk and slowing down the database. Check the cache hit rate in the
+          Query Performance report if you see this pattern.
+        </li>
+        <li>
+          <span className="font-medium text-foreground">Other fluctuations</span>
+          {' — '}
+          Occasional bumps or periodic cycles in memory are generally normal and can be safely
+          ignored unless they coincide with visible database degradation (slow queries, connection
+          errors, or downtime).
+        </li>
+      </ul>
+    </Admonition>
   )
 }

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -42,9 +42,9 @@ import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganizati
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
+import { MemoryPatternCallout } from './MemoryPatternCallout'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import type { NextPageWithLayout } from '@/types'
-import { MemoryPatternCallout } from './MemoryPatternCallout'
 
 const DatabaseReport: NextPageWithLayout = () => {
   return (


### PR DESCRIPTION
Fixes [DEBUG-121](https://linear.app/supabase/issue/DEBUG-121)

## Problem

The database memory charts in the Observability report showed raw metrics without any guidance on what patterns indicate a problem. Users had no context for distinguishing a dangerous overcommitment spike from a normal memory fluctuation.

## Fix

- Added a `titleTooltip` to the **Memory usage** chart summarising the three hazardous patterns: overcommitment/spikes past Total RAM, steady linear growth (leak signal), and shrinking cache under low Postgres hit rate.
- Added a `MemoryPatternCallout` component (rendered below the **Swap usage** chart) with expanded explanations of all four patterns, including a "normal fluctuations" note to reduce alert fatigue.
- Wrapped each chart + optional callout in a `Fragment` to preserve stable React list keys.

## Testing

- [ ] Open the Database Observability report and verify the Memory usage chart title shows the tooltip on hover.
- [ ] Confirm the callout panel appears below the Swap usage chart.
- [ ] Verify no regressions on charts without a callout.
- [ ] Check that charts without entitlement still show the upsell panel correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)