### PR TITLE
feat(tests): type addAPIMock resolver against OpenAPI contract

### DIFF
--- a/.claude/skills/studio-mock-api-tests/SKILL.md
+++ b/.claude/skills/studio-mock-api-tests/SKILL.md
@@ -47,7 +47,7 @@ describe('MyComponent', () => {
       method: 'get',
       path: '/platform/organizations',
       response: () =>
-        HttpResponse.json([
+        HttpResponse.json<OrganizationResponse[]>([
           {
             /* ... */
           },
@@ -93,8 +93,8 @@ which silently breaks `onSuccess` callbacks.
 // ❌ Mutation onSuccess silently never fires
 response: () => new HttpResponse(null, { status: 201 })
 
-// ✅ Works
-response: () => HttpResponse.json({}, { status: 201 })
+// ✅ Works (pass the OpenAPI body shape explicitly — see gotcha #8)
+response: () => HttpResponse.json<MyResponse>({}, { status: 201 })
 ```
 
 ### 3. Submit buttons in Sheets/Modals need `fireEvent.click`
@@ -176,6 +176,33 @@ addAPIMock({
 })
 ```
 
+### 8. Always pass an explicit generic to `HttpResponse.json`
+
+`addAPIMock`'s resolver is typed against the OpenAPI success body (and the
+standard `{ message: string }` error envelope, exported as `APIErrorBody`).
+But MSW's `HttpResponse.json` uses `NoInfer`, so the body type doesn't
+narrow from context. Pass the expected shape explicitly — it doubles as a
+self-documenting contract assertion:
+
+```ts
+import { addAPIMock, type APIErrorBody } from '@/tests/lib/msw'
+
+response: () => HttpResponse.json<OrganizationResponse[]>([...])
+response: () =>
+  HttpResponse.json<APIErrorBody>({ message: 'Boom' }, { status: 500 })
+```
+
+A mock that drifts from the contract (wrong envelope, missing fields,
+stale enum values) now fails at compile time, not at runtime. The cost is
+one type annotation per resolver — well worth it.
+
+For mocks at the network boundary, also prefer `createMockOrganizationResponse`
+(returns the raw OpenAPI `OrganizationResponse`) over `createMockOrganization`
+(which extends with frontend-derived `managed_by` / `partner_id` that the
+query layer attaches). Same pattern applies to any type that's a frontend
+extension of an OpenAPI schema: build a `createMockXResponse` helper that
+returns the raw API shape.
+
 ## Prefer asserting on UI state
 
 MSW's own best-practices doc explicitly recommends asserting on what
@@ -196,7 +223,7 @@ addAPIMock({
   path: '/v1/projects/:ref/secrets',
   response: async ({ request, params }) => {
     requests.push({ ref: params.ref as string | undefined, body: await request.json() })
-    return HttpResponse.json({}, { status: 201 })
+    return HttpResponse.json<CreateSecretsResponse>({}, { status: 201 })
   },
 })
 

--- a/apps/studio/components/interfaces/Organization/OrgNotFound.test.tsx
+++ b/apps/studio/components/interfaces/Organization/OrgNotFound.test.tsx
@@ -1,12 +1,16 @@
 import { screen } from '@testing-library/react'
+import { platformComponents as components } from 'api-types'
 import { HttpResponse } from 'msw'
 import { describe, expect, test } from 'vitest'
 
 import { OrgNotFound } from './OrgNotFound'
 import type { ProfileContextType } from '@/lib/profile'
-import { createMockOrganization } from '@/tests/helpers'
+import { createMockOrganizationResponse } from '@/tests/helpers'
 import { customRender } from '@/tests/lib/custom-render'
-import { addAPIMock } from '@/tests/lib/msw'
+import { addAPIMock, type APIErrorBody } from '@/tests/lib/msw'
+
+type OrganizationResponse = components['schemas']['OrganizationResponse']
+type OrganizationProjectsResponse = components['schemas']['OrganizationProjectsResponse']
 
 const PROFILE_CONTEXT: ProfileContextType = {
   profile: {
@@ -34,7 +38,7 @@ const mockEmptyProjectsResponse = () => {
     method: 'get',
     path: '/platform/organizations/:slug/projects',
     response: () =>
-      HttpResponse.json({
+      HttpResponse.json<OrganizationProjectsResponse>({
         pagination: { count: 0, limit: 96, offset: 0 },
         projects: [],
       }),
@@ -46,7 +50,7 @@ describe('OrgNotFound', () => {
     addAPIMock({
       method: 'get',
       path: '/platform/organizations',
-      response: () => HttpResponse.json([]),
+      response: () => HttpResponse.json<OrganizationResponse[]>([]),
     })
 
     customRender(<OrgNotFound slug="ghost-org" />, { profileContext: PROFILE_CONTEXT })
@@ -60,9 +64,9 @@ describe('OrgNotFound', () => {
       method: 'get',
       path: '/platform/organizations',
       response: () =>
-        HttpResponse.json([
-          createMockOrganization({ slug: 'acme-prod', name: 'Acme Production' }),
-          createMockOrganization({ slug: 'acme-dev', name: 'Acme Development' }),
+        HttpResponse.json<OrganizationResponse[]>([
+          createMockOrganizationResponse({ slug: 'acme-prod', name: 'Acme Production' }),
+          createMockOrganizationResponse({ slug: 'acme-dev', name: 'Acme Development' }),
         ]),
     })
     mockEmptyProjectsResponse()
@@ -77,7 +81,11 @@ describe('OrgNotFound', () => {
     addAPIMock({
       method: 'get',
       path: '/platform/organizations',
-      response: () => HttpResponse.json({ message: 'Boom from the backend' }, { status: 500 }),
+      response: () =>
+        HttpResponse.json<APIErrorBody>(
+          { message: 'Boom from the backend' },
+          { status: 500 }
+        ),
     })
 
     customRender(<OrgNotFound slug="ghost-org" />, { profileContext: PROFILE_CONTEXT })

--- a/apps/studio/components/interfaces/RedeemCredits/RedeemCredits.test.tsx
+++ b/apps/studio/components/interfaces/RedeemCredits/RedeemCredits.test.tsx
@@ -1,15 +1,18 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { platformComponents as components } from 'api-types'
 import { FeatureFlagContext } from 'common'
 import { HttpResponse } from 'msw'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
 
 import { RedeemCreditsScreen } from './RedeemCredits'
 import type { ProfileContextType } from '@/lib/profile'
-import { createMockOrganization } from '@/tests/helpers'
+import { createMockOrganizationResponse } from '@/tests/helpers'
 import { customRender } from '@/tests/lib/custom-render'
 import { addAPIMock } from '@/tests/lib/msw'
 import { routerMock } from '@/tests/lib/route-mock'
+
+type OrganizationResponse = components['schemas']['OrganizationResponse']
 
 const { creditRedemptionProps } = vi.hoisted(() => ({
   creditRedemptionProps: vi.fn(),
@@ -52,7 +55,7 @@ const DEFAULT_PROFILE_CONTEXT: ProfileContextType = {
   isSuccess: true,
 }
 
-const ORGANIZATION = createMockOrganization({
+const ORGANIZATION = createMockOrganizationResponse({
   id: 1,
   name: 'Acme Production',
   slug: 'acme-production',
@@ -82,7 +85,7 @@ describe('RedeemCreditsScreen', () => {
     addAPIMock({
       method: 'get',
       path: '/platform/organizations',
-      response: () => HttpResponse.json([ORGANIZATION]),
+      response: () => HttpResponse.json<OrganizationResponse[]>([ORGANIZATION]),
     })
 
     renderScreen()
@@ -106,7 +109,7 @@ describe('RedeemCreditsScreen', () => {
     addAPIMock({
       method: 'get',
       path: '/platform/organizations',
-      response: () => HttpResponse.json([ORGANIZATION]),
+      response: () => HttpResponse.json<OrganizationResponse[]>([ORGANIZATION]),
     })
 
     renderScreen()
@@ -128,7 +131,7 @@ describe('RedeemCreditsScreen', () => {
     addAPIMock({
       method: 'get',
       path: '/platform/organizations',
-      response: () => HttpResponse.json([ORGANIZATION]),
+      response: () => HttpResponse.json<OrganizationResponse[]>([ORGANIZATION]),
     })
 
     renderScreen()

--- a/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
+++ b/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { platformComponents as components } from 'api-types'
 import dayjs from 'dayjs'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
@@ -9,21 +10,71 @@ import { SupportForm, SupportFormPage, SupportFormStatusButton } from '../Suppor
 // End of third-party imports
 
 import { API_URL, BASE_PATH } from '@/lib/constants'
-import { createMockOrganization, createMockProject } from '@/tests/helpers'
+import {
+  createMockOrganizationResponse,
+  createMockProject,
+} from '@/tests/helpers'
 import { customRender } from '@/tests/lib/custom-render'
-import { addAPIMock, mswServer } from '@/tests/lib/msw'
+import { addAPIMock, type APIErrorBody, mswServer } from '@/tests/lib/msw'
 import { createMockProfileContext } from '@/tests/lib/profile-helpers'
+
+type ProjectDetailResponse = components['schemas']['ProjectDetailResponse']
+type OrganizationProjectsResponse = components['schemas']['OrganizationProjectsResponse']
+type OrganizationProjectsProject = OrganizationProjectsResponse['projects'][number]
+type SendFeedbackResponse = components['schemas']['SendFeedbackResponse']
+
+// Builders that return shapes matching the OpenAPI contract for endpoints
+// the support form depends on. The test only exercises a few fields, but the
+// constraints catch silent drift between mocks and the API.
+const toProjectDetailResponse = (project: {
+  id: number
+  ref: string
+  name: string
+  organization_id: number
+}): ProjectDetailResponse => ({
+  id: project.id,
+  ref: project.ref,
+  name: project.name,
+  organization_id: project.organization_id,
+  cloud_provider: 'AWS',
+  db_host: `db.${project.ref}.example.com`,
+  high_availability: false,
+  inserted_at: new Date().toISOString(),
+  integration_source: null,
+  is_branch_enabled: false,
+  is_physical_backups_enabled: false,
+  region: 'us-east-1',
+  restUrl: `https://${project.ref}.example.com/rest`,
+  status: 'ACTIVE_HEALTHY',
+  subscription_id: 'subscription-1',
+  updated_at: new Date().toISOString(),
+})
+
+const toOrganizationProject = (project: {
+  ref: string
+  name: string
+}): OrganizationProjectsProject => ({
+  cloud_provider: 'AWS',
+  databases: [],
+  inserted_at: new Date().toISOString(),
+  integration_source: null,
+  is_branch: false,
+  name: project.name,
+  ref: project.ref,
+  region: 'us-east-1',
+  status: 'ACTIVE_HEALTHY',
+})
 
 type Screen = typeof screen
 
 const mockOrganizations = [
-  createMockOrganization({
+  createMockOrganizationResponse({
     id: 1,
     slug: 'org-1',
     name: 'Organization 1',
     plan: { id: 'free', name: 'Free' },
   }),
-  createMockOrganization({
+  createMockOrganizationResponse({
     id: 2,
     slug: 'org-2',
     name: 'Organization 2',
@@ -421,8 +472,11 @@ describe('SupportFormPage', () => {
         const { ref } = params as { ref: string }
         const project = mockProjects.projects.find((candidate) => candidate.ref === ref)
         return project
-          ? HttpResponse.json(project)
-          : HttpResponse.json({ msg: 'Project not found' }, { status: 404 })
+          ? HttpResponse.json<ProjectDetailResponse>(toProjectDetailResponse(project))
+          : HttpResponse.json<APIErrorBody>(
+              { message: 'Project not found' },
+              { status: 404 }
+            )
       },
     })
 
@@ -461,8 +515,8 @@ describe('SupportFormPage', () => {
 
         const paginated = sorted.slice(offset, offset + limit)
 
-        return HttpResponse.json({
-          projects: paginated,
+        return HttpResponse.json<OrganizationProjectsResponse>({
+          projects: paginated.map(toOrganizationProject),
           pagination: {
             count: projects.length,
             limit,
@@ -706,7 +760,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -751,7 +805,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -795,7 +849,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -898,7 +952,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -990,7 +1044,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -1013,8 +1067,11 @@ describe('SupportFormPage', () => {
         const { ref } = params as { ref: string }
         const project = mockProjects.projects.find((candidate) => candidate.ref === ref)
         return project
-          ? HttpResponse.json(project)
-          : HttpResponse.json({ msg: 'Project not found' }, { status: 404 })
+          ? HttpResponse.json<ProjectDetailResponse>(toProjectDetailResponse(project))
+          : HttpResponse.json<APIErrorBody>(
+              { message: 'Project not found' },
+              { status: 404 }
+            )
       },
     })
 
@@ -1190,7 +1247,7 @@ describe('SupportFormPage', () => {
       response: async () => {
         submitSpy()
         await submission.promise
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -1301,7 +1358,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -1370,7 +1427,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -1433,7 +1490,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -1495,7 +1552,7 @@ describe('SupportFormPage', () => {
       method: 'post',
       path: '/platform/feedback/send',
       response: async () => {
-        return HttpResponse.json({ message: errorMessage }, { status: 500 })
+        return HttpResponse.json<APIErrorBody>({ message: errorMessage }, { status: 500 })
       },
     })
 
@@ -1534,7 +1591,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -1614,7 +1671,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 
@@ -1731,7 +1788,7 @@ describe('SupportFormPage', () => {
       path: '/platform/feedback/send',
       response: async ({ request }) => {
         submitSpy(await request.json())
-        return HttpResponse.json({ ok: true })
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
       },
     })
 

--- a/apps/studio/tests/components/ApiAuthorization.test.tsx
+++ b/apps/studio/tests/components/ApiAuthorization.test.tsx
@@ -1,5 +1,6 @@
 import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { platformComponents as components } from 'api-types'
 import dayjs from 'dayjs'
 import { HttpResponse } from 'msw'
 import { describe, expect, test, vi } from 'vitest'
@@ -10,10 +11,14 @@ import {
 } from '@/components/interfaces/ApiAuthorization/ApiAuthorization'
 import type { ApiAuthorizationResponse } from '@/data/api-authorization/api-authorization-query'
 import type { ProfileContextType } from '@/lib/profile'
-import { createMockOrganization } from '@/tests/helpers'
+import { createMockOrganizationResponse } from '@/tests/helpers'
 import { customRender } from '@/tests/lib/custom-render'
-import { addAPIMock } from '@/tests/lib/msw'
-import type { Organization } from '@/types'
+import { addAPIMock, type APIErrorBody } from '@/tests/lib/msw'
+
+type OrganizationResponse = components['schemas']['OrganizationResponse']
+type GetOAuthAuthorizationResponse = components['schemas']['GetOAuthAuthorizationResponse']
+type ApproveAuthorizationResponse = components['schemas']['ApproveAuthorizationResponse']
+type DeclineAuthorizationResponse = components['schemas']['DeclineAuthorizationResponse']
 
 // --- Fixtures ---
 
@@ -54,8 +59,12 @@ function createMockAuthResponse(
   }
 }
 
-const DEFAULT_ORG = createMockOrganization({ name: 'My Org', slug: 'my-org' })
-const SECOND_ORG = createMockOrganization({ id: 2, name: 'Second Org', slug: 'second-org' })
+const DEFAULT_ORG = createMockOrganizationResponse({ name: 'My Org', slug: 'my-org' })
+const SECOND_ORG = createMockOrganizationResponse({
+  id: 2,
+  name: 'Second Org',
+  slug: 'second-org',
+})
 
 // --- MSW helpers ---
 
@@ -66,21 +75,28 @@ function mockAuthEndpoint(authResponse: ApiAuthorizationResponse) {
   addAPIMock({
     method: 'get',
     path: '/platform/oauth/authorizations/:id',
-    response: () => HttpResponse.json(authResponse),
+    // The frontend `ApiAuthorizationResponse` widens the OpenAPI shape
+    // (looser `registration_type`, nullable `icon`/`approved_at`), and the
+    // query layer casts via `data as ApiAuthorizationResponse`. Cast here to
+    // satisfy the network-boundary contract.
+    response: () =>
+      HttpResponse.json<GetOAuthAuthorizationResponse>(
+        authResponse as unknown as GetOAuthAuthorizationResponse
+      ),
   })
 }
 
-function mockOrgsEndpoint(orgs: Array<Organization> = [DEFAULT_ORG]) {
+function mockOrgsEndpoint(orgs: OrganizationResponse[] = [DEFAULT_ORG]) {
   addAPIMock({
     method: 'get',
     path: '/platform/organizations',
-    response: () => HttpResponse.json(orgs),
+    response: () => HttpResponse.json<OrganizationResponse[]>(orgs),
   })
 }
 
 function mockBothEndpoints(
   authResponse: ApiAuthorizationResponse = createMockAuthResponse(),
-  orgs: Array<Organization> = [DEFAULT_ORG]
+  orgs: OrganizationResponse[] = [DEFAULT_ORG]
 ) {
   mockAuthEndpoint(authResponse)
   mockOrgsEndpoint(orgs)
@@ -119,7 +135,7 @@ describe('ApiAuthorizationScreen', () => {
       addAPIMock({
         method: 'get',
         path: '/platform/oauth/authorizations/:id',
-        response: () => new Promise(() => {}),
+        response: () => new Promise<never>(() => {}),
       })
       const { container } = renderScreen()
       expect(screen.getByText('Loading...')).toBeInTheDocument()
@@ -131,7 +147,8 @@ describe('ApiAuthorizationScreen', () => {
       addAPIMock({
         method: 'get',
         path: '/platform/oauth/authorizations/:id',
-        response: () => HttpResponse.json({ message: 'Not found' }, { status: 404 }),
+        response: () =>
+          HttpResponse.json<APIErrorBody>({ message: 'Not found' }, { status: 404 }),
       })
       renderScreen()
       await screen.findByText('Failed to fetch details for API authorization request')
@@ -170,7 +187,7 @@ describe('ApiAuthorizationScreen', () => {
           addAPIMock({
             method: 'get',
             path: '/platform/organizations',
-            response: () => new Promise(() => {}),
+            response: () => new Promise<never>(() => {}),
           })
           renderScreen()
           await screen.findByText('Authorize API access for Test App')
@@ -183,7 +200,8 @@ describe('ApiAuthorizationScreen', () => {
           addAPIMock({
             method: 'get',
             path: '/platform/organizations',
-            response: () => HttpResponse.json({ message: 'Server error' }, { status: 500 }),
+            response: () =>
+              HttpResponse.json<APIErrorBody>({ message: 'Server error' }, { status: 500 }),
           })
           renderScreen()
           await screen.findByText('There was an error loading your organizations')
@@ -282,7 +300,9 @@ describe('ApiAuthorizationScreen', () => {
         test('calls approve endpoint when Authorize button is clicked', async () => {
           const user = userEvent.setup()
           const approveHandler = vi.fn(() =>
-            HttpResponse.json({ url: 'https://redirect.example.com' })
+            HttpResponse.json<ApproveAuthorizationResponse>({
+              url: 'https://redirect.example.com',
+            })
           )
           mockBothEndpoints()
           addAPIMock({
@@ -300,7 +320,9 @@ describe('ApiAuthorizationScreen', () => {
       describe('decline action', () => {
         test('navigates to /organizations after declining', async () => {
           const user = userEvent.setup()
-          const declineHandler = vi.fn(() => HttpResponse.json({ id: 'test-auth-id' }))
+          const declineHandler = vi.fn(() =>
+            HttpResponse.json<DeclineAuthorizationResponse>({ id: 'test-auth-id' })
+          )
           mockBothEndpoints()
           addAPIMock({
             method: 'delete',

--- a/apps/studio/tests/helpers.tsx
+++ b/apps/studio/tests/helpers.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, getByText, render as originalRender, screen } from '@testing-library/react'
+import { platformComponents as components } from 'api-types'
 import type React from 'react'
 import { useState } from 'react'
 import { TooltipProvider } from 'ui'
@@ -7,6 +8,8 @@ import { CommandProvider } from 'ui-patterns/CommandMenu'
 
 import { ProjectInfoInfinite } from '@/data/projects/projects-infinite-query'
 import type { Organization } from '@/types'
+
+type OrganizationResponse = components['schemas']['OrganizationResponse']
 
 interface SelectorOptions {
   container?: HTMLElement
@@ -52,6 +55,40 @@ export const createMockOrganization = (details: Partial<Organization>): Organiza
     slug: 'abcdefghijklmnopqrst',
     plan: { id: 'free', name: 'Free' },
     managed_by: 'supabase',
+    is_owner: true,
+    billing_email: 'billing@example.com',
+    billing_partner: null,
+    integration_source: null,
+    usage_billing_enabled: false,
+    stripe_customer_id: 'stripe-1',
+    subscription_id: 'subscription-1',
+    organization_requires_mfa: false,
+    opt_in_tags: [],
+    restriction_status: null,
+    restriction_data: null,
+    organization_missing_address: false,
+    organization_missing_tax_id: false,
+  }
+
+  return Object.assign(base, details)
+}
+
+/**
+ * Returns the raw OpenAPI `OrganizationResponse` shape — without the
+ * frontend-derived fields (`managed_by`, `partner_id`) that
+ * `castOrganizationResponseToOrganization` attaches in the query layer.
+ *
+ * Use this for MSW mocks at the network boundary (e.g. `/platform/organizations`).
+ * Use `createMockOrganization` for in-app fixtures that need the cast shape.
+ */
+export const createMockOrganizationResponse = (
+  details: Partial<OrganizationResponse> = {}
+): OrganizationResponse => {
+  const base: OrganizationResponse = {
+    id: 1,
+    name: 'Organization 1',
+    slug: 'abcdefghijklmnopqrst',
+    plan: { id: 'free', name: 'Free' },
     is_owner: true,
     billing_email: 'billing@example.com',
     billing_partner: null,

--- a/apps/studio/tests/lib/msw.ts
+++ b/apps/studio/tests/lib/msw.ts
@@ -1,4 +1,10 @@
-import { http, HttpResponse, HttpResponseResolver } from 'msw'
+import {
+  DefaultBodyType,
+  http,
+  HttpResponse,
+  HttpResponseResolver,
+  PathParams,
+} from 'msw'
 import { setupServer } from 'msw/node'
 
 import type { paths } from '../../data/api'
@@ -39,6 +45,20 @@ type SuccessResponse<P extends Endpoints, M extends Methods> = RemapPaths[P][M] 
     ? R201
     : never
 
+// Studio's standard error envelope — what `handleError` and `ResponseError` consume.
+// OpenAPI doesn't document error bodies (4xx/5xx are `content?: never`), so we
+// hardcode this convention to keep error-state tests strongly typed.
+export type APIErrorBody = { message: string }
+
+// Resolver constrained to the OpenAPI success body (or the error envelope above).
+// Catches drift between mocks and the API contract. `Extract<..., DefaultBodyType>`
+// filters to the JSON-body subset to satisfy `HttpResponseResolver`'s body constraint.
+type TypedResolver<P extends Endpoints, M extends Methods> = HttpResponseResolver<
+  PathParams,
+  DefaultBodyType,
+  Extract<SuccessResponse<P, M>, DefaultBodyType> | APIErrorBody
+>
+
 const isResponseResolver = (val: unknown): val is HttpResponseResolver => typeof val === `function`
 
 export const addAPIMock = <P extends Endpoints | `${Endpoints}?${string}`, M extends Methods>({
@@ -52,7 +72,7 @@ export const addAPIMock = <P extends Endpoints | `${Endpoints}?${string}`, M ext
   : {
       method: M
       path: P
-      response: SuccessResponse<TrimQueryParams<P>, M> | HttpResponseResolver
+      response: SuccessResponse<TrimQueryParams<P>, M> | TypedResolver<TrimQueryParams<P>, M>
     }) => {
   const fullPath = `${API_URL}${path}`
   console.log('[MSW] Adding mock:', method.toUpperCase(), fullPath)

--- a/apps/studio/tests/pages/aws-marketplace-onboarding.test.tsx
+++ b/apps/studio/tests/pages/aws-marketplace-onboarding.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
+import { platformComponents as components } from 'api-types'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import { http, HttpResponse } from 'msw'
 import { beforeEach, describe, expect, test, vi } from 'vitest'
@@ -12,10 +13,11 @@ import type {
 import { CREATE_AWS_MANAGED_ORG_FORM_ID } from '@/components/interfaces/Organization/CloudMarketplace/NewAwsMarketplaceOrgForm'
 import { API_URL } from '@/lib/constants'
 import type { ProfileContextType } from '@/lib/profile'
-import { createMockOrganization } from '@/tests/helpers'
+import { createMockOrganizationResponse } from '@/tests/helpers'
 import { customRender } from '@/tests/lib/custom-render'
 import { addAPIMock, mswServer } from '@/tests/lib/msw'
-import type { Organization } from '@/types'
+
+type OrganizationResponse = components['schemas']['OrganizationResponse']
 
 const DEFAULT_PROFILE_CONTEXT: ProfileContextType = {
   profile: {
@@ -38,13 +40,13 @@ const DEFAULT_PROFILE_CONTEXT: ProfileContextType = {
   isSuccess: true,
 }
 
-const LINKABLE_ORG = createMockOrganization({
+const LINKABLE_ORG = createMockOrganizationResponse({
   id: 1,
   name: 'Acme Production',
   slug: 'acme-production',
   plan: { id: 'pro', name: 'Pro' },
 })
-const UNAVAILABLE_ORG = createMockOrganization({
+const UNAVAILABLE_ORG = createMockOrganizationResponse({
   id: 2,
   name: 'Legacy Billing',
   slug: 'legacy-billing',
@@ -63,7 +65,7 @@ function createOnboardingInfo({
   organizations = [LINKABLE_ORG, UNAVAILABLE_ORG],
   eligibleSlugs = [LINKABLE_ORG.slug],
 }: {
-  organizations?: Organization[]
+  organizations?: OrganizationResponse[]
   eligibleSlugs?: string[]
 } = {}): CloudMarketplaceOnboardingInfo {
   return {
@@ -86,24 +88,24 @@ function mockAwsEndpoints({
   eligibility = ELIGIBLE_CONTRACT,
   onboardingInfo = createOnboardingInfo({ organizations }),
 }: {
-  organizations?: Organization[]
+  organizations?: OrganizationResponse[]
   eligibility?: CloudMarketplaceContractLinkingEligibility
   onboardingInfo?: CloudMarketplaceOnboardingInfo
 } = {}) {
   addAPIMock({
     method: 'get',
     path: '/platform/organizations',
-    response: () => HttpResponse.json(organizations),
+    response: () => HttpResponse.json<OrganizationResponse[]>(organizations),
   })
   addAPIMock({
     method: 'get',
     path: '/platform/cloud-marketplace/buyers/:buyer_id/contract-linking-eligibility',
-    response: () => HttpResponse.json(eligibility),
+    response: () => HttpResponse.json<CloudMarketplaceContractLinkingEligibility>(eligibility),
   })
   addAPIMock({
     method: 'get',
     path: '/platform/cloud-marketplace/buyers/:buyer_id/onboarding-info',
-    response: () => HttpResponse.json(onboardingInfo),
+    response: () => HttpResponse.json<CloudMarketplaceOnboardingInfo>(onboardingInfo),
   })
 }
 
@@ -180,7 +182,7 @@ describe('AwsMarketplaceOnboardingScreen', () => {
       http.post(`${API_URL}/platform/organizations/cloud-marketplace`, async ({ request }) => {
         createRequest = await request.json()
         return HttpResponse.json(
-          createMockOrganization({
+          createMockOrganizationResponse({
             id: 3,
             name: 'Mock Marketplace Org',
             slug: 'mock-marketplace-org',
@@ -263,11 +265,11 @@ describe('AwsMarketplaceOnboardingScreen', () => {
 
   test('promotes the last visited organization into the first visible organizations', async () => {
     const organizations = [
-      createMockOrganization({ id: 1, name: 'Alpha Team', slug: 'alpha-team' }),
-      createMockOrganization({ id: 2, name: 'Beta Team', slug: 'beta-team' }),
-      createMockOrganization({ id: 3, name: 'Delta Team', slug: 'delta-team' }),
-      createMockOrganization({ id: 4, name: 'Gamma Team', slug: 'gamma-team' }),
-      createMockOrganization({ id: 5, name: 'Zeta Team', slug: 'zeta-team' }),
+      createMockOrganizationResponse({ id: 1, name: 'Alpha Team', slug: 'alpha-team' }),
+      createMockOrganizationResponse({ id: 2, name: 'Beta Team', slug: 'beta-team' }),
+      createMockOrganizationResponse({ id: 3, name: 'Delta Team', slug: 'delta-team' }),
+      createMockOrganizationResponse({ id: 4, name: 'Gamma Team', slug: 'gamma-team' }),
+      createMockOrganizationResponse({ id: 5, name: 'Zeta Team', slug: 'zeta-team' }),
     ]
 
     window.localStorage.setItem(


### PR DESCRIPTION
Stacked on top of #46439 (POC: bring back MSW). Set the base to that PR
when reviewing the diff.

## Why

Today, `addAPIMock` constrains response types when the user passes a
literal body, but accepts an unconstrained `HttpResponseResolver` when
the user passes a function. Every test in the MSW POC uses the function
form, so mocks can drift from the OpenAPI contract silently — exactly
the bug class the SKILL claims MSW prevents.

This PR tightens the constraint so the OpenAPI contract is actually
enforced at the type level for the function-resolver form too.

## What changed

- **`apps/studio/tests/lib/msw.ts`** — add `TypedResolver<P, M>` (parameterized
  on the path + method) and `APIErrorBody` (`{ message: string }`).
  Resolvers passed to `addAPIMock` for endpoints with a documented JSON
  success body now must return that shape or the error envelope.
- **`apps/studio/tests/helpers.tsx`** — add `createMockOrganizationResponse`,
  a sibling to `createMockOrganization` that returns the raw OpenAPI
  `OrganizationResponse`. Use this at the network boundary; the existing
  `createMockOrganization` stays for in-app fixtures that need the
  frontend-derived `managed_by` / `partner_id` fields that
  `castOrganizationResponseToOrganization` attaches in the query layer.
- **SKILL update** — `.claude/skills/studio-mock-api-tests/SKILL.md`
  documents the explicit-generic pattern and rationale.

## The `HttpResponse.json<T>` requirement

MSW's `HttpResponse.json<T>(body)` uses `NoInfer<T>` on the body
argument, so inside a resolver `HttpResponse.json(value)` always returns
`HttpResponse<JsonBodyType>` — the body type never narrows from the
contextual return type. Result: even valid mocks like
`HttpResponse.json([])` fail to typecheck against the new constraint.

**Fix**: pass an explicit generic in each resolver:
```ts
response: () => HttpResponse.json<OrganizationResponse[]>([])
response: () => HttpResponse.json<APIErrorBody>({ message: 'Boom' }, { status: 500 })
```
This doubles as a self-documenting contract assertion — exactly the
behavior we want.

## Drift fixed (each verified against the OpenAPI schema, not just
silenced)

- `/platform/feedback/send` — mocks returned `{ ok: true }`; schema is
  `SendFeedbackResponse = { result: string }`. Updated all 12 sites in
  `SupportFormPage.test.tsx`.
- `/platform/projects/:ref` — mock returned a `ProjectInfoInfinite`
  (shape of `/platform/projects[]`); schema is `ProjectDetailResponse`
  (richer: `db_host`, `high_availability`, `restUrl`, ...). Added a
  local `toProjectDetailResponse` builder in the test.
- `/platform/organizations/:slug/projects` — mock returned a
  `ProjectInfoInfinite[]` envelope; schema is `OrganizationProjectsResponse`
  (different per-project fields: `databases[]`, `is_branch`, no
  `organization_slug`). Added a local `toOrganizationProject` builder.
- Error envelope `{ msg: ... }` → `{ message: ... }` for `addAPIMock`
  resolvers (the consumer reads `message` — the `msg` mock was wrong).
- `Organization` fixtures handed to `/platform/organizations` mocks
  switched to `createMockOrganizationResponse` to match the response
  contract (organizations endpoint returns the pre-cast shape).

## Not drift — left as-is with a deliberate cast

- `ApiAuthorization.test.tsx`: the frontend `ApiAuthorizationResponse`
  intentionally widens the OpenAPI `GetOAuthAuthorizationResponse`
  (looser `registration_type`, nullable `icon`/`approved_at`), and the
  query layer casts the API response. The test cast at the MSW boundary
  preserves the existing frontend convention; correcting the local type
  is out of scope.

## Verification

- `pnpm --filter=studio typecheck` — clean
- All 5 affected test files (64 tests total) pass:
  `OrgNotFound.test.tsx`, `RedeemCredits.test.tsx`,
  `SupportFormPage.test.tsx`, `ApiAuthorization.test.tsx`,
  `aws-marketplace-onboarding.test.tsx`

## Reviewer attention

- The `NoInfer` workaround is the most surprising part — the new
  constraint won't catch a drifting mock unless the test passes an
  explicit generic. Worth highlighting in the SKILL (done) and in
  reviews of future MSW tests.
- The error envelope assumption (`{ message: string }`) is hardcoded.
  OpenAPI doesn't document 4xx/5xx bodies for these endpoints
  (`content?: never`), so we encode Studio's convention. If another
  error shape shows up, widen `APIErrorBody`.