### PR TITLE
fix(www): update Default.com script on contact sales form

### DIFF
--- a/apps/www/pages/contact/sales.tsx
+++ b/apps/www/pages/contact/sales.tsx
@@ -31,7 +31,7 @@ const ContactSales = () => {
       <Head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `!function(e,t){var _=0;e.__default__=e.__default__||{},e.__default__.form_id=299973,e.__default__.team_id=715,e.__default__.listenToIds=["hsForm_de9a785a-fb65-4164-bd7d-000ae6eff219_5037","de9a785a-fb65-4164-bd7d-000ae6eff219_5037"],function e(){var o=t.createElement("script");o.async=!0,o.src="https://import-cdn.default.com",o.onload=function(){!0,console.info("[Default.com] Powered by Default.com")},o.onerror=function(){++_<=3&&setTimeout(e,1e3*_)},t.head.appendChild(o)}()}(window,document);`,
+            __html: `!function(e,t){var _=0;e.__default__=e.__default__||{},e.__default__.form_id=879120,e.__default__.team_id=715,e.__default__.listenToIds=["support-form"],function e(){var o=t.createElement("script");o.async=!0,o.src="https://import-cdn.default.com",o.onload=function(){!0,console.info("[Default.com] Powered by Default.com")},o.onerror=function(){++_<=3&&setTimeout(e,1e3*_)},t.head.appendChild(o)}()}(window,document);`,
           }}
         />
       </Head>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update (third-party integration script).

## What is the current behavior?

The Default.com snippet on `/contact/sales` used the old `form_id` (`299973`) and listened to the legacy HubSpot form element IDs (`hsForm_de9a785a-…_5037`), which no longer match the form rendered on the page.

## What is the new behavior?

The snippet now uses `form_id=879120` and listens to `["support-form"]`, the actual `id` of the `RequestADemoForm` rendered on the page, so submissions are enriched and routed correctly.

## Additional context

`team_id` and the loader logic are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated form configuration on the sales contact page to enhance data processing and routing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46510?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->