### PR TITLE
docs: replace stale auth hook overview links

### DIFF
--- a/apps/docs/content/errorCodes/authErrorCodes.toml
+++ b/apps/docs/content/errorCodes/authErrorCodes.toml
@@ -126,7 +126,7 @@ description = "MFA challenge could not be verified -- wrong TOTP code."
 [mfa_verification_rejected]
 description = "Further MFA verification is rejected. Only returned if the MFA verification attempt hook returns a reject decision."
 [[mfa_verification_rejected.references]]
-href = "https://supabase.com/docs/guides/auth/auth-hooks?language=add-admin-role#hook-mfa-verification-attempt"
+href = "https://supabase.com/docs/guides/auth/auth-hooks/mfa-verification-hook"
 description = "MFA verification hook"
 
 [mfa_verified_factor_exists]

--- a/apps/docs/content/guides/api/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/api/custom-claims-and-role-based-access-control-rbac.mdx
@@ -18,7 +18,7 @@ Custom Claims are special attributes attached to a user that you can use to cont
 }
 ```
 
-To implement Role-Based Access Control (RBAC) with `custom claims`, use a [Custom Access Token Auth Hook](/docs/guides/auth/auth-hooks#hook-custom-access-token). This hook runs before a token is issued. You can use it to add additional claims to the user's JWT.
+To implement Role-Based Access Control (RBAC) with `custom claims`, use a [Custom Access Token Auth Hook](/docs/guides/auth/auth-hooks/custom-access-token-hook). This hook runs before a token is issued. You can use it to add additional claims to the user's JWT.
 
 This guide uses the [Slack Clone example](https://github.com/supabase/supabase/tree/master/examples/slack-clone/nextjs-slack-clone) to demonstrate how to add a `user_role` claim and use it in your [Row Level Security (RLS) policies](/docs/guides/database/postgres/row-level-security).
 
@@ -71,7 +71,7 @@ values
 
 ## Create Auth Hook to apply user role
 
-The [Custom Access Token Auth Hook](/docs/guides/auth/auth-hooks#hook-custom-access-token) runs before a token is issued. You can use it to edit the JWT.
+The [Custom Access Token Auth Hook](/docs/guides/auth/auth-hooks/custom-access-token-hook) runs before a token is issued. You can use it to edit the JWT.
 
 <Tabs
   scrollable


### PR DESCRIPTION
I have read the CONTRIBUTING.md file.

YES

What kind of change does this PR introduce?

Docs update.

What is the current behavior?

A few docs still point at old auth-hooks overview hashes such as #hook-custom-access-token and #hook-mfa-verification-attempt.
The current auth hooks overview page links to dedicated hook subpages instead, so these older links are no longer the clearest target.

What is the new behavior?

This PR replaces the stale overview hash links with direct links to the current hook pages:
- /docs/guides/auth/auth-hooks/custom-access-token-hook
- /docs/guides/auth/auth-hooks/mfa-verification-hook

Additional context

Testing:
- searched for the remaining auth-hooks hash links in docs content
- verified the current auth hooks overview page points readers to dedicated hook subpages
- no runtime tests; this changes documentation links only