### PR TITLE
fix(docs): scope js-libs-update vitest run and make tests self-contained

### DIFF
--- a/.github/workflows/docs-js-libs-update.yml
+++ b/.github/workflows/docs-js-libs-update.yml
@@ -54,7 +54,8 @@ jobs:
 
       - name: Refresh reference-content snapshot
         working-directory: apps/docs
-        run: npx vitest run --update scripts/build-reference-content.test.ts
+        # Using --dir (not a file path) so Vitest 4 doesn't run unrelated tests.
+        run: npx vitest run --update --dir scripts
 
       - name: Generate token
         id: app-token
@@ -64,7 +65,6 @@ jobs:
           private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write
-
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0

--- a/apps/docs/vitest.config.ts
+++ b/apps/docs/vitest.config.ts
@@ -1,12 +1,12 @@
 import tsconfigPaths from 'vite-tsconfig-paths'
 import { defineConfig } from 'vitest/config'
 
-// eslint-disable-next-line no-restricted-exports
 export default defineConfig({
   test: {
     // Exclude examples from test discovery (does not affect tsconfig scanning)
     exclude: ['examples/**/*', '**/node_modules/**'],
     setupFiles: ['vitest.setup.ts'],
+    globalSetup: ['vitest.globalSetup.ts'],
   },
   // Restrict tsconfig-paths to only use this app's tsconfig
   plugins: [

--- a/apps/docs/vitest.globalSetup.ts
+++ b/apps/docs/vitest.globalSetup.ts
@@ -1,0 +1,16 @@
+import { cpSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Mirrors `pnpm run codegen:examples` so the test suite is self-contained.
+// CodeSample.test.ts reads fixtures from apps/docs/examples/_internal/fixtures/,
+// which are sourced from the repo-root examples/ directory. Without this,
+// `npx vitest`, `pnpm test:local`, or IDE single-test runs all fail with ENOENT
+// because they bypass the `pretest` npm lifecycle hook.
+export default function setup() {
+  const source = join(import.meta.dirname, '..', '..', 'examples')
+  const dest = join(import.meta.dirname, 'examples')
+  if (!existsSync(source)) {
+    throw new Error(`Expected repo-root examples directory at ${source}`)
+  }
+  cpSync(source, dest, { recursive: true })
+}


### PR DESCRIPTION
The `Update JS Client Libraries Docs` workflow's "Refresh reference-content snapshot" step fails because `npx vitest run --update scripts/build-reference-content.test.ts` is treated as a filter, not a restriction, under Vitest 4, so all docs tests
  run. `CodeSample.test.ts` then fails with ENOENT on `apps/docs/examples/_internal/fixtures/*` because the workflow bypasses the `pretest` npm hook that runs `codegen:examples`.
  
This is a regression of #44943 (commit 28ef62cf31), reintroduced by #46163 when the snapshot step was renamed and rewritten back to the file-path form.
  
Fixes:
- Workflow: use `--dir scripts` so only the snapshot test runs.
- Tests: add a vitest globalSetup that mirrors `codegen:examples`, so `npx vitest`, `pnpm test:local`, and IDE single-test runs no longer depend on the `pretest` lifecycle hook being triggered first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test infrastructure configuration and initialization process for improved test suite management.
  * Refined test execution workflow to efficiently manage test discovery and execution across project directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->