### PR TITLE
refactor(logs): rename Reports logs `sql` field to `safeSql`

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -149,7 +149,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
     queries: {
       totalRequests: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-total-requests
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -167,7 +167,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       topRoutes: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-top-routes
         select
           request.path as path,
@@ -190,7 +190,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       errorCounts: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-error-counts
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -211,7 +211,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       topErrorRoutes: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-top-error-routes
         select
           request.path as path,
@@ -236,7 +236,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       responseSpeed: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-response-speed
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -256,7 +256,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       topSlowRoutes: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-top-slow-routes
         select
           request.path as path,
@@ -280,7 +280,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       networkTraffic: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-network-traffic
         select
           cast(timestamp_trunc(t.timestamp, hour) as datetime) as timestamp,
@@ -318,7 +318,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       },
       requestsByCountry: {
         queryType: 'logs',
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-api-requests-by-country
         select
           cf.country as country,
@@ -348,7 +348,7 @@ export const PRESET_CONFIG: Record<Presets, PresetConfig> = {
       cacheHitRate: {
         queryType: 'logs',
         // storage report does not perform any filtering
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-storage-cache-hit-rate
 SELECT
   timestamp_trunc(timestamp, hour) as timestamp,
@@ -368,7 +368,7 @@ order by timestamp desc
       topCacheMisses: {
         queryType: 'logs',
         // storage report does not perform any filtering
-        sql: (filters) => safeLogSql`
+        safeSql: (filters) => safeLogSql`
         -- reports-storage-top-cache-misses
 SELECT
   r.path as path,

--- a/apps/studio/components/interfaces/Reports/Reports.types.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.types.ts
@@ -24,7 +24,7 @@ export type BaseQueries<Keys extends string> = Record<Keys, ReportQuery>
 
 export interface ReportQueryLogs {
   queryType: 'logs'
-  sql: (
+  safeSql: (
     filters: ReportFilterItem[],
     where?: string,
     orderBy?: string,

--- a/apps/studio/components/interfaces/Reports/Reports.utils.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.tsx
@@ -54,7 +54,7 @@ export function getLogsSql(query: ReportQuery, filters: ReportFilterItem[]): Saf
   if (query.queryType !== 'logs') {
     throw new Error(`Expected logs query, got ${query.queryType}`)
   }
-  return query.sql(filters)
+  return query.safeSql(filters)
 }
 
 /**

--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
@@ -22,7 +22,7 @@ function sourceTable(src: string): SafeLogSqlFragment {
 export const SHARED_API_REPORT_SQL = {
   totalRequests: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+    safeSql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
       safeSql`
         --reports-api-total-requests
         select
@@ -41,7 +41,7 @@ export const SHARED_API_REPORT_SQL = {
   },
   topRoutes: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+    safeSql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
       safeSql`
         -- reports-api-top-routes
         select
@@ -65,7 +65,7 @@ export const SHARED_API_REPORT_SQL = {
   },
   errorCounts: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+    safeSql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
       safeSql`
         -- reports-api-error-counts
         select
@@ -87,7 +87,7 @@ export const SHARED_API_REPORT_SQL = {
   },
   topErrorRoutes: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+    safeSql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
       safeSql`
         -- reports-api-top-error-routes
         select
@@ -113,7 +113,7 @@ export const SHARED_API_REPORT_SQL = {
   },
   responseSpeed: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+    safeSql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
       safeSql`
         -- reports-api-response-speed
         select
@@ -134,7 +134,7 @@ export const SHARED_API_REPORT_SQL = {
   },
   topSlowRoutes: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+    safeSql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
       safeSql`
         -- reports-api-top-slow-routes
         select
@@ -159,7 +159,7 @@ export const SHARED_API_REPORT_SQL = {
   },
   networkTraffic: {
     queryType: 'logs',
-    sql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
+    safeSql: (filters: ReportFilterItem[], src = 'edge_logs'): SafeLogSqlFragment =>
       safeSql`
         -- reports-api-network-traffic
         select
@@ -269,7 +269,7 @@ export const useSharedAPIReport = ({
           const data = await executeAnalyticsSql({
             projectRef: ref,
             endpoint: '/platform/projects/{ref}/analytics/endpoints/logs.all',
-            sql: value.sql(allFilters, filterByMapSource[filterBy]),
+            sql: value.safeSql(allFilters, filterByMapSource[filterBy]),
             iso_timestamp_start: start,
             iso_timestamp_end: end,
             method: 'get',
@@ -334,16 +334,25 @@ export const useSharedAPIReport = ({
   const isLoadingData = Object.values(isLoading).some(Boolean)
 
   const SQLMap: Record<SharedAPIReportKey, SafeLogSqlFragment> = {
-    totalRequests: SHARED_API_REPORT_SQL.totalRequests.sql(allFilters, filterByMapSource[filterBy]),
-    topRoutes: SHARED_API_REPORT_SQL.topRoutes.sql(allFilters, filterByMapSource[filterBy]),
-    errorCounts: SHARED_API_REPORT_SQL.errorCounts.sql(allFilters, filterByMapSource[filterBy]),
-    topErrorRoutes: SHARED_API_REPORT_SQL.topErrorRoutes.sql(
+    totalRequests: SHARED_API_REPORT_SQL.totalRequests.safeSql(
       allFilters,
       filterByMapSource[filterBy]
     ),
-    responseSpeed: SHARED_API_REPORT_SQL.responseSpeed.sql(allFilters, filterByMapSource[filterBy]),
-    topSlowRoutes: SHARED_API_REPORT_SQL.topSlowRoutes.sql(allFilters, filterByMapSource[filterBy]),
-    networkTraffic: SHARED_API_REPORT_SQL.networkTraffic.sql(
+    topRoutes: SHARED_API_REPORT_SQL.topRoutes.safeSql(allFilters, filterByMapSource[filterBy]),
+    errorCounts: SHARED_API_REPORT_SQL.errorCounts.safeSql(allFilters, filterByMapSource[filterBy]),
+    topErrorRoutes: SHARED_API_REPORT_SQL.topErrorRoutes.safeSql(
+      allFilters,
+      filterByMapSource[filterBy]
+    ),
+    responseSpeed: SHARED_API_REPORT_SQL.responseSpeed.safeSql(
+      allFilters,
+      filterByMapSource[filterBy]
+    ),
+    topSlowRoutes: SHARED_API_REPORT_SQL.topSlowRoutes.safeSql(
+      allFilters,
+      filterByMapSource[filterBy]
+    ),
+    networkTraffic: SHARED_API_REPORT_SQL.networkTraffic.safeSql(
       allFilters,
       filterByMapSource[filterBy]
     ),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor (naming consistency cleanup).

## What is the current behavior?

`ReportQueryLogs` exposed its SQL builder under a `sql:` field while `ReportQueryDb` used `safeSql:`. Both already returned branded fragments (`SafeLogSqlFragment` / `SafeSqlFragment`), so should consolidate on `safeSql`.

## What is the new behavior?

Renames `sql:` → `safeSql:` on `ReportQueryLogs` so the two report-query shapes use the same field name. Updates every Logs preset under `PRESET_CONFIG[API|STORAGE]`, every entry and call site in `SharedAPIReport.constants.ts`, and `getLogsSql` in `Reports.utils.tsx`.

Part of the analytics SQL safety series; PRs 10 (remaining analytics callers) and 11 (ESLint rules) still to follow.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced query handling across API analytics reports (requests, top routes, errors, performance metrics) and Storage analytics reports (cache metrics) for improved consistency in query processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46469?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->