### PR TITLE
Change IPv6 compatibility test link

### DIFF
--- a/apps/docs/content/guides/platform/ipv4-address.mdx
+++ b/apps/docs/content/guides/platform/ipv4-address.mdx
@@ -77,7 +77,7 @@ By default, Supabase Postgres use IPv6 addresses. If your system doesn't support
 
 ### Checking your network IPv6 support
 
-You can check if your personal network is IPv6 compatible at https://test-ipv6.com.
+You can check if your personal network is IPv6 compatible at https://ipv6test.google.com/.
 
 ### Checking platforms for IPv6 support:
 


### PR DESCRIPTION
Updated the link for checking IPv6 compatibility.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

https://test-ipv6.com, the original site we recommended to users to check for IPv6 compatibility appears to be dead.

## What is the new behavior?

Changed the link to  https://ipv6test.google.com/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated IPv6 network support guidance to reference a new testing resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->