### PR TITLE
fix: clip overflowing text in collapsed sonner toasts

### DIFF
--- a/packages/ui/src/components/shadcn/ui/sonner.tsx
+++ b/packages/ui/src/components/shadcn/ui/sonner.tsx
@@ -38,6 +38,7 @@ const SonnerToaster = ({ toastOptions, ...props }: ToasterProps) => {
             'items-start',
             'font-normal',
             'text-sm',
+            'data-[expanded=false]:overflow-hidden',
             'group-[.toaster]:bg-overlay group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-overlay group-[.toaster]:shadow-lg'
           ),
           icon: 'mt-0.5',


### PR DESCRIPTION
When multiple toasts stack up, Sonner compresses background toasts. The text content in these collapsed toasts was overflowing past the boundary and leaking into the page layout. This adds `data-[expanded=false]:overflow-hidden` to clip the overflowing text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated toast notification styling to better handle content overflow behavior when toasts are in a collapsed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->