### PR TITLE
Improve unified logs formatting for auth logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
@@ -1,5 +1,4 @@
 import { type Table as TTable } from '@tanstack/react-table'
-import { capitalize } from 'lodash'
 import { cn } from 'ui'
 
 import { FacetMetadataSchema } from './UnifiedLogs.schema'

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
@@ -1,4 +1,5 @@
 import { type Table as TTable } from '@tanstack/react-table'
+import { capitalize } from 'lodash'
 import { cn } from 'ui'
 
 import { FacetMetadataSchema } from './UnifiedLogs.schema'
@@ -124,16 +125,28 @@ export function formatServiceTypeForDisplay(serviceType: string): string {
  */
 export function parseAuthLogEventMessage(value: string | undefined): string | undefined {
   if (!value) return value
+
   try {
     const parsed = JSON.parse(value)
+
     if (parsed && typeof parsed === 'object') {
+      const err = parsed.error || parsed.error_code
+      if (typeof err === 'string' && err.trim()) {
+        return !/^\d{3}:/.test(err) ? err.replaceAll('_', ' ') : err
+      }
+
       const msg = parsed.msg
-      const err = parsed.error
-      if (typeof msg === 'string' && msg.trim()) return msg
-      if (typeof err === 'string' && err.trim()) return err
+      if (typeof msg === 'string' && msg.trim()) {
+        const authEvent =
+          'action' in parsed || 'auth_event_action' in parsed
+            ? (parsed.action || parsed.auth_event.action).replaceAll('_', ' ')
+            : undefined
+        return `${authEvent ? `${authEvent}: ` : ''}${msg}`
+      }
     }
+
     return value
-  } catch {
+  } catch (error) {
     return value
   }
 }

--- a/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
@@ -1,5 +1,5 @@
 import { ColumnDef } from '@tanstack/react-table'
-import { Checkbox, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { Checkbox, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import { STATUS_CODE_LABELS } from '../UnifiedLogs.constants'
 import { ColumnFilterSchema, ColumnSchema } from '../UnifiedLogs.schema'
@@ -203,10 +203,6 @@ export function generateDynamicColumns({ data }: { data: ColumnSchema[] }): {
     {
       accessorKey: 'pathname',
       header: 'Pathname',
-      cell: ({ row }) => {
-        const value = row.getValue<ColumnFilterSchema['pathname']>('pathname') ?? ''
-        return value
-      },
       enableSorting: false,
       enableResizing: false,
       size: 250,
@@ -215,6 +211,10 @@ export function generateDynamicColumns({ data }: { data: ColumnSchema[] }): {
       meta: {
         cellClassName: 'font-mono tracking-tight w-[250px]',
         headerClassName: 'w-[250px]',
+      },
+      cell: ({ row }) => {
+        const value = row.getValue<ColumnFilterSchema['pathname']>('pathname') ?? ''
+        return value
       },
     },
     // Event message column - controlled by columnVisibility
@@ -241,7 +241,13 @@ export function generateDynamicColumns({ data }: { data: ColumnSchema[] }): {
                 </TooltipContent>
               </Tooltip>
             )}
-            {displayMessage && <span className="text-muted-foreground">{displayMessage}</span>}
+            {displayMessage && (
+              <span
+                className={cn('text-muted-foreground', logType === 'auth' && 'capitalize-sentence')}
+              >
+                {displayMessage}
+              </span>
+            )}
           </div>
         )
       },

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -13,7 +13,6 @@ import {
   QuerySearchParamsType,
 } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.types'
 import { handleError } from '@/data/fetchers'
-import { tryParseJson } from '@/lib/helpers'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from '@/types'
 
 const LOGS_PAGE_LIMIT = 50

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -12,6 +12,7 @@ import {
   QuerySearchParamsType,
 } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.types'
 import { handleError } from '@/data/fetchers'
+import { tryParseJson } from '@/lib/helpers'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from '@/types'
 
 const LOGS_PAGE_LIMIT = 50
@@ -28,6 +29,11 @@ export const UNIFIED_LOGS_QUERY_OPTIONS = {
 export type UnifiedLogsData = any
 export type UnifiedLogsError = ResponseError
 export type UnifiedLogsVariables = { projectRef?: string; search: QuerySearchParamsType }
+
+const extractLeadingStatus = (s?: string) => {
+  const m = typeof s === 'string' ? s.match(/^(\d{3})\b/) : null
+  return m ? Number(m[1]) : undefined
+}
 
 export const getUnifiedLogsISOStartEnd = (
   search: QuerySearchParamsType,
@@ -134,15 +140,30 @@ export async function getUnifiedLogs(
       ? new Date(/Z$|[+-]\d{2}:?\d{2}$/.test(ts) ? ts : `${ts}Z`)
       : new Date(Number(ts) / 1000)
 
+    // [Joshen] For auth logs, these metadata are nested within event_message,
+    // so opting to bring them out at the query level
+    const eventMessage = tryParseJson(row.event_message)
+    const status =
+      row.log_type === 'auth'
+        ? (eventMessage?.status ??
+          extractLeadingStatus(eventMessage?.msg) ??
+          extractLeadingStatus(eventMessage?.error))
+        : (row.status ?? 200)
+    const method = row.log_type === 'auth' ? eventMessage?.method : row.method
+    const pathname =
+      row.log_type === 'auth'
+        ? eventMessage?.path
+        : (row.url || '').replace(/^https?:\/\/[^\/]+/, '') || row.pathname || ''
+
     return {
       id: row.id,
       date,
+      method,
+      pathname,
+      status,
       timestamp: row.timestamp,
       level: row.level as LogLevel,
-      status: row.status || 200,
-      method: row.method,
       host: row.host,
-      pathname: (row.url || '').replace(/^https?:\/\/[^\/]+/, '') || row.pathname || '',
       event_message: row.event_message || row.body || '',
       headers:
         typeof row.headers === 'string' ? JSON.parse(row.headers || '{}') : row.headers || {},

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -30,11 +30,6 @@ export type UnifiedLogsData = any
 export type UnifiedLogsError = ResponseError
 export type UnifiedLogsVariables = { projectRef?: string; search: QuerySearchParamsType }
 
-const extractLeadingStatus = (s?: string) => {
-  const m = typeof s === 'string' ? s.match(/^(\d{3})\b/) : null
-  return m ? Number(m[1]) : undefined
-}
-
 export const getUnifiedLogsISOStartEnd = (
   search: QuerySearchParamsType,
   endHoursFromNow: number = 1

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -5,6 +5,7 @@ import { executeAnalyticsSql } from './execute-analytics-sql'
 import { logsKeys } from './keys'
 import { logsAllEndpointUrl, pickLogsQueryBuilder } from './logs-endpoint'
 import { analyticsLiteral, safeSql } from './safe-analytics-sql'
+import { extractLogMetadata } from './unified-logs.utils'
 import { getUnifiedLogsQuery } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries'
 import { getUnifiedLogsQuery as getUnifiedLogsQueryBq } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.queries.bq'
 import {
@@ -140,20 +141,7 @@ export async function getUnifiedLogs(
       ? new Date(/Z$|[+-]\d{2}:?\d{2}$/.test(ts) ? ts : `${ts}Z`)
       : new Date(Number(ts) / 1000)
 
-    // [Joshen] For auth logs, these metadata are nested within event_message,
-    // so opting to bring them out at the query level
-    const eventMessage = tryParseJson(row.event_message)
-    const status =
-      row.log_type === 'auth'
-        ? (eventMessage?.status ??
-          extractLeadingStatus(eventMessage?.msg) ??
-          extractLeadingStatus(eventMessage?.error))
-        : (row.status ?? 200)
-    const method = row.log_type === 'auth' ? eventMessage?.method : row.method
-    const pathname =
-      row.log_type === 'auth'
-        ? eventMessage?.path
-        : (row.url || '').replace(/^https?:\/\/[^\/]+/, '') || row.pathname || ''
+    const { status, method, pathname } = extractLogMetadata(row)
 
     return {
       id: row.id,

--- a/apps/studio/data/logs/unified-logs.utils.test.ts
+++ b/apps/studio/data/logs/unified-logs.utils.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractLogMetadata } from './unified-logs.utils'
+
+describe('extractLogMetadata', () => {
+  describe('non-auth logs', () => {
+    it('returns the row status, method, and url-derived pathname', () => {
+      const row = {
+        log_type: 'api',
+        status: 404,
+        method: 'GET',
+        url: 'https://example.supabase.co/rest/v1/users?select=id',
+        pathname: '/ignored',
+        event_message: 'irrelevant',
+      }
+
+      expect(extractLogMetadata(row)).toEqual({
+        status: 404,
+        method: 'GET',
+        pathname: '/rest/v1/users?select=id',
+      })
+    })
+
+    it('falls back to row.pathname when url is missing', () => {
+      const row = {
+        log_type: 'api',
+        status: 500,
+        method: 'POST',
+        url: '',
+        pathname: '/fallback',
+        event_message: '',
+      }
+
+      expect(extractLogMetadata(row).pathname).toBe('/fallback')
+    })
+
+    it('returns empty string for pathname when both url and pathname are missing', () => {
+      const row = {
+        log_type: 'api',
+        status: 200,
+        method: 'GET',
+        event_message: '',
+      }
+
+      expect(extractLogMetadata(row).pathname).toBe('')
+    })
+
+    it('defaults status to 200 when missing', () => {
+      const row = {
+        log_type: 'api',
+        method: 'GET',
+        url: 'https://example.supabase.co/health',
+        event_message: '',
+      }
+
+      expect(extractLogMetadata(row).status).toBe(200)
+    })
+  })
+
+  describe('auth logs', () => {
+    it('extracts status, method, and pathname from event_message JSON', () => {
+      const row = {
+        log_type: 'auth',
+        status: 999,
+        method: 'IGNORED',
+        url: 'https://ignored',
+        event_message: JSON.stringify({
+          status: 400,
+          method: 'POST',
+          path: '/token',
+          msg: 'request completed',
+        }),
+      }
+
+      expect(extractLogMetadata(row)).toEqual({
+        status: 400,
+        method: 'POST',
+        pathname: '/token',
+      })
+    })
+
+    it('falls back to leading 3-digit status in msg when event_message.status is missing', () => {
+      const row = {
+        log_type: 'auth',
+        event_message: JSON.stringify({
+          method: 'POST',
+          path: '/token',
+          msg: '400: Invalid login credentials',
+        }),
+      }
+
+      expect(extractLogMetadata(row).status).toBe(400)
+    })
+
+    it('falls back to leading 3-digit status in error when neither status nor msg has one', () => {
+      const row = {
+        log_type: 'auth',
+        event_message: JSON.stringify({
+          method: 'POST',
+          path: '/token',
+          msg: 'request completed',
+          error: '403: forbidden',
+        }),
+      }
+
+      expect(extractLogMetadata(row).status).toBe(403)
+    })
+
+    it('returns undefined status when no status can be found anywhere', () => {
+      const row = {
+        log_type: 'auth',
+        event_message: JSON.stringify({
+          method: 'POST',
+          path: '/token',
+          msg: 'request completed',
+        }),
+      }
+
+      expect(extractLogMetadata(row).status).toBeUndefined()
+    })
+
+    it('does not extract status from a non-leading 3-digit number in msg', () => {
+      const row = {
+        log_type: 'auth',
+        event_message: JSON.stringify({
+          msg: 'attempt 500 failed',
+        }),
+      }
+
+      expect(extractLogMetadata(row).status).toBeUndefined()
+    })
+
+    it('does not match 4+ digit numbers at the start of msg', () => {
+      const row = {
+        log_type: 'auth',
+        event_message: JSON.stringify({
+          msg: '4000 something',
+        }),
+      }
+
+      expect(extractLogMetadata(row).status).toBeUndefined()
+    })
+
+    it('returns undefined metadata when event_message is not valid JSON', () => {
+      const row = {
+        log_type: 'auth',
+        status: 200,
+        method: 'GET',
+        url: 'https://example.supabase.co/token',
+        event_message: 'not json',
+      }
+
+      expect(extractLogMetadata(row)).toEqual({
+        status: undefined,
+        method: undefined,
+        pathname: undefined,
+      })
+    })
+
+    it('prefers explicit event_message.status over msg/error extraction', () => {
+      const row = {
+        log_type: 'auth',
+        event_message: JSON.stringify({
+          status: 200,
+          msg: '500: something went wrong',
+          error: '503: service unavailable',
+        }),
+      }
+
+      expect(extractLogMetadata(row).status).toBe(200)
+    })
+  })
+})

--- a/apps/studio/data/logs/unified-logs.utils.ts
+++ b/apps/studio/data/logs/unified-logs.utils.ts
@@ -1,0 +1,27 @@
+import { tryParseJson } from '@/lib/helpers'
+
+const extractLeadingStatus = (s?: string) => {
+  const m = typeof s === 'string' ? s.match(/^(\d{3})\b/) : null
+  return m ? Number(m[1]) : undefined
+}
+
+// [Joshen] Row has an unknown type in this case so `any` is accurate
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export const extractLogMetadata = (row: any) => {
+  // [Joshen] For auth logs, these metadata are nested within event_message,
+  // so opting to bring them out at the query level
+  const eventMessage = tryParseJson(row.event_message)
+  const status =
+    row.log_type === 'auth'
+      ? (eventMessage?.status ??
+        extractLeadingStatus(eventMessage?.msg) ??
+        extractLeadingStatus(eventMessage?.error))
+      : (row.status ?? 200)
+  const method = row.log_type === 'auth' ? eventMessage?.method : row.method
+  const pathname =
+    row.log_type === 'auth'
+      ? eventMessage?.path
+      : (row.url || '').replace(/^https?:\/\/[^\/]+/, '') || row.pathname || ''
+
+  return { status, method, pathname }
+}


### PR DESCRIPTION
## Context

Improved formatting for auth logs in unified logs - their metadata are seemingly all hidden within "event_message" so the changes here bring them up
- Fix detecting status, pathname, and method for auth logs from `event_message`
  - None were showing originally, status was mostly defaulting to `200`
- Improve formatting of `event_message` by prioritising errors + floating up the auth action
  - Currently only shows "request completed"

## Before
<img width="1449" height="955" alt="image" src="https://github.com/user-attachments/assets/f0c7f166-06ab-4bfc-8653-6f5638bf1ae7" />

## After
<img width="1449" height="956" alt="image" src="https://github.com/user-attachments/assets/cdf49bd8-c33a-4f40-a6b7-8783dc38d174" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust parsing of auth log messages to extract error/status/method/path values and fall back to the original text when parsing fails.
  * Fixed cases where displayed status/method/pathname could be incorrect for auth logs.

* **Improvements**
  * Normalized auth error text (underscores → spaces) and optional auth-action prefixes for clearer messages.
  * Conditional sentence-capitalization for auth event messages.

* **New Features**
  * Centralized log metadata extraction for unified log display.

* **Tests**
  * Added tests covering auth and non-auth log parsing and metadata extraction.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46365?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->