### PR TITLE
fix(www): order rss feed items based on date and time

### DIFF
--- a/apps/www/scripts/generateStaticContent.mjs
+++ b/apps/www/scripts/generateStaticContent.mjs
@@ -134,22 +134,11 @@ const validateBlogFrontmatterImages = (frontmatter, filePath) => {
 }
 
 /**
- * Fixes Safari dates sorting bug
+ * Sort posts by their full publish timestamp to keep same-day posts in the correct order
  */
 const sortDates = (a, b, direction = 'desc') => {
-  const isAsc = direction === 'asc'
-  var reg = /-|:|T|\+/ //The regex on which matches the string should be split (any used delimiter) -> could also be written like /[.:T\+]/
-  var parsed = [
-    //an array which holds the date parts for a and b
-    a.date.split(reg), //Split the datestring by the regex to get an array like [Year,Month,Day]
-    b.date.split(reg),
-  ]
-  var dates = [
-    //Create an array of dates for a and b
-    new Date(parsed[0][0], parsed[0][1], parsed[0][2]), //Constructs an date of the above parsed parts (Year,Month...
-    new Date(parsed[1][0], parsed[1][1], parsed[1][2]),
-  ]
-  return isAsc ? dates[0] - dates[1] : dates[1] - dates[0] //Returns the difference between the date (if b > a then a - b < 0)
+  const diff = new Date(a.date).getTime() - new Date(b.date).getTime()
+  return direction === 'asc' ? diff : -diff
 }
 
 /**
@@ -335,7 +324,6 @@ try {
     const encodedDescription = xmlEncode(post.description)
     const formattedDate = dayjs(post.date)
       .utcOffset(0, true)
-      .startOf('day')
       .format('ddd, DD MMM YYYY HH:mm:ss [-0700]')
 
     return `<item>
@@ -391,8 +379,12 @@ try {
     const { Octokit } = await import('@octokit/core')
     const { paginateGraphql } = await import('@octokit/plugin-paginate-graphql')
 
-    const { generateChangelogRssXml, generateChangelogTagRssXml, labelToFileSlug, changelogEntrySlug } =
-      await import('../lib/changelog-rss.mjs')
+    const {
+      generateChangelogRssXml,
+      generateChangelogTagRssXml,
+      labelToFileSlug,
+      changelogEntrySlug,
+    } = await import('../lib/changelog-rss.mjs')
     const rewritesPath = path.join(__dirname, 'data/changelog-deleted-discussions.json')
     const rewrites = JSON.parse(await fs.readFile(rewritesPath, 'utf8'))
     const discussionDisplayDate = (item) => {
@@ -515,9 +507,12 @@ try {
           trimmed.startsWith('<') ||
           trimmed.startsWith('|') ||
           trimmed.startsWith('---')
-        ) continue
+        )
+          continue
         const oneLiner = trimmed.replace(/\n/g, ' ')
-        return oneLiner.length > 200 ? oneLiner.slice(0, 200).replace(/\s+\S*$/, '') + '…' : oneLiner
+        return oneLiner.length > 200
+          ? oneLiner.slice(0, 200).replace(/\s+\S*$/, '') + '…'
+          : oneLiner
       }
       return ''
     }
@@ -525,7 +520,11 @@ try {
     const mdSections = visibleEntries.map((entry) => {
       const date = dayjs(entry.sortDate).isValid() ? dayjs(entry.sortDate).format('YYYY-MM-DD') : ''
       const labels = (entry.labels ?? []).join(', ')
-      const meta = [date, labels, `[supabase.com/changelog/${entry.slug}](https://supabase.com/changelog/${entry.slug})`]
+      const meta = [
+        date,
+        labels,
+        `[supabase.com/changelog/${entry.slug}](https://supabase.com/changelog/${entry.slug})`,
+      ]
         .filter(Boolean)
         .join(' · ')
       const summary = extractSummary(entry.body)


### PR DESCRIPTION
The rss didn't order items based on specified date and time but it trimmed each item to start of day, making the sorting fall back to alphabetical and not triggering the "latest" rss atom in case of same-day items but ordered based on time.

## Before

The "Supabase Series F" blog post is not ordered as latest in the rss even though it was published with a later timestamp, not triggering rss feeds.

<img width="1217" height="455" alt="Screenshot 2026-06-10 at 12 40 24" src="https://github.com/user-attachments/assets/7ac77d8c-26b8-4073-9474-ee03fd318240" />

Blog is ordered correctly:

<img width="1309" height="680" alt="Screenshot 2026-06-10 at 12 42 10" src="https://github.com/user-attachments/assets/58f1d683-1254-468e-a2da-0eeebf1bc862" />

## After

The pr doesn't show the result because the rss feed is .gitignored and generated only on prod build.
But this is the rss generated locally for reference:
<img width="713" height="497" alt="Screenshot 2026-06-10 at 12 35 52" src="https://github.com/user-attachments/assets/4dade2f9-a8cb-4b03-a234-1d89fdbf29c5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved blog post sorting inconsistencies across different browsers by updating the date computation logic
  * Improved RSS feed generation formatting for both blog posts and changelog entries
  * Enhanced changelog markdown generation with refined content filtering to exclude additional formatting patterns

<!-- end of auto-generated comment: release notes by coderabbit.ai -->