### PR TITLE
docs: fix internal links to the API guide (database/api → api)

### DIFF
--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -181,7 +181,7 @@ create table movies (
 
 ## Loading data
 
-There are several ways to load data in Supabase. You can load data directly into the database or using the [APIs](../../guides/database/api).
+There are several ways to load data in Supabase. You can load data directly into the database or using the [APIs](../../guides/api).
 Use the "Bulk Loading" instructions if you are loading large data sets.
 
 ### Basic data loading

--- a/apps/docs/content/guides/telemetry/logs.mdx
+++ b/apps/docs/content/guides/telemetry/logs.mdx
@@ -21,7 +21,7 @@ Supabase provides a logging interface specific to each product. You can use simp
 >
 <TabPanel id="api" label="API">
 
-[API logs](/dashboard/project/_/logs/edge-logs) show all network requests and response for the REST and GraphQL [APIs](../../guides/database/api). If [Read Replicas](/docs/guides/platform/read-replicas) are enabled, logs are automatically filtered between databases as well as the [API Load Balancer](/docs/guides/platform/read-replicas#api-load-balancer) endpoint. Logs for a specific endpoint can be toggled with the `Source` button on the upper-right section of the dashboard.
+[API logs](/dashboard/project/_/logs/edge-logs) show all network requests and response for the REST and GraphQL [APIs](../../guides/api). If [Read Replicas](/docs/guides/platform/read-replicas) are enabled, logs are automatically filtered between databases as well as the [API Load Balancer](/docs/guides/platform/read-replicas#api-load-balancer) endpoint. Logs for a specific endpoint can be toggled with the `Source` button on the upper-right section of the dashboard.
 
 When viewing logs originating from the API Load Balancer endpoint, the upstream database or the one that eventually handles the request can be found under the `Redirect Identifier` field. This is equivalent to `metadata.load_balancer_redirect_identifier` when querying the underlying logs.
 
@@ -171,7 +171,7 @@ alter role postgres set pgaudit.log to 'function, write, ddl';
 
 To help with debugging, we recommend adjusting the log scope to only relevant statements as having too wide of a scope would result in a lot of noise in your Postgres logs.
 
-Note that in the above example, the role is set to `postgres`. To log user-traffic flowing through the [HTTP APIs](../../guides/database/api#rest-api-overview) powered by PostgREST, set your configuration values for the `authenticator`.
+Note that in the above example, the role is set to `postgres`. To log user-traffic flowing through the [HTTP APIs](../../guides/api#rest-api-overview) powered by PostgREST, set your configuration values for the `authenticator`.
 
 ```sql
 -- for API-related logs


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update (broken internal link fix).

## What is the current behavior?

Three links in the docs point to `/docs/guides/database/api`, which is not a real page. That path only resolves because of a permanent redirect (`/docs/guides/database/api` → `/docs/guides/api` in `apps/www/lib/redirects.js`). Readers therefore take an extra redirect hop, and the links are fragile if that redirect is ever removed.

Affected links:
- `apps/docs/content/guides/database/tables.mdx` — "load data … using the [APIs]"
- `apps/docs/content/guides/telemetry/logs.mdx` — REST/GraphQL "[APIs]"
- `apps/docs/content/guides/telemetry/logs.mdx` — "[HTTP APIs]…#rest-api-overview"

## What is the new behavior?

The links now point directly to the canonical guide path `/docs/guides/api` (`../../guides/api`). The `#rest-api-overview` anchor is preserved and still resolves (`## Features [#rest-api-overview]` in `guides/api.mdx`). No content changes — links only.

## Additional context

Pure documentation link cleanup, no functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation

* Updated internal documentation links in database and logging guides to reference the appropriate API documentation sections.
* Improved cross-reference consistency and navigation experience across guides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->