### PR TITLE
fix(studio): add hover delay to unified logs status code tooltip FE-3499

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
@@ -149,7 +149,7 @@ export function generateDynamicColumns({ data }: { data: ColumnSchema[] }): {
               </div>
             )} */}
             {label ? (
-              <Tooltip>
+              <Tooltip delayDuration={500}>
                 <TooltipTrigger asChild>
                   <span>
                     <DataTableColumnStatusCode


### PR DESCRIPTION
## Problem

The status code tooltip in Unified Logs appeared instantly on hover because the global `TooltipProvider` in `_app.tsx` sets `delayDuration={0}`. That made it easy to trigger accidentally while moving the cursor across the table.

## Fix

Override `delayDuration` to `500` on the status column's `Tooltip` root so it only shows on intentional hover.

## How to test

- Open Studio and navigate to Logs (Unified Logs)
- Move the cursor quickly across the status code column
- Expected: the status label tooltip does not appear unless you hover for about half a second