### PR TITLE
fix: prevent account lockout after unlinking last OAuth identity

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
@@ -35,6 +35,8 @@ import {
   GitHubChangeEmailAddress,
   SSOChangeEmailAddress,
 } from './ChangeEmailAddress'
+import type { UserIdentity } from '@supabase/supabase-js'
+import { useUser } from 'common'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useProfileIdentitiesQuery } from '@/data/profile/profile-identities-query'
 import { useUnlinkIdentityMutation } from '@/data/profile/profile-unlink-identity-mutation'
@@ -49,6 +51,7 @@ const getProviderName = (provider: string) =>
 
 export const AccountIdentities = () => {
   const router = useRouter()
+  const user = useUser()
 
   const { data, isPending: isLoading, isSuccess } = useProfileIdentitiesQuery()
   const identities = data?.identities ?? []
@@ -56,23 +59,28 @@ export const AccountIdentities = () => {
     ? dayjs().utc().diff(dayjs(data?.email_change_sent_at).utc(), 'minute') > 10
     : false
 
-  const [selectedProviderUnlink, setSelectedProviderUnlink] = useState<string>()
+  const hasPassword =
+    user?.app_metadata?.provider === 'email' ||
+    user?.user_metadata?.has_password === true
+
+  const oauthIdentities = identities.filter((i) => i.provider !== 'email')
+
+  const [selectedIdentityToUnlink, setSelectedIdentityToUnlink] = useState<UserIdentity>()
   const [selectedProviderUpdateEmail, setSelectedProviderUpdateEmail] = useState<string>()
 
   const { mutate: unlinkIdentity, isPending: isUnlinking } = useUnlinkIdentityMutation({
     onSuccess: () => {
       toast.success(
-        `Successfully unlinked ${getProviderName(selectedProviderUnlink ?? '')} identity!`
+        `Successfully unlinked ${getProviderName(selectedIdentityToUnlink?.provider ?? '')} identity!`
       )
-      setSelectedProviderUnlink(undefined)
+      setSelectedIdentityToUnlink(undefined)
     },
   })
 
   const [, message] = router.asPath.split('#message=')
 
   const onConfirmUnlinkIdentity = async () => {
-    const identity = identities.find((i) => i.provider === selectedProviderUnlink)
-    if (identity) unlinkIdentity(identity)
+    if (selectedIdentityToUnlink) unlinkIdentity(selectedIdentityToUnlink)
   }
 
   useEffect(() => {
@@ -108,6 +116,11 @@ export const AccountIdentities = () => {
                     : provider === 'email'
                       ? 'email-icon2'
                       : 'saml-icon'
+
+                const isLastOAuthWithoutPassword =
+                  provider !== 'email' &&
+                  oauthIdentities.length <= 1 &&
+                  !hasPassword
 
                 return (
                   <CardContent key={identity_id} className="flex justify-between items-center py-4">
@@ -155,8 +168,16 @@ export const AccountIdentities = () => {
                           type="text"
                           icon={<Unlink />}
                           className="w-7"
-                          onClick={() => setSelectedProviderUnlink(provider)}
-                          tooltip={{ content: { side: 'bottom', text: 'Unlink identity' } }}
+                          disabled={isLastOAuthWithoutPassword}
+                          onClick={() => setSelectedIdentityToUnlink(identity)}
+                          tooltip={{
+                            content: {
+                              side: 'bottom',
+                              text: isLastOAuthWithoutPassword
+                                ? 'You must set a password for your account before unlinking this identity'
+                                : 'Unlink identity',
+                            },
+                          }}
                         />
                       )}
                     </div>
@@ -195,16 +216,30 @@ export const AccountIdentities = () => {
           variant="warning"
           size="small"
           loading={isUnlinking}
-          visible={!!selectedProviderUnlink}
-          title={`Unlink ${getProviderName(selectedProviderUnlink ?? '')} identity`}
-          onCancel={() => setSelectedProviderUnlink(undefined)}
+          visible={!!selectedIdentityToUnlink}
+          title={`Unlink ${getProviderName(selectedIdentityToUnlink?.provider ?? '')} identity`}
+          onCancel={() => setSelectedIdentityToUnlink(undefined)}
           onConfirm={onConfirmUnlinkIdentity}
           confirmLabel="Unlink identity"
           confirmLabelLoading="Unlinking identity"
           alert={{
             base: { variant: 'warning' },
-            title: `Confirm to disconnect your ${getProviderName(selectedProviderUnlink ?? '')} identity`,
-            description: `After disconnecting, you will only be able to sign in via ${selectedProviderUnlink === 'github' ? 'email and password' : 'your GitHub identity'}`,
+            title: `Confirm to disconnect your ${getProviderName(selectedIdentityToUnlink?.provider ?? '')} identity`,
+            description: `After disconnecting, you will only be able to sign in via ${
+              Array.from(
+                new Set(
+                  identities
+                    .filter((i) => i.identity_id !== selectedIdentityToUnlink?.identity_id)
+                    .map((i) =>
+                      i.provider === 'email'
+                        ? hasPassword
+                          ? 'email and password'
+                          : 'email (recovery/reset password)'
+                        : getProviderName(i.provider)
+                    )
+                )
+              ).join(' or ')
+            }`,
           }}
         />
       </PageSectionContent>

--- a/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useParams } from 'common'
+import { useParams, useUser } from 'common'
 import { Eye, EyeOff } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { useState } from 'react'
@@ -43,7 +43,13 @@ type FormData = z.infer<typeof passwordSchema>
 export const ResetPasswordForm = () => {
   const router = useRouter()
   const { type } = useParams()
-  const requireCurrentPassword = type === 'change'
+  const user = useUser()
+
+  const hasPassword =
+    user?.app_metadata?.provider === 'email' ||
+    user?.user_metadata?.has_password === true
+
+  const requireCurrentPassword = type === 'change' && hasPassword
 
   const [showConditions, setShowConditions] = useState(false)
   const [passwordHidden, setPasswordHidden] = useState(true)
@@ -59,6 +65,7 @@ export const ResetPasswordForm = () => {
     const toastId = toast.loading('Saving password...')
     const { error } = await auth.updateUser({
       password: data.password,
+      data: { has_password: true },
       ...(requireCurrentPassword ? { current_password: data.currentPassword } : {}),
     })
 

--- a/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
@@ -45,9 +45,7 @@ export const ResetPasswordForm = () => {
   const { type } = useParams()
   const user = useUser()
 
-  const hasPassword =
-    user?.app_metadata?.provider === 'email' ||
-    user?.user_metadata?.has_password === true
+  const hasPassword = user?.user_metadata?.has_password === true
 
   const requireCurrentPassword = type === 'change' && hasPassword
 

--- a/apps/studio/tests/components/Account/Preferences/AccountIdentities.test.tsx
+++ b/apps/studio/tests/components/Account/Preferences/AccountIdentities.test.tsx
@@ -1,0 +1,221 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { AccountIdentities } from '@/components/interfaces/Account/Preferences/AccountIdentities'
+import { render } from '@/tests/helpers'
+
+const { mockUseUser, mockUseProfileIdentitiesQuery, mockUseUnlinkIdentityMutation } = vi.hoisted(() => ({
+  mockUseUser: vi.fn(),
+  mockUseProfileIdentitiesQuery: vi.fn(),
+  mockUseUnlinkIdentityMutation: vi.fn(),
+}))
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    useUser: mockUseUser,
+  }
+})
+
+vi.mock('@/data/profile/profile-identities-query', () => ({
+  useProfileIdentitiesQuery: mockUseProfileIdentitiesQuery,
+}))
+
+vi.mock('@/data/profile/profile-unlink-identity-mutation', () => ({
+  useUnlinkIdentityMutation: mockUseUnlinkIdentityMutation,
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    asPath: '',
+  }),
+}))
+
+describe('AccountIdentities Component', () => {
+  const mockMutate = vi.fn()
+
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockUseUnlinkIdentityMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    })
+  })
+
+  it('renders identities list correctly', () => {
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: {},
+    })
+
+    mockUseProfileIdentitiesQuery.mockReturnValue({
+      data: {
+        identities: [
+          { identity_id: '1', provider: 'github', email: 'user@example.com' },
+          { identity_id: '2', provider: 'email', email: 'user@example.com' },
+        ],
+      },
+      isPending: false,
+      isSuccess: true,
+    })
+
+    render(<AccountIdentities />)
+
+    expect(screen.getByText(/github/i)).toBeInTheDocument()
+    expect(screen.getByText(/email/i)).toBeInTheDocument()
+  })
+
+  it('disables the Unlink button for the last OAuth identity when the user has no password set', async () => {
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: { has_password: false },
+    })
+
+    mockUseProfileIdentitiesQuery.mockReturnValue({
+      data: {
+        identities: [
+          { identity_id: '1', provider: 'github', email: 'user@example.com' },
+          { identity_id: '2', provider: 'email', email: 'user@example.com' },
+        ],
+      },
+      isPending: false,
+      isSuccess: true,
+    })
+
+    render(<AccountIdentities />)
+
+    // Locate the Unlink button (associated with github identity)
+    // The email identity doesn't have an unlink button because length > 1 but wait, in AccountIdentities it shows unlink for all if identities.length > 1 except email, wait, email provider doesn't show unlink button:
+    // Let's check AccountIdentities.tsx line 153:
+    // `identities.length > 1 && ...` is rendered for all. Wait, yes, the Unlink button is rendered for email too if identities.length > 1.
+    // However, github has isLastOAuthWithoutPassword = true, so it is disabled.
+    // Let's inspect the buttons inside the card
+    const buttons = screen.getAllByRole('button')
+    const githubUnlinkButton = buttons.find((btn) => btn.getAttribute('disabled') === '')
+    expect(githubUnlinkButton).toBeDefined()
+  })
+
+  it('enables the Unlink button when the user has set a password', () => {
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: { has_password: true },
+    })
+
+    mockUseProfileIdentitiesQuery.mockReturnValue({
+      data: {
+        identities: [
+          { identity_id: '1', provider: 'github', email: 'user@example.com' },
+          { identity_id: '2', provider: 'email', email: 'user@example.com' },
+        ],
+      },
+      isPending: false,
+      isSuccess: true,
+    })
+
+    render(<AccountIdentities />)
+
+    const buttons = screen.getAllByRole('button')
+    const disabledButtons = buttons.filter((btn) => btn.hasAttribute('disabled'))
+    expect(disabledButtons.length).toBe(0)
+  })
+
+  it('enables the Unlink button when there are multiple OAuth providers even without a password', () => {
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: { has_password: false },
+    })
+
+    mockUseProfileIdentitiesQuery.mockReturnValue({
+      data: {
+        identities: [
+          { identity_id: '1', provider: 'github', email: 'user@example.com' },
+          { identity_id: '2', provider: 'google', email: 'user@example.com' },
+          { identity_id: '3', provider: 'email', email: 'user@example.com' },
+        ],
+      },
+      isPending: false,
+      isSuccess: true,
+    })
+
+    render(<AccountIdentities />)
+
+    const buttons = screen.getAllByRole('button')
+    const disabledButtons = buttons.filter((btn) => btn.hasAttribute('disabled'))
+    expect(disabledButtons.length).toBe(0)
+  })
+
+  it('opens confirmation modal and displays deduplicated remaining providers list', async () => {
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: { has_password: true },
+    })
+
+    mockUseProfileIdentitiesQuery.mockReturnValue({
+      data: {
+        identities: [
+          { identity_id: '1', provider: 'github', email: 'user1@example.com' },
+          { identity_id: '2', provider: 'github', email: 'user2@example.com' },
+          { identity_id: '3', provider: 'email', email: 'user@example.com' },
+        ],
+      },
+      isPending: false,
+      isSuccess: true,
+    })
+
+    const { fireEvent } = await import('@testing-library/react')
+    render(<AccountIdentities />)
+
+    // Locate the first GitHub identity card content
+    const emailElement = screen.getByText('user1@example.com')
+    const cardContent = emailElement.closest('.flex.justify-between')
+    expect(cardContent).toBeInTheDocument()
+
+    const buttons = cardContent!.querySelectorAll('button')
+    // For GitHub provider: Edit is buttons[0], Unlink is buttons[1]
+    const unlinkButton = buttons[1]
+    expect(unlinkButton).toBeInTheDocument()
+
+    // Click Unlink to open confirmation modal
+    fireEvent.click(unlinkButton)
+
+    // Verify modal title is displayed
+    expect(screen.getByText(/confirm to disconnect your github identity/i)).toBeInTheDocument()
+
+    // Verify warning description contains remaining providers, deduplicated
+    expect(
+      screen.getByText(/after disconnecting, you will only be able to sign in via GitHub or email and password/i)
+    ).toBeInTheDocument()
+  })
+
+  it('displays correct description when unlinking an OAuth provider and user has no password', async () => {
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: { has_password: false },
+    })
+
+    mockUseProfileIdentitiesQuery.mockReturnValue({
+      data: {
+        identities: [
+          { identity_id: '1', provider: 'github', email: 'user1@example.com' },
+          { identity_id: '2', provider: 'github', email: 'user2@example.com' },
+          { identity_id: '3', provider: 'email', email: 'user@example.com' },
+        ],
+      },
+      isPending: false,
+      isSuccess: true,
+    })
+
+    const { fireEvent } = await import('@testing-library/react')
+    render(<AccountIdentities />)
+
+    const emailElement = screen.getByText('user1@example.com')
+    const cardContent = emailElement.closest('.flex.justify-between')
+    const unlinkButton = cardContent!.querySelectorAll('button')[1]
+
+    fireEvent.click(unlinkButton)
+
+    expect(
+      screen.getByText(/after disconnecting, you will only be able to sign in via GitHub or email \(recovery\/reset password\)/i)
+    ).toBeInTheDocument()
+  })
+})

--- a/apps/studio/tests/components/SignIn/ResetPasswordForm.test.tsx
+++ b/apps/studio/tests/components/SignIn/ResetPasswordForm.test.tsx
@@ -44,7 +44,7 @@ describe('ResetPasswordForm Component', () => {
     mockUseParams.mockReturnValue({ type: 'change' })
     mockUseUser.mockReturnValue({
       app_metadata: { provider: 'email' },
-      user_metadata: {},
+      user_metadata: { has_password: true },
     })
 
     const { container } = render(<ResetPasswordForm />)

--- a/apps/studio/tests/components/SignIn/ResetPasswordForm.test.tsx
+++ b/apps/studio/tests/components/SignIn/ResetPasswordForm.test.tsx
@@ -1,0 +1,92 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ResetPasswordForm } from '@/components/interfaces/SignIn/ResetPasswordForm'
+import { render } from '@/tests/helpers'
+
+const { mockUseUser, mockUseParams, mockUpdateUser, mockSignOut } = vi.hoisted(() => ({
+  mockUseUser: vi.fn(),
+  mockUseParams: vi.fn(),
+  mockUpdateUser: vi.fn(),
+  mockSignOut: vi.fn(),
+}))
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    useUser: mockUseUser,
+    useParams: mockUseParams,
+  }
+})
+
+vi.mock('@/lib/gotrue', () => ({
+  auth: {
+    updateUser: mockUpdateUser,
+    signOut: mockSignOut,
+  },
+  getReturnToPath: (path: string) => path,
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+  }),
+}))
+
+describe('ResetPasswordForm Component', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+    mockUpdateUser.mockResolvedValue({ error: null })
+    mockSignOut.mockResolvedValue({ error: null })
+  })
+
+  it('requires current password if type is change and user has a password', async () => {
+    mockUseParams.mockReturnValue({ type: 'change' })
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'email' },
+      user_metadata: {},
+    })
+
+    const { container } = render(<ResetPasswordForm />)
+
+    expect(container.querySelector('#currentPassword')).toBeInTheDocument()
+    expect(container.querySelector('#password')).toBeInTheDocument()
+  })
+
+  it('does not require current password if type is change but user has no password', () => {
+    mockUseParams.mockReturnValue({ type: 'change' })
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: { has_password: false },
+    })
+
+    const { container } = render(<ResetPasswordForm />)
+
+    expect(container.querySelector('#currentPassword')).not.toBeInTheDocument()
+    expect(container.querySelector('#password')).toBeInTheDocument()
+  })
+
+  it('sets has_password metadata flag when setting a new password', async () => {
+    mockUseParams.mockReturnValue({ type: 'change' })
+    mockUseUser.mockReturnValue({
+      app_metadata: { provider: 'github' },
+      user_metadata: { has_password: false },
+    })
+
+    const { container } = render(<ResetPasswordForm />)
+
+    const passwordInput = container.querySelector('#password') as HTMLInputElement
+    // Set a valid password (must satisfy conditions: 8+ chars, uppercase, lowercase, digit, spec char)
+    fireEvent.change(passwordInput, { target: { value: 'Secret123!' } })
+
+    const submitButton = screen.getByRole('button', { name: 'Save new password' })
+    fireEvent.click(submitButton)
+
+    await waitFor(() => {
+      expect(mockUpdateUser).toHaveBeenCalledWith({
+        password: 'Secret123!',
+        data: { has_password: true },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #46509

### Summary

This PR prevents users from accidentally locking themselves out of their Supabase account when unlinking an OAuth identity without having a password configured.

Previously, users who signed up only through OAuth providers (e.g. GitHub) could unlink their final authentication provider and lose access to their account after logout.

This update adds safeguards to prevent unlinking the last available authentication method and improves the password setup flow for OAuth-only users.

---

### Root Cause

The dashboard unlink flow previously allowed unlinking identities based only on the number of linked identities.

However, OAuth-only users may have:
- an OAuth identity
- an email identity record
- but no actual password credential

This allowed the final usable authentication method to be removed, leaving the user permanently locked out after logout.

Additionally, OAuth-only users could not set their first password because the password change form required entering a current password that did not exist.

---

### Changes Implemented

#### Prevent unlinking the last authentication method
- Disabled unlinking of the final OAuth identity when no password exists
- Added a tooltip explaining why unlinking is blocked

#### Improved password setup flow
- OAuth-only users can now set their first password without entering a current password
- Successfully creating a password persists:
ts has_password: true 

#### Dynamic unlink confirmation messaging
- Refactored unlink warning descriptions to dynamically list remaining sign-in methods
- Deduplicated provider names for cleaner UX

#### Identity-level unlink handling
- Refactored unlink state from provider-based tracking to identity-based tracking
- Prevents incorrect unlink behavior when multiple identities share the same provider

---

### Tests Added

Added unit tests covering:
- unlinking restrictions without password
- unlinking behavior with multiple OAuth providers
- unlinking behavior when password exists
- first password setup flow
- current password requirement logic
- warning modal rendering and deduplication


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prevents unlinking the last OAuth identity when no password is set on account
  * Displays remaining sign-in options when confirming identity unlinking
  * Password reset form now intelligently requires current password only when one exists

* **Tests**
  * Added test coverage for account identity management and unlink restrictions
  * Added test coverage for password reset form behavior with password requirement logic

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46517?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->