### PR TITLE
feat(docs) Add external link indicator for screenreader and visual

### DIFF
--- a/apps/docs/features/docs/MdxAnchor.tsx
+++ b/apps/docs/features/docs/MdxAnchor.tsx
@@ -1,0 +1,50 @@
+import { ExternalLink as ExternalLinkIcon } from 'lucide-react'
+import { type ComponentPropsWithoutRef } from 'react'
+import { cn } from 'ui'
+
+const isExternalHref = (href?: string) => {
+  if (!href || !/^https?:\/\//i.test(href)) return false
+  try {
+    return !/(^|\.)supabase\.com$/i.test(new URL(href).hostname)
+  } catch {
+    return false
+  }
+}
+
+// Walk the tree and concatenate text so the aria-label matches the visible link
+const flattenChildrenToText = (node: unknown): string => {
+  if (node == null || typeof node === 'boolean') return ''
+  if (typeof node === 'string' || typeof node === 'number') return String(node)
+  if (Array.isArray(node)) return node.map(flattenChildrenToText).join('')
+  if (typeof node === 'object' && node !== null && 'props' in node) {
+    const props = (node as { props?: { children?: unknown } }).props
+    return flattenChildrenToText(props?.children)
+  }
+  return ''
+}
+
+export function MdxAnchor({ href, children, ...rest }: ComponentPropsWithoutRef<'a'>) {
+  if (!isExternalHref(href)) {
+    return (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )
+  }
+  const label = flattenChildrenToText(children).trim()
+  return (
+    <a
+      href={href}
+      aria-label={label ? `External Source: ${label}` : undefined}
+      {...rest}
+    >
+      {children}
+      <ExternalLinkIcon
+        size={14}
+        strokeWidth={1.5}
+        aria-hidden="true"
+        className="inline-block align-[-1px] ml-0.5 text-lighter"
+      />
+    </a>
+  )
+}

--- a/apps/docs/features/docs/MdxAnchor.tsx
+++ b/apps/docs/features/docs/MdxAnchor.tsx
@@ -33,11 +33,7 @@ export function MdxAnchor({ href, children, ...rest }: ComponentPropsWithoutRef<
   }
   const label = flattenChildrenToText(children).trim()
   return (
-    <a
-      href={href}
-      aria-label={label ? `External Source: ${label}` : undefined}
-      {...rest}
-    >
+    <a href={href} aria-label={label ? `External Source: ${label}` : undefined} {...rest}>
       {children}
       <ExternalLinkIcon
         size={14}

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -19,6 +19,7 @@ import { SharedData } from '~/components/SharedData'
 import StepHikeCompact from '~/components/StepHikeCompact'
 import { CodeSampleDummy, CodeSampleWrapper } from '~/features/directives/CodeSample.client'
 import { NamedCodeBlock } from '~/features/directives/CodeTabs.components'
+import { MdxAnchor } from '~/features/docs/MdxAnchor'
 import { Accordion, AccordionItem } from '~/features/ui/Accordion'
 import { CodeBlock } from '~/features/ui/CodeBlock/CodeBlock'
 import InfoTooltip from '~/features/ui/InfoTooltip'
@@ -100,6 +101,7 @@ const components = {
   Tabs,
   TabPanel,
   InfoTooltip,
+  a: MdxAnchor,
   h2: (props: any) => (
     <Heading tag="h2" {...props}>
       {props.children}


### PR DESCRIPTION
Closes DOCS-1027

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature: This adds an `MdxAnchor` component to our docs so that we can dynamically check if links are absolute and label them as an external source.

**Note:** All supabase.com URLs including subdomains are considered internal. However, this does not include aliases such as `database.new`. Is there a list of aliases to consider? Or perhaps this rule should only include docs links.

## What is the current behavior?

There is no indication when you are navigating away from Supabase.
See WCAG rule: [Link Purpose (In Context) (Level A)](https://w3c.github.io/wcag21/understanding/link-purpose-in-context)

## What is the new behavior?

See icon indicator below:

<img width="739" height="173" alt="Screenshot 2026-06-10 at 12 34 53 PM" src="https://github.com/user-attachments/assets/04713f55-8423-4272-9ac1-7533a29e2ef3" />

**Caption:** 'database.new' above is technically an internal alias. Should we ignore this case? Any others?

You can see this in action on pages like `/docs/guides/getting-started/quickstarts/reactjs`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docs links now use an enhanced anchor that consistently handles internal and external URLs.
  * External links display a visual external-link indicator for clearer identification.
  * Accessibility improved: external links receive descriptive ARIA labels derived from link text to assist screen readers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->