### PR TITLE
fix(docker): correct send sms hook example uri

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -242,7 +242,7 @@ services:
       # GOTRUE_HOOK_PASSWORD_VERIFICATION_ATTEMPT_URI: "pg-functions://postgres/public/password_verification_attempt"
 
       # GOTRUE_HOOK_SEND_SMS_ENABLED: "false"
-      # GOTRUE_HOOK_SEND_SMS_URI: "pg-functions://postgres/public/custom_access_token_hook"
+      # GOTRUE_HOOK_SEND_SMS_URI: "pg-functions://postgres/public/send_sms"
       # GOTRUE_HOOK_SEND_SMS_SECRETS: "v1,whsec_VGhpcyBpcyBhbiBleGFtcGxlIG9mIGEgc2hvcnRlciBCYXNlNjQgc3RyaW5n"
 
       # GOTRUE_HOOK_SEND_EMAIL_ENABLED: "false"


### PR DESCRIPTION
I have read the CONTRIBUTING.md file.

YES

What kind of change does this PR introduce?

Bug fix.

What is the current behavior?

`docker/docker-compose.yml` shows `GOTRUE_HOOK_SEND_SMS_URI` pointing at `pg-functions://postgres/public/custom_access_token_hook`.
The send SMS hook guide uses `create or replace function send_sms(...)` for the Postgres hook example.
That leaves the self-hosted compose example pointing at the wrong function name.

What is the new behavior?

The commented `GOTRUE_HOOK_SEND_SMS_URI` example now points at `pg-functions://postgres/public/send_sms`.
The self-hosted compose example now matches the documented Postgres send SMS hook name.

Additional context

Testing:
- inspected `docker/docker-compose.yml`
- inspected `apps/docs/content/guides/auth/auth-hooks/send-sms-hook.mdx`
- no runtime tests; this changes a commented example only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SMS notification delivery endpoint configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->