### PR TITLE
chore(llms): consolidate /llms.txt to single root path

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -31,7 +31,7 @@ const generateMetadata = async (_, parent: ResolvingMetadata): Promise<Metadata>
         media: parentAlternates.media || undefined,
         types: {
           ...(parentAlternates.types ?? {}),
-          'text/markdown': '/llms-full.txt',
+          'text/markdown': 'https://supabase.com/llms-full.txt',
         },
       }),
     },

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -3203,16 +3203,6 @@ module.exports = [
     destination: '/dashboard/redeem?code=:code',
     permanent: false,
   },
-  {
-    permanent: true,
-    source: '/docs/llms.txt',
-    destination: '/llms.txt',
-  },
-  {
-    permanent: true,
-    source: '/docs/llms-full.txt',
-    destination: '/llms-full.txt',
-  },
   // Legacy product .txt URLs → new .md routes
   { permanent: true, source: '/llms/homepage.txt', destination: '/homepage.md' },
   { permanent: true, source: '/llms/auth.txt', destination: '/auth.md' },


### PR DESCRIPTION
## Summary

Removes the preemptive 301 redirects from `/docs/llms.txt` and `/docs/llms-full.txt` to root, and switches the docs homepage `rel=alternate` to an absolute URL. The `/docs/*` paths never had a producer in `apps/docs` (no route handler, no static file at `public/llms.txt` or `public/llms-full.txt`); the redirects were cruft from before the root paths were canonical. Now `/docs/llms*` cleanly 404s and the only advertised path is the root canonical per llmstxt.org.

## Changes

- Delete `/docs/llms.txt` and `/docs/llms-full.txt` 301 entries from `apps/www/lib/redirects.js`
- Switch `apps/docs/app/page.tsx` rel=alternate `text/markdown` from relative `/llms-full.txt` to absolute `https://supabase.com/llms-full.txt`, so `basePath: '/docs'` does not reconstruct the now-dead `/docs/llms-full.txt` path

## Testing

Verify on Vercel preview:

- [ ] `curl -sI -L <preview>/docs/llms.txt` returns 404 (no producer, redirect removed)
- [ ] `curl -sI -L <preview>/docs/llms-full.txt` returns 404
- [ ] `curl -sI -L <preview>/llms.txt` returns 200 with `content-type: text/plain`
- [ ] `curl -sI -L <preview>/llms-full.txt` returns 200, ~9 MB body
- [ ] `curl -s <preview>/docs/ | grep 'rel="alternate".*llms-full'` shows the absolute `https://supabase.com/llms-full.txt` href (no `/docs/` prefix)

Caveat: the absolute alternate URL points at production from preview deploys. Acceptable because Vercel previews are `noindex` by default and the existing `canonical: BASE_PATH` already crosses environments via basePath resolution.

## Linear

- fixes GROWTH-881


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation URL references to use absolute Supabase-hosted paths
  * Reorganized legacy product documentation redirects to new markdown-based routes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46468?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->