### PR TITLE
fix(studio): copy updates to revoke oauth modal

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -53,14 +53,14 @@ export const RevokeAppModal = ({ selectedApp, onClose }: RevokeAppModalProps) =>
                 <li className="flex gap-3 text-sm">
                   <Lock size={14} className="shrink-0" />
                   <div>
-                    <strong>Before you remove this app:</strong>
+                    <strong>Before you remove this app, consider:</strong>
                     <ul className="space-y-2 mt-2">
-                      <li className="list-disc ml-4">
-                        Ensure that no users are currently using the application.
-                      </li>
                       <li className="list-disc ml-4">
                         The application will no longer have access to your organization after being
                         revoked.
+                      </li>
+                      <li className="list-disc ml-4">
+                        This will remove the application for all members in your organization.
                       </li>
                       <li className="list-disc ml-4">
                         Restoring access will require an organization administrator to re-authorize

--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -40,24 +40,31 @@ export const RevokeAppModal = ({ selectedApp, onClose }: RevokeAppModalProps) =>
     <AlertDialog open={selectedApp !== undefined} onOpenChange={onClose}>
       <AlertDialogContent size="medium">
         <AlertDialogHeader>
-          <AlertDialogTitle>{`Confirm to revoke ${selectedApp?.name}`}</AlertDialogTitle>
+          <AlertDialogTitle>{`Revoke access for ${selectedApp?.name}?`}</AlertDialogTitle>
           <AlertDialogDescription>
             <div className="flex flex-col space-y-2">
               <Admonition
                 type="warning"
                 title="This action cannot be undone"
-                description={`${selectedApp?.name} application will no longer have access to your organization's settings
+                description={`${selectedApp?.name} will no longer have access to your organization's settings
           and projects.`}
               />
               <ul className="space-y-5">
                 <li className="flex gap-3 text-sm">
                   <Lock size={14} className="shrink-0" />
                   <div>
-                    <strong>Before you remove this app, consider:</strong>
+                    <strong>Before you remove this app:</strong>
                     <ul className="space-y-2 mt-2">
                       <li className="list-disc ml-4">
-                        No users are currently using this application. The application will no
-                        longer have access to your organization after being revoked.
+                        Ensure that no users are currently using the application.
+                      </li>
+                      <li className="list-disc ml-4">
+                        The application will no longer have access to your organization after being
+                        revoked.
+                      </li>
+                      <li className="list-disc ml-4">
+                        Restoring access will require an organization administrator to re-authorize
+                        the application.
                       </li>
                     </ul>
                   </div>


### PR DESCRIPTION
Before:

<img width="525" height="318" alt="Screenshot 2026-06-05 at 4 28 09 PM" src="https://github.com/user-attachments/assets/3658c41d-ff62-4377-a4fc-49891f206d3c" />

* "Confirm to revoke Doppler" and "Doppler application will no longer have access" read awkwardly
* "No users are currently using this application" could easily be construed as a statement of fact, not something the user needs to confirm.

After:

<img width="519" height="409" alt="Screenshot 2026-06-05 at 5 28 17 PM" src="https://github.com/user-attachments/assets/8601122b-3720-4c49-8414-d0f55d445a78" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Clarified the OAuth app revocation dialog: updated the title to "Revoke access for …?", reworded the warning for readability, and expanded the "Before you remove this app" guidance into three concise points covering current usage, loss of access after revocation, and re-authorization by an organization administrator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->