### PR TITLE
docs: document swap as a series in the memory usage chart DEBUG-127

### DIFF
--- a/apps/docs/content/guides/telemetry/reports.mdx
+++ b/apps/docs/content/guides/telemetry/reports.mdx
@@ -119,14 +119,18 @@ height={650}
 | **Used**            | RAM actively used by Postgres and the operating system |
 | **Cache + buffers** | Memory used for page cache and OS buffers              |
 | **Free**            | Available unallocated memory                           |
+| **Swap**            | Disk overflow used when physical RAM is exhausted      |
+
+The **Swap** series only appears when the system is swapping. Swap is disk space the operating system uses as an overflow when physical RAM is full. Because disk is much slower than RAM, sustained swap activity indicates memory pressure and can significantly degrade database performance.
 
 How it helps debug issues:
 
-| Issue                          | Description                                      |
-| ------------------------------ | ------------------------------------------------ |
-| Memory pressure detection      | Identify when free memory is consistently low    |
-| Cache effectiveness monitoring | Monitor cache performance for query optimization |
-| Memory leak detection          | Detect inefficient memory usage patterns         |
+| Issue                          | Description                                                                               |
+| ------------------------------ | ----------------------------------------------------------------------------------------- |
+| Memory pressure detection      | Identify when free memory is consistently low                                             |
+| Cache effectiveness monitoring | Monitor cache performance for query optimization                                          |
+| Memory leak detection          | Detect inefficient memory usage patterns                                                  |
+| Swap activity monitoring       | Sustained swap usage signals RAM is exhausted and paging to disk is degrading performance |
 
 Actions you can take:
 


### PR DESCRIPTION
## Problem

The Memory usage chart now includes a Swap series, but the telemetry reports docs do not mention it. Swap is shown alongside Used, Cache + buffers, and Free in the same chart, not as a standalone chart.

## Fix

- Add **Swap** to the Memory usage component table
- Add a short note that the Swap series only appears when the system is swapping, with a brief explanation of what swap means for performance
- Add a swap-activity row to the Memory usage "How it helps debug issues" table

No standalone Swap section and no separate entry in the charts summary table, since swap is part of the Memory usage chart.

## How to test

- Run the docs site and open the Reports guide (`/docs/guides/telemetry/reports`)
- Confirm the Memory usage section lists Swap as a component and the tables render correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Advanced Telemetry (Database) to include "Swap" in the memory-usage breakdown, explain what swap is, and note its impact when RAM is exhausted.
  * Added "Swap activity monitoring" to troubleshooting guidance as a signal of sustained paging to disk and its effect on database performance, plus recommended mitigation actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->