### PR TITLE
docs(storage): clarify imgproxy is bundled in the self-hosted stack

### DIFF
--- a/apps/docs/content/guides/storage/serving/image-transformations.mdx
+++ b/apps/docs/content/guides/storage/serving/image-transformations.mdx
@@ -683,7 +683,13 @@ response = supabase.storage.from_('bucket').download(
 
 ## Self hosting
 
-Our solution to image resizing and optimization can be self-hosted as with any other Supabase product. Under the hood we use [imgproxy](https://imgproxy.net/)
+Our solution to image resizing and optimization can be self-hosted as with any other Supabase product. Under the hood we use [imgproxy](https://imgproxy.net/).
+
+<Admonition type="note">
+
+If you run the official self-hosted stack from the [`supabase/supabase`](https://github.com/supabase/supabase/tree/master/docker) Docker Compose setup, an `imgproxy` service is **already included** and wired up to the `storage` service for you (the `storage` service sets `ENABLE_IMAGE_TRANSFORMATION: "true"` and `IMGPROXY_URL: http://imgproxy:5001`). You only need the steps below if you run `storage-api` outside of that Compose stack and have to provide your own imgproxy container.
+
+</Admonition>
 
 #### imgproxy configuration:
 


### PR DESCRIPTION
## What

The "Self hosting" section of the image transformations guide tells users to deploy a `darthsim/imgproxy` container, but the official self-hosted Docker Compose stack in `docker/docker-compose.yml` already ships an `imgproxy` service wired up to `storage` (`ENABLE_IMAGE_TRANSFORMATION: "true"` and `IMGPROXY_URL: http://imgproxy:5001`). This caused confusion about whether a second imgproxy needs to be deployed (reported in #40895).

## Fix

Add a note explaining that the bundled imgproxy already handles this for users of the official stack, and that the manual steps are only needed when running `storage-api` outside of that Compose setup.

Closes #40895


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the Storage Image Transformations guide by improving the presentation and formatting of self-hosting guidance for better clarity and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->