### PR TITLE
fix: restore button focus state design

### DIFF
--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -13,8 +13,6 @@ const buttonVariants = cva(
   `relative
   flex items-center justify-center
   cursor-pointer
-  inline-flex
-  items-center
   space-x-2
   text-center
   font-regular
@@ -24,6 +22,7 @@ const buttonVariants = cva(
   outline-hidden
   transition-all
   outline-0
+  focus-visible:outline-solid
   focus-visible:outline-4
   focus-visible:outline-offset-1
   border
@@ -45,7 +44,7 @@ const buttonVariants = cva(
           text-foreground
           bg-alternative dark:bg-muted  hover:bg-selection
           border-strong hover:border-stronger
-          focus-visible:outline-brand-600
+          focus-visible:outline-border-strong
           data-[state=open]:bg-selection
           data-[state=open]:outline-brand-600
           data-[state=open]:border-button-hover


### PR DESCRIPTION
## Problem

We lost the button focus state design while migrating to tailwind v4
See https://supabase.com/design-system/docs/components/button and move to each buttons with the _Tab_ key.

## Solution

Restore it.

## How to test

- Open https://design-system-git-fix-button-focus-state-supabase.vercel.app/design-system/docs/components/button
- Move to each buttons with the _Tab_ key.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated Button component styling for improved layout, typography, and transitions.
  * Refined focus state and outline styling for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->