### PR TITLE
feat: override wrappers in dashboard with those from marketplace db

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -95,7 +95,7 @@ export const useAvailableIntegrations = () => {
             featured: !!featured,
             type: 'oauth' as const, // Currently marketplace only supports oauth apps
             source: 'Partner' as const,
-            categories: Array.isArray(categories) ? categories.map((x) => x.slug) : [],
+            categories: categories.map((x) => x.slug),
             content,
             files: images?.map((image) => fullImageUrl(image)),
             description,
@@ -142,9 +142,7 @@ export const useAvailableIntegrations = () => {
     const map: Record<string, MarketplaceIntegration> = {}
     ;(data ?? []).forEach((integration) => {
       if (!isForeignDataWrapper(integration)) return
-      const slug = integration.slug
-      if (!slug) return
-      map[slug.replaceAll('-', '_')] = integration
+      map[integration.slug.replaceAll('-', '_')] = integration
     })
     return map
   }, [data])
@@ -154,10 +152,7 @@ export const useAvailableIntegrations = () => {
   // extensions are not available on this DB image), the UI will provide a tooltip explaining why.
   const allIntegrations = useMemo(() => {
     return INTEGRATIONS.filter((integration) => {
-      if (
-        !integrationsWrappers &&
-        (integration.type === 'wrapper' || integration.id.endsWith('_wrapper'))
-      ) {
+      if (!integrationsWrappers && integration.type === 'wrapper') {
         return false
       }
 
@@ -167,7 +162,7 @@ export const useAvailableIntegrations = () => {
 
       return true
     }).map((integration) => {
-      const isWrapper = integration.type === 'wrapper' || integration.id.endsWith('_wrapper')
+      const isWrapper = integration.type === 'wrapper'
       if (!isWrapper) return integration
 
       const marketplaceWrapper = marketplaceWrappers[integration.id]
@@ -184,16 +179,20 @@ export const useAvailableIntegrations = () => {
         listing_logo: listingLogo,
       } = marketplaceWrapper
 
+      const overrides = {
+        name: title,
+        description,
+        content,
+        docsUrl,
+        siteUrl,
+        author: authorName ? { name: authorName, websiteUrl: '' } : undefined,
+        files: images?.map((image) => fullImageUrl(image)),
+        icon: listingLogo ? renderMarketplaceLogo(listingLogo) : undefined,
+      }
+
       return {
         ...integration,
-        ...(title ? { name: title } : {}),
-        ...(description ? { description } : {}),
-        ...(content ? { content } : {}),
-        ...(docsUrl ? { docsUrl } : {}),
-        ...(siteUrl ? { siteUrl } : {}),
-        ...(authorName ? { author: { name: authorName, websiteUrl: '' } } : {}),
-        ...(images ? { files: images.map((image) => fullImageUrl(image)) } : {}),
-        ...(listingLogo ? { icon: renderMarketplaceLogo(listingLogo) } : {}),
+        ...Object.fromEntries(Object.entries(overrides).filter(([, v]) => v !== undefined)),
       }
     })
   }, [integrationsWrappers, isCLI, marketplaceWrappers])

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -34,100 +34,125 @@ export const useAvailableIntegrations = () => {
   const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!data && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
 
+  const renderMarketplaceLogo =
+    (listingLogo?: string | null) =>
+    ({ className, ...props }: { className?: string } = {}) => (
+      <div className="relative w-full h-full">
+        {listingLogo ? (
+          <Image
+            fill
+            unoptimized
+            src={fullImageUrl(listingLogo)}
+            alt=""
+            className={cn('p-2', className)}
+            {...props}
+          />
+        ) : (
+          <Boxes className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
+        )}
+      </div>
+    )
+
+  const isMarketplaceWrapper = (integration: { categories?: unknown }) =>
+    Array.isArray(integration.categories) &&
+    (integration.categories as Array<{ slug: string }>).some(
+      (c) => c?.slug === 'foreign-data-wrapper'
+    )
+
   // [Joshen] Format marketplace integrations into existing ones for now
   // Likely that we might need to change, but can look into separately
+  // Wrappers from marketplace are excluded here — they are merged into the
+  // hardcoded studio wrappers below as content overrides.
   const marketplaceIntegrations: IntegrationDefinition[] = useMemo(
     () =>
-      (data ?? [])?.map((integration) => {
-        const {
-          id: listingId,
-          slug,
-          categories,
-          featured,
-          title,
-          description,
-          documentation_url: docsUrl,
-          website_url: siteUrl,
-          installation_url: installUrl,
-          installation_url_type: installUrlType,
-          installation_identification_method: installMethod,
-          secret_key_prefix: secretKeyPrefix,
-          edge_function_secret_name: edgeFunctionSecretName,
-          images,
-          content,
-          partner_name: authorName,
-          listing_logo: listingLogo,
-        } = integration
+      (data ?? [])
+        ?.filter((integration) => !isMarketplaceWrapper(integration))
+        .map((integration) => {
+          const {
+            id: listingId,
+            slug,
+            categories,
+            featured,
+            title,
+            description,
+            documentation_url: docsUrl,
+            website_url: siteUrl,
+            installation_url: installUrl,
+            installation_url_type: installUrlType,
+            installation_identification_method: installMethod,
+            secret_key_prefix: secretKeyPrefix,
+            edge_function_secret_name: edgeFunctionSecretName,
+            images,
+            content,
+            partner_name: authorName,
+            listing_logo: listingLogo,
+          } = integration
 
-        const status = undefined
-        const author = { name: authorName ?? '', websiteUrl: '' }
+          const status = undefined
+          const author = { name: authorName ?? '', websiteUrl: '' }
 
-        return {
-          id: slug ?? '',
-          name: title ?? '',
-          status,
-          featured: !!featured,
-          type: 'oauth' as const, // Currently marketplace only supports oauth apps
-          source: 'Partner' as const,
-          categories: Array.isArray(categories)
-            ? (categories as Array<{ slug: string }>).map((x) => x.slug)
-            : [],
-          content,
-          files: images?.map((image) => fullImageUrl(image)),
-          description,
-          docsUrl,
-          siteUrl,
-          installUrl,
-          installUrlType: installUrlType ?? undefined,
-          installIdentificationMethod: installMethod ?? undefined,
-          secretKeyPrefix: secretKeyPrefix ?? undefined,
-          edgeFunctionSecretName: edgeFunctionSecretName ?? undefined,
-          listingId: listingId ?? undefined,
-          author,
-          requiredExtensions: [],
-          icon: ({ className, ...props } = {}) => (
-            <div className="relative w-full h-full">
-              {listingLogo ? (
-                <Image
-                  fill
-                  src={fullImageUrl(listingLogo)}
-                  alt=""
-                  className={cn('p-2', className)}
-                  {...props}
-                />
-              ) : (
-                <Boxes
-                  className={cn('inset-0 p-2 text-black w-full h-full', className)}
-                  {...props}
-                />
-              )}
-            </div>
-          ),
-          navigation: [
-            {
-              route: 'overview',
-              label: 'Overview',
+          return {
+            id: slug ?? '',
+            name: title ?? '',
+            status,
+            featured: !!featured,
+            type: 'oauth' as const, // Currently marketplace only supports oauth apps
+            source: 'Partner' as const,
+            categories: Array.isArray(categories)
+              ? (categories as Array<{ slug: string }>).map((x) => x.slug)
+              : [],
+            content,
+            files: images?.map((image) => fullImageUrl(image)),
+            description,
+            docsUrl,
+            siteUrl,
+            installUrl,
+            installUrlType: installUrlType ?? undefined,
+            installIdentificationMethod: installMethod ?? undefined,
+            secretKeyPrefix: secretKeyPrefix ?? undefined,
+            edgeFunctionSecretName: edgeFunctionSecretName ?? undefined,
+            listingId: listingId ?? undefined,
+            author,
+            requiredExtensions: [],
+            icon: renderMarketplaceLogo(listingLogo),
+            navigation: [
+              {
+                route: 'overview',
+                label: 'Overview',
+              },
+            ],
+            navigate: ({ pageId = 'overview' }) => {
+              switch (pageId) {
+                case 'overview':
+                  return dynamic(
+                    () =>
+                      import('@/components/interfaces/Integrations/Integration/MarketplaceIntegrationOverviewTab').then(
+                        (mod) => mod.MarketplaceIntegrationOverviewTab
+                      ),
+                    {
+                      loading: Loading,
+                    }
+                  )
+              }
+              return null
             },
-          ],
-          navigate: ({ pageId = 'overview' }) => {
-            switch (pageId) {
-              case 'overview':
-                return dynamic(
-                  () =>
-                    import('@/components/interfaces/Integrations/Integration/MarketplaceIntegrationOverviewTab').then(
-                      (mod) => mod.MarketplaceIntegrationOverviewTab
-                    ),
-                  {
-                    loading: Loading,
-                  }
-                )
-            }
-            return null
-          },
-        }
-      }),
+          }
+        }),
     [data]
   )
+
+  // Marketplace wrapper listings keyed by their studio-equivalent id
+  // (marketplace uses dash-separated slugs, studio uses underscore-separated ids).
+  const marketplaceWrappers = useMemo(() => {
+    const map: Record<string, NonNullable<typeof data>[number]> = {}
+    ;(data ?? []).forEach((integration) => {
+      if (!isMarketplaceWrapper(integration)) return
+      const slug = integration.slug
+      if (!slug) return
+      map[slug.replaceAll('-', '_')] = integration
+    })
+    return map
+  }, [data])
 
   // [Joshen] Existing integrations that are defined within studio
   // Available integrations are all integrations that can be installed. If an integration can't be installed (needed
@@ -146,8 +171,37 @@ export const useAvailableIntegrations = () => {
       }
 
       return true
+    }).map((integration) => {
+      const isWrapper = integration.type === 'wrapper' || integration.id.endsWith('_wrapper')
+      if (!isWrapper) return integration
+
+      const marketplaceWrapper = marketplaceWrappers[integration.id]
+      if (!marketplaceWrapper) return integration
+
+      const {
+        title,
+        description,
+        content,
+        documentation_url: docsUrl,
+        website_url: siteUrl,
+        images,
+        partner_name: authorName,
+        listing_logo: listingLogo,
+      } = marketplaceWrapper
+
+      return {
+        ...integration,
+        ...(title ? { name: title } : {}),
+        ...(description ? { description } : {}),
+        ...(content ? { content } : {}),
+        ...(docsUrl ? { docsUrl } : {}),
+        ...(siteUrl ? { siteUrl } : {}),
+        ...(authorName ? { author: { name: authorName, websiteUrl: '' } } : {}),
+        ...(images ? { files: images.map((image) => fullImageUrl(image)) } : {}),
+        ...(listingLogo ? { icon: renderMarketplaceLogo(listingLogo) } : {}),
+      }
     })
-  }, [integrationsWrappers, isCLI])
+  }, [integrationsWrappers, isCLI, marketplaceWrappers])
 
   const dataWithMarketplace = useMemo(() => {
     return [...marketplaceIntegrations, ...allIntegrations].sort((a, b) =>

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -192,7 +192,7 @@ export const useAvailableIntegrations = () => {
 
       return {
         ...integration,
-        ...Object.fromEntries(Object.entries(overrides).filter(([, v]) => v !== undefined)),
+        ...Object.fromEntries(Object.entries(overrides).filter(([, v]) => v != null)),
       }
     })
   }, [integrationsWrappers, isCLI, marketplaceWrappers])

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query'
 import { FeatureFlagContext, IS_PLATFORM } from 'common'
 import { fullImageUrl } from 'common/marketplace-client'
 import { Boxes } from 'lucide-react'
@@ -9,7 +8,10 @@ import { cn } from 'ui'
 
 import { INTEGRATIONS, Loading, type IntegrationDefinition } from './Integrations.constants'
 import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
-import { marketplaceIntegrationsQueryOptions } from '@/data/marketplace/integrations-query'
+import {
+  useMarketplaceIntegrationsQuery,
+  type MarketplaceIntegration,
+} from '@/data/marketplace/integrations-query'
 import { useCLIReleaseVersionQuery } from '@/data/misc/cli-release-version-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
@@ -26,10 +28,7 @@ export const useAvailableIntegrations = () => {
   const { data: cliData } = useCLIReleaseVersionQuery()
   const isCLI = !!cliData?.current
 
-  const { data, error } = useQuery({
-    ...marketplaceIntegrationsQueryOptions(),
-    enabled: isMarketplaceEnabled,
-  })
+  const { data, error } = useMarketplaceIntegrationsQuery({ enabled: isMarketplaceEnabled })
   const isPending = IS_PLATFORM && (!hasLoaded || (isMarketplaceEnabled && !data && !error))
   const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!data && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
@@ -54,11 +53,8 @@ export const useAvailableIntegrations = () => {
     return MarketplaceLogo
   }
 
-  const isMarketplaceWrapper = (integration: { categories?: unknown }) =>
-    Array.isArray(integration.categories) &&
-    (integration.categories as Array<{ slug: string }>).some(
-      (c) => c?.slug === 'foreign-data-wrapper'
-    )
+  const isForeignDataWrapper = (integration: MarketplaceIntegration) =>
+    integration.categories.some((c) => c?.slug === 'foreign-data-wrapper')
 
   // [Joshen] Format marketplace integrations into existing ones for now
   // Likely that we might need to change, but can look into separately
@@ -67,7 +63,7 @@ export const useAvailableIntegrations = () => {
   const marketplaceIntegrations: IntegrationDefinition[] = useMemo(
     () =>
       (data ?? [])
-        ?.filter((integration) => !isMarketplaceWrapper(integration))
+        ?.filter((integration) => !isForeignDataWrapper(integration))
         .map((integration) => {
           const {
             id: listingId,
@@ -99,9 +95,7 @@ export const useAvailableIntegrations = () => {
             featured: !!featured,
             type: 'oauth' as const, // Currently marketplace only supports oauth apps
             source: 'Partner' as const,
-            categories: Array.isArray(categories)
-              ? (categories as Array<{ slug: string }>).map((x) => x.slug)
-              : [],
+            categories: Array.isArray(categories) ? categories.map((x) => x.slug) : [],
             content,
             files: images?.map((image) => fullImageUrl(image)),
             description,
@@ -145,9 +139,9 @@ export const useAvailableIntegrations = () => {
   // Marketplace wrapper listings keyed by their studio-equivalent id
   // (marketplace uses dash-separated slugs, studio uses underscore-separated ids).
   const marketplaceWrappers = useMemo(() => {
-    const map: Record<string, NonNullable<typeof data>[number]> = {}
+    const map: Record<string, MarketplaceIntegration> = {}
     ;(data ?? []).forEach((integration) => {
-      if (!isMarketplaceWrapper(integration)) return
+      if (!isForeignDataWrapper(integration)) return
       const slug = integration.slug
       if (!slug) return
       map[slug.replaceAll('-', '_')] = integration

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -34,14 +34,12 @@ export const useAvailableIntegrations = () => {
   const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!data && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
 
-  const renderMarketplaceLogo =
-    (listingLogo?: string | null) =>
-    ({ className, ...props }: { className?: string } = {}) => (
+  const renderMarketplaceLogo = (listingLogo?: string | null) => {
+    const MarketplaceLogo = ({ className, ...props }: { className?: string } = {}) => (
       <div className="relative w-full h-full">
         {listingLogo ? (
           <Image
             fill
-            unoptimized
             src={fullImageUrl(listingLogo)}
             alt=""
             className={cn('p-2', className)}
@@ -52,6 +50,9 @@ export const useAvailableIntegrations = () => {
         )}
       </div>
     )
+    MarketplaceLogo.displayName = 'MarketplaceLogo'
+    return MarketplaceLogo
+  }
 
   const isMarketplaceWrapper = (integration: { categories?: unknown }) =>
     Array.isArray(integration.categories) &&

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -15,6 +15,29 @@ import {
 import { useCLIReleaseVersionQuery } from '@/data/misc/cli-release-version-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 
+const renderMarketplaceLogo = (listingLogo?: string | null) => {
+  const MarketplaceLogo = ({ className, ...props }: { className?: string } = {}) => (
+    <div className="relative w-full h-full">
+      {listingLogo ? (
+        <Image
+          fill
+          src={fullImageUrl(listingLogo)}
+          alt=""
+          className={cn('p-2', className)}
+          {...props}
+        />
+      ) : (
+        <Boxes className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
+      )}
+    </div>
+  )
+  return MarketplaceLogo
+}
+
+function isForeignDataWrapper(integration: MarketplaceIntegration) {
+  return integration.categories.some((c) => c?.slug === 'foreign-data-wrapper')
+}
+
 /**
  * [Joshen] Returns a combination of
  * - Marketplace integrations retrieved remotely (Only if feature flag enabled)
@@ -32,29 +55,6 @@ export const useAvailableIntegrations = () => {
   const isPending = IS_PLATFORM && (!hasLoaded || (isMarketplaceEnabled && !data && !error))
   const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!data && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
-
-  const renderMarketplaceLogo = (listingLogo?: string | null) => {
-    const MarketplaceLogo = ({ className, ...props }: { className?: string } = {}) => (
-      <div className="relative w-full h-full">
-        {listingLogo ? (
-          <Image
-            fill
-            src={fullImageUrl(listingLogo)}
-            alt=""
-            className={cn('p-2', className)}
-            {...props}
-          />
-        ) : (
-          <Boxes className={cn('inset-0 p-2 text-black w-full h-full', className)} {...props} />
-        )}
-      </div>
-    )
-    MarketplaceLogo.displayName = 'MarketplaceLogo'
-    return MarketplaceLogo
-  }
-
-  const isForeignDataWrapper = (integration: MarketplaceIntegration) =>
-    integration.categories.some((c) => c?.slug === 'foreign-data-wrapper')
 
   // [Joshen] Format marketplace integrations into existing ones for now
   // Likely that we might need to change, but can look into separately

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceIndex.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceIndex.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query'
 import { parseAsString, parseAsStringEnum, useQueryState } from 'nuqs'
 import { useMemo, useRef } from 'react'
 import { Button, Card, ShadowScrollArea, Table, TableBody, TableHeader } from 'ui'
@@ -33,7 +32,7 @@ import { useInstalledIntegrations } from '@/components/interfaces/Integrations/L
 import { useIntegrationFilteringAndSort } from '@/components/interfaces/Integrations/Landing/useIntegrationFilteringAndSort'
 import { AlertError } from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
-import { marketplaceCategoriesQueryOptions } from '@/data/marketplace/integration-categories-query'
+import { useMarketplaceCategoriesQuery } from '@/data/marketplace/integration-categories-query'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { DOCS_URL } from '@/lib/constants'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
@@ -89,7 +88,7 @@ export const MarketplaceIndex = () => {
   const isLoading = isLoadingAvailable || isLoadingInstalled
   const isSuccess = isSuccessAvailable && isSuccessInstalled
 
-  const { data: marketplaceCategories = [] } = useQuery(marketplaceCategoriesQueryOptions())
+  const { data: marketplaceCategories = [] } = useMarketplaceCategoriesQuery()
 
   const categoryOptions = useMemo(() => {
     // Start with marketplace DB categories

--- a/apps/studio/components/layouts/ProjectIntegrationsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectIntegrationsLayout.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query'
 import { IS_PLATFORM, useFeatureFlags, useParams } from 'common'
 import { useRouter } from 'next/router'
 import { PropsWithChildren } from 'react'
@@ -10,8 +9,8 @@ import { useInstalledIntegrations } from '@/components/interfaces/Integrations/L
 import { ProjectLayout } from '@/components/layouts/ProjectLayout'
 import AlertError from '@/components/ui/AlertError'
 import { ProductMenu } from '@/components/ui/ProductMenu'
-import { marketplaceCategoriesQueryOptions } from '@/data/marketplace/integration-categories-query'
-import { marketplaceIntegrationsQueryOptions } from '@/data/marketplace/integrations-query'
+import { useMarketplaceCategoriesQuery } from '@/data/marketplace/integration-categories-query'
+import { useMarketplaceIntegrationsQuery } from '@/data/marketplace/integrations-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { withAuth } from '@/hooks/misc/withAuth'
 
@@ -54,18 +53,16 @@ const IntegrationCategoriesMenu = ({ page }: { page: string }) => {
   const pageKey = categoryParam || page
 
   const { integrationsWrappers: showWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
-  const { data: categories = [], isPending: isPendingCategories } = useQuery(
-    marketplaceCategoriesQueryOptions({ enabled: isMarketplaceEnabled })
-  )
-  const { data: listings = [], isPending: isPendingListings } = useQuery(
-    marketplaceIntegrationsQueryOptions({ enabled: isMarketplaceEnabled })
-  )
+  const { data: categories = [], isPending: isPendingCategories } = useMarketplaceCategoriesQuery({
+    enabled: isMarketplaceEnabled,
+  })
+  const { data: listings = [], isPending: isPendingListings } = useMarketplaceIntegrationsQuery({
+    enabled: isMarketplaceEnabled,
+  })
 
   const populatedCategoryIds = new Set(
     listings.flatMap((listing) =>
-      Array.isArray(listing.categories)
-        ? (listing.categories as Array<{ id: string }>).map((c) => c.id)
-        : []
+      Array.isArray(listing.categories) ? listing.categories.map((c) => c.id) : []
     )
   )
   const nonEmptyCategories = categories.filter(

--- a/apps/studio/components/layouts/ProjectIntegrationsLayout.tsx
+++ b/apps/studio/components/layouts/ProjectIntegrationsLayout.tsx
@@ -61,9 +61,7 @@ const IntegrationCategoriesMenu = ({ page }: { page: string }) => {
   })
 
   const populatedCategoryIds = new Set(
-    listings.flatMap((listing) =>
-      Array.isArray(listing.categories) ? listing.categories.map((c) => c.id) : []
-    )
+    listings.flatMap((listing) => listing.categories.map((c) => c.id))
   )
   const nonEmptyCategories = categories.filter(
     (category) => category.id && populatedCategoryIds.has(category.id)

--- a/apps/studio/data/marketplace/integration-categories-query.ts
+++ b/apps/studio/data/marketplace/integration-categories-query.ts
@@ -1,23 +1,32 @@
-import { queryOptions } from '@tanstack/react-query'
-import { createMarketplaceClient } from 'common/marketplace-client'
+import { useQuery } from '@tanstack/react-query'
+import { createMarketplaceClient, type Category } from 'common/marketplace-client'
 
 import { marketplaceIntegrationsKeys } from './keys'
 import { handleError } from '@/data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
-async function getMarketplaceCategories() {
+export type MarketplaceCategory = Category
+
+export async function getMarketplaceCategories(signal?: AbortSignal) {
   const marketplaceClient = createMarketplaceClient()
-  const { data, error } = await marketplaceClient.from('categories').select('*')
+  let query = marketplaceClient.from('categories').select('*')
+  if (signal) query = query.abortSignal(signal)
+  const { data, error } = await query
 
   if (error) handleError(error)
   return data ?? []
 }
 
-export const marketplaceCategoriesQueryOptions = ({
+export type MarketplaceCategoriesData = Awaited<ReturnType<typeof getMarketplaceCategories>>
+export type MarketplaceCategoriesError = ResponseError
+
+export const useMarketplaceCategoriesQuery = <TData = MarketplaceCategoriesData>({
   enabled = true,
-}: { enabled?: boolean } = {}) => {
-  return queryOptions({
+  ...options
+}: UseCustomQueryOptions<MarketplaceCategoriesData, MarketplaceCategoriesError, TData> = {}) =>
+  useQuery<MarketplaceCategoriesData, MarketplaceCategoriesError, TData>({
     queryKey: marketplaceIntegrationsKeys.categories(),
-    queryFn: () => getMarketplaceCategories(),
+    queryFn: ({ signal }) => getMarketplaceCategories(signal),
     enabled,
+    ...options,
   })
-}

--- a/apps/studio/data/marketplace/integrations-query.ts
+++ b/apps/studio/data/marketplace/integrations-query.ts
@@ -1,26 +1,32 @@
-import { queryOptions } from '@tanstack/react-query'
-import { createMarketplaceClient } from 'common/marketplace-client'
+import { useQuery } from '@tanstack/react-query'
+import { createMarketplaceClient, type Listing } from 'common/marketplace-client'
 
 import { marketplaceIntegrationsKeys } from './keys'
 import { handleError } from '@/data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
-async function getMarketplaceIntegrations() {
+export type MarketplaceIntegration = Listing
+
+export async function getMarketplaceIntegrations(signal?: AbortSignal) {
   const marketplaceClient = createMarketplaceClient()
-  const { data, error } = await marketplaceClient
-    .from('listings')
-    .select('*')
-    .is('publish_dashboard', true)
+  let query = marketplaceClient.from('listings').select('*').is('publish_dashboard', true)
+  if (signal) query = query.abortSignal(signal)
+  const { data, error } = await query
 
   if (error) handleError(error)
   return data ?? []
 }
 
-export const marketplaceIntegrationsQueryOptions = ({
+export type MarketplaceIntegrationsData = Awaited<ReturnType<typeof getMarketplaceIntegrations>>
+export type MarketplaceIntegrationsError = ResponseError
+
+export const useMarketplaceIntegrationsQuery = <TData = MarketplaceIntegrationsData>({
   enabled = true,
-}: { enabled?: boolean } = {}) => {
-  return queryOptions({
+  ...options
+}: UseCustomQueryOptions<MarketplaceIntegrationsData, MarketplaceIntegrationsError, TData> = {}) =>
+  useQuery<MarketplaceIntegrationsData, MarketplaceIntegrationsError, TData>({
     queryKey: marketplaceIntegrationsKeys.list(),
-    queryFn: () => getMarketplaceIntegrations(),
+    queryFn: ({ signal }) => getMarketplaceIntegrations(signal),
     enabled,
+    ...options,
   })
-}

--- a/apps/studio/pages/project/[ref]/integrations/index.tsx
+++ b/apps/studio/pages/project/[ref]/integrations/index.tsx
@@ -1,4 +1,3 @@
-import { useQuery } from '@tanstack/react-query'
 import { IS_PLATFORM, useFeatureFlags } from 'common'
 import { Database } from 'common/marketplace.types'
 import { Search } from 'lucide-react'
@@ -33,7 +32,7 @@ import { ProjectIntegrationsLayoutDispatch } from '@/components/layouts/ProjectI
 import { AlertError } from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { NoSearchResults } from '@/components/ui/NoSearchResults'
-import { marketplaceCategoriesQueryOptions } from '@/data/marketplace/integration-categories-query'
+import { useMarketplaceCategoriesQuery } from '@/data/marketplace/integration-categories-query'
 import { BASE_PATH, DOCS_URL } from '@/lib/constants'
 import type { NextPageWithLayout } from '@/types'
 
@@ -183,9 +182,9 @@ const LegacyIntegrationsPage = () => {
 
   const selectedCategory = useFilterCategory()
 
-  const { data: categories = [], isPending: isPendingCategories } = useQuery(
-    marketplaceCategoriesQueryOptions({ enabled: isMarketplaceEnabled })
-  )
+  const { data: categories = [], isPending: isPendingCategories } = useMarketplaceCategoriesQuery({
+    enabled: isMarketplaceEnabled,
+  })
 
   const isLoadingSelectedCategory =
     selectedCategory !== 'all' &&


### PR DESCRIPTION
This PR overrides title, description, content, logo, images, docs url, and site url from marketplace db for wrappers. If marketplace doesn't yet publish a wrapper listing, the page falls back to the hardcoded content we show today.

It also improves the marketplace listings and categories queries by returning typed results, making the code more type safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Studio integrations now surface updated marketplace metadata (name, description, icon, docs, site, author, files) when available.
  * Marketplace wrapper integrations are consolidated and shown alongside studio integrations.

* **Refactor**
  * Marketplace category and integration fetching rewritten for more reliable loading, cancellation support, and improved menu/category population.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->