### PR TITLE
refactor(replication): remove useless expire snapshot configuration

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.schema.ts
@@ -43,7 +43,6 @@ export const DestinationPanelFormSchema = z.object({
   ducklakeS3UrlStyle: z.enum(['path', 'vhost']).optional(),
   ducklakeS3UseSsl: z.boolean().optional(),
   ducklakeMetadataSchema: z.string().optional(),
-  ducklakeExpireSnapshotsOlderThan: z.string().optional(),
 })
 
 export type DestinationPanelSchemaType = z.infer<typeof DestinationPanelFormSchema>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
@@ -35,7 +35,6 @@ const baseDucklakeFormData = {
   ducklakeS3UrlStyle: 'path' as const,
   ducklakeS3UseSsl: true,
   ducklakeMetadataSchema: ' ducklake_metadata ',
-  ducklakeExpireSnapshotsOlderThan: ' 7 days ',
 }
 
 describe('DestinationForm.utils DuckLake', () => {
@@ -46,7 +45,6 @@ describe('DestinationForm.utils DuckLake', () => {
       data: {
         ...baseDucklakeFormData,
         ducklakeMetadataSchema: '   ',
-        ducklakeExpireSnapshotsOlderThan: '   ',
       },
     })
 
@@ -62,7 +60,6 @@ describe('DestinationForm.utils DuckLake', () => {
         s3UrlStyle: 'path',
         s3UseSsl: true,
         metadataSchema: undefined,
-        expireSnapshotsOlderThan: undefined,
       },
     })
   })
@@ -91,7 +88,6 @@ describe('DestinationForm.utils DuckLake', () => {
         s3UrlStyle: 'path',
         s3UseSsl: true,
         metadataSchema: 'ducklake_metadata',
-        expireSnapshotsOlderThan: '7 days',
       },
     })
     expect(createS3AccessKey).not.toHaveBeenCalled()

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
@@ -176,7 +176,6 @@ export const buildDestinationConfigForValidation = ({
         s3UrlStyle: data.ducklakeS3UrlStyle,
         s3UseSsl: data.ducklakeS3UseSsl,
         metadataSchema: normalizeOptionalString(data.ducklakeMetadataSchema),
-        expireSnapshotsOlderThan: normalizeOptionalString(data.ducklakeExpireSnapshotsOlderThan),
       },
     }
   } else {
@@ -255,7 +254,6 @@ export const buildDestinationConfig = async ({
       s3UrlStyle: data.ducklakeS3UrlStyle,
       s3UseSsl: data.ducklakeS3UseSsl,
       metadataSchema: normalizeOptionalString(data.ducklakeMetadataSchema),
-      expireSnapshotsOlderThan: normalizeOptionalString(data.ducklakeExpireSnapshotsOlderThan),
     }
     destinationConfig = { ducklake: ducklakeConfig }
   }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
@@ -318,9 +318,9 @@ export const DuckLakeFields = ({ form }: { form: UseFormReturn<DestinationPanelS
       </div>
 
       <div className="flex flex-col gap-y-1">
-        <p className="text-sm font-medium text-foreground">Maintenance</p>
+        <p className="text-sm font-medium text-foreground">Metadata</p>
         <p className="text-sm text-foreground-light">
-          Optional settings for DuckLake metadata tables and snapshot cleanup.
+          Optional schema setting for DuckLake metadata tables.
         </p>
       </div>
 
@@ -336,22 +336,6 @@ export const DuckLakeFields = ({ form }: { form: UseFormReturn<DestinationPanelS
             >
               <FormControl>
                 <Input {...field} placeholder="ducklake" value={field.value ?? ''} />
-              </FormControl>
-            </FormItemLayout>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="ducklakeExpireSnapshotsOlderThan"
-          render={({ field }) => (
-            <FormItemLayout
-              layout="horizontal"
-              label="Expire snapshots older than"
-              description="Optional snapshot retention interval, for example `7 days`"
-            >
-              <FormControl>
-                <Input {...field} placeholder="7 days" value={field.value ?? ''} />
               </FormControl>
             </FormItemLayout>
           )}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -84,7 +84,6 @@ type DucklakeApiConfig = {
   s3_url_style?: 'path' | 'vhost'
   s3_use_ssl?: boolean
   metadata_schema?: string
-  expire_snapshots_older_than?: string
 }
 
 export const DestinationForm = ({
@@ -237,7 +236,6 @@ export const DestinationForm = ({
       ducklakeS3UrlStyle: ducklakeConfig?.s3_url_style ?? 'path',
       ducklakeS3UseSsl: ducklakeConfig?.s3_use_ssl ?? true,
       ducklakeMetadataSchema: ducklakeConfig?.metadata_schema ?? 'ducklake',
-      ducklakeExpireSnapshotsOlderThan: ducklakeConfig?.expire_snapshots_older_than ?? '',
     }
   }, [destinationData, pipelineData, catalogToken, projectSettings])
 

--- a/apps/studio/data/replication/create-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/create-destination-pipeline-mutation.ts
@@ -46,7 +46,6 @@ export type DucklakeDestinationConfig = {
   s3UrlStyle?: 'path' | 'vhost'
   s3UseSsl?: boolean
   metadataSchema?: string
-  expireSnapshotsOlderThan?: string
 }
 
 export type BatchConfig = {
@@ -137,7 +136,6 @@ async function createDestinationPipeline(
       s3UrlStyle,
       s3UseSsl,
       metadataSchema,
-      expireSnapshotsOlderThan,
     } = destinationConfig.ducklake
 
     destination_config = {
@@ -152,7 +150,6 @@ async function createDestinationPipeline(
         s3_url_style: s3UrlStyle,
         s3_use_ssl: s3UseSsl,
         metadata_schema: metadataSchema,
-        expire_snapshots_older_than: expireSnapshotsOlderThan,
       },
     } as unknown as components['schemas']['CreateReplicationDestinationPipelineBody']['destination_config']
   } else {

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -93,7 +93,6 @@ async function updateDestinationPipeline(
       s3UrlStyle,
       s3UseSsl,
       metadataSchema,
-      expireSnapshotsOlderThan,
     } = destinationConfig.ducklake
     destination_config = {
       ducklake: {
@@ -107,7 +106,6 @@ async function updateDestinationPipeline(
         s3_url_style: s3UrlStyle,
         s3_use_ssl: s3UseSsl,
         metadata_schema: metadataSchema,
-        expire_snapshots_older_than: expireSnapshotsOlderThan,
       },
     } as unknown as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
   } else {

--- a/apps/studio/data/replication/validate-destination-mutation.ts
+++ b/apps/studio/data/replication/validate-destination-mutation.ts
@@ -71,7 +71,6 @@ async function validateDestination(
       s3UrlStyle,
       s3UseSsl,
       metadataSchema,
-      expireSnapshotsOlderThan,
     } = destinationConfig.ducklake
 
     config = {
@@ -86,7 +85,6 @@ async function validateDestination(
         s3_url_style: s3UrlStyle,
         s3_use_ssl: s3UseSsl,
         metadata_schema: metadataSchema,
-        expire_snapshots_older_than: expireSnapshotsOlderThan,
       },
     } as unknown as components['schemas']['ValidateReplicationDestinationBody']['config']
   } else {

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5733,11 +5733,6 @@ export interface components {
                */
               data_path: string
               /**
-               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
-               * @example 7 days
-               */
-              expire_snapshots_older_than?: string
-              /**
                * @description Schema used for DuckLake metadata tables stored in PostgreSQL
                * @default ducklake
                * @example ducklake
@@ -5870,11 +5865,6 @@ export interface components {
                * @example s3://<bucket-name>/
                */
               data_path: string
-              /**
-               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
-               * @example 7 days
-               */
-              expire_snapshots_older_than?: string
               /**
                * @description Schema used for DuckLake metadata tables stored in PostgreSQL
                * @default ducklake
@@ -9394,11 +9384,6 @@ export interface components {
                */
               data_path: string
               /**
-               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
-               * @example 7 days
-               */
-              expire_snapshots_older_than?: string
-              /**
                * @description Schema used for DuckLake metadata tables stored in PostgreSQL
                * @default ducklake
                * @example ducklake
@@ -9543,11 +9528,6 @@ export interface components {
                  * @example s3://<bucket-name>/
                  */
                 data_path: string
-                /**
-                 * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
-                 * @example 7 days
-                 */
-                expire_snapshots_older_than?: string
                 /**
                  * @description Schema used for DuckLake metadata tables stored in PostgreSQL
                  * @default ducklake
@@ -11385,11 +11365,6 @@ export interface components {
                */
               data_path: string
               /**
-               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
-               * @example 7 days
-               */
-              expire_snapshots_older_than?: string
-              /**
                * @description Schema used for DuckLake metadata tables stored in PostgreSQL
                * @default ducklake
                * @example ducklake
@@ -11522,11 +11497,6 @@ export interface components {
                * @example s3://<bucket-name>/
                */
               data_path: string
-              /**
-               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
-               * @example 7 days
-               */
-              expire_snapshots_older_than?: string
               /**
                * @description Schema used for DuckLake metadata tables stored in PostgreSQL
                * @default ducklake
@@ -12071,11 +12041,6 @@ export interface components {
                * @example s3://<bucket-name>/
                */
               data_path: string
-              /**
-               * @description DuckLake snapshot retention interval (format: https://duckdb.org/docs/current/sql/data_types/interval)
-               * @example 7 days
-               */
-              expire_snapshots_older_than?: string
               /**
                * @description Schema used for DuckLake metadata tables stored in PostgreSQL
                * @default ducklake


### PR DESCRIPTION
Remove useless expire snapshot configuration

> This is an alpha feature not already deployed to any of our customers so breaking changes are not an issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed "Expire snapshots older than" field from DuckLake replication destination configuration
  * Updated DuckLake settings to prioritize metadata schema configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->