### PR TITLE
fix(studio): remove default DataGrid borders in table editor

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -403,7 +403,7 @@ export const Grid = memo(
                   ref={ref}
                   className={cn(
                     gridClass,
-                    'grow border-t-0! border-b-0!',
+                    'grow border-t-default! border-b-0!',
                     isContextMenuOpen && 'rdg-context-menu-open'
                   )}
                   rowClass={computedRowClass}

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -401,7 +401,11 @@ export const Grid = memo(
                 )}
                 <DataGrid
                   ref={ref}
-                  className={cn(gridClass, 'grow', isContextMenuOpen && 'rdg-context-menu-open')}
+                  className={cn(
+                    gridClass,
+                    'grow border-t-0! border-b-0!',
+                    isContextMenuOpen && 'rdg-context-menu-open'
+                  )}
                   rowClass={computedRowClass}
                   columns={columnsWithDirtyCellClass}
                   rows={rows ?? []}


### PR DESCRIPTION
Follow-up to #46448, which removed the doubled DataGrid borders across Studio. The table editor grid had the same doubled border at the bottom, but unlike the other grids it still needs a top border — and that top border was rendering in react-data-grid's own `--rdg-border-color` rather than the studio default.

**Changed:**
- Removed the doubled bottom border on the table editor `<DataGrid>` (`border-b-0!`)
- Forced the top border to the default border color via the `border-t-default!` token (≈ rgb(46,46,46) / `--border-default`) instead of leaning on react-data-grid's `--rdg-border-color`

## To test

- Open the table editor for any table (`/project/[ref]/editor/[id]`)
- Confirm there's a single top border between the filter/sort toolbar and the grid header, in the standard border color
- Confirm there's no extra line at the bottom of the grid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined grid visuals and spacing to improve alignment and visual consistency across the app. Adjustments to border and growth behavior reduce border inconsistencies and layout jitter during resizing. Context menu display behavior remains intact, ensuring expected right-click interactions continue to work smoothly for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->