### PR TITLE
fix(studio): guard priceMonthly lookup on new project page

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
@@ -17,7 +17,6 @@ import { InfoTooltip } from 'ui-patterns/info-tooltip'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import { instanceLabel, monthlyInstancePrice } from './ProjectCreation.utils'
 import { InlineLink } from '@/components/ui/InlineLink'
-import { DesiredInstanceSize, instanceSizeSpecs } from '@/data/projects/new-project.constants'
 import { OrgProject } from '@/data/projects/org-projects-infinite-query'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -54,7 +53,7 @@ export const ProjectCreationFooter = ({
   const availableComputeCredits = organizationProjects.length === 0 ? 10 : 0
   const additionalMonthlySpend = isFreePlan
     ? 0
-    : instanceSizeSpecs[instanceSize as DesiredInstanceSize]!.priceMonthly - availableComputeCredits
+    : monthlyInstancePrice(instanceSize) - availableComputeCredits
 
   // [kevin] This will eventually all be provided by a new API endpoint to preview and validate project creation, this is just for kaizen now
   const monthlyComputeCosts =

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -26,6 +26,7 @@ import { sizes } from '@/components/interfaces/ProjectCreation/ProjectCreation.c
 import { FormSchema } from '@/components/interfaces/ProjectCreation/ProjectCreation.schema'
 import {
   instanceLabel,
+  monthlyInstancePrice,
   smartRegionToExactRegion,
 } from '@/components/interfaces/ProjectCreation/ProjectCreation.utils'
 import { ProjectCreationFooter } from '@/components/interfaces/ProjectCreation/ProjectCreationFooter'
@@ -46,7 +47,7 @@ import { useAuthorizedAppsQuery } from '@/data/oauth/authorized-apps-query'
 import { useFreeProjectLimitCheckQuery } from '@/data/organizations/free-project-limit-check-query'
 import { useOrganizationAvailableRegionsQuery } from '@/data/organizations/organization-available-regions-query'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
-import { DesiredInstanceSize, instanceSizeSpecs } from '@/data/projects/new-project.constants'
+import { DesiredInstanceSize } from '@/data/projects/new-project.constants'
 import {
   OrgProject,
   useOrgProjectsInfiniteQuery,
@@ -227,7 +228,7 @@ const Wizard: NextPageWithLayout = () => {
   const availableComputeCredits = organizationProjects.length === 0 ? 10 : 0
   const additionalMonthlySpend = isFreePlan
     ? 0
-    : instanceSizeSpecs[instanceSize as DesiredInstanceSize]!.priceMonthly - availableComputeCredits
+    : monthlyInstancePrice(instanceSize) - availableComputeCredits
 
   const { data: _defaultRegion, error: defaultRegionError } = useDefaultRegionQuery(
     {


### PR DESCRIPTION
## Summary

Switches the two `instanceSizeSpecs[instanceSize]!.priceMonthly` lookups (on the New Project page and its footer) to the existing `monthlyInstancePrice` helper, which has a defensive fallback. Fixes a render crash that fires when users switch between organizations of different plan tiers via the OrganizationSelector dropdown.

Sentry: [SUPABASE-APP-EJT](https://supabase.sentry.io/issues/SUPABASE-APP-EJT) — 339 occurrences, 312 users impacted.

Fixes FE-3481

## Test plan

- [x] On `/dashboard/new/<freeOrgSlug>`, open the org dropdown and switch to a paid org — no crash
- [x] Verify the "Additional costs" total renders correctly once form state syncs
- [x] `pnpm typecheck` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored pricing calculation logic across project creation components for improved code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46395?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->