### PR TITLE
fix(studio): accept android:apk-key-hash WebAuthn origins

### DIFF
--- a/apps/studio/components/interfaces/Auth/Passkeys/PasskeysSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/Passkeys/PasskeysSettingsForm.tsx
@@ -27,90 +27,9 @@ import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-muta
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
+import { validateRpId, validateWebAuthnOrigins } from './validation'
 
 type GoTrueConfig = components['schemas']['GoTrueConfigResponse']
-
-function isLocalhost(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
-}
-
-function validateRpId(rpId: string): string | null {
-  const trimmed = rpId.trim().toLowerCase()
-  if (!trimmed) return null
-  try {
-    const url = new URL('https://' + trimmed)
-    if (url.hostname !== trimmed) return null
-    return trimmed
-  } catch {
-    return null
-  }
-}
-
-function validateWebAuthnOrigins(
-  value: string,
-  rpId: string | null
-): { valid: true } | { valid: false; message: string } {
-  const origins = value
-    .split(',')
-    .map((o) => o.trim())
-    .filter(Boolean)
-
-  if (origins.length === 0) {
-    return { valid: false, message: 'At least one origin is required' }
-  }
-
-  if (origins.length > 5) {
-    return { valid: false, message: 'A maximum of 5 origins is allowed' }
-  }
-
-  for (const origin of origins) {
-    let url: URL
-    try {
-      url = new URL(origin)
-    } catch {
-      return { valid: false, message: `"${origin}" is not a valid URL` }
-    }
-
-    if (url.protocol === 'http:') {
-      if (!isLocalhost(url.hostname)) {
-        return {
-          valid: false,
-          message: `"${origin}" must use HTTPS unless it is a localhost origin`,
-        }
-      }
-    } else if (url.protocol !== 'https:') {
-      return {
-        valid: false,
-        message: `"${origin}" must use HTTPS unless it is a localhost origin`,
-      }
-    }
-
-    if (url.href !== url.origin + '/') {
-      return {
-        valid: false,
-        message: `"${origin}" must be a plain origin without path, query, or fragment (e.g. "${url.origin}")`,
-      }
-    }
-
-    if (rpId && !isOriginCompatibleWithRpId(url.hostname, rpId)) {
-      return {
-        valid: false,
-        message: `"${origin}" is not compatible with Relying Party ID "${rpId}". The origin's hostname must match or be a subdomain of the RP ID.`,
-      }
-    }
-  }
-
-  return { valid: true }
-}
-
-function isOriginCompatibleWithRpId(originHostname: string, rpId: string): boolean {
-  const host = originHostname.toLowerCase()
-  const id = rpId.toLowerCase()
-  if (isLocalhost(host) && isLocalhost(id)) return true
-  if (host === id) return true
-  if (host.endsWith('.' + id)) return true
-  return false
-}
 
 const schema = z
   .object({
@@ -365,7 +284,7 @@ export const PasskeysSettingsForm = () => {
                     <FormItemLayout
                       layout="flex-row-reverse"
                       label="Relying Party Origins"
-                      description='Comma-separated list of allowed origins (e.g. "https://example.com"). HTTPS is required except for localhost.'
+                      description='Comma-separated list of allowed origins (e.g. "https://example.com"). HTTPS is required except for localhost. Android native apps use "android:apk-key-hash:<sha256>".'
                     >
                       <FormControl>
                         <Input {...field} placeholder="https://example.com" />

--- a/apps/studio/components/interfaces/Auth/Passkeys/__tests__/validation.test.ts
+++ b/apps/studio/components/interfaces/Auth/Passkeys/__tests__/validation.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import { isAndroidApkKeyHashOrigin, validateWebAuthnOrigins } from '../validation'
+
+// Real-looking 43-char base64url body (32-byte SHA-256, no padding). Taken
+// from the example in supabase/supabase#46896.
+const ANDROID_HASH = 'bP7V9_HO4FPHc9aBqmokgPsT_CayrPx7Y2MO_lvS3ck'
+const ANDROID_ORIGIN = `android:apk-key-hash:${ANDROID_HASH}`
+const RP_ID = 'example.com'
+
+describe('isAndroidApkKeyHashOrigin', () => {
+  it('accepts canonical android:apk-key-hash:<43 b64url>', () => {
+    expect(isAndroidApkKeyHashOrigin(ANDROID_ORIGIN)).toBe(true)
+  })
+
+  it('accepts the -sha256 prefix variant', () => {
+    expect(isAndroidApkKeyHashOrigin(`android:apk-key-hash-sha256:${ANDROID_HASH}`)).toBe(true)
+  })
+
+  it('rejects a hash that is too short', () => {
+    expect(isAndroidApkKeyHashOrigin('android:apk-key-hash:tooshort')).toBe(false)
+  })
+
+  it('rejects non-base64url characters in the hash', () => {
+    expect(isAndroidApkKeyHashOrigin(`android:apk-key-hash:${ANDROID_HASH.slice(0, -1)}!`)).toBe(
+      false
+    )
+  })
+
+  it('rejects unrelated android: schemes', () => {
+    expect(isAndroidApkKeyHashOrigin('android:something-else:abc')).toBe(false)
+  })
+
+  it('rejects plain https origins', () => {
+    expect(isAndroidApkKeyHashOrigin('https://example.com')).toBe(false)
+  })
+})
+
+describe('validateWebAuthnOrigins — Android (fix for #46896)', () => {
+  it('accepts a mixed list of https + android origins', () => {
+    const result = validateWebAuthnOrigins(`https://example.com,${ANDROID_ORIGIN}`, RP_ID)
+    expect(result).toEqual({ valid: true })
+  })
+
+  it('accepts an android-only origin even when an rpId is configured', () => {
+    expect(validateWebAuthnOrigins(ANDROID_ORIGIN, RP_ID)).toEqual({ valid: true })
+  })
+
+  it('accepts the -sha256 variant', () => {
+    const origin = `android:apk-key-hash-sha256:${ANDROID_HASH}`
+    expect(validateWebAuthnOrigins(origin, RP_ID)).toEqual({ valid: true })
+  })
+
+  it('rejects malformed android origins with a format-specific error, not the HTTPS error', () => {
+    const result = validateWebAuthnOrigins('android:apk-key-hash:tooshort', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.message).toMatch(/not a valid Android origin/)
+      expect(result.message).not.toMatch(/must use HTTPS/)
+    }
+  })
+})
+
+describe('validateWebAuthnOrigins — existing behavior is preserved', () => {
+  it('accepts a plain https origin', () => {
+    expect(validateWebAuthnOrigins('https://example.com', RP_ID)).toEqual({ valid: true })
+  })
+
+  it('accepts http://localhost', () => {
+    expect(validateWebAuthnOrigins('http://localhost:3000', 'localhost')).toEqual({ valid: true })
+  })
+
+  it('accepts an https subdomain of the rpId', () => {
+    expect(validateWebAuthnOrigins('https://app.example.com', RP_ID)).toEqual({ valid: true })
+  })
+
+  it('rejects http on a non-localhost host', () => {
+    const result = validateWebAuthnOrigins('http://example.com', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/must use HTTPS/)
+  })
+
+  it('rejects non-http(s) schemes other than android:', () => {
+    const result = validateWebAuthnOrigins('ftp://example.com', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/must use HTTPS/)
+  })
+
+  it('rejects https origins with a path', () => {
+    const result = validateWebAuthnOrigins('https://example.com/foo', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/plain origin/)
+  })
+
+  it('rejects an empty list', () => {
+    const result = validateWebAuthnOrigins('', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/At least one origin/)
+  })
+
+  it('rejects more than 5 origins', () => {
+    const six = Array.from({ length: 6 }, (_, i) => `https://app${i}.example.com`).join(',')
+    const result = validateWebAuthnOrigins(six, RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/maximum of 5 origins/)
+  })
+
+  it('rejects an origin whose hostname is not compatible with rpId', () => {
+    const result = validateWebAuthnOrigins('https://other.com', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/not compatible with Relying Party ID/)
+  })
+})

--- a/apps/studio/components/interfaces/Auth/Passkeys/validation.ts
+++ b/apps/studio/components/interfaces/Auth/Passkeys/validation.ts
@@ -1,0 +1,109 @@
+// Canonical Android Credential Manager origin emitted in clientDataJSON:
+//   android:apk-key-hash:<base64url SHA-256 of APK signing cert>
+// The base body is 32 bytes -> 43 base64url chars (no padding). The
+// `-sha256:` prefix variant is non-canonical but accepted by go-webauthn
+// via exact-string match, so allow it here to mirror what GoTrue does at
+// request time (see supabase/auth#2545).
+const ANDROID_APK_ORIGIN = /^android:apk-key-hash(?:-sha256)?:[A-Za-z0-9_-]{43}$/
+
+export function isLocalhost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+}
+
+export function isAndroidApkKeyHashOrigin(origin: string): boolean {
+  return ANDROID_APK_ORIGIN.test(origin)
+}
+
+export function validateRpId(rpId: string): string | null {
+  const trimmed = rpId.trim().toLowerCase()
+  if (!trimmed) return null
+  try {
+    const url = new URL('https://' + trimmed)
+    if (url.hostname !== trimmed) return null
+    return trimmed
+  } catch {
+    return null
+  }
+}
+
+export function isOriginCompatibleWithRpId(originHostname: string, rpId: string): boolean {
+  const host = originHostname.toLowerCase()
+  const id = rpId.toLowerCase()
+  if (isLocalhost(host) && isLocalhost(id)) return true
+  if (host === id) return true
+  if (host.endsWith('.' + id)) return true
+  return false
+}
+
+export type OriginsValidationResult = { valid: true } | { valid: false; message: string }
+
+export function validateWebAuthnOrigins(
+  value: string,
+  rpId: string | null
+): OriginsValidationResult {
+  const origins = value
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean)
+
+  if (origins.length === 0) {
+    return { valid: false, message: 'At least one origin is required' }
+  }
+
+  if (origins.length > 5) {
+    return { valid: false, message: 'A maximum of 5 origins is allowed' }
+  }
+
+  for (const origin of origins) {
+    // Android native-app origins are matched as exact strings by the WebAuthn
+    // RP (go-webauthn's IsOriginInHaystack falls through to string equality
+    // when the needle lacks an http(s) scheme), so they must skip URL parsing,
+    // the HTTPS rule, and RP-ID hostname compatibility.
+    if (origin.startsWith('android:')) {
+      if (!isAndroidApkKeyHashOrigin(origin)) {
+        return {
+          valid: false,
+          message: `"${origin}" is not a valid Android origin (expected "android:apk-key-hash:<43-char base64url SHA-256>")`,
+        }
+      }
+      continue
+    }
+
+    let url: URL
+    try {
+      url = new URL(origin)
+    } catch {
+      return { valid: false, message: `"${origin}" is not a valid URL` }
+    }
+
+    if (url.protocol === 'http:') {
+      if (!isLocalhost(url.hostname)) {
+        return {
+          valid: false,
+          message: `"${origin}" must use HTTPS unless it is a localhost origin`,
+        }
+      }
+    } else if (url.protocol !== 'https:') {
+      return {
+        valid: false,
+        message: `"${origin}" must use HTTPS unless it is a localhost origin`,
+      }
+    }
+
+    if (url.href !== url.origin + '/') {
+      return {
+        valid: false,
+        message: `"${origin}" must be a plain origin without path, query, or fragment (e.g. "${url.origin}")`,
+      }
+    }
+
+    if (rpId && !isOriginCompatibleWithRpId(url.hostname, rpId)) {
+      return {
+        valid: false,
+        message: `"${origin}" is not compatible with Relying Party ID "${rpId}". The origin's hostname must match or be a subdomain of the RP ID.`,
+      }
+    }
+  }
+
+  return { valid: true }
+}


### PR DESCRIPTION
## Summary

Fixes the Studio side of #46896. The Passkeys settings form rejects Android native-app origins (`android:apk-key-hash:<sha256>`) with `"<origin>" must use HTTPS unless it is a localhost origin`, blocking Android Credential Manager passkey configuration entirely from the dashboard.

The fix short-circuits `android:` origins inside `validateWebAuthnOrigins` so they skip URL parsing, the HTTPS rule, and the RP-ID hostname compatibility check (Android origins are matched as exact strings by go-webauthn, not by hostname), and instead validates them against the canonical format:

```
android:apk-key-hash[-sha256]:<43-char base64url SHA-256>
```

This mirrors what go-webauthn's `IsOriginInHaystack` does for non-`http(s)` needles (falls through to string equality), so anything Studio accepts here is what GoTrue will accept at request time, consistent with supabase/auth#2545.

While here:
- Extracted the validation helpers from `PasskeysSettingsForm.tsx` into a sibling `validation.ts` so they are unit-testable.
- Added the field-level help-text hint that Android native apps use the `android:apk-key-hash:<sha256>` form.

## Scope note

This PR only fixes the **dashboard UI** layer. The issue also reports the same too-strict rule in the Management API (`api.supabase.com`) and the silent-drop behavior in `supabase config push` — both live in other repos and are out of scope here. Users will need the corresponding Management API fix before they can actually persist Android origins, but unblocking the Studio form is a prerequisite either way.

## Test plan

- [x] `pnpm --filter studio test components/interfaces/Auth/Passkeys/__tests__/validation.test.ts` — 19 tests pass, covering:
  - The exact inputs from the issue (mixed `https://` + `android:apk-key-hash:`, and Android-only)
  - The `-sha256:` prefix variant mentioned in the issue
  - Malformed Android inputs now produce a format-specific error instead of the misleading "must use HTTPS"
  - Regression coverage: plain HTTPS, `http://localhost`, subdomains, `ftp://`, `http://example.com`, paths, empty input, >5 origins, RP-ID hostname mismatch
- [x] `pnpm --filter studio typecheck` — clean
- [ ] Manual verification in the Auth → Passkeys page once the Management API also accepts these origins

Refs: #46896, supabase/auth#2545

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Passkey authentication configuration now supports Android native app origins alongside HTTPS and localhost options.

* **Documentation**
  * Enhanced help text for passkey settings to include Android native app origin format specification with example usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->