### PR TITLE
fix(studio): hide disk IO burst balance charts on 4XL+ compute

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
@@ -401,6 +401,24 @@ export const mapComputeSizeNameToAddonVariantId = (
   return infraToAddonVariant[sizeKey]
 }
 
+// Compute variants below 4XL run on EBS instances that draw on a burst credit
+// pool for disk IO, so burst balance metrics only make sense for these. 4XL
+// and larger instances have sustained disk IO at their baseline (baseline
+// equals max) and don't expose a burst budget.
+const BURSTABLE_IO_VARIANTS: ReadonlySet<ComputeInstanceAddonVariantId> = new Set([
+  'ci_nano',
+  'ci_micro',
+  'ci_small',
+  'ci_medium',
+  'ci_large',
+  'ci_xlarge',
+  'ci_2xlarge',
+])
+
+export const hasBurstableIO = (computeSize: ProjectDetail['infra_compute_size']): boolean => {
+  return BURSTABLE_IO_VARIANTS.has(mapComputeSizeNameToAddonVariantId(computeSize))
+}
+
 const addonVariantToComputeSize: Record<ComputeInstanceAddonVariantId, ComputeInstanceSize> = {
   ci_nano: 'Nano',
   ci_micro: 'Micro',

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagement.utils.ts
@@ -416,7 +416,11 @@ const BURSTABLE_IO_VARIANTS: ReadonlySet<ComputeInstanceAddonVariantId> = new Se
 ])
 
 export const hasBurstableIO = (computeSize: ProjectDetail['infra_compute_size']): boolean => {
-  return BURSTABLE_IO_VARIANTS.has(mapComputeSizeNameToAddonVariantId(computeSize))
+  // Don't fall back to the nano default that mapComputeSizeNameToAddonVariantId
+  // uses: if compute metadata is missing or unrecognized, treat the project as
+  // non-burstable so we don't accidentally surface burst-only charts.
+  if (!computeSize || !isInfraInstanceSize(computeSize)) return false
+  return BURSTABLE_IO_VARIANTS.has(infraToAddonVariant[computeSize])
 }
 
 const addonVariantToComputeSize: Record<ComputeInstanceAddonVariantId, ComputeInstanceSize> = {

--- a/apps/studio/components/interfaces/Reports/MetricOptions.tsx
+++ b/apps/studio/components/interfaces/Reports/MetricOptions.tsx
@@ -17,12 +17,14 @@ import {
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
-import { DEPRECATED_REPORTS } from './Reports.constants'
+import { BURSTABLE_IO_METRIC_KEYS, DEPRECATED_REPORTS } from './Reports.constants'
+import { hasBurstableIO } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { useContentQuery } from '@/data/content/content-query'
 import { useSendEventMutation } from '@/data/telemetry/send-event-mutation'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { Metric, METRIC_CATEGORIES, METRICS } from '@/lib/constants/metrics'
 import { editorPanelState } from '@/state/editor-panel-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
@@ -42,6 +44,7 @@ interface MetricOptionsProps {
 export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsProps) => {
   const { ref: projectRef } = useParams()
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
+  const { data: project } = useSelectedProjectQuery()
   const { openSidebar } = useSidebarManagerSnapshot()
   const [search, setSearch] = useState('')
 
@@ -49,6 +52,8 @@ export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsPro
     'project_auth:all',
     'project_storage:all',
   ])
+
+  const supportsBurstableIO = hasBurstableIO(project?.infra_compute_size)
 
   const metricCategories = Object.values(METRIC_CATEGORIES).filter(({ key }) => {
     if (key === 'api_auth') return authEnabled
@@ -83,7 +88,9 @@ export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsPro
               <DropdownMenuSubContent>
                 {METRICS.filter(
                   (metric) =>
-                    !DEPRECATED_REPORTS.includes(metric.key) && metric?.category?.key === cat.key
+                    !DEPRECATED_REPORTS.includes(metric.key) &&
+                    metric?.category?.key === cat.key &&
+                    (supportsBurstableIO || !BURSTABLE_IO_METRIC_KEYS.includes(metric.key))
                 ).map((metric) => {
                   return (
                     <DropdownMenuCheckboxItem

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -5,9 +5,11 @@ import { X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
-import { DEPRECATED_REPORTS } from '../Reports.constants'
+import { BURSTABLE_IO_METRIC_KEYS, DEPRECATED_REPORTS } from '../Reports.constants'
 import { ChartBlock } from './ChartBlock'
 import { DeprecatedChartBlock } from './DeprecatedChartBlock'
+import { UnavailableChartBlock } from './UnavailableChartBlock'
+import { hasBurstableIO } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
 import { ChartConfig } from '@/components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { DEFAULT_CHART_CONFIG, QueryBlock } from '@/components/ui/QueryBlock/QueryBlock'
@@ -16,6 +18,7 @@ import { useContentIdQuery } from '@/data/content/content-id-query'
 import { usePrimaryDatabase } from '@/data/read-replicas/replicas-query'
 import { executeSql } from '@/data/sql/execute-sql-query'
 import { sqlKeys } from '@/data/sql/keys'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 import type { Dashboards, SqlSnippets } from '@/types'
 
@@ -48,10 +51,14 @@ export const ReportBlock = ({
 }: ReportBlockProps) => {
   const { ref: projectRef } = useParams()
   const state = useDatabaseSelectorStateSnapshot()
+  const { data: project } = useSelectedProjectQuery()
 
   const [isWriteQuery, setIsWriteQuery] = useState(false)
 
   const isSnippet = item.attribute.startsWith('snippet_')
+  const isUnavailableBurstChart =
+    BURSTABLE_IO_METRIC_KEYS.includes(item.attribute) &&
+    !hasBurstableIO(project?.infra_compute_size)
 
   const {
     data,
@@ -172,6 +179,21 @@ export const ReportBlock = ({
           onUpdateChartConfig={onUpdateChart}
           onRemoveChart={() => onRemoveChart({ metric: { key: item.attribute } })}
           disabled={isLoadingContent || snippetMissing || !sql}
+        />
+      ) : isUnavailableBurstChart ? (
+        <UnavailableChartBlock
+          label={item.label}
+          actions={
+            !disableUpdate ? (
+              <ButtonTooltip
+                type="text"
+                icon={<X />}
+                className="h-7 w-7"
+                onClick={() => onRemoveChart({ metric: { key: item.attribute } })}
+                tooltip={{ content: { side: 'bottom', text: 'Remove chart' } }}
+              />
+            ) : null
+          }
         />
       ) : isDeprecatedChart ? (
         <DeprecatedChartBlock

--- a/apps/studio/components/interfaces/Reports/ReportBlock/UnavailableChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/UnavailableChartBlock.tsx
@@ -1,0 +1,33 @@
+import { HeartIcon } from 'lucide-react'
+import { ReactNode } from 'react'
+
+import { ReportBlockContainer } from './ReportBlockContainer'
+
+interface UnavailableChartBlockProps {
+  label: string
+  actions?: ReactNode
+}
+
+export const UnavailableChartBlock = ({ label, actions }: UnavailableChartBlockProps) => {
+  return (
+    <ReportBlockContainer
+      draggable
+      showDragHandle
+      loading={false}
+      icon={<HeartIcon size={14} className="text-foreground-muted" />}
+      label={label}
+      actions={actions}
+    >
+      <div className="flex flex-1 flex-col justify-center">
+        <p className="text-xs text-foreground-light">
+          This chart isn't available on your current compute size
+        </p>
+        <p className="text-xs text-foreground-lighter">
+          Disk IO burst balance only applies to compute sizes below 4XL. Larger instances have
+          sustained disk IO at their baseline, so there's no burst credit pool to track. You can
+          remove this chart from your report.
+        </p>
+      </div>
+    </ReportBlockContainer>
+  )
+}

--- a/apps/studio/components/interfaces/Reports/ReportBlock/UnavailableChartBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/UnavailableChartBlock.tsx
@@ -18,7 +18,7 @@ export const UnavailableChartBlock = ({ label, actions }: UnavailableChartBlockP
       label={label}
       actions={actions}
     >
-      <div className="flex flex-1 flex-col justify-center">
+      <div className="flex flex-1 flex-col justify-center gap-y-1 px-5 py-4">
         <p className="text-xs text-foreground-light">
           This chart isn't available on your current compute size
         </p>

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -730,6 +730,11 @@ SELECT
   },
 }
 
+// Burst-balance-related metric keys. These only apply to compute sizes that
+// have a burst credit pool for disk IO (below 4XL). On 4XL+ disk IO is
+// sustained at baseline, so these charts should be hidden.
+export const BURSTABLE_IO_METRIC_KEYS = ['disk_io_budget', 'disk_io_consumption']
+
 export const DEPRECATED_REPORTS = [
   'total_realtime_ingress',
   'total_rest_options_requests',

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -1,6 +1,9 @@
 import { COMPUTE_DISK, COMPUTE_MAX_IOPS } from 'shared-data'
 
-import { mapComputeSizeNameToAddonVariantId } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
+import {
+  hasBurstableIO,
+  mapComputeSizeNameToAddonVariantId,
+} from '@/components/interfaces/DiskManagement/DiskManagement.utils'
 import { compactNumberFormatter } from '@/components/ui/Charts/Charts.utils'
 import { ReportAttributes } from '@/components/ui/Charts/ComposedChart.utils'
 import { DiskAttributesData } from '@/data/config/disk-attributes-query'
@@ -8,19 +11,6 @@ import { MaxConnectionsData } from '@/data/database/max-connections-query'
 import { Project } from '@/data/projects/project-detail-query'
 import { DOCS_URL } from '@/lib/constants'
 import { formatBytes, formatBytesMinMB } from '@/lib/helpers'
-
-// Compute variants below 4XL run on EBS instances that draw on a burst
-// credit pool for disk IO, so the burst balance chart only makes sense for
-// these. Larger instances have dedicated IOPS and don't expose this metric.
-const BURSTABLE_IO_VARIANTS = new Set([
-  'ci_nano',
-  'ci_micro',
-  'ci_small',
-  'ci_medium',
-  'ci_large',
-  'ci_xlarge',
-  'ci_2xlarge',
-])
 
 export const getReportAttributesV2: (
   entitledFeatures: string[],
@@ -46,8 +36,8 @@ export const getReportAttributesV2: (
     typeof provisionedDiskIops === 'number' && typeof computeIopsLimit === 'number'
       ? Math.min(provisionedDiskIops, computeIopsLimit)
       : provisionedDiskIops
-  const hasBurstableIO = BURSTABLE_IO_VARIANTS.has(computeVariantId)
-  const showBurstBalanceChart = !!showDiskIOBurstBalanceChart && hasBurstableIO
+  const showBurstBalanceChart =
+    !!showDiskIOBurstBalanceChart && hasBurstableIO(project?.infra_compute_size)
   const baselineThroughputMBps = COMPUTE_DISK[computeVariantId]?.baselineThroughputMBps
   const baselineThroughputLabel =
     typeof baselineThroughputMBps === 'number' ? `${baselineThroughputMBps} MB/s` : 'its baseline'


### PR DESCRIPTION
## Problem

On 4XL and larger compute sizes, Supabase disk IO is sustained rather than burst-budget based. Baseline equals max, so there is no extra burst balance to track (the instance can still be throttled if it hits its configured IOPS or throughput limit, but that is unrelated to a burst credit pool). The "Disk IO Burst Balance" / "Disk IO % Remaining" / "Disk IO % Consumed" charts in custom reports are therefore meaningless on 4XL+, yet they are currently still offered in the picker and rendered as empty/misleading charts.

Custom reports persist their layout, so a report created when a project was on a smaller compute and later upgraded to 4XL+ can still contain a saved burst chart that we need to handle gracefully.

## Fix

- Add a shared \`hasBurstableIO(infra_compute_size)\` helper in \`DiskManagement.utils.ts\` (replaces the local \`BURSTABLE_IO_VARIANTS\` set previously defined inline in \`database-charts.ts\`).
- Filter \`disk_io_budget\` and \`disk_io_consumption\` out of the custom report chart picker (\`MetricOptions\`) when the project is on a non-burstable compute size.
- In \`ReportBlock\`, detect saved burst charts on a 4XL+ project and render a new \`UnavailableChartBlock\` that explains the chart no longer applies and can be removed.
- The database observability burst balance chart already gated on \`hasBurstableIO\`; updated to use the shared helper.
- Infrastructure activity page already has equivalent handling via the dedicated-IO admonition, so no change needed there.

Linear: FDBKPRI-1404

## Test plan

- [ ] On a project below 4XL, the custom report picker still lists "Disk IO % Remaining" and "Disk IO % Consumed", and they render normally
- [ ] On a 4XL+ project, neither metric appears in the picker
- [ ] Open an existing custom report that contains a saved burst balance chart on a 4XL+ project, and confirm the placeholder block renders with a clear explanation and a remove action
- [ ] Database observability page on 4XL+: the burst balance chart remains hidden, all other charts render

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Disk IO metrics are now filtered based on your project’s compute size so only relevant charts appear.
  * Metrics tied to burstable IO are hidden when the current instance does not support burstable IO; deprecated metrics remain excluded.
  * When a disk IO chart isn’t available for your instance, the UI shows an explanatory unavailable-chart block with text about burst-balance limits for very large instances and optional actions to remove the unavailable chart.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->