### PR TITLE
docs: [WRA-23] add docs for new wrappers

### DIFF
--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -124,6 +124,22 @@ const pageMap = [
     remoteFile: 'bigquery.md',
   },
   {
+    slug: 'cal',
+    meta: {
+      title: 'Cal.com',
+      dashboardIntegrationPath: 'cal_wrapper',
+    },
+    remoteFile: 'cal.md',
+  },
+  {
+    slug: 'calendly',
+    meta: {
+      title: 'Calendly',
+      dashboardIntegrationPath: 'calendly_wrapper',
+    },
+    remoteFile: 'calendly.md',
+  },
+  {
     slug: 'clerk',
     meta: {
       title: 'Clerk',
@@ -140,6 +156,14 @@ const pageMap = [
     remoteFile: 'clickhouse.md',
   },
   {
+    slug: 'cloudflare-d1',
+    meta: {
+      title: 'Cloudflare D1',
+      dashboardIntegrationPath: 'cfd1_wrapper',
+    },
+    remoteFile: 'cfd1.md',
+  },
+  {
     slug: 'cognito',
     meta: {
       title: 'AWS Cognito',
@@ -151,8 +175,17 @@ const pageMap = [
     slug: 'duckdb',
     meta: {
       title: 'DuckDB',
+      dashboardIntegrationPath: undefined,
     },
     remoteFile: 'duckdb.md',
+  },
+  {
+    slug: 'dynamodb',
+    meta: {
+      title: 'AWS DynamoDB',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'dynamodb.md',
   },
   {
     slug: 'firebase',
@@ -163,12 +196,36 @@ const pageMap = [
     remoteFile: 'firebase.md',
   },
   {
+    slug: 'gravatar',
+    meta: {
+      title: 'Gravatar',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'gravatar.md',
+  },
+  {
+    slug: 'hubspot',
+    meta: {
+      title: 'HubSpot',
+      dashboardIntegrationPath: 'hubspot_wrapper',
+    },
+    remoteFile: 'hubspot.md',
+  },
+  {
     slug: 'iceberg',
     meta: {
       title: 'Iceberg',
       dashboardIntegrationPath: 'iceberg_wrapper',
     },
     remoteFile: 'iceberg.md',
+  },
+  {
+    slug: 'infura',
+    meta: {
+      title: 'Infura',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'infura.md',
   },
   {
     slug: 'logflare',
@@ -187,12 +244,36 @@ const pageMap = [
     remoteFile: 'mssql.md',
   },
   {
+    slug: 'mysql',
+    meta: {
+      title: 'MySQL',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'mysql.md',
+  },
+  {
     slug: 'notion',
     meta: {
       title: 'Notion',
       dashboardIntegrationPath: 'notion_wrapper',
     },
     remoteFile: 'notion.md',
+  },
+  {
+    slug: 'openapi',
+    meta: {
+      title: 'OpenAPI',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'openapi.md',
+  },
+  {
+    slug: 'orb',
+    meta: {
+      title: 'Orb',
+      dashboardIntegrationPath: 'orb_wrapper',
+    },
+    remoteFile: 'orb.md',
   },
   {
     slug: 'paddle',
@@ -225,6 +306,22 @@ const pageMap = [
       dashboardIntegrationPath: 's3_vectors_wrapper',
     },
     remoteFile: 's3vectors.md',
+  },
+  {
+    slug: 'shopify',
+    meta: {
+      title: 'Shopify',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'shopify.md',
+  },
+  {
+    slug: 'slack',
+    meta: {
+      title: 'Slack',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'slack.md',
   },
   {
     slug: 'snowflake',

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1331,76 +1331,130 @@ export const database: NavMenuConstant = {
           url: '/guides/database/extensions/wrappers/overview' as `/${string}`,
         },
         {
-          name: 'Connecting to Auth0',
-          url: '/guides/database/extensions/wrappers/auth0' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Airtable',
-          url: '/guides/database/extensions/wrappers/airtable' as `/${string}`,
-        },
-        {
-          name: 'Connecting to AWS Cognito',
-          url: '/guides/database/extensions/wrappers/cognito' as `/${string}`,
-        },
-        {
-          name: 'Connecting to AWS S3',
-          url: '/guides/database/extensions/wrappers/s3' as `/${string}`,
-        },
-        {
-          name: 'Connecting to AWS S3 Vectors',
-          url: '/guides/database/extensions/wrappers/s3_vectors' as `/${string}`,
-        },
-        {
-          name: 'Connecting to BigQuery',
-          url: '/guides/database/extensions/wrappers/bigquery' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Clerk',
-          url: '/guides/database/extensions/wrappers/clerk' as `/${string}`,
-        },
-        {
-          name: 'Connecting to ClickHouse',
-          url: '/guides/database/extensions/wrappers/clickhouse' as `/${string}`,
-        },
-        {
-          name: 'Connecting to DuckDB',
-          url: '/guides/database/extensions/wrappers/duckdb' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Firebase',
-          url: '/guides/database/extensions/wrappers/firebase' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Iceberg',
-          url: '/guides/database/extensions/wrappers/iceberg' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Logflare',
-          url: '/guides/database/extensions/wrappers/logflare' as `/${string}`,
-        },
-        {
-          name: 'Connecting to MSSQL',
-          url: '/guides/database/extensions/wrappers/mssql' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Notion',
-          url: '/guides/database/extensions/wrappers/notion' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Paddle',
-          url: '/guides/database/extensions/wrappers/paddle' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Redis',
-          url: '/guides/database/extensions/wrappers/redis' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Snowflake',
-          url: '/guides/database/extensions/wrappers/snowflake' as `/${string}`,
-        },
-        {
-          name: 'Connecting to Stripe',
-          url: '/guides/database/extensions/wrappers/stripe' as `/${string}`,
+          name: 'Sources',
+          url: '/guides/database/extensions/wrappers/overview' as `/${string}`,
+          items: [
+            {
+              name: 'Airtable',
+              url: '/guides/database/extensions/wrappers/airtable' as `/${string}`,
+            },
+            {
+              name: 'Auth0',
+              url: '/guides/database/extensions/wrappers/auth0' as `/${string}`,
+            },
+            {
+              name: 'AWS Cognito',
+              url: '/guides/database/extensions/wrappers/cognito' as `/${string}`,
+            },
+            {
+              name: 'AWS DynamoDB',
+              url: '/guides/database/extensions/wrappers/dynamodb' as `/${string}`,
+            },
+            {
+              name: 'AWS S3',
+              url: '/guides/database/extensions/wrappers/s3' as `/${string}`,
+            },
+            {
+              name: 'AWS S3 Vectors',
+              url: '/guides/database/extensions/wrappers/s3_vectors' as `/${string}`,
+            },
+            {
+              name: 'BigQuery',
+              url: '/guides/database/extensions/wrappers/bigquery' as `/${string}`,
+            },
+            {
+              name: 'Cal.com',
+              url: '/guides/database/extensions/wrappers/cal' as `/${string}`,
+            },
+            {
+              name: 'Calendly',
+              url: '/guides/database/extensions/wrappers/calendly' as `/${string}`,
+            },
+            {
+              name: 'Clerk',
+              url: '/guides/database/extensions/wrappers/clerk' as `/${string}`,
+            },
+            {
+              name: 'ClickHouse',
+              url: '/guides/database/extensions/wrappers/clickhouse' as `/${string}`,
+            },
+            {
+              name: 'Cloudflare D1',
+              url: '/guides/database/extensions/wrappers/cloudflare-d1' as `/${string}`,
+            },
+            {
+              name: 'DuckDB',
+              url: '/guides/database/extensions/wrappers/duckdb' as `/${string}`,
+            },
+            {
+              name: 'Firebase',
+              url: '/guides/database/extensions/wrappers/firebase' as `/${string}`,
+            },
+            {
+              name: 'Gravatar',
+              url: '/guides/database/extensions/wrappers/gravatar' as `/${string}`,
+            },
+            {
+              name: 'HubSpot',
+              url: '/guides/database/extensions/wrappers/hubspot' as `/${string}`,
+            },
+            {
+              name: 'Iceberg',
+              url: '/guides/database/extensions/wrappers/iceberg' as `/${string}`,
+            },
+            {
+              name: 'Infura',
+              url: '/guides/database/extensions/wrappers/infura' as `/${string}`,
+            },
+            {
+              name: 'Logflare',
+              url: '/guides/database/extensions/wrappers/logflare' as `/${string}`,
+            },
+            {
+              name: 'MSSQL',
+              url: '/guides/database/extensions/wrappers/mssql' as `/${string}`,
+            },
+            {
+              name: 'MySQL',
+              url: '/guides/database/extensions/wrappers/mysql' as `/${string}`,
+            },
+            {
+              name: 'Notion',
+              url: '/guides/database/extensions/wrappers/notion' as `/${string}`,
+            },
+            {
+              name: 'OpenAPI',
+              url: '/guides/database/extensions/wrappers/openapi' as `/${string}`,
+            },
+            {
+              name: 'Orb',
+              url: '/guides/database/extensions/wrappers/orb' as `/${string}`,
+            },
+            {
+              name: 'Paddle',
+              url: '/guides/database/extensions/wrappers/paddle' as `/${string}`,
+            },
+            {
+              name: 'Redis',
+              url: '/guides/database/extensions/wrappers/redis' as `/${string}`,
+            },
+            {
+              name: 'Shopify',
+              url: '/guides/database/extensions/wrappers/shopify' as `/${string}`,
+            },
+            {
+              name: 'Slack',
+              url: '/guides/database/extensions/wrappers/slack' as `/${string}`,
+            },
+            {
+              name: 'Snowflake',
+              url: '/guides/database/extensions/wrappers/snowflake' as `/${string}`,
+            },
+            {
+              name: 'Stripe',
+              url: '/guides/database/extensions/wrappers/stripe' as `/${string}`,
+            },
+          ],
         },
       ],
     },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR is add missing docs for the newly added wrappers:

- Cal
- Calendly
- Cloudflare D1
- DynamoDB
- Gravatar
- Hubspot
- Infura
- MySQL
- OpenApi
- Orb
- Shopify
- Slack

## What is the current behavior?

Those wrappers was added to Wrappers extension but docs links are not updated.

## What is the new behavior?

- The missing wrappers docs are added.
- Removed the repetitive `Connecting to` title prefix in the Navigation.
- Collapse the lengthy wrappers list into a `Sources` sub navigation item to make the UI tidy.

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guides for new federated data wrappers: Cal, Calendly, Cloudflare D1, Gravatar, Infura, MySQL, OpenAPI, Shopify, and Slack.
  * Reorganized Foreign Data Wrappers navigation menu with an improved hierarchical structure for easier discovery of available vendor integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->