### PR TITLE
fix(studio): run latest query from log explorer Run button

### DIFF
--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -203,7 +203,11 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   const handleRun = (value?: string | React.MouseEvent) => {
     track('log_explorer_query_run_button_clicked', { is_saved_query: !!queryId })
 
-    const query = typeof value === 'string' ? value || editorValue : editorValue
+    // Read the latest value straight from the editor instance rather than from
+    // `editorValue` state, which can lag behind the most recent keystroke. This
+    // keeps the Run button consistent with the Cmd+Enter keybinding.
+    const liveValue = editorRef.current?.getValue()
+    const query = typeof value === 'string' ? value || editorValue : (liveValue ?? editorValue)
     const resolvedParams = buildLogQueryParams(datePickerValue, query)
 
     setSelectedLog(null)


### PR DESCRIPTION
## Problem

In the Logs Explorer, clicking the Run button after editing the SQL did not execute the latest query. It ran a stale version. Pressing Cmd+Enter ran the correct, latest query.

The Run button's handler read the query from the `editorValue` React state, which can lag behind the most recent keystroke. Cmd+Enter works because Monaco's keybinding reads the live value directly off the editor instance.

## Fix

`handleRun` now reads the live value from the editor instance (`editorRef.current.getValue()`), falling back to `editorValue`. This makes the Run button consistent with the Cmd+Enter keybinding.

## How to test

- Open the Logs Explorer (Project > Logs > query/explorer).
- Type or edit a SQL query in the editor.
- Without clicking elsewhere, click the Run button.
- Expected result: the query that runs reflects your latest edit, matching the behavior of Cmd+Enter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the logs explorer where SQL queries would not execute with the most recent code changes you've typed. The query runner now uses the latest content from the editor to ensure your most recent edits are run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->