### PR TITLE
chore(docs): add reference to account audit logs

### DIFF
--- a/apps/docs/content/guides/security/platform-audit-logs.mdx
+++ b/apps/docs/content/guides/security/platform-audit-logs.mdx
@@ -40,6 +40,8 @@ For each audit log, you can see additional details by clicking on the log entry:
   - Metadata such as route and response status
 - Action Target (Project, organization, Edge Function, ...)
 
+Each Supabase user account also has access to [Account Audit logs](/dashboard/account/audit) which displays these logs for only the associated user account.
+
 ## Limitations
 
 - There is currently no way to export the logs via dashboard


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Currently, we have a doc that was created to provide details about platform audit logs (organization level)

## What is the new behavior?

This adds a detail about account audit logs, which provide the same details as the platform audit log. The difference is account audit logs only show logs for the specific user account.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced Platform Audit Logs guide to clarify that each account has access to separate Account Audit logs for tracking individual user activity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->