### PR TITLE
docs: Relink read-only mode in disk size doc

### DIFF
--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -26,7 +26,7 @@ Database size is consumed primarily by your data, indexes, and materialized view
 
 <Admonition type="note">
 
-Depending on your billing plan, your database can go into read-only mode which can prevent you inserting and deleting data. There are instructions for managing read-only mode in the [Disk Management](#disk-management) section.
+Depending on your billing plan, your database can go into read-only mode which can prevent you inserting and deleting data. There are instructions for managing read-only mode in the [Read-Only Mode](#read-only-mode) section.
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the database size guide to link read-only mode management instructions to the correct documentation section for improved navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->