### PR TITLE
fix(self-hosted): reveal and copy secret api key in project settings

### DIFF
--- a/apps/studio/components/interfaces/APIKeys/ApiKeyPill.test.tsx
+++ b/apps/studio/components/interfaces/APIKeys/ApiKeyPill.test.tsx
@@ -78,7 +78,6 @@ describe('ApiKeyPill', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Reveal API key' }))
 
-    // The pill renders the masked prefix + the revealed tail (revealedKey.slice(15)).
     expect(await screen.findByText(FULL.slice(15))).toBeInTheDocument()
   })
 
@@ -89,7 +88,6 @@ describe('ApiKeyPill', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Copy API key' }))
 
     await waitFor(() => expect(mockCopyToClipboard).toHaveBeenCalledTimes(1))
-    // CopyButton hands copyToClipboard a Promise<string> (onCopy reveals via MSW).
     await expect(Promise.resolve(mockCopyToClipboard.mock.calls[0][0])).resolves.toBe(FULL)
   })
 })

--- a/apps/studio/components/interfaces/APIKeys/ApiKeyPill.test.tsx
+++ b/apps/studio/components/interfaces/APIKeys/ApiKeyPill.test.tsx
@@ -1,0 +1,95 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { components } from 'api-types'
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiKeyPill } from './ApiKeyPill'
+import type { APIKeysData } from '@/data/api-keys/api-keys-query'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+type ApiKeyResponse = components['schemas']['ApiKeyResponse']
+
+// Permissions are non-network global state — mock the hook (the skill's allowed
+// exception), matching the neighboring PublishableAPIKeys.test.tsx.
+const { mockUseAsyncCheckPermissions } = vi.hoisted(() => ({
+  mockUseAsyncCheckPermissions: vi.fn(),
+}))
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+// CopyButton writes via copyToClipboard from 'ui'. Stub just that export so we can
+// assert the value handed to the clipboard without depending on jsdom's
+// document.hasFocus() / navigator.clipboard. Everything else in 'ui' stays real.
+const { mockCopyToClipboard } = vi.hoisted(() => ({ mockCopyToClipboard: vi.fn() }))
+vi.mock('ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('ui')>()),
+  copyToClipboard: mockCopyToClipboard,
+}))
+
+// The masked value the list endpoint returns for a secret key (first 15 chars),
+// and the full key the reveal-by-id endpoint returns.
+const MASKED = 'sb_secret_abcde'
+const FULL = 'sb_secret_abcdefghijklmnop'
+
+// ApiKeyPill is strongly typed against the query's secret-key shape; the fields it
+// reads are id/type/api_key, so cast a minimal object through unknown.
+const secretKey = {
+  id: 'secret',
+  name: 'secret',
+  type: 'secret',
+  api_key: MASKED,
+  prefix: MASKED,
+} as unknown as Extract<APIKeysData[number], { type: 'secret' }>
+
+function mockRevealById() {
+  addAPIMock({
+    method: 'get',
+    path: '/v1/projects/:ref/api-keys/:id',
+    response: () =>
+      HttpResponse.json<ApiKeyResponse>({
+        id: 'secret',
+        name: 'secret',
+        type: 'secret',
+        api_key: FULL,
+        prefix: MASKED,
+      }),
+  })
+}
+
+describe('ApiKeyPill', () => {
+  beforeEach(() => {
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isLoading: false })
+    mockCopyToClipboard.mockClear()
+  })
+
+  it('masks the secret key by default and does not expose the full key', () => {
+    customRender(<ApiKeyPill apiKey={secretKey} />)
+
+    expect(screen.getByText(MASKED)).toBeInTheDocument()
+    expect(screen.queryByText(FULL.slice(15))).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reveal API key' })).toBeInTheDocument()
+  })
+
+  it('reveals the full secret key when the reveal button is clicked', async () => {
+    mockRevealById()
+    customRender(<ApiKeyPill apiKey={secretKey} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reveal API key' }))
+
+    // The pill renders the masked prefix + the revealed tail (revealedKey.slice(15)).
+    expect(await screen.findByText(FULL.slice(15))).toBeInTheDocument()
+  })
+
+  it('copies the full secret key to the clipboard', async () => {
+    mockRevealById()
+    customRender(<ApiKeyPill apiKey={secretKey} />)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Copy API key' }))
+
+    await waitFor(() => expect(mockCopyToClipboard).toHaveBeenCalledTimes(1))
+    // CopyButton hands copyToClipboard a Promise<string> (onCopy reveals via MSW).
+    await expect(Promise.resolve(mockCopyToClipboard.mock.calls[0][0])).resolves.toBe(FULL)
+  })
+})

--- a/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
+++ b/apps/studio/components/interfaces/APIKeys/ApiKeyPill.tsx
@@ -112,6 +112,7 @@ export function ApiKeyPill({
           <TooltipTrigger asChild>
             <Button
               type="outline"
+              aria-label={show ? 'Hide API key' : 'Reveal API key'}
               className="rounded-full px-2 pointer-events-auto"
               loading={show && isLoading}
               icon={show ? <EyeOff strokeWidth={2} /> : <Eye strokeWidth={2} />}
@@ -135,6 +136,7 @@ export function ApiKeyPill({
         <TooltipTrigger asChild>
           <CopyButton
             type="default"
+            aria-label="Copy API key"
             asyncText={onCopy}
             iconOnly
             className="rounded-full px-2 pointer-events-auto"

--- a/apps/studio/lib/api/self-hosted/api-keys.ts
+++ b/apps/studio/lib/api/self-hosted/api-keys.ts
@@ -1,0 +1,109 @@
+/**
+ * Synthesizes API key responses for non-platform Studio (local CLI and
+ * self-hosted Docker). Both deployment modes inject the same env vars
+ * (`SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY`, and optionally
+ * `SUPABASE_PUBLISHABLE_KEY` / `SUPABASE_SECRET_KEY`); there is no
+ * CLI-vs-Docker branching here.
+ *
+ * Consumed by the `/api/v1/projects/[ref]/api-keys` mock routes, which
+ * stand in for the platform management API on single-tenant Studio builds.
+ *
+ * _Only call this from server-side non-platform code._
+ */
+import { assertSelfHosted } from './util'
+
+export type NonPlatformApiKey = {
+  name: string
+  api_key: string
+  id: string
+  type: 'legacy' | 'publishable' | 'secret'
+  hash: string
+  prefix: string
+  description: string
+}
+
+/**
+ * Length of the identifying prefix shown for a secret key before it is
+ * revealed. Mirrors the platform management API and the `ApiKeyPill` UI, both
+ * of which expose `sb_secret_` (10 chars) + 5 identifying chars = 15 (see
+ * `ApiKeyPill`'s `api_key.slice(0, 15)` and the `sb_secret_8I4Se•••` mock in
+ * `ApiKeysIllustrations`).
+ */
+const SECRET_KEY_VISIBLE_PREFIX_LENGTH = 15
+
+export function parseRevealQuery(value: string | string[] | undefined): boolean {
+  const raw = Array.isArray(value) ? value[0] : value
+  return raw === 'true'
+}
+
+export function getNonPlatformApiKeys(): NonPlatformApiKey[] {
+  assertSelfHosted()
+
+  const keys: NonPlatformApiKey[] = [
+    {
+      name: 'anon',
+      api_key: process.env.SUPABASE_ANON_KEY ?? '',
+      id: 'anon',
+      type: 'legacy',
+      hash: '',
+      prefix: '',
+      description: 'Legacy anon API key',
+    },
+    {
+      name: 'service_role',
+      api_key: process.env.SUPABASE_SERVICE_KEY ?? '',
+      id: 'service_role',
+      type: 'legacy',
+      hash: '',
+      prefix: '',
+      description: 'Legacy service_role API key',
+    },
+  ]
+
+  const publishableKey = process.env.SUPABASE_PUBLISHABLE_KEY
+  if (publishableKey) {
+    keys.push({
+      name: 'publishable',
+      api_key: publishableKey,
+      id: 'publishable',
+      type: 'publishable',
+      hash: '',
+      prefix: '',
+      description: 'Publishable API key (anon role)',
+    })
+  }
+
+  const secretKey = process.env.SUPABASE_SECRET_KEY
+  if (secretKey) {
+    keys.push({
+      name: 'secret',
+      api_key: secretKey,
+      id: 'secret',
+      type: 'secret',
+      hash: '',
+      // The prefix is always exposed; only the remainder of the key is masked
+      // until revealed (matches the platform management API).
+      prefix: secretKey.slice(0, SECRET_KEY_VISIBLE_PREFIX_LENGTH),
+      description: 'Secret API key (service_role)',
+    })
+  }
+
+  return keys
+}
+
+export function applyRevealToApiKey(key: NonPlatformApiKey, reveal: boolean): NonPlatformApiKey {
+  if (key.type !== 'secret' || reveal) return key
+
+  // Masked: expose only the identifying prefix, never the full secret.
+  return { ...key, api_key: key.prefix }
+}
+
+export function getNonPlatformApiKeyById(
+  id: string,
+  reveal: boolean
+): NonPlatformApiKey | undefined {
+  const key = getNonPlatformApiKeys().find((entry) => entry.id === id)
+  if (!key) return undefined
+
+  return applyRevealToApiKey(key, reveal)
+}

--- a/apps/studio/lib/api/self-hosted/api-keys.ts
+++ b/apps/studio/lib/api/self-hosted/api-keys.ts
@@ -81,9 +81,15 @@ export function getNonPlatformApiKeys(): NonPlatformApiKey[] {
       id: 'secret',
       type: 'secret',
       hash: '',
-      // The prefix is always exposed; only the remainder of the key is masked
-      // until revealed (matches the platform management API).
-      prefix: secretKey.slice(0, SECRET_KEY_VISIBLE_PREFIX_LENGTH),
+      // The prefix is exposed while the rest of the key stays masked until
+      // revealed (matches the platform management API). Only expose it when the
+      // key is genuinely longer than the prefix — otherwise the "prefix" would
+      // be the whole secret, so we mask entirely to avoid leaking a short or
+      // misconfigured key in the unrevealed response.
+      prefix:
+        secretKey.length > SECRET_KEY_VISIBLE_PREFIX_LENGTH
+          ? secretKey.slice(0, SECRET_KEY_VISIBLE_PREFIX_LENGTH)
+          : '',
       description: 'Secret API key (service_role)',
     })
   }

--- a/apps/studio/lib/api/self-hosted/api-keys.ts
+++ b/apps/studio/lib/api/self-hosted/api-keys.ts
@@ -1,14 +1,5 @@
 /**
- * Synthesizes API key responses for non-platform Studio (local CLI and
- * self-hosted Docker). Both deployment modes inject the same env vars
- * (`SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_KEY`, and optionally
- * `SUPABASE_PUBLISHABLE_KEY` / `SUPABASE_SECRET_KEY`); there is no
- * CLI-vs-Docker branching here.
- *
- * Consumed by the `/api/v1/projects/[ref]/api-keys` mock routes, which
- * stand in for the platform management API on single-tenant Studio builds.
- *
- * _Only call this from server-side non-platform code._
+ * Both CLI and self-hosted inject the same env vars.
  */
 import { assertSelfHosted } from './util'
 
@@ -24,10 +15,7 @@ export type NonPlatformApiKey = {
 
 /**
  * Length of the identifying prefix shown for a secret key before it is
- * revealed. Mirrors the platform management API and the `ApiKeyPill` UI, both
- * of which expose `sb_secret_` (10 chars) + 5 identifying chars = 15 (see
- * `ApiKeyPill`'s `api_key.slice(0, 15)` and the `sb_secret_8I4Se•••` mock in
- * `ApiKeysIllustrations`).
+ * revealed. Mirrors the platform management API and the `ApiKeyPill` UI.
  */
 const SECRET_KEY_VISIBLE_PREFIX_LENGTH = 15
 
@@ -81,11 +69,7 @@ export function getNonPlatformApiKeys(): NonPlatformApiKey[] {
       id: 'secret',
       type: 'secret',
       hash: '',
-      // The prefix is exposed while the rest of the key stays masked until
-      // revealed (matches the platform management API). Only expose it when the
-      // key is genuinely longer than the prefix — otherwise the "prefix" would
-      // be the whole secret, so we mask entirely to avoid leaking a short or
-      // misconfigured key in the unrevealed response.
+      // Only expose the prefix when the key is genuinely longer than the prefix.
       prefix:
         secretKey.length > SECRET_KEY_VISIBLE_PREFIX_LENGTH
           ? secretKey.slice(0, SECRET_KEY_VISIBLE_PREFIX_LENGTH)
@@ -100,7 +84,6 @@ export function getNonPlatformApiKeys(): NonPlatformApiKey[] {
 export function applyRevealToApiKey(key: NonPlatformApiKey, reveal: boolean): NonPlatformApiKey {
   if (key.type !== 'secret' || reveal) return key
 
-  // Masked: expose only the identifying prefix, never the full secret.
   return { ...key, api_key: key.prefix }
 }
 

--- a/apps/studio/pages/api/v1/projects/[ref]/api-keys/[id].ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/api-keys/[id].ts
@@ -1,12 +1,11 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import apiWrapper from '@/lib/api/apiWrapper'
-import {
-  getNonPlatformApiKeyById,
-  parseRevealQuery,
-} from '@/lib/api/self-hosted/api-keys'
+import { getNonPlatformApiKeyById, parseRevealQuery } from '@/lib/api/self-hosted/api-keys'
 
-export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
+const apiKeyByIdRoute = (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
+
+export default apiKeyByIdRoute
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { method } = req

--- a/apps/studio/pages/api/v1/projects/[ref]/api-keys/[id].ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/api-keys/[id].ts
@@ -2,8 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import apiWrapper from '@/lib/api/apiWrapper'
 import {
-  applyRevealToApiKey,
-  getNonPlatformApiKeys,
+  getNonPlatformApiKeyById,
   parseRevealQuery,
 } from '@/lib/api/self-hosted/api-keys'
 
@@ -14,16 +13,27 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
 
   switch (method) {
     case 'GET':
-      return handleGetAll(req, res)
+      return handleGet(req, res)
     default:
       res.setHeader('Allow', ['GET'])
       res.status(405).json({ data: null, error: { message: `Method ${method} Not Allowed` } })
   }
 }
 
-const handleGetAll = async (req: NextApiRequest, res: NextApiResponse) => {
-  const reveal = parseRevealQuery(req.query.reveal)
-  const response = getNonPlatformApiKeys().map((key) => applyRevealToApiKey(key, reveal))
+const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
+  const idParam = req.query.id
+  const id = Array.isArray(idParam) ? idParam[0] : idParam
 
-  return res.status(200).json(response)
+  if (!id) {
+    return res.status(404).json({ error: { message: 'API key not found' } })
+  }
+
+  const reveal = parseRevealQuery(req.query.reveal)
+  const apiKey = getNonPlatformApiKeyById(id, reveal)
+
+  if (!apiKey) {
+    return res.status(404).json({ error: { message: 'API key not found' } })
+  }
+
+  return res.status(200).json(apiKey)
 }

--- a/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys.test.ts
+++ b/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys.test.ts
@@ -122,6 +122,22 @@ describe('/api/v1/projects/[ref]/api-keys', () => {
       expect(data.find((k: { type: string }) => k.type === 'publishable')).toBeUndefined()
     })
 
+    it('fully masks a short secret key so the unrevealed list never leaks it', async () => {
+      vi.stubEnv('SUPABASE_ANON_KEY', 'anon-key-value')
+      vi.stubEnv('SUPABASE_SERVICE_KEY', 'service-key-value')
+      vi.stubEnv('SUPABASE_PUBLISHABLE_KEY', '')
+      // <= 15 chars: the prefix would otherwise equal the whole secret.
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_xyz')
+
+      const { req, res } = createMocks({ method: 'GET', query: { ref: 'default' } })
+      await handler(req, res)
+
+      const data = JSON.parse(res._getData())
+      const secret = data.find((k: { id: string }) => k.id === 'secret')
+      expect(secret.api_key).toBe('')
+      expect(secret.prefix).toBe('')
+    })
+
     it('returns the full secret key in the list when reveal=true', async () => {
       vi.stubEnv('SUPABASE_ANON_KEY', 'anon-key-value')
       vi.stubEnv('SUPABASE_SERVICE_KEY', 'service-key-value')

--- a/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys.test.ts
+++ b/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys.test.ts
@@ -103,7 +103,7 @@ describe('/api/v1/projects/[ref]/api-keys', () => {
       vi.stubEnv('SUPABASE_ANON_KEY', 'anon-key-value')
       vi.stubEnv('SUPABASE_SERVICE_KEY', 'service-key-value')
       vi.stubEnv('SUPABASE_PUBLISHABLE_KEY', '')
-      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_xyz')
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_abcdefghijklmnop')
 
       const { req, res } = createMocks({ method: 'GET', query: { ref: 'default' } })
       await handler(req, res)
@@ -112,21 +112,39 @@ describe('/api/v1/projects/[ref]/api-keys', () => {
       expect(data).toHaveLength(3)
       expect(data[2]).toEqual({
         name: 'secret',
-        api_key: 'sb_secret_xyz',
+        api_key: 'sb_secret_abcde',
         id: 'secret',
         type: 'secret',
         hash: '',
-        prefix: '',
+        prefix: 'sb_secret_abcde',
         description: 'Secret API key (service_role)',
       })
       expect(data.find((k: { type: string }) => k.type === 'publishable')).toBeUndefined()
+    })
+
+    it('returns the full secret key in the list when reveal=true', async () => {
+      vi.stubEnv('SUPABASE_ANON_KEY', 'anon-key-value')
+      vi.stubEnv('SUPABASE_SERVICE_KEY', 'service-key-value')
+      vi.stubEnv('SUPABASE_PUBLISHABLE_KEY', '')
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_abcdefghijklmnop')
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: { ref: 'default', reveal: 'true' },
+      })
+      await handler(req, res)
+
+      const data = JSON.parse(res._getData())
+      expect(data.find((k: { id: string }) => k.id === 'secret')?.api_key).toBe(
+        'sb_secret_abcdefghijklmnop'
+      )
     })
 
     it('appends both new entries when both env vars are set, in publishable-then-secret order', async () => {
       vi.stubEnv('SUPABASE_ANON_KEY', 'anon-key-value')
       vi.stubEnv('SUPABASE_SERVICE_KEY', 'service-key-value')
       vi.stubEnv('SUPABASE_PUBLISHABLE_KEY', 'sb_publishable_abc')
-      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_xyz')
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_abcdefghijklmnop')
 
       const { req, res } = createMocks({ method: 'GET', query: { ref: 'default' } })
       await handler(req, res)

--- a/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys/[id].test.ts
+++ b/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys/[id].test.ts
@@ -1,0 +1,108 @@
+import { createMocks } from 'node-mocks-http'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import handler from '../../../../../../../pages/api/v1/projects/[ref]/api-keys/[id]'
+import { mswServer } from '@/tests/lib/msw'
+
+vi.mock('@/lib/constants', () => ({
+  IS_PLATFORM: false,
+  API_URL: 'https://api.example.com',
+}))
+
+describe('/api/v1/projects/[ref]/api-keys/[id]', () => {
+  beforeEach(() => {
+    mswServer.close()
+    vi.unstubAllEnvs()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  describe('Method handling', () => {
+    it('should return 405 for non-GET methods', async () => {
+      const { req, res } = createMocks({
+        method: 'POST',
+        query: { ref: 'default', id: 'secret' },
+      })
+
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(405)
+      expect(JSON.parse(res._getData())).toEqual({
+        data: null,
+        error: { message: 'Method POST Not Allowed' },
+      })
+      expect(res.getHeader('Allow')).toEqual(['GET'])
+    })
+  })
+
+  describe('GET', () => {
+    it('returns 404 when the key id is unknown', async () => {
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_xyz')
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: { ref: 'default', id: 'missing' },
+      })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(404)
+      expect(JSON.parse(res._getData())).toEqual({
+        error: { message: 'API key not found' },
+      })
+    })
+
+    it('returns the publishable key by id', async () => {
+      vi.stubEnv('SUPABASE_PUBLISHABLE_KEY', 'sb_publishable_abc')
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: { ref: 'default', id: 'publishable' },
+      })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(JSON.parse(res._getData())).toMatchObject({
+        id: 'publishable',
+        type: 'publishable',
+        api_key: 'sb_publishable_abc',
+      })
+    })
+
+    it('masks the secret key when reveal is false', async () => {
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_abcdefghijklmnop')
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: { ref: 'default', id: 'secret', reveal: 'false' },
+      })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(JSON.parse(res._getData())).toMatchObject({
+        id: 'secret',
+        type: 'secret',
+        api_key: 'sb_secret_abcde',
+        prefix: 'sb_secret_abcde',
+      })
+    })
+
+    it('returns the full secret key when reveal is true', async () => {
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_abcdefghijklmnop')
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: { ref: 'default', id: 'secret', reveal: 'true' },
+      })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(JSON.parse(res._getData())).toMatchObject({
+        id: 'secret',
+        type: 'secret',
+        api_key: 'sb_secret_abcdefghijklmnop',
+      })
+    })
+  })
+})

--- a/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys/[id].test.ts
+++ b/apps/studio/tests/pages/api/v1/projects/[ref]/api-keys/[id].test.ts
@@ -88,6 +88,24 @@ describe('/api/v1/projects/[ref]/api-keys/[id]', () => {
       })
     })
 
+    it('masks the secret key by default when no reveal query param is set', async () => {
+      vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_abcdefghijklmnop')
+
+      const { req, res } = createMocks({
+        method: 'GET',
+        query: { ref: 'default', id: 'secret' },
+      })
+      await handler(req, res)
+
+      expect(res._getStatusCode()).toBe(200)
+      expect(JSON.parse(res._getData())).toMatchObject({
+        id: 'secret',
+        type: 'secret',
+        api_key: 'sb_secret_abcde',
+        prefix: 'sb_secret_abcde',
+      })
+    })
+
     it('returns the full secret key when reveal is true', async () => {
       vi.stubEnv('SUPABASE_SECRET_KEY', 'sb_secret_abcdefghijklmnop')
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / follow-up to #46554.

The minimal project settings wired the API keys page to the reveal-by-id flow - the Reveal and Copy buttons on a secret key call `GET /v1/projects/{ref}/api-keys/{id}?reveal=true`. Non-platform Studio (self-hosted Docker and local CLI) only mocked the list route (`/api-keys`).

- Adds the missing `/api/v1/projects/[ref]/api-keys/[id]` mock route for non-platform builds, so the reveal/copy flow works on self-hosted and CLI
- Extracts key synthesis out of the list route into a shared `lib/api/self-hosted/api-keys.ts`
- Masks the secret key by default
- No UI changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Secure API key management for self-hosted setups with masked secret display
  * Optional "reveal" query to show full secret keys
  * New endpoint to fetch individual API keys by ID

* **Bug Fixes**
  * Proper HTTP handling for unsupported methods and missing keys (405/404 responses)

* **Accessibility**
  * Added ARIA labels to reveal and copy API key controls

* **Tests**
  * Expanded test coverage for key listing, reveal behavior, per-id endpoint and UI interactions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->