### PR TITLE
feat(billing): label logs ingest/query in restriction banners

### DIFF
--- a/apps/studio/data/usage/constants.ts
+++ b/apps/studio/data/usage/constants.ts
@@ -8,5 +8,7 @@ export const VIOLATION_TYPE_LABELS: Record<string, string> = {
   exceed_realtime_connection_count_quota: 'Realtime Connection Count Exceeded',
   exceed_realtime_message_count_quota: 'Realtime Message Count Exceeded',
   exceed_storage_size_quota: 'Storage Size Exceeded',
+  exceed_log_ingestion_quota: 'Logs Ingest Exceeded',
+  exceed_log_query_quota: 'Logs Query Exceeded',
   overdue_payment: 'Overdue Payment',
 }


### PR DESCRIPTION
## Summary
Surfaces the two new logs fair-use violation keys in Studio's restriction and grace-period banners. When an org exceeds the logs ingest or logs query quota and is restricted, the banner shows a readable label instead of the raw key.

## Changes
- Add `exceed_log_ingestion_quota` → "Logs Ingest Exceeded" and `exceed_log_query_quota` → "Logs Query Exceeded" to `VIOLATION_TYPE_LABELS`

## Testing
Additive entry to the `VIOLATION_TYPE_LABELS` map. The banner (`Restriction.tsx`) already renders `VIOLATION_TYPE_LABELS[violation] || violation`, so every existing key is unchanged and the two new keys render a friendly label once the enforcer emits them.

To verify on the preview, an org would need to carry a logs violation in `restriction_data.violations` (Org → Billing banner should read "(Logs Ingest Exceeded)" / "(Logs Query Exceeded)"). That state depends on the backend enforcer, which ships separately, so it can't be exercised on this preview alone. The `|| violation` fallback makes this non-breaking and order-independent vs the backend.

## Linear
- Related to GROWTH-887 (logs fair-use enforcement — Studio label piece)
- Related to FE-3403


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tracking logs ingestion and logs query quota violations, enabling users to monitor these quota limits separately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->