### PR TITLE
chore: migrate auth policy editor modal to dialog

### DIFF
--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyEditorFooter.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/PolicyEditorFooter.tsx
@@ -1,5 +1,5 @@
 import { noop } from 'lodash'
-import { Button } from 'ui'
+import { Button, DialogFooter } from 'ui'
 
 interface PolicyEditorFooterProps {
   showTemplates: boolean
@@ -12,18 +12,16 @@ const PolicyEditorFooter = ({
   onViewTemplates = noop,
   onReviewPolicy = noop,
 }: PolicyEditorFooterProps) => (
-  <div className="flex justify-between items-center border-t px-6 py-4 border-default">
-    <div className="flex w-full items-center justify-end gap-2">
-      {showTemplates && (
-        <Button type="default" onClick={onViewTemplates}>
-          View templates
-        </Button>
-      )}
-      <Button type="primary" onClick={onReviewPolicy}>
-        Review
+  <DialogFooter>
+    {showTemplates && (
+      <Button type="default" onClick={onViewTemplates}>
+        View templates
       </Button>
-    </div>
-  </div>
+    )}
+    <Button type="primary" onClick={onReviewPolicy}>
+      Review
+    </Button>
+  </DialogFooter>
 )
 
 export default PolicyEditorFooter

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/index.tsx
@@ -29,7 +29,7 @@ export const PolicyEditor = ({
   const selectedRoles = (policyFormFields?.roles ?? []).filter((role: string) => role !== 'public')
 
   return (
-    <div>
+    <>
       <DialogSection>
         <PolicyName
           name={policyFormFields.name}
@@ -72,6 +72,6 @@ export const PolicyEditor = ({
         onViewTemplates={onViewTemplates}
         onReviewPolicy={onReviewPolicy}
       />
-    </div>
+    </>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditor/index.tsx
@@ -1,4 +1,4 @@
-import { Modal } from 'ui'
+import { DialogSection, DialogSectionSeparator } from 'ui'
 
 import PolicyAllowedOperation from './PolicyAllowedOperation'
 import PolicyDefinition from './PolicyDefinition'
@@ -30,33 +30,33 @@ export const PolicyEditor = ({
 
   return (
     <div>
-      <Modal.Content>
+      <DialogSection>
         <PolicyName
           name={policyFormFields.name}
           limit={63}
           onUpdatePolicyName={(name) => onUpdatePolicyFormFields({ name })}
         />
-      </Modal.Content>
-      <Modal.Separator />
+      </DialogSection>
+      <DialogSectionSeparator />
       {isNewPolicy && (
         <>
-          <Modal.Content>
+          <DialogSection>
             <PolicyAllowedOperation
               operation={operation}
               onSelectOperation={(command) => onUpdatePolicyFormFields({ command })}
             />
-          </Modal.Content>
-          <Modal.Separator />
+          </DialogSection>
+          <DialogSectionSeparator />
         </>
       )}
-      <Modal.Content>
+      <DialogSection>
         <PolicyRoles
           selectedRoles={selectedRoles}
           onUpdateSelectedRoles={(roles) => onUpdatePolicyFormFields({ roles })}
         />
-      </Modal.Content>
-      <Modal.Separator />
-      <Modal.Content>
+      </DialogSection>
+      <DialogSectionSeparator />
+      <DialogSection>
         <PolicyDefinition
           operation={operation}
           definition={definition}
@@ -66,7 +66,7 @@ export const PolicyEditor = ({
           }
           onUpdatePolicyCheck={(check: string | undefined) => onUpdatePolicyFormFields({ check })}
         />
-      </Modal.Content>
+      </DialogSection>
       <PolicyEditorFooter
         showTemplates={isNewPolicy}
         onViewTemplates={onViewTemplates}

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyEditorModal/index.tsx
@@ -2,7 +2,7 @@ import { acceptUntrustedSql, PGPolicy } from '@supabase/pg-meta'
 import { isEmpty, noop } from 'lodash'
 import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import { Modal } from 'ui'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from 'ui'
 
 import { POLICY_MODAL_VIEWS } from '../Policies.constants'
 import {
@@ -201,57 +201,56 @@ export const PolicyEditorModal = ({
   }
 
   return (
-    <Modal
-      hideFooter
-      size={view === POLICY_MODAL_VIEWS.SELECTION ? 'medium' : 'xxlarge'}
-      visible={visible}
-      contentStyle={{ padding: 0 }}
-      header={[
-        <PolicyEditorModalTitle
-          key="0"
-          view={view}
-          isNewPolicy={isNewPolicy}
-          schema={schema}
-          table={table}
-          showAssistantPreview={showAssistantPreview}
-          onSelectBackFromTemplates={onSelectBackFromTemplates}
-          onToggleFeaturePreviewModal={onToggleFeaturePreviewModal}
-        />,
-      ]}
-      onCancel={confirmOnClose}
-    >
-      <div>
-        <DiscardChangesConfirmationDialog {...modalProps} />
-        {view === POLICY_MODAL_VIEWS.SELECTION ? (
-          <PolicySelection
-            description="Write rules with PostgreSQL's policies to fit your unique business needs."
-            onViewTemplates={onViewTemplates}
-            onViewEditor={onViewEditor}
-            showAssistantPreview={showAssistantPreview}
-            onToggleFeaturePreviewModal={onToggleFeaturePreviewModal}
-          />
-        ) : view === POLICY_MODAL_VIEWS.EDITOR ? (
-          <PolicyEditor
-            isNewPolicy={isNewPolicy}
-            policyFormFields={policyFormFields}
-            onUpdatePolicyFormFields={onUpdatePolicyFormFields}
-            onViewTemplates={onViewTemplates}
-            onReviewPolicy={validatePolicyFormFields}
-          />
-        ) : view === POLICY_MODAL_VIEWS.TEMPLATES ? (
-          <PolicyTemplates
-            templates={getGeneralPolicyTemplates(schema, table).filter((policy) => !policy.preview)}
-            templatesNote="* References a specific column in the table"
-            onUseTemplate={onUseTemplate}
-          />
-        ) : view === POLICY_MODAL_VIEWS.REVIEW && !!policyStatementForReview ? (
-          <PolicyReview
-            policy={policyStatementForReview}
-            onSelectBack={onViewEditor}
-            onSelectSave={onReviewSave}
-          />
-        ) : null}
-      </div>
-    </Modal>
+    <Dialog open={visible} onOpenChange={(open) => !open && confirmOnClose()}>
+      <DialogContent size={view === POLICY_MODAL_VIEWS.SELECTION ? 'medium' : 'xxlarge'}>
+        <DialogHeader className="border-b">
+          <DialogTitle>
+            <PolicyEditorModalTitle
+              view={view}
+              isNewPolicy={isNewPolicy}
+              schema={schema}
+              table={table}
+              showAssistantPreview={showAssistantPreview}
+              onSelectBackFromTemplates={onSelectBackFromTemplates}
+              onToggleFeaturePreviewModal={onToggleFeaturePreviewModal}
+            />
+          </DialogTitle>
+        </DialogHeader>
+        <div>
+          <DiscardChangesConfirmationDialog {...modalProps} />
+          {view === POLICY_MODAL_VIEWS.SELECTION ? (
+            <PolicySelection
+              description="Write rules with PostgreSQL's policies to fit your unique business needs."
+              onViewTemplates={onViewTemplates}
+              onViewEditor={onViewEditor}
+              showAssistantPreview={showAssistantPreview}
+              onToggleFeaturePreviewModal={onToggleFeaturePreviewModal}
+            />
+          ) : view === POLICY_MODAL_VIEWS.EDITOR ? (
+            <PolicyEditor
+              isNewPolicy={isNewPolicy}
+              policyFormFields={policyFormFields}
+              onUpdatePolicyFormFields={onUpdatePolicyFormFields}
+              onViewTemplates={onViewTemplates}
+              onReviewPolicy={validatePolicyFormFields}
+            />
+          ) : view === POLICY_MODAL_VIEWS.TEMPLATES ? (
+            <PolicyTemplates
+              templates={getGeneralPolicyTemplates(schema, table).filter(
+                (policy) => !policy.preview
+              )}
+              templatesNote="* References a specific column in the table"
+              onUseTemplate={onUseTemplate}
+            />
+          ) : view === POLICY_MODAL_VIEWS.REVIEW && !!policyStatementForReview ? (
+            <PolicyReview
+              policy={policyStatementForReview}
+              onSelectBack={onViewEditor}
+              onSelectSave={onReviewSave}
+            />
+          ) : null}
+        </div>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyReview.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyReview.tsx
@@ -1,6 +1,6 @@
 import { isEmpty, noop } from 'lodash'
 import { useState } from 'react'
-import { Button, DialogSection } from 'ui'
+import { Button, DialogFooter, DialogSection } from 'ui'
 
 import type { PolicyForReview } from './Policies.types'
 import SqlEditor from '@/components/ui/SqlEditor'
@@ -53,14 +53,14 @@ export const PolicyReview = ({
           </div>
         </div>
       </DialogSection>
-      <div className="flex w-full items-center justify-end gap-2 border-t px-6 py-4 border-default">
+      <DialogFooter>
         <Button type="default" onClick={onSelectBack}>
           Back to edit
         </Button>
         <Button type="primary" disabled={isEmpty(policy)} onClick={onSavePolicy} loading={isSaving}>
           Save policy
         </Button>
-      </div>
+      </DialogFooter>
     </>
   )
 }

--- a/apps/studio/components/interfaces/Auth/Policies/PolicyReview.tsx
+++ b/apps/studio/components/interfaces/Auth/Policies/PolicyReview.tsx
@@ -1,6 +1,6 @@
 import { isEmpty, noop } from 'lodash'
 import { useState } from 'react'
-import { Button, Modal } from 'ui'
+import { Button, DialogSection } from 'ui'
 
 import type { PolicyForReview } from './Policies.types'
 import SqlEditor from '@/components/ui/SqlEditor'
@@ -26,7 +26,7 @@ export const PolicyReview = ({
 
   return (
     <>
-      <Modal.Content>
+      <DialogSection>
         <div className="space-y-6">
           <div className="flex items-center justify-between space-y-8">
             <div className="flex flex-col">
@@ -52,7 +52,7 @@ export const PolicyReview = ({
             )}
           </div>
         </div>
-      </Modal.Content>
+      </DialogSection>
       <div className="flex w-full items-center justify-end gap-2 border-t px-6 py-4 border-default">
         <Button type="default" onClick={onSelectBack}>
           Back to edit


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor

## What is the current behavior?

The Auth policy editor flow still uses the deprecated `Modal` component and `Modal.Content` / `Modal.Separator` helpers.

## What is the new behavior?

The Auth policy editor flow now uses `Dialog` primitives instead:

- `Dialog`
- `DialogContent`
- `DialogHeader`
- `DialogTitle`
- `DialogSection`
- `DialogSectionSeparator`

Behavior is intended to remain unchanged.

## Additional context

- Fixes #46375 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the policy editor and review flows to a unified dialog layout for a cleaner, more consistent UI.
  * Sections and footer controls were reorganized for clearer grouping and improved button placement.
  * Existing behaviors (viewing templates, review/save flow, and close confirmation) are preserved.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46374?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->