### PR TITLE
fix(self-hosted): use explicit /bin/sh for kong entrypoint

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       SERVICE_ROLE_KEY_ASYMMETRIC: ${SERVICE_ROLE_KEY_ASYMMETRIC:-}
       DASHBOARD_USERNAME: ${DASHBOARD_USERNAME}
       DASHBOARD_PASSWORD: ${DASHBOARD_PASSWORD}
-    entrypoint: /home/kong/kong-entrypoint.sh
+    entrypoint: ["/bin/sh", "/home/kong/kong-entrypoint.sh"]
 
   auth:
     container_name: supabase-auth


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Change kong entrypoint invocation to explicit `/bin/sh` to avoid +x permissions problem

Closes #46865


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker container startup configuration for improved compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->