### PR TITLE
chore(self-hosted): expand smoke tests

### DIFF
--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -17,19 +17,70 @@ permissions:
 jobs:
   build:
     runs-on: blacksmith-4vcpu-ubuntu-2404
+    strategy:
+      fail-fast: false
+      matrix:
+        config: [default, envoy, s3]
 
     steps:
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+      - uses: actions/checkout@v4
         with:
-          persist-credentials: false
           sparse-checkout: |
             docker/
-      - name: Run docker-compose up
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Generate keys
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          cp .env.example .env
+          sh utils/generate-keys.sh --update-env
+          sh utils/add-new-auth-keys.sh --update-env
+
+      - name: Start self-hosted Supabase
         shell: bash
         # Ensure all services can be started and healthy with default config
         run: |
           set -euo pipefail
           cd docker
-          cp .env.example .env
           yq -i '.services.supavisor.environment.RLIMIT_NOFILE=1024' docker-compose.yml
-          docker compose up --quiet-pull --wait --wait-timeout 180
+          if [ "${{ matrix.config }}" = "envoy" ]; then
+            docker compose -f docker-compose.yml -f docker-compose.envoy.yml up --quiet-pull --wait --wait-timeout 180
+          elif [ "${{ matrix.config }}" = "s3" ]; then
+            docker compose -f docker-compose.yml -f docker-compose.s3.yml up --quiet-pull --wait --wait-timeout 180
+          else
+            docker compose up --quiet-pull --wait --wait-timeout 180
+          fi
+
+      - name: Run container log tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-container-logs.sh
+
+      - name: Run smoke tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-self-hosted.sh
+
+      - name: Run API keys and asymmetric auth tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-auth-keys.sh
+
+      - name: Run S3 protocol tests
+        if: matrix.config == 's3'
+        shell: bash
+        run: |
+          set -euo pipefail
+          cd docker
+          sh tests/test-s3.sh

--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -83,7 +83,6 @@ jobs:
           sh tests/test-auth-keys.sh
 
       - name: Run S3 protocol tests
-        if: matrix.config == 'rustfs' || matrix.config == 'envoy-rustfs' || matrix.config == 's3'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        config: [default, envoy, s3]
+        config: [default, logs, envoy, rustfs, envoy-rustfs]
 
     steps:
       - uses: actions/checkout@v4
@@ -49,10 +49,14 @@ jobs:
           set -euo pipefail
           cd docker
           yq -i '.services.supavisor.environment.RLIMIT_NOFILE=1024' docker-compose.yml
-          if [ "${{ matrix.config }}" = "envoy" ]; then
+          if [ "${{ matrix.config }}" = "logs" ]; then
+            docker compose -f docker-compose.yml -f docker-compose.logs.yml up --quiet-pull --wait --wait-timeout 180
+          elif [ "${{ matrix.config }}" = "envoy" ]; then
             docker compose -f docker-compose.yml -f docker-compose.envoy.yml up --quiet-pull --wait --wait-timeout 180
-          elif [ "${{ matrix.config }}" = "s3" ]; then
-            docker compose -f docker-compose.yml -f docker-compose.s3.yml up --quiet-pull --wait --wait-timeout 180
+          elif [ "${{ matrix.config }}" = "rustfs" ]; then
+            docker compose -f docker-compose.yml -f docker-compose.rustfs.yml up --quiet-pull --wait --wait-timeout 180
+          elif [ "${{ matrix.config }}" = "envoy-rustfs" ]; then
+            docker compose -f docker-compose.yml -f docker-compose.envoy.yml -f docker-compose.rustfs.yml up --quiet-pull --wait --wait-timeout 180
           else
             docker compose up --quiet-pull --wait --wait-timeout 180
           fi

--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -25,6 +25,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           sparse-checkout: |
             docker/
 

--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -83,7 +83,7 @@ jobs:
           sh tests/test-auth-keys.sh
 
       - name: Run S3 protocol tests
-        if: matrix.config == 's3'
+        if: matrix.config == 'rustfs' || matrix.config == 'envoy-rustfs' || matrix.config == 's3'
         shell: bash
         run: |
           set -euo pipefail

--- a/docker/CONFIG.md
+++ b/docker/CONFIG.md
@@ -138,7 +138,7 @@ Self-hosted Studio reads `ENABLED_FEATURES_*` env vars at container start time t
 | Variable | Type | Set by | Description | Notes |
 |---|---|---|---|---|
 | `ENABLED_FEATURES_*` | boolean | | Per-flag runtime override. Set to `true` or `false` (case-insensitive); other values are logged and ignored. | One env var per flag. Full key list: `packages/common/enabled-features/enabled-features.json`. No-op when `NEXT_PUBLIC_IS_PLATFORM=true`. |
-| `ENABLED_FEATURES_LOGS_ALL` | boolean | | Disable the entire Logs section of the dashboard. Maps to the `logs:all` feature flag. | Documented explicitly as the runtime replacement for the legacy build-time `NEXT_PUBLIC_ENABLE_LOGS`. |
+| `ENABLED_FEATURES_LOGS_ALL` | boolean | Self-hosted | Disable the entire Logs section of the dashboard. Maps to the `logs:all` feature flag. | Documented explicitly as the runtime replacement for the legacy build-time `NEXT_PUBLIC_ENABLE_LOGS`. |
 
 ### AI features
 

--- a/docker/tests/test-container-logs.sh
+++ b/docker/tests/test-container-logs.sh
@@ -62,31 +62,37 @@ get_container_id() {
     printf '%s' "$1"
 }
 
-# Check that a service's logs contain all expected patterns
+# Check that a service's logs contain all expected patterns.
+# Logs are written to a temp file so that grep -q exits cleanly.
 check_logs() {
     service="$1"
     shift
 
-    logs=$(docker compose logs "$service" 2>/dev/null || true)
-    if [ -z "$logs" ]; then
+    logfile=$(mktemp)
+
+    docker compose logs "$service" > "$logfile" 2>/dev/null || true
+    if [ ! -s "$logfile" ]; then
         container_id=$(get_container_id "$service")
         if [ -n "$container_id" ]; then
-            logs=$(docker logs "$container_id" 2>&1 || true)
+            docker logs "$container_id" > "$logfile" 2>&1 || true
         fi
     fi
 
-    if [ -z "$logs" ]; then
+    if [ ! -s "$logfile" ]; then
+        rm -f "$logfile"
         fail_msg "$service (no logs found)"
         return
     fi
 
     for pattern in "$@"; do
-        if ! echo "$logs" | grep -q -i -E "$pattern"; then
+        if ! grep -q -i -E "$pattern" "$logfile"; then
+            rm -f "$logfile"
             fail_msg "$service (missing: $pattern)"
             return
         fi
     done
 
+    rm -f "$logfile"
     pass_msg "$service"
 }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Adds tests from `docker/tests` to `workflows/self-host-tests-smoke.yml`
- Run tests for default, default+logs, default+envoy, default+rustfs, and default+envoy+rustfs configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the logging feature environment variable is intended for self-hosted deployments.

* **Tests**
  * Smoke, auth, log and S3 protocol tests now run across multiple deployment configurations (including proxy/storage variants).
  * Improved container-log validation for more reliable diagnostics.

* **Chores**
  * CI updated to run a configuration matrix, perform automated key generation, and refresh runtime setup (including Node tooling and compose startup tweaks).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->