### PR TITLE
fix(studio): correct error message for missing endDate in org daily stats

### DIFF
--- a/apps/studio/data/analytics/org-daily-stats-query.test.ts
+++ b/apps/studio/data/analytics/org-daily-stats-query.test.ts
@@ -42,7 +42,7 @@ describe('org-daily-stats-query', () => {
           startDate: '2025-01-01',
           endDate: undefined,
         })
-      ).rejects.toThrow('Start date is required')
+      ).rejects.toThrow('End date is required')
     })
 
     it('calls API with correct parameters including project_ref', async () => {

--- a/apps/studio/data/analytics/org-daily-stats-query.ts
+++ b/apps/studio/data/analytics/org-daily-stats-query.ts
@@ -130,7 +130,7 @@ export async function getOrgDailyStats(
 ) {
   if (!orgSlug) throw new Error('Org slug is required')
   if (!startDate) throw new Error('Start date is required')
-  if (!endDate) throw new Error('Start date is required')
+  if (!endDate) throw new Error('End date is required')
 
   const { data, error } = await get('/platform/organizations/{slug}/usage/daily', {
     params: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`getOrgDailyStats` in `apps/studio/data/analytics/org-daily-stats-query.ts` validates its inputs:

```ts
if (!orgSlug) throw new Error('Org slug is required')
if (!startDate) throw new Error('Start date is required')
if (!endDate) throw new Error('Start date is required') // <- wrong message
```

When `endDate` is missing it throws `'Start date is required'` — a copy-paste error that points the developer at the wrong parameter. The existing test even codified the wrong string (`.rejects.toThrow('Start date is required')` in the "throws error when endDate is not provided" case).

## What is the new behavior?

Throws `'End date is required'` for a missing `endDate`. Updated the corresponding test assertion.

## Additional context

Small, self-contained correctness fix in a pure function used via `useOrgDailyStatsQuery` (organization usage page).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed validation error messaging in analytics queries to correctly indicate when an end date is required instead of displaying an incorrect start date error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->