### PR TITLE
fix: Search embedding fails due to missing partial

### DIFF
--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -246,12 +246,6 @@ supabase stop --no-backup
 
 </Admonition>
 
-<$Show if="!docs:hide_cli_profiles">
-
-<$Partial path="cli_profiles.mdx" />
-
-</$Show>
-
 ## Running Supabase locally
 
 The Supabase CLI uses Docker containers to manage the local development stack. Follow the official guide to install and configure [Docker Desktop](https://docs.docker.com/desktop):


### PR DESCRIPTION
After improving error handling on guides loader, of course, an error emerged about a missing partial that doesn't exist anymore within the project.

Removing the partial importing within MDX to fix search embedding script.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the CLI getting started guide by streamlining the content structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->