### PR TITLE
feat(www): use 'Publish to Web Title' for Notion event names

### DIFF
--- a/apps/www/lib/events.ts
+++ b/apps/www/lib/events.ts
@@ -79,6 +79,12 @@ function getSelect(page: any, name: string): string {
   return prop.select?.name ?? ''
 }
 
+function getFormulaString(page: any, name: string): string {
+  const prop = page.properties[name]
+  if (!prop || prop.type !== 'formula' || prop.formula?.type !== 'string') return ''
+  return prop.formula.string ?? ''
+}
+
 // ─── Main fetch ─────────────────────────────────────────────────────────────
 
 /**
@@ -104,7 +110,7 @@ export const getNotionEvents = async (): Promise<SupabaseEvent[]> => {
 
     return pages
       .map((page): SupabaseEvent | null => {
-        const title = getTitle(page)
+        const title = getFormulaString(page, 'Publish to Web Title') || getTitle(page)
         const startDate = getDate(page, 'Start Date')
         if (!title || !startDate) return null
 


### PR DESCRIPTION

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature

## What is the current behavior?

Event names use 'Event Name' property from Notion database

## What is the new behavior?

Prefer the 'Publish to Web Title' property for displaying event names, falling back to the 'Event Name'

## Additional context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Event titles now prioritize the "Publish to Web Title" field when available, falling back to the generic title only if that publish-specific value is empty—improves accuracy of displayed event titles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->