### PR TITLE
feat(reports): add memory commitment chart with commit limit and danger zone DEBUG-119

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -78,6 +78,11 @@ export interface ComposedChartProps<D = Datum> extends CommonChartProps<D> {
   highlightActions?: ChartHighlightAction[]
   showNewBadge?: boolean
   normalizeVisibleStackToPercent?: boolean
+  /**
+   * When provided, a red shaded ReferenceArea is rendered above this Y value
+   * to highlight the danger zone (e.g. memory over-commitment region).
+   */
+  dangerZoneAbove?: number
 }
 
 interface CustomizedDotProps {
@@ -138,6 +143,7 @@ export function ComposedChart({
   titleTooltip,
   showNewBadge,
   normalizeVisibleStackToPercent = false,
+  dangerZoneAbove,
 }: ComposedChartProps) {
   const { resolvedTheme } = useTheme()
   const { hoveredIndex, syncTooltip, setHover, clearHover } = useChartHoverState(
@@ -610,6 +616,16 @@ export function ComposedChart({
                 />
               </ReferenceLine>
             ))}
+
+          {/* Danger zone — shaded region above a threshold (e.g. memory commit limit) */}
+          {typeof dangerZoneAbove === 'number' && (
+            <ReferenceArea
+              y1={dangerZoneAbove}
+              fill={isDarkMode ? '#7f1d1d' : '#fecaca'}
+              fillOpacity={0.35}
+              stroke="none"
+            />
+          )}
 
           {/* Selection highlight */}
           {showHighlightActions && (

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -36,6 +36,11 @@ export interface ReportAttributes {
   }
   normalizeVisibleStackToPercent?: boolean
   hideHighlightedValue?: boolean
+  /**
+   * When set, renders a red danger-zone shading above this Y value to indicate
+   * the region where the metric exceeds a safe threshold (e.g. commit limit).
+   */
+  dangerZoneAbove?: number
 }
 
 export type Provider = 'infra-monitoring' | 'daily-stats' | 'mock' | 'reference-line' | 'logs'

--- a/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
@@ -50,6 +50,7 @@ export interface ComposedChartHandlerProps {
     domain?: [number | string, number | string]
     allowDataOverflow?: boolean
   }
+  dangerZoneAbove?: number
 }
 
 /**

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -29,7 +29,8 @@ export const getReportAttributesV2: (
   maxConnections?: MaxConnectionsData,
   pgBouncerMaxConnections?: number,
   isSpendCapEnabled?: boolean,
-  showDiskIOBurstBalanceChart?: boolean
+  showDiskIOBurstBalanceChart?: boolean,
+  memoryCommitLimitBytes?: number
 ) => ReportAttributes[] = (
   entitledFeatures,
   project,
@@ -37,7 +38,8 @@ export const getReportAttributesV2: (
   maxConnections,
   pgBouncerMaxConnections,
   isSpendCapEnabled,
-  showDiskIOBurstBalanceChart
+  showDiskIOBurstBalanceChart,
+  memoryCommitLimitBytes
 ) => {
   const computeVariantId = mapComputeSizeNameToAddonVariantId(project?.infra_compute_size)
   const provisionedDiskIops = diskConfig?.attributes?.iops
@@ -128,6 +130,45 @@ export const getReportAttributesV2: (
           label: 'Swap',
           tooltip:
             'Swap space in use by the operating system. Sustained swap usage indicates memory pressure and may degrade database performance',
+        },
+      ],
+    },
+    {
+      id: 'memory-commitment',
+      label: 'Memory commitment',
+      titleTooltip:
+        'Virtual memory promised to processes (Committed_AS). When this exceeds the commit limit (RAM + swap), the kernel cannot fulfill all allocations, risking out-of-memory kills.',
+      docsUrl: `${DOCS_URL}/guides/troubleshooting/memory-and-swap-usage-explained-aPNgm0`,
+      hide: false,
+      showTooltip: true,
+      showLegend: true,
+      hideChartType: false,
+      defaultChartStyle: 'bar',
+      showMaxValue: true,
+      showGrid: true,
+      syncId: 'database-reports',
+      valuePrecision: 2,
+      dangerZoneAbove: memoryCommitLimitBytes,
+      YAxisProps: {
+        width: 75,
+        tickFormatter: (value: number) => formatBytesMinMB(value, 2),
+      },
+      attributes: [
+        {
+          attribute: 'ram_usage_swap',
+          provider: 'infra-monitoring',
+          label: 'Committed',
+          tooltip:
+            'Virtual memory promised to processes (Committed_AS from /proc/meminfo). Spikes above the commit limit risk out-of-memory kills.',
+        },
+        {
+          attribute: 'memory_commit_limit',
+          provider: 'reference-line',
+          label: 'Commit limit',
+          value: memoryCommitLimitBytes,
+          tooltip:
+            'Maximum virtual memory the system can honor (physical RAM + swap). Sustained commitment above this value risks OOM.',
+          isMaxValue: true,
         },
       ],
     },

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -40,7 +40,7 @@ import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useRefreshHandler, useReportDateRange } from '@/hooks/misc/useReportDateRange'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
-import { DOCS_URL } from '@/lib/constants'
+import { DOCS_URL, INSTANCE_MICRO_SPECS, INSTANCE_NANO_SPECS } from '@/lib/constants'
 import { formatBytes } from '@/lib/helpers'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import type { NextPageWithLayout } from '@/types'
@@ -112,6 +112,15 @@ const DatabaseUsage = () => {
     ]
   const defaultMaxClientConn = poolingOptimizations.maxClientConn ?? 200
 
+  // Memory commit limit = physical RAM + swap. Supabase always provisions 1 GB swap regardless of compute size.
+  const SWAP_BYTES = 1 * 1024 * 1024 * 1024
+  const fallbackSpecs =
+    project?.infra_compute_size === 'nano' ? INSTANCE_NANO_SPECS : INSTANCE_MICRO_SPECS
+  const instanceMemoryGb =
+    (computeInstance?.variant.meta as { memory_gb?: number } | undefined)?.memory_gb ??
+    fallbackSpecs.memory_gb
+  const memoryCommitLimitBytes = instanceMemoryGb * 1024 * 1024 * 1024 + SWAP_BYTES
+
   const { can: canUpdateDiskSizeConfig } = useAsyncCheckPermissions(
     PermissionAction.UPDATE,
     'projects',
@@ -141,7 +150,8 @@ const DatabaseUsage = () => {
     maxConnections,
     defaultMaxClientConn,
     isSpendCapEnabled,
-    showDiskIOBurstBalanceChart
+    showDiskIOBurstBalanceChart,
+    memoryCommitLimitBytes
   )
 
   const { isPending: isUpdatingDiskSize } = useProjectDiskResizeMutation({


### PR DESCRIPTION
## Problem

The database reports page showed memory usage and swap usage in separate charts, but had no way to visualize memory over-commitment. When processes request more virtual memory than physical RAM plus swap can fulfill, the system risks OOM kills. This was impossible to spot at a glance.

Refs: https://linear.app/supabase/issue/DEBUG-119

## Fix

Adds a new "Memory commitment" chart positioned after the swap chart in the database reports page. The chart shows:

- The committed virtual memory series (Committed_AS, surfaced as `ram_usage_swap` from the infra-monitoring API)
- A dashed reference line at the commit limit (physical RAM + 1 GB swap, derived from the project's compute instance metadata)
- A red shaded danger zone above the commit limit to make over-commitment immediately visible

The commit limit is calculated per instance: `memory_gb * 1 GiB + 1 GiB (swap)`. A new optional `dangerZoneAbove` prop on `ComposedChartProps` / `ComposedChartHandlerProps` renders the `ReferenceArea` shading, keeping the implementation self-contained and reusable for other charts in the future.

Swap was intentionally left out of this chart to avoid density, as discussed in review.

## How to test

1. Open the database reports page for any active project: `/project/<ref>/observability/database`
2. Scroll past the swap usage chart
3. A new "Memory commitment" chart should appear
4. The chart shows a bar series labeled "Committed" and a dashed reference line labeled "Commit limit"
5. The region above the commit limit has a faint red background (danger zone)
6. Hovering the chart shows byte-formatted tooltips
7. The "Commit limit" entry appears in the legend and can be toggled
8. Charts stay in sync with other database report charts when scrolling or zooming