### PR TITLE
fix(studio): save button alignment on logs

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -491,7 +491,7 @@ export const LogTable = ({
         </div>
       )}
 
-      <div className="space-x-2">
+      <div className="gap-x-2 flex items-center">
         {IS_PLATFORM && (
           <ButtonTooltip
             type="default"


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Simple one.

| Before | After |
|--------|--------|
| <img width="186" height="114" alt="Screenshot 2026-06-12 at 15 29 18" src="https://github.com/user-attachments/assets/6e83af04-f97a-4cc9-b82b-b5eb86959e0d" /> | <img width="243" height="119" alt="Screenshot 2026-06-12 at 15 29 26" src="https://github.com/user-attachments/assets/2bfb522f-dec2-4205-967f-89223978bcd4" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved spacing and alignment of action buttons in the logs table header for better visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->