### PR TITLE
fix(ci): authenticate git push in decrease-baselines workflow

### DIFF
--- a/.github/workflows/studio-lint-ratchet-decrease.yml
+++ b/.github/workflows/studio-lint-ratchet-decrease.yml
@@ -77,7 +77,7 @@ jobs:
 
           git add apps/studio/.github/eslint-rule-baselines.json
           git commit --message "chore: decrease ESLint ratchet baselines"
-          git push --force origin "$BRANCH"
+          git -c credential.helper= push --force "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${BRANCH}"
 
           pr_url=$(gh pr list --state open --head "$BRANCH" --json url --jq '.[0].url // ""' 2>/dev/null || echo "")
           if [ -z "$pr_url" ]; then


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (CI workflow).

## What is the current behavior?

The weekly `Decrease studio lint ratchet baselines` workflow fails on `git push` with:

```
fatal: could not read Username for 'https://github.com': No such device or address
Error: Process completed with exit code 128.
```

`actions/checkout` runs with `persist-credentials: false`, so no auth is stored for git. The job generates a GitHub App token but never wires it into git, so the push has no credentials.

## What is the new behavior?

Push to an explicit token URL using the already-available `GH_TOKEN`, matching the pattern in `.github/workflows/autofix_linters.yml`. The force-push to `bot/decrease-eslint-ratchet-baselines` now authenticates correctly.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to improve automated process reliability.

**Note:** This release contains no user-facing changes. The updates are internal infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->