### PR TITLE
feat(logs): brand Reports logs presets with SafeLogSqlFragment

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -3,6 +3,13 @@ import dayjs from 'dayjs'
 
 import type { DatetimeHelper } from '../Settings/Logs/Logs.types'
 import { PresetConfig, Presets, ReportFilterItem } from './Reports.types'
+import {
+  analyticsLiteral,
+  joinSqlFragments,
+  quotedIdent,
+  safeSql as safeLogSql,
+  type SafeLogSqlFragment,
+} from '@/data/logs/safe-analytics-sql'
 import { PlanId } from '@/data/subscriptions/types'
 
 export const LAYOUT_COLUMN_COUNT = 2
@@ -133,13 +140,67 @@ export const generateRegexpWhere = (filters: ReportFilterItem[], prepend = true)
   }
 }
 
+// Unlike the legacy `generateRegexpWhere`, this function requires filter values
+// to be raw (unquoted) strings or numbers. `analyticsLiteral` handles all
+// quoting and escaping — callers must NOT pre-wrap values in single quotes.
+export function generateRegexpWhereSafe(
+  filters: ReportFilterItem[],
+  prepend = true
+): SafeLogSqlFragment {
+  if (filters.length === 0) return safeLogSql``
+
+  const conditions = filters
+    .map((filter) => {
+      const splitKey = filter.key.split('.')
+      const normalizedKey = [splitKey[splitKey.length - 2], splitKey[splitKey.length - 1]].join('.')
+      const keyToQuote = filter.key.includes('.') ? normalizedKey : filter.key
+
+      let col: SafeLogSqlFragment
+      try {
+        col = quotedIdent(keyToQuote)
+      } catch {
+        return null
+      }
+
+      const valueIsNumber = !isNaN(Number(filter.value))
+      const lit = valueIsNumber
+        ? analyticsLiteral(Number(filter.value))
+        : analyticsLiteral(String(filter.value).toLowerCase())
+
+      switch (filter.compare) {
+        case 'matches':
+          return safeLogSql`REGEXP_CONTAINS(${col}, ${lit})`
+        case 'is':
+          return safeLogSql`${col} = ${lit}`
+        case '!=':
+          return safeLogSql`${col} != ${lit}`
+        case '>=':
+          return safeLogSql`${col} >= ${lit}`
+        case '<=':
+          return safeLogSql`${col} <= ${lit}`
+        case '>':
+          return safeLogSql`${col} > ${lit}`
+        case '<':
+          return safeLogSql`${col} < ${lit}`
+        default:
+          return safeLogSql`${col} = ${lit}`
+      }
+    })
+    .filter((c) => c !== null)
+
+  if (conditions.length === 0) return safeLogSql``
+
+  const joined = joinSqlFragments(conditions, ' AND ')
+  return prepend ? safeLogSql`WHERE ${joined}` : safeLogSql`AND ${joined}`
+}
+
 export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
   [Presets.API]: {
     title: 'API',
     queries: {
       totalRequests: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-total-requests
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -149,7 +210,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         GROUP BY
           timestamp
         ORDER BY
@@ -157,7 +218,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       topRoutes: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-top-routes
         select
           request.path as path,
@@ -170,7 +231,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         group by
           request.path, request.method, request.search, response.status_code
         order by
@@ -180,7 +241,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       errorCounts: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-error-counts
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -192,7 +253,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(request.headers) as headers
         WHERE
           response.status_code >= 400
-        ${generateRegexpWhere(filters, false)}
+        ${generateRegexpWhereSafe(filters, false)}
         GROUP BY
           timestamp
         ORDER BY
@@ -201,7 +262,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       topErrorRoutes: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-top-error-routes
         select
           request.path as path,
@@ -216,7 +277,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(request.headers) as headers
         where
           response.status_code >= 400
-        ${generateRegexpWhere(filters, false)}
+        ${generateRegexpWhereSafe(filters, false)}
         group by
           request.path, request.method, request.search, response.status_code
         order by
@@ -226,7 +287,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       responseSpeed: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-response-speed
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -237,7 +298,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         GROUP BY
           timestamp
         ORDER BY
@@ -246,7 +307,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       topSlowRoutes: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-top-slow-routes
         select
           request.path as path,
@@ -260,7 +321,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-        ${generateRegexpWhere(filters)}
+        ${generateRegexpWhereSafe(filters)}
         group by
           request.path, request.method, request.search, response.status_code
         order by
@@ -270,7 +331,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       networkTraffic: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-network-traffic
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -299,7 +360,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
           cross join unnest(response.headers) as resp_headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         GROUP BY
           timestamp
         ORDER BY
@@ -308,7 +369,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       requestsByCountry: {
         queryType: 'logs',
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-api-requests-by-country
         select
           cf.country as country,
@@ -321,7 +382,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
           cross join unnest(request.cf) as cf
         where
           cf.country is not null
-        ${generateRegexpWhere(filters, false)}
+        ${generateRegexpWhereSafe(filters, false)}
         group by
           cf.country
         `,
@@ -338,7 +399,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       cacheHitRate: {
         queryType: 'logs',
         // storage report does not perform any filtering
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-storage-cache-hit-rate
 SELECT
   timestamp_trunc(timestamp, hour) as timestamp,
@@ -350,7 +411,7 @@ from edge_logs f
   cross join unnest(m.response) as res
   cross join unnest(res.headers) as h
 where starts_with(r.path, '/storage/v1/object') and r.method = 'GET'
-  ${generateRegexpWhere(filters, false)}
+  ${generateRegexpWhereSafe(filters, false)}
 group by timestamp
 order by timestamp desc
 `,
@@ -358,7 +419,7 @@ order by timestamp desc
       topCacheMisses: {
         queryType: 'logs',
         // storage report does not perform any filtering
-        sql: (filters) => `
+        sql: (filters) => safeLogSql`
         -- reports-storage-top-cache-misses
 SELECT
   r.path as path,
@@ -372,7 +433,7 @@ from edge_logs f
 where starts_with(r.path, '/storage/v1/object')
   and r.method = 'GET'
   and h.cf_cache_status in ('MISS', 'NONE/UNKNOWN', 'EXPIRED', 'BYPASS', 'DYNAMIC')
-  ${generateRegexpWhere(filters, false)}
+  ${generateRegexpWhereSafe(filters, false)}
 group by path, search
 order by count desc
 limit 12

--- a/apps/studio/components/interfaces/Reports/Reports.types.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.types.ts
@@ -1,5 +1,6 @@
 import type { SafeSqlFragment } from '@supabase/pg-meta'
 
+import type { SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
 import type { ResponseError } from '@/types'
 
 export enum Presets {
@@ -31,7 +32,7 @@ export interface ReportQueryLogs {
     filterIndexAdvisor?: boolean,
     page?: number,
     pageSize?: number
-  ) => string
+  ) => SafeLogSqlFragment
 }
 
 export interface ReportQueryDb {

--- a/apps/studio/components/interfaces/Reports/Reports.utils.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.tsx
@@ -10,6 +10,7 @@ import {
   isUnixMicro,
   unixMicroToIsoTimestamp,
 } from '@/components/interfaces/Settings/Logs/Logs.utils'
+import type { SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
 import { REPORT_STATUS_CODE_COLORS } from '@/data/reports/report.utils'
 import useDbQuery, { DbQueryHook } from '@/hooks/analytics/useDbQuery'
 import useLogsQuery, { LogsQueryHook } from '@/hooks/analytics/useLogsQuery'
@@ -49,7 +50,7 @@ export const queriesFactory = <T extends string>(
   return hooks
 }
 
-export function getLogsSql(query: ReportQuery, filters: ReportFilterItem[]): string {
+export function getLogsSql(query: ReportQuery, filters: ReportFilterItem[]): SafeLogSqlFragment {
   if (query.queryType !== 'logs') {
     throw new Error(`Expected logs query, got ${query.queryType}`)
   }

--- a/apps/studio/data/reports/api-report-query.ts
+++ b/apps/studio/data/reports/api-report-query.ts
@@ -66,7 +66,7 @@ export const useApiReport = () => {
   const formattedFilters: ReportFilterItem[] = [
     ...filters,
     ...(identifier !== undefined
-      ? [{ key: 'identifier', value: `'${identifier}'`, compare: 'is' } as ReportFilterItem]
+      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
       : []),
   ]
 

--- a/apps/studio/data/reports/storage-report-query.ts
+++ b/apps/studio/data/reports/storage-report-query.ts
@@ -80,7 +80,7 @@ export const useStorageReport = () => {
   const formattedFilters: ReportFilterItem[] = [
     ...filters,
     ...(identifier !== undefined
-      ? [{ key: 'identifier', value: `'${identifier}'`, compare: 'is' } as ReportFilterItem]
+      ? [{ key: 'identifier', value: identifier, compare: 'is' } as ReportFilterItem]
       : []),
   ]
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor / security hardening (part of a stacked series applying compile-time SQL provenance tracking to analytics call sites).

## What is the current behavior?

The `queryType: 'logs'` presets in `PRESET_CONFIG` (API ×8, Storage ×2) build BigQuery SQL by splicing filter keys and values via plain string interpolation through `generateRegexpWhere`, with no compile-time guarantee that the output is injection-safe. `ReportQueryLogs.sql` returns `string` and `getLogsSql` returns `string`.

## What is the new behavior?

- `generateRegexpWhereSafe` added to `Reports.constants.ts`: routes filter keys through `quotedIdent` (dropping predicates whose identifier fails the `[A-Za-z_][A-Za-z0-9_]*` regex) and values through `analyticsLiteral`. Values must be raw/unquoted — the function handles all quoting and escaping itself.
- All ten `queryType: 'logs'` presets migrated to use the `safeLogSql` template tag and `generateRegexpWhereSafe`.
- `ReportQueryLogs.sql` return type tightened from `string` to `SafeLogSqlFragment`; `getLogsSql` return type updated to match.
- Manual pre-quoting of the `identifier` filter removed in `useApiReport` and `useStorageReport` (`value: \`'${identifier}'\`` → `value: identifier`), since `analyticsLiteral` now handles quoting.

## Additional context

Smoke test: `/observability/api-overview`, `/observability/storage`. To exercise the replica `identifier` filter, select a replica on `/observability/database` first, then navigate to those pages.