### PR TITLE
fix: prevent state updates after component unmount

### DIFF
--- a/apps/studio/components/interfaces/Billing/Payment/AddNewPaymentMethodModal.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/AddNewPaymentMethodModal.tsx
@@ -2,7 +2,7 @@ import HCaptcha from '@hcaptcha/react-hcaptcha'
 import { Elements } from '@stripe/react-stripe-js'
 import { loadStripe } from '@stripe/stripe-js'
 import { useTheme } from 'next-themes'
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Dialog, DialogContent, DialogHeader, DialogSectionSeparator, DialogTitle } from 'ui'
 
@@ -33,6 +33,13 @@ const AddNewPaymentMethodModal = ({
 
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [captchaRef, setCaptchaRef] = useState<HCaptcha | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   const { mutate: setupIntent } = useOrganizationPaymentMethodSetupIntent({
     onSuccess: (intent) => {
@@ -71,6 +78,9 @@ const AddNewPaymentMethodModal = ({
         }
 
         await initSetupIntent(token ?? undefined)
+
+        if (!isMounted.current) return
+
         resetCaptcha()
       }
     }

--- a/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
+++ b/apps/studio/components/interfaces/Billing/Payment/AddPaymentMethodForm.tsx
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { Button, Checkbox, DialogFooter, DialogSection, Label } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
@@ -51,6 +51,13 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
   })
 
   const paymentRef = useRef<PaymentMethodElementRef | null>(null)
+  const isMounted = useRef(true)
+
+  useEffect(() => {
+    return () => {
+      isMounted.current = false
+    }
+  }, [])
 
   const handleSubmit = async (event: any) => {
     event.preventDefault()
@@ -106,6 +113,8 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
 
     // Dry run passed — proceed with Stripe payment method creation / 3DS
     const result = await paymentRef.current?.confirmSetup()
+
+    if (!isMounted.current) return
 
     if (!result) {
       setIsSaving(false)
@@ -165,6 +174,8 @@ const AddPaymentMethodForm = ({ onCancel, onConfirm }: AddPaymentMethodFormProps
           })
         }
       }
+
+      if (!isMounted.current) return
 
       setIsSaving(false)
       onConfirm()


### PR DESCRIPTION
## I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Async operations in the payment flow can continue after a component has unmounted, which may result in state updates and callbacks being executed on unmounted components.

Closes #46546

## What is the new behavior?

Adds mounted-state guards to prevent state updates and callbacks from running after component unmount.

### Changes

- Added mounted-state tracking in `AddPaymentMethodForm`
- Added mounted-state tracking in `AddNewPaymentMethodModal`
- Prevented `setIsSaving`, `onConfirm`, and `resetCaptcha` from executing after component unmount

## Additional context

This change addresses potential state updates after unmount during async payment setup and confirmation flows.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of payment method modals by preventing state updates after component unmount, reducing potential console warnings and errors during cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->