### PR TITLE
fix(common): restore consent state when denyAll fails

### DIFF
--- a/packages/common/consent-state.test.ts
+++ b/packages/common/consent-state.test.ts
@@ -318,13 +318,14 @@ describe('applyPriorDecisionToSDK', () => {
       services?: MockService[]
       areAllAccepted?: boolean
       onAcceptAll?: () => Promise<void>
+      onDenyAll?: () => Promise<void>
       onUpdateServices?: (decisions: UserDecision[]) => Promise<void>
     } = {}
   ) => {
     const services = opts.services ?? []
     return {
       acceptAllServices: vi.fn(opts.onAcceptAll ?? (() => Promise.resolve())),
-      denyAllServices: vi.fn(() => Promise.resolve()),
+      denyAllServices: vi.fn(opts.onDenyAll ?? (() => Promise.resolve())),
       updateServices: vi.fn(opts.onUpdateServices ?? (() => Promise.resolve())),
       getCategoriesBaseInfo: vi.fn(() => []),
       getServicesBaseInfo: vi.fn(() => services),
@@ -446,5 +447,61 @@ describe('applyPriorDecisionToSDK', () => {
 
     expect(UC.updateServices).not.toHaveBeenCalled()
     expect(consentState.hasConsented).toBe(true)
+  })
+})
+
+describe('consentState.denyAll', () => {
+  const flushPromises = () => new Promise((resolve) => setTimeout(resolve, 0))
+
+  beforeEach(() => {
+    consentState.UC = null
+    consentState.categories = null
+    consentState.showConsentToast = false
+    consentState.hasConsented = false
+  })
+
+  it('sets hasConsented false and hides the banner on success', async () => {
+    const UC = makeMockUC()
+    consentState.UC = UC as never
+    consentState.hasConsented = true
+    consentState.showConsentToast = true
+
+    consentState.denyAll()
+    await flushPromises()
+
+    expect(UC.denyAllServices).toHaveBeenCalledOnce()
+    expect(consentState.hasConsented).toBe(false)
+    expect(consentState.showConsentToast).toBe(false)
+  })
+
+  // On failure the optimistic deny must be rolled back, otherwise the app
+  // believes the user denied consent even though the SDK call failed.
+  it('restores hasConsented and re-shows the banner when denyAllServices rejects', async () => {
+    const UC = makeMockUC({ onDenyAll: () => Promise.reject(new Error('network')) })
+    consentState.UC = UC as never
+    consentState.hasConsented = true
+    consentState.showConsentToast = false
+
+    consentState.denyAll()
+    expect(consentState.hasConsented).toBe(false) // optimistic update
+
+    await flushPromises()
+
+    expect(consentState.hasConsented).toBe(true)
+    expect(consentState.showConsentToast).toBe(true)
+  })
+
+  // The banner must be re-shown on failure regardless of the prior consent
+  // value (showConsentToast is a toast-visibility flag, not a consent boolean).
+  it('re-shows the banner on rejection even if the user had not previously consented', async () => {
+    const UC = makeMockUC({ onDenyAll: () => Promise.reject(new Error('network')) })
+    consentState.UC = UC as never
+    consentState.hasConsented = false
+    consentState.showConsentToast = false
+
+    consentState.denyAll()
+    await flushPromises()
+
+    expect(consentState.showConsentToast).toBe(true)
   })
 })

--- a/packages/common/consent-state.ts
+++ b/packages/common/consent-state.ts
@@ -161,7 +161,8 @@ export const consentState = proxy({
         consentState.categories = consentState.UC?.getCategoriesBaseInfo() ?? null
       })
       .catch(() => {
-        consentState.showConsentToast = previousConsentValue
+        consentState.hasConsented = previousConsentValue
+        consentState.showConsentToast = true
       })
   },
   updateServices: (decisions: UserDecision[]) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`consentState.denyAll` (`packages/common/consent-state.ts`) optimistically sets `hasConsented = false` and then handles SDK failure with:

```ts
consentState.UC.denyAllServices()
  .then(() => { ... })
  .catch(() => {
    consentState.showConsentToast = previousConsentValue
  })
```

Compared with its `acceptAll` twin, this `.catch` is wrong in two ways:

1. It never restores `consentState.hasConsented`, so when `denyAllServices()` rejects the optimistic `false` sticks — the app believes the user denied consent even though the call failed.
2. It assigns `previousConsentValue` (a **consent** boolean) to `showConsentToast` (a **toast-visibility** flag). The banner is then shown/hidden based on the wrong piece of state — e.g. if the user had not previously consented (`false`), the banner stays hidden after a failed deny.

For reference, the correct `acceptAll` handler:

```ts
.catch(() => {
  consentState.hasConsented = previousConsentValue
  consentState.showConsentToast = true
})
```

## What is the new behavior?

`denyAll`'s `.catch` now mirrors `acceptAll`: it restores `hasConsented` to its previous value and re-shows the consent banner.

Added tests for `consentState.denyAll` covering the success path and both failure aspects (state rollback and banner re-display).

## Additional context

The mock helper in `consent-state.test.ts` gained an `onDenyAll` option so `denyAllServices` can be made to reject, paralleling the existing `onAcceptAll`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where denying all consent would not properly recover if the operation failed, ensuring the previous consent state is restored and the consent banner reappears for users to retry.

* **Tests**
  * Added comprehensive test coverage for the deny all functionality, including both successful and failed operation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->