### PR TITLE
feat(logs): route unified-logs hooks through executeAnalyticsSql

### DIFF
--- a/apps/studio/data/logs/unified-log-inspection-query.ts
+++ b/apps/studio/data/logs/unified-log-inspection-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import {
   aggregateFunctionLogs,
@@ -198,21 +199,16 @@ WHERE id = ${lit(logId)}
 LIMIT 1
 `
 
-  const { data, error } = await post('/platform/projects/{ref}/analytics/endpoints/logs.all.otel', {
-    params: { path: { ref: projectRef } },
-    body: {
-      iso_timestamp_start: isoTimestampStart,
-      iso_timestamp_end: isoTimestampEnd,
-      sql,
-    },
+  const rawData = await executeAnalyticsSql({
+    projectRef,
+    endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all.otel',
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: isoTimestampEnd,
     signal,
   })
 
-  if (error) {
-    handleError(error)
-  }
-
-  const otelData = data as { result?: OtelLogRow[] } | undefined
+  const otelData = rawData as { result?: OtelLogRow[] } | undefined
   const row = otelData?.result?.[0]
   if (!row) {
     return { result: [] }
@@ -234,23 +230,20 @@ ORDER BY timestamp ASC
 LIMIT 100
 `
 
-      const { data: fnData, error: fnError } = await post(
-        '/platform/projects/{ref}/analytics/endpoints/logs.all.otel',
-        {
-          params: { path: { ref: projectRef } },
-          body: {
-            iso_timestamp_start: isoTimestampStart,
-            iso_timestamp_end: isoTimestampEnd,
-            sql: fnSql,
-          },
+      try {
+        const fnData = await executeAnalyticsSql({
+          projectRef,
+          endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all.otel',
+          sql: fnSql,
+          iso_timestamp_start: isoTimestampStart,
+          iso_timestamp_end: isoTimestampEnd,
           signal,
-        }
-      )
-
-      if (!fnError) {
+        })
         const fnRows = ((fnData as { result?: OtelLogRow[] } | undefined)?.result ??
           []) as OtelLogRow[]
         Object.assign(entry, aggregateFunctionLogs(fnRows))
+      } catch {
+        // function logs are supplementary; silently ignore fetch errors
       }
     }
   }

--- a/apps/studio/data/logs/unified-logs-chart-query.ts
+++ b/apps/studio/data/logs/unified-logs-chart-query.ts
@@ -1,12 +1,12 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
 import { UNIFIED_LOGS_QUERY_OPTIONS, UnifiedLogsVariables } from './unified-logs-infinite-query'
 import { getLogsChartQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getLogsChartQuery as getLogsChartQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
-import { handleError, post } from '@/data/fetchers'
 import { ExecuteSqlError } from '@/data/sql/execute-sql-query'
 import { UseCustomQueryOptions } from '@/types'
 
@@ -42,17 +42,16 @@ export async function getUnifiedLogsChart(
   // Get SQL query from utility function (with dynamic bucketing)
   const sql = pickLogsQueryBuilder(useOtel, getLogsChartQuery, getLogsChartQueryBq)(search)
 
-  let headers = new Headers(headersInit)
-
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { sql, iso_timestamp_start: dateStart, iso_timestamp_end: dateEnd },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: dateStart,
+    iso_timestamp_end: dateEnd,
     signal,
-    headers,
+    headers: headersInit,
   })
-
-  if (error) handleError(error)
 
   const chartData: Array<{
     timestamp: number

--- a/apps/studio/data/logs/unified-logs-count-query.ts
+++ b/apps/studio/data/logs/unified-logs-count-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
 import {
@@ -11,7 +12,6 @@ import {
 import { getLogsCountQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getLogsCountQuery as getLogsCountQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import { FacetMetadataSchema } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.schema'
-import { handleError, post } from '@/data/fetchers'
 import { ExecuteSqlError } from '@/data/sql/execute-sql-query'
 import { UseCustomQueryOptions } from '@/types'
 
@@ -27,13 +27,14 @@ export async function getUnifiedLogsCount(
   const { isoTimestampStart, isoTimestampEnd } = getUnifiedLogsISOStartEnd(search)
 
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { iso_timestamp_start: isoTimestampStart, iso_timestamp_end: isoTimestampEnd, sql },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: isoTimestampEnd,
     signal,
   })
-
-  if (error) handleError(error)
 
   // Process count results into facets structure
   const facets: Record<string, FacetMetadataSchema> = {}

--- a/apps/studio/data/logs/unified-logs-facet-count-query.ts
+++ b/apps/studio/data/logs/unified-logs-facet-count-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl } from './logs-endpoint'
 import { bqIdent, safeSql } from './safe-analytics-sql'
@@ -15,7 +16,6 @@ import {
   getUnifiedLogsCTE,
 } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import { Option } from '@/components/ui/DataTable/DataTable.types'
-import { handleError, post } from '@/data/fetchers'
 import { ExecuteSqlError } from '@/data/sql/execute-sql-query'
 import { UseCustomQueryOptions } from '@/types'
 
@@ -43,13 +43,14 @@ SELECT dimension, value, count from ${bqIdent(facet + '_count')};
 `
 
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { iso_timestamp_start: isoTimestampStart, iso_timestamp_end: isoTimestampEnd, sql },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: isoTimestampEnd,
     signal,
   })
-
-  if (error) handleError(error)
   return (data.result ?? []) as Option[]
 }
 

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -1,15 +1,17 @@
 import { InfiniteData, keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
+import { analyticsLiteral, safeSql } from './safe-analytics-sql'
 import { getUnifiedLogsQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getUnifiedLogsQuery as getUnifiedLogsQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import {
   PageParam,
   QuerySearchParamsType,
 } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.types'
-import { handleError, post } from '@/data/fetchers'
+import { handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from '@/types'
 
 const LOGS_PAGE_LIMIT = 50
@@ -83,7 +85,7 @@ export async function getUnifiedLogs(
 
   const { isoTimestampStart, isoTimestampEnd } = getUnifiedLogsISOStartEnd(search)
   const buildQuery = pickLogsQueryBuilder(useOtel, getUnifiedLogsQuery, getUnifiedLogsQueryBq)
-  const sql = `${buildQuery(search)} ORDER BY timestamp DESC, id DESC LIMIT ${LOGS_PAGE_LIMIT}`
+  const sql = safeSql`${buildQuery(search)} ORDER BY timestamp DESC, id DESC LIMIT ${analyticsLiteral(LOGS_PAGE_LIMIT)}`
 
   const cursorValue = pageParam?.cursor
   const cursorDirection = pageParam?.direction
@@ -105,17 +107,17 @@ export async function getUnifiedLogs(
     timestampEnd = isoTimestampEnd
   }
 
-  let headers = new Headers(headersInit)
-
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { iso_timestamp_start: isoTimestampStart, iso_timestamp_end: timestampEnd, sql },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: timestampEnd,
     signal,
-    headers,
+    headers: headersInit,
   })
 
-  if (error) handleError(error)
   if (data.error) handleError(new Error(data.error as string))
 
   const resultData = data?.result ?? []


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Security / refactor — routes all unified-logs analytics queries through the `executeAnalyticsSql` wire-boundary wrapper (PR 2 of the safe-analytics-sql series).

## What is the current behavior?

All five unified-logs query hooks call `post()` directly with a raw SQL string, bypassing the `SafeLogSqlFragment` type enforcement. The `getUnifiedLogs` infinite-query also drops the brand by composing with a plain template literal before sending to the wire.

## What is the new behavior?

- `unified-logs-infinite-query`: brand-dropping plain template literal replaced with `safeSql` + `analyticsLiteral`; `post()` replaced with `executeAnalyticsSql`
- `unified-logs-count-query`, `unified-logs-chart-query`, `unified-logs-facet-count-query`: `post()` replaced with `executeAnalyticsSql`
- `unified-log-inspection-query` (OTEL branch only): both `post()` calls replaced with `executeAnalyticsSql`; legacy BigQuery branch is unchanged pending PR 3

The wire boundary now rejects plain strings at compile time for all OTEL unified-logs paths.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46333?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->