### PR TITLE
feat(self-hosted): refresh functions page

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionsListItem.tsx
@@ -32,7 +32,7 @@ export const EdgeFunctionsListItem = ({ function: item }: EdgeFunctionsListItemP
   const functionUrl = `${endpoint}/functions/v1/${item.slug}`
 
   const handleNavigation = createNavigationHandler(
-    `/project/${ref}/functions/${item.slug}${IS_PLATFORM ? '' : `/details`}`,
+    `/project/${ref}/functions/${item.slug}${IS_PLATFORM ? '' : `/code`}`,
     router
   )
 

--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.test.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.test.tsx
@@ -1,0 +1,94 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { FunctionsEmptyState } from './FunctionsEmptyState'
+import { customRender as render } from '@/tests/lib/custom-render'
+
+const { mockIsPlatform, mockUseDeploymentMode, mockUseTrack, mockUseIsFeatureEnabled } = vi.hoisted(
+  () => ({
+    mockIsPlatform: { value: true },
+    mockUseDeploymentMode: vi.fn(),
+    mockUseTrack: vi.fn(),
+    mockUseIsFeatureEnabled: vi.fn(),
+  })
+)
+
+vi.mock('@/lib/constants', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/lib/constants')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+  }
+})
+
+vi.mock('@/hooks/misc/useDeploymentMode', () => ({
+  useDeploymentMode: mockUseDeploymentMode,
+}))
+
+vi.mock('@/lib/telemetry/track', () => ({
+  useTrack: mockUseTrack,
+}))
+
+vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
+  useIsFeatureEnabled: mockUseIsFeatureEnabled,
+}))
+
+describe('FunctionsEmptyState', () => {
+  beforeEach(() => {
+    mockIsPlatform.value = true
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: true,
+      isCli: false,
+      isSelfHosted: false,
+    })
+    mockUseTrack.mockReturnValue(vi.fn())
+    mockUseIsFeatureEnabled.mockReturnValue(false)
+  })
+
+  it('renders the templates section on platform', () => {
+    render(<FunctionsEmptyState />)
+
+    expect(screen.getByText('Start with a template')).toBeInTheDocument()
+  })
+
+  it('hides the templates section on self-hosted (Docker mode)', () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: false,
+      isCli: false,
+      isSelfHosted: true,
+    })
+
+    render(<FunctionsEmptyState />)
+
+    expect(screen.queryByText('Start with a template')).not.toBeInTheDocument()
+  })
+
+  it('hides the templates section on CLI mode', () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: false,
+      isCli: true,
+      isSelfHosted: false,
+    })
+
+    render(<FunctionsEmptyState />)
+
+    expect(screen.queryByText('Start with a template')).not.toBeInTheDocument()
+  })
+
+  it('renders the self-hosted manual card when isSelfHosted', () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: false,
+      isCli: false,
+      isSelfHosted: true,
+    })
+
+    render(<FunctionsEmptyState />)
+
+    expect(screen.getByText('Self-Hosted')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -194,9 +194,3 @@ const SelfHostedManualFunctionContent = () => (
     <DocsButton href={`${DOCS_URL}/guides/self-hosting/self-hosted-functions`} />
   </div>
 )
-
-export const SelfHostedManualFunctionCard = () => (
-  <Card>
-    <SelfHostedManualFunctionContent />
-  </Card>
-)

--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -1,27 +1,10 @@
 import { useParams } from 'common'
-import { Code, Play, Terminal } from 'lucide-react'
+import { Code, Server, Terminal } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useMemo } from 'react'
-import {
-  AiIconAnimation,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-  cn,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogSection,
-  DialogTitle,
-  DialogTrigger,
-  Separator,
-} from 'ui'
-import { CodeBlock } from 'ui-patterns/CodeBlock'
+import { AiIconAnimation, Button, Card, CardContent, CardHeader, CardTitle } from 'ui'
 
 import { EDGE_FUNCTION_TEMPLATES } from './Functions.templates'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
@@ -29,8 +12,9 @@ import { ScaffoldSectionTitle } from '@/components/layouts/Scaffold'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { ResourceItem } from '@/components/ui/Resource/ResourceItem'
 import { ResourceList } from '@/components/ui/Resource/ResourceList'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import { DOCS_URL } from '@/lib/constants'
+import { DOCS_URL, IS_PLATFORM } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
@@ -38,6 +22,7 @@ import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 export const FunctionsEmptyState = () => {
   const { ref } = useParams()
   const router = useRouter()
+  const { isCli, isSelfHosted } = useDeploymentMode()
   const aiSnap = useAiAssistantStateSnapshot()
   const { openSidebar } = useSidebarManagerSnapshot()
 
@@ -62,326 +47,152 @@ export const FunctionsEmptyState = () => {
         </CardHeader>
         <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
           {/* Editor Option */}
-          <div className="p-8">
-            <div className="flex items-center gap-2">
-              <Code strokeWidth={1.5} size={20} />
-              <h4 className="text-base text-foreground">Via Editor</h4>
-            </div>
-            <p className="text-sm text-foreground-light mb-4 mt-1">
-              Create and edit functions directly in the browser. Download to local at any time.
-            </p>
-            <Button
-              type="default"
-              onClick={() => {
-                router.push(`/project/${ref}/functions/new`)
-                track('edge_function_via_editor_button_clicked', { origin: 'no_functions_block' })
-              }}
-            >
-              Open Editor
-            </Button>
-          </div>
+          {IS_PLATFORM && (
+            <>
+              <div className="p-8">
+                <div className="flex items-center gap-2">
+                  <Code strokeWidth={1.5} size={20} />
+                  <h4 className="text-base text-foreground">Via Editor</h4>
+                </div>
+                <p className="text-sm text-foreground-light mb-4 mt-1">
+                  Create and edit functions directly in the browser. Download to local at any time.
+                </p>
+                <Button
+                  type="default"
+                  onClick={() => {
+                    router.push(`/project/${ref}/functions/new`)
+                    track('edge_function_via_editor_button_clicked', {
+                      origin: 'no_functions_block',
+                    })
+                  }}
+                >
+                  Open Editor
+                </Button>
+              </div>
 
-          {/* AI Assistant Option */}
-          <div className="p-8">
-            <div className="flex items-center gap-2">
-              <AiIconAnimation size={20} />
-              <h4 className="text-base text-foreground">AI Assistant</h4>
-            </div>
-            <p className="text-sm text-foreground-light mb-4 mt-1">
-              Let our AI assistant help you create functions. Perfect for kickstarting a function.
-            </p>
-            <Button
-              type="default"
-              onClick={() => {
-                openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
-                aiSnap.newChat({
-                  name: 'Create new edge function',
-                  initialInput: 'Create a new edge function that ...',
-                  suggestions: {
-                    title:
-                      'I can help you create a new edge function. Here are a few example prompts to get you started:',
-                    prompts: [
-                      {
-                        label: 'Stripe Payments',
-                        description:
-                          'Create a new edge function that processes payments with Stripe',
+              {/* AI Assistant Option */}
+              <div className="p-8">
+                <div className="flex items-center gap-2">
+                  <AiIconAnimation size={20} />
+                  <h4 className="text-base text-foreground">AI Assistant</h4>
+                </div>
+                <p className="text-sm text-foreground-light mb-4 mt-1">
+                  Let our AI assistant help you create functions. Perfect for kickstarting a
+                  function.
+                </p>
+                <Button
+                  type="default"
+                  onClick={() => {
+                    openSidebar(SIDEBAR_KEYS.AI_ASSISTANT)
+                    aiSnap.newChat({
+                      name: 'Create new edge function',
+                      initialInput: 'Create a new edge function that ...',
+                      suggestions: {
+                        title:
+                          'I can help you create a new edge function. Here are a few example prompts to get you started:',
+                        prompts: [
+                          {
+                            label: 'Stripe Payments',
+                            description:
+                              'Create a new edge function that processes payments with Stripe',
+                          },
+                          {
+                            label: 'Email with Resend',
+                            description: 'Create a new edge function that sends emails with Resend',
+                          },
+                          {
+                            label: 'PDF Generator',
+                            description:
+                              'Create a new edge function that generates PDFs from HTML templates',
+                          },
+                        ],
                       },
-                      {
-                        label: 'Email with Resend',
-                        description: 'Create a new edge function that sends emails with Resend',
-                      },
-                      {
-                        label: 'PDF Generator',
-                        description:
-                          'Create a new edge function that generates PDFs from HTML templates',
-                      },
-                    ],
-                  },
-                })
-                track('edge_function_ai_assistant_button_clicked', { origin: 'no_functions_block' })
-              }}
-            >
-              Open Assistant
-            </Button>
-          </div>
+                    })
+                    track('edge_function_ai_assistant_button_clicked', {
+                      origin: 'no_functions_block',
+                    })
+                  }}
+                >
+                  Open Assistant
+                </Button>
+              </div>
+            </>
+          )}
 
           {/* CLI Option */}
-          <div className="p-8">
-            <div className="flex items-center gap-2">
-              <Terminal strokeWidth={1.5} size={20} />
-              <h4 className="text-base text-foreground">Via CLI</h4>
-            </div>
-            <p className="text-sm text-foreground-light mb-4 mt-1">
-              Create and deploy functions using the Supabase CLI. Ideal for local development and
-              version control.
-            </p>
-
-            <Button
-              type="default"
-              onClick={() => {
-                setCreateMethod('cli')
-                track('edge_function_via_cli_button_clicked', { origin: 'no_functions_block' })
-              }}
-            >
-              View CLI Instructions
-            </Button>
-          </div>
-        </CardContent>
-      </Card>
-      <ScaffoldSectionTitle className="text-xl mb-4 mt-12">
-        Start with a template
-      </ScaffoldSectionTitle>
-      <ResourceList>
-        {templates.map((template) => (
-          <ResourceItem
-            key={template.name}
-            media={<Code strokeWidth={1.5} size={16} className="translate-y-[-9px]" />}
-            onClick={() => {
-              track('edge_function_template_clicked', {
-                templateName: template.name,
-                origin: 'functions_page',
-              })
-            }}
-          >
-            <Link href={`/project/${ref}/functions/new?template=${template.value}`}>
-              <p>{template.name}</p>
-              <p className="text-sm text-foreground-lighter">{template.description}</p>
-            </Link>
-          </ResourceItem>
-        ))}
-      </ResourceList>
-    </>
-  )
-}
-
-export const FunctionsInstructionsLocal = () => {
-  const showStripeExample = useIsFeatureEnabled('edge_functions:show_stripe_example')
-  const templates = useMemo(() => {
-    if (showStripeExample) {
-      return EDGE_FUNCTION_TEMPLATES
-    }
-
-    // Filter out Stripe template
-    return EDGE_FUNCTION_TEMPLATES.filter((template) => template.value !== 'stripe-webhook')
-  }, [showStripeExample])
-
-  return (
-    <>
-      <div className="flex flex-col gap-y-4">
-        <Card>
-          <CardHeader>
-            <CardTitle>Developing Edge Functions with the CLI</CardTitle>
-          </CardHeader>
-          <CardContent
-            className={cn(
-              'p-0 flex flex-col',
-              '2xl:grid 2xl:grid-cols-[repeat(auto-fit,minmax(240px,1fr))] 2xl:divide-y-0 2xl:divide-x',
-              'divide-y divide-default items-stretch'
-            )}
-          >
-            <div className="p-8">
-              <div className="flex items-center gap-2">
-                <Code size={20} />
-                <h4 className="text-base text-foreground">Create an Edge Function</h4>
-              </div>
-              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs text-sm max-w-full">
-                Create a new edge function called <code>hello-world</code> in your project via the
-                Supabase CLI.
-              </p>
-              <div className="mb-4">
-                <CodeBlock
-                  language="bash"
-                  hideLineNumbers={true}
-                  className={cn(
-                    'px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 2xl:min-h-28'
-                  )}
-                  value="supabase functions new hello-world"
-                />
-              </div>
-              <DocsButton
-                href={`${DOCS_URL}/guides/functions/local-quickstart#create-an-edge-function`}
-              />
-            </div>
-
-            <div className="p-8">
-              <div className="flex items-center gap-2">
-                <Play size={20} />
-                <h4 className="text-base text-foreground">Run Edge Functions</h4>
-              </div>
-              <p className="text-sm text-foreground-light mt-1 mb-4 prose [&>code]:text-xs text-sm max-w-full">
-                You can run your Edge Function locally using <code>supabase functions serve</code>.
-              </p>
-              <div className="mb-4">
-                <CodeBlock
-                  language="bash"
-                  hideLineNumbers={true}
-                  className={cn(
-                    'px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 2xl:min-h-28'
-                  )}
-                  value={`
-supabase start # start the supabase stack
-supabase functions serve # start the Functions watcher`.trim()}
-                />
-              </div>
-              <DocsButton
-                href={`${DOCS_URL}/guides/functions/local-quickstart#running-edge-functions-locally`}
-              />
-            </div>
-
+          {(IS_PLATFORM || isCli) && (
             <div className="p-8">
               <div className="flex items-center gap-2">
                 <Terminal strokeWidth={1.5} size={20} />
-                <h4 className="text-base text-foreground">Invoke Edge Functions</h4>
+                <h4 className="text-base text-foreground">Via CLI</h4>
               </div>
-              <p className="text-sm text-foreground-light mt-1 mb-4">
-                While serving your local Edge Functions, you can invoke it using cURL or one of the
-                client libraries.
+              <p className="text-sm text-foreground-light mb-4 mt-1">
+                Create and deploy functions using the Supabase CLI. Ideal for local development and
+                version control.
               </p>
-              <div className="mb-4">
-                <CodeBlock
-                  language="bash"
-                  hideLineNumbers={true}
-                  className={cn(
-                    'px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 2xl:min-h-28'
-                  )}
-                  value={`
-curl --request POST 'http://localhost:54321/functions/v1/hello-world' \\
-  --header 'Authorization: Bearer SUPABASE_ANON_KEY' \\
-  --header 'Content-Type: application/json' \\
-  --data '{ "name":"Functions" }'`.trim()}
-                />
-              </div>
-              <DocsButton
-                href={`${DOCS_URL}/guides/functions/local-quickstart#invoking-edge-functions-locally`}
-              />
-            </div>
-          </CardContent>
-        </Card>
 
-        <Card>
-          <CardHeader>
-            <CardTitle>Self-hosted Supabase</CardTitle>
-          </CardHeader>
-          <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
-            <div className="p-8">
-              <p className="text-sm text-foreground-light mt-1 mb-4">
-                Edge Functions are available in self-hosted Supabase via Supabase Edge Runtime.
-                Unlike the platform, functions must be added manually — place each function at{' '}
-                <code className="text-code-inline">
-                  volumes/functions/&lt;function-name&gt;/index.ts
-                </code>{' '}
-                and restart the <code className="text-code-inline">functions</code> service to pick
-                up changes. See the guide to learn more about configuration, secrets, and routing.
-              </p>
-              <DocsButton href={`${DOCS_URL}/guides/self-hosting/self-hosted-functions`} />
+              <Button
+                type="default"
+                onClick={() => {
+                  setCreateMethod('cli')
+                  track('edge_function_via_cli_button_clicked', { origin: 'no_functions_block' })
+                }}
+              >
+                View CLI Instructions
+              </Button>
             </div>
-          </CardContent>
-        </Card>
+          )}
 
-        <ScaffoldSectionTitle className="text-xl mt-12">Explore our templates</ScaffoldSectionTitle>
-        <ResourceList>
-          {templates.map((template) => (
-            <Dialog key={template.name}>
-              <DialogTrigger asChild>
-                <ResourceItem
-                  key={template.name}
-                  media={<Code strokeWidth={1.5} size={16} className="translate-y-[-9px]" />}
-                >
-                  <div>
-                    <p>{template.name}</p>
-                    <p className="text-sm text-foreground-lighter">{template.description}</p>
-                  </div>
-                </ResourceItem>
-              </DialogTrigger>
-              <DialogContent size="large">
-                <DialogHeader>
-                  <DialogTitle>{template.name}</DialogTitle>
-                  <DialogDescription>{template.description}</DialogDescription>
-                </DialogHeader>
-                <Separator />
-                <DialogSection className="p-0!">
-                  <CodeBlock
-                    language="ts"
-                    hideLineNumbers={true}
-                    className={cn(
-                      'border-0 rounded-none px-3.5 max-w-full prose dark:prose-dark [&>code]:m-0 max-h-[420px]'
-                    )}
-                    value={template.content}
-                  />
-                </DialogSection>
-              </DialogContent>
-            </Dialog>
-          ))}
-        </ResourceList>
-      </div>
+          {isSelfHosted && <SelfHostedManualFunctionContent />}
+        </CardContent>
+      </Card>
+      {IS_PLATFORM && (
+        <>
+          <ScaffoldSectionTitle className="text-xl mb-4 mt-12">
+            Start with a template
+          </ScaffoldSectionTitle>
+          <ResourceList>
+            {templates.map((template) => (
+              <ResourceItem
+                key={template.name}
+                media={<Code strokeWidth={1.5} size={16} className="translate-y-[-9px]" />}
+                onClick={() => {
+                  track('edge_function_template_clicked', {
+                    templateName: template.name,
+                    origin: 'functions_page',
+                  })
+                }}
+              >
+                <Link href={`/project/${ref}/functions/new?template=${template.value}`}>
+                  <p>{template.name}</p>
+                  <p className="text-sm text-foreground-lighter">{template.description}</p>
+                </Link>
+              </ResourceItem>
+            ))}
+          </ResourceList>
+        </>
+      )}
     </>
   )
 }
 
-export const FunctionsSecretsEmptyStateLocal = () => {
-  return (
-    <>
-      <Card>
-        <CardHeader>
-          <CardTitle>Local development & CLI</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-sm text-foreground-light mb-4">
-            <p className="mb-2">Secrets can be loaded in two ways:</p>
-            <ul className="list-disc pl-6 space-y-1">
-              <li>
-                Place a <code className="text-code-inline">.env</code> file at{' '}
-                <code className="text-code-inline">supabase/functions/.env</code> — picked up
-                automatically on <code className="text-code-inline">supabase start</code>.
-              </li>
-              <li>
-                Pass <code className="text-code-inline">--env-file</code> to{' '}
-                <code className="text-code-inline">supabase functions serve</code>, e.g.{' '}
-                <code className="text-code-inline">
-                  supabase functions serve --env-file ./path/to/.env-file
-                </code>
-              </li>
-            </ul>
-          </div>
-          <DocsButton href={`${DOCS_URL}/guides/functions/secrets#using-the-cli`} />
-        </CardContent>
-      </Card>
+const SelfHostedManualFunctionContent = () => (
+  <div className="p-8">
+    <div className="flex items-center gap-2">
+      <Server strokeWidth={1.5} size={20} />
+      <h4 className="text-base text-foreground">Self-Hosted</h4>
+    </div>
+    <p className="text-sm text-foreground-light mb-4 mt-1">
+      Place each function at{' '}
+      <code className="text-code-inline">volumes/functions/&lt;function-name&gt;/index.ts</code> and
+      restart the <code className="text-code-inline">functions</code> service to pick up changes.
+    </p>
+    <DocsButton href={`${DOCS_URL}/guides/self-hosting/self-hosted-functions`} />
+  </div>
+)
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Self-Hosted Supabase</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <p className="text-sm text-foreground-light mb-4">
-            Configure secrets in your <code className="text-code-inline">.env</code> file and{' '}
-            <code className="text-code-inline">docker-compose.yml</code> under the{' '}
-            <code className="text-code-inline">functions</code> service.
-          </p>
-          <DocsButton
-            href={`${DOCS_URL}/guides/self-hosting/self-hosted-functions#custom-environment-variables`}
-          />
-        </CardContent>
-      </Card>
-    </>
-  )
-}
+export const SelfHostedManualFunctionCard = () => (
+  <Card>
+    <SelfHostedManualFunctionContent />
+  </Card>
+)

--- a/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
+++ b/apps/studio/components/interfaces/Functions/FunctionsEmptyState.tsx
@@ -39,11 +39,15 @@ export const FunctionsEmptyState = () => {
     return EDGE_FUNCTION_TEMPLATES.filter((template) => template.value !== 'stripe-webhook')
   }, [showStripeExample])
 
+  const emptyStateTitle = IS_PLATFORM
+    ? 'Deploy your first edge function'
+    : 'Add your first edge function'
+
   return (
     <>
       <Card>
         <CardHeader>
-          <CardTitle>Deploy your first edge function</CardTitle>
+          <CardTitle>{emptyStateTitle}</CardTitle>
         </CardHeader>
         <CardContent className="p-0 grid grid-cols-[repeat(auto-fit,minmax(240px,1fr))] divide-y md:divide-y-0 md:divide-x divide-default items-stretch">
           {/* Editor Option */}

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -129,7 +129,7 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
               <>
                 {hasFunctions ? (
                   <div className="space-y-4">
-                    {isSelfHosted && functions.length === 1 && <SelfHostedManualFunctionCard />}
+                    {isSelfHosted && <SelfHostedManualFunctionCard />}
                     <div className="flex items-center gap-2">
                       <div className="flex items-center gap-2">
                         <div className="relative">

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -27,10 +27,7 @@ import {
   EdgeFunctionsSortOrder,
 } from '@/components/interfaces/EdgeFunctions/EdgeFunctionsSortDropdown'
 import { EdgeFunctionsListItem } from '@/components/interfaces/Functions/EdgeFunctionsListItem'
-import {
-  FunctionsEmptyState,
-  SelfHostedManualFunctionCard,
-} from '@/components/interfaces/Functions/FunctionsEmptyState'
+import { FunctionsEmptyState } from '@/components/interfaces/Functions/FunctionsEmptyState'
 import { TerminalInstructionsDialog } from '@/components/interfaces/Functions/TerminalInstructionsDialog'
 import { useFunctionsListShortcuts } from '@/components/interfaces/Functions/useFunctionsListShortcuts'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
@@ -39,7 +36,6 @@ import AlertError from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useEdgeFunctionsQuery } from '@/data/edge-functions/edge-functions-query'
-import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
 import { useIsProjectActive } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL, IS_PLATFORM } from '@/lib/constants'
 import { onSearchInputEscape } from '@/lib/keyboard'
@@ -51,7 +47,6 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
   const { ref } = useParams()
   const showLastHourStats = useFlag('edgeFunctionsRequestMetrics')
   const isProjectActive = useIsProjectActive()
-  const { isSelfHosted } = useDeploymentMode()
 
   const searchInputRef = useRef<HTMLInputElement>(null)
 
@@ -129,7 +124,6 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
               <>
                 {hasFunctions ? (
                   <div className="space-y-4">
-                    {isSelfHosted && <SelfHostedManualFunctionCard />}
                     <div className="flex items-center gap-2">
                       <div className="flex items-center gap-2">
                         <div className="relative">

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -29,7 +29,7 @@ import {
 import { EdgeFunctionsListItem } from '@/components/interfaces/Functions/EdgeFunctionsListItem'
 import {
   FunctionsEmptyState,
-  FunctionsInstructionsLocal,
+  SelfHostedManualFunctionCard,
 } from '@/components/interfaces/Functions/FunctionsEmptyState'
 import { TerminalInstructionsDialog } from '@/components/interfaces/Functions/TerminalInstructionsDialog'
 import { useFunctionsListShortcuts } from '@/components/interfaces/Functions/useFunctionsListShortcuts'
@@ -39,6 +39,7 @@ import AlertError from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useEdgeFunctionsQuery } from '@/data/edge-functions/edge-functions-query'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
 import { useIsProjectActive } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL, IS_PLATFORM } from '@/lib/constants'
 import { onSearchInputEscape } from '@/lib/keyboard'
@@ -50,6 +51,7 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
   const { ref } = useParams()
   const showLastHourStats = useFlag('edgeFunctionsRequestMetrics')
   const isProjectActive = useIsProjectActive()
+  const { isSelfHosted } = useDeploymentMode()
 
   const searchInputRef = useRef<HTMLInputElement>(null)
 
@@ -127,6 +129,7 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
               <>
                 {hasFunctions ? (
                   <div className="space-y-4">
+                    {isSelfHosted && functions.length === 1 && <SelfHostedManualFunctionCard />}
                     <div className="flex items-center gap-2">
                       <div className="flex items-center gap-2">
                         <div className="relative">
@@ -226,7 +229,6 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
                 )}
               </>
             )}
-            {!IS_PLATFORM && <FunctionsInstructionsLocal />}
           </div>
         </PageSectionContent>
       </PageSection>

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -116,7 +116,8 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
               ) : (
                 <Admonition type="warning" title="Failed to retrieve edge functions">
                   <p className="prose [&>code]:text-xs text-sm">
-                    Local functions can be found at <code>supabase/functions</code> folder.
+                    Edge functions could not be read from disk. The functions directory may be
+                    missing, not mounted into Studio, or unreadable.
                   </p>
                 </Admonition>
               ))}

--- a/apps/studio/pages/project/[ref]/functions/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/functions/secrets.tsx
@@ -1,3 +1,4 @@
+import { Admonition } from 'ui-patterns/admonition'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
@@ -8,19 +9,82 @@ import {
 } from 'ui-patterns/PageHeader'
 import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 
+import { DefaultEdgeFunctionSecrets } from '@/components/interfaces/Functions/EdgeFunctionSecrets/DefaultEdgeFunctionSecrets'
+import { DEFAULT_EDGE_FUNCTION_SECRETS } from '@/components/interfaces/Functions/EdgeFunctionSecrets/DefaultEdgeFunctionSecrets.utils'
 import { EdgeFunctionSecrets } from '@/components/interfaces/Functions/EdgeFunctionSecrets/EdgeFunctionSecrets'
-import { FunctionsSecretsEmptyStateLocal } from '@/components/interfaces/Functions/FunctionsEmptyState'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import EdgeFunctionsLayout from '@/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout'
-import { IS_PLATFORM } from '@/lib/constants'
+import { DocsButton } from '@/components/ui/DocsButton'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
+import { DOCS_URL, IS_PLATFORM } from '@/lib/constants'
 import type { NextPageWithLayout } from '@/types'
 
 const SecretsPage: NextPageWithLayout = () => {
+  const { isCli, isSelfHosted } = useDeploymentMode()
+
+  if (!IS_PLATFORM) {
+    return (
+      <PageContainer size="large">
+        <PageSection>
+          <PageSectionContent className="space-y-4 md:space-y-8">
+            {isCli && (
+              <Admonition
+                type="default"
+                title="Local development with the Supabase CLI"
+                description={
+                  <p>
+                    Add custom secrets to{' '}
+                    <code className="text-code-inline">supabase/functions/.env</code>, or pass{' '}
+                    <code className="text-code-inline">--env-file</code> to{' '}
+                    <code className="text-code-inline">supabase functions serve</code>.
+                  </p>
+                }
+                actions={<DocsButton href={`${DOCS_URL}/guides/functions/secrets#using-the-cli`} />}
+              />
+            )}
+            {isSelfHosted && (
+              <Admonition
+                type="default"
+                title="Self-hosted Supabase"
+                description={<p>Set custom secrets via environment variables.</p>}
+                actions={
+                  <DocsButton
+                    href={`${DOCS_URL}/guides/self-hosting/self-hosted-functions#custom-environment-variables`}
+                  />
+                }
+              />
+            )}
+            <section className="space-y-4">
+              <div className="flex flex-col md:flex-row md:items-center justify-between gap-2">
+                <div className="space-y-1">
+                  <h3 className="text-foreground text-base">Default secrets</h3>
+                  <p className="text-sm text-foreground-light">
+                    Reserved secrets available in every project
+                  </p>
+                </div>
+                <DocsButton
+                  href={
+                    isSelfHosted
+                      ? `${DOCS_URL}/guides/self-hosting/self-hosted-functions#calling-supabase-services-from-functions`
+                      : `${DOCS_URL}/guides/functions/secrets#default-secrets`
+                  }
+                />
+              </div>
+              <DefaultEdgeFunctionSecrets
+                secrets={DEFAULT_EDGE_FUNCTION_SECRETS.filter((secret) => !secret.isRuntime)}
+              />
+            </section>
+          </PageSectionContent>
+        </PageSection>
+      </PageContainer>
+    )
+  }
+
   return (
     <PageContainer size="large">
       <PageSection>
         <PageSectionContent className="space-y-4 md:space-y-8">
-          {IS_PLATFORM ? <EdgeFunctionSecrets /> : <FunctionsSecretsEmptyStateLocal />}
+          <EdgeFunctionSecrets />
         </PageSectionContent>
       </PageSection>
     </PageContainer>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

A follow-up to PR https://github.com/supabase/supabase/pull/46342:

- Consumes `useDeploymentMode` hook to distinguish CLI from self-hosted Studio at runtime
- Functions list page: row click routes to `/code` on non-platform; renders a self-hosted "manage manually" card instead of the table when no functions exists
- Functions empty state: shows Editor / AI Assistant cards only on platform; shows CLI or self-hosted variant card depending on mode; Templates section gated to platform
- Functions secrets page: mode-gated admonitions + Default secrets table on non-platform; self-hosting-specific docs link
- Telemetry plumbing unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI Assistant option available when using the hosted platform.
  * Self-hosted deployments show a manual function setup card.

* **Improvements**
  * Secrets page provides deployment-specific guidance and context-aware docs links.
  * Empty states and template exploration simplified and tailored by deployment mode.

* **Bug Fixes**
  * Function row navigation corrected for non-platform deployments.

* **Tests**
  * Added tests for empty-state rendering across deployment environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->