### PR TITLE
feat(self-hosted): report edge function verify_jwt from FUNCTIONS_VERIFY_JWT

### DIFF
--- a/apps/studio/lib/api/self-hosted/functions/index.test.ts
+++ b/apps/studio/lib/api/self-hosted/functions/index.test.ts
@@ -2,7 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as util from '../util'
 import * as fileSystemStore from './fileSystemStore'
-import { getFunctionsArtifactStore } from './index'
+import {
+  getFunctionsArtifactStore,
+  getSelfHostedVerifyJwt,
+  mapArtifactToFunctionResponse,
+} from './index'
+import { FunctionArtifact } from './types'
 
 vi.mock('../util', () => ({
   assertSelfHosted: vi.fn(),
@@ -14,9 +19,11 @@ vi.mock('./fileSystemStore', () => ({
 
 describe('api/self-hosted/functions/index', () => {
   let originalEdgeFunctionsFolder: string | undefined
+  let originalVerifyJwt: string | undefined
 
   beforeEach(() => {
     originalEdgeFunctionsFolder = process.env.EDGE_FUNCTIONS_MANAGEMENT_FOLDER
+    originalVerifyJwt = process.env.FUNCTIONS_VERIFY_JWT
     vi.resetAllMocks()
   })
 
@@ -25,6 +32,11 @@ describe('api/self-hosted/functions/index', () => {
       process.env.EDGE_FUNCTIONS_MANAGEMENT_FOLDER = originalEdgeFunctionsFolder
     } else {
       delete process.env.EDGE_FUNCTIONS_MANAGEMENT_FOLDER
+    }
+    if (originalVerifyJwt !== undefined) {
+      process.env.FUNCTIONS_VERIFY_JWT = originalVerifyJwt
+    } else {
+      delete process.env.FUNCTIONS_VERIFY_JWT
     }
   })
 
@@ -70,6 +82,52 @@ describe('api/self-hosted/functions/index', () => {
       const result = getFunctionsArtifactStore()
 
       expect(result).toBe(mockInstance)
+    })
+  })
+
+  describe('getSelfHostedVerifyJwt', () => {
+    it('returns true only when FUNCTIONS_VERIFY_JWT is exactly "true"', () => {
+      process.env.FUNCTIONS_VERIFY_JWT = 'true'
+      expect(getSelfHostedVerifyJwt()).toBe(true)
+    })
+
+    it('returns false when FUNCTIONS_VERIFY_JWT is "false"', () => {
+      process.env.FUNCTIONS_VERIFY_JWT = 'false'
+      expect(getSelfHostedVerifyJwt()).toBe(false)
+    })
+
+    it('returns false when FUNCTIONS_VERIFY_JWT is unset', () => {
+      delete process.env.FUNCTIONS_VERIFY_JWT
+      expect(getSelfHostedVerifyJwt()).toBe(false)
+    })
+  })
+
+  describe('mapArtifactToFunctionResponse', () => {
+    const artifact: FunctionArtifact = {
+      slug: 'health',
+      entrypoint_path: 'file:///app/edge-functions/health/index.ts',
+      created_at: 1000,
+      updated_at: 2000,
+    }
+
+    it('maps artifact fields onto the function response shape', () => {
+      delete process.env.FUNCTIONS_VERIFY_JWT
+      expect(mapArtifactToFunctionResponse(artifact)).toMatchObject({
+        slug: 'health',
+        name: 'health',
+        status: 'ACTIVE',
+        entrypoint_path: artifact.entrypoint_path,
+        created_at: 1000,
+        updated_at: 2000,
+      })
+    })
+
+    it('derives verify_jwt from FUNCTIONS_VERIFY_JWT', () => {
+      process.env.FUNCTIONS_VERIFY_JWT = 'true'
+      expect(mapArtifactToFunctionResponse(artifact).verify_jwt).toBe(true)
+
+      process.env.FUNCTIONS_VERIFY_JWT = 'false'
+      expect(mapArtifactToFunctionResponse(artifact).verify_jwt).toBe(false)
     })
   })
 })

--- a/apps/studio/lib/api/self-hosted/functions/index.ts
+++ b/apps/studio/lib/api/self-hosted/functions/index.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert'
 
+import type { components } from 'api-types'
+
 import { assertSelfHosted } from '../util'
 import { FileSystemFunctionsArtifactStore } from './fileSystemStore'
+import { FunctionArtifact } from './types'
+import { uuidv4 } from '@/lib/helpers'
+
+type FunctionResponse = components['schemas']['FunctionResponse']
 
 export function getFunctionsArtifactStore() {
   assertSelfHosted()
@@ -11,4 +17,29 @@ export function getFunctionsArtifactStore() {
   )
 
   return new FileSystemFunctionsArtifactStore(process.env.EDGE_FUNCTIONS_MANAGEMENT_FOLDER)
+}
+
+/**
+ * Self-hosted edge functions don't persist per-function metadata, so JWT verification is a single
+ * global setting controlled by `FUNCTIONS_VERIFY_JWT` (mapped to the edge-runtime's `VERIFY_JWT`).
+ * It only reports verification as enabled when explicitly set to `true`, matching the shipped
+ * default (`FUNCTIONS_VERIFY_JWT=false` in `docker/.env.example`).
+ */
+export function getSelfHostedVerifyJwt() {
+  return process.env.FUNCTIONS_VERIFY_JWT === 'true'
+}
+
+/** Maps a self-hosted function artifact (read from disk) to the management API's response shape. */
+export function mapArtifactToFunctionResponse(artifact: FunctionArtifact): FunctionResponse {
+  return {
+    id: uuidv4(),
+    slug: artifact.slug,
+    version: 1,
+    name: artifact.slug,
+    status: 'ACTIVE',
+    entrypoint_path: artifact.entrypoint_path,
+    created_at: artifact.created_at,
+    updated_at: artifact.updated_at,
+    verify_jwt: getSelfHostedVerifyJwt(),
+  }
 }

--- a/apps/studio/pages/api/v1/projects/[ref]/functions/[slug]/index.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/functions/[slug]/index.ts
@@ -1,9 +1,10 @@
-import type { components } from 'api-types'
 import { type NextApiRequest, type NextApiResponse } from 'next'
 
 import apiWrapper from '@/lib/api/apiWrapper'
-import { getFunctionsArtifactStore } from '@/lib/api/self-hosted/functions'
-import { uuidv4 } from '@/lib/helpers'
+import {
+  getFunctionsArtifactStore,
+  mapArtifactToFunctionResponse,
+} from '@/lib/api/self-hosted/functions'
 
 export default function handlerWithErrorCatching(req: NextApiRequest, res: NextApiResponse) {
   return apiWrapper(req, res, handler, { withAuth: true })
@@ -21,8 +22,6 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 }
 
-type EdgeFunctionsResponse = components['schemas']['FunctionResponse']
-
 const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
   const slugParam = req.query.slug
   const slug = Array.isArray(slugParam) ? slugParam[0] : slugParam
@@ -34,16 +33,5 @@ const handleGet = async (req: NextApiRequest, res: NextApiResponse) => {
   const functionsArtifact = await store.getFunctionBySlug(slug)
   if (!functionsArtifact) return res.status(404).json({ error: { message: `Function not found` } })
 
-  const functionResponse = {
-    id: uuidv4(),
-    slug: functionsArtifact.slug,
-    version: 1,
-    name: functionsArtifact.slug,
-    status: 'ACTIVE',
-    entrypoint_path: functionsArtifact.entrypoint_path,
-    created_at: functionsArtifact.created_at,
-    updated_at: functionsArtifact.updated_at,
-  } satisfies EdgeFunctionsResponse
-
-  return res.status(200).json(functionResponse)
+  return res.status(200).json(mapArtifactToFunctionResponse(functionsArtifact))
 }

--- a/apps/studio/pages/api/v1/projects/[ref]/functions/index.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/functions/index.ts
@@ -1,9 +1,10 @@
-import type { components } from 'api-types'
 import { type NextApiRequest, type NextApiResponse } from 'next'
 
 import apiWrapper from '@/lib/api/apiWrapper'
-import { getFunctionsArtifactStore } from '@/lib/api/self-hosted/functions'
-import { uuidv4 } from '@/lib/helpers'
+import {
+  getFunctionsArtifactStore,
+  mapArtifactToFunctionResponse,
+} from '@/lib/api/self-hosted/functions'
 
 export default function handlerWithErrorCatching(req: NextApiRequest, res: NextApiResponse) {
   return apiWrapper(req, res, handler, { withAuth: true })
@@ -21,27 +22,11 @@ async function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 }
 
-type EdgeFunctionsResponse = components['schemas']['FunctionResponse']
-
 const handleGetAll = async (_req: NextApiRequest, res: NextApiResponse) => {
   const store = getFunctionsArtifactStore()
 
   const functionsArtifacts = await store.getFunctions()
   if (functionsArtifacts.length === 0) return res.status(200).json([])
 
-  const functions = functionsArtifacts.map(
-    (func) =>
-      ({
-        id: uuidv4(),
-        slug: func.slug,
-        version: 1,
-        name: func.slug,
-        status: 'ACTIVE',
-        entrypoint_path: func.entrypoint_path,
-        created_at: func.created_at,
-        updated_at: func.updated_at,
-      }) satisfies EdgeFunctionsResponse
-  )
-
-  return res.status(200).json(functions)
+  return res.status(200).json(functionsArtifacts.map(mapArtifactToFunctionResponse))
 }

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -61,6 +61,9 @@ services:
 
       SNIPPETS_MANAGEMENT_FOLDER: /app/snippets
       EDGE_FUNCTIONS_MANAGEMENT_FOLDER: /app/edge-functions
+      # Mirrors the edge-runtime's global VERIFY_JWT so Studio's invoke snippet shows the
+      # Authorization header when JWT verification is enforced.
+      FUNCTIONS_VERIFY_JWT: ${FUNCTIONS_VERIFY_JWT}
     volumes:
       - ./volumes/snippets:/app/snippets:z
       - ./volumes/functions:/app/edge-functions:ro,z


### PR DESCRIPTION
## What

Makes the self-hosted Studio API report a function's `verify_jwt` value, derived from the `FUNCTIONS_VERIFY_JWT` environment variable.

- Adds a shared `mapArtifactToFunctionResponse` helper (+ `getSelfHostedVerifyJwt`) in the self-hosted functions layer, and uses it from both the list and detail handlers (removing the duplicated inline response objects).
- Wires `FUNCTIONS_VERIFY_JWT` into the **studio** service in `docker/docker-compose.yml` (previously it only reached the edge-runtime container).

## Why

Self-hosted edge functions don't persist per-function metadata, so JWT verification is a single global setting (`FUNCTIONS_VERIFY_JWT`, mapped to the edge-runtime's `VERIFY_JWT`). Until now the self-hosted functions API never returned `verify_jwt`, so Studio always treated it as `false`.

That means the invoke snippet from #46602 — which shows the `Authorization` header only when `verify_jwt` is on — could never reflect a self-hosted deployment that enforces JWT verification, leaving self-hosted users with a snippet that 401s (`UNAUTHORIZED_NO_AUTH_HEADER`). This change lets the snippet render correctly for self-hosted.

It only reports verification as enabled when `FUNCTIONS_VERIFY_JWT === 'true'`, matching the shipped default (`FUNCTIONS_VERIFY_JWT=false` in `docker/.env.example`).

## Depends on / pairs with

The user-facing snippet behavior lives in #46602. This PR is the self-hosted enabler — harmless on its own (it just populates an already schema-valid field), but only *useful* once #46602 consumes it.

## How to test

1. Set `FUNCTIONS_VERIFY_JWT=true` in the studio env and restart (it's read server-side in the API route, so a restart is required).
2. Open a function detail page → the cURL invoke snippet now shows the `Authorization` header.
3. Set it to `false` and restart → `apikey` header only.

Covered by unit tests in `lib/api/self-hosted/functions/index.test.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
