### PR TITLE
fix: Handle non existant columns when sorting tables

### DIFF
--- a/apps/studio/components/grid/SupabaseGrid.utils.ts
+++ b/apps/studio/components/grid/SupabaseGrid.utils.ts
@@ -24,14 +24,20 @@ import { BASE_PATH } from '@/lib/constants'
 import { eventMatchesAnyShortcut } from '@/state/shortcuts/matchEvent'
 import { tableEditorRegistry } from '@/state/shortcuts/registry/table-editor'
 
-export function formatSortURLParams(tableName: string, sort?: string[]): Sort[] {
+export function formatSortURLParams(
+  // Should match the Entity type.
+  table: { name: string; columns: { name: string }[] },
+  sort?: string[]
+): Sort[] {
   if (Array.isArray(sort)) {
     return compact(
       sort.map((s) => {
         const [column, order] = s.split(':')
         // Reject any possible malformed sort param
         if (!column || !order) return undefined
-        else return { table: tableName, column, ascending: order === 'asc' }
+        // if the sort column name doesn't exist in the table, reject it as well to avoid confusion
+        if (table.columns.find((c) => c.name === column) === undefined) return undefined
+        else return { table: table.name, column, ascending: order === 'asc' }
       })
     )
   }

--- a/apps/studio/components/grid/components/header/sort/SortPopover.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopover.tsx
@@ -13,12 +13,11 @@ export const SortPopover = ({ tableQueriesEnabled }: SortPopoverProps) => {
   const { urlSorts, onApplySorts } = useTableSort()
 
   const snap = useTableEditorTableStateSnapshot()
-  const tableName = snap.table?.name || ''
 
   // Convert string[] to Sort[]
   const sorts = useMemo(() => {
-    return tableName && urlSorts ? formatSortURLParams(tableName, urlSorts) : []
-  }, [tableName, urlSorts])
+    return snap.originalTable && urlSorts ? formatSortURLParams(snap.originalTable, urlSorts) : []
+  }, [snap.originalTable, urlSorts])
 
   return (
     <SortPopoverPrimitive

--- a/apps/studio/components/grid/hooks/useTableSort.ts
+++ b/apps/studio/components/grid/hooks/useTableSort.ts
@@ -18,8 +18,8 @@ export function useTableSort() {
   const tableName = useMemo(() => snap.table?.name || '', [snap])
 
   const sorts = useMemo(() => {
-    return formatSortURLParams(tableName, urlSorts)
-  }, [tableName, urlSorts])
+    return formatSortURLParams(snap.originalTable, urlSorts)
+  }, [snap.originalTable, urlSorts])
 
   const onApplySorts = useCallback(
     (appliedSorts: Sort[]) => {
@@ -29,7 +29,7 @@ export function useTableSort() {
         )
       }
 
-      const sortsWithTable = appliedSorts.map((sort) => ({ ...sort, table: tableName }))
+      const sortsWithTable = appliedSorts.map((sort) => ({ ...sort }))
       const newUrlSorts = sortsToUrlParams(sortsWithTable)
 
       setParams((prevParams) => ({ ...prevParams, sort: newUrlSorts }))

--- a/apps/studio/components/grid/hooks/useTableSort.ts
+++ b/apps/studio/components/grid/hooks/useTableSort.ts
@@ -18,23 +18,18 @@ export function useTableSort() {
   const tableName = useMemo(() => snap.table?.name || '', [snap])
 
   const sorts = useMemo(() => {
+    if (!snap.originalTable) return []
     return formatSortURLParams(snap.originalTable, urlSorts)
   }, [snap.originalTable, urlSorts])
 
   const onApplySorts = useCallback(
     (appliedSorts: Sort[]) => {
-      if (!tableName) {
-        return console.warn(
-          '[useTableSort] Table name missing in callback, cannot apply sort correctly.'
-        )
-      }
-
       const sortsWithTable = appliedSorts.map((sort) => ({ ...sort }))
       const newUrlSorts = sortsToUrlParams(sortsWithTable)
 
       setParams((prevParams) => ({ ...prevParams, sort: newUrlSorts }))
     },
-    [snap, setParams]
+    [setParams]
   )
 
   /**

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/ForeignRowSelector/ForeignRowSelector.tsx
@@ -123,12 +123,13 @@ export const ForeignRowSelector = ({
 
   // Load sorts from local storage
   useEffect(() => {
-    if (!project?.ref || !table?.name || !table?.schema) return
+    if (!project?.ref || !table) return
 
     try {
       const savedState = loadTableEditorStateFromLocalStorage(project.ref, table.id)
       const urlSorts = savedState?.sorts ?? []
-      const parsedSorts = formatSortURLParams(table.name, urlSorts)
+      const parsedSorts = formatSortURLParams(table, urlSorts)
+
       if (parsedSorts.length > 0) {
         setFiltersAndSorts((prev) => ({ ...prev, sort: parsedSorts }))
       }
@@ -137,7 +138,7 @@ export const ForeignRowSelector = ({
     } finally {
       setShouldSaveSorts(true)
     }
-  }, [project?.ref, table?.schema, table?.name, table?.id])
+  }, [project?.ref, table])
 
   // Persist sorts to local storage
   useEffect(() => {

--- a/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
+++ b/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
@@ -7,7 +7,6 @@ import {
   formatFilterURLParams,
   formatSortURLParams,
   loadTableEditorStateFromLocalStorage,
-  parseSupaTable,
 } from '@/components/grid/SupabaseGrid.utils'
 import { Filter, Sort } from '@/components/grid/types'
 import { useConnectionStringForReadOps } from '@/data/read-replicas/replicas-query'

--- a/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
+++ b/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
@@ -55,7 +55,7 @@ export function prefetchEditorTablePage({
         connectionString,
         readReplicaIdentifier,
         tableId: id,
-        sorts: sorts ?? formatSortURLParams(supaTable.name, localSorts),
+        sorts: sorts ?? formatSortURLParams(entity, localSorts),
         filters: filters ?? formatFilterURLParams(localFilters),
         page: 1,
         limit: TABLE_EDITOR_DEFAULT_ROWS_PER_PAGE,

--- a/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
+++ b/apps/studio/data/prefetchers/project.$ref.editor.$id.tsx
@@ -45,8 +45,6 @@ export function prefetchEditorTablePage({
     id,
   }).then((entity) => {
     if (entity) {
-      const supaTable = parseSupaTable(entity)
-
       const { sorts: localSorts = [], filters: localFilters = [] } =
         loadTableEditorStateFromLocalStorage(projectRef, entity.id) ?? {}
 

--- a/apps/studio/tests/components/Grid/Grid.utils.test.ts
+++ b/apps/studio/tests/components/Grid/Grid.utils.test.ts
@@ -23,7 +23,7 @@ vi.mock('sonner', () => ({
 describe('SupabaseGrid.utils: formatSortURLParams', () => {
   test('should return an array of sort options based on URL params', () => {
     const mockInput = ['id:asc', 'name:desc']
-    const output = formatSortURLParams('fakeTable', mockInput)
+    const output = formatSortURLParams({ name: 'fakeTable', columns: [] }, mockInput)
     expect(output).toStrictEqual([
       { table: 'fakeTable', column: 'id', ascending: true },
       { table: 'fakeTable', column: 'name', ascending: false },
@@ -31,7 +31,7 @@ describe('SupabaseGrid.utils: formatSortURLParams', () => {
   })
   test('should reject any malformed sort options based on URL params', () => {
     const mockInput = ['id', 'name:asc', ':asc']
-    const output = formatSortURLParams('fakeTable', mockInput)
+    const output = formatSortURLParams({ name: 'fakeTable', columns: [] }, mockInput)
     expect(output).toStrictEqual([
       {
         table: 'fakeTable',
@@ -39,6 +39,15 @@ describe('SupabaseGrid.utils: formatSortURLParams', () => {
         ascending: true,
       },
     ])
+  })
+
+  test('should reject any sort options with non-existent columns based on URL params', () => {
+    const mockInput = ['name2:asc']
+    const output = formatSortURLParams(
+      { name: 'fakeTable', columns: [{ name: 'name' }] },
+      mockInput
+    )
+    expect(output).toStrictEqual([])
   })
 })
 

--- a/apps/studio/tests/components/Grid/Grid.utils.test.ts
+++ b/apps/studio/tests/components/Grid/Grid.utils.test.ts
@@ -23,7 +23,10 @@ vi.mock('sonner', () => ({
 describe('SupabaseGrid.utils: formatSortURLParams', () => {
   test('should return an array of sort options based on URL params', () => {
     const mockInput = ['id:asc', 'name:desc']
-    const output = formatSortURLParams({ name: 'fakeTable', columns: [] }, mockInput)
+    const output = formatSortURLParams(
+      { name: 'fakeTable', columns: [{ name: 'id' }, { name: 'name' }] },
+      mockInput
+    )
     expect(output).toStrictEqual([
       { table: 'fakeTable', column: 'id', ascending: true },
       { table: 'fakeTable', column: 'name', ascending: false },
@@ -31,7 +34,10 @@ describe('SupabaseGrid.utils: formatSortURLParams', () => {
   })
   test('should reject any malformed sort options based on URL params', () => {
     const mockInput = ['id', 'name:asc', ':asc']
-    const output = formatSortURLParams({ name: 'fakeTable', columns: [] }, mockInput)
+    const output = formatSortURLParams(
+      { name: 'fakeTable', columns: [{ name: 'name' }] },
+      mockInput
+    )
     expect(output).toStrictEqual([
       {
         table: 'fakeTable',


### PR DESCRIPTION
When a user has sorted by some column in the Table Editor and the column is deleted, the sort data is wrong so it causes issues. In the general view in the Table Editor, the error is handled by removing the sort key when a specific error is detected but it can still happen in ForeignRowSelector.

To test:
1. Have 2 tables with references between them.
2. In the `sessionStorage`, under the `supabase_grid-<ref>` key, update the sort key to a non-existant column for a table.
3. Try to open the `ForeignRowSelector` for that table by clicking on a cell in the referencing column.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sorting now validates referenced columns and ignores invalid sort entries.
  * Local sort restoration and UI sort application now derive sorts from the original table context for more consistent behavior across editors and popovers.
  * Prefetch logic uses the resolved table context when falling back to saved sorts.

* **Tests**
  * Added cases for malformed and out-of-scope sort parameters to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->