### PR TITLE
fix(pg-meta): quote reserved "table" keyword in policy retrieve clause

### DIFF
--- a/packages/pg-meta/src/pg-meta-policies.ts
+++ b/packages/pg-meta/src/pg-meta-policies.ts
@@ -41,7 +41,7 @@ function getIdentifierWhereClause(identifier: PolicyIdentifier): SafeSqlFragment
   if ('id' in identifier && identifier.id) {
     return safeSql`id = ${literal(identifier.id)}`
   } else if ('name' in identifier && identifier.name && identifier.schema && identifier.table) {
-    return safeSql`name = ${literal(identifier.name)} AND schema = ${literal(identifier.schema)} AND table = ${literal(identifier.table)}`
+    return safeSql`name = ${literal(identifier.name)} AND schema = ${literal(identifier.schema)} AND ${ident('table')} = ${literal(identifier.table)}`
   }
   throw new Error('Must provide either id or name, schema and table')
 }

--- a/packages/pg-meta/test/policies.test.ts
+++ b/packages/pg-meta/test/policies.test.ts
@@ -140,3 +140,16 @@ withTestDatabase('retrieve, create, update, delete policies', async ({ executeQu
   const result = await executeQuery(verifyRemoveSql)
   expect(result).toHaveLength(0)
 })
+
+test('retrieve by name/schema/table quotes the reserved "table" keyword', () => {
+  const { sql } = pgMeta.policies.retrieve({
+    name: 'my_policy',
+    schema: 'public',
+    table: 'memes',
+  })
+
+  // `table` is a reserved keyword, so it must be quoted to be a valid column
+  // reference. An unquoted `AND table = '...'` is a syntax error in Postgres.
+  expect(sql).toContain(`"table" = 'memes'`)
+  expect(sql).not.toContain(`AND table = 'memes'`)
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`getIdentifierWhereClause` in `packages/pg-meta/src/pg-meta-policies.ts` builds the WHERE clause for retrieving a policy by `{ name, schema, table }`:

```ts
return safeSql`name = ${literal(identifier.name)} AND schema = ${literal(identifier.schema)} AND table = ${literal(identifier.table)}`
```

`table` is a **reserved Postgres keyword**, but it is interpolated as a bare, unquoted column reference. For `{ name: 'p1', schema: 'public', table: 'memes' }` this produces:

```sql
... select * from policies where name = 'p1' AND schema = 'public' AND table = 'memes';
```

`AND table = 'memes'` is invalid SQL — Postgres parses the reserved word `table` as the start of a command, not a column, and the query fails with `syntax error at or near "table"`. So `policies.retrieve` by name/schema/table is broken and always errors.

Every sibling builder quotes this identifier correctly — e.g. `pg-meta-columns.ts` uses `${ident('table')}`. Policies is the only one interpolating the column name as raw text.

## What is the new behavior?

Quotes the reserved keyword via `ident('table')` (which yields `"table"`), matching the existing pattern in `pg-meta-columns.ts`. `name` and `schema` are not reserved and remain unquoted, so the previously-working columns are unchanged.

Added a DB-free unit test asserting the generated SQL contains `"table" = '...'` rather than a bare `table = '...'`.

## Additional context

The existing `policies.test.ts` only exercised `retrieve({ id })`, so the broken name/schema/table branch was never covered.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SQL query generation to properly quote reserved keywords when retrieving policies. Database queries now safely handle reserved keywords like "table" to prevent query errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->