### PR TITLE
fix(reports): remove CPU idle chart DEBUG-135

### DIFF
--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -231,16 +231,6 @@ export const getReportAttributesV2: (
             'CPU time spent on other tasks (e.g., background processes, software interrupts)',
         },
         {
-          attribute: 'cpu_usage_busy_idle',
-          provider: 'infra-monitoring',
-          label: 'Idle',
-          format: '%',
-          omitFromTotal: true,
-          color: { light: '#6EA85F', dark: '#A3FFC2' },
-          fill: { light: '#A6D8AE', dark: '#2A5C3F' },
-          tooltip: 'CPU time spent idle and available for new work',
-        },
-        {
           attribute: 'cpu_usage_max',
           provider: 'reference-line',
           label: 'Max',


### PR DESCRIPTION
## Problem

The `cpu_usage_busy_idle` series in the CPU usage chart of the database report flat-lines at 100% and provides no useful signal to users.

## Fix

Removed the `cpu_usage_busy_idle` attribute object from the CPU usage chart config in `database-charts.ts`. All other CPU series (System, User, IOwait, IRQs, Other) are unchanged.

## How to test

- Open the database report in Studio
- View the CPU usage chart
- Confirm the Idle series is no longer shown
- Confirm the remaining series (System, User, IOwait, IRQs, Other) still display correctly