### PR TITLE
fix(studio): tolerate empty API responses without Content-Length

### DIFF
--- a/apps/studio/data/fetchers.test.ts
+++ b/apps/studio/data/fetchers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@sentry/nextjs', () => ({ captureException: vi.fn() }))
+vi.mock('common', () => ({ IS_PLATFORM: false, getAccessToken: vi.fn() }))
+vi.mock('@/lib/constants', () => ({ API_URL: 'http://localhost' }))
+vi.mock('@/lib/helpers', () => ({ uuidv4: () => 'test-uuid' }))
+
+// Import after mocks are set up
+const { isEmptyResponseBody } = await import('./fetchers')
+
+describe('isEmptyResponseBody', () => {
+  it('returns true for a response with no body', async () => {
+    const response = new Response(null, { status: 201 })
+    expect(await isEmptyResponseBody(response)).toBe(true)
+  })
+
+  it('returns true for an empty string body', async () => {
+    const response = new Response('', { status: 200 })
+    expect(await isEmptyResponseBody(response)).toBe(true)
+  })
+
+  it('returns false for a non-empty body', async () => {
+    const response = new Response('{"id":1}', { status: 200 })
+    expect(await isEmptyResponseBody(response)).toBe(false)
+  })
+
+  it('does not drain the original body (reads from a clone)', async () => {
+    const response = new Response('{"id":1}', { status: 200 })
+    await isEmptyResponseBody(response)
+    // The original response must still be readable by openapi-fetch afterwards.
+    expect(await response.json()).toEqual({ id: 1 })
+  })
+})

--- a/apps/studio/data/fetchers.ts
+++ b/apps/studio/data/fetchers.ts
@@ -84,6 +84,17 @@ function pgMetaGuard(request: Request) {
   return request
 }
 
+/**
+ * Determines whether a response has an empty body. Reads from a clone so the original
+ * response stays intact for openapi-fetch (or a streaming consumer) to read afterwards.
+ */
+export async function isEmptyResponseBody(response: Response) {
+  if (response.body === null) return true
+
+  const buffer = await response.clone().arrayBuffer()
+  return buffer.byteLength === 0
+}
+
 // Middleware
 client.use(
   {
@@ -98,6 +109,25 @@ client.use(
     // Middleware to format errors
     async onResponse({ request, response }) {
       if (response.ok) {
+        // openapi-fetch only skips JSON parsing when the response is a 204 or carries a
+        // `Content-Length: 0` header. Over HTTP/2 and HTTP/3 the `Content-Length` header is
+        // optional, so a successful-but-empty response (endpoints that return no content) can
+        // arrive without it. openapi-fetch then calls `response.json()` on the empty body and
+        // throws "Unexpected end of JSON input", which surfaces as an error toast even though
+        // the request succeeded. Normalize empty success bodies so openapi-fetch treats them as
+        // empty content instead of trying to parse them.
+        if (response.status !== 204 && !response.headers.has('Content-Length')) {
+          const isEmpty = await isEmptyResponseBody(response)
+          if (isEmpty) {
+            const headers = new Headers(response.headers)
+            headers.set('Content-Length', '0')
+            return new Response(null, {
+              headers,
+              status: response.status,
+              statusText: response.statusText,
+            })
+          }
+        }
         return response
       }
 


### PR DESCRIPTION
## Problem

Several mutations show a `Failed to ...: Unexpected end of JSON input` error toast even though the request actually succeeded (refresh and the change is there). Reported for creating a custom report and adding a compute addon, but it affects any endpoint that returns an empty success body.

Root cause: those endpoints return an empty `2xx` body (handlers typed `Promise<void>`). Our API client (`openapi-fetch`) only skips JSON parsing when the response is a `204` **or** carries a `Content-Length: 0` header. Otherwise it calls `response.json()`, and on an empty body that throws `Unexpected end of JSON input`. The rejection bubbles to the mutation's `onError` and fires the toast.

### Why only on staging

`Content-Length` is optional over HTTP/2 and HTTP/3. Staging's API domain (`api.supabase.green`) advertises HTTP/3 (`Alt-Svc: h3`), so once the browser upgrades to h3, empty responses come back **without** `Content-Length` and the client throws. Prod (`api.supabase.com`) does not advertise h3, so it serves over HTTP/2/1.1 with `Content-Length: 0`, which the client handles. This also explains why it is intermittent even on staging: the first request typically uses HTTP/2, and only later connections upgrade to h3.

Confirmed from a HAR capture (`httpVersion: h3`, `status: 201`, empty body, no `Content-Length`) and from the platform API source (the handlers return `Promise<void>` with no body and no response-transform interceptor).

## Fix

Normalize empty success bodies in the `onResponse` middleware in `fetchers.ts`: for an `ok` response with no `Content-Length` header, detect an empty body and return a response with `Content-Length: 0` so openapi-fetch treats it as empty content instead of trying to parse it. This covers every endpoint, not just the ones reported.

Emptiness is checked against a clone, so the original response stays readable by openapi-fetch (and by the one streaming consumer that uses `parseAs: 'stream'`).

## Testing

- Added unit tests for the `isEmptyResponseBody` helper (empty/null/non-empty bodies, and that it does not drain the original response).
- `vitest run data/fetchers.test.ts` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of empty successful API responses to prevent JSON parsing errors.

* **Tests**
  * Added test coverage for empty response body detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->