### PR TITLE
docs(storage): add ADMIN_RETURN_TENANT_SENSITIVE_DATA to config reference

### DIFF
--- a/docker/CONFIG.md
+++ b/docker/CONFIG.md
@@ -946,6 +946,7 @@ The fields below are repeated for each provider. Substitute `<PROVIDER>` with on
 |---|---|---|---|---|
 | `ADMIN_API_KEYS` | string |  | Comma-separated API keys accepted on the admin port. Legacy alias for `SERVER_ADMIN_API_KEYS`. | Default: empty |
 | `ADMIN_PORT` | integer |  | Port the admin HTTP server listens on. Legacy alias for `SERVER_ADMIN_PORT`. | Default: `5001` |
+| `ADMIN_RETURN_TENANT_SENSITIVE_DATA` | boolean | | Controls whether admin tenant endpoints return decrypted, sensitive tenant configuration values (e.g., anonKey, DB URLs, jwtSecret, jwks, serviceKey). | Default: `true` |
 | `EXPOSE_DOCS` | boolean |  | Expose `/docs` Swagger UI. | Default: `true` |
 | `HOST` | string |  | Host the public server binds to. Legacy alias for `SERVER_HOST`. | Default: `0.0.0.0` |
 | `NODE_ENV` | enum |  | Node.js runtime mode. When `production`, sets `isProduction` and forces HTTPS in TUS link generation. | Default: unset |


### PR DESCRIPTION
Syncs the self-hosted configuration reference with the recent upstream `supabase/storage` v1.59.1 release.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The self-hosted `docker/CONFIG.md` reference does not currently document the `ADMIN_RETURN_TENANT_SENSITIVE_DATA` environment variable for the Storage service.

## What is the new behavior?

Adds the `ADMIN_RETURN_TENANT_SENSITIVE_DATA` environment variable to the `## Storage` -> `### Server` configuration table, keeping the documentation in sync with recent upstream updates. 

This flag controls whether admin tenant endpoints return decrypted, sensitive tenant configuration values (e.g., anonKey, DB URLs, jwtSecret, jwks, serviceKey). The variable was added alphabetically to the Server table to maintain the established file formatting.

## Additional context

- **Introduced in:** `supabase/storage` release v1.59.1
- **Upstream PR:** supabase/storage#989
- **Upstream Commit:** 4778d47

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `ADMIN_RETURN_TENANT_SENSITIVE_DATA` environment variable, which controls whether admin tenant endpoints return decrypted sensitive configuration values including keys and database URLs (defaults to `true`).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46420?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->