### PR TITLE
fix(blog): update stale links and remove outdated content in Studio post

### DIFF
--- a/apps/www/_blog/2021-11-30-supabase-studio.mdx
+++ b/apps/www/_blog/2021-11-30-supabase-studio.mdx
@@ -108,4 +108,3 @@ Check out the full instructions in our [Studio Readme](https://github.com/supaba
 Our new open source Studio is also on Product Hunt right now. If you like what you see, please give it an upvote and a review.
 
 [![Open Source Table Editor](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=321226&theme=light)](https://www.producthunt.com/posts/open-source-postgresql-studio?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-open-source-postgresql-studio)
-

--- a/apps/www/_blog/2021-11-30-supabase-studio.mdx
+++ b/apps/www/_blog/2021-11-30-supabase-studio.mdx
@@ -99,7 +99,6 @@ The features exposed on Studio for existing deployments are limited to those whi
 - Database management: Policies, roles, extensions, replication.
 - API documentation.
 
-
 ## How to contribute?
 
 Check out the full instructions in our [Studio Readme](https://github.com/supabase/supabase/tree/master/apps/studio).

--- a/apps/www/_blog/2021-11-30-supabase-studio.mdx
+++ b/apps/www/_blog/2021-11-30-supabase-studio.mdx
@@ -103,4 +103,9 @@ The features exposed on Studio for existing deployments are limited to those whi
 
 Check out the full instructions in our [Studio Readme](https://github.com/supabase/supabase/tree/master/apps/studio).
 
+### We are live and launched on Product Hunt
+
+Our new open source Studio is also on Product Hunt right now. If you like what you see, please give it an upvote and a review.
+
+[![Open Source Table Editor](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=321226&theme=light)](https://www.producthunt.com/posts/open-source-postgresql-studio?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-open-source-postgresql-studio)
 

--- a/apps/www/_blog/2021-11-30-supabase-studio.mdx
+++ b/apps/www/_blog/2021-11-30-supabase-studio.mdx
@@ -16,7 +16,7 @@ date: '2021-11-30'
 toc_depth: 2
 ---
 
-Today we're releasing [Supabase Studio](https://github.com/supabase/supabase/tree/master/studio).
+Today we're releasing [Supabase Studio](https://github.com/supabase/supabase/tree/master/apps/studio).
 The same Dashboard that you're using on our Platform is now available for [Local Development](https://supabase.com/docs/guides/local-development)
 and [Self-Hosting](https://supabase.com/docs/guides/hosting/overview).
 
@@ -47,7 +47,7 @@ We investigated a few different approaches used in the open source world. There 
 - Keep two repos in sync using some mixture of git submodules or a tool like [copycat](https://github.com/atomix/copycat)
 - Use the same codebase, abstracting platform-specific code behind an API and feature flags.
 
-Our frontend [team](https://github.com/orgs/supabase/teams/frontend/members) experimented with the first two approaches where they plucked (injected, merged, and wrangled) code for our Platform.
+Our frontend team experimented with the first two approaches where they plucked (injected, merged, and wrangled) code for our Platform.
 Time-to-production become a lot slower, an unacceptable outcome at Supabase.
 
 Eventually we decided to open source all the frontend code, a shared codebase for both the Platform and Self Hosting.
@@ -63,7 +63,7 @@ Eventually we decided to open source all the frontend code, a shared codebase fo
 
 ## Build in public
 
-For the past week, the dashboard you've been using on the Platform has been deployed from our [main repository](https://github.com/supabase/supabase/tree/master/studio).
+For the past week, the dashboard you've been using on the Platform has been deployed from our [main repository](https://github.com/supabase/supabase/tree/master/apps/studio).
 
 This fits one of our core philosophies at Supabase: do less. Less code to manage means less bugs. Fewer codebases means faster shipping.
 
@@ -86,7 +86,7 @@ Studio is a Javascript application with a few key pieces of technology:
 - [Tailwind](https://tailwindcss.com/) - A utility-first CSS framework.
 - [Supabase UI](https://ui.supabase.com/) - Our own component library.
 - [MobX](https://www.mobxjs.com/) - A state management library.
-- A host of other [useful libraries](https://github.com/supabase/supabase/blob/master/studio/package.json), including [Radix UI](https://www.radix-ui.com), [Lottiefiles](https://lottiefiles.com/), [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout), and [zxcvbn](https://github.com/dropbox/zxcvbn).
+- A host of other [useful libraries](https://github.com/supabase/supabase/blob/master/apps/studio/package.json), including [Radix UI](https://www.radix-ui.com), [Lottiefiles](https://lottiefiles.com/), [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout), and [zxcvbn](https://github.com/dropbox/zxcvbn).
 
 ### What's included
 
@@ -95,18 +95,13 @@ It is not intended for managing the deployment and administration of projects - 
 
 The features exposed on Studio for existing deployments are limited to those which manage your database:
 
-- Table & SQL editors. (Saved queries are unavailable for now)
+- Table & SQL editors.
 - Database management: Policies, roles, extensions, replication.
 - API documentation.
 
-Over time we'll expose a lot more of the codebase in the self-hosted Dashboard, this was as much as we could do for this Launch Week!
 
 ## How to contribute?
 
-Check out the full instructions in our [Studio Readme](https://github.com/supabase/supabase/tree/master/studio).
+Check out the full instructions in our [Studio Readme](https://github.com/supabase/supabase/tree/master/apps/studio).
 
-### We are live and launched on Product Hunt
 
-Our new open source Studio is also on Product Hunt right now. If you like what you see, please give it an upvote and a review.
-
-[![Open Source Table Editor](https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=321226&theme=light)](https://www.producthunt.com/posts/open-source-postgresql-studio?utm_source=badge-featured&utm_medium=badge&utm_souce=badge-open-source-postgresql-studio)

--- a/apps/www/_blog/2021-11-30-supabase-studio.mdx
+++ b/apps/www/_blog/2021-11-30-supabase-studio.mdx
@@ -47,7 +47,7 @@ We investigated a few different approaches used in the open source world. There 
 - Keep two repos in sync using some mixture of git submodules or a tool like [copycat](https://github.com/atomix/copycat)
 - Use the same codebase, abstracting platform-specific code behind an API and feature flags.
 
-Our frontend team experimented with the first two approaches where they plucked (injected, merged, and wrangled) code for our Platform.
+Our frontend [team](https://github.com/orgs/supabase/teams/frontend/members) experimented with the first two approaches where they plucked (injected, merged, and wrangled) code for our Platform.
 Time-to-production become a lot slower, an unacceptable outcome at Supabase.
 
 Eventually we decided to open source all the frontend code, a shared codebase for both the Platform and Self Hosting.


### PR DESCRIPTION
The Supabase Studio blog post (`/blog/supabase-studio`) receives a high volume of visits but contains outdated information from its original 2021 publish date. This PR makes minimal surgical fixes — no rewriting.

## Changes

**Broken links (4 fixes)** — the repo was reorganised into a monorepo and `/studio` moved to `/apps/studio`:
- Opening sentence link
- "Build in public" section link
- Tech stack `package.json` link
- "How to contribute" section link

**Stale text removed:**
- `(Saved queries are unavailable for now)` — saved queries have been available for years
- `Over time we'll expose a lot more of the codebase in the self-hosted Dashboard, this was as much as we could do for this Launch Week!` — the promise has been fulfilled, leaving it implies Studio is still a stub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Supabase Studio blog post with refreshed feature highlights emphasizing Table & SQL editors, database management, and API documentation.
  * Corrected internal repository and deployment links to point to the current studio location.
  * Removed outdated notes about unavailable features and an obsolete paragraph following the feature list.
  * Kept the existing Product Hunt section intact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->