### PR TITLE
fix(reports): improve disk size section UI/UX DEBUG-91

### DIFF
--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -351,17 +351,21 @@ const DatabaseUsage = () => {
           renderer={(props) => {
             return (
               <div>
-                <div className="col-span-4 inline-grid grid-cols-12 gap-12 w-full mt-5">
-                  <div className="grid gap-2 col-span-4 xl:col-span-2">
-                    <h5>Space used</h5>
-                    <span className="text-lg">{formatBytes(databaseSizeBytes, 2, 'GB')}</span>
+                <div className="flex flex-wrap items-center gap-8 mt-5">
+                  <div className="flex flex-col gap-1">
+                    <p className="text-sm text-foreground-light">Space used</p>
+                    <span className="text-lg font-semibold text-foreground">
+                      {formatBytes(databaseSizeBytes, 2, 'GB')}
+                    </span>
                   </div>
-                  <div className="grid gap-2 col-span-4 xl:col-span-3">
-                    <h5>Provisioned disk size</h5>
-                    <span className="text-lg">{currentDiskSize} GB</span>
+                  <div className="flex flex-col gap-1">
+                    <p className="text-sm text-foreground-light">Provisioned disk size</p>
+                    <span className="text-lg font-semibold text-foreground">
+                      {currentDiskSize} GB
+                    </span>
                   </div>
 
-                  <div className="col-span-full lg:col-span-4 xl:col-span-7 lg:text-right">
+                  <div className="ml-auto">
                     {project?.cloud_provider === 'AWS' ? (
                       <Button asChild type="default">
                         <Link href={`/project/${ref}/settings/compute-and-disk`}>
@@ -388,8 +392,12 @@ const DatabaseUsage = () => {
                   </div>
                 </div>
 
-                <h3 className="mt-8 text-sm">Large Objects</h3>
-                {!props.isLoading && props.data.length === 0 && <span>No large objects found</span>}
+                <p className="mt-8 text-sm font-medium text-foreground-light">Large Objects</p>
+                {!props.isLoading && props.data.length === 0 && (
+                  <span className="text-sm text-foreground-light mt-2 block">
+                    No large objects found
+                  </span>
+                )}
                 {!props.isLoading && props.data.length > 0 && (
                   <Table
                     className="space-y-3 mt-4"


### PR DESCRIPTION
## Problem

The Disk Size section in the database report used raw HTML headings and unstyled spans without semantic Tailwind tokens, resulting in inconsistent typography and spacing compared to the rest of the report.

## Fix

- Replace bare `<h5>` labels with `<p className="text-sm text-foreground-light">` for consistent muted label styling
- Add `font-semibold text-foreground` to stat values so they stand out clearly
- Simplify the stat row layout from a brittle `inline-grid grid-cols-12 gap-12` to `flex flex-wrap items-center gap-8` with `ml-auto` on the action button
- Replace `<h3 className="mt-8 text-sm">` with a properly styled `<p>` label for the Large Objects sub-section
- Style the empty-state "No large objects found" message with `text-sm text-foreground-light`

## How to test

- Go to `/project/<ref>/observability/database`
- Scroll to the Database Size section
- Confirm the Space used and Provisioned disk size labels are muted and values are bold/prominent
- Confirm the layout is clean and the Increase disk size button sits to the right
- Confirm the Large Objects sub-section label and empty state are consistently styled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the visual layout and styling of the Database Size widget's summary area, improving the presentation of disk space metrics.
  * Enhanced the styling of the Large Objects section header and empty-state messaging for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->