### PR TITLE
fix(studio): new wrapper form closing bug

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrappersTab.tsx
@@ -1,6 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { useParams } from 'common'
-import { HTMLProps, ReactNode, useCallback, useState } from 'react'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import { useCallback, useState } from 'react'
 import { Sheet, SheetContent } from 'ui'
 
 import { CreateWrapperSheet } from './CreateWrapperSheet'
@@ -20,14 +21,18 @@ import { useShortcut } from '@/state/shortcuts/useShortcut'
 export const WrappersTab = () => {
   const { id } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const [createWrapperShown, setCreateWrapperShown] = useState(false)
+
+  const [isCreating, setIsCreating] = useQueryState(
+    'new',
+    parseAsBoolean.withDefault(false).withOptions({ clearOnDefault: true })
+  )
 
   const { can: canCreateWrapper } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_WRITE,
     'wrappers'
   )
 
-  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setCreateWrapperShown(true), {
+  useShortcut(SHORTCUT_IDS.LIST_PAGE_NEW_ITEM, () => setIsCreating(true), {
     label: 'Add new wrapper',
     enabled: canCreateWrapper,
   })
@@ -40,7 +45,6 @@ export const WrappersTab = () => {
   const wrappers = data ?? []
   const wrapperMeta = WRAPPERS.find((w) => w.name === id)
 
-  // this contains a collection of all wrapper instances for the wrapper type
   const createdWrappers = wrapperMeta
     ? wrappers.filter((w) => wrapperMetaComparator(wrapperMeta, w))
     : []
@@ -49,47 +53,26 @@ export const WrappersTab = () => {
   const { confirmOnClose, handleOpenChange, modalProps } = useConfirmOnClose({
     checkIsDirty: useCallback(() => isDirty, [isDirty]),
     onClose: useCallback(() => {
-      setCreateWrapperShown(false)
+      setIsCreating(null)
       setIsDirty(false)
-    }, []),
+    }, [setIsCreating]),
   })
-
-  const Container = useCallback(
-    ({ ...props }: { children: ReactNode } & HTMLProps<HTMLDivElement>) => (
-      <div className="w-full p-10">
-        {props.children}
-        <Sheet open={!!createWrapperShown} onOpenChange={handleOpenChange}>
-          <SheetContent size="lg" tabIndex={undefined}>
-            {wrapperMeta && (
-              <CreateWrapperSheet
-                wrapperMeta={wrapperMeta}
-                onDirty={setIsDirty}
-                onClose={() => setCreateWrapperShown(false)}
-                onCloseWithConfirmation={confirmOnClose}
-              />
-            )}
-          </SheetContent>
-        </Sheet>
-      </div>
-    ),
-    [createWrapperShown, handleOpenChange, wrapperMeta, confirmOnClose]
-  )
 
   if (!wrapperMeta) {
     return <div>Missing integration.</div>
   }
 
-  if (createdWrappers.length === 0) {
-    return (
-      <Container>
-        <div className=" w-full h-48 max-w-4xl">
+  return (
+    <div className="w-full p-10">
+      {createdWrappers.length === 0 ? (
+        <div className="w-full h-48 max-w-4xl">
           <div className="border rounded-lg h-full flex flex-col gap-y-2 items-center justify-center">
             <p className="text-sm text-foreground-light">
               No {wrapperMeta.label} wrappers have been installed
             </p>
             <ButtonTooltip
               type="default"
-              onClick={() => setCreateWrapperShown(true)}
+              onClick={() => setIsCreating(true)}
               disabled={!canCreateWrapper}
               tooltip={{
                 content: {
@@ -103,31 +86,45 @@ export const WrappersTab = () => {
             </ButtonTooltip>
           </div>
         </div>
-      </Container>
-    )
-  }
+      ) : (
+        <div className="max-w-5xl flex items-center gap-x-2 justify-end mb-4">
+          <DocsButton href={wrapperMeta.docsUrl} />
+          <ButtonTooltip
+            type="primary"
+            onClick={() => setIsCreating(true)}
+            disabled={!canCreateWrapper}
+            tooltip={{
+              content: {
+                text: !canCreateWrapper
+                  ? 'You need additional permissions to create a foreign data wrapper'
+                  : undefined,
+              },
+            }}
+          >
+            Add new wrapper
+          </ButtonTooltip>
+        </div>
+      )}
 
-  return (
-    <Container>
-      <div className="max-w-5xl flex items-center gap-x-2 justify-end mb-4">
-        <DocsButton href={wrapperMeta.docsUrl} />
-        <ButtonTooltip
-          type="primary"
-          onClick={() => setCreateWrapperShown(true)}
-          disabled={!canCreateWrapper}
-          tooltip={{
-            content: {
-              text: !canCreateWrapper
-                ? 'You need additional permissions to create a foreign data wrapper'
-                : undefined,
-            },
-          }}
-        >
-          Add new wrapper
-        </ButtonTooltip>
-      </div>
-      <WrapperTable />
+      {createdWrappers.length > 0 && <WrapperTable />}
+
+      <Sheet open={!!isCreating} onOpenChange={handleOpenChange}>
+        <SheetContent size="lg" tabIndex={undefined}>
+          {wrapperMeta && (
+            <CreateWrapperSheet
+              wrapperMeta={wrapperMeta}
+              onDirty={setIsDirty}
+              onClose={() => {
+                setIsCreating(null)
+                setIsDirty(false)
+              }}
+              onCloseWithConfirmation={confirmOnClose}
+            />
+          )}
+        </SheetContent>
+      </Sheet>
+
       <DiscardChangesConfirmationDialog {...modalProps} />
-    </Container>
+    </div>
   )
 }


### PR DESCRIPTION
When trying to create a new wrapper from the integrations page and no wrappers exist yet, then the sheet is not closable unless you submit the form or refresh the page.

https://github.com/user-attachments/assets/7d46cce3-0a0f-4efd-ba98-d141cfcfe31c

## After

- The sheet is closable with confirmation modal
- added nuqs to open "new" wrapper form via `new=true` params

https://github.com/user-attachments/assets/36c4ae9e-7aa8-430c-9741-6d84978997f1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved state management for the wrapper creation dialog, enabling state persistence through URL parameters for better shareability and navigation consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->