### PR TITLE
Remove State of Startups pill banner from homepage hero

### DIFF
--- a/apps/www/components/Hero/Hero.tsx
+++ b/apps/www/components/Hero/Hero.tsx
@@ -1,6 +1,5 @@
 import SectionContainer from '~/components/Layouts/SectionContainer'
 import { useSendTelemetryEvent } from '~/lib/telemetry'
-import AnnouncementBadge from 'components/Announcement/Badge'
 import Link from 'next/link'
 import { Button } from 'ui'
 
@@ -14,11 +13,6 @@ const Hero = () => {
           <div className="mx-auto">
             <div className="mx-auto max-w-2xl lg:col-span-6 lg:flex lg:items-center justify-center text-center">
               <div className="relative z-10 lg:h-auto pt-[90px] lg:pt-[90px] lg:min-h-[300px] flex flex-col items-center justify-center sm:mx-auto md:w-3/4 lg:mx-0 lg:w-full gap-4 lg:gap-8">
-                <AnnouncementBadge
-                  url="/state-of-startups"
-                  announcement="State of Startups 2026: Take the survey."
-                />
-
                 <div className="flex flex-col items-center">
                   <h1 className="text-foreground text-4xl sm:text-5xl sm:leading-none lg:text-7xl">
                     <span className="block text-foreground">Build in a weekend</span>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

UI update

## What is the current behavior?

The homepage hero displays an announcement badge promoting the State of Startups 2026 survey.

## What is the new behavior?

The announcement badge has been removed from the hero section, allowing the main heading to be more prominent.

## Additional context

Removed the AnnouncementBadge component and its import from the Hero component in apps/www.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed announcement badge from the Hero section

<!-- end of auto-generated comment: release notes by coderabbit.ai -->