### PR TITLE
docs(studio): document local Docker backend setup

### DIFF
--- a/apps/studio/README.md
+++ b/apps/studio/README.md
@@ -57,28 +57,43 @@ pnpm run test -- --watch # run tests in watch mode
 
 Follow the [self-hosting guide](https://supabase.com/docs/guides/hosting/docker) to get started.
 
-```
+```bash
 cd ..
 cd docker
 docker compose -f docker-compose.yml -f ./dev/docker-compose.dev.yml up
 ```
 
-Once you've got that set up, update `.env` in the studio folder with the corresponding values.
+The Docker command also starts a Studio container on port `8082`. If you want to run the Studio frontend from your local checkout with Next.js, stop the Docker Studio container from another terminal:
+
+```bash
+docker stop supabase-studio
+```
+
+Once you've got that set up, update `.env` in the studio folder, or `.env.local` for local-only overrides, with the corresponding values from `docker/.env`.
 
 ```
 POSTGRES_PASSWORD=
+PG_META_CRYPTO_KEY=
 SUPABASE_ANON_KEY=
 SUPABASE_SERVICE_KEY=
 ```
 
+When running the local Studio frontend against Docker services, use the postgres-meta port exposed by `docker-compose.dev.yml`:
+
+```
+STUDIO_PG_META_URL=http://localhost:5555
+```
+
+`PG_META_CRYPTO_KEY` must match the value in `docker/.env`. Studio uses this key to encrypt the connection string sent to postgres-meta, and postgres-meta must use the same key to decrypt it.
+
 Then run the following commands to install dependencies and start the dashboard.
 
-```
-npm install
-npm run dev
+```bash
+pnpm install
+pnpm run dev
 ```
 
-If you would like to configure different defaults for "Default Organization" and "Default Project", you will need to update the `.env` in the studio folder with the corresponding values.
+If you would like to configure different defaults for "Default Organization" and "Default Project", you will need to update `.env` in the studio folder, or `.env.local` for local-only overrides, with the corresponding values.
 
 ```
 DEFAULT_ORGANIZATION_NAME=


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update.

## What is the current behavior?

The Studio README explains how to start the Docker backend services, but does not mention that the Docker setup also starts a Studio container on port `8082`.

When running Studio locally from the checkout against the Docker backend, contributors also need to point Studio at the postgres-meta port exposed by `docker-compose.dev.yml` and ensure `PG_META_CRYPTO_KEY` matches the value used by postgres-meta.

## What is the new behavior?

This updates the Studio README to document the local Studio frontend + Docker backend workflow:

- Stop the Docker Studio container before running Studio locally
- Use `.env`, or `.env.local` for local-only overrides, with values from `docker/.env`
- Set `STUDIO_PG_META_URL=http://localhost:5555`
- Ensure `PG_META_CRYPTO_KEY` matches `docker/.env`

## Additional context

This avoids confusing local setup failures where Studio can reach postgres-meta, but postgres-meta cannot decrypt the connection string because the frontend and backend use different `PG_META_CRYPTO_KEY` values.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated self-hosted and local development setup instructions, including revised Docker initialization workflow and clarified environment configuration requirements for running Studio locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->