### PR TITLE
 fix: check token.scope for access resource display

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/ViewTokenSheet.tsx
@@ -231,11 +231,16 @@ export function ViewTokenSheet({ visible, tokenId, onClose }: ViewTokenSheetProp
                               <TableRow>
                                 <TableCell colSpan={2}>
                                   <p className="text-foreground-light text-center py-4">
-                                    {(token?.organization_slugs &&
-                                      token.organization_slugs.length > 0) ||
-                                    (token?.project_refs && token.project_refs.length > 0)
-                                      ? 'This token has access to specific organizations and projects.'
-                                      : 'This token has access to all resources.'}
+                                    {token?.scope === 'organization'
+                                      ? token.organization_slugs &&
+                                        token.organization_slugs.length > 0
+                                        ? 'This token has access to specific organizations.'
+                                        : 'This token has no accessible organizations.'
+                                      : token?.scope === 'project'
+                                        ? token.project_refs && token.project_refs.length > 0
+                                          ? 'This token has access to specific projects.'
+                                          : 'This token has no accessible projects.'
+                                        : 'This token has access to all resources.'}
                                   </p>
                                 </TableCell>
                               </TableRow>

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -7031,6 +7031,8 @@ export interface components {
       organization_slugs?: string[]
       permissions: string[]
       project_refs?: string[]
+      /** @enum {string} */
+      scope: 'user' | 'organization' | 'project'
       token_alias: string
     }
     GetScopedAccessTokensResponse: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Scoped PAT access message checks `organization_slugs`/`project_refs` to determine display text. This breaks when an org/project is deleted; its tuple is removed and consequently from the token's slugs/refs, causing a scoped token to incorrectly show "This token has access to all resources."

## What is the new behavior?

Check the `token.scope` directly:
- `user` → "This token has access to all resources."
- `organization` → "This token has access to specific organizations." (or "This token has no accessible organizations." if all scoped orgs were removed)
- `project` → "This token has access to specific projects." (or "This token has no accessible projects." if all scoped projects were removed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clarity of access token scope messaging. The resource access information now displays more specific and accurate details based on token type, distinguishing between organization-level, project-level, and user-level access permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->