### PR TITLE
chore(docs) Prescribe more detailed docs style lints

### DIFF
--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -345,7 +345,7 @@ Here are some exceptions and Supabase-specific guidelines.
 
 ### General word usage
 
-- **Filler words**: You can often make your writing more concise by removing these words. (Some of these words can also sound patronizing.)
+- **Filler words**: You can often make your writing more concise by removing these words. (Some of these words can also sound patronizing.) Most filler, marketing, and vague-verb phrases are flagged by `supa-mdx-lint` as warnings, with suggested alternatives where a direct replacement exists. Run `pnpm lint:mdx` in `apps/docs` to check your changes.
   - Actually
   - Easy, easily
   - Just
@@ -360,16 +360,17 @@ Here are some exceptions and Supabase-specific guidelines.
 
 ### Word list
 
-- `Backend` isn't hyphenated (not `back-end`).
 - `Frontend` isn't hyphenated (not `front-end`).
 - `Login` is a noun. `Log in` is a verb.
 - `Postgres` is capitalized, except in code, and used instead of `PostgreSQL`.
 - `Setup` is a noun. `Set up` is a verb.
 - `Supabase` is capitalized (not `supabase`), except in code.
 - `Supabase Platform` is in title case (not `Supabase platform`).
+- `Backend` isn't hyphenated (not `back-end`).
+- English instead of Latin abbreviations: `for example` (not `e.g.`), `that is` (not `i.e.`), and `with`, `by`, or `through` (not `via`). 
 
 ## Search
 
-Search is handled using a Supabase instance. During CI, [a script](https://github.com/supabase/supabase/blob/master/apps/docs/scripts/search/generate-embeddings.ts) aggregates all content sources (eg. guides, reference docs, etc), indexes them using OpenAI embeddings, and stores them in a Supabase database.
+Search is handled using a Supabase instance. During CI, [a script](https://github.com/supabase/supabase/blob/master/apps/docs/scripts/search/generate-embeddings.ts) aggregates all content sources (for example, guides, reference docs, etc), indexes them using OpenAI embeddings, and stores them in a Supabase database.
 
 Search uses a hybrid of native Postgres FTS and embedding similarity search based on [`pgvector`](https://github.com/pgvector/pgvector). At runtime, a PostgREST call triggers the RPC that runs the weighted FTS search, and an [Edge Function](https://github.com/supabase/supabase/tree/master/supabase/functions) is executed to perform the embedding search.

--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -361,13 +361,12 @@ Here are some exceptions and Supabase-specific guidelines.
 ### Word list
 
 - `Frontend` isn't hyphenated (not `front-end`).
+- `Backend` isn't hyphenated (not `back-end`).
 - `Login` is a noun. `Log in` is a verb.
 - `Postgres` is capitalized, except in code, and used instead of `PostgreSQL`.
 - `Setup` is a noun. `Set up` is a verb.
 - `Supabase` is capitalized (not `supabase`), except in code.
 - `Supabase Platform` is in title case (not `Supabase platform`).
-- `Backend` isn't hyphenated (not `back-end`).
-- English instead of Latin abbreviations: `for example` (not `e.g.`), `that is` (not `i.e.`), and `with`, `by`, or `through` (not `via`). 
 
 ## Search
 

--- a/supa-mdx-lint.config.toml
+++ b/supa-mdx-lint.config.toml
@@ -13,10 +13,16 @@ admonition_types = ["note", "tip", "caution", "deprecation", "danger"]
 
 [Rule004ExcludeWords]
 rules.filler = "include('supa-mdx-lint/Rule004ExcludeWords/filler.toml')"
+rules.marketing = "include('supa-mdx-lint/Rule004ExcludeWords/marketing.toml')"
+rules.vague_verbs = "include('supa-mdx-lint/Rule004ExcludeWords/vague_verbs.toml')"
+rules.generic_phrases_apology = "include('supa-mdx-lint/Rule004ExcludeWords/generic_phrases_apology.toml')"
 rules.first_person = "include('supa-mdx-lint/Rule004ExcludeWords/first_person.toml')"
 rules.gender_neutral = "include('supa-mdx-lint/Rule004ExcludeWords/gender_neutral.toml')"
 rules.inclusive_wording = "include('supa-mdx-lint/Rule004ExcludeWords/inclusive_wording.toml')"
+rules.human_language = "include('supa-mdx-lint/Rule004ExcludeWords/human_language.toml')"
+rules.latin_phrases = "include('supa-mdx-lint/Rule004ExcludeWords/latin_phrases.toml')"
 rules.preferred_usage = "include('supa-mdx-lint/Rule004ExcludeWords/preferred_usage.toml')"
+rules.formal_corporate = "include('supa-mdx-lint/Rule004ExcludeWords/formal_corporate.toml')"
 rules.slang = "include('supa-mdx-lint/Rule004ExcludeWords/slang.toml')"
 
 [Rule006NoAbsoluteUrls]

--- a/supa-mdx-lint/Rule004ExcludeWords/filler.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/filler.toml
@@ -1,3 +1,16 @@
-description = "Don't use '%s'. The sentence is more concise and/or the tone is more neutral without it."
+description = "Remove '%s' for a more concise, direct sentence."
 level = "WARNING"
-words = ["easily", "please", "simply", "that's it"]
+words = [
+    "actually",
+    "easily",
+    "easy",
+    "just",
+    "let's",
+    "obviously",
+    "of course",
+    "please",
+    "quickly",
+    "simple",
+    "simply",
+    "that's it",
+]

--- a/supa-mdx-lint/Rule004ExcludeWords/formal_corporate.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/formal_corporate.toml
@@ -1,0 +1,45 @@
+description = "Use a direct, simpler phrase instead of '%s'."
+level = "WARNING"
+words = [
+    [
+        "in order to",
+        "to",
+    ],
+    [
+        "prior to",
+        "before",
+    ],
+    [
+        "subsequent to",
+        "after",
+    ],
+    [
+        "for the purpose of",
+        "to",
+    ],
+    [
+        "leverage",
+        "use",
+    ],
+    [
+        "whilst",
+        "while",
+    ],
+    [
+        "amongst",
+        "among",
+    ],
+    [
+        "facilitate",
+        "help",
+    ],
+    [
+        "endeavor",
+        "try",
+    ],
+    [
+        "endeavour",
+        "try",
+    ],
+    "aforementioned",
+]

--- a/supa-mdx-lint/Rule004ExcludeWords/generic_phrases_apology.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/generic_phrases_apology.toml
@@ -1,0 +1,6 @@
+description = "Remove '%s' and state what happened directly. For example: 'Unable to connect to database' instead of 'Sorry, we couldn't connect'."
+level = "WARNING"
+words = [
+    "oops",
+    "sorry",
+]

--- a/supa-mdx-lint/Rule004ExcludeWords/human_language.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/human_language.toml
@@ -2,16 +2,12 @@ description = "Prefer '%r' to '%s'."
 level = "WARNING"
 words = [
     [
-        "e.g.",
-        "for example",
-    ],
-    [
         "eg.",
-        "for example",
+        "e.g.",
     ],
     [
         "eg",
-        "for example",
+        "e.g.",
     ],
     [
         "i.e.",

--- a/supa-mdx-lint/Rule004ExcludeWords/human_language.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/human_language.toml
@@ -1,0 +1,28 @@
+description = "Prefer '%r' to '%s'."
+level = "WARNING"
+words = [
+    [
+        "e.g.",
+        "for example",
+    ],
+    [
+        "eg.",
+        "for example",
+    ],
+    [
+        "eg",
+        "for example",
+    ],
+    [
+        "i.e.",
+        "that is",
+    ],
+    [
+        "ie.",
+        "that is",
+    ],
+    [
+        "ie",
+        "that is",
+    ],
+]

--- a/supa-mdx-lint/Rule004ExcludeWords/latin_phrases.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/latin_phrases.toml
@@ -1,0 +1,6 @@
+description = "Prefer 'with', 'by', or 'through' instead of '%s', depending on context."
+level = "WARNING"
+words = [
+    "via",
+    "powered by"
+]

--- a/supa-mdx-lint/Rule004ExcludeWords/latin_phrases.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/latin_phrases.toml
@@ -1,6 +1,5 @@
 description = "Prefer 'with', 'by', or 'through' instead of '%s', depending on context."
 level = "WARNING"
 words = [
-    "via",
     "powered by"
 ]

--- a/supa-mdx-lint/Rule004ExcludeWords/marketing.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/marketing.toml
@@ -1,0 +1,15 @@
+description = "Remove '%s' to avoid marketing language and describe what the feature does specifically."
+level = "WARNING"
+words = [
+    "best in class",
+    "best-in-class",
+    "cutting edge",
+    "cutting-edge",
+    "effortlessly",
+    "game changer",
+    "game-changer",
+    "hassle free",
+    "hassle-free",
+    "powerful",
+    "seamlessly",
+]

--- a/supa-mdx-lint/Rule004ExcludeWords/preferred_usage.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/preferred_usage.toml
@@ -1,22 +1,6 @@
 description = "Prefer '%r' to '%s'."
-level = "ERROR"
+level = "WARNING"
 words = [
-    [
-        "eg.",
-        "e.g.",
-    ],
-    [
-        "eg",
-        "e.g.",
-    ],
-    [
-        "ie.",
-        "i.e.",
-    ],
-    [
-        "ie",
-        "i.e.",
-    ],
     [
         "PostgreSQL",
         "Postgres",
@@ -24,5 +8,29 @@ words = [
     [
         "concurrent clients",
         "concurrent connections",
+    ],
+    [
+        "utilize",
+        "use",
+    ],
+    [
+        "utilise",
+        "use",
+    ],
+    [
+        "utilizes",
+        "uses",
+    ],
+    [
+        "utilises",
+        "uses",
+    ],
+    [
+        "utilizing",
+        "using",
+    ],
+    [
+        "utilising",
+        "using",
     ],
 ]

--- a/supa-mdx-lint/Rule004ExcludeWords/slang.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/slang.toml
@@ -1,3 +1,3 @@
 description = "Don't use Internet slang abbreviations"
-level = "ERROR"
+level = "WARNING"
 words = ["tl;dr", "ymmv", "rtfm", "imo", "fwiw"]

--- a/supa-mdx-lint/Rule004ExcludeWords/vague_verbs.toml
+++ b/supa-mdx-lint/Rule004ExcludeWords/vague_verbs.toml
@@ -1,0 +1,7 @@
+description = "Use '%r' instead of '%s'."
+level = "WARNING"
+words = [
+    ["handle errors", "view and resolve errors"],
+    ["manage tables", "create, edit, or delete tables"],
+    ["work with data", "query and update data"],
+]


### PR DESCRIPTION
Closes [DOCS-1036](https://linear.app/supabase/issue/DOCS-1036/add-docs-lint-rule-for-copywriting-style-gaps)

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This change expands upon the "us this, not that" style rules and applies them to our linting.

## What is the current behavior?

Our current behavior does far fewer checks.

## What is the new behavior?

The new behavior spots the following:

- Suggesting swapping Latin phrases for common English
- Remove formal words for simpler words
- Removes marketing language
- And more (see code diff)

## Additional context

For more information about general style rules, see the style guide:
https://supabase.com/design-system/docs/copywriting


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refined contribution guidelines with clearer style guidance for filler words, terminology (including “Backend” hyphenation), abbreviation usage, and updated wording examples.
  * Updated the foundations quickstart wording to “Utilize shadcn/ui” under setup guidance.

* **Chores**
  * Expanded MDX linting guidance to flag filler/marketing language, vague verbs, formal corporate phrasing, apologies, human-language punctuation variants, and certain Latin phrases.
  * Adjusted related lint preferences and downgraded several checks to **WARNING** for a less disruptive experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->