### PR TITLE
fix(www): open footer social links in a new tab

### DIFF
--- a/apps/www/components/Footer/index.tsx
+++ b/apps/www/components/Footer/index.tsx
@@ -119,6 +119,8 @@ const Footer = (props: Props) => {
             <div className="flex space-x-5">
               <a
                 href="https://twitter.com/supabase"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
                 <span className="sr-only">Twitter</span>
@@ -127,6 +129,8 @@ const Footer = (props: Props) => {
 
               <a
                 href="https://github.com/supabase"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
                 <span className="sr-only">GitHub</span>
@@ -135,6 +139,8 @@ const Footer = (props: Props) => {
 
               <a
                 href="https://discord.supabase.com/"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
                 <span className="sr-only">Discord</span>
@@ -143,6 +149,8 @@ const Footer = (props: Props) => {
 
               <a
                 href="https://youtube.com/c/supabase"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
                 <span className="sr-only">Youtube</span>
@@ -151,6 +159,8 @@ const Footer = (props: Props) => {
 
               <a
                 href="https://www.tiktok.com/@supabase.com"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
                 <span className="sr-only">TikTok</span>
@@ -159,6 +169,8 @@ const Footer = (props: Props) => {
 
               <a
                 href="https://www.instagram.com/supabasecom"
+                target="_blank"
+                rel="noopener noreferrer"
                 className="text-foreground-lighter hover:text-foreground transition"
               >
                 <span className="sr-only">Instagram</span>


### PR DESCRIPTION
The footer social links (X, GitHub, Discord, YouTube, TikTok, Instagram) opened in the same tab, navigating users away from supabase.com. Add target="_blank" and rel="noopener noreferrer" so they open in a new tab, with rel preventing the opened page from accessing window.opener.

Fixes #45342

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Social media links in the footer now open in new tabs, allowing you to maintain your current browsing session without interruption.
  * Enhanced security for external link navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->