### PR TITLE
fix(pg-meta): avoid mutating table columns in row SQL

### DIFF
--- a/packages/pg-meta/src/query/table-row-query.ts
+++ b/packages/pg-meta/src/query/table-row-query.ts
@@ -183,7 +183,7 @@ export const getTableRowsSql = ({
   // all the rows within the table
   const baseSelectQuery = safeSql`with _base_query as (${queryChains.range(from, to).toSql({ isCTE: false, isFinal: false })})`
 
-  const allColumnNames = table.columns
+  const allColumnNames = [...table.columns]
     .sort((a, b) => a.ordinal_position - b.ordinal_position)
     .map((column) => ({ name: column.name, format: column.format.toLowerCase() }))
 

--- a/packages/pg-meta/test/query/table-row-query.test.ts
+++ b/packages/pg-meta/test/query/table-row-query.test.ts
@@ -61,6 +61,39 @@ describe('Table Row Query', () => {
   })
 
   describe('getTableRowsSql', () => {
+    test('should not mutate table columns when generating SQL', () => {
+      const table = {
+        name: 'test_table',
+        schema: 'public',
+        columns: [
+          {
+            name: 'second',
+            data_type: 'integer',
+            format: 'int4',
+            ordinal_position: 2,
+          },
+          {
+            name: 'first',
+            data_type: 'integer',
+            format: 'int4',
+            ordinal_position: 1,
+          },
+        ],
+        primary_keys: [],
+        live_rows_estimate: 0,
+      }
+      const originalColumnOrder = table.columns.map((column) => column.name)
+
+      const sql = getTableRowsSql({
+        table: table as any,
+        page: 1,
+        limit: 10,
+      })
+
+      expect(sql).toContain('select first,second from _base_query;')
+      expect(table.columns.map((column) => column.name)).toEqual(originalColumnOrder)
+    })
+
     withTestDatabase('should handle array of enums correctly', async (db) => {
       // Create an enum type and a table with an array of that enum
       await db.executeQuery(`


### PR DESCRIPTION
  ## Summary

  Fixes `getTableRowsSql` so it does not mutate caller-owned table column metadata while generating row SQL.

  Previously, the function sorted `table.columns` in place before building the select list. That produced the expected SQL, but also changed the original table metadata object passed by the caller.

  ## Changes

  - Copy `table.columns` before sorting by `ordinal_position`
  - Add a regression test that verifies SQL generation preserves the caller's original column order

  ## Testing

  - `git diff --check`
  - `PATH=/home/bulut/.local/node-v24.16.0/bin:$PATH corepack pnpm --filter @supabase/pg-meta exec vitest run test/query/table-row-query.test.ts -t "should not mutate table columns when generating SQL"`
  - `PATH=/home/bulut/.local/node-v24.16.0/bin:$PATH corepack pnpm --filter @supabase/pg-meta typecheck`
  - `PATH=/home/bulut/.local/node-v24.16.0/bin:$PATH corepack pnpm exec prettier --check packages/pg-meta/src/query/table-row-query.ts packages/pg-meta/test/query/table-row-query.test.ts`

  The targeted regression test passes locally with Node `v24.16.0`.

  I did not run the full Docker-backed `@supabase/pg-meta` test wrapper locally because Docker is not available in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling in table row queries to avoid unintended modification of input data, ensuring queries preserve original table metadata and produce stable results.

* **Tests**
  * Added unit test coverage to verify input data integrity during query generation, reducing risk of regressions and increasing confidence in query behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->