### PR TITLE
fix: confirmation modal alert misses its title

### DIFF
--- a/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
@@ -86,7 +86,7 @@ export const ConfirmationModal = forwardRef<
     }, [loading_])
 
     const { title: _alertBaseTitle, children: _alertBaseChildren, ...alertBase } = alert?.base ?? {}
-    const alertTitleProps = alert?.title ? { label: alert.title } : {}
+    const alertTitleProps = alert?.title ? { title: alert.title } : {}
 
     return (
       <Dialog


### PR DESCRIPTION
Backport `ConfirmationModal` from #46383

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed alert title display in confirmation modals to render correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46428?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->