### PR TITLE
docs(skills): scope studio-ui-patterns description to Studio codebase

### DIFF
--- a/.claude/skills/studio-ui-patterns/SKILL.md
+++ b/.claude/skills/studio-ui-patterns/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: studio-ui-patterns
-description: Design system UI patterns for Supabase Studio. Use when building or updating
-  pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels
-  (sheets). Covers layout selection, component choice, and placement conventions.
+description: Design system UI patterns for the Supabase Studio dashboard codebase
+  (apps/studio). Use when building or updating UI inside apps/studio — including
+  pages, forms, tables, charts, empty states, navigation, cards, alerts, or side
+  panels (sheets) — that should follow the Studio design system. Do not use for
+  external Supabase consumer apps, marketing site work, or unrelated frontend
+  projects.
 ---
 
 # Studio UI Patterns


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update to the `studio-ui-patterns` skill description.

## What is the current behavior?

The `description` field in `.claude/skills/studio-ui-patterns/SKILL.md` is too broad. It lists generic UI nouns without scoping them to the Studio codebase, causing false positives when the skill triggers on unrelated frontend requests in other repos or apps.

Fixes #45347

## What is the new behavior?

The description now explicitly scopes the skill to `apps/studio` and includes a negative clause to prevent false positives:

- Adds concrete path signal (`apps/studio`) for unambiguous matching
- Names the constraint ("should follow the Studio design system")
- Adds explicit negative clause for common false-positive cases (consumer apps, marketing site, unrelated work)

## Additional context

This change follows the pattern recommended in Anthropic's skill authoring guidance and is consistent with how other skills in the repo are scoped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal guidance documentation to clarify scope and applicability of UI patterns for the Supabase Studio dashboard codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->