### PR TITLE
Add skeleton loader for unified logs chart

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -14,7 +14,7 @@ import {
   VisibilityState,
 } from '@tanstack/react-table'
 import { LOCAL_STORAGE_KEYS, useDebounce, useParams } from 'common'
-import { PanelLeftClose, PanelLeftOpen } from 'lucide-react'
+import { Loader2, PanelLeftClose, PanelLeftOpen } from 'lucide-react'
 import { useQueryStates } from 'nuqs'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import {
@@ -433,16 +433,22 @@ export const UnifiedLogs = () => {
                 </div>
               </div>
 
-              <TimelineChart
-                data={unifiedLogsChart}
-                className={cn(
-                  '-mb-1.5 mt-1.5',
-                  isFetchingCharts && 'opacity-60 transition-opacity duration-150'
-                )}
-                columnId="timestamp"
-                filterColumnId="date"
-                chartConfig={filteredChartConfig}
-              />
+              {isLoading ? (
+                <div className="h-[60px] flex items-center justify-center">
+                  <Loader2 size={14} className="animate-spin text-foreground-lighter" />
+                </div>
+              ) : (
+                <TimelineChart
+                  data={unifiedLogsChart}
+                  className={cn(
+                    '-mb-1.5 mt-1.5',
+                    isFetchingCharts && 'opacity-60 transition-opacity duration-150'
+                  )}
+                  columnId="timestamp"
+                  filterColumnId="date"
+                  chartConfig={filteredChartConfig}
+                />
+              )}
             </div>
 
             <RowSelectionHeader />

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -21,8 +21,6 @@ export interface DataTableInfiniteProps<TData, TValue, _TMeta> {
   totalRows?: number
   filterRows?: number
   totalRowsFetched?: number
-  isFetching?: boolean
-  isLoading?: boolean
   hasNextPage?: boolean
   fetchNextPage: (options?: FetchNextPageOptions | undefined) => Promise<unknown>
   setColumnOrder: (columnOrder: string[]) => void


### PR DESCRIPTION
## Context

Opting for just a loading spinner as the skeleton loader for charts

<img width="1468" height="952" alt="image" src="https://github.com/user-attachments/assets/d6c291c8-9151-40c8-bfbe-f838431dd6dc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a loading spinner to the unified logs view that displays while logs are being fetched, providing clear visual feedback during data retrieval.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46460?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->