### PR TITLE
fix(pg-meta): avoid mutating table columns in row SQL

### DIFF
--- a/packages/pg-meta/src/query/table-row-query.ts
+++ b/packages/pg-meta/src/query/table-row-query.ts
@@ -183,7 +183,7 @@ export const getTableRowsSql = ({
   // all the rows within the table
   const baseSelectQuery = safeSql`with _base_query as (${queryChains.range(from, to).toSql({ isCTE: false, isFinal: false })})`
 
-  const allColumnNames = table.columns
+  const allColumnNames = [...table.columns]
     .sort((a, b) => a.ordinal_position - b.ordinal_position)
     .map((column) => ({ name: column.name, format: column.format.toLowerCase() }))
 

--- a/packages/pg-meta/test/query/table-row-query.test.ts
+++ b/packages/pg-meta/test/query/table-row-query.test.ts
@@ -61,6 +61,39 @@ describe('Table Row Query', () => {
   })
 
   describe('getTableRowsSql', () => {
+    test('should not mutate table columns when generating SQL', () => {
+      const table = {
+        name: 'test_table',
+        schema: 'public',
+        columns: [
+          {
+            name: 'second',
+            data_type: 'integer',
+            format: 'int4',
+            ordinal_position: 2,
+          },
+          {
+            name: 'first',
+            data_type: 'integer',
+            format: 'int4',
+            ordinal_position: 1,
+          },
+        ],
+        primary_keys: [],
+        live_rows_estimate: 0,
+      }
+      const originalColumnOrder = table.columns.map((column) => column.name)
+
+      const sql = getTableRowsSql({
+        table: table as any,
+        page: 1,
+        limit: 10,
+      })
+
+      expect(sql).toContain('select first,second from _base_query;')
+      expect(table.columns.map((column) => column.name)).toEqual(originalColumnOrder)
+    })
+
     withTestDatabase('should handle array of enums correctly', async (db) => {
       // Create an enum type and a table with an array of that enum
       await db.executeQuery(`


### PR DESCRIPTION
## Summary

  Fixes `getTableRowsSql` so it does not mutate caller-owned table column metadata while generating row SQL.

  Previously, the function sorted `table.columns` in place before building the select list. That produced the expected SQL, but also changed the original table metadata object passed by the caller.

## Changes

  - Copy `table.columns` before sorting by `ordinal_position`
  - Add a regression test that verifies SQL generation preserves the caller's original column order

## Testing

  - `git diff --check`

  Attempted:

  - `npx pnpm@10.24.0 --filter @supabase/pg-meta test -- query/table-row-query.test.ts`

  Could not complete locally because this machine has Node `v18.19.1`, while the repo requires Node `>=22`. The pg-meta test script also requires Docker, and `docker` is not installed in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where table column data could be inadvertently modified during row query operations. The system now preserves the original column structure without any side effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->