### PR TITLE
chore: migrate `Modal` to `Dialog` (JWT, PITR)

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
@@ -52,11 +52,7 @@ export const PITRSelection = () => {
 
   const hasReadReplicas = (databases ?? []).length > 1
 
-  const {
-    mutateAsync: restoreFromPitr,
-    isPending: isRestoring,
-    isSuccess: isSuccessPITR,
-  } = usePitrRestoreMutation({
+  const { mutateAsync: restoreFromPitr } = usePitrRestoreMutation({
     onSuccess: (_, variables) => {
       setTimeout(() => {
         setShowConfirmation(false)

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
@@ -170,7 +170,7 @@ export const PITRSelection = () => {
               </p>
             </DialogSection>
             <AlertDialogFooter>
-              <AlertDialogCancel disabled={isRestoring || isSuccessPITR}>Cancel</AlertDialogCancel>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
               <AlertDialogAction variant="warning" onClick={onConfirmRestore}>
                 I understand, begin restore
               </AlertDialogAction>

--- a/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/PITR/PITRSelection.tsx
@@ -2,7 +2,23 @@ import { useParams } from 'common'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
-import { Alert, AlertDescription, AlertTitle, Button, Modal, WarningIcon } from 'ui'
+import {
+  Alert,
+  AlertDescription,
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertTitle,
+  Button,
+  DialogSection,
+  DialogSectionSeparator,
+  WarningIcon,
+} from 'ui'
 
 import { BackupsEmpty } from '../BackupsEmpty'
 import { BackupsStorageAlert } from '../BackupsStorageAlert'
@@ -37,7 +53,7 @@ export const PITRSelection = () => {
   const hasReadReplicas = (databases ?? []).length > 1
 
   const {
-    mutate: restoreFromPitr,
+    mutateAsync: restoreFromPitr,
     isPending: isRestoring,
     isSuccess: isSuccessPITR,
   } = usePitrRestoreMutation({
@@ -59,7 +75,7 @@ export const PITRSelection = () => {
     if (!selectedRecoveryPoint?.recoveryTimeTargetUnix)
       return console.error('Recovery time target unix is required')
 
-    restoreFromPitr({
+    await restoreFromPitr({
       ref,
       recovery_time_target_unix: selectedRecoveryPoint.recoveryTimeTargetUnix,
     })
@@ -115,66 +131,53 @@ export const PITRSelection = () => {
         </>
       )}
 
-      <Modal
-        size="medium"
-        visible={showConfirmation}
-        onCancel={() => setShowConfirmation(false)}
-        header="Point in time recovery review"
-        customFooter={
-          <div className="flex items-center justify-end space-x-2">
-            <Button
-              type="default"
-              disabled={isRestoring || isSuccessPITR}
-              onClick={() => setShowConfirmation(false)}
-            >
-              Cancel
-            </Button>
-            <Button
-              type="warning"
-              disabled={isRestoring || isSuccessPITR}
-              loading={isRestoring || isSuccessPITR}
-              onClick={onConfirmRestore}
-            >
-              I understand, begin restore
-            </Button>
-          </div>
-        }
-      >
-        <Modal.Content>
-          <div className="py-2 space-y-1">
-            <p className="text-sm text-foreground-light">Your database will be restored to:</p>
-          </div>
-          <div className="py-2 flex flex-col gap-3">
-            <div>
-              <p className="text-sm font-mono text-foreground-lighter">Local Time</p>
-              <p className="text-2xl">{selectedRecoveryPoint?.recoveryTimeString}</p>
-            </div>
-            <div>
-              <p className="text-sm font-mono text-foreground-lighter">(UTC+00:00)</p>
-              <p className="text-2xl">{selectedRecoveryPoint?.recoveryTimeStringUtc}</p>
-            </div>
-          </div>
-        </Modal.Content>
-        <Modal.Separator />
-        <Modal.Content>
-          <Alert variant="warning">
-            <WarningIcon />
-            <AlertTitle>This action cannot be undone, not canceled once started</AlertTitle>
-            <AlertDescription>
-              Any changes made to your database after this point in time will be lost. This includes
-              any changes to your project's storage and authentication.
-            </AlertDescription>
-          </Alert>
-        </Modal.Content>
-        <Modal.Separator />
-        <Modal.Content>
-          <p className="text-sm text-foreground-light">
-            Restores may take from a few minutes up to several hours depending on the size of your
-            database. During this period, your project will not be available, until the restoration
-            is completed.
-          </p>
-        </Modal.Content>
-      </Modal>
+      <AlertDialog open={showConfirmation} onOpenChange={(open) => setShowConfirmation(open)}>
+        <AlertDialogContent size="medium">
+          <AlertDialogHeader>
+            <AlertDialogTitle>Point in time recovery review</AlertDialogTitle>
+            <AlertDialogDescription asChild>
+              <div className="flex flex-col space-y-2">
+                <p className="text-sm text-foreground-light">Your database will be restored to:</p>
+                <div className="py-2 flex flex-col gap-3">
+                  <div>
+                    <p className="text-sm font-mono text-foreground-lighter">Local Time</p>
+                    <p className="text-2xl">{selectedRecoveryPoint?.recoveryTimeString}</p>
+                  </div>
+                  <div>
+                    <p className="text-sm font-mono text-foreground-lighter">(UTC+00:00)</p>
+                    <p className="text-2xl">{selectedRecoveryPoint?.recoveryTimeStringUtc}</p>
+                  </div>
+                </div>
+              </div>
+            </AlertDialogDescription>
+            <DialogSectionSeparator />
+            <DialogSection>
+              <Alert variant="warning">
+                <WarningIcon />
+                <AlertTitle>This action cannot be undone, not canceled once started</AlertTitle>
+                <AlertDescription>
+                  Any changes made to your database after this point in time will be lost. This
+                  includes any changes to your project's storage and authentication.
+                </AlertDescription>
+              </Alert>
+            </DialogSection>
+            <DialogSectionSeparator />
+            <DialogSection>
+              <p className="text-sm text-foreground-light">
+                Restores may take from a few minutes up to several hours depending on the size of
+                your database. During this period, your project will not be available, until the
+                restoration is completed.
+              </p>
+            </DialogSection>
+            <AlertDialogFooter>
+              <AlertDialogCancel disabled={isRestoring || isSuccessPITR}>Cancel</AlertDialogCancel>
+              <AlertDialogAction variant="warning" onClick={onConfirmRestore}>
+                I understand, begin restore
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogHeader>
+        </AlertDialogContent>
+      </AlertDialog>
     </>
   )
 }

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -29,6 +29,14 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -41,7 +49,6 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupText,
-  Modal,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -621,19 +628,54 @@ export const JWTSettings = () => {
         </ul>
       </TextConfirmModal>
 
-      <Modal
-        header="Pick a new JWT secret"
-        visible={isCreatingKey && !disableLegacyJwtSecretRotation}
-        size="medium"
-        variant="danger"
-        onCancel={() => {
+      <Dialog
+        open={isCreatingKey && !disableLegacyJwtSecretRotation}
+        onOpenChange={() => {
           setIsCreatingKey(false)
           setCustomToken('')
           customJwtSecretForm.reset({ customToken: '' })
         }}
-        loading={isSubmittingJwtSecretUpdateRequest}
-        customFooter={
-          <div className="space-x-2">
+      >
+        <DialogContent size="medium">
+          <DialogHeader>
+            <DialogTitle>Pick a new JWT secret</DialogTitle>
+            <DialogDescription>
+              Pick a new custom JWT secret. Make sure it is a strong combination of characters that
+              cannot be guessed easily.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogSectionSeparator />
+          <DialogSection>
+            <Form {...customJwtSecretForm}>
+              <form
+                id={customJwtSecretFormId}
+                onSubmit={customJwtSecretForm.handleSubmit((values) => {
+                  setIsGeneratingKey(true)
+                  setIsCreatingKey(false)
+                  setCustomToken(values.customToken)
+                })}
+                className="flex flex-col space-y-2"
+                noValidate
+              >
+                <FormField
+                  control={customJwtSecretForm.control}
+                  name="customToken"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      layout="vertical"
+                      label="Custom JWT secret"
+                      description="Minimally 32 characters long, '@' and '$' are not allowed."
+                    >
+                      <FormControl>
+                        <Input copy reveal icon={<Key />} className="w-full text-left" {...field} />
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
+              </form>
+            </Form>
+          </DialogSection>
+          <DialogFooter>
             <Button
               type="default"
               onClick={() => {
@@ -641,6 +683,7 @@ export const JWTSettings = () => {
                 setCustomToken('')
                 customJwtSecretForm.reset({ customToken: '' })
               }}
+              disabled={isSubmittingJwtSecretUpdateRequest}
             >
               Cancel
             </Button>
@@ -649,47 +692,13 @@ export const JWTSettings = () => {
               htmlType="submit"
               form={customJwtSecretFormId}
               loading={isSubmittingJwtSecretUpdateRequest}
+              disabled={isSubmittingJwtSecretUpdateRequest}
             >
               Proceed to final confirmation
             </Button>
-          </div>
-        }
-      >
-        <Modal.Content>
-          <Form {...customJwtSecretForm}>
-            <form
-              id={customJwtSecretFormId}
-              onSubmit={customJwtSecretForm.handleSubmit((values) => {
-                setIsGeneratingKey(true)
-                setIsCreatingKey(false)
-                setCustomToken(values.customToken)
-              })}
-              className="flex flex-col space-y-2"
-              noValidate
-            >
-              <p className="text-sm text-foreground-light">
-                Pick a new custom JWT secret. Make sure it is a strong combination of characters
-                that cannot be guessed easily.
-              </p>
-              <FormField
-                control={customJwtSecretForm.control}
-                name="customToken"
-                render={({ field }) => (
-                  <FormItemLayout
-                    layout="vertical"
-                    label="Custom JWT secret"
-                    description="Minimally 32 characters long, '@' and '$' are not allowed."
-                  >
-                    <FormControl>
-                      <Input copy reveal icon={<Key />} className="w-full text-left" {...field} />
-                    </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-            </form>
-          </Form>
-        </Modal.Content>
-      </Modal>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }


### PR DESCRIPTION
## Problem

Some pages still uses the deprecated `Modal` for:
- Legacy JWT new secret
- PITR recovery confirmation

## Test

Hard to test the JWT. I had to force its display by settings its `open` prop to `true` in `apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx`

## Solution

- use `Dialog` instead

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved database restore (PITR) confirmation: replaced modal flow with an alert dialog, reorganized review sections (timing, warnings), and made the restore action await completion for clearer feedback.
  * Redesigned JWT secrets dialog: replaced modal with dialog primitives, centralized form and state reset on open/close, moved confirmation into dialog footer, and disabled confirm during submission.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46366?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->