### PR TITLE
feat(studio): keyboard shortcuts for integration tabs

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/HooksList/HooksList.tsx
@@ -2,7 +2,7 @@ import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { includes, map as lodashMap, uniqBy } from 'lodash'
 import { Search } from 'lucide-react'
 import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { InputGroup, InputGroupAddon, InputGroupInput } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -16,6 +16,9 @@ import { useDatabaseHooksQuery } from '@/data/database-triggers/database-trigger
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
+import { onSearchInputEscape } from '@/lib/keyboard'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export const HooksList = () => {
   const { data: project } = useSelectedProjectQuery()
@@ -44,15 +47,33 @@ export const HooksList = () => {
     'triggers'
   )
 
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useShortcut(
+    SHORTCUT_IDS.LIST_PAGE_FOCUS_SEARCH,
+    () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
+    { label: 'Search webhooks' }
+  )
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_RESET_FILTERS, () => setFilterString(''))
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setShowCreateHookForm(true), {
+    label: 'Create webhook',
+    enabled: isPermissionsLoaded && canCreateWebhooks,
+  })
+
   return (
     <div className="w-full space-y-4">
       <div className="flex items-center justify-between">
         <InputGroup className="w-52">
           <InputGroupInput
+            ref={searchInputRef}
             size="tiny"
             placeholder="Search for a webhook"
             value={filterString}
             onChange={(e) => setFilterString(e.target.value)}
+            onKeyDown={onSearchInputEscape(filterString, setFilterString)}
           />
           <InputGroupAddon>
             <Search />

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.Header.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.Header.tsx
@@ -1,11 +1,14 @@
 import { RefreshCw, Search, X } from 'lucide-react'
-import type { KeyboardEvent } from 'react'
+import type { KeyboardEvent, Ref } from 'react'
 import { Button } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
+
+import { onSearchInputEscape } from '@/lib/keyboard'
 
 interface CronJobsTabHeaderProps {
   search: string
   isRefreshing: boolean
+  searchInputRef?: Ref<HTMLInputElement>
   onSearchChange: (value: string) => void
   onSearchSubmit: () => void
   onClearSearch: () => void
@@ -16,6 +19,7 @@ interface CronJobsTabHeaderProps {
 export const CronJobsTabHeader = ({
   search,
   isRefreshing,
+  searchInputRef,
   onSearchChange,
   onSearchSubmit,
   onClearSearch,
@@ -23,6 +27,7 @@ export const CronJobsTabHeader = ({
   onCreateJob,
 }: CronJobsTabHeaderProps) => {
   const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    onSearchInputEscape(search, onClearSearch)(event)
     if (event.key === 'Enter' || event.code === 'NumpadEnter') {
       onSearchSubmit()
     }
@@ -31,6 +36,7 @@ export const CronJobsTabHeader = ({
   return (
     <div className="bg-surface-200 py-3 px-10 flex items-center justify-between flex-wrap gap-y-2">
       <Input
+        ref={searchInputRef}
         size="tiny"
         className="w-52"
         placeholder="Search for a job"

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobsTab.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { Loader2 } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
-import { MouseEvent, useEffect, useMemo, useState } from 'react'
+import { MouseEvent, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { LoadingLine } from 'ui'
 
@@ -20,6 +20,8 @@ import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganizati
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { cleanPointerEventsNoneOnBody } from '@/lib/helpers'
 import { createNavigationHandler } from '@/lib/navigation'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 const EMPTY_CRON_JOB = { jobname: '', schedule: '', active: true, command: '' }
 
@@ -96,6 +98,19 @@ export const CronjobsTab = () => {
     setCreateCronJobSheetShown(true)
   }
 
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useShortcut(
+    SHORTCUT_IDS.LIST_PAGE_FOCUS_SEARCH,
+    () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
+    { label: 'Search cron jobs' }
+  )
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_RESET_FILTERS, handleClearSearch)
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, onOpenCreateJobSheet, { label: 'Create cron job' })
+
   // Row click handler
   const handleRowClick = (row: CronJob, event: MouseEvent<HTMLDivElement>) => {
     const { jobid, jobname } = row
@@ -131,6 +146,7 @@ export const CronjobsTab = () => {
           <CronJobsTabHeader
             search={search}
             isRefreshing={grid.isRefetching && !grid.isFetchingNextPage}
+            searchInputRef={searchInputRef}
             onSearchChange={setSearch}
             onSearchSubmit={handleSearchSubmit}
             onClearSearch={handleClearSearch}

--- a/apps/studio/components/interfaces/Integrations/Queues/QueuesTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueuesTab.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { RefreshCw, Search, X } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { parseAsBoolean, parseAsString, useQueryState } from 'nuqs'
-import { useMemo, useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
 import DataGrid, { Row } from 'react-data-grid'
 import { Button, cn, LoadingLine } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -13,6 +13,9 @@ import { formatQueueColumns, prepareQueuesForDataGrid } from './Queues.utils'
 import AlertError from '@/components/ui/AlertError'
 import { useQueuesQuery } from '@/data/database-queues/database-queues-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { onSearchInputEscape } from '@/lib/keyboard'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export const QueuesTab = () => {
   const router = useRouter()
@@ -26,6 +29,26 @@ export const QueuesTab = () => {
     'new',
     parseAsBoolean.withDefault(false).withOptions({ history: 'push', clearOnDefault: true })
   )
+
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  const clearSearch = () => {
+    setSearch('')
+    setSearchQuery('')
+  }
+
+  useShortcut(
+    SHORTCUT_IDS.LIST_PAGE_FOCUS_SEARCH,
+    () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
+    { label: 'Search queues' }
+  )
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_RESET_FILTERS, clearSearch)
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setCreateQueueSheetShown(true), {
+    label: 'Create queue',
+  })
 
   const {
     data: queues,
@@ -60,6 +83,7 @@ export const QueuesTab = () => {
         <div className="h-full w-full flex flex-col relative">
           <div className="bg-surface-200 py-3 px-10 flex items-center justify-between flex-wrap">
             <Input
+              ref={searchInputRef}
               size="tiny"
               className="w-52"
               placeholder="Search for a queue"
@@ -67,6 +91,7 @@ export const QueuesTab = () => {
               value={search ?? ''}
               onChange={(e) => setSearch(e.target.value)}
               onKeyDown={(e) => {
+                onSearchInputEscape(search ?? '', clearSearch)(e)
                 if (e.code === 'Enter' || e.code === 'NumpadEnter') setSearchQuery(search.trim())
               }}
               actions={[
@@ -76,10 +101,7 @@ export const QueuesTab = () => {
                     size="tiny"
                     type="text"
                     icon={<X />}
-                    onClick={() => {
-                      setSearch('')
-                      setSearchQuery('')
-                    }}
+                    onClick={clearSearch}
                     className="p-0 h-5 w-5"
                   />
                 ),

--- a/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretsManagement.tsx
+++ b/apps/studio/components/interfaces/Integrations/Vault/Secrets/SecretsManagement.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'common'
 import { sortBy } from 'lodash'
 import { RefreshCw, Search, X } from 'lucide-react'
 import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import DataGrid, { Row } from 'react-data-grid'
 import {
   Button,
@@ -28,6 +28,9 @@ import { useVaultSecretsQuery } from '@/data/vault/vault-secrets-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
+import { onSearchInputEscape } from '@/lib/keyboard'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 import type { VaultSecret } from '@/types'
 
 export const SecretsManagement = () => {
@@ -78,6 +81,22 @@ export const SecretsManagement = () => {
     if (search !== undefined) setSearchValue(search)
   }, [search])
 
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  useShortcut(
+    SHORTCUT_IDS.LIST_PAGE_FOCUS_SEARCH,
+    () => {
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    },
+    { label: 'Search secrets' }
+  )
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_RESET_FILTERS, () => setSearchValue(''))
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setShowAddSecretModal(true), {
+    label: 'Add new secret',
+    enabled: canManageSecrets,
+  })
+
   return (
     <>
       <div className="h-full w-full space-y-4">
@@ -85,12 +104,14 @@ export const SecretsManagement = () => {
           <div className="bg-surface-200 py-3 px-10 flex items-center justify-between flex-wrap">
             <div className="flex items-center gap-2">
               <Input
+                ref={searchInputRef}
                 size="tiny"
                 className="w-52"
                 placeholder="Search by name or key ID"
                 icon={<Search />}
                 value={searchValue ?? ''}
                 onChange={(e) => setSearchValue(e.target.value)}
+                onKeyDown={onSearchInputEscape(searchValue ?? '', setSearchValue)}
                 actions={[
                   searchValue && (
                     <Button

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
@@ -14,6 +14,8 @@ import { useFDWsQuery } from '@/data/fdw/fdws-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export const WrappersTab = () => {
   const { id } = useParams()
@@ -24,6 +26,11 @@ export const WrappersTab = () => {
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'wrappers'
   )
+
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setCreateWrapperShown(true), {
+    label: 'Add new wrapper',
+    enabled: canCreateWrapper,
+  })
 
   const { data } = useFDWsQuery({
     projectRef: project?.ref,


### PR DESCRIPTION
## Summary

Adds search / clear / new shortcuts to each integration tab. Search inputs honor the staged-Escape pattern per the studio-shortcuts skill.

## Shortcuts

| Tab | Shortcuts |
|---|---|
| Queues | `Shift+F` search · `F C` clear · `Shift+N` Create queue |
| Cron jobs | `Shift+F` search · `F C` clear · `Shift+N` Create cron job |
| Webhooks | `Shift+F` search · `F C` clear · `Shift+N` Create webhook |
| Vault secrets | `Shift+F` search · `F C` clear · `Shift+N` Add new secret |
| Wrappers | `Shift+N` Add new wrapper |

All search inputs: `Esc` clears value (1st press), blurs (2nd). Permission-gated "new" entries are hidden from Cmd+K when the user lacks the permission.

Follow-up to #46348. Linear: [FE-3416](https://linear.app/supabase/issue/FE-3416)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts across studio list pages for enhanced productivity: focus and manage search filters, and open creation dialogs for webhooks, cron jobs, queues, secrets, and wrappers using keyboard commands for faster navigation and item creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->