### PR TITLE
docs: update URLs after `supabase/mcp` repo transfer

### DIFF
--- a/apps/docs/content/guides/ai-tools/mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/mcp.mdx
@@ -197,4 +197,4 @@ We recommend the following best practices to mitigate security risks when using 
 
 ## On GitHub
 
-The MCP server repository is available at [github.com/supabase-community/supabase-mcp](https://github.com/supabase-community/supabase-mcp).
+The MCP server repository is available at [github.com/supabase/mcp](https://github.com/supabase/mcp).

--- a/apps/www/_blog/2025-04-04-mcp-server.mdx
+++ b/apps/www/_blog/2025-04-04-mcp-server.mdx
@@ -19,7 +19,7 @@ launchweek: '14'
   information.
 </Admonition>
 
-We are launching an official [Supabase MCP server](https://github.com/supabase-community/supabase-mcp). You can use this server to connect your favorite AI tools (such as [Cursor](https://www.cursor.com/) or [Claude](https://claude.ai/download)) directly with Supabase.
+We are launching an official [Supabase MCP server](https://github.com/supabase/mcp). You can use this server to connect your favorite AI tools (such as [Cursor](https://www.cursor.com/) or [Claude](https://claude.ai/download)) directly with Supabase.
 
 <div className="video-container mb-8">
   <iframe
@@ -61,11 +61,11 @@ You can:
 - Retrieve logs to debug issues
 - Generate TypeScript types based on your database schema
 
-For a full list of abilities, see [Tools](https://github.com/supabase-community/supabase-mcp#tools) in the project README.
+For a full list of abilities, see [Tools](https://github.com/supabase/mcp#tools) in the project README.
 
 ## Setup
 
-You can [setup](https://github.com/supabase-community/supabase-mcp#2-configure-mcp-client) Supabase MCP on most AI clients using the following JSON:
+You can [setup](https://github.com/supabase/mcp#2-configure-mcp-client) Supabase MCP on most AI clients using the following JSON:
 
 ```json name=.cursor/mcp.json
 {
@@ -193,6 +193,6 @@ We've built the Supabase MCP server to bridge the gap between AI tools and your 
 
 The MCP protocol is evolving with proposals like the new [Streamable HTTP transport](https://github.com/modelcontextprotocol/specification/pull/206) that supports fully stateless servers without requiring long-lived connections. We're following these developments closely and evaluating how they might benefit the Supabase MCP experience.
 
-If you run into issues or have ideas for new tools we should add, [open an issue](https://github.com/supabase-community/supabase-mcp/issues/new) on the GitHub repo. We're particularly interested in hearing about your experiences with schema discovery, database branching, and other safety features as we continue to refine its protections.
+If you run into issues or have ideas for new tools we should add, [open an issue](https://github.com/supabase/mcp/issues/new) on the GitHub repo. We're particularly interested in hearing about your experiences with schema discovery, database branching, and other safety features as we continue to refine its protections.
 
 Check out our [docs](/docs/guides/getting-started/mcp) for the latest updates and examples of what you can build with Supabase MCP.

--- a/apps/www/_blog/2025-10-03-remote-mcp-server.mdx
+++ b/apps/www/_blog/2025-10-03-remote-mcp-server.mdx
@@ -92,14 +92,14 @@ Feature groups allow you to pick and choose which tools you want to expose to yo
 
 Today we support the following feature groups:
 
-- [`account`](https://github.com/supabase-community/supabase-mcp#account)
-- [`docs`](https://github.com/supabase-community/supabase-mcp#knowledge-base)
-- [`database`](https://github.com/supabase-community/supabase-mcp#database)
-- [`debugging`](https://github.com/supabase-community/supabase-mcp#debugging)
-- [`development`](https://github.com/supabase-community/supabase-mcp#development)
-- [`functions`](https://github.com/supabase-community/supabase-mcp#edge-functions)
-- [`storage`](https://github.com/supabase-community/supabase-mcp#storage)
-- [`branching`](https://github.com/supabase-community/supabase-mcp#branching-experimental-requires-a-paid-plan)
+- [`account`](https://github.com/supabase/mcp#account)
+- [`docs`](https://github.com/supabase/mcp#knowledge-base)
+- [`database`](https://github.com/supabase/mcp#database)
+- [`debugging`](https://github.com/supabase/mcp#debugging)
+- [`development`](https://github.com/supabase/mcp#development)
+- [`functions`](https://github.com/supabase/mcp#edge-functions)
+- [`storage`](https://github.com/supabase/mcp#storage)
+- [`branching`](https://github.com/supabase/mcp#branching-experimental-requires-a-paid-plan)
 
 See the [MCP docs](https://supabase.com/docs/guides/getting-started/mcp) for instructions on how to enable or disable these groups.
 
@@ -121,7 +121,7 @@ Our solution is a feature that already exists on our platform - advisors. [Advis
 
 We also added initial support for [Supabase Storage](https://supabase.com/docs/guides/storage) on our MCP server. This first version allows your agent to see which buckets exist on your project and update their configuration, but in the future we'll look into more abilities like listing files and their details.
 
-This feature was actually a community contribution (thanks [Nico](https://github.com/Ngineer101)!). If there are ever missing features that you'd like to see, [PR's](https://github.com/supabase-community/supabase-mcp/issues/new/choose) are always welcome!
+This feature was actually a community contribution (thanks [Nico](https://github.com/Ngineer101)!). If there are ever missing features that you'd like to see, [PR's](https://github.com/supabase/mcp/issues/new/choose) are always welcome!
 
 ## What's next?
 

--- a/apps/www/_blog/2026-01-15-read-replicas-vs-bigger-compute.mdx
+++ b/apps/www/_blog/2026-01-15-read-replicas-vs-bigger-compute.mdx
@@ -130,7 +130,7 @@ Sometimes a $0 index beats a $200/month compute upgrade.
 
 **Analyze your queries with Claude Code:**
 
-If you use [Claude Code](https://claude.ai/claude-code) with the [Supabase MCP Server](https://github.com/supabase-community/supabase-mcp), you can ask Claude to analyze your database and suggest indexes:
+If you use [Claude Code](https://claude.ai/claude-code) with the [Supabase MCP Server](https://github.com/supabase/mcp), you can ask Claude to analyze your database and suggest indexes:
 
 ```
 Analyze my Supabase database for missing indexes:

--- a/docker/CHANGELOG.md
+++ b/docker/CHANGELOG.md
@@ -159,7 +159,7 @@ See per-service updates below for details. Only the most important changes relev
 - ⚠️ Added `PGRST_DB_SCHEMAS`, `PGRST_DB_EXTRA_SEARCH_PATH`, and `PGRST_DB_MAX_ROWS` to Studio configuration (requires `docker-compose.yml` update) - PR [#43268](https://github.com/supabase/supabase/pull/43268)
 
 ### MCP Server
-- Updated to `v0.7.0` - [Release](https://github.com/supabase-community/supabase-mcp/releases/tag/v0.7.0)
+- Updated to `v0.7.0` - [Release](https://github.com/supabase/mcp/releases/tag/v0.7.0)
 
 ### API gateway
 - ⚠️ Updated Kong to `3.9.1` - PR [#43554](https://github.com/supabase/supabase/pull/43554)
@@ -206,7 +206,7 @@ See per-service updates below for details. Only the most important changes relev
 - Added Edge Functions management UI (requires `docker-compose.yml` update) - PR [#40690](https://github.com/supabase/supabase/pull/40690), PR [#42322](https://github.com/supabase/supabase/pull/42322), PR [#42349](https://github.com/supabase/supabase/pull/42349), PR [#42350](https://github.com/supabase/supabase/pull/42350)
 
 ### MCP Server
-- Updated to `v0.6.3` - [Release](https://github.com/supabase-community/supabase-mcp/releases/tag/v0.6.3)
+- Updated to `v0.6.3` - [Release](https://github.com/supabase/mcp/releases/tag/v0.6.3)
 
 ### Auth
 - Updated to `v2.186.0` - [Changelog](https://github.com/supabase/auth/blob/master/CHANGELOG.md) | [Release](https://github.com/supabase/auth/releases/tag/v2.186.0)
@@ -304,7 +304,7 @@ See per-service updates below for details. Only the most important changes relev
 - Fixed an issue with the Users page not being updated on changes - PR [#41254](https://github.com/supabase/supabase/pull/41254)
 
 ### MCP Server
-- Updated to `v0.5.10` - [Release](https://github.com/supabase-community/supabase-mcp/releases/tag/v0.5.10)
+- Updated to `v0.5.10` - [Release](https://github.com/supabase/mcp/releases/tag/v0.5.10)
 
 ### Auth
 - Updated to `v2.184.0` - [Changelog](https://github.com/supabase/auth/blob/master/CHANGELOG.md) | [Release](https://github.com/supabase/auth/releases/tag/v2.184.0)
@@ -325,7 +325,7 @@ See per-service updates below for details. Only the most important changes relev
 - ⚠️ Fixed security issues related to [React2Shell](https://vercel.com/kb/bulletin/react2shell)
 
 ### MCP Server
-- Updated to `v0.5.9` - [Release](https://github.com/supabase-community/supabase-mcp/releases/tag/v0.5.9)
+- Updated to `v0.5.9` - [Release](https://github.com/supabase/mcp/releases/tag/v0.5.9)
 - ⚠️ Changed MCP tool `get_anon_key` to `get_publishable_keys`
 
 ### PostgREST


### PR DESCRIPTION
The Supabase MCP repo transferred from `supabase-community/supabase-mcp` -> `supabase/mcp`. This updates links on docs and www to point to the new location: https://github.com/supabase/mcp

The main one needing this change is the MCP docs page at `mcp.mdx`: https://supabase.com/mcp

I also updated links in the changelog / blog for good measure, though I can remove those changes if desired since the old URL redirects to the new location.

Related: https://github.com/supabase/mcp/pull/295
Ref: AI-792

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Supabase MCP server repository references across all documentation guides, blog articles, changelog entries, and supporting materials to direct users to the current official location.
  * Refreshed documentation links including feature groups, setup instructions, abilities documentation, and GitHub issue tracking URLs for consistency.
  * Updated MCP server release links in changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->