### PR TITLE
fix: correct usage page URL from /organization to /org

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -277,9 +277,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                                     docs
                                   </InlineLink>{' '}
                                   on how billing for {item.description} works and{' '}
-                                  <InlineLink href={`/org/${slug}/usage`}>
-                                    usage page
-                                  </InlineLink>{' '}
+                                  <InlineLink href={`/org/${slug}/usage`}>usage page</InlineLink>{' '}
                                   for a detailed breakdown.
                                 </p>
                               )}

--- a/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/BillingBreakdown/UpcomingInvoice.tsx
@@ -277,7 +277,7 @@ export const UpcomingInvoice = ({ slug }: UpcomingInvoiceProps) => {
                                     docs
                                   </InlineLink>{' '}
                                   on how billing for {item.description} works and{' '}
-                                  <InlineLink href={`/organization/${slug}/usage`}>
+                                  <InlineLink href={`/org/${slug}/usage`}>
                                     usage page
                                   </InlineLink>{' '}
                                   for a detailed breakdown.


### PR DESCRIPTION
The usage page link in the UpcomingInvoice billing breakdown used the incorrect  path, resulting in a 404. Corrected to  to match the rest of the app.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the usage page link shown in the billing breakdown tooltip for non-compute items so it now points to the proper /org/... URL, ensuring users are taken to the correct usage page from billing documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->