### PR TITLE
fix(www): z-index clash between event filter and event label

### DIFF
--- a/apps/www/components/Events/new/EventGallery.tsx
+++ b/apps/www/components/Events/new/EventGallery.tsx
@@ -7,7 +7,7 @@ import { EventTimeline } from './EventTimeline'
 export function EventGallery() {
   return (
     <section className={cn('grid md:grid-cols-[minmax(320px,35%)_16px_1fr] gap-12 min-h-[60vh]')}>
-      <div className="sticky top-16 md:top-24 py-4 bg-background self-start z-10">
+      <div className="sticky top-16 md:top-24 py-4 bg-background self-start z-20">
         <EventGalleryFilters />
       </div>
       <EventTimeline />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

UI bug fix in `/events` page. The z index of event filters clashes with event labels

## What is the current behavior?

https://github.com/user-attachments/assets/fda9947b-5a2b-4f0a-9964-6e00184ecb8c

## What is the new behavior?

https://github.com/user-attachments/assets/97c962da-734f-4fd7-87d7-9a0e51bc301a

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the event gallery's sticky container layering so it reliably appears above overlapping page elements, preventing visual obstruction and improving scrolling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->