### PR TITLE
feat(studio): add Snowflake replication destination

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.schema.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.schema.ts
@@ -43,6 +43,14 @@ export const DestinationPanelFormSchema = z.object({
   ducklakeS3UrlStyle: z.enum(['path', 'vhost']).optional(),
   ducklakeS3UseSsl: z.boolean().optional(),
   ducklakeMetadataSchema: z.string().optional(),
+  // Snowflake fields
+  snowflakeAccountId: z.string().optional(),
+  snowflakeUser: z.string().optional(),
+  snowflakePrivateKey: z.string().optional(),
+  snowflakePrivateKeyPassphrase: z.string().optional(),
+  snowflakeDatabase: z.string().optional(),
+  snowflakeSchema: z.string().optional(),
+  snowflakeRole: z.string().optional(),
 })
 
 export type DestinationPanelSchemaType = z.infer<typeof DestinationPanelFormSchema>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
@@ -4,6 +4,7 @@ import {
   buildDestinationConfig,
   buildDestinationConfigForValidation,
   getDucklakeValidationIssues,
+  getSnowflakeValidationIssues,
 } from './DestinationForm.utils'
 
 const baseDucklakeFormData = {
@@ -35,6 +36,44 @@ const baseDucklakeFormData = {
   ducklakeS3UrlStyle: 'path' as const,
   ducklakeS3UseSsl: true,
   ducklakeMetadataSchema: ' ducklake_metadata ',
+}
+
+const baseSnowflakeFormData = {
+  name: 'Snowflake Destination',
+  publicationName: 'pub',
+  maxFillMs: undefined,
+  maxTableSyncWorkers: undefined,
+  maxCopyConnectionsPerTable: undefined,
+  invalidatedSlotBehavior: undefined,
+  projectId: undefined,
+  datasetId: undefined,
+  serviceAccountKey: undefined,
+  connectionPoolSize: undefined,
+  maxStalenessMins: undefined,
+  warehouseName: undefined,
+  namespace: undefined,
+  newNamespaceName: undefined,
+  catalogToken: undefined,
+  s3AccessKeyId: undefined,
+  s3SecretAccessKey: undefined,
+  s3Region: undefined,
+  ducklakeCatalogUrl: undefined,
+  ducklakeDataPath: undefined,
+  ducklakePoolSize: undefined,
+  ducklakeS3AccessKeyId: undefined,
+  ducklakeS3SecretAccessKey: undefined,
+  ducklakeS3Region: undefined,
+  ducklakeS3Endpoint: undefined,
+  ducklakeS3UrlStyle: undefined,
+  ducklakeS3UseSsl: undefined,
+  ducklakeMetadataSchema: undefined,
+  snowflakeAccountId: ' MYORG-MYACCOUNT ',
+  snowflakeUser: ' ETL_USER ',
+  snowflakePrivateKey: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
+  snowflakePrivateKeyPassphrase: ' secret passphrase ',
+  snowflakeDatabase: ' ANALYTICS ',
+  snowflakeSchema: ' PUBLIC ',
+  snowflakeRole: ' ETL_ROLE ',
 }
 
 describe('DestinationForm.utils DuckLake', () => {
@@ -158,5 +197,76 @@ describe('DestinationForm.utils DuckLake', () => {
         ducklakeMetadataSchema: 'ducklake_schema_1',
       })
     ).toEqual([])
+  })
+})
+
+describe('DestinationForm.utils Snowflake', () => {
+  it('builds Snowflake validation config with identifiers trimmed and secrets preserved', () => {
+    const config = buildDestinationConfigForValidation({
+      projectRef: 'project-ref',
+      selectedType: 'Snowflake',
+      data: {
+        ...baseSnowflakeFormData,
+        snowflakePrivateKeyPassphrase: '',
+        snowflakeRole: '   ',
+      },
+    })
+
+    expect(config).toEqual({
+      snowflake: {
+        accountId: 'MYORG-MYACCOUNT',
+        user: 'ETL_USER',
+        privateKey: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
+        privateKeyPassphrase: undefined,
+        database: 'ANALYTICS',
+        schema: 'PUBLIC',
+        role: undefined,
+      },
+    })
+  })
+
+  it('builds Snowflake submit config with normalized values', async () => {
+    const createS3AccessKey = vi.fn()
+    const resolveNamespace = vi.fn()
+
+    const config = await buildDestinationConfig({
+      projectRef: 'project-ref',
+      selectedType: 'Snowflake',
+      data: baseSnowflakeFormData,
+      createS3AccessKey,
+      resolveNamespace,
+    })
+
+    expect(config).toEqual({
+      snowflake: {
+        accountId: 'MYORG-MYACCOUNT',
+        user: 'ETL_USER',
+        privateKey: '-----BEGIN PRIVATE KEY-----\nabc\n-----END PRIVATE KEY-----',
+        privateKeyPassphrase: ' secret passphrase ',
+        database: 'ANALYTICS',
+        schema: 'PUBLIC',
+        role: 'ETL_ROLE',
+      },
+    })
+    expect(createS3AccessKey).not.toHaveBeenCalled()
+    expect(resolveNamespace).not.toHaveBeenCalled()
+  })
+
+  it('returns required-field errors for missing Snowflake settings', () => {
+    const issues = getSnowflakeValidationIssues({
+      snowflakeAccountId: '',
+      snowflakeUser: '',
+      snowflakePrivateKey: '',
+      snowflakeDatabase: '',
+      snowflakeSchema: '',
+    })
+
+    expect(issues).toEqual([
+      { path: 'snowflakeAccountId', message: 'Account ID is required' },
+      { path: 'snowflakeUser', message: 'User is required' },
+      { path: 'snowflakePrivateKey', message: 'Private key is required' },
+      { path: 'snowflakeDatabase', message: 'Database is required' },
+      { path: 'snowflakeSchema', message: 'Schema is required' },
+    ])
   })
 })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
@@ -28,7 +28,7 @@ const normalizeOptionalString = (value?: string) => {
 
 const normalizeRequiredString = (value?: string) => value?.trim() ?? ''
 
-const normalizeOptionalSecretString = (value?: string) => {
+const normalizeOptionalUntrimmedString = (value?: string) => {
   return value && value.length > 0 ? value : undefined
 }
 
@@ -236,7 +236,7 @@ export const buildDestinationConfigForValidation = ({
         accountId: normalizeRequiredString(data.snowflakeAccountId),
         user: normalizeRequiredString(data.snowflakeUser),
         privateKey: data.snowflakePrivateKey ?? '',
-        privateKeyPassphrase: normalizeOptionalSecretString(data.snowflakePrivateKeyPassphrase),
+        privateKeyPassphrase: normalizeOptionalUntrimmedString(data.snowflakePrivateKeyPassphrase),
         database: normalizeRequiredString(data.snowflakeDatabase),
         schema: normalizeRequiredString(data.snowflakeSchema),
         role: normalizeOptionalString(data.snowflakeRole),
@@ -325,7 +325,7 @@ export const buildDestinationConfig = async ({
       accountId: normalizeRequiredString(data.snowflakeAccountId),
       user: normalizeRequiredString(data.snowflakeUser),
       privateKey: data.snowflakePrivateKey ?? '',
-      privateKeyPassphrase: normalizeOptionalSecretString(data.snowflakePrivateKeyPassphrase),
+      privateKeyPassphrase: normalizeOptionalUntrimmedString(data.snowflakePrivateKeyPassphrase),
       database: normalizeRequiredString(data.snowflakeDatabase),
       schema: normalizeRequiredString(data.snowflakeSchema),
       role: normalizeOptionalString(data.snowflakeRole),

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
@@ -13,6 +13,7 @@ import {
   DestinationConfig,
   DucklakeDestinationConfig,
   IcebergDestinationConfig,
+  SnowflakeDestinationConfig,
 } from '@/data/replication/create-destination-pipeline-mutation'
 import {
   type CreateS3AccessKeyCredentialVariables,
@@ -26,6 +27,10 @@ const normalizeOptionalString = (value?: string) => {
 }
 
 const normalizeRequiredString = (value?: string) => value?.trim() ?? ''
+
+const normalizeOptionalSecretString = (value?: string) => {
+  return value && value.length > 0 ? value : undefined
+}
 
 type DucklakeFieldPath =
   | 'ducklakeCatalogUrl'
@@ -116,6 +121,53 @@ export const getDucklakeValidationIssues = (
   return issues
 }
 
+type SnowflakeFieldPath =
+  | 'snowflakeAccountId'
+  | 'snowflakeUser'
+  | 'snowflakePrivateKey'
+  | 'snowflakeDatabase'
+  | 'snowflakeSchema'
+
+export type SnowflakeValidationIssue = {
+  path: SnowflakeFieldPath
+  message: string
+}
+
+export const getSnowflakeValidationIssues = (
+  data: Pick<
+    DestinationPanelSchemaType,
+    | 'snowflakeAccountId'
+    | 'snowflakeUser'
+    | 'snowflakePrivateKey'
+    | 'snowflakeDatabase'
+    | 'snowflakeSchema'
+  >
+): SnowflakeValidationIssue[] => {
+  const issues: SnowflakeValidationIssue[] = []
+
+  if (!data.snowflakeAccountId?.trim().length) {
+    issues.push({ path: 'snowflakeAccountId', message: 'Account ID is required' })
+  }
+
+  if (!data.snowflakeUser?.trim().length) {
+    issues.push({ path: 'snowflakeUser', message: 'User is required' })
+  }
+
+  if (!data.snowflakePrivateKey?.trim().length) {
+    issues.push({ path: 'snowflakePrivateKey', message: 'Private key is required' })
+  }
+
+  if (!data.snowflakeDatabase?.trim().length) {
+    issues.push({ path: 'snowflakeDatabase', message: 'Database is required' })
+  }
+
+  if (!data.snowflakeSchema?.trim().length) {
+    issues.push({ path: 'snowflakeSchema', message: 'Schema is required' })
+  }
+
+  return issues
+}
+
 // Helper function to build destination config for validation
 export const buildDestinationConfigForValidation = ({
   projectRef,
@@ -176,6 +228,18 @@ export const buildDestinationConfigForValidation = ({
         s3UrlStyle: data.ducklakeS3UrlStyle,
         s3UseSsl: data.ducklakeS3UseSsl,
         metadataSchema: normalizeOptionalString(data.ducklakeMetadataSchema),
+      },
+    }
+  } else if (selectedType === 'Snowflake') {
+    return {
+      snowflake: {
+        accountId: normalizeRequiredString(data.snowflakeAccountId),
+        user: normalizeRequiredString(data.snowflakeUser),
+        privateKey: data.snowflakePrivateKey ?? '',
+        privateKeyPassphrase: normalizeOptionalSecretString(data.snowflakePrivateKeyPassphrase),
+        database: normalizeRequiredString(data.snowflakeDatabase),
+        schema: normalizeRequiredString(data.snowflakeSchema),
+        role: normalizeOptionalString(data.snowflakeRole),
       },
     }
   } else {
@@ -256,6 +320,17 @@ export const buildDestinationConfig = async ({
       metadataSchema: normalizeOptionalString(data.ducklakeMetadataSchema),
     }
     destinationConfig = { ducklake: ducklakeConfig }
+  } else if (selectedType === 'Snowflake') {
+    const snowflakeConfig: SnowflakeDestinationConfig = {
+      accountId: normalizeRequiredString(data.snowflakeAccountId),
+      user: normalizeRequiredString(data.snowflakeUser),
+      privateKey: data.snowflakePrivateKey ?? '',
+      privateKeyPassphrase: normalizeOptionalSecretString(data.snowflakePrivateKeyPassphrase),
+      database: normalizeRequiredString(data.snowflakeDatabase),
+      schema: normalizeRequiredString(data.snowflakeSchema),
+      role: normalizeOptionalString(data.snowflakeRole),
+    }
+    destinationConfig = { snowflake: snowflakeConfig }
   }
 
   return destinationConfig

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
@@ -345,6 +345,168 @@ export const DuckLakeFields = ({ form }: { form: UseFormReturn<DestinationPanelS
   )
 }
 
+export const SnowflakeFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
+  const [showPrivateKeyPassphrase, setShowPrivateKeyPassphrase] = useState(false)
+
+  return (
+    <div className="flex flex-col gap-y-6 p-5">
+      <p className="text-sm font-medium text-foreground">Snowflake settings</p>
+
+      <div className="flex flex-col gap-y-1">
+        <p className="text-sm font-medium text-foreground">Connection</p>
+        <p className="text-sm text-foreground-light">
+          Configure the Snowflake account, user, and target namespace for replicated data.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-y-4">
+        <FormField
+          control={form.control}
+          name="snowflakeAccountId"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="horizontal"
+              label="Account ID"
+              description="Snowflake account identifier, for example ORGNAME-ACCOUNTNAME"
+            >
+              <FormControl>
+                <Input {...field} placeholder="MYORG-MYACCOUNT" value={field.value ?? ''} />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="snowflakeUser"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="horizontal"
+              label="User"
+              description="Snowflake user configured for key-pair authentication"
+            >
+              <FormControl>
+                <Input {...field} placeholder="ETL_USER" value={field.value ?? ''} />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="snowflakeDatabase"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="horizontal"
+              label="Database"
+              description="Snowflake database where replicated tables will be created"
+            >
+              <FormControl>
+                <Input {...field} placeholder="ANALYTICS" value={field.value ?? ''} />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="snowflakeSchema"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="horizontal"
+              label="Schema"
+              description="Snowflake schema where replicated tables will be created"
+            >
+              <FormControl>
+                <Input {...field} placeholder="PUBLIC" value={field.value ?? ''} />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="snowflakeRole"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="horizontal"
+              label="Role"
+              description="Optional Snowflake role to assume after connecting"
+            >
+              <FormControl>
+                <Input {...field} placeholder="ETL_ROLE" value={field.value ?? ''} />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+      </div>
+
+      <div className="flex flex-col gap-y-1">
+        <p className="text-sm font-medium text-foreground">Authentication</p>
+        <p className="text-sm text-foreground-light">
+          Use the RSA private key whose public key is registered on the Snowflake user.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-y-4">
+        <FormField
+          control={form.control}
+          name="snowflakePrivateKey"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="horizontal"
+              label="Private key"
+              description="RSA private key PEM contents in PKCS#8 or PKCS#1 format"
+            >
+              <FormControl>
+                <TextArea
+                  {...field}
+                  rows={8}
+                  maxLength={10000}
+                  placeholder={'-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----'}
+                  value={field.value ?? ''}
+                  className="font-mono text-xs"
+                />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+
+        <FormField
+          control={form.control}
+          name="snowflakePrivateKeyPassphrase"
+          render={({ field }) => (
+            <FormItemLayout
+              layout="horizontal"
+              label="Private key passphrase"
+              description="Optional passphrase for encrypted private keys"
+            >
+              <FormControl>
+                <PasswordInput
+                  value={field.value ?? ''}
+                  type={showPrivateKeyPassphrase ? 'text' : 'password'}
+                  placeholder="Optional"
+                  onChange={(event) => field.onChange(event.target.value)}
+                  actions={
+                    <div className="flex items-center justify-center">
+                      <Button
+                        type="default"
+                        className="w-7"
+                        icon={showPrivateKeyPassphrase ? <Eye /> : <EyeOff />}
+                        onClick={() => setShowPrivateKeyPassphrase(!showPrivateKeyPassphrase)}
+                      />
+                    </div>
+                  }
+                />
+              </FormControl>
+            </FormItemLayout>
+          )}
+        />
+      </div>
+    </div>
+  )
+}
+
 /**
  * [Joshen] JFYI I'd foresee a possible UX friction point here regarding S3 access key IDs and secret access keys
  * - We'd allow users to select access key IDs via a dropdown here, but require a text input for secret access keys

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -13,6 +13,7 @@ import {
   useIsETLBigQueryPrivateAlpha,
   useIsETLDucklakePrivateAlpha,
   useIsETLIcebergPrivateAlpha,
+  useIsETLSnowflakePrivateAlpha,
 } from '../../useIsETLPrivateAlpha'
 import { DestinationType } from '../DestinationPanel.types'
 import { AdvancedSettings } from './AdvancedSettings'
@@ -22,9 +23,15 @@ import {
   buildDestinationConfig,
   buildDestinationConfigForValidation,
   getDucklakeValidationIssues,
+  getSnowflakeValidationIssues,
 } from './DestinationForm.utils'
 import { DestinationNameInput } from './DestinationNameInput'
-import { AnalyticsBucketFields, BigQueryFields, DuckLakeFields } from './DestinationPanelFields'
+import {
+  AnalyticsBucketFields,
+  BigQueryFields,
+  DuckLakeFields,
+  SnowflakeFields,
+} from './DestinationPanelFields'
 import { NewPublicationPanel } from './NewPublicationPanel'
 import { NoDestinationsAvailable } from './NoDestinationsAvailable'
 import { PublicationSelection } from './PublicationSelection'
@@ -86,6 +93,16 @@ type DucklakeApiConfig = {
   metadata_schema?: string
 }
 
+type SnowflakeApiConfig = {
+  account_id: string
+  user: string
+  private_key: string
+  private_key_passphrase?: string
+  database: string
+  schema: string
+  role?: string
+}
+
 export const DestinationForm = ({
   selectedType,
   visible,
@@ -98,6 +115,7 @@ export const DestinationForm = ({
   const etlEnableBigQuery = useIsETLBigQueryPrivateAlpha()
   const etlEnableIceberg = useIsETLIcebergPrivateAlpha()
   const etlEnableDucklake = useIsETLDucklakePrivateAlpha()
+  const etlEnableSnowflake = useIsETLSnowflakePrivateAlpha()
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
 
   const [isFormInteracting, setIsFormInteracting] = useState(false)
@@ -126,8 +144,9 @@ export const DestinationForm = ({
     if (etlEnableIceberg)
       destinations.push({ value: 'Analytics Bucket', label: 'Analytics Bucket' })
     if (etlEnableDucklake) destinations.push({ value: 'DuckLake', label: 'DuckLake' })
+    if (etlEnableSnowflake) destinations.push({ value: 'Snowflake', label: 'Snowflake' })
     return destinations
-  }, [etlEnableBigQuery, etlEnableDucklake, etlEnableIceberg])
+  }, [etlEnableBigQuery, etlEnableDucklake, etlEnableIceberg, etlEnableSnowflake])
   const hasNoAvailableDestinations = availableDestinations.length === 0
 
   const { data: sourcesData } = useReplicationSourcesQuery({ projectRef })
@@ -198,6 +217,14 @@ export const DestinationForm = ({
       ducklakeConfigValue && typeof ducklakeConfigValue === 'object'
         ? (ducklakeConfigValue as DucklakeApiConfig)
         : undefined
+    const snowflakeConfigValue =
+      config && 'snowflake' in (config as Record<string, unknown>)
+        ? (config as Record<string, unknown>).snowflake
+        : undefined
+    const snowflakeConfig =
+      snowflakeConfigValue && typeof snowflakeConfigValue === 'object'
+        ? (snowflakeConfigValue as SnowflakeApiConfig)
+        : undefined
 
     return {
       // Common fields
@@ -237,6 +264,14 @@ export const DestinationForm = ({
       ducklakeS3UrlStyle: ducklakeConfig?.s3_url_style ?? 'path',
       ducklakeS3UseSsl: ducklakeConfig?.s3_use_ssl ?? true,
       ducklakeMetadataSchema: ducklakeConfig?.metadata_schema ?? 'ducklake',
+      // Snowflake fields
+      snowflakeAccountId: snowflakeConfig?.account_id ?? '',
+      snowflakeUser: snowflakeConfig?.user ?? '',
+      snowflakePrivateKey: snowflakeConfig?.private_key ?? '',
+      snowflakePrivateKeyPassphrase: snowflakeConfig?.private_key_passphrase ?? '',
+      snowflakeDatabase: snowflakeConfig?.database ?? '',
+      snowflakeSchema: snowflakeConfig?.schema ?? '',
+      snowflakeRole: snowflakeConfig?.role ?? '',
     }
   }, [destinationData, pipelineData, catalogToken, projectSettings])
 
@@ -284,6 +319,10 @@ export const DestinationForm = ({
           }
         } else if (selectedType === 'DuckLake') {
           getDucklakeValidationIssues(data).forEach(({ path, message }) => {
+            addRequiredFieldError(path, message)
+          })
+        } else if (selectedType === 'Snowflake') {
+          getSnowflakeValidationIssues(data).forEach(({ path, message }) => {
             addRequiredFieldError(path, message)
           })
         }
@@ -583,6 +622,8 @@ export const DestinationForm = ({
                 />
               ) : selectedType === 'DuckLake' && etlEnableDucklake ? (
                 <DuckLakeFields form={form} />
+              ) : selectedType === 'Snowflake' && etlEnableSnowflake ? (
+                <SnowflakeFields form={form} />
               ) : null}
 
               <DialogSectionSeparator />

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.tsx
@@ -42,6 +42,7 @@ export const DestinationPanel = ({ onSuccessCreateReadReplica }: DestinationPane
       'BigQuery',
       'Analytics Bucket',
       'DuckLake',
+      'Snowflake',
     ]).withOptions({
       history: 'push',
       clearOnDefault: true,

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.types.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationPanel.types.ts
@@ -1,1 +1,6 @@
-export type DestinationType = 'Read Replica' | 'BigQuery' | 'Analytics Bucket' | 'DuckLake'
+export type DestinationType =
+  | 'Read Replica'
+  | 'BigQuery'
+  | 'Analytics Bucket'
+  | 'DuckLake'
+  | 'Snowflake'

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -1,4 +1,5 @@
 import { AnalyticsBucket, BigQuery, Database } from 'icons'
+import { Snowflake } from 'lucide-react'
 import { parseAsInteger, parseAsStringEnum, useQueryState } from 'nuqs'
 import { Badge, cn, RadioGroupStacked, RadioGroupStackedItem } from 'ui'
 
@@ -7,6 +8,7 @@ import {
   useIsETLBigQueryPrivateAlpha,
   useIsETLDucklakePrivateAlpha,
   useIsETLIcebergPrivateAlpha,
+  useIsETLSnowflakePrivateAlpha,
 } from '../useIsETLPrivateAlpha'
 import { DestinationType } from './DestinationPanel.types'
 import { InlineLink } from '@/components/ui/InlineLink'
@@ -16,6 +18,7 @@ export const DestinationTypeSelection = () => {
   const etlEnableBigQuery = useIsETLBigQueryPrivateAlpha()
   const etlEnableIceberg = useIsETLIcebergPrivateAlpha()
   const etlEnableDucklake = useIsETLDucklakePrivateAlpha()
+  const etlEnableSnowflake = useIsETLSnowflakePrivateAlpha()
   const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
 
   const numberOfTypes = [
@@ -23,6 +26,7 @@ export const DestinationTypeSelection = () => {
     etlEnableBigQuery,
     etlEnableIceberg,
     etlEnableDucklake,
+    etlEnableSnowflake,
   ].filter(Boolean).length
 
   const [urlDestinationType, setDestinationType] = useQueryState(
@@ -32,6 +36,7 @@ export const DestinationTypeSelection = () => {
       'BigQuery',
       'Analytics Bucket',
       'DuckLake',
+      'Snowflake',
     ]).withOptions({
       history: 'push',
       clearOnDefault: true,
@@ -61,11 +66,13 @@ export const DestinationTypeSelection = () => {
         onValueChange={(value) => setDestinationType(value as DestinationType)}
         className={cn(
           'grid [&>button>div]:py-4',
-          !editMode && numberOfTypes >= 4
-            ? 'grid-cols-4'
-            : !editMode && numberOfTypes === 3
-              ? 'grid-cols-3'
-              : 'grid-cols-2',
+          !editMode && numberOfTypes >= 5
+            ? 'grid-cols-5'
+            : !editMode && numberOfTypes === 4
+              ? 'grid-cols-4'
+              : !editMode && numberOfTypes === 3
+                ? 'grid-cols-3'
+                : 'grid-cols-2',
           '[&>button:first-of-type]:rounded-none [&>button:last-of-type]:rounded-none',
           '[&>button:first-of-type]:rounded-l-lg! [&>button:last-of-type]:rounded-r-lg!'
         )}
@@ -144,6 +151,23 @@ export const DestinationTypeSelection = () => {
                 <p className="text-foreground-lighter">
                   Send data to a DuckLake catalog backed by S3-compatible object storage for
                   flexible lakehouse workflows
+                </p>
+              </div>
+            </div>
+          </RadioGroupStackedItem>
+        )}
+
+        {((!editMode && etlEnableSnowflake) || (editMode && destinationType === 'Snowflake')) && (
+          <RadioGroupStackedItem label="" showIndicator={false} id="Snowflake" value="Snowflake">
+            <div className="flex flex-col gap-y-2">
+              <Snowflake size={20} />
+              <div className="flex flex-col gap-y-0.5 text-sm text-left">
+                <div className="flex items-center gap-x-2">
+                  <p>Snowflake</p>
+                  <Badge>Alpha</Badge>
+                </div>
+                <p className="text-foreground-lighter">
+                  Send data to Snowflake for warehouse analytics and downstream data workflows
                 </p>
               </div>
             </div>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationRow.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'common'
 import { AnalyticsBucket, BigQuery, Database } from 'icons'
-import { Minus } from 'lucide-react'
+import { Minus, Snowflake } from 'lucide-react'
 import Link from 'next/link'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
@@ -140,6 +140,8 @@ export const DestinationRow = ({ destinationId }: DestinationRowProps) => {
               <AnalyticsBucket size={18} className="text-foreground-light" />
             ) : type === 'DuckLake' ? (
               <Database size={18} className="text-foreground-light" />
+            ) : type === 'Snowflake' ? (
+              <Snowflake size={18} className="text-foreground-light" />
             ) : (
               <Database size={18} className="text-foreground-light" />
             )}

--- a/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/Destinations.tsx
@@ -32,6 +32,7 @@ import {
   useIsETLBigQueryPrivateAlpha,
   useIsETLDucklakePrivateAlpha,
   useIsETLIcebergPrivateAlpha,
+  useIsETLSnowflakePrivateAlpha,
 } from './useIsETLPrivateAlpha'
 import { AlertError } from '@/components/ui/AlertError'
 import { DocsButton } from '@/components/ui/DocsButton'
@@ -54,6 +55,7 @@ export const Destinations = () => {
   const etlEnableBigQuery = useIsETLBigQueryPrivateAlpha()
   const etlEnableIceberg = useIsETLIcebergPrivateAlpha()
   const etlEnableDucklake = useIsETLDucklakePrivateAlpha()
+  const etlEnableSnowflake = useIsETLSnowflakePrivateAlpha()
   const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
 
   const newDestinationDefaultType = infrastructureReadReplicas
@@ -64,7 +66,9 @@ export const Destinations = () => {
         ? 'Analytics Bucket'
         : etlEnableDucklake
           ? 'DuckLake'
-          : null
+          : etlEnableSnowflake
+            ? 'Snowflake'
+            : null
 
   const prefetchedRef = useRef(false)
   const searchInputRef = useRef<HTMLInputElement>(null)
@@ -80,6 +84,7 @@ export const Destinations = () => {
       'BigQuery',
       'Analytics Bucket',
       'DuckLake',
+      'Snowflake',
     ]).withOptions({
       history: 'push',
       clearOnDefault: true,

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.tsx
@@ -1,6 +1,7 @@
 import { Handle, Position } from '@xyflow/react'
 import { useParams } from 'common'
 import { AnalyticsBucket, BigQuery, Database } from 'icons'
+import { Snowflake } from 'lucide-react'
 import { ComponentType, PropsWithChildren, useMemo } from 'react'
 import { AWS_REGIONS } from 'shared-data'
 import { cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
@@ -26,6 +27,7 @@ const destinationIconByType: Record<
   BigQuery,
   'Analytics Bucket': AnalyticsBucket,
   DuckLake: Database,
+  Snowflake,
 }
 
 const NodeContainer = ({ className, children }: PropsWithChildren<{ className?: string }>) => {

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.utils.test.ts
@@ -15,6 +15,10 @@ describe('getReplicationDestinationType', () => {
     expect(getReplicationDestinationType({ ducklake: {} })).toBe('DuckLake')
   })
 
+  it('returns Snowflake for snowflake configs', () => {
+    expect(getReplicationDestinationType({ snowflake: {} })).toBe('Snowflake')
+  })
+
   it('returns undefined for unknown or missing configs', () => {
     expect(getReplicationDestinationType({})).toBeUndefined()
     expect(getReplicationDestinationType(undefined)).toBeUndefined()

--- a/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/ReplicationDiagram/Nodes.utils.ts
@@ -1,4 +1,4 @@
-export type ReplicationDestinationType = 'BigQuery' | 'Analytics Bucket' | 'DuckLake'
+export type ReplicationDestinationType = 'BigQuery' | 'Analytics Bucket' | 'DuckLake' | 'Snowflake'
 
 export const getReplicationDestinationType = (
   config?: Record<string, unknown>
@@ -7,5 +7,6 @@ export const getReplicationDestinationType = (
   if ('big_query' in config) return 'BigQuery'
   if ('iceberg' in config) return 'Analytics Bucket'
   if ('ducklake' in config) return 'DuckLake'
+  if ('snowflake' in config) return 'Snowflake'
   return undefined
 }

--- a/apps/studio/components/interfaces/Database/Replication/useIsETLPrivateAlpha.ts
+++ b/apps/studio/components/interfaces/Database/Replication/useIsETLPrivateAlpha.ts
@@ -35,10 +35,20 @@ export const useIsETLDucklakePrivateAlpha = () => {
   return useIsCurrentOrgInFlagList('etlEnableDucklakePrivateAlpha')
 }
 
+export const useIsETLSnowflakePrivateAlpha = () => {
+  return useIsCurrentOrgInFlagList('etlEnableSnowflakePrivateAlpha')
+}
+
 export const useIsETLPrivateAlpha = () => {
   const hasAccessToETLBigQuery = useIsCurrentOrgInFlagList('etlEnableBigQueryPrivateAlpha')
   const hasAccessToETLIceberg = useIsCurrentOrgInFlagList('etlEnableIcebergPrivateAlpha')
   const hasAccessToETLDucklake = useIsCurrentOrgInFlagList('etlEnableDucklakePrivateAlpha')
+  const hasAccessToETLSnowflake = useIsCurrentOrgInFlagList('etlEnableSnowflakePrivateAlpha')
 
-  return hasAccessToETLBigQuery || hasAccessToETLIceberg || hasAccessToETLDucklake
+  return (
+    hasAccessToETLBigQuery ||
+    hasAccessToETLIceberg ||
+    hasAccessToETLDucklake ||
+    hasAccessToETLSnowflake
+  )
 }

--- a/apps/studio/data/replication/create-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/create-destination-pipeline-mutation.ts
@@ -16,6 +16,9 @@ export type DestinationConfig =
   | {
       ducklake: DucklakeDestinationConfig
     }
+  | {
+      snowflake: SnowflakeDestinationConfig
+    }
 
 export type BigQueryDestinationConfig = {
   projectId: string
@@ -46,6 +49,16 @@ export type DucklakeDestinationConfig = {
   s3UrlStyle?: 'path' | 'vhost'
   s3UseSsl?: boolean
   metadataSchema?: string
+}
+
+export type SnowflakeDestinationConfig = {
+  accountId: string
+  user: string
+  privateKey: string
+  privateKeyPassphrase?: string
+  database: string
+  schema: string
+  role?: string
 }
 
 export type BatchConfig = {
@@ -152,8 +165,25 @@ async function createDestinationPipeline(
         metadata_schema: metadataSchema,
       },
     } as unknown as components['schemas']['CreateReplicationDestinationPipelineBody']['destination_config']
+  } else if ('snowflake' in destinationConfig) {
+    const { accountId, user, privateKey, privateKeyPassphrase, database, schema, role } =
+      destinationConfig.snowflake
+
+    destination_config = {
+      snowflake: {
+        account_id: accountId,
+        user,
+        private_key: privateKey,
+        private_key_passphrase: privateKeyPassphrase,
+        database,
+        schema,
+        role,
+      },
+    } as unknown as components['schemas']['CreateReplicationDestinationPipelineBody']['destination_config']
   } else {
-    throw new Error('Invalid destination config: must specify bigQuery, iceberg, or ducklake')
+    throw new Error(
+      'Invalid destination config: must specify bigQuery, iceberg, ducklake, or snowflake'
+    )
   }
 
   const pipeline_config = {

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -108,8 +108,24 @@ async function updateDestinationPipeline(
         metadata_schema: metadataSchema,
       },
     } as unknown as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
+  } else if ('snowflake' in destinationConfig) {
+    const { accountId, user, privateKey, privateKeyPassphrase, database, schema, role } =
+      destinationConfig.snowflake
+    destination_config = {
+      snowflake: {
+        account_id: accountId,
+        user,
+        private_key: privateKey,
+        private_key_passphrase: privateKeyPassphrase,
+        database,
+        schema,
+        role,
+      },
+    } as unknown as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
   } else {
-    throw new Error('Invalid destination config: must specify bigQuery, iceberg, or ducklake')
+    throw new Error(
+      'Invalid destination config: must specify bigQuery, iceberg, ducklake, or snowflake'
+    )
   }
 
   const pipeline_config = {

--- a/apps/studio/data/replication/validate-destination-mutation.ts
+++ b/apps/studio/data/replication/validate-destination-mutation.ts
@@ -87,8 +87,25 @@ async function validateDestination(
         metadata_schema: metadataSchema,
       },
     } as unknown as components['schemas']['ValidateReplicationDestinationBody']['config']
+  } else if ('snowflake' in destinationConfig) {
+    const { accountId, user, privateKey, privateKeyPassphrase, database, schema, role } =
+      destinationConfig.snowflake
+
+    config = {
+      snowflake: {
+        account_id: accountId,
+        user,
+        private_key: privateKey,
+        private_key_passphrase: privateKeyPassphrase,
+        database,
+        schema,
+        role,
+      },
+    } as unknown as components['schemas']['ValidateReplicationDestinationBody']['config']
   } else {
-    throw new Error('Invalid destination config: must specify bigQuery, iceberg, or ducklake')
+    throw new Error(
+      'Invalid destination config: must specify bigQuery, iceberg, ducklake, or snowflake'
+    )
   }
 
   const { data, error } = await post('/platform/replication/{ref}/destinations/validate', {

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -5858,6 +5858,39 @@ export interface components {
               s3_use_ssl?: boolean
             }
           }
+        | {
+            snowflake: {
+              /**
+               * @description Snowflake account identifier
+               * @example MYORG-MYACCOUNT
+               */
+              account_id: string
+              /**
+               * @description Snowflake target database
+               * @example ANALYTICS
+               */
+              database: string
+              /** @description Snowflake RSA private key PEM contents */
+              private_key: string
+              /** @description Optional passphrase for encrypted private keys */
+              private_key_passphrase?: string
+              /**
+               * @description Optional Snowflake role
+               * @example ETL_ROLE
+               */
+              role?: string
+              /**
+               * @description Snowflake target schema
+               * @example PUBLIC
+               */
+              schema: string
+              /**
+               * @description Snowflake user configured for key-pair authentication
+               * @example ETL_USER
+               */
+              user: string
+            }
+          }
       /**
        * @description Destination name
        * @example bq-analytics
@@ -5989,6 +6022,39 @@ export interface components {
                * @example false
                */
               s3_use_ssl?: boolean
+            }
+          }
+        | {
+            snowflake: {
+              /**
+               * @description Snowflake account identifier
+               * @example MYORG-MYACCOUNT
+               */
+              account_id: string
+              /**
+               * @description Snowflake target database
+               * @example ANALYTICS
+               */
+              database: string
+              /** @description Snowflake RSA private key PEM contents */
+              private_key: string
+              /** @description Optional passphrase for encrypted private keys */
+              private_key_passphrase?: string
+              /**
+               * @description Optional Snowflake role
+               * @example ETL_ROLE
+               */
+              role?: string
+              /**
+               * @description Snowflake target schema
+               * @example PUBLIC
+               */
+              schema: string
+              /**
+               * @description Snowflake user configured for key-pair authentication
+               * @example ETL_USER
+               */
+              user: string
             }
           }
       /**
@@ -9553,6 +9619,39 @@ export interface components {
               s3_use_ssl?: boolean
             }
           }
+        | {
+            snowflake: {
+              /**
+               * @description Snowflake account identifier
+               * @example MYORG-MYACCOUNT
+               */
+              account_id: string
+              /**
+               * @description Snowflake target database
+               * @example ANALYTICS
+               */
+              database: string
+              /** @description Snowflake RSA private key PEM contents */
+              private_key: string
+              /** @description Optional passphrase for encrypted private keys */
+              private_key_passphrase?: string
+              /**
+               * @description Optional Snowflake role
+               * @example ETL_ROLE
+               */
+              role?: string
+              /**
+               * @description Snowflake target schema
+               * @example PUBLIC
+               */
+              schema: string
+              /**
+               * @description Snowflake user configured for key-pair authentication
+               * @example ETL_USER
+               */
+              user: string
+            }
+          }
       /**
        * @description Destination id
        * @example 2001
@@ -9696,6 +9795,39 @@ export interface components {
                  * @example false
                  */
                 s3_use_ssl?: boolean
+              }
+            }
+          | {
+              snowflake: {
+                /**
+                 * @description Snowflake account identifier
+                 * @example MYORG-MYACCOUNT
+                 */
+                account_id: string
+                /**
+                 * @description Snowflake target database
+                 * @example ANALYTICS
+                 */
+                database: string
+                /** @description Snowflake RSA private key PEM contents */
+                private_key: string
+                /** @description Optional passphrase for encrypted private keys */
+                private_key_passphrase?: string
+                /**
+                 * @description Optional Snowflake role
+                 * @example ETL_ROLE
+                 */
+                role?: string
+                /**
+                 * @description Snowflake target schema
+                 * @example PUBLIC
+                 */
+                schema: string
+                /**
+                 * @description Snowflake user configured for key-pair authentication
+                 * @example ETL_USER
+                 */
+                user: string
               }
             }
         /**
@@ -11534,6 +11666,39 @@ export interface components {
               s3_use_ssl?: boolean
             }
           }
+        | {
+            snowflake: {
+              /**
+               * @description Snowflake account identifier
+               * @example MYORG-MYACCOUNT
+               */
+              account_id: string
+              /**
+               * @description Snowflake target database
+               * @example ANALYTICS
+               */
+              database: string
+              /** @description Snowflake RSA private key PEM contents */
+              private_key: string
+              /** @description Optional passphrase for encrypted private keys */
+              private_key_passphrase?: string
+              /**
+               * @description Optional Snowflake role
+               * @example ETL_ROLE
+               */
+              role?: string
+              /**
+               * @description Snowflake target schema
+               * @example PUBLIC
+               */
+              schema: string
+              /**
+               * @description Snowflake user configured for key-pair authentication
+               * @example ETL_USER
+               */
+              user: string
+            }
+          }
       /**
        * @description Destination name
        * @example bq-analytics
@@ -11665,6 +11830,39 @@ export interface components {
                * @example false
                */
               s3_use_ssl?: boolean
+            }
+          }
+        | {
+            snowflake: {
+              /**
+               * @description Snowflake account identifier
+               * @example MYORG-MYACCOUNT
+               */
+              account_id: string
+              /**
+               * @description Snowflake target database
+               * @example ANALYTICS
+               */
+              database: string
+              /** @description Snowflake RSA private key PEM contents */
+              private_key: string
+              /** @description Optional passphrase for encrypted private keys */
+              private_key_passphrase?: string
+              /**
+               * @description Optional Snowflake role
+               * @example ETL_ROLE
+               */
+              role?: string
+              /**
+               * @description Snowflake target schema
+               * @example PUBLIC
+               */
+              schema: string
+              /**
+               * @description Snowflake user configured for key-pair authentication
+               * @example ETL_USER
+               */
+              user: string
             }
           }
       /**
@@ -12217,6 +12415,39 @@ export interface components {
                * @example false
                */
               s3_use_ssl?: boolean
+            }
+          }
+        | {
+            snowflake: {
+              /**
+               * @description Snowflake account identifier
+               * @example MYORG-MYACCOUNT
+               */
+              account_id: string
+              /**
+               * @description Snowflake target database
+               * @example ANALYTICS
+               */
+              database: string
+              /** @description Snowflake RSA private key PEM contents */
+              private_key: string
+              /** @description Optional passphrase for encrypted private keys */
+              private_key_passphrase?: string
+              /**
+               * @description Optional Snowflake role
+               * @example ETL_ROLE
+               */
+              role?: string
+              /**
+               * @description Snowflake target schema
+               * @example PUBLIC
+               */
+              schema: string
+              /**
+               * @description Snowflake user configured for key-pair authentication
+               * @example ETL_USER
+               */
+              user: string
             }
           }
     }


### PR DESCRIPTION
## Details of change

Adds Snowflake to the Studio replication destination flow:
- destination selection and display
- create/edit form fields
- validate/create/update payload serialization
- generated Platform API types

Snowflake remains gated behind `etlEnableSnowflakePrivateAlpha`.

**Note:** I have configured `etlEnableSnowflakePrivateAlpha` in ConfigCat ("all" in staging and tied to my own org id in prod).

## Details of Verification Process

- Studio focused Vitest coverage for form serialization and diagram mapping
- Studio typecheck
- ESLint on changed Studio replication files
- Local `mise fullstack:dev` smoke test to confirm the Snowflake form renders ok. 

<img width="937" height="569" alt="image" src="https://github.com/user-attachments/assets/8d6b3a87-1f9d-4a59-91da-be719714ea49" />


Full create/validate E2E depends on the Platform PR and ETL runtime rollout.


## Review Requests

Please check the Snowflake wire payload matches the Platform/ETL contract and that gating/edit/display behavior follows the existing ETL destination patterns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Snowflake added as a supported replication destination (private-alpha gated), including UI for selecting and configuring connection and auth (account, user, database, schema, role, private key, optional passphrase).
* **Validation**
  * Form validation and submission now handle Snowflake-specific required/optional fields.
* **Tests**
  * Unit tests added for Snowflake form behavior and replication-type detection.
* **API**
  * Destination create/update/validate flows extended to accept Snowflake payloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->