### PR TITLE
fix(studio): wrappers install state + one-click install

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
@@ -36,20 +36,22 @@ export const useIntegrationDetail = () => {
     [installedIntegrations, id]
   )
 
-  const installableExtensions = (extensions ?? []).filter((ext) =>
-    (integration?.requiredExtensions ?? []).includes(ext.name)
-  )
-  const extensionsInstalled = installableExtensions.every((x) => x.installed_version)
+  const isInstalled = !!integration && !!installation
 
-  // installedIntegrations doesn't return wrappers unless there's a wrapper created
-  const isInstalled =
-    !!integration && (!!installation || (integration.type === 'wrapper' && extensionsInstalled))
+  // True when all pg extensions required by this integration are already enabled.
+  // Used by wrappers to hide the "Install integration" button once the shared
+  // extensions are in place — wrapper instances are managed via the Wrappers tab.
+  const areRequiredExtensionsInstalled = useMemo(() => {
+    if (!integration?.requiredExtensions?.length || !extensions) return false
+    return integration.requiredExtensions.every(
+      (name) => !!extensions.find((ext) => ext.name === name)?.installed_version
+    )
+  }, [integration, extensions])
 
   const navItems = useMemo(() => {
     if (!integration?.navigation) return []
-    return isInstalled
-      ? integration.navigation
-      : integration.navigation.filter((nav) => nav.route === 'overview')
+    if (isInstalled || integration.type === 'wrapper') return integration.navigation
+    return integration.navigation.filter((nav) => nav.route === 'overview')
   }, [integration, isInstalled])
 
   const activeRoute = pageId ?? 'overview'
@@ -115,6 +117,7 @@ export const useIntegrationDetail = () => {
     integration,
     installation,
     isInstalled,
+    areRequiredExtensionsInstalled,
     isAvailableLoading,
     isInstalledLoading,
     Component,

--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
@@ -4,6 +4,12 @@ import { useEffect, useMemo } from 'react'
 
 import { useAvailableIntegrations } from './useAvailableIntegrations'
 import { useInstalledIntegrations } from './useInstalledIntegrations'
+import {
+  areRequiredExtensionsInstalledFor,
+  getFilteredNavItems,
+  getInstallActionType,
+  type InstallActionType,
+} from './useIntegrationDetail.utils'
 import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
@@ -43,21 +49,23 @@ export const useIntegrationDetail = () => {
   // True when all pg extensions required by this integration are already enabled.
   // Used by wrappers to hide the "Install integration" button once the shared
   // extensions are in place — wrapper instances are managed via the Wrappers tab.
-  const areRequiredExtensionsInstalled = useMemo(() => {
-    if (!integration?.requiredExtensions?.length || !extensions) return false
-    return integration.requiredExtensions.every(
-      (name) => !!extensions.find((ext) => ext.name === name)?.installed_version
-    )
-  }, [integration, extensions])
+  const areRequiredExtensionsInstalled = useMemo(
+    () => areRequiredExtensionsInstalledFor(integration, extensions),
+    [integration, extensions]
+  )
 
-  const navItems = useMemo(() => {
-    if (!integration?.navigation) return []
-    if (isInstalled || integration.type !== 'wrapper') return integration.navigation
-    // For wrapper integrations, show the Wrappers tab only when the marketplace flag is on
-    // (the sheet handles implicit extension install) or when extensions are already installed.
-    if (isMarketplaceEnabled || areRequiredExtensionsInstalled) return integration.navigation
-    return integration.navigation.filter((nav) => nav.route !== 'wrappers')
-  }, [integration, isInstalled, isMarketplaceEnabled, areRequiredExtensionsInstalled])
+  // For wrapper integrations, show the Wrappers tab only when the marketplace flag is on
+  // (the sheet handles implicit extension install) or when extensions are already installed.
+  const navItems = useMemo(
+    () =>
+      getFilteredNavItems({
+        integration,
+        isInstalled,
+        isMarketplaceEnabled,
+        areRequiredExtensionsInstalled,
+      }),
+    [integration, isInstalled, isMarketplaceEnabled, areRequiredExtensionsInstalled]
+  )
 
   const activeRoute = pageId ?? 'overview'
 
@@ -82,6 +90,22 @@ export const useIntegrationDetail = () => {
   const Component = useMemo(
     () => integration?.navigate({ id, pageId, childId }),
     [integration, id, pageId, childId]
+  )
+
+  const wrappersTabHref = useMemo(
+    () => tabs.find((tab) => tab.href.endsWith('/wrappers'))?.href,
+    [tabs]
+  )
+
+  const installActionType: InstallActionType = useMemo(
+    () =>
+      getInstallActionType({
+        integration,
+        isMarketplaceEnabled,
+        areRequiredExtensionsInstalled,
+        isInstalled,
+      }),
+    [integration, isMarketplaceEnabled, areRequiredExtensionsInstalled, isInstalled]
   )
 
   const isReady = !!router?.isReady
@@ -123,6 +147,8 @@ export const useIntegrationDetail = () => {
     installation,
     isInstalled,
     areRequiredExtensionsInstalled,
+    installActionType,
+    wrappersTabHref,
     isAvailableLoading,
     isInstalledLoading,
     Component,

--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
@@ -4,6 +4,7 @@ import { useEffect, useMemo } from 'react'
 
 import { useAvailableIntegrations } from './useAvailableIntegrations'
 import { useInstalledIntegrations } from './useInstalledIntegrations'
+import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -19,6 +20,7 @@ export const useIntegrationDetail = () => {
   const { ref, id, pageId, childId } = useParams()
 
   const { integrationsWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
+  const isMarketplaceEnabled = useIsMarketplaceEnabled()
 
   const { data: project } = useSelectedProjectQuery()
   const { data: extensions } = useDatabaseExtensionsQuery({
@@ -50,9 +52,12 @@ export const useIntegrationDetail = () => {
 
   const navItems = useMemo(() => {
     if (!integration?.navigation) return []
-    if (isInstalled || integration.type === 'wrapper') return integration.navigation
-    return integration.navigation.filter((nav) => nav.route === 'overview')
-  }, [integration, isInstalled])
+    if (isInstalled || integration.type !== 'wrapper') return integration.navigation
+    // For wrapper integrations, show the Wrappers tab only when the marketplace flag is on
+    // (the sheet handles implicit extension install) or when extensions are already installed.
+    if (isMarketplaceEnabled || areRequiredExtensionsInstalled) return integration.navigation
+    return integration.navigation.filter((nav) => nav.route !== 'wrappers')
+  }, [integration, isInstalled, isMarketplaceEnabled, areRequiredExtensionsInstalled])
 
   const activeRoute = pageId ?? 'overview'
 

--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
@@ -46,16 +46,11 @@ export const useIntegrationDetail = () => {
 
   const isInstalled = !!integration && !!installation
 
-  // True when all pg extensions required by this integration are already enabled.
-  // Used by wrappers to hide the "Install integration" button once the shared
-  // extensions are in place — wrapper instances are managed via the Wrappers tab.
   const areRequiredExtensionsInstalled = useMemo(
     () => areRequiredExtensionsInstalledFor(integration, extensions),
     [integration, extensions]
   )
 
-  // For wrapper integrations, show the Wrappers tab only when the marketplace flag is on
-  // (the sheet handles implicit extension install) or when extensions are already installed.
   const navItems = useMemo(
     () =>
       getFilteredNavItems({

--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.utils.ts
@@ -1,0 +1,66 @@
+import type { IntegrationDefinition, Navigation } from './Integrations.constants'
+
+export type InstallActionType = 'oauth' | 'add-wrapper' | 'installed' | 'install-sheet' | null
+
+export type DatabaseExtension = {
+  name: string
+  installed_version: string | null
+}
+
+/**
+ * Returns whether all required extensions for an integration are enabled in the database.
+ */
+export function areRequiredExtensionsInstalledFor(
+  integration: IntegrationDefinition | undefined,
+  extensions: DatabaseExtension[] | undefined
+): boolean {
+  if (!integration?.requiredExtensions?.length || !extensions) return false
+  return integration.requiredExtensions.every(
+    (name) => !!extensions.find((ext) => ext.name === name)?.installed_version
+  )
+}
+
+/**
+ * Returns the filtered navigation items for an integration based on install / feature-flag state.
+ * Wrapper integrations only expose the Wrappers tab once extensions are installed (or marketplace flag is on).
+ */
+export function getFilteredNavItems({
+  integration,
+  isInstalled,
+  isMarketplaceEnabled,
+  areRequiredExtensionsInstalled,
+}: {
+  integration: IntegrationDefinition | undefined
+  isInstalled: boolean
+  isMarketplaceEnabled: boolean
+  areRequiredExtensionsInstalled: boolean
+}): Navigation[] {
+  if (!integration?.navigation) return []
+  if (isInstalled || integration.type !== 'wrapper') return integration.navigation
+  if (isMarketplaceEnabled || areRequiredExtensionsInstalled) return integration.navigation
+  return integration.navigation.filter((nav) => nav.route !== 'wrappers')
+}
+
+/**
+ * Returns which install action type to render for an integration.
+ * Keeps conditional logic out of the component and makes it unit-testable.
+ */
+export function getInstallActionType({
+  integration,
+  isMarketplaceEnabled,
+  areRequiredExtensionsInstalled,
+  isInstalled,
+}: {
+  integration: IntegrationDefinition | undefined
+  isMarketplaceEnabled: boolean
+  areRequiredExtensionsInstalled: boolean
+  isInstalled: boolean
+}): InstallActionType {
+  if (!integration) return null
+  if (integration.type === 'oauth') return 'oauth'
+  if (integration.type === 'wrapper' && (isMarketplaceEnabled || areRequiredExtensionsInstalled)) {
+    return 'add-wrapper'
+  }
+  if (isInstalled) return 'installed'
+  return 'install-sheet'
+}

--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.utils.ts
@@ -22,7 +22,7 @@ export function areRequiredExtensionsInstalledFor(
 
 /**
  * Returns the filtered navigation items for an integration based on install / feature-flag state.
- * Wrapper integrations only expose the Wrappers tab once extensions are installed (or marketplace flag is on).
+ * If the marketplace flag is off, only expose the Wrappers tab once extensions are installed
  */
 export function getFilteredNavItems({
   integration,
@@ -43,7 +43,6 @@ export function getFilteredNavItems({
 
 /**
  * Returns which install action type to render for an integration.
- * Keeps conditional logic out of the component and makes it unit-testable.
  */
 export function getInstallActionType({
   integration,

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight, BookOpen } from 'lucide-react'
-import { Button, cn } from 'ui'
+import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import { GenericSkeletonLoader, ShimmeringLoader } from 'ui-patterns'
 import { Admonition } from 'ui-patterns/admonition'
 
@@ -27,6 +27,7 @@ export const MarketplaceDetail = () => {
     pageSubTitle,
     integration,
     isInstalled,
+    areRequiredExtensionsInstalled,
     isAvailableLoading,
     isInstalledLoading,
     Component,
@@ -74,6 +75,23 @@ export const MarketplaceDetail = () => {
         <Button type="outline" disabled>
           Installed
         </Button>
+      )
+    }
+    if (integration.type === 'wrapper' && areRequiredExtensionsInstalled) {
+      return (
+        <Tooltip>
+          <TooltipTrigger>
+            <Button type="outline" className="shrink-0" disabled>
+              Installed
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="bottom" align="end" className="w-64 text-pretty">
+            <p>Required extensions are already installed</p>
+            <p className="text-foreground-lighter">
+              Visit the <i>Wrappers</i> tab to add a new {integration.name} instance.
+            </p>
+          </TooltipContent>
+        </Tooltip>
       )
     }
     return <InstallIntegrationSheet integration={integration} />

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -1,5 +1,6 @@
 import { ArrowUpRight, BookOpen } from 'lucide-react'
-import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+import { useRouter } from 'next/router'
+import { Button, cn } from 'ui'
 import { GenericSkeletonLoader, ShimmeringLoader } from 'ui-patterns'
 import { Admonition } from 'ui-patterns/admonition'
 
@@ -10,11 +11,13 @@ import { IntegrationDetailTabShortcuts } from '@/components/interfaces/Integrati
 import { InstallIntegrationSheet } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallIntegrationSheet'
 import { InstallOAuthIntegrationButton } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton'
 import { useIntegrationDetail } from '@/components/interfaces/Integrations/Landing/useIntegrationDetail'
+import { AddWrapperButton } from '@/components/interfaces/Integrations/Wrappers/AddWrapperButton'
 import { UnknownInterface } from '@/components/ui/UnknownInterface'
 
 export const centeredContentClass = 'mx-auto w-full max-w-6xl px-6 xl:px-10'
 
 export const MarketplaceDetail = () => {
+  const router = useRouter()
   const {
     ref,
     activeRoute,
@@ -78,20 +81,13 @@ export const MarketplaceDetail = () => {
       )
     }
     if (integration.type === 'wrapper' && areRequiredExtensionsInstalled) {
+      const wrappersTabHref = tabs.find((tab) => tab.href.endsWith('/wrappers'))?.href
       return (
-        <Tooltip>
-          <TooltipTrigger>
-            <Button type="outline" className="shrink-0" disabled>
-              Installed
-            </Button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" align="end" className="w-64 text-pretty">
-            <p>Required extensions are already installed</p>
-            <p className="text-foreground-lighter">
-              Visit the <i>Wrappers</i> tab to add a new {integration.name} instance.
-            </p>
-          </TooltipContent>
-        </Tooltip>
+        <AddWrapperButton
+          onClick={() => {
+            if (wrappersTabHref) router.push(`${wrappersTabHref}?action=new`)
+          }}
+        />
       )
     }
     return <InstallIntegrationSheet integration={integration} />

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -7,7 +7,6 @@ import { Admonition } from 'ui-patterns/admonition'
 import { MarketplaceDetailBreadrumbs } from './MarketplaceDetailBreadcrumbs'
 import { MarketplaceDetailHero } from './MarketplaceDetailHero'
 import { OverviewTab } from './OverviewTab'
-import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { IntegrationDetailTabShortcuts } from '@/components/interfaces/Integrations/Integration/IntegrationDetailTabShortcuts'
 import { InstallIntegrationSheet } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallIntegrationSheet'
 import { InstallOAuthIntegrationButton } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton'
@@ -19,7 +18,6 @@ export const centeredContentClass = 'mx-auto w-full max-w-6xl px-6 xl:px-10'
 
 export const MarketplaceDetail = () => {
   const router = useRouter()
-  const isMarketplaceEnabled = useIsMarketplaceEnabled()
   const {
     ref,
     activeRoute,
@@ -32,7 +30,8 @@ export const MarketplaceDetail = () => {
     pageSubTitle,
     integration,
     isInstalled,
-    areRequiredExtensionsInstalled,
+    installActionType,
+    wrappersTabHref,
     isAvailableLoading,
     isInstalledLoading,
     Component,
@@ -72,31 +71,27 @@ export const MarketplaceDetail = () => {
   }
 
   const renderInstallAction = () => {
-    if (integration.type === 'oauth') {
-      return <InstallOAuthIntegrationButton integration={integration} />
+    switch (installActionType) {
+      case 'oauth':
+        return <InstallOAuthIntegrationButton integration={integration} />
+      case 'add-wrapper':
+        return (
+          <AddWrapperButton
+            type="primary"
+            onClick={() => {
+              if (wrappersTabHref) router.push(`${wrappersTabHref}?new=true`)
+            }}
+          />
+        )
+      case 'installed':
+        return (
+          <Button type="outline" disabled>
+            Installed
+          </Button>
+        )
+      default:
+        return <InstallIntegrationSheet integration={integration} />
     }
-    if (
-      integration.type === 'wrapper' &&
-      (isMarketplaceEnabled || areRequiredExtensionsInstalled)
-    ) {
-      const wrappersTabHref = tabs.find((tab) => tab.href.endsWith('/wrappers'))?.href
-      return (
-        <AddWrapperButton
-          type="primary"
-          onClick={() => {
-            if (wrappersTabHref) router.push(`${wrappersTabHref}?new=true`)
-          }}
-        />
-      )
-    }
-    if (isInstalled) {
-      return (
-        <Button type="outline" disabled>
-          Installed
-        </Button>
-      )
-    }
-    return <InstallIntegrationSheet integration={integration} />
   }
 
   // For overview route, get the integration-specific overview component if available

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -85,7 +85,7 @@ export const MarketplaceDetail = () => {
       return (
         <AddWrapperButton
           onClick={() => {
-            if (wrappersTabHref) router.push(`${wrappersTabHref}?action=new`)
+            if (wrappersTabHref) router.push(`${wrappersTabHref}?new=true`)
           }}
         />
       )

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -7,6 +7,7 @@ import { Admonition } from 'ui-patterns/admonition'
 import { MarketplaceDetailBreadrumbs } from './MarketplaceDetailBreadcrumbs'
 import { MarketplaceDetailHero } from './MarketplaceDetailHero'
 import { OverviewTab } from './OverviewTab'
+import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { IntegrationDetailTabShortcuts } from '@/components/interfaces/Integrations/Integration/IntegrationDetailTabShortcuts'
 import { InstallIntegrationSheet } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallIntegrationSheet'
 import { InstallOAuthIntegrationButton } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton'
@@ -18,6 +19,7 @@ export const centeredContentClass = 'mx-auto w-full max-w-6xl px-6 xl:px-10'
 
 export const MarketplaceDetail = () => {
   const router = useRouter()
+  const isMarketplaceEnabled = useIsMarketplaceEnabled()
   const {
     ref,
     activeRoute,
@@ -73,21 +75,25 @@ export const MarketplaceDetail = () => {
     if (integration.type === 'oauth') {
       return <InstallOAuthIntegrationButton integration={integration} />
     }
+    if (
+      integration.type === 'wrapper' &&
+      (isMarketplaceEnabled || areRequiredExtensionsInstalled)
+    ) {
+      const wrappersTabHref = tabs.find((tab) => tab.href.endsWith('/wrappers'))?.href
+      return (
+        <AddWrapperButton
+          type="primary"
+          onClick={() => {
+            if (wrappersTabHref) router.push(`${wrappersTabHref}?new=true`)
+          }}
+        />
+      )
+    }
     if (isInstalled) {
       return (
         <Button type="outline" disabled>
           Installed
         </Button>
-      )
-    }
-    if (integration.type === 'wrapper' && areRequiredExtensionsInstalled) {
-      const wrappersTabHref = tabs.find((tab) => tab.href.endsWith('/wrappers'))?.href
-      return (
-        <AddWrapperButton
-          onClick={() => {
-            if (wrappersTabHref) router.push(`${wrappersTabHref}?new=true`)
-          }}
-        />
       )
     }
     return <InstallIntegrationSheet integration={integration} />

--- a/apps/studio/components/interfaces/Integrations/Wrappers/AddWrapperButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/AddWrapperButton.tsx
@@ -1,0 +1,33 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+
+interface AddWrapperButtonProps {
+  type?: 'default' | 'primary' | 'outline'
+  onClick: () => void
+}
+
+export const AddWrapperButton = ({ type = 'default', onClick }: AddWrapperButtonProps) => {
+  const { can: canCreateWrapper } = useAsyncCheckPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_WRITE,
+    'wrappers'
+  )
+
+  return (
+    <ButtonTooltip
+      type={type}
+      onClick={onClick}
+      disabled={!canCreateWrapper}
+      tooltip={{
+        content: {
+          text: !canCreateWrapper
+            ? 'You need additional permissions to create a foreign data wrapper'
+            : undefined,
+        },
+      }}
+    >
+      Add new wrapper
+    </ButtonTooltip>
+  )
+}

--- a/apps/studio/components/interfaces/Integrations/Wrappers/AddWrapperButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/AddWrapperButton.tsx
@@ -1,7 +1,12 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useMemo } from 'react'
 
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+
+const WRAPPER_REQUIRED_EXTENSION_NAMES = ['wrappers', 'supabase_vault']
 
 interface AddWrapperButtonProps {
   type?: 'default' | 'primary' | 'outline'
@@ -12,6 +17,20 @@ export const AddWrapperButton = ({ type = 'default', onClick }: AddWrapperButton
   const { can: canCreateWrapper } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'wrappers'
+  )
+
+  const { data: project } = useSelectedProjectQuery()
+  const { data: extensions } = useDatabaseExtensionsQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
+  const needsExtensions = useMemo(
+    () =>
+      WRAPPER_REQUIRED_EXTENSION_NAMES.some(
+        (name) => !extensions?.find((ext) => ext.name === name)?.installed_version
+      ),
+    [extensions]
   )
 
   return (
@@ -27,7 +46,7 @@ export const AddWrapperButton = ({ type = 'default', onClick }: AddWrapperButton
         },
       }}
     >
-      Add new wrapper
+      {needsExtensions ? 'Install wrapper' : 'Add new wrapper'}
     </ButtonTooltip>
   )
 }

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -84,12 +84,8 @@ export const CreateWrapperSheet = ({
   )
 
   const wrappersExtension = extensions?.find((ext) => ext.name === 'wrappers')
-  // The import foreign schema requires a minimum extension version of 0.5.0
   const hasRequiredVersionForeignSchema = hasForeignSchemaSupport(wrappersExtension)
-
-  // True when there are extensions that still need installing
   const needsExtensions = isMarketplaceEnabled && (requiredExtensionsToInstall?.length ?? 0) > 0
-  // True while extension state is unresolved — blocks submit and disables the button
   const isExtensionDataLoading = isMarketplaceEnabled && requiredExtensionsToInstall === null
 
   const { data: schemas } = useSchemasQuery({

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -235,7 +235,9 @@ export const CreateWrapperSheet = ({
       if (hasNewSchema) invalidateSchemasQuery(queryClient, project?.ref)
 
       track('foreign_data_wrapper_created', { wrapperType: wrapperMeta.label })
-      toast.success(`Successfully created ${wrapperMeta.label} wrapper`, { id: toastId })
+      toast.success(`Successfully created ${wrapperMeta.label} foreign data wrapper`, {
+        id: toastId,
+      })
       onClose()
       form.reset()
     } catch (error) {

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import { useQueryClient } from '@tanstack/react-query'
 import { Edit, Trash } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { SubmitHandler, useFieldArray, useForm, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -18,6 +18,7 @@ import {
   SheetTitle,
   WarningIcon,
 } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
@@ -25,19 +26,25 @@ import InputField from './InputField'
 import { WrapperMeta } from './Wrappers.types'
 import { FormattedWrapperTable, getWrapperCreationFormSchema, NewTable } from './Wrappers.utils'
 import WrapperTableEditor from './WrapperTableEditor'
+import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { getExtensionDefaultSchema } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/IntegrationOverviewTabV2.utils'
+import { RequiredExtensionsSection } from '@/components/interfaces/Integrations/Integration/RequiredExtensionsSection'
 import {
   FormSection,
   FormSectionContent,
   FormSectionLabel,
 } from '@/components/ui/Forms/FormSection'
+import { useDatabaseExtensionEnableMutation } from '@/data/database-extensions/database-extension-enable-mutation'
 import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useSchemaCreateMutation } from '@/data/database/schema-create-mutation'
 import { invalidateSchemasQuery, useSchemasQuery } from '@/data/database/schemas-query'
 import { useFDWCreateMutation } from '@/data/fdw/fdw-create-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useTrack } from '@/lib/telemetry/track'
+import type { ResponseError } from '@/types'
 
 const FORM_ID = 'create-wrapper-form'
+const WRAPPER_REQUIRED_EXTENSION_NAMES = ['wrappers', 'supabase_vault']
 
 export interface CreateWrapperSheetProps {
   wrapperMeta: WrapperMeta
@@ -53,18 +60,23 @@ export const CreateWrapperSheet = ({
   onCloseWithConfirmation,
 }: CreateWrapperSheetProps) => {
   const queryClient = useQueryClient()
+  const isMarketplaceEnabled = useIsMarketplaceEnabled()
 
   const { data: project } = useSelectedProjectQuery()
   const track = useTrack()
-
-  const [selectedTableToEdit, setSelectedTableToEdit] = useState<
-    FormattedWrapperTable | undefined
-  >()
 
   const { data: extensions } = useDatabaseExtensionsQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+
+  const requiredExtensionsToInstall = useMemo(
+    () =>
+      (extensions ?? []).filter(
+        (ext) => WRAPPER_REQUIRED_EXTENSION_NAMES.includes(ext.name) && !ext.installed_version
+      ),
+    [extensions]
+  )
 
   const wrappersExtension = extensions?.find((ext) => ext.name === 'wrappers')
   // The import foreign schema requires a minimum extension version of 0.5.0
@@ -113,7 +125,34 @@ export const CreateWrapperSheet = ({
     name: 'tables',
   })
 
-  const { mutateAsync: createSchema, isPending: isCreatingSchema } = useSchemaCreateMutation()
+  const [selectedTableToEdit, setSelectedTableToEdit] = useState<FormattedWrapperTable | undefined>(
+    undefined
+  )
+
+  const { mutateAsync: enableExtension } = useDatabaseExtensionEnableMutation({ onError: () => {} })
+  const { mutateAsync: createSchema } = useSchemaCreateMutation({ onError: () => {} })
+  const { mutateAsync: createFDW } = useFDWCreateMutation({ onError: () => {} })
+
+  const installRequiredExtensions = async () => {
+    if (!project) return
+    const { ref: projectRef, connectionString } = project
+    const results = await Promise.allSettled(
+      requiredExtensionsToInstall.map((ext) => {
+        const schema = getExtensionDefaultSchema(ext) ?? 'extensions'
+        return enableExtension({
+          projectRef,
+          connectionString,
+          schema,
+          name: ext.name,
+          version: ext.default_version,
+          cascade: true,
+          createSchema: false,
+        })
+      })
+    )
+    const failure = results.find((r) => r.status === 'rejected')
+    if (failure) throw new Error((failure as PromiseRejectedResult).reason.message)
+  }
 
   const onUpdateTable = (values: FormattedWrapperTable) => {
     if (values.index !== undefined) {
@@ -124,19 +163,6 @@ export const CreateWrapperSheet = ({
     }
     setSelectedTableToEdit(undefined)
   }
-
-  const { mutateAsync: createFDW, isPending: isCreatingWrapper } = useFDWCreateMutation({
-    onSuccess: () => {
-      toast.success(`Successfully created ${wrapperMeta?.label} foreign data wrapper`)
-
-      const { tables } = getValues()
-      const hasNewSchema = (tables as Record<string, any>[]).some((table) => table.is_new_schema)
-      if (hasNewSchema) invalidateSchemasQuery(queryClient, project?.ref)
-
-      onClose()
-      form.reset()
-    },
-  })
 
   const onSubmit: SubmitHandler<FormSchema> = async (values) => {
     const { mode, tables = [], ...wrapperValues } = values
@@ -158,13 +184,27 @@ export const CreateWrapperSheet = ({
       }
     }
 
+    const needsExtensions = isMarketplaceEnabled && requiredExtensionsToInstall.length > 0
+    const toastId = toast.loading(
+      needsExtensions
+        ? `Installing extensions (${requiredExtensionsToInstall.map((e) => e.name).join(', ')})…`
+        : `Creating ${wrapperMeta.label} wrapper…`
+    )
+
     try {
+      if (needsExtensions) {
+        await installRequiredExtensions()
+        toast.loading(`Creating ${wrapperMeta.label} wrapper…`, { id: toastId })
+      }
+
       if (mode === 'schema') {
+        toast.loading(`Creating schema "${wrapperValues.target_schema}"…`, { id: toastId })
         await createSchema({
           projectRef: project?.ref,
           connectionString: project?.connectionString,
           name: wrapperValues.target_schema,
         })
+        toast.loading(`Creating ${wrapperMeta.label} wrapper…`, { id: toastId })
       }
 
       await createFDW({
@@ -182,14 +222,22 @@ export const CreateWrapperSheet = ({
         targetSchema: wrapperValues.target_schema,
       })
 
+      const { tables: formTables } = getValues()
+      const hasNewSchema = (formTables as Record<string, any>[]).some((t) => t.is_new_schema)
+      if (hasNewSchema) invalidateSchemasQuery(queryClient, project?.ref)
+
       track('foreign_data_wrapper_created', { wrapperType: wrapperMeta.label })
+      toast.success(`Successfully created ${wrapperMeta.label} wrapper`, { id: toastId })
+      onClose()
+      form.reset()
     } catch (error) {
-      console.error(error)
-      // The error will be handled by the mutation onError callback (toast.error)
+      toast.error(
+        `Failed to create ${wrapperMeta.label} wrapper: ${(error as ResponseError).message}`,
+        { id: toastId }
+      )
     }
   }
 
-  const isLoading = isCreatingWrapper || isCreatingSchema
   const wrapper_name = useWatch({ name: 'wrapper_name', control: form.control })
   const mode = useWatch({ name: 'mode', control: form.control })
 
@@ -206,6 +254,16 @@ export const CreateWrapperSheet = ({
               <SheetTitle>Create a {wrapperMeta.label} wrapper</SheetTitle>
             </SheetHeader>
             <div className="flex-grow overflow-y-auto">
+              {isMarketplaceEnabled && requiredExtensionsToInstall.length > 0 && (
+                <div className="px-5 pt-5 flex flex-col gap-y-4">
+                  <Admonition
+                    type="default"
+                    title="Required extensions will be installed"
+                    description="Proceeding will also install the following extensions required by this wrapper."
+                  />
+                  <RequiredExtensionsSection hideSeparator />
+                </div>
+              )}
               <FormSection header={<FormSectionLabel>Wrapper Configuration</FormSectionLabel>}>
                 <FormSectionContent className="flex flex-col space-y-2" loading={false}>
                   <FormField
@@ -443,7 +501,7 @@ export const CreateWrapperSheet = ({
                 type="default"
                 htmlType="button"
                 onClick={onCloseWithConfirmation}
-                disabled={isLoading}
+                disabled={isSubmitting}
               >
                 Cancel
               </Button>
@@ -452,8 +510,8 @@ export const CreateWrapperSheet = ({
                 type="primary"
                 form={FORM_ID}
                 htmlType="submit"
-                disabled={isSubmitting || isLoading}
-                loading={isLoading}
+                disabled={isSubmitting}
+                loading={isSubmitting}
               >
                 Create wrapper
               </Button>

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -24,7 +24,13 @@ import * as z from 'zod'
 
 import InputField from './InputField'
 import { WrapperMeta } from './Wrappers.types'
-import { FormattedWrapperTable, getWrapperCreationFormSchema, NewTable } from './Wrappers.utils'
+import {
+  FormattedWrapperTable,
+  getRequiredExtensionsToInstall,
+  getWrapperCreationFormSchema,
+  hasForeignSchemaSupport,
+  NewTable,
+} from './Wrappers.utils'
 import WrapperTableEditor from './WrapperTableEditor'
 import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { getExtensionDefaultSchema } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/IntegrationOverviewTabV2.utils'
@@ -66,28 +72,25 @@ export const CreateWrapperSheet = ({
   const { data: project } = useSelectedProjectQuery()
   const track = useTrack()
 
-  const { data: extensions, isLoading: isExtensionsLoading } = useDatabaseExtensionsQuery({
+  const { data: extensions } = useDatabaseExtensionsQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
 
   // null while the query is in flight — distinct from [] which means "all installed"
   const requiredExtensionsToInstall = useMemo(
-    () =>
-      extensions === undefined
-        ? null
-        : extensions.filter(
-            (ext) =>
-              (integration?.requiredExtensions ?? []).includes(ext.name) && !ext.installed_version
-          ),
+    () => getRequiredExtensionsToInstall(extensions, integration?.requiredExtensions ?? []),
     [extensions, integration?.requiredExtensions]
   )
 
   const wrappersExtension = extensions?.find((ext) => ext.name === 'wrappers')
   // The import foreign schema requires a minimum extension version of 0.5.0
-  const hasRequiredVersionForeignSchema = wrappersExtension?.installed_version
-    ? wrappersExtension?.installed_version >= '0.5.0'
-    : false
+  const hasRequiredVersionForeignSchema = hasForeignSchemaSupport(wrappersExtension)
+
+  // True when there are extensions that still need installing
+  const needsExtensions = isMarketplaceEnabled && (requiredExtensionsToInstall?.length ?? 0) > 0
+  // True while extension state is unresolved — blocks submit and disables the button
+  const isExtensionDataLoading = isMarketplaceEnabled && requiredExtensionsToInstall === null
 
   const { data: schemas } = useSchemasQuery({
     projectRef: project?.ref!,
@@ -189,13 +192,11 @@ export const CreateWrapperSheet = ({
       }
     }
 
-    // Extension metadata not yet resolved — block rather than silently skip the install step
-    if (isMarketplaceEnabled && requiredExtensionsToInstall === null) return
+    if (isExtensionDataLoading) return
 
-    const needsExtensions = isMarketplaceEnabled && (requiredExtensionsToInstall?.length ?? 0) > 0
     const toastId = toast.loading(
       needsExtensions
-        ? `Installing extensions (${(requiredExtensionsToInstall ?? []).map((e) => e.name).join(', ')})…`
+        ? `Installing extensions ${(requiredExtensionsToInstall ?? []).map((e) => e.name).join(', ')}…`
         : `Creating ${wrapperMeta.label} wrapper…`
     )
 
@@ -266,7 +267,7 @@ export const CreateWrapperSheet = ({
             <div className="grow overflow-y-auto">
               {isMarketplaceEnabled && (
                 <div className="px-5 py-5 flex flex-col gap-y-4 border-b">
-                  {!!requiredExtensionsToInstall?.length && (
+                  {needsExtensions && (
                     <Admonition
                       type="warning"
                       title="Required extensions will be installed"
@@ -522,7 +523,7 @@ export const CreateWrapperSheet = ({
                 type="primary"
                 form={FORM_ID}
                 htmlType="submit"
-                disabled={isSubmitting || (isMarketplaceEnabled && isExtensionsLoading)}
+                disabled={isSubmitting || isExtensionDataLoading}
                 loading={isSubmitting}
               >
                 Create wrapper

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -65,16 +65,19 @@ export const CreateWrapperSheet = ({
   const { data: project } = useSelectedProjectQuery()
   const track = useTrack()
 
-  const { data: extensions } = useDatabaseExtensionsQuery({
+  const { data: extensions, isLoading: isExtensionsLoading } = useDatabaseExtensionsQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
 
+  // null while the query is in flight — distinct from [] which means "all installed"
   const requiredExtensionsToInstall = useMemo(
     () =>
-      (extensions ?? []).filter(
-        (ext) => WRAPPER_REQUIRED_EXTENSION_NAMES.includes(ext.name) && !ext.installed_version
-      ),
+      extensions === undefined
+        ? null
+        : extensions.filter(
+            (ext) => WRAPPER_REQUIRED_EXTENSION_NAMES.includes(ext.name) && !ext.installed_version
+          ),
     [extensions]
   )
 
@@ -137,7 +140,7 @@ export const CreateWrapperSheet = ({
     if (!project) return
     const { ref: projectRef, connectionString } = project
     const results = await Promise.allSettled(
-      requiredExtensionsToInstall.map((ext) => {
+      (requiredExtensionsToInstall ?? []).map((ext) => {
         const schema = getExtensionDefaultSchema(ext) ?? 'extensions'
         return enableExtension({
           projectRef,
@@ -184,10 +187,13 @@ export const CreateWrapperSheet = ({
       }
     }
 
-    const needsExtensions = isMarketplaceEnabled && requiredExtensionsToInstall.length > 0
+    // Extension metadata not yet resolved — block rather than silently skip the install step
+    if (isMarketplaceEnabled && requiredExtensionsToInstall === null) return
+
+    const needsExtensions = isMarketplaceEnabled && (requiredExtensionsToInstall?.length ?? 0) > 0
     const toastId = toast.loading(
       needsExtensions
-        ? `Installing extensions (${requiredExtensionsToInstall.map((e) => e.name).join(', ')})…`
+        ? `Installing extensions (${(requiredExtensionsToInstall ?? []).map((e) => e.name).join(', ')})…`
         : `Creating ${wrapperMeta.label} wrapper…`
     )
 
@@ -254,7 +260,7 @@ export const CreateWrapperSheet = ({
               <SheetTitle>Create a {wrapperMeta.label} wrapper</SheetTitle>
             </SheetHeader>
             <div className="flex-grow overflow-y-auto">
-              {isMarketplaceEnabled && requiredExtensionsToInstall.length > 0 && (
+              {isMarketplaceEnabled && !!requiredExtensionsToInstall?.length && (
                 <div className="px-5 pt-5 flex flex-col gap-y-4">
                   <Admonition
                     type="default"
@@ -510,7 +516,7 @@ export const CreateWrapperSheet = ({
                 type="primary"
                 form={FORM_ID}
                 htmlType="submit"
-                disabled={isSubmitting}
+                disabled={isSubmitting || (isMarketplaceEnabled && isExtensionsLoading)}
                 loading={isSubmitting}
               >
                 Create wrapper

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -29,6 +29,7 @@ import WrapperTableEditor from './WrapperTableEditor'
 import { useIsMarketplaceEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { getExtensionDefaultSchema } from '@/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/IntegrationOverviewTabV2.utils'
 import { RequiredExtensionsSection } from '@/components/interfaces/Integrations/Integration/RequiredExtensionsSection'
+import { useIntegrationDetail } from '@/components/interfaces/Integrations/Landing/useIntegrationDetail'
 import {
   FormSection,
   FormSectionContent,
@@ -44,7 +45,6 @@ import { useTrack } from '@/lib/telemetry/track'
 import type { ResponseError } from '@/types'
 
 const FORM_ID = 'create-wrapper-form'
-const WRAPPER_REQUIRED_EXTENSION_NAMES = ['wrappers', 'supabase_vault']
 
 export interface CreateWrapperSheetProps {
   wrapperMeta: WrapperMeta
@@ -61,6 +61,7 @@ export const CreateWrapperSheet = ({
 }: CreateWrapperSheetProps) => {
   const queryClient = useQueryClient()
   const isMarketplaceEnabled = useIsMarketplaceEnabled()
+  const { integration } = useIntegrationDetail()
 
   const { data: project } = useSelectedProjectQuery()
   const track = useTrack()
@@ -76,9 +77,10 @@ export const CreateWrapperSheet = ({
       extensions === undefined
         ? null
         : extensions.filter(
-            (ext) => WRAPPER_REQUIRED_EXTENSION_NAMES.includes(ext.name) && !ext.installed_version
+            (ext) =>
+              (integration?.requiredExtensions ?? []).includes(ext.name) && !ext.installed_version
           ),
-    [extensions]
+    [extensions, integration?.requiredExtensions]
   )
 
   const wrappersExtension = extensions?.find((ext) => ext.name === 'wrappers')

--- a/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/CreateWrapperSheet.tsx
@@ -263,14 +263,16 @@ export const CreateWrapperSheet = ({
             <SheetHeader>
               <SheetTitle>Create a {wrapperMeta.label} wrapper</SheetTitle>
             </SheetHeader>
-            <div className="flex-grow overflow-y-auto">
-              {isMarketplaceEnabled && !!requiredExtensionsToInstall?.length && (
-                <div className="px-5 pt-5 flex flex-col gap-y-4">
-                  <Admonition
-                    type="default"
-                    title="Required extensions will be installed"
-                    description="Proceeding will also install the following extensions required by this wrapper."
-                  />
+            <div className="grow overflow-y-auto">
+              {isMarketplaceEnabled && (
+                <div className="px-5 py-5 flex flex-col gap-y-4 border-b">
+                  {!!requiredExtensionsToInstall?.length && (
+                    <Admonition
+                      type="warning"
+                      title="Required extensions will be installed"
+                      description="Proceeding will also install the extensions required by this wrapper."
+                    />
+                  )}
                   <RequiredExtensionsSection hideSeparator />
                 </div>
               )}

--- a/apps/studio/components/interfaces/Integrations/Wrappers/Wrappers.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/Wrappers.utils.test.ts
@@ -4,8 +4,10 @@ import { SUPABASE_TARGET_SCHEMA_OPTION, WRAPPER_HANDLERS } from './Wrappers.cons
 import { Table } from './Wrappers.types'
 import {
   getEditionFormSchema,
+  getRequiredExtensionsToInstall,
   getTableFormSchema,
   getWrapperCreationFormSchema,
+  hasForeignSchemaSupport,
 } from './Wrappers.utils'
 
 const stripe_wrapper = {
@@ -205,5 +207,84 @@ describe('getTableFormSchema', () => {
     expect(
       result.error?.issues.find((issue) => issue.path.some((p) => p === 'schema_name'))
     ).toBeDefined()
+  })
+})
+
+// ─── getRequiredExtensionsToInstall ──────────────────────────────────────────
+
+describe('getRequiredExtensionsToInstall', () => {
+  const wrappers = { name: 'wrappers', installed_version: null }
+  const vault = { name: 'supabase_vault', installed_version: null }
+  const wrappersInstalled = { name: 'wrappers', installed_version: '0.4.1' }
+  const vaultInstalled = { name: 'supabase_vault', installed_version: '0.2.8' }
+  const unrelated = { name: 'pgmq', installed_version: null }
+
+  it('returns null when extensions are undefined (still loading)', () => {
+    expect(getRequiredExtensionsToInstall(undefined, ['wrappers'])).toBeNull()
+  })
+
+  it('returns empty array when required list is empty', () => {
+    expect(getRequiredExtensionsToInstall([wrappers], [])).toEqual([])
+  })
+
+  it('returns empty array when all required extensions are already installed', () => {
+    expect(
+      getRequiredExtensionsToInstall(
+        [wrappersInstalled, vaultInstalled],
+        ['wrappers', 'supabase_vault']
+      )
+    ).toEqual([])
+  })
+
+  it('returns extensions that are required but not installed', () => {
+    const result = getRequiredExtensionsToInstall(
+      [wrappers, vaultInstalled],
+      ['wrappers', 'supabase_vault']
+    )
+    expect(result).toHaveLength(1)
+    expect(result![0].name).toBe('wrappers')
+  })
+
+  it('returns all required extensions when none are installed', () => {
+    const result = getRequiredExtensionsToInstall([wrappers, vault], ['wrappers', 'supabase_vault'])
+    expect(result).toHaveLength(2)
+  })
+
+  it('excludes extensions that are not in the required list', () => {
+    const result = getRequiredExtensionsToInstall([wrappers, unrelated], ['wrappers'])
+    expect(result).toHaveLength(1)
+    expect(result![0].name).toBe('wrappers')
+  })
+
+  it('returns empty array when extensions list is empty', () => {
+    expect(getRequiredExtensionsToInstall([], ['wrappers'])).toEqual([])
+  })
+})
+
+// ─── hasForeignSchemaSupport ──────────────────────────────────────────────────
+
+describe('hasForeignSchemaSupport', () => {
+  it('returns false when extension is undefined', () => {
+    expect(hasForeignSchemaSupport(undefined)).toBe(false)
+  })
+
+  it('returns false when installed_version is null (not installed)', () => {
+    expect(hasForeignSchemaSupport({ installed_version: null })).toBe(false)
+  })
+
+  it('returns false for version below 0.5.0', () => {
+    expect(hasForeignSchemaSupport({ installed_version: '0.4.9' })).toBe(false)
+    expect(hasForeignSchemaSupport({ installed_version: '0.3.0' })).toBe(false)
+    expect(hasForeignSchemaSupport({ installed_version: '0.1.0' })).toBe(false)
+  })
+
+  it('returns true for exactly version 0.5.0', () => {
+    expect(hasForeignSchemaSupport({ installed_version: '0.5.0' })).toBe(true)
+  })
+
+  it('returns true for version above 0.5.0', () => {
+    expect(hasForeignSchemaSupport({ installed_version: '0.6.0' })).toBe(true)
+    expect(hasForeignSchemaSupport({ installed_version: '0.5.1' })).toBe(true)
+    expect(hasForeignSchemaSupport({ installed_version: '1.0.0' })).toBe(true)
   })
 })

--- a/apps/studio/components/interfaces/Integrations/Wrappers/Wrappers.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/Wrappers.utils.ts
@@ -239,3 +239,30 @@ export function wrapperMetaComparator(
 export function getWrapperMetaForWrapper(wrapper: FDW | undefined) {
   return WRAPPERS.find((w) => wrapperMetaComparator(w, wrapper))
 }
+
+/**
+ * Returns the subset of extensions that are required but not yet installed.
+ * Returns `null` when the extensions list is still loading (undefined),
+ * so callers can distinguish "loading" from "nothing to install".
+ * Generic so the full extension type (including `default_version`) is preserved.
+ */
+export function getRequiredExtensionsToInstall<
+  T extends { name: string; installed_version: string | null },
+>(extensions: T[] | undefined, requiredExtensionNames: string[]): T[] | null {
+  if (extensions === undefined) return null
+  return extensions.filter(
+    (ext) => requiredExtensionNames.includes(ext.name) && !ext.installed_version
+  )
+}
+
+/**
+ * Returns true when the wrappers extension is installed at >= 0.5.0,
+ * which is the minimum version required for IMPORT FOREIGN SCHEMA support.
+ */
+export function hasForeignSchemaSupport(
+  wrappersExtension: { installed_version: string | null } | undefined
+): boolean {
+  return wrappersExtension?.installed_version
+    ? wrappersExtension.installed_version >= '0.5.0'
+    : false
+}

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
@@ -1,14 +1,15 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import { HTMLProps, ReactNode, useCallback, useState } from 'react'
+import { useRouter } from 'next/router'
+import { HTMLProps, ReactNode, useCallback, useEffect, useState } from 'react'
 import { Sheet, SheetContent } from 'ui'
 
+import { AddWrapperButton } from './AddWrapperButton'
 import { CreateWrapperSheet } from './CreateWrapperSheet'
 import { WRAPPERS } from './Wrappers.constants'
 import { wrapperMetaComparator } from './Wrappers.utils'
 import { WrapperTable } from './WrapperTable'
 import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
-import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { useFDWsQuery } from '@/data/fdw/fdws-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
@@ -19,6 +20,7 @@ import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export const WrappersTab = () => {
   const { id } = useParams()
+  const router = useRouter()
   const { data: project } = useSelectedProjectQuery()
   const [createWrapperShown, setCreateWrapperShown] = useState(false)
 
@@ -26,6 +28,16 @@ export const WrappersTab = () => {
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'wrappers'
   )
+
+  useEffect(() => {
+    if (router.query.action === 'new' && canCreateWrapper) {
+      setCreateWrapperShown(true)
+      const { action: _, ...remainingQuery } = router.query
+      router.replace({ pathname: router.pathname, query: remainingQuery }, undefined, {
+        shallow: true,
+      })
+    }
+  }, [router.query.action, canCreateWrapper])
 
   useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setCreateWrapperShown(true), {
     label: 'Add new wrapper',
@@ -87,20 +99,7 @@ export const WrappersTab = () => {
             <p className="text-sm text-foreground-light">
               No {wrapperMeta.label} wrappers have been installed
             </p>
-            <ButtonTooltip
-              type="default"
-              onClick={() => setCreateWrapperShown(true)}
-              disabled={!canCreateWrapper}
-              tooltip={{
-                content: {
-                  text: !canCreateWrapper
-                    ? 'You need additional permissions to create a foreign data wrapper'
-                    : undefined,
-                },
-              }}
-            >
-              Add new wrapper
-            </ButtonTooltip>
+            <AddWrapperButton onClick={() => setCreateWrapperShown(true)} />
           </div>
         </div>
       </Container>
@@ -111,20 +110,7 @@ export const WrappersTab = () => {
     <Container>
       <div className="max-w-5xl flex items-center gap-x-2 justify-end mb-4">
         <DocsButton href={wrapperMeta.docsUrl} />
-        <ButtonTooltip
-          type="primary"
-          onClick={() => setCreateWrapperShown(true)}
-          disabled={!canCreateWrapper}
-          tooltip={{
-            content: {
-              text: !canCreateWrapper
-                ? 'You need additional permissions to create a foreign data wrapper'
-                : undefined,
-            },
-          }}
-        >
-          Add new wrapper
-        </ButtonTooltip>
+        <AddWrapperButton type="primary" onClick={() => setCreateWrapperShown(true)} />
       </div>
       <WrapperTable />
       <DiscardChangesConfirmationDialog {...modalProps} />

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
@@ -1,8 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
 import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useRouter } from 'next/router'
-import { HTMLProps, ReactNode, useCallback, useEffect, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Sheet, SheetContent } from 'ui'
 
 import { AddWrapperButton } from './AddWrapperButton'
@@ -21,7 +20,6 @@ import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 export const WrappersTab = () => {
   const { id } = useParams()
-  const router = useRouter()
   const { data: project } = useSelectedProjectQuery()
 
   const [isCreating, setIsCreating] = useQueryState(
@@ -34,17 +32,7 @@ export const WrappersTab = () => {
     'wrappers'
   )
 
-  useEffect(() => {
-    if (router.query.action === 'new' && canCreateWrapper) {
-      setCreateWrapperShown(true)
-      const { action: _, ...remainingQuery } = router.query
-      router.replace({ pathname: router.pathname, query: remainingQuery }, undefined, {
-        shallow: true,
-      })
-    }
-  }, [router.query.action, canCreateWrapper])
-
-  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setCreateWrapperShown(true), {
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setIsCreating(true), {
     label: 'Add new wrapper',
     enabled: canCreateWrapper,
   })
@@ -82,30 +70,18 @@ export const WrappersTab = () => {
             <p className="text-sm text-foreground-light">
               No {wrapperMeta.label} wrappers have been installed
             </p>
-            <AddWrapperButton onClick={() => setCreateWrapperShown(true)} />
+            <AddWrapperButton onClick={() => setIsCreating(true)} />
           </div>
         </div>
       ) : (
-        <div className="max-w-5xl flex items-center gap-x-2 justify-end mb-4">
-          <DocsButton href={wrapperMeta.docsUrl} />
-          <ButtonTooltip
-            type="primary"
-            onClick={() => setIsCreating(true)}
-            disabled={!canCreateWrapper}
-            tooltip={{
-              content: {
-                text: !canCreateWrapper
-                  ? 'You need additional permissions to create a foreign data wrapper'
-                  : undefined,
-              },
-            }}
-          >
-            Add new wrapper
-          </ButtonTooltip>
-        </div>
+        <>
+          <div className="max-w-5xl flex items-center gap-x-2 justify-end mb-4">
+            <DocsButton href={wrapperMeta.docsUrl} />
+            <AddWrapperButton type="primary" onClick={() => setIsCreating(true)} />
+          </div>
+          <WrapperTable />
+        </>
       )}
-
-      {createdWrappers.length > 0 && <WrapperTable />}
 
       <Sheet open={!!isCreating} onOpenChange={handleOpenChange}>
         <SheetContent size="lg" tabIndex={undefined}>
@@ -123,13 +99,6 @@ export const WrappersTab = () => {
         </SheetContent>
       </Sheet>
 
-  return (
-    <Container>
-      <div className="max-w-5xl flex items-center gap-x-2 justify-end mb-4">
-        <DocsButton href={wrapperMeta.docsUrl} />
-        <AddWrapperButton type="primary" onClick={() => setCreateWrapperShown(true)} />
-      </div>
-      <WrapperTable />
       <DiscardChangesConfirmationDialog {...modalProps} />
     </div>
   )

--- a/apps/studio/tests/components/Integrations/Landing/useIntegrationDetail.utils.test.ts
+++ b/apps/studio/tests/components/Integrations/Landing/useIntegrationDetail.utils.test.ts
@@ -1,0 +1,266 @@
+import { describe, expect, it } from 'vitest'
+
+import type { IntegrationDefinition } from '@/components/interfaces/Integrations/Landing/Integrations.constants'
+import {
+  areRequiredExtensionsInstalledFor,
+  getFilteredNavItems,
+  getInstallActionType,
+} from '@/components/interfaces/Integrations/Landing/useIntegrationDetail.utils'
+
+// Minimal stubs — only fields exercised by the utils
+const oauthIntegration = {
+  id: 'github',
+  type: 'oauth' as const,
+  requiredExtensions: [],
+  navigation: [{ route: 'overview', label: 'Overview' }],
+} as unknown as IntegrationDefinition
+
+const wrapperIntegration = {
+  id: 'stripe_wrapper',
+  type: 'wrapper' as const,
+  requiredExtensions: ['wrappers', 'supabase_vault'],
+  navigation: [
+    { route: 'overview', label: 'Overview' },
+    { route: 'wrappers', label: 'Wrappers' },
+  ],
+} as unknown as IntegrationDefinition
+
+const extensionIntegration = {
+  id: 'queues',
+  type: 'postgres_extension' as const,
+  requiredExtensions: ['pgmq'],
+  navigation: [{ route: 'overview', label: 'Overview' }],
+} as unknown as IntegrationDefinition
+
+// ─── areRequiredExtensionsInstalledFor ───────────────────────────────────────
+
+describe('areRequiredExtensionsInstalledFor', () => {
+  it('returns false when integration is undefined', () => {
+    expect(areRequiredExtensionsInstalledFor(undefined, [])).toBe(false)
+  })
+
+  it('returns false when extensions list is undefined', () => {
+    expect(areRequiredExtensionsInstalledFor(extensionIntegration, undefined)).toBe(false)
+  })
+
+  it('returns false when integration has no required extensions', () => {
+    const noExts = {
+      ...extensionIntegration,
+      requiredExtensions: [],
+    } as unknown as IntegrationDefinition
+    expect(
+      areRequiredExtensionsInstalledFor(noExts, [{ name: 'pgmq', installed_version: '1.0' }])
+    ).toBe(false)
+  })
+
+  it('returns false when a required extension is not installed', () => {
+    expect(
+      areRequiredExtensionsInstalledFor(extensionIntegration, [
+        { name: 'pgmq', installed_version: null },
+      ])
+    ).toBe(false)
+  })
+
+  it('returns false when a required extension is missing from list entirely', () => {
+    expect(areRequiredExtensionsInstalledFor(extensionIntegration, [])).toBe(false)
+  })
+
+  it('returns true when all required extensions are installed', () => {
+    expect(
+      areRequiredExtensionsInstalledFor(extensionIntegration, [
+        { name: 'pgmq', installed_version: '1.4.4' },
+      ])
+    ).toBe(true)
+  })
+
+  it('returns true only when every required extension is installed (multiple)', () => {
+    expect(
+      areRequiredExtensionsInstalledFor(wrapperIntegration, [
+        { name: 'wrappers', installed_version: '0.4.1' },
+        { name: 'supabase_vault', installed_version: '0.2.8' },
+      ])
+    ).toBe(true)
+  })
+
+  it('returns false when only some of multiple required extensions are installed', () => {
+    expect(
+      areRequiredExtensionsInstalledFor(wrapperIntegration, [
+        { name: 'wrappers', installed_version: '0.4.1' },
+        { name: 'supabase_vault', installed_version: null },
+      ])
+    ).toBe(false)
+  })
+})
+
+// ─── getFilteredNavItems ─────────────────────────────────────────────────────
+
+describe('getFilteredNavItems', () => {
+  it('returns empty array when integration is undefined', () => {
+    expect(
+      getFilteredNavItems({
+        integration: undefined,
+        isInstalled: false,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: false,
+      })
+    ).toEqual([])
+  })
+
+  it('returns empty array when integration has no navigation', () => {
+    const noNav = {
+      ...wrapperIntegration,
+      navigation: undefined,
+    } as unknown as IntegrationDefinition
+    expect(
+      getFilteredNavItems({
+        integration: noNav,
+        isInstalled: false,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: false,
+      })
+    ).toEqual([])
+  })
+
+  it('returns full navigation for non-wrapper integrations regardless of flags', () => {
+    const result = getFilteredNavItems({
+      integration: extensionIntegration,
+      isInstalled: false,
+      isMarketplaceEnabled: false,
+      areRequiredExtensionsInstalled: false,
+    })
+    expect(result).toEqual(extensionIntegration.navigation)
+  })
+
+  it('returns full navigation for installed wrapper integrations', () => {
+    const result = getFilteredNavItems({
+      integration: wrapperIntegration,
+      isInstalled: true,
+      isMarketplaceEnabled: false,
+      areRequiredExtensionsInstalled: false,
+    })
+    expect(result).toEqual(wrapperIntegration.navigation)
+  })
+
+  it('hides wrappers tab for uninstalled wrapper when marketplace is off and extensions missing', () => {
+    const result = getFilteredNavItems({
+      integration: wrapperIntegration,
+      isInstalled: false,
+      isMarketplaceEnabled: false,
+      areRequiredExtensionsInstalled: false,
+    })
+    expect(result.some((nav) => nav.route === 'wrappers')).toBe(false)
+    expect(result.some((nav) => nav.route === 'overview')).toBe(true)
+  })
+
+  it('shows wrappers tab when marketplace flag is enabled', () => {
+    const result = getFilteredNavItems({
+      integration: wrapperIntegration,
+      isInstalled: false,
+      isMarketplaceEnabled: true,
+      areRequiredExtensionsInstalled: false,
+    })
+    expect(result).toEqual(wrapperIntegration.navigation)
+  })
+
+  it('shows wrappers tab when required extensions are installed', () => {
+    const result = getFilteredNavItems({
+      integration: wrapperIntegration,
+      isInstalled: false,
+      isMarketplaceEnabled: false,
+      areRequiredExtensionsInstalled: true,
+    })
+    expect(result).toEqual(wrapperIntegration.navigation)
+  })
+})
+
+// ─── getInstallActionType ────────────────────────────────────────────────────
+
+describe('getInstallActionType', () => {
+  it('returns null when integration is undefined', () => {
+    expect(
+      getInstallActionType({
+        integration: undefined,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: false,
+        isInstalled: false,
+      })
+    ).toBeNull()
+  })
+
+  it('returns "oauth" for OAuth integrations', () => {
+    expect(
+      getInstallActionType({
+        integration: oauthIntegration,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: false,
+        isInstalled: false,
+      })
+    ).toBe('oauth')
+  })
+
+  it('returns "oauth" for installed OAuth integrations (type check takes priority)', () => {
+    expect(
+      getInstallActionType({
+        integration: oauthIntegration,
+        isMarketplaceEnabled: true,
+        areRequiredExtensionsInstalled: true,
+        isInstalled: true,
+      })
+    ).toBe('oauth')
+  })
+
+  it('returns "add-wrapper" for wrapper when marketplace is enabled', () => {
+    expect(
+      getInstallActionType({
+        integration: wrapperIntegration,
+        isMarketplaceEnabled: true,
+        areRequiredExtensionsInstalled: false,
+        isInstalled: false,
+      })
+    ).toBe('add-wrapper')
+  })
+
+  it('returns "add-wrapper" for wrapper when required extensions are installed', () => {
+    expect(
+      getInstallActionType({
+        integration: wrapperIntegration,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: true,
+        isInstalled: false,
+      })
+    ).toBe('add-wrapper')
+  })
+
+  it('returns "installed" for a non-wrapper installed integration when marketplace is off', () => {
+    expect(
+      getInstallActionType({
+        integration: extensionIntegration,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: false,
+        isInstalled: true,
+      })
+    ).toBe('installed')
+  })
+
+  it('returns "install-sheet" for an uninstalled non-wrapper integration', () => {
+    expect(
+      getInstallActionType({
+        integration: extensionIntegration,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: false,
+        isInstalled: false,
+      })
+    ).toBe('install-sheet')
+  })
+
+  it('returns "install-sheet" for wrapper when marketplace off and extensions missing and not installed', () => {
+    expect(
+      getInstallActionType({
+        integration: wrapperIntegration,
+        isMarketplaceEnabled: false,
+        areRequiredExtensionsInstalled: false,
+        isInstalled: false,
+      })
+    ).toBe('install-sheet')
+  })
+})


### PR DESCRIPTION
## Problem

The "Install" button in the Wrappers integrations manage the "required extensions" installation, not specific wrapper instances. The installation badge state wasn't in sync with the actual wrapper instances being installed. (bug happens only in the new layout)

## New behaviour

- fix install badge state in wrappers detail page
- add "Install" button in top action bar
  - "Install wrapper" if required extensions _aren't_ installed
  - "Add new wrapper" if required extensions _are_ installed
- make wrappers "one-click install" by 
  - showing the required extensions in the CreateWrappersSheet 
  - and automatically installing them on wrapper submission

This functionality is only available behind `isMarketplaceEnabled` flag.

https://github.com/user-attachments/assets/38f5549d-938e-4e2f-a723-53b9a028e9dc

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More accurate detection of installed integrations so navigation and install options display correctly.

* **New Features**
  * Added an "Add wrapper" button in marketplace and wrappers views that navigates to Wrappers and opens the create-wrapper flow.

* **Improvements**
  * Create-wrapper flow now installs required extensions when needed, centralizes submit/error handling, simplifies loading states, and preserves permission-aware button/tooltips.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->