### PR TITLE
docs: add Next.js Drizzle template to serverless drivers

### DIFF
--- a/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
@@ -29,6 +29,17 @@ Choose one of these Vercel Deploy Templates which use our [Vercel Deploy Integra
         and Tailwind CSS.
       </GlassPanel>
     </Link>
+
+    <Link
+      href="https://supabase.link/nextjs-supabase-drizzle"
+      className="col-span-12 md:col-span-4"
+      passHref
+    >
+      <GlassPanel title="Drizzle" hasLightIcon={true} background={false} showIconBg={true}>
+        Simple Next.js template that uses Supabase as the database and Drizzle as the ORM.
+      </GlassPanel>
+    </Link>
+
     <Link
       href="https://supabase.link/nextjs-supabase-kysely"
       className="col-span-12 md:col-span-4"
@@ -75,8 +86,8 @@ export const UsersTable = pgTable(
   }
 )
 
-export type User = InferSelectModel<typeof UsersTable>
-export type NewUser = InferInsertModel<typeof UsersTable>
+export type User = InferSelectModel< typeof UsersTable>
+export type NewUser = InferInsertModel< typeof UsersTable>
 
 // Connect to Vercel Postgres
 export const db = drizzle(sql)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

Fixes #46529

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The Next.js Drizzle ORM template is missing from the template list in `serverless-drivers.mdx`.

## What is the new behavior?

Adds the Next.js Drizzle ORM template to the list of available templates:

* https://supabase.link/nextjs-supabase-drizzle

This makes the template easier to discover for developers looking to build with Next.js, Supabase, and Drizzle ORM.

## Additional context

This PR recreates the change from #46530, which was accidentally closed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Quickstart template card for Drizzle-based Next.js apps with an integrated Vercel deploy option.
  * Updated the Drizzle example snippet with minor generic-type formatting adjustments for improved readability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46568?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->