### PR TITLE
fix: wrappers link when marketplace feature preview is enabled

### DIFF
--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
@@ -1,7 +1,10 @@
 import { useParams } from 'common'
 import { ArrowUpRight } from 'lucide-react'
 
-import { useIsColumnLevelPrivilegesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import {
+  useIsColumnLevelPrivilegesEnabled,
+  useIsMarketplaceEnabled,
+} from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useIsETLPrivateAlpha } from '@/components/interfaces/Database/Replication/useIsETLPrivateAlpha'
 import type {
   ProductMenuGroup,
@@ -38,6 +41,12 @@ export const useGenerateDatabaseMenu = (): ProductMenuGroup[] => {
   const enablePgReplicate = useIsETLPrivateAlpha()
 
   const getDatabaseURL = (path: string) => `/project/${ref}/database/${path}`
+
+  // In the new marketplace revamped page the `category=wrapper` query param has
+  // changed to `type=wrapper`. So fix this link below based on which version is
+  // the user viewing.
+  const isMarketplaceEnabled = useIsMarketplaceEnabled()
+  const wrappersLinkParamName = isMarketplaceEnabled ? 'type' : 'category'
 
   return [
     {
@@ -148,7 +157,7 @@ export const useGenerateDatabaseMenu = (): ProductMenuGroup[] => {
         showWrappers && {
           name: 'Wrappers',
           key: 'wrappers',
-          url: `/project/${ref}/integrations?category=wrapper`,
+          url: `/project/${ref}/integrations?${wrappersLinkParamName}=wrapper`,
           rightIcon: ExternalLinkIcon,
         },
         pgNetExtensionExists && {


### PR DESCRIPTION
In the new marketplace revamped view the link to filter wrappers should be `/project/_/integrations?type=wrapper` instead of the old `/project/_/integrations?category=wrapper`. This PR fixes the broken link when the marketplace feature preview is enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Wrappers menu item now routes correctly when different marketplace page variants are enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->