### PR TITLE
Trying to fix form submission to Notion and HubSpot

### DIFF
--- a/packages/marketing/src/go/actions/formCrmResolver.ts
+++ b/packages/marketing/src/go/actions/formCrmResolver.ts
@@ -11,7 +11,22 @@ export type FormCrmResolver = (
   ref: FormRef
 ) => GoFormCrmConfig | undefined | Promise<GoFormCrmConfig | undefined>
 
-let resolver: FormCrmResolver | null = null
+/**
+ * The resolver is stored on `globalThis` rather than in a module-level variable.
+ * `instrumentation.ts` registers it via the `marketing` package barrel, while
+ * `submitFormAction` reads it via a relative import. In a bundled build those
+ * two paths can resolve to separate instances of this module, so a plain
+ * module-level singleton set on one instance is invisible to the other — the
+ * action then sees `null` and every submission fails with "Form not found".
+ * A `globalThis` slot is shared across all module instances in the process.
+ */
+const RESOLVER_KEY = Symbol.for('marketing.go.formCrmResolver')
+
+type ResolverStore = { [key: symbol]: FormCrmResolver | null | undefined }
+
+function resolverStore(): ResolverStore {
+  return globalThis as unknown as ResolverStore
+}
 
 /**
  * Register the function used by `submitFormAction` to look up the trusted CRM
@@ -23,10 +38,11 @@ let resolver: FormCrmResolver | null = null
  * `submitFormAction` for the security rationale.
  */
 export function setFormCrmResolver(fn: FormCrmResolver): void {
-  resolver = fn
+  resolverStore()[RESOLVER_KEY] = fn
 }
 
 export async function resolveFormCrmConfig(ref: FormRef): Promise<GoFormCrmConfig | undefined> {
+  const resolver = resolverStore()[RESOLVER_KEY]
   if (!resolver) return undefined
   return await resolver(ref)
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

go pages can have forms. Those forms can also submit to HubSpot and Notion, if configured properly. There appears to be a bug in the form submission that we thought we had fixed on Friday. I'm attempting to fix it here because the web developer working on this project has left the company. I can definitively rule out API keys and form UUIDs as the culprit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CRM resolver configuration in bundled application builds to ensure proper CRM form integration across all module instances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->