### PR TITLE
feat(reports): add swap usage series to memory chart DEBUG-127

### DIFF
--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -92,6 +92,14 @@ export const getReportAttributesV2: (
           omitFromTotal: true,
           tooltip: 'Total RAM available on this instance',
         },
+        {
+          attribute: 'swap_usage',
+          provider: 'infra-monitoring',
+          label: 'Swap',
+          omitFromTotal: true,
+          tooltip:
+            'Swap space in use by the operating system. Sustained swap usage indicates memory pressure and may degrade database performance',
+        },
       ],
     },
     {

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -93,7 +93,7 @@ export const getReportAttributesV2: (
           tooltip: 'Total RAM available on this instance',
         },
         {
-          attribute: 'swap_usage',
+          attribute: 'ram_usage_swap',
           provider: 'infra-monitoring',
           label: 'Swap',
           omitFromTotal: true,


### PR DESCRIPTION
## Problem

The Memory usage chart in the database report showed RAM used, cache, free, and total, but did not include swap. Swap activity is a meaningful signal of memory pressure and was only visible in a hidden standalone chart.

## Fix

Added `swap_usage` (from the `infra-monitoring` provider) as an additional series in the `ram-usage` Memory chart. The series uses `omitFromTotal: true` so it does not inflate the stacked total, and carries the same tooltip text as the hidden standalone swap chart. The standalone `swap-usage` chart remains hidden as before.

## How to test

- Open the database report for a project on any compute size.
- Navigate to the Memory usage chart.
- Confirm a "Swap" series appears in the legend and renders data alongside Used, Cache + Buffers, and Free.
- Hover a data point and confirm the tooltip shows a Swap value with the memory-pressure description.
- Confirm the Swap value does not contribute to the stacked total.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Swap" metric to the RAM usage chart in reports, displaying swap memory usage information with an updated tooltip.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->