### PR TITLE
chore: update banner for pooler w/ new dates

### DIFF
--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -30,7 +30,7 @@ const SUPAVISOR_UPDATE_REGIONS = {
   'us-east-1': {
     start: Date.UTC(2026, 5, 3, 13, 0, 0),
     end: Date.UTC(2026, 5, 3, 15, 0, 0),
-    url: 'https://status.supabase.com/incidents/7zgmgh2p343n',
+    url: 'https://status.supabase.com/incidents/y8rp6dwjyplw',
   },
 }
 

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -17,9 +17,9 @@ const SUPAVISOR_UPDATE_REGIONS = {
     end: Date.UTC(2026, 4, 26, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/jy1tm4wfs68t',
   },
-  'eu-west-1': {
-    start: Date.UTC(2026, 5, 1, 13, 0, 0),
-    end: Date.UTC(2026, 5, 1, 15, 0, 0),
+  'eu-west-2': {
+    start: Date.UTC(2026, 5, 9, 13, 0, 0),
+    end: Date.UTC(2026, 5, 9, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/3t293hpd545z',
   },
   'us-west-1': {
@@ -27,9 +27,9 @@ const SUPAVISOR_UPDATE_REGIONS = {
     end: Date.UTC(2026, 5, 2, 18, 0, 0),
     url: 'https://status.supabase.com/incidents/8f72bnv3xs8r',
   },
-  'us-east-2': {
-    start: Date.UTC(2026, 5, 9, 13, 0, 0),
-    end: Date.UTC(2026, 5, 9, 15, 0, 0),
+  'us-east-1': {
+    start: Date.UTC(2026, 5, 3, 13, 0, 0),
+    end: Date.UTC(2026, 5, 3, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/7zgmgh2p343n',
   },
 }

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -9,7 +9,7 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 // Update this whenever the banner content below changes so old client bundles
 // stop displaying outdated notices after the relevant date passes.
-const BANNER_EXPIRES_AT = new Date('2026-06-03T15:00:00Z')
+const BANNER_EXPIRES_AT = new Date('2026-06-09T18:00:00Z')
 
 const SUPAVISOR_UPDATE_REGIONS = {
   'eu-central-1': {
@@ -22,9 +22,9 @@ const SUPAVISOR_UPDATE_REGIONS = {
     end: Date.UTC(2026, 5, 1, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/3t293hpd545z',
   },
-  'us-west-1': {
-    start: Date.UTC(2026, 5, 2, 16, 0, 0),
-    end: Date.UTC(2026, 5, 2, 18, 0, 0),
+  'us-west-2': {
+    start: Date.UTC(2026, 5, 9, 16, 0, 0),
+    end: Date.UTC(2026, 5, 9, 18, 0, 0),
     url: 'https://status.supabase.com/incidents/8f72bnv3xs8r',
   },
   'us-east-1': {

--- a/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
+++ b/apps/studio/components/layouts/AppLayout/NoticeBanner.tsx
@@ -9,7 +9,7 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 // Update this whenever the banner content below changes so old client bundles
 // stop displaying outdated notices after the relevant date passes.
-const BANNER_EXPIRES_AT = new Date('2026-06-09T18:00:00Z')
+const BANNER_EXPIRES_AT = new Date('2026-06-09T15:00:00Z')
 
 const SUPAVISOR_UPDATE_REGIONS = {
   'eu-central-1': {
@@ -22,14 +22,14 @@ const SUPAVISOR_UPDATE_REGIONS = {
     end: Date.UTC(2026, 5, 1, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/3t293hpd545z',
   },
-  'us-west-2': {
-    start: Date.UTC(2026, 5, 9, 16, 0, 0),
-    end: Date.UTC(2026, 5, 9, 18, 0, 0),
+  'us-west-1': {
+    start: Date.UTC(2026, 5, 2, 16, 0, 0),
+    end: Date.UTC(2026, 5, 2, 18, 0, 0),
     url: 'https://status.supabase.com/incidents/8f72bnv3xs8r',
   },
-  'us-east-1': {
-    start: Date.UTC(2026, 5, 3, 13, 0, 0),
-    end: Date.UTC(2026, 5, 3, 15, 0, 0),
+  'us-east-2': {
+    start: Date.UTC(2026, 5, 9, 13, 0, 0),
+    end: Date.UTC(2026, 5, 9, 15, 0, 0),
     url: 'https://status.supabase.com/incidents/7zgmgh2p343n',
   },
 }

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -71,7 +71,7 @@ export const LOCAL_STORAGE_KEYS = {
   // Notice banner keys
   API_KEYS_FEEDBACK_DISMISSED: (ref: string) => `supabase-api-keys-feedback-dismissed-${ref}`,
   TERMS_OF_SERVICE_UPDATE: 'terms-of-service-update-2026-06-06',
-  SUPAVISOR_MAINTENANCE: (ref: string) => `supavisor-maintenance-2026-05-21-${ref}`,
+  SUPAVISOR_MAINTENANCE: (ref: string) => `supavisor-maintenance-2026-06-09-${ref}`,
   REPORT_DATERANGE: 'supabase-report-daterange',
   PROJECT_PAUSING_STARTED_AT: (ref: string) => `supabase-project-pausing-started-at-${ref}`,
   PROJECT_RESTORING_STARTED_AT: (ref: string) => `supabase-project-restoring-started-at-${ref}`,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Minor updates to date on pooler changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Extended the on-screen maintenance notice so the banner remains visible until June 9, 2026.
  * Updated scheduled maintenance window details (region identifier, start/end times) and refreshed incident links for affected regions.
  * Revised local maintenance tracking key to use the new June 9, 2026 date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->