### PR TITLE
feat(studio): paginate Schema Designer via useInfiniteTablesQuery

### DIFF
--- a/apps/studio/components/interfaces/Database/Schemas/FindTableSelector.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/FindTableSelector.tsx
@@ -1,0 +1,144 @@
+import { Loader2, Search } from 'lucide-react'
+import { ComponentPropsWithoutRef, forwardRef, useMemo, useState } from 'react'
+import {
+  Button,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  ScrollArea,
+} from 'ui'
+
+import { useInfiniteTablesQuery } from '@/data/tables/tables-query'
+import { useDebouncedValue } from '@/hooks/misc/useDebouncedValue'
+import type { SafePostgresTable } from '@/lib/postgres-types'
+
+type FindTableSelectorProps = Omit<ComponentPropsWithoutRef<'div'>, 'onSelect'> & {
+  projectRef?: string
+  connectionString?: string | null
+  schema?: string
+  disabled?: boolean
+  size?: 'tiny' | 'small'
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  onSelect: (table: SafePostgresTable) => void
+}
+
+export const FindTableSelector = forwardRef<HTMLDivElement, FindTableSelectorProps>(
+  (
+    {
+      className,
+      projectRef,
+      connectionString,
+      schema,
+      disabled = false,
+      size = 'tiny',
+      open,
+      onOpenChange,
+      onSelect,
+      ...rest
+    },
+    ref
+  ) => {
+    const [search, setSearch] = useState('')
+    const debouncedSearch = useDebouncedValue(search, 300)
+    const nameFilter = debouncedSearch.trim() || undefined
+
+    const { data, isFetching, hasNextPage, isFetchingNextPage, fetchNextPage } =
+      useInfiniteTablesQuery(
+        {
+          projectRef,
+          connectionString,
+          schema,
+          includeColumns: false,
+          pageSize: 50,
+          nameFilter,
+        },
+        { enabled: open }
+      )
+
+    const tables = useMemo(() => data?.pages.flat() ?? [], [data])
+
+    const handleOpenChange = (next: boolean) => {
+      if (!next) setSearch('')
+      onOpenChange(next)
+    }
+
+    return (
+      <div ref={ref} className={className} {...rest}>
+        <Popover open={open} onOpenChange={handleOpenChange} modal={false}>
+          <PopoverTrigger asChild>
+            <Button
+              size={size}
+              type="default"
+              disabled={disabled}
+              data-testid="find-table-selector"
+              icon={<Search size={14} strokeWidth={1.5} className="text-foreground-muted" />}
+            >
+              <span className="text-foreground-lighter">Find table…</span>
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent className="p-0 w-[260px] pointer-events-auto" side="bottom" align="start">
+            <Command shouldFilter={false}>
+              <CommandInput
+                className="text-xs"
+                placeholder="Find table…"
+                value={search}
+                onValueChange={setSearch}
+              />
+              <CommandList>
+                {isFetching && tables.length === 0 ? (
+                  <div className="flex items-center justify-center gap-x-2 py-6 text-xs text-foreground-light">
+                    <Loader2 className="animate-spin" size={14} />
+                    <span>Loading tables</span>
+                  </div>
+                ) : (
+                  <>
+                    <CommandEmpty>No tables found</CommandEmpty>
+                    <CommandGroup>
+                      <ScrollArea className={tables.length > 7 ? 'h-[210px]' : ''}>
+                        {tables.map((table) => (
+                          <CommandItem
+                            key={table.id}
+                            value={String(table.id)}
+                            className="cursor-pointer flex items-center justify-between space-x-2 w-full"
+                            onSelect={() => {
+                              onSelect(table)
+                              handleOpenChange(false)
+                            }}
+                          >
+                            <span>{table.name}</span>
+                          </CommandItem>
+                        ))}
+                        {hasNextPage && (
+                          <div className="px-2 py-1.5">
+                            <Button
+                              block
+                              size="tiny"
+                              type="default"
+                              loading={isFetchingNextPage}
+                              onClick={() => fetchNextPage()}
+                            >
+                              Load more
+                            </Button>
+                          </div>
+                        )}
+                      </ScrollArea>
+                    </CommandGroup>
+                  </>
+                )}
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      </div>
+    )
+  }
+)
+
+FindTableSelector.displayName = 'FindTableSelector'

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -8,6 +8,7 @@ import {
   MiniMap,
   Node,
   OnSelectionChangeParams,
+  Panel,
   ReactFlow,
   useReactFlow,
 } from '@xyflow/react'
@@ -56,7 +57,7 @@ import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import SchemaSelector from '@/components/ui/SchemaSelector'
 import { Shortcut } from '@/components/ui/Shortcut'
 import { useSchemasQuery } from '@/data/database/schemas-query'
-import { useTablesQuery } from '@/data/tables/tables-query'
+import { useInfiniteTablesQuery } from '@/data/tables/tables-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useLocalStorage } from '@/hooks/misc/useLocalStorage'
 import { useQuerySchemaState } from '@/hooks/misc/useSchemaQueryState'
@@ -118,18 +119,23 @@ export const SchemaGraph = () => {
   })
 
   const {
-    data: tables = [],
+    data: tablesData,
     error: errorTables,
     isSuccess: isSuccessTables,
     isPending: isLoadingTables,
     isError: isErrorTables,
-  } = useTablesQuery({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  } = useInfiniteTablesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
     schema: selectedSchema,
     includeColumns: true,
+    pageSize: 100,
   })
-  const hasNoTables = isSuccessSchemas && tables.length === 0
+  const tables = useMemo(() => tablesData?.pages.flat() ?? [], [tablesData])
+  const hasNoTables = isSuccessTables && isSuccessSchemas && tables.length === 0 && !hasNextPage
 
   const schema = (schemas ?? []).find((s) => s.name === selectedSchema)
   const [, setStoredPositions] = useLocalStorage(
@@ -483,6 +489,18 @@ export const SchemaGraph = () => {
                     className="border rounded-md shadow-xs"
                   />
                   <SchemaGraphLegend />
+                  {hasNextPage && (
+                    <Panel position="bottom-center" className="mb-11!">
+                      <Button
+                        type="default"
+                        size="tiny"
+                        loading={isFetchingNextPage}
+                        onClick={() => fetchNextPage()}
+                      >
+                        Load more tables
+                      </Button>
+                    </Panel>
+                  )}
                 </ReactFlow>
               </div>
             </SchemaGraphContextProvider>

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -249,6 +249,7 @@ export const SchemaGraph = () => {
   })
 
   const isFirstLoad = useRef(true)
+  const fitViewOnNextLayout = useRef(false)
   useEffect(() => {
     if (isSuccessTables && isSuccessSchemas && tables.length > 0) {
       const schema = schemas.find((s) => s.name === selectedSchema) as PGSchema
@@ -256,8 +257,9 @@ export const SchemaGraph = () => {
         reactFlowInstance.setNodes(nodes)
         reactFlowInstance.setEdges(edges)
         // Prevent resetting a view after first load to avoid layout changes after editing a column
-        if (isFirstLoad.current) {
+        if (isFirstLoad.current || fitViewOnNextLayout.current) {
           isFirstLoad.current = false
+          fitViewOnNextLayout.current = false
           setTimeout(() => reactFlowInstance.fitView({})) // it needs to happen during next event tick
         }
       })
@@ -495,7 +497,10 @@ export const SchemaGraph = () => {
                         type="default"
                         size="tiny"
                         loading={isFetchingNextPage}
-                        onClick={() => fetchNextPage()}
+                        onClick={() => {
+                          fitViewOnNextLayout.current = true
+                          fetchNextPage()
+                        }}
                       >
                         Load more tables
                       </Button>

--- a/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
+++ b/apps/studio/components/interfaces/Database/Schemas/SchemaGraph.tsx
@@ -42,6 +42,7 @@ import { Admonition } from 'ui-patterns/admonition'
 
 import { SidePanelEditor } from '../../TableGridEditor/SidePanelEditor/SidePanelEditor'
 import { DefaultEdge } from './DefaultEdge'
+import { FindTableSelector } from './FindTableSelector'
 import { SchemaGraphContextProvider, SchemaGraphContextType } from './SchemaGraphContext'
 import { SchemaGraphLegend } from './SchemaGraphLegend'
 import { EdgeData, TableNodeData } from './Schemas.constants'
@@ -233,7 +234,13 @@ export const SchemaGraph = () => {
   }
 
   const [schemaSelectorOpen, setSchemaSelectorOpen] = useState(false)
+  const [findTableOpen, setFindTableOpen] = useState(false)
   const [autoLayoutDialogOpen, setAutoLayoutDialogOpen] = useState(false)
+
+  const handleSelectSchema = (name: string) => {
+    setFindTableOpen(false)
+    setSelectedSchema(name)
+  }
 
   const shortcutsEnabled = isSuccessSchemas && !hasNoTables
 
@@ -247,9 +254,13 @@ export const SchemaGraph = () => {
   useShortcut(SHORTCUT_IDS.SCHEMA_VISUALIZER_DOWNLOAD_SVG, () => downloadImage('svg'), {
     enabled: shortcutsEnabled,
   })
+  useShortcut(SHORTCUT_IDS.SCHEMA_VISUALIZER_FIND_TABLE, () => setFindTableOpen(true), {
+    enabled: shortcutsEnabled,
+  })
 
   const isFirstLoad = useRef(true)
   const fitViewOnNextLayout = useRef(false)
+  const pendingFocusTableIdRef = useRef<string | null>(null)
   useEffect(() => {
     if (isSuccessTables && isSuccessSchemas && tables.length > 0) {
       const schema = schemas.find((s) => s.name === selectedSchema) as PGSchema
@@ -262,9 +273,43 @@ export const SchemaGraph = () => {
           fitViewOnNextLayout.current = false
           setTimeout(() => reactFlowInstance.fitView({})) // it needs to happen during next event tick
         }
+        const pendingId = pendingFocusTableIdRef.current
+        if (pendingId !== null && nodes.some((n) => n.id === pendingId)) {
+          pendingFocusTableIdRef.current = null
+          setTimeout(() =>
+            reactFlowInstance.fitView({
+              nodes: [{ id: pendingId }],
+              duration: 300,
+              maxZoom: 1.5,
+            })
+          )
+        }
       })
     }
   }, [isSuccessTables, isSuccessSchemas, tables, reactFlowInstance, ref, schemas, selectedSchema])
+
+  const handleFindTableSelect = async (table: SafePostgresTable) => {
+    const targetId = String(table.id)
+    if (reactFlowInstance.getNode(targetId)) {
+      reactFlowInstance.fitView({
+        nodes: [{ id: targetId }],
+        duration: 300,
+        maxZoom: 1.5,
+      })
+      return
+    }
+    // Selected table isn't loaded yet — queue the fitView and pull pages until
+    // it shows up. The build-effect above will consume the pending id once the
+    // node is mounted.
+    pendingFocusTableIdRef.current = targetId
+    let result = await fetchNextPage()
+    while (
+      result.hasNextPage &&
+      !result.data?.pages.some((page) => page.some((t) => t.id === table.id))
+    ) {
+      result = await fetchNextPage()
+    }
+  }
 
   const schemaGraphContext = useMemo<SchemaGraphContextType>(
     () => ({
@@ -302,23 +347,43 @@ export const SchemaGraph = () => {
 
         {isSuccessSchemas && (
           <>
-            <Shortcut
-              id={SHORTCUT_IDS.SCHEMA_VISUALIZER_FOCUS_SCHEMA}
-              onTrigger={() => setSchemaSelectorOpen(true)}
-              options={{ enabled: isSuccessSchemas }}
-              side="bottom"
-              tooltipOpen={schemaSelectorOpen ? false : undefined}
-            >
-              <SchemaSelector
-                className="w-[180px]"
-                size="tiny"
-                showError={false}
-                selectedSchemaName={selectedSchema}
-                onSelectSchema={setSelectedSchema}
-                open={schemaSelectorOpen}
-                onOpenChange={setSchemaSelectorOpen}
-              />
-            </Shortcut>
+            <div className="flex items-center gap-x-2">
+              <Shortcut
+                id={SHORTCUT_IDS.SCHEMA_VISUALIZER_FOCUS_SCHEMA}
+                onTrigger={() => setSchemaSelectorOpen(true)}
+                options={{ enabled: isSuccessSchemas }}
+                side="bottom"
+                tooltipOpen={schemaSelectorOpen ? false : undefined}
+              >
+                <SchemaSelector
+                  className="w-[180px]"
+                  size="tiny"
+                  showError={false}
+                  selectedSchemaName={selectedSchema}
+                  onSelectSchema={handleSelectSchema}
+                  open={schemaSelectorOpen}
+                  onOpenChange={setSchemaSelectorOpen}
+                />
+              </Shortcut>
+              {!hasNoTables && (
+                <Shortcut
+                  id={SHORTCUT_IDS.SCHEMA_VISUALIZER_FIND_TABLE}
+                  onTrigger={() => setFindTableOpen(true)}
+                  options={{ enabled: shortcutsEnabled }}
+                  side="bottom"
+                  tooltipOpen={findTableOpen ? false : undefined}
+                >
+                  <FindTableSelector
+                    projectRef={project?.ref}
+                    connectionString={project?.connectionString}
+                    schema={selectedSchema}
+                    open={findTableOpen}
+                    onOpenChange={setFindTableOpen}
+                    onSelect={handleFindTableSelect}
+                  />
+                </Shortcut>
+              )}
+            </div>
             {!hasNoTables && (
               <div className="flex items-center gap-x-2">
                 <div className="flex items-center gap-0">

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.tsx
@@ -441,6 +441,9 @@ export const SidePanelEditor = ({
         queryClient.invalidateQueries({
           queryKey: tableKeys.list(project?.ref, selectedTable?.schema, includeColumns),
         }),
+        queryClient.invalidateQueries({
+          queryKey: tableKeys.infiniteListPrefix(project?.ref, selectedTable?.schema),
+        }),
       ])
 
       // We need to invalidate tableRowsAndCount after tableEditor

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SidePanelEditor.utils.tsx
@@ -803,6 +803,14 @@ export const updateTable = async ({
       schema: table.schema,
       payload,
     })
+    await queryClient.invalidateQueries({
+      queryKey: tableKeys.infiniteListPrefix(projectRef, table.schema),
+    })
+    if (payload.schema && payload.schema !== table.schema) {
+      await queryClient.invalidateQueries({
+        queryKey: tableKeys.infiniteListPrefix(projectRef, payload.schema),
+      })
+    }
   }
 
   // Track RLS enablement if it's being turned on

--- a/apps/studio/data/tables/keys.ts
+++ b/apps/studio/data/tables/keys.ts
@@ -2,15 +2,15 @@ export const tableKeys = {
   names: (projectRef: string | undefined) => ['projects', projectRef, 'table-names'] as const,
   list: (projectRef: string | undefined, schema?: string, includeColumns?: boolean) =>
     ['projects', projectRef, 'tables', schema, includeColumns].filter(Boolean),
-  infiniteList: (
-    projectRef: string | undefined,
-    schema?: string,
-    includeColumns?: boolean,
-    pageSize?: number
-  ) =>
-    ['projects', projectRef, 'tables', 'infinite', schema, includeColumns, pageSize].filter(
+  infiniteListPrefix: (projectRef: string | undefined, schema?: string) =>
+    ['projects', projectRef, 'tables', 'infinite', schema].filter(
       (part) => part !== undefined && part !== null && part !== ''
     ),
+  infiniteList: (
+    projectRef: string | undefined,
+    schema: string | undefined,
+    options: { includeColumns?: boolean; pageSize?: number; nameFilter?: string }
+  ) => [...tableKeys.infiniteListPrefix(projectRef, schema), options],
   retrieve: (projectRef: string | undefined, name: string, schema: string) =>
     ['projects', projectRef, 'table', schema, name].filter(Boolean),
 }

--- a/apps/studio/data/tables/tables-query.ts
+++ b/apps/studio/data/tables/tables-query.ts
@@ -130,6 +130,7 @@ export type InfiniteTablesVariables = Pick<
   'projectRef' | 'connectionString' | 'schema' | 'includeColumns'
 > & {
   pageSize?: number
+  nameFilter?: string
 }
 
 export async function getTablesPage(
@@ -140,9 +141,11 @@ export async function getTablesPage(
     includeColumns = false,
     limit,
     afterOid,
+    nameFilter,
   }: Pick<TablesVariables, 'projectRef' | 'connectionString' | 'schema' | 'includeColumns'> & {
     limit: number
     afterOid: number
+    nameFilter?: string
   },
   signal?: AbortSignal
 ) {
@@ -150,16 +153,22 @@ export async function getTablesPage(
     throw new Error('projectRef is required')
   }
 
-  const sql = getTablesPaginatedSql({ schema, includeColumns, limit, afterOid })
+  const sql = getTablesPaginatedSql({ schema, includeColumns, limit, afterOid, nameFilter })
 
   const { result } = await executeSql(
     {
       projectRef,
       connectionString,
       sql,
-      queryKey: tableKeys
-        .infiniteList(projectRef, schema, includeColumns, limit)
-        .concat([afterOid]),
+      queryKey: [
+        `project:${projectRef}`,
+        `schema:${schema}`,
+        `infinite_tables`,
+        includeColumns ? 'with_columns' : null,
+        nameFilter ? `search:${nameFilter}` : null,
+        limit ? `page_size:${limit}` : null,
+        afterOid ? `after:${afterOid}` : null,
+      ],
     },
     signal
   )
@@ -168,14 +177,21 @@ export async function getTablesPage(
 }
 
 export const useInfiniteTablesQuery = <TData = InfiniteData<TablesData>>(
-  { projectRef, connectionString, schema, includeColumns, pageSize = 50 }: InfiniteTablesVariables,
+  {
+    projectRef,
+    connectionString,
+    schema,
+    includeColumns,
+    pageSize = 50,
+    nameFilter,
+  }: InfiniteTablesVariables,
   {
     enabled = true,
     ...options
   }: UseCustomInfiniteQueryOptions<TablesData, TablesError, TData, readonly unknown[], number> = {}
 ) => {
   return useInfiniteQuery({
-    queryKey: tableKeys.infiniteList(projectRef, schema, includeColumns, pageSize),
+    queryKey: tableKeys.infiniteList(projectRef, schema, { includeColumns, pageSize, nameFilter }),
     queryFn: ({ signal, pageParam }) =>
       getTablesPage(
         {
@@ -185,6 +201,7 @@ export const useInfiniteTablesQuery = <TData = InfiniteData<TablesData>>(
           includeColumns,
           limit: pageSize,
           afterOid: pageParam,
+          nameFilter,
         },
         signal
       ),

--- a/apps/studio/state/shortcuts/registry/schema-visualizer.ts
+++ b/apps/studio/state/shortcuts/registry/schema-visualizer.ts
@@ -7,6 +7,7 @@ export const SCHEMA_VISUALIZER_SHORTCUT_IDS = {
   SCHEMA_VISUALIZER_DOWNLOAD_SVG: 'schema-visualizer.download-svg',
   SCHEMA_VISUALIZER_AUTO_LAYOUT: 'schema-visualizer.auto-layout',
   SCHEMA_VISUALIZER_FOCUS_SCHEMA: 'schema-visualizer.focus-schema',
+  SCHEMA_VISUALIZER_FIND_TABLE: 'schema-visualizer.find-table',
 }
 
 export type SchemaVisualizerShortcutId =
@@ -52,6 +53,13 @@ export const schemaVisualizerRegistry: RegistryDefinations<SchemaVisualizerShort
     id: SCHEMA_VISUALIZER_SHORTCUT_IDS.SCHEMA_VISUALIZER_FOCUS_SCHEMA,
     label: 'Open schema selector',
     sequence: ['O', 'S'],
+    showInSettings: false,
+    options: { ignoreInputs: true, registerInCommandMenu: true },
+  },
+  [SCHEMA_VISUALIZER_SHORTCUT_IDS.SCHEMA_VISUALIZER_FIND_TABLE]: {
+    id: SCHEMA_VISUALIZER_SHORTCUT_IDS.SCHEMA_VISUALIZER_FIND_TABLE,
+    label: 'Find table in schema',
+    sequence: ['O', 'T'],
     showInSettings: false,
     options: { ignoreInputs: true, registerInCommandMenu: true },
   },

--- a/e2e/studio/features/database.spec.ts
+++ b/e2e/studio/features/database.spec.ts
@@ -1,4 +1,4 @@
-import { expect } from '@playwright/test'
+import { expect, type Page } from '@playwright/test'
 
 import { env } from '../env.config.js'
 import { expectClipboardValue } from '../utils/clipboard.js'
@@ -13,6 +13,12 @@ import {
   waitForSchemaVisualizerToLoad,
 } from '../utils/wait-for-response.js'
 
+async function focusTableInVisualizer(page: Page, tableName: string) {
+  await page.getByTestId('find-table-selector').click()
+  await page.getByPlaceholder('Find table…').fill(tableName)
+  await page.getByRole('option', { name: tableName, exact: true }).click()
+}
+
 test.describe('Database', () => {
   test.describe('Schema Visualizer', () => {
     test('actions works as expected', async ({ page, ref }) => {
@@ -26,9 +32,18 @@ test.describe('Database', () => {
           await dropTable(databaseTableName)
         }
       )
-      const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=tables-infinite-public')
+
+      const wait = createApiResponseWaiter(
+        page,
+        'pg-meta',
+        ref,
+        'query?key=project:default-schema:public-infinite_tables'
+      )
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/schemas?schema=public`))
       await wait
+
+      // focus the test table so it mounts inside the viewport
+      await focusTableInVisualizer(page, databaseTableName)
 
       // validates table and column exists
       await expect(page.getByText(databaseTableName, { exact: true })).toBeVisible()
@@ -66,9 +81,11 @@ test.describe('Database', () => {
       await page.getByTestId('schema-selector').click()
       await page.getByRole('option', { name: 'auth' }).click()
       await waitForSchemaVisualizerToLoad(page, ref, 'auth')
-      await expect(page.getByText('users', { exact: true })).toBeVisible()
-      await expect(page.getByText('sso_providers', { exact: true })).toBeVisible()
-      await expect(page.getByText('saml_providers', { exact: true })).toBeVisible()
+
+      for (const tableName of ['users', 'sso_providers', 'saml_providers']) {
+        await focusTableInVisualizer(page, tableName)
+        await expect(page.getByText(tableName, { exact: true })).toBeVisible()
+      }
     })
 
     test('table actions work as expected', async ({ page, ref }) => {
@@ -82,9 +99,17 @@ test.describe('Database', () => {
           await dropTable(databaseTableName)
         }
       )
-      const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=tables-infinite-public')
+      const wait = createApiResponseWaiter(
+        page,
+        'pg-meta',
+        ref,
+        'query?key=project:default-schema:public-infinite_tables'
+      )
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/schemas?schema=public`))
       await wait
+
+      // focus the test table so it mounts inside the viewport
+      await focusTableInVisualizer(page, databaseTableName)
 
       // validates table and column exists
       await expect(page.getByText(databaseTableName, { exact: true })).toBeVisible()
@@ -145,9 +170,17 @@ test.describe('Database', () => {
           await dropTable(databaseTableName)
         }
       )
-      const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=tables-infinite-public')
+      const wait = createApiResponseWaiter(
+        page,
+        'pg-meta',
+        ref,
+        'query?key=project:default-schema:public-infinite_tables'
+      )
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/schemas?schema=public`))
       await wait
+
+      // focus the test table so it mounts inside the viewport
+      await focusTableInVisualizer(page, databaseTableName)
 
       // validates table and column exists
       await expect(page.getByText(databaseTableName, { exact: true })).toBeVisible()

--- a/e2e/studio/features/database.spec.ts
+++ b/e2e/studio/features/database.spec.ts
@@ -10,6 +10,7 @@ import {
   createApiResponseWaiter,
   waitForApiResponse,
   waitForDatabaseToLoad,
+  waitForSchemaVisualizerToLoad,
 } from '../utils/wait-for-response.js'
 
 test.describe('Database', () => {
@@ -25,12 +26,7 @@ test.describe('Database', () => {
           await dropTable(databaseTableName)
         }
       )
-      const wait = createApiResponseWaiter(
-        page,
-        'pg-meta',
-        ref,
-        'tables?include_columns=true&included_schemas=public'
-      )
+      const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=tables-infinite-public')
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/schemas?schema=public`))
       await wait
 
@@ -69,7 +65,7 @@ test.describe('Database', () => {
       // changing schema -> auth
       await page.getByTestId('schema-selector').click()
       await page.getByRole('option', { name: 'auth' }).click()
-      await waitForDatabaseToLoad(page, ref, 'auth')
+      await waitForSchemaVisualizerToLoad(page, ref, 'auth')
       await expect(page.getByText('users', { exact: true })).toBeVisible()
       await expect(page.getByText('sso_providers', { exact: true })).toBeVisible()
       await expect(page.getByText('saml_providers', { exact: true })).toBeVisible()
@@ -86,12 +82,7 @@ test.describe('Database', () => {
           await dropTable(databaseTableName)
         }
       )
-      const wait = createApiResponseWaiter(
-        page,
-        'pg-meta',
-        ref,
-        'tables?include_columns=true&included_schemas=public'
-      )
+      const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=tables-infinite-public')
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/schemas?schema=public`))
       await wait
 
@@ -154,12 +145,7 @@ test.describe('Database', () => {
           await dropTable(databaseTableName)
         }
       )
-      const wait = createApiResponseWaiter(
-        page,
-        'pg-meta',
-        ref,
-        'tables?include_columns=true&included_schemas=public'
-      )
+      const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=tables-infinite-public')
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/schemas?schema=public`))
       await wait
 

--- a/e2e/studio/utils/wait-for-response.ts
+++ b/e2e/studio/utils/wait-for-response.ts
@@ -119,6 +119,6 @@ export async function waitForSchemaVisualizerToLoad(page: Page, ref: string, sch
     page,
     'pg-meta',
     ref,
-    `query?key=tables-infinite-${databaseSchema}`
+    `query?key=project:default-schema:${schema ?? 'public'}-infinite_tables`
   )
 }

--- a/e2e/studio/utils/wait-for-response.ts
+++ b/e2e/studio/utils/wait-for-response.ts
@@ -112,3 +112,13 @@ export async function waitForDatabaseToLoad(page: Page, ref: string, schema?: st
     `tables?include_columns=true&included_schemas=${databaseSchema}`
   )
 }
+
+export async function waitForSchemaVisualizerToLoad(page: Page, ref: string, schema?: string) {
+  const databaseSchema = schema || 'public'
+  return await waitForApiResponse(
+    page,
+    'pg-meta',
+    ref,
+    `query?key=tables-infinite-${databaseSchema}`
+  )
+}

--- a/packages/pg-meta/src/sql/studio/database/tables-paginated.ts
+++ b/packages/pg-meta/src/sql/studio/database/tables-paginated.ts
@@ -21,11 +21,13 @@ export const getTablesPaginatedSql = ({
   includeColumns = false,
   limit,
   afterOid,
+  nameFilter,
 }: {
   schema?: string
   includeColumns?: boolean
   limit: number
   afterOid: number
+  nameFilter?: string
 }): SafeSqlFragment => {
   const filter = filterByList(
     schema ? [schema] : undefined,
@@ -33,6 +35,10 @@ export const getTablesPaginatedSql = ({
     schema ? undefined : DEFAULT_SYSTEM_SCHEMAS
   )
   const schemaFilter = filter ? safeSql`and nc.nspname ${filter}` : safeSql``
+  const nameFilterClause =
+    nameFilter && nameFilter.length > 0
+      ? safeSql`and c.relname ilike ${literal(`%${escapeIlikeLiteral(nameFilter)}%`)}`
+      : safeSql``
 
   const columnsCte = includeColumns
     ? safeSql`, columns as (${getColumnsSql({
@@ -70,6 +76,7 @@ export const getTablesPaginatedSql = ({
           or has_any_column_privilege(c.oid, 'SELECT, INSERT, UPDATE, REFERENCES')
         )
         ${schemaFilter}
+        ${nameFilterClause}
       order by c.oid
       limit ${literal(limit)}
     ),
@@ -196,3 +203,8 @@ export const getTablesPaginatedSql = ({
     order by tables.id
   `
 }
+
+// Escape LIKE/ILIKE wildcards so user input is matched literally. ILIKE's
+// default escape character is `\`, so we escape `\`, `%`, and `_` and let the
+// pattern carry its own surrounding `%`s as wildcards.
+const escapeIlikeLiteral = (value: string) => value.replace(/([\\%_])/g, '\\$1')

--- a/packages/pg-meta/test/sql/studio/tables-paginated.test.ts
+++ b/packages/pg-meta/test/sql/studio/tables-paginated.test.ts
@@ -287,6 +287,48 @@ withTestDatabase('includeColumns: true returns columns per row', async ({ execut
   expect(empty.columns).toEqual([])
 })
 
+withTestDatabase(
+  'nameFilter restricts results to tables whose name matches (case-insensitive)',
+  async ({ executeQuery }) => {
+    await executeQuery(`
+      create table public.users_archive_2024 (id bigint primary key);
+      create table public.users_archive_2025 (id bigint primary key);
+    `)
+
+    const sql = getTablesPaginatedSql({
+      schema: 'public',
+      limit: 100,
+      afterOid: 0,
+      nameFilter: 'USERS_ARCHIVE',
+    })
+    const rows = await executeQuery<Row[]>(sql)
+    const names = rows.map((r) => r.name).sort()
+    expect(names).toEqual(['users_archive_2024', 'users_archive_2025'])
+  }
+)
+
+withTestDatabase(
+  'nameFilter escapes LIKE wildcards so they match literally',
+  async ({ executeQuery }) => {
+    await executeQuery(`
+      create table public."weird_name" (id bigint primary key);
+      create table public."weird%name" (id bigint primary key);
+    `)
+
+    const sql = getTablesPaginatedSql({
+      schema: 'public',
+      limit: 100,
+      afterOid: 0,
+      nameFilter: 'weird%',
+    })
+    const rows = await executeQuery<Row[]>(sql)
+    const names = rows.map((r) => r.name)
+    // Only the table with a literal `%` in its name should match.
+    expect(names).toContain('weird%name')
+    expect(names).not.toContain('weird_name')
+  }
+)
+
 withTestDatabase('afterOid skips tables with smaller oids', async ({ executeQuery }) => {
   const fullSql = getTablesPaginatedSql({ schema: 'public', limit: 1000, afterOid: 0 })
   const all = await executeQuery<Row[]>(fullSql)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Performance improvement / feature

## What is the current behavior?

The Schema Designer fetches all tables in a single request via `useTablesQuery`. For schemas with 400+ tables this blocks first paint on a large payload.

## What is the new behavior?

`SchemaGraph` uses `useInfiniteTablesQuery` (pageSize: 100) so the first 100 tables paint immediately. A "Load more tables" button appears above the legend whenever more pages remain, letting users load the rest on demand.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Find table…" selector and keyboard shortcut to quickly locate and focus tables; supports incremental loading and debounced name search (with literal wildcard handling).
  * Schema Graph shows a bottom "Load more tables" control with loading state and preserves view after loading more.

* **Refactor**
  * Table listing switched to infinite/paginated retrieval and improved "no tables" logic; server-side name filtering supported.

* **Tests**
  * E2E tests add a schema-visualizer wait helper and update flows to support the paginated visualizer.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->