### PR TITLE
fix(studio): use default tooltip hover delay

### DIFF
--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -207,7 +207,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                         applicationName="Supabase Studio"
                         route={isNonProdEnv ? '/favicon/staging' : '/favicon'}
                       />
-                      <TooltipProvider delayDuration={0}>
+                      <TooltipProvider>
                         <RouteValidationWrapper>
                           <ThemeProvider>
                             <DevToolbarProvider apiUrl={API_URL}>


### PR DESCRIPTION
## Problem

The global `TooltipProvider` in `apps/studio/pages/_app.tsx` sets `delayDuration={0}`, so every tooltip in Studio appears instantly on hover. This makes tooltips easy to trigger accidentally while moving the cursor, and contributed to issues like FE-3499 (status code tooltip in Unified Logs).

The zero delay was introduced in #32679 when tooltips were migrated to shadcn, without a stated reason.

## Fix

Remove the `delayDuration={0}` prop so tooltips use the Radix default (700ms).

## How to test

- Open Studio
- Hover briefly over icons, buttons, and other elements with tooltips
- Expected: tooltips no longer appear instantly; they show after a short hover delay
- Hovering long enough (around 700ms) still shows the tooltip as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated tooltip behavior to use default delay duration instead of immediate display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46456?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->