### PR TITLE
fix(studio): classify auth log 4xx as warning, 5xx as error

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
@@ -2,6 +2,7 @@ import { Column } from 'react-data-grid'
 import { TimestampInfo } from 'ui-patterns/TimestampInfo'
 
 import type { LogData } from '../Logs.types'
+import { getAuthLogSeverity } from '../Logs.utils'
 import { RowLayout, SeverityFormatter, TextFormatter } from '../LogsFormatters'
 import { defaultRenderCell } from './DefaultPreviewColumnRenderer'
 import { parseAuthLogEventMessage } from '@/components/interfaces/UnifiedLogs/UnifiedLogs.utils'
@@ -19,7 +20,14 @@ const columns: Column<LogData>[] = [
       return (
         <RowLayout>
           <TimestampInfo utcTimestamp={props.row.timestamp!} />
-          {props.row.level && <SeverityFormatter value={props.row.level as string} />}
+          {props.row.level && (
+            <SeverityFormatter
+              value={getAuthLogSeverity(
+                props.row.level as string,
+                props.row.status as string | number | undefined
+              )}
+            />
+          )}
           <TextFormatter
             className="w-full"
             value={`${props.row.path ? props.row.path + ' | ' : ''}${

--- a/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogColumnRenderers/AuthColumnRenderer.tsx
@@ -21,12 +21,7 @@ const columns: Column<LogData>[] = [
         <RowLayout>
           <TimestampInfo utcTimestamp={props.row.timestamp!} />
           {props.row.level && (
-            <SeverityFormatter
-              value={getAuthLogSeverity(
-                props.row.level as string,
-                props.row.status as string | number | undefined
-              )}
-            />
+            <SeverityFormatter value={getAuthLogSeverity(props.row.level, props.row.status)} />
           )}
           <TextFormatter
             className="w-full"

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -294,16 +294,12 @@ const _SQL_FILTER_COMMON: Record<string, SqlFilterEntry> = {
     safeSql`regexp_contains(event_message, ${analyticsLiteral(value)})`,
 }
 
-// Auth logs are emitted at `level: info` even for failed requests (e.g. a
-// 422 from a duplicate signup), so the HTTP status code is the only reliable
-// signal of severity. These conditions derive severity from the status as well
-// as the log level so the severity filter, the chart, and the table badge all
-// agree: a 5xx (or an explicit error/fatal level) is an error, a 4xx (or an
-// explicit warning level) is a warning, everything else is info.
-//
-// `IFNULL` keeps each condition strictly boolean (never NULL) so the info
-// condition can safely negate the other two without three-valued-logic
-// surprises when a row has no status or no level.
+// Auth logs always emit `level: info` even for failed requests, so HTTP status
+// is the reliable severity signal. Shared by the severity filter, the chart,
+// and the table badge so all three agree: 5xx (or level error/fatal) = error,
+// 4xx (or level warning) = warning, everything else = info. IFNULL keeps each
+// condition strictly boolean (never NULL) so the info condition can safely
+// negate the other two when a row has no status or no level.
 export const AUTH_LOG_ERROR_CONDITION: SafeLogSqlFragment = safeSql`IFNULL(metadata.level, '') IN ('error', 'fatal') OR IFNULL(SAFE_CAST(metadata.status AS INT64), 0) >= 500`
 export const AUTH_LOG_WARNING_CONDITION: SafeLogSqlFragment = safeSql`IFNULL(metadata.level, '') = 'warning' OR IFNULL(SAFE_CAST(metadata.status AS INT64), 0) BETWEEN 400 AND 499`
 export const AUTH_LOG_INFO_CONDITION: SafeLogSqlFragment = safeSql`NOT (${AUTH_LOG_ERROR_CONDITION}) AND NOT (${AUTH_LOG_WARNING_CONDITION})`

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.constants.ts
@@ -294,6 +294,20 @@ const _SQL_FILTER_COMMON: Record<string, SqlFilterEntry> = {
     safeSql`regexp_contains(event_message, ${analyticsLiteral(value)})`,
 }
 
+// Auth logs are emitted at `level: info` even for failed requests (e.g. a
+// 422 from a duplicate signup), so the HTTP status code is the only reliable
+// signal of severity. These conditions derive severity from the status as well
+// as the log level so the severity filter, the chart, and the table badge all
+// agree: a 5xx (or an explicit error/fatal level) is an error, a 4xx (or an
+// explicit warning level) is a warning, everything else is info.
+//
+// `IFNULL` keeps each condition strictly boolean (never NULL) so the info
+// condition can safely negate the other two without three-valued-logic
+// surprises when a row has no status or no level.
+export const AUTH_LOG_ERROR_CONDITION: SafeLogSqlFragment = safeSql`IFNULL(metadata.level, '') IN ('error', 'fatal') OR IFNULL(SAFE_CAST(metadata.status AS INT64), 0) >= 500`
+export const AUTH_LOG_WARNING_CONDITION: SafeLogSqlFragment = safeSql`IFNULL(metadata.level, '') = 'warning' OR IFNULL(SAFE_CAST(metadata.status AS INT64), 0) BETWEEN 400 AND 499`
+export const AUTH_LOG_INFO_CONDITION: SafeLogSqlFragment = safeSql`NOT (${AUTH_LOG_ERROR_CONDITION}) AND NOT (${AUTH_LOG_WARNING_CONDITION})`
+
 export const SQL_FILTER_TEMPLATES: Record<string, Record<string, SqlFilterEntry>> = {
   postgres_logs: {
     ..._SQL_FILTER_COMMON,
@@ -338,9 +352,9 @@ export const SQL_FILTER_TEMPLATES: Record<string, Record<string, SqlFilterEntry>
   },
   auth_logs: {
     ..._SQL_FILTER_COMMON,
-    'severity.error': safeSql`metadata.level = 'error' or metadata.level = 'fatal'`,
-    'severity.warning': safeSql`metadata.level = 'warning'`,
-    'severity.info': safeSql`metadata.level = 'info'`,
+    'severity.error': AUTH_LOG_ERROR_CONDITION,
+    'severity.warning': AUTH_LOG_WARNING_CONDITION,
+    'severity.info': AUTH_LOG_INFO_CONDITION,
     'status_code.server_error': safeSql`cast(metadata.status as int64) between 500 and 599`,
     'status_code.client_error': safeSql`cast(metadata.status as int64) between 400 and 499`,
     'status_code.redirection': safeSql`cast(metadata.status as int64) between 300 and 399`,

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
@@ -7,6 +7,7 @@ import {
   formatLogsAsCsv,
   formatLogsAsJson,
   formatLogsAsMarkdown,
+  getAuthLogSeverity,
   parseMultigresEventMessage,
 } from './Logs.utils'
 
@@ -217,6 +218,46 @@ describe('Logs.utils', () => {
       expect(parseMultigresEventMessage(undefined)).toBeNull()
       expect(parseMultigresEventMessage(null)).toBeNull()
       expect(parseMultigresEventMessage(42)).toBeNull()
+    })
+  })
+
+  describe('getAuthLogSeverity', () => {
+    test('reports server errors (5xx) as error', () => {
+      expect(getAuthLogSeverity('info', 500)).toBe('error')
+      expect(getAuthLogSeverity('info', 503)).toBe('error')
+    })
+
+    test('reports client errors (4xx) as error', () => {
+      expect(getAuthLogSeverity('info', 400)).toBe('error')
+      expect(getAuthLogSeverity('info', 401)).toBe('error')
+      expect(getAuthLogSeverity('info', 429)).toBe('error')
+    })
+
+    test('handles status passed as a string', () => {
+      expect(getAuthLogSeverity('info', '404')).toBe('error')
+      expect(getAuthLogSeverity('info', '200')).toBe('info')
+    })
+
+    test('preserves the original level for non-error statuses', () => {
+      expect(getAuthLogSeverity('info', 200)).toBe('info')
+      expect(getAuthLogSeverity('warning', 302)).toBe('warning')
+      expect(getAuthLogSeverity('info', 399)).toBe('info')
+    })
+
+    test('falls back to the level when status is missing or invalid', () => {
+      expect(getAuthLogSeverity('info')).toBe('info')
+      expect(getAuthLogSeverity('warning', null)).toBe('warning')
+      expect(getAuthLogSeverity('info', 'not-a-number')).toBe('info')
+    })
+
+    test('keeps explicit error levels even without a status', () => {
+      expect(getAuthLogSeverity('error')).toBe('error')
+      expect(getAuthLogSeverity('fatal')).toBe('fatal')
+    })
+
+    test('returns an empty string when level is missing', () => {
+      expect(getAuthLogSeverity()).toBe('')
+      expect(getAuthLogSeverity(null, 200)).toBe('')
     })
   })
 })

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, test } from 'vitest'
 
-import type { LogData } from './Logs.types'
+import { LogsTableName } from './Logs.constants'
+import type { Filters, LogData } from './Logs.types'
 import {
   buildLogsPrompt,
   extractEdgeFunctionName,
   formatLogsAsCsv,
   formatLogsAsJson,
   formatLogsAsMarkdown,
+  genDefaultQuery,
   getAuthLogSeverity,
   parseMultigresEventMessage,
 } from './Logs.utils'
@@ -269,6 +271,28 @@ describe('Logs.utils', () => {
       expect(getAuthLogSeverity(42, 500)).toBe('error')
       expect(getAuthLogSeverity('info', {})).toBe('info')
       expect(getAuthLogSeverity('info', [500])).toBe('info')
+    })
+  })
+
+  describe('auth_logs severity filter query', () => {
+    const queryFor = (severity: Filters['severity']) =>
+      genDefaultQuery(LogsTableName.AUTH, { severity } as Filters, 100)
+
+    test('error severity filter matches 5xx status as well as the log level', () => {
+      const sql = queryFor({ error: true })
+      expect(sql).toContain("IFNULL(metadata.level, '') IN ('error', 'fatal')")
+      expect(sql).toContain('IFNULL(SAFE_CAST(metadata.status AS INT64), 0) >= 500')
+    })
+
+    test('warning severity filter matches 4xx status as well as the log level', () => {
+      const sql = queryFor({ warning: true })
+      expect(sql).toContain("IFNULL(metadata.level, '') = 'warning'")
+      expect(sql).toContain('IFNULL(SAFE_CAST(metadata.status AS INT64), 0) BETWEEN 400 AND 499')
+    })
+
+    test('info severity filter excludes error and warning rows', () => {
+      const sql = queryFor({ info: true })
+      expect(sql).toContain('NOT (')
     })
   })
 })

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
@@ -227,20 +227,22 @@ describe('Logs.utils', () => {
       expect(getAuthLogSeverity('info', 503)).toBe('error')
     })
 
-    test('reports client errors (4xx) as error', () => {
-      expect(getAuthLogSeverity('info', 400)).toBe('error')
-      expect(getAuthLogSeverity('info', 401)).toBe('error')
-      expect(getAuthLogSeverity('info', 429)).toBe('error')
+    test('reports client errors (4xx) as warning', () => {
+      expect(getAuthLogSeverity('info', 400)).toBe('warning')
+      expect(getAuthLogSeverity('info', 401)).toBe('warning')
+      expect(getAuthLogSeverity('info', 429)).toBe('warning')
+      expect(getAuthLogSeverity('info', 499)).toBe('warning')
     })
 
     test('handles status passed as a string', () => {
-      expect(getAuthLogSeverity('info', '404')).toBe('error')
+      expect(getAuthLogSeverity('info', '500')).toBe('error')
+      expect(getAuthLogSeverity('info', '404')).toBe('warning')
       expect(getAuthLogSeverity('info', '200')).toBe('info')
     })
 
     test('preserves the original level for non-error statuses', () => {
       expect(getAuthLogSeverity('info', 200)).toBe('info')
-      expect(getAuthLogSeverity('warning', 302)).toBe('warning')
+      expect(getAuthLogSeverity('info', 302)).toBe('info')
       expect(getAuthLogSeverity('info', 399)).toBe('info')
     })
 
@@ -250,9 +252,11 @@ describe('Logs.utils', () => {
       expect(getAuthLogSeverity('info', 'not-a-number')).toBe('info')
     })
 
-    test('keeps explicit error levels even without a status', () => {
+    test('keeps explicit error levels even with a non-error status', () => {
       expect(getAuthLogSeverity('error')).toBe('error')
       expect(getAuthLogSeverity('fatal')).toBe('fatal')
+      expect(getAuthLogSeverity('error', 200)).toBe('error')
+      expect(getAuthLogSeverity('fatal', 404)).toBe('fatal')
     })
 
     test('returns an empty string when level is missing', () => {

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.test.ts
@@ -263,5 +263,12 @@ describe('Logs.utils', () => {
       expect(getAuthLogSeverity()).toBe('')
       expect(getAuthLogSeverity(null, 200)).toBe('')
     })
+
+    test('ignores non-string levels and non-numeric statuses', () => {
+      expect(getAuthLogSeverity({}, {})).toBe('')
+      expect(getAuthLogSeverity(42, 500)).toBe('error')
+      expect(getAuthLogSeverity('info', {})).toBe('info')
+      expect(getAuthLogSeverity('info', [500])).toBe('info')
+    })
   })
 })

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -751,27 +751,14 @@ function getWarningCondition(table: LogsTableName): SafeLogSqlFragment {
   }
 }
 
-// HTTP status code boundaries used to classify auth log severity. Kept
-// consistent with the other log services (e.g. edge logs): a 5xx is an error,
-// a 4xx is a warning.
 export const HTTP_SERVER_ERROR_STATUS = 500
 export const HTTP_CLIENT_ERROR_STATUS = 400
 
 /**
- * Auth logs are emitted at `level: info` even when they represent a failed
- * request (e.g. a 400/401/429 from a failed login). The auth logs chart derives
- * severity from the HTTP status (see `getErrorCondition`/`getWarningCondition`),
- * so when a user filters by status code the chart shows errors/warnings while
- * the table still shows "INFO" badges, making the filter look like it was never
- * applied.
- *
- * This helper derives the severity shown in the table from both the log level
- * and the HTTP status so the table stays consistent with the chart and with the
- * other log services: 5xx is an error, 4xx is a warning, everything else falls
- * back to the log level.
- *
- * `level` and `status` are untyped log row values, so they are validated rather
- * than cast: anything that is not a usable string/number is ignored.
+ * Derives the severity badge shown in the auth log table from the log level and
+ * HTTP status, matching the chart: 5xx → error, 4xx → warning, otherwise the
+ * log level. See the AUTH_LOG_*_CONDITION constants in Logs.constants.ts for the
+ * matching SQL and the reason auth logs need this.
  */
 export function getAuthLogSeverity(level?: unknown, status?: unknown): string {
   const normalizedLevel = typeof level === 'string' ? level : ''

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -764,16 +764,20 @@ export const HTTP_CLIENT_ERROR_STATUS = 400
  * and the HTTP status so the table stays consistent with the chart and with the
  * other log services: 5xx is an error, 4xx is a warning, everything else falls
  * back to the log level.
+ *
+ * `level` and `status` are untyped log row values, so they are validated rather
+ * than cast: anything that is not a usable string/number is ignored.
  */
-export function getAuthLogSeverity(level?: string | null, status?: string | number | null): string {
-  const normalizedLevel = level ?? ''
+export function getAuthLogSeverity(level?: unknown, status?: unknown): string {
+  const normalizedLevel = typeof level === 'string' ? level : ''
 
   // Preserve explicit error-class levels so we never downgrade them and so the
   // original label (e.g. "fatal") is kept.
   if (normalizedLevel === 'error' || normalizedLevel === 'fatal') return normalizedLevel
 
-  const statusCode = typeof status === 'string' ? Number(status) : status
-  const hasStatus = typeof statusCode === 'number' && Number.isFinite(statusCode)
+  const statusCode =
+    typeof status === 'number' ? status : typeof status === 'string' ? Number(status) : NaN
+  const hasStatus = Number.isFinite(statusCode)
 
   if (hasStatus && statusCode >= HTTP_SERVER_ERROR_STATUS) return 'error'
   if (normalizedLevel === 'warning') return 'warning'

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -713,7 +713,7 @@ function getErrorCondition(table: LogsTableName): SafeLogSqlFragment {
     case 'postgres_logs':
       return safeSql`parsed.error_severity IN ('ERROR', 'FATAL', 'PANIC')`
     case 'auth_logs':
-      return safeSql`metadata.level = 'error' OR SAFE_CAST(metadata.status AS INT64) >= 400`
+      return safeSql`metadata.level = 'error' OR SAFE_CAST(metadata.status AS INT64) >= 500`
     case 'function_edge_logs':
       return safeSql`response.status_code >= 500`
     case 'function_logs':
@@ -734,7 +734,7 @@ function getWarningCondition(table: LogsTableName): SafeLogSqlFragment {
     case 'postgres_logs':
       return safeSql`parsed.error_severity IN ('WARNING')`
     case 'auth_logs':
-      return safeSql`metadata.level = 'warning'`
+      return safeSql`metadata.level = 'warning' OR SAFE_CAST(metadata.status AS INT64) BETWEEN 400 AND 499`
     case 'function_edge_logs':
       return safeSql`response.status_code >= 400 AND response.status_code < 500`
     case 'function_logs':
@@ -746,27 +746,40 @@ function getWarningCondition(table: LogsTableName): SafeLogSqlFragment {
   }
 }
 
+// HTTP status code boundaries used to classify auth log severity. Kept
+// consistent with the other log services (e.g. edge logs): a 5xx is an error,
+// a 4xx is a warning.
+export const HTTP_SERVER_ERROR_STATUS = 500
+export const HTTP_CLIENT_ERROR_STATUS = 400
+
 /**
  * Auth logs are emitted at `level: info` even when they represent a failed
- * request (e.g. a 400/401/429 from a failed login). The auth logs chart treats
- * any response with an HTTP status >= 400 as an error (see `getErrorCondition`),
- * so when a user filters by status code the chart turns red while the table
- * still shows "INFO" badges, making the filter look like it was never applied.
+ * request (e.g. a 400/401/429 from a failed login). The auth logs chart derives
+ * severity from the HTTP status (see `getErrorCondition`/`getWarningCondition`),
+ * so when a user filters by status code the chart shows errors/warnings while
+ * the table still shows "INFO" badges, making the filter look like it was never
+ * applied.
  *
  * This helper derives the severity shown in the table from both the log level
- * and the HTTP status so the table stays consistent with the chart.
+ * and the HTTP status so the table stays consistent with the chart and with the
+ * other log services: 5xx is an error, 4xx is a warning, everything else falls
+ * back to the log level.
  */
-export const AUTH_LOG_ERROR_STATUS_THRESHOLD = 400
-
 export function getAuthLogSeverity(level?: string | null, status?: string | number | null): string {
-  const statusCode = typeof status === 'string' ? Number(status) : status
-  const hasErrorStatus =
-    typeof statusCode === 'number' &&
-    Number.isFinite(statusCode) &&
-    statusCode >= AUTH_LOG_ERROR_STATUS_THRESHOLD
+  const normalizedLevel = level ?? ''
 
-  if (hasErrorStatus) return 'error'
-  return level ?? ''
+  // Preserve explicit error-class levels so we never downgrade them and so the
+  // original label (e.g. "fatal") is kept.
+  if (normalizedLevel === 'error' || normalizedLevel === 'fatal') return normalizedLevel
+
+  const statusCode = typeof status === 'string' ? Number(status) : status
+  const hasStatus = typeof statusCode === 'number' && Number.isFinite(statusCode)
+
+  if (hasStatus && statusCode >= HTTP_SERVER_ERROR_STATUS) return 'error'
+  if (normalizedLevel === 'warning') return 'warning'
+  if (hasStatus && statusCode >= HTTP_CLIENT_ERROR_STATUS) return 'warning'
+
+  return normalizedLevel
 }
 
 export function jwtAPIKey(metadata: any) {

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -746,6 +746,29 @@ function getWarningCondition(table: LogsTableName): SafeLogSqlFragment {
   }
 }
 
+/**
+ * Auth logs are emitted at `level: info` even when they represent a failed
+ * request (e.g. a 400/401/429 from a failed login). The auth logs chart treats
+ * any response with an HTTP status >= 400 as an error (see `getErrorCondition`),
+ * so when a user filters by status code the chart turns red while the table
+ * still shows "INFO" badges, making the filter look like it was never applied.
+ *
+ * This helper derives the severity shown in the table from both the log level
+ * and the HTTP status so the table stays consistent with the chart.
+ */
+export const AUTH_LOG_ERROR_STATUS_THRESHOLD = 400
+
+export function getAuthLogSeverity(level?: string | null, status?: string | number | null): string {
+  const statusCode = typeof status === 'string' ? Number(status) : status
+  const hasErrorStatus =
+    typeof statusCode === 'number' &&
+    Number.isFinite(statusCode) &&
+    statusCode >= AUTH_LOG_ERROR_STATUS_THRESHOLD
+
+  if (hasErrorStatus) return 'error'
+  return level ?? ''
+}
+
 export function jwtAPIKey(metadata: any) {
   const apikeyHeader = metadata?.[0]?.request?.[0]?.sb?.[0]?.jwt?.[0]?.apikey?.[0]
   if (!apikeyHeader) {

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -6,7 +6,12 @@ import uniqBy from 'lodash/uniqBy'
 import { useEffect } from 'react'
 import logConstants from 'shared-data/log-constants'
 
-import { LogsTableName, SQL_FILTER_TEMPLATES } from './Logs.constants'
+import {
+  AUTH_LOG_ERROR_CONDITION,
+  AUTH_LOG_WARNING_CONDITION,
+  LogsTableName,
+  SQL_FILTER_TEMPLATES,
+} from './Logs.constants'
 import type { Filters, LogData, LogsEndpointParams, QueryType } from './Logs.types'
 import { convertResultsToCSV } from '@/components/interfaces/SQLEditor/UtilityPanel/Results.utils'
 import BackwardIterator from '@/components/ui/CodeEditor/Providers/BackwardIterator'
@@ -713,7 +718,7 @@ function getErrorCondition(table: LogsTableName): SafeLogSqlFragment {
     case 'postgres_logs':
       return safeSql`parsed.error_severity IN ('ERROR', 'FATAL', 'PANIC')`
     case 'auth_logs':
-      return safeSql`metadata.level = 'error' OR SAFE_CAST(metadata.status AS INT64) >= 500`
+      return AUTH_LOG_ERROR_CONDITION
     case 'function_edge_logs':
       return safeSql`response.status_code >= 500`
     case 'function_logs':
@@ -734,7 +739,7 @@ function getWarningCondition(table: LogsTableName): SafeLogSqlFragment {
     case 'postgres_logs':
       return safeSql`parsed.error_severity IN ('WARNING')`
     case 'auth_logs':
-      return safeSql`metadata.level = 'warning' OR SAFE_CAST(metadata.status AS INT64) BETWEEN 400 AND 499`
+      return AUTH_LOG_WARNING_CONDITION
     case 'function_edge_logs':
       return safeSql`response.status_code >= 400 AND response.status_code < 500`
     case 'function_logs':


### PR DESCRIPTION
## Problem

On the auth logs page (`/logs/auth-logs`), opening with a status-code filter made it look like the filter was not applied to the results table: the chart reflected errors while the table showed `INFO` rows. The deeper issue is that auth logs are emitted at `level: info` even for failed requests (a 422 from a duplicate signup, a 401, a 429, a 5xx, etc.), and severity was derived inconsistently across the page.

Linear: FE-3587

## Root cause

Auth severity was computed three different ways on the old logs page:

- **Severity filter** (`Logs.constants.ts`): `metadata.level` only.
- **Chart** error/warning conditions: level OR status.
- **Table badge**: raw `metadata.level`.

So filtering by Severity = Warning/Error returned nothing (no row has `level = 'warning'`), while the chart and badges classified the same rows as warnings/errors by status. Display and filter disagreed.

## Fix

Derive auth severity from the HTTP status consistently, matching the other log services (edge logs): **5xx = error, 4xx = warning, otherwise the log level**.

- Shared SQL conditions `AUTH_LOG_ERROR_CONDITION` / `AUTH_LOG_WARNING_CONDITION` / `AUTH_LOG_INFO_CONDITION` (`Logs.constants.ts`), null-safe via `IFNULL` so the info condition can negate the other two.
- Reused by both the severity **filter** templates and the chart `getErrorCondition` / `getWarningCondition`, so they can't drift.
- New pure helper `getAuthLogSeverity(level, status)` for the table **badge** (`AuthColumnRenderer`), validating untyped row values rather than casting.

After this, filtering by Warning/Error returns the 4xx/5xx auth logs, and the chart bars and table badges agree.

## Scope

This PR covers the **old logs page** (`LogsPreviewer`), which is the surface the customer reported (their URL was `/logs/auth-logs`).

The **unified logs** page and the **observability overview** have the same symptom but a different root cause (the OTEL severity expression reads `log_attributes['response.status_code']`, which auth-service rows don't populate, so they fall back to `severity_text` and classify as `success`; observability is bucketed server-side). Tracked separately in FE-3592.

## How to test

Prereq: an auth log set with a mix of statuses. Duplicate signups generate 422s; failed logins generate 4xx.

1. Run Studio locally (`pnpm dev:studio`) and open `/project/<ref>/logs/auth-logs`.
2. With no filter, confirm rows with a 4xx status show an amber **WARNING** badge, 5xx show a red **ERROR** badge, and 2xx/no-status `info` rows still show **INFO**. Explicit `error`/`fatal` level rows are unchanged.
3. Open the **Severity** filter, select **Warning** + **Error**, apply. The table should now return the 4xx/5xx rows (previously empty). Reload the page to confirm it also works when applied from the URL on first load.
4. Confirm the chart bars match: 4xx contributes to the warning (amber) count, 5xx to the error (red) count.
5. Select **Info** only and confirm 4xx/5xx rows are excluded (no overlap with warning/error).

## Tests

- `getAuthLogSeverity` unit tests (5xx, 4xx, string statuses, non-error statuses, missing/invalid input, explicit error levels, non-string/array inputs).
- `genDefaultQuery` tests asserting the auth severity filter SQL includes the status-based conditions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auth logs now calculate severity based on both HTTP status codes and log levels, providing more accurate classification in the Logs interface.

* **Tests**
  * Added comprehensive test coverage for auth log severity mapping across different status codes and log levels, and for SQL filter query generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->