### PR TITLE
fix: omit branching params when org lacks entitlement

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/GithubIntegration/GitHubIntegrationConnectionForm.tsx
@@ -217,9 +217,11 @@ export const GitHubIntegrationConnectionForm = ({
         project_ref: selectedProject.ref,
         repository_id: Number(selectedRepo.id),
         workdir: data.supabaseDirectory,
-        supabase_changes_only: data.supabaseChangesOnly,
-        branch_limit: Number(data.branchLimit),
-        new_branch_per_pr: data.new_branch_per_pr ?? false,
+        ...(hasAccessToBranching && {
+          supabase_changes_only: data.supabaseChangesOnly,
+          branch_limit: Number(data.branchLimit),
+          new_branch_per_pr: data.new_branch_per_pr ?? false,
+        }),
       },
     })
 
@@ -266,9 +268,11 @@ export const GitHubIntegrationConnectionForm = ({
       organizationId: selectedOrganization.id,
       connection: {
         workdir: data.supabaseDirectory,
-        supabase_changes_only: data.supabaseChangesOnly,
-        branch_limit: Number(data.branchLimit),
-        new_branch_per_pr: data.new_branch_per_pr ?? false,
+        ...(hasAccessToBranching && {
+          supabase_changes_only: data.supabaseChangesOnly,
+          branch_limit: Number(data.branchLimit),
+          new_branch_per_pr: data.new_branch_per_pr ?? false,
+        }),
       },
     })
 


### PR DESCRIPTION
## Summary
- On the Free plan the GitHub integration form disables the branching section, but the create/update payloads still included `branch_limit`, `new_branch_per_pr`, and `supabase_changes_only`.
- These three fields are now only sent when the org has the `branching_limit` entitlement.

## Manual testing
- [ ] As a Free plan org, open Project Settings → Integrations → GitHub and connect a repository. In the network tab, verify the `POST /platform/integrations/github/connections` request body does **not** include `branch_limit`, `new_branch_per_pr`, or `supabase_changes_only`.
- [ ] Still on a Free org, edit the working directory / production branch on an existing connection. Verify the `PATCH` body also omits those three fields.
- [ ] As a Pro (or higher) plan org with branching enabled, repeat both flows and confirm the three branching fields are still sent with the values from the form.
- [ ] Confirm the UI itself is unchanged: the branching controls remain disabled on Free and editable on Pro+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub integration to conditionally send branching-related configuration fields based on user access permissions, preventing unnecessary data transmission for users without branching access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46388?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->