### PR TITLE
chore(self-hosted): use /bin/sh shebang in kong-entrypoint.sh

### DIFF
--- a/docker/volumes/api/kong-entrypoint.sh
+++ b/docker/volumes/api/kong-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # Custom entrypoint for Kong that builds Lua expressions for request-transformer
 # and performs environment variable substitution in the declarative config.
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Refactor. Follow up to #46873 

## What is the current behavior?

`kong-entrypoint.sh` uses a `/bin/bash` shebang, while the compose file invokes the entrypoint with the `sh` interpreter. Doesn't break anything.

## What is the new behavior?

Updated the shebang in `kong-entrypoint.sh` from `/bin/bash` to `/bin/sh` for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker entrypoint script configuration to enhance shell compatibility. The underlying functionality and behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->