### PR TITLE
feat(studio): add test connection button for project log drains

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/LogDrains.tsx
@@ -7,6 +7,7 @@ import { LogDrainsEmpty } from './LogDrainsEmpty'
 import { LogDrainsList } from './LogDrainsList'
 import { useDeleteLogDrainMutation } from '@/data/log-drains/delete-log-drain-mutation'
 import { LogDrainData, useLogDrainsQuery } from '@/data/log-drains/log-drains-query'
+import { useTestLogDrainMutation } from '@/data/log-drains/test-log-drain-mutation'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useTrack } from '@/lib/telemetry/track'
 
@@ -35,6 +36,12 @@ export function LogDrains({
     },
   })
 
+  const { mutate: testLogDrain } = useTestLogDrainMutation({
+    onSuccess: () => {
+      toast.success('Log drain connection test succeeded')
+    },
+  })
+
   if (isLoadingEntitlement) {
     return (
       <div>
@@ -59,6 +66,11 @@ export function LogDrains({
         if (ref) {
           deleteLogDrain({ token: drain.token, projectRef: ref })
           track('log_drain_removed', { destination: drain.type })
+        }
+      }}
+      onTestDrain={(drain) => {
+        if (ref) {
+          testLogDrain({ token: drain.token, projectRef: ref })
         }
       }}
     />

--- a/apps/studio/data/log-drains/log-drains.test.tsx
+++ b/apps/studio/data/log-drains/log-drains.test.tsx
@@ -1,0 +1,33 @@
+import { waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { useTestLogDrainMutation } from './test-log-drain-mutation'
+import { API_URL } from '@/lib/constants'
+import { customRenderHook } from '@/tests/lib/custom-render'
+import { mswServer } from '@/tests/lib/msw'
+
+const REF = 'my-project'
+const BASE = `${API_URL}/platform/projects/:ref/analytics/log-drains`
+
+describe('project log drain hooks', () => {
+  it('tests a log drain connection by token at the project-scoped path', async () => {
+    let receivedRef: string | undefined
+    let receivedToken: string | undefined
+    mswServer.use(
+      http.post(`${BASE}/:token/test`, ({ params }) => {
+        receivedRef = params.ref as string
+        receivedToken = params.token as string
+        return HttpResponse.json({})
+      })
+    )
+
+    const { result } = customRenderHook(() => useTestLogDrainMutation())
+
+    result.current.mutate({ projectRef: REF, token: 'tok-1' })
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true))
+    expect(receivedRef).toBe(REF)
+    expect(receivedToken).toBe('tok-1')
+  })
+})

--- a/apps/studio/data/log-drains/test-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/test-log-drain-mutation.ts
@@ -10,12 +10,9 @@ export type LogDrainTestVariables = {
 }
 
 export async function testLogDrain({ projectRef, token }: LogDrainTestVariables) {
-  const { data, error } = await post(
-    '/platform/projects/{ref}/analytics/log-drains/{token}/test',
-    {
-      params: { path: { ref: projectRef, token } },
-    }
-  )
+  const { data, error } = await post('/platform/projects/{ref}/analytics/log-drains/{token}/test', {
+    params: { path: { ref: projectRef, token } },
+  })
 
   if (error) handleError(error)
   return data

--- a/apps/studio/data/log-drains/test-log-drain-mutation.ts
+++ b/apps/studio/data/log-drains/test-log-drain-mutation.ts
@@ -1,0 +1,48 @@
+import { useMutation } from '@tanstack/react-query'
+import { toast } from 'sonner'
+
+import { handleError, post } from '@/data/fetchers'
+import type { ResponseError, UseCustomMutationOptions } from '@/types'
+
+export type LogDrainTestVariables = {
+  projectRef: string
+  token: string
+}
+
+export async function testLogDrain({ projectRef, token }: LogDrainTestVariables) {
+  const { data, error } = await post(
+    '/platform/projects/{ref}/analytics/log-drains/{token}/test',
+    {
+      params: { path: { ref: projectRef, token } },
+    }
+  )
+
+  if (error) handleError(error)
+  return data
+}
+
+type LogDrainTestData = Awaited<ReturnType<typeof testLogDrain>>
+
+export const useTestLogDrainMutation = ({
+  onSuccess,
+  onError,
+  ...options
+}: Omit<
+  UseCustomMutationOptions<LogDrainTestData, ResponseError, LogDrainTestVariables>,
+  'mutationFn'
+> = {}) => {
+  return useMutation<LogDrainTestData, ResponseError, LogDrainTestVariables>({
+    mutationFn: (vars) => testLogDrain(vars),
+    async onSuccess(data, variables, context) {
+      await onSuccess?.(data, variables, context)
+    },
+    async onError(data, variables, context) {
+      if (onError === undefined) {
+        toast.error(`Failed to test log drain: ${data.message}`)
+      } else {
+        onError(data, variables, context)
+      }
+    },
+    ...options,
+  })
+}


### PR DESCRIPTION
## Problem

Project log drains had no way for users to verify a destination connection before relying on it. Audit log drains already have a "Test connection" action, and the management API exposes the equivalent endpoint for project log drains (`POST /platform/projects/{ref}/analytics/log-drains/{token}/test`).

## Fix

- Add `useTestLogDrainMutation` (`apps/studio/data/log-drains/test-log-drain-mutation.ts`), mirroring `useTestAuditLogDrainMutation`.
- Wire the already-present `onTestDrain` action in `LogDrains` to the new mutation, so the "Test connection" item now appears in the project log drains row menu.
- On success it shows a confirmation toast; failures surface the API error message.

## Testing

- Added `apps/studio/data/log-drains/log-drains.test.tsx` covering the test mutation hitting the project-scoped path.
- Manual: open Project Settings -> Log Drains, open a drain's menu, click "Test connection".

Closes DEBUG-132


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a test capability for log drain connections. Users can now validate that their log drain configurations are functioning correctly before deployment to ensure proper log collection and data integrity. The system provides immediate confirmation when tests succeed and detailed error messages when issues occur, enabling users to quickly troubleshoot and resolve connectivity problems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->