### PR TITLE
Add Hanefi Önaldı to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -109,6 +109,7 @@ Greg P
 Greg Richardson
 Gregor Vand
 Guilherme Souza
+Hanefi Önaldı
 Hannah Bowers
 Hardik Maheshwari
 Haritabh Gupta


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

https://supabase.com/humans.txt does not list my name.

## What is the new behavior?

https://supabase.com/humans.txt will list my name

## Additional context

Started yesterday as a Postgres Engineer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated public team contributor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->