### PR TITLE
fix(studio): derive unified auth log severity from log_attributes[status]

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -70,6 +70,16 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(sql).toMatch(/END\) NOT IN \('401'\)/)
     })
 
+    it('reads the HTTP status from log_attributes[status] for auth rows', () => {
+      // Auth-service logs expose their status under `status`, not the gateway's
+      // `response.status_code`, so without this their 4xx/5xx classify as
+      // success and the severity filter returns nothing.
+      const sql = getUnifiedLogsQuery(withFilters('log_type:eq:auth'))
+      expect(sql).toContain(
+        `if(source = 'auth_logs', log_attributes['status'], log_attributes['response.status_code'])`
+      )
+    })
+
     it('flips LIKE to NOT LIKE when the pathname/host operator is `<>`', () => {
       const sql = getUnifiedLogsQuery(withFilters('pathname:neq:/health', 'host:neq:cdn.foo'))
       expect(sql).toContain(`log_attributes['request.path'] NOT LIKE '%/health%'`)
@@ -170,6 +180,13 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
         date: [new Date('2026-05-01T00:00:00Z'), new Date('2026-05-08T00:00:00Z')],
       } as any)
       expect(sql).toContain('toStartOfDay(timestamp)')
+    })
+
+    it('buckets auth rows by their log_attributes[status] so 4xx/5xx are not counted as success', () => {
+      const sql = getLogsChartQuery(baseSearch)
+      expect(sql).toContain(
+        `if(source = 'auth_logs', log_attributes['status'], log_attributes['response.status_code'])`
+      )
     })
   })
 

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -36,6 +36,14 @@ const ATTR = {
   path: safeSql`log_attributes['request.path']`,
 } as const
 
+// The HTTP status code lives under different OTEL attribute keys per service:
+// gateway rows (edge / postgrest / storage / edge function) expose it as
+// `response.status_code`, while auth-service rows expose it as `status`. This
+// normalizes the two so both the displayed status and the derived severity are
+// correct for auth logs (which would otherwise have an empty status and fall
+// back to their `severity_text` of INFO, classifying every 4xx/5xx as success).
+const HTTP_STATUS_EXPR: SafeLogSqlFragment = safeSql`if(source = 'auth_logs', log_attributes['status'], ${ATTR.status})`
+
 /**
  * Predicate that matches rows belonging to a given log_type. Mirrors the
  * shape of the original BigQuery unified-logs CTEs: edge gateway traffic
@@ -72,25 +80,26 @@ const LOG_TYPE_EXPR: SafeLogSqlFragment = safeSql`CASE
       ELSE source
     END`
 
-// Status code is sourced from the HTTP response for gateway-style rows and
-// from the Postgres `parsed.sql_state_code` (e.g. `42P01`) for postgres rows.
+// Status code is sourced from the HTTP response for gateway-style rows, the
+// auth-service `status` attribute for auth rows, and the Postgres
+// `parsed.sql_state_code` (e.g. `42P01`) for postgres rows.
 const STATUS_EXPR: SafeLogSqlFragment = safeSql`CASE
       WHEN source = 'postgres_logs' THEN toString(log_attributes['parsed.sql_state_code'])
-      ELSE toString(${ATTR.status})
+      ELSE toString((${HTTP_STATUS_EXPR}))
     END`
 
 // SQL expression for derived `level`. Used inline (not as alias reference)
 // because the OTEL endpoint can't resolve aliases inside countIf when the
 // alias is not in GROUP BY.
 //
-// HTTP status is checked first so gateway rows (which always carry an
+// HTTP status is checked first so gateway and auth rows (which carry a
 // `severity_text` of `INFO` regardless of response code) bucket as
 // success/warning/error by status. Postgres-style severity is the
 // fallback for rows without a status code.
 const LEVEL_EXPR: SafeLogSqlFragment = safeSql`CASE
-      WHEN ${ATTR.status} != '' AND toInt32OrZero(${ATTR.status}) >= 500 THEN 'error'
-      WHEN ${ATTR.status} != '' AND toInt32OrZero(${ATTR.status}) BETWEEN 400 AND 499 THEN 'warning'
-      WHEN ${ATTR.status} != '' AND toInt32OrZero(${ATTR.status}) BETWEEN 200 AND 299 THEN 'success'
+      WHEN (${HTTP_STATUS_EXPR}) != '' AND toInt32OrZero((${HTTP_STATUS_EXPR})) >= 500 THEN 'error'
+      WHEN (${HTTP_STATUS_EXPR}) != '' AND toInt32OrZero((${HTTP_STATUS_EXPR})) BETWEEN 400 AND 499 THEN 'warning'
+      WHEN (${HTTP_STATUS_EXPR}) != '' AND toInt32OrZero((${HTTP_STATUS_EXPR})) BETWEEN 200 AND 299 THEN 'success'
       WHEN severity_text IN ('ERROR','FATAL','CRITICAL','ALERT','EMERGENCY') THEN 'error'
       WHEN severity_text IN ('WARN','WARNING') THEN 'warning'
       WHEN severity_text IN ('TRACE','DEBUG','INFO','LOG','NOTICE') THEN 'success'


### PR DESCRIPTION
## Problem

On the unified logs page, auth logs with a 4xx/5xx response are classified as **success**: the chart shows no warnings/errors, the severity filter (Warning/Error) returns no results, and the status column is empty for auth rows. (Follow-up from FE-3587, which fixed the same symptom on the old logs page.)

Linear: FE-3592

## Root cause

The OTEL severity expression `LEVEL_EXPR` reads the HTTP status from a single attribute:

```
status: log_attributes['response.status_code']
```

That key is only populated for **gateway** rows (edge/postgrest/storage/edge function). **Auth-service rows expose their status under `log_attributes['status']`** instead. Example auth row attributes:

```
"level": "info", "status": "422", "severity_text": "INFO", "source": "auth_logs"
```

So for auth rows `response.status_code` is empty, every status branch in `LEVEL_EXPR` is skipped, and it falls through to `severity_text` (`INFO`) → `success`. Because the same expression powers the table `level` column, the chart aggregation, and the severity filter, all three are wrong together. `STATUS_EXPR` (the displayed status) had the same gap.

## Fix

Normalize the HTTP status across sources and use it in both the status column and the severity expression:

```
HTTP_STATUS_EXPR = if(source = 'auth_logs', log_attributes['status'], log_attributes['response.status_code'])
```

Now auth 4xx => warning, 5xx => error, consistent with gateway rows and with the old logs page. Gateway/postgres behavior is unchanged.

The legacy BigQuery path (`getAuthLogsQuery`) already derives auth severity from the joined edge response status, so it is not affected.

## How to test

1. Open the unified logs page on a project with auth 4xx/5xx logs (duplicate signups produce 422s).
2. Confirm the chart now shows warning (4xx) / error (5xx) bars instead of all-success.
3. Open the **Severity** filter, select **Warning** + **Error**, apply: the 4xx/5xx auth rows are returned (previously "No results found").
4. Confirm the status column shows the code (e.g. 422) for auth rows.

## Tests

- `getUnifiedLogsQuery` / `getLogsChartQuery` assertions that the auth status is read from `log_attributes['status']` via the normalized expression.

## Not included

The observability overview AUTH chart buckets severity server-side (`/analytics/endpoints/service-health`) and needs a separate backend change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of HTTP status classification for authentication service logs to use the correct status field.
  * Fixed severity level computation to properly reflect HTTP status across all log sources.
  * Enhanced consistency in how log attributes are normalized across different log source types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->