### PR TITLE
fix: Throw error on mdx parsing

### DIFF
--- a/apps/docs/content/guides/local-development/customizing-email-templates.mdx
+++ b/apps/docs/content/guides/local-development/customizing-email-templates.mdx
@@ -101,7 +101,7 @@ There are several authentication-related email templates which can be configured
 
 ### `auth.email.template.reauthentication`
 
-**Default subject**: "`{{ .Token }} is your verification code`"
+**Default subject**: "{{ .Token }} is your verification code"
 **When sent**: When a user needs to re-authenticate for sensitive operations
 **Purpose**: Ask users to verify their identity before a sensitive operation
 **Content**: Contains a 6-digit OTP code for verification

--- a/apps/docs/content/guides/local-development/customizing-email-templates.mdx
+++ b/apps/docs/content/guides/local-development/customizing-email-templates.mdx
@@ -101,7 +101,7 @@ There are several authentication-related email templates which can be configured
 
 ### `auth.email.template.reauthentication`
 
-**Default subject**: "{{ .Token }} is your verification code"
+**Default subject**: "`{{ .Token }} is your verification code`"
 **When sent**: When a user needs to re-authenticate for sensitive operations
 **Purpose**: Ask users to verify their identity before a sensitive operation
 **Content**: Contains a 6-digit OTP code for verification

--- a/apps/docs/resources/guide/guideModelLoader.ts
+++ b/apps/docs/resources/guide/guideModelLoader.ts
@@ -140,9 +140,9 @@ export class GuideModelLoader {
       },
       (error) => {
         if (error instanceof Error && 'code' in error && error.code === 'ENOENT') {
-          return new FileNotFoundError('', error)
+          throw new FileNotFoundError('', error)
         }
-        return new Error(
+        throw new Error(
           `Failed to load guide from ${relPath}: ${extractMessageFromAnyError(error)}`,
           {
             cause: error,


### PR DESCRIPTION
In this PR:
 - On guides custom loader, we throw errors instead of returning them so they failed on build, preventing syntax errors and others to leak into production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing guide files to ensure proper error propagation through the application's error handling pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->