### PR TITLE
chore(docs): add openapi to lint rule003

### DIFF
--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -313,6 +313,7 @@ allow_list = [
     "Ollama",
     "OneLogin",
     "OpenAI",
+    "[Oo]pen[Aa][Pp][Ii]",
     "OpenID",
     "OpenMetrics",
     "[Oo]pen[Ss]l",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Add OpenAPI/openapi to lint Rule003


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spelling validation configuration to recognize additional term variations in the linting allowlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->