### PR TITLE
fix(studio): unified logs status color consistency DEBUG-113

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/blocks/PostgresFlowDetail.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/blocks/PostgresFlowDetail.tsx
@@ -45,7 +45,7 @@ const FieldDetailRow = ({
   return (
     <DetailRow
       label={config.label}
-      value={<FieldValue config={config} value={value} wrap={config.wrap} />}
+      value={<FieldValue config={config} value={value} wrap={config.wrap} level={data?.level} />}
       filterId={config.id}
       filterValue={typeof value === 'string' || typeof value === 'number' ? value : undefined}
       filterFields={filterFields}

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/Block.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/Block.tsx
@@ -42,7 +42,7 @@ const FieldRow = ({
   return (
     <DetailRow
       label={config.label}
-      value={<FieldValue config={config} value={value} wrap={config.wrap} />}
+      value={<FieldValue config={config} value={value} wrap={config.wrap} level={data?.level} />}
       filterId={config.id}
       filterValue={typeof value === 'string' || typeof value === 'number' ? value : undefined}
       filterFields={filterFields}

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/BlockField.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/BlockField.tsx
@@ -1,6 +1,5 @@
 import { Skeleton } from 'ui'
 
-import { getStatusLevel } from '../../../UnifiedLogs.utils'
 import { BlockFieldProps } from '../../types'
 import { TruncatedTextWithPopover } from './TruncatedTextWithPopover'
 import { DataTableColumnStatusCode } from '@/components/ui/DataTable/DataTableColumn/DataTableColumnStatusCode'
@@ -37,11 +36,7 @@ export const BlockField = ({
         {shouldShowSkeleton ? (
           <Skeleton className="h-4 w-24" />
         ) : isStatusField && displayValue !== 'N/A' ? (
-          <DataTableColumnStatusCode
-            value={displayValue}
-            level={getStatusLevel(displayValue)}
-            className="text-xs"
-          />
+          <DataTableColumnStatusCode value={displayValue} level={data?.level} className="text-xs" />
         ) : isApiKeyField && displayValue !== 'N/A' ? (
           <TruncatedTextWithPopover
             text={stringValue}

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/FieldValue.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/FieldValue.tsx
@@ -1,7 +1,6 @@
 import { ReactNode } from 'react'
 import { cn } from 'ui'
 
-import { getStatusLevel } from '../../../UnifiedLogs.utils'
 import { BlockFieldConfig } from '../../types'
 import { DataTableColumnStatusCode } from '@/components/ui/DataTable/DataTableColumn/DataTableColumnStatusCode'
 
@@ -9,16 +8,17 @@ interface FieldValueProps {
   config: BlockFieldConfig
   value: unknown
   wrap?: boolean
+  level?: string
 }
 
-export const FieldValue = ({ config, value, wrap }: FieldValueProps): ReactNode => {
+export const FieldValue = ({ config, value, wrap, level }: FieldValueProps): ReactNode => {
   if (value === null || value === undefined || value === '') return null
 
   if (config.id === 'status') {
     return (
       <DataTableColumnStatusCode
         value={value as string | number}
-        level={getStatusLevel(value as string | number)}
+        level={level}
         className="text-xs"
       />
     )


### PR DESCRIPTION
## Problem

In the unified logs UI, the status badge for a Postgres row showed a different color in the detail view than in the table view. The table view colors by the row's pre-computed `level` (derived in SQL from `severity_text`), so a Postgres ERROR row's SQL state code (e.g. `42P01`) renders red. The detail view re-derived the level via `getStatusLevel(value)` which only handles HTTP numeric codes. `Number('42P01')` is `NaN`, every branch fell through, and the badge always rendered neutral regardless of severity.

## Fix

Color the status badge in the detail view by `data.level`, the same canonical row level the table view uses. Threaded `level` through `FieldValue` and used `data.level` directly in `BlockField`.

`getStatusLevel` is still used by the Webhooks platform views, where `responseCode` is always a numeric HTTP status, so those callers stay correct.

## How to test

- Open the dashboard and navigate to a project's unified logs page.
- Filter to `log_type: postgres` and find an ERROR row.
- Confirm the status code (a SQL state like `42P01`) is colored red in the table.
- Click the row to open the detail pane and confirm the Status field in the Postgres block is also red.
- Repeat with a WARNING-severity Postgres row, confirming both views render warning color.
- Sanity check a 5xx HTTP row (PostgREST or Storage) still shows red in both views, and a 2xx row stays neutral in both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved consistency in how log level context is propagated through logging interface components, enabling more uniform formatting and rendering behavior across the unified logs display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46450?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->