### PR TITLE
fix: Rely on docs tag for wrappers content fetching

### DIFF
--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -15,7 +15,7 @@ import { linkTransform, type UrlTransformFunction } from '~/lib/mdx/plugins/rehy
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
 import { removeTitle } from '~/lib/mdx/plugins/remarkRemoveTitle'
 import remarkPyMdownTabs from '~/lib/mdx/plugins/remarkTabs'
-import { getGitHubFileContents } from '~/lib/octokit'
+import { getGitHubFileContents, octokit, OCTOKIT_RETRY_OPTIONS } from '~/lib/octokit'
 import type { SerializeOptions } from '~/types/next-mdx-remote-serialize'
 import { isFeatureEnabled } from 'common'
 import matter from 'gray-matter'
@@ -29,9 +29,27 @@ import { Admonition } from 'ui-patterns'
 // We fetch these docs at build time from an external repo
 const org = 'supabase'
 const repo = 'wrappers'
-const branch = 'main'
 const docsDir = 'docs/catalog'
 const externalSite = 'https://supabase.github.io/wrappers'
+
+async function getLatestDocsTag() {
+  try {
+    const { data } = await octokit().request('GET /repos/{owner}/{repo}/git/matching-refs/{ref}', {
+      owner: org,
+      repo,
+      ref: 'tags/docs',
+      request: OCTOKIT_RETRY_OPTIONS,
+    })
+
+    const latestRef = data.at(-1)
+
+    const latestTag = latestRef?.ref.replace(/^refs\/tags\//, '')
+    return latestTag
+  } catch (error) {
+    console.error(`Error fetching docs tags for wrappers federated pages: ${error}`)
+    return null
+  }
+}
 
 // Each external docs page is mapped to a local page
 const pageMap = [
@@ -378,16 +396,21 @@ const getContent = async (params: Params) => {
     let remoteFile: string
     ;({ remoteFile, meta } = federatedPage)
 
-    editLink = `${org}/${repo}/blob/${branch}/${docsDir}/${remoteFile}`
+    const tag = await getLatestDocsTag()
+    if (!tag) {
+      throw new Error('No latest docs tag found for federated wrappers pages')
+    }
+
+    editLink = `${org}/${repo}/blob/${tag}/${docsDir}/${remoteFile}`
 
     let rawContent = await getGitHubFileContents({
       org,
       repo,
       path: `${docsDir}/${remoteFile}`,
-      branch,
+      branch: tag,
     })
 
-    assetsBaseUrl = `https://raw.githubusercontent.com/${org}/${repo}/${branch}/docs/assets/`
+    assetsBaseUrl = `https://raw.githubusercontent.com/${org}/${repo}/${tag}/docs/assets/`
 
     const { content: contentWithoutFrontmatter } = matter(rawContent)
     content = removeRedundantH1(contentWithoutFrontmatter)

--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -15,7 +15,7 @@ import { linkTransform, type UrlTransformFunction } from '~/lib/mdx/plugins/rehy
 import remarkMkDocsAdmonition from '~/lib/mdx/plugins/remarkAdmonition'
 import { removeTitle } from '~/lib/mdx/plugins/remarkRemoveTitle'
 import remarkPyMdownTabs from '~/lib/mdx/plugins/remarkTabs'
-import { getGitHubFileContents, octokit, OCTOKIT_RETRY_OPTIONS } from '~/lib/octokit'
+import { getGitHubFileContents, octokit } from '~/lib/octokit'
 import type { SerializeOptions } from '~/types/next-mdx-remote-serialize'
 import { isFeatureEnabled } from 'common'
 import matter from 'gray-matter'
@@ -32,19 +32,53 @@ const repo = 'wrappers'
 const docsDir = 'docs/catalog'
 const externalSite = 'https://supabase.github.io/wrappers'
 
-async function getLatestDocsTag() {
+type DocsTagsQueryResponse = {
+  repository: {
+    refs: {
+      nodes: { name: string }[] | null
+      pageInfo: { hasNextPage: boolean; endCursor: string | null }
+    }
+  }
+}
+
+const docsTagsQuery = `
+  query DocsTagsQuery($owner: String!, $name: String!, $after: String) {
+    repository(owner: $owner, name: $name) {
+      refs(
+        refPrefix: "refs/tags/",
+        orderBy: { field: TAG_COMMIT_DATE, direction: DESC },
+        first: 5,
+        after: $after
+      ) {
+        nodes { name }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+`
+
+async function getLatestDocsTag(after: string | null = null): Promise<string | null> {
   try {
-    const { data } = await octokit().request('GET /repos/{owner}/{repo}/git/matching-refs/{ref}', {
+    /**
+     * We use GraphQL as it's the only way to use `orderBy` on Github API.
+     */
+    const {
+      repository: {
+        refs: {
+          nodes,
+          pageInfo: { hasNextPage, endCursor },
+        },
+      },
+    } = await octokit().graphql<DocsTagsQueryResponse>(docsTagsQuery, {
       owner: org,
-      repo,
-      ref: 'tags/docs',
-      request: OCTOKIT_RETRY_OPTIONS,
+      name: repo,
+      after,
     })
 
-    const latestRef = data.at(-1)
-
-    const latestTag = latestRef?.ref.replace(/^refs\/tags\//, '')
-    return latestTag
+    return (
+      nodes?.find(({ name }) => /^docs_v\d+\.\d+\.\d+/.test(name))?.name ??
+      (hasNextPage && endCursor ? await getLatestDocsTag(endCursor) : null)
+    )
   } catch (error) {
     console.error(`Error fetching docs tags for wrappers federated pages: ${error}`)
     return null
@@ -397,6 +431,7 @@ const getContent = async (params: Params) => {
     ;({ remoteFile, meta } = federatedPage)
 
     const tag = await getLatestDocsTag()
+
     if (!tag) {
       throw new Error('No latest docs tag found for federated wrappers pages')
     }


### PR DESCRIPTION
In this PR:
 - Rely on `docs...` tag again to fetch wrappers content.
 - Re-add latest tag function getter, but using the same methods present in our codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database wrappers docs now resolve the latest stable documentation tag dynamically, ensuring users see docs matching released versions rather than the development branch.

* **Updates**
  * External documentation pages now point edit links, file fetches, and asset URLs to the resolved release tag so content and assets reflect the correct published version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->