### PR TITLE
fix(docs) Resolve React Router auth setup errors and confusion

### DIFF
--- a/apps/studio/components/interfaces/Connect/Connect.constants.ts
+++ b/apps/studio/components/interfaces/Connect/Connect.constants.ts
@@ -109,7 +109,7 @@ export const FRAMEWORKS: ConnectionType[] = [
   },
   {
     key: 'remix',
-    label: 'Remix',
+    label: 'React Router',
     icon: 'remix',
     guideLink: `${DOCS_URL}/guides/auth/server-side/creating-a-client?framework=remix&environment=remix-loader`,
     children: [

--- a/apps/studio/components/interfaces/Connect/content/remix/supabasejs/content.tsx
+++ b/apps/studio/components/interfaces/Connect/content/remix/supabasejs/content.tsx
@@ -44,7 +44,7 @@ export function createClient(request: Request) {
 
   const supabase = createServerClient(
     process.env.VITE_SUPABASE_URL!,
-    process.env.VITE_${projectKeys.publishableKey ? 'SUPABASE_PUBLISHABLE_KEY' : 'SUPABASE_ANON_KEY'};,
+    process.env.VITE_${projectKeys.publishableKey ? 'SUPABASE_PUBLISHABLE_KEY' : 'SUPABASE_ANON_KEY'}!,
     {
       cookies: {
         getAll() {

--- a/apps/studio/components/interfaces/ConnectSheet/Connect.constants.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/Connect.constants.ts
@@ -109,7 +109,7 @@ export const FRAMEWORKS: ConnectionType[] = [
   },
   {
     key: 'remix',
-    label: 'Remix',
+    label: 'React Router',
     icon: 'remix',
     guideLink: `${DOCS_URL}/guides/auth/server-side/creating-a-client?framework=remix&environment=remix-loader`,
     children: [

--- a/apps/studio/components/interfaces/ConnectSheet/content/remix/supabasejs/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/remix/supabasejs/content.tsx
@@ -30,7 +30,7 @@ export function createClient(request: Request) {
 
   const supabase = createServerClient(
     process.env.VITE_SUPABASE_URL!,
-    process.env.VITE_${projectKeys.publishableKey ? 'SUPABASE_PUBLISHABLE_KEY' : 'SUPABASE_ANON_KEY'},
+    process.env.VITE_${projectKeys.publishableKey ? 'SUPABASE_PUBLISHABLE_KEY' : 'SUPABASE_ANON_KEY'}!,
     {
       cookies: {
         getAll() {


### PR DESCRIPTION
Fixes DOCS-651

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This adds a non-null assertion to a Supabase method that expects non-null.
Additionally, it updates a label from 'Remix' to 'React Router'.


## What is the current behavior?

Two issues: 
- Following the Auth client steps with React Router creates a `deprecation` error and downstream Typescript errors.
- 'Remix' is renamed to 'React Router'.
  > Remix and React Router are the same thing, made by the same people. Remix was simply renamed React Router Framework Mode starting in version 7 of React Router.
  - [Blog Source](https://reacttraining.com/blog/remix-vs-react-router-framework)

<img width="894" height="754" alt="Screenshot 2026-06-04 at 4 00 45 PM" src="https://github.com/user-attachments/assets/33dc5d89-4a76-44b6-a5c3-39a30dca3b57" />


<img width="604" height="464" alt="Screenshot 2026-06-05 at 11 21 54 AM" src="https://github.com/user-attachments/assets/10ea458f-22e5-498c-b43a-df13f7902a17" />

## What is the new behavior?

- Adding a non-null assertion clears up all error. Running the application does not produce errors.
- Changing the label from "Remix" to "React Router" updates the dropdown name to match the rebrand. Now, it does not look outdated and matches the docs.

<img width="609" height="519" alt="Screenshot 2026-06-05 at 11 22 48 AM" src="https://github.com/user-attachments/assets/c18ee5b7-4693-40c9-9c20-8f95756c8298" />




## Additional context

The task was to clarify our documentation on this page: [Create a Client](https://supabase.com/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=react-router&queryGroups=environment&environment=react-router-loader#create-a-client)

However, the code sample in the docs is correct; the documentation in **Dashboard** produced the errors.

## Future improvements

- To make this more robust, the code could have a single source of truth. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified generated Supabase server client template text to improve type/reference safety in the Remix integration guide.

* **UI**
  * Renamed framework label from "Remix" to "React Router" across the Connect interfaces for clearer framework identification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->