### PR TITLE
feat(self-hosted): add minimal project settings

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
+++ b/apps/studio/components/interfaces/APIKeys/APIKeyRow.tsx
@@ -1,4 +1,4 @@
-import { useFlag } from 'common'
+import { IS_PLATFORM, useFlag } from 'common'
 import { motion } from 'framer-motion'
 import { MoreVertical } from 'lucide-react'
 import {
@@ -85,27 +85,29 @@ export const APIKeyRow = ({
           </TableCell>
         )}
 
-        <TableCell className="py-2">
-          <div className="flex justify-end">
-            <DropdownMenu>
-              <DropdownMenuTrigger className="px-1 focus-visible:outline-hidden" asChild>
-                <Button
-                  type="text"
-                  size="tiny"
-                  icon={
-                    <MoreVertical
-                      size="14"
-                      className="text-foreground-light hover:text-foreground"
-                    />
-                  }
-                />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent className="max-w-40" align="end">
-                <APIKeyDeleteDialog apiKey={apiKey} setKeyToDelete={setKeyToDelete} />
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
-        </TableCell>
+        {IS_PLATFORM && (
+          <TableCell className="py-2">
+            <div className="flex justify-end">
+              <DropdownMenu>
+                <DropdownMenuTrigger className="px-1 focus-visible:outline-hidden" asChild>
+                  <Button
+                    type="text"
+                    size="tiny"
+                    icon={
+                      <MoreVertical
+                        size="14"
+                        className="text-foreground-light hover:text-foreground"
+                      />
+                    }
+                  />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent className="max-w-40" align="end">
+                  <APIKeyDeleteDialog apiKey={apiKey} setKeyToDelete={setKeyToDelete} />
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
+          </TableCell>
+        )}
       </MotionTableRow>
 
       <TextConfirmModal

--- a/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.test.tsx
+++ b/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.test.tsx
@@ -1,0 +1,160 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { PublishableAPIKeys } from './PublishableAPIKeys'
+import { customRender as render } from '@/tests/lib/custom-render'
+
+const {
+  mockIsPlatform,
+  mockUseAPIKeysQuery,
+  mockUseAsyncCheckPermissions,
+  mockUseAPIKeyDeleteMutation,
+} = vi.hoisted(() => ({
+  mockIsPlatform: { value: true },
+  mockUseAPIKeysQuery: vi.fn(),
+  mockUseAsyncCheckPermissions: vi.fn(),
+  mockUseAPIKeyDeleteMutation: vi.fn(),
+}))
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+    useParams: () => ({ ref: 'default' }),
+  }
+})
+
+vi.mock('@/data/api-keys/api-keys-query', () => ({
+  useAPIKeysQuery: mockUseAPIKeysQuery,
+}))
+
+vi.mock('@/data/api-keys/api-key-delete-mutation', () => ({
+  useAPIKeyDeleteMutation: mockUseAPIKeyDeleteMutation,
+}))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('./CreatePublishableAPIKeyDialog', () => ({
+  CreatePublishableAPIKeyDialog: () => <div>CreatePublishableAPIKeyDialog</div>,
+}))
+
+vi.mock('./APIKeyRow', () => ({
+  APIKeyRow: ({ apiKey }: { apiKey: { id: string; name: string } }) => (
+    <tr>
+      <td>api-key-row:{apiKey.name}</td>
+    </tr>
+  ),
+}))
+
+const publishableKey = {
+  id: 'pk-1',
+  name: 'default-publishable',
+  type: 'publishable' as const,
+  api_key: 'sb_publishable_xyz',
+}
+
+const secretKey = {
+  id: 'sk-1',
+  name: 'default-secret',
+  type: 'secret' as const,
+  api_key: 'sb_secret_xyz',
+}
+
+describe('PublishableAPIKeys', () => {
+  beforeEach(() => {
+    mockIsPlatform.value = true
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isLoading: false })
+    mockUseAPIKeyDeleteMutation.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+      isSuccess: false,
+    })
+  })
+
+  it('renders the table with publishable keys', () => {
+    mockUseAPIKeysQuery.mockReturnValue({
+      data: [publishableKey],
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+    })
+
+    render(<PublishableAPIKeys />)
+
+    expect(screen.getByText('api-key-row:default-publishable')).toBeInTheDocument()
+    expect(screen.queryByText('No publishable API keys found')).not.toBeInTheDocument()
+  })
+
+  it('on platform with secret-only keys, shows the inline "No publishable keys created yet" admonition', () => {
+    mockUseAPIKeysQuery.mockReturnValue({
+      data: [secretKey],
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+    })
+
+    render(<PublishableAPIKeys />)
+
+    expect(screen.getByText('No publishable keys created yet')).toBeInTheDocument()
+    expect(screen.queryByText('No publishable API keys found')).not.toBeInTheDocument()
+  })
+
+  it('on platform with no keys, does NOT show the self-hosted empty-state card', () => {
+    mockUseAPIKeysQuery.mockReturnValue({
+      data: [],
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+    })
+
+    render(<PublishableAPIKeys />)
+
+    expect(screen.queryByText('No publishable API keys found')).not.toBeInTheDocument()
+  })
+
+  it('on self-hosted with no publishable keys, shows the empty-state card', () => {
+    mockIsPlatform.value = false
+    mockUseAPIKeysQuery.mockReturnValue({
+      data: [],
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+    })
+
+    render(<PublishableAPIKeys />)
+
+    expect(screen.getByText('No publishable API keys found')).toBeInTheDocument()
+  })
+
+  it('hides the create button on non-platform', () => {
+    mockIsPlatform.value = false
+    mockUseAPIKeysQuery.mockReturnValue({
+      data: [publishableKey],
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+    })
+
+    render(<PublishableAPIKeys />)
+
+    expect(screen.queryByText('CreatePublishableAPIKeyDialog')).not.toBeInTheDocument()
+  })
+
+  it('shows the create button on platform', () => {
+    mockUseAPIKeysQuery.mockReturnValue({
+      data: [publishableKey],
+      isPending: false,
+      isSuccess: true,
+      isError: false,
+    })
+
+    render(<PublishableAPIKeys />)
+
+    expect(screen.getByText('CreatePublishableAPIKeyDialog')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.tsx
+++ b/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useEffect, useMemo } from 'react'
 import { toast } from 'sonner'
@@ -54,6 +54,9 @@ export const PublishableAPIKeys = () => {
     [apiKeysData]
   )
 
+  const showSelfHostedEmptyState =
+    !IS_PLATFORM && publishableApiKeys.length === 0 && !isLoadingApiKeys && !isLoadingPermissions
+
   const [deleteId, setDeleteId] = useQueryState('deletePublishableKey', parseAsString)
   const apiKeyToDelete = publishableApiKeys?.find((key) => key.id === deleteId)
 
@@ -86,7 +89,7 @@ export const PublishableAPIKeys = () => {
       <FormHeader
         title="Publishable key"
         description="This key is safe to use in a browser if you have enabled Row Level Security (RLS) for your tables and configured policies."
-        actions={<CreatePublishableAPIKeyDialog />}
+        actions={IS_PLATFORM ? <CreatePublishableAPIKeyDialog /> : null}
       />
 
       {!canReadAPIKeys && !isLoadingPermissions ? (
@@ -95,6 +98,15 @@ export const PublishableAPIKeys = () => {
         <GenericSkeletonLoader />
       ) : isErrorApiKeys ? (
         <AlertError error={error} subject="Failed to load API keys" />
+      ) : showSelfHostedEmptyState ? (
+        <Card>
+          <div className="rounded-b-md! overflow-hidden py-12 flex flex-col gap-1 items-center justify-center">
+            <p className="text-sm text-foreground">No publishable API keys found</p>
+            <p className="text-sm text-foreground-light">
+              This may be a configuration issue. Ensure your API keys are available to Studio.
+            </p>
+          </div>
+        </Card>
       ) : (
         <Card className="bg-surface-100">
           <Table>
@@ -102,7 +114,7 @@ export const PublishableAPIKeys = () => {
               <TableRow className="bg-200">
                 <TableHead>Name</TableHead>
                 <TableHead>API Key</TableHead>
-                <TableHead />
+                {IS_PLATFORM && <TableHead />}
               </TableRow>
             </TableHeader>
 

--- a/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.tsx
+++ b/apps/studio/components/interfaces/APIKeys/PublishableAPIKeys.tsx
@@ -121,7 +121,7 @@ export const PublishableAPIKeys = () => {
             <TableBody>
               {hasApiKeys && publishableApiKeys.length === 0 && (
                 <TableRow>
-                  <TableCell colSpan={3} className="p-0">
+                  <TableCell colSpan={IS_PLATFORM ? 3 : 2} className="p-0">
                     <Admonition showIcon={false} type="default" className="border-0 rounded-none">
                       <p className="text-foreground-light">No publishable keys created yet</p>
                     </Admonition>
@@ -143,7 +143,7 @@ export const PublishableAPIKeys = () => {
 
             <TableFooter className="border-t">
               <TableRow className="border-b-0">
-                <TableCell colSpan={3} className="py-2">
+                <TableCell colSpan={IS_PLATFORM ? 3 : 2} className="py-2">
                   <p className="text-xs text-foreground-lighter font-normal">
                     Publishable keys can be safely shared publicly
                   </p>

--- a/apps/studio/components/interfaces/APIKeys/SecretAPIKeys.tsx
+++ b/apps/studio/components/interfaces/APIKeys/SecretAPIKeys.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useFlag, useParams } from 'common'
+import { IS_PLATFORM, useFlag, useParams } from 'common'
 import dayjs from 'dayjs'
 import { parseAsString, useQueryState } from 'nuqs'
 import { useEffect, useMemo, useRef } from 'react'
@@ -130,7 +130,7 @@ export const SecretAPIKeys = () => {
       <FormHeader
         title="Secret keys"
         description="These API keys allow privileged access to your project's APIs. Use in servers, functions, workers or other backend components of your application."
-        actions={<CreateSecretAPIKeyDialog />}
+        actions={IS_PLATFORM ? <CreateSecretAPIKeyDialog /> : null}
       />
 
       {!canReadAPIKeys && !isLoadingPermissions ? (
@@ -159,7 +159,7 @@ export const SecretAPIKeys = () => {
                 {showApiKeysLastUsed && (
                   <TableHead className="hidden lg:table-cell">Last Used</TableHead>
                 )}
-                <TableHead />
+                {IS_PLATFORM && <TableHead />}
               </TableRow>
             </TableHeader>
             <TableBody>

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -29,6 +29,14 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSection,
+  DialogSectionSeparator,
+  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -41,7 +49,6 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupText,
-  Modal,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -112,7 +119,7 @@ export const JWTSettings = () => {
     'custom_config_gotrue'
   )
 
-  const { data } = useJwtSecretUpdatingStatusQuery({ projectRef })
+  const { data } = useJwtSecretUpdatingStatusQuery({ projectRef }, { enabled: IS_PLATFORM })
   const { data: config, isError } = useProjectPostgrestConfigQuery({ projectRef })
   const { mutateAsync: updateJwt, isPending: isSubmittingJwtSecretUpdateRequest } =
     useJwtSecretUpdateMutation()
@@ -120,14 +127,17 @@ export const JWTSettings = () => {
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
   const { data: legacyKey, isPending } = useLegacyJWTSigningKeyQuery(
     { projectRef },
-    { enabled: canReadAPIKeys, retry: false }
+    { enabled: IS_PLATFORM && canReadAPIKeys, retry: false }
   )
   const { data: legacyAPIKeysStatus } = useLegacyAPIKeysStatusQuery(
     { projectRef },
-    { enabled: canReadAPIKeys }
+    { enabled: IS_PLATFORM && canReadAPIKeys }
   )
 
-  const { data: authConfig, isPending: isLoadingAuthConfig } = useAuthConfigQuery({ projectRef })
+  const { data: authConfig, isPending: isLoadingAuthConfig } = useAuthConfigQuery(
+    { projectRef },
+    { enabled: IS_PLATFORM }
+  )
   const { mutate: updateAuthConfig, isPending: isUpdatingAuthConfig } =
     useAuthConfigUpdateMutation()
 
@@ -641,19 +651,54 @@ export const JWTSettings = () => {
         </ul>
       </TextConfirmModal>
 
-      <Modal
-        header="Pick a new JWT secret"
-        visible={isCreatingKey && !disableLegacyJwtSecretRotation}
-        size="medium"
-        variant="danger"
-        onCancel={() => {
+      <Dialog
+        open={isCreatingKey && !disableLegacyJwtSecretRotation}
+        onOpenChange={() => {
           setIsCreatingKey(false)
           setCustomToken('')
           customJwtSecretForm.reset({ customToken: '' })
         }}
-        loading={isSubmittingJwtSecretUpdateRequest}
-        customFooter={
-          <div className="space-x-2">
+      >
+        <DialogContent size="medium">
+          <DialogHeader>
+            <DialogTitle>Pick a new JWT secret</DialogTitle>
+            <DialogDescription>
+              Pick a new custom JWT secret. Make sure it is a strong combination of characters that
+              cannot be guessed easily.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogSectionSeparator />
+          <DialogSection>
+            <Form {...customJwtSecretForm}>
+              <form
+                id={customJwtSecretFormId}
+                onSubmit={customJwtSecretForm.handleSubmit((values) => {
+                  setIsGeneratingKey(true)
+                  setIsCreatingKey(false)
+                  setCustomToken(values.customToken)
+                })}
+                className="flex flex-col space-y-2"
+                noValidate
+              >
+                <FormField
+                  control={customJwtSecretForm.control}
+                  name="customToken"
+                  render={({ field }) => (
+                    <FormItemLayout
+                      layout="vertical"
+                      label="Custom JWT secret"
+                      description="Minimally 32 characters long, '@' and '$' are not allowed."
+                    >
+                      <FormControl>
+                        <Input copy reveal icon={<Key />} className="w-full text-left" {...field} />
+                      </FormControl>
+                    </FormItemLayout>
+                  )}
+                />
+              </form>
+            </Form>
+          </DialogSection>
+          <DialogFooter>
             <Button
               type="default"
               onClick={() => {
@@ -661,6 +706,7 @@ export const JWTSettings = () => {
                 setCustomToken('')
                 customJwtSecretForm.reset({ customToken: '' })
               }}
+              disabled={isSubmittingJwtSecretUpdateRequest}
             >
               Cancel
             </Button>
@@ -669,47 +715,13 @@ export const JWTSettings = () => {
               htmlType="submit"
               form={customJwtSecretFormId}
               loading={isSubmittingJwtSecretUpdateRequest}
+              disabled={isSubmittingJwtSecretUpdateRequest}
             >
               Proceed to final confirmation
             </Button>
-          </div>
-        }
-      >
-        <Modal.Content>
-          <Form {...customJwtSecretForm}>
-            <form
-              id={customJwtSecretFormId}
-              onSubmit={customJwtSecretForm.handleSubmit((values) => {
-                setIsGeneratingKey(true)
-                setIsCreatingKey(false)
-                setCustomToken(values.customToken)
-              })}
-              className="flex flex-col space-y-2"
-              noValidate
-            >
-              <p className="text-sm text-foreground-light">
-                Pick a new custom JWT secret. Make sure it is a strong combination of characters
-                that cannot be guessed easily.
-              </p>
-              <FormField
-                control={customJwtSecretForm.control}
-                name="customToken"
-                render={({ field }) => (
-                  <FormItemLayout
-                    layout="vertical"
-                    label="Custom JWT secret"
-                    description="Minimally 32 characters long, '@' and '$' are not allowed."
-                  >
-                    <FormControl>
-                      <Input copy reveal icon={<Key />} className="w-full text-left" {...field} />
-                    </FormControl>
-                  </FormItemLayout>
-                )}
-              />
-            </form>
-          </Form>
-        </Modal.Content>
-      </Modal>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   )
 }

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -5,7 +5,7 @@ import {
   JwtSecretUpdateProgress,
   JwtSecretUpdateStatus,
 } from '@supabase/shared-types/out/events'
-import { useFlag, useParams } from 'common'
+import { IS_PLATFORM, useFlag, useParams } from 'common'
 import {
   AlertCircle,
   ChevronDown,
@@ -29,14 +29,6 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogSection,
-  DialogSectionSeparator,
-  DialogTitle,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -49,6 +41,7 @@ import {
   InputGroup,
   InputGroupAddon,
   InputGroupText,
+  Modal,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -206,6 +199,26 @@ export const JWTSettings = () => {
       toast.error(`Failed to update JWT secret: ${error.message}`)
     }
   }
+
+  if (!IS_PLATFORM) {
+    return (
+      <Panel>
+        <Panel.Content className="border-t border-panel-border-interior-light in-data-[theme*=dark]:border-panel-border-interior-dark">
+          <Form {...form}>
+            <FormItemLayout
+              layout="flex-row-reverse"
+              id="JWT_SECRET"
+              label="JWT secret"
+              description="Used to verify legacy user session JWTs issued by Supabase Auth."
+            >
+              <Input id="JWT_SECRET" copy reveal readOnly value={config?.jwt_secret || ''} />
+            </FormItemLayout>
+          </Form>
+        </Panel.Content>
+      </Panel>
+    )
+  }
+
   return (
     <>
       <Panel
@@ -628,54 +641,19 @@ export const JWTSettings = () => {
         </ul>
       </TextConfirmModal>
 
-      <Dialog
-        open={isCreatingKey && !disableLegacyJwtSecretRotation}
-        onOpenChange={() => {
+      <Modal
+        header="Pick a new JWT secret"
+        visible={isCreatingKey && !disableLegacyJwtSecretRotation}
+        size="medium"
+        variant="danger"
+        onCancel={() => {
           setIsCreatingKey(false)
           setCustomToken('')
           customJwtSecretForm.reset({ customToken: '' })
         }}
-      >
-        <DialogContent size="medium">
-          <DialogHeader>
-            <DialogTitle>Pick a new JWT secret</DialogTitle>
-            <DialogDescription>
-              Pick a new custom JWT secret. Make sure it is a strong combination of characters that
-              cannot be guessed easily.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogSectionSeparator />
-          <DialogSection>
-            <Form {...customJwtSecretForm}>
-              <form
-                id={customJwtSecretFormId}
-                onSubmit={customJwtSecretForm.handleSubmit((values) => {
-                  setIsGeneratingKey(true)
-                  setIsCreatingKey(false)
-                  setCustomToken(values.customToken)
-                })}
-                className="flex flex-col space-y-2"
-                noValidate
-              >
-                <FormField
-                  control={customJwtSecretForm.control}
-                  name="customToken"
-                  render={({ field }) => (
-                    <FormItemLayout
-                      layout="vertical"
-                      label="Custom JWT secret"
-                      description="Minimally 32 characters long, '@' and '$' are not allowed."
-                    >
-                      <FormControl>
-                        <Input copy reveal icon={<Key />} className="w-full text-left" {...field} />
-                      </FormControl>
-                    </FormItemLayout>
-                  )}
-                />
-              </form>
-            </Form>
-          </DialogSection>
-          <DialogFooter>
+        loading={isSubmittingJwtSecretUpdateRequest}
+        customFooter={
+          <div className="space-x-2">
             <Button
               type="default"
               onClick={() => {
@@ -683,7 +661,6 @@ export const JWTSettings = () => {
                 setCustomToken('')
                 customJwtSecretForm.reset({ customToken: '' })
               }}
-              disabled={isSubmittingJwtSecretUpdateRequest}
             >
               Cancel
             </Button>
@@ -692,13 +669,47 @@ export const JWTSettings = () => {
               htmlType="submit"
               form={customJwtSecretFormId}
               loading={isSubmittingJwtSecretUpdateRequest}
-              disabled={isSubmittingJwtSecretUpdateRequest}
             >
               Proceed to final confirmation
             </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+          </div>
+        }
+      >
+        <Modal.Content>
+          <Form {...customJwtSecretForm}>
+            <form
+              id={customJwtSecretFormId}
+              onSubmit={customJwtSecretForm.handleSubmit((values) => {
+                setIsGeneratingKey(true)
+                setIsCreatingKey(false)
+                setCustomToken(values.customToken)
+              })}
+              className="flex flex-col space-y-2"
+              noValidate
+            >
+              <p className="text-sm text-foreground-light">
+                Pick a new custom JWT secret. Make sure it is a strong combination of characters
+                that cannot be guessed easily.
+              </p>
+              <FormField
+                control={customJwtSecretForm.control}
+                name="customToken"
+                render={({ field }) => (
+                  <FormItemLayout
+                    layout="vertical"
+                    label="Custom JWT secret"
+                    description="Minimally 32 characters long, '@' and '$' are not allowed."
+                  >
+                    <FormControl>
+                      <Input copy reveal icon={<Key />} className="w-full text-left" {...field} />
+                    </FormControl>
+                  </FormItemLayout>
+                )}
+              />
+            </form>
+          </Form>
+        </Modal.Content>
+      </Modal>
     </>
   )
 }

--- a/apps/studio/components/interfaces/Settings/General/General.test.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.test.tsx
@@ -1,0 +1,149 @@
+import { screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { General } from './General'
+import { customRender as render } from '@/tests/lib/custom-render'
+
+const {
+  mockIsPlatform,
+  mockUseAsyncCheckPermissions,
+  mockUseDeploymentMode,
+  mockUseProjectUpdateMutation,
+  mockUseSelectedProjectQuery,
+} = vi.hoisted(() => ({
+  mockIsPlatform: { value: true },
+  mockUseAsyncCheckPermissions: vi.fn(),
+  mockUseDeploymentMode: vi.fn(),
+  mockUseProjectUpdateMutation: vi.fn(),
+  mockUseSelectedProjectQuery: vi.fn(),
+}))
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+  }
+})
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: mockUseSelectedProjectQuery,
+}))
+
+vi.mock('@/hooks/misc/useDeploymentMode', () => ({
+  useDeploymentMode: mockUseDeploymentMode,
+}))
+
+vi.mock('@/data/projects/project-update-mutation', () => ({
+  useProjectUpdateMutation: mockUseProjectUpdateMutation,
+}))
+
+vi.mock('./ProjectAccessSection', () => ({
+  ProjectAccessSection: () => <div>ProjectAccessSection</div>,
+}))
+
+describe('General', () => {
+  beforeEach(() => {
+    mockIsPlatform.value = true
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isLoading: false })
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: true,
+      isCli: false,
+      isSelfHosted: false,
+    })
+    mockUseProjectUpdateMutation.mockReturnValue({ mutate: vi.fn(), isPending: false })
+    mockUseSelectedProjectQuery.mockReturnValue({
+      data: {
+        id: 1,
+        ref: 'project-ref',
+        name: 'My Project',
+        region: 'us-east-1',
+        parent_project_ref: null,
+      },
+    })
+  })
+
+  describe('platform', () => {
+    it('renders the editable form with project name, ID, region, and Save action', () => {
+      render(<General />)
+
+      // Editable project name input populated with current value
+      const nameInput = screen.getByDisplayValue('My Project') as HTMLInputElement
+      expect(nameInput).toBeInTheDocument()
+      expect(nameInput).not.toBeDisabled()
+      expect(nameInput).not.toHaveAttribute('readonly')
+
+      // Project ID and region rows visible
+      expect(screen.getByText('Project ID')).toBeInTheDocument()
+      expect(screen.getByText('Project region')).toBeInTheDocument()
+
+      // Save changes button rendered (initially disabled because form isn't dirty)
+      expect(screen.getByRole('button', { name: /Save changes/i })).toBeInTheDocument()
+
+      // Member access section rendered
+      expect(screen.getByText('ProjectAccessSection')).toBeInTheDocument()
+
+      // No deployment-mode admonitions
+      expect(screen.queryByText(/Local development with the Supabase CLI/i)).not.toBeInTheDocument()
+      expect(screen.queryByText(/Self-hosted Supabase/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('self-hosted (CLI mode)', () => {
+    beforeEach(() => {
+      mockIsPlatform.value = false
+      mockUseDeploymentMode.mockReturnValue({
+        isPlatform: false,
+        isCli: true,
+        isSelfHosted: false,
+      })
+    })
+
+    it('renders the CLI admonition alongside a read-only project name', () => {
+      render(<General />)
+
+      expect(screen.getByText('Project name')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('My Project')).toHaveAttribute('readonly')
+
+      expect(screen.getByText(/Local development with the Supabase CLI/i)).toBeInTheDocument()
+      expect(screen.queryByText(/Self-hosted Supabase/i)).not.toBeInTheDocument()
+    })
+  })
+
+  describe('self-hosted (Docker mode)', () => {
+    beforeEach(() => {
+      mockIsPlatform.value = false
+      mockUseDeploymentMode.mockReturnValue({
+        isPlatform: false,
+        isCli: false,
+        isSelfHosted: true,
+      })
+    })
+
+    it('renders the self-hosted admonition alongside a read-only project name', () => {
+      render(<General />)
+
+      expect(screen.getByText('Project name')).toBeInTheDocument()
+      expect(screen.getByDisplayValue('My Project')).toHaveAttribute('readonly')
+
+      expect(screen.getByText(/Self-hosted Supabase/i)).toBeInTheDocument()
+      expect(screen.queryByText(/Local development with the Supabase CLI/i)).not.toBeInTheDocument()
+    })
+
+    it('does not render Project ID, region, Save action, or the member access section', () => {
+      render(<General />)
+
+      expect(screen.queryByText('Project ID')).not.toBeInTheDocument()
+      expect(screen.queryByText('Project region')).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /Save changes/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('button', { name: /Cancel/i })).not.toBeInTheDocument()
+      expect(screen.queryByText('ProjectAccessSection')).not.toBeInTheDocument()
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Settings/General/General.tsx
+++ b/apps/studio/components/interfaces/Settings/General/General.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { IS_PLATFORM } from 'common'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import { Button, Card, CardContent, CardFooter, Form, FormControl, FormField, Input } from 'ui'
@@ -18,10 +19,13 @@ import * as z from 'zod'
 
 import { AVAILABLE_REPLICA_REGIONS } from '../Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
 import { ProjectAccessSection } from './ProjectAccessSection'
+import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useProjectUpdateMutation } from '@/data/projects/project-update-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { DOCS_URL } from '@/lib/constants'
 
 export const General = () => {
   const { data: project } = useSelectedProjectQuery()
@@ -63,6 +67,65 @@ export const General = () => {
           toast.success('Successfully saved settings')
         },
       }
+    )
+  }
+
+  const { isCli, isSelfHosted } = useDeploymentMode()
+
+  if (!IS_PLATFORM) {
+    return (
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>General settings</PageSectionTitle>
+          </PageSectionSummary>
+        </PageSectionMeta>
+        <PageSectionContent className="space-y-4">
+          {project === undefined ? (
+            <Card>
+              <CardContent>
+                <GenericSkeletonLoader />
+              </CardContent>
+            </Card>
+          ) : (
+            <Form {...form}>
+              <Card>
+                <CardContent>
+                  <FormItemLayout
+                    layout="flex-row-reverse"
+                    label="Project name"
+                    className="[&>div]:md:w-1/2 [&>div>div]:md:w-full"
+                  >
+                    <Input readOnly value={project.name ?? ''} />
+                  </FormItemLayout>
+                </CardContent>
+              </Card>
+            </Form>
+          )}
+          {isCli && (
+            <Admonition
+              type="default"
+              title="Local development with the Supabase CLI"
+              description={
+                <p>
+                  Project settings are configured in{' '}
+                  <code className="text-code-inline">supabase/config.toml</code> — applied on{' '}
+                  <code className="text-code-inline">supabase start</code>.
+                </p>
+              }
+              actions={<DocsButton href={`${DOCS_URL}/guides/local-development`} />}
+            />
+          )}
+          {isSelfHosted && (
+            <Admonition
+              type="default"
+              title="Self-hosted Supabase"
+              description={<p>Project settings are configured via environment variables.</p>}
+              actions={<DocsButton href={`${DOCS_URL}/guides/self-hosting`} />}
+            />
+          )}
+        </PageSectionContent>
+      </PageSection>
     )
   }
 

--- a/apps/studio/components/layouts/Navigation/LayoutHeader/LocalVersionPopover.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/LocalVersionPopover.tsx
@@ -24,12 +24,14 @@ import { getSemver, semverGte, semverLte } from './LocalVersionPopover.utils'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useCLIReleaseVersionQuery } from '@/data/misc/cli-release-version-query'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
 import { DOCS_URL } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
 
 export const LocalVersionPopover = () => {
   const track = useTrack()
-  const { data, isSuccess } = useCLIReleaseVersionQuery()
+  const { isCli } = useDeploymentMode()
+  const { data, isSuccess } = useCLIReleaseVersionQuery({ enabled: isCli })
   const { current: currentCliVersion, latest: latestCliVersion } = data || {}
   const hasLatestCLIVersion = isSuccess && !!latestCliVersion
 

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.test.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.test.tsx
@@ -177,20 +177,14 @@ describe('generateOtherRoutes', () => {
 })
 
 describe('generateSettingsRoutes', () => {
-  it('links to general settings on platform', () => {
-    const routes = generateSettingsRoutes(REF, { isPlatform: true })
+  it('links to general settings', () => {
+    const routes = generateSettingsRoutes(REF)
     const settingsRoute = routes.find((r) => r.key === 'settings')
     expect(settingsRoute?.link).toBe(`/project/${REF}/settings/general`)
   })
 
-  it('links to log-drains settings in self-hosted mode', () => {
-    const routes = generateSettingsRoutes(REF, { isPlatform: false })
-    const settingsRoute = routes.find((r) => r.key === 'settings')
-    expect(settingsRoute?.link).toBe(`/project/${REF}/settings/log-drains`)
-  })
-
   it('returns a link as false when ref is undefined', () => {
-    const routes = generateSettingsRoutes(undefined, { isPlatform: true })
+    const routes = generateSettingsRoutes(undefined)
     const settingsRoute = routes.find((r) => r.key === 'settings')
     expect(settingsRoute?.link).toBe(undefined)
   })

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -30,10 +30,6 @@ interface OtherFeatures {
   showLogs?: boolean
 }
 
-interface SettingsFeatures {
-  isPlatform?: boolean
-}
-
 function getRouteContext(ref?: string, project?: Project): RouteContext {
   return {
     ref,
@@ -210,17 +206,13 @@ export const generateOtherRoutes = (
   ]
 }
 
-export const generateSettingsRoutes = (ref?: string, features?: SettingsFeatures): Route[] => {
-  const isPlatform = features?.isPlatform ?? IS_PLATFORM
-
+export const generateSettingsRoutes = (ref?: string): Route[] => {
   return [
     {
       key: 'settings',
       label: 'Project Settings',
       icon: <Settings size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-      link:
-        ref &&
-        (isPlatform ? `/project/${ref}/settings/general` : `/project/${ref}/settings/log-drains`),
+      link: ref && `/project/${ref}/settings/general`,
       disabled: false,
       shortcutId: SHORTCUT_IDS.NAV_SETTINGS,
     },

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.selfhosted.test.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.selfhosted.test.tsx
@@ -38,14 +38,25 @@ vi.mock('@/components/interfaces/App/FeaturePreview/FeaturePreviewContext', () =
 }))
 
 describe('useGenerateSettingsMenu (self-hosted)', () => {
-  it('includes Log Drains in self-hosted mode', () => {
+  it('includes General, API Keys, JWT Keys, and Log Drains in self-hosted mode', () => {
     const { result } = renderHook(() => useGenerateSettingsMenu())
     const configGroup = result.current.find((group) => group.title === 'Configuration')
 
+    expect(configGroup?.items.some((item) => item.key === 'general')).toBe(true)
+    expect(configGroup?.items.some((item) => item.key === 'api-keys')).toBe(true)
+    expect(configGroup?.items.some((item) => item.key === 'jwt')).toBe(true)
     expect(configGroup?.items.some((item) => item.key === 'log-drains')).toBe(true)
     expect(getShortcutId(configGroup?.items.find((item) => item.key === 'log-drains'))).toBe(
       SHORTCUT_IDS.NAV_PROJECT_SETTINGS_LOG_DRAINS
     )
+  })
+
+  it('includes Data API and Vault integrations in self-hosted mode', () => {
+    const { result } = renderHook(() => useGenerateSettingsMenu())
+    const integrationsGroup = result.current.find((group) => group.title === 'Integrations')
+
+    expect(integrationsGroup?.items.some((item) => item.key === 'api')).toBe(true)
+    expect(integrationsGroup?.items.some((item) => item.key === 'vault')).toBe(true)
   })
 
   it('does not include dashboard settings in self-hosted mode', () => {
@@ -59,8 +70,13 @@ describe('useGenerateSettingsMenu (self-hosted)', () => {
     const { result } = renderHook(() => useGenerateSettingsMenu())
     const configGroup = result.current.find((group) => group.title === 'Configuration')
 
-    expect(configGroup?.items.some((item) => item.key === 'general')).toBe(false)
-    expect(configGroup?.items.some((item) => item.key === 'api-keys')).toBe(false)
+    expect(configGroup?.items.some((item) => item.key === 'compute-and-disk')).toBe(false)
     expect(configGroup?.items.some((item) => item.key === 'infrastructure')).toBe(false)
+    expect(configGroup?.items.some((item) => item.key === 'addons')).toBe(false)
+  })
+
+  it('does not include billing group in self-hosted mode', () => {
+    const { result } = renderHook(() => useGenerateSettingsMenu())
+    expect(result.current.some((group) => group.title === 'Billing')).toBe(false)
   })
 })

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -27,11 +27,51 @@ export const useGenerateSettingsMenu = () => {
         title: 'Configuration',
         items: [
           {
+            name: 'General',
+            key: 'general',
+            url: `/project/${ref}/settings/general`,
+            items: [],
+          },
+          {
+            name: 'API Keys',
+            key: 'api-keys',
+            url: `/project/${ref}/settings/api-keys`,
+            items: [],
+          },
+          {
+            name: 'JWT Keys',
+            key: 'jwt',
+            url: legacyJwtKeysEnabled
+              ? `/project/${ref}/settings/jwt`
+              : `/project/${ref}/settings/jwt/signing-keys`,
+            items: [],
+          },
+          {
             name: `Log Drains`,
             key: `log-drains`,
             url: `/project/${ref}/settings/log-drains`,
             items: [],
             shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_LOG_DRAINS,
+          },
+        ],
+      },
+      {
+        title: 'Integrations',
+        items: [
+          {
+            name: 'Data API',
+            key: 'api',
+            url: `/project/${ref}/integrations/data_api/overview`,
+            items: [],
+            rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
+          },
+          {
+            name: 'Vault',
+            key: 'vault',
+            url: `/project/${ref}/integrations/vault/overview`,
+            items: [],
+            rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
+            label: 'Beta',
           },
         ],
       },

--- a/apps/studio/components/ui/LocalSetupGuide.tsx
+++ b/apps/studio/components/ui/LocalSetupGuide.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from 'react'
+import { Card, CardContent, CardHeader, CardTitle } from 'ui'
+
+import { DocsButton } from '@/components/ui/DocsButton'
+
+export type LocalSetupGuideVariant = 'cli' | 'selfHosted'
+
+interface LocalSetupGuideProps {
+  variant: LocalSetupGuideVariant
+  body: ReactNode
+  docsHref: string
+}
+
+const VARIANT_TITLES: Record<LocalSetupGuideVariant, string> = {
+  cli: 'Local development & CLI',
+  selfHosted: 'Self-Hosted Supabase',
+}
+
+/**
+ * Card used on `!IS_PLATFORM` pages to point users at the right docs for
+ * configuring a feature outside of Studio. Renders a single audience-specific
+ * card; call twice (one per variant) and gate each render on the matching
+ * `isCli` / `isSelfHosted` flag from `useDeploymentMode`.
+ */
+export const LocalSetupGuide = ({ variant, body, docsHref }: LocalSetupGuideProps) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{VARIANT_TITLES[variant]}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-sm text-foreground-light mb-4">{body}</div>
+        <DocsButton href={docsHref} />
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/studio/lib/api/self-hosted/constants.test.ts
+++ b/apps/studio/lib/api/self-hosted/constants.test.ts
@@ -102,4 +102,18 @@ describe('api/self-hosted/constants', () => {
       expect(POSTGRES_USER_READ_ONLY).toBe('supabase_read_only_user')
     })
   })
+
+  describe('AUTH_JWT_SECRET', () => {
+    it('should use AUTH_JWT_SECRET when set', async () => {
+      vi.stubEnv('AUTH_JWT_SECRET', 'custom-jwt-secret-32-chars-long-xyz')
+      const { AUTH_JWT_SECRET } = await import('./constants')
+      expect(AUTH_JWT_SECRET).toBe('custom-jwt-secret-32-chars-long-xyz')
+    })
+
+    it('should fall back to DEFAULT_AUTH_JWT_SECRET when unset', async () => {
+      vi.stubEnv('AUTH_JWT_SECRET', '')
+      const { AUTH_JWT_SECRET, DEFAULT_AUTH_JWT_SECRET } = await import('./constants')
+      expect(AUTH_JWT_SECRET).toBe(DEFAULT_AUTH_JWT_SECRET)
+    })
+  })
 })

--- a/apps/studio/lib/api/self-hosted/constants.ts
+++ b/apps/studio/lib/api/self-hosted/constants.ts
@@ -13,3 +13,9 @@ export const POSTGRES_PASSWORD = process.env.POSTGRES_PASSWORD || 'postgres'
 export const POSTGRES_USER_READ_WRITE = process.env.POSTGRES_USER_READ_WRITE || 'supabase_admin'
 export const POSTGRES_USER_READ_ONLY =
   process.env.POSTGRES_USER_READ_ONLY || 'supabase_read_only_user'
+
+// Fallback used when AUTH_JWT_SECRET is not provided to the Studio container
+// (e.g. local dev without docker-compose). The string is the same default
+// shipped by the supabase/cli — keep them in sync.
+export const DEFAULT_AUTH_JWT_SECRET = 'super-secret-jwt-token-with-at-least-32-characters-long'
+export const AUTH_JWT_SECRET = process.env.AUTH_JWT_SECRET || DEFAULT_AUTH_JWT_SECRET

--- a/apps/studio/lib/api/self-hosted/settings.test.ts
+++ b/apps/studio/lib/api/self-hosted/settings.test.ts
@@ -71,10 +71,10 @@ describe('api/self-hosted/settings', () => {
       const settings = getProjectSettings()
 
       expect(settings.service_api_keys).toHaveLength(2)
-      expect(settings.service_api_keys[0].name).toBe('service_role key')
-      expect(settings.service_api_keys[0].tags).toBe('service_role')
-      expect(settings.service_api_keys[1].name).toBe('anon key')
-      expect(settings.service_api_keys[1].tags).toBe('anon')
+      expect(settings.service_api_keys[0].name).toBe('anon key')
+      expect(settings.service_api_keys[0].tags).toBe('anon')
+      expect(settings.service_api_keys[1].name).toBe('service_role key')
+      expect(settings.service_api_keys[1].tags).toBe('service_role')
     })
 
     it('should use environment variables when set', async () => {
@@ -91,8 +91,8 @@ describe('api/self-hosted/settings', () => {
 
       expect(settings.jwt_secret).toBe('custom-jwt-secret-with-at-least-32-chars')
       expect(settings.name).toBe('My Custom Project')
-      expect(settings.service_api_keys[0].api_key).toBe('custom-service-key')
-      expect(settings.service_api_keys[1].api_key).toBe('custom-anon-key')
+      expect(settings.service_api_keys[0].api_key).toBe('custom-anon-key')
+      expect(settings.service_api_keys[1].api_key).toBe('custom-service-key')
     })
 
     it('should use default JWT secret when not set', async () => {

--- a/apps/studio/lib/api/self-hosted/settings.ts
+++ b/apps/studio/lib/api/self-hosted/settings.ts
@@ -1,6 +1,6 @@
 import { components } from 'api-types'
 
-import { POSTGRES_PORT } from './constants'
+import { AUTH_JWT_SECRET, POSTGRES_PORT } from './constants'
 import { assertSelfHosted } from './util'
 import { PROJECT_DB_HOST, PROJECT_ENDPOINT, PROJECT_ENDPOINT_PROTOCOL } from '@/lib/constants/api'
 
@@ -36,21 +36,20 @@ export function getProjectSettings() {
     db_port: POSTGRES_PORT,
     db_user: 'postgres',
     inserted_at: '2021-08-02T06:40:40.646Z',
-    jwt_secret:
-      process.env.AUTH_JWT_SECRET ?? 'super-secret-jwt-token-with-at-least-32-characters-long',
+    jwt_secret: AUTH_JWT_SECRET,
     name: process.env.DEFAULT_PROJECT_NAME || 'Default Project',
     ref: 'default',
     region: 'ap-southeast-1',
     service_api_keys: [
       {
-        api_key: process.env.SUPABASE_SERVICE_KEY ?? '',
-        name: 'service_role key',
-        tags: 'service_role',
-      },
-      {
         api_key: process.env.SUPABASE_ANON_KEY ?? '',
         name: 'anon key',
         tags: 'anon',
+      },
+      {
+        api_key: process.env.SUPABASE_SERVICE_KEY ?? '',
+        name: 'service_role key',
+        tags: 'service_role',
       },
     ],
     ssl_enforced: false,

--- a/apps/studio/lib/api/self-hosted/signing-keys.test.ts
+++ b/apps/studio/lib/api/self-hosted/signing-keys.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { getLegacySigningKey } from './signing-keys'
+
+vi.mock('./util', () => ({
+  assertSelfHosted: vi.fn(),
+}))
+
+describe('api/self-hosted/signing-keys', () => {
+  let mockAssertSelfHosted: ReturnType<typeof vi.fn>
+
+  beforeEach(async () => {
+    vi.clearAllMocks()
+    vi.resetModules()
+
+    const util = await import('./util')
+    mockAssertSelfHosted = vi.mocked(util.assertSelfHosted)
+  })
+
+  describe('getLegacySigningKey', () => {
+    it('should call assertSelfHosted', () => {
+      getLegacySigningKey()
+
+      expect(mockAssertSelfHosted).toHaveBeenCalled()
+    })
+
+    it('should return a SigningKeyResponse-shaped legacy entry', () => {
+      const key = getLegacySigningKey()
+
+      expect(key).toEqual({
+        id: '00000000-0000-0000-0000-000000000000',
+        algorithm: 'HS256',
+        status: 'in_use',
+        created_at: '1970-01-01T00:00:00.000Z',
+        updated_at: '1970-01-01T00:00:00.000Z',
+      })
+    })
+  })
+})

--- a/apps/studio/lib/api/self-hosted/signing-keys.ts
+++ b/apps/studio/lib/api/self-hosted/signing-keys.ts
@@ -1,0 +1,31 @@
+import { components } from 'api-types'
+
+import { assertSelfHosted } from './util'
+
+type SigningKeyResponse = components['schemas']['SigningKeyResponse']
+
+const LEGACY_KEY_ID = '00000000-0000-0000-0000-000000000000'
+const LEGACY_KEY_CREATED_AT = '1970-01-01T00:00:00.000Z'
+
+/**
+ * Returns a synthetic legacy signing key entry representing the symmetric
+ * `AUTH_JWT_SECRET` so the Legacy JWT Secret page can render with the
+ * "secret has been migrated" state on self-hosted.
+ *
+ * The asymmetric signing-key lifecycle (create/rotate/revoke) is not
+ * supported here — those endpoints remain unmocked, and the JWT Signing
+ * Keys page renders a docs-pointing admonition instead of a table.
+ *
+ * _Only call this from server-side self-hosted code._
+ */
+export function getLegacySigningKey(): SigningKeyResponse {
+  assertSelfHosted()
+
+  return {
+    id: LEGACY_KEY_ID,
+    algorithm: 'HS256',
+    status: 'in_use',
+    created_at: LEGACY_KEY_CREATED_AT,
+    updated_at: LEGACY_KEY_CREATED_AT,
+  }
+}

--- a/apps/studio/pages/api/platform/projects/[ref]/config/secrets/update-status.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/secrets/update-status.ts
@@ -1,0 +1,26 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import apiWrapper from '@/lib/api/apiWrapper'
+
+export default function updateStatus(req: NextApiRequest, res: NextApiResponse) {
+  return apiWrapper(req, res, handler)
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req
+
+  switch (method) {
+    case 'GET':
+      return handleGet(req, res)
+    default:
+      res.setHeader('Allow', ['GET'])
+      res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
+  }
+}
+
+const handleGet = async (_req: NextApiRequest, res: NextApiResponse) => {
+  // Self-hosted Studio cannot trigger JWT secret rotations, so there is never
+  // an in-flight update. Return null so the consuming UI renders the steady
+  // state instead of spinning a loader against a 404'd endpoint.
+  return res.status(200).json({ update_status: null })
+}

--- a/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/index.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/index.ts
@@ -1,0 +1,24 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import apiWrapper from '@/lib/api/apiWrapper'
+import { getLegacySigningKey } from '@/lib/api/self-hosted/signing-keys'
+
+export default function signingKeys(req: NextApiRequest, res: NextApiResponse) {
+  return apiWrapper(req, res, handler)
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req
+
+  switch (method) {
+    case 'GET':
+      return handleGet(req, res)
+    default:
+      res.setHeader('Allow', ['GET'])
+      res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
+  }
+}
+
+const handleGet = async (_req: NextApiRequest, res: NextApiResponse) => {
+  return res.status(200).json({ keys: [getLegacySigningKey()] })
+}

--- a/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/legacy.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/legacy.ts
@@ -1,0 +1,24 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+
+import apiWrapper from '@/lib/api/apiWrapper'
+import { getLegacySigningKey } from '@/lib/api/self-hosted/signing-keys'
+
+export default function legacySigningKey(req: NextApiRequest, res: NextApiResponse) {
+  return apiWrapper(req, res, handler)
+}
+
+async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { method } = req
+
+  switch (method) {
+    case 'GET':
+      return handleGet(req, res)
+    default:
+      res.setHeader('Allow', ['GET'])
+      res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
+  }
+}
+
+const handleGet = async (_req: NextApiRequest, res: NextApiResponse) => {
+  return res.status(200).json(getLegacySigningKey())
+}

--- a/apps/studio/pages/project/[ref]/settings/api-keys/index.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api-keys/index.tsx
@@ -1,7 +1,8 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { useMemo } from 'react'
 import { Separator } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 
 import {
   ApiKeysCreateCallout,
@@ -13,12 +14,16 @@ import ApiKeysLayout from '@/components/layouts/APIKeys/APIKeysLayout'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import SettingsLayout from '@/components/layouts/ProjectSettingsLayout/SettingsLayout'
 import { DisableInteraction } from '@/components/ui/DisableInteraction'
+import { DocsButton } from '@/components/ui/DocsButton'
 import { useAPIKeysQuery } from '@/data/api-keys/api-keys-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
+import { DOCS_URL } from '@/lib/constants'
 import type { NextPageWithLayout } from '@/types'
 
 const ApiKeysNewPage: NextPageWithLayout = () => {
   const { ref: projectRef } = useParams()
+  const { isCli, isSelfHosted } = useDeploymentMode()
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
   const { data: apiKeysData = [] } = useAPIKeysQuery(
     {
@@ -33,6 +38,43 @@ const ApiKeysNewPage: NextPageWithLayout = () => {
     [apiKeysData]
   )
   const hasNewApiKeys = newApiKeys.length > 0
+
+  if (!IS_PLATFORM) {
+    return (
+      <div className="flex flex-col gap-8">
+        {isCli && (
+          <Admonition
+            type="default"
+            title="Local development with the Supabase CLI"
+            description={
+              <p>
+                The API keys are automatically managed by the Supabase CLI and are not manually
+                configurable.
+              </p>
+            }
+            actions={<DocsButton href={`${DOCS_URL}/guides/local-development`} />}
+          />
+        )}
+        {isSelfHosted && (
+          <Admonition
+            type="default"
+            title="Self-hosted Supabase"
+            description={
+              <p>
+                <code className="text-code-inline">SUPABASE_PUBLISHABLE_KEY</code> and{' '}
+                <code className="text-code-inline">SUPABASE_SECRET_KEY</code> are set via
+                environment variables.
+              </p>
+            }
+            actions={<DocsButton href={`${DOCS_URL}/guides/self-hosting/self-hosted-auth-keys`} />}
+          />
+        )}
+        <PublishableAPIKeys />
+        <Separator />
+        <SecretAPIKeys />
+      </div>
+    )
+  }
 
   return (
     <>

--- a/apps/studio/pages/project/[ref]/settings/api-keys/legacy.tsx
+++ b/apps/studio/pages/project/[ref]/settings/api-keys/legacy.tsx
@@ -1,3 +1,5 @@
+import { IS_PLATFORM } from 'common'
+
 import ApiKeysLayout from '@/components/layouts/APIKeys/APIKeysLayout'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import SettingsLayout from '@/components/layouts/ProjectSettingsLayout/SettingsLayout'
@@ -9,7 +11,7 @@ const ApiKeysLegacyPage: NextPageWithLayout = () => {
   return (
     <>
       <DisplayApiSettings showTitle={false} showNotice={false} />
-      <ToggleLegacyApiKeysPanel />
+      {IS_PLATFORM && <ToggleLegacyApiKeysPanel />}
     </>
   )
 }

--- a/apps/studio/pages/project/[ref]/settings/general.tsx
+++ b/apps/studio/pages/project/[ref]/settings/general.tsx
@@ -1,6 +1,4 @@
 import { IS_PLATFORM } from 'common'
-import { useRouter } from 'next/router'
-import { useEffect } from 'react'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
@@ -32,15 +30,11 @@ const ProjectSettings: NextPageWithLayout = () => {
   const isBranch = !!project?.parent_project_ref
   const { projectsTransfer: projectTransferEnabled, projectSettingsCustomDomains } =
     useIsFeatureEnabled(['projects:transfer', 'project_settings:custom_domains'])
-  const router = useRouter()
 
-  useEffect(() => {
-    if (!IS_PLATFORM) {
-      router.push(`/project/default/settings/log-drains`)
-    }
-  }, [router])
-
-  const { data: subscription } = useOrgSubscriptionQuery({ orgSlug: selectedOrganization?.slug })
+  const { data: subscription } = useOrgSubscriptionQuery(
+    { orgSlug: selectedOrganization?.slug },
+    { enabled: IS_PLATFORM }
+  )
   const hasHipaaAddon = subscriptionHasHipaaAddon(subscription)
 
   return (
@@ -57,12 +51,16 @@ const ProjectSettings: NextPageWithLayout = () => {
       </PageHeader>
       <PageContainer size="small">
         <General />
-        <Project />
-        {/* this is only settable on compliance orgs, currently that means HIPAA orgs */}
-        {!isBranch && hasHipaaAddon && <ComplianceConfig />}
-        {projectSettingsCustomDomains && <CustomDomainConfig />}
-        {!isBranch && projectTransferEnabled && <TransferProjectPanel />}
-        {!isBranch && <DeleteProjectPanel />}
+        {IS_PLATFORM && (
+          <>
+            <Project />
+            {/* this is only settable on compliance orgs, currently that means HIPAA orgs */}
+            {!isBranch && hasHipaaAddon && <ComplianceConfig />}
+            {projectSettingsCustomDomains && <CustomDomainConfig />}
+            {!isBranch && projectTransferEnabled && <TransferProjectPanel />}
+            {!isBranch && <DeleteProjectPanel />}
+          </>
+        )}
       </PageContainer>
     </>
   )

--- a/apps/studio/pages/project/[ref]/settings/jwt/index.tsx
+++ b/apps/studio/pages/project/[ref]/settings/jwt/index.tsx
@@ -1,19 +1,55 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { IS_PLATFORM } from 'common'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { JWTSecretKeysTable } from '@/components/interfaces/JwtSecrets/jwt-secret-keys-table'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import JWTKeysLayout from '@/components/layouts/JWTKeys/JWTKeysLayout'
 import SettingsLayout from '@/components/layouts/ProjectSettingsLayout/SettingsLayout'
+import { LocalSetupGuide } from '@/components/ui/LocalSetupGuide'
 import NoPermission from '@/components/ui/NoPermission'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
+import { DOCS_URL } from '@/lib/constants'
 import type { NextPageWithLayout } from '@/types'
 
 const JWTSigningKeysPage: NextPageWithLayout = () => {
+  const { isCli, isSelfHosted } = useDeploymentMode()
   const { can: canReadAPIKeys, isSuccess: isPermissionsLoaded } = useAsyncCheckPermissions(
     PermissionAction.READ,
     'auth_signing_keys'
   )
+
+  if (!IS_PLATFORM) {
+    return (
+      <div className="space-y-4">
+        {isCli && (
+          <LocalSetupGuide
+            variant="cli"
+            body={
+              <p>
+                The asymmetric key pair used to sign user session JWTs is configured by the Supabase
+                CLI.
+              </p>
+            }
+            docsHref={`${DOCS_URL}/guides/local-development`}
+          />
+        )}
+        {isSelfHosted && (
+          <LocalSetupGuide
+            variant="selfHosted"
+            body={
+              <p>
+                The asymmetric key pair used to sign user session JWTs is configured via environment
+                variables.
+              </p>
+            }
+            docsHref={`${DOCS_URL}/guides/self-hosting/self-hosted-auth-keys`}
+          />
+        )}
+      </div>
+    )
+  }
 
   return (
     <>

--- a/apps/studio/tests/pages/project/[ref]/settings/api-keys/index.test.tsx
+++ b/apps/studio/tests/pages/project/[ref]/settings/api-keys/index.test.tsx
@@ -1,0 +1,139 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ApiKeysPage from '@/pages/project/[ref]/settings/api-keys/index'
+
+const { mockIsPlatform, mockUseAsyncCheckPermissions, mockUseAPIKeysQuery, mockUseDeploymentMode } =
+  vi.hoisted(() => ({
+    mockIsPlatform: { value: true },
+    mockUseAsyncCheckPermissions: vi.fn(),
+    mockUseAPIKeysQuery: vi.fn(),
+    mockUseDeploymentMode: vi.fn(),
+  }))
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+    useParams: () => ({ ref: 'project-ref' }),
+  }
+})
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('@/data/api-keys/api-keys-query', () => ({
+  useAPIKeysQuery: mockUseAPIKeysQuery,
+}))
+
+vi.mock('@/hooks/misc/useDeploymentMode', () => ({
+  useDeploymentMode: mockUseDeploymentMode,
+}))
+
+vi.mock('@/components/layouts/DefaultLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/ProjectSettingsLayout/SettingsLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/APIKeys/APIKeysLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/interfaces/APIKeys/ApiKeysIllustrations', () => ({
+  ApiKeysCreateCallout: () => <div>ApiKeysCreateCallout</div>,
+  ApiKeysFeedbackBanner: () => <div>ApiKeysFeedbackBanner</div>,
+}))
+
+vi.mock('@/components/interfaces/APIKeys/PublishableAPIKeys', () => ({
+  PublishableAPIKeys: () => <div>PublishableAPIKeys</div>,
+}))
+
+vi.mock('@/components/interfaces/APIKeys/SecretAPIKeys', () => ({
+  SecretAPIKeys: () => <div>SecretAPIKeys</div>,
+}))
+
+vi.mock('@/components/ui/DisableInteraction', () => ({
+  DisableInteraction: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+describe('/project/[ref]/settings/api-keys', () => {
+  beforeEach(() => {
+    mockIsPlatform.value = true
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isLoading: false })
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: true,
+      isCli: false,
+      isSelfHosted: false,
+    })
+    mockUseAPIKeysQuery.mockReturnValue({
+      data: [{ type: 'publishable' }, { type: 'secret' }],
+    })
+  })
+
+  it('renders publishable and secret keys with the feedback banner on platform when keys exist', () => {
+    render(<ApiKeysPage dehydratedState={{}} />)
+
+    expect(screen.getByText('PublishableAPIKeys')).toBeInTheDocument()
+    expect(screen.getByText('SecretAPIKeys')).toBeInTheDocument()
+    expect(screen.getByText('ApiKeysFeedbackBanner')).toBeInTheDocument()
+    expect(screen.queryByText('ApiKeysCreateCallout')).not.toBeInTheDocument()
+    expect(screen.queryByText(/Local development with the Supabase CLI/i)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Self-hosted Supabase/i)).not.toBeInTheDocument()
+  })
+
+  it('renders the create callout on platform when no new keys exist', () => {
+    mockUseAPIKeysQuery.mockReturnValue({ data: [] })
+
+    render(<ApiKeysPage dehydratedState={{}} />)
+
+    expect(screen.getByText('ApiKeysCreateCallout')).toBeInTheDocument()
+    expect(screen.queryByText('ApiKeysFeedbackBanner')).not.toBeInTheDocument()
+  })
+
+  it('renders the CLI admonition above the keys on self-hosted (CLI mode)', () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: false,
+      isCli: true,
+      isSelfHosted: false,
+    })
+
+    render(<ApiKeysPage dehydratedState={{}} />)
+
+    expect(screen.getByText(/Local development with the Supabase CLI/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Self-hosted Supabase/i)).not.toBeInTheDocument()
+    expect(screen.getByText('PublishableAPIKeys')).toBeInTheDocument()
+    expect(screen.getByText('SecretAPIKeys')).toBeInTheDocument()
+    expect(screen.queryByText('ApiKeysCreateCallout')).not.toBeInTheDocument()
+    expect(screen.queryByText('ApiKeysFeedbackBanner')).not.toBeInTheDocument()
+  })
+
+  it('renders the self-hosted admonition above the keys on self-hosted (Docker mode)', () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: false,
+      isCli: false,
+      isSelfHosted: true,
+    })
+
+    render(<ApiKeysPage dehydratedState={{}} />)
+
+    expect(screen.getByText(/Self-hosted Supabase/i)).toBeInTheDocument()
+    expect(screen.queryByText(/Local development with the Supabase CLI/i)).not.toBeInTheDocument()
+    expect(screen.getByText('PublishableAPIKeys')).toBeInTheDocument()
+    expect(screen.getByText('SecretAPIKeys')).toBeInTheDocument()
+    expect(screen.queryByText('ApiKeysCreateCallout')).not.toBeInTheDocument()
+    expect(screen.queryByText('ApiKeysFeedbackBanner')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/tests/pages/project/[ref]/settings/api-keys/legacy.test.tsx
+++ b/apps/studio/tests/pages/project/[ref]/settings/api-keys/legacy.test.tsx
@@ -1,0 +1,64 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ApiKeysLegacyPage from '@/pages/project/[ref]/settings/api-keys/legacy'
+
+const { mockIsPlatform } = vi.hoisted(() => ({
+  mockIsPlatform: { value: true },
+}))
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+  }
+})
+
+vi.mock('@/components/layouts/DefaultLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/ProjectSettingsLayout/SettingsLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/APIKeys/APIKeysLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/ProjectSettings/DisplayApiSettings', () => ({
+  DisplayApiSettings: () => <div>DisplayApiSettings</div>,
+}))
+
+vi.mock('@/components/ui/ProjectSettings/ToggleLegacyApiKeys', () => ({
+  ToggleLegacyApiKeysPanel: () => <div>ToggleLegacyApiKeysPanel</div>,
+}))
+
+describe('/project/[ref]/settings/api-keys/legacy', () => {
+  beforeEach(() => {
+    mockIsPlatform.value = true
+  })
+
+  it('renders both legacy keys and the disable toggle on platform', () => {
+    render(<ApiKeysLegacyPage dehydratedState={{}} />)
+
+    expect(screen.getByText('DisplayApiSettings')).toBeInTheDocument()
+    expect(screen.getByText('ToggleLegacyApiKeysPanel')).toBeInTheDocument()
+  })
+
+  it('renders legacy keys but hides the disable toggle on self-hosted', () => {
+    mockIsPlatform.value = false
+
+    render(<ApiKeysLegacyPage dehydratedState={{}} />)
+
+    expect(screen.getByText('DisplayApiSettings')).toBeInTheDocument()
+    expect(screen.queryByText('ToggleLegacyApiKeysPanel')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/tests/pages/project/[ref]/settings/jwt/index.test.tsx
+++ b/apps/studio/tests/pages/project/[ref]/settings/jwt/index.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import JWTSigningKeysPage from '@/pages/project/[ref]/settings/jwt/index'
+
+const { mockIsPlatform, mockUseAsyncCheckPermissions, mockUseDeploymentMode } = vi.hoisted(() => ({
+  mockIsPlatform: { value: true },
+  mockUseAsyncCheckPermissions: vi.fn(),
+  mockUseDeploymentMode: vi.fn(),
+}))
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+  }
+})
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('@/hooks/misc/useDeploymentMode', () => ({
+  useDeploymentMode: mockUseDeploymentMode,
+}))
+
+vi.mock('@/components/layouts/DefaultLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/ProjectSettingsLayout/SettingsLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/JWTKeys/JWTKeysLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/interfaces/JwtSecrets/jwt-secret-keys-table', () => ({
+  JWTSecretKeysTable: () => <div>JWTSecretKeysTable</div>,
+}))
+
+vi.mock('@/components/ui/LocalSetupGuide', () => ({
+  LocalSetupGuide: () => <div>LocalSetupGuide</div>,
+}))
+
+describe('/project/[ref]/settings/jwt', () => {
+  beforeEach(() => {
+    mockIsPlatform.value = true
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isSuccess: true })
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: true,
+      isCli: false,
+      isSelfHosted: false,
+    })
+  })
+
+  it('renders the JWT signing keys table on platform', () => {
+    render(<JWTSigningKeysPage dehydratedState={{}} />)
+
+    expect(screen.getByText('JWTSecretKeysTable')).toBeInTheDocument()
+    expect(screen.queryByText('LocalSetupGuide')).not.toBeInTheDocument()
+  })
+
+  it('renders only the CLI LocalSetupGuide on self-hosted (CLI mode)', () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: false,
+      isCli: true,
+      isSelfHosted: false,
+    })
+
+    render(<JWTSigningKeysPage dehydratedState={{}} />)
+
+    expect(screen.queryByText('JWTSecretKeysTable')).not.toBeInTheDocument()
+    expect(screen.getAllByText('LocalSetupGuide')).toHaveLength(1)
+  })
+
+  it('renders only the self-hosted LocalSetupGuide on self-hosted (Docker mode)', () => {
+    mockIsPlatform.value = false
+    mockUseDeploymentMode.mockReturnValue({
+      isPlatform: false,
+      isCli: false,
+      isSelfHosted: true,
+    })
+
+    render(<JWTSigningKeysPage dehydratedState={{}} />)
+
+    expect(screen.queryByText('JWTSecretKeysTable')).not.toBeInTheDocument()
+    expect(screen.getAllByText('LocalSetupGuide')).toHaveLength(1)
+  })
+})

--- a/apps/studio/tests/pages/project/[ref]/settings/jwt/legacy.test.tsx
+++ b/apps/studio/tests/pages/project/[ref]/settings/jwt/legacy.test.tsx
@@ -1,0 +1,74 @@
+import { screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import JWTKeysLegacyPage from '@/pages/project/[ref]/settings/jwt/legacy'
+import { customRender as render } from '@/tests/lib/custom-render'
+
+const { mockIsPlatform, mockUseIsFeatureEnabled, mockUseJwtSecretUpdatingStatusQuery } = vi.hoisted(
+  () => ({
+    mockIsPlatform: { value: true },
+    mockUseIsFeatureEnabled: vi.fn(),
+    mockUseJwtSecretUpdatingStatusQuery: vi.fn(),
+  })
+)
+
+vi.mock('common', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('common')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return mockIsPlatform.value
+    },
+    useParams: () => ({ ref: 'project-ref' }),
+  }
+})
+
+vi.mock('@/hooks/misc/useIsFeatureEnabled', () => ({
+  useIsFeatureEnabled: mockUseIsFeatureEnabled,
+}))
+
+vi.mock('@/data/config/jwt-secret-updating-status-query', () => ({
+  useJwtSecretUpdatingStatusQuery: mockUseJwtSecretUpdatingStatusQuery,
+}))
+
+vi.mock('@/components/layouts/DefaultLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/ProjectSettingsLayout/SettingsLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/layouts/JWTKeys/JWTKeysLayout', () => ({
+  __esModule: true,
+  default: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/interfaces/JwtSecrets/jwt-settings', () => ({
+  JWTSettings: () => <div>JWTSettings</div>,
+}))
+
+describe('/project/[ref]/settings/jwt/legacy', () => {
+  beforeEach(() => {
+    mockIsPlatform.value = true
+    mockUseIsFeatureEnabled.mockReturnValue({ projectSettingsLegacyJwtKeys: true })
+    mockUseJwtSecretUpdatingStatusQuery.mockReturnValue({ data: undefined })
+  })
+
+  it('renders the JWT settings on platform', () => {
+    render(<JWTKeysLegacyPage dehydratedState={{}} />)
+
+    expect(screen.getByText('JWTSettings')).toBeInTheDocument()
+  })
+
+  it('renders the JWT settings on self-hosted', () => {
+    mockIsPlatform.value = false
+
+    render(<JWTKeysLegacyPage dehydratedState={{}} />)
+
+    expect(screen.getByText('JWTSettings')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

A follow-up to PR https://github.com/supabase/supabase/pull/46342:

- Settings menu: adds General / API Keys / JWT Keys (Configuration) entries on non-platform Studio. Default settings route is now /settings/general
- General settings: non-platform shows read-only project name + mode admonition
- API Keys: non-platform hides dot-menu, create-dialog buttons, trailing TableHead; adds mode admonitions; publishable-keys empty-state Card on self-hosted when no key configured
- JWT Keys: non-platform LocalSetupGuide variants per mode; legacy JWT secret tab shows only the read-only secret on non-platform
- New mock routes synthesize signing-keys + signing-keys/legacy + config/secrets/update-status from the new env var
- Refactors the AUTH_JWT_SECRET env-var read out of lib/api/self-hosted/settings.ts into named exports in lib/api/self-hosted/constants.ts (AUTH_JWT_SECRET + DEFAULT_AUTH_JWT_SECRET), so the new signing-keys mock route can reuse it; no env-var or default-value change.
- Adds an Integrations sub-group (Data API + Vault) under the self-hosted Settings menu, mirroring the platform Settings structure. These pages have been reachable on self-hosted via the main nav Integrations entry since Mar 2026 (commit b7cbc11d); this just adds the corresponding Settings-menu shortcuts
- Telemetry, keyboard shortcuts unchanged.

Plus a minor fix:
- LocalVersionPopover: gates the GitHub-releases ping to CLI mode only; self-hosted Docker no longer pings GitHub on every Studio load

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced self-hosted deployment support with platform-specific UI adaptations for API keys, JWT settings, and general settings.
  * Added documentation and setup guides for self-hosted and CLI deployments within the settings interface.
  * New API endpoints for accessing signing keys in self-hosted environments.

* **Bug Fixes & Improvements**
  * Simplified JWT settings interface for self-hosted deployments with read-only secret display.
  * Improved settings navigation menu structure for self-hosted setups.

* **Tests**
  * Added comprehensive test coverage for API keys, JWT, and settings pages across platform and self-hosted modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->