### PR TITLE
fix(studio): don't misclassify write queries as read-only via column-name allow-list

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.test.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.test.ts
@@ -86,6 +86,21 @@ describe('AIAssistant.utils.ts:isReadOnlySelect', () => {
     const result2 = isReadOnlySelect(sql2)
     expect(result2).toBe(false)
   })
+  test('Should return false for an UPDATE hidden behind an allowed column name', () => {
+    const sql = `select updated_at from countries; update countries set name = 'hello' where id = 2;`
+    const result = isReadOnlySelect(sql)
+    expect(result).toBe(false)
+  })
+  test('Should return false for a DELETE hidden behind an allowed column name', () => {
+    const sql = `select deleted_at from countries; delete from countries where id = 2;`
+    const result = isReadOnlySelect(sql)
+    expect(result).toBe(false)
+  })
+  test('Should return true for a SELECT that only references timestamp-like columns', () => {
+    const sql = `select created_at, updated_at from countries where id > 100;`
+    const result = isReadOnlySelect(sql)
+    expect(result).toBe(true)
+  })
 })
 
 describe('AIAssistant.utils.ts:hasPendingToolApproval', () => {

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.utils.ts
@@ -57,17 +57,14 @@ export const isReadOnlySelect = (query: string): boolean => {
   // List of keywords that indicate write operations
   const writeOperations = ['insert', 'update', 'delete', 'alter', 'drop', 'create', 'replace']
 
-  // Words that may appear in column names etc
-  const allowedPatterns = ['created', 'inserted', 'updated', 'deleted', 'truncate']
-
-  // Check for any write operations
-  const hasWriteOperation = writeOperations.some((op) => {
-    // Ignore if part of allowed pattern
-    const isAllowed = allowedPatterns.some(
-      (allowed) => normalizedQuery.includes(allowed) && allowed.includes(op)
-    )
-    return !isAllowed && normalizedQuery.includes(op)
-  })
+  // Match write keywords only as whole words so that identifiers such as
+  // `created_at` or `updated_at` aren't mistaken for `create`/`update`
+  // operations. A previous substring-based allow-list incorrectly masked real
+  // write statements whenever such an identifier appeared anywhere in the query
+  // (e.g. `select updated_at from t; update t set ...` was treated as read-only).
+  const hasWriteOperation = writeOperations.some((op) =>
+    new RegExp(`\\b${op}\\b`).test(normalizedQuery)
+  )
   if (hasWriteOperation) return false
 
   const hasUnknownFunction = containsUnknownFunction(normalizedQuery)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`isReadOnlySelect` (`apps/studio/.../AIAssistantPanel/AIAssistant.utils.ts`) decides whether a query is read-only. To avoid flagging timestamp-like column names (`created_at`, `updated_at`, ...) as write operations, it used a substring allow-list:

```ts
const allowedPatterns = ['created', 'inserted', 'updated', 'deleted', 'truncate']
const hasWriteOperation = writeOperations.some((op) => {
  const isAllowed = allowedPatterns.some(
    (allowed) => normalizedQuery.includes(allowed) && allowed.includes(op)
  )
  return !isAllowed && normalizedQuery.includes(op)
})
```

The `isAllowed` check is **global**: if any allowed identifier appears *anywhere* in the query, the matching write keyword is ignored for the whole query. So a query that both references such a column **and** performs a real write is misclassified as read-only. For example:

```sql
select updated_at from countries; update countries set name = 'x' where id = 1;
```

returns `true` (read-only). `isReadOnlySelect` is used in `EditorPanel` to decide whether to show the destructive-query confirmation prompt — so a real `UPDATE`/`DELETE` like the above is run **without** the safety prompt.

## What is the new behavior?

Matches write keywords as whole words via `\b<op>\b`, so identifiers like `created_at`/`updated_at` no longer match `create`/`update`, while a genuine `update`/`delete` elsewhere in the query is still caught. The leaky substring allow-list is no longer needed and has been removed.

Added regression tests:
- a write operation hidden behind an allowed column name (`UPDATE` and `DELETE`) now returns `false`
- a `SELECT` that only references `created_at`/`updated_at` still returns `true`

All existing `isReadOnlySelect` tests continue to pass.

## Additional context

Note this helper is marked `@deprecated` in favor of a read-only connection string, but it is still wired into the editor's write-confirmation path today, so the misclassification has a real safety impact until the deprecation is complete.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query classification to more accurately detect read-only operations, preventing false positives from timestamp-related column names.

* **Tests**
  * Added test coverage for edge cases in SQL read-only query detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->