### PR TITLE
fix: make Realtime card clickable

### DIFF
--- a/apps/www/components/Products/index.tsx
+++ b/apps/www/components/Products/index.tsx
@@ -118,7 +118,7 @@ const Products: React.FC<Props> = (props) => {
         onClick={() => sendTelemetryEvent(PRODUCT_SHORTNAMES.REALTIME)}
         image={<RealtimeVisual className="hidden sm:block" />}
         className="
-          col-span-6 pointer-events-none xl:col-span-3
+          col-span-6 xl:col-span-3
           hover:cursor-[url('/images/index/products/realtime-cursor-light.svg'),auto]!
           dark:hover:cursor-[url('/images/index/products/realtime-cursor-dark.svg'),auto]!
         "


### PR DESCRIPTION
To reproduce:
- resize viewport to mobile
- try to click the Realtime card

Tested on Brave.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Click doesn't work on mobile.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Product cards are now interactive and respond to user clicks and hover interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->