### PR TITLE
feat(studio): small modification to logs drawer rows

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/DetailRow.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/DetailRow.tsx
@@ -48,12 +48,6 @@ export const DetailRow = ({
         wrap ? 'shrink-0' : 'min-w-0 truncate'
       )}
     >
-      <span
-        aria-hidden
-        className="select-none font-mono text-foreground-muted translate-y-0.5 ml-5"
-      >
-        └
-      </span>
       <span className={cn('font-mono', !wrap && 'truncate')}>{label}</span>
     </span>
   )
@@ -80,7 +74,7 @@ export const DetailRow = ({
       label={label}
       className={cn(rowClass, 'rounded-none group w-full cursor-pointer hover:bg-surface-100!')}
     >
-      <div className="flex items-center gap-x-2">
+      <div className="flex items-center gap-x-2 pl-[22px]">
         {labelEl}
         {isFilterable && resolvedFilterValue !== undefined && (
           <Filter size={12} className="text-foreground-lighter" />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes the `└` shaped character before each property. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated detail row layout in service flow display with refined spacing and removed visual connectors for improved readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46396?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->