### PR TITLE
fix(studio): hide swap usage chart in database report

### DIFF
--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -96,7 +96,7 @@ export const getReportAttributesV2: (
       id: 'swap-usage',
       label: 'Swap usage',
       docsUrl: `${DOCS_URL}/guides/telemetry/reports#memory-usage`,
-      hide: false,
+      hide: true,
       showTooltip: true,
       showLegend: false,
       hideChartType: false,


### PR DESCRIPTION
## Problem

The Swap usage chart in the database report (Observability > Database) displays inaccurate data.

## Fix

Set the swap-usage chart's `hide` flag to `true` in [`database-charts.ts`](apps/studio/data/reports/database-charts.ts) so it no longer renders. The chart definition is kept so it can be re-enabled once the underlying metric is reliable.

## Test plan

- [ ] Open Observability > Database report and confirm the Swap usage chart is no longer shown
- [ ] Confirm other charts (Memory, CPU, Disk, etc.) continue to render

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the visibility of the swap usage chart in reports—it is now properly hidden from display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46465?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->