### PR TITLE
fix(studio): prevent SQL editor TreeView crash when an expanded folder leaves the tree

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorNav.tsx
@@ -176,11 +176,6 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
     [privateSnippetsTreeState]
   )
 
-  const validExpandedFolderIds = useMemo(
-    () => expandedFolderIds.filter((id) => privateSnippetsTreeNodeIds.has(id)),
-    [expandedFolderIds, privateSnippetsTreeNodeIds]
-  )
-
   const privateSnippetsLastItemIds = useMemo(
     () => getLastItemIds(privateSnippetsTreeState),
     [privateSnippetsTreeState]
@@ -407,7 +402,11 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
       } else if (snippet.visibility === 'user') {
         setSectionVisibility({ ...sectionVisibility, private: true })
       }
-      if (snippet.folder_id && !expandedFolderIds.includes(snippet.folder_id)) {
+      if (
+        snippet.folder_id &&
+        !expandedFolderIds.includes(snippet.folder_id) &&
+        privateSnippetsTreeNodeIds.has(snippet.folder_id)
+      ) {
         setExpandedFolderIds([...expandedFolderIds, snippet.folder_id])
       }
     }
@@ -654,7 +653,7 @@ export const SQLEditorNav = ({ sort = 'inserted_at' }: SQLEditorNavProps) => {
                   setExpandedFolderIds(expandedFolderIds.filter((x) => x !== folderId))
                 }
               }}
-              expandedIds={validExpandedFolderIds}
+              expandedIds={expandedFolderIds}
               nodeRenderer={({ element, ...props }) => {
                 const isOpened = Object.values(tabs.tabsMap).some(
                   (tab) => tab.metadata?.sqlId === element.metadata?.id


### PR DESCRIPTION
## Problem

Sentry [SUPABASE-APP-J7C](https://supabase.sentry.io/issues/7492405004) — `Error: Node with id=new-folder doesn't exist in the tree.` (328 events / 280 users). Crashes the SQL editor.

## Root cause

`react-accessible-treeview` throws when an id is dropped from the controlled `expandedIds` prop in the same render its node leaves the tree data — its collapse effect calls `getTreeNode(data, id)` on a node that's already gone. The prior fix (`8bcb878a01`) reactively filtered `expandedIds` against the live tree, which is exactly what produces that simultaneous drop when a `new-folder` placeholder (or any expanded folder) is removed.

## Fix

- Guard additions: only expand folder ids that exist in the tree.
- Tolerate stale ids: pass `expandedFolderIds` as-is instead of the reactively filtered list, so we never create a "removed" delta for a node that's already gone. Stale ids are harmless — the library only inspects the add/remove delta.

## Reproduction (to verify the fix)

1. Open the SQL Editor for a project.
2. Create a folder and add a snippet into it.
3. **Expand** the folder.
4. Right-click the folder → **Delete folder** (confirm).
5. Before: the editor crashes with `Node with id=... doesn't exist in the tree.` After: no crash.

Fixes SUPABASE-APP-J7C

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of private snippet folder expansion in the SQL editor: auto-expansion now respects the current snippet tree state to avoid unexpected collapses or visual glitches in the folder tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->