### PR TITLE
[DO NOT MERGE] feat(studio): banner when org exceeds logs quota FE-3403

### DIFF
--- a/apps/studio/components/interfaces/Organization/restriction.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.tsx
@@ -54,4 +54,13 @@ export const RESTRICTION_MESSAGES = {
       </>
     ),
   },
+  LOGS_QUOTA_EXCEEDED: {
+    title: 'Logs quota exceeded',
+    description: (slug: string, metricLabels: string[]): ReactNode => (
+      <>
+        Your organization has exceeded its {metricLabels.join(' and ')} quota.{' '}
+        <InlineLink href={`/org/${slug}/usage`}>Review usage</InlineLink>
+      </>
+    ),
+  },
 }

--- a/apps/studio/components/ui/DevToolbar/OrgBannersTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/OrgBannersTab.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { useEffect, useRef, useState } from 'react'
+import { cn } from 'ui'
+
+import { PricingMetric } from '@/data/analytics/org-daily-stats-query'
+import { usageKeys } from '@/data/usage/keys'
+import type { OrgMetricsUsage, OrgUsageData } from '@/data/usage/org-usage-query'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+
+const LOGS_METRICS = [
+  { metric: PricingMetric.LOG_INGESTION, label: 'Log Ingestion' },
+  { metric: PricingMetric.LOG_QUERYING, label: 'Log Query' },
+] as const
+
+type LogsMetric = (typeof LOGS_METRICS)[number]['metric']
+type ExceededState = Record<LogsMetric, boolean>
+
+const INITIAL_STATE: ExceededState = {
+  [PricingMetric.LOG_INGESTION]: false,
+  [PricingMetric.LOG_QUERYING]: false,
+}
+
+/**
+ * Build a usage entry that trips the exceeded-quota predicate in
+ * useOrganizationRestrictions (capped, not unlimited, usage over free units).
+ */
+const makeExceededMetric = (metric: LogsMetric): OrgMetricsUsage => ({
+  metric,
+  usage: 100,
+  usage_original: 100,
+  cost: 0,
+  unit_price_desc: 'Mocked via DevToolbar',
+  available_in_plan: true,
+  unlimited: false,
+  capped: true,
+  pricing_free_units: 1,
+  pricing_strategy: 'UNIT',
+  project_allocations: [],
+})
+
+export const OrgBannersTab = () => {
+  const queryClient = useQueryClient()
+  const { data: selectedOrg, isLoading: isOrgLoading } = useSelectedOrganizationQuery()
+  const orgSlug = selectedOrg?.slug
+  const [exceeded, setExceeded] = useState<ExceededState>(INITIAL_STATE)
+
+  // Track the latest slug so the unmount cleanup invalidates the correct cache
+  // key even when the slug was still loading at mount time.
+  const latestSlug = useRef(orgSlug)
+  useEffect(() => {
+    latestSlug.current = orgSlug
+  })
+
+  // Only invalidate on unmount if overrides were actually applied, to avoid
+  // unnecessary refetches when the toolbar is opened but this tab is unused.
+  const hasOverridesRef = useRef(false)
+
+  // Revert to real usage data when the toolbar sheet closes (unmounts this tab).
+  useEffect(() => {
+    return () => {
+      if (!hasOverridesRef.current || !latestSlug.current) return
+      queryClient.invalidateQueries({ queryKey: usageKeys.orgUsage(latestSlug.current) })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const applyOverrides = (next: ExceededState) => {
+    if (!orgSlug) return
+    const current = queryClient.getQueryData<OrgUsageData>(usageKeys.orgUsage(orgSlug))
+    const baseUsages = (current?.usages ?? []).filter(
+      (metric) =>
+        metric.metric !== PricingMetric.LOG_INGESTION &&
+        metric.metric !== PricingMetric.LOG_QUERYING
+    )
+    const mockedUsages = LOGS_METRICS.filter(({ metric }) => next[metric]).map(({ metric }) =>
+      makeExceededMetric(metric)
+    )
+    queryClient.setQueryData<OrgUsageData>(usageKeys.orgUsage(orgSlug), {
+      usage_billing_enabled: current?.usage_billing_enabled ?? true,
+      usages: [...baseUsages, ...mockedUsages],
+    })
+    hasOverridesRef.current = true
+  }
+
+  const handleToggle = (metric: LogsMetric, value: boolean) => {
+    const next = { ...exceeded, [metric]: value }
+    setExceeded(next)
+    applyOverrides(next)
+  }
+
+  const handleReset = () => {
+    setExceeded(INITIAL_STATE)
+    hasOverridesRef.current = false
+    if (orgSlug) {
+      queryClient.invalidateQueries({ queryKey: usageKeys.orgUsage(orgSlug) })
+    }
+  }
+
+  const isDisabled = isOrgLoading || !orgSlug
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-foreground-light">
+          Override the logs quota banner for the current organization.
+        </p>
+        <button
+          onClick={handleReset}
+          disabled={isDisabled}
+          className="text-xs text-foreground-lighter hover:text-foreground transition underline disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Reset to real data
+        </button>
+      </div>
+
+      {isDisabled && <p className="text-xs text-foreground-muted">Loading org context...</p>}
+
+      <div className={cn('space-y-3', isDisabled && 'opacity-50 pointer-events-none')}>
+        {LOGS_METRICS.map(({ metric, label }) => (
+          <div key={metric} className="flex items-center justify-between">
+            <span className="text-sm text-foreground-light">{label} quota exceeded</span>
+            <div className="flex gap-1">
+              <ToggleButton active={!exceeded[metric]} onClick={() => handleToggle(metric, false)}>
+                Off
+              </ToggleButton>
+              <ToggleButton
+                active={exceeded[metric]}
+                variant="warning"
+                onClick={() => handleToggle(metric, true)}
+              >
+                Exceeded
+              </ToggleButton>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+interface ToggleButtonProps {
+  active: boolean
+  variant?: 'off' | 'warning'
+  onClick: () => void
+  children: React.ReactNode
+}
+
+const ToggleButton = ({ active, variant = 'off', onClick, children }: ToggleButtonProps) => (
+  <button
+    onClick={onClick}
+    className={cn(
+      'px-1.5 py-0.5 rounded-sm text-xs font-mono transition border',
+      active
+        ? variant === 'off'
+          ? 'bg-surface-300 text-foreground border-strong'
+          : 'bg-warning/20 text-warning border-warning'
+        : 'bg-transparent text-foreground-muted border-transparent hover:border-border'
+    )}
+  >
+    {children}
+  </button>
+)

--- a/apps/studio/hooks/misc/useOrganizationRestrictions.ts
+++ b/apps/studio/hooks/misc/useOrganizationRestrictions.ts
@@ -2,14 +2,25 @@ import type { ReactNode } from 'react'
 
 import { useIsFeatureEnabled } from './useIsFeatureEnabled'
 import { RESTRICTION_MESSAGES } from '@/components/interfaces/Organization/restriction.constants'
+import { PricingMetric } from '@/data/analytics/org-daily-stats-query'
 import { useOverdueInvoicesQuery } from '@/data/invoices/invoices-overdue-query'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
+import { useOrgUsageQuery } from '@/data/usage/org-usage-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 
 export type WarningBannerProps = {
   variant: 'danger' | 'warning' | 'note'
   title: string
   description: ReactNode
+}
+
+/**
+ * Logs metrics that are subject to fair-use quotas, mapped to the labels used on
+ * the org usage page. Keep these in sync with the logs entries in Usage.constants.
+ */
+const LOGS_QUOTA_METRIC_LABELS: Partial<Record<PricingMetric, string>> = {
+  [PricingMetric.LOG_INGESTION]: 'Log Ingestion',
+  [PricingMetric.LOG_QUERYING]: 'Log Query',
 }
 
 /**
@@ -27,6 +38,7 @@ export function useOrganizationRestrictions() {
 
   const { data: overdueInvoices } = useOverdueInvoicesQuery()
   const { data: organizations } = useOrganizationsQuery()
+  const { data: usage, isSuccess: isSuccessOrgUsage } = useOrgUsageQuery({ orgSlug: org?.slug })
 
   const warnings: WarningBannerProps[] = []
 
@@ -88,6 +100,35 @@ export function useOrganizationRestrictions() {
       title: RESTRICTION_MESSAGES.RESTRICTED.title,
       description: RESTRICTION_MESSAGES.RESTRICTED.description(org.slug),
     })
+  }
+
+  // Logs fair-use quota banner. Suppressed while the org is under a billing
+  // restriction status (those banners cover the same exceeded-quota situation)
+  // and until usage has loaded, to avoid flashing stale cross-org data. Uses
+  // the same exceeded-quota predicate as the in-page Restriction component, so
+  // it auto-resolves once usage drops back under the quota.
+  if (!org?.restriction_status && isSuccessOrgUsage) {
+    const exceededLogsMetricLabels = (usage?.usages ?? [])
+      .filter(
+        (metric) =>
+          (metric.metric === PricingMetric.LOG_INGESTION ||
+            metric.metric === PricingMetric.LOG_QUERYING) &&
+          !metric.unlimited &&
+          metric.capped &&
+          metric.usage > (metric.pricing_free_units ?? 0)
+      )
+      .map((metric) => LOGS_QUOTA_METRIC_LABELS[metric.metric as PricingMetric] ?? metric.metric)
+
+    if (exceededLogsMetricLabels.length > 0) {
+      warnings.push({
+        variant: 'warning',
+        title: RESTRICTION_MESSAGES.LOGS_QUOTA_EXCEEDED.title,
+        description: RESTRICTION_MESSAGES.LOGS_QUOTA_EXCEEDED.description(
+          org?.slug ?? 'default',
+          exceededLogsMetricLabels
+        ),
+      })
+    }
   }
 
   return { warnings, org }

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -82,8 +82,15 @@ const ResourceWarningsTab = IS_DEV_TOOLBAR_ENABLED
     )
   : () => null
 
+const OrgBannersTab = IS_DEV_TOOLBAR_ENABLED
+  ? dynamic(() => import('@/components/ui/DevToolbar/OrgBannersTab').then((m) => m.OrgBannersTab))
+  : () => null
+
 const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
-  ? [{ id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> }]
+  ? [
+      { id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> },
+      { id: 'org-banners', label: 'Org Banners', content: <OrgBannersTab /> },
+    ]
   : []
 
 const FeatureFlagProviderWithOrgContext = ({


### PR DESCRIPTION
> [!WARNING]
> **Do not merge yet.** Holding until the Logs Pricing launch (July 1) and its backend dependency GROWTH-887 (enforce fair use for Logs Ingest/Query) are ready. The banner only triggers once logs metrics are configured as limited usage-based prices, so there is no flag — we are simply waiting to merge until the launch window.

## Problem

As part of the Logs Pricing launch, orgs that exceed a logs quota (ingest or query) are only notified by email. Studio surfaces no in-product signal, so customers can be unaware they are over quota.

## Fix

Show an org-level banner in Studio when the organization has exceeded its logs ingest or logs query fair-use quota. The banner reuses the existing `OrganizationResourceBanner` pattern (no new primitives) and links to the org usage page.

- Add `LOGS_QUOTA_EXCEEDED` message to `restriction.constants`.
- Detect exceeded `LOG_INGESTION` / `LOG_QUERYING` metrics in `useOrganizationRestrictions`, using the same `capped` and free-units predicate as the in-page `Restriction` component.
- Suppress the banner while a billing restriction status is already active, and until usage has loaded (avoids flashing stale cross-org data).
- Auto-resolves once usage drops back under quota, since the hook recomputes from `useOrgUsageQuery`.
- Add an "Org Banners" DevToolbar tab to mock the banner by overriding the org usage query cache. The DevToolbar is enabled on both local and staging.

Note: the banner only triggers once the org's Orb plan has logs ingest/query configured as limited usage-based prices (GROWTH-887). Until then it stays hidden, with no errors.

## How to test

- Open the studio-staging preview deploy for this PR: https://studio-staging-git-jordi-fe-3403-logs-quota-banner-supabase.vercel.app and navigate to an organization (or run Studio locally with `NEXT_PUBLIC_ENVIRONMENT=local`).
- Open the DevToolbar and go to the "Org Banners" tab.
- Toggle "Log Ingestion quota exceeded" and/or "Log Query quota exceeded" to "Exceeded".
- Expected result: a warning banner appears at the top reading "Logs quota exceeded" with a "Review usage" link to `/org/<slug>/usage`.
- Toggle back to "Off" or click "Reset to real data".
- Expected result: the banner disappears.