### PR TITLE
fix: missing install integration button

### DIFF
--- a/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/OverviewTab.tsx
@@ -219,7 +219,6 @@ const StripeSyncContent = () => {
             isUpgrade={upgradeAvailable}
           />
           <IntegrationNotInstalledActions
-            hideInstallCTA
             installing={installing}
             canInstall={canInstall}
             isUninstallRequested={isUninstallRequested}

--- a/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/OverviewTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/templates/StripeSyncEngine/OverviewTab.tsx
@@ -51,7 +51,7 @@ const installFormSchema = z.object({
   stripeSecretKey: z.string().min(1, 'Stripe API key is required'),
 })
 
-const StripeSyncContent = () => {
+const StripeSyncContent = ({ hideInstallCTA = false }: { hideInstallCTA?: boolean }) => {
   const track = useTrack()
   const hasTrackedInstallFailed = useRef(false)
   const { data: project } = useSelectedProjectQuery()
@@ -219,6 +219,7 @@ const StripeSyncContent = () => {
             isUpgrade={upgradeAvailable}
           />
           <IntegrationNotInstalledActions
+            hideInstallCTA={hideInstallCTA}
             installing={installing}
             canInstall={canInstall}
             isUninstallRequested={isUninstallRequested}
@@ -397,7 +398,7 @@ export const StripeSyncEngineOverviewTab = () => {
     return (
       <>
         <RequiredExtensionsSection />
-        <StripeSyncContent />
+        <StripeSyncContent hideInstallCTA />
       </>
     )
   }


### PR DESCRIPTION
The install integration button on stripe sync engine page was missing entirely when the marketplace feature preview was disabled. Now we hide only when the feature preview is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Stripe integration installation prompt handling based on marketplace configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46368?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->