### PR TITLE
bugfix: timezone issue with template block cutoff date

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
@@ -1,4 +1,7 @@
 import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+
+dayjs.extend(utc)
 
 import { isSmtpEnabled } from '../SmtpForm/SmtpForm.utils'
 import { type AuthTemplateType, type KebabCase } from './EmailTemplates.types'
@@ -46,7 +49,7 @@ export const isCustomEmailTemplateRestrictionStatusKnown = ({
 }
 
 export const isBeforeFreeTierTemplateBlockCutoff = (projectInsertedAt?: string) => {
-  return dayjs(projectInsertedAt).isBefore(FREE_TIER_TEMPLATE_BLOCK_CUTOFF_DATE)
+  return dayjs.utc(projectInsertedAt).isBefore(FREE_TIER_TEMPLATE_BLOCK_CUTOFF_DATE)
 }
 
 export const isCustomEmailTemplateEditingRestricted = ({

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.utils.ts
@@ -1,12 +1,12 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 
-dayjs.extend(utc)
-
 import { isSmtpEnabled } from '../SmtpForm/SmtpForm.utils'
 import { type AuthTemplateType, type KebabCase } from './EmailTemplates.types'
 import type { components } from '@/data/api'
 import type { Organization } from '@/types'
+
+dayjs.extend(utc)
 
 type AuthConfig = components['schemas']['GoTrueConfigResponse']
 


### PR DESCRIPTION
Fix to small issue with our block to free tier. The /project endpoint does not return a timestamp so it is being interpreted as local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved timezone handling inconsistencies in email template availability checks to ensure accurate and consistent results across all geographic locations and server configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->