### PR TITLE
fix: Add intro text above suggested support articles

### DIFF
--- a/apps/studio/components/interfaces/Support/DocsSuggestions.tsx
+++ b/apps/studio/components/interfaces/Support/DocsSuggestions.tsx
@@ -64,7 +64,7 @@ function DocsSuggestions_Results({ results, isStale }: DocsSuggestions_ResultsPr
       </p>
       <ul
         className={cn(
-          'flex flex-col gap-y-0.5 transition-opacity duration-200',
+          'flex flex-col gap-y-0.5 py-1 transition-opacity duration-200',
           isStale ? 'opacity-50' : 'opacity-100'
         )}
       >

--- a/apps/studio/components/interfaces/Support/DocsSuggestions.tsx
+++ b/apps/studio/components/interfaces/Support/DocsSuggestions.tsx
@@ -59,33 +59,35 @@ interface DocsSuggestions_ResultsProps {
 function DocsSuggestions_Results({ results, isStale }: DocsSuggestions_ResultsProps) {
   return (
     <div>
-      <p className="text-sm text-foreground-light">Below are some articles that might help with your issue</p>
+      <p className="text-sm text-foreground-light">
+        Below are some articles that might help with your issue
+      </p>
       <ul
         className={cn(
           'flex flex-col gap-y-0.5 transition-opacity duration-200',
           isStale ? 'opacity-50' : 'opacity-100'
         )}
       >
-      {results.slice(0, 5).map((page) => {
-        return (
-          <li key={page.id} className="flex items-center gap-x-1">
-            {page.type === 'github-discussions' ? (
-              <Github size={16} className="text-foreground-muted" />
-            ) : (
-              <Book size={16} className="text-foreground-muted" />
-            )}
-            <a
-              href={page.type === 'github-discussions' ? page.path : `${DOCS_URL}${page.path}`}
-              target="_blank"
-              rel="noreferrer"
-              className="text-sm text-foreground-light hover:text-foreground transition"
-            >
-              {page.title}
-            </a>
-          </li>
-        )
-      })}
-    </ul>
+        {results.slice(0, 5).map((page) => {
+          return (
+            <li key={page.id} className="flex items-center gap-x-1">
+              {page.type === 'github-discussions' ? (
+                <Github size={16} className="text-foreground-muted" />
+              ) : (
+                <Book size={16} className="text-foreground-muted" />
+              )}
+              <a
+                href={page.type === 'github-discussions' ? page.path : `${DOCS_URL}${page.path}`}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-foreground-light hover:text-foreground transition"
+              >
+                {page.title}
+              </a>
+            </li>
+          )
+        })}
+      </ul>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Support/DocsSuggestions.tsx
+++ b/apps/studio/components/interfaces/Support/DocsSuggestions.tsx
@@ -58,12 +58,14 @@ interface DocsSuggestions_ResultsProps {
 
 function DocsSuggestions_Results({ results, isStale }: DocsSuggestions_ResultsProps) {
   return (
-    <ul
-      className={cn(
-        'flex flex-col gap-y-0.5 transition-opacity duration-200',
-        isStale ? 'opacity-50' : 'opacity-100'
-      )}
-    >
+    <div>
+      <p className="text-sm text-foreground-light">Below are some articles that might help with your issue</p>
+      <ul
+        className={cn(
+          'flex flex-col gap-y-0.5 transition-opacity duration-200',
+          isStale ? 'opacity-50' : 'opacity-100'
+        )}
+      >
       {results.slice(0, 5).map((page) => {
         return (
           <li key={page.id} className="flex items-center gap-x-1">
@@ -84,5 +86,6 @@ function DocsSuggestions_Results({ results, isStale }: DocsSuggestions_ResultsPr
         )
       })}
     </ul>
+    </div>
   )
 }


### PR DESCRIPTION
Adds a short intro line above the suggested support articles list in the new support case form so it's clearer that the items are clickable links. Resolves FE-3548.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Documentation suggestions now include a short introductory message above results and place recommendations inside a clearer grouped container with improved spacing, enhancing readability while preserving subtle dimming for older suggestions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->