### PR TITLE
chore(ci): block merge while api-deploy-required label is present

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,5 +1,10 @@
 # Add 'documentation' to any change in apps/docs
 # https://github.com/marketplace/actions/labeler
 documentation:
-- changed-files:
-  - any-glob-to-any-file: 'apps/docs/**/*'
+  - changed-files:
+      - any-glob-to-any-file: 'apps/docs/**/*'
+
+# Add 'api-deploy-required' to any change in packages/api-types/types
+api-deploy-required:
+  - changed-files:
+      - any-glob-to-any-file: 'packages/api-types/types/**'

--- a/.github/workflows/label_prs.yml
+++ b/.github/workflows/label_prs.yml
@@ -1,10 +1,7 @@
 name: 'Pull Request Labeler'
 
-# only docs uses the labeler at the moment
 on:
   pull_request_target:
-    paths:
-      - 'apps/docs/**/*'
 
 jobs:
   labeler:
@@ -13,4 +10,17 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+      - id: label
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+
+      - name: Comment when api-deploy-required is auto-applied
+        if: contains(steps.label.outputs.new-labels, 'api-deploy-required')
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: 'The `api-deploy-required` label was auto-applied to this PR because it updates the API types. Ensure that the new or updated API, if any, is deployed on production before **removing the label** and merging this PR.',
+            })

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,6 +17,12 @@ jobs:
           echo "PR blocked: [tag: do not merge]"
           exit 1
 
+      - name: Tagged with 'api-deploy-required'
+        if: contains( github.event.pull_request.labels.*.name, 'api-deploy-required')
+        run: |
+          echo "PR blocked: [tag: api-deploy-required] — confirm the API is deployed in production, then remove the label."
+          exit 1
+
       - name: All good
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

CI / tooling — GitHub Actions workflow update.

## What is the current behavior?

PRs that modify `packages/api-types/types/**` can be merged before the corresponding API has shipped to production, breaking the Studio frontend when it calls endpoints that do not exist yet. The `api-deploy-required` label is enforced only by convention and code review, which is easy to miss.

## What is the new behavior?

- `.github/labeler.yml`: auto-applies `api-deploy-required` to any PR that touches `packages/api-types/types/**`.
- `.github/workflows/label_prs.yml`: drops the `apps/docs/**/*` path filter so the labeler runs on all PRs, and posts a one-time comment when `api-deploy-required` is newly added (uses the labeler's `new-labels` output so re-pushes do not re-comment).
- `.github/workflows/validate-pr.yml`: adds a step that fails the `Validate pull request` check while the `api-deploy-required` label is present, mirroring the existing `do-not-merge` pattern. The author removes the label after confirming the API is live to unblock merge.

Reviewer: please confirm `Validate pull request` is configured as a required check on `master` in branch protection — that step is what enforces the block.

## Additional context

Resolves FE-3479

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced pull request automation with improved labeling rules for API-related changes.
  * Added validation that blocks pull request merging until API deployment is confirmed for changes affecting API types.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46482?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->