### PR TITLE
fix(reports): guard against malformed URI in route renderer

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.utils.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.test.ts
@@ -2,9 +2,23 @@ import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import { describe, expect, it } from 'vitest'
 
-import { formatTimestamp } from './Reports.utils'
+import { formatTimestamp, safeDecodeURIComponent } from './Reports.utils'
 
 dayjs.extend(utc)
+
+describe('safeDecodeURIComponent', () => {
+  it('decodes a valid percent-encoded string', () => {
+    expect(safeDecodeURIComponent('a%20b')).toBe('a b')
+  })
+
+  it('returns the original string when percent-encoding is malformed', () => {
+    expect(safeDecodeURIComponent('?discount=100%')).toBe('?discount=100%')
+  })
+
+  it('handles an empty string', () => {
+    expect(safeDecodeURIComponent('')).toBe('')
+  })
+})
 
 describe('formatTimestamp', () => {
   it('formats milliseconds timestamp correctly', () => {

--- a/apps/studio/components/interfaces/Reports/Reports.utils.tsx
+++ b/apps/studio/components/interfaces/Reports/Reports.utils.tsx
@@ -23,6 +23,21 @@ export const queryParamsToObject = (params: string) => {
   return Object.fromEntries(new URLSearchParams(params))
 }
 
+/**
+ * Decodes a URI component, returning the original string if it is malformed.
+ *
+ * `decodeURIComponent` throws a `URIError` on invalid percent-encoding (e.g. a
+ * literal `%` such as `?discount=100%`). Request paths are user-controlled, so
+ * decoding inline during render can crash the page.
+ */
+export const safeDecodeURIComponent = (value: string) => {
+  try {
+    return decodeURIComponent(value)
+  } catch {
+    return value
+  }
+}
+
 export type PresetHookResult = LogsQueryHook | DbQueryHook
 type PresetHooks = Record<keyof PresetConfig['queries'], () => PresetHookResult>
 /**

--- a/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
+++ b/apps/studio/components/interfaces/Reports/renderers/ApiRenderers.tsx
@@ -16,7 +16,7 @@ import {
 } from 'ui'
 import * as z from 'zod'
 
-import { queryParamsToObject } from '../Reports.utils'
+import { queryParamsToObject, safeDecodeURIComponent } from '../Reports.utils'
 import { ReportWidgetProps, ReportWidgetRendererProps } from '../ReportWidget'
 import { COUNTRY_LAT_LON } from '@/components/interfaces/ProjectCreation/ProjectCreation.constants'
 import {
@@ -372,7 +372,7 @@ const RouteTdContent = (datum: RouteTdContentProps) => (
           <TextFormatter className="text-foreground-light" value={datum.path} />
           <TextFormatter
             className="max-w-sm text-foreground-lighter truncate "
-            value={decodeURIComponent(datum.search || '')}
+            value={safeDecodeURIComponent(datum.search || '')}
           />
         </div>
       </div>

--- a/apps/studio/components/interfaces/Reports/renderers/StorageRenderers.tsx
+++ b/apps/studio/components/interfaces/Reports/renderers/StorageRenderers.tsx
@@ -1,5 +1,6 @@
 import { Fragment } from 'react'
 
+import { safeDecodeURIComponent } from '../Reports.utils'
 import { ReportWidgetProps, ReportWidgetRendererProps } from '../ReportWidget'
 import { TextFormatter } from '@/components/interfaces/Settings/Logs/LogsFormatters'
 import Table from '@/components/to-be-cleaned/Table'
@@ -70,7 +71,7 @@ export const TopCacheMissesRenderer = (
                       <TextFormatter className="text-foreground-light" value={datum.path} />
                       <TextFormatter
                         className="max-w-sm text-foreground-lighter truncate "
-                        value={decodeURIComponent(datum.search || '')}
+                        value={safeDecodeURIComponent(datum.search || '')}
                       />
                     </div>
                   </Table.td>


### PR DESCRIPTION
## Problem

The PostgREST observability page crashes for some projects with `URIError: URI malformed`. The route renderer calls `decodeURIComponent` directly on the request query string, which is user-controlled. A malformed percent-sequence (for example a literal `%` in `?discount=100%`) makes `decodeURIComponent` throw during render, taking down the whole page via the global error boundary.

Tracked in Sentry issue 7536581822.

## Fix

Add a `safeDecodeURIComponent` helper that wraps `decodeURIComponent` in a try/catch and falls back to the raw string on failure. Use it in the route renderer. The sibling `queryParamsToObject` call is unaffected since `URLSearchParams` already tolerates malformed escapes.

## How to test

- Open a project's PostgREST observability report (`/project/[ref]/observability/postgrest`).
- Ensure a request with a malformed query string (e.g. a path containing a bare `%`) appears in the data.
- Expected result: the row renders with the raw search string instead of crashing the page.
- Unit tests for `safeDecodeURIComponent` cover valid decode, malformed input, and empty string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced handling of malformed URI-encoded characters in query parameters and search parameters. The application now gracefully manages decoding failures and displays the original values instead of breaking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->