### PR TITLE
feat(logs): brand ServiceFlow.sql.ts with SafeLogSqlFragment

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/Queries/ServiceFlowQueries/ServiceFlow.sql.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/Queries/ServiceFlowQueries/ServiceFlow.sql.ts
@@ -5,6 +5,8 @@
  * showing how requests flow through different layers of the infrastructure.
  */
 
+import { analyticsLiteral, safeSql, type SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
+
 // Service configuration for different log types
 const SERVICE_CONFIGS = {
   postgrest: {
@@ -23,17 +25,27 @@ const SERVICE_CONFIGS = {
 
 type EdgeServiceType = keyof typeof SERVICE_CONFIGS
 
+const SAFE_SERVICE_LITERAL: Record<EdgeServiceType, SafeLogSqlFragment> = {
+  postgrest: analyticsLiteral('postgrest'),
+  auth: analyticsLiteral('auth'),
+  'edge-function': analyticsLiteral('edge-function'),
+  storage: analyticsLiteral('storage'),
+}
+
 /**
  * Base Edge Logs Service Flow Query
  * Consolidated query for all edge-based services (postgrest, auth, edge-function, storage)
  * to eliminate 500+ lines of SQL duplication
  */
-const getBaseEdgeServiceFlowQuery = (logId: string, serviceType: EdgeServiceType): string => {
-  return `
-  select 
+const getBaseEdgeServiceFlowQuery = (
+  logId: string,
+  serviceType: EdgeServiceType
+): SafeLogSqlFragment => {
+  return safeSql`
+  select
       id,
       el.timestamp as timestamp,
-      '${serviceType}' as log_type,
+      ${SAFE_SERVICE_LITERAL[serviceType]} as log_type,
       CAST(edge_logs_response.status_code AS STRING) as status,
       CASE
         WHEN edge_logs_response.status_code BETWEEN 200 AND 299 THEN 'success'
@@ -41,106 +53,106 @@ const getBaseEdgeServiceFlowQuery = (logId: string, serviceType: EdgeServiceType
         WHEN edge_logs_response.status_code >= 500 THEN 'error'
         ELSE 'success'
       END as level,
-      
+
       -- Request data
       edge_logs_request.path as request_path,
-      edge_logs_request.host as request_host, 
+      edge_logs_request.host as request_host,
       edge_logs_request.method as request_method,
       edge_logs_request.url as request_url,
       edge_logs_request.search as request_search,
-      
+
       -- Response data
       edge_logs_response.origin_time as response_origin_time,
       edge_logs_response_headers.content_type as response_content_type,
       edge_logs_response_headers.cf_cache_status as response_cache_status,
-      
+
       -- Client location data
       edge_logs_cf.continent as client_continent,
-      edge_logs_cf.country as client_country, 
+      edge_logs_cf.country as client_country,
       edge_logs_cf.city as client_city,
       edge_logs_cf.region as client_region,
       edge_logs_cf.regionCode as client_region_code,
       edge_logs_cf.latitude as client_latitude,
-      edge_logs_cf.longitude as client_longitude, 
+      edge_logs_cf.longitude as client_longitude,
       edge_logs_cf.timezone as client_timezone,
-      
+
       -- Network data
       edge_logs_cf.httpProtocol as network_protocol,
       edge_logs_cf.colo as network_datacenter,
-      
+
       -- Request headers
       edge_logs_request_headers.user_agent as headers_user_agent,
       edge_logs_request_headers.x_client_info as headers_x_client_info,
       edge_logs_request_headers.x_forwarded_proto as headers_x_forwarded_proto,
       edge_logs_request_headers.x_real_ip as headers_x_real_ip,
       edge_logs_request_headers.referer as headers_referer,
-      
+
       -- Auth data
       authorization_payload.role as api_role,
       COALESCE(sb.auth_user, null) as auth_user,
-      
+
       -- JWT Key Authentication (old keys)
       CASE
-          WHEN apikey_payload.algorithm = 'HS256' AND 
-               apikey_payload.issuer = 'supabase' AND 
+          WHEN apikey_payload.algorithm = 'HS256' AND
+               apikey_payload.issuer = 'supabase' AND
                apikey_payload.role IN ('anon', 'service_role')
           THEN apikey_payload.role
           WHEN apikey_payload IS NOT NULL THEN '<unrecognized>'
           ELSE NULL
       END as jwt_key_role,
-      
+
       apikey_payload.signature_prefix as jwt_key_prefix,
-      
+
       -- API Key Authentication (new keys from sb.apikey[0].apikey[0])
-      CASE 
+      CASE
           WHEN sb_apikey_inner.prefix LIKE '%publishable%' THEN 'anon'
           WHEN sb_apikey_inner.prefix LIKE '%secret%' THEN 'service_role'
           WHEN sb_apikey_inner.prefix IS NOT NULL THEN 'unknown'
           ELSE NULL
       END as api_key_role,
-      
+
       sb_apikey_inner.prefix as api_key_prefix,
       sb_apikey_inner.error as api_key_error,
       sb_apikey_inner.hash as api_key_hash,
-      
-      -- User Authorization 
+
+      -- User Authorization
       authorization_payload.role as authorization_role,
       null as user_id,
       null as user_email,
-      
+
       -- Cloudflare Network Info
       edge_logs_response_headers.cf_ray as cf_ray,
       edge_logs_request_headers.cf_ipcountry as cf_country,
       edge_logs_cf.colo as cf_datacenter,
       edge_logs_request_headers.cf_connecting_ip as client_ip,
-      
+
       -- JWT data
       apikey_payload.role as jwt_apikey_role,
-      apikey_payload.algorithm as jwt_apikey_algorithm, 
+      apikey_payload.algorithm as jwt_apikey_algorithm,
       apikey_payload.expires_at as jwt_apikey_expires_at,
       apikey_payload.issuer as jwt_apikey_issuer,
       apikey_payload.signature_prefix as jwt_apikey_signature_prefix,
       null as jwt_apikey_key_id,
       null as jwt_apikey_session_id,
       apikey_payload.subject as jwt_apikey_subject,
-      
+
       authorization_payload.role as jwt_auth_role,
       authorization_payload.algorithm as jwt_auth_algorithm,
-      authorization_payload.expires_at as jwt_auth_expires_at, 
+      authorization_payload.expires_at as jwt_auth_expires_at,
       authorization_payload.issuer as jwt_auth_issuer,
       authorization_payload.signature_prefix as jwt_auth_signature_prefix,
       authorization_payload.key_id as jwt_auth_key_id,
       authorization_payload.session_id as jwt_auth_session_id,
       authorization_payload.subject as jwt_auth_subject,
-      
+
       -- Storage specific data (included for all but only populated for storage)
       edge_logs_response_headers.sb_gateway_mode as storage_edge_gateway_mode,
       edge_logs_response_headers.sb_gateway_version as storage_edge_gateway_version,
       edge_logs_response_headers.cf_ray as correlation_cf_ray,
-      
+
       -- Raw data
       el as raw_log_data
-      
+
     from edge_logs as el
     cross join unnest(metadata) as edge_logs_metadata
     cross join unnest(edge_logs_metadata.request) as edge_logs_request
@@ -157,8 +169,8 @@ const getBaseEdgeServiceFlowQuery = (logId: string, serviceType: EdgeServiceType
     left join unnest(COALESCE(sb.apikey, [])) as sb_apikey_outer
     left join unnest(COALESCE(sb_apikey_outer.apikey, [])) as sb_apikey_inner
 
-WHERE 
-  el.id = '${logId}'
+WHERE
+  el.id = ${analyticsLiteral(logId)}
 `
 }
 
@@ -166,7 +178,7 @@ WHERE
  * PostgREST Service Flow Query for /rest/ requests
  * Fetches enriched edge log data for PostgREST requests with additional service-specific metadata
  */
-export const getPostgrestServiceFlowQuery = (logId: string): string => {
+export const getPostgrestServiceFlowQuery = (logId: string): SafeLogSqlFragment => {
   return getBaseEdgeServiceFlowQuery(logId, 'postgrest')
 }
 
@@ -174,7 +186,7 @@ export const getPostgrestServiceFlowQuery = (logId: string): string => {
  * Auth Service Flow Query for /auth/ requests
  * Fetches enriched edge log data for GoTrue auth requests with service-specific metadata
  */
-export const getAuthServiceFlowQuery = (logId: string): string => {
+export const getAuthServiceFlowQuery = (logId: string): SafeLogSqlFragment => {
   return getBaseEdgeServiceFlowQuery(logId, 'auth')
 }
 
@@ -183,9 +195,9 @@ export const getAuthServiceFlowQuery = (logId: string): string => {
  * Fetches enriched edge log data for Edge Function requests with service-specific metadata
  * NOTE: Uses function_edge_logs table instead of edge_logs, so kept separate like postgres
  */
-export const getEdgeFunctionServiceFlowQuery = (logId: string): string => {
-  return `
-  select 
+export const getEdgeFunctionServiceFlowQuery = (logId: string): SafeLogSqlFragment => {
+  return safeSql`
+  select
       fel.id as id,
       fel.timestamp as timestamp,
       'edge-function' as log_type,
@@ -196,16 +208,16 @@ export const getEdgeFunctionServiceFlowQuery = (logId: string): string => {
           WHEN fel_response.status_code >= 500 THEN 'error'
           ELSE 'success'
       END as level,
-      
+
       -- Request data
       fel_request.pathname as request_path,
-      fel_request.host as request_host, 
+      fel_request.host as request_host,
       fel_request.method as request_method,
       fel_request.url as request_url,
       fel_request.search as request_search,
       fel_request.protocol as request_protocol,
       fel_request.port as request_port,
-      
+
       -- Response data (no origin_time in function_edge_logs)
       fel_response_headers.content_type as response_content_type,
       fel_response_headers.content_length as response_content_length,
@@ -215,7 +227,7 @@ export const getEdgeFunctionServiceFlowQuery = (logId: string): string => {
       fel_response_headers.x_sb_compute_multiplier as response_compute_multiplier,
       fel_response_headers.x_sb_resource_multiplier as response_resource_multiplier,
       fel_response_headers.x_served_by as response_served_by,
-      
+
       -- Function specific data
       fel_metadata.execution_id as execution_id,
       fel_metadata.function_id as function_id,
@@ -223,7 +235,7 @@ export const getEdgeFunctionServiceFlowQuery = (logId: string): string => {
       fel_metadata.execution_time_ms as execution_time_ms,
       fel_metadata.project_ref as project_ref,
       fel_metadata.version as function_version,
-      
+
       -- Request headers
       fel_request_headers.user_agent as headers_user_agent,
       fel_request_headers.x_client_info as headers_x_client_info,
@@ -232,67 +244,67 @@ export const getEdgeFunctionServiceFlowQuery = (logId: string): string => {
       fel_request_headers.connection as headers_connection,
       fel_request_headers.cookie as headers_cookie,
       fel_request_headers.host as headers_host,
-      
+
       -- Auth data
       authorization_payload.role as api_role,
       COALESCE(sb.auth_user, null) as auth_user,
-      
+
       -- JWT Key Authentication (old keys)
       CASE
-          WHEN apikey_payload.algorithm = 'HS256' AND 
-               apikey_payload.issuer = 'supabase' AND 
+          WHEN apikey_payload.algorithm = 'HS256' AND
+               apikey_payload.issuer = 'supabase' AND
                apikey_payload.role IN ('anon', 'service_role')
           THEN apikey_payload.role
           WHEN apikey_payload IS NOT NULL THEN '<unrecognized>'
           ELSE NULL
       END as jwt_key_role,
-      
+
       apikey_payload.signature_prefix as jwt_key_prefix,
-      
+
       -- API Key Authentication (new keys from sb.apikey[0].apikey[0])
-      CASE 
+      CASE
           WHEN sb_apikey_inner.prefix LIKE '%publishable%' THEN 'anon'
           WHEN sb_apikey_inner.prefix LIKE '%secret%' THEN 'service_role'
           WHEN sb_apikey_inner.prefix IS NOT NULL THEN 'unknown'
           ELSE NULL
       END as api_key_role,
-      
+
       sb_apikey_inner.prefix as api_key_prefix,
       sb_apikey_inner.error as api_key_error,
       sb_apikey_inner.hash as api_key_hash,
-      
-      -- User Authorization 
+
+      -- User Authorization
       authorization_payload.role as authorization_role,
       null as user_id,
       null as user_email,
-      
+
       -- JWT data
       apikey_payload.role as jwt_apikey_role,
-      apikey_payload.algorithm as jwt_apikey_algorithm, 
+      apikey_payload.algorithm as jwt_apikey_algorithm,
       apikey_payload.expires_at as jwt_apikey_expires_at,
       apikey_payload.issuer as jwt_apikey_issuer,
       apikey_payload.signature_prefix as jwt_apikey_signature_prefix,
       null as jwt_apikey_key_id,
       null as jwt_apikey_session_id,
       apikey_payload.subject as jwt_apikey_subject,
-      
+
       authorization_payload.role as jwt_auth_role,
       authorization_payload.algorithm as jwt_auth_algorithm,
-      authorization_payload.expires_at as jwt_auth_expires_at, 
+      authorization_payload.expires_at as jwt_auth_expires_at,
       authorization_payload.issuer as jwt_auth_issuer,
       authorization_payload.signature_prefix as jwt_auth_signature_prefix,
       authorization_payload.key_id as jwt_auth_key_id,
       authorization_payload.session_id as jwt_auth_session_id,
       authorization_payload.subject as jwt_auth_subject,
-      
+
       -- Function logs aggregation
       function_logs_agg.function_log_count as function_log_count,
       function_logs_agg.logs as function_logs,
       function_logs_agg.last_event_message as last_event_message,
-      
+
       -- Raw data
       fel as raw_log_data
-      
+
     from function_edge_logs as fel
     cross join unnest(metadata) as fel_metadata
     cross join unnest(fel_metadata.response) as fel_response
@@ -319,8 +331,8 @@ export const getEdgeFunctionServiceFlowQuery = (logId: string): string => {
       GROUP BY fl_metadata.execution_id
     ) as function_logs_agg on fel_metadata.execution_id = function_logs_agg.execution_id
 
-WHERE 
-  fel.id = '${logId}'
+WHERE
+  fel.id = ${analyticsLiteral(logId)}
 `
 }
 
@@ -328,7 +340,7 @@ WHERE
  * Storage Service Flow Query for /storage/ requests
  * Fetches enriched edge log data for Storage requests with service-specific metadata
  */
-export const getStorageServiceFlowQuery = (logId: string): string => {
+export const getStorageServiceFlowQuery = (logId: string): SafeLogSqlFragment => {
   return getBaseEdgeServiceFlowQuery(logId, 'storage')
 }
 
@@ -339,9 +351,9 @@ export const getStorageServiceFlowQuery = (logId: string): string => {
  * This handles direct database operations, connections, and queries
  * NOTE: Uses postgres_logs table instead of edge_logs, so kept separate
  */
-export const getPostgresServiceFlowQuery = (logId: string): string => {
-  return `
-  select 
+export const getPostgresServiceFlowQuery = (logId: string): SafeLogSqlFragment => {
+  return safeSql`
+  select
       pgl.id as id,
       pgl.timestamp as timestamp,
       'postgres' as log_type,
@@ -353,18 +365,18 @@ export const getPostgresServiceFlowQuery = (logId: string): string => {
           WHEN pgl_parsed.error_severity = 'ERROR' THEN 'error'
           ELSE 'success'
       END as level,
-      
+
       -- Database connection details
       pgl_parsed.database_name as database_name,
       pgl_parsed.user_name as database_user,
       pgl_parsed.connection_from as connection_from,
       pgl_metadata.host as database_host,
-      
+
       -- Query/Operation details
       pgl_parsed.command_tag as command_tag,
       pgl_parsed.backend_type as backend_type,
       pgl_parsed.query_id as query_id,
-      
+
       -- Session details
       pgl_parsed.session_id as session_id,
       pgl_parsed.process_id as process_id,
@@ -372,23 +384,23 @@ export const getPostgresServiceFlowQuery = (logId: string): string => {
       pgl_parsed.transaction_id as transaction_id,
       pgl_parsed.session_start_time as session_start_time,
       pgl_parsed.session_line_num as session_line_num,
-      
+
       -- Error/Status details
       pgl_parsed.error_severity as error_severity,
       pgl_parsed.sql_state_code as sql_state_code,
       pgl.event_message as event_message,
-      
+
       -- Timing
       pgl_parsed.timestamp as operation_timestamp,
-      
+
       -- Raw data
       pgl as raw_log_data
-      
+
     from postgres_logs as pgl
     cross join unnest(pgl.metadata) as pgl_metadata
     cross join unnest(pgl_metadata.parsed) as pgl_parsed
-    
-WHERE 
-  pgl.id = '${logId}'
+
+WHERE
+  pgl.id = ${analyticsLiteral(logId)}
 `
 }

--- a/apps/studio/data/logs/unified-log-inspection-query.ts
+++ b/apps/studio/data/logs/unified-log-inspection-query.ts
@@ -8,7 +8,7 @@ import {
   flattenOtelInspectionRow,
   type OtelLogRow,
 } from './otel-inspection.utils'
-import { analyticsLiteral as lit, safeSql } from './safe-analytics-sql'
+import { analyticsLiteral as lit, safeSql, type SafeLogSqlFragment } from './safe-analytics-sql'
 import {
   getUnifiedLogsISOStartEnd,
   UNIFIED_LOGS_QUERY_OPTIONS,
@@ -21,7 +21,6 @@ import {
   getStorageServiceFlowQuery,
 } from '@/components/interfaces/UnifiedLogs/Queries/ServiceFlowQueries/ServiceFlow.sql'
 import { QuerySearchParamsType } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.types'
-import { handleError, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 // Service flow types - subset of LOG_TYPES that support service flows
@@ -141,7 +140,7 @@ export async function getUnifiedLogInspection(
   const { isoTimestampStart, isoTimestampEnd } = getUnifiedLogsISOStartEnd(search)
 
   if (!useOtel) {
-    let sql = ''
+    let sql: SafeLogSqlFragment
     switch (type) {
       case 'postgrest':
         sql = getPostgrestServiceFlowQuery(logId)
@@ -162,19 +161,14 @@ export async function getUnifiedLogInspection(
         throw new Error('Invalid type')
     }
 
-    const { data, error } = await post('/platform/projects/{ref}/analytics/endpoints/logs.all', {
-      params: { path: { ref: projectRef } },
-      body: {
-        iso_timestamp_start: isoTimestampStart,
-        iso_timestamp_end: isoTimestampEnd,
-        sql: sql,
-      },
+    const data = await executeAnalyticsSql({
+      projectRef,
+      endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all',
+      sql,
+      iso_timestamp_start: isoTimestampStart,
+      iso_timestamp_end: isoTimestampEnd,
       signal,
     })
-
-    if (error) {
-      handleError(error)
-    }
 
     return data as unknown as UnifiedLogInspectionResponse
   }

--- a/apps/studio/data/logs/unified-log-inspection-query.ts
+++ b/apps/studio/data/logs/unified-log-inspection-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import {
   aggregateFunctionLogs,
@@ -198,21 +199,16 @@ WHERE id = ${lit(logId)}
 LIMIT 1
 `
 
-  const { data, error } = await post('/platform/projects/{ref}/analytics/endpoints/logs.all.otel', {
-    params: { path: { ref: projectRef } },
-    body: {
-      iso_timestamp_start: isoTimestampStart,
-      iso_timestamp_end: isoTimestampEnd,
-      sql,
-    },
+  const rawData = await executeAnalyticsSql({
+    projectRef,
+    endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all.otel',
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: isoTimestampEnd,
     signal,
   })
 
-  if (error) {
-    handleError(error)
-  }
-
-  const otelData = data as { result?: OtelLogRow[] } | undefined
+  const otelData = rawData as { result?: OtelLogRow[] } | undefined
   const row = otelData?.result?.[0]
   if (!row) {
     return { result: [] }
@@ -234,23 +230,20 @@ ORDER BY timestamp ASC
 LIMIT 100
 `
 
-      const { data: fnData, error: fnError } = await post(
-        '/platform/projects/{ref}/analytics/endpoints/logs.all.otel',
-        {
-          params: { path: { ref: projectRef } },
-          body: {
-            iso_timestamp_start: isoTimestampStart,
-            iso_timestamp_end: isoTimestampEnd,
-            sql: fnSql,
-          },
+      try {
+        const fnData = await executeAnalyticsSql({
+          projectRef,
+          endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all.otel',
+          sql: fnSql,
+          iso_timestamp_start: isoTimestampStart,
+          iso_timestamp_end: isoTimestampEnd,
           signal,
-        }
-      )
-
-      if (!fnError) {
+        })
         const fnRows = ((fnData as { result?: OtelLogRow[] } | undefined)?.result ??
           []) as OtelLogRow[]
         Object.assign(entry, aggregateFunctionLogs(fnRows))
+      } catch {
+        // function logs are supplementary; silently ignore fetch errors
       }
     }
   }

--- a/apps/studio/data/logs/unified-logs-chart-query.ts
+++ b/apps/studio/data/logs/unified-logs-chart-query.ts
@@ -1,12 +1,12 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
 import { UNIFIED_LOGS_QUERY_OPTIONS, UnifiedLogsVariables } from './unified-logs-infinite-query'
 import { getLogsChartQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getLogsChartQuery as getLogsChartQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
-import { handleError, post } from '@/data/fetchers'
 import { ExecuteSqlError } from '@/data/sql/execute-sql-query'
 import { UseCustomQueryOptions } from '@/types'
 
@@ -42,17 +42,16 @@ export async function getUnifiedLogsChart(
   // Get SQL query from utility function (with dynamic bucketing)
   const sql = pickLogsQueryBuilder(useOtel, getLogsChartQuery, getLogsChartQueryBq)(search)
 
-  let headers = new Headers(headersInit)
-
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { sql, iso_timestamp_start: dateStart, iso_timestamp_end: dateEnd },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: dateStart,
+    iso_timestamp_end: dateEnd,
     signal,
-    headers,
+    headers: headersInit,
   })
-
-  if (error) handleError(error)
 
   const chartData: Array<{
     timestamp: number

--- a/apps/studio/data/logs/unified-logs-count-query.ts
+++ b/apps/studio/data/logs/unified-logs-count-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
 import {
@@ -11,7 +12,6 @@ import {
 import { getLogsCountQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getLogsCountQuery as getLogsCountQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import { FacetMetadataSchema } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.schema'
-import { handleError, post } from '@/data/fetchers'
 import { ExecuteSqlError } from '@/data/sql/execute-sql-query'
 import { UseCustomQueryOptions } from '@/types'
 
@@ -27,13 +27,14 @@ export async function getUnifiedLogsCount(
   const { isoTimestampStart, isoTimestampEnd } = getUnifiedLogsISOStartEnd(search)
 
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { iso_timestamp_start: isoTimestampStart, iso_timestamp_end: isoTimestampEnd, sql },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: isoTimestampEnd,
     signal,
   })
-
-  if (error) handleError(error)
 
   // Process count results into facets structure
   const facets: Record<string, FacetMetadataSchema> = {}

--- a/apps/studio/data/logs/unified-logs-facet-count-query.ts
+++ b/apps/studio/data/logs/unified-logs-facet-count-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl } from './logs-endpoint'
 import { bqIdent, safeSql } from './safe-analytics-sql'
@@ -15,7 +16,6 @@ import {
   getUnifiedLogsCTE,
 } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import { Option } from '@/components/ui/DataTable/DataTable.types'
-import { handleError, post } from '@/data/fetchers'
 import { ExecuteSqlError } from '@/data/sql/execute-sql-query'
 import { UseCustomQueryOptions } from '@/types'
 
@@ -43,13 +43,14 @@ SELECT dimension, value, count from ${bqIdent(facet + '_count')};
 `
 
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { iso_timestamp_start: isoTimestampStart, iso_timestamp_end: isoTimestampEnd, sql },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: isoTimestampEnd,
     signal,
   })
-
-  if (error) handleError(error)
   return (data.result ?? []) as Option[]
 }
 

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -1,15 +1,17 @@
 import { InfiniteData, keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
 import { useFlag } from 'common'
 
+import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
+import { analyticsLiteral, safeSql } from './safe-analytics-sql'
 import { getUnifiedLogsQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getUnifiedLogsQuery as getUnifiedLogsQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import {
   PageParam,
   QuerySearchParamsType,
 } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.types'
-import { handleError, post } from '@/data/fetchers'
+import { handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from '@/types'
 
 const LOGS_PAGE_LIMIT = 50
@@ -83,7 +85,7 @@ export async function getUnifiedLogs(
 
   const { isoTimestampStart, isoTimestampEnd } = getUnifiedLogsISOStartEnd(search)
   const buildQuery = pickLogsQueryBuilder(useOtel, getUnifiedLogsQuery, getUnifiedLogsQueryBq)
-  const sql = `${buildQuery(search)} ORDER BY timestamp DESC, id DESC LIMIT ${LOGS_PAGE_LIMIT}`
+  const sql = safeSql`${buildQuery(search)} ORDER BY timestamp DESC, id DESC LIMIT ${analyticsLiteral(LOGS_PAGE_LIMIT)}`
 
   const cursorValue = pageParam?.cursor
   const cursorDirection = pageParam?.direction
@@ -105,17 +107,17 @@ export async function getUnifiedLogs(
     timestampEnd = isoTimestampEnd
   }
 
-  let headers = new Headers(headersInit)
-
   const endpoint = logsAllEndpointUrl(useOtel)
-  const { data, error } = await post(endpoint, {
-    params: { path: { ref: projectRef } },
-    body: { iso_timestamp_start: isoTimestampStart, iso_timestamp_end: timestampEnd, sql },
+  const data = await executeAnalyticsSql({
+    projectRef,
+    endpoint,
+    sql,
+    iso_timestamp_start: isoTimestampStart,
+    iso_timestamp_end: timestampEnd,
     signal,
-    headers,
+    headers: headersInit,
   })
 
-  if (error) handleError(error)
   if (data.error) handleError(new Error(data.error as string))
 
   const resultData = data?.result ?? []


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor / security hardening (part 3 of stacked analytics safe-SQL series; stacks on top of PR 2: "feat(logs): route unified-logs hooks through executeAnalyticsSql")

## What is the current behavior?

`ServiceFlow.sql.ts` interpolates `logId` and `serviceType` as raw template-literal strings directly into SQL (e.g. `` `WHERE el.id = '${logId}'` ``). The legacy BigQuery branch of `unified-log-inspection-query.ts` calls `post()` directly with a plain `string`-typed SQL value, bypassing the `executeAnalyticsSql` wire-boundary.

## What is the new behavior?

- Add `SAFE_SERVICE_LITERAL: Record<EdgeServiceType, SafeLogSqlFragment>` — pre-branded SQL string literals for each service type, built with `analyticsLiteral`.
- Rewrite `getBaseEdgeServiceFlowQuery`, `getEdgeFunctionServiceFlowQuery`, and `getPostgresServiceFlowQuery` to use `safeSql` template tag with `analyticsLiteral(logId)` and `SAFE_SERVICE_LITERAL[serviceType]`. Return types changed to `SafeLogSqlFragment`.
- Update the four thin wrappers (`getPostgrestServiceFlowQuery`, `getAuthServiceFlowQuery`, `getStorageServiceFlowQuery`) to return `SafeLogSqlFragment`.
- Replace `let sql = ''` + direct `post()` call in `unified-log-inspection-query.ts`'s legacy BigQuery branch with `let sql: SafeLogSqlFragment` + `executeAnalyticsSql`, eliminating the last direct `post()` call to the analytics endpoint in this file.

`pnpm typecheck` passes cleanly.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Secured analytics and log inspection queries through parameterized SQL execution, preventing potential SQL injection vulnerabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46336?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->