### PR TITLE
docs: fix broken internal links in database and telemetry guides

### DIFF
--- a/apps/docs/content/guides/database/postgres/data-deletion.mdx
+++ b/apps/docs/content/guides/database/postgres/data-deletion.mdx
@@ -202,4 +202,4 @@ The most efficient way to reclaim disk space, without locks, is to use [pg_repac
 - [Safe Cascading Deletes](/docs/guides/database/postgres/cascade-deletes)
 - [Inspecting your Database](/docs/guides/database/inspect)
 - [Understanding Database and Disk Size](/docs/guides/platform/database-size)
-- [Bloat in Postgres](/docs/blog/postgres-bloat)
+- [Bloat in Postgres](/blog/postgres-bloat)

--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -414,7 +414,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
             ```
             <Admonition type="note" title="conflict management">
 
-              If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma-troubleshooting) for more details
+              If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 
             </Admonition>
 

--- a/apps/docs/content/guides/telemetry/reports.mdx
+++ b/apps/docs/content/guides/telemetry/reports.mdx
@@ -133,7 +133,7 @@ Actions you can take:
 | Action                                                                      | Description                                    |
 | --------------------------------------------------------------------------- | ---------------------------------------------- |
 | [Upgrade compute size](/docs/guides/platform/compute-and-disk#compute-size) | Increase available memory resources            |
-| [Optimize queries](/docs/content/guides/database/query-optimization)        | Reduce memory consumption of expensive queries |
+| [Optimize queries](/docs/guides/database/query-optimization)                | Reduce memory consumption of expensive queries |
 | [Tune Postgres configuration](https://pgtune.leopard.in.ua)                 | Improve memory management settings             |
 | Implement application caching                                               | Add query result caching to reduce memory load |
 
@@ -169,12 +169,12 @@ How it helps debug issues:
 
 Actions you can take:
 
-| Action                                                                             | Description                                     |
-| ---------------------------------------------------------------------------------- | ----------------------------------------------- |
-| [Optimize CPU-intensive queries](/docs/content/guides/database/query-optimization) | Target queries causing high User CPU usage      |
-| Address IO bottlenecks                                                             | Resolve disk/network issues when IOWait is high |
-| [Upgrade compute size](/docs/guides/platform/compute-and-disk)                     | Increase available CPU capacity                 |
-| [Implement proper indexing](/docs/guides/database/postgres/indexes)                | Use query optimization techniques               |
+| Action                                                                     | Description                                     |
+| -------------------------------------------------------------------------- | ----------------------------------------------- |
+| [Optimize CPU-intensive queries](/docs/guides/database/query-optimization) | Target queries causing high User CPU usage      |
+| Address IO bottlenecks                                                     | Resolve disk/network issues when IOWait is high |
+| [Upgrade compute size](/docs/guides/platform/compute-and-disk)             | Increase available CPU capacity                 |
+| [Implement proper indexing](/docs/guides/database/postgres/indexes)        | Use query optimization techniques               |
 
 ### Disk input/output operations per second (IOPS)
 
@@ -227,7 +227,7 @@ Actions you can take:
 
 | Action                                                                               | Description                                                   |
 | ------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| [Optimize disk-intensive queries](/docs/content/guides/database/query-optimization)  | Reduce queries that perform excessive reads/writes            |
+| [Optimize disk-intensive queries](/docs/guides/database/query-optimization)          | Reduce queries that perform excessive reads/writes            |
 | Tune caching and batching                                                            | Minimize repeated disk access and improve throughput headroom |
 | [Upgrade compute size](/docs/guides/platform/compute-and-disk)                       | Increase throughput limits for sustained workloads            |
 | Review database design                                                               | Optimize schema and query patterns for efficiency             |


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (documentation) — fixes three internal links that currently 404.

## What is the current behavior?

Three docs pages link to internal paths that do not resolve (no matching page, and no redirect in `apps/www/lib/redirects.js`):

| File | Link | Problem |
| --- | --- | --- |
| `guides/telemetry/reports.mdx` (×3) | `/docs/content/guides/database/query-optimization` | Stray `content/` path segment (the content folder name leaked into the public URL) |
| `guides/database/prisma.mdx` | `/docs/guides/database/prisma-troubleshooting` | Page lives under the `prisma/` subfolder |
| `guides/database/postgres/data-deletion.mdx` | `/docs/blog/postgres-bloat` | Blog posts are served from `/blog`, not `/docs/blog` |

No related issue — these are self-evident broken links found by checking every internal `/docs/...` link against the actual pages, the redirects config, and the dynamic doc routes.

## What is the new behavior?

The links now point to the correct, existing pages:

- `/docs/guides/database/query-optimization` (page: `apps/docs/content/guides/database/query-optimization.mdx`)
- `/docs/guides/database/prisma/prisma-troubleshooting` (page: `apps/docs/content/guides/database/prisma/prisma-troubleshooting.mdx`)
- `/blog/postgres-bloat` (post: `apps/www/_blog/2024-04-26-postgres-bloat.mdx`; consistent with the ~30 other `/blog/...` links across the docs)

Docs-only change; no wording changes beyond the URLs. The `reports.mdx` tables were re-aligned by Prettier as a result of the shortened links.

## Additional context

For each link I confirmed the target page/post file exists, that the broken path has no rule in `apps/www/lib/redirects.js`, and that it is not served by a dynamic Next.js route under `apps/docs/app/`.
