### PR TITLE
docs(functions): recommend per-function deno.json in dev-tips example

### DIFF
--- a/apps/docs/content/guides/functions/development-tips.mdx
+++ b/apps/docs/content/guides/functions/development-tips.mdx
@@ -29,15 +29,16 @@ We recommend this folder structure:
 ```bash
 └── supabase
     ├── functions
-    │   ├── import_map.json # A top-level import map to use across functions.
     │   ├── _shared
     │   │   ├── supabaseAdmin.ts # Supabase client with SECRET key.
     │   │   └── supabaseClient.ts # Supabase client with PUBLISHABLE key.
     │   │   └── cors.ts # Reusable CORS headers.
     │   ├── function-one # Use hyphens to name functions.
-    │   │   └── index.ts
+    │   │   ├── index.ts
+    │   │   └── deno.json # Function-specific Deno configuration.
     │   └── function-two
-    │   │   └── index.ts
+    │       ├── index.ts
+    │       └── deno.json # Function-specific Deno configuration.
     │   └── tests
     │       └── function-one-test.ts
     │       └── function-two-test.ts
@@ -45,14 +46,15 @@ We recommend this folder structure:
     └── config.toml
 ```
 
+Each function should have its own [`deno.json`](/docs/guides/functions/dependencies#using-denojson-recommended) to manage dependencies. Import maps are [supported but legacy](/docs/guides/functions/dependencies#using-import-maps-legacy) — if both exist, `deno.json` takes precedence.
+
 ### Using config.toml
 
-Individual function configuration like [JWT verification](/docs/guides/cli/config#functions.function_name.verify_jwt) and [import map location](/docs/guides/cli/config#functions.function_name.import_map) can be set via the `config.toml` file.
+Individual function configuration like [JWT verification](/docs/guides/cli/config#functions.function_name.verify_jwt) can be set via the `config.toml` file.
 
 ```toml supabase/config.toml
 [functions.hello-world]
 verify_jwt = false
-import_map = './import_map.json'
 ```
 
 ### Not using TypeScript


### PR DESCRIPTION
## Summary

Fixes #36303. The Edge Functions [development-tips guide](https://supabase.com/docs/guides/functions/development-tips#organizing-your-edge-functions) recommended a top-level `import_map.json` in its folder-structure example, while the [dependencies guide](https://supabase.com/docs/guides/functions/dependencies#using-denojson-recommended) explicitly recommends a per-function `deno.json` and labels import maps as legacy. The two pages contradicted each other.

This PR aligns the development-tips example with the dependencies guide:

- Replaces the top-level `import_map.json` with per-function `deno.json` files in the folder tree (matching the canonical layout shown in dependencies.mdx).
- Removes the now-irrelevant `import_map = './import_map.json'` line from the `config.toml` example, and removes the matching link from the prose above it.
- Adds a one-line pointer + cross-links so readers who want the legacy import-map approach can find it.

## Test plan

- [x] `pnpm prettier --check apps/docs/content/guides/functions/development-tips.mdx` — clean
- [x] Cross-links resolve to existing headings in `apps/docs/content/guides/functions/dependencies.mdx`:
  - `#using-denojson-recommended` → line 28 `### Using \`deno.json\` (recommended)`
  - `#using-import-maps-legacy` → line 61 `### Using import maps (legacy)`
- [ ] Visual check in the rendered docs preview (Vercel deploy on this PR)

Refs: #36303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Supabase Functions development guide with refined folder structure recommendations.
  * Added guidance for per-function `deno.json` configuration files.
  * Clarified that `deno.json` takes precedence over legacy import maps.
  * Enhanced configuration documentation for per-function settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->