### PR TITLE
Fix property name format for current password in updateUser for JS

### DIFF
--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -1050,7 +1050,7 @@ If your app requires users to confirm their current password before setting a ne
 ```js
 await supabase.auth.updateUser({
   password: 'new_password',
-  currentPassword: 'old_password',
+  current_password: 'old_password',
 })
 ```
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

It's basically a docs update/fix.

## What is the current behavior?

The current live docs for https://supabase.com/docs/guides/auth/passwords?queryGroups=language&language=js&queryGroups=flow&flow=implicit#verifying-the-current-password incorrectly use camelCase instead of snake_case for the property name "currentPassword" for Javascript.

## What is the new behavior?

Simple modified the property name so it aligns with what the js SDK expect.

## Additional context

I verified it manually on my own instance. Using @supabase/supabase-js SDK v2.107.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the password verification example in the authentication guide to reflect the proper API field naming convention for current password validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->