### PR TITLE
fix: Disable paused projects

### DIFF
--- a/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.ComboBox.tsx
+++ b/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.ComboBox.tsx
@@ -21,6 +21,7 @@ export interface ComboBoxOption {
   id: string
   value: string
   displayName: string
+  disabled?: boolean
 }
 
 export function ComboBox<Opt extends ComboBoxOption>({
@@ -131,6 +132,7 @@ export function ComboBox<Opt extends ComboBoxOption>({
                     {options.map((option) => (
                       <CommandItem
                         key={option.id}
+                        disabled={option.disabled}
                         value={option.value}
                         onSelect={(selectedValue: string) => {
                           setOpen(false)

--- a/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.tsx
+++ b/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.tsx
@@ -138,10 +138,14 @@ function OrgProjectSelector() {
         : (projects!
             .map((project) => {
               const organization = organizations!.find((org) => org.id === project.organization_id)!
+              const paused = isProjectPaused(project)
               return {
                 id: project.ref,
                 value: toOrgProjectValue(organization, project),
-                displayName: toDisplayNameOrgProject(organization, project),
+                displayName: paused
+                  ? `${toDisplayNameOrgProject(organization, project)} (paused)`
+                  : toDisplayNameOrgProject(organization, project),
+                disabled: paused,
               }
             })
             .filter(Boolean) as ComboBoxOption[]),
@@ -162,10 +166,14 @@ function OrgProjectSelector() {
 
       if (storedOrg && storedProject && storedProject.organization_id === storedOrg.id) {
         setSelectedOrgProject(storedOrg, storedProject)
-      } else if (projects!.length > 0) {
-        const firstProject = projects![0]
-        const matchingOrg = organizations!.find((org) => org.id === firstProject.organization_id)
-        if (matchingOrg) setSelectedOrgProject(matchingOrg, firstProject)
+      } else {
+        const firstActiveProject = projects!.find((project) => !isProjectPaused(project))
+        if (firstActiveProject) {
+          const matchingOrg = organizations!.find(
+            (org) => org.id === firstActiveProject.organization_id
+          )
+          if (matchingOrg) setSelectedOrgProject(matchingOrg, firstActiveProject)
+        }
       }
     }
   }, [organizations, projects, selectedOrg, selectedProject, setSelectedOrgProject, stateSummary])


### PR DESCRIPTION
Modified the project combobox component to signal paused projects and disable them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Paused projects are now visually distinguished with a "(paused)" label and disabled in the project selector.

* **Bug Fixes**
  * Fixed selection logic to automatically switch to the first active project when previously stored selections are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46503?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->