### PR TITLE
fix: restore edgefn docs 

### DIFF
--- a/apps/docs/content/guides/functions/connect-to-postgres.mdx
+++ b/apps/docs/content/guides/functions/connect-to-postgres.mdx
@@ -80,9 +80,10 @@ language="json"
 
 Then define your schema and query the database:
 
+{/* prettier-ignore */}
 <$CodeSample
-path="/edge-functions/supabase/functions/\_shared/schema.ts"
-title="supabase/functions/\_shared/schema.ts"
+path="/edge-functions/supabase/functions/_shared/schema.ts"
+title="supabase/functions/_shared/schema.ts"
 language="typescript"
 />
 


### PR DESCRIPTION
- closes https://github.com/supabase/supabase/issues/46397


b4: https://supabase.com/docs/guides/functions/connect-to-postgres (404)
after: https://docs-git-fork-7ttp-fix-404-edgefn-supabase.vercel.app/docs/guides/functions/connect-to-postgres (200)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a broken snippet reference in the Drizzle guide and added a formatting override to ensure the code sample renders correctly (documentation-only change).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46399?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->