### PR TITLE
fix(ui): strip custom anchor when it leads a heading

### DIFF
--- a/packages/ui/src/components/CustomHTMLElements/CustomHTMLElements.utils.test.tsx
+++ b/packages/ui/src/components/CustomHTMLElements/CustomHTMLElements.utils.test.tsx
@@ -93,6 +93,14 @@ describe('CustomHTMLElementsUtils', () => {
         // Original implementation didn't trim the resulting string - not sure if it really matters
         expect(result).toStrictEqual('My (Very) Awesome Heading ')
       })
+
+      it('strips out a custom anchor at the start of the string', () => {
+        const value = '[#my-custom-heading]'
+
+        const result = removeAnchor(value)
+
+        expect(result).toStrictEqual('')
+      })
     })
   })
 })

--- a/packages/ui/src/components/CustomHTMLElements/CustomHTMLElements.utils.ts
+++ b/packages/ui/src/components/CustomHTMLElements/CustomHTMLElements.utils.ts
@@ -63,7 +63,7 @@ export const removeAnchor = (text: any) => {
   if (typeof text === 'object' && Array.isArray(text)) {
     return text.filter((x) => !(typeof x === 'string' && hasCustomAnchor(x)))
   } else if (typeof text === 'string') {
-    if (text.indexOf('[#') > 0) return text.slice(0, text.indexOf('[#'))
+    if (text.indexOf('[#') >= 0) return text.slice(0, text.indexOf('[#'))
     else return text
   }
   return text


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`removeAnchor` in `packages/ui/.../CustomHTMLElements.utils.ts` strips a custom heading anchor (`[#anchor]`) using:

```ts
if (text.indexOf('[#') > 0) return text.slice(0, text.indexOf('[#'))
```

The `> 0` check means that when a heading string *begins* with a custom anchor (the `[#` token is at index `0`), `indexOf` returns `0`, `0 > 0` is false, and the raw `[#anchor]` markup is returned untouched instead of being stripped.

This is inconsistent with the sibling helpers `getAnchor`/`hasCustomAnchor`, which detect the same token at index `0` via `String.includes`. So for an input like `'[#my-anchor]'`, `getAnchor` parses the anchor correctly while `removeAnchor` leaks the raw markup into the rendered text.

## What is the new behavior?

Uses `>= 0`, so a custom anchor at the start of the string is stripped, matching `getAnchor`'s detection. Anchors in the middle/end and strings without an anchor are unaffected.

Added a unit test covering a leading custom anchor.

## Additional context

One-character logic fix plus a regression test, alongside the existing `removeAnchor` tests.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved anchor marker handling to correctly process markers appearing at the start of strings.

* **Tests**
  * Added test coverage for anchor marker handling at string start.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->