### PR TITLE
fix: add vector bucket local CLI section

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -2184,6 +2184,11 @@ export const storage: NavMenuConstant = {
           url: '/guides/storage/vector/querying-vectors' as `/${string}`,
         },
         {
+          name: 'Local Development',
+          url: '/guides/storage/vector/local-development' as `/${string}`,
+          enabled: billingEnabled,
+        },
+        {
           name: 'Limits',
           url: '/guides/storage/vector/limits' as `/${string}`,
           enabled: billingEnabled,

--- a/apps/docs/content/guides/storage/vector/local-development.mdx
+++ b/apps/docs/content/guides/storage/vector/local-development.mdx
@@ -21,6 +21,7 @@ The Hosted version uses S3Vectors as the Storage engine for vectors, which is op
 
 The API remain consistent between local and hosted environments, so you can build your application logic against the local pg_vector implementation and expect it to work with the S3Vectors engine in production.
 
+</Admonition>
 ## Setting up local vector buckets
 
 Make sure you have the feature enabled in your `config.toml` file:

--- a/apps/docs/content/guides/storage/vector/local-development.mdx
+++ b/apps/docs/content/guides/storage/vector/local-development.mdx
@@ -14,7 +14,7 @@ You can now develop and test Vector Bucket integrations in your local environmen
 This allows you to build and iterate on your vector search applications without needing to deploy to a live environment.
 Make sure you have the latest version of the Supabase CLI installed to access this feature.
 
-<Admonition type="info" title="Local driver">
+<Admonition type="note" title="Local driver">
 
 In local development, vector buckets uses pg_vector as the underlying storage engine under the hood.
 The Hosted version uses S3Vectors as the Storage engine for vectors, which is optimized for large-scale vector storage and similarity search. This means that while you can develop and test your vector bucket integrations locally, there may be differences in performance and behavior compared to the cloud environment.

--- a/apps/docs/content/guides/storage/vector/local-development.mdx
+++ b/apps/docs/content/guides/storage/vector/local-development.mdx
@@ -15,6 +15,7 @@ This allows you to build and iterate on your vector search applications without 
 Make sure you have the latest version of the Supabase CLI installed to access this feature.
 
 <Admonition type="info" title="Local driver">
+
 In local development, vector buckets uses pg_vector as the underlying storage engine under the hood.
 The Hosted version uses S3Vectors as the Storage engine for vectors, which is optimized for large-scale vector storage and similarity search. This means that while you can develop and test your vector bucket integrations locally, there may be differences in performance and behavior compared to the cloud environment.
 

--- a/apps/docs/content/guides/storage/vector/local-development.mdx
+++ b/apps/docs/content/guides/storage/vector/local-development.mdx
@@ -1,0 +1,45 @@
+---
+title: 'Vector Bucket Local Development'
+subtitle: 'Develop and test vector bucket integrations in your local environment with the Supabase CLI.'
+---
+
+<Admonition type="caution" title="This feature is in alpha">
+
+Expect rapid changes, limited features, and possible breaking updates. [Share feedback](https://github.com/orgs/supabase/discussions/40116) as we refine the experience and expand access.
+
+</Admonition>
+
+You can now develop and test Vector Bucket integrations in your local environment using the Supabase CLI.
+
+This allows you to build and iterate on your vector search applications without needing to deploy to a live environment.
+Make sure you have the latest version of the Supabase CLI installed to access this feature.
+
+<Admonition type="info" title="Local driver">
+In local development, vector buckets uses pg_vector as the underlying storage engine under the hood.
+The Hosted version uses S3Vectors as the Storage engine for vectors, which is optimized for large-scale vector storage and similarity search. This means that while you can develop and test your vector bucket integrations locally, there may be differences in performance and behavior compared to the cloud environment.
+
+The API remain consistent between local and hosted environments, so you can build your application logic against the local pg_vector implementation and expect it to work with the S3Vectors engine in production.
+</Admonition>
+
+## Setting up local vector buckets
+
+Make sure you have the feature enabled in your `config.toml` file:
+
+```toml
+
+# Store vector embeddings in S3 for large and durable datasets
+[storage.vector]
+enabled = true
+```
+
+### Declarative configuration
+
+You can define your vector buckets in the `config.toml` file using the following syntax:
+
+```toml
+[storage.vector.buckets.documents-openai]
+[storage.vector.buckets.images]
+```
+
+Then use `supabase seed buckets` to create the buckets in your local environment or linked project.
+

--- a/apps/docs/content/guides/storage/vector/local-development.mdx
+++ b/apps/docs/content/guides/storage/vector/local-development.mdx
@@ -21,9 +21,6 @@ The Hosted version uses S3Vectors as the Storage engine for vectors, which is op
 
 The API remain consistent between local and hosted environments, so you can build your application logic against the local pg_vector implementation and expect it to work with the S3Vectors engine in production.
 
-
-
-
 ## Setting up local vector buckets
 
 Make sure you have the feature enabled in your `config.toml` file:
@@ -45,4 +42,3 @@ You can define your vector buckets in the `config.toml` file using the following
 ```
 
 Then use `supabase seed buckets` to create the buckets in your local environment or linked project.
-

--- a/apps/docs/content/guides/storage/vector/local-development.mdx
+++ b/apps/docs/content/guides/storage/vector/local-development.mdx
@@ -20,6 +20,7 @@ In local development, vector buckets uses pg_vector as the underlying storage en
 The Hosted version uses S3Vectors as the Storage engine for vectors, which is optimized for large-scale vector storage and similarity search. This means that while you can develop and test your vector bucket integrations locally, there may be differences in performance and behavior compared to the cloud environment.
 
 The API remain consistent between local and hosted environments, so you can build your application logic against the local pg_vector implementation and expect it to work with the S3Vectors engine in production.
+
 </Admonition>
 
 ## Setting up local vector buckets

--- a/apps/docs/content/guides/storage/vector/local-development.mdx
+++ b/apps/docs/content/guides/storage/vector/local-development.mdx
@@ -21,7 +21,8 @@ The Hosted version uses S3Vectors as the Storage engine for vectors, which is op
 
 The API remain consistent between local and hosted environments, so you can build your application logic against the local pg_vector implementation and expect it to work with the S3Vectors engine in production.
 
-</Admonition>
+
+
 
 ## Setting up local vector buckets
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the nee current behavior?

Added new section to explain how  vector buckets works locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Local Development" guide for Vector Buckets covering alpha-status cautions, differences between local and hosted storage behavior, steps to enable local vector storage, declarative bucket configuration, and how to create buckets for local testing.
  * Updated site navigation to include the new Local Development guide under Storage → Vector.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->