### PR TITLE
docs(functions): add error codes page

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1745,6 +1745,10 @@ export const functions: NavMenuConstant = {
           url: '/guides/functions/status-codes' as `/${string}`,
         },
         {
+          name: 'Error codes',
+          url: '/guides/functions/error-codes' as `/${string}`,
+        },
+        {
           name: 'Recursive/Nested function calls',
           url: '/guides/functions/recursive-functions' as `/${string}`,
         },

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -95,9 +95,25 @@ try {
 
 **Cause:** Your Edge Function threw an uncaught exception.
 
+```ts
+// ...
+
+function initSomething() {
+  throw new Error('Some unhandled error')
+}
+
+initSomething() // Error threw outsite request handler
+
+export default {
+  fetch: withSupabase({ auth: 'none' }, async () => {
+    return new Response()
+  }),
+}
+```
+
 **Common causes:**
 
-- Unhandled JavaScript errors in your function code
+- Unhandled JavaScript errors in your function code, outsite request handler
 - Missing error handling for async operations
 - Invalid JSON parsing
 

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -1,8 +1,8 @@
 ---
 id: 'functions-error-codes'
 title: 'Error codes'
-description: 'Edge Functions can return following error codes.'
-subtitle: 'Understand Error codes returned by Edge Functions to properly debug issues and handle responses.'
+description: 'Edge Functions can return the following error codes.'
+subtitle: 'Understand the error codes returned by Edge Functions to properly debug issues and handle responses.'
 ---
 
 {/* supa-mdx-lint-disable Rule001HeadingCase */}
@@ -15,15 +15,15 @@ These errors indicate issues with the request itself, which typically require ch
 
 #### EDGE_FUNCTION_ERROR
 
-**Cause:** Your Edge Function is throwing an unhandled Error
+**Cause:** Your Edge Function is throwing an unhandled error.
 
 **Solution:**
 
-- Ensure you're try-catching Errors on your code logic
+- Ensure you are catching errors in your code logic with try-catch blocks.
 
 #### IDLE_TIMEOUT
 
-**Cause:** Your Edge Function didn't respond within the [request timeout limit](/docs/guides/functions/limits).
+**Cause:** Your Edge Function did not respond within the [request timeout limit](/docs/guides/functions/limits).
 
 **Common causes:**
 
@@ -39,7 +39,7 @@ These errors indicate issues with the request itself, which typically require ch
 
 #### WORKER_RESOURCE_LIMIT, WORKER_LIMIT
 
-**Cause:** Your Edge Function execution was stopped due to exceeding resource limits. Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.
+**Cause:** Your Edge Function execution was stopped due to exceeding resource limits. Edge Function logs should indicate which [resource limit](/docs/guides/functions/limits) was exceeded.
 
 **Common causes:**
 
@@ -51,7 +51,7 @@ These errors indicate issues with the request itself, which typically require ch
 
 #### WORKER_ERROR
 
-**Cause:** Your Edge Function threw an uncaught exception (`WORKER_ERROR`).
+**Cause:** Your Edge Function threw an uncaught exception.
 
 **Common causes:**
 
@@ -63,108 +63,108 @@ These errors indicate issues with the request itself, which typically require ch
 
 #### INVALID_RESPONSE_STATUS_CODE
 
-**Cause:** Your Edge Function is returning a invalid HTTP status code, not equal to `101` and outside the range `[200, 599]`
+**Cause:** Your Edge Function is returning an invalid HTTP status code — not equal to `101` and outside the range `[200, 599]`.
 
 **Common causes:**
 
-- Proxying a `fetch()` response from external service that is resulting a invalid HTTP Status code
+- Proxying a `fetch()` response from an external service that returns an invalid HTTP status code
 
 **Solution:**
 
-- Ensure you're returning a valid HTTP status code
-- For proxy endpoints, don't return the `fetch()` result direclty, but a cloned `Response`, wrapped by a try-catch block
+- Ensure you are returning a valid HTTP status code
+- For proxy endpoints, do not return the `fetch()` result directly; instead return a new `Response` wrapped in a try-catch block
 
 ### Authentication Errors
 
 #### UNAUTHORIZED_NO_AUTH_HEADER
 
-**Cause:** The Edge Function has JWT verification enabled, but the request was made missing the `Authorization` or `apikey` header.
+**Cause:** The Edge Function has JWT verification enabled, but the request is missing the `Authorization` or `apikey` header.
 
 **Solution:**
 
-- Ensure you're passing a valid JWT token in the `Authorization` header
-- Check that you're sending an API key in the `apikey` header
+- Ensure you are passing a valid JWT token in the `Authorization` header
+- Check that you are sending an API key in the `apikey` header
 - For webhooks or public endpoints, consider disabling JWT verification
 
 #### UNAUTHORIZED_ASYMMETRIC_JWT
 
-**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` contains a invalid asymetric `ES256 | RS256` token
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header contains an invalid asymmetric `ES256 | RS256` token.
 
 **Solution:**
 
-- Ensure you're passing a valid user JWT token in the `Authorization` header
-- Check that your token hasn't expired
+- Ensure you are passing a valid user JWT token in the `Authorization` header
+- Check that your token has not expired
 
 #### UNAUTHORIZED_LEGACY_JWT
 
-**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` contains a invalid legacy `HS256` token
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header contains an invalid legacy `HS256` token.
 
 **Solution:**
 
-- Ensure you're passing a valid legacy JWT token in the `Authorization` header
-- Check that your token hasn't expired
-- Verify if legacy JWT Secret was revoked or disabled
+- Ensure you are passing a valid legacy JWT token in the `Authorization` header
+- Check that your token has not expired
+- Verify that the legacy JWT secret has not been revoked or disabled
 
 #### UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM
 
-**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` not contains a `ES256 | RS256 | HS256` token
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header does not contain an `ES256 | RS256 | HS256` token.
 
 **Solution:**
 
-- Ensure you're passing a Supabase issued valid JWT token in the `Authorization` header
+- Ensure you are passing a valid Supabase-issued JWT token in the `Authorization` header
 
 #### UNAUTHORIZED_INVALID_JWT_FORMAT
 
-**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` not contains `Bearer <JWT Token>` format
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header does not follow the `Bearer <JWT Token>` format.
 
 **Solution:**
 
-- Check that you're passing `Bearer <JWT Token>` in the `Authorization` header
-- Ensure you're sending an API key in the `apikey` header instead of `Authorization`
+- Check that you are passing `Bearer <JWT Token>` in the `Authorization` header
+- Ensure you are sending an API key in the `apikey` header instead of `Authorization`
 - For webhooks or public endpoints, consider disabling JWT verification
 
 ### Request Errors
 
 #### RATE_LIMIT_EXCEEDED
 
-**Cause:** The Platorm detected a [recursive / nested function call](/docs/guides/functions/recursive-functions) behaviour
+**Cause:** The platform detected [recursive or nested function call](/docs/guides/functions/recursive-functions) behavior.
 
 **Common causes:**
 
-- Multiple Function-to-Function calls
-- Recursive / Circular calls
+- Multiple function-to-function calls
+- Recursive or circular calls
 
 **Solution:**
 
-- Use the suggested re-try window in seconds from the error message to call your function again
-- Ensure you're not performing unecessary individual calls and try using batch operations when its possible
-- Delegate large workloads to queues instead of recursive calling other Edge Function
+- Use the suggested retry window in seconds from the error message before calling your function again
+- Ensure you are not performing unnecessary individual calls; use batch operations where possible
+- Delegate large workloads to queues instead of recursively calling other Edge Functions
 
 #### INVALID_URL
 
-**Cause:** Platorm rejects malformed URLs
+**Cause:** The platform rejected a malformed URL.
 
 **Solution:**
 
-- Ensure you're calling with a valid [formated URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
+- Ensure you are calling with a valid [formatted URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
 
 ---
 
 ## Server Errors
 
-These errors indicate issues with the function loading, execution or underlying platform.
+These errors indicate issues with function loading, execution, or the underlying platform.
 
 ### Function Loading Errors
 
 #### NOT_FOUND
 
-**Cause:** The Edge Function metadata / files wasn't found or is missing on the specific region
+**Cause:** The Edge Function metadata or files were not found or are missing in the specific region.
 
-**Solution:** Try redeploy your function and wait for few minutes to make sure all regions got updated
+**Solution:** Try redeploying your function and wait a few minutes to make sure all regions have been updated.
 
 #### BOOT_ERROR
 
-**Cause:** Your Edge Function failed to start
+**Cause:** Your Edge Function failed to start.
 
 **Common causes:**
 
@@ -172,11 +172,11 @@ These errors indicate issues with the function loading, execution or underlying 
 - Import errors or missing dependencies
 - Invalid function configuration
 
-**Solution:** Check your Edge Function logs and verify your function code can be executed locally with `supabase functions serve`.
+**Solution:** Check your Edge Function logs and also verify that your function code can be executed locally with `supabase functions serve`.
 
 #### LOAD_FUNCTION_ERROR
 
-**Cause:** The Platorm wasn't able to load your function metadata / files
+**Cause:** The platform was unable to load your function metadata or files.
 
 **Solution:**
 
@@ -185,18 +185,18 @@ These errors indicate issues with the function loading, execution or underlying 
 
 #### LOAD_FUNCTION_METADATA_ERROR
 
-**Cause:** The Platorm couldn't fetch your function metadata, possible due external cache issues.
+**Cause:** The platform could not fetch your function metadata, possibly due to external cache issues.
 
 **Solution:**
 
-- Wait few minutes before calling your function again
+- Wait a few minutes before calling your function again
 - If the problem persists, contact support
 
 #### LOAD_FUNCTION_INVALID_ENTRYPOINT_PATH_ERROR
 
-**Cause:** Your Edge Function metadata is broken or contain an invalid entrypoint
+**Cause:** Your Edge Function metadata is broken or contains an invalid entrypoint.
 
 **Solution:**
 
-- Try redeploy your function
+- Try redeploying your function
 - If the problem persists, contact support

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -102,7 +102,7 @@ function initSomething() {
   throw new Error('Some unhandled error')
 }
 
-initSomething() // Error threw outsite request handler
+initSomething() // Error threw outside request handler
 
 export default {
   fetch: withSupabase({ auth: 'none' }, async () => {
@@ -113,7 +113,7 @@ export default {
 
 **Common causes:**
 
-- Unhandled JavaScript errors in your function code, outsite request handler
+- Unhandled JavaScript errors in your function code, outside request handler
 - Missing error handling for async operations
 - Invalid JSON parsing
 

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -21,15 +21,47 @@ if (!response.ok) {
 
 ## Bad Implementation Errors
 
-These errors are caused by issues in your function's code or logic which requires updating your function's implementation.
+These errors are caused by issues in your function's code or logic which requires updating its implementation.
 
 ### EDGE_FUNCTION_ERROR
 
-**Cause:** Your Edge Function is throwing an unhandled error.
+**Cause:** Your Edge Function is throwing an unhandled error or resulting a 5XX code.
+
+```ts
+// ...
+
+function process() {
+  throw new Error('Some unhandled error')
+}
+
+export default {
+  fetch: withSupabase({ auth: 'none' }, async () => {
+    process()
+
+    return new Response()
+  }),
+}
+```
 
 **Solution:**
 
 - Ensure you are catching errors in your code logic with try-catch blocks.
+
+```ts
+function process() {
+  throw new Error('Some unhandled error')
+}
+
+// ...
+
+try {
+  process()
+  return new Response()
+} catch (e) {
+  console.error('Process fail:', e)
+  return new Response(null, { status: 500 })
+}
+```
 
 ### IDLE_TIMEOUT
 

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -7,13 +7,23 @@ subtitle: 'Understand the error codes returned by Edge Functions to properly deb
 
 {/* supa-mdx-lint-disable Rule001HeadingCase */}
 
-## Client Errors
+When an Edge Function request fails, the response includes a `sb-error-code` header that identifies the specific error.
+You can inspect this header in your HTTP client or application code to detect and handle errors programmatically.
 
-These errors indicate issues with the request itself, which typically require changing how the function is called.
+```js
+const response = await fetch('<your-function-url>')
 
-### Bad Implementation Errors
+if (!response.ok) {
+  const errorCode = response.headers.get('sb-error-code')
+  console.error('Edge Function error:', errorCode)
+}
+```
 
-#### EDGE_FUNCTION_ERROR
+## Bad Implementation Errors
+
+These errors are caused by issues in your function's code or logic which requires updating your function's implementation.
+
+### EDGE_FUNCTION_ERROR
 
 **Cause:** Your Edge Function is throwing an unhandled error.
 
@@ -21,7 +31,7 @@ These errors indicate issues with the request itself, which typically require ch
 
 - Ensure you are catching errors in your code logic with try-catch blocks.
 
-#### IDLE_TIMEOUT
+### IDLE_TIMEOUT
 
 **Cause:** Your Edge Function did not respond within the [request timeout limit](/docs/guides/functions/limits).
 
@@ -37,7 +47,7 @@ These errors indicate issues with the request itself, which typically require ch
 - Add timeout handling to external requests
 - Consider breaking large operations into smaller chunks
 
-#### WORKER_RESOURCE_LIMIT, WORKER_LIMIT
+### WORKER_RESOURCE_LIMIT, WORKER_LIMIT
 
 **Cause:** Your Edge Function execution was stopped due to exceeding resource limits. Edge Function logs should indicate which [resource limit](/docs/guides/functions/limits) was exceeded.
 
@@ -49,7 +59,7 @@ These errors indicate issues with the request itself, which typically require ch
 
 **Solution:** Check your Edge Function logs to see which resource limit was exceeded, then optimize your function accordingly.
 
-#### WORKER_ERROR
+### WORKER_ERROR
 
 **Cause:** Your Edge Function threw an uncaught exception.
 
@@ -61,7 +71,7 @@ These errors indicate issues with the request itself, which typically require ch
 
 **Solution:** Check your Edge Function logs to identify the specific error and add proper error handling to your code.
 
-#### INVALID_RESPONSE_STATUS_CODE
+### INVALID_RESPONSE_STATUS_CODE
 
 **Cause:** Your Edge Function is returning an invalid HTTP status code — not equal to `101` and outside the range `[200, 599]`.
 
@@ -74,9 +84,11 @@ These errors indicate issues with the request itself, which typically require ch
 - Ensure you are returning a valid HTTP status code
 - For proxy endpoints, do not return the `fetch()` result directly; instead return a new `Response` wrapped in a try-catch block
 
-### Authentication Errors
+## Authentication Errors
 
-#### UNAUTHORIZED_NO_AUTH_HEADER
+These errors occur when the request contains a missing, malformed, or unsupported JWT token. Fixing them requires ensuring your requests include a valid authorization header, or disabling JWT verification for public endpoints.
+
+### UNAUTHORIZED_NO_AUTH_HEADER
 
 **Cause:** The Edge Function has JWT verification enabled, but the request is missing the `Authorization` or `apikey` header.
 
@@ -86,7 +98,7 @@ These errors indicate issues with the request itself, which typically require ch
 - Check that you are sending an API key in the `apikey` header
 - For webhooks or public endpoints, consider disabling JWT verification
 
-#### UNAUTHORIZED_ASYMMETRIC_JWT
+### UNAUTHORIZED_ASYMMETRIC_JWT
 
 **Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header contains an invalid asymmetric `ES256 | RS256` token.
 
@@ -95,7 +107,7 @@ These errors indicate issues with the request itself, which typically require ch
 - Ensure you are passing a valid user JWT token in the `Authorization` header
 - Check that your token has not expired
 
-#### UNAUTHORIZED_LEGACY_JWT
+### UNAUTHORIZED_LEGACY_JWT
 
 **Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header contains an invalid legacy `HS256` token.
 
@@ -105,7 +117,7 @@ These errors indicate issues with the request itself, which typically require ch
 - Check that your token has not expired
 - Verify that the legacy JWT secret has not been revoked or disabled
 
-#### UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM
+### UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM
 
 **Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header does not contain an `ES256 | RS256 | HS256` token.
 
@@ -113,7 +125,7 @@ These errors indicate issues with the request itself, which typically require ch
 
 - Ensure you are passing a valid Supabase-issued JWT token in the `Authorization` header
 
-#### UNAUTHORIZED_INVALID_JWT_FORMAT
+### UNAUTHORIZED_INVALID_JWT_FORMAT
 
 **Cause:** The Edge Function has JWT verification enabled, but the `Authorization` header does not follow the `Bearer <JWT Token>` format.
 
@@ -123,9 +135,11 @@ These errors indicate issues with the request itself, which typically require ch
 - Ensure you are sending an API key in the `apikey` header instead of `Authorization`
 - For webhooks or public endpoints, consider disabling JWT verification
 
-### Request Errors
+## Request Errors
 
-#### RATE_LIMIT_EXCEEDED
+These errors indicate issues with the request itself, which typically require changing how the function is called.
+
+### RATE_LIMIT_EXCEEDED
 
 **Cause:** The platform detected [recursive or nested function call](/docs/guides/functions/recursive-functions) behavior.
 
@@ -140,7 +154,7 @@ These errors indicate issues with the request itself, which typically require ch
 - Ensure you are not performing unnecessary individual calls; use batch operations where possible
 - Delegate large workloads to queues instead of recursively calling other Edge Functions
 
-#### INVALID_URL
+### INVALID_URL
 
 **Cause:** The platform rejected a malformed URL.
 
@@ -154,15 +168,13 @@ These errors indicate issues with the request itself, which typically require ch
 
 These errors indicate issues with function loading, execution, or the underlying platform.
 
-### Function Loading Errors
-
-#### NOT_FOUND
+### NOT_FOUND
 
 **Cause:** The Edge Function metadata or files were not found or are missing in the specific region.
 
 **Solution:** Try redeploying your function and wait a few minutes to make sure all regions have been updated.
 
-#### BOOT_ERROR
+### BOOT_ERROR
 
 **Cause:** Your Edge Function failed to start.
 
@@ -174,7 +186,7 @@ These errors indicate issues with function loading, execution, or the underlying
 
 **Solution:** Check your Edge Function logs and also verify that your function code can be executed locally with `supabase functions serve`.
 
-#### LOAD_FUNCTION_ERROR
+### LOAD_FUNCTION_ERROR
 
 **Cause:** The platform was unable to load your function metadata or files.
 
@@ -183,7 +195,7 @@ These errors indicate issues with function loading, execution, or the underlying
 - Try calling your function again after a short delay
 - If the problem persists, contact support
 
-#### LOAD_FUNCTION_METADATA_ERROR
+### LOAD_FUNCTION_METADATA_ERROR
 
 **Cause:** The platform could not fetch your function metadata, possibly due to external cache issues.
 
@@ -192,7 +204,7 @@ These errors indicate issues with function loading, execution, or the underlying
 - Wait a few minutes before calling your function again
 - If the problem persists, contact support
 
-#### LOAD_FUNCTION_INVALID_ENTRYPOINT_PATH_ERROR
+### LOAD_FUNCTION_INVALID_ENTRYPOINT_PATH_ERROR
 
 **Cause:** Your Edge Function metadata is broken or contains an invalid entrypoint.
 

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -1,0 +1,202 @@
+---
+id: 'functions-error-codes'
+title: 'Error codes'
+description: 'Edge Functions can return following error codes.'
+subtitle: 'Understand Error codes returned by Edge Functions to properly debug issues and handle responses.'
+---
+
+{/* supa-mdx-lint-disable Rule001HeadingCase */}
+
+## Client Errors
+
+These errors indicate issues with the request itself, which typically require changing how the function is called.
+
+### Bad Implementation Errors
+
+#### EDGE_FUNCTION_ERROR
+
+**Cause:** Your Edge Function is throwing an unhandled Error
+
+**Solution:**
+
+- Ensure you're try-catching Errors on your code logic
+
+#### IDLE_TIMEOUT
+
+**Cause:** Your Edge Function didn't respond within the [request timeout limit](/docs/guides/functions/limits).
+
+**Common causes:**
+
+- Long-running database queries
+- Slow external API calls
+- Infinite loops or blocking operations
+
+**Solution:**
+
+- Optimize slow operations
+- Add timeout handling to external requests
+- Consider breaking large operations into smaller chunks
+
+#### WORKER_RESOURCE_LIMIT, WORKER_LIMIT
+
+**Cause:** Your Edge Function execution was stopped due to exceeding resource limits. Edge Function logs should provide which [resource limit](/docs/guides/functions/limits) was exceeded.
+
+**Common causes:**
+
+- Memory usage exceeded available limits
+- CPU time exceeded execution quotas
+- Too many concurrent operations
+
+**Solution:** Check your Edge Function logs to see which resource limit was exceeded, then optimize your function accordingly.
+
+#### WORKER_ERROR
+
+**Cause:** Your Edge Function threw an uncaught exception (`WORKER_ERROR`).
+
+**Common causes:**
+
+- Unhandled JavaScript errors in your function code
+- Missing error handling for async operations
+- Invalid JSON parsing
+
+**Solution:** Check your Edge Function logs to identify the specific error and add proper error handling to your code.
+
+#### INVALID_RESPONSE_STATUS_CODE
+
+**Cause:** Your Edge Function is returning a invalid HTTP status code, not equal to `101` and outside the range `[200, 599]`
+
+**Common causes:**
+
+- Proxying a `fetch()` response from external service that is resulting a invalid HTTP Status code
+
+**Solution:**
+
+- Ensure you're returning a valid HTTP status code
+- For proxy endpoints, don't return the `fetch()` result direclty, but a cloned `Response`, wrapped by a try-catch block
+
+### Authentication Errors
+
+#### UNAUTHORIZED_NO_AUTH_HEADER
+
+**Cause:** The Edge Function has JWT verification enabled, but the request was made missing the `Authorization` or `apikey` header.
+
+**Solution:**
+
+- Ensure you're passing a valid JWT token in the `Authorization` header
+- Check that you're sending an API key in the `apikey` header
+- For webhooks or public endpoints, consider disabling JWT verification
+
+#### UNAUTHORIZED_ASYMMETRIC_JWT
+
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` contains a invalid asymetric `ES256 | RS256` token
+
+**Solution:**
+
+- Ensure you're passing a valid user JWT token in the `Authorization` header
+- Check that your token hasn't expired
+
+#### UNAUTHORIZED_LEGACY_JWT
+
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` contains a invalid legacy `HS256` token
+
+**Solution:**
+
+- Ensure you're passing a valid legacy JWT token in the `Authorization` header
+- Check that your token hasn't expired
+- Verify if legacy JWT Secret was revoked or disabled
+
+#### UNAUTHORIZED_UNSUPPORTED_TOKEN_ALGORITHM
+
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` not contains a `ES256 | RS256 | HS256` token
+
+**Solution:**
+
+- Ensure you're passing a Supabase issued valid JWT token in the `Authorization` header
+
+#### UNAUTHORIZED_INVALID_JWT_FORMAT
+
+**Cause:** The Edge Function has JWT verification enabled, but the `Authorization` not contains `Bearer <JWT Token>` format
+
+**Solution:**
+
+- Check that you're passing `Bearer <JWT Token>` in the `Authorization` header
+- Ensure you're sending an API key in the `apikey` header instead of `Authorization`
+- For webhooks or public endpoints, consider disabling JWT verification
+
+### Request Errors
+
+#### RATE_LIMIT_EXCEEDED
+
+**Cause:** The Platorm detected a [recursive / nested function call](/docs/guides/functions/recursive-functions) behaviour
+
+**Common causes:**
+
+- Multiple Function-to-Function calls
+- Recursive / Circular calls
+
+**Solution:**
+
+- Use the suggested re-try window in seconds from the error message to call your function again
+- Ensure you're not performing unecessary individual calls and try using batch operations when its possible
+- Delegate large workloads to queues instead of recursive calling other Edge Function
+
+#### INVALID_URL
+
+**Cause:** Platorm rejects malformed URLs
+
+**Solution:**
+
+- Ensure you're calling with a valid [formated URL](https://developer.mozilla.org/en-US/docs/Web/API/URL/URL)
+
+---
+
+## Server Errors
+
+These errors indicate issues with the function loading, execution or underlying platform.
+
+### Function Loading Errors
+
+#### NOT_FOUND
+
+**Cause:** The Edge Function metadata / files wasn't found or is missing on the specific region
+
+**Solution:** Try redeploy your function and wait for few minutes to make sure all regions got updated
+
+#### BOOT_ERROR
+
+**Cause:** Your Edge Function failed to start
+
+**Common causes:**
+
+- Syntax errors preventing the function from loading
+- Import errors or missing dependencies
+- Invalid function configuration
+
+**Solution:** Check your Edge Function logs and verify your function code can be executed locally with `supabase functions serve`.
+
+#### LOAD_FUNCTION_ERROR
+
+**Cause:** The Platorm wasn't able to load your function metadata / files
+
+**Solution:**
+
+- Try calling your function again after a short delay
+- If the problem persists, contact support
+
+#### LOAD_FUNCTION_METADATA_ERROR
+
+**Cause:** The Platorm couldn't fetch your function metadata, possible due external cache issues.
+
+**Solution:**
+
+- Wait few minutes before calling your function again
+- If the problem persists, contact support
+
+#### LOAD_FUNCTION_INVALID_ENTRYPOINT_PATH_ERROR
+
+**Cause:** Your Edge Function metadata is broken or contain an invalid entrypoint
+
+**Solution:**
+
+- Try redeploy your function
+- If the problem persists, contact support

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -121,16 +121,57 @@ export default {
 
 ### INVALID_RESPONSE_STATUS_CODE
 
-**Cause:** Your Edge Function is returning an invalid HTTP status code — not equal to `101` and outside the range `[200, 599]`.
+**Cause:** Your Edge Function is returning an invalid HTTP status code — not equal to `101` and outside the range `[200, 599]`
 
 **Common causes:**
 
-- Proxying a `fetch()` response from an external service that returns an invalid HTTP status code
+- Proxying an external service that returns an invalid HTTP status code
+
+```ts
+// ...
+
+export default {
+  fetch: withSupabase({ auth: 'none' }, async (req) => {
+    // Fails in case this proxied server return a status >599
+    return fetch('https://some-server-to-proxy', {
+      method: req.method,
+      headers: req.headers,
+      body: req.body,
+    })
+  }),
+}
+```
 
 **Solution:**
 
 - Ensure you are returning a valid HTTP status code
 - For proxy endpoints, do not return the `fetch()` result directly; instead return a new `Response` wrapped in a try-catch block
+
+```ts
+// ...
+
+export default {
+  fetch: withSupabase({ auth: 'none' }, async (req) => {
+    try {
+      const res = await fetch('https://some-server-to-proxy', {
+        method: req.method,
+        headers: req.headers,
+        body: req.body,
+      })
+
+      // Creating a 'new Response()' ensures contructor checks
+      return new Response(await res.body, {
+        headers: res.headers,
+        status: res.status,
+        statusText: res.statusText,
+      })
+    } catch (e) {
+      console.error('Proxy Error', e)
+      return new Response(null, { status: 502 })
+    }
+  }),
+}
+```
 
 ## Authentication Errors
 
@@ -260,3 +301,7 @@ These errors indicate issues with function loading, execution, or the underlying
 
 - Try redeploying your function
 - If the problem persists, contact support
+
+```
+
+```

--- a/apps/docs/content/guides/functions/error-codes.mdx
+++ b/apps/docs/content/guides/functions/error-codes.mdx
@@ -176,6 +176,7 @@ export default {
 ## Authentication Errors
 
 These errors occur when the request contains a missing, malformed, or unsupported JWT token. Fixing them requires ensuring your requests include a valid authorization header, or disabling JWT verification for public endpoints.
+For further information, see [Authorization headers](/docs/guides/functions/auth-headers) and [Securing Edge Functions](/guides/functions/auth).
 
 ### UNAUTHORIZED_NO_AUTH_HEADER
 
@@ -301,7 +302,3 @@ These errors indicate issues with function loading, execution, or the underlying
 
 - Try redeploying your function
 - If the problem persists, contact support
-
-```
-
-```


### PR DESCRIPTION
Towards FUNC-308

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Missing error codes definitions for Edge Functions

## What is the new behavior?

This PR adds maps the possible error codes that Edge Functions can return

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Error Codes” guide for Edge Functions, explaining how to use the `sb-error-code` response header and covering error categories (bad implementation, authentication, request, server) with causes and solutions.
* **New Features**
  * Updated site navigation to include a direct “Error Codes” link under the functions menu for quicker access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->