### PR TITLE
Remove unexposed extensions

### DIFF
--- a/apps/docs/content/guides/database/extensions.mdx
+++ b/apps/docs/content/guides/database/extensions.mdx
@@ -44,7 +44,7 @@ To disable an extension call `drop extension`.
 
 <Admonition type="note">
 
-Most extensions are installed under the `extensions` schema, which is accessible to public by default. To avoid namespace pollution, we do not recommend creating other entities in the `extensions` schema.
+Most extensions are installed under the `extensions` schema, which is accessible to `public` by default. To avoid namespace pollution, we do not recommend creating other entities in the `extensions` schema.
 
 If you need to restrict user access to tables managed by extensions, we recommend creating a separate schema for installing that specific extension.
 

--- a/packages/shared-data/extensions.json
+++ b/packages/shared-data/extensions.json
@@ -18,15 +18,6 @@
     "product_url": null
   },
   {
-    "name": "amcheck",
-    "comment": "functions for verifying relation integrity",
-    "tags": ["Admin", "Utility"],
-    "link": "https://www.postgresql.org/docs/current/amcheck.html",
-    "github_url": null,
-    "product": null,
-    "product_url": null
-  },
-  {
     "name": "autoinc",
     "comment": "functions for autoincrementing fields",
     "tags": ["Utility"],
@@ -234,15 +225,6 @@
     "product_url": "/project/{ref}/integrations/cron"
   },
   {
-    "name": "pg_freespacemap",
-    "comment": "examine the free space map (FSM)",
-    "tags": ["Admin", "Utility"],
-    "link": "https://www.postgresql.org/docs/current/pgfreespacemap.html",
-    "github_url": null,
-    "product": null,
-    "product_url": null
-  },
-  {
     "name": "pg_graphql",
     "comment": "pg_graphql: GraphQL support",
     "tags": ["Utility"],
@@ -304,15 +286,6 @@
     "github_url": null,
     "product": "Query Performance",
     "product_url": "/project/{ref}/observability/query-performance"
-  },
-  {
-    "name": "pg_surgery",
-    "comment": "extension to perform surgery on a damaged relation",
-    "tags": ["Admin", "Utility"],
-    "link": "https://www.postgresql.org/docs/current/pgsurgery.html",
-    "github_url": null,
-    "product": null,
-    "product_url": null
   },
   {
     "name": "pg_trgm",


### PR DESCRIPTION
removes three extensions from the list on the Postgres Extensions docs page because we do not expose those extensions to users. extensions removed are: amcheck, pg_surgery, pg_freespacemap

also adds a small cosmetic change to clarify that "public" refers to the `public` schema on the same documentation page

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

extensions are listed at https://supabase.com/docs/guides/database/extensions that will result in permissions errors should users try to install them themselves, as they require superuser access to install

## What is the new behavior?

removes those items from the list

## Additional context


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated extensions overview documentation with improved formatting for better readability

* **Chores**
  * Removed three extensions from the available extensions metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->