### PR TITLE
fix: visual regression in documentation menu dropdowns

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/GlobalNavigationMenu.tsx
+++ b/apps/docs/components/Navigation/NavigationMenu/GlobalNavigationMenu.tsx
@@ -170,7 +170,7 @@ export const MenuItem = React.forwardRef<
       ref={ref}
       className={cn(
         'group/menu-item flex items-center gap-2',
-        'w-full flex h-8 items-center text-foreground-light text-sm hover:text-foreground select-none rounded-md py-2 leading-none no-underline outline-hidden! focus-visible:ring-2 focus-visible:ring-foreground-lighter focus-visible:text-foreground',
+        'w-full flex h-8 items-center text-foreground-light text-sm hover:text-foreground select-none rounded-md p-2 leading-none no-underline outline-hidden! focus-visible:ring-2 focus-visible:ring-foreground-lighter focus-visible:text-foreground',
         className
       )}
       {...props}


### PR DESCRIPTION
## Problem

Padding if off:
<img width="640" height="950" alt="image" src="https://github.com/user-attachments/assets/586b912e-bad4-4245-a1ca-1675362f7fa0" />

## Solution

<img width="546" height="764" alt="image" src="https://github.com/user-attachments/assets/ffae0c56-8f07-47e8-9c05-cd219bdd101d" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated navigation menu item spacing to include horizontal padding alongside vertical padding, providing improved visual balance and spacing within the navigation menu.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->