### PR TITLE
fix: correct canonical tags on 4 docs pages

### DIFF
--- a/apps/docs/app/guides/database/database-advisors/page.tsx
+++ b/apps/docs/app/guides/database/database-advisors/page.tsx
@@ -25,7 +25,7 @@ const meta = {
 }
 
 const generateMetadata = genGuideMeta(() => ({
-  pathname: '/guides/database/database-linter',
+  pathname: '/guides/database/database-advisors',
   meta,
 }))
 

--- a/apps/docs/app/guides/deployment/ci/[slug]/page.tsx
+++ b/apps/docs/app/guides/deployment/ci/[slug]/page.tsx
@@ -87,7 +87,7 @@ const getContent = async ({ slug }: Params) => {
   )
 
   return {
-    pathname: `/guides/cli/github-action/${slug}` satisfies `/${string}`,
+    pathname: `/guides/deployment/ci/${slug}` satisfies `/${string}`,
     meta,
     content,
     editLink,

--- a/apps/docs/app/guides/deployment/terraform/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/deployment/terraform/[[...slug]]/page.tsx
@@ -136,7 +136,7 @@ const getContent = async ({ slug }: Params) => {
 
   return {
     pathname:
-      `/guides/platform/terraform${slug?.length ? `/${slug.join('/')}` : ''}` satisfies `/${string}`,
+      `/guides/deployment/terraform${slug?.length ? `/${slug.join('/')}` : ''}` satisfies `/${string}`,
     meta,
     content,
     editLink,

--- a/apps/docs/app/guides/deployment/terraform/reference/page.tsx
+++ b/apps/docs/app/guides/deployment/terraform/reference/page.tsx
@@ -22,7 +22,7 @@ const meta = {
 }
 
 const generateMetadata = genGuideMeta(() => ({
-  pathname: '/guides/platform/terraform/reference',
+  pathname: '/guides/deployment/terraform/reference',
   meta,
 }))
 

--- a/apps/docs/app/guides/local-development/cli/config/page.tsx
+++ b/apps/docs/app/guides/local-development/cli/config/page.tsx
@@ -12,7 +12,7 @@ const meta = {
 }
 
 const generateMetadata = genGuideMeta(() => ({
-  pathname: '/guides/cli/config',
+  pathname: '/guides/local-development/cli/config',
   meta,
 }))
 


### PR DESCRIPTION
## Summary

Four pages in `apps/docs` have a mismatch between the `pathname` in `generateMetadata` and the `pathname` in `GuideTemplate`. The `generateMetadata` pathname is what generates the `<link rel="canonical">` and `<link rel="alternate" type="text/markdown">` tags — so both tags point to the wrong URL on all 4 pages.

The wrong canonical destinations either loop back to the source page (308 → source) or end in a 404, meaning Google is being told the authoritative URL is somewhere it can't reliably reach.

## Changes

One-line fix in each file — update `pathname` in `generateMetadata` to match the `pathname` already correctly set in `GuideTemplate`:

- `apps/docs/app/guides/database/database-advisors/page.tsx` — `/guides/database/database-linter` → `/guides/database/database-advisors`
- `apps/docs/app/guides/local-development/cli/config/page.tsx` — `/guides/cli/config` → `/guides/local-development/cli/config`
- `apps/docs/app/guides/deployment/ci/[slug]/page.tsx` — `/guides/cli/github-action/${slug}` → `/guides/deployment/ci/${slug}`
- `apps/docs/app/guides/deployment/terraform/[[...slug]]/page.tsx` — `/guides/platform/terraform` → `/guides/deployment/terraform`

## Verification

Before fix — view source on any of these pages and search for `canonical`:
- https://supabase.com/docs/guides/database/database-advisors
- https://supabase.com/docs/guides/local-development/cli/config
- https://supabase.com/docs/guides/deployment/ci/testing
- https://supabase.com/docs/guides/deployment/terraform

After fix — canonical on each page should be self-referencing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation routing paths across multiple guides to align with proper navigation structure:
    * Database advisors guide
    * CI/deployment guide
    * Terraform deployment guide
    * Terraform provider reference guide
    * Local development CLI configuration guide
<!-- end of auto-generated comment: release notes by coderabbit.ai -->