### PR TITLE
Reduce z index on row selection header

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/RowSelectionHeader.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/RowSelectionHeader.tsx
@@ -61,7 +61,7 @@ export const RowSelectionHeader = () => {
               damping: 30,
               mass: 0.4,
             }}
-            className="pl-4 pr-2 flex items-center justify-between border-t absolute top-0 z-99 bg-surface-75 w-full"
+            className="pl-4 pr-2 flex items-center justify-between border-t absolute top-0 z-2 bg-surface-75 w-full"
             style={{ overflow: 'hidden' }}
           >
             <p className="text-xs">


### PR DESCRIPTION
## Context

`RowSelectionHeader` was unnecessarily using a 99 z-index value which was conflicting with the tooltips, so reducing it down to 2 which should be all that we need

### Before
<img width="558" height="280" alt="image" src="https://github.com/user-attachments/assets/362be2df-aca7-4cb9-9bfb-84e77dac06ab" />


### After
<img width="374" height="161" alt="image" src="https://github.com/user-attachments/assets/118c8411-f25c-4513-9cce-2d24dcc71759" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the z-index layering of the selected-rows overlay header component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->