### PR TITLE
fix(studio): use public support link on MFA sign-in error

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
@@ -103,10 +103,18 @@ export const SignInMfaForm = ({ context = 'sign-in' }: SignInMfaFormProps) => {
       <AlertError
         error={error}
         subject="Error while signing in"
+        hideContactSupport
         additionalActions={
-          <Button asChild type="default">
-            <Link href="/sign-in">Back to sign in</Link>
-          </Button>
+          <>
+            <Button asChild type="default">
+              <Link href="/sign-in">Back to sign in</Link>
+            </Button>
+            <Button asChild type="default">
+              <Link href="https://supabase.com/support" target="_blank" rel="noreferrer">
+                Contact support
+              </Link>
+            </Button>
+          </>
         }
       />
     )

--- a/apps/studio/components/ui/AlertError.tsx
+++ b/apps/studio/components/ui/AlertError.tsx
@@ -17,6 +17,7 @@ export interface AlertErrorProps {
   showInstructions?: boolean
   showErrorPrefix?: boolean
   additionalActions?: React.ReactNode
+  hideContactSupport?: boolean
 }
 
 export const ContactSupportButton = ({
@@ -57,6 +58,7 @@ export const AlertError = ({
   showErrorPrefix = true,
   children,
   additionalActions,
+  hideContactSupport = false,
 }: PropsWithChildren<AlertErrorProps>) => {
   const track = useTrack()
   const hasTrackedRef = useRef(false)
@@ -95,7 +97,9 @@ export const AlertError = ({
         </>
       }
       actions={
-        additionalActions ? (
+        hideContactSupport ? (
+          (additionalActions ?? null)
+        ) : additionalActions ? (
           <>
             {additionalActions}
             <ContactSupportButton projectRef={projectRef} subject={subject} error={error} />


### PR DESCRIPTION
Fixes: 
https://x.com/acgfbr/status/2058995058167185731

The default `<AlertError>`appends a `<ContactSupportButton>` that opens the support form. It requires an authenticated session and `projectRef`. On the pre-auth MFA error, neither exists, so the button doesn't work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging in multi-factor authentication sign-in with improved navigation options, allowing users to quickly return to sign-in or contact support directly from error states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46382?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->