### PR TITLE
fix(studio): spacing below audit log drains page header

### DIFF
--- a/apps/studio/pages/org/[slug]/audit-log-drains.tsx
+++ b/apps/studio/pages/org/[slug]/audit-log-drains.tsx
@@ -35,7 +35,7 @@ const OrgAuditLogDrainsPage: NextPageWithLayout = () => {
           </PageHeaderSummary>
         </PageHeaderMeta>
       </PageHeader>
-      <PageContainer size="default">
+      <PageContainer size="default" className="pt-8">
         <OrgAuditLogDrains />
       </PageContainer>
     </>


### PR DESCRIPTION
## Problem

On the org Audit Log Drains page, the description "Export your organization audit logs to third party destinations" sits flush against the destination cards below it, with no separation.

## Fix

Add `pt-8` to the page's `PageContainer` so the content has a clear gap below the header. `PageHeader` only applies top padding and relies on the following content for the gap (other org settings pages get this from `PageSection`); this page renders the cards directly in `PageContainer`, so it needed the explicit top padding.

## How to test

- Open `/org/{slug}/audit-log-drains` (with the `auditLogsLogDrain` flag enabled).
- Confirm there is clear vertical spacing between the page description and the destination cards.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the top spacing of the audit log drains page for improved visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->