### PR TITLE
fix(studio): prevent ghost redirects on unmounted SignInPartner

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
@@ -9,6 +9,8 @@ export const SignInPartner = () => {
   const router = useRouter()
 
   useEffect(() => {
+    let isMounted = true
+
     ;(async () => {
       const params = new URLSearchParams(window.location.hash.substring(1))
 
@@ -17,16 +19,28 @@ export const SignInPartner = () => {
 
       const { data } = await auth.getSession()
 
+      if (!isMounted) return
+
       if (!data.session && partner && token) {
         try {
           await auth.signInWithIdToken({ provider: partner, token })
         } finally {
-          router.replace({ pathname: '/sign-in-mfa' })
+          if (isMounted) {
+            router.replace({ pathname: '/sign-in-mfa' })
+          }
         }
       } else {
-        router.replace({ pathname: '/sign-in' })
+        if (isMounted) {
+          router.replace({ pathname: '/sign-in' })
+        }
       }
     })()
+
+    return () => {
+      isMounted = false
+    }
+    // Intentionally omitting `router` so the auth flow runs once on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (


### PR DESCRIPTION
Fixes #46593

Adds an isMounted guard in SignInPartner so redirects do not fire after the component unmounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sign-in flow behavior when navigating away from the sign-in page during authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->