### PR TITLE
chore: add AUP clause 1.6 - Privacy Violations, Doxxing, and Targeted Harassment

### DIFF
--- a/apps/www/pages/aup.mdx
+++ b/apps/www/pages/aup.mdx
@@ -10,7 +10,7 @@ export const meta = {
 
 # Acceptable Use Policy
 
-_Last Modified: 25 February 2026_
+_Last Modified: 1 June 2026_
 
 This Acceptable Use Policy (this "Policy") describes prohibited uses of the web services offered by Supabase, Inc. and its affiliates (the "Services") and the website located at https://supabase.com (the "Supabase Site").  
 By using the Services or accessing the Supabase Site, you agree to the latest version of this Policy. Violation of this Policy may result in the immediate suspension or termination of your Accounts and / or Services.
@@ -21,7 +21,8 @@ By using the Services or accessing the Supabase Site, you agree to the latest ve
 **1.2. Illegal & Fraudulent Activities:** Any activity that violates applicable laws or regulations. This includes but is not limited to the dissemination of child sexual abuse material (CSAM), promoting fraudulent schemes (e.g., Ponzi or "make-money-fast" scams), and identity theft.  
 **1.3. Infringing Content:** Content that infringes or misappropriates the intellectual property or proprietary rights of others, including wholesale copyright infringement (piracy) or hosting unauthorized streaming services.  
 **1.4. Harmful Technology:** Viruses, malware, Trojan horses, or any technology intended to damage systems and/or surreptitiously intercept data.  
-**1.5. Obfuscation:** Using techniques to obfuscate code or application logic uploaded to the Supabase platform to hide malicious intent or bypass platform detection and security controls.
+**1.5. Obfuscation:** Using techniques to obfuscate code or application logic uploaded to the Supabase platform to hide malicious intent or bypass platform detection and security controls.  
+**1.6. Privacy Violations, Doxxing, and Targeted Harassment:** You may not use the Services to publish, disclose, distribute, store, or facilitate the dissemination of another person's personal, confidential, or identifying information without an appropriate legal basis, authorization, or legitimate purpose. This includes using the Services to doxx, harass, intimidate, threaten, stalk, extort, facilitate abuse of, or otherwise target individuals. This provision does not prohibit lawful processing, publication, or distribution of information for legitimate purposes, including journalism, research, public-interest reporting, legal compliance, public records uses, or other activities protected by applicable law.
 
 ## 2. Artificial Intelligence and Content Manipulation
 


### PR DESCRIPTION
## Summary

Adds AUP clause **1.6 — Privacy Violations, Doxxing, and Targeted Harassment** to Section 1 (General Prohibitions), positioned between the existing 1.5 (Obfuscation) and Section 2.

**The wording for clause 1.6 was supplied verbatim by Supabase Legal.** This PR is the mechanical addition of that text in the right place with the right formatting and numbering — the wording itself is not up for review.

Driven by the "namehim" case — see the Slack `#team-security` investigation thread for the specific events that drove this addition. Codifies the AUP grounds for handling that abuse pattern so future enforcement actions for the same shape don't have to lean on General Prohibitions stretch interpretations.

Linear: [ABU-44](https://linear.app/supabase/issue/ABU-44/chore-add-aup-clause-16-privacy-violations-doxxing-and-targeted)

## What changed

- New clause 1.6 inserted in Section 1
- `_Last Modified:_` date bumped to 1 June 2026
- Trailing-two-spaces added to the previous 1.5 line so 1.6 renders on a new line (matches the existing within-section line-break convention)

## Wording rationale (per Legal)

The clause prohibits using the Services to publish, disclose, or facilitate dissemination of another person's personal/confidential/identifying information, plus using the Services to doxx, harass, intimidate, threaten, stalk, extort, or otherwise target individuals.

The legitimate-uses carve-out at the end was specifically requested by Legal:

> This provision does not prohibit lawful processing, publication, or distribution of information for legitimate purposes, including journalism, research, public-interest reporting, legal compliance, public records uses, or other activities protected by applicable law.

Keeps the clause from accidentally prohibiting customers doing journalism, public-records work, breach research, or other lawful uses.

## Open question for review

The AUP doesn't currently follow the date-suffixed-archive pattern that `privacy.mdx` does (e.g. `privacy-260316.mdx`). Should this substantive change trigger archiving the prior version as `aup-260225.mdx`? Flagging for the reviewers — happy to add the archive copy in a follow-up commit on this branch if so.

## Test plan

- [ ] Reviewer renders the page locally (`pnpm --filter www dev`, then `http://localhost:3000/aup`) and confirms clause 1.6 displays correctly between 1.5 and Section 2
- [ ] Clause numbering convention matches existing pattern (bold title with period and colon, two-trailing-space line breaks within sections)
- [x] Wording supplied by Supabase Legal (no wordsmith review required)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Acceptable Use Policy with an effective date of 1 June 2026.
  * Enhanced General Prohibitions section with revised Obfuscation guidance and newly added provisions addressing Privacy Violations, Doxxing, and Targeted Harassment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->