### PR TITLE
docs: note minimum supabase-js version for passkeys

### DIFF
--- a/apps/docs/content/guides/auth/passkeys.mdx
+++ b/apps/docs/content/guides/auth/passkeys.mdx
@@ -12,6 +12,12 @@ Passkey support is experimental. The API may change without notice. You must exp
 
 </Admonition>
 
+<Admonition type="note">
+
+**Requires `@supabase/supabase-js` v2.106.2 and later.** Upgrade your client library to use passkey authentication.
+
+</Admonition>
+
 ## How does it work?
 
 Each sign-in or registration is a WebAuthn ceremony with three steps:

--- a/apps/docs/content/guides/auth/passkeys.mdx
+++ b/apps/docs/content/guides/auth/passkeys.mdx
@@ -14,7 +14,7 @@ Passkey support is experimental. The API may change without notice. You must exp
 
 <Admonition type="note">
 
-**Requires `@supabase/supabase-js` v2.106.2 and later.** Upgrade your client library to use passkey authentication.
+**Requires `@supabase/supabase-js` v2.105.0 and later.** Upgrade your client library to use passkey authentication.
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update passkeys docs to note the min required `supabase-js` version

## What is the current behavior?

No mention of what `supabase-js` version is required

## What is the new behavior?

Add note with the min `supabase-js` version.

## Additional context
<img width="949" height="537" alt="Screenshot 2026-05-28 at 23 29 04" src="https://github.com/user-attachments/assets/96427b23-146b-4373-a1a6-db2a1f7d2da4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified passkey authentication guide with a new note specifying that passkey support requires the client library v2.105.0 or later and instructing readers to upgrade their client to enable passkey authentication.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46491?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->