### PR TITLE
feat(studio): Marketplace integration partner links

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
@@ -2,6 +2,7 @@ import { useParams } from 'common'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo } from 'react'
 
+import { useProjectOAuthIntegrationData } from './Landing.utils'
 import { useAvailableIntegrations } from './useAvailableIntegrations'
 import { useInstalledIntegrations } from './useInstalledIntegrations'
 import {
@@ -42,6 +43,14 @@ export const useIntegrationDetail = () => {
   const installation = useMemo(
     () => installedIntegrations.find((i) => i.id === id),
     [installedIntegrations, id]
+  )
+
+  // There does exist a mgmt-api endpoint to get a single status by integration-id, but the bulk results are likely already cached so go ahead and use them.
+  const { data: projectData, isLoading: isIntegrationStatusLoading } =
+    useProjectOAuthIntegrationData(project?.ref, { enabled: integration?.type === 'oauth' })
+  const integrationStatus = useMemo(
+    () => projectData.partnerIntegrations.find((i) => i.listing_slug === id),
+    [projectData, id]
   )
 
   const isInstalled = !!integration && !!installation
@@ -140,12 +149,14 @@ export const useIntegrationDetail = () => {
     integrationsWrappers,
     integration,
     installation,
+    integrationStatus,
     isInstalled,
     areRequiredExtensionsInstalled,
     installActionType,
     wrappersTabHref,
     isAvailableLoading,
     isInstalledLoading,
+    isIntegrationStatusLoading,
     Component,
   }
 }

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, BookOpen } from 'lucide-react'
+import { ArrowUpRight, BookOpen, Gauge, Settings } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { Button, cn } from 'ui'
 import { GenericSkeletonLoader, ShimmeringLoader } from 'ui-patterns'
@@ -29,18 +29,20 @@ export const MarketplaceDetail = () => {
     pageTitle,
     pageSubTitle,
     integration,
+    integrationStatus,
     isInstalled,
     installActionType,
     wrappersTabHref,
     isAvailableLoading,
     isInstalledLoading,
+    isIntegrationStatusLoading,
     Component,
   } = useIntegrationDetail()
 
   if (!isReady) return null
   if (isWrapperBlocked) return <UnknownInterface urlBack={`/project/${ref}/integrations`} />
 
-  if (isAvailableLoading || isInstalledLoading) {
+  if (isAvailableLoading || isInstalledLoading || isIntegrationStatusLoading) {
     return (
       <>
         <MarketplaceDetailBreadrumbs isLoading />
@@ -106,6 +108,36 @@ export const MarketplaceDetail = () => {
         isInstalled={isInstalled}
         actions={
           <>
+            {integrationStatus?.partner_links?.dashboard && (
+              <Button
+                type="text"
+                size="tiny"
+                icon={<Gauge size={13} />}
+                iconRight={<ArrowUpRight size={13} />}
+                asChild
+              >
+                <a
+                  href={integrationStatus.partner_links.dashboard}
+                  target="_blank"
+                  rel="noreferrer"
+                >
+                  Dashboard
+                </a>
+              </Button>
+            )}
+            {integrationStatus?.partner_links?.manage && (
+              <Button
+                type="text"
+                size="tiny"
+                icon={<Settings size={13} />}
+                iconRight={<ArrowUpRight size={13} />}
+                asChild
+              >
+                <a href={integrationStatus.partner_links.manage} target="_blank" rel="noreferrer">
+                  Manage
+                </a>
+              </Button>
+            )}
             {integration.docsUrl && (
               <Button
                 type="text"

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -108,7 +108,7 @@ export const MarketplaceDetail = () => {
         isInstalled={isInstalled}
         actions={
           <>
-            {integrationStatus?.partner_links?.dashboard && (
+            {isInstalled && integrationStatus?.partner_links?.dashboard && (
               <Button
                 type="text"
                 size="tiny"
@@ -125,7 +125,7 @@ export const MarketplaceDetail = () => {
                 </a>
               </Button>
             )}
-            {integrationStatus?.partner_links?.manage && (
+            {isInstalled && integrationStatus?.partner_links?.manage && (
               <Button
                 type="text"
                 size="tiny"


### PR DESCRIPTION
Adds partner-provided links for installed marketplace integrations (if provided) to the marketplace detail breadcrumbs

<img width="1332" height="570" alt="Screenshot 2026-06-10 at 4 11 03 PM" src="https://github.com/user-attachments/assets/24f1f4f6-b8ad-4ceb-85d1-8d04afa872cf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced OAuth integration details in the Marketplace: shows partner-specific action links (Dashboard, Manage) when available, opening in a new tab.
  * Improved loading behavior: marketplace detail view displays its skeleton until partner integration status finishes loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->