### PR TITLE
fix(docker): add healthcheck to edge functions container

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -437,6 +437,11 @@ services:
     depends_on:
       kong:
         condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "timeout 1 bash -c '</dev/tcp/127.0.0.1/9000'"]
+      interval: 5s
+      timeout: 5s
+      retries: 3
     environment:
       # Legacy symmetric HS256 key
       JWT_SECRET: ${JWT_SECRET}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The Edge Functions container in the Docker Compose setup did not have a healthcheck configured. This could affect container orchestration and monitoring tools that rely on health status to determine service readiness.

## What is the new behavior?

Added a healthcheck to the Edge Functions container in `docker/docker-compose.yml` so that its health status can be properly tracked.

## Additional context

This is a cherry-pick from the commit in PR #46024.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added health check monitoring for the edge runtime service to ensure service availability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->