### PR TITLE
fix(studio): handle stale sorts and filters referencing dropped columns

### DIFF
--- a/apps/studio/data/table-rows/table-rows-query.ts
+++ b/apps/studio/data/table-rows/table-rows-query.ts
@@ -126,6 +126,14 @@ export const getAllTableRowsSql = ({
 }): { sql: QueryFilter; cursorColumns: string[] | false } => {
   const query = new Query()
 
+  // Drop any sorts/filters referencing columns no longer present on the table.
+  // Stale sort/filter state can persist (URL/local storage) after a column is
+  // dropped or renamed, which would otherwise generate a query against a
+  // non-existent column and fail. See getTableRowsSql for the equivalent guard.
+  const validColumnNames = new Set(table.columns.map((column) => column.name))
+  const validFilters = filters.filter((filter) => validColumnNames.has(filter.column))
+  const validSorts = sorts.filter((sort) => validColumnNames.has(sort.column))
+
   const arrayBasedColumns = table.columns
     .filter(
       (column) => (column?.enum ?? []).length > 0 && column.dataType.toLowerCase() === 'array'
@@ -140,7 +148,7 @@ export const getAllTableRowsSql = ({
         : safeSql`*`
     )
 
-  filters
+  validFilters
     .filter((filter) => filter.value && filter.value !== '')
     .forEach((filter) => {
       const value = formatFilterValue(table, filter)
@@ -153,7 +161,7 @@ export const getAllTableRowsSql = ({
 
   const hasCtid = checkIfCtidAvailable(table)
 
-  if (sorts.length === 0) {
+  if (validSorts.length === 0) {
     if (cursorPaginationEligible.length > 0) {
       cursorColumns = cursorPaginationEligible[0]
       cursorPaginationEligible[0].forEach((col) => {
@@ -172,7 +180,7 @@ export const getAllTableRowsSql = ({
       }
     }
   } else {
-    sorts.forEach((sort) => {
+    validSorts.forEach((sort) => {
       queryChains = queryChains.order(sort.table, sort.column, sort.ascending, sort.nullsFirst)
     })
 
@@ -180,7 +188,7 @@ export const getAllTableRowsSql = ({
     const tieBreaker = cursorPaginationEligible[0]
     if (tieBreaker) {
       const sortedColumns = new Set(
-        sorts.filter((s) => s.table === table.name).map((s) => s.column)
+        validSorts.filter((s) => s.table === table.name).map((s) => s.column)
       )
       tieBreaker
         .filter((col) => !sortedColumns.has(col))

--- a/packages/pg-meta/src/query/table-row-query.ts
+++ b/packages/pg-meta/src/query/table-row-query.ts
@@ -141,12 +141,23 @@ export const getTableRowsSql = ({
 }: BuildTableRowsQueryArgs): SafeSqlFragment => {
   if (!table || !table.columns) return safeSql``
 
+  // Drop any sorts/filters that reference columns no longer present on the
+  // table. Stale sort/filter state can be persisted in the URL or local storage
+  // and survive a column being dropped or renamed; without this guard it would
+  // generate a query referencing a non-existent column (e.g. `order by
+  // "table"."key"`), which fails with `column ... does not exist` and prevents
+  // any rows from loading. Filtering happens up front so a sort list containing
+  // only stale columns falls back to the default ordering below.
+  const validColumnNames = new Set(table.columns.map((column) => column.name))
+  const validFilters = filters.filter((filter) => validColumnNames.has(filter.column))
+  const validSorts = sorts.filter((sort) => validColumnNames.has(sort.column))
+
   const query = new Query()
 
   // Properly escape the table name and schema
   let queryChains = query.from(table.name, table.schema).select()
 
-  filters.forEach((x) => {
+  validFilters.forEach((x) => {
     const col = table.columns?.find((y) => y.name === x.column)
     const isStringTypeColumn = !!col ? (TEXT_TYPES as string[]).includes(col.format) : true
     queryChains = queryChains.filter(
@@ -159,7 +170,7 @@ export const getTableRowsSql = ({
   // If sorts is empty and table row count is within threshold, use the primary key as the default sort.
   // Only apply for selections over a Table, not View, MaterializedViews, ...
   const liveRowCount = (table as PGTable).live_rows_estimate || 0
-  if (sorts.length === 0 && liveRowCount <= THRESHOLD_COUNT && table.columns.length > 0) {
+  if (validSorts.length === 0 && liveRowCount <= THRESHOLD_COUNT && table.columns.length > 0) {
     const defaultOrderByColumns = getDefaultOrderByColumns(table as PGTable, {
       excludedColumns: sortExcludedColumns,
     })
@@ -169,7 +180,7 @@ export const getTableRowsSql = ({
       })
     }
   } else {
-    sorts.forEach((x) => {
+    validSorts.forEach((x) => {
       queryChains = queryChains.order(x.table, x.column, x.ascending, x.nullsFirst)
     })
   }

--- a/packages/pg-meta/test/query/table-row-query.test.ts
+++ b/packages/pg-meta/test/query/table-row-query.test.ts
@@ -1214,6 +1214,125 @@ describe('Table Row Query', () => {
       expect(xItemIndex).toBeLessThan(zItemIndex)
     })
 
+    withTestDatabase('should drop sorts referencing columns that no longer exist', async (db) => {
+      // Reproduces the case where a column used in a persisted sort (e.g. from
+      // the URL or local storage) has since been dropped from the table. The
+      // generated query must not reference the missing column.
+      await db.executeQuery(`
+        CREATE TABLE test_stale_sort (
+          id SERIAL PRIMARY KEY,
+          name TEXT
+        );
+
+        INSERT INTO test_stale_sort (name) VALUES
+          ('B Item'),
+          ('A Item'),
+          ('C Item');
+      `)
+
+      const { sql: tablesSql, zod: tablesZod } = pgMeta.tables.list()
+      const tables = tablesZod.parse(await db.executeQuery(tablesSql))
+      const testTable = tables.find((table) => table.name === 'test_stale_sort')
+
+      expect(testTable).toBeDefined()
+
+      // 'key' no longer exists; 'name' is still valid.
+      const sorts: Sort[] = [
+        { column: 'key', table: 'test_stale_sort', ascending: true, nullsFirst: false },
+        { column: 'name', table: 'test_stale_sort', ascending: true, nullsFirst: false },
+      ]
+
+      const sql = getTableRowsSql({
+        table: testTable!,
+        sorts,
+        page: 1,
+        limit: 10,
+      })
+
+      // The stale 'key' sort is dropped; only the valid 'name' sort remains.
+      expect(sql).not.toContain('test_stale_sort.key')
+      expect(sql).toContain('order by test_stale_sort.name asc nulls last')
+
+      // The query executes successfully instead of erroring on the missing column.
+      const queryResult = await db.executeQuery(sql)
+      expect(queryResult.map((row: any) => row.name)).toEqual(['A Item', 'B Item', 'C Item'])
+    })
+
+    withTestDatabase(
+      'should fall back to default ordering when all sorts reference missing columns',
+      async (db) => {
+        await db.executeQuery(`
+          CREATE TABLE test_all_stale_sort (
+            id SERIAL PRIMARY KEY,
+            name TEXT
+          );
+
+          INSERT INTO test_all_stale_sort (name) VALUES ('first'), ('second');
+        `)
+
+        const { sql: tablesSql, zod: tablesZod } = pgMeta.tables.list()
+        const tables = tablesZod.parse(await db.executeQuery(tablesSql))
+        const testTable = tables.find((table) => table.name === 'test_all_stale_sort')
+
+        expect(testTable).toBeDefined()
+
+        const sorts: Sort[] = [
+          { column: 'key', table: 'test_all_stale_sort', ascending: true, nullsFirst: false },
+        ]
+
+        const sql = getTableRowsSql({
+          table: testTable!,
+          sorts,
+          page: 1,
+          limit: 10,
+        })
+
+        // With no valid sorts left, it falls back to the default primary-key ordering.
+        expect(sql).not.toContain('test_all_stale_sort.key')
+        expect(sql).toContain('order by test_all_stale_sort.id asc nulls last')
+
+        const queryResult = await db.executeQuery(sql)
+        expect(queryResult.length).toBe(2)
+      }
+    )
+
+    withTestDatabase('should drop filters referencing columns that no longer exist', async (db) => {
+      await db.executeQuery(`
+        CREATE TABLE test_stale_filter (
+          id SERIAL PRIMARY KEY,
+          name TEXT
+        );
+
+        INSERT INTO test_stale_filter (name) VALUES ('keep'), ('keep'), ('other');
+      `)
+
+      const { sql: tablesSql, zod: tablesZod } = pgMeta.tables.list()
+      const tables = tablesZod.parse(await db.executeQuery(tablesSql))
+      const testTable = tables.find((table) => table.name === 'test_stale_filter')
+
+      expect(testTable).toBeDefined()
+
+      const filters: Filter[] = [
+        { column: 'key', operator: '=', value: 'whatever' },
+        { column: 'name', operator: '=', value: 'keep' },
+      ]
+
+      const sql = getTableRowsSql({
+        table: testTable!,
+        filters,
+        page: 1,
+        limit: 10,
+      })
+
+      // The stale 'key' filter is dropped; only the valid 'name' filter remains.
+      expect(sql).not.toContain('whatever')
+      expect(sql).toContain("name = 'keep'")
+
+      const queryResult = await db.executeQuery(sql)
+      expect(queryResult.length).toBe(2)
+      expect(queryResult.every((row: any) => row.name === 'keep')).toBe(true)
+    })
+
     withTestDatabase('should generate SQL for special/quoted column names', async (db) => {
       // Create test table with quoted names and insert data
       await db.executeQuery(`


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a column is dropped from a table, persisted sort or filter state (stored in URL or local storage) that references the deleted column causes the generated SQL query to reference a non-existent column. This results in a database error (`column ... does not exist`) and prevents any rows from loading.

## What is the new behavior?

The query builders now filter out sorts and filters that reference columns no longer present on the table before generating SQL. If all sorts reference missing columns, the query falls back to default ordering (primary key). This allows the application to gracefully handle stale state without errors.

Changes made:
- `packages/pg-meta/src/query/table-row-query.ts`: Filter `sorts` and `filters` to only include those referencing valid columns before building the query
- `apps/studio/data/table-rows/table-rows-query.ts`: Apply the same filtering logic to the cursor-based pagination query builder
- Added comprehensive test coverage for both scenarios (partial and complete stale state)

## Additional context

This fix ensures that users with persisted sort/filter preferences in their browser storage or URL state won't experience broken table views after schema changes. The filtering happens early in the query building process so that fallback logic (like default ordering) works correctly.

Test Plan: Added three new test cases covering:
1. Dropping sorts that reference missing columns while keeping valid sorts
2. Falling back to default ordering when all sorts reference missing columns  
3. Dropping filters that reference missing columns while keeping valid filters

All tests verify both that the generated SQL is correct and that the query executes successfully.

https://claude.ai/code/session_01MqX4CC4P4aYRVXmHNsxbe5