### PR TITLE
fix(www): bucket Codex/ChatGPT/OpenAI responses in SoS chart (DEBR-302)

### DIFF
--- a/apps/www/app/state-of-startups/components/charts/AICodingToolsChart.tsx
+++ b/apps/www/app/state-of-startups/components/charts/AICodingToolsChart.tsx
@@ -18,12 +18,12 @@ function generateAICodingToolsSQL(activeFilters: Record<string, string>) {
           'Tempo',
           'None'
         ) THEN technology
+        WHEN LOWER(technology) LIKE '%antigravity%' THEN 'Antigravity'
         WHEN LOWER(technology) LIKE '%claude%' THEN 'Claude or Claude Code'
         WHEN LOWER(technology) LIKE '%codex%'
           OR LOWER(technology) LIKE '%chatgpt%'
           OR LOWER(technology) LIKE '%chat gpt%'
           OR LOWER(technology) LIKE '%openai%' THEN 'Codex'
-        ELSE 'Other'
       END AS technology_clean
     FROM (
       SELECT id, unnest(ai_coding_tools) AS technology
@@ -31,10 +31,11 @@ function generateAICodingToolsSQL(activeFilters: Record<string, string>) {
       ${whereClause}
     ) sub
   )
-  SELECT 
+  SELECT
     technology_clean AS technology,
     COUNT(DISTINCT id) AS total
   FROM ai_coding_tools_mapping
+  WHERE technology_clean IS NOT NULL
   GROUP BY technology_clean
   ORDER BY total DESC;`
 }

--- a/apps/www/app/state-of-startups/components/charts/AICodingToolsChart.tsx
+++ b/apps/www/app/state-of-startups/components/charts/AICodingToolsChart.tsx
@@ -19,7 +19,10 @@ function generateAICodingToolsSQL(activeFilters: Record<string, string>) {
           'None'
         ) THEN technology
         WHEN LOWER(technology) LIKE '%claude%' THEN 'Claude or Claude Code'
-        WHEN LOWER(technology) = 'chatgpt' THEN 'ChatGPT'
+        WHEN LOWER(technology) LIKE '%codex%'
+          OR LOWER(technology) LIKE '%chatgpt%'
+          OR LOWER(technology) LIKE '%chat gpt%'
+          OR LOWER(technology) LIKE '%openai%' THEN 'Codex'
         ELSE 'Other'
       END AS technology_clean
     FROM (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In the State of Startups 2026 "AI coding tools" chart, unaided Codex responses (~178 across casing/spelling variants such as `Codex`, `codex`, `OpenAI Codex`, `Codex CLI`, `ChatGPT Codex`, `gpt-codex`) were folded into "Other" because the aggregation only had explicit buckets for Cursor, Windsurf, Cline, Visual Studio Code, Lovable, Bolt, v0, Tempo, None, Claude (`%claude%`), and an exact-match ChatGPT. As a result Codex never appeared in the chart even though it was the 7th-most-frequent answer in the raw data.

Linear: DEBR-302

## What is the new behavior?

The actual aggregation is owned by `get_ai_coding_tools_stats_2026` in the external State of Startups Supabase project (`iddgenoqmqztnnefcbwp`) and was updated server-side via `CREATE OR REPLACE FUNCTION` to add a combined `Codex` bucket that matches `LOWER(technology) LIKE '%codex%' | '%chatgpt%' | '%chat gpt%' | '%openai%'`, replacing the previous narrow `'chatgpt'` exact match. All other buckets are unchanged.

This PR updates the SQL preview string in `AICodingToolsChart.tsx` so the chart's "SQL" toggle reflects the new RPC logic. Net effect once the RPC is deployed: a new `Codex` bar (~213 responses) appears, the standalone `ChatGPT` bucket is folded into it, every other bucket and the respondent totals stay the same.

## Additional context

- Raw `responses_2026` data is untouched; only the aggregation function changed.
- `ai_models_used` / `get_ai_models_stats_2026` may need a similar audit (Prashant flagged the same OpenAI/Codex/ChatGPT cleanup concern for the unaided models question) but is out of scope here.
- Open question from the comment thread: "Visual Studio Code" (1,113 responses) is ambiguous re: Copilot vs. other in-editor AI. Not addressed in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency for AI coding tools by consolidating multiple naming variants into standardized labels (e.g., consolidated OpenAI/ChatGPT/Codex variants).
  * Added recognition for a new tool label ("Antigravity").
  * Charts now exclude unrecognized/ambiguous tool names, which may change counts and visual totals in related reports.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46398?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->