### PR TITLE
fix(docs): Fix broken Edge Functions 401 troubleshooting guide link

### DIFF
--- a/apps/docs/content/guides/functions/auth-headers.mdx
+++ b/apps/docs/content/guides/functions/auth-headers.mdx
@@ -40,4 +40,4 @@ Set the flag per function in `supabase/config.toml`:
 verify_jwt = false
 ```
 
-For 401 failure modes and how to diagnose them, see [Edge Function 401 error response](/docs/troubleshooting/edge-function-401-error-response).
+For 401 failure modes and how to diagnose them, see [Edge Function 401 error response](/docs/guides/troubleshooting/edge-function-401-error-response).


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Fix broken link
- Affected page https://supabase.com/docs/guides/functions/auth-headers
- Currently links to https://supabase.com/docs/troubleshooting/edge-function-401-error-response which 404s
- Correct link https://supabase.com/docs/guides/troubleshooting/edge-function-401-error-response

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated troubleshooting guide reference link for Edge Function 401 error responses to point to the correct location.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46355?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->