### PR TITLE
chore: regenerate marketplace types

### DIFF
--- a/packages/common/marketplace.types.ts
+++ b/packages/common/marketplace.types.ts
@@ -125,22 +125,7 @@ export type Database = {
       }
     }
     Functions: {
-      get_redirect_url: {
-        Args: {
-          p_listing_id: string
-          p_organization_slug: string
-          p_project_id: string
-        }
-        Returns: Json
-      }
-      get_redirect_url_by_slug: {
-        Args: {
-          p_listing_slug: string
-          p_organization_slug: string
-          p_project_id: string
-        }
-        Returns: Json
-      }
+      [_ in never]: never
     }
     Enums: {
       [_ in never]: never


### PR DESCRIPTION
Regenerates types for marketplace schema bindings to remove deprecated RPC functions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed access to certain database functions previously available in the public API. Update your code if you depend on these functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->