### PR TITLE
[FE-3483] fix(studio): redirect OAuth callback errors to /sign-in

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -2,6 +2,7 @@ import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { zodResolver } from '@hookform/resolvers/zod'
 import type { AuthError } from '@supabase/supabase-js'
 import { useQueryClient } from '@tanstack/react-query'
+import { useAuthError } from 'common'
 import { Eye, EyeOff } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -13,6 +14,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import z from 'zod'
 
 import { LastSignInWrapper } from './LastSignInWrapper'
+import AlertError from '@/components/ui/AlertError'
 import { useAddLoginEvent } from '@/data/misc/audit-login-mutation'
 import { getMfaAuthenticatorAssuranceLevel } from '@/data/profile/mfa-authenticator-assurance-level-query'
 import { useLastSignIn } from '@/hooks/misc/useLastSignIn'
@@ -115,9 +117,12 @@ export const SignInForm = () => {
     }
   }
 
+  const authError = useAuthError()
+
   return (
     <Form {...form}>
       <form id={formId} className="flex flex-col gap-4" onSubmit={form.handleSubmit(onSubmit)}>
+        {authError && <AlertError error={authError} subject="Error while signing in" />}
         <FormField
           key="email"
           name="email"

--- a/apps/studio/pages/sign-in-mfa.tsx
+++ b/apps/studio/pages/sign-in-mfa.tsx
@@ -42,9 +42,10 @@ const SignInMfaPage: NextPageWithLayout = () => {
       .initialize()
       .then(async ({ error }) => {
         if (error) {
-          // if there was a problem signing in via the url, don't redirect
-          setLoading(false)
-          return
+          // OAuth/SSO callback failed — bounce back to /sign-in so the error renders under the
+          // correct heading instead of "Two-factor authentication". The error is held in the
+          // shared auth context and surfaces via useAuthError() on /sign-in.
+          return router.replace({ pathname: '/sign-in', query: router.query })
         }
 
         const token = await getAccessToken()


### PR DESCRIPTION
OAuth/SSO callback failures (e.g. GitHub returning an email that collides with gotrue's `users_email_partial_key` constraint) were stranding users on `/sign-in-mfa` with the raw error rendered under the "Two-factor authentication" heading. They now redirect to `/sign-in`, where the error surfaces above the email form under "Welcome back" and the form stays interactive so users can fall back to email/password without refreshing.

Addresses FE-3483.

**Changed:**
- `pages/sign-in-mfa.tsx`: redirect to `/sign-in` when `auth.initialize()` returns an error, instead of stopping the loader and rendering the error on the MFA page. The error is already captured in the shared `AuthProvider` state by `gotrueClient.initialize()` before the redirect, so it survives the navigation via `useAuthError()`.
- `components/interfaces/SignIn/SignInForm.tsx`: render `useAuthError()` as an inline `AlertError` above the email/password fields. Form stays interactive so users hitting the duplicate-email case can use email sign-in inline.

This is the "surgical" option from the ticket — option 3 (point the OAuth callbacks at `/sign-in` directly) is still the right long-term cleanup.

## To test

1. Visit `/sign-in-mfa#error=server_error&error_description=Database+error+saving+new+user` — should redirect to `/sign-in` with the error rendered above the email form under "Welcome back".
2. Type into the email/password fields — form should be interactive (this is the part the "replace the form" alternative would have broken).
3. Hard-reload `/sign-in` — no `AlertError`, normal form.
4. Sign in with a real email/password account that has MFA enabled — `/sign-in-mfa` should load normally with the "Two-factor authentication" heading and verification form. No redirect, no `AlertError`.
5. Try `/sign-in-mfa?returnTo=%2Forganizations#error=server_error&error_description=test` — after redirect the URL should be `/sign-in?returnTo=%2Forganizations` (query preserved, hash consumed by gotrue).