### PR TITLE
fix(studio): restore project home request chart bars

### DIFF
--- a/packages/ui-patterns/src/LogsBarChart/index.tsx
+++ b/packages/ui-patterns/src/LogsBarChart/index.tsx
@@ -70,10 +70,7 @@ export const LogsBarChart = ({
       data-testid="logs-bar-chart"
       className={cn('flex flex-col gap-y-3', isFullHeight ? 'h-full' : 'h-24')}
     >
-      <ChartContainer
-        className={cn('h-full', isFullHeight && 'aspect-auto')}
-        config={chartConfig ?? defaultChartConfig}
-      >
+      <ChartContainer className="h-full" config={chartConfig ?? defaultChartConfig}>
         <RechartBarChart
           data={data}
           onMouseMove={(e: any) => {


### PR DESCRIPTION
## Problem

On the project home page, the **Total Requests** section (Database / Auth / Storage / Realtime Requests cards) renders the totals and the date range row, but the chart bars themselves are invisible — leaving the cards visually empty.

| Broken (today on master) |
|---|
| ![empty bars](https://github.com/user-attachments/assets) |

## Root cause

[#46274](https://github.com/supabase/supabase/pull/46274) ("streamline status health visual") added an `aspect-auto` class to `ChartContainer` inside `LogsBarChart` whenever `isFullHeight` is set:

```ts
<ChartContainer
  className={cn('h-full', isFullHeight && 'aspect-auto')}
  ...
>
```

`ChartContainer`'s base classes include `aspect-video`, which `aspect-auto` overrides. In `ProjectUsageSection` the chart lives inside a flex-column wrapper that *also* contains the date-range row below it; with `aspect-auto` removing the aspect-ratio fallback, the recharts `ResponsiveContainer` ends up with no resolved height and the bars don't paint.

The PR was scoped to the Observability page (`ServiceHealthTable`), so this was an unintended regression on the project home.

## Fix

Restore `ChartContainer`'s prior className — drop the `aspect-auto` branch. The `hideDateRange` prop added in #46274 is kept since `ServiceHealthTable` relies on it. `ServiceHealthTable`'s chart still sizes correctly because its parent row has an explicit `h-16`, so it doesn't depend on the `aspect-auto` override.

## Test plan

- [ ] Project home → Total Requests: bars render in all four service cards
- [ ] Observability page → Service Health table: bars still render correctly in each row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Optimized LogsBarChart styling to streamline the component's responsive rendering behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->