### PR TITLE
fix(self-hosted): run pg_cron in the configured POSTGRES_DB

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -567,6 +567,8 @@ services:
         "-c",
         "config_file=/etc/postgresql/postgresql.conf",
         "-c",
+        "cron.database_name=${POSTGRES_DB}", # pg_cron must run in the configured database, not the hard-coded "postgres"
+        "-c",
         "log_min_messages=fatal" # prevents Realtime polling queries from appearing in logs
       ]
 


### PR DESCRIPTION
## What

`pg_cron` cannot be enabled in a self-hosted deployment when `POSTGRES_DB` is set to anything other than `postgres`. Enabling the extension fails because the bundled `postgresql.conf` hard-codes `cron.database_name = postgres`, so the pg_cron background worker targets a database that does not match the one the stack actually uses (reported in #42413).

## Fix

Override `cron.database_name` with the `POSTGRES_DB` value via the `postgres` start command in `docker/docker-compose.yml`. Compose interpolates `POSTGRES_DB` (default `postgres` in `.env.example`), so existing default deployments are unaffected and only custom database names change behavior.

## Notes

Verified by inspecting the db service `command` and `.env.example`. Not run against a live stack.

Closes #42413


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated PostgreSQL pg_cron extension configuration to use the specified database instance instead of the default, ensuring scheduled jobs run in the correct database environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->