### PR TITLE
fix(studio) updated analytics regex to avoid conflicting names within tables

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportFilterBar.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportFilterBar.tsx
@@ -23,7 +23,7 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { DatePickerValue, LogsDatePicker } from '../Settings/Logs/Logs.DatePickers'
-import { REPORTS_DATEPICKER_HELPERS } from './Reports.constants'
+import { PRODUCT_FILTER_PATHS, REPORTS_DATEPICKER_HELPERS } from './Reports.constants'
 import type { ReportFilterItem } from './Reports.types'
 import { DatabaseSelector } from '@/components/ui/DatabaseSelector'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
@@ -53,35 +53,35 @@ const PRODUCT_FILTERS = [
   {
     key: 'rest',
     filterKey: 'request.path',
-    filterValue: '/rest',
+    filterValue: PRODUCT_FILTER_PATHS.rest,
     label: 'Data API (PostgREST)',
     icon: Database,
   },
   {
     key: 'auth',
     filterKey: 'request.path',
-    filterValue: '/auth',
+    filterValue: PRODUCT_FILTER_PATHS.auth,
     label: 'Auth',
     icon: Auth,
   },
   {
     key: 'storage',
     filterKey: 'request.path',
-    filterValue: '/storage',
+    filterValue: PRODUCT_FILTER_PATHS.storage,
     label: 'Storage',
     icon: Storage,
   },
   {
     key: 'realtime',
     filterKey: 'request.path',
-    filterValue: '/realtime',
+    filterValue: PRODUCT_FILTER_PATHS.realtime,
     label: 'Realtime',
     icon: Realtime,
   },
   {
     key: 'graphql',
     filterKey: 'request.path',
-    filterValue: '/graphql',
+    filterValue: PRODUCT_FILTER_PATHS.graphql,
     label: 'GraphQL (pg_graphql)',
     icon: null,
   },

--- a/apps/studio/components/interfaces/Reports/Reports.constants.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { generateRegexpWhereSafe } from './Reports.constants'
+import { generateRegexpWhereSafe, PRODUCT_FILTER_PATHS } from './Reports.constants'
 import type { ReportFilterItem } from './Reports.types'
 
 describe('generateRegexpWhereSafe', () => {
@@ -117,5 +117,52 @@ describe('generateRegexpWhereSafe', () => {
     ]
     const result = generateRegexpWhereSafe(filters, true)
     expect(result).toBe("WHERE `request`.`method` = 'get'")
+  })
+})
+
+describe('PRODUCT_FILTER_PATHS (REGEXP_CONTAINS product filters) are anchored to the gateway prefix', () => {
+  // Product filters match request.path with REGEXP_CONTAINS (a substring match).
+  // Each value MUST keep its trailing slash so it matches only the real gateway
+  // prefix (e.g. /storage/v1/...) and never a user table whose name merely starts
+  // with the service word (e.g. the Data-API path /rest/v1/storage_workers).
+  it('every product path value is slash-delimited on both sides', () => {
+    for (const value of Object.values(PRODUCT_FILTER_PATHS)) {
+      expect(value.startsWith('/')).toBe(true)
+      expect(value.endsWith('/')).toBe(true)
+    }
+  })
+
+  it('emits a trailing-slash REGEXP_CONTAINS for the storage product filter', () => {
+    const result = generateRegexpWhereSafe(
+      [{ key: 'request.path', value: PRODUCT_FILTER_PATHS.storage, compare: 'matches' }],
+      true
+    )
+    expect(result).toBe("WHERE REGEXP_CONTAINS(`request`.`path`, '/storage/')")
+  })
+
+  it('does not bucket a PostgREST request to a `storage_*` table as storage', () => {
+    // Regression: `/rest/v1/storage_workers` was counted as a Storage request because
+    // the old value `/storage` is a substring of `/storage_workers`.
+    const storageRe = new RegExp(PRODUCT_FILTER_PATHS.storage)
+    expect(storageRe.test('/rest/v1/storage_workers')).toBe(false)
+    expect(storageRe.test('/storage/v1/object/bucket/key')).toBe(true)
+  })
+
+  it('does not match a Data-API request to a table named after another service', () => {
+    // For every non-rest service, a `/rest/v1/<service>_*` table request must NOT
+    // match that service's filter (it is a PostgREST/Data-API request).
+    for (const [service, value] of Object.entries(PRODUCT_FILTER_PATHS)) {
+      if (service === 'rest') continue
+      const re = new RegExp(value)
+      expect(re.test(`/rest/v1/${service}_workers`)).toBe(false)
+      // ...but the genuine gateway path for that service still matches.
+      expect(re.test(`${value}v1/whatever`)).toBe(true)
+    }
+  })
+
+  it('still matches genuine Data-API traffic for the rest filter', () => {
+    const restRe = new RegExp(PRODUCT_FILTER_PATHS.rest)
+    expect(restRe.test('/rest/v1/storage_workers')).toBe(true)
+    expect(restRe.test('/storage/v1/object/x')).toBe(false)
   })
 })

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -14,6 +14,15 @@ import { PlanId } from '@/data/subscriptions/types'
 
 export const LAYOUT_COLUMN_COUNT = 2
 
+export const PRODUCT_FILTER_PATHS = {
+  rest: '/rest/',
+  auth: '/auth/',
+  storage: '/storage/',
+  realtime: '/realtime/',
+  graphql: '/graphql/',
+  functions: '/functions/',
+} as const
+
 export interface ReportsDatetimeHelper extends DatetimeHelper {
   availableIn: PlanId[]
 }

--- a/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
+++ b/apps/studio/components/interfaces/Reports/SharedAPIReport/SharedAPIReport.constants.ts
@@ -1,10 +1,10 @@
 import * as Sentry from '@sentry/nextjs'
 import { useQueries, useQueryClient } from '@tanstack/react-query'
-import { useParams } from 'common'
+import { useParams } from 'common/hooks'
 import { isEqual } from 'lodash'
 import { useState } from 'react'
 
-import { generateRegexpWhereSafe } from '../Reports.constants'
+import { generateRegexpWhereSafe, PRODUCT_FILTER_PATHS } from '../Reports.constants'
 import { ReportFilterItem } from '../Reports.types'
 import { executeAnalyticsSql } from '@/data/logs/execute-analytics-sql'
 import { safeSql, type SafeLogSqlFragment } from '@/data/logs/safe-analytics-sql'
@@ -235,12 +235,12 @@ export const useSharedAPIReport = ({
   }
 
   const filterByMapValue = {
-    functions: '/functions',
-    realtime: '/realtime',
-    storage: '/storage',
-    graphql: '/graphql',
-    postgrest: '/rest',
-    auth: '/auth',
+    functions: PRODUCT_FILTER_PATHS.functions,
+    realtime: PRODUCT_FILTER_PATHS.realtime,
+    storage: PRODUCT_FILTER_PATHS.storage,
+    graphql: PRODUCT_FILTER_PATHS.graphql,
+    postgrest: PRODUCT_FILTER_PATHS.rest,
+    auth: PRODUCT_FILTER_PATHS.auth,
   }
 
   const baseFilter = {

--- a/apps/studio/components/interfaces/Reports/useReportFilters.ts
+++ b/apps/studio/components/interfaces/Reports/useReportFilters.ts
@@ -1,6 +1,7 @@
 import { parseAsString, useQueryStates } from 'nuqs'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import { PRODUCT_FILTER_PATHS } from './Reports.constants'
 import type { ReportFilter, ReportFilterItem, ReportFilterProperty } from './Reports.types'
 
 export enum ReportFilterKeys {
@@ -220,7 +221,13 @@ export const useReportFilters = ({
 
       // Separate product filters (managed by dropdown) from other filters (managed by ReportFilterPopover)
       const PRODUCT_FILTER_KEYS = ['request.path']
-      const PRODUCT_FILTER_VALUES = ['/rest', '/auth', '/storage', '/realtime', '/graphql']
+      const PRODUCT_FILTER_VALUES: string[] = [
+        PRODUCT_FILTER_PATHS.rest,
+        PRODUCT_FILTER_PATHS.auth,
+        PRODUCT_FILTER_PATHS.storage,
+        PRODUCT_FILTER_PATHS.realtime,
+        PRODUCT_FILTER_PATHS.graphql,
+      ]
 
       const productFilters = filters.filter(
         (f) =>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On the API report, the product filters (Data API / Auth / Storage / Realtime / GraphQL) match `request.path` with `REGEXP_CONTAINS` using a **bare service prefix** like `/storage`. Because `REGEXP_CONTAINS` is a substring match, `/storage` matches **any** path that merely contains it — including PostgREST requests to user tables whose name starts with the service word.

For example, a request to a user table named `storage_workers`:

```
/rest/v1/storage_workers?select=id,attempt_count&status=eq.processing
```

is a **Data API (PostgREST)** request, but gets counted as a **Storage** request (the `/storage` value is a substring of `/storage_workers`). The same flaw affects every product value: `/rest` matches `/restaurant`, `/auth` matches `/author`, etc.

## What is the new behavior?

Each product path filter is now **anchored with a trailing slash** (`/storage/`, `/rest/`, `/auth/`, `/realtime/`, `/graphql/`, `/functions/`), so it matches only the real gateway prefix (e.g. `/storage/v1/...`) and never a table name. `/rest/v1/storage_workers` is now correctly bucketed as a Data API request.

The product → path values were previously **duplicated** across three files (and used both as the regex pattern and as an identity key, which is how they drifted). They are now consolidated into a single source of truth, `PRODUCT_FILTER_PATHS` in `Reports.constants.ts`, that all callers derive from.

**Files changed**

- `Reports/Reports.constants.ts` — new exported `PRODUCT_FILTER_PATHS` (with rationale comment)
- `Reports/ReportFilterBar.tsx` — `PRODUCT_FILTERS` derive from it
- `Reports/useReportFilters.ts` — `PRODUCT_FILTER_VALUES` derive from it
- `Reports/SharedAPIReport/SharedAPIReport.constants.ts` — `filterByMapValue` derive from it
- `Reports/Reports.constants.test.ts` — regression tests, incl. the `/rest/v1/storage_workers` case

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated product filter path definitions across the Reports interface for improved consistency.

* **Tests**
  * Added test coverage to verify product filter path matching and behavior across different services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->