### PR TITLE
feat(www): redesign Realtime marketing page

### DIFF
--- a/apps/www/components/Realtime/Hero/Cursor.tsx
+++ b/apps/www/components/Realtime/Hero/Cursor.tsx
@@ -1,0 +1,29 @@
+import { memo } from 'react'
+import { MousePointer2 } from 'lucide-react'
+import { cn } from 'ui'
+
+function CursorInner({
+  className,
+  style,
+  color,
+  name,
+}: {
+  className?: string
+  style?: React.CSSProperties
+  color: string
+  name: string
+}) {
+  return (
+    <div className={cn('pointer-events-none', className)} style={style}>
+      <MousePointer2 color={color} fill={color} size={30} />
+      <div
+        className="mt-1 px-2 py-1 rounded-sm text-xs font-bold text-white text-center whitespace-nowrap"
+        style={{ backgroundColor: color }}
+      >
+        {name}
+      </div>
+    </div>
+  )
+}
+
+export const Cursor = memo(CursorInner)

--- a/apps/www/components/Realtime/Hero/DemoGridCell.tsx
+++ b/apps/www/components/Realtime/Hero/DemoGridCell.tsx
@@ -1,0 +1,52 @@
+'use client'
+
+import { memo } from 'react'
+import type { RenderCellProps } from 'react-data-grid'
+import { cn } from 'ui'
+
+import { cellKey, useDemoGridFocus } from './demoGridContext'
+import type { UserRow } from './mockUserTableData'
+
+type DemoGridCellProps = RenderCellProps<UserRow>
+
+function DemoGridCellInner({ row, column }: DemoGridCellProps) {
+  const focusedCells = useDemoGridFocus()
+  const key = cellKey(row.id, column.key)
+  const remoteFocus = focusedCells[key]
+  const rawValue = row[column.key as keyof UserRow]
+  const displayValue = rawValue === null || rawValue === undefined ? null : String(rawValue)
+
+  const focusStyle = remoteFocus
+    ? {
+        boxShadow: `inset 0 0 0 1px ${remoteFocus.color}`,
+        backgroundColor: `${remoteFocus.color}15`,
+      }
+    : undefined
+
+  return (
+    <div
+      data-cell={`${row.id}:${column.key}`}
+      className={cn(
+        'sb-grid-text-editor__trigger h-full w-full select-none',
+        remoteFocus && 'realtime-hero-cell--remote-focus'
+      )}
+      style={focusStyle}
+    >
+      {displayValue === null ? (
+        <span className="null-value">NULL</span>
+      ) : (
+        <span className="truncate">{displayValue}</span>
+      )}
+      {remoteFocus && (
+        <span
+          className="realtime-hero-cell__editor-badge"
+          style={{ backgroundColor: remoteFocus.color }}
+        >
+          {remoteFocus.name}
+        </span>
+      )}
+    </div>
+  )
+}
+
+export const DemoGridCell = memo(DemoGridCellInner)

--- a/apps/www/components/Realtime/Hero/GridColumnHeader.tsx
+++ b/apps/www/components/Realtime/Hero/GridColumnHeader.tsx
@@ -1,0 +1,26 @@
+import { ChevronDown, Key } from 'lucide-react'
+
+type GridColumnHeaderProps = {
+  name: string
+  format: string
+  isPrimaryKey?: boolean
+}
+
+export function GridColumnHeader({ name, format, isPrimaryKey }: GridColumnHeaderProps) {
+  return (
+    <div className="w-full bg-surface-200">
+      <div className="sb-grid-column-header">
+        <div className="sb-grid-column-header__inner grow">
+          {isPrimaryKey && (
+            <div className="sb-grid-column-header__inner__primary-key">
+              <Key size={14} strokeWidth={2} />
+            </div>
+          )}
+          <span className="sb-grid-column-header__inner__name">{name}</span>
+          <span className="sb-grid-column-header__inner__format">{format}</span>
+        </div>
+        <ChevronDown size={14} className="text-foreground-lighter shrink-0 opacity-50" />
+      </div>
+    </div>
+  )
+}

--- a/apps/www/components/Realtime/Hero/RealtimeCursorLayer.tsx
+++ b/apps/www/components/Realtime/Hero/RealtimeCursorLayer.tsx
@@ -1,0 +1,38 @@
+'use client'
+
+import { memo, useSyncExternalStore } from 'react'
+
+import { Cursor } from './Cursor'
+import type { CursorStore } from './cursorStore'
+
+type RealtimeCursorLayerProps = {
+  store: CursorStore
+}
+
+function RealtimeCursorLayerInner({ store }: RealtimeCursorLayerProps) {
+  const cursors = useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getServerSnapshot
+  )
+
+  return (
+    <div className="pointer-events-none absolute inset-0 z-50 overflow-hidden">
+      {Object.values(cursors).map((cursor) => (
+        <Cursor
+          key={cursor.user.id}
+          className="absolute transition-transform ease-linear duration-[20ms]"
+          style={{
+            top: 0,
+            left: 0,
+            transform: `translate3d(${cursor.position.x}px, ${cursor.position.y}px, 0)`,
+          }}
+          color={cursor.color}
+          name={cursor.user.name}
+        />
+      ))}
+    </div>
+  )
+}
+
+export const RealtimeCursorLayer = memo(RealtimeCursorLayerInner)

--- a/apps/www/components/Realtime/Hero/RealtimeTableChrome.tsx
+++ b/apps/www/components/Realtime/Hero/RealtimeTableChrome.tsx
@@ -1,0 +1,117 @@
+import { ChevronDown, MoreVertical, Plus, RefreshCw, Search, Table2 } from 'lucide-react'
+import { Button, cn } from 'ui'
+
+function LivePresenceBadge({ count }: { count: number }) {
+  return (
+    <div
+      className="ml-auto flex items-center gap-2 pr-2 text-xs font-medium tabular-nums text-brand"
+      aria-label={`${count} people viewing this demo`}
+    >
+      <span className="relative flex h-2 w-2 shrink-0">
+        <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-brand opacity-60" />
+        <span className="relative inline-flex h-2 w-2 rounded-full bg-brand" />
+      </span>
+      <span>
+        {count} {count === 1 ? 'person' : 'people'}
+      </span>
+    </div>
+  )
+}
+
+type RealtimeTableChromeProps = {
+  presenceCount: number
+}
+
+export function RealtimeTableChrome({ presenceCount }: RealtimeTableChromeProps) {
+  return (
+    <div className="flex flex-col bg-dash-sidebar dark:bg-surface-100">
+      {/* Tab bar */}
+      <div className="flex items-center gap-1 px-2 pt-2 border-b border-default bg-dash-sidebar dark:bg-surface-100">
+        <div className="flex items-center gap-1">
+          <div className="relative flex items-center gap-2 px-3 h-9 text-xs bg-surface-100 border border-default border-b-0 rounded-t-sm">
+            <Table2 size={14} className="text-foreground-light" />
+            <span className="text-foreground">User</span>
+            <div className="absolute top-0 left-0 right-0 h-px bg-foreground-muted" />
+          </div>
+          <button
+            type="button"
+            disabled
+            aria-label="Add tab"
+            className="flex h-7 w-7 items-center justify-center rounded-sm text-foreground-lighter opacity-50 cursor-not-allowed"
+          >
+            <Plus size={14} />
+          </button>
+        </div>
+        <LivePresenceBadge count={presenceCount} />
+      </div>
+
+      {/* Toolbar */}
+      <div className="flex flex-nowrap items-center gap-2 px-2 py-1.5 border-b border-default overflow-x-auto">
+        <div
+          aria-hidden
+          className="flex min-w-[200px] flex-1 items-center gap-2 h-8 px-2 rounded-md border border-default bg-surface-75 opacity-60 cursor-not-allowed"
+        >
+          <Search size={14} className="text-foreground-lighter shrink-0" />
+          <span className="text-sm text-foreground-lighter truncate select-none">
+            Filter by id, name, email... or ask AI
+          </span>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-1.5">
+          <Button disabled type="default" size="tiny" className="h-[26px] px-2.5">
+            <span className="flex items-center gap-1 whitespace-nowrap">
+              Sort
+              <ChevronDown size={12} strokeWidth={1} className="text-foreground-lighter" />
+            </span>
+          </Button>
+
+          <Button disabled type="default" size="tiny" className="h-[26px] px-2.5">
+            <span className="flex items-center gap-1 whitespace-nowrap">
+              <span className="text-foreground-muted">Role</span>
+              <span>postgres</span>
+              <ChevronDown size={12} strokeWidth={1} className="text-foreground-lighter" />
+            </span>
+          </Button>
+
+          <button
+            type="button"
+            disabled
+            aria-label="More actions"
+            className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-md text-foreground-lighter opacity-50 cursor-not-allowed"
+          >
+            <MoreVertical size={14} />
+          </button>
+
+          <button
+            type="button"
+            disabled
+            aria-label="Refresh"
+            className="flex h-[26px] w-[26px] shrink-0 items-center justify-center rounded-md text-foreground-lighter opacity-50 cursor-not-allowed"
+          >
+            <RefreshCw size={14} />
+          </button>
+
+          <Button disabled type="primary" size="tiny" className="h-[26px] pl-2.5 pr-1.5">
+            <span className="flex items-center gap-0.5 whitespace-nowrap">
+              Insert
+              <ChevronDown size={14} strokeWidth={1.5} />
+            </span>
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export function RealtimeTableFrame({ children, className }: { children: React.ReactNode; className?: string }) {
+  return (
+    <div
+      className={cn(
+        'border-default border rounded-md overflow-hidden shadow-md bg-dash-sidebar',
+        className
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/www/components/Realtime/Hero/RealtimeTableGrid.tsx
+++ b/apps/www/components/Realtime/Hero/RealtimeTableGrid.tsx
@@ -1,0 +1,89 @@
+'use client'
+
+import { memo } from 'react'
+import DataGrid, { type Column, type RenderCellProps } from 'react-data-grid'
+import { Checkbox, cn } from 'ui'
+
+import { DemoGridCell } from './DemoGridCell'
+import { DemoGridProvider } from './demoGridContext'
+import { GridColumnHeader } from './GridColumnHeader'
+import {
+  HERO_GRID_HEIGHT,
+  HERO_HEADER_HEIGHT,
+  HERO_ROW_COUNT,
+  HERO_ROW_HEIGHT,
+  USER_TABLE_COLUMNS,
+  type UserRow,
+} from './mockUserTableData'
+import type { CellFocusPayload } from './types'
+
+type RealtimeTableGridProps = {
+  rows: UserRow[]
+  focusedCells: Record<string, CellFocusPayload>
+}
+
+const SELECT_COLUMN: Column<UserRow> = {
+  key: 'select',
+  name: '',
+  width: 70,
+  resizable: false,
+  frozen: true,
+  headerCellClass: 'border-default border-r border-b',
+  cellClass: 'border-default border-r',
+  renderHeaderCell: () => (
+    <div className="flex h-full w-full items-center justify-center px-2">
+      <Checkbox disabled checked={false} aria-label="Select all rows" />
+    </div>
+  ),
+  renderCell: () => (
+    <div className="flex h-full w-full items-center justify-center gap-1 px-1">
+      <Checkbox disabled checked={false} aria-label="Select row" />
+    </div>
+  ),
+}
+
+const DATA_COLUMNS: Column<UserRow>[] = USER_TABLE_COLUMNS.map((col) => ({
+  key: col.key,
+  name: col.name,
+  minWidth: col.minWidth,
+  width: col.width,
+  resizable: false,
+  headerCellClass: 'border-default border-r border-b p-0!',
+  cellClass: 'p-0!',
+  renderHeaderCell: () => (
+    <GridColumnHeader name={col.name} format={col.format} isPrimaryKey={col.isPrimaryKey} />
+  ),
+  renderCell: (props: RenderCellProps<UserRow>) => <DemoGridCell {...props} />,
+}))
+
+const GRID_COLUMNS: Column<UserRow>[] = [SELECT_COLUMN, ...DATA_COLUMNS]
+
+const ROW_CLASS_BASE =
+  'bg-dash-sidebar [&>.rdg-cell]:border-box [&>.rdg-cell]:outline-hidden [&>.rdg-cell]:shadow-none [&>.rdg-cell]:border-secondary [&>.rdg-cell:not(:last-child)]:border-r'
+const ROW_CLASS_WITH_BORDER = `${ROW_CLASS_BASE} [&>.rdg-cell]:border-b`
+
+function RealtimeTableGridInner({ rows, focusedCells }: RealtimeTableGridProps) {
+  const rowClass = (_row: UserRow, idx: number) =>
+    idx === HERO_ROW_COUNT - 1 ? ROW_CLASS_BASE : ROW_CLASS_WITH_BORDER
+
+  return (
+    <DemoGridProvider focusedCells={focusedCells}>
+      <div
+        className="sb-grid realtime-hero-grid relative w-full"
+        style={{ height: HERO_GRID_HEIGHT }}
+      >
+        <DataGrid
+          className="grow border-t-0 bg-dash-canvas"
+          rowHeight={HERO_ROW_HEIGHT}
+          headerRowHeight={HERO_HEADER_HEIGHT}
+          columns={GRID_COLUMNS}
+          rows={rows}
+          rowKeyGetter={(row) => row.id}
+          rowClass={rowClass}
+        />
+      </div>
+    </DemoGridProvider>
+  )
+}
+
+export const RealtimeTableGrid = memo(RealtimeTableGridInner)

--- a/apps/www/components/Realtime/Hero/RealtimeTableHero.tsx
+++ b/apps/www/components/Realtime/Hero/RealtimeTableHero.tsx
@@ -1,0 +1,62 @@
+'use client'
+
+import { memo, useState } from 'react'
+
+import { RealtimeCursorLayer } from './RealtimeCursorLayer'
+import { RealtimeTableChrome, RealtimeTableFrame } from './RealtimeTableChrome'
+import { RealtimeTableGrid } from './RealtimeTableGrid'
+import { useAugmentedUsers } from './useAugmentedUsers'
+import { useDemoTable } from './useDemoTable'
+
+const HERO_GRID_TRANSFORM = {
+  transform: 'rotateX(10deg) scale(0.9)',
+  transformOrigin: '50% 0%',
+  transformStyle: 'preserve-3d' as const,
+}
+
+function RealtimeTableHeroInner() {
+  const [presenceCount, setPresenceCount] = useState(0)
+
+  const {
+    rows,
+    focusedCells,
+    containerRef,
+    cursorStore,
+    setUserCursor,
+    setUserCellFocus,
+    disconnectUser,
+  } = useDemoTable()
+
+  useAugmentedUsers({
+    containerRef,
+    onCursorMove: setUserCursor,
+    onCellFocus: setUserCellFocus,
+    onUserDisconnect: disconnectUser,
+    onActiveUsersChange: setPresenceCount,
+  })
+
+  return (
+    <div className="container relative mx-auto px-6 pt-8 pb-0 sm:px-16 lg:pt-12 xl:px-20">
+      <div className="relative [perspective:1200px]">
+        <div style={HERO_GRID_TRANSFORM}>
+          <RealtimeTableFrame>
+            <div ref={containerRef} className="relative">
+              <RealtimeTableChrome presenceCount={presenceCount} />
+              <div className="relative overflow-hidden">
+                <RealtimeTableGrid rows={rows} focusedCells={focusedCells} />
+              </div>
+              <RealtimeCursorLayer store={cursorStore} />
+            </div>
+          </RealtimeTableFrame>
+        </div>
+
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-x-0 -bottom-px z-10 h-40 bg-gradient-to-t from-background to-transparent"
+        />
+      </div>
+    </div>
+  )
+}
+
+export default memo(RealtimeTableHeroInner)

--- a/apps/www/components/Realtime/Hero/augmentedUsers.constants.ts
+++ b/apps/www/components/Realtime/Hero/augmentedUsers.constants.ts
@@ -1,0 +1,17 @@
+import { COLLABORATOR_500_COLORS } from './participantColors'
+
+export type AugmentedUser = {
+  id: string
+  name: string
+  color: string
+}
+
+/** Fixed demo collaborators — not live sessions. */
+export const AUGMENTED_USERS: AugmentedUser[] = [
+  { id: 'jonny', name: 'Jonny', color: COLLABORATOR_500_COLORS[6]! }, // blue-500
+  { id: 'paul', name: 'Paul', color: COLLABORATOR_500_COLORS[9]! }, // purple-500
+  { id: 'ant', name: 'Ant', color: COLLABORATOR_500_COLORS[1]! }, // orange-500
+  { id: 'matt', name: 'Matt', color: COLLABORATOR_500_COLORS[8]! }, // cyan-500
+]
+
+export const AUGMENTED_USER_COUNT = AUGMENTED_USERS.length

--- a/apps/www/components/Realtime/Hero/cursorStore.ts
+++ b/apps/www/components/Realtime/Hero/cursorStore.ts
@@ -1,0 +1,59 @@
+import type { CursorPayload } from './types'
+
+export type CursorStore = {
+  subscribe: (listener: () => void) => () => void
+  getSnapshot: () => Record<string, CursorPayload>
+  getServerSnapshot: () => Record<string, CursorPayload>
+  setCursor: (id: string, payload: CursorPayload) => void
+  removeCursor: (id: string) => void
+  clear: () => void
+}
+
+const EMPTY_CURSORS: Record<string, CursorPayload> = {}
+
+export function createCursorStore(): CursorStore {
+  let cursors = EMPTY_CURSORS
+  const listeners = new Set<() => void>()
+
+  const emit = () => {
+    listeners.forEach((listener) => listener())
+  }
+
+  return {
+    subscribe: (listener) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    },
+    getSnapshot: () => cursors,
+    getServerSnapshot: () => EMPTY_CURSORS,
+    setCursor: (id, payload) => {
+      const prev = cursors[id]
+      if (
+        prev &&
+        prev.position.x === payload.position.x &&
+        prev.position.y === payload.position.y
+      ) {
+        if (Date.now() - prev.timestamp > 1000) {
+          cursors = { ...cursors, [id]: { ...payload, timestamp: Date.now() } }
+          emit()
+        }
+        return
+      }
+
+      cursors = { ...cursors, [id]: { ...payload, timestamp: Date.now() } }
+      emit()
+    },
+    removeCursor: (id) => {
+      if (!cursors[id]) return
+      const next = { ...cursors }
+      delete next[id]
+      cursors = next
+      emit()
+    },
+    clear: () => {
+      if (cursors === EMPTY_CURSORS) return
+      cursors = EMPTY_CURSORS
+      emit()
+    },
+  }
+}

--- a/apps/www/components/Realtime/Hero/demoGridContext.tsx
+++ b/apps/www/components/Realtime/Hero/demoGridContext.tsx
@@ -1,0 +1,27 @@
+'use client'
+
+import { createContext, use } from 'react'
+
+import type { CellFocusPayload } from './types'
+
+const DemoGridContext = createContext<Record<string, CellFocusPayload> | null>(null)
+
+export function DemoGridProvider({
+  focusedCells,
+  children,
+}: {
+  focusedCells: Record<string, CellFocusPayload>
+  children: React.ReactNode
+}) {
+  return <DemoGridContext value={focusedCells}>{children}</DemoGridContext>
+}
+
+export function useDemoGridFocus() {
+  const context = use(DemoGridContext)
+  if (!context) {
+    throw new Error('useDemoGridFocus must be used within DemoGridProvider')
+  }
+  return context
+}
+
+export const cellKey = (rowId: string, columnKey: string) => `${rowId}:${columnKey}`

--- a/apps/www/components/Realtime/Hero/heroCoordinates.ts
+++ b/apps/www/components/Realtime/Hero/heroCoordinates.ts
@@ -1,0 +1,45 @@
+type Point = { x: number; y: number }
+
+/** Local coordinates inside `container`, unaffected by ancestor 3D transforms. */
+export function getLocalPointInContainer(
+  container: HTMLElement,
+  element: HTMLElement,
+  relativeX: number,
+  relativeY: number
+): Point {
+  let x = element.offsetLeft + element.offsetWidth * relativeX
+  let y = element.offsetTop + element.offsetHeight * relativeY
+  let offsetParent = element.offsetParent as HTMLElement | null
+
+  while (offsetParent && offsetParent !== container && container.contains(offsetParent)) {
+    x += offsetParent.offsetLeft
+    y += offsetParent.offsetTop
+    offsetParent = offsetParent.offsetParent as HTMLElement | null
+  }
+
+  if (offsetParent === container) {
+    return { x, y }
+  }
+
+  x = element.offsetWidth * relativeX
+  y = element.offsetHeight * relativeY
+  let node: HTMLElement | null = element
+
+  while (node && node !== container) {
+    x += node.offsetLeft
+    y += node.offsetTop
+    node = node.parentElement
+  }
+
+  return { x, y }
+}
+
+export function randomPointInContainer(container: HTMLElement, index: number): Point {
+  const width = container.clientWidth
+  const height = container.clientHeight
+
+  return {
+    x: Math.min(width - 24, 40 + Math.random() * Math.max(width * 0.55, 120) + index * 12),
+    y: Math.min(height - 24, 60 + Math.random() * Math.max(height * 0.45, 80)),
+  }
+}

--- a/apps/www/components/Realtime/Hero/index.ts
+++ b/apps/www/components/Realtime/Hero/index.ts
@@ -1,0 +1,1 @@
+export { default as RealtimeTableHero } from './RealtimeTableHero'

--- a/apps/www/components/Realtime/Hero/mockUserTableData.ts
+++ b/apps/www/components/Realtime/Hero/mockUserTableData.ts
@@ -1,0 +1,96 @@
+export type UserRow = {
+  id: string
+  name: string
+  email: string
+  emailVerified: string | null
+  image: string
+}
+
+export const HERO_ROW_COUNT = 9
+export const HERO_ROW_HEIGHT = 36
+export const HERO_HEADER_HEIGHT = 36
+export const HERO_GRID_HEIGHT = HERO_HEADER_HEIGHT + HERO_ROW_COUNT * HERO_ROW_HEIGHT
+
+/** Fictional demo data only — no real user records. */
+export const MOCK_USER_ROWS: UserRow[] = [
+  {
+    id: '00528d53-c761-4f76-bb27-e763d02ee185',
+    name: 'MelvinTh17',
+    email: 'melvinth17@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-01.png',
+  },
+  {
+    id: '0a8b3c21-d4e5-4f67-9a12-b8c7d6e5f4a3',
+    name: 'Ayoub Bigharassine',
+    email: 'ayoub.bigharassine@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-02.png',
+  },
+  {
+    id: '1b9c4d32-e5f6-4a78-0b23-c9d8e7f6a5b4',
+    name: 'Alex Demo',
+    email: 'alex.demo@example.com',
+    emailVerified: '2026-02-01 00:01:01',
+    image: 'https://example.com/avatars/demo-user-03.png',
+  },
+  {
+    id: '2c0d5e43-f6a7-4b89-1c34-d0e9f8a7b6c5',
+    name: 'Fynn Bauer',
+    email: 'fynn.bauer@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-04.png',
+  },
+  {
+    id: '3d1e6f54-a7b8-4c9a-2d45-e1f0a9b8c7d6',
+    name: 'Andrei Cojocari',
+    email: 'andrei.cojocari@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-05.png',
+  },
+  {
+    id: '4e2f7a65-b8c9-4dab-3e56-f2a1b0c9d8e7',
+    name: 'Eltaj Mammadzada',
+    email: 'eltaj.mammadzada@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-06.png',
+  },
+  {
+    id: '5f3a8b76-c9da-4ebc-4f67-a3b2c1d0e9f8',
+    name: 'emreozogul',
+    email: 'emreozogul@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-07.png',
+  },
+  {
+    id: '6a4b9c87-daeb-4fcd-5a78-b4c3d2e1f0a9',
+    name: 'hammadmasoodofficial',
+    email: 'hammadmasoodofficial@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-08.png',
+  },
+  {
+    id: '7b5c0d98-ebfc-4ade-6b89-c5d4e3f2a1b0',
+    name: 'Majid Vesal Azad',
+    email: 'majid.vesal.azad@example.com',
+    emailVerified: null,
+    image: 'https://example.com/avatars/demo-user-09.png',
+  },
+]
+
+export type ColumnDef = {
+  key: keyof UserRow
+  name: string
+  format: string
+  isPrimaryKey?: boolean
+  minWidth?: number
+  width?: number
+}
+
+export const USER_TABLE_COLUMNS: ColumnDef[] = [
+  { key: 'id', name: 'id', format: 'text', isPrimaryKey: true, minWidth: 280 },
+  { key: 'name', name: 'name', format: 'text', minWidth: 140 },
+  { key: 'email', name: 'email', format: 'text', minWidth: 220 },
+  { key: 'emailVerified', name: 'emailVerified', format: 'timestamp', minWidth: 180 },
+  { key: 'image', name: 'image', format: 'text', minWidth: 320 },
+]

--- a/apps/www/components/Realtime/Hero/participantColors.ts
+++ b/apps/www/components/Realtime/Hero/participantColors.ts
@@ -1,0 +1,19 @@
+/** Tailwind CSS v3 default 500 palette — humans only; Supabruv uses brand green. */
+export const COLLABORATOR_500_COLORS = [
+  '#ef4444', // red-500
+  '#f97316', // orange-500
+  '#f59e0b', // amber-500
+  '#eab308', // yellow-500
+  '#06b6d4', // cyan-500
+  '#0ea5e9', // sky-500
+  '#3b82f6', // blue-500
+  '#6366f1', // indigo-500
+  '#8b5cf6', // violet-500
+  '#a855f7', // purple-500
+  '#d946ef', // fuchsia-500
+  '#ec4899', // pink-500
+  '#f43f5e', // rose-500
+] as const
+
+export const pickCollaboratorColor = () =>
+  COLLABORATOR_500_COLORS[Math.floor(Math.random() * COLLABORATOR_500_COLORS.length)]!

--- a/apps/www/components/Realtime/Hero/types.ts
+++ b/apps/www/components/Realtime/Hero/types.ts
@@ -1,0 +1,15 @@
+export type CursorPayload = {
+  position: { x: number; y: number }
+  user: { id: string; name: string }
+  color: string
+  timestamp: number
+}
+
+export type CellFocusPayload = {
+  rowId: string
+  columnKey: string
+  userId: string
+  name: string
+  color: string
+  isFocused: boolean
+}

--- a/apps/www/components/Realtime/Hero/useAugmentedUsers.ts
+++ b/apps/www/components/Realtime/Hero/useAugmentedUsers.ts
@@ -1,0 +1,308 @@
+'use client'
+
+import { useEffect, useRef } from 'react'
+
+import { AUGMENTED_USERS, type AugmentedUser } from './augmentedUsers.constants'
+import { getLocalPointInContainer, randomPointInContainer } from './heroCoordinates'
+import type { UserRow } from './mockUserTableData'
+
+type Point = { x: number; y: number }
+type BotPhase = 'offline' | 'idle' | 'moving' | 'focusing'
+
+const MOVE_MS = 2000
+const ARC_LIFT = 56
+const DISCONNECT_CHANCE = 0.22
+const MIN_IDLE_MS = 900
+const MAX_IDLE_MS = 5200
+const MIN_FOCUS_MS = 1100
+const MAX_FOCUS_MS = 3200
+const MIN_OFFLINE_MS = 2500
+const MAX_OFFLINE_MS = 11000
+
+const randomBetween = (min: number, max: number) => min + Math.random() * (max - min)
+
+const easeInOutCubic = (t: number) =>
+  t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2
+
+const quadBezier = (t: number, p0: Point, p1: Point, p2: Point): Point => {
+  const u = 1 - t
+  return {
+    x: u * u * p0.x + 2 * u * t * p1.x + t * t * p2.x,
+    y: u * u * p0.y + 2 * u * t * p1.y + t * t * p2.y,
+  }
+}
+
+type CellTarget = {
+  rowId: string
+  columnKey: keyof UserRow
+  x: number
+  y: number
+}
+
+type BotState = {
+  user: AugmentedUser
+  position: Point
+  phase: BotPhase
+  phaseStarted: number
+  moveFrom: Point
+  moveTo: Point
+  arcControl: Point
+  target: CellTarget | null
+  idleDelayMs: number
+  focusDurationMs: number
+  offlineUntil: number
+}
+
+const pickCellTarget = (container: HTMLElement): CellTarget | null => {
+  const cells = container.querySelectorAll<HTMLElement>('[data-cell]')
+  if (cells.length === 0) return null
+
+  const cell = cells[Math.floor(Math.random() * cells.length)]!
+  const dataCell = cell.dataset.cell
+  if (!dataCell) return null
+
+  const [rowId, columnKey] = dataCell.split(':') as [string, keyof UserRow]
+  if (!rowId || !columnKey) return null
+
+  const { x, y } = getLocalPointInContainer(container, cell, 0.35, 0.55)
+
+  return {
+    rowId,
+    columnKey,
+    x,
+    y,
+  }
+}
+
+const createInitialBots = (container: HTMLElement | null): BotState[] =>
+  AUGMENTED_USERS.map((user, index) => {
+    const position = container ? randomPointInContainer(container, index) : { x: 120 + index * 20, y: 120 }
+    const startsOffline = Math.random() < 0.35
+    const now = performance.now()
+
+    return {
+      user,
+      position,
+      phase: startsOffline ? 'offline' : 'idle',
+      phaseStarted: now,
+      moveFrom: position,
+      moveTo: position,
+      arcControl: { x: position.x, y: position.y - 40 },
+      target: null,
+      idleDelayMs: randomBetween(MIN_IDLE_MS, MAX_IDLE_MS),
+      focusDurationMs: randomBetween(MIN_FOCUS_MS, MAX_FOCUS_MS),
+      offlineUntil: startsOffline ? now + randomBetween(MIN_OFFLINE_MS, MAX_OFFLINE_MS) : 0,
+    }
+  })
+
+type UseAugmentedUsersOptions = {
+  containerRef: React.RefObject<HTMLElement | null>
+  onCursorMove: (userId: string, name: string, color: string, x: number, y: number) => void
+  onCellFocus: (
+    userId: string,
+    name: string,
+    color: string,
+    rowId: string,
+    columnKey: keyof UserRow,
+    isFocused: boolean
+  ) => void
+  onUserDisconnect: (userId: string) => void
+  onActiveUsersChange: (count: number) => void
+}
+
+export function useAugmentedUsers({
+  containerRef,
+  onCursorMove,
+  onCellFocus,
+  onUserDisconnect,
+  onActiveUsersChange,
+}: UseAugmentedUsersOptions) {
+  const botsRef = useRef<BotState[]>([])
+  const initializedRef = useRef(false)
+  const callbacksRef = useRef({
+    onCursorMove,
+    onCellFocus,
+    onUserDisconnect,
+    onActiveUsersChange,
+  })
+  callbacksRef.current = {
+    onCursorMove,
+    onCellFocus,
+    onUserDisconnect,
+    onActiveUsersChange,
+  }
+
+  const syncActiveCount = () => {
+    const count = botsRef.current.filter((bot) => bot.phase !== 'offline').length
+    callbacksRef.current.onActiveUsersChange(count)
+  }
+
+  useEffect(() => {
+    let raf = 0
+    let isVisible = !document.hidden
+
+    const onVisibilityChange = () => {
+      isVisible = !document.hidden
+    }
+
+    document.addEventListener('visibilitychange', onVisibilityChange)
+
+    const clearFocus = (bot: BotState) => {
+      const target = bot.target
+      if (!target) return
+
+      callbacksRef.current.onCellFocus(
+        bot.user.id,
+        bot.user.name,
+        bot.user.color,
+        target.rowId,
+        target.columnKey,
+        false
+      )
+      bot.target = null
+    }
+
+    const disconnect = (bot: BotState, now: number) => {
+      clearFocus(bot)
+      callbacksRef.current.onUserDisconnect(bot.user.id)
+      bot.phase = 'offline'
+      bot.phaseStarted = now
+      bot.offlineUntil = now + randomBetween(MIN_OFFLINE_MS, MAX_OFFLINE_MS)
+      syncActiveCount()
+    }
+
+    const reconnect = (bot: BotState, now: number, index: number, containerEl: HTMLElement) => {
+      bot.position = randomPointInContainer(containerEl, index)
+      bot.moveFrom = bot.position
+      bot.moveTo = bot.position
+      bot.target = null
+      bot.phase = 'idle'
+      bot.phaseStarted = now
+      bot.idleDelayMs = randomBetween(MIN_IDLE_MS, MAX_IDLE_MS)
+      syncActiveCount()
+    }
+
+    const beginMove = (bot: BotState, target: CellTarget) => {
+      bot.target = target
+      bot.moveFrom = { ...bot.position }
+      bot.moveTo = { x: target.x, y: target.y }
+
+      const midX = (bot.moveFrom.x + bot.moveTo.x) / 2
+      const midY = (bot.moveFrom.y + bot.moveTo.y) / 2
+      const dx = bot.moveTo.x - bot.moveFrom.x
+      const dy = bot.moveTo.y - bot.moveFrom.y
+      const dist = Math.hypot(dx, dy) || 1
+      const lift = Math.min(ARC_LIFT, dist * 0.35)
+
+      bot.arcControl = {
+        x: midX + (-dy / dist) * lift * 0.25,
+        y: midY - lift,
+      }
+
+      bot.phase = 'moving'
+      bot.phaseStarted = performance.now()
+    }
+
+    const beginFocus = (bot: BotState) => {
+      const target = bot.target
+      if (!target) {
+        bot.phase = 'idle'
+        bot.phaseStarted = performance.now()
+        bot.idleDelayMs = randomBetween(MIN_IDLE_MS, MAX_IDLE_MS)
+        return
+      }
+
+      bot.focusDurationMs = randomBetween(MIN_FOCUS_MS, MAX_FOCUS_MS)
+      callbacksRef.current.onCellFocus(
+        bot.user.id,
+        bot.user.name,
+        bot.user.color,
+        target.rowId,
+        target.columnKey,
+        true
+      )
+      bot.phase = 'focusing'
+      bot.phaseStarted = performance.now()
+    }
+
+    const endFocus = (bot: BotState, now: number) => {
+      clearFocus(bot)
+      bot.phase = 'idle'
+      bot.phaseStarted = now
+      bot.idleDelayMs = randomBetween(MIN_IDLE_MS, MAX_IDLE_MS)
+
+      if (Math.random() < DISCONNECT_CHANCE) {
+        disconnect(bot, now)
+      }
+    }
+
+    const tick = (now: number) => {
+      if (!isVisible) {
+        raf = requestAnimationFrame(tick)
+        return
+      }
+
+      const container = containerRef.current
+      if (!container) {
+        raf = requestAnimationFrame(tick)
+        return
+      }
+
+      if (!initializedRef.current) {
+        botsRef.current = createInitialBots(container)
+        initializedRef.current = true
+        syncActiveCount()
+      }
+
+      botsRef.current.forEach((bot, index) => {
+        const elapsed = now - bot.phaseStarted
+
+        if (bot.phase === 'offline') {
+          if (now >= bot.offlineUntil) {
+            reconnect(bot, now, index, container)
+          }
+          return
+        }
+
+        if (bot.phase === 'idle') {
+          if (elapsed >= bot.idleDelayMs) {
+            if (Math.random() < DISCONNECT_CHANCE * 0.35) {
+              disconnect(bot, now)
+              return
+            }
+
+            const target = pickCellTarget(container)
+            if (target) beginMove(bot, target)
+            else {
+              bot.phaseStarted = now
+              bot.idleDelayMs = randomBetween(400, 1200)
+            }
+          }
+        } else if (bot.phase === 'moving') {
+          const t = easeInOutCubic(Math.min(elapsed / MOVE_MS, 1))
+          bot.position = quadBezier(t, bot.moveFrom, bot.arcControl, bot.moveTo)
+
+          if (elapsed >= MOVE_MS) {
+            bot.position = { ...bot.moveTo }
+            beginFocus(bot)
+          }
+        } else if (bot.phase === 'focusing') {
+          if (elapsed >= bot.focusDurationMs) {
+            endFocus(bot, now)
+          }
+        }
+
+        const { x, y } = bot.position
+        callbacksRef.current.onCursorMove(bot.user.id, bot.user.name, bot.user.color, x, y)
+      })
+
+      raf = requestAnimationFrame(tick)
+    }
+
+    raf = requestAnimationFrame(tick)
+    return () => {
+      cancelAnimationFrame(raf)
+      document.removeEventListener('visibilitychange', onVisibilityChange)
+    }
+  }, [containerRef])
+}

--- a/apps/www/components/Realtime/Hero/useDemoTable.ts
+++ b/apps/www/components/Realtime/Hero/useDemoTable.ts
@@ -1,0 +1,92 @@
+'use client'
+
+import { useCallback, useRef, useState } from 'react'
+
+import { cellKey } from './demoGridContext'
+import { createCursorStore, type CursorStore } from './cursorStore'
+import { MOCK_USER_ROWS, type UserRow } from './mockUserTableData'
+import type { CellFocusPayload, CursorPayload } from './types'
+
+export function useDemoTable() {
+  const [rows] = useState<UserRow[]>(() => MOCK_USER_ROWS.map((row) => ({ ...row })))
+  const [focusedCells, setFocusedCells] = useState<Record<string, CellFocusPayload>>({})
+  const containerRef = useRef<HTMLDivElement>(null)
+  const cursorStoreRef = useRef<CursorStore | null>(null)
+
+  if (!cursorStoreRef.current) {
+    cursorStoreRef.current = createCursorStore()
+  }
+
+  const cursorStore = cursorStoreRef.current
+
+  const setUserCursor = useCallback(
+    (userId: string, name: string, color: string, x: number, y: number) => {
+      const payload: CursorPayload = {
+        position: { x, y },
+        user: { id: userId, name },
+        color,
+        timestamp: Date.now(),
+      }
+      cursorStore.setCursor(userId, payload)
+    },
+    [cursorStore]
+  )
+
+  const setUserCellFocus = useCallback(
+    (
+      userId: string,
+      name: string,
+      color: string,
+      rowId: string,
+      columnKey: string,
+      isFocused: boolean
+    ) => {
+      setFocusedCells((prev) => {
+        const key = cellKey(rowId, columnKey)
+
+        if (isFocused) {
+          return {
+            ...prev,
+            [key]: { rowId, columnKey, userId, name, color, isFocused: true },
+          }
+        }
+
+        if (prev[key]?.userId !== userId) return prev
+        const next = { ...prev }
+        delete next[key]
+        return next
+      })
+    },
+    []
+  )
+
+  const disconnectUser = useCallback(
+    (userId: string) => {
+      cursorStore.removeCursor(userId)
+      setFocusedCells((prev) => {
+        let changed = false
+        const next = { ...prev }
+
+        for (const [key, focus] of Object.entries(next)) {
+          if (focus.userId === userId) {
+            delete next[key]
+            changed = true
+          }
+        }
+
+        return changed ? next : prev
+      })
+    },
+    [cursorStore]
+  )
+
+  return {
+    rows,
+    focusedCells,
+    containerRef,
+    cursorStore,
+    setUserCursor,
+    setUserCellFocus,
+    disconnectUser,
+  }
+}

--- a/apps/www/components/Realtime/RealtimeFeatureSections.tsx
+++ b/apps/www/components/Realtime/RealtimeFeatureSections.tsx
@@ -1,0 +1,93 @@
+import Link from 'next/link'
+import { Button } from 'ui'
+
+import { BroadcastIllustration } from './illustrations/BroadcastIllustration'
+import { DatabaseChangesIllustration } from './illustrations/DatabaseChangesIllustration'
+import { PresenceIllustration } from './illustrations/PresenceIllustration'
+
+type Feature = {
+  title: string
+  description: string
+  href: string
+  iconSrc: string
+  Illustration?: React.ComponentType
+}
+
+const FEATURES: Feature[] = [
+  {
+    title: 'Broadcast',
+    description: 'Send any data to any client subscribed to the same channel.',
+    href: '/docs/guides/realtime/broadcast',
+    iconSrc: '/images/realtime/icons/broadcast.svg',
+    Illustration: BroadcastIllustration,
+  },
+  {
+    title: 'Presence',
+    description: 'Store and synchronize online user state consistently across clients.',
+    href: '/docs/guides/realtime/presence',
+    iconSrc: '/images/realtime/icons/presence.svg',
+    Illustration: PresenceIllustration,
+  },
+  {
+    title: 'Database changes',
+    description:
+      'Listen to inserts, updates, and deletes in your Postgres database as they happen.',
+    href: '/docs/guides/realtime/postgres-changes',
+    iconSrc: '/images/realtime/icons/database-changes.svg',
+    Illustration: DatabaseChangesIllustration,
+  },
+]
+
+function FeatureContent({ feature }: { feature: Feature }) {
+  return (
+    <div className="prose max-w-none">
+      <div className="mb-4 not-prose">
+        <img src={feature.iconSrc} alt="" className="h-9 w-9" />
+      </div>
+      <h3 className="text-foreground">{feature.title}</h3>
+      <p className="text-foreground-light">{feature.description}</p>
+      <div className="not-prose mt-4">
+        <Button asChild type="default">
+          <Link href={feature.href}>View docs</Link>
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+function IllustrationSlot({ Illustration }: { Illustration?: React.ComponentType }) {
+  if (Illustration) {
+    return <Illustration />
+  }
+
+  return (
+    <div
+      aria-hidden
+      className="min-h-52 w-full rounded-lg border border-dashed border-default/60 md:min-h-60"
+    />
+  )
+}
+
+export function RealtimeFeatureSections() {
+  return (
+    <div className="flex flex-col gap-20 lg:gap-28">
+      {FEATURES.map((feature, index) => {
+        const contentFirst = index % 2 === 0
+
+        return (
+          <div
+            key={feature.title}
+            className="grid grid-cols-1 items-center gap-10 lg:grid-cols-2 lg:gap-12"
+          >
+            <div className={contentFirst ? undefined : 'lg:order-2'}>
+              <FeatureContent feature={feature} />
+            </div>
+            <div className={contentFirst ? undefined : 'lg:order-1'}>
+              <IllustrationSlot Illustration={feature.Illustration} />
+            </div>
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/www/components/Realtime/RealtimePageHeader.tsx
+++ b/apps/www/components/Realtime/RealtimePageHeader.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import Link from 'next/link'
+import { Button } from 'ui'
+
+import SectionContainer from '~/components/Layouts/SectionContainer'
+
+export function RealtimePageHeader() {
+  const scrollToPlayground = () => {
+    document.getElementById('playground')?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+  }
+
+  return (
+    <SectionContainer className="pb-0! pt-10! md:pt-12! lg:pt-14!">
+      <div className="max-w-3xl">
+        <h1 className="h1 text-foreground">Realtime</h1>
+        <p className="mt-3 mb-8 max-w-xl text-lg text-foreground-light">
+          Sync Postgres changes, presence, and custom events to every connected client.
+        </p>
+        <div className="flex flex-wrap gap-3">
+          <Button type="primary" size="large" asChild>
+            <Link href="/docs/guides/realtime">View documentation</Link>
+          </Button>
+          <Button type="default" size="large" onClick={scrollToPlayground}>
+            View examples
+          </Button>
+        </div>
+      </div>
+    </SectionContainer>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/BroadcastIllustration.tsx
+++ b/apps/www/components/Realtime/illustrations/BroadcastIllustration.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { BroadcastReactions } from './BroadcastReactions'
+import { IllustrationFrame } from './IllustrationFrame'
+
+export function BroadcastIllustration() {
+  return (
+    <IllustrationFrame interactive>
+      <BroadcastReactions />
+    </IllustrationFrame>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/BroadcastReactions.tsx
+++ b/apps/www/components/Realtime/illustrations/BroadcastReactions.tsx
@@ -1,0 +1,129 @@
+'use client'
+
+import { AnimatePresence, motion } from 'framer-motion'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { cn } from 'ui'
+
+const REACTIONS = ['❤️', '😂', '👍'] as const
+type ReactionEmoji = (typeof REACTIONS)[number]
+
+type FloatingReaction = {
+  id: string
+  emoji: ReactionEmoji
+  x: number
+  drift: number
+  scale: number
+  duration: number
+}
+
+const MAX_AUTO_INTERVAL_MS = 1200
+const MIN_AUTO_INTERVAL_MS = 350
+
+function pickReaction(): ReactionEmoji {
+  return REACTIONS[Math.floor(Math.random() * REACTIONS.length)]!
+}
+
+function createReaction(xPercent: number): FloatingReaction {
+  return {
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+    emoji: pickReaction(),
+    x: xPercent,
+    drift: (Math.random() - 0.5) * 48,
+    scale: 0.85 + Math.random() * 0.55,
+    duration: 2.2 + Math.random() * 1.4,
+  }
+}
+
+type BroadcastReactionsProps = {
+  className?: string
+}
+
+export function BroadcastReactions({ className }: BroadcastReactionsProps) {
+  const [reactions, setReactions] = useState<FloatingReaction[]>([])
+  const sequenceRef = useRef(0)
+
+  const spawnReaction = useCallback((xPercent: number) => {
+    sequenceRef.current += 1
+    const reaction = createReaction(xPercent)
+
+    setReactions((current) => [...current.slice(-18), reaction])
+  }, [])
+
+  const handlePointerDown = useCallback(
+    (event: React.PointerEvent<HTMLDivElement>) => {
+      const bounds = event.currentTarget.getBoundingClientRect()
+      const xPercent = ((event.clientX - bounds.left) / bounds.width) * 100
+      spawnReaction(Math.min(92, Math.max(8, xPercent)))
+    },
+    [spawnReaction]
+  )
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>
+    let cancelled = false
+
+    const scheduleNext = () => {
+      const delay = MIN_AUTO_INTERVAL_MS + Math.random() * (MAX_AUTO_INTERVAL_MS - MIN_AUTO_INTERVAL_MS)
+
+      timeoutId = setTimeout(() => {
+        if (cancelled) return
+
+        spawnReaction(12 + Math.random() * 76)
+        scheduleNext()
+      }, delay)
+    }
+
+    spawnReaction(22)
+    spawnReaction(68)
+    scheduleNext()
+
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+    }
+  }, [spawnReaction])
+
+  const removeReaction = useCallback((id: string) => {
+    setReactions((current) => current.filter((reaction) => reaction.id !== id))
+  }, [])
+
+  return (
+    <div
+      className={cn('absolute inset-0 z-10 cursor-pointer touch-none', className)}
+      onPointerDown={handlePointerDown}
+    >
+      <AnimatePresence>
+        {reactions.map((reaction) => (
+          <motion.span
+            key={reaction.id}
+            aria-hidden
+            className="pointer-events-none absolute bottom-0 select-none text-2xl will-change-transform md:text-3xl"
+            style={{
+              left: `${reaction.x}%`,
+              marginLeft: '-0.75rem',
+            }}
+            initial={{ opacity: 0, y: 0, x: 0, scale: reaction.scale * 0.6 }}
+            animate={{
+              opacity: [0, 1, 1, 0],
+              y: '-115%',
+              x: reaction.drift,
+              scale: [reaction.scale * 0.6, reaction.scale * 1.08, reaction.scale],
+            }}
+            transition={{
+              duration: reaction.duration,
+              ease: 'easeOut',
+              times: [0, 0.08, 0.72, 1],
+            }}
+            onAnimationComplete={() => removeReaction(reaction.id)}
+          >
+            {reaction.emoji}
+          </motion.span>
+        ))}
+      </AnimatePresence>
+
+      <p className="pointer-events-none absolute bottom-3 left-0 right-0 text-center text-[10px] text-foreground-lighter/80">
+        Tap to react
+      </p>
+    </div>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/DatabaseChangesIllustration.tsx
+++ b/apps/www/components/Realtime/illustrations/DatabaseChangesIllustration.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { StatusIcon } from 'ui'
+
+import { IllustrationFrame } from './IllustrationFrame'
+import { NotificationsStack, type NotificationStackItem } from './NotificationsStack'
+
+const GRAY_BADGE = 'border-default bg-surface-300 text-foreground-light'
+
+const DB_CHANGE_ITEMS: NotificationStackItem[] = [
+  {
+    id: 'insert-users',
+    badge: 'INSERT',
+    badgeClassName: GRAY_BADGE,
+    title: 'public.users',
+    description: 'New row added via Realtime',
+    icon: <StatusIcon variant="default" className="size-4" hideBackground />,
+  },
+  {
+    id: 'update-messages',
+    badge: 'UPDATE',
+    badgeClassName: GRAY_BADGE,
+    title: 'public.messages',
+    description: 'Row modified in channel events',
+    icon: <StatusIcon variant="default" className="size-4" hideBackground />,
+  },
+  {
+    id: 'delete-sessions',
+    badge: 'DELETE',
+    badgeClassName: GRAY_BADGE,
+    title: 'public.sessions',
+    description: 'Row removed from table',
+    icon: <StatusIcon variant="default" className="size-4" hideBackground />,
+  },
+  {
+    id: 'insert-orders',
+    badge: 'INSERT',
+    badgeClassName: GRAY_BADGE,
+    title: 'public.orders',
+    description: 'Checkout completed on mobile',
+    icon: <StatusIcon variant="default" className="size-4" hideBackground />,
+  },
+  {
+    id: 'update-profiles',
+    badge: 'UPDATE',
+    badgeClassName: GRAY_BADGE,
+    title: 'public.profiles',
+    description: 'Avatar URL changed',
+    icon: <StatusIcon variant="default" className="size-4" hideBackground />,
+  },
+  {
+    id: 'delete-events',
+    badge: 'DELETE',
+    badgeClassName: GRAY_BADGE,
+    title: 'public.events',
+    description: 'Expired event cleaned up',
+    icon: <StatusIcon variant="default" className="size-4" hideBackground />,
+  },
+]
+
+export function DatabaseChangesIllustration() {
+  return (
+    <IllustrationFrame className="items-center justify-center">
+      <NotificationsStack
+        items={DB_CHANGE_ITEMS}
+        skewY={-5}
+        rotateX={0}
+        rotateY={-3}
+        rotateZ={5}
+        spacing={1.6}
+        className="relative z-10 scale-[1.6] px-4"
+      />
+    </IllustrationFrame>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/DebugSlider.tsx
+++ b/apps/www/components/Realtime/illustrations/DebugSlider.tsx
@@ -1,0 +1,28 @@
+import { Slider } from 'ui'
+
+type DebugSliderProps = {
+  label: string
+  value: number
+  min: number
+  max: number
+  step: number
+  onChange: (value: number) => void
+}
+
+export function DebugSlider({ label, value, min, max, step, onChange }: DebugSliderProps) {
+  return (
+    <label className="grid gap-1.5 text-[10px] text-foreground-lighter">
+      <span className="flex items-center justify-between tabular-nums">
+        <span>{label}</span>
+        <span className="text-foreground">{value.toFixed(step < 1 ? 2 : 0)}</span>
+      </span>
+      <Slider
+        value={[value]}
+        min={min}
+        max={max}
+        step={step}
+        onValueChange={([next]) => onChange(next ?? value)}
+      />
+    </label>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/IllustrationFrame.tsx
+++ b/apps/www/components/Realtime/illustrations/IllustrationFrame.tsx
@@ -1,0 +1,27 @@
+import { cn } from 'ui'
+
+const DOT_GRID_STYLE = {
+  backgroundImage: 'radial-gradient(circle, hsl(var(--border-default)) 1px, transparent 1px)',
+  backgroundSize: '18px 18px',
+} as const
+
+type IllustrationFrameProps = {
+  children: React.ReactNode
+  className?: string
+  interactive?: boolean
+}
+
+export function IllustrationFrame({ children, className, interactive = false }: IllustrationFrameProps) {
+  return (
+    <div
+      aria-hidden={interactive ? undefined : true}
+      className={cn(
+        'relative flex h-52 w-full overflow-hidden rounded-lg border border-default bg-surface-200/50 md:h-60',
+        className
+      )}
+    >
+      <div aria-hidden className="pointer-events-none absolute inset-0" style={DOT_GRID_STYLE} />
+      {children}
+    </div>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/JoinChatFeed.tsx
+++ b/apps/www/components/Realtime/illustrations/JoinChatFeed.tsx
@@ -1,0 +1,255 @@
+'use client'
+
+import { AnimatePresence, motion } from 'framer-motion'
+import { useEffect, useRef, useState } from 'react'
+import { cn } from 'ui'
+
+import { COLLABORATOR_500_COLORS } from '../Hero/participantColors'
+import { DebugSlider } from './DebugSlider'
+
+const MAX_VISIBLE = 6
+const MAX_INTERVAL_MS = 1500
+
+const JOIN_USERS = [
+  'Jonny',
+  'Paul',
+  'Ant',
+  'Matt',
+  'Sarah',
+  'Alex',
+  'Jordan',
+  'Casey',
+  'Riley',
+  'Morgan',
+  'Taylor',
+  'Jamie',
+  'Quinn',
+  'Avery',
+  'Blake',
+  'Charlie',
+  'Drew',
+  'Emery',
+  'Finley',
+  'Hayden',
+] as const
+
+const CHAT_MESSAGES = [
+  { name: 'Sarah', message: '💚💚💚💚💚💚💚💚' },
+  { name: 'Matt', message: 'Hey everyone, this is so cool!' },
+  { name: 'Jonny', message: 'ok this is actually insane 🔥' },
+  { name: 'Paul', message: 'presence sync goes hard' },
+  { name: 'Ant', message: 'anyone else seeing the cursors?' },
+  { name: 'Alex', message: 'hiiii 👋' },
+  { name: 'Jordan', message: 'wow realtime postgres 🤯' },
+  { name: 'Casey', message: 'brb grabbing coffee ☕' },
+  { name: 'Riley', message: 'we love supabase' },
+  { name: 'Morgan', message: 'this demo is sick' },
+  { name: 'Taylor', message: '🎉🎉🎉' },
+  { name: 'Jamie', message: 'synced in milliseconds' },
+  { name: 'Quinn', message: 'no refresh needed!!' },
+  { name: 'Avery', message: 'peak developer experience' },
+  { name: 'Blake', message: 'ok who invited everyone lol' },
+  { name: 'Charlie', message: 'hello from london 🇬🇧' },
+  { name: 'Drew', message: 'lets ship it 🚀' },
+  { name: 'Emery', message: 'the latency is crazy good' },
+  { name: 'Finley', message: '💜💜💜' },
+  { name: 'Hayden', message: 'just joined, what did i miss?' },
+] as const
+
+type JoinFeedEntry = {
+  id: string
+  type: 'join'
+  name: string
+}
+
+type MessageFeedEntry = {
+  id: string
+  type: 'message'
+  name: string
+  message: string
+}
+
+type FeedEntry = JoinFeedEntry | MessageFeedEntry
+
+type JoinChatFeedProps = {
+  className?: string
+  debug?: boolean
+  skewY?: number
+  rotateX?: number
+  rotateY?: number
+  rotateZ?: number
+  scale?: number
+  offsetX?: number
+  offsetY?: number
+}
+
+function getColorForName(name: string) {
+  let hash = 0
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash)
+  }
+  return COLLABORATOR_500_COLORS[Math.abs(hash) % COLLABORATOR_500_COLORS.length]!
+}
+
+function getInitials(name: string) {
+  return name.slice(0, 2).toUpperCase()
+}
+
+function pushEntry(entries: FeedEntry[], entry: FeedEntry) {
+  return [...entries, entry].slice(-MAX_VISIBLE)
+}
+
+function FeedAvatar({ name }: { name: string }) {
+  return (
+    <div
+      className="flex size-6 shrink-0 items-center justify-center rounded-full text-[10px] font-medium text-white"
+      style={{ backgroundColor: getColorForName(name) }}
+    >
+      {getInitials(name)}
+    </div>
+  )
+}
+
+function FeedRow({ entry }: { entry: FeedEntry }) {
+  if (entry.type === 'join') {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-default/60 bg-surface-200/90 px-2.5 py-1.5 shadow-sm backdrop-blur-sm">
+        <FeedAvatar name={entry.name} />
+        <p className="min-w-0 text-xs leading-snug text-foreground-light">
+          <span className="font-medium text-foreground">{entry.name}</span> has joined the chat!
+        </p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex items-start gap-2 px-0.5 py-0.5">
+      <FeedAvatar name={entry.name} />
+      <p className="min-w-0 text-xs leading-snug text-foreground-light">
+        <span className="font-medium text-foreground">{entry.name}:</span> {entry.message}
+      </p>
+    </div>
+  )
+}
+
+export function JoinChatFeed({
+  className,
+  debug = false,
+  skewY: skewYProp = 0,
+  rotateX: rotateXProp = 0,
+  rotateY: rotateYProp = 0,
+  rotateZ: rotateZProp = 0,
+  scale: scaleProp = 1,
+  offsetX: offsetXProp = 0,
+  offsetY: offsetYProp = 0,
+}: JoinChatFeedProps) {
+  const [entries, setEntries] = useState<FeedEntry[]>([])
+  const joinIndexRef = useRef(0)
+  const messageIndexRef = useRef(0)
+  const sequenceRef = useRef(0)
+
+  const [debugSkewY, setDebugSkewY] = useState(skewYProp)
+  const [debugRotateX, setDebugRotateX] = useState(rotateXProp)
+  const [debugRotateY, setDebugRotateY] = useState(rotateYProp)
+  const [debugRotateZ, setDebugRotateZ] = useState(rotateZProp)
+  const [debugScale, setDebugScale] = useState(scaleProp)
+  const [debugOffsetX, setDebugOffsetX] = useState(offsetXProp)
+  const [debugOffsetY, setDebugOffsetY] = useState(offsetYProp)
+
+  const skewY = debug ? debugSkewY : skewYProp
+  const rotateX = debug ? debugRotateX : rotateXProp
+  const rotateY = debug ? debugRotateY : rotateYProp
+  const rotateZ = debug ? debugRotateZ : rotateZProp
+  const scale = debug ? debugScale : scaleProp
+  const offsetX = debug ? debugOffsetX : offsetXProp
+  const offsetY = debug ? debugOffsetY : offsetYProp
+
+  useEffect(() => {
+    let timeoutId: ReturnType<typeof setTimeout>
+    let cancelled = false
+
+    const nextEntry = (): FeedEntry => {
+      sequenceRef.current += 1
+      const id = `feed-${sequenceRef.current}`
+
+      if (Math.random() < 0.45) {
+        const { name, message } = CHAT_MESSAGES[messageIndexRef.current % CHAT_MESSAGES.length]!
+        messageIndexRef.current += 1
+        return { id, type: 'message', name, message }
+      }
+
+      const name = JOIN_USERS[joinIndexRef.current % JOIN_USERS.length]!
+      joinIndexRef.current += 1
+      return { id, type: 'join', name }
+    }
+
+    const scheduleNext = (delayMs: number) => {
+      timeoutId = setTimeout(() => {
+        if (cancelled) return
+
+        setEntries((current) => pushEntry(current, nextEntry()))
+        scheduleNext(Math.random() * MAX_INTERVAL_MS)
+      }, delayMs)
+    }
+
+    sequenceRef.current = 1
+    joinIndexRef.current = 1
+    setEntries([{ id: 'feed-0', type: 'join', name: JOIN_USERS[0]! }])
+
+    scheduleNext(Math.random() * MAX_INTERVAL_MS)
+
+    return () => {
+      cancelled = true
+      clearTimeout(timeoutId)
+    }
+  }, [])
+
+  return (
+    <>
+      <div className="absolute inset-0" style={{ perspective: '1200px' }}>
+        <div
+          className={cn(
+            'absolute bottom-4 left-4 flex w-[min(100%,18rem)] origin-bottom-left flex-col justify-end gap-1.5',
+            className
+          )}
+          style={{
+            transform: `translate(${offsetX}px, ${offsetY}px) scale(${scale}) skewY(${skewY}deg) rotateX(${rotateX}deg) rotateY(${rotateY}deg) rotateZ(${rotateZ}deg)`,
+            transformStyle: 'preserve-3d',
+          }}
+        >
+          <AnimatePresence initial={false} mode="popLayout">
+            {entries.map((entry) => (
+              <motion.div
+                key={entry.id}
+                layout
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -12 }}
+                transition={{ duration: 0.32, ease: [0.4, 0, 0.2, 1] }}
+              >
+                <FeedRow entry={entry} />
+              </motion.div>
+            ))}
+          </AnimatePresence>
+        </div>
+      </div>
+
+      {debug ? (
+        <div className="pointer-events-auto absolute right-3 top-3 z-20 max-h-[calc(100%-1.5rem)] w-44 overflow-y-auto rounded-md border border-default bg-surface-100/95 p-3 shadow-sm backdrop-blur-sm">
+          <p className="mb-3 text-[10px] font-medium uppercase tracking-wide text-foreground-lighter">
+            Composition debug
+          </p>
+          <div className="grid gap-3">
+            <DebugSlider label="scale" value={debugScale} min={0.5} max={2.5} step={0.05} onChange={setDebugScale} />
+            <DebugSlider label="offsetX" value={debugOffsetX} min={-80} max={80} step={1} onChange={setDebugOffsetX} />
+            <DebugSlider label="offsetY" value={debugOffsetY} min={-80} max={80} step={1} onChange={setDebugOffsetY} />
+            <DebugSlider label="skewY" value={debugSkewY} min={-20} max={20} step={1} onChange={setDebugSkewY} />
+            <DebugSlider label="rotateX" value={debugRotateX} min={-45} max={45} step={1} onChange={setDebugRotateX} />
+            <DebugSlider label="rotateY" value={debugRotateY} min={-45} max={45} step={1} onChange={setDebugRotateY} />
+            <DebugSlider label="rotateZ" value={debugRotateZ} min={-45} max={45} step={1} onChange={setDebugRotateZ} />
+          </div>
+        </div>
+      ) : null}
+    </>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/NotificationsStack.tsx
+++ b/apps/www/components/Realtime/illustrations/NotificationsStack.tsx
@@ -1,0 +1,144 @@
+'use client'
+
+import { motion } from 'framer-motion'
+import { useEffect, useState } from 'react'
+import { cn } from 'ui'
+
+import { DebugSlider } from './DebugSlider'
+
+const CYCLE_MS = 3000
+
+const dynamicPositions = [
+  { x: 0, y: 0, opacity: 1 },
+  { x: 10, y: 12, opacity: 0.94 },
+  { x: 20, y: 24, opacity: 0.88 },
+  { x: 30, y: 36, opacity: 0.82 },
+  { x: 40, y: 48, opacity: 0.76 },
+  { x: 50, y: 60, opacity: 0.7 },
+]
+
+export type NotificationStackItem = {
+  id: string
+  title: string
+  description: string
+  badge?: string
+  badgeClassName?: string
+  icon?: React.ReactNode
+}
+
+type NotificationsStackProps = {
+  items: NotificationStackItem[]
+  className?: string
+  debug?: boolean
+  skewY?: number
+  rotateX?: number
+  rotateY?: number
+  rotateZ?: number
+  spacing?: number
+}
+
+export function NotificationsStack({
+  items,
+  className,
+  debug = false,
+  skewY: skewYProp = 5,
+  rotateX: rotateXProp = 15,
+  rotateY: rotateYProp = 20,
+  rotateZ: rotateZProp = 0,
+  spacing: spacingProp = 0.8,
+}: NotificationsStackProps) {
+  const [cycleIndex, setCycleIndex] = useState(0)
+  const [debugSkewY, setDebugSkewY] = useState(skewYProp)
+  const [debugRotateX, setDebugRotateX] = useState(rotateXProp)
+  const [debugRotateY, setDebugRotateY] = useState(rotateYProp)
+  const [debugRotateZ, setDebugRotateZ] = useState(rotateZProp)
+  const [debugSpacing, setDebugSpacing] = useState(spacingProp)
+
+  const skewY = debug ? debugSkewY : skewYProp
+  const rotateX = debug ? debugRotateX : rotateXProp
+  const rotateY = debug ? debugRotateY : rotateYProp
+  const rotateZ = debug ? debugRotateZ : rotateZProp
+  const spacing = debug ? debugSpacing : spacingProp
+  const itemCount = items.length
+
+  useEffect(() => {
+    if (itemCount < 2) return
+
+    const interval = setInterval(() => {
+      setCycleIndex((current) => current + 1)
+    }, CYCLE_MS)
+
+    return () => clearInterval(interval)
+  }, [itemCount])
+
+  if (itemCount === 0) return null
+
+  return (
+    <div className={cn('relative flex w-full flex-col items-center', className)}>
+      <div
+        className="relative flex items-center justify-center"
+        style={{
+          transform: `skewY(${skewY}deg) rotateX(${rotateX}deg) rotateY(${rotateY}deg) rotateZ(${rotateZ}deg)`,
+          transformStyle: 'preserve-3d',
+          perspective: '1200px',
+        }}
+      >
+        <div className="grid place-items-center" style={{ gridTemplateAreas: '"stack"' }}>
+          {items.map((item, index) => {
+            const posIdx = (index + cycleIndex) % itemCount
+            const position = dynamicPositions[posIdx % dynamicPositions.length]!
+
+            return (
+              <motion.div
+                key={item.id}
+                className="w-[min(18rem,calc(100vw-3rem))] rounded-lg border border-default bg-surface-200 p-4 shadow-md [grid-area:stack]"
+                style={{ zIndex: 50 - posIdx * 10 }}
+                animate={{
+                  x: position.x * spacing,
+                  y: position.y * spacing,
+                  opacity: position.opacity,
+                }}
+                transition={{ duration: 0.6, ease: [0.4, 0, 0.2, 1] }}
+              >
+                <div className="flex items-start gap-3">
+                  {item.icon ? <div className="mt-0.5 shrink-0 text-foreground-muted">{item.icon}</div> : null}
+                  <div className="min-w-0 flex-1">
+                    <div className="flex flex-wrap items-center gap-2">
+                      {item.badge ? (
+                        <span
+                          className={cn(
+                            'rounded border px-1.5 py-0.5 font-mono text-[10px] uppercase tracking-wide',
+                            item.badgeClassName
+                          )}
+                        >
+                          {item.badge}
+                        </span>
+                      ) : null}
+                      <p className="text-sm font-normal text-foreground">{item.title}</p>
+                    </div>
+                    <p className="mt-1 text-xs text-foreground-lighter">{item.description}</p>
+                  </div>
+                </div>
+              </motion.div>
+            )
+          })}
+        </div>
+      </div>
+
+      {debug ? (
+        <div className="pointer-events-auto mt-6 w-full max-w-sm rounded-md border border-default bg-surface-100 p-3">
+          <p className="mb-3 text-[10px] font-medium uppercase tracking-wide text-foreground-lighter">
+            Stack debug
+          </p>
+          <div className="grid gap-3">
+            <DebugSlider label="skewY" value={debugSkewY} min={-20} max={20} step={1} onChange={setDebugSkewY} />
+            <DebugSlider label="rotateX" value={debugRotateX} min={-45} max={45} step={1} onChange={setDebugRotateX} />
+            <DebugSlider label="rotateY" value={debugRotateY} min={-45} max={45} step={1} onChange={setDebugRotateY} />
+            <DebugSlider label="rotateZ" value={debugRotateZ} min={-45} max={45} step={1} onChange={setDebugRotateZ} />
+            <DebugSlider label="spacing" value={debugSpacing} min={0} max={2} step={0.05} onChange={setDebugSpacing} />
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/www/components/Realtime/illustrations/PresenceIllustration.tsx
+++ b/apps/www/components/Realtime/illustrations/PresenceIllustration.tsx
@@ -1,0 +1,12 @@
+'use client'
+
+import { IllustrationFrame } from './IllustrationFrame'
+import { JoinChatFeed } from './JoinChatFeed'
+
+export function PresenceIllustration() {
+  return (
+    <IllustrationFrame>
+      <JoinChatFeed scale={1.5} rotateX={20} />
+    </IllustrationFrame>
+  )
+}

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -76,6 +76,7 @@
     "react": "catalog:",
     "react-copy-to-clipboard": "^5.1.0",
     "react-countdown": "^2.3.5",
+    "react-data-grid": "7.0.0-beta.47",
     "react-dom": "catalog:",
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.6",

--- a/apps/www/pages/_app.tsx
+++ b/apps/www/pages/_app.tsx
@@ -1,6 +1,8 @@
 import '@code-hike/mdx/styles.css'
 import 'config/code-hike.css'
 import '../styles/globals.css'
+import '../styles/studio-grid.css'
+import 'react-data-grid/lib/styles.css'
 import './launch-week/launchWeek.css'
 
 import {

--- a/apps/www/pages/realtime.tsx
+++ b/apps/www/pages/realtime.tsx
@@ -4,50 +4,27 @@ import CTABanner from '~/components/CTABanner'
 import DefaultLayout from '~/components/Layouts/Default'
 import SectionContainer from '~/components/Layouts/SectionContainer'
 import ProductsNav from '~/components/Products/ProductsNav'
+import { RealtimeFeatureSections } from '~/components/Realtime/RealtimeFeatureSections'
+import { RealtimePageHeader } from '~/components/Realtime/RealtimePageHeader'
 import RealtimeShowcase from '~/components/Realtime/realtime-showcase'
 import APISection from '~/components/Sections/APISection'
-import ProductHeader from '~/components/Sections/ProductHeader'
-import MainProducts from '~/data/MainProducts'
-import RealtimeStyles from '~/styles/realtime.module.css'
 import ApiExamples from 'data/products/realtime/api-examples'
-import { Grid, Layers, Menu } from 'lucide-react'
 import { NextSeo } from 'next-seo'
 import dynamic from 'next/dynamic'
 import Head from 'next/head'
-import Image from 'next/image'
-import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { PRODUCT_NAMES } from 'shared-data/products'
-import { Button } from 'ui'
 
 import { breadcrumbs } from '@/lib/breadcrumbs'
 import { breadcrumbListSchema, serializeJsonLd, softwareApplicationSchema } from '@/lib/json-ld'
 
-const SingleQuote = dynamic(() => import('~/components/Sections/SingleQuote'))
+const RealtimeTableHero = dynamic(() => import('~/components/Realtime/Hero/RealtimeTableHero'), {
+  ssr: false,
+})
 
 // When updating page content, also update public/llms/realtime.txt
 
-const Cursor = ({ className = '', color = 'none' }) => {
-  return (
-    <svg
-      xmlns="http://www.w3.org/2000/svg"
-      fill={color}
-      viewBox="0 0 24 24"
-      aria-hidden="true"
-      className={`h-10 w-10 stroke-foreground ${className}`}
-    >
-      <path
-        strokeLinecap="round"
-        strokeLinejoin="round"
-        strokeWidth="1.5"
-        d="M3 3l7.07 16.97 2.51-7.39 7.39-2.51L3 3z"
-      />
-    </svg>
-  )
-}
-
 function RealtimePage() {
-  // base path for images
   const { basePath } = useRouter()
   const meta_title = 'Realtime | Sync your data in real time'
   const meta_description =
@@ -92,151 +69,16 @@ function RealtimePage() {
       </Head>
       <DefaultLayout>
         <ProductsNav activePage={PRODUCT_NAMES.REALTIME} />
-        <ProductHeader
-          icon={MainProducts['realtime']?.icon}
-          title={MainProducts['realtime']?.name}
-          h1={[<span key={'authentication-h1'}>Build modern web and mobile applications</span>]}
-          subheader={['Sync client state globally over WebSockets in Realtime']}
-          image={[
-            <div className="bg-surface-100 border-default relative flex h-[372px] w-[560px] items-center justify-center overflow-hidden rounded-sm border drop-shadow-md">
-              <div
-                className={[
-                  'border-brand-300 relative h-12 w-48 bg-brand',
-                  `flex items-center justify-center ${RealtimeStyles['shape']}`,
-                ].join(' ')}
-              >
-                <p
-                  className={`text-foreground text-[18px] font-medium ${RealtimeStyles['button-text']}`}
-                >
-                  Start a project
-                </p>
-              </div>
-              <Cursor
-                color="var(--color-yellow-900)"
-                className={`${RealtimeStyles['cursor-one']} absolute top-[220px] right-[130px]`}
-              />
-              <Cursor
-                color="var(--color-indigo-900)"
-                className={`${RealtimeStyles['cursor-two']} absolute top-[180px] right-[280px]`}
-              />
-              <div
-                className={[
-                  'border-foreground absolute bottom-[40px] left-[175px] flex h-10 w-20',
-                  'items-center justify-center space-x-2 rounded-full border-[3px] bg-indigo-900',
-                  `${RealtimeStyles['cursor-two-comment']}`,
-                ].join(' ')}
-              >
-                <p className="text-lg">🤔</p>
-              </div>
-              <Cursor
-                color="var(--color-tomato-900)"
-                className={`${RealtimeStyles['cursor-three']} absolute top-[170px] right-[180px]`}
-              />
-              <div
-                className={[
-                  'border-foreground absolute top-[72px] left-[320px] flex h-10 w-20',
-                  'items-center justify-center space-x-2 rounded-full border-[3px] bg-tomato-900',
-                  `${RealtimeStyles['cursor-three-comment']}`,
-                ].join(' ')}
-              >
-                <p className="text-lg">😄</p>
-              </div>
-              <div className="bg-background border-default absolute top-0 flex h-9 w-full items-center justify-between border-b">
-                <div className="flex items-center">
-                  <Menu className="text-foreground mx-3" strokeWidth={1} size={16} />
-                  <Grid className="text-foreground mx-3" strokeWidth={1} size={15} />
-                  <Layers className="text-foreground mx-3" strokeWidth={1} size={15} />
-                </div>
-                <div className="mx-3 flex items-center">
-                  <div className="border-foreground bg-tomato-900 relative -right-4 h-5 w-5 rounded-full border" />
-                  <div className="border-foreground bg-yellow-900 relative -right-2 z-2 h-5 w-5 rounded-full border" />
-                  <div className="border-foreground bg-indigo-900 z-3 h-5 w-5 rounded-full border" />
-                </div>
-              </div>
-            </div>,
-          ]}
-          documentation_url={'/docs/guides/realtime/broadcast'}
-        />
+        <RealtimePageHeader />
+        <RealtimeTableHero />
 
         <SectionContainer>
-          <div className="grid grid-cols-12">
-            <div className="prose col-span-12 mb-10 lg:col-span-3 lg:mb-0">
-              <div className="p mb-4">
-                <img
-                  src="/images/realtime/icons/database-changes.svg"
-                  alt="realtime broadcast"
-                  className="-mb-4 w-9"
-                />
-              </div>
-              <h3>Database changes</h3>
-              <p>
-                Listen to changes in the Database inserts, updates, and deletes and other changes.
-              </p>
-              <div className="not-prose mt-3">
-                <Button asChild type="default">
-                  <Link href="/docs/guides/realtime/postgres-changes">View docs</Link>
-                </Button>
-              </div>
-            </div>
-            <div className="prose col-span-12 mb-10 lg:col-span-3 lg:col-start-5 lg:mb-0">
-              <div className="p mb-4">
-                <img
-                  src="/images/realtime/icons/presence.svg"
-                  alt="realtime broadcast"
-                  className="-mb-4 w-9"
-                />
-              </div>
-              <h3>Presence</h3>
-              <p>Store and synchronize online user state consistently across clients.</p>
-              <div className="not-prose mt-3">
-                <Button asChild type="default">
-                  <Link href="/docs/guides/realtime/presence">View docs</Link>
-                </Button>
-              </div>
-            </div>
-            <div className="prose col-span-12 lg:col-span-3 lg:col-start-9">
-              <div className="p mb-4">
-                <img
-                  src="/images/realtime/icons/broadcast.svg"
-                  alt="realtime broadcast"
-                  className="-mb-4 w-9"
-                />
-              </div>
-              <h3>Broadcast</h3>
-              <p>Send any data to any client subscribed to the same Channel.</p>
-              <div className="not-prose mt-3">
-                <Button asChild type="default">
-                  <Link href="/docs/guides/realtime/broadcast">View docs</Link>
-                </Button>
-              </div>
-            </div>
-          </div>
+          <RealtimeFeatureSections />
         </SectionContainer>
 
-        <SingleQuote
-          id="quote"
-          className="pb-8! md:pb-12!"
-          quote={{
-            text: 'Supabase takes out the mental effort from our back-end infrastructure so we can focus on our customers needs.',
-            author: 'Aaron Sullivan',
-            role: 'Principal Software Engineer Epsilon3',
-            link: '/customers/epsilon3',
-            logo: (
-              <Image
-                draggable={false}
-                src="/images/blog/avatars/aaron-epsilon3.png"
-                alt="Aaron Sullivan, Principal Software Engineer Epsilon3"
-                className="w-10 h-10 rounded-full overflow-hidden object-cover"
-                width={28}
-                height={28}
-              />
-            ),
-          }}
-        />
-
-        <SectionContainer className="pb-0! mb-0!">
+        <SectionContainer id="playground" className="pb-0! mb-0! scroll-mt-24">
           <div className="mb-12 prose">
-            <h3>What you can build with Realtime</h3>
+            <h3>Playground - give it a go!</h3>
             <p className="text-foreground-light mt-0">
               Build any kind of Realtime application with ease, including any of these scenarios.
             </p>
@@ -250,14 +92,11 @@ function RealtimePage() {
             content={ApiExamples}
             size="large"
             text={[
-              <p key={0}>
-                <p className="text-base lg:text-lg">
-                  APIs that you can understand. With powerful libraries that work on client and
-                  server-side applications.
-                </p>
+              <p key={0} className="text-base lg:text-lg">
+                APIs that you can understand. With powerful libraries that work on client and
+                server-side applications.
               </p>,
             ]}
-            // [TODO] Point to the correct docs URL
             documentation_link={'/docs/guides/realtime/broadcast'}
           />
         </SectionContainer>

--- a/apps/www/styles/studio-grid.css
+++ b/apps/www/styles/studio-grid.css
@@ -1,0 +1,131 @@
+@reference "./globals.css";
+
+.sb-grid {
+  @apply flex h-full flex-col;
+}
+
+.sb-grid-fill-container:after {
+  content: '';
+  display: inline-block;
+  width: 100%;
+}
+
+.rdg-cell {
+  @apply flex border-secondary border-r border-b text-foreground;
+  font-size: 14px;
+  padding-inline: 0.5rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  line-height: inherit;
+}
+
+.rdg-cell.rdg-editor-container > * {
+  background-color: inherit;
+}
+
+.rdg-cell[aria-selected='true'] {
+  box-shadow: inset 0 0 0 1px #24b47e;
+}
+
+.rdg:not(:focus-within) .rdg-cell[aria-selected='true'] {
+  box-shadow: none;
+  outline: none;
+}
+
+.rdg {
+  @apply box-border select-none overflow-x-auto overflow-y-scroll bg-dash-canvas border-t border-r-0 border-l-0;
+  contain: strict;
+  font-size: 14px;
+}
+
+.rdg *,
+.rdg ::after,
+.rdg ::before {
+  box-sizing: inherit;
+}
+
+.rdg-header-row {
+  @apply bg-surface-200 select-none border-none;
+  height: var(--header-row-height, 36px);
+  line-height: var(--header-row-height, 36px);
+  top: 0;
+}
+
+.rdg-header-row .rdg-cell {
+  @apply bg-surface-200 border-default border-b;
+}
+
+.rdg-row {
+  @apply bg-dash-sidebar transition-colors hover:bg-surface-200;
+}
+
+.rdg-row[aria-selected='true'] {
+  @apply bg-surface-200;
+}
+
+.sb-grid [type='checkbox'] {
+  appearance: none;
+  display: inline-block;
+  vertical-align: middle;
+  user-select: none;
+  flex-shrink: 0;
+  height: 1rem;
+  width: 1rem;
+  @apply cursor-pointer rounded-sm border border-solid text-foreground border-strong transition-all hover:border-foreground focus:ring-0 focus:outline-hidden bg-control;
+  margin-top: 2px;
+}
+
+.sb-grid [type='checkbox']:checked {
+  @apply bg-foreground;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='hsl(0, 0%, 100%)'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E") !important;
+}
+
+[data-theme='dark'] .sb-grid [type='checkbox']:checked {
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='hsl(0, 0%, 0%)'%3E%3Cpath d='M12.207 4.793a1 1 0 010 1.414l-5 5a1 1 0 01-1.414 0l-2-2a1 1 0 011.414-1.414L6.5 9.086l4.293-4.293a1 1 0 011.414 0z'/%3E%3C/svg%3E") !important;
+}
+
+.null-value {
+  @apply block opacity-50;
+}
+
+.sb-grid-column-header {
+  @apply flex h-full w-full items-center justify-between px-2;
+}
+
+.sb-grid-column-header__inner {
+  @apply flex items-center gap-2 overflow-hidden text-ellipsis;
+}
+
+.sb-grid-column-header__inner__name {
+  @apply text-foreground overflow-hidden text-ellipsis text-xs select-text;
+}
+
+.sb-grid-column-header__inner__format {
+  @apply text-xs overflow-hidden text-ellipsis font-normal text-foreground-light;
+}
+
+.sb-grid-column-header__inner__primary-key {
+  @apply flex rotate-45 transform items-center;
+}
+
+.sb-grid-column-header__inner svg {
+  @apply text-brand;
+}
+
+.sb-grid-text-editor__input {
+  @apply h-full w-full bg-inherit px-2 outline-none;
+  font-size: 14px;
+}
+
+.realtime-hero-cell--remote-focus {
+  position: relative;
+}
+
+.realtime-hero-cell__editor-badge {
+  @apply absolute -top-px right-0 z-10 px-1.5 py-0.5 text-[10px] font-bold text-white rounded-bl-sm pointer-events-none;
+}
+
+.realtime-hero-grid .rdg {
+  overflow-y: hidden;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1762,6 +1762,9 @@ importers:
       react-countdown:
         specifier: ^2.3.5
         version: 2.3.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react-data-grid:
+        specifier: 7.0.0-beta.47
+        version: 7.0.0-beta.47(patch_hash=803f02d6cede565990ab9675326b93195b98bcc6477a4811715405892c257488)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react-dom:
         specifier: 'catalog:'
         version: 19.2.6(react@19.2.6)


### PR DESCRIPTION
## Summary
- Adds a Studio-style Realtime hero with a read-only users table, augmented collaborator cursors, and 3D perspective composition
- Introduces animated feature illustrations for Broadcast (interactive floating reactions), Presence (join/chat feed), and Database changes (3D notification stack)
- Refreshes the Realtime page header with documentation and playground CTAs, reorders feature sections, and removes the old static mockup

## Test plan
- [x] `pnpm run lint` in `apps/www` (0 errors)
- [x] `pnpm run typecheck` in `apps/www`
- [x] `pnpm run test` in `apps/www` (59 tests passed)
- [ ] Open `/realtime` locally and verify hero cursors align with focused cells under the 3D tilt
- [ ] Confirm Broadcast reactions float up and respond to tap/click
- [ ] Confirm Presence join/chat feed animates in the bottom-left
- [ ] Confirm Database changes notification stack cycles correctly
- [ ] Verify "View documentation" links to `/docs/guides/realtime`
- [ ] Verify "View examples" smooth-scrolls to the playground section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new Realtime section to the website with an interactive table demo showcasing multiple concurrent users
* Implemented real-time cursor tracking to display active user positions
* Added live presence counter and cell focus indicators for collaborative editing scenarios
* Created animated illustrations demonstrating Broadcast and Presence features with interactive elements

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46474?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->