### PR TITLE
feat(logs): brand SharedAPIReport SQL with SafeLogSqlFragment

### DIFF
--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
@@ -4,24 +4,36 @@ import { useParams } from 'common'
 import { isEqual } from 'lodash'
 import { useState } from 'react'
 
-import { generateRegexpWhere } from '../Reports.constants'
+import { generateRegexpWhereSafe } from '../Reports.constants'
 import { ReportFilterItem } from '../Reports.types'
-import { get } from '@/data/fetchers'
+import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
+import { safeSql, type SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
+
+const SOURCE_TABLE: Record<string, SafeLogSqlFragment> = {
+  edge_logs: safeSql`edge_logs`,
+  function_edge_logs: safeSql`function_edge_logs`,
+}
+
+/** Returns a branded source table fragment, falling back to `edge_logs`. */
+function sourceTable(src: string): SafeLogSqlFragment {
+  return SOURCE_TABLE[src] ?? SOURCE_TABLE.edge_logs
+}
 
 export const SHARED_API_REPORT_SQL = {
   totalRequests: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs') => `
+    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+      safeSql`
         --reports-api-total-requests
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
           count(t.id) as count
-        FROM ${src} t
+        FROM ${sourceTable(src)} t
           cross join unnest(metadata) as m
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         GROUP BY
           timestamp
         ORDER BY
@@ -29,7 +41,8 @@ export const SHARED_API_REPORT_SQL = {
   },
   topRoutes: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs') => `
+    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+      safeSql`
         -- reports-api-top-routes
         select
           request.path as path,
@@ -37,12 +50,12 @@ export const SHARED_API_REPORT_SQL = {
           request.search as search,
           response.status_code as status_code,
           count(t.id) as count
-        from ${src} t
+        from ${sourceTable(src)} t
           cross join unnest(metadata) as m
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         group by
           request.path, request.method, request.search, response.status_code
         order by
@@ -52,19 +65,20 @@ export const SHARED_API_REPORT_SQL = {
   },
   errorCounts: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs') => `
+    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+      safeSql`
         -- reports-api-error-counts
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
           count(t.id) as count
-        FROM ${src} t
+        FROM ${sourceTable(src)} t
           cross join unnest(metadata) as m
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
         WHERE
           response.status_code >= 400
-        ${generateRegexpWhere(filters, false)}
+        ${generateRegexpWhereSafe(filters, false)}
         GROUP BY
           timestamp
         ORDER BY
@@ -73,7 +87,8 @@ export const SHARED_API_REPORT_SQL = {
   },
   topErrorRoutes: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs') => `
+    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+      safeSql`
         -- reports-api-top-error-routes
         select
           request.path as path,
@@ -81,14 +96,14 @@ export const SHARED_API_REPORT_SQL = {
           request.search as search,
           response.status_code as status_code,
           count(t.id) as count
-        from ${src} t
+        from ${sourceTable(src)} t
           cross join unnest(metadata) as m
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
         where
           response.status_code >= 400
-        ${generateRegexpWhere(filters, false)}
+        ${generateRegexpWhereSafe(filters, false)}
         group by
           request.path, request.method, request.search, response.status_code
         order by
@@ -98,18 +113,19 @@ export const SHARED_API_REPORT_SQL = {
   },
   responseSpeed: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs') => `
+    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+      safeSql`
         -- reports-api-response-speed
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
           avg(response.origin_time) as avg
         FROM
-          ${src} t
+          ${sourceTable(src)} t
           cross join unnest(metadata) as m
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         GROUP BY
           timestamp
         ORDER BY
@@ -118,7 +134,8 @@ export const SHARED_API_REPORT_SQL = {
   },
   topSlowRoutes: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs') => `
+    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+      safeSql`
         -- reports-api-top-slow-routes
         select
           request.path as path,
@@ -127,12 +144,12 @@ export const SHARED_API_REPORT_SQL = {
           response.status_code as status_code,
           count(t.id) as count,
           avg(response.origin_time) as avg
-        from ${src} t
+        from ${sourceTable(src)} t
           cross join unnest(metadata) as m
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
-        ${generateRegexpWhere(filters)}
+        ${generateRegexpWhereSafe(filters)}
         group by
           request.path, request.method, request.search, response.status_code
         order by
@@ -142,7 +159,8 @@ export const SHARED_API_REPORT_SQL = {
   },
   networkTraffic: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs') => `
+    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+      safeSql`
         -- reports-api-network-traffic
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -165,13 +183,13 @@ export const SHARED_API_REPORT_SQL = {
             0
           ) as egress_mb,
         FROM
-          ${src} t
+          ${sourceTable(src)} t
           cross join unnest(metadata) as m
           cross join unnest(m.response) as response
           cross join unnest(m.request) as request
           cross join unnest(request.headers) as headers
           cross join unnest(response.headers) as resp_headers
-          ${generateRegexpWhere(filters)}
+          ${generateRegexpWhereSafe(filters)}
         GROUP BY
           timestamp
         ORDER BY
@@ -181,42 +199,6 @@ export const SHARED_API_REPORT_SQL = {
 }
 
 export type SharedAPIReportKey = keyof typeof SHARED_API_REPORT_SQL
-
-const fetchLogs = async ({
-  projectRef,
-  sql,
-  start,
-  end,
-}: {
-  projectRef: string
-  sql: string
-  start: string
-  end: string
-}) => {
-  const { data, error } = await get(`/platform/projects/{ref}/analytics/endpoints/logs.all`, {
-    params: {
-      path: { ref: projectRef },
-      query: {
-        sql,
-        iso_timestamp_start: start,
-        iso_timestamp_end: end,
-      },
-    },
-  })
-
-  if (error || data?.error) {
-    Sentry.captureException({
-      message: 'Shared API Report Error',
-      data: {
-        error,
-        data,
-      },
-    })
-    throw error || data?.error
-  }
-
-  return data
-}
 
 const DEFAULT_KEYS = ['shared-api-report']
 
@@ -282,13 +264,23 @@ export const useSharedAPIReport = ({
         ref,
       ],
       enabled: enabled && !!ref && !!filterBy,
-      queryFn: () =>
-        fetchLogs({
-          projectRef: ref,
-          sql: value.sql(allFilters, filterByMapSource[filterBy]),
-          start,
-          end,
-        }),
+      queryFn: async () => {
+        try {
+          const data = await executeAnalyticsSql({
+            projectRef: ref,
+            endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all',
+            sql: value.sql(allFilters, filterByMapSource[filterBy]),
+            iso_timestamp_start: start,
+            iso_timestamp_end: end,
+            method: 'get',
+          })
+          if (data?.error) throw data.error
+          return data
+        } catch (err) {
+          Sentry.captureException({ message: 'Shared API Report Error', data: { error: err } })
+          throw err
+        }
+      },
     })),
   })
 
@@ -341,7 +333,7 @@ export const useSharedAPIReport = ({
 
   const isLoadingData = Object.values(isLoading).some(Boolean)
 
-  const SQLMap: Record<SharedAPIReportKey, string> = {
+  const SQLMap: Record<SharedAPIReportKey, SafeLogSqlFragment> = {
     totalRequests: SHARED_API_REPORT_SQL.totalRequests.sql(allFilters, filterByMapSource[filterBy]),
     topRoutes: SHARED_API_REPORT_SQL.topRoutes.sql(allFilters, filterByMapSource[filterBy]),
     errorCounts: SHARED_API_REPORT_SQL.errorCounts.sql(allFilters, filterByMapSource[filterBy]),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Security / refactor — migrates `SharedAPIReport.constants.ts` to the proven-authorship model (`SafeLogSqlFragment`).

## What is the current behavior?

All seven SQL builders in `SHARED_API_REPORT_SQL` return plain `string` and interpolate filter values via `generateRegexpWhere`, which performs manual quoting without sanitization. The source table name (`edge_logs` / `function_edge_logs`) is also interpolated as a raw string. Queries are executed via a local `fetchLogs` function that calls `get()` directly, bypassing the `executeAnalyticsSql` wire boundary.

## What is the new behavior?

- Each SQL builder is rewritten with the `safeLogSql` template tag and returns `SafeLogSqlFragment`.
- Filter keys route through `quotedIdent` (predicates with invalid identifiers are dropped); values route through `analyticsLiteral` (single quotes and backslashes are escaped).
- A `SOURCE_TABLE` branded map covers the two possible source tables; `sourceTable()` looks up the branded fragment instead of interpolating a raw string.
- `fetchLogs` is removed; `useQueries` calls `executeAnalyticsSql` directly with `method: 'get'`, routing through the shared wire boundary.
- The `queryFn` wraps the call in a try/catch that also checks `data?.error`, preserving the original Sentry capture behaviour (`'Shared API Report Error'`) for both network and API-level errors.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error detection and reporting for analytics queries with enhanced monitoring integration.

* **Chores**
  * Strengthened internal security measures and stability protocols for report generation and data processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46405?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->