### PR TITLE
fix(telemetry): fix and unify dashboard_error_created tracking

### DIFF
--- a/apps/studio/components/interfaces/ErrorHandling/ErrorMatcher.tsx
+++ b/apps/studio/components/interfaces/ErrorHandling/ErrorMatcher.tsx
@@ -26,11 +26,13 @@ export function ErrorMatcher({ title, error, supportFormParams, className }: Err
       supportFormParams={supportFormParams}
       className={className}
       onRender={() => {
-        track('dashboard_error_created', {
-          source: 'error_display',
-          errorType: mapping?.id,
-          hasTroubleshooting: !!mapping,
-        })
+        if (Math.random() < 0.1) {
+          track('dashboard_error_created', {
+            source: 'error_display',
+            errorType: mapping?.id,
+            hasTroubleshooting: !!mapping,
+          })
+        }
         if (mapping) {
           track('inline_error_troubleshooter_exposed', { errorType: mapping.id })
         }

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -61,6 +61,7 @@ import { API_URL, BASE_PATH, IS_PLATFORM, useDefaultProvider } from '@/lib/const
 import { TimezoneProvider, useTimezone } from '@/lib/datetime'
 import { ProfileProvider } from '@/lib/profile'
 import { Telemetry } from '@/lib/telemetry'
+import { ToastErrorTracker } from '@/lib/toast-errors'
 import { Toaster } from '@/lib/toaster'
 import { AiAssistantStateContextProvider } from '@/state/ai-assistant-state'
 import type { AppPropsWithLayout } from '@/types'
@@ -234,6 +235,7 @@ function CustomApp({ Component, pageProps }: AppPropsWithLayout) {
                         </RouteValidationWrapper>
                       </TooltipProvider>
                       <Telemetry />
+                      <ToastErrorTracker />
                       {!isTestEnv && (
                         <ReactQueryDevtools initialIsOpen={false} buttonPosition="bottom-left" />
                       )}

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2919,7 +2919,7 @@ export interface ComputeBadgeUpgradeClickedEvent {
   properties: {
     computeSize: string
     planId: string
-    upgradeType: 'pro_upgrade' | 'free_micro_upgrade' | 'compute_upgrade'
+    upgradeType: 'free_micro_upgrade' | 'compute_upgrade'
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
## Summary

Three telemetry fixes from the weekly PostHog instrumentation review (May 2 - Jun 1), all touching how `dashboard_error_created` and the compute-badge upgrade event are tracked.

## Changes

- **Mount `<ToastErrorTracker />`** in `_app.tsx`, next to `<Telemetry />`. The component (`apps/studio/lib/toast-errors.tsx`) emits `dashboard_error_created { source: 'toast' }` at 10% sampling but had existed since #41431 without ever being added to the React tree, so the event had 0 fires in 30 days.
- **Unify `dashboard_error_created` sampling to 10%.** `error_display` (`ErrorMatcher.tsx`) was firing at 100% while `admonition` and `toast` sampled at 10% (the guard was added for those in #41743, but the `error_display` source added later in #43564 missed it). This wraps the `error_display` emit in the same `Math.random() < 0.1` guard so all three `source` values are comparable. The `inline_error_troubleshooter_exposed` event in the same `onRender` is deliberately left unsampled (100%).
- **Remove the dead `'pro_upgrade'`** value from `compute_badge_upgrade_clicked.upgradeType`. The only call site (`ComputeBadgeWrapper.tsx`) emits just `free_micro_upgrade` or `compute_upgrade`. Dead-type cleanup, no live event path removed.

## Heads up: `error_display` volume steps down ~10x

The sampling change intentionally reduces observed `dashboard_error_created` with `source=error_display` by ~10x going forward (it was previously unsampled). That is the goal: raw `source` counts become apples-to-apples across all three sources. Any dashboard or alert keyed on the raw `error_display` count will see a one-time ~90% step down at deploy. Context: original sampling intent in #41743, `error_display` source added in #43564.

## Testing

Tested on the Vercel preview, confirmed in PostHog live events. The 10% guard was forced deterministically via `Math.random = () => 0` in the console so each emit could be observed on a single trigger:

- [x] `source: toast` (the event this PR enables) — triggered a Sonner error toast via a failed mutation; `dashboard_error_created { source: toast }` fired in PostHog. It was at 0 fires before the mount, so this confirms the fix.
- [x] `source: error_display` (the path this PR re-samples) — blocked the Table Editor entity-types fetch so `ErrorMatcher` rendered its error card; `dashboard_error_created { source: error_display }` fired under the new 10% guard.

`source: admonition` (`AlertError`) is untouched by this PR, so it was not re-tested. The `pro_upgrade` removal is compile-time only (type narrowing, no runtime change).

## Linear

- fixes GROWTH-893

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added toast-based error notifications integrated into global error handling to improve visibility of issues.
  * Reduced telemetry noise and updated event classifications: dashboard error events are now sampled (~10%) and an obsolete upgrade type was removed from telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
