### PR TITLE
feat: refactored copy placement so that it can be used in peak and headers for table editor

### DIFF
--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -94,6 +94,13 @@ export const ForeignKeyFormatter = (props: Props) => {
                 onContextMenu={(e) => {
                   e.stopPropagation()
                 }}
+                onFocusOutside={(e) => {
+                  // The embedded DataGrid and nested portals (DropdownMenu, ContextMenu)
+                  // move focus around as the user interacts; treating those as "outside"
+                  // closes the popover on every click. Only close on real pointer-down
+                  // outside, which Radix still handles by default.
+                  e.preventDefault()
+                }}
               >
                 <ReferenceRecordPeek
                   table={targetTable}

--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -95,10 +95,6 @@ export const ForeignKeyFormatter = (props: Props) => {
                   e.stopPropagation()
                 }}
                 onFocusOutside={(e) => {
-                  // The embedded DataGrid and nested portals (DropdownMenu, ContextMenu)
-                  // move focus around as the user interacts; treating those as "outside"
-                  // closes the popover on every click. Only close on real pointer-down
-                  // outside, which Radix still handles by default.
                   e.preventDefault()
                 }}
               >

--- a/apps/studio/components/grid/components/formatter/ReferenceRecordPeek.tsx
+++ b/apps/studio/components/grid/components/formatter/ReferenceRecordPeek.tsx
@@ -7,12 +7,14 @@ import DataGrid, { CalculatedColumn, Column } from 'react-data-grid'
 import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
+import { CopyExportRowsActions } from '../header/CopyExportRowsActions'
 import { BinaryFormatter } from './BinaryFormatter'
 import { BooleanFormatter } from './BooleanFormatter'
 import { CellContextMenuWrapper } from './CellContextMenuWrapper'
 import { DefaultFormatter } from './DefaultFormatter'
 import { JsonFormatter } from './JsonFormatter'
 import { COLUMN_MIN_WIDTH } from '@/components/grid/constants'
+import { parseSupaTable } from '@/components/grid/SupabaseGrid.utils'
 import type { SupaColumn, SupaRow } from '@/components/grid/types'
 import {
   ESTIMATED_CHARACTER_PIXEL_WIDTH,
@@ -25,6 +27,7 @@ import {
   isJsonColumn,
 } from '@/components/grid/utils/types'
 import { EditorTablePageLink } from '@/data/prefetchers/project.$ref.editor.$id'
+import { useTableEditorQuery } from '@/data/table-editor/table-editor-query'
 import { useTableRowsQuery } from '@/data/table-rows/table-rows-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
@@ -54,6 +57,13 @@ export const ReferenceRecordPeek = ({ table, column, value }: ReferenceRecordPee
     },
     { placeholderData: keepPreviousData }
   )
+
+  const { data: entity } = useTableEditorQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+    id: table.id,
+  })
+  const supaTable = useMemo(() => (entity ? parseSupaTable(entity) : undefined), [entity])
 
   const rows = useMemo(() => data?.rows ?? [], [data?.rows])
   const selectedCellRef = useRef<{ idx: number; rowIdx: number } | null>(null)
@@ -155,14 +165,28 @@ export const ReferenceRecordPeek = ({ table, column, value }: ReferenceRecordPee
           ),
         }}
       />
-      <div className="flex items-center justify-end px-2 py-1">
+      <div className="flex items-center justify-between gap-x-2 px-2 py-1">
+        <div className="flex items-center gap-x-2">
+          <CopyExportRowsActions
+            rows={rows}
+            table={supaTable}
+            project={
+              project
+                ? { ref: project.ref, connectionString: project.connectionString ?? null }
+                : undefined
+            }
+          />
+        </div>
+
         <EditorTablePageLink
           href={`/project/${ref}/editor/${table.id}?schema=${table.schema}&filter=${column}%3Aeq%3A${value}`}
           projectRef={ref}
           id={String(table.id)}
           filters={[{ column, operator: '=', value: String(value) }]}
         >
-          <Button type="default">Open table</Button>
+          <Button type="default" size="tiny">
+            Open table
+          </Button>
         </EditorTablePageLink>
       </div>
     </>

--- a/apps/studio/components/grid/components/header/AllRowsCopyExportActions.tsx
+++ b/apps/studio/components/grid/components/header/AllRowsCopyExportActions.tsx
@@ -53,9 +53,15 @@ export const AllRowsCopyExportActions = ({
 
   const runExport = async (exporter: () => Promise<void>) => {
     if (!project) return toast.error('Project is required')
-    setIsExporting(true)
-    await exporter()
-    setIsExporting(false)
+
+    try {
+      setIsExporting(true)
+      await exporter()
+    } catch (error) {
+      toast.error('Failed to export rows due to error. Please try again later')
+    } finally {
+      setIsExporting(false)
+    }
   }
 
   return (

--- a/apps/studio/components/grid/components/header/AllRowsCopyExportActions.tsx
+++ b/apps/studio/components/grid/components/header/AllRowsCopyExportActions.tsx
@@ -1,0 +1,107 @@
+import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from 'ui'
+
+import { ExportDialog } from './ExportDialog'
+import type { Filter, Sort, SupaTable } from '@/components/grid/types'
+import {
+  useExportAllRowsAsCsv,
+  useExportAllRowsAsSql,
+} from '@/components/layouts/TableEditorLayout/ExportAllRows'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+
+interface AllRowsCopyExportActionsProps {
+  table: SupaTable
+  filters: Filter[]
+  sorts: Sort[]
+  totalRows: number
+  project: { ref: string; connectionString: string | null } | undefined
+}
+
+export const AllRowsCopyExportActions = ({
+  table,
+  filters,
+  sorts,
+  totalRows,
+  project,
+}: AllRowsCopyExportActionsProps) => {
+  const [isExporting, setIsExporting] = useState(false)
+  const [showExportModal, setShowExportModal] = useState(false)
+
+  const exportParams = project
+    ? ({
+        enabled: true as const,
+        projectRef: project.ref,
+        connectionString: project.connectionString,
+        entity: table,
+        totalRows,
+        type: 'fetch_all' as const,
+        filters,
+        sorts,
+      } as const)
+    : ({ enabled: false } as const)
+
+  const { exportCsv, confirmationModal: csvModal } = useExportAllRowsAsCsv(exportParams)
+  const { exportSql, confirmationModal: sqlModal } = useExportAllRowsAsSql(exportParams)
+
+  const runExport = async (exporter: () => Promise<void>) => {
+    if (!project) return toast.error('Project is required')
+    setIsExporting(true)
+    await exporter()
+    setIsExporting(false)
+  }
+
+  return (
+    <>
+      <ButtonTooltip
+        disabled
+        type="default"
+        tooltip={{
+          content: {
+            side: 'bottom',
+            className: 'w-64 text-center',
+            text: 'Copy to clipboard is not supported while all rows in the table are selected',
+          },
+        }}
+      >
+        Copy
+      </ButtonTooltip>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button type="default" size="tiny" iconRight={<ChevronDown />} loading={isExporting}>
+            Export
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-52">
+          <DropdownMenuItem onClick={() => runExport(exportCsv)}>Export as CSV</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => runExport(exportSql)}>Export as SQL</DropdownMenuItem>
+          <DropdownMenuItem className="group" onClick={() => setShowExportModal(true)}>
+            <div>
+              <p className="group-hover:text-foreground">Export via CLI</p>
+              <p className="text-foreground-lighter">Recommended for large tables</p>
+            </div>
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ExportDialog
+        table={table}
+        filters={filters}
+        sorts={sorts}
+        open={showExportModal}
+        onOpenChange={() => setShowExportModal(false)}
+      />
+
+      {csvModal}
+      {sqlModal}
+    </>
+  )
+}

--- a/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
+++ b/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
@@ -1,5 +1,4 @@
 import { ChevronDown } from 'lucide-react'
-import { useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
@@ -25,9 +24,6 @@ interface CopyExportRowsActionsProps {
 }
 
 export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsActionsProps) => {
-  const [isCopying, setIsCopying] = useState(false)
-  const [isExporting, setIsExporting] = useState(false)
-
   const exportParams =
     table && project && rows.length > 0
       ? ({
@@ -63,7 +59,6 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
       )
     }
 
-    setIsCopying(true)
     const formatted = formatRowsForCopy({
       rows,
       table,
@@ -72,15 +67,11 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
       connectionString: project.connectionString,
     })
 
-    copyToClipboard(formatted, () => toast.success('Copied rows to clipboard')).finally(() => {
-      setIsCopying(false)
-    })
+    copyToClipboard(formatted, () => toast.success('Copied rows to clipboard'))
   }
 
   const onExportRows = async (exporter: () => Promise<void>) => {
-    setIsExporting(true)
     await exporter()
-    setIsExporting(false)
   }
 
   return (
@@ -91,7 +82,6 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
             type="default"
             size="tiny"
             iconRight={<ChevronDown />}
-            loading={isCopying}
             disabled={disabled}
           >
             Copy
@@ -116,7 +106,6 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
             type="default"
             size="tiny"
             iconRight={<ChevronDown />}
-            loading={isExporting}
             disabled={disabled}
           >
             Export

--- a/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
+++ b/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
@@ -97,7 +97,17 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
             Copy
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-40">
+        <DropdownMenuContent
+          align="start"
+          className="w-40"
+          onFocusOutside={(e) => {
+            // When rendered inside a popover with a focused DataGrid (the
+            // linked record peek), the grid grabs focus back as soon as the
+            // menu opens, which closes it. Suppress focus-driven dismissal;
+            // outside pointer-down still closes the menu normally.
+            e.preventDefault()
+          }}
+        >
           <DropdownMenuItem onClick={() => onCopyRows('csv')}>Copy as CSV</DropdownMenuItem>
           <DropdownMenuItem onClick={() => onCopyRows('sql')}>Copy as SQL</DropdownMenuItem>
           <DropdownMenuItem onClick={() => onCopyRows('json')}>Copy as JSON</DropdownMenuItem>
@@ -116,7 +126,17 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
             Export
           </Button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="w-40">
+        <DropdownMenuContent
+          align="start"
+          className="w-40"
+          onFocusOutside={(e) => {
+            // When rendered inside a popover with a focused DataGrid (the
+            // linked record peek), the grid grabs focus back as soon as the
+            // menu opens, which closes it. Suppress focus-driven dismissal;
+            // outside pointer-down still closes the menu normally.
+            e.preventDefault()
+          }}
+        >
           <DropdownMenuItem onClick={() => onExportRows(exportCsv)}>Export as CSV</DropdownMenuItem>
           <DropdownMenuItem onClick={() => onExportRows(exportSql)}>Export as SQL</DropdownMenuItem>
           <DropdownMenuItem onClick={() => onExportRows(exportJson)}>

--- a/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
+++ b/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
@@ -101,10 +101,6 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
           align="start"
           className="w-40"
           onFocusOutside={(e) => {
-            // When rendered inside a popover with a focused DataGrid (the
-            // linked record peek), the grid grabs focus back as soon as the
-            // menu opens, which closes it. Suppress focus-driven dismissal;
-            // outside pointer-down still closes the menu normally.
             e.preventDefault()
           }}
         >
@@ -130,10 +126,6 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
           align="start"
           className="w-40"
           onFocusOutside={(e) => {
-            // When rendered inside a popover with a focused DataGrid (the
-            // linked record peek), the grid grabs focus back as soon as the
-            // menu opens, which closes it. Suppress focus-driven dismissal;
-            // outside pointer-down still closes the menu normally.
             e.preventDefault()
           }}
         >

--- a/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
+++ b/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
@@ -1,0 +1,133 @@
+import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import {
+  Button,
+  copyToClipboard,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from 'ui'
+
+import { formatRowsForCopy, hasTruncatedCellValues } from './Header.utils'
+import type { SupaRow, SupaTable } from '@/components/grid/types'
+import {
+  useExportAllRowsAsCsv,
+  useExportAllRowsAsJson,
+  useExportAllRowsAsSql,
+} from '@/components/layouts/TableEditorLayout/ExportAllRows'
+
+interface CopyExportRowsActionsProps {
+  rows: SupaRow[]
+  table: SupaTable | undefined
+  project: { ref: string; connectionString: string | null } | undefined
+}
+
+export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsActionsProps) => {
+  const [isCopying, setIsCopying] = useState(false)
+  const [isExporting, setIsExporting] = useState(false)
+
+  const exportParams =
+    table && project && rows.length > 0
+      ? ({
+          enabled: true as const,
+          projectRef: project.ref,
+          connectionString: project.connectionString,
+          entity: { id: table.id, name: table.name, type: table.type },
+          type: 'provided_rows' as const,
+          table,
+          rows,
+        } as const)
+      : ({ enabled: false } as const)
+
+  const { exportCsv, confirmationModal: csvModal } = useExportAllRowsAsCsv(exportParams)
+  const { exportSql, confirmationModal: sqlModal } = useExportAllRowsAsSql(exportParams)
+  const { exportJson, confirmationModal: jsonModal } = useExportAllRowsAsJson(exportParams)
+
+  const disabled = !table || !project || rows.length === 0
+
+  const onCopyRows = (format: 'csv' | 'json' | 'sql') => {
+    if (!project || !table) return
+
+    if (hasTruncatedCellValues(rows) && (!table.primaryKey || table.primaryKey.length === 0)) {
+      return toast(
+        <div>
+          <p>Unable to copy rows</p>
+          <p className="text-foreground-light text-sm">
+            A row has a column value that needs to be fetched on demand due to its size, but the
+            table has no primary key.
+          </p>
+        </div>,
+        { duration: 8000 }
+      )
+    }
+
+    setIsCopying(true)
+    const formatted = formatRowsForCopy({
+      rows,
+      table,
+      format,
+      projectRef: project.ref,
+      connectionString: project.connectionString,
+    })
+
+    copyToClipboard(formatted, () => toast.success('Copied rows to clipboard')).finally(() => {
+      setIsCopying(false)
+    })
+  }
+
+  const onExportRows = async (exporter: () => Promise<void>) => {
+    setIsExporting(true)
+    await exporter()
+    setIsExporting(false)
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="default"
+            size="tiny"
+            iconRight={<ChevronDown />}
+            loading={isCopying}
+            disabled={disabled}
+          >
+            Copy
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-40">
+          <DropdownMenuItem onClick={() => onCopyRows('csv')}>Copy as CSV</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onCopyRows('sql')}>Copy as SQL</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onCopyRows('json')}>Copy as JSON</DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="default"
+            size="tiny"
+            iconRight={<ChevronDown />}
+            loading={isExporting}
+            disabled={disabled}
+          >
+            Export
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-40">
+          <DropdownMenuItem onClick={() => onExportRows(exportCsv)}>Export as CSV</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onExportRows(exportSql)}>Export as SQL</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => onExportRows(exportJson)}>
+            Export as JSON
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      {csvModal}
+      {sqlModal}
+      {jsonModal}
+    </>
+  )
+}

--- a/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
+++ b/apps/studio/components/grid/components/header/CopyExportRowsActions.tsx
@@ -78,12 +78,7 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button
-            type="default"
-            size="tiny"
-            iconRight={<ChevronDown />}
-            disabled={disabled}
-          >
+          <Button type="default" size="tiny" iconRight={<ChevronDown />} disabled={disabled}>
             Copy
           </Button>
         </DropdownMenuTrigger>
@@ -102,12 +97,7 @@ export const CopyExportRowsActions = ({ rows, table, project }: CopyExportRowsAc
 
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
-          <Button
-            type="default"
-            size="tiny"
-            iconRight={<ChevronDown />}
-            disabled={disabled}
-          >
+          <Button type="default" size="tiny" iconRight={<ChevronDown />} disabled={disabled}>
             Export
           </Button>
         </DropdownMenuTrigger>

--- a/apps/studio/components/grid/components/header/Header.tsx
+++ b/apps/studio/components/grid/components/header/Header.tsx
@@ -1,34 +1,18 @@
 import { keepPreviousData } from '@tanstack/react-query'
 import { useBreakpoint, useParams } from 'common'
 import { AnimatePresence, motion } from 'framer-motion'
-import { ChevronDown, Trash } from 'lucide-react'
+import { Trash } from 'lucide-react'
 import { ReactNode, useEffect, useRef, useState } from 'react'
-import { toast } from 'sonner'
-import {
-  Button,
-  copyToClipboard,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-  Separator,
-} from 'ui'
+import { Button, Separator } from 'ui'
 
 import { useInitializeFiltersFromUrl, useSyncFiltersToUrl } from '../../hooks/useFilterLifeCycle'
-import { ExportDialog } from './ExportDialog'
+import { AllRowsCopyExportActions } from './AllRowsCopyExportActions'
+import { CopyExportRowsActions } from './CopyExportRowsActions'
 import { FilterPopoverNew } from './filter/FilterPopoverNew'
-import { formatRowsForCSV, hydrateTruncatedRows } from './Header.utils'
 import { SortPopover } from './sort/SortPopover'
 import { useTableRowOperations } from '@/components/grid/hooks/useTableRowOperations'
 import { useTableSort } from '@/components/grid/hooks/useTableSort'
 import { GridHeaderActions } from '@/components/interfaces/TableGridEditor/GridHeaderActions'
-import { isValueTruncated } from '@/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
-import { formatTableRowsToSQL } from '@/components/interfaces/TableGridEditor/TableEntity.utils'
-import {
-  useExportAllRowsAsCsv,
-  useExportAllRowsAsJson,
-  useExportAllRowsAsSql,
-} from '@/components/layouts/TableEditorLayout/ExportAllRows'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { Shortcut } from '@/components/ui/Shortcut'
 import { useTableRowsCountQuery } from '@/data/table-rows/table-rows-count-query'
@@ -146,10 +130,6 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   const filters = snap.filters
   const { sorts } = useTableSort()
 
-  const [isCopying, setIsCopying] = useState(false)
-  const [isExporting, setIsExporting] = useState(false)
-  const [showExportModal, setShowExportModal] = useState(false)
-
   const preflightCheck = !tableEditorSnap.tablesToIgnorePreflightCheck.includes(tableId ?? -1)
 
   const { data } = useTableRowsQuery(
@@ -179,6 +159,9 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
 
   const allRows = data?.rows ?? []
   const totalRows = countData?.count ?? 0
+  const projectActionsParam = project
+    ? { ref: project.ref, connectionString: project.connectionString ?? null }
+    : undefined
 
   const onSelectAllRows = () => {
     snap.setSelectedRows(new Set(allRows.map((row) => row.idx)), true)
@@ -207,122 +190,6 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
     })
   }
 
-  const onCopyRows = (type: 'csv' | 'json' | 'sql') => {
-    if (!project) return toast.error('Project is required')
-
-    const selected = allRows.filter((x) => snap.selectedRows.has(x.idx))
-
-    const hasTruncated = selected.some((row) =>
-      Object.values(row).some((v) => typeof v === 'string' && isValueTruncated(v))
-    )
-    if (hasTruncated && (!snap.table.primaryKey || snap.table.primaryKey.length === 0)) {
-      return toast(
-        <div>
-          <p>Unable to copy selected rows</p>
-          <p className="text-foreground-light text-sm">
-            A selected row has a column value that needs to be fetched on demand due to its size,
-            but the table has no primary key.
-          </p>
-        </div>,
-        { duration: 8000 }
-      )
-    }
-
-    setIsCopying(true)
-    const formatted = (async () => {
-      const hydrated = await hydrateTruncatedRows({
-        rows: selected,
-        table: snap.table,
-        projectRef: project.ref,
-        connectionString: project.connectionString ?? null,
-      })
-      if (hydrated.status !== 'ok') {
-        throw new Error('Failed to fetch full values for truncated cells')
-      }
-      const rows = hydrated.rows
-      if (type === 'csv') {
-        return formatRowsForCSV({
-          rows,
-          columns: snap.table!.columns.map((column) => column.name),
-        })
-      } else if (type === 'sql') {
-        return formatTableRowsToSQL(snap.table, rows)
-      } else {
-        return JSON.stringify(rows)
-      }
-    })()
-
-    copyToClipboard(formatted, () => toast.success('Copied rows to clipboard')).finally(() => {
-      setIsCopying(false)
-    })
-  }
-
-  const exportParams = snap.allRowsSelected
-    ? ({ type: 'fetch_all', filters, sorts } as const)
-    : ({
-        type: 'provided_rows',
-        table: snap.table,
-        rows: allRows.filter((x) => snap.selectedRows.has(x.idx)),
-      } as const)
-
-  const { exportCsv, confirmationModal: exportCsvConfirmationModal } = useExportAllRowsAsCsv(
-    project
-      ? {
-          enabled: true,
-          projectRef: project.ref,
-          connectionString: project?.connectionString ?? null,
-          entity: snap.table,
-          totalRows,
-          ...exportParams,
-        }
-      : { enabled: false }
-  )
-  const onRowsExportCSV = async () => {
-    if (!project) return toast.error('Project is required')
-
-    setIsExporting(true)
-    await exportCsv()
-    setIsExporting(false)
-  }
-
-  const { exportSql, confirmationModal: exportSqlConfirmationModal } = useExportAllRowsAsSql(
-    project
-      ? {
-          enabled: true,
-          projectRef: project.ref,
-          connectionString: project?.connectionString ?? null,
-          entity: snap.table,
-          ...exportParams,
-        }
-      : { enabled: false }
-  )
-  const onRowsExportSQL = async () => {
-    if (!project) return toast.error('Project is required')
-
-    setIsExporting(true)
-    await exportSql()
-    setIsExporting(false)
-  }
-
-  const { exportJson, confirmationModal: exportJsonConfirmationModal } = useExportAllRowsAsJson(
-    project
-      ? {
-          enabled: true,
-          projectRef: project.ref,
-          connectionString: project?.connectionString ?? null,
-          entity: snap.table,
-          ...exportParams,
-        }
-      : { enabled: false }
-  )
-  const onRowsExportJSON = async () => {
-    if (!project) return toast.error('Project is required')
-
-    setIsExporting(true)
-    await exportJson()
-    setIsExporting(false)
-  }
-
   useSubscribeToImpersonatedRole(() => {
     if (snap.allRowsSelected || snap.selectedRows.size > 0) {
       snap.resetSelectedRows()
@@ -330,126 +197,77 @@ const RowHeader = ({ tableQueriesEnabled = true }: RowHeaderProps) => {
   })
 
   return (
-    <>
-      <div className="flex items-center justify-between">
-        <div className="flex items-center gap-x-2">
-          {!snap.allRowsSelected ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button type="default" size="tiny" iconRight={<ChevronDown />} loading={isCopying}>
-                  Copy
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="w-40">
-                <DropdownMenuItem onClick={() => onCopyRows('csv')}>Copy as CSV</DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onCopyRows('sql')}>Copy as SQL</DropdownMenuItem>
-                <DropdownMenuItem onClick={() => onCopyRows('json')}>Copy as JSON</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <ButtonTooltip
-              disabled
-              type="default"
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  className: 'w-64 text-center',
-                  text: 'Copy to clipboard is not supported while all rows in the table are selected',
-                },
-              }}
-            >
-              Copy
-            </ButtonTooltip>
-          )}
+    <div className="flex items-center justify-between">
+      <div className="flex items-center gap-x-2">
+        {snap.allRowsSelected ? (
+          <AllRowsCopyExportActions
+            table={snap.table}
+            filters={filters}
+            sorts={sorts}
+            totalRows={totalRows}
+            project={projectActionsParam}
+          />
+        ) : (
+          <CopyExportRowsActions
+            rows={allRows.filter((x) => snap.selectedRows.has(x.idx))}
+            table={snap.table}
+            project={projectActionsParam}
+          />
+        )}
 
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button type="default" size="tiny" iconRight={<ChevronDown />} loading={isExporting}>
-                Export
+        {snap.selectedRows.size > 0 && totalRows > allRows.length && (
+          <>
+            <div className="h-6 ml-0.5">
+              <Separator orientation="vertical" className="bg-border" />
+            </div>
+            <Shortcut
+              id={SHORTCUT_IDS.TABLE_EDITOR_SELECT_ALL_IN_TABLE}
+              onTrigger={onToggleSelectAllInTable}
+              options={{ registerInCommandMenu: true }}
+              side="bottom"
+            >
+              <Button type="text" onClick={onToggleSelectAllInTable}>
+                {snap.allRowsSelected ? 'Deselect all rows in table' : 'Select all rows in table'}
               </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className={snap.allRowsSelected ? 'w-52' : 'w-40'}>
-              <DropdownMenuItem onClick={onRowsExportCSV}>Export as CSV</DropdownMenuItem>
-              <DropdownMenuItem onClick={onRowsExportSQL}>Export as SQL</DropdownMenuItem>
-              {snap.allRowsSelected ? (
-                <DropdownMenuItem className="group" onClick={() => setShowExportModal(true)}>
-                  <div>
-                    <p className="group-hover:text-foreground">Export via CLI</p>
-                    <p className="text-foreground-lighter">Recommended for large tables</p>
-                  </div>
-                </DropdownMenuItem>
-              ) : (
-                <DropdownMenuItem onClick={onRowsExportJSON}>Export as JSON</DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {snap.selectedRows.size > 0 && totalRows > allRows.length && (
-            <>
-              <div className="h-6 ml-0.5">
-                <Separator orientation="vertical" className="bg-border" />
-              </div>
-              <Shortcut
-                id={SHORTCUT_IDS.TABLE_EDITOR_SELECT_ALL_IN_TABLE}
-                onTrigger={onToggleSelectAllInTable}
-                options={{ registerInCommandMenu: true }}
-                side="bottom"
-              >
-                <Button type="text" onClick={onToggleSelectAllInTable}>
-                  {snap.allRowsSelected ? 'Deselect all rows in table' : 'Select all rows in table'}
-                </Button>
-              </Shortcut>
-            </>
-          )}
-        </div>
-
-        {snap.editable && (
-          <Shortcut
-            id={SHORTCUT_IDS.TABLE_EDITOR_DELETE_SELECTED_ROWS}
-            onTrigger={onRowsDelete}
-            side="bottom"
-            options={{
-              registerInCommandMenu: true,
-              enabled: !(snap.allRowsSelected && isImpersonatingRole),
-            }}
-          >
-            <ButtonTooltip
-              type="danger"
-              size="tiny"
-              icon={<Trash />}
-              onClick={onRowsDelete}
-              disabled={snap.allRowsSelected && isImpersonatingRole}
-              tooltip={{
-                content: {
-                  side: 'bottom',
-                  text:
-                    snap.allRowsSelected && isImpersonatingRole
-                      ? 'Table truncation is not supported when impersonating a role'
-                      : undefined,
-                },
-              }}
-            >
-              {snap.allRowsSelected
-                ? `Delete all rows in table`
-                : snap.selectedRows.size > 1
-                  ? `Delete ${snap.selectedRows.size} rows`
-                  : `Delete ${snap.selectedRows.size} row`}
-            </ButtonTooltip>
-          </Shortcut>
+            </Shortcut>
+          </>
         )}
       </div>
 
-      <ExportDialog
-        table={snap.table}
-        filters={filters}
-        sorts={sorts}
-        open={showExportModal}
-        onOpenChange={() => setShowExportModal(false)}
-      />
-
-      {exportCsvConfirmationModal}
-      {exportSqlConfirmationModal}
-      {exportJsonConfirmationModal}
-    </>
+      {snap.editable && (
+        <Shortcut
+          id={SHORTCUT_IDS.TABLE_EDITOR_DELETE_SELECTED_ROWS}
+          onTrigger={onRowsDelete}
+          side="bottom"
+          options={{
+            registerInCommandMenu: true,
+            enabled: !(snap.allRowsSelected && isImpersonatingRole),
+          }}
+        >
+          <ButtonTooltip
+            type="danger"
+            size="tiny"
+            icon={<Trash />}
+            onClick={onRowsDelete}
+            disabled={snap.allRowsSelected && isImpersonatingRole}
+            tooltip={{
+              content: {
+                side: 'bottom',
+                text:
+                  snap.allRowsSelected && isImpersonatingRole
+                    ? 'Table truncation is not supported when impersonating a role'
+                    : undefined,
+              },
+            }}
+          >
+            {snap.allRowsSelected
+              ? `Delete all rows in table`
+              : snap.selectedRows.size > 1
+                ? `Delete ${snap.selectedRows.size} rows`
+                : `Delete ${snap.selectedRows.size} row`}
+          </ButtonTooltip>
+        </Shortcut>
+      )}
+    </div>
   )
 }

--- a/apps/studio/components/grid/components/header/Header.utils.ts
+++ b/apps/studio/components/grid/components/header/Header.utils.ts
@@ -86,7 +86,6 @@ export const hydrateTruncatedRows = async ({
   return { status: 'ok', rows: hydrated }
 }
 
-
 export const hasTruncatedCellValues = (rows: Record<string, unknown>[]) =>
   rows.some((row) =>
     Object.values(row).some((value) => typeof value === 'string' && isValueTruncated(value))

--- a/apps/studio/components/grid/components/header/Header.utils.ts
+++ b/apps/studio/components/grid/components/header/Header.utils.ts
@@ -2,7 +2,10 @@ import Papa from 'papaparse'
 
 import type { SupaTable } from '@/components/grid/types'
 import { isValueTruncated } from '@/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/RowEditor.utils'
+import { formatTableRowsToSQL } from '@/components/interfaces/TableGridEditor/TableEntity.utils'
 import { getCellValue } from '@/data/table-rows/get-cell-value-mutation'
+
+export type CopyRowsFormat = 'csv' | 'json' | 'sql'
 
 export const formatRowsForCSV = ({ rows, columns }: { rows: any[]; columns: string[] }) => {
   const formattedRows = rows.map((row) => {
@@ -81,4 +84,45 @@ export const hydrateTruncatedRows = async ({
   }
 
   return { status: 'ok', rows: hydrated }
+}
+
+
+export const hasTruncatedCellValues = (rows: Record<string, unknown>[]) =>
+  rows.some((row) =>
+    Object.values(row).some((value) => typeof value === 'string' && isValueTruncated(value))
+  )
+
+/**
+ * Hydrates truncated cell values and serializes the rows to the requested
+ * format. Throws if hydration fails so the caller can surface an error in the
+ * surrounding async flow (e.g. copyToClipboard).
+ */
+export const formatRowsForCopy = async ({
+  rows,
+  table,
+  format,
+  projectRef,
+  connectionString,
+}: {
+  rows: Record<string, unknown>[]
+  table: SupaTable
+  format: CopyRowsFormat
+  projectRef: string
+  connectionString: string | null
+}): Promise<string> => {
+  const hydrated = await hydrateTruncatedRows({ rows, table, projectRef, connectionString })
+  if (hydrated.status !== 'ok') {
+    throw new Error('Failed to fetch full values for truncated cells')
+  }
+  const hydratedRows = hydrated.rows
+  if (format === 'csv') {
+    return formatRowsForCSV({
+      rows: hydratedRows,
+      columns: table.columns.map((column) => column.name),
+    })
+  } else if (format === 'sql') {
+    return formatTableRowsToSQL(table, hydratedRows)
+  } else {
+    return JSON.stringify(hydratedRows)
+  }
 }

--- a/apps/studio/tests/components/Grid/Header.utils.test.ts
+++ b/apps/studio/tests/components/Grid/Header.utils.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  formatRowsForCopy,
+  hasTruncatedCellValues,
+} from '@/components/grid/components/header/Header.utils'
+import type { SupaTable } from '@/components/grid/types'
+import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
+
+const usersTable: SupaTable = {
+  id: 1,
+  name: 'users',
+  schema: 'public',
+  type: ENTITY_TYPE.TABLE,
+  estimateRowCount: 0,
+  primaryKey: ['id'],
+  columns: [
+    { name: 'id', dataType: 'bigint', format: 'int8', position: 1 },
+    { name: 'name', dataType: 'text', format: 'text', position: 2 },
+  ],
+}
+
+const aliceAndBob = [
+  { idx: 0, id: 1, name: 'Alice' },
+  { idx: 1, id: 2, name: 'Bob' },
+]
+
+describe('Header.utils: hasTruncatedCellValues', () => {
+  test('returns false for an empty array', () => {
+    expect(hasTruncatedCellValues([])).toBe(false)
+  })
+
+  test('returns false when no string cell looks truncated', () => {
+    expect(hasTruncatedCellValues(aliceAndBob)).toBe(false)
+  })
+
+  test('detects the JSON-array truncation marker', () => {
+    // Server marks truncated json arrays by appending {"truncated":true} as the last element.
+    const rows = [{ idx: 0, id: 1, tags: '[1,2,3,{"truncated":true}]' }]
+    expect(hasTruncatedCellValues(rows)).toBe(true)
+  })
+
+  test('detects multi-dimensional array values as possibly truncated', () => {
+    const rows = [{ idx: 0, id: 1, matrix: '[["a"],["b"]]' }]
+    expect(hasTruncatedCellValues(rows)).toBe(true)
+  })
+
+  test('flags the whole batch when any single row has a truncated cell', () => {
+    const rows = [
+      { idx: 0, id: 1, name: 'Alice' },
+      { idx: 1, id: 2, tags: '[1,2,3,{"truncated":true}]' },
+    ]
+    expect(hasTruncatedCellValues(rows)).toBe(true)
+  })
+
+  test('ignores non-string cell values', () => {
+    const rows = [{ idx: 0, id: 1, active: true, balance: 100, deleted_at: null }]
+    expect(hasTruncatedCellValues(rows)).toBe(false)
+  })
+})
+
+describe('Header.utils: formatRowsForCopy', () => {
+  const baseParams = {
+    table: usersTable,
+    projectRef: 'test-project',
+    connectionString: null,
+  }
+
+  test('serializes rows as CSV with a header line from the table columns', async () => {
+    const csv = await formatRowsForCopy({
+      ...baseParams,
+      rows: aliceAndBob,
+      format: 'csv',
+    })
+    // Papa.unparse uses CRLF between rows
+    expect(csv).toBe('id,name\r\n1,Alice\r\n2,Bob')
+  })
+
+  test('only emits CSV columns that exist on the table (extra row keys ignored)', async () => {
+    const csv = await formatRowsForCopy({
+      ...baseParams,
+      rows: [{ idx: 0, id: 1, name: 'Alice', __internal: 'should-not-leak' }],
+      format: 'csv',
+    })
+    expect(csv).toBe('id,name\r\n1,Alice')
+  })
+
+  test('serializes rows as a SQL INSERT statement with quoted identifiers', async () => {
+    const sql = await formatRowsForCopy({
+      ...baseParams,
+      rows: aliceAndBob,
+      format: 'sql',
+    })
+    expect(sql).toBe(`INSERT INTO "public"."users" ("id", "name") VALUES (1, 'Alice'), (2, 'Bob');`)
+  })
+
+  test('escapes single quotes in text values when serializing to SQL', async () => {
+    const sql = await formatRowsForCopy({
+      ...baseParams,
+      rows: [{ idx: 0, id: 1, name: "O'Brien" }],
+      format: 'sql',
+    })
+    expect(sql).toBe(`INSERT INTO "public"."users" ("id", "name") VALUES (1, 'O''Brien');`)
+  })
+
+  test('serializes rows as a JSON string', async () => {
+    const json = await formatRowsForCopy({
+      ...baseParams,
+      rows: aliceAndBob,
+      format: 'json',
+    })
+    expect(JSON.parse(json)).toStrictEqual(aliceAndBob)
+  })
+
+  test('throws when a row has a truncated cell but the table has no primary key', async () => {
+    const tableWithoutPk: SupaTable = { ...usersTable, primaryKey: undefined }
+    const rows = [{ idx: 0, id: 1, tags: '[1,2,3,{"truncated":true}]' }]
+
+    await expect(
+      formatRowsForCopy({
+        ...baseParams,
+        table: tableWithoutPk,
+        rows,
+        format: 'csv',
+      })
+    ).rejects.toThrow(/truncated/i)
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Add ability to check and copy rows from table editor from peak and headers
- Refactored logic to be reusable in both components
- Added unit tests for truncation on copy 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New copy/export action components for selected rows and all rows (CSV, SQL, JSON) including “Export via CLI”
  * Reference record peek footer now shows copy/export actions
  * Header UI reworked to use the new copy/export action components

* **Bug Fixes / UX**
  * Improved popover focus handling to reduce accidental closures
  * Safer handling of truncated cell values when copying/exporting (pre-checks and hydration)

* **Tests**
  * Unit tests added for row-formatting and truncation utilities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46400?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->