### PR TITLE
fix: Don't use the custom domain when resolving OpenID config

### DIFF
--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
@@ -1,7 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { useForm } from 'react-hook-form'
@@ -17,13 +16,14 @@ import {
   Input,
   Switch,
 } from 'ui'
-import { PageSection, PageSectionContent } from 'ui-patterns'
 import { Admonition } from 'ui-patterns/admonition'
 import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { PageSection, PageSectionContent } from 'ui-patterns/PageSection'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import * as z from 'zod'
 
+import { OAuthEndpointsTable } from './OAuthEndpointsTable'
 import { InlineLink } from '@/components/ui/InlineLink'
 import NoPermission from '@/components/ui/NoPermission'
 import { useAuthConfigQuery } from '@/data/auth/auth-config-query'
@@ -31,10 +31,6 @@ import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-muta
 import { useOAuthServerAppsQuery } from '@/data/oauth-server-apps/oauth-server-apps-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { DOCS_URL } from '@/lib/constants'
-
-const OAuthEndpointsTable = dynamic(() =>
-  import('./OAuthEndpointsTable').then((mod) => ({ default: mod.OAuthEndpointsTable }))
-)
 
 const configUrlSchema = z.object({
   id: z.string(),

--- a/apps/studio/data/oauth-server-apps/oauth-openid-configuration-query.ts
+++ b/apps/studio/data/oauth-server-apps/oauth-openid-configuration-query.ts
@@ -31,13 +31,13 @@ export type OpenIDConfiguration = {
 }
 
 export async function getOpenIDConfiguration({
-  clientEndpoint,
+  endpoint,
 }: {
-  clientEndpoint: string | undefined
+  endpoint: string | undefined
 }): Promise<OpenIDConfiguration> {
-  if (!clientEndpoint) throw new Error('Client endpoint is required')
+  if (!endpoint) throw new Error('Client endpoint is required')
 
-  const response = await fetch(`${clientEndpoint}/auth/v1/.well-known/openid-configuration`)
+  const response = await fetch(`${endpoint}/auth/v1/.well-known/openid-configuration`)
 
   if (!response.ok) {
     handleError({ message: `Failed to fetch OpenID configuration: ${response.statusText}` })
@@ -56,7 +56,7 @@ export const useOpenIDConfigurationQuery = <TData = OpenIDConfigurationData>(
     ...options
   }: UseCustomQueryOptions<OpenIDConfigurationData, OpenIDConfigurationError, TData> = {}
 ) => {
-  const { data: clientEndpoint, isPending: isEndpointLoading } = useProjectApiUrl({
+  const { hostEndpoint, isPending: isEndpointLoading } = useProjectApiUrl({
     projectRef,
   })
 
@@ -70,13 +70,13 @@ export const useOpenIDConfigurationQuery = <TData = OpenIDConfigurationData>(
   const isQueryEnabled =
     enabled &&
     typeof projectRef !== 'undefined' &&
-    !!clientEndpoint &&
+    !!hostEndpoint &&
     isSuccessConfig &&
     isOAuthServerEnabled
 
   const query = useQuery<OpenIDConfigurationData, OpenIDConfigurationError, TData>({
     queryKey: oauthServerAppKeys.openidConfiguration(projectRef),
-    queryFn: () => getOpenIDConfiguration({ clientEndpoint }),
+    queryFn: () => getOpenIDConfiguration({ endpoint: hostEndpoint }),
     enabled: isQueryEnabled,
     ...options,
   })


### PR DESCRIPTION
When setting up an OAuth Server app, the Studio fetches OpenID config from the URL. If the project uses custom domain, it'll cause a CORS because the custom domain is not whitelisted. This PR changes to use the `<ref>.supabase.co` URL to resolve the config.

How to test:

1. Have a project with custom domain
2. Open `/project/_/auth/oauth-server`
3. Enable the Supabase OAuth Server
4. The OAuth endpoints in the bottom should appear

BEFORE:
<img width="1172" height="412" alt="Screenshot 2026-06-04 at 10 43 35" src="https://github.com/user-attachments/assets/d6157281-dc80-4a55-9356-10efb7953b7c" />

AFTER:
<img width="1182" height="406" alt="Screenshot 2026-06-04 at 10 42 20" src="https://github.com/user-attachments/assets/6222124e-5f9e-4898-9fae-41d295211403" />

Fixes https://linear.app/supabase/issue/FE-2987/oauth-endpoint-fields-are-empty-with-custom-domains
