### PR TITLE
test(docs): smoke test /guides/* markdown negotiation

### DIFF
--- a/apps/docs/app/api/guides-md/guides-negotiation.smoke.test.ts
+++ b/apps/docs/app/api/guides-md/guides-negotiation.smoke.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+const GUIDES_URL = 'https://supabase.com/docs/guides/auth'
+
+const BROWSER_ACCEPT = 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8'
+
+describe('prod smoke test: /guides/* markdown content negotiation', () => {
+  it('serves HTML for a browser Accept header', async () => {
+    const res = await fetch(GUIDES_URL, { headers: { Accept: BROWSER_ACCEPT } })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('serves markdown for Accept: text/markdown', async () => {
+    const res = await fetch(GUIDES_URL, { headers: { Accept: 'text/markdown' } })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/markdown')
+  })
+
+  it('prefers HTML when its q-value outranks markdown', async () => {
+    const res = await fetch(GUIDES_URL, {
+      headers: { Accept: 'text/html;q=1.0, text/markdown;q=0.5' },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/html')
+  })
+
+  it('returns 406 when Accept excludes every type the route serves', async () => {
+    const res = await fetch(GUIDES_URL, {
+      headers: { Accept: 'application/x-content-negotiation-probe' },
+    })
+    expect(res.status).toBe(406)
+    expect(res.headers.get('cache-control')).toContain('no-store')
+    expect(res.headers.get('vary')?.toLowerCase()).toContain('accept')
+  })
+
+  it('serves markdown to an LLM user agent regardless of Accept', async () => {
+    const res = await fetch(GUIDES_URL, {
+      headers: { 'User-Agent': 'Claude-User/1.0', Accept: BROWSER_ACCEPT },
+    })
+    expect(res.status).toBe(200)
+    expect(res.headers.get('content-type')).toContain('text/markdown')
+  })
+})


### PR DESCRIPTION
## Summary

PR #45432 brought docs `/guides/*` to full content negotiation (q-value `Accept` parsing, 406 on unsupported types, LLM user-agent rewrites to markdown) but covered it with unit tests only, which mock the request and never hit a server. This adds a synthetic smoke test that exercises the negotiation over real HTTP against production, so a misconfigured middleware matcher, a broken rewrite to `/api/guides-md/<slug>`, or a missing pre-generated `.md` asset gets caught instead of slipping through.

It rides the existing docs smoke suite with no CI changes: the daily `docs-tests-smoke.yml` workflow runs `vitest -t "prod smoke test"`, and the new `describe` block carries that name. The `.smoke.test.ts` suffix keeps it out of the PR unit run.

## Changes

- Add `apps/docs/app/api/guides-md/guides-negotiation.smoke.test.ts`: five live-HTTP assertions against `supabase.com/docs/guides/auth` covering HTML default, `Accept: text/markdown`, q-value precedence, the 406 path (`no-store` + `Vary: Accept`), and the LLM-UA override.

## Testing

Ran the file against production locally:

```
pnpm --prefix=apps/docs exec vitest --run app/api/guides-md/guides-negotiation.smoke.test.ts
```

- [x] Browser `Accept` → 200 `text/html`
- [x] `Accept: text/markdown` → 200 `text/markdown`
- [x] `text/html;q=1.0, text/markdown;q=0.5` → 200 HTML (html wins on q)
- [x] `Accept: application/x-content-negotiation-probe` → 406 with `Cache-Control: no-store` and `Vary: Accept`
- [x] `User-Agent: Claude-User/1.0` + browser `Accept` → 200 `text/markdown` (UA overrides Accept)
- [x] `-t "prod smoke test"` filter selects the block (so the daily workflow picks it up)

This is a post-deploy regression net on the daily cron, not a pre-merge gate. Pre-merge confidence on previews still relies on the manual curl probes in #45432; a per-PR preview probe is a separate follow-up.

## Linear

- fixes GROWTH-916


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added production smoke tests for guides content negotiation to validate proper content type handling and cache control responses across different request scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->