### PR TITLE
fix(self-hosted): grant supabase_functions_admin USAGE on extensions schema

### DIFF
--- a/docker/volumes/db/webhooks.sql
+++ b/docker/volumes/db/webhooks.sql
@@ -122,6 +122,12 @@ BEGIN;
   ALTER table "supabase_functions".hooks OWNER TO supabase_functions_admin;
   ALTER function "supabase_functions".http_request() OWNER TO supabase_functions_admin;
   GRANT supabase_functions_admin TO postgres;
+  -- http_request() runs as supabase_functions_admin (SECURITY DEFINER) and builds the
+  -- webhook payload from NEW/OLD. Serializing rows whose columns use a type defined in
+  -- the extensions schema (e.g. PostGIS geometry) invokes that type's I/O functions, which
+  -- requires USAGE on the schema. Without this grant the trigger fails with
+  -- "permission denied for schema extensions".
+  GRANT USAGE ON SCHEMA extensions TO supabase_functions_admin;
   -- Remove unused supabase_pg_net_admin role
   DO
   $$


### PR DESCRIPTION
## What

Database webhooks fail with `permission denied for schema extensions` when the webhook fires on a table that has a column whose type is defined in the `extensions` schema (for example a PostGIS `extensions.geometry` column).

## Why

`supabase_functions.http_request()` is `SECURITY DEFINER` and runs as `supabase_functions_admin`. For a `POST` webhook it builds the payload with `jsonb_build_object('record', NEW, ...)`, which serializes the row to `jsonb`. Serializing a value whose type lives in `extensions` invokes that type's I/O functions, and that requires `USAGE` on the schema that owns the type. `supabase_functions_admin` is never granted `USAGE` on `extensions`, so the trigger raises `permission denied for schema extensions` and the insert/update is rolled back.

## Fix

Grant `supabase_functions_admin` `USAGE` on the `extensions` schema in `docker/volumes/db/webhooks.sql`.

## Reproduction (from the issue)

```sql
-- PostGIS enabled in the extensions schema
create table geom (coordinates extensions.geometry(Point, 4326));
-- create an INSERT webhook on public.geom, then:
insert into geom(coordinates)
values (ST_GeomFromText('POINT(-71.060316 48.432044)', 4326));
-- ERROR: permission denied for schema extensions
```

## Notes

Verified by reasoning about the function definition in `webhooks.sql` (SECURITY DEFINER owned by `supabase_functions_admin`, `search_path = supabase_functions`, no USAGE on `extensions`). Not run against a live stack.

Closes #17811


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database permissions to ensure webhook functionality operates correctly with all supported data types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->