### PR TITLE
feat(studio): add Database Debugger tab to Advisors

### DIFF
--- a/apps/studio/components/interfaces/Advisors/Debugger/ConnectionsReplicationSection.tsx
+++ b/apps/studio/components/interfaces/Advisors/Debugger/ConnectionsReplicationSection.tsx
@@ -1,0 +1,106 @@
+import ReportWidget from '@/components/interfaces/Reports/ReportWidget'
+import type { ReportWidgetRendererProps } from '@/components/interfaces/Reports/ReportWidget'
+import type { DbStatsRow } from '@/data/database/debugger/db-stats-query'
+import { dbStatsSql } from '@/data/database/debugger/db-stats-query'
+import type { ReplicationSlotsRow } from '@/data/database/debugger/replication-slots-query'
+import { replicationSlotsSql } from '@/data/database/debugger/replication-slots-query'
+import type { RoleStatsRow } from '@/data/database/debugger/role-stats-query'
+import { roleStatsSql } from '@/data/database/debugger/role-stats-query'
+
+function renderTable<T extends Record<string, unknown>>(
+  emptyMessage: string
+): (props: ReportWidgetRendererProps<T>) => React.ReactNode {
+  return function TableRenderer({ data }: ReportWidgetRendererProps<T>) {
+    if (!data || data.length === 0) {
+      return <p className="text-sm text-foreground-light py-2">{emptyMessage}</p>
+    }
+
+    const columns = Object.keys(data[0]) as (keyof T)[]
+
+    return (
+      <div className="overflow-x-auto rounded border border-overlay">
+        <table className="w-full text-xs">
+          <thead className="bg-surface-100">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={String(col)}
+                  className="px-3 py-2 text-left font-medium text-foreground-light whitespace-nowrap"
+                >
+                  {String(col).replace(/_/g, ' ')}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-overlay">
+            {data.map((row, i) => (
+              <tr key={i} className="hover:bg-surface-100">
+                {columns.map((col) => (
+                  <td
+                    key={String(col)}
+                    className="px-3 py-2 text-foreground whitespace-nowrap max-w-xs truncate"
+                  >
+                    {String(row[col] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+
+interface ConnectionsReplicationSectionProps {
+  roleStatsData: RoleStatsRow[] | undefined
+  replicationSlotsData: ReplicationSlotsRow[] | undefined
+  dbStatsData: DbStatsRow[] | undefined
+  isRoleStatsLoading: boolean
+  isReplicationSlotsLoading: boolean
+  isDbStatsLoading: boolean
+}
+
+export function ConnectionsReplicationSection({
+  roleStatsData,
+  replicationSlotsData,
+  dbStatsData,
+  isRoleStatsLoading,
+  isReplicationSlotsLoading,
+  isDbStatsLoading,
+}: ConnectionsReplicationSectionProps) {
+  return (
+    <div className="space-y-4">
+      <ReportWidget
+        title="Role Connection Stats"
+        description="Active connections and connection limits per database role."
+        data={roleStatsData ?? []}
+        isLoading={isRoleStatsLoading}
+        renderer={renderTable<RoleStatsRow>('No role stats available.')}
+        params={{ sql: String(roleStatsSql) } as any}
+        queryType="db"
+        resolvedSql={String(roleStatsSql)}
+      />
+      <ReportWidget
+        title="Replication Slots"
+        description="Active and inactive replication slots. Inactive slots with high lag can cause disk bloat."
+        data={replicationSlotsData ?? []}
+        isLoading={isReplicationSlotsLoading}
+        renderer={renderTable<ReplicationSlotsRow>('No replication slots found.')}
+        params={{ sql: String(replicationSlotsSql) } as any}
+        queryType="db"
+        resolvedSql={String(replicationSlotsSql)}
+      />
+      <ReportWidget
+        title="Database Stats"
+        description="Overall database size, cache hit rates, and WAL size."
+        data={dbStatsData ?? []}
+        isLoading={isDbStatsLoading}
+        renderer={renderTable<DbStatsRow>('No database stats available.')}
+        params={{ sql: String(dbStatsSql) } as any}
+        queryType="db"
+        resolvedSql={String(dbStatsSql)}
+      />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Advisors/Debugger/Debugger.tsx
+++ b/apps/studio/components/interfaces/Advisors/Debugger/Debugger.tsx
@@ -1,0 +1,270 @@
+import { useParams } from 'common'
+import { Bug } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+  Button,
+  Tabs_Shadcn_ as Tabs,
+  TabsContent_Shadcn_ as TabsContent,
+  TabsList_Shadcn_ as TabsList,
+  TabsTrigger_Shadcn_ as TabsTrigger,
+} from 'ui'
+
+import { ConnectionsReplicationSection } from './ConnectionsReplicationSection'
+import { DebuggerScanSummary } from './DebuggerScanSummary'
+import { LocksActivitySection } from './LocksActivitySection'
+import { PerformanceSection } from './PerformanceSection'
+import { StorageHealthSection } from './StorageHealthSection'
+import { interpretDebuggerResults, type DebuggerCheckInput } from './triage/debugger-triage'
+import { FormHeader } from '@/components/ui/Forms/FormHeader'
+import { useBloatQuery } from '@/data/database/debugger/bloat-query'
+import { useBlockingQuery } from '@/data/database/debugger/blocking-query'
+import { useCacheHitQuery } from '@/data/database/debugger/cache-hit-query'
+import { useDbStatsQuery } from '@/data/database/debugger/db-stats-query'
+import { useDebuggerPreconditionsQuery } from '@/data/database/debugger/debugger-preconditions-query'
+import { useIndexStatsQuery } from '@/data/database/debugger/index-stats-query'
+import { useIndexUsageQuery } from '@/data/database/debugger/index-usage-query'
+import { useLocksQuery } from '@/data/database/debugger/locks-query'
+import { useLongRunningQueriesQuery } from '@/data/database/debugger/long-running-queries-query'
+import { useReplicationSlotsQuery } from '@/data/database/debugger/replication-slots-query'
+import { useRoleStatsQuery } from '@/data/database/debugger/role-stats-query'
+import { useSeqScansQuery } from '@/data/database/debugger/seq-scans-query'
+import { useTableRecordCountsQuery } from '@/data/database/debugger/table-record-counts-query'
+import { useTableStatsQuery } from '@/data/database/debugger/table-stats-query'
+import { useTrafficProfileQuery } from '@/data/database/debugger/traffic-profile-query'
+import { useUnusedIndexesQuery } from '@/data/database/debugger/unused-indexes-query'
+import { useVacuumStatsQuery } from '@/data/database/debugger/vacuum-stats-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useTrack } from '@/lib/telemetry/track'
+
+type DebuggerTab = 'locks' | 'storage' | 'performance' | 'connections'
+
+export function Debugger() {
+  const { ref } = useParams()
+  const track = useTrack()
+  const { data: project } = useSelectedProjectQuery()
+  const connectionString = project?.connectionString
+
+  const [hasScanned, setHasScanned] = useState(false)
+  const [activeTab, setActiveTab] = useState<DebuggerTab>('locks')
+
+  const queryVars = { projectRef: ref, connectionString }
+  const queryOpts = { enabled: hasScanned }
+
+  const preconditions = useDebuggerPreconditionsQuery(queryVars)
+  const hasPgStatStatements = preconditions.data?.hasPgStatStatements ?? true
+
+  const locksQuery = useLocksQuery(queryVars, queryOpts)
+  const blockingQuery = useBlockingQuery(queryVars, queryOpts)
+  const longRunningQueriesQuery = useLongRunningQueriesQuery(queryVars, queryOpts)
+  const bloatQuery = useBloatQuery(queryVars, queryOpts)
+  const vacuumStatsQuery = useVacuumStatsQuery(queryVars, queryOpts)
+  const tableStatsQuery = useTableStatsQuery(queryVars, queryOpts)
+  const tableRecordCountsQuery = useTableRecordCountsQuery(queryVars, queryOpts)
+  const trafficProfileQuery = useTrafficProfileQuery(queryVars, queryOpts)
+  const cacheHitQuery = useCacheHitQuery(queryVars, queryOpts)
+  const indexUsageQuery = useIndexUsageQuery(queryVars, queryOpts)
+  const indexStatsQuery = useIndexStatsQuery(queryVars, queryOpts)
+  const seqScansQuery = useSeqScansQuery(queryVars, queryOpts)
+  const unusedIndexesQuery = useUnusedIndexesQuery(queryVars, queryOpts)
+  const roleStatsQuery = useRoleStatsQuery(queryVars, queryOpts)
+  const replicationSlotsQuery = useReplicationSlotsQuery(queryVars, queryOpts)
+  const dbStatsQuery = useDbStatsQuery(queryVars, queryOpts)
+
+  const isScanning =
+    hasScanned &&
+    (locksQuery.isFetching ||
+      blockingQuery.isFetching ||
+      longRunningQueriesQuery.isFetching ||
+      bloatQuery.isFetching ||
+      vacuumStatsQuery.isFetching ||
+      tableStatsQuery.isFetching ||
+      tableRecordCountsQuery.isFetching ||
+      trafficProfileQuery.isFetching ||
+      cacheHitQuery.isFetching ||
+      indexUsageQuery.isFetching ||
+      indexStatsQuery.isFetching ||
+      seqScansQuery.isFetching ||
+      unusedIndexesQuery.isFetching ||
+      roleStatsQuery.isFetching ||
+      replicationSlotsQuery.isFetching ||
+      dbStatsQuery.isFetching)
+
+  const hasScanResults =
+    hasScanned &&
+    !isScanning &&
+    (locksQuery.isSuccess || blockingQuery.isSuccess || longRunningQueriesQuery.isSuccess)
+
+  const findings = useMemo(() => {
+    if (!hasScanResults) return []
+
+    const input: DebuggerCheckInput = {
+      locks: locksQuery.data ?? [],
+      blocking: blockingQuery.data ?? [],
+      longRunningQueries: longRunningQueriesQuery.data ?? [],
+      bloat: bloatQuery.data ?? [],
+      vacuumStats: vacuumStatsQuery.data ?? [],
+      cacheHit: cacheHitQuery.data ?? [],
+      indexUsage: indexUsageQuery.data ?? [],
+      unusedIndexes: unusedIndexesQuery.data ?? [],
+      seqScans: seqScansQuery.data ?? [],
+      roleStats: roleStatsQuery.data ?? [],
+      replicationSlots: replicationSlotsQuery.data ?? [],
+    }
+
+    return interpretDebuggerResults(input)
+  }, [
+    hasScanResults,
+    locksQuery.data,
+    blockingQuery.data,
+    longRunningQueriesQuery.data,
+    bloatQuery.data,
+    vacuumStatsQuery.data,
+    cacheHitQuery.data,
+    indexUsageQuery.data,
+    unusedIndexesQuery.data,
+    seqScansQuery.data,
+    roleStatsQuery.data,
+    replicationSlotsQuery.data,
+  ])
+
+  function handleRunScan() {
+    track('debugger_scan_button_clicked')
+    setHasScanned(true)
+  }
+
+  return (
+    <div className="h-full flex flex-col">
+      <FormHeader
+        className="py-4 px-6 mb-0!"
+        title="Database Debugger"
+        description="Run a health scan to diagnose issues with locks, storage, performance, and connections."
+        actions={
+          <Button
+            type="primary"
+            icon={<Bug size={14} />}
+            loading={isScanning}
+            disabled={isScanning}
+            onClick={handleRunScan}
+          >
+            {hasScanned ? 'Re-run scan' : 'Run scan'}
+          </Button>
+        }
+      />
+
+      <div className="flex-1 overflow-auto px-6 py-4 space-y-4">
+        {preconditions.isSuccess && !hasPgStatStatements && (
+          <Alert variant="warning">
+            <AlertTitle>pg_stat_statements is not enabled</AlertTitle>
+            <AlertDescription>
+              Cache hit rates and index usage checks require the <code>pg_stat_statements</code>{' '}
+              extension. Enable it via <strong>Database &rarr; Extensions</strong> to get full
+              coverage. Other checks will still run.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {preconditions.isSuccess && !preconditions.data?.canReadStats && (
+          <Alert variant="warning">
+            <AlertTitle>Limited access to system views</AlertTitle>
+            <AlertDescription>
+              The current role may not have permission to read <code>pg_stat_activity</code> or{' '}
+              <code>pg_locks</code>. Some checks may return empty results.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        {!hasScanned && (
+          <div className="flex flex-col items-center justify-center py-16 gap-3 text-center">
+            <Bug size={32} className="text-foreground-muted" strokeWidth={1.5} />
+            <p className="text-foreground font-medium">No scan results yet</p>
+            <p className="text-sm text-foreground-light max-w-sm">
+              Click <strong>Run scan</strong> to inspect your database for locks, bloat, slow
+              queries, and connection issues. Queries run against your production database.
+            </p>
+          </div>
+        )}
+
+        {hasScanResults && (
+          <div className="space-y-1">
+            <h4 className="text-sm font-medium text-foreground">Scan Summary</h4>
+            <DebuggerScanSummary findings={findings} />
+          </div>
+        )}
+
+        {hasScanned && (
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as DebuggerTab)}
+            className="space-y-4"
+          >
+            <TabsList>
+              <TabsTrigger value="locks">Locks &amp; Activity</TabsTrigger>
+              <TabsTrigger value="storage">Storage</TabsTrigger>
+              <TabsTrigger value="performance">Performance</TabsTrigger>
+              <TabsTrigger value="connections">Connections</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="locks">
+              <LocksActivitySection
+                locksData={locksQuery.data}
+                blockingData={blockingQuery.data}
+                longRunningQueriesData={longRunningQueriesQuery.data}
+                isLocksLoading={locksQuery.isFetching}
+                isBlockingLoading={blockingQuery.isFetching}
+                isLongRunningQueriesLoading={longRunningQueriesQuery.isFetching}
+                isLocksError={locksQuery.isError}
+                isBlockingError={blockingQuery.isError}
+                isLongRunningQueriesError={longRunningQueriesQuery.isError}
+              />
+            </TabsContent>
+
+            <TabsContent value="storage">
+              <StorageHealthSection
+                bloatData={bloatQuery.data}
+                vacuumStatsData={vacuumStatsQuery.data}
+                tableStatsData={tableStatsQuery.data}
+                tableRecordCountsData={tableRecordCountsQuery.data}
+                trafficProfileData={trafficProfileQuery.data}
+                isBloatLoading={bloatQuery.isFetching}
+                isVacuumStatsLoading={vacuumStatsQuery.isFetching}
+                isTableStatsLoading={tableStatsQuery.isFetching}
+                isTableRecordCountsLoading={tableRecordCountsQuery.isFetching}
+                isTrafficProfileLoading={trafficProfileQuery.isFetching}
+              />
+            </TabsContent>
+
+            <TabsContent value="performance">
+              <PerformanceSection
+                cacheHitData={cacheHitQuery.data}
+                indexUsageData={indexUsageQuery.data}
+                indexStatsData={indexStatsQuery.data}
+                seqScansData={seqScansQuery.data}
+                unusedIndexesData={unusedIndexesQuery.data}
+                isCacheHitLoading={cacheHitQuery.isFetching}
+                isIndexUsageLoading={indexUsageQuery.isFetching}
+                isIndexStatsLoading={indexStatsQuery.isFetching}
+                isSeqScansLoading={seqScansQuery.isFetching}
+                isUnusedIndexesLoading={unusedIndexesQuery.isFetching}
+                hasPgStatStatements={hasPgStatStatements}
+              />
+            </TabsContent>
+
+            <TabsContent value="connections">
+              <ConnectionsReplicationSection
+                roleStatsData={roleStatsQuery.data}
+                replicationSlotsData={replicationSlotsQuery.data}
+                dbStatsData={dbStatsQuery.data}
+                isRoleStatsLoading={roleStatsQuery.isFetching}
+                isReplicationSlotsLoading={replicationSlotsQuery.isFetching}
+                isDbStatsLoading={dbStatsQuery.isFetching}
+              />
+            </TabsContent>
+          </Tabs>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Advisors/Debugger/Debugger.tsx
+++ b/apps/studio/components/interfaces/Advisors/Debugger/Debugger.tsx
@@ -139,7 +139,7 @@ export function Debugger() {
     <div className="h-full flex flex-col">
       <FormHeader
         className="py-4 px-6 mb-0!"
-        title="Database Debugger"
+        title="Database Scan"
         description="Run a health scan to diagnose issues with locks, storage, performance, and connections."
         actions={
           <Button
@@ -198,16 +198,24 @@ export function Debugger() {
           <Tabs
             value={activeTab}
             onValueChange={(v) => setActiveTab(v as DebuggerTab)}
-            className="space-y-4"
+            className="w-full"
           >
-            <TabsList>
-              <TabsTrigger value="locks">Locks &amp; Activity</TabsTrigger>
-              <TabsTrigger value="storage">Storage</TabsTrigger>
-              <TabsTrigger value="performance">Performance</TabsTrigger>
-              <TabsTrigger value="connections">Connections</TabsTrigger>
+            <TabsList className="flex gap-x-6 border-b rounded-none px-0 mb-4">
+              <TabsTrigger value="locks" className="text-xs py-2">
+                Locks &amp; Activity
+              </TabsTrigger>
+              <TabsTrigger value="storage" className="text-xs py-2">
+                Storage
+              </TabsTrigger>
+              <TabsTrigger value="performance" className="text-xs py-2">
+                Performance
+              </TabsTrigger>
+              <TabsTrigger value="connections" className="text-xs py-2">
+                Connections
+              </TabsTrigger>
             </TabsList>
 
-            <TabsContent value="locks">
+            <TabsContent value="locks" className="mt-0">
               <LocksActivitySection
                 locksData={locksQuery.data}
                 blockingData={blockingQuery.data}
@@ -221,7 +229,7 @@ export function Debugger() {
               />
             </TabsContent>
 
-            <TabsContent value="storage">
+            <TabsContent value="storage" className="mt-0">
               <StorageHealthSection
                 bloatData={bloatQuery.data}
                 vacuumStatsData={vacuumStatsQuery.data}
@@ -236,7 +244,7 @@ export function Debugger() {
               />
             </TabsContent>
 
-            <TabsContent value="performance">
+            <TabsContent value="performance" className="mt-0">
               <PerformanceSection
                 cacheHitData={cacheHitQuery.data}
                 indexUsageData={indexUsageQuery.data}
@@ -252,7 +260,7 @@ export function Debugger() {
               />
             </TabsContent>
 
-            <TabsContent value="connections">
+            <TabsContent value="connections" className="mt-0">
               <ConnectionsReplicationSection
                 roleStatsData={roleStatsQuery.data}
                 replicationSlotsData={replicationSlotsQuery.data}

--- a/apps/studio/components/interfaces/Advisors/Debugger/DebuggerScanSummary.tsx
+++ b/apps/studio/components/interfaces/Advisors/Debugger/DebuggerScanSummary.tsx
@@ -1,0 +1,98 @@
+import { AlertCircle, AlertTriangle, CheckCircle, Info } from 'lucide-react'
+import { Badge, cn } from 'ui'
+
+import type { DebuggerFinding, DebuggerSeverity } from './triage/debugger-triage'
+
+const SEVERITY_ORDER: DebuggerSeverity[] = ['critical', 'warning', 'info', 'ok']
+
+const SEVERITY_CONFIG: Record<
+  DebuggerSeverity,
+  {
+    label: string
+    icon: React.ComponentType<{ size?: number; className?: string }>
+    badgeVariant: string
+    rowClass: string
+  }
+> = {
+  critical: {
+    label: 'Critical',
+    icon: AlertCircle,
+    badgeVariant: 'destructive',
+    rowClass: 'border-l-2 border-destructive',
+  },
+  warning: {
+    label: 'Warning',
+    icon: AlertTriangle,
+    badgeVariant: 'warning',
+    rowClass: 'border-l-2 border-warning',
+  },
+  info: {
+    label: 'Info',
+    icon: Info,
+    badgeVariant: 'default',
+    rowClass: 'border-l-2 border-foreground-muted',
+  },
+  ok: {
+    label: 'OK',
+    icon: CheckCircle,
+    badgeVariant: 'outline',
+    rowClass: 'border-l-2 border-brand',
+  },
+}
+
+const CATEGORY_LABELS: Record<string, string> = {
+  locks: 'Locks',
+  storage: 'Storage',
+  performance: 'Performance',
+  connections: 'Connections',
+}
+
+interface DebuggerScanSummaryProps {
+  findings: DebuggerFinding[]
+}
+
+export function DebuggerScanSummary({ findings }: DebuggerScanSummaryProps) {
+  const sorted = [...findings].sort(
+    (a, b) => SEVERITY_ORDER.indexOf(a.severity) - SEVERITY_ORDER.indexOf(b.severity)
+  )
+
+  if (sorted.length === 0) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-foreground-light py-2">
+        <CheckCircle size={14} className="text-brand" />
+        <span>No issues detected. Your database looks healthy.</span>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      {sorted.map((finding) => {
+        const config = SEVERITY_CONFIG[finding.severity]
+        const Icon = config.icon
+
+        return (
+          <div
+            key={finding.id}
+            className={cn(
+              'flex flex-col gap-1 rounded-r bg-surface-100 px-4 py-3',
+              config.rowClass
+            )}
+          >
+            <div className="flex items-center gap-2">
+              <Icon size={14} className="shrink-0 text-foreground-light" />
+              <span className="text-sm font-medium text-foreground">{finding.title}</span>
+              <Badge variant={config.badgeVariant as any} className="ml-auto text-xs shrink-0">
+                {CATEGORY_LABELS[finding.category] ?? finding.category}
+              </Badge>
+            </div>
+            <p className="text-xs text-foreground-light pl-5">{finding.description}</p>
+            {finding.recommendation && (
+              <p className="text-xs text-foreground-light pl-5 italic">{finding.recommendation}</p>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Advisors/Debugger/LocksActivitySection.tsx
+++ b/apps/studio/components/interfaces/Advisors/Debugger/LocksActivitySection.tsx
@@ -1,0 +1,115 @@
+import ReportWidget from '@/components/interfaces/Reports/ReportWidget'
+import type { ReportWidgetRendererProps } from '@/components/interfaces/Reports/ReportWidget'
+import type { BlockingRow } from '@/data/database/debugger/blocking-query'
+import { blockingSql } from '@/data/database/debugger/blocking-query'
+import type { LocksRow } from '@/data/database/debugger/locks-query'
+import { locksSql } from '@/data/database/debugger/locks-query'
+import type { LongRunningQueriesRow } from '@/data/database/debugger/long-running-queries-query'
+import { buildLongRunningQueriesSql } from '@/data/database/debugger/long-running-queries-query'
+
+function renderTable<T extends Record<string, unknown>>(
+  emptyMessage: string
+): (props: ReportWidgetRendererProps<T>) => React.ReactNode {
+  return function TableRenderer({ data }: ReportWidgetRendererProps<T>) {
+    if (!data || data.length === 0) {
+      return <p className="text-sm text-foreground-light py-2">{emptyMessage}</p>
+    }
+
+    const columns = Object.keys(data[0]) as (keyof T)[]
+
+    return (
+      <div className="overflow-x-auto rounded border border-overlay">
+        <table className="w-full text-xs">
+          <thead className="bg-surface-100">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={String(col)}
+                  className="px-3 py-2 text-left font-medium text-foreground-light whitespace-nowrap"
+                >
+                  {String(col).replace(/_/g, ' ')}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-overlay">
+            {data.map((row, i) => (
+              <tr key={i} className="hover:bg-surface-100">
+                {columns.map((col) => (
+                  <td
+                    key={String(col)}
+                    className="px-3 py-2 text-foreground whitespace-nowrap max-w-xs truncate"
+                  >
+                    {String(row[col] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+
+interface LocksActivitySectionProps {
+  locksData: LocksRow[] | undefined
+  blockingData: BlockingRow[] | undefined
+  longRunningQueriesData: LongRunningQueriesRow[] | undefined
+  isLocksLoading: boolean
+  isBlockingLoading: boolean
+  isLongRunningQueriesLoading: boolean
+  isLocksError: boolean
+  isBlockingError: boolean
+  isLongRunningQueriesError: boolean
+}
+
+export function LocksActivitySection({
+  locksData,
+  blockingData,
+  longRunningQueriesData,
+  isLocksLoading,
+  isBlockingLoading,
+  isLongRunningQueriesLoading,
+}: LocksActivitySectionProps) {
+  const locksRenderer = renderTable<LocksRow>('No exclusive locks detected.')
+  const blockingRenderer = renderTable<BlockingRow>('No blocked queries detected.')
+  const longRunningRenderer = renderTable<LongRunningQueriesRow>(
+    'No long-running queries detected (threshold: 5 minutes).'
+  )
+
+  return (
+    <div className="space-y-4">
+      <ReportWidget
+        title="Active Locks"
+        description="Queries holding exclusive locks. Persistent locks may indicate stuck transactions."
+        data={locksData ?? []}
+        isLoading={isLocksLoading}
+        renderer={locksRenderer}
+        params={{ sql: String(locksSql) } as any}
+        queryType="db"
+        resolvedSql={String(locksSql)}
+      />
+      <ReportWidget
+        title="Blocking Queries"
+        description="Queries that are blocking other queries from running."
+        data={blockingData ?? []}
+        isLoading={isBlockingLoading}
+        renderer={blockingRenderer}
+        params={{ sql: String(blockingSql) } as any}
+        queryType="db"
+        resolvedSql={String(blockingSql)}
+      />
+      <ReportWidget
+        title="Long-Running Queries"
+        description="Active queries running longer than 5 minutes."
+        data={longRunningQueriesData ?? []}
+        isLoading={isLongRunningQueriesLoading}
+        renderer={longRunningRenderer}
+        params={{ sql: String(buildLongRunningQueriesSql()) } as any}
+        queryType="db"
+        resolvedSql={String(buildLongRunningQueriesSql())}
+      />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Advisors/Debugger/PerformanceSection.tsx
+++ b/apps/studio/components/interfaces/Advisors/Debugger/PerformanceSection.tsx
@@ -1,0 +1,161 @@
+import { useParams } from 'common'
+import { ExternalLink } from 'lucide-react'
+import Link from 'next/link'
+
+import ReportWidget from '@/components/interfaces/Reports/ReportWidget'
+import type { ReportWidgetRendererProps } from '@/components/interfaces/Reports/ReportWidget'
+import type { CacheHitRow } from '@/data/database/debugger/cache-hit-query'
+import { cacheHitSql } from '@/data/database/debugger/cache-hit-query'
+import type { IndexStatsRow } from '@/data/database/debugger/index-stats-query'
+import { indexStatsSql } from '@/data/database/debugger/index-stats-query'
+import type { IndexUsageRow } from '@/data/database/debugger/index-usage-query'
+import { indexUsageSql } from '@/data/database/debugger/index-usage-query'
+import type { SeqScansRow } from '@/data/database/debugger/seq-scans-query'
+import { seqScansSql } from '@/data/database/debugger/seq-scans-query'
+import type { UnusedIndexesRow } from '@/data/database/debugger/unused-indexes-query'
+import { unusedIndexesSql } from '@/data/database/debugger/unused-indexes-query'
+
+function renderTable<T extends Record<string, unknown>>(
+  emptyMessage: string
+): (props: ReportWidgetRendererProps<T>) => React.ReactNode {
+  return function TableRenderer({ data }: ReportWidgetRendererProps<T>) {
+    if (!data || data.length === 0) {
+      return <p className="text-sm text-foreground-light py-2">{emptyMessage}</p>
+    }
+
+    const columns = Object.keys(data[0]) as (keyof T)[]
+
+    return (
+      <div className="overflow-x-auto rounded border border-overlay">
+        <table className="w-full text-xs">
+          <thead className="bg-surface-100">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={String(col)}
+                  className="px-3 py-2 text-left font-medium text-foreground-light whitespace-nowrap"
+                >
+                  {String(col).replace(/_/g, ' ')}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-overlay">
+            {data.map((row, i) => (
+              <tr key={i} className="hover:bg-surface-100">
+                {columns.map((col) => (
+                  <td
+                    key={String(col)}
+                    className="px-3 py-2 text-foreground whitespace-nowrap max-w-xs truncate"
+                  >
+                    {String(row[col] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+
+interface PerformanceSectionProps {
+  cacheHitData: CacheHitRow[] | undefined
+  indexUsageData: IndexUsageRow[] | undefined
+  indexStatsData: IndexStatsRow[] | undefined
+  seqScansData: SeqScansRow[] | undefined
+  unusedIndexesData: UnusedIndexesRow[] | undefined
+  isCacheHitLoading: boolean
+  isIndexUsageLoading: boolean
+  isIndexStatsLoading: boolean
+  isSeqScansLoading: boolean
+  isUnusedIndexesLoading: boolean
+  hasPgStatStatements: boolean
+}
+
+export function PerformanceSection({
+  cacheHitData,
+  indexUsageData,
+  indexStatsData,
+  seqScansData,
+  unusedIndexesData,
+  isCacheHitLoading,
+  isIndexUsageLoading,
+  isIndexStatsLoading,
+  isSeqScansLoading,
+  isUnusedIndexesLoading,
+  hasPgStatStatements,
+}: PerformanceSectionProps) {
+  const { ref } = useParams()
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded border border-overlay bg-surface-100 px-4 py-3 flex items-start gap-3">
+        <ExternalLink size={14} className="mt-0.5 shrink-0 text-foreground-light" />
+        <p className="text-xs text-foreground-light">
+          For slow queries, most-called queries, and per-statement statistics, visit the{' '}
+          <Link
+            href={`/project/${ref}/observability/query-performance`}
+            className="text-foreground underline underline-offset-2"
+          >
+            Query Performance
+          </Link>{' '}
+          page. Those metrics require <code>pg_stat_statements</code>
+          {!hasPgStatStatements && <span className="text-warning"> (not currently enabled)</span>}.
+        </p>
+      </div>
+
+      <ReportWidget
+        title="Cache Hit Rates"
+        description="Buffer cache hit ratio for tables and indexes. Values below 0.99 may indicate memory pressure."
+        data={cacheHitData ?? []}
+        isLoading={isCacheHitLoading}
+        renderer={renderTable<CacheHitRow>('No cache hit data available.')}
+        params={{ sql: String(cacheHitSql) } as any}
+        queryType="db"
+        resolvedSql={String(cacheHitSql)}
+      />
+      <ReportWidget
+        title="Index Usage"
+        description="Percentage of scans that used an index vs. a sequential scan per table."
+        data={indexUsageData ?? []}
+        isLoading={isIndexUsageLoading}
+        renderer={renderTable<IndexUsageRow>('No index usage data available.')}
+        params={{ sql: String(indexUsageSql) } as any}
+        queryType="db"
+        resolvedSql={String(indexUsageSql)}
+      />
+      <ReportWidget
+        title="Index Stats"
+        description="Size, scan counts, and usage flags for all user indexes."
+        data={indexStatsData ?? []}
+        isLoading={isIndexStatsLoading}
+        renderer={renderTable<IndexStatsRow>('No index stats available.')}
+        params={{ sql: String(indexStatsSql) } as any}
+        queryType="db"
+        resolvedSql={String(indexStatsSql)}
+      />
+      <ReportWidget
+        title="Sequential Scans"
+        description="Tables ordered by sequential scan count. High counts on large tables may indicate missing indexes."
+        data={seqScansData ?? []}
+        isLoading={isSeqScansLoading}
+        renderer={renderTable<SeqScansRow>('No sequential scan data available.')}
+        params={{ sql: String(seqScansSql) } as any}
+        queryType="db"
+        resolvedSql={String(seqScansSql)}
+      />
+      <ReportWidget
+        title="Unused Indexes"
+        description="Indexes that have never been used in a scan. Unused indexes waste space and slow writes."
+        data={unusedIndexesData ?? []}
+        isLoading={isUnusedIndexesLoading}
+        renderer={renderTable<UnusedIndexesRow>('No unused indexes found.')}
+        params={{ sql: String(unusedIndexesSql) } as any}
+        queryType="db"
+        resolvedSql={String(unusedIndexesSql)}
+      />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Advisors/Debugger/StorageHealthSection.tsx
+++ b/apps/studio/components/interfaces/Advisors/Debugger/StorageHealthSection.tsx
@@ -1,0 +1,138 @@
+import ReportWidget from '@/components/interfaces/Reports/ReportWidget'
+import type { ReportWidgetRendererProps } from '@/components/interfaces/Reports/ReportWidget'
+import type { BloatRow } from '@/data/database/debugger/bloat-query'
+import { bloatSql } from '@/data/database/debugger/bloat-query'
+import type { TableRecordCountsRow } from '@/data/database/debugger/table-record-counts-query'
+import { tableRecordCountsSql } from '@/data/database/debugger/table-record-counts-query'
+import type { TableStatsRow } from '@/data/database/debugger/table-stats-query'
+import { tableStatsSql } from '@/data/database/debugger/table-stats-query'
+import type { TrafficProfileRow } from '@/data/database/debugger/traffic-profile-query'
+import { trafficProfileSql } from '@/data/database/debugger/traffic-profile-query'
+import type { VacuumStatsRow } from '@/data/database/debugger/vacuum-stats-query'
+import { vacuumStatsSql } from '@/data/database/debugger/vacuum-stats-query'
+
+function renderTable<T extends Record<string, unknown>>(
+  emptyMessage: string
+): (props: ReportWidgetRendererProps<T>) => React.ReactNode {
+  return function TableRenderer({ data }: ReportWidgetRendererProps<T>) {
+    if (!data || data.length === 0) {
+      return <p className="text-sm text-foreground-light py-2">{emptyMessage}</p>
+    }
+
+    const columns = Object.keys(data[0]) as (keyof T)[]
+
+    return (
+      <div className="overflow-x-auto rounded border border-overlay">
+        <table className="w-full text-xs">
+          <thead className="bg-surface-100">
+            <tr>
+              {columns.map((col) => (
+                <th
+                  key={String(col)}
+                  className="px-3 py-2 text-left font-medium text-foreground-light whitespace-nowrap"
+                >
+                  {String(col).replace(/_/g, ' ')}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-overlay">
+            {data.map((row, i) => (
+              <tr key={i} className="hover:bg-surface-100">
+                {columns.map((col) => (
+                  <td
+                    key={String(col)}
+                    className="px-3 py-2 text-foreground whitespace-nowrap max-w-xs truncate"
+                  >
+                    {String(row[col] ?? '')}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    )
+  }
+}
+
+interface StorageHealthSectionProps {
+  bloatData: BloatRow[] | undefined
+  vacuumStatsData: VacuumStatsRow[] | undefined
+  tableStatsData: TableStatsRow[] | undefined
+  tableRecordCountsData: TableRecordCountsRow[] | undefined
+  trafficProfileData: TrafficProfileRow[] | undefined
+  isBloatLoading: boolean
+  isVacuumStatsLoading: boolean
+  isTableStatsLoading: boolean
+  isTableRecordCountsLoading: boolean
+  isTrafficProfileLoading: boolean
+}
+
+export function StorageHealthSection({
+  bloatData,
+  vacuumStatsData,
+  tableStatsData,
+  tableRecordCountsData,
+  trafficProfileData,
+  isBloatLoading,
+  isVacuumStatsLoading,
+  isTableStatsLoading,
+  isTableRecordCountsLoading,
+  isTrafficProfileLoading,
+}: StorageHealthSectionProps) {
+  return (
+    <div className="space-y-4">
+      <ReportWidget
+        title="Table and Index Bloat"
+        description="Estimated bloat for tables and indexes. High bloat wastes disk space and can slow queries."
+        data={bloatData ?? []}
+        isLoading={isBloatLoading}
+        renderer={renderTable<BloatRow>('No significant bloat detected.')}
+        params={{ sql: String(bloatSql) } as any}
+        queryType="db"
+        resolvedSql={String(bloatSql)}
+      />
+      <ReportWidget
+        title="Vacuum Stats"
+        description="Last vacuum/analyze timestamps and autovacuum thresholds per table."
+        data={vacuumStatsData ?? []}
+        isLoading={isVacuumStatsLoading}
+        renderer={renderTable<VacuumStatsRow>('No vacuum stats available.')}
+        params={{ sql: String(vacuumStatsSql) } as any}
+        queryType="db"
+        resolvedSql={String(vacuumStatsSql)}
+      />
+      <ReportWidget
+        title="Table Stats"
+        description="Size and sequential scan count per table."
+        data={tableStatsData ?? []}
+        isLoading={isTableStatsLoading}
+        renderer={renderTable<TableStatsRow>('No table stats available.')}
+        params={{ sql: String(tableStatsSql) } as any}
+        queryType="db"
+        resolvedSql={String(tableStatsSql)}
+      />
+      <ReportWidget
+        title="Table Record Counts"
+        description="Estimated live row counts per user table."
+        data={tableRecordCountsData ?? []}
+        isLoading={isTableRecordCountsLoading}
+        renderer={renderTable<TableRecordCountsRow>('No tables found.')}
+        params={{ sql: String(tableRecordCountsSql) } as any}
+        queryType="db"
+        resolvedSql={String(tableRecordCountsSql)}
+      />
+      <ReportWidget
+        title="Traffic Profile"
+        description="Most-active tables by read and write I/O."
+        data={trafficProfileData ?? []}
+        isLoading={isTrafficProfileLoading}
+        renderer={renderTable<TrafficProfileRow>('No traffic data available.')}
+        params={{ sql: String(trafficProfileSql) } as any}
+        queryType="db"
+        resolvedSql={String(trafficProfileSql)}
+      />
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Advisors/Debugger/triage/debugger-triage.test.ts
+++ b/apps/studio/components/interfaces/Advisors/Debugger/triage/debugger-triage.test.ts
@@ -1,0 +1,781 @@
+import { describe, expect, test } from 'vitest'
+
+import {
+  interpretBloat,
+  interpretBlocking,
+  interpretCacheHit,
+  interpretDebuggerResults,
+  interpretIndexUsage,
+  interpretLocks,
+  interpretLongRunningQueries,
+  interpretReplicationSlots,
+  interpretRoleStats,
+  interpretSeqScans,
+  interpretUnusedIndexes,
+  interpretVacuumStats,
+  parseIntervalMinutes,
+} from './debugger-triage'
+import type { BloatRow } from '@/data/database/debugger/bloat-query'
+import type { BlockingRow } from '@/data/database/debugger/blocking-query'
+import type { CacheHitRow } from '@/data/database/debugger/cache-hit-query'
+import type { IndexUsageRow } from '@/data/database/debugger/index-usage-query'
+import type { LocksRow } from '@/data/database/debugger/locks-query'
+import type { LongRunningQueriesRow } from '@/data/database/debugger/long-running-queries-query'
+import type { ReplicationSlotsRow } from '@/data/database/debugger/replication-slots-query'
+import type { RoleStatsRow } from '@/data/database/debugger/role-stats-query'
+import type { SeqScansRow } from '@/data/database/debugger/seq-scans-query'
+import type { UnusedIndexesRow } from '@/data/database/debugger/unused-indexes-query'
+import type { VacuumStatsRow } from '@/data/database/debugger/vacuum-stats-query'
+
+// ---------------------------------------------------------------------------
+// parseIntervalMinutes
+// ---------------------------------------------------------------------------
+
+describe('parseIntervalMinutes', () => {
+  test('parses HH:MM:SS format', () => {
+    expect(parseIntervalMinutes('00:05:00')).toBe(5)
+  })
+
+  test('parses HH:MM:SS.fraction format', () => {
+    const result = parseIntervalMinutes('00:30:00.123')
+    expect(result).not.toBeNull()
+    expect(result!).toBeCloseTo(30, 1)
+  })
+
+  test('parses 1 hour 30 min', () => {
+    expect(parseIntervalMinutes('01:30:00')).toBe(90)
+  })
+
+  test('parses interval with day component', () => {
+    const result = parseIntervalMinutes('1 day 02:00:00')
+    expect(result).not.toBeNull()
+    expect(result!).toBeCloseTo(1560, 0) // 24*60 + 2*60
+  })
+
+  test('parses plural days', () => {
+    const result = parseIntervalMinutes('3 days 00:00:00')
+    expect(result).not.toBeNull()
+    expect(result!).toBeCloseTo(3 * 24 * 60, 0)
+  })
+
+  test('returns null for empty string', () => {
+    expect(parseIntervalMinutes('')).toBeNull()
+  })
+
+  test('returns null for unparseable string', () => {
+    expect(parseIntervalMinutes('not-a-duration')).toBeNull()
+  })
+
+  test('parses exactly 30 minutes', () => {
+    expect(parseIntervalMinutes('00:30:00')).toBe(30)
+  })
+
+  test('parses slightly above 30 minutes', () => {
+    const result = parseIntervalMinutes('00:30:01')
+    expect(result).not.toBeNull()
+    expect(result!).toBeGreaterThan(30)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretBlocking
+// ---------------------------------------------------------------------------
+
+describe('interpretBlocking', () => {
+  test('returns ok when no blocking rows', () => {
+    const finding = interpretBlocking([])
+    expect(finding.severity).toBe('ok')
+    expect(finding.id).toBe('blocking')
+    expect(finding.category).toBe('locks')
+  })
+
+  test('returns critical when blocking rows present', () => {
+    const row: BlockingRow = {
+      blocked_pid: 1,
+      blocking_statement: 'SELECT 1',
+      blocking_duration: '00:01:00',
+      blocking_pid: 2,
+      blocked_statement: 'UPDATE foo SET x=1',
+      blocked_duration: '00:00:30',
+    }
+    const finding = interpretBlocking([row])
+    expect(finding.severity).toBe('critical')
+    expect(finding.id).toBe('blocking')
+  })
+
+  test('description mentions count of blocking and blocked queries', () => {
+    const rows: BlockingRow[] = [
+      {
+        blocked_pid: 1,
+        blocking_statement: 'SELECT 1',
+        blocking_duration: '00:02:00',
+        blocking_pid: 3,
+        blocked_statement: 'UPDATE a',
+        blocked_duration: '00:01:00',
+      },
+      {
+        blocked_pid: 2,
+        blocking_statement: 'SELECT 1',
+        blocking_duration: '00:01:30',
+        blocking_pid: 4,
+        blocked_statement: 'UPDATE b',
+        blocked_duration: '00:00:45',
+      },
+    ]
+    const finding = interpretBlocking(rows)
+    expect(finding.description).toContain('2')
+  })
+
+  test('undefined input skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ blocking: undefined })
+    const blockingFindings = findings.filter((f) => f.id === 'blocking')
+    expect(blockingFindings).toHaveLength(0)
+  })
+
+  test('empty array input produces ok in aggregator', () => {
+    const findings = interpretDebuggerResults({ blocking: [] })
+    const blockingFindings = findings.filter((f) => f.id === 'blocking')
+    expect(blockingFindings).toHaveLength(1)
+    expect(blockingFindings[0].severity).toBe('ok')
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretLocks
+// ---------------------------------------------------------------------------
+
+describe('interpretLocks', () => {
+  test('returns ok when no rows', () => {
+    expect(interpretLocks([]).severity).toBe('ok')
+  })
+
+  test('returns ok when all locks are granted', () => {
+    const row: LocksRow = {
+      pid: 1,
+      relname: 'users',
+      transactionid: '123',
+      granted: true,
+      stmt: 'SELECT 1',
+      age: '00:00:10',
+    }
+    expect(interpretLocks([row]).severity).toBe('ok')
+  })
+
+  test('returns warning when any lock is ungranted', () => {
+    const row: LocksRow = {
+      pid: 2,
+      relname: 'orders',
+      transactionid: '456',
+      granted: false,
+      stmt: 'UPDATE orders SET status=1',
+      age: '00:00:05',
+    }
+    expect(interpretLocks([row]).severity).toBe('warning')
+  })
+
+  test('mentions relation name in description', () => {
+    const row: LocksRow = {
+      pid: 2,
+      relname: 'my_table',
+      transactionid: '789',
+      granted: false,
+      stmt: 'DELETE FROM my_table',
+      age: '00:00:02',
+    }
+    const finding = interpretLocks([row])
+    expect(finding.description).toContain('my_table')
+  })
+
+  test('only ungranted locks counted — mixed granted/ungranted is warning', () => {
+    const rows: LocksRow[] = [
+      { pid: 1, relname: 'a', transactionid: '1', granted: true, stmt: 'q1', age: '00:00:01' },
+      { pid: 2, relname: 'b', transactionid: '2', granted: false, stmt: 'q2', age: '00:00:02' },
+    ]
+    expect(interpretLocks(rows).severity).toBe('warning')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ locks: undefined })
+    expect(findings.filter((f) => f.id === 'locks')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretLongRunningQueries
+// ---------------------------------------------------------------------------
+
+describe('interpretLongRunningQueries', () => {
+  test('returns ok when no rows', () => {
+    expect(interpretLongRunningQueries([]).severity).toBe('ok')
+  })
+
+  test('returns warning for query under 30 minutes', () => {
+    const row: LongRunningQueriesRow = {
+      pid: 1,
+      duration: '00:10:00',
+      query: 'SELECT pg_sleep(600)',
+    }
+    expect(interpretLongRunningQueries([row]).severity).toBe('warning')
+  })
+
+  test('returns warning for query at exactly 30 minutes', () => {
+    const row: LongRunningQueriesRow = {
+      pid: 1,
+      duration: '00:30:00',
+      query: 'SELECT pg_sleep(1800)',
+    }
+    // 30 min is NOT > 30, so should be warning
+    expect(interpretLongRunningQueries([row]).severity).toBe('warning')
+  })
+
+  test('returns critical for query just above 30 minutes', () => {
+    const row: LongRunningQueriesRow = {
+      pid: 1,
+      duration: '00:30:01',
+      query: 'SELECT pg_sleep(1801)',
+    }
+    expect(interpretLongRunningQueries([row]).severity).toBe('critical')
+  })
+
+  test('returns critical for query exceeding 1 hour', () => {
+    const row: LongRunningQueriesRow = {
+      pid: 1,
+      duration: '01:30:00',
+      query: 'SELECT slow_thing()',
+    }
+    expect(interpretLongRunningQueries([row]).severity).toBe('critical')
+  })
+
+  test('returns warning when duration cannot be parsed', () => {
+    const row: LongRunningQueriesRow = {
+      pid: 1,
+      duration: 'unknown',
+      query: 'SELECT 1',
+    }
+    // Unparseable duration should not throw; should fall back to warning
+    const finding = interpretLongRunningQueries([row])
+    expect(finding.severity).toBe('warning')
+  })
+
+  test('description includes the longest duration', () => {
+    const rows: LongRunningQueriesRow[] = [
+      { pid: 1, duration: '00:45:00', query: 'q1' },
+      { pid: 2, duration: '00:10:00', query: 'q2' },
+    ]
+    const finding = interpretLongRunningQueries(rows)
+    expect(finding.description).toContain('00:45:00')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ longRunningQueries: undefined })
+    expect(findings.filter((f) => f.id === 'long-running-queries')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretCacheHit
+// ---------------------------------------------------------------------------
+
+describe('interpretCacheHit', () => {
+  test('returns ok finding for each entry when ratio >= 0.99', () => {
+    const rows: CacheHitRow[] = [
+      { name: 'index hit rate', ratio: '0.9990' },
+      { name: 'table hit rate', ratio: '1.0000' },
+    ]
+    const findings = interpretCacheHit(rows)
+    expect(findings).toHaveLength(2)
+    expect(findings.every((f) => f.severity === 'ok')).toBe(true)
+  })
+
+  test('returns warning for ratio exactly at 0.99 (boundary — ok)', () => {
+    const rows: CacheHitRow[] = [{ name: 'table hit rate', ratio: '0.9900' }]
+    // 0.99 is NOT < 0.99, so ok
+    expect(interpretCacheHit(rows)[0].severity).toBe('ok')
+  })
+
+  test('returns warning for ratio just below 0.99', () => {
+    const rows: CacheHitRow[] = [{ name: 'table hit rate', ratio: '0.9899' }]
+    expect(interpretCacheHit(rows)[0].severity).toBe('warning')
+  })
+
+  test('returns warning for ratio between 0.95 and 0.99', () => {
+    const rows: CacheHitRow[] = [{ name: 'index hit rate', ratio: '0.9700' }]
+    expect(interpretCacheHit(rows)[0].severity).toBe('warning')
+  })
+
+  test('returns critical for ratio exactly at 0.95 (boundary)', () => {
+    const rows: CacheHitRow[] = [{ name: 'table hit rate', ratio: '0.9500' }]
+    // 0.95 IS < 0.95? No, it is NOT. So warning.
+    expect(interpretCacheHit(rows)[0].severity).toBe('warning')
+  })
+
+  test('returns critical for ratio just below 0.95', () => {
+    const rows: CacheHitRow[] = [{ name: 'table hit rate', ratio: '0.9499' }]
+    expect(interpretCacheHit(rows)[0].severity).toBe('critical')
+  })
+
+  test('returns critical for very low ratio', () => {
+    const rows: CacheHitRow[] = [{ name: 'index hit rate', ratio: '0.5000' }]
+    expect(interpretCacheHit(rows)[0].severity).toBe('critical')
+  })
+
+  test('handles N/A ratio gracefully', () => {
+    const rows: CacheHitRow[] = [{ name: 'table hit rate', ratio: 'N/A' }]
+    const findings = interpretCacheHit(rows)
+    expect(findings).toHaveLength(1)
+    expect(findings[0].severity).toBe('ok')
+    expect(findings[0].description).toContain('statistics are available')
+  })
+
+  test('index and table findings have distinct ids', () => {
+    const rows: CacheHitRow[] = [
+      { name: 'index hit rate', ratio: '0.9000' },
+      { name: 'table hit rate', ratio: '0.9800' },
+    ]
+    const findings = interpretCacheHit(rows)
+    expect(findings.find((f) => f.id === 'cache-hit-index')?.severity).toBe('critical')
+    expect(findings.find((f) => f.id === 'cache-hit-table')?.severity).toBe('warning')
+  })
+
+  test('returns empty array for empty input', () => {
+    expect(interpretCacheHit([])).toHaveLength(0)
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ cacheHit: undefined })
+    expect(findings.filter((f) => f.id.startsWith('cache-hit'))).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretBloat
+// ---------------------------------------------------------------------------
+
+describe('interpretBloat', () => {
+  test('returns ok when no rows', () => {
+    expect(interpretBloat([]).severity).toBe('ok')
+  })
+
+  test('returns ok when all bloat ratios <= 10', () => {
+    const rows: BloatRow[] = [
+      { type: 'table', name: 'public.users', bloat: '10.0', waste: '1024 bytes' },
+      { type: 'index', name: 'public.orders::idx', bloat: '5.0', waste: '512 bytes' },
+    ]
+    expect(interpretBloat(rows).severity).toBe('ok')
+  })
+
+  test('returns warning when any bloat ratio > 10', () => {
+    const rows: BloatRow[] = [{ type: 'table', name: 'public.big', bloat: '10.1', waste: '1 MB' }]
+    expect(interpretBloat(rows).severity).toBe('warning')
+  })
+
+  test('exactly 10 is not flagged', () => {
+    const rows: BloatRow[] = [
+      { type: 'table', name: 'public.edge', bloat: '10.0', waste: '100 bytes' },
+    ]
+    expect(interpretBloat(rows).severity).toBe('ok')
+  })
+
+  test('description lists offending table names', () => {
+    const rows: BloatRow[] = [
+      { type: 'table', name: 'public.bloated_table', bloat: '15.0', waste: '10 MB' },
+    ]
+    const finding = interpretBloat(rows)
+    expect(finding.description).toContain('public.bloated_table')
+  })
+
+  test('handles non-numeric bloat gracefully', () => {
+    const rows: BloatRow[] = [{ type: 'table', name: 'public.x', bloat: 'N/A', waste: '0 bytes' }]
+    expect(interpretBloat(rows).severity).toBe('ok')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ bloat: undefined })
+    expect(findings.filter((f) => f.id === 'bloat')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretVacuumStats
+// ---------------------------------------------------------------------------
+
+describe('interpretVacuumStats', () => {
+  const makeRow = (
+    name: string,
+    expect_autovacuum: string,
+    dead_rowcount: string
+  ): VacuumStatsRow => ({
+    name,
+    last_vacuum: '',
+    last_autovacuum: '',
+    last_analyze: '',
+    last_autoanalyze: '',
+    rowcount: '10,000',
+    dead_rowcount,
+    autovacuum_threshold: '50',
+    expect_autovacuum,
+    autoanalyze_threshold: '50',
+    expect_autoanalyze: 'no',
+  })
+
+  test('returns ok when no rows', () => {
+    expect(interpretVacuumStats([]).severity).toBe('ok')
+  })
+
+  test('returns ok when expect_autovacuum is no', () => {
+    const row = makeRow('public.clean', 'no', '5,000')
+    expect(interpretVacuumStats([row]).severity).toBe('ok')
+  })
+
+  test('returns ok when expect_autovacuum is yes but dead rows <= threshold', () => {
+    const row = makeRow('public.small', 'yes', '500')
+    expect(interpretVacuumStats([row]).severity).toBe('ok')
+  })
+
+  test('returns ok when dead rows exactly at threshold (1000)', () => {
+    const row = makeRow('public.edge', 'yes', '1,000')
+    // 1000 is NOT > 1000, so ok
+    expect(interpretVacuumStats([row]).severity).toBe('ok')
+  })
+
+  test('returns warning when expect_autovacuum yes and dead rows > 1000', () => {
+    const row = makeRow('public.dirty', 'yes', '1,001')
+    expect(interpretVacuumStats([row]).severity).toBe('warning')
+  })
+
+  test('returns warning for heavily dead table', () => {
+    const row = makeRow('public.huge', 'yes', ' 1,234,567')
+    expect(interpretVacuumStats([row]).severity).toBe('warning')
+  })
+
+  test('description includes table name', () => {
+    const row = makeRow('public.mytable', 'yes', '50,000')
+    const finding = interpretVacuumStats([row])
+    expect(finding.description).toContain('public.mytable')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ vacuumStats: undefined })
+    expect(findings.filter((f) => f.id === 'vacuum')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretIndexUsage
+// ---------------------------------------------------------------------------
+
+describe('interpretIndexUsage', () => {
+  const makeRow = (
+    name: string,
+    percent_of_times_index_used: string,
+    rows_in_table: number
+  ): IndexUsageRow => ({ name, percent_of_times_index_used, rows_in_table })
+
+  test('returns ok when no rows', () => {
+    expect(interpretIndexUsage([]).severity).toBe('ok')
+  })
+
+  test('returns ok when usage >= 95% on large table', () => {
+    const row = makeRow('public.big', '95.0%', 50_000)
+    expect(interpretIndexUsage([row]).severity).toBe('ok')
+  })
+
+  test('returns ok when low usage but table is small', () => {
+    const row = makeRow('public.tiny', '50.0%', 9_999)
+    expect(interpretIndexUsage([row]).severity).toBe('ok')
+  })
+
+  test('returns ok when table is exactly at min row count threshold', () => {
+    const row = makeRow('public.edge', '50.0%', 10_000)
+    // 10_000 is NOT > 10_000, so ok
+    expect(interpretIndexUsage([row]).severity).toBe('ok')
+  })
+
+  test('returns warning when usage < 95% on table with > 10000 rows', () => {
+    const row = makeRow('public.missing_idx', '80.5%', 50_000)
+    expect(interpretIndexUsage([row]).severity).toBe('warning')
+  })
+
+  test('returns warning just below 95% on large table', () => {
+    const row = makeRow('public.borderline', '94.9%', 20_000)
+    expect(interpretIndexUsage([row]).severity).toBe('warning')
+  })
+
+  test('skips Insufficient data rows', () => {
+    const row = makeRow('public.new', 'Insufficient data', 100_000)
+    expect(interpretIndexUsage([row]).severity).toBe('ok')
+  })
+
+  test('description includes table name', () => {
+    const row = makeRow('public.slow_table', '60.0%', 100_000)
+    const finding = interpretIndexUsage([row])
+    expect(finding.description).toContain('public.slow_table')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ indexUsage: undefined })
+    expect(findings.filter((f) => f.id === 'index-usage')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretUnusedIndexes
+// ---------------------------------------------------------------------------
+
+describe('interpretUnusedIndexes', () => {
+  const makeRow = (
+    name: string,
+    index: string,
+    index_size: string,
+    index_scans: number
+  ): UnusedIndexesRow => ({ name, index, index_size, index_scans })
+
+  test('returns ok when no rows', () => {
+    expect(interpretUnusedIndexes([]).severity).toBe('ok')
+  })
+
+  test('returns ok when all indexes have scans > 0', () => {
+    const row = makeRow('public.users', 'idx_users_email', '512 kB', 5)
+    expect(interpretUnusedIndexes([row]).severity).toBe('ok')
+  })
+
+  test('returns info when any index has 0 scans', () => {
+    const row = makeRow('public.orders', 'idx_orders_old', '2 MB', 0)
+    expect(interpretUnusedIndexes([row]).severity).toBe('info')
+  })
+
+  test('mixed: only zero-scan indexes flagged', () => {
+    const rows: UnusedIndexesRow[] = [
+      makeRow('public.a', 'idx_a', '1 MB', 10),
+      makeRow('public.b', 'idx_b', '2 MB', 0),
+    ]
+    const finding = interpretUnusedIndexes(rows)
+    expect(finding.severity).toBe('info')
+    expect(finding.description).toContain('1 non-unique index')
+  })
+
+  test('description includes index name', () => {
+    const row = makeRow('public.events', 'idx_events_old_col', '5 MB', 0)
+    const finding = interpretUnusedIndexes([row])
+    expect(finding.description).toContain('idx_events_old_col')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ unusedIndexes: undefined })
+    expect(findings.filter((f) => f.id === 'unused-indexes')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretSeqScans
+// ---------------------------------------------------------------------------
+
+describe('interpretSeqScans', () => {
+  test('returns ok when no rows', () => {
+    expect(interpretSeqScans([]).severity).toBe('ok')
+  })
+
+  test('returns ok when all counts <= 1000', () => {
+    const rows: SeqScansRow[] = [
+      { name: 'public.a', count: 1_000 },
+      { name: 'public.b', count: 500 },
+    ]
+    expect(interpretSeqScans(rows).severity).toBe('ok')
+  })
+
+  test('returns info when count is exactly 1000 (boundary)', () => {
+    const rows: SeqScansRow[] = [{ name: 'public.a', count: 1_000 }]
+    // 1000 is NOT > 1000, so ok
+    expect(interpretSeqScans(rows).severity).toBe('ok')
+  })
+
+  test('returns info when count just above 1000', () => {
+    const rows: SeqScansRow[] = [{ name: 'public.big', count: 1_001 }]
+    expect(interpretSeqScans(rows).severity).toBe('info')
+  })
+
+  test('description includes table name and count', () => {
+    const rows: SeqScansRow[] = [{ name: 'public.scanned_a_lot', count: 5_000 }]
+    const finding = interpretSeqScans(rows)
+    expect(finding.description).toContain('public.scanned_a_lot')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ seqScans: undefined })
+    expect(findings.filter((f) => f.id === 'seq-scans')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretRoleStats
+// ---------------------------------------------------------------------------
+
+describe('interpretRoleStats', () => {
+  const makeRow = (
+    role_name: string,
+    active_connections: number,
+    connection_limit: number
+  ): RoleStatsRow => ({ role_name, active_connections, connection_limit, custom_config: '' })
+
+  test('returns ok when no rows', () => {
+    expect(interpretRoleStats([]).severity).toBe('ok')
+  })
+
+  test('returns ok when usage < 80%', () => {
+    const row = makeRow('app_user', 79, 100)
+    expect(interpretRoleStats([row]).severity).toBe('ok')
+  })
+
+  test('returns ok when usage exactly at 80% boundary', () => {
+    const row = makeRow('app_user', 80, 100)
+    // 80/100 = 0.80 which is NOT >= 0.80? It IS >= 0.80, so warning
+    expect(interpretRoleStats([row]).severity).toBe('warning')
+  })
+
+  test('returns warning when usage just above 80%', () => {
+    const row = makeRow('app_user', 81, 100)
+    expect(interpretRoleStats([row]).severity).toBe('warning')
+  })
+
+  test('returns warning when usage at 100%', () => {
+    const row = makeRow('app_user', 100, 100)
+    expect(interpretRoleStats([row]).severity).toBe('warning')
+  })
+
+  test('skips roles with connection_limit of 0', () => {
+    const row = makeRow('nologin_role', 0, 0)
+    expect(interpretRoleStats([row]).severity).toBe('ok')
+  })
+
+  test('description includes role name and counts', () => {
+    const row = makeRow('api_user', 90, 100)
+    const finding = interpretRoleStats([row])
+    expect(finding.description).toContain('api_user')
+    expect(finding.description).toContain('90/100')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ roleStats: undefined })
+    expect(findings.filter((f) => f.id === 'role-connections')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretReplicationSlots
+// ---------------------------------------------------------------------------
+
+describe('interpretReplicationSlots', () => {
+  const makeRow = (
+    slot_name: string,
+    active: boolean,
+    replication_lag_gb: number
+  ): ReplicationSlotsRow => ({
+    slot_name,
+    active,
+    state: active ? 'streaming' : 'N/A',
+    replication_client_address: active ? '10.0.0.1' : 'N/A',
+    replication_lag_gb,
+  })
+
+  test('returns ok when no rows', () => {
+    expect(interpretReplicationSlots([]).severity).toBe('ok')
+  })
+
+  test('returns ok when all slots are active and lag <= 1 GB', () => {
+    const rows: ReplicationSlotsRow[] = [makeRow('slot_a', true, 0.5), makeRow('slot_b', true, 1.0)]
+    expect(interpretReplicationSlots(rows).severity).toBe('ok')
+  })
+
+  test('returns ok when lag exactly at 1 GB (boundary)', () => {
+    const row = makeRow('slot_edge', true, 1.0)
+    // 1.0 is NOT > 1, so ok
+    expect(interpretReplicationSlots([row]).severity).toBe('ok')
+  })
+
+  test('returns warning when active slot lag just above 1 GB', () => {
+    const row = makeRow('slot_lagged', true, 1.01)
+    expect(interpretReplicationSlots([row]).severity).toBe('warning')
+  })
+
+  test('returns warning when slot is inactive regardless of lag', () => {
+    const row = makeRow('slot_dead', false, 0)
+    expect(interpretReplicationSlots([row]).severity).toBe('warning')
+  })
+
+  test('description includes slot name', () => {
+    const row = makeRow('my_dead_slot', false, 0)
+    const finding = interpretReplicationSlots([row])
+    expect(finding.description).toContain('my_dead_slot')
+  })
+
+  test('undefined skips in aggregator', () => {
+    const findings = interpretDebuggerResults({ replicationSlots: undefined })
+    expect(findings.filter((f) => f.id === 'replication-slots')).toHaveLength(0)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// interpretDebuggerResults (aggregator)
+// ---------------------------------------------------------------------------
+
+describe('interpretDebuggerResults', () => {
+  test('returns empty array for empty input object', () => {
+    expect(interpretDebuggerResults({})).toHaveLength(0)
+  })
+
+  test('only runs checks for provided fields', () => {
+    const findings = interpretDebuggerResults({ blocking: [] })
+    const ids = findings.map((f) => f.id)
+    expect(ids).toContain('blocking')
+    expect(ids).not.toContain('bloat')
+    expect(ids).not.toContain('vacuum')
+    expect(ids).not.toContain('locks')
+  })
+
+  test('all-ok scenario returns one ok finding per loaded check', () => {
+    const findings = interpretDebuggerResults({
+      blocking: [],
+      locks: [],
+      longRunningQueries: [],
+      bloat: [],
+      vacuumStats: [],
+      indexUsage: [],
+      unusedIndexes: [],
+      seqScans: [],
+      roleStats: [],
+      replicationSlots: [],
+      // cacheHit with empty array returns 0 findings (no rows to iterate)
+      cacheHit: [],
+    })
+    expect(findings.every((f) => f.severity === 'ok')).toBe(true)
+  })
+
+  test('critical finding from blocking propagates correctly', () => {
+    const findings = interpretDebuggerResults({
+      blocking: [
+        {
+          blocked_pid: 1,
+          blocking_statement: 'SELECT 1',
+          blocking_duration: '00:01:00',
+          blocking_pid: 2,
+          blocked_statement: 'UPDATE x',
+          blocked_duration: '00:00:30',
+        },
+      ],
+    })
+    const blocking = findings.find((f) => f.id === 'blocking')
+    expect(blocking?.severity).toBe('critical')
+  })
+
+  test('each finding has a non-empty id, title, and description', () => {
+    const findings = interpretDebuggerResults({
+      blocking: [],
+      locks: [{ pid: 1, relname: 'x', transactionid: '1', granted: false, stmt: 'q', age: '1s' }],
+    })
+    for (const f of findings) {
+      expect(f.id.length).toBeGreaterThan(0)
+      expect(f.title.length).toBeGreaterThan(0)
+      expect(f.description.length).toBeGreaterThan(0)
+    }
+  })
+})

--- a/apps/studio/components/interfaces/Advisors/Debugger/triage/debugger-triage.ts
+++ b/apps/studio/components/interfaces/Advisors/Debugger/triage/debugger-triage.ts
@@ -1,0 +1,585 @@
+import type { BloatRow } from '@/data/database/debugger/bloat-query'
+import type { BlockingRow } from '@/data/database/debugger/blocking-query'
+import type { CacheHitRow } from '@/data/database/debugger/cache-hit-query'
+import type { IndexUsageRow } from '@/data/database/debugger/index-usage-query'
+import type { LocksRow } from '@/data/database/debugger/locks-query'
+import type { LongRunningQueriesRow } from '@/data/database/debugger/long-running-queries-query'
+import type { ReplicationSlotsRow } from '@/data/database/debugger/replication-slots-query'
+import type { RoleStatsRow } from '@/data/database/debugger/role-stats-query'
+import type { SeqScansRow } from '@/data/database/debugger/seq-scans-query'
+import type { UnusedIndexesRow } from '@/data/database/debugger/unused-indexes-query'
+import type { VacuumStatsRow } from '@/data/database/debugger/vacuum-stats-query'
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type DebuggerSeverity = 'critical' | 'warning' | 'info' | 'ok'
+export type DebuggerCategory = 'locks' | 'storage' | 'performance' | 'connections'
+
+export interface DebuggerFinding {
+  id: string
+  category: DebuggerCategory
+  severity: DebuggerSeverity
+  title: string
+  description: string
+  recommendation?: string
+}
+
+export interface DebuggerCheckInput {
+  locks?: LocksRow[]
+  blocking?: BlockingRow[]
+  longRunningQueries?: LongRunningQueriesRow[]
+  bloat?: BloatRow[]
+  vacuumStats?: VacuumStatsRow[]
+  cacheHit?: CacheHitRow[]
+  indexUsage?: IndexUsageRow[]
+  unusedIndexes?: UnusedIndexesRow[]
+  seqScans?: SeqScansRow[]
+  roleStats?: RoleStatsRow[]
+  replicationSlots?: ReplicationSlotsRow[]
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Postgres interval string such as "00:30:15.123" or
+ * "1 day 02:03:04" into total minutes (floating point).
+ * Returns null if the string cannot be parsed.
+ */
+export function parseIntervalMinutes(interval: string): number | null {
+  if (!interval) return null
+
+  let totalMinutes = 0
+
+  // Handle "N day(s)" prefix, e.g. "1 day 02:03:04" or "3 days 00:00:00"
+  const dayMatch = interval.match(/(\d+)\s+days?/)
+  if (dayMatch) {
+    totalMinutes += parseInt(dayMatch[1], 10) * 24 * 60
+  }
+
+  // Handle HH:MM:SS[.fraction] component
+  const timeMatch = interval.match(/(\d+):(\d{2}):(\d{2})(?:\.\d+)?/)
+  if (timeMatch) {
+    totalMinutes +=
+      parseInt(timeMatch[1], 10) * 60 + parseInt(timeMatch[2], 10) + parseInt(timeMatch[3], 10) / 60
+    return totalMinutes
+  }
+
+  // Nothing parseable
+  return totalMinutes > 0 ? totalMinutes : null
+}
+
+// ---------------------------------------------------------------------------
+// Per-check interpreters
+// ---------------------------------------------------------------------------
+
+/**
+ * Blocking check: any active blocking chain is critical.
+ */
+export function interpretBlocking(rows: BlockingRow[]): DebuggerFinding {
+  if (rows.length === 0) {
+    return {
+      id: 'blocking',
+      category: 'locks',
+      severity: 'ok',
+      title: 'No blocking queries',
+      description: 'No queries are currently blocking other queries.',
+    }
+  }
+
+  const uniqueBlockers = new Set(rows.map((r) => r.blocking_pid)).size
+  const uniqueBlocked = new Set(rows.map((r) => r.blocked_pid)).size
+
+  return {
+    id: 'blocking',
+    category: 'locks',
+    severity: 'critical',
+    title: 'Active query blocking detected',
+    description:
+      `${uniqueBlockers} quer${uniqueBlockers !== 1 ? 'ies' : 'y'} ` +
+      `${uniqueBlockers !== 1 ? 'are' : 'is'} blocking ${uniqueBlocked} ` +
+      `other quer${uniqueBlocked !== 1 ? 'ies' : 'y'}. ` +
+      `Longest blocking duration: ${rows[0].blocking_duration}.`,
+    recommendation:
+      'Identify and terminate the blocking query using pg_terminate_backend(pid), ' +
+      'or investigate the transaction holding the lock.',
+  }
+}
+
+/**
+ * Locks check: an ungranted (waiting) exclusive lock means a query is stalled.
+ */
+export function interpretLocks(rows: LocksRow[]): DebuggerFinding {
+  const ungranted = rows.filter((r) => !r.granted)
+
+  if (ungranted.length === 0) {
+    return {
+      id: 'locks',
+      category: 'locks',
+      severity: 'ok',
+      title: 'No ungranted locks',
+      description: 'All exclusive locks are currently granted.',
+    }
+  }
+
+  return {
+    id: 'locks',
+    category: 'locks',
+    severity: 'warning',
+    title: `${ungranted.length} ungranted lock${ungranted.length !== 1 ? 's' : ''} detected`,
+    description:
+      `${ungranted.length} exclusive lock${ungranted.length !== 1 ? 's' : ''} ` +
+      `${ungranted.length !== 1 ? 'are' : 'is'} waiting to be granted. ` +
+      `Affected relations: ${[...new Set(ungranted.map((r) => r.relname))].join(', ')}.`,
+    recommendation:
+      'Check for long-running transactions or blocking queries holding conflicting locks.',
+  }
+}
+
+/**
+ * Long-running queries check:
+ * - Any row is at least a warning.
+ * - duration > 30 minutes is critical.
+ */
+export function interpretLongRunningQueries(rows: LongRunningQueriesRow[]): DebuggerFinding {
+  if (rows.length === 0) {
+    return {
+      id: 'long-running-queries',
+      category: 'performance',
+      severity: 'ok',
+      title: 'No long-running queries',
+      description: 'No queries have been running beyond the configured threshold.',
+    }
+  }
+
+  const longestRow = rows[0]
+  const longestMinutes = parseIntervalMinutes(longestRow.duration)
+  // Critical threshold: > 30 minutes
+  const isCritical = longestMinutes !== null && longestMinutes > 30
+
+  return {
+    id: 'long-running-queries',
+    category: 'performance',
+    severity: isCritical ? 'critical' : 'warning',
+    title: isCritical
+      ? `${rows.length} long-running quer${rows.length !== 1 ? 'ies' : 'y'} (critical)`
+      : `${rows.length} long-running quer${rows.length !== 1 ? 'ies' : 'y'} detected`,
+    description:
+      `${rows.length} quer${rows.length !== 1 ? 'ies' : 'y'} exceeded the configured threshold. ` +
+      `Longest running duration: ${longestRow.duration}.`,
+    recommendation:
+      'Review whether these queries are expected to run this long. ' +
+      'Consider adding indexes, optimizing the query plan, or terminating runaway queries with pg_terminate_backend(pid).',
+  }
+}
+
+/**
+ * Cache hit check: separate findings for table and index hit rate.
+ * Thresholds:
+ *   - ratio >= 0.99: ok
+ *   - ratio >= 0.95 and < 0.99: warning
+ *   - ratio < 0.95: critical
+ */
+export function interpretCacheHit(rows: CacheHitRow[]): DebuggerFinding[] {
+  const findings: DebuggerFinding[] = []
+
+  for (const row of rows) {
+    const isIndex = row.name === 'index hit rate'
+    const id = isIndex ? 'cache-hit-index' : 'cache-hit-table'
+    const label = isIndex ? 'Index' : 'Table'
+
+    const ratio = parseFloat(row.ratio)
+    if (isNaN(ratio)) {
+      findings.push({
+        id,
+        category: 'performance',
+        severity: 'ok',
+        title: `${label} cache hit rate: no data`,
+        description: `No ${label.toLowerCase()} access statistics are available yet.`,
+      })
+      continue
+    }
+
+    const pct = (ratio * 100).toFixed(2)
+
+    if (ratio < 0.95) {
+      findings.push({
+        id,
+        category: 'performance',
+        severity: 'critical',
+        title: `${label} cache hit rate is critically low (${pct}%)`,
+        description:
+          `The ${label.toLowerCase()} buffer cache hit ratio is ${pct}%, well below the 95% minimum. ` +
+          `A significant number of reads are going to disk.`,
+        recommendation:
+          'Consider increasing shared_buffers or instance RAM. ' +
+          'Investigate workload patterns that bypass the cache.',
+      })
+    } else if (ratio < 0.99) {
+      findings.push({
+        id,
+        category: 'performance',
+        severity: 'warning',
+        title: `${label} cache hit rate is below 99% (${pct}%)`,
+        description:
+          `The ${label.toLowerCase()} buffer cache hit ratio is ${pct}%. ` +
+          `Some reads are going to disk, which may slow queries under load.`,
+        recommendation:
+          'Monitor memory usage and consider increasing shared_buffers if this persists.',
+      })
+    } else {
+      findings.push({
+        id,
+        category: 'performance',
+        severity: 'ok',
+        title: `${label} cache hit rate is healthy (${pct}%)`,
+        description: `The ${label.toLowerCase()} buffer cache hit ratio is ${pct}%.`,
+      })
+    }
+  }
+
+  return findings
+}
+
+/**
+ * Bloat check: bloat ratio > 10 is flagged.
+ * The bloat value is a ratio of actual pages to estimated optimal pages.
+ */
+export function interpretBloat(rows: BloatRow[]): DebuggerFinding {
+  // bloatThreshold: ratio > 10x means 10x more pages than optimal
+  const BLOAT_THRESHOLD = 10
+
+  const bloated = rows.filter((r) => {
+    const val = parseFloat(r.bloat)
+    return !isNaN(val) && val > BLOAT_THRESHOLD
+  })
+
+  if (bloated.length === 0) {
+    return {
+      id: 'bloat',
+      category: 'storage',
+      severity: 'ok',
+      title: 'No significant table or index bloat',
+      description: `All tables and indexes have a bloat ratio at or below ${BLOAT_THRESHOLD}x.`,
+    }
+  }
+
+  const sorted = [...bloated].sort((a, b) => parseFloat(b.bloat) - parseFloat(a.bloat))
+  const top = sorted.slice(0, 5)
+  const offenderList = top.map((r) => `${r.name} (${r.bloat}x, wasted: ${r.waste})`).join('; ')
+
+  return {
+    id: 'bloat',
+    category: 'storage',
+    severity: 'warning',
+    title: `${bloated.length} bloated table${bloated.length !== 1 ? 's' : ''} or index${bloated.length !== 1 ? 'es' : ''} detected`,
+    description:
+      `${bloated.length} object${bloated.length !== 1 ? 's' : ''} exceed a ${BLOAT_THRESHOLD}x bloat ratio. ` +
+      `Worst offenders: ${offenderList}.`,
+    recommendation:
+      'Run VACUUM FULL or use pg_repack to reclaim wasted space without taking exclusive locks.',
+  }
+}
+
+/**
+ * Vacuum stats check: tables where autovacuum is expected (expect_autovacuum = 'yes')
+ * and have > 1000 dead rows are flagged.
+ */
+export function interpretVacuumStats(rows: VacuumStatsRow[]): DebuggerFinding {
+  const DEAD_ROW_THRESHOLD = 1000
+
+  const needsVacuum = rows.filter((r) => {
+    if (r.expect_autovacuum !== 'yes') return false
+    const dead = parseInt(r.dead_rowcount.replace(/[^0-9]/g, ''), 10)
+    return !isNaN(dead) && dead > DEAD_ROW_THRESHOLD
+  })
+
+  if (needsVacuum.length === 0) {
+    return {
+      id: 'vacuum',
+      category: 'storage',
+      severity: 'ok',
+      title: 'Autovacuum is keeping up',
+      description: 'No tables have a dead row count above the autovacuum threshold.',
+    }
+  }
+
+  const tableList = needsVacuum
+    .slice(0, 5)
+    .map((r) => `${r.name} (${r.dead_rowcount.trim()} dead rows)`)
+    .join('; ')
+
+  return {
+    id: 'vacuum',
+    category: 'storage',
+    severity: 'warning',
+    title: `${needsVacuum.length} table${needsVacuum.length !== 1 ? 's' : ''} need autovacuum`,
+    description:
+      `${needsVacuum.length} table${needsVacuum.length !== 1 ? 's' : ''} ` +
+      `exceed the autovacuum dead-row threshold. Tables: ${tableList}.`,
+    recommendation:
+      'Check that autovacuum is enabled and not blocked. ' +
+      'Consider manually running VACUUM on high-priority tables, or tuning autovacuum_vacuum_scale_factor.',
+  }
+}
+
+/**
+ * Index usage check: tables with < 95% of scans using an index AND > 10000 rows.
+ */
+export function interpretIndexUsage(rows: IndexUsageRow[]): DebuggerFinding {
+  const INDEX_USAGE_THRESHOLD = 95
+  const MIN_ROWS = 10_000
+
+  const underIndexed = rows.filter((r) => {
+    if (r.rows_in_table <= MIN_ROWS) return false
+    const pct = parseFloat(r.percent_of_times_index_used)
+    return !isNaN(pct) && pct < INDEX_USAGE_THRESHOLD
+  })
+
+  if (underIndexed.length === 0) {
+    return {
+      id: 'index-usage',
+      category: 'performance',
+      severity: 'ok',
+      title: 'Index usage is healthy',
+      description: `All large tables (>${MIN_ROWS.toLocaleString()} rows) use indexes for at least ${INDEX_USAGE_THRESHOLD}% of scans.`,
+    }
+  }
+
+  const tableList = underIndexed
+    .slice(0, 5)
+    .map(
+      (r) =>
+        `${r.name} (${r.percent_of_times_index_used} index use, ${r.rows_in_table.toLocaleString()} rows)`
+    )
+    .join('; ')
+
+  return {
+    id: 'index-usage',
+    category: 'performance',
+    severity: 'warning',
+    title: `${underIndexed.length} large table${underIndexed.length !== 1 ? 's' : ''} with low index usage`,
+    description:
+      `${underIndexed.length} table${underIndexed.length !== 1 ? 's' : ''} with ` +
+      `>${MIN_ROWS.toLocaleString()} rows use indexes for fewer than ${INDEX_USAGE_THRESHOLD}% of scans. ` +
+      `Tables: ${tableList}.`,
+    recommendation:
+      'Add indexes on frequently queried columns. Review query plans with EXPLAIN ANALYZE to identify full sequential scans.',
+  }
+}
+
+/**
+ * Unused indexes check: non-unique indexes with 0 scans are info-level candidates for removal.
+ */
+export function interpretUnusedIndexes(rows: UnusedIndexesRow[]): DebuggerFinding {
+  const unused = rows.filter((r) => r.index_scans === 0)
+
+  if (unused.length === 0) {
+    return {
+      id: 'unused-indexes',
+      category: 'storage',
+      severity: 'ok',
+      title: 'No unused indexes found',
+      description: 'All non-unique indexes have been scanned at least once.',
+    }
+  }
+
+  const indexList = unused
+    .slice(0, 5)
+    .map((r) => `${r.index} on ${r.name} (${r.index_size})`)
+    .join('; ')
+
+  return {
+    id: 'unused-indexes',
+    category: 'storage',
+    severity: 'info',
+    title: `${unused.length} unused index${unused.length !== 1 ? 'es' : ''} detected`,
+    description:
+      `${unused.length} non-unique index${unused.length !== 1 ? 'es' : ''} have 0 scans recorded. ` +
+      `Candidates: ${indexList}.`,
+    recommendation:
+      'Confirm these indexes are not needed, then drop them to reduce write overhead and disk usage. ' +
+      'Be cautious: statistics reset after pg_stat_reset().',
+  }
+}
+
+/**
+ * Sequential scans check: tables with > 1000 seq scans flagged as info.
+ */
+export function interpretSeqScans(rows: SeqScansRow[]): DebuggerFinding {
+  const SEQ_SCAN_THRESHOLD = 1_000
+
+  const highSeqScans = rows.filter((r) => r.count > SEQ_SCAN_THRESHOLD)
+
+  if (highSeqScans.length === 0) {
+    return {
+      id: 'seq-scans',
+      category: 'performance',
+      severity: 'ok',
+      title: 'No high sequential scan counts',
+      description: `No tables have more than ${SEQ_SCAN_THRESHOLD.toLocaleString()} sequential scans.`,
+    }
+  }
+
+  const tableList = highSeqScans
+    .slice(0, 5)
+    .map((r) => `${r.name} (${r.count.toLocaleString()} seq scans)`)
+    .join('; ')
+
+  return {
+    id: 'seq-scans',
+    category: 'performance',
+    severity: 'info',
+    title: `${highSeqScans.length} table${highSeqScans.length !== 1 ? 's' : ''} with high sequential scan counts`,
+    description:
+      `${highSeqScans.length} table${highSeqScans.length !== 1 ? 's' : ''} have more than ` +
+      `${SEQ_SCAN_THRESHOLD.toLocaleString()} sequential scans: ${tableList}.`,
+    recommendation:
+      'Review query plans with EXPLAIN ANALYZE. Adding indexes on frequently filtered columns may reduce seq scans.',
+  }
+}
+
+/**
+ * Role stats check: roles using >= 80% of connection limit flagged as warning.
+ */
+export function interpretRoleStats(rows: RoleStatsRow[]): DebuggerFinding {
+  const CONNECTION_USAGE_THRESHOLD = 0.8
+
+  const approaching = rows.filter((r) => {
+    if (r.connection_limit <= 0) return false
+    return r.active_connections / r.connection_limit >= CONNECTION_USAGE_THRESHOLD
+  })
+
+  if (approaching.length === 0) {
+    return {
+      id: 'role-connections',
+      category: 'connections',
+      severity: 'ok',
+      title: 'Connection usage is normal',
+      description: 'No roles are using more than 80% of their connection limit.',
+    }
+  }
+
+  const roleList = approaching
+    .slice(0, 5)
+    .map(
+      (r) =>
+        `${r.role_name} (${r.active_connections}/${r.connection_limit}, ${Math.round((r.active_connections / r.connection_limit) * 100)}%)`
+    )
+    .join('; ')
+
+  return {
+    id: 'role-connections',
+    category: 'connections',
+    severity: 'warning',
+    title: `${approaching.length} role${approaching.length !== 1 ? 's' : ''} approaching connection limit`,
+    description:
+      `${approaching.length} role${approaching.length !== 1 ? 's' : ''} ` +
+      `${approaching.length !== 1 ? 'are' : 'is'} using over 80% of their connection limit. ` +
+      `Roles: ${roleList}.`,
+    recommendation:
+      'Consider using a connection pooler such as Supavisor, increasing the connection limit, ' +
+      'or auditing long-lived idle connections.',
+  }
+}
+
+/**
+ * Replication slots check: inactive slots or lag > 1 GB flagged as warning.
+ */
+export function interpretReplicationSlots(rows: ReplicationSlotsRow[]): DebuggerFinding {
+  const LAG_GB_THRESHOLD = 1
+
+  const problematic = rows.filter((r) => !r.active || r.replication_lag_gb > LAG_GB_THRESHOLD)
+
+  if (problematic.length === 0) {
+    return {
+      id: 'replication-slots',
+      category: 'connections',
+      severity: 'ok',
+      title: 'Replication slots are healthy',
+      description: 'All replication slots are active and have acceptable lag.',
+    }
+  }
+
+  const slotList = problematic
+    .slice(0, 5)
+    .map((r) => `${r.slot_name} (active: ${r.active}, lag: ${r.replication_lag_gb} GB)`)
+    .join('; ')
+
+  return {
+    id: 'replication-slots',
+    category: 'connections',
+    severity: 'warning',
+    title: `${problematic.length} problematic replication slot${problematic.length !== 1 ? 's' : ''}`,
+    description:
+      `${problematic.length} replication slot${problematic.length !== 1 ? 's' : ''} ` +
+      `${problematic.length !== 1 ? 'are' : 'is'} either inactive or have lag exceeding ${LAG_GB_THRESHOLD} GB. ` +
+      `Slots: ${slotList}.`,
+    recommendation:
+      'Drop unused replication slots with pg_drop_replication_slot(slot_name). ' +
+      'Inactive slots prevent WAL cleanup and can fill the disk.',
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Aggregator
+// ---------------------------------------------------------------------------
+
+/**
+ * Runs all per-check interpreters over the provided input.
+ * A field being undefined means "not loaded / not run" -- those checks are
+ * silently skipped (no finding emitted). An empty array means "loaded, no
+ * rows found" -- in that case the interpreter will return an ok finding.
+ */
+export function interpretDebuggerResults(input: DebuggerCheckInput): DebuggerFinding[] {
+  const findings: DebuggerFinding[] = []
+
+  if (input.blocking !== undefined) {
+    findings.push(interpretBlocking(input.blocking))
+  }
+
+  if (input.locks !== undefined) {
+    findings.push(interpretLocks(input.locks))
+  }
+
+  if (input.longRunningQueries !== undefined) {
+    findings.push(interpretLongRunningQueries(input.longRunningQueries))
+  }
+
+  if (input.cacheHit !== undefined) {
+    findings.push(...interpretCacheHit(input.cacheHit))
+  }
+
+  if (input.bloat !== undefined) {
+    findings.push(interpretBloat(input.bloat))
+  }
+
+  if (input.vacuumStats !== undefined) {
+    findings.push(interpretVacuumStats(input.vacuumStats))
+  }
+
+  if (input.indexUsage !== undefined) {
+    findings.push(interpretIndexUsage(input.indexUsage))
+  }
+
+  if (input.unusedIndexes !== undefined) {
+    findings.push(interpretUnusedIndexes(input.unusedIndexes))
+  }
+
+  if (input.seqScans !== undefined) {
+    findings.push(interpretSeqScans(input.seqScans))
+  }
+
+  if (input.roleStats !== undefined) {
+    findings.push(interpretRoleStats(input.roleStats))
+  }
+
+  if (input.replicationSlots !== undefined) {
+    findings.push(interpretReplicationSlots(input.replicationSlots))
+  }
+
+  return findings
+}

--- a/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import { ArrowUpRight } from 'lucide-react'
+import { ArrowUpRight, Bug } from 'lucide-react'
 
 import { useIsAdvisorRulesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import type { ProductMenuGroup } from '@/components/ui/ProductMenu/ProductMenu.types'
@@ -27,6 +27,14 @@ export const useGenerateAdvisorsMenu = (): ProductMenuGroup[] => {
           url: `/project/${ref}/advisors/performance`,
           items: [],
           shortcutId: SHORTCUT_IDS.NAV_ADVISORS_PERFORMANCE,
+        },
+        {
+          name: 'Database Debugger',
+          key: 'debugger',
+          url: `/project/${ref}/advisors/debugger`,
+          items: [],
+          shortcutId: SHORTCUT_IDS.NAV_ADVISORS_DEBUGGER,
+          icon: <Bug size={14} strokeWidth={1.5} />,
         },
         {
           name: 'Query Performance',

--- a/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
+++ b/apps/studio/components/layouts/AdvisorsLayout/AdvisorsMenu.utils.tsx
@@ -1,5 +1,5 @@
 import { useParams } from 'common'
-import { ArrowUpRight, Bug } from 'lucide-react'
+import { ArrowUpRight } from 'lucide-react'
 
 import { useIsAdvisorRulesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import type { ProductMenuGroup } from '@/components/ui/ProductMenu/ProductMenu.types'
@@ -29,12 +29,11 @@ export const useGenerateAdvisorsMenu = (): ProductMenuGroup[] => {
           shortcutId: SHORTCUT_IDS.NAV_ADVISORS_PERFORMANCE,
         },
         {
-          name: 'Database Debugger',
+          name: 'Database Scan',
           key: 'debugger',
           url: `/project/${ref}/advisors/debugger`,
           items: [],
           shortcutId: SHORTCUT_IDS.NAV_ADVISORS_DEBUGGER,
-          icon: <Bug size={14} strokeWidth={1.5} />,
         },
         {
           name: 'Query Performance',

--- a/apps/studio/data/database/debugger/bloat-query.ts
+++ b/apps/studio/data/database/debugger/bloat-query.ts
@@ -1,0 +1,137 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type BloatVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface BloatRow {
+  type: string
+  name: string
+  bloat: string
+  waste: string
+}
+
+/**
+ * Schema patterns excluded from bloat analysis, matching the CLI's InternalSchemas list.
+ * Uses SQL LIKE syntax so pg_* covers all pg_ prefixed schemas.
+ */
+export const bloatSql = safeSql`
+WITH constants AS (
+  SELECT current_setting('block_size')::numeric AS bs, 23 AS hdr, 4 AS ma
+), bloat_info AS (
+  SELECT
+    ma,bs,schemaname,tablename,
+    (datawidth+(hdr+ma-(case when hdr%ma=0 THEN ma ELSE hdr%ma END)))::numeric AS datahdr,
+    (maxfracsum*(nullhdr+ma-(case when nullhdr%ma=0 THEN ma ELSE nullhdr%ma END))) AS nullhdr2
+  FROM (
+    SELECT
+      schemaname, tablename, hdr, ma, bs,
+      SUM((1-null_frac)*avg_width) AS datawidth,
+      MAX(null_frac) AS maxfracsum,
+      hdr+(
+        SELECT 1+count(*)/8
+        FROM pg_stats s2
+        WHERE null_frac<>0 AND s2.schemaname = s.schemaname AND s2.tablename = s.tablename
+      ) AS nullhdr
+    FROM pg_stats s, constants
+    GROUP BY 1,2,3,4,5
+  ) AS foo
+), table_bloat AS (
+  SELECT
+    schemaname, tablename, cc.relpages, bs,
+    CEIL((cc.reltuples*((datahdr+ma-
+      (CASE WHEN datahdr%ma=0 THEN ma ELSE datahdr%ma END))+nullhdr2+4))/(bs-20::float)) AS otta
+  FROM bloat_info
+  JOIN pg_class cc ON cc.relname = bloat_info.tablename
+  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname
+  WHERE nn.nspname NOT LIKE 'pg_%'
+    AND nn.nspname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND nn.nspname NOT LIKE 'timescaledb_%'
+    AND nn.nspname NOT LIKE '_timescaledb_%'
+), index_bloat AS (
+  SELECT
+    schemaname, tablename, bs,
+    COALESCE(c2.relname,'?') AS iname, COALESCE(c2.reltuples,0) AS ituples, COALESCE(c2.relpages,0) AS ipages,
+    COALESCE(CEIL((c2.reltuples*(datahdr-12))/(bs-20::float)),0) AS iotta
+  FROM bloat_info
+  JOIN pg_class cc ON cc.relname = bloat_info.tablename
+  JOIN pg_namespace nn ON cc.relnamespace = nn.oid AND nn.nspname = bloat_info.schemaname
+  JOIN pg_index i ON indrelid = cc.oid
+  JOIN pg_class c2 ON c2.oid = i.indexrelid
+  WHERE nn.nspname NOT LIKE 'pg_%'
+    AND nn.nspname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND nn.nspname NOT LIKE 'timescaledb_%'
+    AND nn.nspname NOT LIKE '_timescaledb_%'
+), bloat_summary AS (
+  SELECT
+    'table' as type,
+    FORMAT('%I.%I', schemaname, tablename) AS name,
+    ROUND(CASE WHEN otta=0 THEN 0.0 ELSE table_bloat.relpages/otta::numeric END,1)::text AS bloat,
+    CASE WHEN relpages < otta THEN '0' ELSE (bs*(table_bloat.relpages-otta)::bigint)::bigint END AS raw_waste
+  FROM table_bloat
+  UNION
+  SELECT
+    'index' as type,
+    FORMAT('%I.%I::%I', schemaname, tablename, iname) AS name,
+    ROUND(CASE WHEN iotta=0 OR ipages=0 THEN 0.0 ELSE ipages/iotta::numeric END,1)::text AS bloat,
+    CASE WHEN ipages < iotta THEN '0' ELSE (bs*(ipages-iotta))::bigint END AS raw_waste
+  FROM index_bloat
+)
+SELECT type, name, bloat, pg_size_pretty(raw_waste) as waste
+FROM bloat_summary
+ORDER BY raw_waste DESC, bloat DESC
+`
+
+export async function getBloat(
+  { projectRef, connectionString }: BloatVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<BloatRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: bloatSql,
+      queryKey: ['debugger-bloat'],
+    },
+    signal
+  )
+  return result
+}
+
+export type BloatData = Awaited<ReturnType<typeof getBloat>>
+export type BloatError = ExecuteSqlError
+
+export const useBloatQuery = <TData = BloatData>(
+  { projectRef, connectionString }: BloatVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<BloatData, BloatError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<BloatData, BloatError, TData>({
+    queryKey: databaseKeys.debuggerBloat(projectRef),
+    queryFn: ({ signal }) => getBloat({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/blocking-query.ts
+++ b/apps/studio/data/database/debugger/blocking-query.ts
@@ -1,0 +1,74 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type BlockingVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface BlockingRow {
+  blocked_pid: number
+  blocking_statement: string
+  blocking_duration: string
+  blocking_pid: number
+  blocked_statement: string
+  blocked_duration: string
+}
+
+export const blockingSql = safeSql`
+SELECT
+  bl.pid AS blocked_pid,
+  ka.query AS blocking_statement,
+  age(now(), ka.query_start)::text AS blocking_duration,
+  kl.pid AS blocking_pid,
+  a.query AS blocked_statement,
+  age(now(), a.query_start)::text AS blocked_duration
+FROM pg_catalog.pg_locks bl
+JOIN pg_catalog.pg_stat_activity a
+  ON bl.pid = a.pid
+JOIN pg_catalog.pg_locks kl
+JOIN pg_catalog.pg_stat_activity ka
+  ON kl.pid = ka.pid
+  ON bl.transactionid = kl.transactionid AND bl.pid != kl.pid
+WHERE NOT bl.granted
+`
+
+export async function getBlocking(
+  { projectRef, connectionString }: BlockingVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<BlockingRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: blockingSql,
+      queryKey: ['debugger-blocking'],
+    },
+    signal
+  )
+  return result
+}
+
+export type BlockingData = Awaited<ReturnType<typeof getBlocking>>
+export type BlockingError = ExecuteSqlError
+
+export const useBlockingQuery = <TData = BlockingData>(
+  { projectRef, connectionString }: BlockingVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<BlockingData, BlockingError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<BlockingData, BlockingError, TData>({
+    queryKey: databaseKeys.debuggerBlocking(projectRef),
+    queryFn: ({ signal }) => getBlocking({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/cache-hit-query.ts
+++ b/apps/studio/data/database/debugger/cache-hit-query.ts
@@ -1,0 +1,123 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type CacheHitVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface CacheHitRow {
+  name: string
+  ratio: string
+}
+
+/**
+ * Reports buffer cache hit ratio for tables and indexes.
+ * Values close to 1.00 are healthy; values below 0.99 may indicate memory pressure.
+ */
+export const cacheHitSql = safeSql`
+SELECT
+  'index hit rate' AS name,
+  COALESCE(
+    ROUND(
+      SUM(idx_blks_hit)::numeric / NULLIF(SUM(idx_blks_hit + idx_blks_read), 0),
+      4
+    )::text,
+    'N/A'
+  ) AS ratio
+FROM pg_statio_user_indexes
+WHERE schemaname NOT LIKE 'pg_%'
+  AND schemaname NOT IN (
+    'information_schema','_analytics','_realtime','_supavisor',
+    'auth','etl','extensions','pgbouncer','realtime','storage',
+    'supabase_functions','supabase_migrations','cron','dbdev',
+    'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+    'pgtle','repack','tiger','tiger_data','topology'
+  )
+  AND schemaname NOT LIKE 'timescaledb_%'
+  AND schemaname NOT LIKE '_timescaledb_%'
+UNION ALL
+SELECT
+  'table hit rate' AS name,
+  COALESCE(
+    ROUND(
+      SUM(
+        COALESCE(
+          (to_jsonb(s) ->> 'rel_blks_hit')::bigint,
+          (to_jsonb(s) ->> 'heap_blks_hit')::bigint,
+          0
+        )
+      )::numeric
+      /
+      NULLIF(
+        SUM(
+          COALESCE(
+            (to_jsonb(s) ->> 'rel_blks_hit')::bigint,
+            (to_jsonb(s) ->> 'heap_blks_hit')::bigint,
+            0
+          )
+          +
+          COALESCE(
+            (to_jsonb(s) ->> 'rel_blks_read')::bigint,
+            (to_jsonb(s) ->> 'heap_blks_read')::bigint,
+            0
+          )
+        ),
+        0
+      ),
+      4
+    )::text,
+    'N/A'
+  ) AS ratio
+FROM pg_statio_user_tables s
+WHERE schemaname NOT LIKE 'pg_%'
+  AND schemaname NOT IN (
+    'information_schema','_analytics','_realtime','_supavisor',
+    'auth','etl','extensions','pgbouncer','realtime','storage',
+    'supabase_functions','supabase_migrations','cron','dbdev',
+    'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+    'pgtle','repack','tiger','tiger_data','topology'
+  )
+  AND schemaname NOT LIKE 'timescaledb_%'
+  AND schemaname NOT LIKE '_timescaledb_%'
+`
+
+export async function getCacheHit(
+  { projectRef, connectionString }: CacheHitVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<CacheHitRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: cacheHitSql,
+      queryKey: ['debugger-cache-hit'],
+    },
+    signal
+  )
+  return result
+}
+
+export type CacheHitData = Awaited<ReturnType<typeof getCacheHit>>
+export type CacheHitError = ExecuteSqlError
+
+export const useCacheHitQuery = <TData = CacheHitData>(
+  { projectRef, connectionString }: CacheHitVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<CacheHitData, CacheHitError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<CacheHitData, CacheHitError, TData>({
+    queryKey: databaseKeys.debuggerCacheHit(projectRef),
+    queryFn: ({ signal }) => getCacheHit({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/db-stats-query.ts
+++ b/apps/studio/data/database/debugger/db-stats-query.ts
@@ -1,0 +1,142 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type DbStatsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface DbStatsRow {
+  database_size: string
+  total_index_size: string
+  total_table_size: string
+  total_toast_size: string
+  time_since_stats_reset: string
+  index_hit_rate: string
+  table_hit_rate: string
+  wal_size: string
+}
+
+export const dbStatsSql = safeSql`
+WITH total_objects AS (
+  SELECT c.relkind, pg_size_pretty(SUM(pg_relation_size(c.oid))) AS size
+  FROM pg_class c JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE c.relkind IN ('i', 'r', 't')
+    AND n.nspname NOT LIKE 'pg_%'
+    AND n.nspname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND n.nspname NOT LIKE 'timescaledb_%'
+    AND n.nspname NOT LIKE '_timescaledb_%'
+  GROUP BY c.relkind
+), cache_hit AS (
+  SELECT
+    'i' AS relkind,
+    ROUND(SUM(idx_blks_hit)::numeric / NULLIF(SUM(idx_blks_hit + idx_blks_read), 0), 2) AS ratio
+  FROM pg_statio_user_indexes
+  WHERE schemaname NOT LIKE 'pg_%'
+    AND schemaname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND schemaname NOT LIKE 'timescaledb_%'
+    AND schemaname NOT LIKE '_timescaledb_%'
+  UNION
+  SELECT
+    't' AS relkind,
+    ROUND(
+      SUM(
+        COALESCE(
+          (to_jsonb(s) ->> 'rel_blks_hit')::bigint,
+          (to_jsonb(s) ->> 'heap_blks_hit')::bigint,
+          0
+        )
+      )::numeric
+      /
+      NULLIF(
+        SUM(
+          COALESCE(
+            (to_jsonb(s) ->> 'rel_blks_hit')::bigint,
+            (to_jsonb(s) ->> 'heap_blks_hit')::bigint,
+            0
+          )
+          +
+          COALESCE(
+            (to_jsonb(s) ->> 'rel_blks_read')::bigint,
+            (to_jsonb(s) ->> 'heap_blks_read')::bigint,
+            0
+          )
+        ),
+        0
+      ),
+      2
+    ) AS ratio
+  FROM pg_statio_user_tables s
+  WHERE schemaname NOT LIKE 'pg_%'
+    AND schemaname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND schemaname NOT LIKE 'timescaledb_%'
+    AND schemaname NOT LIKE '_timescaledb_%'
+)
+SELECT
+  pg_size_pretty(pg_database_size(current_database())) AS database_size,
+  COALESCE((SELECT size FROM total_objects WHERE relkind = 'i'), '0 bytes') AS total_index_size,
+  COALESCE((SELECT size FROM total_objects WHERE relkind = 'r'), '0 bytes') AS total_table_size,
+  COALESCE((SELECT size FROM total_objects WHERE relkind = 't'), '0 bytes') AS total_toast_size,
+  COALESCE((SELECT (now() - stats_reset)::text FROM extensions.pg_stat_statements_info), 'N/A') AS time_since_stats_reset,
+  (SELECT COALESCE(ratio::text, 'N/A') FROM cache_hit WHERE relkind = 'i') AS index_hit_rate,
+  (SELECT COALESCE(ratio::text, 'N/A') FROM cache_hit WHERE relkind = 't') AS table_hit_rate,
+  COALESCE((SELECT pg_size_pretty(SUM(size)) FROM pg_ls_waldir()), '0 bytes') AS wal_size
+`
+
+export async function getDbStats(
+  { projectRef, connectionString }: DbStatsVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<DbStatsRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: dbStatsSql,
+      queryKey: ['debugger-db-stats'],
+    },
+    signal
+  )
+  return result
+}
+
+export type DbStatsData = Awaited<ReturnType<typeof getDbStats>>
+export type DbStatsError = ExecuteSqlError
+
+export const useDbStatsQuery = <TData = DbStatsData>(
+  { projectRef, connectionString }: DbStatsVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<DbStatsData, DbStatsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<DbStatsData, DbStatsError, TData>({
+    queryKey: databaseKeys.debuggerDbStats(projectRef),
+    queryFn: ({ signal }) => getDbStats({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/debugger-preconditions-query.ts
+++ b/apps/studio/data/database/debugger/debugger-preconditions-query.ts
@@ -1,0 +1,87 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type DebuggerPreconditionsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface DebuggerPreconditionsResult {
+  /** Whether pg_stat_statements extension is installed and enabled. */
+  hasPgStatStatements: boolean
+  /**
+   * Whether the current role can read pg_stat_activity and pg_locks.
+   * Best-effort: false when a permission error is caught, true otherwise.
+   */
+  canReadStats: boolean
+}
+
+const pgStatStatementsCheckSql = safeSql`
+SELECT EXISTS (
+  SELECT 1
+  FROM pg_extension
+  WHERE extname = 'pg_stat_statements'
+) AS has_pg_stat_statements
+`
+
+const statsReadCheckSql = safeSql`
+SELECT count(*) AS accessible_rows FROM pg_stat_activity LIMIT 1
+`
+
+export async function getDebuggerPreconditions(
+  { projectRef, connectionString }: DebuggerPreconditionsVariables,
+  signal?: AbortSignal
+): Promise<DebuggerPreconditionsResult> {
+  const [extensionResult, statsResult] = await Promise.all([
+    executeSql<{ has_pg_stat_statements: boolean }[]>(
+      {
+        projectRef,
+        connectionString,
+        sql: pgStatStatementsCheckSql,
+        queryKey: ['debugger-preconditions-pg-stat-statements'],
+      },
+      signal
+    ).catch(() => ({ result: [{ has_pg_stat_statements: false }] })),
+    executeSql<{ accessible_rows: number }[]>(
+      {
+        projectRef,
+        connectionString,
+        sql: statsReadCheckSql,
+        queryKey: ['debugger-preconditions-stats-read'],
+      },
+      signal
+    ).catch(() => null),
+  ])
+
+  return {
+    hasPgStatStatements: extensionResult.result?.[0]?.has_pg_stat_statements === true,
+    canReadStats: statsResult !== null,
+  }
+}
+
+export type DebuggerPreconditionsData = Awaited<ReturnType<typeof getDebuggerPreconditions>>
+export type DebuggerPreconditionsError = ExecuteSqlError
+
+export const useDebuggerPreconditionsQuery = <TData = DebuggerPreconditionsData>(
+  { projectRef, connectionString }: DebuggerPreconditionsVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<DebuggerPreconditionsData, DebuggerPreconditionsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<DebuggerPreconditionsData, DebuggerPreconditionsError, TData>({
+    queryKey: databaseKeys.debuggerPreconditions(projectRef),
+    queryFn: ({ signal }) => getDebuggerPreconditions({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/index-stats-query.ts
+++ b/apps/studio/data/database/debugger/index-stats-query.ts
@@ -1,0 +1,134 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type IndexStatsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface IndexStatsRow {
+  name: string
+  size: string
+  percent_used: string
+  index_scans: number
+  seq_scans: number
+  unused: boolean
+}
+
+export const indexStatsSql = safeSql`
+WITH idx_sizes AS (
+  SELECT
+    i.indexrelid AS oid,
+    FORMAT('%I.%I', n.nspname, c.relname) AS name,
+    pg_relation_size(i.indexrelid) AS index_size_bytes
+  FROM pg_stat_user_indexes ui
+  JOIN pg_index i ON ui.indexrelid = i.indexrelid
+  JOIN pg_class c ON ui.indexrelid = c.oid
+  JOIN pg_namespace n ON c.relnamespace = n.oid
+  WHERE n.nspname NOT LIKE 'pg_%'
+    AND n.nspname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND n.nspname NOT LIKE 'timescaledb_%'
+    AND n.nspname NOT LIKE '_timescaledb_%'
+),
+idx_usage AS (
+  SELECT
+    indexrelid AS oid,
+    idx_scan::bigint AS idx_scans
+  FROM pg_stat_user_indexes ui
+  WHERE schemaname NOT LIKE 'pg_%'
+    AND schemaname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND schemaname NOT LIKE 'timescaledb_%'
+    AND schemaname NOT LIKE '_timescaledb_%'
+),
+seq_usage AS (
+  SELECT
+    relid AS oid,
+    seq_scan::bigint AS seq_scans
+  FROM pg_stat_user_tables
+  WHERE schemaname NOT LIKE 'pg_%'
+    AND schemaname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND schemaname NOT LIKE 'timescaledb_%'
+    AND schemaname NOT LIKE '_timescaledb_%'
+),
+usage_pct AS (
+  SELECT
+    u.oid,
+    CASE
+      WHEN u.idx_scans IS NULL OR u.idx_scans = 0 THEN 0
+      WHEN s.seq_scans IS NULL THEN 100
+      ELSE ROUND(100.0 * u.idx_scans / (s.seq_scans + u.idx_scans), 1)
+    END AS percent_used
+  FROM idx_usage u
+  LEFT JOIN seq_usage s ON s.oid = u.oid
+)
+SELECT
+  s.name,
+  pg_size_pretty(s.index_size_bytes) AS size,
+  COALESCE(up.percent_used, 0)::text || '%' AS percent_used,
+  COALESCE(u.idx_scans, 0) AS index_scans,
+  COALESCE(sq.seq_scans, 0) AS seq_scans,
+  CASE WHEN COALESCE(u.idx_scans, 0) = 0 THEN true ELSE false END AS unused
+FROM idx_sizes s
+LEFT JOIN idx_usage u ON u.oid = s.oid
+LEFT JOIN seq_usage sq ON sq.oid = s.oid
+LEFT JOIN usage_pct up ON up.oid = s.oid
+ORDER BY s.index_size_bytes DESC
+`
+
+export async function getIndexStats(
+  { projectRef, connectionString }: IndexStatsVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<IndexStatsRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: indexStatsSql,
+      queryKey: ['debugger-index-stats'],
+    },
+    signal
+  )
+  return result
+}
+
+export type IndexStatsData = Awaited<ReturnType<typeof getIndexStats>>
+export type IndexStatsError = ExecuteSqlError
+
+export const useIndexStatsQuery = <TData = IndexStatsData>(
+  { projectRef, connectionString }: IndexStatsVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<IndexStatsData, IndexStatsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<IndexStatsData, IndexStatsError, TData>({
+    queryKey: databaseKeys.debuggerIndexStats(projectRef),
+    queryFn: ({ signal }) => getIndexStats({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/index-usage-query.ts
+++ b/apps/studio/data/database/debugger/index-usage-query.ts
@@ -1,0 +1,81 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type IndexUsageVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface IndexUsageRow {
+  name: string
+  percent_of_times_index_used: string
+  rows_in_table: number
+}
+
+/**
+ * Shows the percentage of table scans that used an index vs a sequential scan.
+ * Tables with low index usage and high row counts may benefit from new indexes.
+ */
+export const indexUsageSql = safeSql`
+SELECT
+  FORMAT('%I.%I', schemaname, relname) AS name,
+  CASE idx_scan
+    WHEN 0 THEN 'Insufficient data'
+    ELSE ROUND(100.0 * idx_scan / (seq_scan + idx_scan), 1)::text || '%'
+  END AS percent_of_times_index_used,
+  n_live_tup AS rows_in_table
+FROM pg_stat_user_tables
+WHERE schemaname NOT LIKE 'pg_%'
+  AND schemaname NOT IN (
+    'information_schema','_analytics','_realtime','_supavisor',
+    'auth','etl','extensions','pgbouncer','realtime','storage',
+    'supabase_functions','supabase_migrations','cron','dbdev',
+    'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+    'pgtle','repack','tiger','tiger_data','topology'
+  )
+  AND schemaname NOT LIKE 'timescaledb_%'
+  AND schemaname NOT LIKE '_timescaledb_%'
+ORDER BY
+  n_live_tup DESC,
+  relname ASC
+`
+
+export async function getIndexUsage(
+  { projectRef, connectionString }: IndexUsageVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<IndexUsageRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: indexUsageSql,
+      queryKey: ['debugger-index-usage'],
+    },
+    signal
+  )
+  return result
+}
+
+export type IndexUsageData = Awaited<ReturnType<typeof getIndexUsage>>
+export type IndexUsageError = ExecuteSqlError
+
+export const useIndexUsageQuery = <TData = IndexUsageData>(
+  { projectRef, connectionString }: IndexUsageVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<IndexUsageData, IndexUsageError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<IndexUsageData, IndexUsageError, TData>({
+    queryKey: databaseKeys.debuggerIndexUsage(projectRef),
+    queryFn: ({ signal }) => getIndexUsage({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/locks-query.ts
+++ b/apps/studio/data/database/debugger/locks-query.ts
@@ -1,0 +1,71 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type LocksVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface LocksRow {
+  pid: number
+  relname: string
+  transactionid: string
+  granted: boolean
+  stmt: string
+  age: string
+}
+
+export const locksSql = safeSql`
+SELECT
+  pg_stat_activity.pid,
+  COALESCE(pg_class.relname, 'null') AS relname,
+  COALESCE(pg_locks.transactionid::text, 'null') AS transactionid,
+  pg_locks.granted,
+  pg_stat_activity.query AS stmt,
+  age(now(), pg_stat_activity.query_start)::text AS age
+FROM pg_stat_activity, pg_locks LEFT OUTER JOIN pg_class ON (pg_locks.relation = pg_class.oid)
+WHERE pg_stat_activity.query <> '<insufficient privilege>'
+AND pg_locks.pid = pg_stat_activity.pid
+AND pg_locks.mode = 'ExclusiveLock'
+ORDER BY query_start
+`
+
+export async function getLocks(
+  { projectRef, connectionString }: LocksVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<LocksRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: locksSql,
+      queryKey: ['debugger-locks'],
+    },
+    signal
+  )
+  return result
+}
+
+export type LocksData = Awaited<ReturnType<typeof getLocks>>
+export type LocksError = ExecuteSqlError
+
+export const useLocksQuery = <TData = LocksData>(
+  { projectRef, connectionString }: LocksVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<LocksData, LocksError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<LocksData, LocksError, TData>({
+    queryKey: databaseKeys.debuggerLocks(projectRef),
+    queryFn: ({ signal }) => getLocks({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/long-running-queries-query.ts
+++ b/apps/studio/data/database/debugger/long-running-queries-query.ts
@@ -1,0 +1,77 @@
+import { literal, safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type LongRunningQueriesVariables = {
+  projectRef?: string
+  connectionString?: string | null
+  /** Postgres interval string, e.g. '5 minutes'. Defaults to '5 minutes'. */
+  threshold?: string
+}
+
+export interface LongRunningQueriesRow {
+  pid: number
+  duration: string
+  query: string
+}
+
+export function buildLongRunningQueriesSql(threshold = '5 minutes') {
+  return safeSql`
+SELECT
+  pid,
+  age(now(), pg_stat_activity.query_start)::text AS duration,
+  query AS query
+FROM
+  pg_stat_activity
+WHERE
+  pg_stat_activity.query <> ''::text
+  AND state <> 'idle'
+  AND age(now(), pg_stat_activity.query_start) > interval ${literal(threshold)}
+ORDER BY
+  age(now(), pg_stat_activity.query_start) DESC
+`
+}
+
+export async function getLongRunningQueries(
+  { projectRef, connectionString, threshold }: LongRunningQueriesVariables,
+  signal?: AbortSignal
+) {
+  const sql = buildLongRunningQueriesSql(threshold)
+  const { result } = await executeSql<LongRunningQueriesRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql,
+      queryKey: ['debugger-long-running-queries', threshold ?? '5 minutes'],
+    },
+    signal
+  )
+  return result
+}
+
+export type LongRunningQueriesData = Awaited<ReturnType<typeof getLongRunningQueries>>
+export type LongRunningQueriesError = ExecuteSqlError
+
+export const useLongRunningQueriesQuery = <TData = LongRunningQueriesData>(
+  { projectRef, connectionString, threshold }: LongRunningQueriesVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<LongRunningQueriesData, LongRunningQueriesError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<LongRunningQueriesData, LongRunningQueriesError, TData>({
+    queryKey: databaseKeys.debuggerLongRunningQueries(projectRef, threshold),
+    queryFn: ({ signal }) =>
+      getLongRunningQueries({ projectRef, connectionString, threshold }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/replication-slots-query.ts
+++ b/apps/studio/data/database/debugger/replication-slots-query.ts
@@ -1,0 +1,72 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type ReplicationSlotsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface ReplicationSlotsRow {
+  slot_name: string
+  active: boolean
+  state: string
+  replication_client_address: string
+  replication_lag_gb: number
+}
+
+export const replicationSlotsSql = safeSql`
+SELECT
+  s.slot_name,
+  s.active,
+  COALESCE(r.state, 'N/A') AS state,
+  CASE WHEN r.client_addr IS NULL
+    THEN 'N/A'
+    ELSE r.client_addr::text
+  END AS replication_client_address,
+  GREATEST(0, ROUND((redo_lsn - restart_lsn) / 1024 / 1024 / 1024, 2)) AS replication_lag_gb
+FROM pg_control_checkpoint(), pg_replication_slots s
+LEFT JOIN pg_stat_replication r ON (r.pid = s.active_pid)
+`
+
+export async function getReplicationSlots(
+  { projectRef, connectionString }: ReplicationSlotsVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<ReplicationSlotsRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: replicationSlotsSql,
+      queryKey: ['debugger-replication-slots'],
+    },
+    signal
+  )
+  return result
+}
+
+export type ReplicationSlotsData = Awaited<ReturnType<typeof getReplicationSlots>>
+export type ReplicationSlotsError = ExecuteSqlError
+
+export const useReplicationSlotsQuery = <TData = ReplicationSlotsData>(
+  { projectRef, connectionString }: ReplicationSlotsVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<ReplicationSlotsData, ReplicationSlotsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<ReplicationSlotsData, ReplicationSlotsError, TData>({
+    queryKey: databaseKeys.debuggerReplicationSlots(projectRef),
+    queryFn: ({ signal }) => getReplicationSlots({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/role-stats-query.ts
+++ b/apps/studio/data/database/debugger/role-stats-query.ts
@@ -1,0 +1,71 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type RoleStatsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface RoleStatsRow {
+  role_name: string
+  active_connections: number
+  connection_limit: number
+  custom_config: string
+}
+
+export const roleStatsSql = safeSql`
+SELECT
+  rolname AS role_name,
+  (
+    SELECT count(*)
+    FROM pg_stat_activity
+    WHERE pg_roles.rolname = pg_stat_activity.usename
+  ) AS active_connections,
+  CASE WHEN rolconnlimit = -1
+    THEN current_setting('max_connections')::int8
+    ELSE rolconnlimit
+  END AS connection_limit,
+  array_to_string(rolconfig, ',', '*') AS custom_config
+FROM pg_roles
+ORDER BY 1 DESC
+`
+
+export async function getRoleStats(
+  { projectRef, connectionString }: RoleStatsVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<RoleStatsRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: roleStatsSql,
+      queryKey: ['debugger-role-stats'],
+    },
+    signal
+  )
+  return result
+}
+
+export type RoleStatsData = Awaited<ReturnType<typeof getRoleStats>>
+export type RoleStatsError = ExecuteSqlError
+
+export const useRoleStatsQuery = <TData = RoleStatsData>(
+  { projectRef, connectionString }: RoleStatsVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<RoleStatsData, RoleStatsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<RoleStatsData, RoleStatsError, TData>({
+    queryKey: databaseKeys.debuggerRoleStats(projectRef),
+    queryFn: ({ signal }) => getRoleStats({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/seq-scans-query.ts
+++ b/apps/studio/data/database/debugger/seq-scans-query.ts
@@ -1,0 +1,74 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type SeqScansVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface SeqScansRow {
+  name: string
+  count: number
+}
+
+/**
+ * Tables ordered by sequential scan count. High seq_scan on large tables
+ * typically indicates a missing index.
+ */
+export const seqScansSql = safeSql`
+SELECT
+  FORMAT('%I.%I', schemaname, relname) AS name,
+  seq_scan AS count
+FROM pg_stat_user_tables
+WHERE schemaname NOT LIKE 'pg_%'
+  AND schemaname NOT IN (
+    'information_schema','_analytics','_realtime','_supavisor',
+    'auth','etl','extensions','pgbouncer','realtime','storage',
+    'supabase_functions','supabase_migrations','cron','dbdev',
+    'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+    'pgtle','repack','tiger','tiger_data','topology'
+  )
+  AND schemaname NOT LIKE 'timescaledb_%'
+  AND schemaname NOT LIKE '_timescaledb_%'
+ORDER BY seq_scan DESC
+`
+
+export async function getSeqScans(
+  { projectRef, connectionString }: SeqScansVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<SeqScansRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: seqScansSql,
+      queryKey: ['debugger-seq-scans'],
+    },
+    signal
+  )
+  return result
+}
+
+export type SeqScansData = Awaited<ReturnType<typeof getSeqScans>>
+export type SeqScansError = ExecuteSqlError
+
+export const useSeqScansQuery = <TData = SeqScansData>(
+  { projectRef, connectionString }: SeqScansVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<SeqScansData, SeqScansError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<SeqScansData, SeqScansError, TData>({
+    queryKey: databaseKeys.debuggerSeqScans(projectRef),
+    queryFn: ({ signal }) => getSeqScans({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/table-record-counts-query.ts
+++ b/apps/studio/data/database/debugger/table-record-counts-query.ts
@@ -1,0 +1,77 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type TableRecordCountsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface TableRecordCountsRow {
+  name: string
+  estimated_row_count: number
+}
+
+/**
+ * Returns estimated live row counts per user table, excluding internal Supabase schemas.
+ * Uses pg_stat_user_tables.n_live_tup for a fast estimate (same source as table_stats).
+ */
+export const tableRecordCountsSql = safeSql`
+SELECT
+  FORMAT('%I.%I', schemaname, relname) AS name,
+  n_live_tup AS estimated_row_count
+FROM pg_stat_user_tables
+WHERE schemaname NOT LIKE 'pg_%'
+  AND schemaname NOT IN (
+    'information_schema','_analytics','_realtime','_supavisor',
+    'auth','etl','extensions','pgbouncer','realtime','storage',
+    'supabase_functions','supabase_migrations','cron','dbdev',
+    'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+    'pgtle','repack','tiger','tiger_data','topology'
+  )
+  AND schemaname NOT LIKE 'timescaledb_%'
+  AND schemaname NOT LIKE '_timescaledb_%'
+ORDER BY n_live_tup DESC
+`
+
+export async function getTableRecordCounts(
+  { projectRef, connectionString }: TableRecordCountsVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<TableRecordCountsRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: tableRecordCountsSql,
+      queryKey: ['debugger-table-record-counts'],
+    },
+    signal
+  )
+  return result
+}
+
+export type TableRecordCountsData = Awaited<ReturnType<typeof getTableRecordCounts>>
+export type TableRecordCountsError = ExecuteSqlError
+
+export const useTableRecordCountsQuery = <TData = TableRecordCountsData>(
+  { projectRef, connectionString }: TableRecordCountsVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<TableRecordCountsData, TableRecordCountsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<TableRecordCountsData, TableRecordCountsError, TData>({
+    queryKey: databaseKeys.debuggerTableRecordCounts(projectRef),
+    queryFn: ({ signal }) => getTableRecordCounts({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/table-stats-query.ts
+++ b/apps/studio/data/database/debugger/table-stats-query.ts
@@ -1,0 +1,104 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type TableStatsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface TableStatsRow {
+  name: string
+  table_size: string
+  index_size: string
+  total_size: string
+  estimated_row_count: number
+  seq_scans: number
+}
+
+export const tableStatsSql = safeSql`
+SELECT
+  ts.name,
+  pg_size_pretty(ts.table_size_bytes) AS table_size,
+  pg_size_pretty(ts.index_size_bytes) AS index_size,
+  pg_size_pretty(ts.total_size_bytes) AS total_size,
+  COALESCE(rc.estimated_row_count, 0) AS estimated_row_count,
+  COALESCE(rc.seq_scans, 0) AS seq_scans
+FROM (
+  SELECT
+    FORMAT('%I.%I', n.nspname, c.relname) AS name,
+    pg_table_size(c.oid) AS table_size_bytes,
+    pg_indexes_size(c.oid) AS index_size_bytes,
+    pg_total_relation_size(c.oid) AS total_size_bytes
+  FROM pg_class c
+  LEFT JOIN pg_namespace n ON n.oid = c.relnamespace
+  WHERE n.nspname NOT LIKE 'pg_%'
+    AND n.nspname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND n.nspname NOT LIKE 'timescaledb_%'
+    AND n.nspname NOT LIKE '_timescaledb_%'
+    AND c.relkind = 'r'
+) ts
+LEFT JOIN (
+  SELECT
+    FORMAT('%I.%I', schemaname, relname) AS name,
+    n_live_tup AS estimated_row_count,
+    seq_scan AS seq_scans
+  FROM pg_stat_user_tables
+  WHERE schemaname NOT LIKE 'pg_%'
+    AND schemaname NOT IN (
+      'information_schema','_analytics','_realtime','_supavisor',
+      'auth','etl','extensions','pgbouncer','realtime','storage',
+      'supabase_functions','supabase_migrations','cron','dbdev',
+      'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+      'pgtle','repack','tiger','tiger_data','topology'
+    )
+    AND schemaname NOT LIKE 'timescaledb_%'
+    AND schemaname NOT LIKE '_timescaledb_%'
+) rc ON rc.name = ts.name
+ORDER BY ts.total_size_bytes DESC
+`
+
+export async function getTableStats(
+  { projectRef, connectionString }: TableStatsVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<TableStatsRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: tableStatsSql,
+      queryKey: ['debugger-table-stats'],
+    },
+    signal
+  )
+  return result
+}
+
+export type TableStatsData = Awaited<ReturnType<typeof getTableStats>>
+export type TableStatsError = ExecuteSqlError
+
+export const useTableStatsQuery = <TData = TableStatsData>(
+  { projectRef, connectionString }: TableStatsVariables,
+  { enabled = true, ...options }: UseCustomQueryOptions<TableStatsData, TableStatsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<TableStatsData, TableStatsError, TData>({
+    queryKey: databaseKeys.debuggerTableStats(projectRef),
+    queryFn: ({ signal }) => getTableStats({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/traffic-profile-query.ts
+++ b/apps/studio/data/database/debugger/traffic-profile-query.ts
@@ -1,0 +1,99 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type TrafficProfileVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface TrafficProfileRow {
+  schemaname: string
+  table_name: string
+  blocks_read: number
+  write_tuples: number
+  blocks_write: number
+  activity_ratio: string
+}
+
+export const trafficProfileSql = safeSql`
+WITH
+ratio_target AS (SELECT 5 AS ratio),
+table_list AS (
+  SELECT
+    s.schemaname,
+    s.relname AS table_name,
+    si.heap_blks_read + si.idx_blks_read AS blocks_read,
+    s.n_tup_ins + s.n_tup_upd + s.n_tup_del AS write_tuples,
+    relpages * (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) / (CASE WHEN reltuples = 0 THEN 1 ELSE reltuples END) AS blocks_write
+  FROM pg_stat_user_tables AS s
+  JOIN pg_statio_user_tables AS si ON s.relid = si.relid
+  JOIN pg_class c ON c.oid = s.relid
+  WHERE (s.n_tup_ins + s.n_tup_upd + s.n_tup_del) > 0
+    AND (si.heap_blks_read + si.idx_blks_read) > 0
+)
+SELECT
+  schemaname,
+  table_name,
+  blocks_read,
+  write_tuples,
+  blocks_write,
+  CASE
+    WHEN blocks_read = 0 AND blocks_write = 0 THEN 'No Activity'
+    WHEN blocks_write * ratio > blocks_read THEN
+      CASE
+        WHEN blocks_read = 0 THEN 'Write-Only'
+        ELSE ROUND(blocks_write::numeric / blocks_read::numeric, 1)::text || ':1 (Write-Heavy)'
+      END
+    WHEN blocks_read > blocks_write * ratio THEN
+      CASE
+        WHEN blocks_write = 0 THEN 'Read-Only'
+        ELSE '1:' || ROUND(blocks_read::numeric / blocks_write::numeric, 1)::text || ' (Read-Heavy)'
+      END
+    ELSE '1:1 (Balanced)'
+  END AS activity_ratio
+FROM table_list, ratio_target
+ORDER BY (blocks_read + blocks_write) DESC
+`
+
+export async function getTrafficProfile(
+  { projectRef, connectionString }: TrafficProfileVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<TrafficProfileRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: trafficProfileSql,
+      queryKey: ['debugger-traffic-profile'],
+    },
+    signal
+  )
+  return result
+}
+
+export type TrafficProfileData = Awaited<ReturnType<typeof getTrafficProfile>>
+export type TrafficProfileError = ExecuteSqlError
+
+export const useTrafficProfileQuery = <TData = TrafficProfileData>(
+  { projectRef, connectionString }: TrafficProfileVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<TrafficProfileData, TrafficProfileError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<TrafficProfileData, TrafficProfileError, TData>({
+    queryKey: databaseKeys.debuggerTrafficProfile(projectRef),
+    queryFn: ({ signal }) => getTrafficProfile({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/unused-indexes-query.ts
+++ b/apps/studio/data/database/debugger/unused-indexes-query.ts
@@ -1,0 +1,83 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type UnusedIndexesVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface UnusedIndexesRow {
+  name: string
+  index: string
+  index_size: string
+  index_scans: number
+}
+
+export const unusedIndexesSql = safeSql`
+SELECT
+  FORMAT('%I.%I', schemaname, relname) AS name,
+  indexrelname AS index,
+  pg_size_pretty(pg_relation_size(i.indexrelid)) AS index_size,
+  idx_scan AS index_scans
+FROM pg_stat_user_indexes ui
+JOIN pg_index i ON ui.indexrelid = i.indexrelid
+WHERE NOT indisunique
+  AND idx_scan < 50
+  AND pg_relation_size(relid) > 5 * 8192
+  AND schemaname NOT LIKE 'pg_%'
+  AND schemaname NOT IN (
+    'information_schema','_analytics','_realtime','_supavisor',
+    'auth','etl','extensions','pgbouncer','realtime','storage',
+    'supabase_functions','supabase_migrations','cron','dbdev',
+    'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+    'pgtle','repack','tiger','tiger_data','topology'
+  )
+  AND schemaname NOT LIKE 'timescaledb_%'
+  AND schemaname NOT LIKE '_timescaledb_%'
+ORDER BY
+  pg_relation_size(i.indexrelid) / NULLIF(idx_scan, 0) DESC NULLS FIRST,
+  pg_relation_size(i.indexrelid) DESC
+`
+
+export async function getUnusedIndexes(
+  { projectRef, connectionString }: UnusedIndexesVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<UnusedIndexesRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: unusedIndexesSql,
+      queryKey: ['debugger-unused-indexes'],
+    },
+    signal
+  )
+  return result
+}
+
+export type UnusedIndexesData = Awaited<ReturnType<typeof getUnusedIndexes>>
+export type UnusedIndexesError = ExecuteSqlError
+
+export const useUnusedIndexesQuery = <TData = UnusedIndexesData>(
+  { projectRef, connectionString }: UnusedIndexesVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<UnusedIndexesData, UnusedIndexesError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<UnusedIndexesData, UnusedIndexesError, TData>({
+    queryKey: databaseKeys.debuggerUnusedIndexes(projectRef),
+    queryFn: ({ signal }) => getUnusedIndexes({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/debugger/vacuum-stats-query.ts
+++ b/apps/studio/data/database/debugger/vacuum-stats-query.ts
@@ -1,0 +1,139 @@
+import { safeSql } from '@supabase/pg-meta/src/pg-format'
+import { useQuery } from '@tanstack/react-query'
+
+import { databaseKeys } from '../keys'
+import { executeSql, ExecuteSqlError } from '@/data/sql/execute-sql-query'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+import type { UseCustomQueryOptions } from '@/types'
+
+export type VacuumStatsVariables = {
+  projectRef?: string
+  connectionString?: string | null
+}
+
+export interface VacuumStatsRow {
+  name: string
+  last_vacuum: string
+  last_autovacuum: string
+  last_analyze: string
+  last_autoanalyze: string
+  rowcount: string
+  dead_rowcount: string
+  autovacuum_threshold: string
+  expect_autovacuum: string
+  autoanalyze_threshold: string
+  expect_autoanalyze: string
+}
+
+export const vacuumStatsSql = safeSql`
+WITH table_opts AS (
+  SELECT
+    pg_class.oid, relname, nspname, array_to_string(reloptions, '') AS relopts
+  FROM
+    pg_class INNER JOIN pg_namespace ns ON relnamespace = ns.oid
+), vacuum_settings AS (
+  SELECT
+    oid, relname, nspname,
+    CASE
+      WHEN relopts LIKE '%autovacuum_vacuum_threshold%'
+        THEN substring(relopts, '.*autovacuum_vacuum_threshold=([0-9.]+).*')::integer
+        ELSE current_setting('autovacuum_vacuum_threshold')::integer
+      END AS autovacuum_vacuum_threshold,
+    CASE
+      WHEN relopts LIKE '%autovacuum_vacuum_scale_factor%'
+        THEN substring(relopts, '.*autovacuum_vacuum_scale_factor=([0-9.]+).*')::real
+        ELSE current_setting('autovacuum_vacuum_scale_factor')::real
+      END AS autovacuum_vacuum_scale_factor,
+    CASE
+      WHEN relopts LIKE '%autovacuum_analyze_threshold%'
+        THEN substring(relopts, '.*autovacuum_analyze_threshold=([0-9.]+).*')::integer
+        ELSE current_setting('autovacuum_analyze_threshold')::integer
+      END AS autovacuum_analyze_threshold,
+    CASE
+      WHEN relopts LIKE '%autovacuum_analyze_scale_factor%'
+        THEN substring(relopts, '.*autovacuum_analyze_scale_factor=([0-9.]+).*')::real
+        ELSE current_setting('autovacuum_analyze_scale_factor')::real
+      END AS autovacuum_analyze_scale_factor
+  FROM
+    table_opts
+)
+SELECT
+  FORMAT('%I.%I', vacuum_settings.nspname, vacuum_settings.relname) AS name,
+  coalesce(to_char(psut.last_vacuum, 'YYYY-MM-DD HH24:MI'), '') AS last_vacuum,
+  coalesce(to_char(psut.last_autovacuum, 'YYYY-MM-DD HH24:MI'), '') AS last_autovacuum,
+  coalesce(to_char(psut.last_analyze, 'YYYY-MM-DD HH24:MI'), '') AS last_analyze,
+  coalesce(to_char(psut.last_autoanalyze, 'YYYY-MM-DD HH24:MI'), '') AS last_autoanalyze,
+  to_char(pg_class.reltuples, '9G999G999G999') AS rowcount,
+  to_char(psut.n_dead_tup, '9G999G999G999') AS dead_rowcount,
+  to_char(autovacuum_vacuum_threshold
+       + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples), '9G999G999G999') AS autovacuum_threshold,
+  CASE
+    WHEN autovacuum_vacuum_threshold + (autovacuum_vacuum_scale_factor::numeric * pg_class.reltuples) < psut.n_dead_tup
+    THEN 'yes'
+    ELSE 'no'
+  END AS expect_autovacuum,
+  to_char(autovacuum_analyze_threshold
+       + (autovacuum_analyze_scale_factor::numeric * pg_class.reltuples), '9G999G999G999') AS autoanalyze_threshold,
+  CASE
+    WHEN autovacuum_analyze_threshold + (autovacuum_analyze_scale_factor::numeric * pg_class.reltuples) < psut.n_dead_tup
+    THEN 'yes'
+    ELSE 'no'
+  END AS expect_autoanalyze
+FROM
+  pg_stat_user_tables psut INNER JOIN pg_class ON psut.relid = pg_class.oid
+INNER JOIN vacuum_settings ON pg_class.oid = vacuum_settings.oid
+WHERE vacuum_settings.nspname NOT LIKE 'pg_%'
+  AND vacuum_settings.nspname NOT IN (
+    'information_schema','_analytics','_realtime','_supavisor',
+    'auth','etl','extensions','pgbouncer','realtime','storage',
+    'supabase_functions','supabase_migrations','cron','dbdev',
+    'graphql','graphql_public','net','pgmq','pgsodium','pgsodium_masks',
+    'pgtle','repack','tiger','tiger_data','topology'
+  )
+  AND vacuum_settings.nspname NOT LIKE 'timescaledb_%'
+  AND vacuum_settings.nspname NOT LIKE '_timescaledb_%'
+ORDER BY
+  case
+    when pg_class.reltuples = -1 then 1
+    else 0
+  end,
+  1
+`
+
+export async function getVacuumStats(
+  { projectRef, connectionString }: VacuumStatsVariables,
+  signal?: AbortSignal
+) {
+  const { result } = await executeSql<VacuumStatsRow[]>(
+    {
+      projectRef,
+      connectionString,
+      sql: vacuumStatsSql,
+      queryKey: ['debugger-vacuum-stats'],
+    },
+    signal
+  )
+  return result
+}
+
+export type VacuumStatsData = Awaited<ReturnType<typeof getVacuumStats>>
+export type VacuumStatsError = ExecuteSqlError
+
+export const useVacuumStatsQuery = <TData = VacuumStatsData>(
+  { projectRef, connectionString }: VacuumStatsVariables,
+  {
+    enabled = true,
+    ...options
+  }: UseCustomQueryOptions<VacuumStatsData, VacuumStatsError, TData> = {}
+) => {
+  const { data: project } = useSelectedProjectQuery()
+  const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
+
+  return useQuery<VacuumStatsData, VacuumStatsError, TData>({
+    queryKey: databaseKeys.debuggerVacuumStats(projectRef),
+    queryFn: ({ signal }) => getVacuumStats({ projectRef, connectionString }, signal),
+    enabled: enabled && typeof projectRef !== 'undefined' && isActive,
+    ...options,
+  })
+}

--- a/apps/studio/data/database/keys.ts
+++ b/apps/studio/data/database/keys.ts
@@ -64,6 +64,42 @@ export const databaseKeys = {
   ) => ['projects', projectRef, 'table-index-advisor', schema, table] as const,
   supamonitorEnabled: (projectRef: string | undefined) =>
     ['projects', projectRef, 'supamonitor-enabled'] as const,
+
+  // Debugger (inspect db) keys
+  debuggerPreconditions: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'preconditions'] as const,
+  debuggerLocks: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'locks'] as const,
+  debuggerBlocking: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'blocking'] as const,
+  debuggerLongRunningQueries: (projectRef: string | undefined, threshold?: string) =>
+    ['projects', projectRef, 'debugger', 'long-running-queries', threshold ?? '5 minutes'] as const,
+  debuggerBloat: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'bloat'] as const,
+  debuggerVacuumStats: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'vacuum-stats'] as const,
+  debuggerTableStats: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'table-stats'] as const,
+  debuggerTableRecordCounts: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'table-record-counts'] as const,
+  debuggerTrafficProfile: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'traffic-profile'] as const,
+  debuggerCacheHit: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'cache-hit'] as const,
+  debuggerIndexUsage: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'index-usage'] as const,
+  debuggerIndexStats: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'index-stats'] as const,
+  debuggerSeqScans: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'seq-scans'] as const,
+  debuggerUnusedIndexes: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'unused-indexes'] as const,
+  debuggerRoleStats: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'role-stats'] as const,
+  debuggerReplicationSlots: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'replication-slots'] as const,
+  debuggerDbStats: (projectRef: string | undefined) =>
+    ['projects', projectRef, 'debugger', 'db-stats'] as const,
 }
 
 export const getLiveTupleEstimateKey = (

--- a/apps/studio/pages/project/[ref]/advisors/debugger.tsx
+++ b/apps/studio/pages/project/[ref]/advisors/debugger.tsx
@@ -9,7 +9,7 @@ const DebuggerPage: NextPageWithLayout = () => {
 
 DebuggerPage.getLayout = (page) => (
   <DefaultLayout>
-    <AdvisorsLayout title="Debugger">{page}</AdvisorsLayout>
+    <AdvisorsLayout title="Database Scan">{page}</AdvisorsLayout>
   </DefaultLayout>
 )
 

--- a/apps/studio/pages/project/[ref]/advisors/debugger.tsx
+++ b/apps/studio/pages/project/[ref]/advisors/debugger.tsx
@@ -1,0 +1,16 @@
+import { Debugger } from '@/components/interfaces/Advisors/Debugger/Debugger'
+import AdvisorsLayout from '@/components/layouts/AdvisorsLayout/AdvisorsLayout'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
+import type { NextPageWithLayout } from '@/types'
+
+const DebuggerPage: NextPageWithLayout = () => {
+  return <Debugger />
+}
+
+DebuggerPage.getLayout = (page) => (
+  <DefaultLayout>
+    <AdvisorsLayout title="Debugger">{page}</AdvisorsLayout>
+  </DefaultLayout>
+)
+
+export default DebuggerPage

--- a/apps/studio/state/shortcuts/registry/advisors-nav.ts
+++ b/apps/studio/state/shortcuts/registry/advisors-nav.ts
@@ -12,6 +12,7 @@ import { RegistryDefinations } from '../types'
 export const ADVISORS_NAV_SHORTCUT_IDS = {
   NAV_ADVISORS_SECURITY: 'nav.advisors-security',
   NAV_ADVISORS_PERFORMANCE: 'nav.advisors-performance',
+  NAV_ADVISORS_DEBUGGER: 'nav.advisors-debugger',
   NAV_ADVISORS_RULES: 'nav.advisors-rules',
 }
 
@@ -30,6 +31,13 @@ export const advisorsNavRegistry: RegistryDefinations<AdvisorsNavShortcutId> = {
     id: ADVISORS_NAV_SHORTCUT_IDS.NAV_ADVISORS_PERFORMANCE,
     label: 'Go to Performance Advisor',
     sequence: ['V', 'P'],
+    showInSettings: false,
+    referenceGroup: SHORTCUT_REFERENCE_GROUPS.NAVIGATION_ADVISORS,
+  },
+  [ADVISORS_NAV_SHORTCUT_IDS.NAV_ADVISORS_DEBUGGER]: {
+    id: ADVISORS_NAV_SHORTCUT_IDS.NAV_ADVISORS_DEBUGGER,
+    label: 'Go to Database Debugger',
+    sequence: ['V', 'D'],
     showInSettings: false,
     referenceGroup: SHORTCUT_REFERENCE_GROUPS.NAVIGATION_ADVISORS,
   },

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3385,6 +3385,17 @@ export interface RLSTesterRunQueryClickedEvent {
 }
 
 /**
+ * User clicked the "Run scan" button in the Database Debugger.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface DebuggerScanButtonClickedEvent {
+  action: 'debugger_scan_button_clicked'
+  groups: Partial<TelemetryGroups>
+}
+
+/**
  * @hidden
  */
 export type TelemetryEvent =
@@ -3577,3 +3588,4 @@ export type TelemetryEvent =
   | HeaderLocalDropdownOpenedEvent
   | HeaderLocalVersionPopoverOpenedEvent
   | RLSTesterRunQueryClickedEvent
+  | DebuggerScanButtonClickedEvent


### PR DESCRIPTION
## Problem

Diagnosing a database (locks, bloat, cache hit rates, slow vacuums, connection saturation, replication lag) currently requires running the `supabase inspect db` CLI commands locally. There is no equivalent inside the dashboard, and the raw CLI output leaves interpretation to the user.

## Fix

Adds a new "Database Debugger" tab under Advisors that ports the `inspect db` diagnostics into Studio and frames them as a triaged health scan.

- Data layer: 16 predefined SQL queries (ported from the CLI's `internal/inspect`) as `executeSql`-backed React Query hooks under `data/database/debugger/`. `calls` and `outliers` are intentionally skipped since they already exist as Query Performance.
- Triage engine: a pure, unit-tested module (`interpretDebuggerResults`) that turns raw rows into severity-rated findings (critical / warning / info / ok) with plain-English descriptions and recommendations. 95 unit tests cover the threshold boundaries.
- UI: a "Run scan" page that runs the checks on demand (queries do not auto-fire, since they hit the production database), shows a triaged summary on top, and four drill-down tabs (Locks & Activity, Storage, Performance, Connections) rendering the raw inspection tables with "Open in SQL Editor". Includes precondition handling for when `pg_stat_statements` is disabled.
- Telemetry: captures a `debugger_scan_button_clicked` event.

## How to test

- Run `pnpm dev:studio` and open a project
- Navigate to Advisors, then the "Database Debugger" tab (or use the `V D` shortcut)
- Confirm no queries run on load and an empty state is shown
- Click "Run scan" and confirm the triaged summary renders, sorted by severity
- Open each of the four category tabs and confirm the inspection tables populate with "Open in SQL Editor" working
- On a project without `pg_stat_statements`, confirm the precondition warning shows and the other checks still run
- Run `cd apps/studio && node node_modules/vitest/dist/cli.js run components/interfaces/Advisors/Debugger/triage/debugger-triage.test.ts` and confirm 95 tests pass