### PR TITLE
test(studio): unflake schema visualizer Copy as SQL assertion

### DIFF
--- a/e2e/studio/features/database.spec.ts
+++ b/e2e/studio/features/database.spec.ts
@@ -52,9 +52,7 @@ test.describe('Database', () => {
       // copies schema definition to clipboard
       await page.getByRole('button', { name: 'Copy as SQL' }).click()
       await expect(page.getByTestId('copy-sql-ready')).toBeVisible()
-      // "Copy as SQL" copies the entire public schema (which, in CI, also contains
-      // tables from other tests running in parallel), and pg-meta does not guarantee
-      // column order within a table. So isolate this table's CREATE TABLE block and
+      //pg-meta does not guarantee column order within a table. So isolate this table's CREATE TABLE block and
       // assert each line is present regardless of column order.
       const expectedTableLines = [
         `CREATE TABLE public.${databaseTableName} (`,

--- a/e2e/studio/features/database.spec.ts
+++ b/e2e/studio/features/database.spec.ts
@@ -52,15 +52,28 @@ test.describe('Database', () => {
       // copies schema definition to clipboard
       await page.getByRole('button', { name: 'Copy as SQL' }).click()
       await expect(page.getByTestId('copy-sql-ready')).toBeVisible()
-      await expectClipboardValue({
-        page,
-        value: `CREATE TABLE public.${databaseTableName} (
-  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,
-  created_at timestamp with time zone DEFAULT now(),
-  ${databaseColumnName} text,
-  CONSTRAINT ${databaseTableName}_pkey PRIMARY KEY (id)
-);`,
-      })
+      // "Copy as SQL" copies the entire public schema (which, in CI, also contains
+      // tables from other tests running in parallel), and pg-meta does not guarantee
+      // column order within a table. So isolate this table's CREATE TABLE block and
+      // assert each line is present regardless of column order.
+      const expectedTableLines = [
+        `CREATE TABLE public.${databaseTableName} (`,
+        `  id bigint GENERATED ALWAYS AS IDENTITY NOT NULL,`,
+        `  created_at timestamp with time zone DEFAULT now(),`,
+        `  ${databaseColumnName} text,`,
+        `  CONSTRAINT ${databaseTableName}_pkey PRIMARY KEY (id)`,
+      ]
+      await expect(async () => {
+        await using handle = await page.evaluateHandle(() => navigator.clipboard.readText())
+        const clipboard = await handle.jsonValue()
+        // The trailing " (" disambiguates from tables sharing this name as a prefix.
+        const start = clipboard.indexOf(`CREATE TABLE public.${databaseTableName} (`)
+        expect(start, 'clipboard should contain the table definition').toBeGreaterThanOrEqual(0)
+        const block = clipboard.slice(start, clipboard.indexOf(');', start) + 2)
+        for (const line of expectedTableLines) {
+          expect(block).toContain(line)
+        }
+      }).toPass({ timeout: 2000 })
 
       await expect(page.getByText('Successfully copied as SQL')).toBeVisible({ timeout: 15000 })
       await dismissToastsIfAny(page)


### PR DESCRIPTION
Makes the Schema Visualizer "Copy as SQL" E2E assertion column-order-independent. The clipboard holds the whole public schema (incl. other parallel tests' tables) and pg-meta doesn't guarantee column order, so the exact-block check was flaky. Now isolates this table's `CREATE TABLE` block and asserts each line regardless of order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made the Schema Visualizer "Copy as SQL" end-to-end test more robust: clipboard validation is now tolerant of nondeterministic column ordering and minor formatting differences, by locating the table block and asserting required lines are present within a short retry window, reducing flaky failures across varied data configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->