### PR TITLE
fix(www): add canonical tags to blog, pricing, features, and changelog templates

### DIFF
--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -190,6 +190,7 @@ function ChangelogIndex({ featured, restIndex, allIndex }: PageProps) {
         <link rel="alternate" type="text/markdown" href="/changelog.md" />
       </Head>
       <NextSeo
+              canonical="https://supabase.com/changelog"
         title={TITLE}
         description={DESCRIPTION}
         openGraph={{

--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -190,7 +190,7 @@ function ChangelogIndex({ featured, restIndex, allIndex }: PageProps) {
         <link rel="alternate" type="text/markdown" href="/changelog.md" />
       </Head>
       <NextSeo
-              canonical="https://supabase.com/changelog"
+        canonical="https://supabase.com/changelog"
         title={TITLE}
         description={DESCRIPTION}
         openGraph={{

--- a/apps/www/pages/company.tsx
+++ b/apps/www/pages/company.tsx
@@ -29,7 +29,7 @@ const Index = ({}: Props) => {
   return (
     <>
       <NextSeo
-              canonical="https://supabase.com/company"
+        canonical="https://supabase.com/company"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/company.tsx
+++ b/apps/www/pages/company.tsx
@@ -29,6 +29,7 @@ const Index = ({}: Props) => {
   return (
     <>
       <NextSeo
+              canonical="https://supabase.com/company"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/database.tsx
+++ b/apps/www/pages/database.tsx
@@ -62,6 +62,7 @@ function Database() {
   return (
     <>
       <NextSeo
+              canonical="https://supabase.com/database"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/database.tsx
+++ b/apps/www/pages/database.tsx
@@ -62,7 +62,7 @@ function Database() {
   return (
     <>
       <NextSeo
-              canonical="https://supabase.com/database"
+        canonical="https://supabase.com/database"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/edge-functions.tsx
+++ b/apps/www/pages/edge-functions.tsx
@@ -36,7 +36,7 @@ function EdgeFunctions() {
   return (
     <>
       <NextSeo
-              canonical="https://supabase.com/edge-functions"
+        canonical="https://supabase.com/edge-functions"
         title={pageData.metaTitle}
         description={pageData.metaDescription}
         openGraph={{

--- a/apps/www/pages/edge-functions.tsx
+++ b/apps/www/pages/edge-functions.tsx
@@ -36,6 +36,7 @@ function EdgeFunctions() {
   return (
     <>
       <NextSeo
+              canonical="https://supabase.com/edge-functions"
         title={pageData.metaTitle}
         description={pageData.metaDescription}
         openGraph={{

--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -113,7 +113,7 @@ function FeaturesPage() {
   return (
     <>
       <NextSeo
-              canonical="https://supabase.com/features"
+        canonical="https://supabase.com/features"
         title={meta.title}
         description={meta.description}
         openGraph={{

--- a/apps/www/pages/features.tsx
+++ b/apps/www/pages/features.tsx
@@ -113,6 +113,7 @@ function FeaturesPage() {
   return (
     <>
       <NextSeo
+              canonical="https://supabase.com/features"
         title={meta.title}
         description={meta.description}
         openGraph={{

--- a/apps/www/pages/realtime.tsx
+++ b/apps/www/pages/realtime.tsx
@@ -56,6 +56,7 @@ function RealtimePage() {
   return (
     <>
       <NextSeo
+              canonical="https://supabase.com/realtime"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/realtime.tsx
+++ b/apps/www/pages/realtime.tsx
@@ -56,7 +56,7 @@ function RealtimePage() {
   return (
     <>
       <NextSeo
-              canonical="https://supabase.com/realtime"
+        canonical="https://supabase.com/realtime"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/solutions/enterprise.tsx
+++ b/apps/www/pages/solutions/enterprise.tsx
@@ -20,7 +20,7 @@ const CTAForm = dynamic(() => import('components/Enterprise/CTAForm'))
 const Enterprise: NextPage = () => (
   <>
     <NextSeo
-            canonical="https://supabase.com/enterprise"
+      canonical="https://supabase.com/enterprise"
       title={content.metadata.metaTitle}
       description={content.metadata.metaDescription}
       openGraph={{

--- a/apps/www/pages/solutions/enterprise.tsx
+++ b/apps/www/pages/solutions/enterprise.tsx
@@ -20,6 +20,7 @@ const CTAForm = dynamic(() => import('components/Enterprise/CTAForm'))
 const Enterprise: NextPage = () => (
   <>
     <NextSeo
+            canonical="https://supabase.com/enterprise"
       title={content.metadata.metaTitle}
       description={content.metadata.metaDescription}
       openGraph={{

--- a/apps/www/pages/storage.tsx
+++ b/apps/www/pages/storage.tsx
@@ -43,6 +43,7 @@ function StoragePage() {
   return (
     <>
       <NextSeo
+              canonical="https://supabase.com/storage"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/storage.tsx
+++ b/apps/www/pages/storage.tsx
@@ -43,7 +43,7 @@ function StoragePage() {
   return (
     <>
       <NextSeo
-              canonical="https://supabase.com/storage"
+        canonical="https://supabase.com/storage"
         title={meta_title}
         description={meta_description}
         openGraph={{

--- a/apps/www/pages/support.tsx
+++ b/apps/www/pages/support.tsx
@@ -34,6 +34,7 @@ const Index = () => {
   return (
     <>
       <NextSeo
+              canonical="https://supabase.com/support"
         title={data.meta_title}
         description={data.meta_description}
         openGraph={{

--- a/apps/www/pages/support.tsx
+++ b/apps/www/pages/support.tsx
@@ -34,7 +34,7 @@ const Index = () => {
   return (
     <>
       <NextSeo
-              canonical="https://supabase.com/support"
+        canonical="https://supabase.com/support"
         title={data.meta_title}
         description={data.meta_description}
         openGraph={{


### PR DESCRIPTION
## What

Adds `<link rel="canonical">` to www page templates that were missing it.

## Why

Without canonical tags, URL variants (UTM parameters, tracking suffixes, referral params) are treated as potentially distinct pages by Google. Link equity from external sources pointing to tagged URLs doesn't consolidate on the clean URL. Self-referencing canonicals close that gap.

## Pages covered

| Template | Type | Pages |
|---|---|---|
| `app/blog/[slug]/page.tsx` | App Router | ~626 blog posts |
| `app/blog/page.tsx` | App Router | Blog index |
| `app/blog/tags/[tag]/page.tsx` | App Router | ~129 tag pages |
| `app/blog/authors/[author]/page.tsx` | App Router | ~98 author pages |
| `app/blog/categories/[category]/page.tsx` | App Router | Category pages |
| `app/pricing/page.tsx` | App Router | /pricing |
| `pages/features/[slug].tsx` | Pages Router | ~86 feature pages |
| `pages/changelog/[slug].tsx` | Pages Router | Changelog entries |
| `pages/changelog.tsx` + 8 marketing pages | Pages Router | Core marketing pages |

Pages already with canonical tags (`/`, `/state-of-startups`, `/state-of-startups-2025`) were left untouched.

## Changes

- App Router pages: `alternates.canonical` added to `metadata` / `generateMetadata`
- Pages Router pages: `canonical` prop added to `<NextSeo>`
- Purely additive — no logic, styling, or content changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)