### PR TITLE
Fix: Remove list style from flags

### DIFF
--- a/apps/docs/features/docs/Reference.sections.tsx
+++ b/apps/docs/features/docs/Reference.sections.tsx
@@ -206,7 +206,7 @@ async function CliCommandSection({ link, section }: CliCommandSectionProps) {
         {(command.flags ?? []).length > 0 && (
           <>
             <h3 className="mb-3 text-base text-foreground">Flags</h3>
-            <ul>
+            <ul className="not-prose">
               {command.flags.map((flag, index) => (
                 <li key={index} className="border-t last-of-type:border-b py-5 flex flex-col gap-3">
                   <div className="flex flex-wrap items-baseline gap-3">


### PR DESCRIPTION
Removing list markers from _Flags_ lists in CLI reference.

**Before**
<img width="551" height="527" alt="Screenshot 2026-05-29 at 16 07 16" src="https://github.com/user-attachments/assets/ba59968a-25a5-4b5d-b869-035c78d6ca13" />

**After**
<img width="586" height="365" alt="Screenshot 2026-05-29 at 16 07 33" src="https://github.com/user-attachments/assets/d7f87e70-642d-4ff9-bf64-7db792043182" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for the flags list in CLI command documentation to improve visual presentation and prevent unintended markdown prose styling from being applied.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46507?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->