### PR TITLE
chore(docs): add note for newer projects that use physical backups

### DIFF
--- a/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
@@ -6,6 +6,12 @@ breadcrumb: 'Migrations'
 
 ## Before you begin
 
+<Admonition type="note">
+
+Dashboard backups are only available for older projects that still use logical backups. Projects that use physical backups should follow steps in [Backup and Restore using the CLI](/docs/guides/platform/migrating-within-supabase/backup-restore).
+
+</Admonition>
+
 <Accordion
   type="default"
   openBehaviour="multiple"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Currently, this doc outlines how to restore a dashboard backup which only applies to projects that still use logical backups. Newer projects cannot follow this process.

## What is the new behavior?

Adds an admonition to direct users with projects that use physical backups to the correct guide. 

Keeping the legacy guide content for now for older projects that may still be using logical backups.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification that dashboard backups are only available for Supabase projects using logical backups. Projects using physical backups are directed to refer to the CLI backup and restore guide instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->