### PR TITLE
refactor(studio): add chart view-model types and consolidate value-format detection

### DIFF
--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -17,6 +17,7 @@ import {
 import { CategoricalChartState } from 'recharts/types/chart/types'
 import { cn } from 'ui'
 
+import { getChartValueFlags } from './chart-formatters'
 import { ChartHeader } from './ChartHeader'
 import { ChartHighlightAction, ChartHighlightActions } from './ChartHighlightActions'
 import {
@@ -371,22 +372,12 @@ export function ComposedChart({
     [data, normalizeVisibleStackToPercent, visibleAttributes]
   )
 
-  const isPercentage = format === '%'
-  const isRamChart =
-    !chartData?.some((att: any) => att.name.toLowerCase() === 'ram_usage') &&
-    chartData?.some((att: any) => att.name.toLowerCase().includes('ram_'))
-  const isSwapChart = chartData?.some((att: any) => att.name.toLowerCase().includes('swap_'))
-  const isMemoryChart = isRamChart || isSwapChart
-  const isDiskSpaceChart = chartData?.some((att: any) =>
-    att.name.toLowerCase().includes('disk_space_')
-  )
-  const isDBSizeChart = chartData?.some((att: any) =>
-    att.name.toLowerCase().includes('pg_database_size')
-  )
-  const isNetworkChart = chartData?.some((att: any) => att.name.toLowerCase().includes('network_'))
-  const isBytesFormat = format === 'bytes' || format === 'bytes-per-second'
-  const shouldFormatBytes =
-    isBytesFormat || isMemoryChart || isDiskSpaceChart || isDBSizeChart || isNetworkChart
+  const { isPercentage, isBytesFormat, isMemoryChart, isNetworkChart, shouldFormatBytes } =
+    getChartValueFlags(
+      chartData.map((c) => c.name),
+      format,
+      attributes
+    )
   const yMaxFromVisible = Math.max(
     0,
     ...visibleAttributes.map((att) => (typeof att.value === 'number' ? att.value : 0))

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { cn, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'ui'
 
+import { type FormatStyle, type MetricDoc } from './chart-view-model'
 import { CHART_COLORS, DateTimeFormats } from './Charts.constants'
 import { formatPercentage, numberFormatter } from './Charts.utils'
 import { useFormatDateTime, useTimezone } from '@/lib/datetime'
@@ -26,6 +27,7 @@ export interface ReportAttributes {
   showMaxValue?: boolean
   valuePrecision?: number
   docsUrl?: string
+  doc?: MetricDoc
   syncId?: string
   showGrid?: boolean
   YAxisProps?: {
@@ -59,6 +61,8 @@ export type MultiAttribute = {
   format?: string
   description?: string
   docsLink?: string
+  formatStyle?: FormatStyle
+  doc?: MetricDoc
   isMaxValue?: boolean
   type?: 'line' | 'area-bar'
   omitFromTotal?: boolean

--- a/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.utils.tsx
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import { cn, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'ui'
 
+import { getChartValueFlags } from './chart-formatters'
 import { type FormatStyle, type MetricDoc } from './chart-view-model'
 import { CHART_COLORS, DateTimeFormats } from './Charts.constants'
 import { formatPercentage, numberFormatter } from './Charts.utils'
@@ -175,17 +176,11 @@ export const CustomTooltip = ({
         ? Number(rawDataPoint[maxValueAttribute.attribute])
         : undefined
     const hasFiniteMaxValue = typeof maxValue === 'number' && Number.isFinite(maxValue)
-    const isRamChart =
-      !payload?.some((p: any) => p.dataKey.toLowerCase() === 'ram_usage') &&
-      payload?.some((p: any) => p.dataKey.toLowerCase().includes('ram_'))
-    const isSwapChart = payload?.some((p: any) => p.dataKey.toLowerCase().includes('swap_'))
-    const isMemoryChart = isRamChart || isSwapChart
-    const isDBSizeChart =
-      payload?.some((p: any) => p.dataKey.toLowerCase().includes('disk_fs_')) ||
-      payload?.some((p: any) => p.dataKey.toLowerCase().includes('pg_database_size'))
-    const isNetworkChart = payload?.some((p: any) => p.dataKey.toLowerCase().includes('network_'))
-    const isBytesFormat = format === 'bytes' || format === 'bytes-per-second'
-    const shouldFormatBytes = isBytesFormat || isMemoryChart || isDBSizeChart || isNetworkChart
+    const { isBytesFormat, isMemoryChart, isNetworkChart, shouldFormatBytes } = getChartValueFlags(
+      payload.map((p: any) => p.dataKey),
+      typeof format === 'string' ? format : undefined,
+      attributes
+    )
     const byteUnitSuffix = format === 'bytes-per-second' ? '/s' : ''
 
     const attributesToIgnore =

--- a/apps/studio/components/ui/Charts/chart-formatters.test.ts
+++ b/apps/studio/components/ui/Charts/chart-formatters.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest'
+
+import { getChartValueFlags } from './chart-formatters'
+
+describe('getChartValueFlags', () => {
+  // ---- RAM / memory ----
+
+  it('detects ram chart from ram_ prefix keys (not ram_usage alone)', () => {
+    const flags = getChartValueFlags(['ram_available', 'ram_total'])
+    expect(flags.isMemoryChart).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('does NOT treat ram_usage-only key as memory chart', () => {
+    const flags = getChartValueFlags(['ram_usage'])
+    expect(flags.isMemoryChart).toBe(false)
+  })
+
+  it('treats ram_usage alongside other ram_ keys as memory chart', () => {
+    // ram_usage present AND another ram_ key => ram_usage !== exact-only => isRamChart true
+    const flags = getChartValueFlags(['ram_usage', 'ram_available'])
+    expect(flags.isMemoryChart).toBe(true)
+  })
+
+  it('detects swap chart', () => {
+    const flags = getChartValueFlags(['swap_used', 'swap_total'])
+    expect(flags.isMemoryChart).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  // ---- network ----
+
+  it('detects network chart', () => {
+    const flags = getChartValueFlags(['network_ingress', 'network_egress'])
+    expect(flags.isNetworkChart).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  // ---- disk / db size (byte-like extras) ----
+
+  it('detects disk_space_ key as shouldFormatBytes', () => {
+    const flags = getChartValueFlags(['disk_space_used'])
+    expect(flags.shouldFormatBytes).toBe(true)
+    expect(flags.isMemoryChart).toBe(false)
+    expect(flags.isNetworkChart).toBe(false)
+  })
+
+  it('detects disk_fs_ key as shouldFormatBytes', () => {
+    const flags = getChartValueFlags(['disk_fs_used'])
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('detects pg_database_size key as shouldFormatBytes', () => {
+    const flags = getChartValueFlags(['pg_database_size'])
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  // ---- format strings ----
+
+  it('sets isBytesFormat for format=bytes', () => {
+    const flags = getChartValueFlags(['cpu_usage'], 'bytes')
+    expect(flags.isBytesFormat).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('sets isBytesFormat for format=bytes-per-second', () => {
+    const flags = getChartValueFlags(['cpu_usage'], 'bytes-per-second')
+    expect(flags.isBytesFormat).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('sets isPercentage for format=%', () => {
+    const flags = getChartValueFlags(['cpu_usage'], '%')
+    expect(flags.isPercentage).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(false)
+  })
+
+  // ---- plain numeric keys ----
+
+  it('returns all-false for plain numeric keys with no format', () => {
+    const flags = getChartValueFlags(['active_connections', 'idle_connections'])
+    expect(flags.isPercentage).toBe(false)
+    expect(flags.isBytesFormat).toBe(false)
+    expect(flags.isMemoryChart).toBe(false)
+    expect(flags.isNetworkChart).toBe(false)
+    expect(flags.shouldFormatBytes).toBe(false)
+  })
+
+  it('handles empty keys array', () => {
+    const flags = getChartValueFlags([])
+    expect(flags.isMemoryChart).toBe(false)
+    expect(flags.shouldFormatBytes).toBe(false)
+  })
+
+  // ---- formatStyle overrides ----
+
+  it('formatStyle=memory forces isMemoryChart', () => {
+    const flags = getChartValueFlags(['some_metric'], undefined, [
+      { attribute: 'some_metric', formatStyle: 'memory' },
+    ])
+    expect(flags.isMemoryChart).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('formatStyle=network forces isNetworkChart', () => {
+    const flags = getChartValueFlags(['some_metric'], undefined, [
+      { attribute: 'some_metric', formatStyle: 'network' },
+    ])
+    expect(flags.isNetworkChart).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('formatStyle=bytes forces isBytesFormat and shouldFormatBytes', () => {
+    const flags = getChartValueFlags(['some_metric'], undefined, [
+      { attribute: 'some_metric', formatStyle: 'bytes' },
+    ])
+    expect(flags.isBytesFormat).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('formatStyle=bytes-per-second forces isBytesFormat', () => {
+    const flags = getChartValueFlags(['some_metric'], undefined, [
+      { attribute: 'some_metric', formatStyle: 'bytes-per-second' },
+    ])
+    expect(flags.isBytesFormat).toBe(true)
+    expect(flags.shouldFormatBytes).toBe(true)
+  })
+
+  it('formatStyle=percent forces isPercentage', () => {
+    const flags = getChartValueFlags(['some_metric'], undefined, [
+      { attribute: 'some_metric', formatStyle: 'percent' },
+    ])
+    expect(flags.isPercentage).toBe(true)
+  })
+
+  it('formatStyle overrides are applied without format param', () => {
+    const flags = getChartValueFlags(['some_metric'], undefined, [
+      { attribute: 'some_metric', formatStyle: 'memory' },
+    ])
+    expect(flags.isMemoryChart).toBe(true)
+    expect(flags.isBytesFormat).toBe(false)
+  })
+})

--- a/apps/studio/components/ui/Charts/chart-formatters.ts
+++ b/apps/studio/components/ui/Charts/chart-formatters.ts
@@ -1,0 +1,68 @@
+import type { FormatStyle, MultiAttribute } from './chart-view-model'
+
+export interface ChartValueFlags {
+  isPercentage: boolean
+  isBytesFormat: boolean
+  isMemoryChart: boolean
+  isNetworkChart: boolean
+  shouldFormatBytes: boolean
+}
+
+/**
+ * Detect, from the series keys and the chart's format, how values should be
+ * formatted. If any attribute declares an explicit formatStyle, that takes
+ * precedence over the name-pattern heuristics.
+ *
+ * Note on reconciled drift: Copy A (ComposedChart.tsx) matched disk_space_
+ * but not disk_fs_; Copy B (ComposedChart.utils.tsx) matched disk_fs_ but not
+ * disk_space_. This helper treats both, plus pg_database_size, as byte-like
+ * (the union of what both copies matched).
+ */
+export function getChartValueFlags(
+  seriesKeys: string[],
+  format?: string,
+  attributes?: Pick<MultiAttribute, 'attribute' | 'formatStyle'>[]
+): ChartValueFlags {
+  const lower = seriesKeys.map((k) => k.toLowerCase())
+
+  // Name-pattern heuristics (same logic as the two originals, unified)
+  const isRamChart = !lower.some((k) => k === 'ram_usage') && lower.some((k) => k.includes('ram_'))
+  const isSwapChart = lower.some((k) => k.includes('swap_'))
+  const isMemoryHeuristic = isRamChart || isSwapChart
+
+  const isNetworkHeuristic = lower.some((k) => k.includes('network_'))
+
+  // Byte-like extras: union of both originals' patterns
+  const byteLikeExtras =
+    lower.some((k) => k.includes('disk_space_')) ||
+    lower.some((k) => k.includes('disk_fs_')) ||
+    lower.some((k) => k.includes('pg_database_size'))
+
+  const isBytesFormatHeuristic = format === 'bytes' || format === 'bytes-per-second'
+  const isPercentageHeuristic = format === '%'
+
+  // Explicit formatStyle overrides from attribute metadata
+  let forceMemory = false
+  let forceNetwork = false
+  let forceBytesFormat = false
+  let forcePercentage = false
+
+  if (attributes && attributes.length > 0) {
+    for (const attr of attributes) {
+      const fs = attr.formatStyle as FormatStyle | undefined
+      if (!fs) continue
+      if (fs === 'memory') forceMemory = true
+      else if (fs === 'network') forceNetwork = true
+      else if (fs === 'bytes' || fs === 'bytes-per-second') forceBytesFormat = true
+      else if (fs === 'percent') forcePercentage = true
+    }
+  }
+
+  const isPercentage = isPercentageHeuristic || forcePercentage
+  const isBytesFormat = isBytesFormatHeuristic || forceBytesFormat
+  const isMemoryChart = isMemoryHeuristic || forceMemory
+  const isNetworkChart = isNetworkHeuristic || forceNetwork
+  const shouldFormatBytes = isBytesFormat || isMemoryChart || isNetworkChart || byteLikeExtras
+
+  return { isPercentage, isBytesFormat, isMemoryChart, isNetworkChart, shouldFormatBytes }
+}

--- a/apps/studio/components/ui/Charts/chart-view-model.ts
+++ b/apps/studio/components/ui/Charts/chart-view-model.ts
@@ -1,0 +1,46 @@
+/** How a numeric value should be formatted for display. Replaces the old
+ *  practice of inferring chart type by string-matching attribute names. */
+export type FormatStyle =
+  | 'number'
+  | 'percent'
+  | 'bytes'
+  | 'bytes-per-second'
+  | 'memory'
+  | 'network'
+  | 'duration-ms'
+  | 'seconds'
+
+/** Structured in-tooltip documentation for a chart or a series. */
+export interface MetricDoc {
+  /** What the metric means. */
+  description: string
+  /** When a reading is problematic / what a bad value looks like. */
+  whenProblematic?: string
+  /** Optional deep-dive link, demoted to a secondary "Learn more". */
+  docsUrl?: string
+}
+
+export type ChartSeriesKind = 'area' | 'bar' | 'line' | 'reference-line'
+
+/** A single render-ready series. All visual properties are already resolved
+ *  (theme colors resolved upstream); the chart component does no derivation. */
+export interface ChartSeries {
+  key: string
+  label: string
+  kind: ChartSeriesKind
+  color: string
+  fill: string
+  stackId?: string
+  strokeDasharray?: string
+  referenceValue?: number
+  doc?: MetricDoc
+}
+
+/** Fully-prepared input for the render-only chart. Contains no logic. */
+export interface ChartViewModel {
+  series: ChartSeries[]
+  rows: Array<Record<string, number | string>>
+  xKey: string
+  yAxisDomain: [number | string, number | string]
+  doc?: MetricDoc
+}


### PR DESCRIPTION
## Problem

Charts in the database report infer how to format their values by string-matching attribute names, and that detection logic is duplicated across `ComposedChart.tsx` and `ComposedChart.utils.tsx`. The two copies have drifted (one checks `disk_space_`, the other `disk_fs_`), which is exactly the kind of silent inconsistency we want to remove. This is also the first step toward replacing `ComposedChart` with a render-only chart that consumes a prepared view model.

## What this does

- Adds a shared type contract in `chart-view-model.ts`: `FormatStyle`, `MetricDoc`, `ChartSeries`, `ChartViewModel`. Additive optional `formatStyle?` / `doc?` fields on `MultiAttribute` and `ReportAttributes` (no behavior change).
- Consolidates the duplicated chart-type detection into one tested helper, `getChartValueFlags()`, in `chart-formatters.ts`. Both call sites now use it. An explicit `formatStyle` on an attribute overrides the name-based detection.
- Reconciles the drift: the helper treats `disk_space_`, `disk_fs_`, and `pg_database_size` as byte-like (the union of the two old copies). Noted in a code comment.
- Adds unit tests for the helper.

Net: removes two duplicated detection blocks, adds one helper plus tests.

## Testing

`chart-formatters.test.ts` covers ram/swap/network detection, the `ram_usage` negative case, each byte-like key prefix, plain numeric keys, the `bytes` / `bytes-per-second` / `%` formats, and the `formatStyle` overrides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chart metrics now include optional documentation (description, when problematic, docs link) and per-series formatting styles.
  * Charts support explicit format styles (number, percent, bytes, bytes/sec, memory, network, durations) for clearer display.

* **Bug Fixes / Improvements**
  * Unified chart value detection so formatting/units are determined consistently across charts.

* **Tests**
  * Added tests validating formatting detection and override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->