### PR TITLE
fix: visual bug in webhook configuration UI

### DIFF
--- a/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
+++ b/apps/studio/components/interfaces/Database/Hooks/FormContents.tsx
@@ -252,7 +252,7 @@ export const FormContents = ({ form, selectedHook }: FormContentsProps) => {
                         label=""
                         showIndicator={false}
                       >
-                        <div className="flex items-center space-x-5">
+                        <div className="flex items-center gap-5">
                           <Image
                             alt={webhook.label}
                             src={webhook.icon}


### PR DESCRIPTION
Before:
<img width="752" height="230" alt="image" src="https://github.com/user-attachments/assets/1cfce3c9-26fa-4b36-bf1b-fa3c4e7560fc" />

After:
<img width="747" height="227" alt="image" src="https://github.com/user-attachments/assets/7b1b6654-3532-4fca-8fbc-dae38ea99dc1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing in the webhook type selector UI for improved visual alignment and consistency across the database hooks interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->