### PR TITLE
docs: add React Native CLI quickstart guide

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1,4 +1,4 @@
-// End of third-party imports
+﻿// End of third-party imports
 
 import { isFeatureEnabled } from 'common/enabled-features'
 import type { ComponentProps } from 'react'
@@ -377,6 +377,10 @@ export const gettingstarted: NavMenuConstant = {
           url: '/guides/getting-started/quickstarts/expo-react-native',
         },
         {
+          name: 'React Native CLI',
+          url: '/guides/getting-started/quickstarts/react-native-cli',
+        },
+        {
           name: 'Flutter',
           url: '/guides/getting-started/quickstarts/flutter',
         },
@@ -643,7 +647,7 @@ export const PhoneLoginsItems = [
   {
     name: 'MessageBird',
     icon: '/docs/img/icons/messagebird-icon',
-    linkDescription: 'Communication between businesses and their customers — across any channel.',
+    linkDescription: 'Communication between businesses and their customers â€” across any channel.',
     url: '/guides/auth/phone-login/messagebird',
   },
   {
@@ -3583,3 +3587,4 @@ export const navDataForMdx = {
   ormQuickstarts,
   guiQuickstarts,
 }
+

--- a/apps/docs/content/guides/getting-started/quickstarts/react-native-cli.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/react-native-cli.mdx
@@ -1,0 +1,214 @@
+﻿---
+title: 'Use Supabase with React Native CLI'
+subtitle: 'Learn how to create a Supabase project, add some sample data to your database, and query the data from a React Native CLI app.'
+breadcrumb: 'Framework Quickstarts'
+hideToc: true
+---
+
+<StepHikeCompact>
+
+  <StepHikeCompact.Step step={1}>
+
+    <$Partial path="quickstart_db_setup.mdx" />
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={2}>
+
+    <StepHikeCompact.Details title="Create a React Native app">
+
+    Create a minimal React Native app using the React Native CLI with the TypeScript template.
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+```bash name=Terminal
+      npx @react-native-community/cli init MyApp
+```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={3}>
+    <StepHikeCompact.Details title="Install the Supabase client library">
+
+    The fastest way to get started is to use the `@supabase/supabase-js` client library which provides a convenient interface for working with Supabase from a React Native app.
+
+    Navigate to the app directory and install `supabase-js` along with the required dependencies for storage and URL handling.
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+```bash name=Terminal
+      cd MyApp && npm install @supabase/supabase-js @react-native-async-storage/async-storage react-native-url-polyfill
+```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={4}>
+    <StepHikeCompact.Details title="Declare Supabase Environment Variables">
+
+    Unlike Expo, the React Native CLI does not provide built-in support for environment variables. We recommend using `react-native-config` to manage your Supabase connection variables.
+
+    Install it with:
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+```bash name=Terminal
+      npm install react-native-config
+```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={5}>
+    <StepHikeCompact.Details title="Add your Supabase credentials">
+
+    Create a `.env` file in the root of your project and populate it with your Supabase connection variables.
+
+    <ProjectConfigVariables variable="url" />
+    <ProjectConfigVariables variable="publishable" />
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+```text name=.env
+      SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
+      SUPABASE_PUBLISHABLE_KEY=<SUBSTITUTE_SUPABASE_PUBLISHABLE_KEY>
+```
+      <$Partial path="api_settings_steps.mdx" variables={{ "framework": "", "tab": "" }} />
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={6}>
+    <StepHikeCompact.Details title="Initialize the Supabase client">
+
+    Create a helper file at `lib/supabase.ts` to initialize the Supabase client using your environment variables.
+
+    Unlike on the web, React Native does not have access to `localStorage`. Instead, we use `@react-native-async-storage/async-storage` to persist the user's session.
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+```ts name=lib/supabase.ts
+      import 'react-native-url-polyfill/auto'
+      import { createClient } from '@supabase/supabase-js'
+      import AsyncStorage from '@react-native-async-storage/async-storage'
+      import Config from 'react-native-config'
+
+      const supabaseUrl = Config.SUPABASE_URL
+      const supabasePublishableKey = Config.SUPABASE_PUBLISHABLE_KEY
+
+      export const supabase = createClient(supabaseUrl, supabasePublishableKey, {
+        auth: {
+          storage: AsyncStorage,
+          autoRefreshToken: true,
+          persistSession: true,
+          detectSessionInUrl: false,
+        },
+      })
+```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={7}>
+    <StepHikeCompact.Details title="Query data from the app">
+
+    Replace the contents of `App.tsx` with the following code to fetch and display the instruments from your database.
+
+    Use `useEffect` to fetch the data when the component mounts and display the query result using React Native components.
+
+    </StepHikeCompact.Details>
+    <StepHikeCompact.Code>
+
+```tsx name=App.tsx
+      import { useEffect, useState } from 'react'
+      import { StyleSheet, View, FlatList, Text } from 'react-native'
+      import { supabase } from './lib/supabase'
+
+      export default function App() {
+        const [instruments, setInstruments] = useState([])
+
+        useEffect(() => {
+          getInstruments()
+        }, [])
+
+        async function getInstruments() {
+          const { data } = await supabase.from('instruments').select()
+          setInstruments(data)
+        }
+
+        return (
+          <View style={styles.container}>
+            <FlatList
+              data={instruments}
+              keyExtractor={(item) => item.id.toString()}
+              renderItem={({ item }) => (
+                <Text style={styles.item}>{item.name}</Text>
+              )}
+            />
+          </View>
+        )
+      }
+
+      const styles = StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: '#fff',
+          paddingTop: 50,
+          paddingHorizontal: 16,
+        },
+        item: {
+          padding: 16,
+          borderBottomWidth: 1,
+          borderBottomColor: '#ccc',
+        },
+      })
+```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+  <StepHikeCompact.Step step={8}>
+    <StepHikeCompact.Details title="Start the app">
+
+    Run the development server, then build and run the app on an Android emulator or device.
+
+    </StepHikeCompact.Details>
+
+    <StepHikeCompact.Code>
+
+```bash name=Terminal
+      npx react-native start
+```
+
+```bash name=Terminal
+      npx react-native run-android
+```
+
+    </StepHikeCompact.Code>
+
+  </StepHikeCompact.Step>
+
+</StepHikeCompact>
+
+## Next steps
+
+- Set up [Auth](/docs/guides/auth) for your app
+- [Insert more data](/docs/guides/database/import-data) into your database
+- Upload and serve static files using [Storage](/docs/guides/storage)


### PR DESCRIPTION
## What kind of change does this PR introduce?
Documentation - adds a new quickstart guide for React Native CLI

## What is the current behavior?
Closes #46889

There is currently no documentation for setting up Supabase with a React Native CLI project (only Expo is covered).

## What is the new behavior?
- Adds a new quickstart guide at `/guides/getting-started/quickstarts/react-native-cli`, mirroring the structure of the existing Expo React Native quickstart.
- Covers React Native CLI project setup, installing `@supabase/supabase-js`, environment variable management with `react-native-config`, and session persistence using `@react-native-async-storage/async-storage` (since `localStorage` is unavailable in React Native).
- Adds the new guide to the navigation menu, alongside the existing Expo React Native entry.

## Additional context
This addresses the gap raised in #46889, where AsyncStorage is needed instead of localStorage for session persistence on React Native CLI projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added React Native CLI quickstart guide covering setup, dependency installation, environment configuration, and Supabase client initialization.
  * Updated navigation menu to reference the new quickstart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->