### PR TITLE
fix(docs): use a valid comparator when sorting reference params

### DIFF
--- a/apps/docs/lib/refGenerator/helpers.test.ts
+++ b/apps/docs/lib/refGenerator/helpers.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { compareParamsByRequiredThenName } from './helpers'
+
+type Param = { name?: string; flags?: { isOptional?: boolean } }
+
+const sortNames = (params: Param[]) =>
+  [...params].sort(compareParamsByRequiredThenName).map((p) => p.name ?? '')
+
+describe('compareParamsByRequiredThenName', () => {
+  it('orders required params before optional ones', () => {
+    expect(
+      sortNames([
+        { name: 'b', flags: { isOptional: true } },
+        { name: 'a', flags: { isOptional: false } },
+      ])
+    ).toEqual(['a', 'b'])
+  })
+
+  it('orders alphabetically within the same optionality', () => {
+    expect(
+      sortNames([
+        { name: 'charlie', flags: { isOptional: false } },
+        { name: 'alpha', flags: { isOptional: false } },
+        { name: 'bravo', flags: { isOptional: false } },
+      ])
+    ).toEqual(['alpha', 'bravo', 'charlie'])
+  })
+
+  it('groups required (alphabetical) before optional (alphabetical)', () => {
+    expect(
+      sortNames([
+        { name: 'opt_b', flags: { isOptional: true } },
+        { name: 'req_b', flags: { isOptional: false } },
+        { name: 'opt_a', flags: { isOptional: true } },
+        { name: 'req_a', flags: { isOptional: false } },
+      ])
+    ).toEqual(['req_a', 'req_b', 'opt_a', 'opt_b'])
+  })
+
+  it('treats missing flags as required and missing names as empty strings', () => {
+    expect(
+      sortNames([
+        { name: 'named', flags: { isOptional: true } },
+        { flags: { isOptional: true } }, // optional, no name
+        { name: 'required_no_flags' }, // no flags => required
+      ])
+    ).toEqual(['required_no_flags', '', 'named'])
+  })
+
+  it('is a total, symmetric comparator (sign flips when operands swap)', () => {
+    const a: Param = { name: 'a', flags: { isOptional: false } }
+    const b: Param = { name: 'b', flags: { isOptional: true } }
+    expect(Math.sign(compareParamsByRequiredThenName(a, b))).toBe(
+      -Math.sign(compareParamsByRequiredThenName(b, a))
+    )
+    expect(compareParamsByRequiredThenName(a, { ...a })).toBe(0)
+  })
+})

--- a/apps/docs/lib/refGenerator/helpers.ts
+++ b/apps/docs/lib/refGenerator/helpers.ts
@@ -42,6 +42,24 @@ export function generateParameters(tsDefinition: any) {
   return parameters
 }
 
+type SortableParam = { name?: string; flags?: { isOptional?: boolean } }
+
+/**
+ * Order params with required ones first, then alphabetically by name.
+ *
+ * Both comparisons are done in a single comparator so the ordering is stable
+ * and total. The previous implementation chained two `.sort()` calls, the
+ * second of which (`(a, b) => (a.flags?.isOptional ? 1 : -1)`) never inspected
+ * `b` and never returned 0 — an invalid comparator whose result is
+ * implementation-defined and can scramble the alphabetical pre-sort.
+ */
+export function compareParamsByRequiredThenName(a: SortableParam, b: SortableParam): number {
+  const aOptional = a.flags?.isOptional ? 1 : 0
+  const bOptional = b.flags?.isOptional ? 1 : 0
+  if (aOptional !== bOptional) return aOptional - bOptional // required (0) before optional (1)
+  return (a.name ?? '').localeCompare(b.name ?? '')
+}
+
 function recurseThroughParams(paramDefinition: any) {
   const param = { ...paramDefinition }
   const labelParams = generateLabelParam(param)
@@ -102,8 +120,7 @@ function recurseThroughParams(paramDefinition: any) {
 
   if (children) {
     const properties = children
-      .sort((a, b) => a.name?.localeCompare(b.name)) // first alphabetical
-      .sort((a, b) => (a.flags?.isOptional ? 1 : -1)) // required params first
+      .sort(compareParamsByRequiredThenName) // required params first, then alphabetical
       .map((x) => recurseThroughParams(x))
     labelParams.subContent = properties
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`recurseThroughParams` in `apps/docs/lib/refGenerator/helpers.ts` sorts reference params by chaining two `.sort()` calls:

```ts
const properties = children
  .sort((a, b) => a.name?.localeCompare(b.name)) // first alphabetical
  .sort((a, b) => (a.flags?.isOptional ? 1 : -1)) // required params first
  .map((x) => recurseThroughParams(x))
```

The second comparator is invalid: it never inspects `b` and never returns `0`. For two optional params it returns `1` for both `compare(x, y)` and `compare(y, x)`, which is contradictory. A non-total comparator produces implementation-defined ordering, so the intended "required first, then alphabetical" result isn't guaranteed and the alphabetical pre-sort can be scrambled. The first comparator can also return `undefined` when `a.name` is missing (optional chaining), which is likewise not a valid comparator result.

## What is the new behavior?

A single total comparator, `compareParamsByRequiredThenName`, that:
- puts required params before optional ones, and
- sorts alphabetically by name within each group,

with missing `flags` treated as required and missing names as empty strings. Added unit tests, including a check that the comparator is symmetric (sign flips when operands swap) and returns `0` for equal items.

## Additional context

The comparator is exported so it can be unit-tested directly without constructing full TsDoc nodes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Documentation parameter ordering now consistently displays required parameters before optional ones, with alphabetical sorting applied within each group for improved readability and predictability.

* **Tests**
  * Added comprehensive test coverage for parameter sorting functionality, validating behavior across various scenarios including mixed required/optional parameters and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->