### PR TITLE
fix(logs): allow mouse wheel scroll in field reference source picker

### DIFF
--- a/apps/studio/components/ui/Logs/LogsExplorerHeader.tsx
+++ b/apps/studio/components/ui/Logs/LogsExplorerHeader.tsx
@@ -1,5 +1,6 @@
 import { BookOpen, Check, ChevronsUpDown, Copy, ExternalLink, List, X } from 'lucide-react'
 import Link from 'next/link'
+import { Popover as PopoverPrimitive } from 'radix-ui'
 import { useState } from 'react'
 import { logConstants } from 'shared-data'
 import {
@@ -13,7 +14,6 @@ import {
   CommandList,
   copyToClipboard,
   Popover,
-  PopoverContent,
   PopoverTrigger,
   SidePanel,
   Tooltip,
@@ -114,7 +114,12 @@ const LogsExplorerHeader = ({ subtitle }: LogsExplorerHeaderProps) => {
                   {selectedSchema?.name ?? 'Select source...'}
                 </Button>
               </PopoverTrigger>
-              <PopoverContent className="p-0" sameWidthAsTrigger>
+              <PopoverPrimitive.Content
+                align="center"
+                sideOffset={4}
+                style={{ width: 'var(--radix-popover-trigger-width)' }}
+                className="z-50 rounded-md border border-overlay bg-overlay p-0 text-popover-foreground shadow-md outline-hidden animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
+              >
                 <Command>
                   <CommandInput placeholder="Search source..." />
                   <CommandList>
@@ -141,7 +146,7 @@ const LogsExplorerHeader = ({ subtitle }: LogsExplorerHeaderProps) => {
                     </CommandGroup>
                   </CommandList>
                 </Command>
-              </PopoverContent>
+              </PopoverPrimitive.Content>
             </Popover>
             <Table
               head={[

--- a/apps/studio/components/ui/Logs/LogsExplorerHeader.tsx
+++ b/apps/studio/components/ui/Logs/LogsExplorerHeader.tsx
@@ -1,6 +1,5 @@
 import { BookOpen, Check, ChevronsUpDown, Copy, ExternalLink, List, X } from 'lucide-react'
 import Link from 'next/link'
-import { Popover as PopoverPrimitive } from 'radix-ui'
 import { useState } from 'react'
 import { logConstants } from 'shared-data'
 import {
@@ -14,7 +13,9 @@ import {
   CommandList,
   copyToClipboard,
   Popover,
+  PopoverContent,
   PopoverTrigger,
+  ScrollArea,
   SidePanel,
   Tooltip,
   TooltipContent,
@@ -101,7 +102,7 @@ const LogsExplorerHeader = ({ subtitle }: LogsExplorerHeaderProps) => {
           </SidePanel.Content>
           <SidePanel.Separator />
           <div className="px-4 pb-4 flex flex-col gap-4">
-            <Popover open={open} onOpenChange={setOpen}>
+            <Popover open={open} onOpenChange={setOpen} modal={false}>
               <PopoverTrigger asChild>
                 <Button
                   type="default"
@@ -114,39 +115,36 @@ const LogsExplorerHeader = ({ subtitle }: LogsExplorerHeaderProps) => {
                   {selectedSchema?.name ?? 'Select source...'}
                 </Button>
               </PopoverTrigger>
-              <PopoverPrimitive.Content
-                align="center"
-                sideOffset={4}
-                style={{ width: 'var(--radix-popover-trigger-width)' }}
-                className="z-50 rounded-md border border-overlay bg-overlay p-0 text-popover-foreground shadow-md outline-hidden animate-in data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2"
-              >
+              <PopoverContent className="p-0 pointer-events-auto" sameWidthAsTrigger>
                 <Command>
                   <CommandInput placeholder="Search source..." />
-                  <CommandList>
+                  <CommandList onWheel={(event) => event.stopPropagation()}>
                     <CommandEmpty>No source found.</CommandEmpty>
                     <CommandGroup>
-                      {logConstants.schemas.map((schema) => (
-                        <CommandItem
-                          key={schema.reference}
-                          value={schema.reference}
-                          onSelect={() => {
-                            setSelectedSchema(schema)
-                            setOpen(false)
-                          }}
-                        >
-                          <Check
-                            className={cn(
-                              'mr-2 h-4 w-4',
-                              selectedSchema === schema ? 'opacity-100' : 'opacity-0'
-                            )}
-                          />
-                          {schema.name}
-                        </CommandItem>
-                      ))}
+                      <ScrollArea className={logConstants.schemas.length > 7 ? 'h-[210px]' : ''}>
+                        {logConstants.schemas.map((schema) => (
+                          <CommandItem
+                            key={schema.reference}
+                            value={schema.reference}
+                            onSelect={() => {
+                              setSelectedSchema(schema)
+                              setOpen(false)
+                            }}
+                          >
+                            <Check
+                              className={cn(
+                                'mr-2 h-4 w-4',
+                                selectedSchema === schema ? 'opacity-100' : 'opacity-0'
+                              )}
+                            />
+                            {schema.name}
+                          </CommandItem>
+                        ))}
+                      </ScrollArea>
                     </CommandGroup>
                   </CommandList>
                 </Command>
-              </PopoverPrimitive.Content>
+              </PopoverContent>
             </Popover>
             <Table
               head={[


### PR DESCRIPTION
## Problem

In Logs Explorer, opening the Field Reference side panel and clicking the source picker shows a list of log sources, but mouse wheel scrolling inside that list does not work. Users can only navigate by keyboard or scrollbar drag.

The picker is a Popover whose content is portaled to `document.body`, which sits outside the SidePanel's Radix Dialog tree. The Dialog's scroll lock (react-remove-scroll) intercepts wheel events on elements outside its tree, so the Popover's `CommandList` never receives them.

## Fix

Render the Popover content inline via `PopoverPrimitive.Content` (no Portal) so it lives inside the Dialog tree. Wheel events are no longer blocked by the scroll lock and the source list scrolls normally.

## How to test

- Open Studio and navigate to Logs Explorer
- Click "Field Reference" to open the side panel
- Click the source dropdown
- Hover over the list of sources and scroll with the mouse wheel
- Expected: the list scrolls through all sources