### PR TITLE
fix(reports): remove CPU idle chart DEBUG-135

### DIFF
--- a/apps/docs/content/guides/telemetry/reports.mdx
+++ b/apps/docs/content/guides/telemetry/reports.mdx
@@ -84,6 +84,7 @@ The following charts are available for Free and Pro plans:
 | Chart                        | Available Plans | Description                                  | Key Insights                                                   |
 | ---------------------------- | --------------- | -------------------------------------------- | -------------------------------------------------------------- |
 | Memory usage                 | Free, Pro       | RAM usage percentage by the database         | Memory pressure and resource utilization                       |
+| Swap usage                   | Free, Pro       | Swap space used when RAM is exhausted        | Memory pressure and risk of disk paging                        |
 | CPU usage                    | Free, Pro       | Average CPU usage percentage                 | CPU-intensive query identification                             |
 | Disk IOPS                    | Free, Pro       | Read/write operations per second with limits | IO bottleneck detection and workload analysis                  |
 | Database connections         | Free, Pro       | Number of pooler connections to the database | Connection pool monitoring                                     |
@@ -136,6 +137,30 @@ Actions you can take:
 | [Optimize queries](/docs/guides/database/query-optimization)                | Reduce memory consumption of expensive queries |
 | [Tune Postgres configuration](https://pgtune.leopard.in.ua)                 | Improve memory management settings             |
 | Implement application caching                                               | Add query result caching to reduce memory load |
+
+### Swap usage
+
+Swap usage shows how much swap space the system is using. Swap is disk space the operating system uses as an overflow when physical RAM is full. Because disk is much slower than RAM, sustained swap activity indicates memory pressure and can significantly degrade database performance.
+
+| Component    | Description                                          |
+| ------------ | ---------------------------------------------------- |
+| **Used**     | Swap space currently in use                          |
+| **Free**     | Available swap space                                 |
+
+How it helps debug issues:
+
+| Issue                        | Description                                                              |
+| ---------------------------- | ------------------------------------------------------------------------ |
+| Memory pressure detection    | Persistent swap usage signals that RAM is exhausted and paging is active |
+| Performance degradation root cause | Elevated swap correlates with slow queries caused by disk IO instead of RAM access |
+
+Actions you can take:
+
+| Action                                                                      | Description                                      |
+| --------------------------------------------------------------------------- | ------------------------------------------------ |
+| [Upgrade compute size](/docs/guides/platform/compute-and-disk#compute-size) | Add more RAM to eliminate swap usage             |
+| [Optimize queries](/docs/guides/database/query-optimization)                | Reduce memory-intensive operations               |
+| [Tune Postgres configuration](https://pgtune.leopard.in.ua)                 | Lower `work_mem` or `shared_buffers` if over-allocated |
 
 ### CPU usage
 

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
@@ -7,12 +7,17 @@ describe('columnFiltersToLogsFilters', () => {
     // The shared DataTable checkbox writes a plain array via setFilterValue.
     // It must still round-trip into the `filter` URL param, otherwise clicking
     // a sidebar facet never re-runs the query (the reported regression).
-    const filters = columnFiltersToLogsFilters([{ id: 'log_type', value: ['postgres', 'postgrest'] }])
+    const filters = columnFiltersToLogsFilters([
+      { id: 'log_type', value: ['postgres', 'postgrest'] },
+    ])
     expect(filters).toEqual([
       { column: 'log_type', operator: '=', value: 'postgres' },
       { column: 'log_type', operator: '=', value: 'postgrest' },
     ])
-    expect(logsFiltersToUrlParams(filters)).toEqual(['log_type:eq:postgres', 'log_type:eq:postgrest'])
+    expect(logsFiltersToUrlParams(filters)).toEqual([
+      'log_type:eq:postgres',
+      'log_type:eq:postgrest',
+    ])
   })
 
   it('preserves the operator from a wrapped value (top filter bar)', () => {

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
@@ -58,8 +58,6 @@ describe('columnFiltersToLogsFilters', () => {
 
 describe('logsFiltersToColumnFilters', () => {
   it('seeds an `=` group as a bare string[] so sidebar checkboxes render ticked', () => {
-    // The shared checkbox only reads Array.isArray(value); a wrapped
-    // { operator, values } object leaves every box unticked on URL load.
     const columnFilters = logsFiltersToColumnFilters([
       { column: 'log_type', operator: '=', value: 'postgres' },
       { column: 'log_type', operator: '=', value: 'postgrest' },
@@ -97,8 +95,6 @@ describe('buildFilterSearchUpdate', () => {
   ]
 
   it('serializes a bare sidebar checkbox into the `filter` param (the regression)', () => {
-    // The reported bug: a sidebar click produced an empty `filter` so the query
-    // never re-ran. This guards the click-to-URL wiring, not just the transform.
     const update = buildFilterSearchUpdate([{ id: 'log_type', value: ['postgres'] }], fields)
     expect(update.filter).toEqual(['log_type:eq:postgres'])
   })

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
-import { columnFiltersToLogsFilters, logsFiltersToUrlParams } from './UnifiedLogs.filters'
+import {
+  buildFilterSearchUpdate,
+  columnFiltersToLogsFilters,
+  logsFiltersToUrlParams,
+} from './UnifiedLogs.filters'
 
 describe('columnFiltersToLogsFilters', () => {
   it('serializes a bare string[] (sidebar checkbox) using the default `=` operator', () => {
-    // The shared DataTable checkbox writes a plain array via setFilterValue.
-    // It must still round-trip into the `filter` URL param, otherwise clicking
-    // a sidebar facet never re-runs the query (the reported regression).
     const filters = columnFiltersToLogsFilters([
       { id: 'log_type', value: ['postgres', 'postgrest'] },
     ])
@@ -33,9 +34,6 @@ describe('columnFiltersToLogsFilters', () => {
   })
 
   it('excludes columns not in filterableNames (e.g. the `date` timerange brush)', () => {
-    // `date` is a plain [start, end] array; it round-trips through its own URL
-    // key, so it must not leak into the `filter` param now that bare arrays are
-    // normalized.
     const filterable = new Set(['log_type', 'method'])
     const filters = columnFiltersToLogsFilters(
       [
@@ -53,5 +51,43 @@ describe('columnFiltersToLogsFilters', () => {
       { id: 'method', value: undefined },
     ])
     expect(filters).toEqual([])
+  })
+})
+
+describe('buildFilterSearchUpdate', () => {
+  const fields = [
+    { value: 'date', type: 'timerange' },
+    { value: 'log_type', type: 'checkbox' },
+    { value: 'method', type: 'checkbox' },
+  ]
+
+  it('serializes a bare sidebar checkbox into the `filter` param (the regression)', () => {
+    // The reported bug: a sidebar click produced an empty `filter` so the query
+    // never re-ran. This guards the click-to-URL wiring, not just the transform.
+    const update = buildFilterSearchUpdate([{ id: 'log_type', value: ['postgres'] }], fields)
+    expect(update.filter).toEqual(['log_type:eq:postgres'])
+  })
+
+  it('clears the `filter` param to null when no equality filters are set', () => {
+    const update = buildFilterSearchUpdate([{ id: 'log_type', value: null }], fields)
+    expect(update.filter).toBeNull()
+  })
+
+  it('routes a timerange to its own URL key, never into `filter`', () => {
+    const range = [new Date('2026-05-08T00:00:00Z'), new Date('2026-05-08T01:00:00Z')]
+    const update = buildFilterSearchUpdate(
+      [
+        { id: 'date', value: range },
+        { id: 'method', value: ['GET'] },
+      ],
+      fields
+    )
+    expect(update.filter).toEqual(['method:eq:GET'])
+    expect(update.date).toBe(range)
+  })
+
+  it('nulls an absent timerange key so a cleared brush is removed from the URL', () => {
+    const update = buildFilterSearchUpdate([{ id: 'method', value: ['GET'] }], fields)
+    expect(update.date).toBeNull()
   })
 })

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it } from 'vitest'
 import {
   buildFilterSearchUpdate,
   columnFiltersToLogsFilters,
+  logsFiltersToColumnFilters,
   logsFiltersToUrlParams,
+  parseLogsFilterUrlParams,
 } from './UnifiedLogs.filters'
 
 describe('columnFiltersToLogsFilters', () => {
@@ -51,6 +53,39 @@ describe('columnFiltersToLogsFilters', () => {
       { id: 'method', value: undefined },
     ])
     expect(filters).toEqual([])
+  })
+})
+
+describe('logsFiltersToColumnFilters', () => {
+  it('seeds an `=` group as a bare string[] so sidebar checkboxes render ticked', () => {
+    // The shared checkbox only reads Array.isArray(value); a wrapped
+    // { operator, values } object leaves every box unticked on URL load.
+    const columnFilters = logsFiltersToColumnFilters([
+      { column: 'log_type', operator: '=', value: 'postgres' },
+      { column: 'log_type', operator: '=', value: 'postgrest' },
+    ])
+    expect(columnFilters).toEqual([{ id: 'log_type', value: ['postgres', 'postgrest'] }])
+  })
+
+  it('keeps non-eq groups wrapped so the operator survives a round-trip', () => {
+    const columnFilters = logsFiltersToColumnFilters([
+      { column: 'event_message', operator: '~~*', value: 'error' },
+    ])
+    expect(columnFilters).toEqual([
+      { id: 'event_message', value: { operator: '~~*', values: ['error'] } },
+    ])
+  })
+
+  it('round-trips an eq URL filter back to the same param without flipping the operator', () => {
+    const seeded = logsFiltersToColumnFilters(parseLogsFilterUrlParams(['method:eq:GET']))
+    const update = buildFilterSearchUpdate(seeded, [{ value: 'method', type: 'checkbox' }])
+    expect(update.filter).toEqual(['method:eq:GET'])
+  })
+
+  it('round-trips a neq URL filter without downgrading it to eq', () => {
+    const seeded = logsFiltersToColumnFilters(parseLogsFilterUrlParams(['method:neq:GET']))
+    const update = buildFilterSearchUpdate(seeded, [{ value: 'method', type: 'checkbox' }])
+    expect(update.filter).toEqual(['method:neq:GET'])
   })
 })
 

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { columnFiltersToLogsFilters, logsFiltersToUrlParams } from './UnifiedLogs.filters'
+
+describe('columnFiltersToLogsFilters', () => {
+  it('serializes a bare string[] (sidebar checkbox) using the default `=` operator', () => {
+    // The shared DataTable checkbox writes a plain array via setFilterValue.
+    // It must still round-trip into the `filter` URL param, otherwise clicking
+    // a sidebar facet never re-runs the query (the reported regression).
+    const filters = columnFiltersToLogsFilters([{ id: 'log_type', value: ['postgres', 'postgrest'] }])
+    expect(filters).toEqual([
+      { column: 'log_type', operator: '=', value: 'postgres' },
+      { column: 'log_type', operator: '=', value: 'postgrest' },
+    ])
+    expect(logsFiltersToUrlParams(filters)).toEqual(['log_type:eq:postgres', 'log_type:eq:postgrest'])
+  })
+
+  it('preserves the operator from a wrapped value (top filter bar)', () => {
+    const filters = columnFiltersToLogsFilters([
+      { id: 'method', value: { operator: '<>', values: ['GET'] } },
+    ])
+    expect(filters).toEqual([{ column: 'method', operator: '<>', value: 'GET' }])
+  })
+
+  it('treats a bare non-array scalar as a single `=` value', () => {
+    const filters = columnFiltersToLogsFilters([{ id: 'status', value: '500' }])
+    expect(filters).toEqual([{ column: 'status', operator: '=', value: '500' }])
+  })
+
+  it('excludes columns not in filterableNames (e.g. the `date` timerange brush)', () => {
+    // `date` is a plain [start, end] array; it round-trips through its own URL
+    // key, so it must not leak into the `filter` param now that bare arrays are
+    // normalized.
+    const filterable = new Set(['log_type', 'method'])
+    const filters = columnFiltersToLogsFilters(
+      [
+        { id: 'date', value: [new Date('2026-05-08T00:00:00Z'), new Date('2026-05-08T01:00:00Z')] },
+        { id: 'log_type', value: ['postgres'] },
+      ],
+      filterable
+    )
+    expect(filters).toEqual([{ column: 'log_type', operator: '=', value: 'postgres' }])
+  })
+
+  it('skips null/undefined values (cleared filters)', () => {
+    const filters = columnFiltersToLogsFilters([
+      { id: 'log_type', value: null },
+      { id: 'method', value: undefined },
+    ])
+    expect(filters).toEqual([])
+  })
+})

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
@@ -82,13 +82,24 @@ export const groupLogsFiltersByColumn = (
 }
 
 export const columnFiltersToLogsFilters = (
-  columnFilters: { id: string; value: unknown }[]
+  columnFilters: { id: string; value: unknown }[],
+  filterableNames?: Set<string>
 ): LogsFilter[] => {
   const filters: LogsFilter[] = []
   for (const { id, value } of columnFilters) {
-    if (!isLogsFilterColumnValue(value)) continue
-    for (const v of value.values) {
-      filters.push({ column: id, operator: value.operator, value: String(v) })
+    // Skip columns that don't serialize into the `filter` param (e.g. the
+    // `date` timerange brush, which round-trips through its own URL key).
+    if (filterableNames && !filterableNames.has(id)) continue
+    if (value === null || value === undefined) continue
+    // The top filter bar writes a wrapped { operator, values }, while the shared
+    // sidebar checkbox writes a bare string[] (TanStack convention). Normalize
+    // the bare array to the default `=` operator so sidebar clicks serialize and
+    // re-run the query the same way the filter bar does.
+    const { operator, values } = isLogsFilterColumnValue(value)
+      ? value
+      : { operator: '=' as LogsFilterOperator, values: Array.isArray(value) ? value : [value] }
+    for (const v of values) {
+      filters.push({ column: id, operator, value: String(v) })
     }
   }
   return filters

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
@@ -81,6 +81,18 @@ export const groupLogsFiltersByColumn = (
   return grouped
 }
 
+// Seeds table column filters from URL-parsed logs filters. Equality groups (what
+// the sidebar checkboxes write) become a bare string[] so the checkboxes render
+// ticked on load; non-eq groups (top filter bar's neq/ilike) keep the wrapped
+// { operator, values } shape so the operator survives a round-trip.
+export const logsFiltersToColumnFilters = (
+  filters: LogsFilter[]
+): { id: string; value: string[] | LogsColumnFilterValue }[] => {
+  return Object.entries(groupLogsFiltersByColumn(filters)).map(([id, group]) =>
+    group.operator === '=' ? { id, value: group.values } : { id, value: group }
+  )
+}
+
 export const columnFiltersToLogsFilters = (
   columnFilters: { id: string; value: unknown }[],
   filterableNames?: Set<string>

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
@@ -87,20 +87,43 @@ export const columnFiltersToLogsFilters = (
 ): LogsFilter[] => {
   const filters: LogsFilter[] = []
   for (const { id, value } of columnFilters) {
-    // Skip columns that don't serialize into the `filter` param (e.g. the
-    // `date` timerange brush, which round-trips through its own URL key).
+    // `date` (timerange brush) round-trips through its own URL key, not `filter`.
     if (filterableNames && !filterableNames.has(id)) continue
     if (value === null || value === undefined) continue
-    // The top filter bar writes a wrapped { operator, values }, while the shared
-    // sidebar checkbox writes a bare string[] (TanStack convention). Normalize
-    // the bare array to the default `=` operator so sidebar clicks serialize and
-    // re-run the query the same way the filter bar does.
-    const { operator, values } = isLogsFilterColumnValue(value)
-      ? value
-      : { operator: '=' as LogsFilterOperator, values: Array.isArray(value) ? value : [value] }
+    // Filter bar writes a wrapped { operator, values }; sidebar checkboxes write a
+    // bare string[] — normalize the latter to an `=` filter so both serialize alike.
+    const fallback: LogsColumnFilterValue = {
+      operator: '=',
+      values: (Array.isArray(value) ? value : [value]).map(String),
+    }
+    const { operator, values } = isLogsFilterColumnValue(value) ? value : fallback
     for (const v of values) {
-      filters.push({ column: id, operator, value: String(v) })
+      filters.push({ column: id, operator, value: v })
     }
   }
   return filters
+}
+
+// Builds the URL-state patch for a filter apply. Equality/pattern filters collapse
+// into the repeatable `filter` param; timerange fields keep their own per-column key
+// (their range semantics aren't expressible as eq/neq/like).
+export const buildFilterSearchUpdate = (
+  columnFilters: { id: string; value: unknown }[],
+  filterFields: { value: string; type: string }[]
+): Record<string, unknown> => {
+  const filterableNames = new Set(
+    filterFields.filter((field) => field.type !== 'timerange').map((field) => field.value)
+  )
+  const filterEntries = logsFiltersToUrlParams(
+    columnFiltersToLogsFilters(columnFilters, filterableNames)
+  )
+  const update: Record<string, unknown> = {
+    filter: filterEntries.length > 0 ? filterEntries : null,
+  }
+  for (const field of filterFields) {
+    if (field.type !== 'timerange') continue
+    const current = columnFilters.find((c) => c.id === field.value)?.value
+    update[field.value] = current ?? null
+  }
+  return update
 }

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.filters.ts
@@ -81,10 +81,6 @@ export const groupLogsFiltersByColumn = (
   return grouped
 }
 
-// Seeds table column filters from URL-parsed logs filters. Equality groups (what
-// the sidebar checkboxes write) become a bare string[] so the checkboxes render
-// ticked on load; non-eq groups (top filter bar's neq/ilike) keep the wrapped
-// { operator, values } shape so the operator survives a round-trip.
 export const logsFiltersToColumnFilters = (
   filters: LogsFilter[]
 ): { id: string; value: string[] | LogsColumnFilterValue }[] => {
@@ -99,11 +95,8 @@ export const columnFiltersToLogsFilters = (
 ): LogsFilter[] => {
   const filters: LogsFilter[] = []
   for (const { id, value } of columnFilters) {
-    // `date` (timerange brush) round-trips through its own URL key, not `filter`.
     if (filterableNames && !filterableNames.has(id)) continue
     if (value === null || value === undefined) continue
-    // Filter bar writes a wrapped { operator, values }; sidebar checkboxes write a
-    // bare string[] — normalize the latter to an `=` filter so both serialize alike.
     const fallback: LogsColumnFilterValue = {
       operator: '=',
       values: (Array.isArray(value) ? value : [value]).map(String),
@@ -116,9 +109,6 @@ export const columnFiltersToLogsFilters = (
   return filters
 }
 
-// Builds the URL-state patch for a filter apply. Equality/pattern filters collapse
-// into the repeatable `filter` param; timerange fields keep their own per-column key
-// (their range semantics aren't expressible as eq/neq/like).
 export const buildFilterSearchUpdate = (
   columnFilters: { id: string; value: unknown }[],
   filterFields: { value: string; type: string }[]

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -39,9 +39,8 @@ import { ServiceFlowPanel } from './ServiceFlowPanel'
 import { SEARCH_PARAMS_PARSER } from './UnifiedLogs.constants'
 import { filterFields as defaultFilterFields } from './UnifiedLogs.fields'
 import {
-  columnFiltersToLogsFilters,
+  buildFilterSearchUpdate,
   groupLogsFiltersByColumn,
-  logsFiltersToUrlParams,
   parseLogsFilterUrlParams,
 } from './UnifiedLogs.filters'
 import { useLiveMode, useResetFocus } from './UnifiedLogs.hooks'
@@ -294,26 +293,9 @@ export const UnifiedLogs = () => {
     })
   }, [facets])
 
-  // Debounced filter application to avoid too many API calls when user clicks multiple filters quickly.
-  // All equality/pattern column filters serialize into the repeatable `filter` URL param. Slider/timerange
-  // column filters keep their dedicated per-column URL keys so things like the timeline brush still
-  // round-trip — they have their own range semantics and aren't covered by eq/neq/like.
+  // Debounced to avoid too many API calls when the user clicks multiple filters quickly.
   const applyFilterSearch = () => {
-    const filterableNames = new Set(
-      filterFields.filter((field) => field.type !== 'timerange').map((field) => field.value)
-    )
-    const filterEntries = logsFiltersToUrlParams(
-      columnFiltersToLogsFilters(columnFilters, filterableNames)
-    )
-    const update: Record<string, unknown> = {
-      filter: filterEntries.length > 0 ? filterEntries : null,
-    }
-    for (const field of filterFields) {
-      if (field.type !== 'timerange') continue
-      const current = columnFilters.find((c) => c.id === field.value)?.value
-      update[field.value] = current ?? null
-    }
-    setSearch(update)
+    setSearch(buildFilterSearchUpdate(columnFilters, filterFields))
   }
 
   const debouncedApplyFilterSearch = useDebounce(applyFilterSearch, 250)

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -299,7 +299,12 @@ export const UnifiedLogs = () => {
   // column filters keep their dedicated per-column URL keys so things like the timeline brush still
   // round-trip — they have their own range semantics and aren't covered by eq/neq/like.
   const applyFilterSearch = () => {
-    const filterEntries = logsFiltersToUrlParams(columnFiltersToLogsFilters(columnFilters))
+    const filterableNames = new Set(
+      filterFields.filter((field) => field.type !== 'timerange').map((field) => field.value)
+    )
+    const filterEntries = logsFiltersToUrlParams(
+      columnFiltersToLogsFilters(columnFilters, filterableNames)
+    )
     const update: Record<string, unknown> = {
       filter: filterEntries.length > 0 ? filterEntries : null,
     }

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -40,7 +40,7 @@ import { SEARCH_PARAMS_PARSER } from './UnifiedLogs.constants'
 import { filterFields as defaultFilterFields } from './UnifiedLogs.fields'
 import {
   buildFilterSearchUpdate,
-  groupLogsFiltersByColumn,
+  logsFiltersToColumnFilters,
   parseLogsFilterUrlParams,
 } from './UnifiedLogs.filters'
 import { useLiveMode, useResetFocus } from './UnifiedLogs.hooks'
@@ -91,12 +91,9 @@ export const UnifiedLogs = () => {
 
   const defaultColumnSorting = search.sort ? [search.sort] : []
   const defaultColumnVisibility = { uuid: false }
-  // Column filters are seeded from the repeatable `filter` URL param. Each entry
-  // (`col:opAbbrev:value`) is grouped per column into a wrapped { operator, values }
-  // shape that the query builder reads back.
-  const defaultColumnFilters = Object.entries(
-    groupLogsFiltersByColumn(parseLogsFilterUrlParams(search.filter))
-  ).map(([id, value]) => ({ id, value }))
+  // Column filters are seeded from the repeatable `filter` URL param so the sidebar
+  // checkboxes and top filter bar both render their state on load.
+  const defaultColumnFilters = logsFiltersToColumnFilters(parseLogsFilterUrlParams(search.filter))
 
   const [topBarHeight, setTopBarHeight] = useState(0)
   const topBarRef = useRef<HTMLDivElement>(null)

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.tsx
@@ -91,8 +91,6 @@ export const UnifiedLogs = () => {
 
   const defaultColumnSorting = search.sort ? [search.sort] : []
   const defaultColumnVisibility = { uuid: false }
-  // Column filters are seeded from the repeatable `filter` URL param so the sidebar
-  // checkboxes and top filter bar both render their state on load.
   const defaultColumnFilters = logsFiltersToColumnFilters(parseLogsFilterUrlParams(search.filter))
 
   const [topBarHeight, setTopBarHeight] = useState(0)
@@ -290,7 +288,6 @@ export const UnifiedLogs = () => {
     })
   }, [facets])
 
-  // Debounced to avoid too many API calls when the user clicks multiple filters quickly.
   const applyFilterSearch = () => {
     setSearch(buildFilterSearchUpdate(columnFilters, filterFields))
   }

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -193,16 +193,6 @@ export const getReportAttributesV2: (
             'CPU time spent on other tasks (e.g., background processes, software interrupts)',
         },
         {
-          attribute: 'cpu_usage_busy_idle',
-          provider: 'infra-monitoring',
-          label: 'Idle',
-          format: '%',
-          omitFromTotal: true,
-          color: { light: '#6EA85F', dark: '#A3FFC2' },
-          fill: { light: '#A6D8AE', dark: '#2A5C3F' },
-          tooltip: 'CPU time spent idle and available for new work',
-        },
-        {
           attribute: 'cpu_usage_max',
           provider: 'reference-line',
           label: 'Max',


### PR DESCRIPTION
## Problem

The CPU idle chart in the database report flat-lines at 100% because idle time is always the inverse of active CPU usage. It adds visual noise without providing any actionable signal.

## Fix

Removed the `cpu_usage_busy_idle` attribute from the `cpu-usage` chart config in `apps/studio/data/reports/database-charts.ts`. All other CPU breakdown attributes (System, User, IOwait, IRQs, Other) are retained.

## How to test

1. Open the database report for any project (Reports > Database).
2. Verify the CPU usage chart shows System, User, IOwait, IRQs, and Other series.
3. Confirm there is no "Idle" series in the chart or its legend.