### PR TITLE
fix(docs): honor the index-0 cursor in in-memory GraphQL pagination

### DIFF
--- a/apps/docs/resources/utils/connections.test.ts
+++ b/apps/docs/resources/utils/connections.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { GraphQLCollectionBuilder, type IPaginationArgs } from './connections'
+
+const buildInMemory = async (args: IPaginationArgs) => {
+  const result = await GraphQLCollectionBuilder.create({ items: ['A', 'B', 'C'], args })
+  return result.unwrap()
+}
+
+describe('GraphQLCollectionBuilder in-memory pagination', () => {
+  it('returns all items when no pagination args are provided', async () => {
+    const page = await buildInMemory({})
+    expect(page.nodes).toStrictEqual(['A', 'B', 'C'])
+    expect(page.pageInfo.hasNextPage).toBe(false)
+    expect(page.pageInfo.hasPreviousPage).toBe(false)
+  })
+
+  it('excludes the first item when paginating after the index-0 cursor', async () => {
+    // Cursors are stringified array indices, so the first item's cursor is "0".
+    // A falsy guard previously dropped this cursor, wrongly including item "A".
+    const page = await buildInMemory({ after: '0' })
+    expect(page.nodes).toStrictEqual(['B', 'C'])
+    expect(page.pageInfo.hasPreviousPage).toBe(true)
+  })
+
+  it('returns an empty page when paginating before the index-0 cursor', async () => {
+    const page = await buildInMemory({ before: '0' })
+    expect(page.nodes).toStrictEqual([])
+    expect(page.pageInfo.hasNextPage).toBe(true)
+  })
+
+  it('still paginates correctly for non-zero cursors', async () => {
+    const afterFirst = await buildInMemory({ after: '1' })
+    expect(afterFirst.nodes).toStrictEqual(['C'])
+
+    const beforeLast = await buildInMemory({ before: '2' })
+    expect(beforeLast.nodes).toStrictEqual(['A', 'B'])
+  })
+})

--- a/apps/docs/resources/utils/connections.ts
+++ b/apps/docs/resources/utils/connections.ts
@@ -349,12 +349,12 @@ function getRequestedSlice<ItemType>(
   let afterIndex = -1
 
   const requestedBefore = pageArgs.before ? toNumber(pageArgs.before) : undefined
-  if (requestedBefore && requestedBefore >= 0 && requestedBefore < beforeIndex) {
+  if (requestedBefore !== undefined && requestedBefore >= 0 && requestedBefore < beforeIndex) {
     beforeIndex = requestedBefore
     hasNextPage = true
   }
   const requestedAfter = pageArgs.after ? toNumber(pageArgs.after) : undefined
-  if (requestedAfter && requestedAfter >= 0) {
+  if (requestedAfter !== undefined && requestedAfter >= 0) {
     afterIndex = requestedAfter
     hasPreviousPage = true
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`GraphQLCollectionBuilder.paginateArray` (`apps/docs/resources/utils/connections.ts`) generates cursors as stringified array indices, so the first item's cursor is `"0"`. `getRequestedSlice` then guards the `after`/`before` cursors with a truthiness check:

```ts
const requestedAfter = pageArgs.after ? toNumber(pageArgs.after) : undefined
if (requestedAfter && requestedAfter >= 0) { ... }
```

`requestedAfter` is `0` for the index-0 cursor, which is falsy, so the branch is skipped. Paginating with `after: "0"` is therefore ignored: the first item is wrongly **included** and `hasPreviousPage` stays `false`. `before: "0"` similarly returns the full list (and `hasNextPage: false`) instead of an empty page.

This in-memory builder backs real GraphQL resolvers in the docs (e.g. the guide and global-search schemas).

## What is the new behavior?

Uses explicit `!== undefined` checks instead of truthiness, so the index-0 cursor is honored. The existing `>= 0` bound still rejects negative cursors.

Added a unit test for `GraphQLCollectionBuilder` in-memory pagination covering `after: "0"`, `before: "0"`, non-zero cursors, and the no-args case.

## Additional context

Classic "0 is falsy" guard bug. Verified by exercising the public `GraphQLCollectionBuilder.create({ items })` API.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination to correctly handle navigating to the first item in a collection.

* **Tests**
  * Added comprehensive test suite for pagination behavior, including edge cases for cursor handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->