### PR TITLE
fix(docs): generate new reference pipeline output before embeddings

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -31,7 +31,7 @@
     "postbuild": "pnpm run build:sitemap && pnpm run build:llms && ./../../scripts/upload-static-assets.sh",
     "prebuild": "pnpm run codegen:graphql && pnpm run codegen:references && pnpm run codegen:references:new && pnpm run codegen:examples && pnpm run build:guides-markdown && pnpm run build:gz-archive",
     "predev": "pnpm run codegen:graphql && pnpm run codegen:references && pnpm run codegen:references:new && pnpm run codegen:examples",
-    "preembeddings": "pnpm run codegen:references",
+    "preembeddings": "pnpm run codegen:references && pnpm run codegen:references:new",
     "preinstall": "npx only-allow pnpm",
     "presync": "pnpm run codegen:graphql",
     "pretest": "pnpm run codegen:examples",


### PR DESCRIPTION
The embeddings workflow started failing after #46163 with `ENOENT: ... content/reference/javascript/v2/sections.json`. That PR routed the JS v2 search ingest through the new reference pipeline (`loadClientLibReferenceFromNewPipeline` in `apps/docs/scripts/search/sources/reference-doc.ts`), and updated `predev` and `prebuild` to run both `codegen:references` and `codegen:references:new`, but missed `preembeddings`. This chains `codegen:references:new` into `preembeddings` so `pnpm run embeddings` (and the `:nimbus` / `:refresh` variants that fan out to it) produces the new pipeline output before the search ingest reads it.