### PR TITLE
feat: detect integration install state based on partner callbacks

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -85,6 +85,7 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
   }, [
     apiKeys,
     edgeFunctionSecrets,
+    partnerIntegrations,
     integration,
     isApiKeysLoading,
     isEdgeFunctionSecretsLoading,

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -24,7 +24,7 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
     !!integration.edgeFunctionSecretName
 
   const requiresPartnerIntegrationsCheck =
-    integration.installIdentificationMethod === 'callback_status'
+    integration.installIdentificationMethod === 'integration_status'
 
   const { data: apiKeys, isLoading: isApiKeysLoading } = useAPIKeysQuery(
     { projectRef, reveal: false },
@@ -74,7 +74,7 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
       return edgeFunctionSecrets.some((secret) => secret.name === secretName)
     }
 
-    if (integration.installIdentificationMethod === 'callback_status') {
+    if (integration.installIdentificationMethod === 'integration_status') {
       if (isPartnerIntegrationsLoading || !partnerIntegrations) return false
       return partnerIntegrations.some(
         (i) => i.listing_slug === integration.id && i.status === 'ready'

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -6,6 +6,7 @@ import { Button } from 'ui'
 import type { IntegrationDefinition } from '@/components/interfaces/Integrations/Landing/Integrations.constants'
 import { useAPIKeysQuery } from '@/data/api-keys/api-keys-query'
 import { useInstallOAuthIntegrationMutation } from '@/data/marketplace/install-oauth-integration-mutation'
+import { usePartnerIntegrationsQuery } from '@/data/partners/integration-status-query'
 import { useSecretsQuery } from '@/data/secrets/secrets-query'
 
 interface InstallOAuthIntegrationButtonProps {
@@ -22,6 +23,9 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
     integration.installIdentificationMethod === 'edge_function_secret_name' &&
     !!integration.edgeFunctionSecretName
 
+  const requiresPartnerIntegrationsCheck =
+    integration.installIdentificationMethod === 'callback_status'
+
   const { data: apiKeys, isLoading: isApiKeysLoading } = useAPIKeysQuery(
     { projectRef, reveal: false },
     { enabled: requiresApiKeysCheck }
@@ -31,6 +35,9 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
     { projectRef },
     { enabled: requiresEdgeFunctionSecretsCheck }
   )
+
+  const { data: partnerIntegrations, isPending: isPartnerIntegrationsLoading } =
+    usePartnerIntegrationsQuery({ projectRef }, { enabled: requiresPartnerIntegrationsCheck })
 
   const { mutate: installOAuthIntegration, isPending: isInstalling } =
     useInstallOAuthIntegrationMutation({
@@ -49,7 +56,8 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
 
   const isLoading =
     (requiresApiKeysCheck && isApiKeysLoading) ||
-    (requiresEdgeFunctionSecretsCheck && isEdgeFunctionSecretsLoading)
+    (requiresEdgeFunctionSecretsCheck && isEdgeFunctionSecretsLoading) ||
+    (requiresPartnerIntegrationsCheck && isPartnerIntegrationsLoading)
 
   const isIntegrationInstalled = useMemo(() => {
     if (!integration) return false
@@ -66,8 +74,22 @@ export function InstallOAuthIntegrationButton({ integration }: InstallOAuthInteg
       return edgeFunctionSecrets.some((secret) => secret.name === secretName)
     }
 
+    if (integration.installIdentificationMethod === 'callback_status') {
+      if (isPartnerIntegrationsLoading || !partnerIntegrations) return false
+      return partnerIntegrations.some(
+        (i) => i.listing_slug === integration.id && i.status === 'ready'
+      )
+    }
+
     return false
-  }, [apiKeys, edgeFunctionSecrets, integration, isApiKeysLoading, isEdgeFunctionSecretsLoading])
+  }, [
+    apiKeys,
+    edgeFunctionSecrets,
+    integration,
+    isApiKeysLoading,
+    isEdgeFunctionSecretsLoading,
+    isPartnerIntegrationsLoading,
+  ])
 
   const handleInstallClick = async () => {
     if (!integration || !projectRef) return

--- a/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
@@ -31,7 +31,7 @@ export const isOAuthInstalled = ({
   secrets: ProjectSecret[]
   partnerIntegrations: IntegrationStatus[]
 }) => {
-  if (integration.installIdentificationMethod === 'callback_status') {
+  if (integration.installIdentificationMethod === 'integration_status') {
     return partnerIntegrations.some(
       (i) => i.listing_slug === integration.id && i.status === 'ready'
     )

--- a/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
@@ -11,6 +11,7 @@ import { type APIKey } from '@/data/api-keys/api-keys-query'
 import { type DatabaseExtension } from '@/data/database-extensions/database-extensions-query'
 import { type Schema } from '@/data/database/schemas-query'
 import { type FDW } from '@/data/fdw/fdws-query'
+import { IntegrationStatus } from '@/data/partners/integration-status-query'
 import { type ProjectSecret } from '@/data/secrets/secrets-query'
 
 export const isStripeSyncEngineInstalled = (schemas: Schema[]) => {
@@ -23,11 +24,19 @@ export const isOAuthInstalled = ({
   integration,
   apiKeys,
   secrets,
+  partnerIntegrations: partnerIntegrations,
 }: {
   integration: IntegrationDefinition
   apiKeys: APIKey[]
   secrets: ProjectSecret[]
+  partnerIntegrations: IntegrationStatus[]
 }) => {
+  if (integration.installIdentificationMethod === 'callback_status') {
+    return partnerIntegrations.some(
+      (i) => i.listing_slug === integration.id && i.status === 'ready'
+    )
+  }
+
   if (integration.installIdentificationMethod === 'secret_key_prefix') {
     const prefix = integration.secretKeyPrefix
     if (!prefix) return false

--- a/apps/studio/components/interfaces/Integrations/Landing/useInstalledIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useInstalledIntegrations.tsx
@@ -49,7 +49,7 @@ export const useInstalledIntegrations = () => {
     return allIntegrations.some(
       (integration) =>
         integration.type === 'oauth' &&
-        integration.installIdentificationMethod === 'callback_status'
+        integration.installIdentificationMethod === 'integration_status'
     )
   }, [allIntegrations])
 

--- a/apps/studio/components/interfaces/Integrations/Landing/useInstalledIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useInstalledIntegrations.tsx
@@ -11,6 +11,7 @@ import { useAPIKeysQuery } from '@/data/api-keys/api-keys-query'
 import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useFDWsQuery } from '@/data/fdw/fdws-query'
+import { usePartnerIntegrationsQuery } from '@/data/partners/integration-status-query'
 import { useSecretsQuery } from '@/data/secrets/secrets-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { EMPTY_ARR } from '@/lib/void'
@@ -44,6 +45,14 @@ export const useInstalledIntegrations = () => {
     )
   }, [allIntegrations])
 
+  const hasCallbackStatusIntegration = useMemo(() => {
+    return allIntegrations.some(
+      (integration) =>
+        integration.type === 'oauth' &&
+        integration.installIdentificationMethod === 'callback_status'
+    )
+  }, [allIntegrations])
+
   const {
     data: apiKeys = EMPTY_ARR,
     error: apiKeysError,
@@ -64,6 +73,17 @@ export const useInstalledIntegrations = () => {
   } = useSecretsQuery(
     { projectRef: project?.ref },
     { enabled: hasEdgeFunctionSecretNameIntegration }
+  )
+
+  const {
+    data: partnerIntegrations = EMPTY_ARR,
+    error: partnerIntegrationsError,
+    isError: isErrorPartnerIntegrations,
+    isLoading: isPartnerIntegrationsLoading,
+    isSuccess: isSuccessPartnerIntegrations,
+  } = usePartnerIntegrationsQuery(
+    { projectRef: project?.ref },
+    { enabled: hasCallbackStatusIntegration }
   )
 
   const {
@@ -115,7 +135,12 @@ export const useInstalledIntegrations = () => {
           return hasRequiredExtensions({ integration, extensions })
         }
         if (integration.type === 'oauth') {
-          return isOAuthInstalled({ integration, apiKeys, secrets: edgeFunctionSecrets })
+          return isOAuthInstalled({
+            integration,
+            apiKeys,
+            partnerIntegrations,
+            secrets: edgeFunctionSecrets,
+          })
         }
         return false
       })
@@ -128,28 +153,32 @@ export const useInstalledIntegrations = () => {
     schemasError ||
     availableIntegrationsError ||
     (hasSecretKeyPrefixIntegration ? apiKeysError : null) ||
-    (hasEdgeFunctionSecretNameIntegration ? edgeFunctionSecretsError : null)
+    (hasEdgeFunctionSecretNameIntegration ? edgeFunctionSecretsError : null) ||
+    (hasCallbackStatusIntegration ? partnerIntegrationsError : null)
   const isLoading =
     isSchemasLoading ||
     isFDWLoading ||
     isExtensionsLoading ||
     isAvailableIntegrationsLoading ||
     (hasSecretKeyPrefixIntegration && isApiKeysLoading) ||
-    (hasEdgeFunctionSecretNameIntegration && isEdgeFunctionSecretsLoading)
+    (hasEdgeFunctionSecretNameIntegration && isEdgeFunctionSecretsLoading) ||
+    (hasCallbackStatusIntegration && isPartnerIntegrationsLoading)
   const isError =
     isErrorFDWs ||
     isErrorExtensions ||
     isErrorSchemas ||
     isErrorAvailableIntegrations ||
     (hasSecretKeyPrefixIntegration && isErrorApiKeys) ||
-    (hasEdgeFunctionSecretNameIntegration && isErrorEdgeFunctionSecrets)
+    (hasEdgeFunctionSecretNameIntegration && isErrorEdgeFunctionSecrets) ||
+    (hasCallbackStatusIntegration && isErrorPartnerIntegrations)
   const isSuccess =
     isSuccessFDWs &&
     isSuccessExtensions &&
     isSuccessSchemas &&
     isSuccessAvailableIntegrations &&
     (!hasSecretKeyPrefixIntegration || isSuccessApiKeys) &&
-    (!hasEdgeFunctionSecretNameIntegration || isSuccessEdgeFunctionSecrets)
+    (!hasEdgeFunctionSecretNameIntegration || isSuccessEdgeFunctionSecrets) &&
+    (!hasCallbackStatusIntegration || isSuccessPartnerIntegrations)
 
   return {
     // show all integrations at once instead of showing partial results

--- a/apps/studio/data/partners/integration-status-query.ts
+++ b/apps/studio/data/partners/integration-status-query.ts
@@ -1,0 +1,42 @@
+import { useQuery } from '@tanstack/react-query'
+
+import { partnersKeys } from './keys'
+import type { components } from '@/data/api'
+import { get, handleError } from '@/data/fetchers'
+import type { ResponseError, UseCustomQueryOptions } from '@/types'
+
+export type IntegrationVariables = {
+  projectRef?: string
+}
+
+export type IntegrationStatus =
+  components['schemas']['PartnerIntegrationListResponse']['integrations'][0]
+
+async function getIntegrations({ projectRef }: IntegrationVariables, signal?: AbortSignal) {
+  if (!projectRef) throw new Error('Project ref is required')
+
+  const { data, error } = await get(`/platform/integrations/partners/{ref}`, {
+    params: { path: { ref: projectRef } },
+    signal,
+  })
+
+  if (error) handleError(error)
+  return data.integrations
+}
+
+export type IntegrationsData = Awaited<ReturnType<typeof getIntegrations>>
+export type IntegrationsError = ResponseError
+
+export const usePartnerIntegrationsQuery = <TData = IntegrationsData>(
+  { projectRef }: IntegrationVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<IntegrationsData, IntegrationsError, TData> = {}
+) =>
+  useQuery<IntegrationsData, IntegrationsError, TData>({
+    queryKey: partnersKeys.getIntegrations(projectRef),
+    queryFn: ({ signal }) => getIntegrations({ projectRef }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined',
+    ...options,
+  })

--- a/apps/studio/data/partners/keys.ts
+++ b/apps/studio/data/partners/keys.ts
@@ -1,3 +1,4 @@
-export const stripeProjectsKeys = {
-  get: (arId: string | undefined) => ['stripe', 'projects', arId] as const,
+export const partnersKeys = {
+  getIntegrations: (projectId?: string) => ['partners', 'integrations', projectId] as const,
+  getStripeProjects: (arId: string | undefined) => ['stripe', 'projects', arId] as const,
 }

--- a/apps/studio/data/partners/stripe-projects-query.ts
+++ b/apps/studio/data/partners/stripe-projects-query.ts
@@ -1,7 +1,7 @@
 import { queryOptions } from '@tanstack/react-query'
 import type { components } from 'api-types'
 
-import { stripeProjectsKeys } from './keys'
+import { partnersKeys } from './keys'
 import { get, handleError } from '@/data/fetchers'
 
 type GetAccountRequestVariables = {
@@ -30,7 +30,7 @@ export const accountRequestQueryOptions = (
   { enabled = true }: { enabled?: boolean } = { enabled: true }
 ) => {
   return queryOptions({
-    queryKey: stripeProjectsKeys.get(arId),
+    queryKey: partnersKeys.getStripeProjects(arId),
     queryFn: ({ signal }) => getAccountRequest({ arId }, signal),
     enabled: enabled && typeof arId !== 'undefined',
   })

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -687,6 +687,23 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/integrations/partners/{ref}': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    /** Lists installed marketplace integrations for the given project. */
+    get: operations['PartnerIntegrationsController_listIntegrations']
+    put?: never
+    post?: never
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/integrations/partners/{ref}/{listing_slug}': {
     parameters: {
       query?: never
@@ -694,7 +711,8 @@ export interface paths {
       path?: never
       cookie?: never
     }
-    get?: never
+    /** Gets the installation status of the given marketplace integration for the given project. */
+    get: operations['PartnerIntegrationsController_getIntegration']
     put?: never
     /** Creates a partner integration and returns the redirect URL */
     post: operations['PartnerIntegrationsController_createIntegration']
@@ -986,6 +1004,23 @@ export interface paths {
     head?: never
     /** Patch an audit log drain */
     patch: operations['AuditLogDrainController_patchAuditLogDrain']
+    trace?: never
+  }
+  '/platform/organizations/{slug}/analytics/audit-log-drains/{token}/test': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Test an audit log drain connection */
+    post: operations['AuditLogDrainController_testAuditLogDrain']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
     trace?: never
   }
   '/platform/organizations/{slug}/apps': {
@@ -2630,6 +2665,23 @@ export interface paths {
     patch: operations['LogDrainController_patchLogDrain']
     trace?: never
   }
+  '/platform/projects/{ref}/analytics/log-drains/{token}/test': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Test a log drain connection */
+    post: operations['LogDrainController_testLogDrain']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/projects/{ref}/api-keys/temporary': {
     parameters: {
       query?: never
@@ -2925,7 +2977,7 @@ export interface paths {
     /** Creates project's content folder */
     post: operations['ContentFoldersController_createFolder']
     /** Deletes project's content folders */
-    delete: operations['ContentFoldersController_DeleteFolder']
+    delete: operations['ContentFoldersController_deleteFolder']
     options?: never
     head?: never
     patch?: never
@@ -4519,6 +4571,26 @@ export interface paths {
     patch?: never
     trace?: never
   }
+  '/platform/support/verify-email': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /**
+     * Verify a support conversation email
+     * @description Called by the Supabase dashboard when a user clicks their email verification link. Validates the token, checks org/project ownership, updates the Front conversation custom fields, and removes unverified tags.
+     */
+    post: operations['VerifyEmailController_verifyEmail']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/telemetry/event': {
     parameters: {
       query?: never
@@ -4880,6 +4952,10 @@ export interface components {
         remediation: string
         title: string
       }[]
+    }
+    BackendConnectionTest: {
+      'connected?': boolean
+      reason: string
     }
     BackupsResponse: {
       backups: {
@@ -5511,13 +5587,13 @@ export interface components {
       custom_supabase_internal_requests?: {
         ami: {
           /**
-           * @description Exact AWS instance type to provision (e.g. `t3.nano`, `t4g.nano`). When omitted the default for `desired_instance_size` is used. Only for internal use; rejected for user-facing requests in production.
+           * @description Exact AWS instance type to provision (e.g. `t3.nano`, `t4g.nano`). Hard pin — no ODCR fallback. Only for internal use; rejected for user-facing requests in production.
            * @enum {string}
            */
           instance_type?:
             | 't4g.nano'
-            | 't3.nano'
             | 't3a.nano'
+            | 't3.nano'
             | 't4g.micro'
             | 't4g.small'
             | 't4g.medium'
@@ -5537,6 +5613,11 @@ export interface components {
             | 'c8g.48xlarge'
             | 'r8g.48xlarge'
             | 'x8g.48xlarge'
+          /**
+           * @description Preferred architecture for WPP projects. Soft hint — the worker selects the cheapest region-available type for this arch and may cross to the other arch if no ODCR capacity is available. Cannot be set together with instance_type. Only for internal use.
+           * @enum {string}
+           */
+          preferred_arch?: 'x86_64' | 'arm64'
           search_tags?: {
             [key: string]: string
           }
@@ -8357,12 +8438,42 @@ export interface components {
       organization_id: number
       overdue_invoice_count: number
     }
+    PartnerIntegrationListResponse: {
+      integrations: {
+        listing_slug: string
+        partner_links?: {
+          dashboard?: string
+          manage?: string
+        }
+        /** @enum {string} */
+        status: 'installing' | 'ready' | 'error'
+        user_alert?: {
+          message: string
+        }
+        version?: string
+      }[]
+    }
     PartnerIntegrationsResponse: {
       /**
        * Format: uri
        * @description URL to redirect the user's browser to
        */
       redirectUrl: string
+    }
+    PartnerIntegrationStatusResponse: {
+      install_state?: {
+        partner_links?: {
+          dashboard?: string
+          manage?: string
+        }
+        /** @enum {string} */
+        status: 'installing' | 'ready' | 'error'
+        user_alert?: {
+          message: string
+        }
+        version?: string
+      }
+      installed: boolean
     }
     PauseStatusResponse: {
       can_restore: boolean
@@ -12134,6 +12245,13 @@ export interface components {
     VercelRedirectResponse: {
       url: string
     }
+    VerifyEmailBody: {
+      token: string
+    }
+    VerifyEmailResponse: {
+      /** @enum {string} */
+      result: 'success'
+    }
     WorkflowRunResponse: {
       branch_id: string
       check_run_id: number | null
@@ -14071,6 +14189,108 @@ export interface operations {
       }
     }
   }
+  PartnerIntegrationsController_listIntegrations: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PartnerIntegrationListResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Project not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  PartnerIntegrationsController_getIntegration: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description The slug of the listing in the marketplace database */
+        listing_slug: string
+        /** @description Supabase project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['PartnerIntegrationStatusResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Project not found */
+      404: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   PartnerIntegrationsController_createIntegration: {
     parameters: {
       query?: never
@@ -15044,6 +15264,58 @@ export interface operations {
         content?: never
       }
       /** @description Failed to patch audit log drain */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  AuditLogDrainController_testAuditLogDrain: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Organization slug */
+        slug: string
+        /** @description Audit log drain identifier */
+        token: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['BackendConnectionTest']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to test audit log drain */
       500: {
         headers: {
           [name: string]: unknown
@@ -21159,6 +21431,58 @@ export interface operations {
       }
     }
   }
+  LogDrainController_testLogDrain: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+        /** @description Log drains identifier */
+        token: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['BackendConnectionTest']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to test log drain */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
   ApiKeysController_createTemporaryApiKey: {
     parameters: {
       query: {
@@ -22468,7 +22792,7 @@ export interface operations {
       }
     }
   }
-  ContentFoldersController_DeleteFolder: {
+  ContentFoldersController_deleteFolder: {
     parameters: {
       query: {
         ids: string
@@ -28387,6 +28711,30 @@ export interface operations {
           [name: string]: unknown
         }
         content?: never
+      }
+    }
+  }
+  VerifyEmailController_verifyEmail: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['VerifyEmailBody']
+      }
+    }
+    responses: {
+      /** @description Verification successful */
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['VerifyEmailResponse']
+        }
       }
     }
   }

--- a/packages/common/marketplace.types.ts
+++ b/packages/common/marketplace.types.ts
@@ -1,10 +1,4 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
 export type Database = {
   public: {
@@ -45,13 +39,13 @@ export type Database = {
           id: string | null
           images: string[] | null
           installation_identification_method:
-            | "secret_key_prefix"
-            | "edge_function_secret_name"
-            | "integration_status"
-            | "oauth_authorization"
+            | 'secret_key_prefix'
+            | 'edge_function_secret_name'
+            | 'integration_status'
+            | 'oauth_authorization'
             | null
           installation_url: string | null
-          installation_url_type: "get" | "post" | null
+          installation_url_type: 'get' | 'post' | null
           listing_logo: string | null
           listing_tsv: unknown
           marketplace_url: string | null
@@ -78,7 +72,7 @@ export type Database = {
           name: string | null
           num_of_employees: number | null
           slug: string | null
-          type: "technology" | "expert" | null
+          type: 'technology' | 'expert' | null
           website: string | null
         }
         Insert: {
@@ -89,7 +83,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: "technology" | "expert" | null
+          type?: 'technology' | 'expert' | null
           website?: string | null
         }
         Update: {
@@ -100,7 +94,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: "technology" | "expert" | null
+          type?: 'technology' | 'expert' | null
           website?: string | null
         }
         Relationships: []
@@ -112,7 +106,7 @@ export type Database = {
           listing_slug: string | null
           partner_links: Json | null
           project_ref: string | null
-          status: "installing" | "ready" | "error" | null
+          status: 'installing' | 'ready' | 'error' | null
           updated_at: string | null
           user_alert: Json | null
           version: string | null
@@ -147,33 +141,31 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -182,23 +174,23 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -207,23 +199,23 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -232,36 +224,36 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
+    | keyof DefaultSchema['Enums']
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
     : never
 
 export const Constants = {
@@ -269,4 +261,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/packages/common/marketplace.types.ts
+++ b/packages/common/marketplace.types.ts
@@ -41,12 +41,15 @@ export type Database = {
           installation_identification_method:
             | 'secret_key_prefix'
             | 'edge_function_secret_name'
+            | 'callback_status'
+            | 'oauth_authorization'
             | null
           installation_url: string | null
           installation_url_type: 'get' | 'post' | null
           listing_logo: string | null
           listing_tsv: unknown
           marketplace_url: string | null
+          oauth_client_id: string | null
           partner_logo: string | null
           partner_name: string | null
           partner_slug: string | null
@@ -93,6 +96,20 @@ export type Database = {
           slug?: string | null
           type?: 'technology' | 'expert' | null
           website?: string | null
+        }
+        Relationships: []
+      }
+      project_integration_status: {
+        Row: {
+          created_at: string | null
+          integration_id: string | null
+          listing_slug: string | null
+          partner_links: Json | null
+          project_ref: string | null
+          status: 'installing' | 'ready' | 'error' | null
+          updated_at: string | null
+          user_alert: Json | null
+          version: string | null
         }
         Relationships: []
       }

--- a/packages/common/marketplace.types.ts
+++ b/packages/common/marketplace.types.ts
@@ -1,4 +1,10 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
   public: {
@@ -39,13 +45,13 @@ export type Database = {
           id: string | null
           images: string[] | null
           installation_identification_method:
-            | 'secret_key_prefix'
-            | 'edge_function_secret_name'
-            | 'callback_status'
-            | 'oauth_authorization'
+            | "secret_key_prefix"
+            | "edge_function_secret_name"
+            | "integration_status"
+            | "oauth_authorization"
             | null
           installation_url: string | null
-          installation_url_type: 'get' | 'post' | null
+          installation_url_type: "get" | "post" | null
           listing_logo: string | null
           listing_tsv: unknown
           marketplace_url: string | null
@@ -72,7 +78,7 @@ export type Database = {
           name: string | null
           num_of_employees: number | null
           slug: string | null
-          type: 'technology' | 'expert' | null
+          type: "technology" | "expert" | null
           website: string | null
         }
         Insert: {
@@ -83,7 +89,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: 'technology' | 'expert' | null
+          type?: "technology" | "expert" | null
           website?: string | null
         }
         Update: {
@@ -94,7 +100,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: 'technology' | 'expert' | null
+          type?: "technology" | "expert" | null
           website?: string | null
         }
         Relationships: []
@@ -106,7 +112,7 @@ export type Database = {
           listing_slug: string | null
           partner_links: Json | null
           project_ref: string | null
-          status: 'installing' | 'ready' | 'error' | null
+          status: "installing" | "ready" | "error" | null
           updated_at: string | null
           user_alert: Json | null
           version: string | null
@@ -141,31 +147,33 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -174,23 +182,23 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -199,23 +207,23 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -224,36 +232,36 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
 export const Constants = {
@@ -261,3 +269,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+


### PR DESCRIPTION
Adds support for the new `integration_status` installation identification method for OAuth marketplace integrations, which will use the new integration state stored in Marketplace DB and updated via partner callbacks.

- Depends on https://github.com/supabase/marketplace/pull/105 and https://github.com/supabase/platform/pull/33280
- Fixes INT-123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth installations can be detected via partner integration status
  * Partner marketplace integrations can be retrieved and surfaced
  * Added endpoints to test audit-log and log-drain connections
  * Support for email verification workflow
  * Optional architecture preference (x86_64 or arm64) for project provisioning

* **Chores**
  * Reorganized partner-related query key management and data fetching logic
<!-- end of auto-generated comment: release notes by coderabbit.ai -->