### PR TITLE
fix: create pr need contents-write

### DIFF
--- a/.github/workflows/update-js-libs.yml
+++ b/.github/workflows/update-js-libs.yml
@@ -94,6 +94,7 @@ jobs:
           app-id: ${{ secrets.GH_AUTOFIX_APP_ID }}
           private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
           permission-pull-requests: write
+          permission-contents: write
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?

Bug fix - CI

## What is the current behavior?

action fails: https://github.com/supabase/supabase/actions/runs/26818877603/job/79068294605

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow permissions to enhance automated update capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->