### PR TITLE
feat(studio): dedicated telemetry events for org audit log drains

### DIFF
--- a/apps/studio/components/interfaces/LogDrains/OrgAuditLogDrains.tsx
+++ b/apps/studio/components/interfaces/LogDrains/OrgAuditLogDrains.tsx
@@ -210,7 +210,7 @@ export function OrgAuditLogDrains() {
         isLoading={isLoading}
         existingDrainNames={(logDrains ?? []).map((drain) => drain.name)}
         onSaveClick={(type) => {
-          track('log_drain_save_button_clicked', { destination: type })
+          track('audit_log_drain_save_button_clicked', { destination: type })
         }}
         onSubmit={({ name, description, type, ...values }) => {
           const logDrainValues = {
@@ -245,7 +245,7 @@ export function OrgAuditLogDrains() {
         onNewDrainClick={handleNewClick}
         onDeleteDrain={(drain) => {
           deleteLogDrain({ token: drain.token, slug })
-          track('log_drain_removed', { destination: drain.type })
+          track('audit_log_drain_removed', { destination: drain.type })
         }}
         onTestDrain={(drain) => testLogDrain({ token: drain.token, slug })}
       />

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -2509,6 +2509,66 @@ export interface LogDrainRemovedEvent {
   groups: TelemetryGroups
 }
 
+/**
+ * User clicked the save destination button in the add audit log drain sheet.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/org/{slug}/audit-log-drains (LogDrainDestinationSheetForm)
+ */
+export interface AuditLogDrainSaveButtonClickedEvent {
+  action: 'audit_log_drain_save_button_clicked'
+  properties: {
+    /**
+     * Type of the destination saved
+     */
+    destination:
+      | 'postgres'
+      | 'bigquery'
+      | 'clickhouse'
+      | 'webhook'
+      | 'datadog'
+      | 'loki'
+      | 'sentry'
+      | 's3'
+      | 'axiom'
+      | 'last9'
+      | 'otlp'
+      | 'syslog'
+  }
+  groups: Omit<TelemetryGroups, 'project'>
+}
+
+/**
+ * User confirmed removal of an audit log drain destination in the delete-confirm modal.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/org/{slug}/audit-log-drains
+ */
+export interface AuditLogDrainRemovedEvent {
+  action: 'audit_log_drain_removed'
+  properties: {
+    /**
+     * Type of the destination removed
+     */
+    destination:
+      | 'postgres'
+      | 'bigquery'
+      | 'clickhouse'
+      | 'webhook'
+      | 'datadog'
+      | 'loki'
+      | 'sentry'
+      | 's3'
+      | 'axiom'
+      | 'last9'
+      | 'otlp'
+      | 'syslog'
+  }
+  groups: Omit<TelemetryGroups, 'project'>
+}
+
 type AdvisorCategory = 'PERFORMANCE' | 'SECURITY'
 type AdvisorLevel = 'ERROR' | 'WARN' | 'INFO'
 
@@ -3425,6 +3485,8 @@ export type TelemetryEvent =
   | SidebarOpenedEvent
   | LogDrainSaveButtonClickedEvent
   | LogDrainRemovedEvent
+  | AuditLogDrainSaveButtonClickedEvent
+  | AuditLogDrainRemovedEvent
   | AdvisorDetailOpenedEvent
   | AdvisorAssistantButtonClickedEvent
   | QueryPerformanceAIExplanationButtonClickedEvent


### PR DESCRIPTION
## Problem

The org Audit Log Drains page fires the same `log_drain_save_button_clicked` and `log_drain_removed` telemetry events as the project Log Drains page, even though they are distinct features (project product logs vs. the org audit log). Org-scoped events should have their own names and drop the project group.

## Fix

Add dedicated org-scoped events and use them in the org container:

- `audit_log_drain_save_button_clicked`
- `audit_log_drain_removed`

Both declare `groups: Omit<TelemetryGroups, 'project'>` (no project group), matching the convention used by other org-scoped events (e.g. the documents page events). The project Log Drains page keeps the original `log_drain_*` events unchanged.

## How to test

- Open `/org/{slug}/audit-log-drains` (with the `auditLogsLogDrain` flag enabled).
- Create a drain and confirm `audit_log_drain_save_button_clicked` fires (with the destination type, org group, no project group).
- Delete a drain and confirm `audit_log_drain_removed` fires.
- Confirm the project Log Drains page still fires `log_drain_*` events.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal telemetry tracking for audit log drain operations to improve monitoring and analytics of system behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->