### PR TITLE
feat(observability): surface table and index hit rates in Overview DEBUG-120

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -17,6 +17,7 @@ import {
 import { useInfraMonitoringAttributesQuery } from '@/data/analytics/infra-monitoring-query'
 import { useMaxConnectionsQuery } from '@/data/database/max-connections-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useTrack } from '@/lib/telemetry/track'
 
 type DatabaseInfrastructureSectionProps = {
   interval: '1hr' | '1day' | '7day'
@@ -43,6 +44,7 @@ export const DatabaseInfrastructureSection = ({
 }: DatabaseInfrastructureSectionProps) => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
+  const track = useTrack()
 
   // refreshKey forces date recalculation when user clicks refresh button
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -269,51 +271,47 @@ export const DatabaseInfrastructureSection = ({
           </MetricCard>
         </Link>
 
-        <Link
-          href={`/project/${projectRef}/observability/query-performance`}
-          className="block group"
+        <MetricCard
+          isLoading={hitRatesLoading}
+          onClick={() => track('observability_table_hit_rate_card_clicked')}
         >
-          <MetricCard isLoading={hitRatesLoading}>
-            <MetricCardHeader
-              href={`/project/${projectRef}/observability/query-performance`}
-              linkTooltip="Go to query performance"
-            >
-              <MetricCardLabel tooltip="Percentage of table block reads served from shared memory (buffer cache) vs disk. Values above 99% are healthy. Lower values suggest the shared_buffers setting may need tuning or the working set exceeds available memory.">
-                Table Hit Rate
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              {tableHitRate != null ? (
-                <MetricCardValue>{tableHitRate.toFixed(2)}%</MetricCardValue>
-              ) : (
-                <MetricCardValue>--</MetricCardValue>
-              )}
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+          <MetricCardHeader
+            href={`/project/${projectRef}/observability/query-performance`}
+            linkTooltip="Go to query performance"
+          >
+            <MetricCardLabel tooltip="Percentage of table block reads served from shared memory (buffer cache) vs disk. Values above 99% are healthy. Lower values suggest the shared_buffers setting may need tuning or the working set exceeds available memory.">
+              Table Hit Rate
+            </MetricCardLabel>
+          </MetricCardHeader>
+          <MetricCardContent>
+            {tableHitRate != null ? (
+              <MetricCardValue>{tableHitRate.toFixed(2)}%</MetricCardValue>
+            ) : (
+              <MetricCardValue>--</MetricCardValue>
+            )}
+          </MetricCardContent>
+        </MetricCard>
 
-        <Link
-          href={`/project/${projectRef}/observability/query-performance`}
-          className="block group"
+        <MetricCard
+          isLoading={hitRatesLoading}
+          onClick={() => track('observability_index_hit_rate_card_clicked')}
         >
-          <MetricCard isLoading={hitRatesLoading}>
-            <MetricCardHeader
-              href={`/project/${projectRef}/observability/query-performance`}
-              linkTooltip="Go to query performance"
-            >
-              <MetricCardLabel tooltip="Percentage of index block reads served from shared memory (buffer cache) vs disk. Values above 99% are healthy. Low values may indicate missing indexes or insufficient memory.">
-                Index Hit Rate
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              {indexHitRate != null ? (
-                <MetricCardValue>{indexHitRate.toFixed(2)}%</MetricCardValue>
-              ) : (
-                <MetricCardValue>--</MetricCardValue>
-              )}
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+          <MetricCardHeader
+            href={`/project/${projectRef}/observability/query-performance`}
+            linkTooltip="Go to query performance"
+          >
+            <MetricCardLabel tooltip="Percentage of index block reads served from shared memory (buffer cache) vs disk. Values above 99% are healthy. Low values may indicate missing indexes or insufficient memory.">
+              Index Hit Rate
+            </MetricCardLabel>
+          </MetricCardHeader>
+          <MetricCardContent>
+            {indexHitRate != null ? (
+              <MetricCardValue>{indexHitRate.toFixed(2)}%</MetricCardValue>
+            ) : (
+              <MetricCardValue>--</MetricCardValue>
+            )}
+          </MetricCardContent>
+        </MetricCard>
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -25,6 +25,9 @@ type DatabaseInfrastructureSectionProps = {
   isLoading: boolean
   slowQueriesCount?: number
   slowQueriesLoading?: boolean
+  tableHitRate?: number | null
+  indexHitRate?: number | null
+  hitRatesLoading?: boolean
 }
 
 export const DatabaseInfrastructureSection = ({
@@ -34,6 +37,9 @@ export const DatabaseInfrastructureSection = ({
   isLoading: _dbLoading,
   slowQueriesCount = 0,
   slowQueriesLoading = false,
+  tableHitRate,
+  indexHitRate,
+  hitRatesLoading = false,
 }: DatabaseInfrastructureSectionProps) => {
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -256,6 +262,52 @@ export const DatabaseInfrastructureSection = ({
                 <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
               ) : metrics ? (
                 <MetricCardValue>{metrics.cpu.current.toFixed(0)}%</MetricCardValue>
+              ) : (
+                <MetricCardValue>--</MetricCardValue>
+              )}
+            </MetricCardContent>
+          </MetricCard>
+        </Link>
+
+        <Link
+          href={`/project/${projectRef}/observability/query-performance`}
+          className="block group"
+        >
+          <MetricCard isLoading={hitRatesLoading}>
+            <MetricCardHeader
+              href={`/project/${projectRef}/observability/query-performance`}
+              linkTooltip="Go to query performance"
+            >
+              <MetricCardLabel tooltip="Percentage of table block reads served from shared memory (buffer cache) vs disk. Values above 99% are healthy. Lower values suggest the shared_buffers setting may need tuning or the working set exceeds available memory.">
+                Table Hit Rate
+              </MetricCardLabel>
+            </MetricCardHeader>
+            <MetricCardContent>
+              {tableHitRate != null ? (
+                <MetricCardValue>{tableHitRate.toFixed(2)}%</MetricCardValue>
+              ) : (
+                <MetricCardValue>--</MetricCardValue>
+              )}
+            </MetricCardContent>
+          </MetricCard>
+        </Link>
+
+        <Link
+          href={`/project/${projectRef}/observability/query-performance`}
+          className="block group"
+        >
+          <MetricCard isLoading={hitRatesLoading}>
+            <MetricCardHeader
+              href={`/project/${projectRef}/observability/query-performance`}
+              linkTooltip="Go to query performance"
+            >
+              <MetricCardLabel tooltip="Percentage of index block reads served from shared memory (buffer cache) vs disk. Values above 99% are healthy. Low values may indicate missing indexes or insufficient memory.">
+                Index Hit Rate
+              </MetricCardLabel>
+            </MetricCardHeader>
+            <MetricCardContent>
+              {indexHitRate != null ? (
+                <MetricCardValue>{indexHitRate.toFixed(2)}%</MetricCardValue>
               ) : (
                 <MetricCardValue>--</MetricCardValue>
               )}

--- a/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
+++ b/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
@@ -47,7 +47,7 @@ export const ObservabilityOverview = () => {
     refreshKey
   )
 
-  const { tableHitRate, indexHitRate, isLoading: hitRatesLoading } = useHitRates(refreshKey)
+  const { tableHitRate, indexHitRate, isLoading: hitRatesLoading } = useHitRates()
 
   const handleRefresh = useCallback(() => {
     setRefreshKey((prev) => prev + 1)
@@ -55,6 +55,8 @@ export const ObservabilityOverview = () => {
     queryClient.invalidateQueries({ queryKey: ['project-metrics'] })
     queryClient.invalidateQueries({ queryKey: ['infra-monitoring'] })
     queryClient.invalidateQueries({ queryKey: ['max-connections'] })
+    // invalidates useDbQuery-based hooks (slow queries count, hit rates)
+    queryClient.invalidateQueries({ queryKey: ['projects', projectRef, 'db'] })
   }, [queryClient, projectRef])
 
   const serviceBase = useMemo(

--- a/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
+++ b/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
@@ -10,6 +10,7 @@ import { DatabaseInfrastructureSection } from './DatabaseInfrastructureSection'
 import { useObservabilityOverviewData } from './ObservabilityOverview.utils'
 import { ObservabilityOverviewFooter } from './ObservabilityOverviewFooter'
 import { ServiceHealthTable } from './ServiceHealthTable'
+import { useHitRates } from './useHitRates'
 import { useSlowQueriesCount } from './useSlowQueriesCount'
 import ReportHeader from '@/components/interfaces/Reports/ReportHeader'
 import ReportPadding from '@/components/interfaces/Reports/ReportPadding'
@@ -45,6 +46,8 @@ export const ObservabilityOverview = () => {
     projectRef,
     refreshKey
   )
+
+  const { tableHitRate, indexHitRate, isLoading: hitRatesLoading } = useHitRates(refreshKey)
 
   const handleRefresh = useCallback(() => {
     setRefreshKey((prev) => prev + 1)
@@ -165,6 +168,9 @@ export const ObservabilityOverview = () => {
           isLoading={dbServiceData.isLoading}
           slowQueriesCount={slowQueriesCount}
           slowQueriesLoading={slowQueriesLoading}
+          tableHitRate={tableHitRate}
+          indexHitRate={indexHitRate}
+          hitRatesLoading={hitRatesLoading}
         />
 
         <ServiceHealthTable

--- a/apps/studio/components/interfaces/Observability/useHitRates.test.ts
+++ b/apps/studio/components/interfaces/Observability/useHitRates.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildHitRatesSql, parseHitRates } from './useHitRates'
+
+describe('buildHitRatesSql', () => {
+  it('queries pg_statio_user_indexes for index hit rate', () => {
+    const sql = buildHitRatesSql()
+    expect(sql).toContain('pg_statio_user_indexes')
+    expect(sql).toContain('idx_blks_hit')
+    expect(sql).toContain('idx_blks_read')
+  })
+
+  it('queries pg_statio_user_tables for table hit rate', () => {
+    const sql = buildHitRatesSql()
+    expect(sql).toContain('pg_statio_user_tables')
+    expect(sql).toContain('heap_blks_hit')
+    expect(sql).toContain('heap_blks_read')
+  })
+
+  it('uses NULLIF to guard against division by zero', () => {
+    const sql = buildHitRatesSql()
+    expect(sql).toContain('nullif')
+  })
+
+  it('returns union of index and table rows', () => {
+    const sql = buildHitRatesSql()
+    expect(sql).toContain('union all')
+    expect(sql).toContain("'index hit rate'")
+    expect(sql).toContain("'table hit rate'")
+  })
+})
+
+describe('parseHitRates', () => {
+  it('returns nulls for non-array input', () => {
+    expect(parseHitRates(null)).toEqual({ tableHitRate: null, indexHitRate: null })
+    expect(parseHitRates(undefined)).toEqual({ tableHitRate: null, indexHitRate: null })
+    expect(parseHitRates({})).toEqual({ tableHitRate: null, indexHitRate: null })
+  })
+
+  it('returns nulls for empty array', () => {
+    expect(parseHitRates([])).toEqual({ tableHitRate: null, indexHitRate: null })
+  })
+
+  it('converts 0–1 ratios to percentages', () => {
+    const data = [
+      { name: 'index hit rate', ratio: 0.997 },
+      { name: 'table hit rate', ratio: 0.985 },
+    ]
+    const result = parseHitRates(data)
+    expect(result.indexHitRate).toBeCloseTo(99.7)
+    expect(result.tableHitRate).toBeCloseTo(98.5)
+  })
+
+  it('handles string ratios from pg driver', () => {
+    const data = [
+      { name: 'index hit rate', ratio: '0.9987654321' },
+      { name: 'table hit rate', ratio: '0.9912345678' },
+    ]
+    const result = parseHitRates(data)
+    expect(result.indexHitRate).toBeCloseTo(99.88)
+    expect(result.tableHitRate).toBeCloseTo(99.12)
+  })
+
+  it('returns null when ratio is null (no data yet)', () => {
+    const data = [
+      { name: 'index hit rate', ratio: null },
+      { name: 'table hit rate', ratio: null },
+    ]
+    expect(parseHitRates(data)).toEqual({ tableHitRate: null, indexHitRate: null })
+  })
+
+  it('handles partial results', () => {
+    const data = [{ name: 'table hit rate', ratio: 0.99 }]
+    const result = parseHitRates(data)
+    expect(result.tableHitRate).toBeCloseTo(99)
+    expect(result.indexHitRate).toBeNull()
+  })
+})

--- a/apps/studio/components/interfaces/Observability/useHitRates.test.ts
+++ b/apps/studio/components/interfaces/Observability/useHitRates.test.ts
@@ -1,32 +1,29 @@
 import { describe, expect, it } from 'vitest'
 
-import { buildHitRatesSql, parseHitRates } from './useHitRates'
+import { QUERY_HIT_RATE_SQL } from '@/components/interfaces/Reports/Reports.constants'
+import { parseHitRates } from './useHitRates'
 
-describe('buildHitRatesSql', () => {
+describe('QUERY_HIT_RATE_SQL', () => {
   it('queries pg_statio_user_indexes for index hit rate', () => {
-    const sql = buildHitRatesSql()
-    expect(sql).toContain('pg_statio_user_indexes')
-    expect(sql).toContain('idx_blks_hit')
-    expect(sql).toContain('idx_blks_read')
+    expect(QUERY_HIT_RATE_SQL).toContain('pg_statio_user_indexes')
+    expect(QUERY_HIT_RATE_SQL).toContain('idx_blks_hit')
+    expect(QUERY_HIT_RATE_SQL).toContain('idx_blks_read')
   })
 
   it('queries pg_statio_user_tables for table hit rate', () => {
-    const sql = buildHitRatesSql()
-    expect(sql).toContain('pg_statio_user_tables')
-    expect(sql).toContain('heap_blks_hit')
-    expect(sql).toContain('heap_blks_read')
+    expect(QUERY_HIT_RATE_SQL).toContain('pg_statio_user_tables')
+    expect(QUERY_HIT_RATE_SQL).toContain('heap_blks_hit')
+    expect(QUERY_HIT_RATE_SQL).toContain('heap_blks_read')
   })
 
   it('uses NULLIF to guard against division by zero', () => {
-    const sql = buildHitRatesSql()
-    expect(sql).toContain('nullif')
+    expect(QUERY_HIT_RATE_SQL).toContain('nullif')
   })
 
   it('returns union of index and table rows', () => {
-    const sql = buildHitRatesSql()
-    expect(sql).toContain('union all')
-    expect(sql).toContain("'index hit rate'")
-    expect(sql).toContain("'table hit rate'")
+    expect(QUERY_HIT_RATE_SQL).toContain('union all')
+    expect(QUERY_HIT_RATE_SQL).toContain("'index hit rate'")
+    expect(QUERY_HIT_RATE_SQL).toContain("'table hit rate'")
   })
 })
 

--- a/apps/studio/components/interfaces/Observability/useHitRates.ts
+++ b/apps/studio/components/interfaces/Observability/useHitRates.ts
@@ -1,0 +1,77 @@
+import { safeSql, type SafeSqlFragment } from '@supabase/pg-meta'
+import { useMemo } from 'react'
+
+import useDbQuery from '@/hooks/analytics/useDbQuery'
+
+type HitRateRow = {
+  name: string
+  ratio: number | null
+}
+
+export type HitRates = {
+  tableHitRate: number | null
+  indexHitRate: number | null
+}
+
+/**
+ * Builds the SQL to fetch table and index hit rates from
+ * pg_statio_user_tables and pg_statio_user_indexes.
+ *
+ * Returns ratios as 0–1 decimals (multiply by 100 for percentage display).
+ * Returns null when there is no data (e.g. no user tables yet).
+ */
+export function buildHitRatesSql(): SafeSqlFragment {
+  return safeSql`
+    -- observability-hit-rates
+    select
+      'index hit rate' as name,
+      (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read), 0) as ratio
+    from pg_statio_user_indexes
+    union all
+    select
+      'table hit rate' as name,
+      sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read), 0) as ratio
+    from pg_statio_user_tables;
+  `
+}
+
+export function parseHitRates(data: unknown): HitRates {
+  if (!Array.isArray(data)) {
+    return { tableHitRate: null, indexHitRate: null }
+  }
+
+  let tableHitRate: number | null = null
+  let indexHitRate: number | null = null
+
+  for (const row of data as HitRateRow[]) {
+    const ratio = row.ratio != null ? parseFloat(String(row.ratio)) : null
+    const value = ratio != null && !isNaN(ratio) ? ratio * 100 : null
+
+    if (row.name === 'table hit rate') {
+      tableHitRate = value
+    } else if (row.name === 'index hit rate') {
+      indexHitRate = value
+    }
+  }
+
+  return { tableHitRate, indexHitRate }
+}
+
+export const useHitRates = (refreshKey: number = 0) => {
+  // refreshKey is included in useMemo to force recomputation when refresh is triggered
+  const sql = useMemo(
+    () => buildHitRatesSql(),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [refreshKey]
+  )
+
+  const { data, isLoading, error } = useDbQuery({ sql })
+
+  const hitRates = useMemo(() => parseHitRates(data), [data])
+
+  return {
+    ...hitRates,
+    isLoading,
+    error,
+  }
+}

--- a/apps/studio/components/interfaces/Observability/useHitRates.ts
+++ b/apps/studio/components/interfaces/Observability/useHitRates.ts
@@ -1,6 +1,6 @@
-import { safeSql, type SafeSqlFragment } from '@supabase/pg-meta'
 import { useMemo } from 'react'
 
+import { QUERY_HIT_RATE_SQL } from '@/components/interfaces/Reports/Reports.constants'
 import useDbQuery from '@/hooks/analytics/useDbQuery'
 
 type HitRateRow = {
@@ -11,28 +11,6 @@ type HitRateRow = {
 export type HitRates = {
   tableHitRate: number | null
   indexHitRate: number | null
-}
-
-/**
- * Builds the SQL to fetch table and index hit rates from
- * pg_statio_user_tables and pg_statio_user_indexes.
- *
- * Returns ratios as 0–1 decimals (multiply by 100 for percentage display).
- * Returns null when there is no data (e.g. no user tables yet).
- */
-export function buildHitRatesSql(): SafeSqlFragment {
-  return safeSql`
-    -- observability-hit-rates
-    select
-      'index hit rate' as name,
-      (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read), 0) as ratio
-    from pg_statio_user_indexes
-    union all
-    select
-      'table hit rate' as name,
-      sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read), 0) as ratio
-    from pg_statio_user_tables;
-  `
 }
 
 export function parseHitRates(data: unknown): HitRates {
@@ -57,15 +35,8 @@ export function parseHitRates(data: unknown): HitRates {
   return { tableHitRate, indexHitRate }
 }
 
-export const useHitRates = (refreshKey: number = 0) => {
-  // refreshKey is included in useMemo to force recomputation when refresh is triggered
-  const sql = useMemo(
-    () => buildHitRatesSql(),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [refreshKey]
-  )
-
-  const { data, isLoading, error } = useDbQuery({ sql })
+export const useHitRates = () => {
+  const { data, isLoading, error } = useDbQuery({ sql: QUERY_HIT_RATE_SQL })
 
   const hitRates = useMemo(() => parseHitRates(data), [data])
 

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -133,6 +133,21 @@ export const generateRegexpWhere = (filters: ReportFilterItem[], prepend = true)
   }
 }
 
+/**
+ * SQL fragment that returns table and index buffer-cache hit rates.
+ * Shared between the Query Performance report and the Observability overview.
+ */
+export const QUERY_HIT_RATE_SQL = safeSql`-- reports-query-performance-cache-and-index-hit-rate
+select
+    'index hit rate' as name,
+    (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read),0) as ratio
+  from pg_statio_user_indexes
+  union all
+  select
+    'table hit rate' as name,
+    sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read),0) as ratio
+  from pg_statio_user_tables;`
+
 export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
   [Presets.API]: {
     title: 'API',
@@ -556,16 +571,7 @@ select
       },
       queryHitRate: {
         queryType: 'db',
-        safeSql: (_params) => safeSql`-- reports-query-performance-cache-and-index-hit-rate
-select
-    'index hit rate' as name,
-    (sum(idx_blks_hit)) / nullif(sum(idx_blks_hit + idx_blks_read),0) as ratio
-  from pg_statio_user_indexes
-  union all
-  select
-    'table hit rate' as name,
-    sum(heap_blks_hit) / nullif(sum(heap_blks_hit) + sum(heap_blks_read),0) as ratio
-  from pg_statio_user_tables;`,
+        safeSql: (_params) => QUERY_HIT_RATE_SQL,
       },
       unified: {
         queryType: 'db',

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3274,6 +3274,30 @@ export interface RLSTesterRunQueryClickedEvent {
 }
 
 /**
+ * User clicked the Table Hit Rate card in the Observability overview.
+ *
+ * @group Events
+ * @source studio
+ * @page /observability/overview
+ */
+export interface ObservabilityTableHitRateCardClickedEvent {
+  action: 'observability_table_hit_rate_card_clicked'
+  groups: TelemetryGroups
+}
+
+/**
+ * User clicked the Index Hit Rate card in the Observability overview.
+ *
+ * @group Events
+ * @source studio
+ * @page /observability/overview
+ */
+export interface ObservabilityIndexHitRateCardClickedEvent {
+  action: 'observability_index_hit_rate_card_clicked'
+  groups: TelemetryGroups
+}
+
+/**
  * @hidden
  */
 export type TelemetryEvent =
@@ -3462,3 +3486,5 @@ export type TelemetryEvent =
   | HeaderLocalDropdownOpenedEvent
   | HeaderLocalVersionPopoverOpenedEvent
   | RLSTesterRunQueryClickedEvent
+  | ObservabilityTableHitRateCardClickedEvent
+  | ObservabilityIndexHitRateCardClickedEvent


### PR DESCRIPTION
## Problem

Table hit rate and index hit rate are actionable database health metrics, but they were only visible deep inside Query Performance. The Observability Overview (General > Overview) did not surface them, making it harder to spot cache pressure at a glance.

Related: https://linear.app/supabase/issue/DEBUG-120

## Fix

Added two new metric cards, Table Hit Rate and Index Hit Rate, to the Database section of the Observability Overview page. The values are fetched directly from `pg_statio_user_tables` and `pg_statio_user_indexes` via a new `useHitRates` hook. Each card shows the hit rate as a percentage and links to Query Performance for further investigation.

Changes:
- `useHitRates.ts`: new hook with `buildHitRatesSql()` and `parseHitRates()` pure functions
- `useHitRates.test.ts`: unit tests for SQL content and all parseHitRates branches
- `DatabaseInfrastructureSection.tsx`: accepts and renders the two new metric cards
- `ObservabilityOverview.tsx`: wires up `useHitRates` and passes data down

## How to test

1. Enable the `observabilityOverview` feature flag for a project.
2. Navigate to Observability > Overview.
3. Observe the Database metric cards section.
4. Confirm two new cards appear: "Table Hit Rate" and "Index Hit Rate".
5. Confirm each shows a percentage value (e.g. 99.74%) or "--" if the database has no user tables yet.
6. Confirm clicking either card navigates to the Query Performance page.
7. Click Refresh and confirm both cards reload their values.
8. Verify existing metric cards (Slow Queries, Connections, Disk Usage, Disk IO, Memory, CPU) are unchanged.