### PR TITLE
fix(studio): show unavailable indicator for legacy API keys when last used flag is off

### DIFF
--- a/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
+++ b/apps/studio/components/ui/ProjectSettings/DisplayApiSettings.tsx
@@ -202,11 +202,11 @@ export const DisplayApiSettings = ({
                         ? 'Updating JWT secret...'
                         : (x?.api_key ?? 'You need additional permissions to view API keys')
                 }
-                onChange={() => {}}
+                onChange={() => { }}
               />
             </FormLayout>
 
-            {showApiKeyLastUsed && (
+            {showApiKeyLastUsed ? (
               <div
                 className="pt-2 text-foreground-lighter w-full text-sm data-[invisible=true]:invisible"
                 data-invisible={isLoadingLastUsed}
@@ -214,6 +214,12 @@ export const DisplayApiSettings = ({
                 {lastUsedAPIKeys[x.api_key]
                   ? `Last request was ${lastUsedAPIKeys[x.api_key]} ago.`
                   : 'No requests in the past 24 hours.'}
+              </div>
+            ) : (
+              <div className="pt-2 text-foreground-lighter w-full text-sm">
+                <span title="Usage tracking for legacy keys is currently unavailable">
+                  Last used: unavailable
+                </span>
               </div>
             )}
           </Panel.Content>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
The "Last used" indicator for legacy API keys is completely invisible when the `showApiKeysLastUsed` feature flag is off. The docs and in-dashboard migration guide explicitly reference this indicator, so users are confused when it doesn't appear.

Closes #46846

## What is the new behavior?
When the `showApiKeysLastUsed` flag is off, instead of hiding the section entirely, the UI now shows "Last used: unavailable" with a tooltip explaining that usage tracking is currently unavailable. This makes the UI honest instead of silently omitting the column.

## Additional context
Root cause: the feature is fully implemented in `DisplayApiSettings.tsx` but gated behind `useFlag('showApiKeysLastUsed')`. When the flag is off the entire block was conditionally removed from the DOM.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced API key settings display to show a clear "Last used: unavailable" message with a tooltip when usage information cannot be displayed, providing better feedback to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->