### PR TITLE
feat(hibernation): automated wake

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/NetworkRestrictions/NetworkRestrictions.tsx
@@ -84,7 +84,10 @@ export const NetworkRestrictions = () => {
   const [isDisallowingAll, setIsDisallowingAll] = useState(false)
   const [selectedRestrictionToRemove, setSelectedRestrictionToRemove] = useState<string>()
 
-  const { data, isPending: isLoading } = useNetworkRestrictionsQuery({ projectRef: ref })
+  const { data, isPending: isLoading } = useNetworkRestrictionsQuery(
+    { projectRef: ref },
+    { enabled: Boolean(project) }
+  )
   const { can: canUpdateNetworkRestrictions } = useAsyncCheckPermissions(
     PermissionAction.UPDATE,
     'projects',

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -1,10 +1,12 @@
 import { QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback } from 'react'
 
+import { replicaKeys } from '../read-replicas/keys'
+import { ReadReplicasData } from '../read-replicas/replicas-query'
 import { projectKeys } from './keys'
 import { OrgProjectsResponse } from './org-projects-infinite-query'
 import type { components } from '@/data/api'
-import { get, handleError, isValidConnString } from '@/data/fetchers'
+import { get, handleError, isValidConnString, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 type ProjectDetailVariables = { ref?: string }
@@ -22,7 +24,8 @@ export interface Project extends Omit<ProjectDetail, 'status'> {
 export async function getProjectDetail(
   { ref }: ProjectDetailVariables,
   signal?: AbortSignal,
-  headers?: Record<string, string>
+  headers?: Record<string, string>,
+  queryClient?: QueryClient
 ) {
   if (!ref) throw new Error('Project ref is required')
 
@@ -32,8 +35,50 @@ export async function getProjectDetail(
     headers,
   })
 
+  let connectionString = data?.connectionString
+
+  /**
+   * A project is marked as active but potentially hibernated and needs to be woken up (typically few seconds only).
+   * To prevent odd side effects like pg-meta queries failing or the likes, we wake up the project proactively and wait for it
+   * to be back online before returning the project details.
+   */
+  if (data?.is_hibernating) {
+    // In case project was scaled down, explicitly wake it up before continuing to return the project details
+    const { error: errorWaking, data: wakeResponse } = await post('/platform/projects/{ref}/wake', {
+      params: { path: { ref } },
+      signal,
+      headers,
+    })
+
+    // We will still let the user load the page in case of a wake error, but log it for debugging purposes
+    if (errorWaking) {
+      console.error('Error waking up the project', { ref, errorWaking })
+    }
+
+    // As the instance IP has changed, we need to use the latest encrypted connection string
+    if (wakeResponse) {
+      connectionString = wakeResponse.connection_string
+
+      // If replicas were previously fetched, they will hold the old connection string that we need to replace
+      queryClient?.setQueryData<ReadReplicasData>(replicaKeys.list(ref), (old) => {
+        if (!old) return old
+
+        return old.map((db) => {
+          if (db.identifier === ref) {
+            return {
+              ...db,
+              connectionString: wakeResponse.connection_string,
+              connection_string_read_only: wakeResponse.connection_string_read_only,
+            }
+          }
+          return db
+        })
+      })
+    }
+  }
+
   if (error) handleError(error)
-  return data as Project
+  return { ...data, connectionString: connectionString } as Project
 }
 
 export type ProjectDetailData = Awaited<ReturnType<typeof getProjectDetail>>
@@ -45,10 +90,12 @@ export const useProjectDetailQuery = <TData = ProjectDetailData>(
     enabled = true,
     ...options
   }: UseCustomQueryOptions<ProjectDetailData, ProjectDetailError, TData> = {}
-) =>
-  useQuery<ProjectDetailData, ProjectDetailError, TData>({
+) => {
+  const queryClient = useQueryClient()
+
+  return useQuery<ProjectDetailData, ProjectDetailError, TData>({
     queryKey: projectKeys.detail(ref),
-    queryFn: ({ signal }) => getProjectDetail({ ref }, signal),
+    queryFn: ({ signal }) => getProjectDetail({ ref }, signal, undefined, queryClient),
     enabled: enabled && typeof ref !== 'undefined',
     staleTime: 30 * 1000,
     refetchInterval: (query) => {
@@ -62,13 +109,15 @@ export const useProjectDetailQuery = <TData = ProjectDetailData>(
 
       return false
     },
+
     ...options,
   })
+}
 
 export function prefetchProjectDetail(client: QueryClient, { ref }: ProjectDetailVariables) {
   return client.fetchQuery({
     queryKey: projectKeys.detail(ref),
-    queryFn: ({ signal }) => getProjectDetail({ ref }, signal),
+    queryFn: ({ signal }) => getProjectDetail({ ref }, signal, undefined, client),
   })
 }
 

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -12188,7 +12188,7 @@ export interface operations {
       }
     }
     responses: {
-      201: {
+      204: {
         headers: {
           [name: string]: unknown
         }
@@ -12240,7 +12240,7 @@ export interface operations {
       }
     }
     responses: {
-      201: {
+      204: {
         headers: {
           [name: string]: unknown
         }

--- a/packages/api-types/types/platform.d.ts
+++ b/packages/api-types/types/platform.d.ts
@@ -469,6 +469,57 @@ export interface paths {
     patch: operations['LinkConversationController_updateConversationCustomFields']
     trace?: never
   }
+  '/platform/feedback/conversations/escalation': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Escalate an AI support conversation in Front */
+    post: operations['ConversationSyncController_escalateConversation']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/feedback/conversations/messages': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Sync AI support chat messages to Front */
+    post: operations['ConversationSyncController_syncConversationMessages']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/feedback/conversations/resolve': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Resolve an AI support conversation in Front */
+    post: operations['ConversationSyncController_resolveConversation']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
   '/platform/feedback/docs': {
     parameters: {
       query?: never
@@ -3566,6 +3617,23 @@ export interface paths {
     put?: never
     /** Previews transferring a project to a different organizations, shows eligibility and impact. */
     post: operations['ProjectTransferController_previewTransfer']
+    delete?: never
+    options?: never
+    head?: never
+    patch?: never
+    trace?: never
+  }
+  '/platform/projects/{ref}/wake': {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    get?: never
+    put?: never
+    /** Wakes a specific project that belongs to the authenticated user */
+    post: operations['ProjectWakeController_wakeUpProject']
     delete?: never
     options?: never
     head?: never
@@ -6728,6 +6796,10 @@ export interface components {
       scope?: string
       token_endpoint_auth_method?: string
     }
+    EscalateConversationBody: {
+      chatId: string
+      conversationId: string
+    }
     GetArchiveResponse: {
       archive_empty: boolean
       file_url: string
@@ -6813,6 +6885,7 @@ export interface components {
       expires_at: string
       icon?: string
       name: string
+      redirect_uri: string
       /** @enum {string} */
       registration_type: 'manual' | 'dynamic'
       scopes?: (
@@ -9266,6 +9339,7 @@ export interface components {
       inserted_at: string
       integration_source: string | null
       is_branch_enabled: boolean
+      is_hibernating?: boolean
       is_physical_backups_enabled: boolean
       lastDatabaseResizeAt?: string
       maxDatabasePreprovisionGb?: number
@@ -9369,6 +9443,10 @@ export interface components {
       }[]
       ssl_enforced: boolean
       status: string
+    }
+    ProjectWakeResponse: {
+      connection_string: string | null
+      connection_string_read_only: string | null
     }
     PublicUrlResponse: {
       publicUrl: string
@@ -10273,6 +10351,12 @@ export interface components {
     ResizeBody: {
       volume_size_gb: number
     }
+    ResolveConversationBody: {
+      /** @enum {string} */
+      aiSupportStatus: 'user_resolved' | 'bot_resolved'
+      chatId: string
+      conversationId: string
+    }
     RestartProjectBody: {
       database_identifier?: string
     }
@@ -10489,10 +10573,12 @@ export interface components {
       siteUrl?: string
       subject?: string
       tags: string[]
+      threadRef?: string
       urlToAirTable?: string
       verified?: boolean
     }
     SendFeedbackResponse: {
+      conversationId?: string
       result: string
     }
     SendUpgradeSurveyBody: {
@@ -10681,6 +10767,32 @@ export interface components {
       max_client_conn: number | null
       /** @enum {string} */
       pool_mode: 'transaction' | 'session'
+    }
+    SyncConversationMessagesBody: {
+      affectedServices?: string
+      allowSupportAccess?: boolean
+      browserInformation?: string
+      category?: string
+      chatId: string
+      conversationId?: string
+      /** @default false */
+      isInitial?: boolean
+      library?: string
+      messages: {
+        content: string
+        id: string
+        /** @enum {string} */
+        role: 'user' | 'assistant'
+      }[]
+      organizationSlug?: string
+      projectRef?: string
+      severity?: string
+      subject: string
+    }
+    SyncConversationMessagesResponse: {
+      conversationId?: string
+      /** @enum {string} */
+      result: 'success'
     }
     TaxIdResponse: {
       tax_id: {
@@ -11030,6 +11142,13 @@ export interface components {
       project_ref?: string
     }
     UpdateConversationCustomFieldsResponse: {
+      /** @enum {string} */
+      result: 'success'
+    }
+    UpdateConversationLifecycleResponse: {
+      /** @enum {string} */
+      aiSupportStatus: 'bot_active' | 'escalated' | 'user_resolved' | 'bot_resolved'
+      conversationId: string
       /** @enum {string} */
       result: 'success'
     }
@@ -13996,6 +14115,117 @@ export interface operations {
         }
       }
       /** @description Failed to update conversation custom fields */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ConversationSyncController_escalateConversation: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['EscalateConversationBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['UpdateConversationLifecycleResponse']
+        }
+      }
+      /** @description User is not a participant in the conversation */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to update conversation status */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ConversationSyncController_syncConversationMessages: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['SyncConversationMessagesBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['SyncConversationMessagesResponse']
+        }
+      }
+      /** @description Supplied conversationId does not match the imported messages */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to sync messages */
+      500: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ConversationSyncController_resolveConversation: {
+    parameters: {
+      query?: never
+      header?: never
+      path?: never
+      cookie?: never
+    }
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['ResolveConversationBody']
+      }
+    }
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['UpdateConversationLifecycleResponse']
+        }
+      }
+      /** @description User is not a participant in the conversation */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Failed to update conversation status */
       500: {
         headers: {
           [name: string]: unknown
@@ -25289,6 +25519,49 @@ export interface operations {
         }
         content: {
           'application/json': components['schemas']['PreviewProjectTransferResponse']
+        }
+      }
+      /** @description Unauthorized */
+      401: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Forbidden action */
+      403: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+      /** @description Rate limit exceeded */
+      429: {
+        headers: {
+          [name: string]: unknown
+        }
+        content?: never
+      }
+    }
+  }
+  ProjectWakeController_wakeUpProject: {
+    parameters: {
+      query?: never
+      header?: never
+      path: {
+        /** @description Project ref */
+        ref: string
+      }
+      cookie?: never
+    }
+    requestBody?: never
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown
+        }
+        content: {
+          'application/json': components['schemas']['ProjectWakeResponse']
         }
       }
       /** @description Unauthorized */


### PR DESCRIPTION
As part of hibernation (suspend and wake), wakes via PostgREST happen automatically. However, if a user goes straight to the dashboard, we want to ensure the project wakes up from it's slumber. I've decided to add this logic at a very central point that will prevent most project-ref related pages to load (purposely).

The project ref details endpoint returns whether the project is hibernating or not - so for any regularly running project, none of the added logic will be invoked and there is no extra network calls, so no negative perf impact for these checks.

Eventually with v3 architecture none of this is needed as wakes are done at the proxy/network layer, but this is a necessary change for v2 for more graceful wakes.

Adjusted network restrictions as it would query before the project loads and potentially time out while still loading


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic wake-up for hibernating projects restores functionality without manual intervention.

* **Platform API Enhancements**
  * New conversation management endpoints for escalation, synchronization, and resolution.
  * New project wake endpoint for managing dormant project states.
  * Updated read-replica operation response codes for improved API consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->