### PR TITLE
fix(docs): stop emitting duplicate subcategory partial entries

### DIFF
--- a/apps/docs/scripts/__snapshots__/build-reference-content.test.ts.snap
+++ b/apps/docs/scripts/__snapshots__/build-reference-content.test.ts.snap
@@ -5,6 +5,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
   "bySlug": {
     "analytics-buckets": {
       "id": "analytics-buckets",
+      "isFunc": false,
+      "product": "storage",
       "slug": "analytics-buckets",
       "title": "Analytics Buckets",
       "type": "function",
@@ -45,8 +47,10 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "auth-admin": {
       "id": "auth-admin",
+      "isFunc": false,
+      "product": "auth",
       "slug": "auth-admin",
-      "title": "Overview",
+      "title": "Auth Admin",
       "type": "function",
     },
     "auth-admin-createprovider": {
@@ -212,6 +216,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "auth-mfa": {
       "id": "auth-mfa",
+      "isFunc": false,
+      "product": "auth",
       "slug": "auth-mfa",
       "title": "Auth MFA",
       "type": "function",
@@ -274,6 +280,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "auth-passkey": {
       "id": "auth-passkey",
+      "isFunc": false,
+      "product": "auth",
       "slug": "auth-passkey",
       "title": "Auth Passkey",
       "type": "function",
@@ -522,6 +530,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "file-buckets": {
       "id": "file-buckets",
+      "isFunc": false,
+      "product": "storage",
       "slug": "file-buckets",
       "title": "File Buckets",
       "type": "function",
@@ -809,6 +819,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "oauth-admin": {
       "id": "oauth-admin",
+      "isFunc": false,
+      "product": "auth",
       "slug": "oauth-admin",
       "title": "OAuth Admin",
       "type": "function",
@@ -857,6 +869,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "oauth-server": {
       "id": "oauth-server",
+      "isFunc": false,
+      "product": "auth",
       "slug": "oauth-server",
       "title": "OAuth Server",
       "type": "function",
@@ -912,8 +926,10 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "passkey-admin": {
       "id": "passkey-admin",
+      "isFunc": false,
+      "product": "auth",
       "slug": "passkey-admin",
-      "title": "Passkey admin",
+      "title": "Passkey Admin",
       "type": "function",
     },
     "passkey-admin-deletepasskey": {
@@ -1107,8 +1123,10 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "using-filters": {
       "id": "using-filters",
+      "isFunc": false,
+      "product": "database",
       "slug": "using-filters",
-      "title": "Using Filters",
+      "title": "Using filters",
       "type": "function",
     },
     "using-filters-containedby": {
@@ -1302,6 +1320,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "using-modifiers": {
       "id": "using-modifiers",
+      "isFunc": false,
+      "product": "database",
       "slug": "using-modifiers",
       "title": "Using modifiers",
       "type": "function",
@@ -1392,6 +1412,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     "vector-buckets": {
       "id": "vector-buckets",
+      "isFunc": false,
+      "product": "storage",
       "slug": "vector-buckets",
       "title": "Vector Buckets",
       "type": "function",
@@ -1638,8 +1660,10 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "using-filters",
+      "isFunc": false,
+      "product": "database",
       "slug": "using-filters",
-      "title": "Using Filters",
+      "title": "Using filters",
       "type": "function",
     },
     {
@@ -1833,6 +1857,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "using-modifiers",
+      "isFunc": false,
+      "product": "database",
       "slug": "using-modifiers",
       "title": "Using modifiers",
       "type": "function",
@@ -2139,8 +2165,10 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "auth-admin",
+      "isFunc": false,
+      "product": "auth",
       "slug": "auth-admin",
-      "title": "Overview",
+      "title": "Auth Admin",
       "type": "function",
     },
     {
@@ -2250,6 +2278,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "auth-mfa",
+      "isFunc": false,
+      "product": "auth",
       "slug": "auth-mfa",
       "title": "Auth MFA",
       "type": "function",
@@ -2305,6 +2335,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "auth-passkey",
+      "isFunc": false,
+      "product": "auth",
       "slug": "auth-passkey",
       "title": "Auth Passkey",
       "type": "function",
@@ -2360,6 +2392,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "oauth-admin",
+      "isFunc": false,
+      "product": "auth",
       "slug": "oauth-admin",
       "title": "OAuth Admin",
       "type": "function",
@@ -2408,6 +2442,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "oauth-server",
+      "isFunc": false,
+      "product": "auth",
       "slug": "oauth-server",
       "title": "OAuth Server",
       "type": "function",
@@ -2449,8 +2485,10 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "passkey-admin",
+      "isFunc": false,
+      "product": "auth",
       "slug": "passkey-admin",
-      "title": "Passkey admin",
+      "title": "Passkey Admin",
       "type": "function",
     },
     {
@@ -2698,6 +2736,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "analytics-buckets",
+      "isFunc": false,
+      "product": "storage",
       "slug": "analytics-buckets",
       "title": "Analytics Buckets",
       "type": "function",
@@ -2732,6 +2772,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "file-buckets",
+      "isFunc": false,
+      "product": "storage",
       "slug": "file-buckets",
       "title": "File Buckets",
       "type": "function",
@@ -2892,6 +2934,8 @@ exports[`build-reference-content — javascript/v2 > matches snapshot 1`] = `
     },
     {
       "id": "vector-buckets",
+      "isFunc": false,
+      "product": "storage",
       "slug": "vector-buckets",
       "title": "Vector Buckets",
       "type": "function",
@@ -4267,12 +4311,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "isFunc": false,
           "items": [
             {
-              "id": "using-filters",
-              "slug": "using-filters",
-              "title": "Using Filters",
-              "type": "function",
-            },
-            {
               "id": "using-filters-containedby",
               "product": "database",
               "slug": "using-filters-containedby",
@@ -4471,12 +4509,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "id": "using-modifiers",
           "isFunc": false,
           "items": [
-            {
-              "id": "using-modifiers",
-              "slug": "using-modifiers",
-              "title": "Using modifiers",
-              "type": "function",
-            },
             {
               "id": "using-modifiers-abortsignal",
               "product": "database",
@@ -4794,12 +4826,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "isFunc": false,
           "items": [
             {
-              "id": "auth-admin",
-              "slug": "auth-admin",
-              "title": "Overview",
-              "type": "function",
-            },
-            {
               "id": "auth-admin-createprovider",
               "product": "auth",
               "slug": "auth-admin-createprovider",
@@ -4915,12 +4941,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "isFunc": false,
           "items": [
             {
-              "id": "auth-mfa",
-              "slug": "auth-mfa",
-              "title": "Auth MFA",
-              "type": "function",
-            },
-            {
               "id": "auth-mfa-challenge",
               "product": "auth",
               "slug": "auth-mfa-challenge",
@@ -4979,12 +4999,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "id": "auth-passkey",
           "isFunc": false,
           "items": [
-            {
-              "id": "auth-passkey",
-              "slug": "auth-passkey",
-              "title": "Auth Passkey",
-              "type": "function",
-            },
             {
               "id": "auth-passkey-delete",
               "product": "auth",
@@ -5045,12 +5059,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "isFunc": false,
           "items": [
             {
-              "id": "oauth-admin",
-              "slug": "oauth-admin",
-              "title": "OAuth Admin",
-              "type": "function",
-            },
-            {
               "id": "oauth-admin-createclient",
               "product": "auth",
               "slug": "oauth-admin-createclient",
@@ -5103,12 +5111,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "isFunc": false,
           "items": [
             {
-              "id": "oauth-server",
-              "slug": "oauth-server",
-              "title": "OAuth Server",
-              "type": "function",
-            },
-            {
               "id": "oauth-server-approveauthorization",
               "product": "auth",
               "slug": "oauth-server-approveauthorization",
@@ -5153,12 +5155,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "id": "passkey-admin",
           "isFunc": false,
           "items": [
-            {
-              "id": "passkey-admin",
-              "slug": "passkey-admin",
-              "title": "Passkey admin",
-              "type": "function",
-            },
             {
               "id": "passkey-admin-deletepasskey",
               "product": "auth",
@@ -5419,12 +5415,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "isFunc": false,
           "items": [
             {
-              "id": "analytics-buckets",
-              "slug": "analytics-buckets",
-              "title": "Analytics Buckets",
-              "type": "function",
-            },
-            {
               "id": "analytics-buckets-createbucket",
               "product": "storage",
               "slug": "analytics-buckets-createbucket",
@@ -5462,12 +5452,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "id": "file-buckets",
           "isFunc": false,
           "items": [
-            {
-              "id": "file-buckets",
-              "slug": "file-buckets",
-              "title": "File Buckets",
-              "type": "function",
-            },
             {
               "id": "file-buckets-copy",
               "product": "storage",
@@ -5632,12 +5616,6 @@ Passkey support is an experimental feature. Enable it when creating the client:"
           "id": "vector-buckets",
           "isFunc": false,
           "items": [
-            {
-              "id": "vector-buckets",
-              "slug": "vector-buckets",
-              "title": "Vector Buckets",
-              "type": "function",
-            },
             {
               "id": "vector-buckets-createbucket",
               "product": "storage",

--- a/apps/docs/scripts/build-reference-content.ts
+++ b/apps/docs/scripts/build-reference-content.ts
@@ -558,8 +558,18 @@ function buildBySlug(
       bySlug[subSlug] = sub
       catItems.push({ ...sub, items: subItems })
 
+      // Enrich the subcategory header's functions.json entry. Do NOT call
+      // writePartial — that would also push a child entry into subItems with
+      // the same slug as the subcategory header itself, producing a
+      // duplicate-slug node that the search-embeddings loader emits twice.
       const subcategoryPartial = partialsBySubcategory.get(subKey)
-      if (subcategoryPartial) writePartial(subcategoryPartial, subItems)
+      if (subcategoryPartial) {
+        if (subcategoryPartial.kind === 'function') {
+          functionsList.push({ id: subSlug, ...subcategoryPartial.body })
+        } else if (subcategoryPartial.ref) {
+          functionsList.push({ id: subSlug, $ref: subcategoryPartial.ref })
+        }
+      }
 
       for (const fn of [...fns].sort(byName)) writeFunction(fn, product, subItems)
     }

--- a/apps/docs/scripts/search/generate-embeddings.ts
+++ b/apps/docs/scripts/search/generate-embeddings.ts
@@ -1,21 +1,21 @@
 import '../utils/dotenv.js'
 
-import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { parseArgs } from 'node:util'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 import { OpenAI } from 'openai'
 import { v4 as uuidv4 } from 'uuid'
 
 import type { Section } from '../helpers.mdx.js'
 import {
+  computePageResults,
+  createBatches,
+  logFailedSections,
+  mapEmbeddingsToSections,
+  updatePageInsertionCounts,
   type PageInfo,
   type PageSectionForEmbedding,
   type PageSectionWithEmbedding,
   type ProcessingResult,
-  createBatches,
-  mapEmbeddingsToSections,
-  updatePageInsertionCounts,
-  computePageResults,
-  logFailedSections,
 } from './embeddings/utils.js'
 import { fetchAllSources } from './sources/index.js'
 
@@ -132,6 +132,24 @@ async function prepareSections(
 ): Promise<PreparedSections> {
   const embeddingSources = await fetchAllSources(fullIndex)
   console.log(`Discovered ${embeddingSources.length} sources`)
+
+  // Diagnostic: identify any sources that share a path. Two sources for the
+  // same path collapse onto the same page row (page.path is UNIQUE) and both
+  // push sections, producing "inserted N/1" mismatches in the failure log.
+  // This warning names the offending loader so we can fix the root cause.
+  const seenPaths = new Map<string, { source: string; type: string }>()
+  for (const s of embeddingSources) {
+    const existing = seenPaths.get(s.path)
+    if (existing) {
+      console.warn(
+        `Duplicate source path: ${s.path} ` +
+          `(first from source="${existing.source}" type="${existing.type}", ` +
+          `also from source="${s.source}" type="${s.type}")`
+      )
+      continue
+    }
+    seenPaths.set(s.path, { source: s.source, type: s.type })
+  }
 
   const allSectionsToProcess: PageSectionForEmbedding[] = []
   const pageInfoMap = new Map<number, PageInfo>()

--- a/apps/docs/scripts/search/generate-embeddings.ts
+++ b/apps/docs/scripts/search/generate-embeddings.ts
@@ -133,24 +133,6 @@ async function prepareSections(
   const embeddingSources = await fetchAllSources(fullIndex)
   console.log(`Discovered ${embeddingSources.length} sources`)
 
-  // Diagnostic: identify any sources that share a path. Two sources for the
-  // same path collapse onto the same page row (page.path is UNIQUE) and both
-  // push sections, producing "inserted N/1" mismatches in the failure log.
-  // This warning names the offending loader so we can fix the root cause.
-  const seenPaths = new Map<string, { source: string; type: string }>()
-  for (const s of embeddingSources) {
-    const existing = seenPaths.get(s.path)
-    if (existing) {
-      console.warn(
-        `Duplicate source path: ${s.path} ` +
-          `(first from source="${existing.source}" type="${existing.type}", ` +
-          `also from source="${s.source}" type="${s.type}")`
-      )
-      continue
-    }
-    seenPaths.set(s.path, { source: s.source, type: s.type })
-  }
-
   const allSectionsToProcess: PageSectionForEmbedding[] = []
   const pageInfoMap = new Map<number, PageInfo>()
 


### PR DESCRIPTION
JSON subcategory partials (e.g. `auth-admin.json`) were being pushed both as the subcategory header AND as a child inside that header's `items` array. Two `sections.json` entries ended up with the same slug, so `flattenSections` walked the slug twice, the search-embeddings loader emitted two sources per path, and the embeddings run reported "inserted 2/1 sections" for the 11 affected pages.

Fix in `build-reference-content.ts`: for subcategory partials, enrich `functions.json` only (so the renderer's `fns.find(f => f.id === section.id)` still resolves), skip the duplicate child push. Matches the pipeline README's documented behavior. Snapshot updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generation of reference pages to avoid emitting duplicate subcategory entries, resulting in cleaner, non-duplicated function lists in docs.
* **Chores**
  * Minor code formatting updates with no functional impact.
* **Notes**
  * No changes to embedding-generation logic or public APIs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/supabase/supabase/pull/46616?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->