### PR TITLE
feat(studio): add keyboard shortcuts for unified logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/RowSelectionHeader.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/RowSelectionHeader.tsx
@@ -45,7 +45,7 @@ export const RowSelectionHeader = () => {
       format === 'json' ? formatLogsAsJson(selectedRows) : formatLogsAsMarkdown(selectedRows)
     copyToClipboard(text, () => {
       toast.success(
-        `Copied ${selectedRows.length} log${selectedRows.length !== 1 ? 's' : ''} as ${format.toUpperCase()}`
+        `Copied ${selectedRows.length} log${selectedRows.length !== 1 ? 's' : ''} as ${format === 'json' ? format.toUpperCase() : format}`
       )
     })
   }

--- a/apps/studio/components/interfaces/UnifiedLogs/RowSelectionHeader.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/RowSelectionHeader.tsx
@@ -19,7 +19,10 @@ import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/L
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useDataTable } from '@/components/ui/DataTable/providers/DataTableProvider'
+import { ShortcutBadge } from '@/components/ui/ShortcutBadge'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 // TODO - format Logs as JSON, as markdown, and as prompt
@@ -46,6 +49,16 @@ export const RowSelectionHeader = () => {
       )
     })
   }
+
+  const hasSelection = selectedRows.length > 0
+  useShortcut(SHORTCUT_IDS.RESULTS_COPY_JSON, () => onCopy('json'), {
+    enabled: hasSelection,
+    registerInCommandMenu: true,
+  })
+  useShortcut(SHORTCUT_IDS.RESULTS_COPY_MARKDOWN, () => onCopy('markdown'), {
+    enabled: hasSelection,
+    registerInCommandMenu: true,
+  })
 
   return (
     <div className="relative">
@@ -83,10 +96,18 @@ export const RowSelectionHeader = () => {
                   <DropdownMenuItem onClick={() => onCopy('json')} className="gap-2 text-xs">
                     <Copy size={13} />
                     Copy as JSON
+                    <ShortcutBadge
+                      shortcutId={SHORTCUT_IDS.RESULTS_COPY_JSON}
+                      className="ml-auto"
+                    />
                   </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => onCopy('markdown')} className="gap-2 text-xs">
                     <Copy size={13} />
                     Copy as Markdown
+                    <ShortcutBadge
+                      shortcutId={SHORTCUT_IDS.RESULTS_COPY_MARKDOWN}
+                      className="ml-auto"
+                    />
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>

--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/ServiceFlowPanelControls.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/ServiceFlowPanelControls.tsx
@@ -1,20 +1,18 @@
 import { Check, ChevronDown, ChevronUp, PanelBottom, PanelRight, X } from 'lucide-react'
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 import {
   Button,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
-  KeyboardShortcut,
   Separator,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
 
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useDataTable } from '@/components/ui/DataTable/providers/DataTableProvider'
+import { Shortcut } from '@/components/ui/Shortcut'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 
 interface ServiceFlowPanelControlsProps {
   dock: 'bottom' | 'right'
@@ -58,70 +56,39 @@ export const ServiceFlowPanelControls = ({
     setOpenRowId(undefined)
   }, [setOpenRowId])
 
-  useEffect(() => {
-    const down = (e: KeyboardEvent) => {
-      if (!openRowId) return
-
-      const activeElement = document.activeElement
-      if (activeElement?.closest('[role="menu"]')) return
-
-      const tag = activeElement?.tagName
-      const isEditable =
-        tag === 'INPUT' ||
-        tag === 'TEXTAREA' ||
-        (activeElement as HTMLElement | null)?.isContentEditable ||
-        activeElement?.getAttribute('role') === 'textbox'
-      if (isEditable) return
-
-      if (e.key === 'ArrowUp') {
-        e.preventDefault()
-        onPrev()
-      }
-      if (e.key === 'ArrowDown') {
-        e.preventDefault()
-        onNext()
-      }
-    }
-
-    document.addEventListener('keydown', down)
-    return () => document.removeEventListener('keydown', down)
-  }, [openRowId, onNext, onPrev])
-
   return (
     <div className="flex h-7 items-center gap-1">
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            size="tiny"
-            type="text"
-            disabled={!prevId}
-            onClick={onPrev}
-            className="px-1"
-            icon={<ChevronUp />}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="top" className="flex items-center gap-2">
-          <span>Previous</span>
-          <KeyboardShortcut keys={['ArrowUp']} />
-        </TooltipContent>
-      </Tooltip>
+      <Shortcut
+        id={SHORTCUT_IDS.UNIFIED_LOGS_PREV_ROW}
+        onTrigger={onPrev}
+        options={{ enabled: !!prevId }}
+        side="top"
+      >
+        <Button
+          size="tiny"
+          type="text"
+          disabled={!prevId}
+          onClick={onPrev}
+          className="px-1"
+          icon={<ChevronUp />}
+        />
+      </Shortcut>
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            size="tiny"
-            type="text"
-            disabled={!nextId}
-            onClick={onNext}
-            className="px-1"
-            icon={<ChevronDown />}
-          />
-        </TooltipTrigger>
-        <TooltipContent side="top" className="flex items-center gap-2">
-          <span>Next</span>
-          <KeyboardShortcut keys={['ArrowDown']} />
-        </TooltipContent>
-      </Tooltip>
+      <Shortcut
+        id={SHORTCUT_IDS.UNIFIED_LOGS_NEXT_ROW}
+        onTrigger={onNext}
+        options={{ enabled: !!nextId }}
+        side="top"
+      >
+        <Button
+          size="tiny"
+          type="text"
+          disabled={!nextId}
+          onClick={onNext}
+          className="px-1"
+          icon={<ChevronDown />}
+        />
+      </Shortcut>
 
       <Separator orientation="vertical" className="mx-1 h-4" />
 
@@ -152,14 +119,14 @@ export const ServiceFlowPanelControls = ({
         </DropdownMenuContent>
       </DropdownMenu>
 
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button size="tiny" type="text" onClick={onClose} className="px-1" icon={<X />} />
-        </TooltipTrigger>
-        <TooltipContent side="top">
-          <span>Close</span>
-        </TooltipContent>
-      </Tooltip>
+      <Shortcut
+        id={SHORTCUT_IDS.UNIFIED_LOGS_CLOSE_PANEL}
+        onTrigger={onClose}
+        options={{ conflictBehavior: 'allow' }}
+        side="top"
+      >
+        <Button size="tiny" type="text" onClick={onClose} className="px-1" icon={<X />} />
+      </Shortcut>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -342,7 +342,9 @@ export const UnifiedLogs = () => {
   const isMobile = useIsMobile()
   const [isFilterBarOpen, setIsFilterBarOpen] = useState(!isMobile)
 
-  useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_FILTERS, () => setIsFilterBarOpen((prev) => !prev))
+  useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_FILTERS, () => setIsFilterBarOpen((prev) => !prev), {
+    registerInCommandMenu: true,
+  })
   useShortcut(SHORTCUT_IDS.UNIFIED_LOGS_CLEAR_FILTERS, () => table.resetColumnFilters(), {
     enabled: columnFilters.length > 0,
     registerInCommandMenu: true,

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -343,6 +343,10 @@ export const UnifiedLogs = () => {
   const [isFilterBarOpen, setIsFilterBarOpen] = useState(!isMobile)
 
   useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_FILTERS, () => setIsFilterBarOpen((prev) => !prev))
+  useShortcut(SHORTCUT_IDS.UNIFIED_LOGS_CLEAR_FILTERS, () => table.resetColumnFilters(), {
+    enabled: columnFilters.length > 0,
+    registerInCommandMenu: true,
+  })
 
   useEffect(() => {
     if (isMobile) {
@@ -414,7 +418,11 @@ export const UnifiedLogs = () => {
                 </div>
 
                 <div className="ml-auto flex items-center gap-x-2">
-                  <RefreshButton isLoading={isRefetchingData} onRefresh={refetchAllData} />
+                  <RefreshButton
+                    isLoading={isRefetchingData}
+                    onRefresh={refetchAllData}
+                    shortcutId={SHORTCUT_IDS.UNIFIED_LOGS_REFRESH}
+                  />
                   <DataTableViewOptions />
                   <DownloadLogsButton searchParameters={searchParameters} />
                   {fetchPreviousPage ? (

--- a/apps/studio/components/interfaces/UnifiedLogs/components/DownloadLogsButton.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/DownloadLogsButton.tsx
@@ -27,8 +27,10 @@ import {
 } from 'ui'
 
 import { QuerySearchParamsType } from '../UnifiedLogs.types'
-import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useGetUnifiedLogsMutation } from '@/data/logs/get-unified-logs'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 const DEFAULT_NUM_ROWS = '100'
 const DEFAULT_DURATION = '1'
@@ -44,6 +46,11 @@ export const DownloadLogsButton = ({ searchParameters }: DownloadLogsButtonProps
   const [numRows, setNumRows] = useState(DEFAULT_NUM_ROWS)
   const [numHours, setNumHours] = useState(DEFAULT_NUM_ROWS)
   const [selectedFormat, setSelectedFormat] = useState<'csv' | 'json'>()
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+
+  useShortcut(SHORTCUT_IDS.UNIFIED_LOGS_DOWNLOAD, () => setIsMenuOpen(true), {
+    registerInCommandMenu: true,
+  })
 
   const { mutate: retrieveLogs, isPending } = useGetUnifiedLogsMutation({
     onSuccess: (res) => {
@@ -93,14 +100,16 @@ export const DownloadLogsButton = ({ searchParameters }: DownloadLogsButtonProps
 
   return (
     <>
-      <DropdownMenu>
+      <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
         <DropdownMenuTrigger asChild>
-          <ButtonTooltip
-            type="default"
-            className="w-[26px]"
-            icon={<Download className="text-foreground" />}
-            tooltip={{ content: { side: 'bottom', text: 'Download logs' } }}
-          />
+          <ShortcutTooltip shortcutId={SHORTCUT_IDS.UNIFIED_LOGS_DOWNLOAD} side="bottom">
+            <Button
+              type="default"
+              className="w-[26px]"
+              icon={<Download className="text-foreground" />}
+              aria-label="Download logs"
+            />
+          </ShortcutTooltip>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-44">
           {isLogs && IS_PLATFORM && (

--- a/apps/studio/components/interfaces/UnifiedLogs/components/DownloadLogsButton.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/DownloadLogsButton.tsx
@@ -101,16 +101,16 @@ export const DownloadLogsButton = ({ searchParameters }: DownloadLogsButtonProps
   return (
     <>
       <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
-        <DropdownMenuTrigger asChild>
-          <ShortcutTooltip shortcutId={SHORTCUT_IDS.UNIFIED_LOGS_DOWNLOAD} side="bottom">
+        <ShortcutTooltip shortcutId={SHORTCUT_IDS.UNIFIED_LOGS_DOWNLOAD} side="bottom">
+          <DropdownMenuTrigger asChild>
             <Button
               type="default"
               className="w-[26px]"
               icon={<Download className="text-foreground" />}
               aria-label="Download logs"
             />
-          </ShortcutTooltip>
-        </DropdownMenuTrigger>
+          </DropdownMenuTrigger>
+        </ShortcutTooltip>
         <DropdownMenuContent align="end" className="w-44">
           {isLogs && IS_PLATFORM && (
             <DropdownMenuItem asChild className="gap-x-2">

--- a/apps/studio/components/interfaces/UnifiedLogs/components/LogsFilterBar.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/LogsFilterBar.tsx
@@ -1,6 +1,12 @@
 import { LoaderCircle, Search } from 'lucide-react'
-import { useEffect, useEffectEvent, useState } from 'react'
-import { FilterBar, FilterCondition, type FilterGroup, type FilterProperty } from 'ui-patterns'
+import { useEffect, useEffectEvent, useRef, useState } from 'react'
+import {
+  FilterBar,
+  FilterCondition,
+  type FilterBarHandle,
+  type FilterGroup,
+  type FilterProperty,
+} from 'ui-patterns'
 
 import {
   isLogsFilterColumnValue,
@@ -8,6 +14,8 @@ import {
   type LogsFilterOperator,
 } from '../UnifiedLogs.filters'
 import { useDataTable } from '@/components/ui/DataTable/providers/DataTableProvider'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 const buildFilterGroup = (
   columnFilters: { id: string; value: unknown }[],
@@ -34,6 +42,11 @@ const buildFilterGroup = (
 
 export const LogsFilterBar = () => {
   const { table, filterFields, columnFilters, isFetching } = useDataTable()
+
+  const filterBarRef = useRef<FilterBarHandle>(null)
+  useShortcut(SHORTCUT_IDS.UNIFIED_LOGS_FOCUS_FILTER, () => filterBarRef.current?.focus(), {
+    registerInCommandMenu: true,
+  })
 
   const [freeformText, setFreeformText] = useState('')
 
@@ -113,6 +126,7 @@ export const LogsFilterBar = () => {
 
   return (
     <FilterBar
+      ref={filterBarRef}
       variant="pill"
       freeformDefaultProperty="event_message"
       className="bg-transparent border-0 [&>div>div>div>input]:!text-xs"

--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -63,10 +63,14 @@ export function DataTableInfinite<TData, TValue, TMeta>({
     [fetchNextPage, isFetching, totalRows, totalRowsFetched]
   )
 
-  useShortcut(SHORTCUT_IDS.DATA_TABLE_RESET_COLUMNS, () => {
-    setColumnOrder([])
-    setColumnVisibility(defaultColumnVisibility)
-  })
+  useShortcut(
+    SHORTCUT_IDS.DATA_TABLE_RESET_COLUMNS,
+    () => {
+      setColumnOrder([])
+      setColumnVisibility(defaultColumnVisibility)
+    },
+    { registerInCommandMenu: true }
+  )
 
   return (
     <Table

--- a/apps/studio/components/ui/DataTable/DataTableResetButton.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableResetButton.tsx
@@ -8,7 +8,9 @@ import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export function DataTableResetButton() {
   const { table } = useDataTable()
-  useShortcut(SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS, () => table.resetColumnFilters())
+  useShortcut(SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS, () => table.resetColumnFilters(), {
+    registerInCommandMenu: true,
+  })
 
   return (
     <ShortcutTooltip

--- a/apps/studio/components/ui/DataTable/DataTableResetButton.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableResetButton.tsx
@@ -1,8 +1,8 @@
 import { X } from 'lucide-react'
-import { Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { Button } from 'ui'
 
-import { Kbd } from './primitives/Kbd'
 import { useDataTable } from './providers/DataTableProvider'
+import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
 
@@ -11,21 +11,14 @@ export function DataTableResetButton() {
   useShortcut(SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS, () => table.resetColumnFilters())
 
   return (
-    <Tooltip>
-      <TooltipTrigger asChild>
-        <Button type="default" size="tiny" onClick={() => table.resetColumnFilters()} icon={<X />}>
-          Reset
-        </Button>
-      </TooltipTrigger>
-      <TooltipContent side="left">
-        <p>
-          Reset filters with{' '}
-          <Kbd className="ml-1 text-muted-foreground group-hover:text-accent-foreground">
-            <span className="mr-1">⌘</span>
-            <span>Esc</span>
-          </Kbd>
-        </p>
-      </TooltipContent>
-    </Tooltip>
+    <ShortcutTooltip
+      shortcutId={SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS}
+      label="Reset filters"
+      side="left"
+    >
+      <Button type="default" size="tiny" onClick={() => table.resetColumnFilters()} icon={<X />}>
+        Reset
+      </Button>
+    </ShortcutTooltip>
   )
 }

--- a/apps/studio/components/ui/DataTable/LiveButton.tsx
+++ b/apps/studio/components/ui/DataTable/LiveButton.tsx
@@ -19,7 +19,7 @@ interface LiveButtonProps {
 export function LiveButton({ fetchPreviousPage, searchParamsParser }: LiveButtonProps) {
   const [{ live, date, sort }, setSearch] = useQueryStates(searchParamsParser)
   const { table } = useDataTable()
-  useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_LIVE, handleClick)
+  useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_LIVE, handleClick, { registerInCommandMenu: true })
 
   useEffect(() => {
     let timeoutId: NodeJS.Timeout

--- a/apps/studio/components/ui/DataTable/LiveButton.tsx
+++ b/apps/studio/components/ui/DataTable/LiveButton.tsx
@@ -2,10 +2,10 @@ import type { FetchPreviousPageOptions } from '@tanstack/react-query'
 import { CirclePause, CirclePlay } from 'lucide-react'
 import { useQueryStates } from 'nuqs'
 import { useEffect } from 'react'
-import { cn } from 'ui'
+import { Button, cn } from 'ui'
 
-import { ButtonTooltip } from '../ButtonTooltip'
 import { useDataTable } from './providers/DataTableProvider'
+import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
 
@@ -60,15 +60,20 @@ export function LiveButton({ fetchPreviousPage, searchParamsParser }: LiveButton
   }
 
   return (
-    <ButtonTooltip
-      className={cn(live && 'border-info text-info hover:text-info')}
-      onClick={handleClick}
-      type={live ? 'primary' : 'default'}
-      size="tiny"
-      icon={live ? <CirclePause className="h-4 w-4" /> : <CirclePlay className="h-4 w-4" />}
-      tooltip={{ content: { side: 'bottom', text: live ? 'Pause live mode' : 'Start live mode' } }}
+    <ShortcutTooltip
+      shortcutId={SHORTCUT_IDS.DATA_TABLE_TOGGLE_LIVE}
+      label={live ? 'Pause live mode' : 'Start live mode'}
+      side="bottom"
     >
-      Live
-    </ButtonTooltip>
+      <Button
+        className={cn(live && 'border-info text-info hover:text-info')}
+        onClick={handleClick}
+        type={live ? 'primary' : 'default'}
+        size="tiny"
+        icon={live ? <CirclePause className="h-4 w-4" /> : <CirclePlay className="h-4 w-4" />}
+      >
+        Live
+      </Button>
+    </ShortcutTooltip>
   )
 }

--- a/apps/studio/components/ui/DataTable/RefreshButton.tsx
+++ b/apps/studio/components/ui/DataTable/RefreshButton.tsx
@@ -1,13 +1,49 @@
 import { LoaderCircle, RefreshCcw } from 'lucide-react'
+import { Button } from 'ui'
 
 import { ButtonTooltip } from '../ButtonTooltip'
+import { Shortcut } from '@/components/ui/Shortcut'
+import type { ShortcutId } from '@/state/shortcuts/registry'
 
 interface RefreshButtonProps {
   isLoading: boolean
   onRefresh: () => void
+  /**
+   * When provided, the button binds this registered shortcut (hotkey + a
+   * tooltip that surfaces the keybind). Otherwise it falls back to a plain
+   * "Refresh logs" tooltip with no keybind.
+   */
+  shortcutId?: ShortcutId
 }
 
-export const RefreshButton = ({ isLoading, onRefresh }: RefreshButtonProps) => {
+export const RefreshButton = ({ isLoading, onRefresh, shortcutId }: RefreshButtonProps) => {
+  const icon = isLoading ? (
+    <LoaderCircle className="text-foreground animate-spin" />
+  ) : (
+    <RefreshCcw className="text-foreground" />
+  )
+
+  if (shortcutId) {
+    return (
+      <Shortcut
+        id={shortcutId}
+        onTrigger={onRefresh}
+        options={{ enabled: !isLoading, registerInCommandMenu: true }}
+        side="bottom"
+      >
+        <Button
+          size="tiny"
+          type="default"
+          disabled={isLoading}
+          onClick={onRefresh}
+          className="w-[26px]"
+          icon={icon}
+          aria-label="Refresh logs"
+        />
+      </Shortcut>
+    )
+  }
+
   return (
     <ButtonTooltip
       size="tiny"
@@ -15,13 +51,7 @@ export const RefreshButton = ({ isLoading, onRefresh }: RefreshButtonProps) => {
       disabled={isLoading}
       onClick={onRefresh}
       className="w-[26px]"
-      icon={
-        isLoading ? (
-          <LoaderCircle className="text-foreground animate-spin" />
-        ) : (
-          <RefreshCcw className="text-foreground" />
-        )
-      }
+      icon={icon}
       tooltip={{ content: { side: 'bottom', text: 'Refresh logs' } }}
     />
   )

--- a/apps/studio/state/shortcuts/referenceGroups.ts
+++ b/apps/studio/state/shortcuts/referenceGroups.ts
@@ -18,6 +18,7 @@ export const SHORTCUT_REFERENCE_GROUPS = {
   NAVIGATION_ADVISORS: 'navigation.advisors',
   NAVIGATION_PROJECT_SETTINGS: 'navigation.project-settings',
   NAVIGATION_INTEGRATIONS_DETAIL: 'navigation.integrations-detail',
+  UNIFIED_LOGS: 'unified-logs',
 } as const
 
 export const SHORTCUT_REFERENCE_GROUP_LABELS: Record<string, string> = {
@@ -40,6 +41,7 @@ export const SHORTCUT_REFERENCE_GROUP_LABELS: Record<string, string> = {
   [SHORTCUT_REFERENCE_GROUPS.NAVIGATION_ADVISORS]: 'Advisors Navigation',
   [SHORTCUT_REFERENCE_GROUPS.NAVIGATION_PROJECT_SETTINGS]: 'Project Settings Navigation',
   [SHORTCUT_REFERENCE_GROUPS.NAVIGATION_INTEGRATIONS_DETAIL]: 'Integration Tabs',
+  [SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS]: 'Logs',
 }
 
 export const SHORTCUT_REFERENCE_GROUP_ORDER = [

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -57,6 +57,7 @@ import { STORAGE_BUCKETS_SHORTCUT_IDS, storageBucketsRegistry } from './registry
 import { STORAGE_EXPLORER_SHORTCUT_IDS, storageExplorerRegistry } from './registry/storage-explorer'
 import { STORAGE_NAV_SHORTCUT_IDS, storageNavRegistry } from './registry/storage-nav'
 import { TABLE_EDITOR_SHORTCUT_IDS, tableEditorRegistry } from './registry/table-editor'
+import { UNIFIED_LOGS_SHORTCUT_IDS, unifiedLogsRegistry } from './registry/unified-logs'
 import { ShortcutDefinition } from './types'
 
 /**
@@ -83,7 +84,6 @@ export const SHORTCUT_IDS = {
   OPERATION_QUEUE_SAVE: 'operation-queue.save',
   OPERATION_QUEUE_TOGGLE: 'operation-queue.toggle',
   OPERATION_QUEUE_UNDO: 'operation-queue.undo',
-  UNIFIED_LOGS_RESET_FOCUS: 'unified-logs.reset-focus',
   NAV_HOME: 'nav.home',
   NAV_TABLE_EDITOR: 'nav.table-editor',
   NAV_SQL_EDITOR: 'nav.sql-editor',
@@ -123,6 +123,9 @@ export const SHORTCUT_IDS = {
 
   // Table editor shortcuts
   ...TABLE_EDITOR_SHORTCUT_IDS,
+
+  // Unified Logs page shortcuts
+  ...UNIFIED_LOGS_SHORTCUT_IDS,
 
   // SQL editor shortcuts
   ...SQL_EDITOR_SHORTCUT_IDS,
@@ -304,12 +307,6 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     sequence: ['Mod+Z'],
     showInSettings: false,
   },
-  [SHORTCUT_IDS.UNIFIED_LOGS_RESET_FOCUS]: {
-    id: SHORTCUT_IDS.UNIFIED_LOGS_RESET_FOCUS,
-    label: 'Reset focus in logs',
-    sequence: ['Mod+.'],
-    showInSettings: false,
-  },
   [SHORTCUT_IDS.NAV_HOME]: {
     id: SHORTCUT_IDS.NAV_HOME,
     label: 'Go to Project Overview',
@@ -479,6 +476,9 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
 
   // Table editor shortcut registration
   ...tableEditorRegistry,
+
+  // Unified Logs page shortcut registration
+  ...unifiedLogsRegistry,
 
   // SQL editor shortcut registration
   ...sqlEditorRegistry,

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -261,19 +261,19 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
   },
   [SHORTCUT_IDS.DATA_TABLE_TOGGLE_FILTERS]: {
     id: SHORTCUT_IDS.DATA_TABLE_TOGGLE_FILTERS,
-    label: 'Toggle data table filter controls',
+    label: 'Toggle filter sidebar',
     sequence: ['Mod+B'],
     showInSettings: false,
   },
   [SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS]: {
     id: SHORTCUT_IDS.DATA_TABLE_RESET_FILTERS,
-    label: 'Reset data table filters',
+    label: 'Reset filters',
     sequence: ['Mod+Escape'],
     showInSettings: false,
   },
   [SHORTCUT_IDS.DATA_TABLE_RESET_COLUMNS]: {
     id: SHORTCUT_IDS.DATA_TABLE_RESET_COLUMNS,
-    label: 'Reset data table columns',
+    label: 'Reset columns',
     sequence: ['Mod+U'],
     showInSettings: false,
   },

--- a/apps/studio/state/shortcuts/registry/unified-logs.ts
+++ b/apps/studio/state/shortcuts/registry/unified-logs.ts
@@ -1,0 +1,91 @@
+import { SHORTCUT_REFERENCE_GROUPS } from '../referenceGroups'
+import { RegistryDefinations } from '../types'
+
+/**
+ * Shortcuts scoped to the Unified Logs page (`components/interfaces/UnifiedLogs`).
+ * They are page-scoped: each is only active while the relevant Unified Logs
+ * component is mounted.
+ *
+ * Grid/detail-panel bindings (prev/next, close) mirror the Logs Explorer
+ * (`logs-preview`) and Table Editor patterns so the keyboard model stays
+ * consistent across our data-grid surfaces. Copying selected logs reuses the
+ * shared `results.copy-*` shortcuts (see `RowSelectionHeader`).
+ */
+export const UNIFIED_LOGS_SHORTCUT_IDS = {
+  UNIFIED_LOGS_RESET_FOCUS: 'unified-logs.reset-focus',
+  UNIFIED_LOGS_REFRESH: 'unified-logs.refresh',
+  UNIFIED_LOGS_DOWNLOAD: 'unified-logs.download',
+  UNIFIED_LOGS_FOCUS_FILTER: 'unified-logs.focus-filter',
+  UNIFIED_LOGS_CLEAR_FILTERS: 'unified-logs.clear-filters',
+  UNIFIED_LOGS_PREV_ROW: 'unified-logs.prev-row',
+  UNIFIED_LOGS_NEXT_ROW: 'unified-logs.next-row',
+  UNIFIED_LOGS_CLOSE_PANEL: 'unified-logs.close-panel',
+}
+
+export type UnifiedLogsShortcutId =
+  (typeof UNIFIED_LOGS_SHORTCUT_IDS)[keyof typeof UNIFIED_LOGS_SHORTCUT_IDS]
+
+export const unifiedLogsRegistry: RegistryDefinations<UnifiedLogsShortcutId> = {
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_RESET_FOCUS]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_RESET_FOCUS,
+    label: 'Reset focus in logs',
+    sequence: ['Mod+.'],
+    showInSettings: false,
+  },
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_REFRESH]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_REFRESH,
+    label: 'Refresh logs',
+    sequence: ['Shift+R'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS,
+    options: { ignoreInputs: true, registerInCommandMenu: true },
+  },
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_DOWNLOAD]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_DOWNLOAD,
+    label: 'Download logs',
+    sequence: ['Shift+E'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS,
+    options: { ignoreInputs: true, registerInCommandMenu: true },
+  },
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_FOCUS_FILTER]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_FOCUS_FILTER,
+    label: 'Focus filter bar',
+    sequence: ['Shift+F'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS,
+    options: { ignoreInputs: true, registerInCommandMenu: true },
+  },
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_CLEAR_FILTERS]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_CLEAR_FILTERS,
+    label: 'Clear filters',
+    sequence: ['F', 'C'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS,
+    options: { ignoreInputs: true, registerInCommandMenu: true },
+  },
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_PREV_ROW]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_PREV_ROW,
+    label: 'Previous log',
+    sequence: ['ArrowUp'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS,
+    options: { ignoreInputs: true },
+  },
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_NEXT_ROW]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_NEXT_ROW,
+    label: 'Next log',
+    sequence: ['ArrowDown'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS,
+    options: { ignoreInputs: true },
+  },
+  [UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_CLOSE_PANEL]: {
+    id: UNIFIED_LOGS_SHORTCUT_IDS.UNIFIED_LOGS_CLOSE_PANEL,
+    label: 'Close log details panel',
+    sequence: ['Escape'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.UNIFIED_LOGS,
+    options: { ignoreInputs: true, conflictBehavior: 'allow' },
+  },
+}


### PR DESCRIPTION
Adds the final set of keyboard shortcuts to the Unified Logs page and converts the last hardcoded `keydown` listener (detail-panel prev/next) to the shared shortcut registry. Each action also surfaces its keybind in a registry-driven tooltip.

Closes FE-3415.

## Shortcuts

| Action | Shortcut | Notes |
| --- | --- | --- |
| Refresh logs | `Shift+R` | new |
| Download logs | `Shift+E` | new — opens export dropdown |
| Focus filter bar | `Shift+F` | new |
| Clear filters | `F` then `C` | new |
| Copy selected as JSON | `Mod+Shift+J` | new — reuses `results.copy-json` |
| Copy selected as Markdown | `Mod+Shift+M` | new — reuses `results.copy-markdown` |
| Previous / next log (detail panel) | `↑` / `↓` | converted from hardcoded listener |
| Close details panel | `Escape` | new |

Existing shared `data-table.*` shortcuts kept as-is: toggle sidebar (`Mod+B`), live mode (`Mod+J`), reset filters (`Mod+Esc`), reset columns (`Mod+U`), reset focus (`Mod+.`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcuts for Unified Logs: copy selected rows as JSON/Markdown, navigate rows, refresh, clear/reset filters, download, and focus filter — shortcuts show in the command menu and display badges/hints in menus and buttons.
* **Refactor**
  * Shortcut handling unified across log controls; shortcuts enable/disable based on context and a new "Logs" group appears in the shortcut reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->