### PR TITLE
docs(migrations): preview lock impact before applying a migration

### DIFF
--- a/apps/docs/content/guides/deployment/database-migrations.mdx
+++ b/apps/docs/content/guides/deployment/database-migrations.mdx
@@ -21,6 +21,36 @@ If a lock timeout error occurs, in your migration file, consider increasing your
 
 </Admonition>
 
+### Preview lock impact before applying
+
+`lock_timeout` limits the damage when a heavy statement runs against a populated table, but it doesn't tell you that a statement was dangerous in the first place. Some DDL takes an `ACCESS EXCLUSIVE` lock that blocks reads and writes for the duration of the rewrite, including:
+
+- `add column ... not null` on an existing table without a default
+- `create index` (without `concurrently`) on a large table
+- `alter column ... type` on a column that requires a full table rewrite
+
+Before you apply a migration, run it through a migration-safety linter. The three open-source options below each read your SQL and report the lock mode of every statement, plus a safer rewrite where one exists:
+
+- [Squawk](https://squawkhq.com) — TypeScript-based, the original Postgres migration linter
+- [Eugene](https://github.com/kaaveland/eugene) — Rust-based, focused on safe online migrations
+- [pgfence](https://pgfence.com) — Python-based, integrates with the Postgres language server
+
+To see which locks a statement is currently waiting on or holding against your running database, query `pg_locks` directly:
+
+```sql name=supabase/migrations/<timestamp>_inspect_locks.sql
+select
+  relation::regclass as table_name,
+  mode,
+  granted,
+  pg_size_pretty(pg_relation_size(relation)) as table_size
+from pg_locks
+join pg_class on pg_class.oid = pg_locks.relation
+where relation is not null
+order by table_size desc;
+```
+
+A long-running migration that shows a non-`granted` row on a large table is the same footgun the linters warn about. Rewriting the migration to take a weaker lock (for example, `create index concurrently`) lets reads and writes continue while the index builds.
+
 <StepHikeCompact>
 
   <StepHikeCompact.Step step={1}>


### PR DESCRIPTION
I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update — extends the existing `lock_timeout` tip in the database migrations guide with a new "Preview lock impact before applying" subsection that links readers to migration-safety linters and shows how to inspect lock state on a running database.

## What is the current behavior?

The guide at `apps/docs/content/guides/deployment/database-migrations.mdx` has a `lock_timeout` tip that acknowledges schema changes take heavy locks, but stops there. A user about to run a migration has no way to tell — before applying it — which lock each statement will acquire or which statements will rewrite the whole table.

The reporter called this out in #46639 and listed the common footguns: `add column ... not null` without a default, `create index` without `concurrently`, and `alter column ... type` on a column that requires a full rewrite. All three take `ACCESS EXCLUSIVE` and block reads and writes for the duration of the rewrite. `lock_timeout` limits the damage, but does not warn the user the statement was dangerous in the first place.

## What is the new behavior?

Adds a "Preview lock impact before applying" subsection directly after the existing `lock_timeout` tip. The new subsection:

- Names the three main footgun statements and the `ACCESS EXCLUSIVE` lock they acquire, so the reader knows what to look out for.
- Lists three open-source migration-safety linters — [Squawk](https://squawkhq.com), [Eugene](https://github.com/kaaveland/eugene), and [pgfence](https://pgfence.com) — each of which reads SQL and reports the lock mode of every statement plus a safer rewrite where one exists. The list reads as a three-tool category note, not a single-vendor backlink, matching the framing the reporter suggested in #46639.
- Adds a `pg_locks` query snippet for users who want to inspect the lock state of a running database right now, not via a linter. This is broader value than the reporter's original proposal (which only suggested the linter category) and is useful when investigating an in-flight migration.

## Steps to verify the change

1. Open `apps/docs/content/guides/deployment/database-migrations.mdx` in the docs preview.
2. Scroll to the top of the "Schema migrations" section. The new "Preview lock impact before applying" subsection sits between the existing `lock_timeout` tip and the first `StepHikeCompact`.
3. The three linter links should resolve to live sites (Squawk → squawkhq.com, Eugene → github.com/kaaveland/eugene, pgfence → pgfence.com).
4. Run `pnpm test:prettier` (or `npx prettier --config prettier.config.mjs --check apps/docs/content/guides/deployment/database-migrations.mdx`) — the file should report "All matched files use Prettier code style".
5. The `pg_locks` query in the new section is a standard Postgres catalog query and should run unchanged on any Postgres ≥ 13 (the version Supabase currently supports).

## Additional context

- All three linter URLs (squawkhq.com, github.com/kaaveland/eugene, pgfence.com) return HTTP 200 at the time of opening this PR.
- I have followed the docs style guide: sentence case heading, present tense, Oxford commas, lowercase SQL in the code block, no filler words like "simply" or "just", and the "Postgres" / "Supabase" capitalization rules from `apps/docs/CONTRIBUTING.md`.
- The reporter disclosed in #46639 that they maintain pgfence; I have framed the linter mention as a three-tool category note to read as a docs improvement rather than a backlink.
- I have not added a nav entry, since this is a subsection of an existing guide page rather than a new page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new guide section on database migration safety, covering lock timeout configuration, PostgreSQL lock patterns, safety linting tools, and techniques to inspect and mitigate migration risks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->