### PR TITLE
[FE-3442] fix(studio): include /rest/v1 in Data API access table URL

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/ApiAccessToggle.tsx
@@ -3,7 +3,6 @@ import { ExternalLink } from 'lucide-react'
 import Link from 'next/link'
 import {
   useEffect,
-  useMemo,
   useRef,
   useState,
   type Dispatch,
@@ -15,6 +14,7 @@ import { Button, Switch } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
 
+import { getApiEndpoint } from '@/components/interfaces/Integrations/DataApi/DataApi.utils'
 import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
 import { defaultPrivilegesQueryOptions } from '@/data/privileges/default-privileges-query'
 import { useTableApiAccessQuery } from '@/data/privileges/table-api-access-query'
@@ -370,35 +370,25 @@ const SchemaExposureOptions = ({
 }): ReactNode => {
   const { selectedDatabaseId } = useDatabaseSelectorStateSnapshot()
 
-  const { data: endpoint } = useProjectApiUrl({ projectRef })
+  const { data: resolvedEndpoint } = useProjectApiUrl({ projectRef })
   const { data: loadBalancers } = useLoadBalancersQuery({ projectRef })
   const { data: databases } = useReadReplicasQuery({ projectRef })
 
-  const apiEndpoint = useMemo(() => {
-    if (selectedDatabaseId === projectRef) {
-      return endpoint
-    }
-
-    const loadBalancerSelected = selectedDatabaseId === 'load-balancer'
-    if (loadBalancerSelected) {
-      return loadBalancers?.[0]?.endpoint
-    }
-
-    const selectedDatabase = databases?.find((db) => db.identifier === selectedDatabaseId)
-    return selectedDatabase?.restUrl
-  }, [selectedDatabaseId, projectRef, databases, endpoint, loadBalancers])
-
-  const apiBaseUrl = useMemo(() => {
-    if (!apiEndpoint) return undefined
-    return apiEndpoint.endsWith('/') ? apiEndpoint.slice(0, -1) : apiEndpoint
-  }, [apiEndpoint])
+  const selectedDatabase = databases?.find((db) => db.identifier === selectedDatabaseId)
+  const apiBaseUrl = getApiEndpoint({
+    selectedDatabaseId,
+    projectRef,
+    resolvedEndpoint,
+    loadBalancers,
+    selectedDatabase,
+  })
 
   const tablePath = !(schemaName && tableName)
     ? undefined
     : schemaName === 'public'
       ? tableName
       : `${schemaName}.${tableName}`
-  const apiUrl = apiBaseUrl && tablePath ? `${apiBaseUrl}/${tablePath}` : undefined
+  const apiUrl = apiBaseUrl && tablePath ? `${apiBaseUrl}${tablePath}` : undefined
 
   return (
     <>


### PR DESCRIPTION
The Data API Access section on the new-table panel was showing `https://<ref>.supabase.co/<table>` instead of the correct `https://<ref>.supabase.co/rest/v1/<table>`.

The bug was duplicated endpoint-resolution logic in `ApiAccessToggle.tsx` that omitted `/rest/v1`. Replaced it with the existing `getApiEndpoint` utility from `DataApi.utils.ts`, which already handles this correctly (and is unit-tested).

Addresses [FE-3442](https://linear.app/supabase/issue/FE-3442/data-api-access-shows-incorrect-table-url).

**Changed:**
- `ApiAccessToggle.tsx` now uses `getApiEndpoint` for URL construction, ensuring `/rest/v1/` is always included.

## To test

1. Open the dashboard, go to Table Editor, click "New table".
2. Scroll to the "Data API Access" section, enter a table name (e.g. `test_table`).
3. Confirm the URL shown is `https://<ref>.supabase.co/rest/v1/test_table` (not `https://<ref>.supabase.co/test_table`).
4. Try the same with a non-public schema — URL should be `.../rest/v1/<schema>.<table>`.
5. With read replicas / load balancer selected via the database selector, confirm the URL still resolves to `<replica-or-lb-host>/rest/v1/<table>`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Data API endpoint computation in the table editor interface to improve performance and code maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->