### PR TITLE
docs(self-hosted): add quick start and describe setup and management scripts

### DIFF
--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -416,7 +416,7 @@ The `config add` / `config remove` commands manage the `COMPOSE_FILE` [variable]
 
 We publish stable releases of the Docker Compose setup approximately once a month. The versions in each release are tested together, so they may lag behind the latest images on Docker Hub. To update, apply the latest changes from the repository and restart the services. If you want to run different versions of individual services, you can change the image tags in the Docker Compose file, but compatibility is **not guaranteed**. All Supabase images are available on [Docker Hub](https://hub.docker.com/u/supabase).
 
-To follow the changes and updates, refer to the self-hosted Supabase [changelog](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md). Make sure to also check the [Discussions](https://github.com/orgs/supabase/discussions/categories/changelog?discussions_q=is%3Aopen+category%3AChangelog+label%3Aself-hosted).
+To follow the changes and updates, refer to the self-hosted Supabase [changelog](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md). Make sure to also check the [GitHub Discussions](https://github.com/orgs/supabase/discussions/categories/changelog?discussions_q=is%3Aopen+category%3AChangelog+label%3Aself-hosted).
 
 After updating the configuration, you need to restart services to pick up the changes, which may result in downtime for your applications and users.
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -56,7 +56,7 @@ If you don't need specific services, such as Realtime, Storage, imgproxy, or Edg
 
 <Admonition type="tip">
 
-The default configuration does not include [Logs & Analytics](/features/logs-analytics). You can enable Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional docker-compose override file. Note that enabling these services will increase resource requirements.
+The default configuration does not include [Logs & Analytics](/features/logs-analytics). You can [enable](#enabling-analytics) Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional docker-compose override file. Note that enabling these services will increase resource requirements.
 
 </Admonition>
 
@@ -77,7 +77,7 @@ curl -fsSL https://supabase.link/setup.sh | sh
 
 The script supports Linux only (Debian/Ubuntu and RHEL/CentOS/Fedora) and will:
 
-- Install prerequisites (`git`, `curl`, `openssl`, `jq`) and Docker Engine if not already present
+- Install prerequisites (`git`, `openssl`, `jq`) and Docker Engine if not already present
 - Sparse-clone the `docker/` directory from the main Supabase [repository](https://github.com/supabase/supabase/)
 - Create a project directory (`supabase-project` by default) and copy the configuration files into it
 - Prompt for the main URLs (`SUPABASE_PUBLIC_URL`, `API_EXTERNAL_URL`, `SITE_URL`, `PROXY_DOMAIN`) and write them to `.env`
@@ -293,7 +293,7 @@ sh tests/test-container-logs.sh
 Then try inspecting the Docker logs for a specific container, e.g.,
 
 ```sh
-sh run.sh logs db
+sh run.sh logs storage
 ```
 
 To stop Supabase, use:

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -599,4 +599,4 @@ Some suggested systems include:
 
 1. The VPS instance is a DigitalOcean droplet. (For server requirements refer to [System requirements](#system-requirements))
 2. To access Studio, use the IPv4 IP address of your Droplet.
-3. XXXXX - If you're unable to use Studio, run `docker compose ps` to see if all services are up and healthy.
+3. If you're unable to use Studio, run `docker compose ps` to see if all services are up and healthy.

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -371,7 +371,7 @@ Each of the APIs is available through the same API gateway:
 
 ## Enabling analytics
 
-Logs & Analytics are not included in the default configuration. To enable them:
+Logs & Analytics are not included in the default configuration to reduce the memory footprint. To enable them:
 
 ```sh
 sh run.sh config add logs && \

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -32,14 +32,12 @@ If you're new to these topics, consider starting with the managed [Supabase plat
 You need the following installed on your system:
 
 - [Git](https://git-scm.com/downloads)
-- OpenSSL
 - [Docker](https://docs.docker.com/manuals/):
   - **Linux server/VPS**: Install [Docker Engine](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
   - **Linux desktop**: Install [Docker Desktop](https://docs.docker.com/desktop/setup/install/linux/)
   - **macOS**: Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/)
   - **Windows**: Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/)
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-
 
 ## System requirements
 
@@ -55,7 +53,7 @@ If you don't need specific services, such as Realtime, Storage, imgproxy, or Edg
 
 <Admonition type="tip">
 
-The default configuration does not include [Logs & Analytics](https://supabase.com/features/logs-analytics). You can enable Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional `docker-compose` override file. Note that enabling these services will increase resource requirements.
+The default configuration does not include [Logs & Analytics](/features/logs-analytics). You can enable Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional `docker-compose` override file. Note that enabling these services will increase resource requirements.
 
 </Admonition>
 
@@ -315,7 +313,7 @@ Each of the APIs is available through the same API gateway:
 - Storage: `http://<your-domain>:8000/storage/v1/`
 - Realtime: `http://<your-domain>:8000/realtime/v1/`
 
-## Enabling Logs & Analytics
+## Enabling analytics
 
 Logs & Analytics are not included in the default configuration. To enable them:
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -5,13 +5,15 @@ subtitle: "Learn how to configure and deploy Supabase with Docker."
 tocVideo: "FqiQKRKsfZE"
 ---
 
-Docker is the easiest way to get started with self-hosted Supabase. It should take you less than 30 minutes to get up and running.
+Docker is the easiest way to get started with self-hosted Supabase. It should take you less than 15 minutes to get up and running.
 
 ## Contents
 
 1. [Before you begin](#before-you-begin)
 2. [System requirements](#system-requirements)
 3. [Installing Supabase](#installing-supabase)
+   - [Quick start (Linux)](#quick-start-linux)
+   - [Manual installation](#manual-installation)
 4. [Configuring and securing Supabase](#configuring-and-securing-supabase)
 5. [Starting and stopping](#starting-and-stopping)
 6. [Accessing Supabase services](#accessing-supabase-studio-dashboard)
@@ -24,6 +26,7 @@ Docker is the easiest way to get started with self-hosted Supabase. It should ta
 This guide assumes you're comfortable with:
 
 - Linux server administration basics
+- Basic `git` usage
 - Docker and Docker Compose
 - Networking fundamentals (ports, DNS, firewalls)
 
@@ -53,13 +56,56 @@ If you don't need specific services, such as Realtime, Storage, imgproxy, or Edg
 
 <Admonition type="tip">
 
-The default configuration does not include [Logs & Analytics](/features/logs-analytics). You can enable Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional `docker-compose` override file. Note that enabling these services will increase resource requirements.
+The default configuration does not include [Logs & Analytics](/features/logs-analytics). You can enable Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional docker-compose override file. Note that enabling these services will increase resource requirements.
 
 </Admonition>
 
 ## Installing Supabase
 
-First, copy the Docker configuration files to your project directory. Choose one of the options below:
+The Docker configuration is distributed as part of the [Supabase repository](https://github.com/supabase/supabase/tree/master/docker). There are two paths to get it onto your machine:
+
+- **[Quick start (Linux)](#quick-start-linux)** - one command installs Docker, fetches the configuration, generates all secrets and keys, and prompts for your URLs. Fastest path if you're on a supported Linux distribution.
+- **[Manual installation](#manual-installation)** - clone the repository yourself on any OS, then configure secrets and URLs as described below.
+
+### Quick start (Linux)
+
+Run the automated install script to set up a new project in the current directory:
+
+```sh
+curl -fsSL https://supabase.link/setup.sh | sh
+```
+
+The script supports Linux only (Debian/Ubuntu and RHEL/CentOS/Fedora) and will:
+
+- Install prerequisites (`git`, `curl`, `openssl`, `jq`) and Docker Engine if not already present
+- Sparse-clone the `docker/` directory from the main Supabase [repository](https://github.com/supabase/supabase/)
+- Create a project directory (`supabase-project` by default) and copy the configuration files into it
+- Prompt for the main URLs (`SUPABASE_PUBLIC_URL`, `API_EXTERNAL_URL`, `SITE_URL`, `PROXY_DOMAIN`) and write them to `.env`
+- Generate all secrets, including a random `DASHBOARD_PASSWORD`, and the asymmetric JWT signing key pair (runs `generate-keys.sh` and `add-new-auth-keys.sh`, and uncomments the matching entries in `docker-compose.yml`)
+- Pull the Docker images
+
+The shortened link points to [setup.sh](https://raw.githubusercontent.com/supabase/supabase/refs/heads/master/docker/setup.sh) - you can inspect it before running. Use `-y` to run non-interactively with default values.
+
+After the script finishes, start the stack:
+
+```sh
+cd supabase-project && \
+sh run.sh start
+```
+
+View the generated credentials any time via:
+
+```sh
+sh run.sh secrets
+```
+
+Next, see [Starting and stopping](#starting-and-stopping) for how to check service health and follow logs, then [Accessing Supabase Studio (Dashboard)](#accessing-supabase-studio-dashboard) and the other related sections. To customize the install further, browse [Configuring and securing Supabase](#configuring-and-securing-supabase) and [Advanced topics](#advanced-topics).
+
+Not on Linux, or want to do it manually? See [Manual installation](#manual-installation) below.
+
+### Manual installation
+
+This path gets the Docker Compose configuration onto your server; you'll configure secrets, keys, and URLs in the [next section](#configuring-and-securing-supabase).
 
 <Tabs
 scrollable
@@ -70,6 +116,8 @@ defaultActiveId="gitclone"
 >
 
 <TabPanel id="gitclone" label="GitHub clone">
+
+A shallow clone of the full Supabase repository. Works on any OS with `git` installed and is the simplest manual option.
 
 ```sh
 # Get the code
@@ -86,7 +134,7 @@ mkdir supabase-project
 # Copy the compose files over to your project
 cp -rf supabase/docker/* supabase-project
 
-# Copy the fake env vars
+# Copy the example environment file
 cp supabase/docker/.env.example supabase-project/.env
 
 # Switch to your project directory
@@ -99,6 +147,8 @@ docker compose pull
 </TabPanel>
 
 <TabPanel id="sparseclone" label="Sparse clone">
+
+Only downloads the `docker/` directory from the repository, saving bandwidth and disk space. Requires a few more steps than the shallow GitHub clone.
 
 ```sh
 # Get the code using git sparse checkout
@@ -120,7 +170,7 @@ mkdir supabase-project
 # Copy the compose files over to your project
 cp -rf supabase/docker/* supabase-project
 
-# Copy the fake env vars
+# Copy the example environment file
 cp supabase/docker/.env.example supabase-project/.env
 
 # Switch to your project directory
@@ -142,7 +192,7 @@ docker compose pull
 
 ## Configuring and securing Supabase
 
-While we provided example placeholder passwords and keys in the `.env.example` file, you should NEVER start your self-hosted Supabase using these defaults.
+While we provided example placeholder passwords and keys in the `.env.example` file, you should **never** start your self-hosted Supabase using these defaults.
 
 <Admonition type="danger">
 
@@ -150,7 +200,13 @@ While we provided example placeholder passwords and keys in the `.env.example` f
 
 </Admonition>
 
-### Quick setup
+<Admonition type="note">
+
+  If you used [Quick start (Linux)](#quick-start-linux), these tasks were already done - `setup.sh` configured secrets, keys, URLs, and a random `DASHBOARD_PASSWORD`. You can skip ahead to [Starting and stopping](#starting-and-stopping), or read on to review what was set and how to change it.
+
+</Admonition>
+
+### Generate keys and secrets
 
 To generate secure passwords and secrets, run:
 
@@ -375,7 +431,7 @@ For example, you'd like to update or rollback the Studio image. Follow the steps
 
 <Admonition type="danger">
 
-    Be careful — the following destroys all data, including the database and storage volumes!
+    Be careful - the following destroys all data, including the database and storage volumes!
 
 </Admonition>
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -52,7 +52,7 @@ Minimum requirements for running all Supabase components, suitable for developme
 | CPU | 2 cores | 4 cores+ |
 | Disk | 40 GB SSD | 80 GB+ SSD |
 
-If you don't need specific services, such as Realtime, Storage, imgproxy, or Edge Runtime (Functions), you can remove the corresponding sections and dependencies from `docker-compose.yml` to reduce resource requirements.
+If you don't need specific services, such as Realtime, Storage, imgproxy, or Edge Runtime (`functions`), you can remove the corresponding sections and dependencies from `docker-compose.yml` to reduce resource requirements.
 
 <Admonition type="tip">
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -48,7 +48,7 @@ Minimum requirements for running all Supabase components, suitable for developme
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
-| RAM | 2 GB | 4 GB+ |
+| RAM | 4 GB | 8 GB+ |
 | CPU | 2 cores | 4 cores+ |
 | Disk | 40 GB SSD | 80 GB+ SSD |
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -32,13 +32,13 @@ If you're new to these topics, consider starting with the managed [Supabase plat
 You need the following installed on your system:
 
 - [Git](https://git-scm.com/downloads)
+- OpenSSL
 - [Docker](https://docs.docker.com/manuals/):
   - **Linux server/VPS**: Install [Docker Engine](https://docs.docker.com/engine/install/) and [Docker Compose](https://docs.docker.com/compose/install/)
   - **Linux desktop**: Install [Docker Desktop](https://docs.docker.com/desktop/setup/install/linux/)
   - **macOS**: Install [Docker Desktop](https://docs.docker.com/desktop/install/mac-install/)
   - **Windows**: Install [Docker Desktop](https://docs.docker.com/desktop/install/windows-install/)
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-- OpenSSL
 
 
 ## System requirements
@@ -47,25 +47,31 @@ Minimum requirements for running all Supabase components, suitable for developme
 
 | Resource | Minimum | Recommended |
 |----------|---------|-------------|
-| RAM | 4 GB | 8 GB+ |
+| RAM | 2 GB | 4 GB+ |
 | CPU | 2 cores | 4 cores+ |
-| Disk | 50 GB SSD | 80 GB+ SSD |
+| Disk | 40 GB SSD | 80 GB+ SSD |
 
-If you don't need specific services, such as Logflare (Analytics), Realtime, Storage, imgproxy, or Edge Runtime (Functions), you can remove the corresponding sections and dependencies from `docker-compose.yml` to reduce resource requirements.
+If you don't need specific services, such as Realtime, Storage, imgproxy, or Edge Runtime (Functions), you can remove the corresponding sections and dependencies from `docker-compose.yml` to reduce resource requirements.
+
+<Admonition type="tip">
+
+The default configuration does not include [Logs & Analytics](https://supabase.com/features/logs-analytics). You can enable Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional `docker-compose` override file. Note that enabling these services will increase resource requirements.
+
+</Admonition>
 
 ## Installing Supabase
 
-Follow these steps to start Supabase on your machine:
+First, copy the Docker configuration files to your project directory. Choose one of the options below:
 
 <Tabs
 scrollable
 size="small"
 type="underlined"
-defaultActiveId="general"
+defaultActiveId="gitclone"
 
 >
 
-<TabPanel id="general" label="General">
+<TabPanel id="gitclone" label="GitHub clone">
 
 ```sh
 # Get the code
@@ -94,7 +100,7 @@ docker compose pull
 
 </TabPanel>
 
-<TabPanel id="advanced" label="Advanced">
+<TabPanel id="sparseclone" label="Sparse clone">
 
 ```sh
 # Get the code using git sparse checkout
@@ -190,6 +196,12 @@ The generated secrets and password are written to the `.env` file. The ones you 
 - `SUPABASE_SECRET_KEY`: secret API key for server-side use. Never expose this in client code
 - `SUPABASE_PUBLIC_URL`: base URL you pass as `supabaseUrl` to the client libraries
 
+You can view them at any time by opening `.env` directly, or by running:
+
+```sh
+sh run.sh secrets
+```
+
 ### Studio authentication
 
 Access to Studio (Dashboard) is protected with **HTTP basic authentication**.
@@ -204,11 +216,13 @@ In the `.env` file, edit `DASHBOARD_PASSWORD` to change the password, and option
 
 ## Starting and stopping
 
-You can start Supabase by using the following command in the same directory as your `docker-compose.yml` file:
+Start Supabase from the same directory as your `docker-compose.yml` file:
 
 ```sh
-docker compose up -d
+sh run.sh start
 ```
+
+This is equivalent to `docker compose up -d --wait`, which starts all services and waits until they are healthy.
 
 Check the status of the services:
 
@@ -225,13 +239,13 @@ sh tests/test-container-logs.sh
 Then try inspecting the Docker logs for a specific container, e.g.,
 
 ```sh
-docker compose logs analytics
+sh run.sh logs db
 ```
 
 To stop Supabase, use:
 
 ```sh
-docker compose down
+sh run.sh stop
 ```
 
 <Admonition type="caution" title="Windows: CRLF line endings">
@@ -254,15 +268,15 @@ The self-hosted Supabase stack provides the [Supavisor](https://supabase.github.
 
 You can connect to the Postgres database via Supavisor using the methods described below. Use your domain name, your server IP, or `localhost` depending on whether you are running self-hosted Supabase on a VPS, or locally.
 
-The default POOLER_TENANT_ID is `your-tenant-id` (can be changed in `.env`), and the password is the one you set previously in [Configure database password](#configure-database-password).
+The default `POOLER_TENANT_ID` is `your-tenant-id` (can be later changed in `.env`), and the password is the value of `POSTGRES_PASSWORD` from the `.env` file.
 
-For session-based connections (equivalent to a direct Postgres connection):
+For session-mode connections (equivalent to a direct Postgres connection):
 
 ```sh
 psql 'postgres://postgres.[POOLER_TENANT_ID]:[POSTGRES_PASSWORD]@[your-domain]:5432/postgres'
 ```
 
-For pooled transactional connections:
+For transaction-mode connections:
 
 ```sh
 psql 'postgres://postgres.[POOLER_TENANT_ID]:[POSTGRES_PASSWORD]@[your-domain]:6543/postgres'
@@ -285,10 +299,12 @@ curl http://<your-domain>:8000/functions/v1/hello
 Add new functions at `volumes/functions/<FUNCTION_NAME>/index.ts`, then restart the service to pick them up:
 
 ```sh
-docker compose restart functions --no-deps
+sh run.sh recreate functions
 ```
 
-See the [self-hosted Edge Functions guide](/docs/guides/self-hosting/self-hosted-functions) for more details.
+This force-recreates the container (equivalent to `docker compose up -d --wait --force-recreate --no-deps functions`). A plain `docker compose restart` is not sufficient as it does not pick up configuration changes.
+
+See the [Self-hosted Edge Functions](/docs/guides/self-hosting/self-hosted-functions) guide for more details.
 
 ## Accessing APIs
 
@@ -299,27 +315,63 @@ Each of the APIs is available through the same API gateway:
 - Storage: `http://<your-domain>:8000/storage/v1/`
 - Realtime: `http://<your-domain>:8000/realtime/v1/`
 
+## Enabling Logs & Analytics
+
+Logs & Analytics are not included in the default configuration. To enable them:
+
+```sh
+sh run.sh config add logs && \
+sh run.sh start
+```
+
+This layers `docker-compose.logs.yml` on top of the base configuration and starts two additional services:
+
+- **Logflare** (Analytics) - log management and event analytics
+- **Vector** - collects logs from all running containers and forwards them to Logflare
+
+The Log Explorer in Studio is also enabled automatically. Note that these services increase resource requirements.
+
 ## Configuring HTTPS
 
 By default, Supabase is accessible over HTTP. For production deployments, especially when using OAuth providers, you need HTTPS with a valid TLS certificate. The recommended approach is to place a reverse proxy (such as Caddy or Nginx) in front of the API gateway.
 
 See the [Configure HTTPS](/docs/guides/self-hosting/self-hosted-proxy-https) guide for detailed setup instructions.
 
+## Managing the stack
+
+Two helper scripts - `run.sh` and `reset.sh` are available in your project directory and wrap common operations.
+
+**`run.sh`** manages the Docker Compose stack. Key commands:
+
+| Command | Description |
+|---|---|
+| `sh run.sh start` / `stop` | Start or stop the stack |
+| `sh run.sh restart [service]` | Restart the stack or a named service |
+| `sh run.sh recreate [service]` | Force-recreate containers, picking up config changes |
+| `sh run.sh secrets` | Print key credentials from `.env` |
+| `sh run.sh config add <name>` | Enable an optional override file |
+| `sh run.sh config remove <name>` | Disable an optional override file |
+| `sh run.sh printenv <service>` | Show environment variables inside the container |
+| `sh run.sh logs [service]` | Follow logs for all or a specific service |
+
+The `config add` / `config remove` commands manage the `COMPOSE_FILE` [variable](https://docs.docker.com/compose/how-tos/environment-variables/envvars/#compose_file) in your `.env`, which controls which override files are layered on top of `docker-compose.yml`. For example, `sh run.sh config add logs` appends `docker-compose.logs.yml` to `COMPOSE_FILE`, and `sh run.sh config remove logs` removes it. Run `sh run.sh help` for the full list of commands.
+
+**`reset.sh`** tears down the stack completely, removes all data, and resets `.env` to defaults. See [Uninstalling](#uninstalling) for details.
+
 ## Updating
 
 We publish stable releases of the Docker Compose setup approximately once a month. The versions in each release are tested together, so they may lag behind the latest images on Docker Hub. To update, apply the latest changes from the repository and restart the services. If you want to run different versions of individual services, you can change the image tags in the Docker Compose file, but compatibility is **not guaranteed**. All Supabase images are available on [Docker Hub](https://hub.docker.com/u/supabase).
 
-To follow the changes and updates, refer to the self-hosted Supabase [changelog](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md).
+To follow the changes and updates, refer to the self-hosted Supabase [changelog](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md). Make sure to also check the [Discussions](https://github.com/orgs/supabase/discussions/categories/changelog?discussions_q=is%3Aopen+category%3AChangelog+label%3Aself-hosted).
 
-You need to restart services to pick up the changes, which may result in downtime for your applications and users.
+After updating the configuration, you need to restart services to pick up the changes, which may result in downtime for your applications and users.
 
-**Example:**
-You'd like to update or rollback the Studio image. Follow the steps below:
+For example, you'd like to update or rollback the Studio image. Follow the steps below:
 
 1. Check the [supabase/studio](https://hub.docker.com/r/supabase/studio/tags) images on [Supabase Docker Hub](https://hub.docker.com/u/supabase)
-2. Find the latest version (tag) number. It looks something like `2025.11.26-sha-8f096b5`
-3. Update the `image` field in the `docker-compose.yml` file. It should look like this: `image: supabase/studio:2025.11.26-sha-8f096b5`
-4. Run `docker compose pull`, followed by `docker compose down && docker compose up -d` to restart Supabase.
+2. Find the latest version (tag) number. It looks something like `2026.04.27-sha-5f60601`
+3. Update the Studio `image` configuration in the `docker-compose.yml` file. It should look like this: `image: supabase/studio:2026.04.27-sha-5f60601`
+4. Run `sh run.sh pull` to pull the new image, then `sh run.sh recreate studio` to restart Studio from it without taking down the rest of the stack.
 
 ## Uninstalling
 
@@ -329,25 +381,18 @@ You'd like to update or rollback the Studio image. Follow the steps below:
 
 </Admonition>
 
-To uninstall, stop Supabase (while in the same directory as your `docker-compose.yml` file).
-
-Stop the containers and remove volumes:
+To uninstall, run the following from the same directory as your `docker-compose.yml` file:
 
 ```sh
-docker compose down -v
+sh reset.sh
 ```
 
-Optionally, ensure removal of all Postgres data:
+This will:
+- Stop all containers and remove Docker-managed volumes (`docker compose down -v --remove-orphans`)
+- Delete the Postgres data directory (`volumes/db/data`) and Storage data (`volumes/storage`)
+- Back up your `.env` to `.env.old` and restore `.env.example` as the new `.env`
 
-```sh
-rm -rf volumes/db/data
-```
-
-and all Storage data:
-
-```sh
-rm -rf volumes/storage
-```
+Run with `-y` to skip the confirmation prompts: `sh reset.sh -y`
 
 ## Advanced topics
 
@@ -392,7 +437,7 @@ You can find all the default extensions inside the [schema migration scripts rep
 
 ### Setting database password
 
-The `generate-keys.sh` script creates a secure random database password. If you want to use your own, you can change `POSTGRES_PASSWORD` in the `.env` file **before** starting Supabase for the first time.
+The `generate-keys.sh` script creates a secure random database password. If you want to use your own, you can change `POSTGRES_PASSWORD` in the `.env` file **before starting Supabase for the first time**.
 
 Follow the [password guidelines](/docs/guides/database/postgres/roles#passwords) for choosing a secure password. For easier configuration, **use only letters and numbers** to avoid URL encoding issues in connection strings.
 
@@ -404,7 +449,11 @@ To change the database password after the initial setup, run:
 sh utils/db-passwd.sh
 ```
 
-The script generates a new password, updates all database roles, and modifies your `.env` file. After running it, restart the services with `docker compose up -d --force-recreate`.
+The script generates a new password, updates all database roles, and modifies your `.env` file. After running it, restart the services with:
+
+```sh
+sh run.sh recreate
+```
 
 ### Configuring secrets
 
@@ -418,7 +467,7 @@ The `generate-keys.sh` script sets the following secrets automatically. You can 
 - `S3_PROTOCOL_ACCESS_KEY_ID`: Access key ID (username-like) for [accessing](/docs/guides/self-hosting/self-hosted-s3) the S3 protocol endpoint in Storage. (Generate with `openssl rand -hex 16`)
 - `S3_PROTOCOL_ACCESS_KEY_SECRET`: Secret key (password-like) used with S3_PROTOCOL_ACCESS_KEY_ID. (Generate with `openssl rand -hex 32`)
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-- `MINIO_ROOT_PASSWORD`: Root administrator password for the [MinIO server](/docs/guides/self-hosting/self-hosted-s3#using-minio). (Must be 8+ characters; generate with `openssl rand -hex 16`)
+- `MINIO_ROOT_PASSWORD`: Root administrator password for the [RustFS or MinIO] server(/docs/guides/self-hosting/self-hosted-s3). (Must be 8+ characters; generate with `openssl rand -hex 16`)
 
 ### Configuring Supabase services
 
@@ -433,7 +482,9 @@ services:
   rest:
     image: postgrest/postgrest
     environment:
-      PGRST_JWT_SECRET: ${JWT_SECRET}
+      PGRST_DB_SCHEMAS: ${PGRST_DB_SCHEMAS}
+      PGRST_DB_MAX_ROWS: ${PGRST_DB_MAX_ROWS:-1000}
+      PGRST_DB_EXTRA_SEARCH_PATH: ${PGRST_DB_EXTRA_SEARCH_PATH:-public}
 ```
 
 ```sh name=.env
@@ -456,21 +507,26 @@ See the [Configure Phone Login & MFA](/docs/guides/self-hosting/self-hosted-phon
 You will need to use a production-ready SMTP server for sending emails. You can configure the SMTP server by updating the following environment variables in the `.env` file:
 
 ```sh name=.env
-SMTP_ADMIN_EMAIL=
-SMTP_HOST=
-SMTP_PORT=
-SMTP_USER=
-SMTP_PASS=
-SMTP_SENDER_NAME=
+SMTP_ADMIN_EMAIL=admin@example.com
+SMTP_HOST=smtp.example.com
+SMTP_PORT=465
+SMTP_USER=your-smtp-user
+SMTP_PASS=your-smtp-password
+SMTP_SENDER_NAME=your-sender-name
 ```
 
 We recommend using [AWS SES](https://aws.amazon.com/ses/). It's affordable and reliable. Restart all services to pick up the new configuration.
 
 ### Configuring S3 Storage
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-By default, all files are stored locally on the server. You can connect Storage to an S3-compatible backend (AWS S3, RustFS, MinIO, Cloudflare R2), enable the S3 protocol endpoint for tools like `rclone`, or both. These are independent features.
+By default, when using self-hosted Storage service, all files are stored locally on your server filesystem (via a bind mount in `docker-compose.yml`). You can connect Storage to an S3-compatible backend (AWS S3, RustFS, MinIO, Cloudflare R2), enable the S3 protocol endpoint for tools like `rclone`, or both. These are independent features.
 
 See the [Configure S3 Storage](/docs/guides/self-hosting/self-hosted-s3) guide for detailed setup instructions.
+
+### Using file backend in Storage on macOS
+
+{/* supa-mdx-lint-disable-next-line Rule003Spelling */}
+By default, the Storage backend uses local files via a bind mount. On macOS, Docker Desktop bind mounts have known limitations (missing xattr support, permission issues) that can prevent Storage from working correctly. Change the [bind mount](https://github.com/supabase/supabase/blob/a5f4a59e0e262394b345600e8d8a2241d6ac3b64/docker/docker-compose.yml#L391) to a named Docker volume instead.
 
 ### Configuring Supabase AI Assistant
 
@@ -517,11 +573,6 @@ postgres://postgres:[POSTGRES_PASSWORD]@[your-server-ip]:5432/[POSTGRES_DB]
 
 By default, the database's `log_min_messages` configuration is set to `fatal` in [docker-compose.yml](https://github.com/supabase/supabase/blob/df8729a82b1847e2989c14ede27965612761d503/docker/docker-compose.yml#L466) to prevent redundant logs generated by Realtime. You can configure `log_min_messages` using any of the Postgres [Severity Levels](https://www.postgresql.org/docs/current/runtime-config-logging.html#RUNTIME-CONFIG-SEVERITY-LEVELS).
 
-### Using file backend in Storage on macOS
-
-{/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-By default, the Storage backend uses local files via a bind mount. On macOS, Docker Desktop bind mounts have known limitations (missing xattr support, permission issues) that can prevent Storage from working correctly. Change the [bind mount](https://github.com/supabase/supabase/blob/a5f4a59e0e262394b345600e8d8a2241d6ac3b64/docker/docker-compose.yml#L391) to a named Docker volume instead.
-
 ## Managing your secrets
 
 Many components inside Supabase rely on secrets and passwords being kept securely. By default, all secrets are in the `.env` file, but we strongly recommend using a secrets manager when deploying to production.
@@ -550,4 +601,4 @@ Some suggested systems include:
 
 1. The VPS instance is a DigitalOcean droplet. (For server requirements refer to [System requirements](#system-requirements))
 2. To access Studio, use the IPv4 IP address of your Droplet.
-3. If you're unable to use Studio, run `docker compose ps` to see if all services are up and healthy.
+3. XXXXX - If you're unable to use Studio, run `docker compose ps` to see if all services are up and healthy.

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -521,7 +521,7 @@ The `generate-keys.sh` script sets the following secrets automatically. You can 
 - `S3_PROTOCOL_ACCESS_KEY_ID`: Access key ID (username-like) for [accessing](/docs/guides/self-hosting/self-hosted-s3) the S3 protocol endpoint in Storage. (Generate with `openssl rand -hex 16`)
 - `S3_PROTOCOL_ACCESS_KEY_SECRET`: Secret key (password-like) used with S3_PROTOCOL_ACCESS_KEY_ID. (Generate with `openssl rand -hex 32`)
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-- `MINIO_ROOT_PASSWORD`: Root administrator password for the [RustFS or MinIO] server(/docs/guides/self-hosting/self-hosted-s3). (Must be 8+ characters; generate with `openssl rand -hex 16`)
+- `MINIO_ROOT_PASSWORD`: Root administrator password for the [RustFS or MinIO server](/docs/guides/self-hosting/self-hosted-s3). (Must be 8+ characters; generate with `openssl rand -hex 16`)
 
 ### Configuring Supabase services
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -81,7 +81,7 @@ The script supports Linux only (Debian/Ubuntu and RHEL/CentOS/Fedora) and will:
 - Sparse-clone the `docker/` directory from the main Supabase [repository](https://github.com/supabase/supabase/)
 - Create a project directory (`supabase-project` by default) and copy the configuration files into it
 - Prompt for the main URLs (`SUPABASE_PUBLIC_URL`, `API_EXTERNAL_URL`, `SITE_URL`, `PROXY_DOMAIN`) and write them to `.env`
-- Generate all secrets, including a random `DASHBOARD_PASSWORD`, and the asymmetric JWT signing key pair (runs `generate-keys.sh` and `add-new-auth-keys.sh`, and uncomments the matching entries in `docker-compose.yml`)
+- Generate all secrets, including a random `DASHBOARD_PASSWORD`, and the asymmetric JWT signing key pair (runs `generate-keys.sh` and `add-new-auth-keys.sh`, and enables the matching entries in `docker-compose.yml`)
 - Pull the Docker images
 
 The shortened link points to [setup.sh](https://raw.githubusercontent.com/supabase/supabase/refs/heads/master/docker/setup.sh) - you can inspect it before running. Use `-y` to run non-interactively with default values.

--- a/apps/docs/content/guides/self-hosting/self-hosted-auth-keys.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-auth-keys.mdx
@@ -10,7 +10,7 @@ You can configure self-hosted Supabase to use the [new API keys](/docs/guides/ge
 
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
 
-- Complete the [Docker setup guide](/docs/guides/self-hosting/docker), including running `generate-keys.sh` so that `JWT_SECRET`, `ANON_KEY`, and `SERVICE_ROLE_KEY` are set in your `.env` file
+- Complete the [Docker setup guide](/docs/guides/self-hosting/docker) so that `JWT_SECRET`, `ANON_KEY`, and `SERVICE_ROLE_KEY` are set in your `.env` file. [Quick start (Linux)](/docs/guides/self-hosting/docker#quick-start-linux) handles this automatically; the manual path runs [`generate-keys.sh`](/docs/guides/self-hosting/docker#generate-keys-and-secrets).
 - If you are upgrading an existing self-hosted Supabase environment, make sure to check the [changelog](https://github.com/supabase/supabase/blob/master/docker/CHANGELOG.md) and add/update the following files:
   - `.env.example` (merge new sections into your `.env` file)
   - `docker-compose.yml`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Add `run.sh` to the docker guide for [self-hosted Supabase](https://supabase.com/docs/guides/self-hosting)
- Explain how to add Logs & Analytics
- Add `setup.sh` and quick start
- Minor edits and improvements

Related: PR #46452, PR #45327


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked self-hosting Docker guide with a faster Linux quick-start and clearer manual installation (including sparse-clone option).
  * Added explicit system requirements, refined prerequisites, and a tip for enabling Logs & Analytics via an optional compose overlay.
  * Strengthened secrets guidance with danger callouts and explicit credential-discovery steps; clarified stack-management and simplified start/stop/recreate/log commands.
  * Updated connection, SMTP, storage, and Edge Functions redeploy instructions; removed duplicate content.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46416?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->