### PR TITLE
fix: added schema switching shortcut

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -22,6 +22,7 @@ import { ProtectedSchemaWarning } from '@/components/interfaces/Database/Protect
 import { ErrorMatcher } from '@/components/interfaces/ErrorHandling/ErrorMatcher'
 import { EditorMenuListSkeleton } from '@/components/layouts/TableEditorLayout/EditorMenuListSkeleton'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { InfiniteListDefault, LoaderForIconMenuItems } from '@/components/ui/InfiniteList'
 import SchemaSelector from '@/components/ui/SchemaSelector'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
@@ -160,21 +161,27 @@ export const TableEditorMenu = () => {
     <>
       <div className="flex flex-col grow gap-5 pt-5 h-full">
         <div className="flex flex-col gap-y-1.5">
-          <SchemaSelector
-            className="mx-4"
-            selectedSchemaName={selectedSchema}
-            onSelectSchema={(name: string) => {
-              setSearchText('')
-              setSelectedSchema(name)
-              setIsSchemaDropdownOpen(false)
-            }}
-            onSelectCreateSchema={() => {
-              snap.onAddSchema()
-              setIsSchemaDropdownOpen(false)
-            }}
-            open={isSchemaDropdownOpen}
-            onOpenChange={setIsSchemaDropdownOpen}
-          />
+          <ShortcutTooltip
+            shortcutId={SHORTCUT_IDS.TABLE_EDITOR_FOCUS_SCHEMA}
+            label="Switch schema"
+            side="bottom"
+          >
+            <SchemaSelector
+              className="mx-4"
+              selectedSchemaName={selectedSchema}
+              onSelectSchema={(name: string) => {
+                setSearchText('')
+                setSelectedSchema(name)
+                setIsSchemaDropdownOpen(false)
+              }}
+              onSelectCreateSchema={() => {
+                snap.onAddSchema()
+                setIsSchemaDropdownOpen(false)
+              }}
+              open={isSchemaDropdownOpen}
+              onOpenChange={setIsSchemaDropdownOpen}
+            />
+          </ShortcutTooltip>
 
           <div className="grid gap-3 mx-4">
             {!isSchemaLocked ? (

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -22,9 +22,9 @@ import { ProtectedSchemaWarning } from '@/components/interfaces/Database/Protect
 import { ErrorMatcher } from '@/components/interfaces/ErrorHandling/ErrorMatcher'
 import { EditorMenuListSkeleton } from '@/components/layouts/TableEditorLayout/EditorMenuListSkeleton'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
-import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { InfiniteListDefault, LoaderForIconMenuItems } from '@/components/ui/InfiniteList'
 import SchemaSelector from '@/components/ui/SchemaSelector'
+import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
 import { useEntityTypesQuery } from '@/data/entity-types/entity-types-infinite-query'
 import { useTableApiAccessQuery } from '@/data/privileges/table-api-access-query'
@@ -110,11 +110,9 @@ export const TableEditorMenu = () => {
     setSelectedSchema(selectedTable.schema)
   }
 
-  useShortcut(
-    SHORTCUT_IDS.TABLE_EDITOR_FOCUS_SCHEMA,
-    () => setIsSchemaDropdownOpen(true),
-    { registerInCommandMenu: true }
-  )
+  useShortcut(SHORTCUT_IDS.TABLE_EDITOR_FOCUS_SCHEMA, () => setIsSchemaDropdownOpen(true), {
+    registerInCommandMenu: true,
+  })
 
   const tableEditorTabsCleanUp = useTableEditorTabsCleanUp()
 

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -165,6 +165,7 @@ export const TableEditorMenu = () => {
             shortcutId={SHORTCUT_IDS.TABLE_EDITOR_FOCUS_SCHEMA}
             label="Switch schema"
             side="bottom"
+            open={isSchemaDropdownOpen ? false : undefined}
           >
             <SchemaSelector
               className="mx-4"

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -33,6 +33,8 @@ import { useLocalStorage } from '@/hooks/misc/useLocalStorage'
 import { useQuerySchemaState } from '@/hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useIsProtectedSchema } from '@/hooks/useProtectedSchemas'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 import { useTableEditorStateSnapshot } from '@/state/table-editor'
 
 export const TableEditorMenu = () => {
@@ -42,6 +44,7 @@ export const TableEditorMenu = () => {
   const { selectedSchema, setSelectedSchema } = useQuerySchemaState()
 
   const [searchText, setSearchText] = useState<string>('')
+  const [isSchemaDropdownOpen, setIsSchemaDropdownOpen] = useState(false)
   const [tableToExport, setTableToExport] = useState<SupaTable>()
   const [visibleTypes, setVisibleTypes] = useState<string[]>(Object.values(ENTITY_TYPE))
   const [sort, setSort] = useLocalStorage<'alphabetical' | 'grouped-alphabetical'>(
@@ -106,6 +109,12 @@ export const TableEditorMenu = () => {
     setSelectedSchema(selectedTable.schema)
   }
 
+  useShortcut(
+    SHORTCUT_IDS.TABLE_EDITOR_FOCUS_SCHEMA,
+    () => setIsSchemaDropdownOpen(true),
+    { registerInCommandMenu: true }
+  )
+
   const tableEditorTabsCleanUp = useTableEditorTabsCleanUp()
 
   const onSelectExportCLI = useCallback(
@@ -157,8 +166,14 @@ export const TableEditorMenu = () => {
             onSelectSchema={(name: string) => {
               setSearchText('')
               setSelectedSchema(name)
+              setIsSchemaDropdownOpen(false)
             }}
-            onSelectCreateSchema={() => snap.onAddSchema()}
+            onSelectCreateSchema={() => {
+              snap.onAddSchema()
+              setIsSchemaDropdownOpen(false)
+            }}
+            open={isSchemaDropdownOpen}
+            onOpenChange={setIsSchemaDropdownOpen}
           />
 
           <div className="grid gap-3 mx-4">

--- a/apps/studio/state/shortcuts/registry/table-editor.ts
+++ b/apps/studio/state/shortcuts/registry/table-editor.ts
@@ -19,6 +19,7 @@ export const TABLE_EDITOR_SHORTCUT_IDS = {
   TABLE_EDITOR_CLEAR_FILTERS: 'table-editor.clear-filters',
   TABLE_EDITOR_CLEAR_SORT: 'table-editor.clear-sort',
   TABLE_EDITOR_REFRESH: 'table-editor.refresh',
+  TABLE_EDITOR_FOCUS_SCHEMA: 'table-editor.focus-schema',
 }
 
 export type TableEditorShortcutId =
@@ -148,6 +149,13 @@ export const tableEditorRegistry: RegistryDefinations<TableEditorShortcutId> = {
     id: TABLE_EDITOR_SHORTCUT_IDS.TABLE_EDITOR_REFRESH,
     label: 'Refresh table',
     sequence: ['Shift+R'],
+    showInSettings: false,
+    options: { ignoreInputs: true },
+  },
+  [TABLE_EDITOR_SHORTCUT_IDS.TABLE_EDITOR_FOCUS_SCHEMA]: {
+    id: TABLE_EDITOR_SHORTCUT_IDS.TABLE_EDITOR_FOCUS_SCHEMA,
+    label: 'Focus schema selector',
+    sequence: ['S', 'S'],
     showInSettings: false,
     options: { ignoreInputs: true },
   },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Added a small shortcut to make it easier to switch schemas in the table editor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut (S+S) to open the schema selector in the table editor for faster navigation and accessibility.
  * Schema selector now supports keyboard/shortcut-driven control and tooltip guidance.
  * Selector automatically closes when a schema is chosen or after creating a new schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->