### PR TITLE
chore: migrate Organization settings `Modal` to `Dialog`

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -1,7 +1,16 @@
 import { MinusCircle, PauseCircle } from 'lucide-react'
 import { useMemo } from 'react'
 import { plans as subscriptionsPlans } from 'shared-data/plans'
-import { Modal } from 'ui'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from 'ui'
 import { Admonition } from 'ui-patterns'
 
 import { getComputeSize, OrgProject } from '@/data/projects/org-projects-infinite-query'
@@ -78,83 +87,92 @@ const DowngradeModal = ({
   })
 
   return (
-    <Modal
-      size="large"
-      alignFooter="right"
-      variant="warning"
-      visible={visible}
-      onCancel={onClose}
-      onConfirm={onConfirm}
-      header={`Confirm to downgrade to ${selectedPlan?.name} plan`}
-    >
-      <Modal.Content>
-        <div className="space-y-2">
-          <Admonition
-            type="warning"
-            title="Downgrading to the Free Plan will lead to reductions in your organization's quota"
-            description="If you're already past the limits of the Free Plan, your projects could become
-              unresponsive or enter read only mode."
-          />
-
-          {((previousProjectAddons.length ?? 0) > 0 || hasInstancesOnMicro) && (
-            <Admonition type="warning" title="Projects affected by the downgrade">
-              <ul className="space-y-1 max-h-[100px] overflow-y-auto">
-                {previousProjectAddons.map((project) => (
-                  <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
-                ))}
-
-                {projects
-                  .filter((it) => {
-                    const computeSize = getComputeSize(it)
-                    return computeSize === 'micro'
-                  })
-                  .map((project) => (
-                    <li className="list-disc ml-6" key={project.ref}>
-                      {project.name}: Compute will be downgraded. Project will also{' '}
-                      <span className="font-bold">need to be restarted</span>.
-                    </li>
-                  ))}
-              </ul>
-            </Admonition>
-          )}
-        </div>
-
-        <ul className="mt-4 space-y-5 text-sm">
-          <li className="flex items-center gap-3">
-            <PauseCircle size={18} />
-            <span>Projects will be paused after a week of inactivity</span>
-          </li>
-
-          <li className="flex items-center gap-3 mb-2">
-            <MinusCircle size={18} />
-            <span>Add ons from all projects under this organization will be removed.</span>
-          </li>
-
-          <li className="flex gap-3">
+    <AlertDialog open={visible} onOpenChange={onClose}>
+      <AlertDialogContent size="large">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{`Confirm to downgrade to ${selectedPlan?.name} plan`}</AlertDialogTitle>
+          <AlertDialogDescription asChild>
             <div>
-              <strong>Before you downgrade to the {selectedPlan?.name} plan, consider:</strong>
-              <ul className="space-y-2 mt-2">
-                <li className="list-disc ml-6 text-foreground-light">
-                  Your projects no longer require their respective add-ons.
+              <div className="flex flex-col space-y-2">
+                <Admonition
+                  type="warning"
+                  title="Downgrading to the Free Plan will lead to reductions in your organization's quota"
+                  description="If you're already past the limits of the Free Plan, your projects could become
+                  unresponsive or enter read only mode."
+                />
+
+                {((previousProjectAddons.length ?? 0) > 0 || hasInstancesOnMicro) && (
+                  <Admonition type="warning" title="Projects affected by the downgrade">
+                    <ul className="space-y-1 max-h-[100px] overflow-y-auto">
+                      {previousProjectAddons.map((project) => (
+                        <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
+                      ))}
+
+                      {projects
+                        .filter((it) => {
+                          const computeSize = getComputeSize(it)
+                          return computeSize === 'micro'
+                        })
+                        .map((project) => (
+                          <li className="list-disc ml-6" key={project.ref}>
+                            {project.name}: Compute will be downgraded. Project will also{' '}
+                            <span className="font-bold">need to be restarted</span>.
+                          </li>
+                        ))}
+                    </ul>
+                  </Admonition>
+                )}
+              </div>
+
+              <ul className="mt-4 space-y-5 text-sm">
+                <li className="flex items-center gap-3">
+                  <PauseCircle size={18} />
+                  <span>Projects will be paused after a week of inactivity</span>
                 </li>
-                <li className="list-disc ml-6 text-foreground-light">
-                  Your resource consumption are well within the {selectedPlan?.name} plan's quota.
+
+                <li className="flex items-center gap-3 mb-2">
+                  <MinusCircle size={18} />
+                  <span>Add ons from all projects under this organization will be removed.</span>
                 </li>
-                <li className="list-disc ml-6 text-foreground-light">
-                  Alternatively, you may also transfer projects across organizations.
+
+                <li className="flex gap-3">
+                  <div>
+                    <strong>
+                      Before you downgrade to the {selectedPlan?.name} plan, consider:
+                    </strong>
+                    <ul className="space-y-2 mt-2">
+                      <li className="list-disc ml-6 text-foreground-light">
+                        Your projects no longer require their respective add-ons.
+                      </li>
+                      <li className="list-disc ml-6 text-foreground-light">
+                        Your resource consumption are well within the {selectedPlan?.name} plan's
+                        quota.
+                      </li>
+                      <li className="list-disc ml-6 text-foreground-light">
+                        Alternatively, you may also transfer projects across organizations.
+                      </li>
+                    </ul>
+                  </div>
                 </li>
               </ul>
-            </div>
-          </li>
-        </ul>
 
-        {subscription?.billing_via_partner === true && subscription.billing_partner === 'fly' && (
-          <p className="mt-4 text-sm">
-            Your organization will be downgraded at the end of your current billing cycle.
-          </p>
-        )}
-      </Modal.Content>
-    </Modal>
+              {subscription?.billing_via_partner === true &&
+                subscription.billing_partner === 'fly' && (
+                  <p className="mt-4 text-sm">
+                    Your organization will be downgraded at the end of your current billing cycle.
+                  </p>
+                )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction variant="warning" onClick={onConfirm}>
+            Confirm
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
@@ -1,7 +1,18 @@
 import { useFlag, useParams } from 'common'
 import { useState } from 'react'
 import { toast } from 'sonner'
-import { Button, cn, Modal, TextArea } from 'ui'
+import {
+  Button,
+  cn,
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  TextArea,
+} from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
 import { ProjectUpdateDisabledTooltip } from '../ProjectUpdateDisabledTooltip'
@@ -101,76 +112,84 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
   }
 
   return (
-    <Modal hideFooter size="xlarge" visible={visible} onCancel={onClose} header="Help us improve">
-      <Modal.Content>
-        <div className="space-y-4">
-          <p className="text-sm text-foreground-light">
-            What made you decide to downgrade your plan?
-          </p>
-          <div className="space-y-8 mt-6">
-            <div className="flex flex-wrap gap-2" data-toggle="buttons">
-              {shuffledReasons.map((option) => {
-                const active = selectedReason[0] === option.value
-                return (
-                  <label
-                    key={option.value}
-                    className={cn(
-                      'flex cursor-pointer items-center space-x-2 rounded-md py-1',
-                      'pl-2 pr-3 text-center text-sm',
-                      'shadow-xs transition-all duration-100',
-                      active
-                        ? `bg-foreground text-background opacity-100 hover:bg-foreground/75`
-                        : `bg-border-strong text-foreground opacity-75 hover:opacity-100`
-                    )}
-                  >
-                    <input
-                      type="radio"
-                      name="options"
-                      value={option.value}
-                      className="hidden"
-                      checked={active}
-                      onChange={() => onSelectCancellationReason(option.value)}
-                    />
-                    <div>{option.value}</div>
-                  </label>
-                )
-              })}
+    <Dialog open={visible} onOpenChange={onClose}>
+      <DialogContent size="xlarge">
+        <DialogHeader>
+          <DialogTitle>Help us improve</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection>
+          <div className="flex flex-col space-y-4">
+            <p className="text-sm text-foreground-light">
+              What made you decide to downgrade your plan?
+            </p>
+            <div className="space-y-8 mt-6">
+              <div className="flex flex-wrap gap-2" data-toggle="buttons">
+                {shuffledReasons.map((option) => {
+                  const active = selectedReason[0] === option.value
+                  return (
+                    <label
+                      key={option.value}
+                      className={cn(
+                        'flex cursor-pointer items-center space-x-2 rounded-md py-1',
+                        'pl-2 pr-3 text-center text-sm',
+                        'shadow-xs transition-all duration-100',
+                        active
+                          ? `bg-foreground text-background opacity-100 hover:bg-foreground/75`
+                          : `bg-border-strong text-foreground opacity-75 hover:opacity-100`
+                      )}
+                    >
+                      <input
+                        type="radio"
+                        name="options"
+                        value={option.value}
+                        className="hidden"
+                        checked={active}
+                        onChange={() => onSelectCancellationReason(option.value)}
+                      />
+                      <div>{option.value}</div>
+                    </label>
+                  )
+                })}
+              </div>
+              <div className="text-area-text-sm flex flex-col gap-y-2">
+                <label htmlFor="message" className="text-sm whitespace-pre-line wrap-break-word">
+                  {textareaLabel}
+                </label>
+                <TextArea
+                  id="message"
+                  name="message"
+                  value={message}
+                  onChange={(event: any) => setMessage(event.target.value)}
+                  rows={3}
+                />
+              </div>
             </div>
-            <div className="text-area-text-sm flex flex-col gap-y-2">
-              <label htmlFor="message" className="text-sm whitespace-pre-line wrap-break-word">
-                {textareaLabel}
-              </label>
-              <TextArea
-                id="message"
-                name="message"
-                value={message}
-                onChange={(event: any) => setMessage(event.target.value)}
-                rows={3}
+            {hasProjectsWithComputeDowngrade && (
+              <Admonition
+                type="warning"
+                layout="horizontal"
+                title={`${projectsWithComputeDowngrade.length} of your projects will be restarted upon clicking confirm,`}
+                description={
+                  <>
+                    This is due to changes in compute instances from the downgrade. Affected
+                    projects include{' '}
+                    {projectsWithComputeDowngrade.map((project) => project.name).join(', ')}.
+                  </>
+                }
               />
-            </div>
+            )}
           </div>
-          {hasProjectsWithComputeDowngrade && (
-            <Admonition
-              type="warning"
-              layout="horizontal"
-              title={`${projectsWithComputeDowngrade.length} of your projects will be restarted upon clicking confirm,`}
-              description={
-                <>
-                  This is due to changes in compute instances from the downgrade. Affected projects
-                  include {projectsWithComputeDowngrade.map((project) => project.name).join(', ')}.
-                </>
-              }
-            />
-          )}
-        </div>
-      </Modal.Content>
 
-      <div className="flex items-center justify-between border-t px-4 py-4">
-        <p className="text-xs text-foreground-lighter">
-          The unused amount for the remaining time of your billing cycle will be refunded as credits
-        </p>
+          <div className="flex items-center justify-between border-t px-4 py-4">
+            <p className="text-xs text-foreground-lighter">
+              The unused amount for the remaining time of your billing cycle will be refunded as
+              credits
+            </p>
+          </div>
+        </DialogSection>
 
-        <div className="flex items-center space-x-2">
+        <DialogFooter>
           <Button type="default" onClick={() => onClose()}>
             Cancel
           </Button>
@@ -185,8 +204,8 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
               Confirm downgrade
             </Button>
           </ProjectUpdateDisabledTooltip>
-        </div>
-      </div>
-    </Modal>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/MembersExceedLimitModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/MembersExceedLimitModal.tsx
@@ -53,9 +53,7 @@ const MembersExceedLimitModal = ({ visible, onClose }: MembersExceedLimitModalPr
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel htmlType="button" type="default" onClick={onClose} block>
-            Understood
-          </AlertDialogCancel>
+          <AlertDialogCancel onClick={onClose} type="button">Understood</AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/MembersExceedLimitModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/MembersExceedLimitModal.tsx
@@ -53,7 +53,9 @@ const MembersExceedLimitModal = ({ visible, onClose }: MembersExceedLimitModalPr
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel onClick={onClose} type="button">Understood</AlertDialogCancel>
+          <AlertDialogCancel onClick={onClose} type="button">
+            Understood
+          </AlertDialogCancel>
         </AlertDialogFooter>
       </AlertDialogContent>
     </AlertDialog>

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/MembersExceedLimitModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/MembersExceedLimitModal.tsx
@@ -1,4 +1,12 @@
-import { Button, Modal } from 'ui'
+import {
+  AlertDialog,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from 'ui'
 
 import { useFreeProjectLimitCheckQuery } from '@/data/organizations/free-project-limit-check-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -17,40 +25,40 @@ const MembersExceedLimitModal = ({ visible, onClose }: MembersExceedLimitModalPr
   )
 
   return (
-    <Modal
-      hideFooter
-      visible={visible}
-      size="medium"
-      header="Your organization has members who have exceeded their free project limits"
-      onCancel={onClose}
-    >
-      <Modal.Content>
-        <div className="space-y-2">
-          <p className="text-sm text-foreground-light">
-            The following members have reached their maximum limits for the number of active free
-            plan projects within organizations where they are an administrator or owner:
-          </p>
-          <ul className="pl-5 text-sm list-disc text-foreground-light">
-            {(membersExceededLimit || []).map((member, idx: number) => (
-              <li key={`member-${idx}`}>
-                {member.username || member.primary_email} (Limit: {member.free_project_limit} free
-                projects)
-              </li>
-            ))}
-          </ul>
-          <p className="text-sm text-foreground-light">
-            These members will need to either delete, pause, or upgrade one or more of these
-            projects before you're able to downgrade this project.
-          </p>
-        </div>
-      </Modal.Content>
-      <Modal.Separator />
-      <Modal.Content className="flex items-center gap-2">
-        <Button htmlType="button" type="default" onClick={onClose} block>
-          Understood
-        </Button>
-      </Modal.Content>
-    </Modal>
+    <AlertDialog open={visible} onOpenChange={onClose}>
+      <AlertDialogContent size="medium">
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Your organization has members who have exceeded their free project limits
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            <div className="flex flex-col space-y-2">
+              <p className="text-sm text-foreground-light">
+                The following members have reached their maximum limits for the number of active
+                free plan projects within organizations where they are an administrator or owner:
+              </p>
+              <ul className="pl-5 text-sm list-disc text-foreground-light">
+                {(membersExceededLimit || []).map((member, idx: number) => (
+                  <li key={`member-${idx}`}>
+                    {member.username || member.primary_email} (Limit: {member.free_project_limit}{' '}
+                    free projects)
+                  </li>
+                ))}
+              </ul>
+              <p className="text-sm text-foreground-light">
+                These members will need to either delete, pause, or upgrade one or more of these
+                projects before you're able to downgrade this project.
+              </p>
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel htmlType="button" type="default" onClick={onClose} block>
+            Understood
+          </AlertDialogCancel>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -433,7 +433,7 @@ export const PlanUpdateSidePanel = () => {
       />
 
       <UpgradeSurveyModal
-        visible={!showUpgradeSurvey}
+        visible={showUpgradeSurvey}
         originalPlan={originalPlanRef.current}
         subscription={subscription}
         onClose={(success?: boolean) => {

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PlanUpdateSidePanel.tsx
@@ -433,7 +433,7 @@ export const PlanUpdateSidePanel = () => {
       />
 
       <UpgradeSurveyModal
-        visible={showUpgradeSurvey}
+        visible={!showUpgradeSurvey}
         originalPlan={originalPlanRef.current}
         subscription={subscription}
         onClose={(success?: boolean) => {

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/UpgradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/UpgradeModal.tsx
@@ -2,7 +2,18 @@ import { useParams } from 'common'
 import { includes, without } from 'lodash'
 import { useReducer, useState } from 'react'
 import { toast } from 'sonner'
-import { Modal, TextArea } from 'ui'
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
+  TextArea,
+} from 'ui'
 
 import { generateUpgradeReasons } from '../helpers'
 import { useSendUpgradeFeedbackMutation } from '@/data/feedback/upgrade-survey-send'
@@ -60,23 +71,18 @@ const UpgradeSurveyModal = ({
   }
 
   return (
-    <>
-      <Modal
-        alignFooter="right"
-        size="xlarge"
-        loading={isSubmitting}
-        visible={visible}
-        onCancel={onClose}
-        onConfirm={onSubmit}
-        cancelText="Skip"
-        header="We're excited for your upgrade"
-      >
-        <Modal.Content className="space-y-4">
-          <p className="text-sm text-foreground-light">
+    <Dialog open={visible} onOpenChange={onClose}>
+      <DialogContent size="xlarge">
+        <DialogHeader>
+          <DialogTitle>We're excited for your upgrade</DialogTitle>
+          <DialogDescription>
             What reasons motivated your decision to upgrade? Your feedback helps us improve Supabase
             as much as we can.
-          </p>
-          <div className="space-y-8 mt-6">
+          </DialogDescription>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <DialogSection>
+          <div className="flex flex-col space-y-8`">
             <div className="flex flex-wrap gap-2" data-toggle="buttons">
               {upgradeReasons.map((option) => {
                 const active = selectedReasons.find((x) => x === option)
@@ -119,9 +125,17 @@ const UpgradeSurveyModal = ({
               />
             </div>
           </div>
-        </Modal.Content>
-      </Modal>
-    </>
+        </DialogSection>
+        <DialogFooter>
+          <Button type="default" disabled={isSubmitting} onClick={() => onClose()}>
+            Skip
+          </Button>
+          <Button type="primary" disabled={isSubmitting} loading={isSubmitting} onClick={onSubmit}>
+            Confirm
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }
 

--- a/apps/studio/components/interfaces/Organization/OAuthApps/DeleteAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/DeleteAppModal.tsx
@@ -1,7 +1,15 @@
 import { useParams } from 'common'
 import { Lock } from 'lucide-react'
 import { toast } from 'sonner'
-import { Modal } from 'ui'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogTitle,
+} from 'ui'
 import { Admonition } from 'ui-patterns'
 
 import { useOAuthAppDeleteMutation } from '@/data/oauth/oauth-app-delete-mutation'
@@ -14,7 +22,7 @@ export interface DeleteAppModalProps {
 
 export const DeleteAppModal = ({ selectedApp, onClose }: DeleteAppModalProps) => {
   const { slug } = useParams()
-  const { mutate: deleteOAuthApp, isPending: isDeleting } = useOAuthAppDeleteMutation({
+  const { mutateAsync: deleteOAuthApp } = useOAuthAppDeleteMutation({
     onSuccess: () => {
       toast.success(`Successfully deleted the app "${selectedApp?.name}"`)
       onClose()
@@ -24,43 +32,44 @@ export const DeleteAppModal = ({ selectedApp, onClose }: DeleteAppModalProps) =>
   const onConfirmDelete = async () => {
     if (!slug) return console.error('Slug is required')
     if (!selectedApp?.id) return console.error('App ID is required')
-    deleteOAuthApp({ slug, id: selectedApp?.id })
+    await deleteOAuthApp({ slug, id: selectedApp?.id })
   }
 
   return (
-    <Modal
-      size="medium"
-      alignFooter="right"
-      header={`Confirm to delete ${selectedApp?.name}`}
-      visible={selectedApp !== undefined}
-      loading={isDeleting}
-      onCancel={onClose}
-      onConfirm={onConfirmDelete}
-    >
-      <Modal.Content>
-        <Admonition
-          type="warning"
-          title="This action cannot be undone"
-          description={`Deleting ${selectedApp?.name} will invalidate any access tokens from this application that
+    <AlertDialog open={selectedApp !== undefined} onOpenChange={onClose}>
+      <AlertDialogContent size="medium">
+        <AlertDialogTitle>{`Confirm to delete ${selectedApp?.name}`}</AlertDialogTitle>
+        <AlertDialogDescription>
+          <div className="flex flex-col space-y-2">
+            <Admonition
+              type="warning"
+              title="This action cannot be undone"
+              description={`Deleting ${selectedApp?.name} will invalidate any access tokens from this application that
           were authorized by users.`}
-        />
-      </Modal.Content>
-      <Modal.Content>
-        <ul className="space-y-5">
-          <li className="flex gap-3 text-sm">
-            <Lock size={14} className="shrink-0" />
-            <div>
-              <strong>Before you remove this application, consider:</strong>
-              <ul className="space-y-2 mt-2">
-                <li className="list-disc ml-4">
-                  No users are currently using this application. It will no longer be available for
-                  use after deletion.
-                </li>
-              </ul>
-            </div>
-          </li>
-        </ul>
-      </Modal.Content>
-    </Modal>
+            />
+            <ul className="space-y-5">
+              <li className="flex gap-3 text-sm">
+                <Lock size={14} className="shrink-0" />
+                <div>
+                  <strong>Before you remove this application, consider:</strong>
+                  <ul className="space-y-2 mt-2">
+                    <li className="list-disc ml-4">
+                      No users are currently using this application. It will no longer be available
+                      for use after deletion.
+                    </li>
+                  </ul>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </AlertDialogDescription>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirmDelete} variant="danger">
+            Confirm
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -7,7 +7,6 @@ import { SubmitHandler, useFieldArray, useForm, useWatch } from 'react-hook-form
 import { toast } from 'sonner'
 import {
   AlertDialog,
-  AlertDialogAction,
   AlertDialogCancel,
   AlertDialogContent,
   AlertDialogDescription,

--- a/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/PublishAppSidePanel/index.tsx
@@ -6,6 +6,14 @@ import { ChangeEvent, useEffect, useRef, useState } from 'react'
 import { SubmitHandler, useFieldArray, useForm, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
   Badge,
   Button,
   cn,
@@ -21,7 +29,6 @@ import {
   InputGroupAddon,
   InputGroupButton,
   InputGroupInput,
-  Modal,
   SidePanel,
 } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -424,46 +431,38 @@ export const PublishAppSidePanel = ({
             </SidePanel.Content>
           </div>
 
-          <Modal
-            hideFooter
-            showCloseButton={false}
-            className="max-w-[600px]!"
-            visible={showPreview}
-            onCancel={() => setShowPreview(false)}
-          >
-            <Modal.Content>
-              <div className="flex items-center gap-x-2 justify-between">
-                <p className="truncate">Authorize API access for {name}</p>
-                <Badge variant="success">Preview</Badge>
-              </div>
-            </Modal.Content>
-            <Modal.Separator />
-            <Modal.Content>
-              <AuthorizeRequesterDetails
-                icon={iconUrl || null}
-                name={name}
-                domain={website}
-                scopes={scopes}
-              />
-              <div className="pt-4 space-y-2">
-                <p className="prose text-sm">Select an organization to grant API access to</p>
-                <div className="border border-control text-foreground-light rounded-sm px-4 py-2 text-sm bg-surface-200">
-                  Organizations that you have access to will be listed here
-                </div>
-              </div>
-            </Modal.Content>
-            <Modal.Separator />
-            <Modal.Content>
-              <div className="flex items-center justify-between">
+          <AlertDialog open={showPreview} onOpenChange={(open) => setShowPreview(open)}>
+            <AlertDialogContent size="large">
+              <AlertDialogHeader>
+                <AlertDialogTitle>
+                  <div className="flex items-center gap-x-2 justify-between">
+                    <p className="truncate">Authorize API access for {name}</p>
+                    <Badge variant="success">Preview</Badge>
+                  </div>
+                </AlertDialogTitle>
+                <AlertDialogDescription>
+                  <AuthorizeRequesterDetails
+                    icon={iconUrl || null}
+                    name={name}
+                    domain={website}
+                    scopes={scopes}
+                  />
+                  <div className="pt-4 space-y-2">
+                    <p className="prose text-sm">Select an organization to grant API access to</p>
+                    <div className="border border-control text-foreground-light rounded-sm px-4 py-2 text-sm bg-surface-200">
+                      Organizations that you have access to will be listed here
+                    </div>
+                  </div>
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter className="items-baseline sm:justify-between">
                 <p className="prose text-xs">
                   This is what your users will see when authorizing with your app
                 </p>
-                <Button type="default" onClick={() => setShowPreview(false)}>
-                  Close
-                </Button>
-              </div>
-            </Modal.Content>
-          </Modal>
+                <AlertDialogCancel>Close</AlertDialogCancel>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </form>
       </Form>
     </SidePanel>

--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -1,7 +1,16 @@
 import { useParams } from 'common'
 import { Lock } from 'lucide-react'
 import { toast } from 'sonner'
-import { Modal } from 'ui'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from 'ui'
 import { Admonition } from 'ui-patterns'
 
 import { useAuthorizedAppRevokeMutation } from '@/data/oauth/authorized-app-revoke-mutation'
@@ -14,7 +23,7 @@ export interface RevokeAppModalProps {
 
 export const RevokeAppModal = ({ selectedApp, onClose }: RevokeAppModalProps) => {
   const { slug } = useParams()
-  const { mutate: revokeAuthorizedApp, isPending: isDeleting } = useAuthorizedAppRevokeMutation({
+  const { mutateAsync: revokeAuthorizedApp } = useAuthorizedAppRevokeMutation({
     onSuccess: () => {
       toast.success(`Successfully revoked the app "${selectedApp?.name}"`)
       onClose()
@@ -24,43 +33,44 @@ export const RevokeAppModal = ({ selectedApp, onClose }: RevokeAppModalProps) =>
   const onConfirmDelete = async () => {
     if (!slug) return console.error('Slug is required')
     if (!selectedApp?.id) return console.error('App ID is required')
-    revokeAuthorizedApp({ slug, id: selectedApp?.id })
+    await revokeAuthorizedApp({ slug, id: selectedApp?.id })
   }
 
   return (
-    <Modal
-      size="medium"
-      alignFooter="right"
-      header={`Confirm to revoke ${selectedApp?.name}`}
-      visible={selectedApp !== undefined}
-      loading={isDeleting}
-      onCancel={onClose}
-      onConfirm={onConfirmDelete}
-    >
-      <Modal.Content>
-        <Admonition
-          type="warning"
-          title="This action cannot be undone"
-          description={`${selectedApp?.name} application will no longer have access to your organization's settings
+    <AlertDialog open={selectedApp !== undefined} onOpenChange={onClose}>
+      <AlertDialogContent size="medium">
+        <AlertDialogHeader>
+          <AlertDialogTitle>{`Confirm to revoke ${selectedApp?.name}`}</AlertDialogTitle>
+          <AlertDialogDescription>
+            <div className="flex flex-col space-y-2">
+              <Admonition
+                type="warning"
+                title="This action cannot be undone"
+                description={`${selectedApp?.name} application will no longer have access to your organization's settings
           and projects.`}
-        />
-      </Modal.Content>
-      <Modal.Content>
-        <ul className="space-y-5">
-          <li className="flex gap-3 text-sm">
-            <Lock size={14} className="shrink-0" />
-            <div>
-              <strong>Before you remove this app, consider:</strong>
-              <ul className="space-y-2 mt-2">
-                <li className="list-disc ml-4">
-                  No users are currently using this application. The application will no longer have
-                  access to your organization after being revoked.
+              />
+              <ul className="space-y-5">
+                <li className="flex gap-3 text-sm">
+                  <Lock size={14} className="shrink-0" />
+                  <div>
+                    <strong>Before you remove this app, consider:</strong>
+                    <ul className="space-y-2 mt-2">
+                      <li className="list-disc ml-4">
+                        No users are currently using this application. The application will no
+                        longer have access to your organization after being revoked.
+                      </li>
+                    </ul>
+                  </div>
                 </li>
               </ul>
             </div>
-          </li>
-        </ul>
-      </Modal.Content>
-    </Modal>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirmDelete}>Confirm</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
   )
 }


### PR DESCRIPTION
## Problem

Organization settings still uses the deprecated `Modal` for:
- downgrading subscription
- requesting feedback after downgrading
- showing an alert about members limit
- requesting feedback after upgrading
- deleting a published OAuth app
- showing preview of a new OAuth app
- Revoking an OAuth app

## Solution

- use `Dialog` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Replaced legacy modal UI with the app's modern dialog/alert-dialog components across billing and OAuth settings (upgrade/downgrade, exit survey, members-limit, delete/revoke, preview), keeping existing content and flows.
  * Confirm/cancel flows updated for more reliable async handling and clearer loading/disabled states during actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->