### PR TITLE
Add Quintin Willison to `humans.txt`

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -218,6 +218,7 @@ Peter Lyn
 Peter Soderberg
 Pierre Ducroquet
 Qiao Han
+Quintin Willison
 Rafael Chacón
 Raminder Singh
 Raúl Barroso


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds my name to the public-facing `humans.txt` endpoint on `supabase.com`.

## What is the current behavior?

Existing humans listed without me.

## What is the new behavior?

I become listed as another human. 🎉 

## Additional context

I think that's enough already. 😈 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated team information in public documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->