### PR TITLE
feat(studio): hide Postgres connection logs by default in unified logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
@@ -61,6 +61,9 @@ export const SEARCH_PARAMS_PARSER = {
 
   uuid: parseAsString,
   id: parseAsString,
+
+  // View options
+  hide_connection_logs: parseAsBoolean.withDefault(true),
 }
 
 const POSTGRES_STATUS_CODE_LABELS = {

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -68,16 +68,15 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
 
     it('excludes connection log messages by default (hide_connection_logs=true)', () => {
       const sql = getUnifiedLogsQuery({ ...baseSearch, hide_connection_logs: true } as any)
-      expect(sql).toContain("event_message LIKE 'connection received%'")
-      expect(sql).toContain("event_message LIKE 'connection authenticated%'")
-      expect(sql).toContain("event_message LIKE 'connection authorized%'")
-      expect(sql).toContain('NOT (')
+      expect(sql).toContain("source != 'postgres_logs'")
+      expect(sql).toContain("event_message NOT LIKE 'connection received%'")
+      expect(sql).toContain("event_message NOT LIKE 'connection authenticated%'")
+      expect(sql).toContain("event_message NOT LIKE 'connection authorized%'")
     })
 
     it('includes connection log messages when hide_connection_logs=false', () => {
       const sql = getUnifiedLogsQuery({ ...baseSearch, hide_connection_logs: false } as any)
-      expect(sql).not.toContain("event_message LIKE 'connection received%'")
-      expect(sql).not.toContain('NOT (')
+      expect(sql).not.toContain("event_message NOT LIKE 'connection received%'")
     })
 
     it('does not emit subqueries or CTEs (rejected by the OTEL endpoint)', () => {

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -66,6 +66,20 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(sql).toContain(`log_attributes['request.path'] LIKE '%/customers%'`)
     })
 
+    it('excludes connection log messages by default (hide_connection_logs=true)', () => {
+      const sql = getUnifiedLogsQuery({ ...baseSearch, hide_connection_logs: true } as any)
+      expect(sql).toContain("event_message LIKE 'connection received%'")
+      expect(sql).toContain("event_message LIKE 'connection authenticated%'")
+      expect(sql).toContain("event_message LIKE 'connection authorized%'")
+      expect(sql).toContain('NOT (')
+    })
+
+    it('includes connection log messages when hide_connection_logs=false', () => {
+      const sql = getUnifiedLogsQuery({ ...baseSearch, hide_connection_logs: false } as any)
+      expect(sql).not.toContain("event_message LIKE 'connection received%'")
+      expect(sql).not.toContain('NOT (')
+    })
+
     it('does not emit subqueries or CTEs (rejected by the OTEL endpoint)', () => {
       const sql = getUnifiedLogsQuery(baseSearch)
       expect(sql).not.toMatch(/WITH\s+\w+\s+AS\s*\(/i)

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -13,7 +13,7 @@ import {
 const PAGINATION_PARAMS = ['sort', 'start', 'size', 'uuid', 'cursor', 'direction', 'live'] as const
 
 // Special filter parameters that need custom handling
-const SPECIAL_FILTER_PARAMS = ['date'] as const
+const SPECIAL_FILTER_PARAMS = ['date', 'hide_connection_logs'] as const
 
 // Combined list of all parameters to exclude from standard filtering
 const EXCLUDED_QUERY_PARAMS = [...PAGINATION_PARAMS, ...SPECIAL_FILTER_PARAMS] as const
@@ -263,6 +263,15 @@ const buildBaseWhere = (
   const parts: SafeLogSqlFragment[] = []
   if (excludeField !== 'log_type') {
     parts.push(logTypeWherePredicate(effectiveLogTypes))
+  }
+  if (search.hide_connection_logs) {
+    parts.push(
+      safeSql`NOT (source = 'postgres_logs' AND (
+        event_message LIKE 'connection received%' OR
+        event_message LIKE 'connection authenticated%' OR
+        event_message LIKE 'connection authorized%'
+      ))`
+    )
   }
   parts.push(...buildPredicates(search, excludeField))
   return parts

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -265,11 +265,13 @@ const buildBaseWhere = (
     parts.push(logTypeWherePredicate(effectiveLogTypes))
   }
   if (search.hide_connection_logs) {
+    // De Morgan equivalent of NOT (source='postgres_logs' AND (msg LIKE x OR msg LIKE y OR ...))
+    // Uses only != and NOT LIKE which the OTEL endpoint already handles elsewhere.
     parts.push(
-      safeSql`NOT (source = 'postgres_logs' AND (
-        event_message LIKE 'connection received%' OR
-        event_message LIKE 'connection authenticated%' OR
-        event_message LIKE 'connection authorized%'
+      safeSql`(source != 'postgres_logs' OR (
+        event_message NOT LIKE 'connection received%' AND
+        event_message NOT LIKE 'connection authenticated%' AND
+        event_message NOT LIKE 'connection authorized%'
       ))`
     )
   }

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -264,19 +264,23 @@ const buildBaseWhere = (
   if (excludeField !== 'log_type') {
     parts.push(logTypeWherePredicate(effectiveLogTypes))
   }
-  if (search.hide_connection_logs) {
-    // De Morgan equivalent of NOT (source='postgres_logs' AND (msg LIKE x OR msg LIKE y OR ...))
-    // Uses only != and NOT LIKE which the OTEL endpoint already handles elsewhere.
-    parts.push(
-      safeSql`(source != 'postgres_logs' OR (
-        event_message NOT LIKE 'connection received%' AND
-        event_message NOT LIKE 'connection authenticated%' AND
-        event_message NOT LIKE 'connection authorized%'
-      ))`
-    )
-  }
   parts.push(...buildPredicates(search, excludeField))
   return parts
+}
+
+/**
+ * Returns a WHERE predicate that excludes Postgres connection lifecycle messages.
+ * Applied only to the row query and chart query so sidebar facets remain unaffected
+ * (the OTEL endpoint's UNION ALL count query fails silently when this predicate is
+ * included there, returning empty facet data).
+ */
+const connectionLogsFilter = (search: QuerySearchParamsType): SafeLogSqlFragment | null => {
+  if (!search.hide_connection_logs) return null
+  return safeSql`(source != 'postgres_logs' OR (
+    event_message NOT LIKE 'connection received%' AND
+    event_message NOT LIKE 'connection authenticated%' AND
+    event_message NOT LIKE 'connection authorized%'
+  ))`
 }
 
 /**
@@ -284,6 +288,8 @@ const buildBaseWhere = (
  */
 export const getUnifiedLogsQuery = (search: QuerySearchParamsType): SafeLogSqlFragment => {
   const predicates = buildBaseWhere(search)
+  const connFilter = connectionLogsFilter(search)
+  if (connFilter) predicates.push(connFilter)
   return safeSql`
 SELECT ${rowProjection()}
 FROM logs
@@ -401,6 +407,8 @@ export const getLogsChartQuery = (search: QuerySearchParamsType): SafeLogSqlFrag
   const truncationLevel = calculateChartBucketing(search)
   const truncFn = truncationFunction(truncationLevel)
   const predicates = buildBaseWhere(search)
+  const connFilter = connectionLogsFilter(search)
+  if (connFilter) predicates.push(connFilter)
 
   return safeSql`
 SELECT

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -29,8 +29,8 @@ import {
 
 import { RefreshButton } from '../../ui/DataTable/RefreshButton'
 import { generateDynamicColumns, UNIFIED_LOGS_COLUMNS } from './components/Columns'
-import { DownloadLogsButton } from './components/DownloadLogsButton'
 import { ConnectionLogsToggle } from './components/ConnectionLogsToggle'
+import { DownloadLogsButton } from './components/DownloadLogsButton'
 import { LogsFilterBar } from './components/LogsFilterBar'
 import { LogsListPanel } from './components/LogsListPanel'
 import { TooltipLabel } from './components/TooltipLabel'

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -30,6 +30,7 @@ import {
 import { RefreshButton } from '../../ui/DataTable/RefreshButton'
 import { generateDynamicColumns, UNIFIED_LOGS_COLUMNS } from './components/Columns'
 import { DownloadLogsButton } from './components/DownloadLogsButton'
+import { ConnectionLogsToggle } from './components/ConnectionLogsToggle'
 import { LogsFilterBar } from './components/LogsFilterBar'
 import { LogsListPanel } from './components/LogsListPanel'
 import { TooltipLabel } from './components/TooltipLabel'
@@ -83,7 +84,7 @@ export const UnifiedLogs = () => {
   const track = useTrack()
   const [search, setSearch] = useQueryStates(SEARCH_PARAMS_PARSER)
 
-  const { sort, start, size, id, cursor, direction, live, ...filter } = search
+  const { sort, start, size, id, cursor, direction, live, hide_connection_logs: _hideConnectionLogs, ...filter } = search
   const defaultColumnSorting = sort ? [sort] : []
   const defaultColumnVisibility = { uuid: false }
   const defaultColumnFilters = Object.entries(filter)
@@ -379,6 +380,7 @@ export const UnifiedLogs = () => {
             isFilterBarOpen={isFilterBarOpen}
             setIsFilterBarOpen={setIsFilterBarOpen}
             dateRangeDisabled={{ after: new Date() }}
+            beforeFilters={<ConnectionLogsToggle />}
           />
           <ResizableHandle withHandle />
           <ResizablePanel

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -84,7 +84,17 @@ export const UnifiedLogs = () => {
   const track = useTrack()
   const [search, setSearch] = useQueryStates(SEARCH_PARAMS_PARSER)
 
-  const { sort, start, size, id, cursor, direction, live, hide_connection_logs: _hideConnectionLogs, ...filter } = search
+  const {
+    sort,
+    start,
+    size,
+    id,
+    cursor,
+    direction,
+    live,
+    hide_connection_logs: _hideConnectionLogs,
+    ...filter
+  } = search
   const defaultColumnSorting = sort ? [sort] : []
   const defaultColumnVisibility = { uuid: false }
   const defaultColumnFilters = Object.entries(filter)

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -390,7 +390,7 @@ export const UnifiedLogs = () => {
             isFilterBarOpen={isFilterBarOpen}
             setIsFilterBarOpen={setIsFilterBarOpen}
             dateRangeDisabled={{ after: new Date() }}
-            beforeFilters={<ConnectionLogsToggle />}
+            afterFilters={<ConnectionLogsToggle />}
           />
           <ResizableHandle withHandle />
           <ResizablePanel

--- a/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
@@ -1,5 +1,5 @@
 import { useQueryStates } from 'nuqs'
-import { Switch } from 'ui'
+import { Switch, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import { SEARCH_PARAMS_PARSER } from '../UnifiedLogs.constants'
 
@@ -7,18 +7,17 @@ export const ConnectionLogsToggle = () => {
   const [{ hide_connection_logs }, setSearch] = useQueryStates(SEARCH_PARAMS_PARSER)
 
   return (
-    <label className="flex cursor-pointer items-start justify-between gap-3 rounded-md border border-border bg-surface-100 px-3 py-2 mx-2 mt-2 mb-1">
-      <div className="flex flex-col gap-0.5">
-        <p className="text-xs font-medium text-foreground">Connection logs</p>
-        <p className="text-xs leading-tight text-foreground-lighter">
-          Show Postgres connection events
-        </p>
-      </div>
-      <Switch
-        checked={!hide_connection_logs}
-        onCheckedChange={(checked: boolean) => setSearch({ hide_connection_logs: !checked })}
-        className="mt-0.5 shrink-0"
-      />
-    </label>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <label className="flex cursor-pointer items-center justify-between px-3 py-1.5">
+          <span className="text-xs text-foreground-light">Connection logs</span>
+          <Switch
+            checked={!hide_connection_logs}
+            onCheckedChange={(checked: boolean) => setSearch({ hide_connection_logs: !checked })}
+          />
+        </label>
+      </TooltipTrigger>
+      <TooltipContent side="right">Show Postgres connection events</TooltipContent>
+    </Tooltip>
   )
 }

--- a/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
@@ -1,5 +1,5 @@
 import { useQueryStates } from 'nuqs'
-import { Switch, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Checkbox, Label } from 'ui'
 
 import { SEARCH_PARAMS_PARSER } from '../UnifiedLogs.constants'
 
@@ -7,17 +7,33 @@ export const ConnectionLogsToggle = () => {
   const [{ hide_connection_logs }, setSearch] = useQueryStates(SEARCH_PARAMS_PARSER)
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <label className="flex cursor-pointer items-center justify-between px-3 py-1.5">
-          <span className="text-xs text-foreground-light">Connection logs</span>
-          <Switch
-            checked={!hide_connection_logs}
-            onCheckedChange={(checked: boolean) => setSearch({ hide_connection_logs: !checked })}
-          />
-        </label>
-      </TooltipTrigger>
-      <TooltipContent side="right">Show Postgres connection events</TooltipContent>
-    </Tooltip>
+    <Accordion type="multiple" defaultValue={['misc']}>
+      <AccordionItem value="misc" className="border-none">
+        <div className="flex items-center gap-2 pr-2">
+          <AccordionTrigger className="flex-1 px-2 py-0 hover:no-underline data-[state=closed]:text-muted-foreground data-open:text-foreground focus-within:data-closed:text-foreground hover:data-closed:text-foreground">
+            <div className="flex items-center gap-2 truncate py-2">
+              <p className="text-sm">Misc</p>
+            </div>
+          </AccordionTrigger>
+        </div>
+        <AccordionContent>
+          <div className="p-1">
+            <div className="group relative flex items-center space-x-2 px-2 py-2 hover:bg-accent/50">
+              <Checkbox
+                id="connection-logs"
+                checked={!hide_connection_logs}
+                onCheckedChange={(checked) => setSearch({ hide_connection_logs: !checked })}
+              />
+              <Label
+                htmlFor="connection-logs"
+                className="flex w-full cursor-pointer items-center justify-between gap-2 text-[0.8rem] font-normal text-foreground/70 group-hover:text-accent-foreground"
+              >
+                Connection logs
+              </Label>
+            </div>
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
   )
 }

--- a/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
@@ -18,18 +18,20 @@ export const ConnectionLogsToggle = () => {
         </div>
         <AccordionContent>
           <div className="p-1">
-            <div className="group relative flex items-center space-x-2 px-2 py-2 hover:bg-accent/50">
-              <Checkbox
-                id="connection-logs"
-                checked={!hide_connection_logs}
-                onCheckedChange={(checked) => setSearch({ hide_connection_logs: !checked })}
-              />
-              <Label
-                htmlFor="connection-logs"
-                className="flex w-full cursor-pointer items-center justify-between gap-2 text-[0.8rem] font-normal text-foreground/70 group-hover:text-accent-foreground"
-              >
-                Connection logs
-              </Label>
+            <div className="rounded-sm border border-border">
+              <div className="group relative flex items-center space-x-2 px-2 py-2 hover:bg-accent/50">
+                <Checkbox
+                  id="connection-logs"
+                  checked={!hide_connection_logs}
+                  onCheckedChange={(checked) => setSearch({ hide_connection_logs: !checked })}
+                />
+                <Label
+                  htmlFor="connection-logs"
+                  className="flex w-full cursor-pointer items-center justify-between gap-2 text-[0.8rem] font-normal text-foreground/70 group-hover:text-accent-foreground"
+                >
+                  Connection logs
+                </Label>
+              </div>
             </div>
           </div>
         </AccordionContent>

--- a/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/ConnectionLogsToggle.tsx
@@ -1,0 +1,24 @@
+import { useQueryStates } from 'nuqs'
+import { Switch } from 'ui'
+
+import { SEARCH_PARAMS_PARSER } from '../UnifiedLogs.constants'
+
+export const ConnectionLogsToggle = () => {
+  const [{ hide_connection_logs }, setSearch] = useQueryStates(SEARCH_PARAMS_PARSER)
+
+  return (
+    <label className="flex cursor-pointer items-start justify-between gap-3 rounded-md border border-border bg-surface-100 px-3 py-2 mx-2 mt-2 mb-1">
+      <div className="flex flex-col gap-0.5">
+        <p className="text-xs font-medium text-foreground">Connection logs</p>
+        <p className="text-xs leading-tight text-foreground-lighter">
+          Show Postgres connection events
+        </p>
+      </div>
+      <Switch
+        checked={!hide_connection_logs}
+        onCheckedChange={(checked: boolean) => setSearch({ hide_connection_logs: !checked })}
+        className="mt-0.5 shrink-0"
+      />
+    </label>
+  )
+}

--- a/apps/studio/components/ui/DataTable/FilterSideBar.tsx
+++ b/apps/studio/components/ui/DataTable/FilterSideBar.tsx
@@ -1,7 +1,7 @@
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
-import React, { useEffect } from 'react'
+import React, { useEffect, type ReactNode } from 'react'
 import { Button, cn, ResizablePanel, usePanelRef } from 'ui'
 
 import { FeaturePreviewBadge } from '../FeaturePreviewBadge'
@@ -17,12 +17,14 @@ interface FilterSideBarProps {
   isFilterBarOpen: boolean
   setIsFilterBarOpen: React.Dispatch<React.SetStateAction<boolean>>
   dateRangeDisabled?: DateRangeDisabled
+  beforeFilters?: ReactNode
 }
 
 export function FilterSideBar({
   isFilterBarOpen,
   setIsFilterBarOpen,
   dateRangeDisabled,
+  beforeFilters,
 }: FilterSideBarProps) {
   const router = useRouter()
   const { ref } = useParams()
@@ -91,6 +93,7 @@ export function FilterSideBar({
             }
           />
         )}
+        {beforeFilters}
         <DataTableFilterControls dateRangeDisabled={dateRangeDisabled} />
         <FeaturePreviewSidebarPanel
           className="mx-2 my-4"

--- a/apps/studio/components/ui/DataTable/FilterSideBar.tsx
+++ b/apps/studio/components/ui/DataTable/FilterSideBar.tsx
@@ -17,14 +17,14 @@ interface FilterSideBarProps {
   isFilterBarOpen: boolean
   setIsFilterBarOpen: React.Dispatch<React.SetStateAction<boolean>>
   dateRangeDisabled?: DateRangeDisabled
-  beforeFilters?: ReactNode
+  afterFilters?: ReactNode
 }
 
 export function FilterSideBar({
   isFilterBarOpen,
   setIsFilterBarOpen,
   dateRangeDisabled,
-  beforeFilters,
+  afterFilters,
 }: FilterSideBarProps) {
   const router = useRouter()
   const { ref } = useParams()
@@ -93,8 +93,8 @@ export function FilterSideBar({
             }
           />
         )}
-        {beforeFilters}
         <DataTableFilterControls dateRangeDisabled={dateRangeDisabled} />
+        {afterFilters}
         <FeaturePreviewSidebarPanel
           className="mx-2 my-4"
           title="Capture your logs"


### PR DESCRIPTION
## Problem

The unified logs view shows Postgres connection lifecycle events (connection received, connection authenticated, connection authorized) alongside application logs. These messages are emitted on every database connection and make it hard to spot meaningful log entries.

## Fix

Adds a SQL-level filter that excludes Postgres connection messages by default. A toggle in the filter sidebar lets users opt in to seeing them when needed. The preference is stored in the URL so it persists across navigation.

**Changes:**
- `SEARCH_PARAMS_PARSER` gets a new `hide_connection_logs` boolean param (default `true`)
- `buildBaseWhere` in the query builder emits a `NOT (source = 'postgres_logs' AND event_message LIKE 'connection %...')` predicate when the param is true, filtering at the query level
- New `ConnectionLogsToggle` component renders a labeled switch in the filter sidebar
- `FilterSideBar` gains a `beforeFilters` slot so the toggle can be injected without coupling the generic component to log-specific logic

## How to test

1. Open a project in Studio and navigate to the unified logs page
2. Confirm that connection log messages (e.g. "connection received: host=...", "connection authorized: user=...") are not visible by default
3. In the left filter sidebar, find the "Connection logs" toggle near the top and switch it on
4. Confirm that connection log messages now appear in the list
5. Toggle it back off and confirm they disappear again
6. Reload the page with the toggle on (URL will contain `hide_connection_logs=false`) and confirm the setting is preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Connection logs" toggle in the filter sidebar to hide Postgres connection lifecycle messages by default (default = hidden); changing it updates the logs view and the logs chart.
  * Filter sidebar now supports placing extra controls so the toggle is available alongside existing filters.

* **Behavior**
  * Facet/count queries remain unaffected by this toggle to preserve existing counts.

* **Tests**
  * Added tests verifying default hide behavior and explicit show behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->