### PR TITLE
chore(docs): Add Lukas Klingsbo to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -179,6 +179,7 @@ Leonardo Santiago
 Liam Cloud Hogan
 Lindsay Moss
 Lukas Bernert
+Lukas Klingsbo
 Łukasz Niemier
 Maksym Ionutsa
 Manuel Mendez


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds Lukas Klingsbo to the humans.txt

## What is the current behavior?

There is no Lukas Klingsbo in humans.txt

## What is the new behavior?

There is a Lukas Klingsbo in humans.txt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team credits listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->