### PR TITLE
fix: add wrappers permission setup and readable error message for FDW permission denied

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -136,6 +136,13 @@ export const CreateWrapperSheet = ({
       onClose()
       form.reset()
     },
+    onError: (error) => {
+      if (error.message.includes('permission denied to create foreign-data wrapper')) {
+        toast.error(`Your project permissions need to be re-initialized. This can happen after a project restore. Please contact Supabase support.`)
+      } else {
+        toast.error(`Failed to create wrapper: ${error.message}`)
+      }      
+    }
   })
 
   const onSubmit: SubmitHandler<FormSchema> = async (values) => {

--- a/packages/pg-meta/src/sql/studio/integrations/enable-wrappers.ts
+++ b/packages/pg-meta/src/sql/studio/integrations/enable-wrappers.ts
@@ -1,0 +1,69 @@
+
+import { safeSql, type SafeSqlFragment } from '../../../pg-format'
+
+export const getCheckWrappersEnabledSQL = (): SafeSqlFragment => 
+    safeSql`
+    SELECT EXISTS (
+        SELECT 1
+        FROM pg_extension
+        WHERE extname = 'wrappers'
+    ) AS is_enabled;
+    `
+
+export const getEnableWrappersSQL = (): SafeSqlFragment =>
+  safeSql`
+BEGIN;
+
+  -- Event trigger that fires when the wrappers extension is created,
+  -- granting standard roles access to use it.
+  CREATE OR REPLACE FUNCTION extensions.grant_wrappers_access()
+  RETURNS event_trigger
+  LANGUAGE plpgsql
+  AS $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_event_trigger_ddl_commands() AS ev
+      JOIN pg_extension AS ext
+      ON ev.objid = ext.oid
+      WHERE ext.extname = 'wrappers'
+    )
+    THEN
+      GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
+    END IF;
+  END;
+  $$;
+  COMMENT ON FUNCTION extensions.grant_wrappers_access IS 'Grants access to wrappers';
+
+  -- Register the event trigger only if it does not already exist
+  DO
+  $$
+  BEGIN
+    IF NOT EXISTS (
+      SELECT 1
+      FROM pg_event_trigger
+      WHERE evtname = 'issue_wrappers_access'
+    ) THEN
+      CREATE EVENT TRIGGER issue_wrappers_access ON ddl_command_end WHEN TAG IN ('CREATE EXTENSION')
+      EXECUTE PROCEDURE extensions.grant_wrappers_access();
+    END IF;
+  END
+  $$;
+
+  -- Apply grants immediately if wrappers extension is already installed
+  DO
+  $$
+  BEGIN
+    IF EXISTS (
+      SELECT 1
+      FROM pg_extension
+      WHERE extname = 'wrappers'
+    )
+    THEN
+      GRANT USAGE ON SCHEMA extensions TO postgres, anon, authenticated, service_role;
+    END IF;
+  END
+  $$;
+
+COMMIT;
+`

--- a/packages/pg-meta/src/sql/studio/integrations/index.ts
+++ b/packages/pg-meta/src/sql/studio/integrations/index.ts
@@ -1,1 +1,2 @@
 export * from './enable-webhooks'
+export * from './enable-wrappers'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix
Contributes to #46480 

## What is the current behavior?

This bug occurs when a user restores or unpauses a project, then attempts to create a ClickHouse wrapper.

By default, postgres doesn't have the permission to grant user to create a new wrapper. Only supabase_admin can grant that privilege to postgres. Because of that, postgres itself requires superuser for `create foreign data wrapper`.

```
create foreign data wrapper clickhouse_wrapper
handler click_house_fdw_handler
validator click_house_fdw_validator;
```

The problem lies when a user tries to create a ClickHouse wrapper by going through FDW (Foreign Data Wrapper) feature.
The FDW creation SQL has zero permission setup before the critical command.

```
  const sql = safeSql`
    ${newSchemasSql}

    ${createWrapperSql}

    ${createEncryptedKeysSql}

    ${createServerSql}

    ${mode === 'tables' ? createTablesSql : safeSql``}

    ${mode === 'schema' ? createImportForeignSchemaSql() : safeSql``}
  `
```
In order to grant access for this process, I follow the same pattern as the existing webhooks setup in `webhooks.ts`.

` GRANT USAGE ON SCHEMA net TO supabase_functions_admin, postgres, anon, authenticated, service_role;
GRANT EXECUTE ON FUNCTION net.http_get(...) TO postgres, ...;
`

However, the permission grants for pg_net originated in Supabase's infrastructure/restore pipeline, which is restricted for open source contribution. So this PR provides a method for Supabase's infra team to call as supabase_admin to permanently re-apply the grants.

When the restore bug hits, the user will see a raw postgres error:

`ERROR: 42501: permission denied to create foreign-data wrapper
`

## What is the new behavior?

I add SQL helpers for this issue:

1. `enable-wrappers.ts` - `getEnableWrappersSQL` and `getCheckWrappersEnabledSQL` for the infra team to wire into the restored pipeline.
2. `CreateWrapperSheet.tsx` - `onError` handler that catches the 42501 error and shows a human-readable message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for integration wrapper creation with clearer permission-related error messages.

* **New Features**
  * Added support for enabling PostgreSQL wrappers extension with appropriate permission management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->