### PR TITLE
fix(docs): update Gemini CLI extension repo URL

### DIFF
--- a/apps/docs/features/ui/AgentPluginsPanel.tsx
+++ b/apps/docs/features/ui/AgentPluginsPanel.tsx
@@ -38,7 +38,7 @@ const PLUGIN_CLIENTS: PluginClient[] = [
     key: 'gemini-cli',
     label: 'Gemini CLI',
     icon: 'gemini-cli',
-    repoUrl: 'https://github.com/supabase-community/gemini-extension',
+    repoUrl: 'https://github.com/supabase-community/supabase-plugin',
     docsUrl: 'https://geminicli.com/docs/extensions/',
   },
   {
@@ -151,7 +151,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
           your terminal.
         </p>
         <CodeBlock
-          value="gemini extensions install https://github.com/supabase-community/gemini-extension"
+          value="gemini extensions install https://github.com/supabase-community/supabase-plugin"
           language="bash"
           focusable={false}
           className="block"
@@ -159,7 +159,7 @@ function PluginInstructions({ client }: { client: PluginClient }) {
         <p className="text-xs text-foreground-lighter">
           You can also find the extension in the{' '}
           <a
-            href="https://geminicli.com/extensions/?name=supabase-communitygemini-extension"
+            href="https://geminicli.com/extensions/?name=supabase-communitysupabase-plugin"
             target="_blank"
             rel="noopener noreferrer"
             className="text-brand-link hover:underline"


### PR DESCRIPTION
## Summary
Update Gemini CLI Extension repo URL from https://github.com/supabase-community/gemini-extension to https://github.com/supabase-community/supabase-plugin.

Closes [AI-807](https://linear.app/supabase/issue/AI-807/update-gemini-cli-installation-command-with-the-new-github-repo-in-our)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Gemini CLI plugin configuration to reference the Supabase community plugin repository
  * Updated installation instructions and repository links to reflect the new plugin location

<!-- end of auto-generated comment: release notes by coderabbit.ai -->