### PR TITLE
fix(studio): show full counts in plan usage card (50,000 not 50k)

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/PlanUsageCard.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/PlanUsageCard.tsx
@@ -51,23 +51,15 @@ const formatGigabyteLimit = (limit: number) => {
   return `${limit} GB`
 }
 
-const formatCount = (value: number) => {
-  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
-  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
-  return value.toLocaleString()
-}
-
-const formatCountLimit = (limit: number) => {
-  if (limit >= 1_000_000) return `${(limit / 1_000_000).toFixed(0)}M`
-  if (limit >= 1_000) return `${(limit / 1_000).toFixed(0)}k`
-  return limit.toLocaleString()
-}
+// Show counts in full with thousands separators (e.g. `50,000`) rather than abbreviated
+// (`50k`), to match the pricing page and avoid ambiguity around plan limits.
+const formatCount = (value: number) => value.toLocaleString()
 
 const formatValue = (value: number, unit: MetricUnit) =>
   unit === 'gigabytes' ? formatGigabytes(value) : formatCount(value)
 
 const formatLimit = (limit: number, unit: MetricUnit) =>
-  unit === 'gigabytes' ? formatGigabyteLimit(limit) : formatCountLimit(limit)
+  unit === 'gigabytes' ? formatGigabyteLimit(limit) : formatCount(limit)
 
 const RING_RADIUS = 7
 const RING_CIRCUMFERENCE = 2 * Math.PI * RING_RADIUS


### PR DESCRIPTION
## Summary

Follow-up to the upgrade CTA placement experiment (#45858). The `PlanUsageCard` count metrics (Monthly active users) were abbreviated to `50k`, which reads ambiguously. This shows them in full with thousands separators (`50,000`) to match the pricing page.

- `Monthly active users` row now renders e.g. `8,200 / 50,000` instead of `8.2k / 50k`.
- Collapses the two count formatters (`formatCount` / `formatCountLimit`) into one `toLocaleString()` call so the current value and limit always use the same format.
- GB metrics (Egress, Database size, File storage) are unchanged.

## Test plan
- [ ] On the org projects page with the `org_projects_list` variant, the Monthly active users row shows full numbers (`0 / 50,000`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated plan usage display formatting to show full numbers with thousands separators instead of abbreviated notation, improving clarity when viewing usage limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->