### PR TITLE
fix(docs): Delete regional availability details for PrivateLink

### DIFF
--- a/apps/docs/content/guides/platform/privatelink.mdx
+++ b/apps/docs/content/guides/platform/privatelink.mdx
@@ -178,9 +178,3 @@ The PrivateLink endpoint is a layer 3 solution so behaves like a standard Postgr
 Ready to enhance your database security with PrivateLink? [Contact our Enterprise team](/contact/enterprise) to discuss your requirements and begin the setup process.
 
 Our support team will guide you through the configuration and ensure your private database connectivity meets your security and performance requirements.
-
-## Regional availability
-
-PrivateLink is not currently available in the following regions:
-
-- **eu-central-2 (Zurich)** - Expected availability: April 2026


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Documenting limited regional availability which is no longer the case

## What is the new behavior?

Section about regional availability limits removed

## Additional context

Privatelink is now available in `eu-central-2`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Removed regional availability information from the PrivateLink guide, streamlining the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->