### PR TITLE
Query logs from SQL Editor

### DIFF
--- a/apps/studio/components/interfaces/App/MonacoThemeProvider.tsx
+++ b/apps/studio/components/interfaces/App/MonacoThemeProvider.tsx
@@ -19,7 +19,10 @@ export const getTheme = (theme: string) => {
       { token: 'comment', foreground: '666666' },
       { token: 'predefined.sql', foreground: isDarkMode ? 'D4D4D4' : '444444' },
     ],
-    colors: { 'editor.background': isDarkMode ? '#1f1f1f' : '#f0f0f0' },
+    colors: {
+      'editor.background': isDarkMode ? '#1f1f1f' : '#f0f0f0',
+      focusBorder: '#00000000',
+    },
   }
 }
 

--- a/apps/studio/components/interfaces/Reports/MetricOptions.tsx
+++ b/apps/studio/components/interfaces/Reports/MetricOptions.tsx
@@ -19,6 +19,7 @@ import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { BURSTABLE_IO_METRIC_KEYS, DEPRECATED_REPORTS } from './Reports.constants'
 import { hasBurstableIO } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
+import { getSqlSnippetSource } from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { useContentQuery } from '@/data/content/content-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
@@ -71,7 +72,12 @@ export const MetricOptions = ({ config, handleChartSelection }: MetricOptionsPro
     type: 'sql',
     name: debouncedSearch.length === 0 ? undefined : debouncedSearch,
   })
-  const snippets = data?.content
+  // Reports execute snippet SQL against Postgres, so logs snippets can't run here — hide them from
+  // the picker. Snippets whose content isn't loaded default to "database" and remain selectable;
+  // ReportBlock guards those at execution time.
+  const snippets = data?.content?.filter(
+    (snippet) => getSqlSnippetSource({ content: snippet.content as any }) !== 'logs'
+  )
 
   return (
     <>

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -1,15 +1,17 @@
 import { acceptUntrustedSql } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { X } from 'lucide-react'
+import { ScrollText, X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
 import { BURSTABLE_IO_METRIC_KEYS, DEPRECATED_REPORTS } from '../Reports.constants'
 import { ChartBlock } from './ChartBlock'
 import { DeprecatedChartBlock } from './DeprecatedChartBlock'
+import { ReportBlockContainer } from './ReportBlockContainer'
 import { UnavailableChartBlock } from './UnavailableChartBlock'
 import { hasBurstableIO } from '@/components/interfaces/DiskManagement/DiskManagement.utils'
+import { getSqlSnippetSource } from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import { ChartConfig } from '@/components/interfaces/SQLEditor/UtilityPanel/ChartConfig'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { DEFAULT_CHART_CONFIG, QueryBlock } from '@/components/ui/QueryBlock/QueryBlock'
@@ -79,6 +81,11 @@ export const ReportBlock = ({
   )
 
   const sql = isSnippet ? (data?.content as SqlSnippets.Content)?.unchecked_sql : undefined
+  // Logs snippets run against the analytics backend, not Postgres. Reports only execute Postgres
+  // SQL, so guard against running log SQL against the database (which would error or return wrong
+  // data) until logs snippets are supported in reports.
+  const isLogsSnippet =
+    isSnippet && getSqlSnippetSource({ content: data?.content as any }) === 'logs'
   const chartConfig = { ...DEFAULT_CHART_CONFIG, ...(item.chartConfig ?? {}) }
   const isDeprecatedChart = DEPRECATED_REPORTS.includes(item.attribute)
   const snippetMissing = contentError?.message.includes('Content not found')
@@ -118,7 +125,7 @@ export const ReportBlock = ({
         sql: acceptUntrustedSql(sql),
       })
     },
-    enabled: !isLoadingContent && contentError == null,
+    enabled: !isLoadingContent && contentError == null && !isLogsSnippet,
     refetchOnWindowFocus: false,
   })
 
@@ -146,7 +153,34 @@ export const ReportBlock = ({
 
   return (
     <>
-      {isSnippet ? (
+      {isLogsSnippet ? (
+        <ReportBlockContainer
+          draggable
+          showDragHandle
+          loading={false}
+          icon={<ScrollText size={14} className="text-foreground-muted" />}
+          label={item.label}
+          actions={
+            <ButtonTooltip
+              type="text"
+              icon={<X />}
+              className="h-7 w-7"
+              onClick={() => onRemoveChart({ metric: { key: item.attribute } })}
+              tooltip={{ content: { side: 'bottom', text: 'Remove chart' } }}
+            />
+          }
+        >
+          <div className="flex flex-1 flex-col justify-center gap-y-1 px-5 py-4">
+            <p className="text-xs text-foreground-light">
+              Logs snippets aren't supported in reports yet
+            </p>
+            <p className="text-xs text-foreground-lighter">
+              This snippet queries the logs backend, which reports can't run. Open it in the SQL
+              editor to view its results, or remove this chart from your report.
+            </p>
+          </div>
+        </ReportBlockContainer>
+      ) : isSnippet ? (
         <QueryBlock
           blockWriteQueries
           portalTooltip

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -15,7 +15,7 @@ export const NEW_SQL_SNIPPET_SKELETON: UserContent<SqlSnippets.Content> = {
     schema_version: SQL_SNIPPET_SCHEMA_VERSION,
     content_id: '',
     unchecked_sql: untrustedSql(''),
-    source: 'project',
+    source: 'database',
   },
 }
 

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.constants.ts
@@ -15,6 +15,7 @@ export const NEW_SQL_SNIPPET_SKELETON: UserContent<SqlSnippets.Content> = {
     schema_version: SQL_SNIPPET_SCHEMA_VERSION,
     content_id: '',
     unchecked_sql: untrustedSql(''),
+    source: 'project',
   },
 }
 

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -11,7 +11,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { LOCAL_STORAGE_KEYS, useFlag, useParams } from 'common'
 import { ChevronUp, Loader2 } from 'lucide-react'
 import dynamic from 'next/dynamic'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
@@ -50,21 +50,30 @@ import {
   isUpdateWithoutWhere,
   suffixWithLimit,
 } from './SQLEditor.utils'
+import { getSqlSnippetSource, SqlSnippetSourceIcon } from './SQLEditorSource.utils'
 import { useAddDefinitions } from './useAddDefinitions'
 import { useCreateDraftSqlTab } from './useCreateDraftSqlTab'
 import { useRestorePersistedDraftSqlTabs } from './useRestorePersistedDraftSqlTabs'
-import { UtilityPanel } from './UtilityPanel/UtilityPanel'
+import { UtilityActions } from './UtilityPanel/UtilityActions'
+import { UtilityPanel, type SqlOutputView } from './UtilityPanel/UtilityPanel'
 import {
   isExplainQuery,
   isExplainSql,
   splitSqlStatements,
 } from '@/components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
+import {
+  EXPLORER_DATEPICKER_HELPERS,
+  getDefaultHelper,
+} from '@/components/interfaces/Settings/Logs/Logs.constants'
+import { resolveLogDateRange } from '@/components/interfaces/Settings/Logs/logsDateRange'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import ResizableAIWidget from '@/components/ui/AIEditor/ResizableAIWidget'
 import { GridFooter } from '@/components/ui/GridFooter'
 import { useDatabaseEventTriggersQuery } from '@/data/database-event-triggers/database-event-triggers-query'
 import { constructHeaders, isValidConnString } from '@/data/fetchers'
 import { lintKeys } from '@/data/lint/keys'
+import { useExecuteLogSqlMutation } from '@/data/logs/execute-log-sql-mutation'
+import { acceptUntrustedLogSql, untrustedLogSql } from '@/data/logs/safe-analytics-sql'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { useExecuteSqlMutation } from '@/data/sql/execute-sql-mutation'
 import { isError } from '@/data/utils/error-check'
@@ -86,6 +95,7 @@ import { useShortcut } from '@/state/shortcuts/useShortcut'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 import { getSqlEditorV2StateSnapshot, useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
 import { createTabId, useTabsStateSnapshot } from '@/state/tabs'
+import type { SqlSnippets } from '@/types'
 
 // Load the monaco editor client-side only (does not behave well server-side)
 const MonacoEditor = dynamic(() => import('./MonacoEditor'), { ssr: false })
@@ -93,6 +103,23 @@ const DiffEditor = dynamic(
   () => import('../../ui/DiffEditor').then(({ DiffEditor }) => DiffEditor),
   { ssr: false }
 )
+
+const getDefaultLogDateRange = (): SqlSnippets.LogDateRange => {
+  const helper = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
+
+  return {
+    from: helper.calcFrom(),
+    to: helper.calcTo(),
+    isHelper: true,
+    text: helper.text,
+  }
+}
+
+const formatLogQueryError = (error: unknown) => {
+  if (typeof error === 'string') return { message: error }
+  if (error && typeof error === 'object' && 'message' in error) return error
+  return { message: 'Failed to run log query' }
+}
 
 export const SQLEditor = () => {
   const os = detectOS()
@@ -140,7 +167,7 @@ export const SQLEditor = () => {
   const [potentialIssues, setPotentialIssues] = useState<PotentialIssues>()
 
   const [showWidget, setShowWidget] = useState(false)
-  const [activeUtilityTab, setActiveUtilityTab] = useState<string>('results')
+  const [activeOutputView, setActiveOutputView] = useState<SqlOutputView>('table')
   const [renameModalOpen, setRenameModalOpen] = useState(false)
 
   const refocusEditor = useCallback(() => {
@@ -182,6 +209,10 @@ export const SQLEditor = () => {
 
   const limit = snapV2.limit
   const results = snapV2.results[id]?.[0]
+  const snippet = snapV2.snippets[id]?.snippet
+  const snippetSource = getSqlSnippetSource(snippet)
+  const defaultLogDateRange = useMemo(() => getDefaultLogDateRange(), [id])
+  const logDateRange = snippet?.content?.logDateRange ?? defaultLogDateRange
   const snippetIsLoading = !(
     id in snapV2.snippets && snapV2.snippets[id].snippet.content !== undefined
   )
@@ -213,10 +244,10 @@ export const SQLEditor = () => {
 
         if (showPrettyExplain && isExplainQuery(data.result)) {
           snapV2.addExplainResult(id, data.result)
-          setActiveUtilityTab('explain')
-        } else if (activeUtilityTab === 'explain') {
+          setActiveOutputView('explain')
+        } else if (activeOutputView === 'explain') {
           // If on Explain tab but ran a non-EXPLAIN query, switch to Results tab
-          setActiveUtilityTab('results')
+          setActiveOutputView('table')
         }
       }
 
@@ -264,17 +295,40 @@ export const SQLEditor = () => {
     },
   })
 
+  const { mutate: executeLogs, isPending: isExecutingLogs } = useExecuteLogSqlMutation({
+    onSuccess(data) {
+      if (id) {
+        if (data.error) {
+          snapV2.addResultError(id, formatLogQueryError(data.error))
+        } else {
+          snapV2.addResult(id, data.result ?? [])
+        }
+        setActiveOutputView('table')
+      }
+
+      refocusEditorAfterRunIfNeeded()
+    },
+    onError(error) {
+      if (id) {
+        snapV2.addResultError(id, formatLogQueryError(error))
+        setActiveOutputView('table')
+      }
+
+      refocusEditorAfterRunIfNeeded()
+    },
+  })
+
   const { mutate: executeExplain, isPending: isExplainExecuting } = useExecuteSqlMutation({
     onSuccess(data) {
       if (id) {
         snapV2.addExplainResult(id, data.result)
-        setActiveUtilityTab('explain')
+        setActiveOutputView('explain')
       }
     },
     onError(error) {
       if (id) {
         snapV2.addExplainResultError(id, error)
-        setActiveUtilityTab('explain')
+        setActiveOutputView('explain')
       }
     },
   })
@@ -323,8 +377,13 @@ export const SQLEditor = () => {
       // use the latest state
       const state = getSqlEditorV2StateSnapshot()
       const snippet = state.snippets[id]
+      const source = getSqlSnippetSource(snippet?.snippet)
 
-      if (editorRef.current === null || isExecuting || project === undefined) {
+      if (
+        editorRef.current === null ||
+        project === undefined ||
+        (source === 'logs' ? isExecutingLogs : isExecuting)
+      ) {
         clearPendingRunRefocus()
         return
       }
@@ -338,6 +397,34 @@ export const SQLEditor = () => {
           snippet.snippet.content?.unchecked_sql)
         : selectedValue || editorRef.current?.getValue()
       const sql = sqlOverride ?? editorSql
+
+      if (source === 'logs') {
+        const logSql = String(sql ?? '')
+        if (!logSql.trim()) {
+          clearPendingRunRefocus()
+          return toast.error('Cannot run an empty log query')
+        }
+
+        if (lineHighlights.length > 0) {
+          editor?.deltaDecorations(lineHighlights, [])
+          setLineHighlights([])
+        }
+
+        const range = resolveLogDateRange(
+          snippet?.snippet.content?.logDateRange ?? defaultLogDateRange
+        )
+
+        snapV2.resetExplainResult(id)
+        executeLogs({
+          projectRef: project.ref,
+          sql: acceptUntrustedLogSql(untrustedLogSql(logSql)),
+          iso_timestamp_start: range.from,
+          iso_timestamp_end: range.to,
+        })
+
+        track('sql_editor_query_run_button_clicked')
+        return
+      }
 
       const hasDestructiveOperations = checkDestructiveQuery(sql)
       const hasUpdateWithoutWhere = isUpdateWithoutWhere(sql)
@@ -403,13 +490,17 @@ export const SQLEditor = () => {
       isDiffOpen,
       id,
       isExecuting,
+      isExecutingLogs,
       project,
       execute,
+      executeLogs,
       getImpersonatedRoleState,
       databaseSelectorState.selectedDatabaseId,
       databases,
       eventTriggers,
       limit,
+      defaultLogDateRange,
+      snapV2,
       track,
     ]
   )
@@ -426,6 +517,11 @@ export const SQLEditor = () => {
     // use the latest state
     const state = getSqlEditorV2StateSnapshot()
     const snippet = state.snippets[id]
+
+    if (getSqlSnippetSource(snippet?.snippet) === 'logs') {
+      setActiveOutputView('table')
+      return
+    }
 
     if (editorRef.current !== null && !isExplainExecuting && project !== undefined) {
       const editor = editorRef.current
@@ -444,7 +540,7 @@ export const SQLEditor = () => {
           message:
             'EXPLAIN only works on a single SQL statement. Please select just one query to analyze.',
         })
-        setActiveUtilityTab('explain')
+        setActiveOutputView('explain')
         return
       }
 
@@ -536,6 +632,33 @@ export const SQLEditor = () => {
       snapV2.addNeedsSaving(id)
     }
   }, [id, snapV2])
+
+  const handleSourceChange = useCallback(
+    (source: SqlSnippets.Source) => {
+      if (!id) return
+
+      snapV2.setSnippetSource({ id, source })
+      if (source === 'logs' && !snapV2.snippets[id]?.snippet.content?.logDateRange) {
+        snapV2.setSnippetLogDateRange({ id, logDateRange: defaultLogDateRange })
+      }
+
+      snapV2.resetResults(id)
+      if (source === 'logs' && activeOutputView === 'explain') {
+        setActiveOutputView('table')
+      }
+
+      tabs.updateTab(createTabId('sql', { id }), { metadata: { sqlSource: source } })
+    },
+    [activeOutputView, defaultLogDateRange, id, snapV2, tabs]
+  )
+
+  const handleLogDateRangeChange = useCallback(
+    (value: SqlSnippets.LogDateRange) => {
+      if (!id) return
+      snapV2.setSnippetLogDateRange({ id, logDateRange: value })
+    },
+    [id, snapV2]
+  )
 
   const buildDebugPrompt = useCallback(() => {
     const snippet = snapV2.snippets[id]
@@ -735,6 +858,15 @@ export const SQLEditor = () => {
   }, [closeDiff, id])
 
   useEffect(() => {
+    if (!id) return
+    tabs.updateTab(createTabId('sql', { id }), { metadata: { sqlSource: snippetSource } })
+    if (snippetSource === 'logs' && activeOutputView === 'explain') {
+      setActiveOutputView('table')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [id, snippetSource])
+
+  useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (!isDiffOpen && !promptState.isOpen) return
 
@@ -864,107 +996,132 @@ export const SQLEditor = () => {
           autoSaveId={LOCAL_STORAGE_KEYS.SQL_EDITOR_SPLIT_SIZE}
         >
           <ResizablePanel defaultSize="50" maxSize="70">
-            <div className="grow overflow-y-auto border-b h-full">
+            <div className="grow border-b h-full flex flex-col overflow-hidden">
               {isLoading ? (
                 <div className="flex h-full w-full items-center justify-center">
                   <Loader2 className="animate-spin text-brand" />
                 </div>
               ) : (
                 <>
-                  {isDiffOpen && (
-                    <div className="w-full h-full">
-                      <DiffEditor
-                        language="pgsql"
-                        original={defaultSqlDiff.original}
-                        modified={defaultSqlDiff.modified}
-                        onMount={(editor) => {
-                          diffEditorRef.current = editor
-                          setIsDiffEditorMounted(true)
+                  <div className="flex items-center justify-between gap-x-4 px-4 min-h-[42px] border-b bg-surface-100">
+                    <div className="flex items-center gap-x-2 min-w-0">
+                      <SqlSnippetSourceIcon source={snippetSource} />
+                      <span className="truncate text-sm text-foreground" title={snippet?.name}>
+                        {snippet?.name ?? 'Untitled query'}
+                      </span>
+                    </div>
+
+                    <UtilityActions
+                      id={id}
+                      isExecuting={snippetSource === 'logs' ? isExecutingLogs : isExecuting}
+                      isDisabled={isDiffOpen}
+                      hasSelection={hasSelection}
+                      source={snippetSource}
+                      logDateRange={logDateRange}
+                      prettifyQuery={prettifyQuery}
+                      executeQuery={executeQueryFromButton}
+                      onSourceChange={handleSourceChange}
+                      onLogDateRangeChange={handleLogDateRangeChange}
+                      onSave={handleSave}
+                    />
+                  </div>
+
+                  <div className="relative grow min-h-0">
+                    {isDiffOpen && (
+                      <div className="w-full h-full">
+                        <DiffEditor
+                          language="pgsql"
+                          original={defaultSqlDiff.original}
+                          modified={defaultSqlDiff.modified}
+                          onMount={(editor) => {
+                            diffEditorRef.current = editor
+                            setIsDiffEditorMounted(true)
+                          }}
+                        />
+                        {showWidget && (
+                          <ResizableAIWidget
+                            editor={diffEditorRef.current!}
+                            id="ask-ai-diff"
+                            value={promptInput}
+                            onChange={setPromptInput}
+                            onSubmit={(prompt: string) => {
+                              handlePrompt(prompt, {
+                                beforeSelection: promptState.beforeSelection,
+                                selection: promptState.selection || defaultSqlDiff.modified,
+                                afterSelection: promptState.afterSelection,
+                              })
+                            }}
+                            onAccept={acceptAiHandler}
+                            onReject={discardAiHandler}
+                            onCancel={resetPrompt}
+                            isDiffVisible={true}
+                            isLoading={isCompletionLoading}
+                            startLineNumber={Math.max(0, promptState.startLineNumber)}
+                            endLineNumber={promptState.endLineNumber}
+                          />
+                        )}
+                      </div>
+                    )}
+                    <div key={id} className="w-full h-full relative">
+                      <MonacoEditor
+                        autoFocus
+                        placeholder={
+                          !promptState.isOpen && !editorRef.current?.getValue()
+                            ? 'Hit ' +
+                              (os === 'macos' ? 'CMD+SHIFT+K' : `CTRL+SHIFT+K`) +
+                              ' to generate query or just start typing'
+                            : ''
+                        }
+                        id={id}
+                        snippetName={snapV2.snippets[id]?.snippet.name ?? ''}
+                        className={cn(isDiffOpen && 'hidden')}
+                        editorRef={editorRef}
+                        monacoRef={monacoRef}
+                        executeQuery={executeQuery}
+                        executeExplainQuery={executeExplainQuery}
+                        prettifyQuery={prettifyQuery}
+                        onSave={handleSave}
+                        onHasSelection={setHasSelection}
+                        onMount={onMount}
+                        onPrompt={({
+                          selection,
+                          beforeSelection,
+                          afterSelection,
+                          startLineNumber,
+                          endLineNumber,
+                        }) => {
+                          setPromptState((prev) => ({
+                            ...prev,
+                            isOpen: true,
+                            selection,
+                            beforeSelection,
+                            afterSelection,
+                            startLineNumber,
+                            endLineNumber,
+                          }))
                         }}
                       />
-                      {showWidget && (
+                      {editorRef.current && promptState.isOpen && !isDiffOpen && (
                         <ResizableAIWidget
-                          editor={diffEditorRef.current!}
-                          id="ask-ai-diff"
+                          editor={editorRef.current}
+                          id="ask-ai"
                           value={promptInput}
                           onChange={setPromptInput}
                           onSubmit={(prompt: string) => {
                             handlePrompt(prompt, {
                               beforeSelection: promptState.beforeSelection,
-                              selection: promptState.selection || defaultSqlDiff.modified,
+                              selection: promptState.selection,
                               afterSelection: promptState.afterSelection,
                             })
                           }}
-                          onAccept={acceptAiHandler}
-                          onReject={discardAiHandler}
                           onCancel={resetPrompt}
-                          isDiffVisible={true}
+                          isDiffVisible={false}
                           isLoading={isCompletionLoading}
                           startLineNumber={Math.max(0, promptState.startLineNumber)}
                           endLineNumber={promptState.endLineNumber}
                         />
                       )}
                     </div>
-                  )}
-                  <div key={id} className="w-full h-full relative">
-                    <MonacoEditor
-                      autoFocus
-                      placeholder={
-                        !promptState.isOpen && !editorRef.current?.getValue()
-                          ? 'Hit ' +
-                            (os === 'macos' ? 'CMD+SHIFT+K' : `CTRL+SHIFT+K`) +
-                            ' to generate query or just start typing'
-                          : ''
-                      }
-                      id={id}
-                      snippetName={snapV2.snippets[id]?.snippet.name ?? ''}
-                      className={cn(isDiffOpen && 'hidden')}
-                      editorRef={editorRef}
-                      monacoRef={monacoRef}
-                      executeQuery={executeQuery}
-                      executeExplainQuery={executeExplainQuery}
-                      prettifyQuery={prettifyQuery}
-                      onSave={handleSave}
-                      onHasSelection={setHasSelection}
-                      onMount={onMount}
-                      onPrompt={({
-                        selection,
-                        beforeSelection,
-                        afterSelection,
-                        startLineNumber,
-                        endLineNumber,
-                      }) => {
-                        setPromptState((prev) => ({
-                          ...prev,
-                          isOpen: true,
-                          selection,
-                          beforeSelection,
-                          afterSelection,
-                          startLineNumber,
-                          endLineNumber,
-                        }))
-                      }}
-                    />
-                    {editorRef.current && promptState.isOpen && !isDiffOpen && (
-                      <ResizableAIWidget
-                        editor={editorRef.current}
-                        id="ask-ai"
-                        value={promptInput}
-                        onChange={setPromptInput}
-                        onSubmit={(prompt: string) => {
-                          handlePrompt(prompt, {
-                            beforeSelection: promptState.beforeSelection,
-                            selection: promptState.selection,
-                            afterSelection: promptState.afterSelection,
-                          })
-                        }}
-                        onCancel={resetPrompt}
-                        isDiffVisible={false}
-                        isLoading={isCompletionLoading}
-                        startLineNumber={Math.max(0, promptState.startLineNumber)}
-                        endLineNumber={promptState.endLineNumber}
-                      />
-                    )}
                   </div>
                 </>
               )}
@@ -981,74 +1138,75 @@ export const SQLEditor = () => {
             ) : (
               <UtilityPanel
                 id={id}
-                isExecuting={isExecuting}
+                isExecuting={snippetSource === 'logs' ? isExecutingLogs : isExecuting}
                 isExplainExecuting={isExplainExecuting}
                 isDisabled={isDiffOpen}
-                hasSelection={hasSelection}
-                prettifyQuery={prettifyQuery}
-                executeQuery={executeQueryFromButton}
                 executeExplainQuery={executeExplainQuery}
-                onSave={handleSave}
                 onDebug={onDebug}
                 buildDebugPrompt={buildDebugPrompt}
-                activeTab={activeUtilityTab}
-                onActiveTabChange={setActiveUtilityTab}
+                source={snippetSource}
+                activeView={activeOutputView}
+                onActiveViewChange={setActiveOutputView}
               />
             )}
           </ResizablePanel>
 
           <div className="h-9">
-            {results?.rows !== undefined && !isExecuting && (
-              <GridFooter className="flex items-center justify-between gap-2">
-                <Tooltip>
-                  <TooltipTrigger>
-                    <p className="text-xs">
-                      <span className="text-foreground">
-                        {results.rows.length} row{results.rows.length > 1 ? 's' : ''}
-                      </span>
-                      <span className="text-foreground-lighter ml-1">
-                        {results.autoLimit !== undefined &&
-                          ` (Limited to only ${results.autoLimit} rows)`}
-                      </span>
-                    </p>
-                  </TooltipTrigger>
-                  <TooltipContent className="max-w-xs">
-                    <p className="flex flex-col gap-y-1">
-                      <span>
-                        Results are automatically limited to preserve browser performance, in
-                        particular if your query returns an exceptionally large number of rows.
-                      </span>
+            {results?.rows !== undefined &&
+              !(snippetSource === 'logs' ? isExecutingLogs : isExecuting) && (
+                <GridFooter className="flex items-center justify-between gap-2">
+                  <Tooltip>
+                    <TooltipTrigger>
+                      <p className="text-xs">
+                        <span className="text-foreground">
+                          {results.rows.length} row{results.rows.length > 1 ? 's' : ''}
+                        </span>
+                        <span className="text-foreground-lighter ml-1">
+                          {results.autoLimit !== undefined &&
+                            ` (Limited to only ${results.autoLimit} rows)`}
+                        </span>
+                      </p>
+                    </TooltipTrigger>
+                    <TooltipContent className="max-w-xs">
+                      <p className="flex flex-col gap-y-1">
+                        <span>
+                          Results are automatically limited to preserve browser performance, in
+                          particular if your query returns an exceptionally large number of rows.
+                        </span>
 
-                      <span className="text-foreground-light">
-                        You may change or remove this limit from the dropdown on the right
-                      </span>
-                    </p>
-                  </TooltipContent>
-                </Tooltip>
-                {results.autoLimit !== undefined && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button type="default" iconRight={<ChevronUp size={14} />}>
-                        Limit results to:{' '}
-                        {ROWS_PER_PAGE_OPTIONS.find((opt) => opt.value === snapV2.limit)?.label}
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent className="w-40" align="end">
-                      <DropdownMenuRadioGroup
-                        value={snapV2.limit.toString()}
-                        onValueChange={(val) => snapV2.setLimit(Number(val))}
-                      >
-                        {ROWS_PER_PAGE_OPTIONS.map((option) => (
-                          <DropdownMenuRadioItem key={option.label} value={option.value.toString()}>
-                            {option.label}
-                          </DropdownMenuRadioItem>
-                        ))}
-                      </DropdownMenuRadioGroup>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-              </GridFooter>
-            )}
+                        <span className="text-foreground-light">
+                          You may change or remove this limit from the dropdown on the right
+                        </span>
+                      </p>
+                    </TooltipContent>
+                  </Tooltip>
+                  {results.autoLimit !== undefined && (
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button type="default" iconRight={<ChevronUp size={14} />}>
+                          Limit results to:{' '}
+                          {ROWS_PER_PAGE_OPTIONS.find((opt) => opt.value === snapV2.limit)?.label}
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent className="w-40" align="end">
+                        <DropdownMenuRadioGroup
+                          value={snapV2.limit.toString()}
+                          onValueChange={(val) => snapV2.setLimit(Number(val))}
+                        >
+                          {ROWS_PER_PAGE_OPTIONS.map((option) => (
+                            <DropdownMenuRadioItem
+                              key={option.label}
+                              value={option.value.toString()}
+                            >
+                              {option.label}
+                            </DropdownMenuRadioItem>
+                          ))}
+                        </DropdownMenuRadioGroup>
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  )}
+                </GridFooter>
+              )}
           </div>
         </ResizablePanelGroup>
       </div>

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -996,34 +996,36 @@ export const SQLEditor = () => {
           autoSaveId={LOCAL_STORAGE_KEYS.SQL_EDITOR_SPLIT_SIZE}
         >
           <ResizablePanel defaultSize="50" maxSize="70">
-            <div className="grow border-b h-full flex flex-col overflow-hidden">
+            <div className="grow h-full flex flex-col overflow-hidden">
               {isLoading ? (
                 <div className="flex h-full w-full items-center justify-center">
                   <Loader2 className="animate-spin text-brand" />
                 </div>
               ) : (
                 <>
-                  <div className="flex items-center justify-between gap-x-4 px-4 min-h-[42px] border-b bg-surface-100">
-                    <div className="flex items-center gap-x-2 min-w-0">
+                  <div className="flex items-center gap-x-4 px-4 min-h-[42px] border-b bg-surface-100 xl:justify-between">
+                    <div className="hidden min-w-0 shrink items-center gap-x-2 xl:flex">
                       <SqlSnippetSourceIcon source={snippetSource} />
                       <span className="truncate text-sm text-foreground" title={snippet?.name}>
                         {snippet?.name ?? 'Untitled query'}
                       </span>
                     </div>
 
-                    <UtilityActions
-                      id={id}
-                      isExecuting={snippetSource === 'logs' ? isExecutingLogs : isExecuting}
-                      isDisabled={isDiffOpen}
-                      hasSelection={hasSelection}
-                      source={snippetSource}
-                      logDateRange={logDateRange}
-                      prettifyQuery={prettifyQuery}
-                      executeQuery={executeQueryFromButton}
-                      onSourceChange={handleSourceChange}
-                      onLogDateRangeChange={handleLogDateRangeChange}
-                      onSave={handleSave}
-                    />
+                    <div className="min-w-0 flex-1">
+                      <UtilityActions
+                        id={id}
+                        isExecuting={snippetSource === 'logs' ? isExecutingLogs : isExecuting}
+                        isDisabled={isDiffOpen}
+                        hasSelection={hasSelection}
+                        source={snippetSource}
+                        logDateRange={logDateRange}
+                        prettifyQuery={prettifyQuery}
+                        executeQuery={executeQueryFromButton}
+                        onSourceChange={handleSourceChange}
+                        onLogDateRangeChange={handleLogDateRangeChange}
+                        onSave={handleSave}
+                      />
+                    </div>
                   </div>
 
                   <div className="relative grow min-h-0">
@@ -1062,7 +1064,10 @@ export const SQLEditor = () => {
                         )}
                       </div>
                     )}
-                    <div key={id} className="w-full h-full relative">
+                    <div
+                      key={id}
+                      className="w-full h-full relative [&_.monaco-editor]:outline-none"
+                    >
                       <MonacoEditor
                         autoFocus
                         placeholder={

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -45,6 +45,7 @@ import {
   checkDestructiveQuery,
   checkIfAppendLimitRequired,
   filterTablesCoveredByEnsureRLSTrigger,
+  formatLogQueryError,
   getCreateTablesMissingRLS,
   hasActiveEnsureRLSTrigger,
   isUpdateWithoutWhere,
@@ -113,12 +114,6 @@ const getDefaultLogDateRange = (): SqlSnippets.LogDateRange => {
     isHelper: true,
     text: helper.text,
   }
-}
-
-const formatLogQueryError = (error: unknown) => {
-  if (typeof error === 'string') return { message: error }
-  if (error && typeof error === 'object' && 'message' in error) return error
-  return { message: 'Failed to run log query' }
 }
 
 export const SQLEditor = () => {

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
@@ -8,6 +8,7 @@ import {
   checkDestructiveQuery,
   checkIfAppendLimitRequired,
   filterTablesCoveredByEnsureRLSTrigger,
+  formatLogQueryError,
   getCreateTablesMissingRLS,
   hasActiveEnsureRLSTrigger,
   isUpdateWithoutWhere,
@@ -942,5 +943,21 @@ describe('SQLEditor.utils:checkAlterDatabaseConnection', () => {
       alter database postgres allow_connections false;
     `)
     expect(match).toBe(true)
+  })
+})
+
+describe('formatLogQueryError', () => {
+  it('wraps a string error in a message object', () => {
+    expect(formatLogQueryError('boom')).toEqual({ message: 'boom' })
+  })
+
+  it('extracts and coerces message from an error-like object, dropping extra fields', () => {
+    expect(formatLogQueryError({ message: 'boom', code: 500 })).toEqual({ message: 'boom' })
+    expect(formatLogQueryError({ message: 123 })).toEqual({ message: '123' })
+  })
+
+  it('falls back to a default message for unrecognized errors', () => {
+    expect(formatLogQueryError(undefined)).toEqual({ message: 'Failed to run log query' })
+    expect(formatLogQueryError({})).toEqual({ message: 'Failed to run log query' })
   })
 })

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -55,7 +55,7 @@ export const createSqlSnippetSkeletonV2 = ({
   project_id,
   folder_id,
   idOverride,
-  source = 'project',
+  source = 'database',
   logDateRange,
 }: {
   name: string

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -268,3 +268,15 @@ export const suffixWithLimit = (sql: SafeSqlFragment, limit: number = 0): SafeSq
     cleanedSql.endsWith(';') ? sql.replace(/[;]+$/, ` limit ${limit};`) : `${sql} limit ${limit};`
   ) as SafeSqlFragment
 }
+
+/**
+ * Normalizes an error from a log query (string, error-like object, or unknown) into a stable
+ * `{ message }` shape suitable for `addResultError`.
+ */
+export const formatLogQueryError = (error: unknown): { message: string } => {
+  if (typeof error === 'string') return { message: error }
+  if (error && typeof error === 'object' && 'message' in error) {
+    return { message: String((error as { message: unknown }).message) }
+  }
+  return { message: 'Failed to run log query' }
+}

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -14,6 +14,7 @@ import { generateUuid } from '@/lib/api/snippets.browser'
 import { removeCommentsFromSql } from '@/lib/helpers'
 import { sqlEventParser } from '@/lib/sql-event-parser'
 import type { SnippetWithContent } from '@/state/sql-editor-v2'
+import type { SqlSnippets } from '@/types'
 
 export type CreateTableWithoutRLS = {
   schema?: string
@@ -54,12 +55,16 @@ export const createSqlSnippetSkeletonV2 = ({
   project_id,
   folder_id,
   idOverride,
+  source = 'project',
+  logDateRange,
 }: {
   name: string
   sql: string
   owner_id: number
   project_id: number
   folder_id?: string
+  source?: SqlSnippets.Source
+  logDateRange?: SqlSnippets.LogDateRange
   /**
    * Optionally, provide a specific snippetId to use for the snippet. This is used to ensure the snippet is created
    * with a known id, such as to prevent flicker in the SQL editor when adding new unsaved snippets.
@@ -82,6 +87,8 @@ export const createSqlSnippetSkeletonV2 = ({
       ...NEW_SQL_SNIPPET_SKELETON.content,
       content_id: id ?? '',
       unchecked_sql: untrustedSql(sql ?? ''),
+      source,
+      ...(logDateRange !== undefined ? { logDateRange } : {}),
     } as any,
     isNotSavedInDatabaseYet: true,
   }

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditorSource.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditorSource.utils.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { getSqlSnippetSource } from './SQLEditorSource.utils'
+
+describe('getSqlSnippetSource', () => {
+  it('defaults to database when no snippet is provided', () => {
+    expect(getSqlSnippetSource(undefined)).toBe('database')
+    expect(getSqlSnippetSource(null)).toBe('database')
+  })
+
+  it('defaults to database when content is missing', () => {
+    expect(getSqlSnippetSource({ content: undefined })).toBe('database')
+  })
+
+  it('returns the explicit source from content', () => {
+    expect(getSqlSnippetSource({ content: { source: 'logs' } } as any)).toBe('logs')
+    expect(getSqlSnippetSource({ content: { source: 'database' } } as any)).toBe('database')
+  })
+})

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditorSource.utils.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditorSource.utils.tsx
@@ -1,0 +1,54 @@
+import { Database, ScrollText } from 'lucide-react'
+import { cn } from 'ui'
+
+import type { SnippetWithContent } from '@/state/sql-editor-v2'
+import type { SqlSnippets } from '@/types'
+
+export const DEFAULT_SQL_SNIPPET_SOURCE: SqlSnippets.Source = 'project'
+
+export const SQL_SNIPPET_SOURCE_LABELS: Record<SqlSnippets.Source, string> = {
+  project: 'Project',
+  logs: 'Logs',
+}
+
+export function getSqlSnippetSource(
+  snippet?: Pick<SnippetWithContent, 'content'> | null
+): SqlSnippets.Source {
+  return snippet?.content?.source ?? DEFAULT_SQL_SNIPPET_SOURCE
+}
+
+export function SqlSnippetSourceIcon({
+  source,
+  size = 15,
+  strokeWidth = 1.5,
+  className,
+}: {
+  source?: SqlSnippets.Source
+  size?: number
+  strokeWidth?: number
+  className?: string
+}) {
+  if (source === 'logs') {
+    return (
+      <ScrollText
+        size={size}
+        strokeWidth={strokeWidth}
+        className={cn(
+          'text-foreground-muted group-hover:text-foreground-lighter group-aria-selected:text-foreground transition-colors',
+          className
+        )}
+      />
+    )
+  }
+
+  return (
+    <Database
+      size={size}
+      strokeWidth={strokeWidth}
+      className={cn(
+        'text-foreground-muted group-hover:text-foreground-lighter group-aria-selected:text-foreground transition-colors',
+        className
+      )}
+    />
+  )
+}

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditorSource.utils.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditorSource.utils.tsx
@@ -4,10 +4,10 @@ import { cn } from 'ui'
 import type { SnippetWithContent } from '@/state/sql-editor-v2'
 import type { SqlSnippets } from '@/types'
 
-export const DEFAULT_SQL_SNIPPET_SOURCE: SqlSnippets.Source = 'project'
+export const DEFAULT_SQL_SNIPPET_SOURCE: SqlSnippets.Source = 'database'
 
 export const SQL_SNIPPET_SOURCE_LABELS: Record<SqlSnippets.Source, string> = {
-  project: 'Project',
+  database: 'Database',
   logs: 'Logs',
 }
 

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
@@ -1,12 +1,12 @@
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
-import dayjs from 'dayjs'
-import { ArrowUpDown, X } from 'lucide-react'
+import { ArrowUpDown, BarChart2, X } from 'lucide-react'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import {
   Badge,
   Button,
   Checkbox,
+  cn,
   Label,
   ResizableHandle,
   ResizablePanel,
@@ -21,10 +21,24 @@ import {
   TooltipTrigger,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
+import {
+  Chart,
+  ChartBar,
+  ChartCard,
+  ChartContent,
+  ChartEmptyState,
+  ChartLine,
+} from 'ui-patterns/Chart'
 
+import {
+  getSqlEditorChartDateTimeFormat,
+  guessChartAxisKeys,
+  isSqlEditorChartXAxisDate,
+  mapSqlRowsToChartTicks,
+  shouldAutoConfigureChartAxes,
+} from './ChartConfig.utils'
+import { SqlEditorResultsEmptyState } from './SqlEditorResultsEmptyState'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
-import BarChart from '@/components/ui/Charts/BarChart'
-import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 
 type Results = { rows: readonly any[] }
@@ -92,6 +106,17 @@ export const ChartConfig = ({
     })
   }, [results])
 
+  useEffect(() => {
+    if (!shouldAutoConfigureChartAxes(results.rows, config)) return
+
+    const guessed = guessChartAxisKeys(results.rows)
+    if (!guessed) return
+
+    onConfigChange({ ...config, ...guessed })
+    // Only re-guess when the result shape or saved axis keys change.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [results.rows, config.xKey, config.yKey])
+
   const hasConfig = config.xKey && config.yKey
 
   const canFlip = useMemo(() => {
@@ -106,14 +131,30 @@ export const ChartConfig = ({
 
   const resultToRender = config.cumulative ? cumulativeResults : results.rows
 
-  const getDateFormat = (key: any) => {
-    const value = resultToRender?.[0]?.[key] || ''
-    if (typeof value === 'number') return 'number'
-    if (dayjs(value).isValid()) return 'date'
-    return 'string'
-  }
+  const xAxisIsDate = useMemo(
+    () => isSqlEditorChartXAxisDate(config.xKey, resultToRender),
+    [config.xKey, resultToRender]
+  )
 
-  const xKeyDateFormat = getDateFormat(config.xKey)
+  const chartData = useMemo(
+    () => mapSqlRowsToChartTicks(resultToRender, config.xKey, config.yKey),
+    [config.xKey, config.yKey, resultToRender]
+  )
+
+  const chartDateTimeFormat = useMemo(
+    () => getSqlEditorChartDateTimeFormat(config.xKey, resultToRender),
+    [config.xKey, resultToRender]
+  )
+
+  const chartConfig = useMemo(
+    () => ({
+      [config.yKey]: {
+        label: config.yKey,
+        color: 'hsl(var(--brand-default))',
+      },
+    }),
+    [config.yKey]
+  )
 
   const onFlip = () => {
     const newY = config.xKey
@@ -122,63 +163,77 @@ export const ChartConfig = ({
   }
 
   if (!resultKeys.length) {
-    return (
-      <div className="p-2">
-        <NoDataPlaceholder
-          size="normal"
-          description="Execute a query and configure the chart options."
-        />
-      </div>
-    )
+    return <SqlEditorResultsEmptyState />
   }
 
+  const configureChartEmptyState = (
+    <ChartEmptyState
+      className="h-full w-full"
+      icon={<BarChart2 size={16} />}
+      title="Configure your chart"
+      description="Select your X and Y axis in the chart options panel"
+    />
+  )
+
+  const chartVisualization =
+    config.type === 'line' ? (
+      <ChartLine
+        data={chartData}
+        dataKey={config.yKey}
+        config={chartConfig}
+        DateTimeFormat={chartDateTimeFormat}
+        isFullHeight
+        showGrid={config.showGrid}
+        showYAxis={config.showLabels}
+        className={cn(
+          'h-full',
+          !xAxisIsDate && '[&_[data-testid=chart-line]>div:last-child]:hidden'
+        )}
+        YAxisProps={{
+          tickFormatter: (value: number) => value.toLocaleString(),
+          width: config.showLabels ? 80 : undefined,
+        }}
+      />
+    ) : (
+      <ChartBar
+        data={chartData}
+        dataKey={config.yKey}
+        config={chartConfig}
+        DateTimeFormat={chartDateTimeFormat}
+        isFullHeight
+        showGrid={config.showGrid}
+        showYAxis={config.showLabels}
+        className={cn(
+          'h-full',
+          !xAxisIsDate && '[&_[data-testid=chart-bar]>div:last-child]:hidden'
+        )}
+        YAxisProps={{
+          tickFormatter: (value: number) => value.toLocaleString(),
+          width: config.showLabels ? 80 : undefined,
+        }}
+      />
+    )
+
   return (
-    <ResizablePanelGroup orientation="horizontal" className="grow h-full">
-      <ResizablePanel className="p-4 h-full" defaultSize="75">
-        {!hasConfig ? (
-          <ResizablePanel className="p-4 h-full" defaultSize="75">
-            <NoDataPlaceholder
-              size="normal"
-              title="Configure your chart"
-              description="Select your X and Y axis in the chart options panel"
-            />
-          </ResizablePanel>
-        ) : config.type === 'bar' ? (
-          <BarChart
-            showLegend
-            size="normal"
-            xAxisIsDate={xKeyDateFormat === 'date'}
-            data={resultToRender}
-            xAxisKey={config.xKey}
-            yAxisKey={config.yKey}
-            showGrid={config.showGrid}
-            XAxisProps={{
-              angle: 0,
-              interval: 'preserveStart',
-              hide: !config.showLabels,
-              tickFormatter: (idx: string) => {
-                const value = resultToRender[+idx][config.xKey]
-                if (xKeyDateFormat === 'date') {
-                  return dayjs(value).format('MMM D YYYY HH:mm')
-                }
-                return value
-              },
-            }}
-            YAxisProps={{
-              tickFormatter: (value: number) => value.toLocaleString(),
-              hide: !config.showLabels,
-              domain: [0, 'dataMax'],
-            }}
-          />
-        ) : null}
+    <ResizablePanelGroup orientation="horizontal" className="h-full min-h-0">
+      <ResizablePanel defaultSize="75" minSize="40" className="min-h-0">
+        <Chart className="flex h-full min-h-0 flex-col">
+          <ChartCard asChild>
+            <div className="flex h-full min-h-0 flex-col">
+              <ChartContent
+                className="flex min-h-0 flex-1 flex-col p-4"
+                isEmpty={!hasConfig}
+                emptyState={configureChartEmptyState}
+              >
+                <div className="min-h-0 flex-1">{chartVisualization}</div>
+              </ChartContent>
+            </div>
+          </ChartCard>
+        </Chart>
       </ResizablePanel>
       <ResizableHandle withHandle />
-      <ResizablePanel
-        defaultSize="25"
-        minSize="15"
-        className="px-3 py-3 space-y-4 overflow-y-auto!"
-      >
-        <div className="flex justify-between items-center h-5">
+      <ResizablePanel defaultSize="25" minSize="15" className="space-y-4 overflow-y-auto px-3 py-3">
+        <div className="flex h-5 items-center justify-between">
           <h2 className="text-sm text-foreground-lighter">Chart options</h2>
           {config.xKey && config.yKey && (
             <ButtonTooltip
@@ -203,11 +258,11 @@ export const ChartConfig = ({
         </div>
 
         {!acknowledged && (
-          <Admonition showIcon={false} type="tip" className="p-2 relative group">
+          <Admonition showIcon={false} type="tip" className="group relative p-2">
             <Tooltip>
               <TooltipTrigger
                 onClick={() => setAcknowledged(true)}
-                className="absolute top-3 right-3 opacity-30 group-hover:opacity-100 transition-opacity"
+                className="absolute right-3 top-3 opacity-30 transition-opacity group-hover:opacity-100"
               >
                 <X size={14} className="text-foreground-light" />
               </TooltipTrigger>
@@ -217,7 +272,7 @@ export const ChartConfig = ({
               <Badge variant="success">New</Badge>
               <p className="text-xs">Add this chart to custom reports</p>
             </div>
-            <p className="text-xs text-foreground-light mt-1!">
+            <p className="mt-1! text-xs text-foreground-light">
               SQL snippets can now be added and saved to your custom reports. Try it out now!
             </p>
             <Button asChild size="tiny" type="default" className="mt-1">
@@ -267,7 +322,7 @@ export const ChartConfig = ({
             </SelectContent>
           </Select>
         </div>
-        <div className="*:flex *:gap-2 *:items-center grid gap-2 *:text-foreground-light *:p-1.5 *:pl-0">
+        <div className="grid gap-2 *:flex *:items-center *:gap-2 *:p-1.5 *:pl-0 *:text-foreground-light">
           <Label className="" htmlFor="cumulative">
             <Checkbox
               id="cumulative"

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getSqlEditorChartDateTimeFormat,
+  guessChartAxisKeys,
+  isCategoricalChartValue,
+  isDateChartValue,
+  isNumericChartValue,
+  isSqlEditorChartXAxisDate,
+  mapSqlRowsToChartTicks,
+  shouldAutoConfigureChartAxes,
+} from './ChartConfig.utils'
+
+describe('ChartConfig.utils', () => {
+  describe('isNumericChartValue', () => {
+    it('returns true for numbers and numeric strings', () => {
+      expect(isNumericChartValue(42)).toBe(true)
+      expect(isNumericChartValue('42')).toBe(true)
+      expect(isNumericChartValue('3.14')).toBe(true)
+    })
+
+    it('returns false for empty and non-numeric values', () => {
+      expect(isNumericChartValue('')).toBe(false)
+      expect(isNumericChartValue('active')).toBe(false)
+      expect(isNumericChartValue(null)).toBe(false)
+    })
+  })
+
+  describe('isDateChartValue', () => {
+    it('returns true for valid date strings', () => {
+      expect(isDateChartValue('2024-01-15T10:00:00Z')).toBe(true)
+    })
+
+    it('returns false for numbers and plain strings', () => {
+      expect(isDateChartValue(42)).toBe(false)
+      expect(isDateChartValue('north-america')).toBe(false)
+    })
+  })
+
+  describe('isCategoricalChartValue', () => {
+    it('returns true for labels and booleans', () => {
+      expect(isCategoricalChartValue('active')).toBe(true)
+      expect(isCategoricalChartValue(true)).toBe(true)
+    })
+  })
+
+  describe('guessChartAxisKeys', () => {
+    it('prefers date columns for x and count columns for y', () => {
+      expect(
+        guessChartAxisKeys([
+          { created_at: '2024-01-01T00:00:00Z', event_count: 12 },
+          { created_at: '2024-01-02T00:00:00Z', event_count: 8 },
+        ])
+      ).toEqual({
+        xKey: 'created_at',
+        yKey: 'event_count',
+      })
+    })
+
+    it('uses a categorical column for x when no date exists', () => {
+      expect(
+        guessChartAxisKeys([
+          { region: 'us-east', total_users: 100 },
+          { region: 'eu-west', total_users: 80 },
+        ])
+      ).toEqual({
+        xKey: 'region',
+        yKey: 'total_users',
+      })
+    })
+
+    it('prefers non-id numeric columns for y', () => {
+      expect(
+        guessChartAxisKeys([
+          { id: 1, name: 'alpha', amount: 10 },
+          { id: 2, name: 'beta', amount: 20 },
+        ])
+      ).toEqual({
+        xKey: 'name',
+        yKey: 'amount',
+      })
+    })
+
+    it('falls back to two numeric columns when needed', () => {
+      expect(
+        guessChartAxisKeys([
+          { month: 1, revenue: 100 },
+          { month: 2, revenue: 150 },
+        ])
+      ).toEqual({
+        xKey: 'month',
+        yKey: 'revenue',
+      })
+    })
+
+    it('returns null when there is no numeric column', () => {
+      expect(
+        guessChartAxisKeys([
+          { region: 'us-east', status: 'active' },
+          { region: 'eu-west', status: 'inactive' },
+        ])
+      ).toBeNull()
+    })
+  })
+
+  describe('shouldAutoConfigureChartAxes', () => {
+    const rows = [{ created_at: '2024-01-01T00:00:00Z', count: 1 }]
+
+    it('returns true when axis keys are missing', () => {
+      expect(shouldAutoConfigureChartAxes(rows, { xKey: '', yKey: '' })).toBe(true)
+    })
+
+    it('returns true when saved keys no longer exist in the results', () => {
+      expect(shouldAutoConfigureChartAxes(rows, { xKey: 'missing', yKey: 'count' })).toBe(true)
+    })
+
+    it('returns false when the current config matches the results', () => {
+      expect(shouldAutoConfigureChartAxes(rows, { xKey: 'created_at', yKey: 'count' })).toBe(false)
+    })
+  })
+
+  describe('mapSqlRowsToChartTicks', () => {
+    it('maps date x values to ISO timestamps and numeric y values', () => {
+      expect(
+        mapSqlRowsToChartTicks(
+          [{ created_at: '2024-01-15T10:00:00Z', count: 12 }],
+          'created_at',
+          'count'
+        )
+      ).toEqual([
+        {
+          timestamp: '2024-01-15T10:00:00.000Z',
+          count: 12,
+        },
+      ])
+    })
+
+    it('maps categorical x values to string timestamps', () => {
+      expect(
+        mapSqlRowsToChartTicks([{ region: 'us-east', total_users: 100 }], 'region', 'total_users')
+      ).toEqual([
+        {
+          timestamp: 'us-east',
+          total_users: 100,
+        },
+      ])
+    })
+  })
+
+  describe('isSqlEditorChartXAxisDate', () => {
+    it('returns true when the first x value is a date', () => {
+      expect(
+        isSqlEditorChartXAxisDate('created_at', [{ created_at: '2024-01-15T10:00:00Z', count: 12 }])
+      ).toBe(true)
+    })
+
+    it('returns false when the first x value is categorical', () => {
+      expect(isSqlEditorChartXAxisDate('region', [{ region: 'us-east', total_users: 100 }])).toBe(
+        false
+      )
+    })
+  })
+
+  describe('getSqlEditorChartDateTimeFormat', () => {
+    it('returns a detailed format for date axes', () => {
+      expect(
+        getSqlEditorChartDateTimeFormat('created_at', [
+          { created_at: '2024-01-15T10:00:00Z', count: 12 },
+        ])
+      ).toBe('MMM D YYYY HH:mm')
+    })
+  })
+})

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.test.ts
@@ -169,5 +169,11 @@ describe('ChartConfig.utils', () => {
         ])
       ).toBe('MMM D YYYY HH:mm')
     })
+
+    it('returns the fallback format for non-date axes', () => {
+      expect(getSqlEditorChartDateTimeFormat('region', [{ region: 'us-east', count: 1 }])).toBe(
+        'MMM D, YYYY, hh:mma'
+      )
+    })
   })
 })

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.ts
@@ -1,0 +1,173 @@
+import dayjs from 'dayjs'
+
+const Y_AXIS_NAME_HINTS = [
+  'count',
+  'total',
+  'sum',
+  'avg',
+  'average',
+  'amount',
+  'value',
+  'num',
+  'size',
+  'quantity',
+  'rate',
+  'percent',
+  'percentage',
+]
+
+const DATE_NAME_HINTS = ['date', 'time', 'timestamp', 'created', 'updated', 'at']
+
+export function isNumericChartValue(value: unknown): boolean {
+  return typeof value === 'number' || (value !== null && value !== '' && !isNaN(Number(value)))
+}
+
+export function isDateChartValue(value: unknown): boolean {
+  if (value === null || value === undefined || value === '') return false
+  if (typeof value === 'number') return false
+  if (typeof value === 'boolean') return false
+
+  return dayjs(value as string | Date).isValid()
+}
+
+export function isCategoricalChartValue(value: unknown): boolean {
+  if (value === null || value === undefined) return false
+  if (typeof value === 'boolean') return true
+  if (typeof value !== 'string') return false
+
+  return !isNumericChartValue(value) && !isDateChartValue(value)
+}
+
+function scoreYAxisKey(key: string): number {
+  const normalized = key.toLowerCase()
+
+  if (normalized === 'id' || normalized.endsWith('_id')) return 0
+
+  const hintIndex = Y_AXIS_NAME_HINTS.findIndex((hint) => normalized.includes(hint))
+  if (hintIndex >= 0) return Y_AXIS_NAME_HINTS.length - hintIndex + 10
+
+  return 1
+}
+
+function scoreXAxisKey(key: string): number {
+  const normalized = key.toLowerCase()
+
+  const dateHintIndex = DATE_NAME_HINTS.findIndex((hint) => normalized.includes(hint))
+  if (dateHintIndex >= 0) return DATE_NAME_HINTS.length - dateHintIndex + 20
+
+  if (normalized === 'name' || normalized === 'label' || normalized === 'category') return 15
+
+  return 1
+}
+
+function getColumnKeys(rows: readonly Record<string, unknown>[]): string[] {
+  return Object.keys(rows[0] ?? {})
+}
+
+function getNumericKeys(rows: readonly Record<string, unknown>[]): string[] {
+  return getColumnKeys(rows).filter((key) => rows.some((row) => isNumericChartValue(row[key])))
+}
+
+function getDateKeys(rows: readonly Record<string, unknown>[]): string[] {
+  return getColumnKeys(rows).filter((key) => rows.some((row) => isDateChartValue(row[key])))
+}
+
+function getCategoricalKeys(rows: readonly Record<string, unknown>[]): string[] {
+  return getColumnKeys(rows).filter((key) => rows.some((row) => isCategoricalChartValue(row[key])))
+}
+
+export type ChartAxisConfig = {
+  xKey: string
+  yKey: string
+}
+
+export function guessChartAxisKeys(
+  rows: readonly Record<string, unknown>[]
+): ChartAxisConfig | null {
+  if (!rows.length) return null
+
+  const columnKeys = getColumnKeys(rows)
+  if (!columnKeys.length) return null
+
+  const numericKeys = getNumericKeys(rows)
+  if (!numericKeys.length) return null
+
+  const yKey = [...numericKeys].sort((a, b) => scoreYAxisKey(b) - scoreYAxisKey(a))[0]
+
+  const dateKeys = getDateKeys(rows).filter((key) => key !== yKey)
+  const categoricalKeys = getCategoricalKeys(rows).filter((key) => key !== yKey)
+  const remainingKeys = columnKeys.filter((key) => key !== yKey)
+
+  const xKey =
+    [...dateKeys].sort((a, b) => scoreXAxisKey(b) - scoreXAxisKey(a))[0] ??
+    [...categoricalKeys].sort((a, b) => scoreXAxisKey(b) - scoreXAxisKey(a))[0] ??
+    remainingKeys.find((key) => !isNumericChartValue(rows[0]?.[key])) ??
+    remainingKeys.find((key) => key !== yKey) ??
+    null
+
+  if (!xKey || !yKey || xKey === yKey) return null
+
+  return { xKey, yKey }
+}
+
+export function shouldAutoConfigureChartAxes(
+  rows: readonly Record<string, unknown>[],
+  config: ChartAxisConfig
+): boolean {
+  if (!rows.length) return false
+
+  const columnKeys = getColumnKeys(rows)
+  const hasValidConfig =
+    Boolean(config.xKey) &&
+    Boolean(config.yKey) &&
+    columnKeys.includes(config.xKey) &&
+    columnKeys.includes(config.yKey)
+
+  return !hasValidConfig
+}
+
+export type SqlEditorChartTick = {
+  timestamp: string
+  [key: string]: string | number
+}
+
+export function mapSqlRowsToChartTicks(
+  rows: readonly Record<string, unknown>[],
+  xKey: string,
+  yKey: string
+): SqlEditorChartTick[] {
+  return rows.map((row, index) => {
+    const xValue = row[xKey]
+    const yValue = row[yKey]
+    const numericY = typeof yValue === 'number' ? yValue : Number(yValue)
+
+    let timestamp: string
+    if (isDateChartValue(xValue)) {
+      timestamp = dayjs(xValue as string | Date).toISOString()
+    } else if (xValue === null || xValue === undefined) {
+      timestamp = String(index)
+    } else {
+      timestamp = String(xValue)
+    }
+
+    return {
+      timestamp,
+      [yKey]: numericY,
+    }
+  })
+}
+
+export function getSqlEditorChartDateTimeFormat(
+  xKey: string,
+  rows: readonly Record<string, unknown>[]
+): string {
+  const sample = rows[0]?.[xKey]
+  return isDateChartValue(sample) ? 'MMM D YYYY HH:mm' : 'MMM D, YYYY, hh:mma'
+}
+
+export function isSqlEditorChartXAxisDate(
+  xKey: string,
+  rows: readonly Record<string, unknown>[]
+): boolean {
+  return isDateChartValue(rows[0]?.[xKey])
+}

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.utils.ts
@@ -92,7 +92,13 @@ export function guessChartAxisKeys(
   const numericKeys = getNumericKeys(rows)
   if (!numericKeys.length) return null
 
-  const yKey = [...numericKeys].sort((a, b) => scoreYAxisKey(b) - scoreYAxisKey(a))[0]
+  const yKey = [...numericKeys].sort((a, b) => {
+    const scoreDiff = scoreYAxisKey(b) - scoreYAxisKey(a)
+    if (scoreDiff !== 0) return scoreDiff
+    // Tie-break: prefer the later numeric column as the measure (y). In typical grouped queries
+    // (e.g. `select month, sum(revenue) ... group by month`) the dimension comes first.
+    return columnKeys.indexOf(b) - columnKeys.indexOf(a)
+  })[0]
 
   const dateKeys = getDateKeys(rows).filter((key) => key !== yKey)
   const categoricalKeys = getCategoricalKeys(rows).filter((key) => key !== yKey)

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/SqlEditorResultsEmptyState.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/SqlEditorResultsEmptyState.tsx
@@ -1,0 +1,13 @@
+import { BarChart2 } from 'lucide-react'
+import { ChartEmptyState } from 'ui-patterns/Chart'
+
+export const SqlEditorResultsEmptyState = () => (
+  <div className="flex h-full min-h-0 items-center justify-center p-4">
+    <ChartEmptyState
+      className="h-full w-full"
+      icon={<BarChart2 size={16} />}
+      title="No data to show"
+      description="Execute a query and configure the chart options."
+    />
+  </div>
+)

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -1,6 +1,6 @@
 import { Hotkey } from '@tanstack/react-hotkeys'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
-import { AlignLeft, Check, Heart, Keyboard, MoreVertical } from 'lucide-react'
+import { AlignLeft, Check, ChevronDown, Heart, Keyboard, MoreVertical } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   Button,
@@ -8,6 +8,8 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
   DropdownMenuTrigger,
   KeyboardShortcut,
   Tooltip,
@@ -19,6 +21,12 @@ import { SqlRunButton } from './RunButton'
 import { SqlSaveButton } from './SaveButton'
 import SavingIndicator from './SavingIndicator'
 import { RoleImpersonationPopover } from '@/components/interfaces/RoleImpersonationSelector/RoleImpersonationPopover'
+import { EXPLORER_DATEPICKER_HELPERS } from '@/components/interfaces/Settings/Logs/Logs.constants'
+import { LogsDatePicker } from '@/components/interfaces/Settings/Logs/Logs.DatePickers'
+import {
+  SQL_SNIPPET_SOURCE_LABELS,
+  SqlSnippetSourceIcon,
+} from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import { DatabaseSelector } from '@/components/ui/DatabaseSelector'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { IS_PLATFORM } from '@/lib/constants'
@@ -26,14 +34,19 @@ import { useProfile } from '@/lib/profile'
 import { hotkeyToKeys } from '@/state/shortcuts/formatShortcut'
 import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
+import type { SqlSnippets } from '@/types'
 
 export type UtilityActionsProps = {
   id: string
   isExecuting?: boolean
   isDisabled?: boolean
   hasSelection?: boolean
+  source: SqlSnippets.Source
+  logDateRange: SqlSnippets.LogDateRange
   prettifyQuery: () => void
   executeQuery: () => void
+  onSourceChange: (source: SqlSnippets.Source) => void
+  onLogDateRangeChange: (value: SqlSnippets.LogDateRange) => void
   onSave: () => void
 }
 
@@ -42,8 +55,12 @@ export const UtilityActions = ({
   isExecuting = false,
   isDisabled = false,
   hasSelection = false,
+  source,
+  logDateRange,
   prettifyQuery,
   executeQuery,
+  onSourceChange,
+  onLogDateRangeChange,
   onSave,
 }: UtilityActionsProps) => {
   const { ref } = useParams()
@@ -65,6 +82,7 @@ export const UtilityActions = ({
   const isSaving = snapV2.savingStates[id] === 'UPDATING'
   const isReadOnly =
     snippet?.snippet.visibility === 'project' && snippet?.snippet.owner_id !== profile?.id
+  const sourceControlsDisabled = isDisabled || isReadOnly
 
   const hotkeySequnece: Hotkey | undefined =
     SHORTCUT_DEFINITIONS[SHORTCUT_IDS.SQL_EDITOR_FORMAT].sequence[0]
@@ -80,6 +98,11 @@ export const UtilityActions = ({
   const addFavorite = () => snapV2.addFavorite(id)
 
   const removeFavorite = () => snapV2.removeFavorite(id)
+
+  const onSelectSource = (source: string) => {
+    if (sourceControlsDisabled) return
+    onSourceChange(source as SqlSnippets.Source)
+  }
 
   const onSelectDatabase = (databaseId: string) => {
     snapV2.resetResults(id)
@@ -187,26 +210,65 @@ export const UtilityActions = ({
             onClick={onSave}
           />
         )}
-        <div className="flex items-center">
-          {IS_PLATFORM && (
-            <DatabaseSelector
-              selectedDatabaseId={lastSelectedDb.length === 0 ? undefined : lastSelectedDb}
-              variant="connected-on-right"
-              onSelectId={onSelectDatabase}
+        <div className="flex items-center gap-x-2">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                type="default"
+                disabled={sourceControlsDisabled}
+                icon={<SqlSnippetSourceIcon source={source} />}
+                iconRight={<ChevronDown strokeWidth={1.5} size={12} />}
+              >
+                {SQL_SNIPPET_SOURCE_LABELS[source]}
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              <DropdownMenuRadioGroup value={source} onValueChange={onSelectSource}>
+                <DropdownMenuRadioItem value="project" className="gap-x-2">
+                  <SqlSnippetSourceIcon source="project" />
+                  Project
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem value="logs" className="gap-x-2">
+                  <SqlSnippetSourceIcon source="logs" />
+                  Logs
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {source === 'logs' && (
+            <LogsDatePicker
+              value={logDateRange}
+              onSubmit={onLogDateRangeChange}
+              helpers={EXPLORER_DATEPICKER_HELPERS}
+              buttonTriggerProps={{ className: 'h-[30px]', disabled: sourceControlsDisabled }}
             />
           )}
-          <RoleImpersonationPopover
-            serviceRoleLabel="postgres"
-            header="Run SQL query as a role"
-            variant={IS_PLATFORM ? 'connected-on-both' : 'connected-on-right'}
-          />
-          <SqlRunButton
-            hasSelection={hasSelection}
-            isDisabled={isDisabled || isExecuting}
-            isExecuting={isExecuting}
-            className="rounded-l-none"
-            onClick={executeQuery}
-          />
+
+          <div className="flex items-center">
+            {source === 'project' && IS_PLATFORM && (
+              <DatabaseSelector
+                selectedDatabaseId={lastSelectedDb.length === 0 ? undefined : lastSelectedDb}
+                variant="connected-on-right"
+                showLabel={false}
+                onSelectId={onSelectDatabase}
+              />
+            )}
+            {source === 'project' && (
+              <RoleImpersonationPopover
+                serviceRoleLabel="postgres"
+                header="Run SQL query as a role"
+                variant={IS_PLATFORM ? 'connected-on-both' : 'connected-on-right'}
+              />
+            )}
+            <SqlRunButton
+              hasSelection={hasSelection}
+              isDisabled={isDisabled || isExecuting}
+              isExecuting={isExecuting}
+              className={cn(source === 'project' && 'rounded-l-none')}
+              onClick={executeQuery}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityActions.tsx
@@ -1,10 +1,9 @@
 import { Hotkey } from '@tanstack/react-hotkeys'
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
-import { AlignLeft, Check, ChevronDown, Heart, Keyboard, MoreVertical } from 'lucide-react'
+import { AlignLeft, Check, ChevronDown, Keyboard, MoreVertical } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   Button,
-  cn,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
@@ -12,9 +11,6 @@ import {
   DropdownMenuRadioItem,
   DropdownMenuTrigger,
   KeyboardShortcut,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
 } from 'ui'
 
 import { SqlRunButton } from './RunButton'
@@ -67,7 +63,6 @@ export const UtilityActions = ({
   const { profile } = useProfile()
   const snapV2 = useSqlEditorV2StateSnapshot()
 
-  const [isAiOpen] = useLocalStorageQuery(LOCAL_STORAGE_KEYS.SQL_EDITOR_AI_OPEN, true)
   const [intellisenseEnabled, setIntellisenseEnabled] = useLocalStorageQuery(
     LOCAL_STORAGE_KEYS.SQL_EDITOR_INTELLISENSE,
     true
@@ -78,7 +73,6 @@ export const UtilityActions = ({
   )
 
   const snippet = snapV2.snippets[id]
-  const isFavorite = snippet !== undefined ? snippet.snippet.favorite : false
   const isSaving = snapV2.savingStates[id] === 'UPDATING'
   const isReadOnly =
     snippet?.snippet.visibility === 'project' && snippet?.snippet.owner_id !== profile?.id
@@ -95,10 +89,6 @@ export const UtilityActions = ({
     )
   }
 
-  const addFavorite = () => snapV2.addFavorite(id)
-
-  const removeFavorite = () => snapV2.removeFavorite(id)
-
   const onSelectSource = (source: string) => {
     if (sourceControlsDisabled) return
     onSourceChange(source as SqlSnippets.Source)
@@ -110,107 +100,38 @@ export const UtilityActions = ({
   }
 
   return (
-    <div className="inline-flex items-center justify-end gap-x-2">
-      {IS_PLATFORM && <SavingIndicator id={id} />}
+    <div className="flex min-w-0 w-full items-center gap-x-2">
+      <div className="min-w-0 flex-1 overflow-x-auto">
+        <div className="ml-auto flex w-max shrink-0 items-center gap-x-2">
+          {IS_PLATFORM && <SavingIndicator id={id} />}
 
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            data-testid="sql-editor-utility-actions"
-            type="default"
-            className={cn('px-1', isAiOpen ? 'block 2xl:hidden' : 'hidden')}
-            icon={<MoreVertical className="text-foreground-light" />}
-          />
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="w-48">
-          <DropdownMenuItem className="justify-between" onClick={toggleIntellisense}>
-            <span className="flex items-center gap-x-2">
-              <Keyboard size={14} className="text-foreground-light" />
-              Intellisense enabled
-            </span>
-            {intellisenseEnabled && <Check className="text-brand" size={16} />}
-          </DropdownMenuItem>
-          <DropdownMenuItem className="justify-between" onClick={prettifyQuery}>
-            <span className="flex items-center gap-x-2">
-              <AlignLeft size={14} strokeWidth={2} className="text-foreground-light" />
-              Prettify SQL
-            </span>
-            {formatKeys && <KeyboardShortcut keys={formatKeys} />}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                data-testid="sql-editor-utility-actions"
+                type="default"
+                className="px-1"
+                icon={<MoreVertical className="text-foreground-light" />}
+              />
+            </DropdownMenuTrigger>
+            <DropdownMenuContent className="w-48">
+              <DropdownMenuItem className="justify-between" onClick={toggleIntellisense}>
+                <span className="flex items-center gap-x-2">
+                  <Keyboard size={14} className="text-foreground-light" />
+                  Intellisense enabled
+                </span>
+                {intellisenseEnabled && <Check className="text-brand" size={16} />}
+              </DropdownMenuItem>
+              <DropdownMenuItem className="justify-between" onClick={prettifyQuery}>
+                <span className="flex items-center gap-x-2">
+                  <AlignLeft size={14} strokeWidth={2} className="text-foreground-light" />
+                  Prettify SQL
+                </span>
+                {formatKeys && <KeyboardShortcut keys={formatKeys} />}
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
 
-      <div className={cn('items-center gap-x-2', isAiOpen ? 'hidden 2xl:flex' : 'flex')}>
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              type="text"
-              className="px-1"
-              icon={<Keyboard className="text-foreground-light" />}
-            />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className="w-48">
-            <DropdownMenuItem className="justify-between" onClick={toggleIntellisense}>
-              Intellisense enabled
-              {intellisenseEnabled && <Check className="text-brand" size={16} />}
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-
-        {IS_PLATFORM && (
-          <Tooltip>
-            <TooltipTrigger asChild>
-              {isFavorite ? (
-                <Button
-                  type="text"
-                  size="tiny"
-                  onClick={removeFavorite}
-                  className="px-1"
-                  icon={<Heart className="fill-brand stroke-none" />}
-                />
-              ) : (
-                <Button
-                  type="text"
-                  size="tiny"
-                  onClick={addFavorite}
-                  className="px-1"
-                  icon={<Heart className="fill-none stroke-foreground-light" />}
-                />
-              )}
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              {isFavorite ? 'Remove from' : 'Add to'} favorites
-            </TooltipContent>
-          </Tooltip>
-        )}
-
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              type="text"
-              onClick={prettifyQuery}
-              className="px-1"
-              icon={<AlignLeft strokeWidth={2} className="text-foreground-light" />}
-            />
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="p-1 pl-2.5">
-            <div className="flex items-center gap-2.5">
-              <span>Prettify SQL</span>
-              {formatKeys && <KeyboardShortcut keys={formatKeys} />}
-            </div>
-          </TooltipContent>
-        </Tooltip>
-      </div>
-
-      <div className="flex items-center justify-between gap-x-2">
-        {IS_PLATFORM && (
-          <SqlSaveButton
-            isDisabled={isDisabled || isReadOnly}
-            isSaving={isSaving}
-            onClick={onSave}
-          />
-        )}
-        <div className="flex items-center gap-x-2">
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
@@ -224,13 +145,13 @@ export const UtilityActions = ({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-40">
               <DropdownMenuRadioGroup value={source} onValueChange={onSelectSource}>
-                <DropdownMenuRadioItem value="project" className="gap-x-2">
-                  <SqlSnippetSourceIcon source="project" />
-                  Project
+                <DropdownMenuRadioItem value="database" className="gap-x-2">
+                  <SqlSnippetSourceIcon source="database" />
+                  {SQL_SNIPPET_SOURCE_LABELS.database}
                 </DropdownMenuRadioItem>
                 <DropdownMenuRadioItem value="logs" className="gap-x-2">
                   <SqlSnippetSourceIcon source="logs" />
-                  Logs
+                  {SQL_SNIPPET_SOURCE_LABELS.logs}
                 </DropdownMenuRadioItem>
               </DropdownMenuRadioGroup>
             </DropdownMenuContent>
@@ -241,35 +162,40 @@ export const UtilityActions = ({
               value={logDateRange}
               onSubmit={onLogDateRangeChange}
               helpers={EXPLORER_DATEPICKER_HELPERS}
-              buttonTriggerProps={{ className: 'h-[30px]', disabled: sourceControlsDisabled }}
+              buttonTriggerProps={{ disabled: sourceControlsDisabled }}
             />
           )}
 
-          <div className="flex items-center">
-            {source === 'project' && IS_PLATFORM && (
-              <DatabaseSelector
-                selectedDatabaseId={lastSelectedDb.length === 0 ? undefined : lastSelectedDb}
-                variant="connected-on-right"
-                showLabel={false}
-                onSelectId={onSelectDatabase}
-              />
-            )}
-            {source === 'project' && (
-              <RoleImpersonationPopover
-                serviceRoleLabel="postgres"
-                header="Run SQL query as a role"
-                variant={IS_PLATFORM ? 'connected-on-both' : 'connected-on-right'}
-              />
-            )}
-            <SqlRunButton
-              hasSelection={hasSelection}
-              isDisabled={isDisabled || isExecuting}
-              isExecuting={isExecuting}
-              className={cn(source === 'project' && 'rounded-l-none')}
-              onClick={executeQuery}
+          {source === 'database' && IS_PLATFORM && (
+            <DatabaseSelector
+              selectedDatabaseId={lastSelectedDb.length === 0 ? undefined : lastSelectedDb}
+              showLabel={false}
+              onSelectId={onSelectDatabase}
             />
-          </div>
+          )}
+          {source === 'database' && (
+            <RoleImpersonationPopover
+              serviceRoleLabel="postgres"
+              header="Run SQL query as a role"
+            />
+          )}
         </div>
+      </div>
+
+      <div className="flex shrink-0 items-center gap-x-2">
+        {IS_PLATFORM && (
+          <SqlSaveButton
+            isDisabled={isDisabled || isReadOnly}
+            isSaving={isSaving}
+            onClick={onSave}
+          />
+        )}
+        <SqlRunButton
+          hasSelection={hasSelection}
+          isDisabled={isDisabled || isExecuting}
+          isExecuting={isExecuting}
+          onClick={executeQuery}
+        />
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -1,9 +1,8 @@
 import { useParams } from 'common'
 import { toast } from 'sonner'
-import { Tabs_Shadcn_, TabsContent_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
+import { ToggleGroup, ToggleGroupItem } from 'ui'
 
 import { ChartConfig } from './ChartConfig'
-import { UtilityActions } from './UtilityActions'
 import { UtilityTabExplain } from './UtilityTabExplain'
 import { UtilityTabResults } from './UtilityTabResults'
 import { DownloadResultsButton } from '@/components/ui/DownloadResultsButton'
@@ -11,6 +10,9 @@ import { useContentUpsertMutation } from '@/data/content/content-upsert-mutation
 import { Snippet } from '@/data/content/sql-folders-query'
 import { useTrack } from '@/lib/telemetry/track'
 import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
+import type { SqlSnippets } from '@/types'
+
+export type SqlOutputView = 'table' | 'chart' | 'explain'
 
 export type UtilityPanelProps = {
   id: string
@@ -18,15 +20,12 @@ export type UtilityPanelProps = {
   isExplainExecuting?: boolean
   isDebugging?: boolean
   isDisabled?: boolean
-  hasSelection: boolean
-  prettifyQuery: () => void
-  executeQuery: () => void
   executeExplainQuery: () => void
-  onSave: () => void
   onDebug: () => void
   buildDebugPrompt: () => string
-  activeTab?: string
-  onActiveTabChange?: (tab: string) => void
+  source: SqlSnippets.Source
+  activeView?: SqlOutputView
+  onActiveViewChange?: (view: SqlOutputView) => void
 }
 
 const DEFAULT_CHART_CONFIG: ChartConfig = {
@@ -44,15 +43,12 @@ export const UtilityPanel = ({
   isExplainExecuting,
   isDebugging,
   isDisabled,
-  hasSelection,
-  prettifyQuery,
-  executeQuery,
   executeExplainQuery,
-  onSave,
   onDebug,
   buildDebugPrompt,
-  activeTab = 'results',
-  onActiveTabChange,
+  source,
+  activeView = 'table',
+  onActiveViewChange,
 }: UtilityPanelProps) => {
   const { ref } = useParams()
   const track = useTrack()
@@ -61,12 +57,15 @@ export const UtilityPanel = ({
   const snippet = snapV2.snippets[id]?.snippet
   const result = snapV2.results[id]?.[0]
 
-  const handleTabChange = (tab: string) => {
+  const handleViewChange = (view: string) => {
+    if (!view) return
+    const nextView = view as SqlOutputView
+
     // When switching to the explain tab, trigger the explain query
-    if (tab === 'explain') {
+    if (nextView === 'explain' && source === 'project') {
       executeExplainQuery()
     }
-    onActiveTabChange?.(tab)
+    onActiveViewChange?.(nextView)
   }
 
   const { mutate: upsertContent } = useContentUpsertMutation({
@@ -128,65 +127,68 @@ export const UtilityPanel = ({
   }
 
   return (
-    <Tabs_Shadcn_
-      value={activeTab}
-      onValueChange={handleTabChange}
-      className="w-full h-full flex flex-col"
-    >
-      <TabsList_Shadcn_ className="flex justify-between gap-2 px-4 overflow-x-auto min-h-[42px]">
-        <div className="flex items-center gap-4">
-          <TabsTrigger_Shadcn_ className="py-3 text-xs" value="results">
-            <span className="translate-y-px">Results</span>
-          </TabsTrigger_Shadcn_>
-          <TabsTrigger_Shadcn_ className="py-3 text-xs" value="explain">
-            <span className="translate-y-px">Explain</span>
-          </TabsTrigger_Shadcn_>
-          <TabsTrigger_Shadcn_ className="py-3 text-xs" value="chart">
-            <span className="translate-y-px">Chart</span>
-          </TabsTrigger_Shadcn_>
+    <div className="w-full h-full flex flex-col">
+      <div className="flex items-center justify-between gap-2 px-4 overflow-x-auto min-h-[42px] border-b">
+        <ToggleGroup
+          type="single"
+          value={activeView}
+          onValueChange={handleViewChange}
+          size="sm"
+          variant="outline"
+          className="flex items-center"
+        >
+          <ToggleGroupItem value="table" className="h-7 px-3 text-xs">
+            Table
+          </ToggleGroupItem>
+          <ToggleGroupItem value="chart" className="h-7 px-3 text-xs">
+            Chart
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="explain"
+            disabled={source === 'logs'}
+            className="h-7 px-3 text-xs"
+          >
+            Explain
+          </ToggleGroupItem>
+        </ToggleGroup>
 
-          {result?.rows && (
-            <DownloadResultsButton
-              type="text"
-              results={result.rows as any[]}
-              fileName={`Supabase Snippet ${snippet.name}`}
-              onDownloadAsCSV={() => track('sql_editor_result_download_csv_clicked')}
-              onCopyAsMarkdown={() => track('sql_editor_result_copy_markdown_clicked')}
-              onCopyAsJSON={() => track('sql_editor_result_copy_json_clicked')}
-              onCopyAsCSV={() => track('sql_editor_result_copy_csv_clicked')}
-            />
-          )}
+        {result?.rows && (
+          <DownloadResultsButton
+            type="text"
+            results={result.rows as any[]}
+            fileName={`Supabase Snippet ${snippet.name}`}
+            onDownloadAsCSV={() => track('sql_editor_result_download_csv_clicked')}
+            onCopyAsMarkdown={() => track('sql_editor_result_copy_markdown_clicked')}
+            onCopyAsJSON={() => track('sql_editor_result_copy_json_clicked')}
+            onCopyAsCSV={() => track('sql_editor_result_copy_csv_clicked')}
+          />
+        )}
+      </div>
+
+      {activeView === 'table' && (
+        <div className="grow min-h-0">
+          <UtilityTabResults
+            id={id}
+            isExecuting={isExecuting}
+            isDisabled={isDisabled}
+            onDebug={onDebug}
+            buildDebugPrompt={buildDebugPrompt}
+            isDebugging={isDebugging}
+          />
         </div>
+      )}
 
-        <UtilityActions
-          id={id}
-          isExecuting={isExecuting}
-          isDisabled={isDisabled}
-          hasSelection={hasSelection}
-          prettifyQuery={prettifyQuery}
-          executeQuery={executeQuery}
-          onSave={onSave}
-        />
-      </TabsList_Shadcn_>
+      {activeView === 'explain' && (
+        <div className="grow min-h-0">
+          <UtilityTabExplain id={id} isExecuting={isExplainExecuting} />
+        </div>
+      )}
 
-      <TabsContent_Shadcn_ asChild value="results" className="mt-0 grow">
-        <UtilityTabResults
-          id={id}
-          isExecuting={isExecuting}
-          isDisabled={isDisabled}
-          onDebug={onDebug}
-          buildDebugPrompt={buildDebugPrompt}
-          isDebugging={isDebugging}
-        />
-      </TabsContent_Shadcn_>
-
-      <TabsContent_Shadcn_ asChild value="explain" className="mt-0 grow">
-        <UtilityTabExplain id={id} isExecuting={isExplainExecuting} />
-      </TabsContent_Shadcn_>
-
-      <TabsContent_Shadcn_ asChild value="chart" className="mt-0 grow">
-        <ChartConfig results={result} config={chartConfig} onConfigChange={onConfigChange} />
-      </TabsContent_Shadcn_>
-    </Tabs_Shadcn_>
+      {activeView === 'chart' && (
+        <div className="grow min-h-0">
+          <ChartConfig results={result} config={chartConfig} onConfigChange={onConfigChange} />
+        </div>
+      )}
+    </div>
   )
 }

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -1,4 +1,6 @@
 import { useParams } from 'common'
+import { BarChart2, ListTree, Table } from 'lucide-react'
+import { useCallback } from 'react'
 import { toast } from 'sonner'
 import { ToggleGroup, ToggleGroupItem } from 'ui'
 
@@ -62,7 +64,7 @@ export const UtilityPanel = ({
     const nextView = view as SqlOutputView
 
     // When switching to the explain tab, trigger the explain query
-    if (nextView === 'explain' && source === 'project') {
+    if (nextView === 'explain' && source === 'database') {
       executeExplainQuery()
     }
     onActiveViewChange?.(nextView)
@@ -107,28 +109,44 @@ export const UtilityPanel = ({
 
   const chartConfig = getChartConfig()
 
-  function onConfigChange(config: ChartConfig) {
-    if (!ref || !snippet?.id) return
+  const onConfigChange = useCallback(
+    (config: ChartConfig) => {
+      if (!snippet?.content) return
 
-    upsertContent({
-      projectRef: ref,
-      payload: {
-        ...snippet,
-        id: snippet.id,
-        description: snippet.description || '',
-        project_id: snippet.project_id || 0,
-        content: {
-          ...snippet.content,
-          content_id: id,
-          chart: config,
+      snapV2.updateSnippet({
+        id,
+        snippet: {
+          content: {
+            ...snippet.content,
+            chart: config,
+          },
         },
-      },
-    })
-  }
+        skipSave: true,
+      })
+
+      if (!ref || !snippet.id) return
+
+      upsertContent({
+        projectRef: ref,
+        payload: {
+          ...snippet,
+          id: snippet.id,
+          description: snippet.description || '',
+          project_id: snippet.project_id || 0,
+          content: {
+            ...snippet.content,
+            content_id: id,
+            chart: config,
+          },
+        },
+      })
+    },
+    [id, ref, snippet, snapV2, upsertContent]
+  )
 
   return (
     <div className="w-full h-full flex flex-col">
-      <div className="flex items-center justify-between gap-2 px-4 overflow-x-auto min-h-[42px] border-b">
+      <div className="flex shrink-0 items-center justify-between gap-2 overflow-x-auto border-b p-1.5">
         <ToggleGroup
           type="single"
           value={activeView}
@@ -137,17 +155,21 @@ export const UtilityPanel = ({
           variant="outline"
           className="flex items-center"
         >
-          <ToggleGroupItem value="table" className="h-7 px-3 text-xs">
+          <ToggleGroupItem value="table" className="h-7 gap-1.5 px-3 text-xs" aria-label="Table">
+            <Table size={14} strokeWidth={1.5} />
             Table
           </ToggleGroupItem>
-          <ToggleGroupItem value="chart" className="h-7 px-3 text-xs">
+          <ToggleGroupItem value="chart" className="h-7 gap-1.5 px-3 text-xs" aria-label="Chart">
+            <BarChart2 size={14} strokeWidth={1.5} />
             Chart
           </ToggleGroupItem>
           <ToggleGroupItem
             value="explain"
             disabled={source === 'logs'}
-            className="h-7 px-3 text-xs"
+            className="h-7 gap-1.5 px-3 text-xs"
+            aria-label="Explain"
           >
+            <ListTree size={14} strokeWidth={1.5} />
             Explain
           </ToggleGroupItem>
         </ToggleGroup>

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback } from 'react'
 import { toast } from 'sonner'
 import { ToggleGroup, ToggleGroupItem } from 'ui'
 
+import { isDraftSqlSnippet } from '../createDraftSqlTab'
 import { ChartConfig } from './ChartConfig'
 import { UtilityTabExplain } from './UtilityTabExplain'
 import { UtilityTabResults } from './UtilityTabResults'
@@ -124,7 +125,8 @@ export const UtilityPanel = ({
         skipSave: true,
       })
 
-      if (!ref || !snippet.id) return
+      // Drafts are never written to the DB until an explicit save — only update local state above.
+      if (!ref || !snippet.id || isDraftSqlSnippet(snippet)) return
 
       upsertContent({
         projectRef: ref,
@@ -152,7 +154,7 @@ export const UtilityPanel = ({
           value={activeView}
           onValueChange={handleViewChange}
           size="sm"
-          variant="outline"
+          variant="default"
           className="flex items-center"
         >
           <ToggleGroupItem value="table" className="h-7 gap-1.5 px-3 text-xs" aria-label="Table">

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityTabResults.tsx
@@ -5,6 +5,7 @@ import { forwardRef } from 'react'
 import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import Results from './Results'
+import { SqlEditorResultsEmptyState } from './SqlEditorResultsEmptyState'
 import { getSqlErrorLines } from './UtilityTabResults.utils'
 import { subscriptionHasHipaaAddon } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
@@ -169,20 +170,8 @@ export const UtilityTabResults = forwardRef<HTMLDivElement, UtilityTabResultsPro
           </div>
         </div>
       )
-    } else if (!result) {
-      return (
-        <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-          <p className="m-0 border-0 px-4 py-4 text-sm text-foreground-light">
-            Click <code className="text-code-inline">Run</code> to execute your query
-          </p>
-        </div>
-      )
-    } else if (result.rows.length <= 0) {
-      return (
-        <div className="bg-table-header-light in-data-[theme*=dark]:bg-table-header-dark overflow-y-auto">
-          <p className="m-0 border-0 px-6 py-4 font-mono text-sm">Success. No rows returned</p>
-        </div>
-      )
+    } else if (!result || result.rows.length <= 0) {
+      return <SqlEditorResultsEmptyState />
     }
 
     return <Results rows={result.rows} />

--- a/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.test.ts
@@ -15,6 +15,12 @@ import {
 import { persistDraftSqlTab, readPersistedDraftSqlTab } from './draftSqlTabStorage.utils'
 
 const PROJECT_REF = 'test-project'
+const LOG_DATE_RANGE = {
+  from: '2026-06-15T00:00:00.000Z',
+  to: '2026-06-15T01:00:00.000Z',
+  isHelper: true,
+  text: 'Last hour',
+}
 
 describe('isDraftSqlSnippet', () => {
   it('is true only when isDraftTab is set', () => {
@@ -181,7 +187,40 @@ describe('createDraftSqlTab', () => {
     expect(addedTab.metadata).toMatchObject({ sqlId: draftId, isDraft: true })
 
     // Persisted to local storage with the initial sql
-    expect(readPersistedDraftSqlTab(PROJECT_REF, draftId)).toMatchObject({ sql: 'select 1' })
+    expect(readPersistedDraftSqlTab(PROJECT_REF, draftId)).toMatchObject({
+      sql: 'select 1',
+      source: 'project',
+    })
+  })
+
+  it('registers a logs draft with source metadata', () => {
+    const addSnippet = vi.fn()
+    const addTab = vi.fn()
+
+    const draftId = createDraftSqlTab({
+      projectRef: PROJECT_REF,
+      projectId: 1,
+      ownerId: 2,
+      snapV2: { addSnippet },
+      tabs: { addTab },
+      initialSql: 'select * from edge_logs',
+      source: 'logs',
+      logDateRange: LOG_DATE_RANGE,
+      skipNavigation: true,
+    })
+
+    const addedSnippet = addSnippet.mock.calls[0][0].snippet
+    expect(addedSnippet.content).toMatchObject({
+      source: 'logs',
+      logDateRange: LOG_DATE_RANGE,
+    })
+
+    const addedTab = addTab.mock.calls[0][0]
+    expect(addedTab.metadata).toMatchObject({ sqlId: draftId, sqlSource: 'logs' })
+    expect(readPersistedDraftSqlTab(PROJECT_REF, draftId)).toMatchObject({
+      source: 'logs',
+      logDateRange: LOG_DATE_RANGE,
+    })
   })
 })
 
@@ -194,6 +233,8 @@ describe('restoreDraftSqlTab', () => {
     persistDraftSqlTab(PROJECT_REF, 'draft-1', {
       sql: 'select 1',
       name: 'My draft',
+      source: 'logs',
+      logDateRange: LOG_DATE_RANGE,
     })
 
     const addSnippet = vi.fn()
@@ -212,7 +253,7 @@ describe('restoreDraftSqlTab', () => {
       id: 'draft-1',
       name: 'My draft',
       isDraftTab: true,
-      content: { unchecked_sql: 'select 1' },
+      content: { unchecked_sql: 'select 1', source: 'logs', logDateRange: LOG_DATE_RANGE },
     })
   })
 
@@ -235,7 +276,7 @@ describe('restoreDraftSqlTab', () => {
       id: 'draft-2',
       name: 'Fallback name',
       isDraftTab: true,
-      content: { unchecked_sql: 'select 2' },
+      content: { unchecked_sql: 'select 2', source: 'project' },
     })
   })
 })
@@ -246,7 +287,12 @@ describe('restoreOpenDraftSqlTabs', () => {
   })
 
   it('restores missing draft snippets and returns all open draft ids', () => {
-    persistDraftSqlTab(PROJECT_REF, 'draft-a', { sql: 'select a', name: 'Draft A' })
+    persistDraftSqlTab(PROJECT_REF, 'draft-a', {
+      sql: 'select a',
+      name: 'Draft A',
+      source: 'logs',
+      logDateRange: LOG_DATE_RANGE,
+    })
     persistDraftSqlTab(PROJECT_REF, 'draft-c', { sql: 'select c', name: 'Draft C' })
 
     const addSnippet = vi.fn()
@@ -279,7 +325,7 @@ describe('restoreOpenDraftSqlTabs', () => {
     expect(restoredDraftA).toMatchObject({
       name: 'Draft A',
       isDraftTab: true,
-      content: { unchecked_sql: 'select a' },
+      content: { unchecked_sql: 'select a', source: 'logs', logDateRange: LOG_DATE_RANGE },
     })
   })
 

--- a/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.test.ts
@@ -189,7 +189,7 @@ describe('createDraftSqlTab', () => {
     // Persisted to local storage with the initial sql
     expect(readPersistedDraftSqlTab(PROJECT_REF, draftId)).toMatchObject({
       sql: 'select 1',
-      source: 'project',
+      source: 'database',
     })
   })
 
@@ -276,7 +276,7 @@ describe('restoreDraftSqlTab', () => {
       id: 'draft-2',
       name: 'Fallback name',
       isDraftTab: true,
-      content: { unchecked_sql: 'select 2', source: 'project' },
+      content: { unchecked_sql: 'select 2', source: 'database' },
     })
   })
 })

--- a/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.ts
+++ b/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.ts
@@ -10,6 +10,7 @@ import { createSqlSnippetSkeletonV2 } from './SQLEditor.utils'
 import { generateUuid } from '@/lib/api/snippets.browser'
 import type { SnippetWithContent } from '@/state/sql-editor-v2'
 import { createTabId } from '@/state/tabs'
+import type { SqlSnippets } from '@/types'
 
 type SqlEditorV2Actions = {
   addSnippet: (args: { projectRef: string; snippet: SnippetWithContent }) => void
@@ -24,6 +25,7 @@ type TabsActions = {
       sqlId?: string
       name?: string
       isDraft?: boolean
+      sqlSource?: SqlSnippets.Source
     }
     isPreview?: boolean
   }) => void
@@ -37,6 +39,8 @@ export type CreateDraftSqlTabParams = {
   tabs: TabsActions
   router?: NextRouter
   initialSql?: string
+  source?: SqlSnippets.Source
+  logDateRange?: SqlSnippets.LogDateRange
   /** When true, only registers state without changing the route */
   skipNavigation?: boolean
 }
@@ -49,6 +53,8 @@ export function createDraftSqlTab({
   tabs,
   router,
   initialSql = '',
+  source = 'project',
+  logDateRange,
   skipNavigation = false,
 }: CreateDraftSqlTabParams): string {
   const name = generateSnippetTitle()
@@ -60,6 +66,8 @@ export function createDraftSqlTab({
     sql: initialSql,
     owner_id: ownerId,
     project_id: projectId,
+    source,
+    logDateRange,
   })
 
   snippet.isDraftTab = true
@@ -69,6 +77,8 @@ export function createDraftSqlTab({
   persistDraftSqlTab(projectRef, draftId, {
     sql: initialSql,
     name,
+    source,
+    logDateRange,
   })
 
   tabs.addTab({
@@ -79,6 +89,7 @@ export function createDraftSqlTab({
       sqlId: draftId,
       name,
       isDraft: true,
+      sqlSource: source,
     },
     // Drafts are permanent tabs (not preview), so opening another draft never evicts an existing
     // empty one — each "new query" gets its own tab.
@@ -100,6 +111,8 @@ export function restoreDraftSqlTab({
   snapV2,
   name = generateSnippetTitle(),
   initialSql = '',
+  source,
+  logDateRange,
 }: Omit<CreateDraftSqlTabParams, 'tabs' | 'router' | 'skipNavigation'> & {
   draftId: string
   name?: string
@@ -108,6 +121,8 @@ export function restoreDraftSqlTab({
   const persisted = readPersistedDraftSqlTab(projectRef, draftId)
   const resolvedName = persisted?.name ?? name
   const resolvedSql = persisted?.sql ?? initialSql
+  const resolvedSource = persisted?.source ?? source ?? 'project'
+  const resolvedLogDateRange = persisted?.logDateRange ?? logDateRange
 
   const snippet = createSqlSnippetSkeletonV2({
     idOverride: draftId,
@@ -115,6 +130,8 @@ export function restoreDraftSqlTab({
     sql: resolvedSql,
     owner_id: ownerId,
     project_id: projectId,
+    source: resolvedSource,
+    logDateRange: resolvedLogDateRange,
   })
 
   snippet.isDraftTab = true
@@ -141,7 +158,15 @@ export function restoreOpenDraftSqlTabs({
   openTabs: readonly string[]
   tabsMap: Record<
     string,
-    { type: string; metadata?: { sqlId?: string; isDraft?: boolean; name?: string } }
+    {
+      type: string
+      metadata?: {
+        sqlId?: string
+        isDraft?: boolean
+        name?: string
+        sqlSource?: SqlSnippets.Source
+      }
+    }
   >
   existingSnippetIds: Set<string>
 }) {
@@ -166,6 +191,7 @@ export function restoreOpenDraftSqlTabs({
       ownerId,
       snapV2,
       name: tab.metadata.name,
+      source: tab.metadata.sqlSource,
     })
   }
 

--- a/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.ts
+++ b/apps/studio/components/interfaces/SQLEditor/createDraftSqlTab.ts
@@ -53,7 +53,7 @@ export function createDraftSqlTab({
   tabs,
   router,
   initialSql = '',
-  source = 'project',
+  source = 'database',
   logDateRange,
   skipNavigation = false,
 }: CreateDraftSqlTabParams): string {
@@ -121,7 +121,7 @@ export function restoreDraftSqlTab({
   const persisted = readPersistedDraftSqlTab(projectRef, draftId)
   const resolvedName = persisted?.name ?? name
   const resolvedSql = persisted?.sql ?? initialSql
-  const resolvedSource = persisted?.source ?? source ?? 'project'
+  const resolvedSource = persisted?.source ?? source ?? 'database'
   const resolvedLogDateRange = persisted?.logDateRange ?? logDateRange
 
   const snippet = createSqlSnippetSkeletonV2({

--- a/apps/studio/components/interfaces/SQLEditor/draftSqlTabStorage.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/draftSqlTabStorage.utils.ts
@@ -59,7 +59,7 @@ export function persistDraftSqlTab(
   storage[draftId] = {
     sql: patch.sql ?? existing?.sql ?? '',
     name: patch.name,
-    source: patch.source ?? existing?.source ?? 'project',
+    source: patch.source ?? existing?.source ?? 'database',
     logDateRange: patch.logDateRange ?? existing?.logDateRange,
     updatedAt: Date.now(),
   }

--- a/apps/studio/components/interfaces/SQLEditor/draftSqlTabStorage.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/draftSqlTabStorage.utils.ts
@@ -1,8 +1,12 @@
 import { LOCAL_STORAGE_KEYS } from 'common'
 
+import type { SqlSnippets } from '@/types'
+
 export type PersistedDraftSqlTab = {
   sql: string
   name: string
+  source?: SqlSnippets.Source
+  logDateRange?: SqlSnippets.LogDateRange
   updatedAt: number
 }
 
@@ -43,6 +47,8 @@ export function persistDraftSqlTab(
   patch: {
     sql?: string
     name: string
+    source?: SqlSnippets.Source
+    logDateRange?: SqlSnippets.LogDateRange
   }
 ) {
   if (typeof window === 'undefined' || !projectRef) return
@@ -53,6 +59,8 @@ export function persistDraftSqlTab(
   storage[draftId] = {
     sql: patch.sql ?? existing?.sql ?? '',
     name: patch.name,
+    source: patch.source ?? existing?.source ?? 'project',
+    logDateRange: patch.logDateRange ?? existing?.logDateRange,
     updatedAt: Date.now(),
   }
 

--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorNavV2/SQLEditorTreeViewItem.tsx
@@ -29,6 +29,10 @@ import {
 } from 'ui'
 
 import { createSqlSnippetSkeletonV2 } from '@/components/interfaces/SQLEditor/SQLEditor.utils'
+import {
+  getSqlSnippetSource,
+  SqlSnippetSourceIcon,
+} from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import { getContentById } from '@/data/content/content-id-query'
 import { useSQLSnippetFolderContentsQuery } from '@/data/content/sql-folder-contents-query'
 import { Snippet } from '@/data/content/sql-folders-query'
@@ -193,6 +197,8 @@ export const SQLEditorTreeViewItem = ({
 
     const snippet = element.metadata
     let sql: string = ''
+    let source = getSqlSnippetSource(snippet)
+    let logDateRange = snippet.content?.logDateRange
 
     if (snippet.content && snippet.content.unchecked_sql) {
       sql = snippet.content.unchecked_sql
@@ -201,6 +207,8 @@ export const SQLEditorTreeViewItem = ({
       const { content } = await getContentById({ projectRef, id: snippet.id })
       if ('unchecked_sql' in content) {
         sql = content.unchecked_sql
+        source = content.source ?? source
+        logDateRange = content.logDateRange ?? logDateRange
       }
     }
 
@@ -209,6 +217,8 @@ export const SQLEditorTreeViewItem = ({
       sql,
       owner_id: profile?.id,
       project_id: project?.id,
+      source,
+      logDateRange,
     })
 
     snapV2.addSnippet({ projectRef, snippet: snippetCopy })
@@ -255,6 +265,11 @@ export const SQLEditorTreeViewItem = ({
             name={element.name}
             nameForTitle={props.nameForTitle}
             description={element.metadata?.description || undefined}
+            icon={
+              !isBranch ? (
+                <SqlSnippetSourceIcon source={getSqlSnippetSource(element.metadata)} />
+              ) : undefined
+            }
             xPadding={16}
           />
         </ContextMenuTrigger>

--- a/apps/studio/components/layouts/Tabs/RecentItems.tsx
+++ b/apps/studio/components/layouts/Tabs/RecentItems.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 
 import { useEditorType } from '../editors/EditorsLayout.hooks'
 import { buildTableEditorUrl } from '@/components/grid/SupabaseGrid.utils'
+import { SqlSnippetSourceIcon } from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import { EntityTypeIcon } from '@/components/ui/EntityTypeIcon'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
 import { editorEntityTypes, useTabsStateSnapshot } from '@/state/tabs'
@@ -71,7 +72,11 @@ export function RecentItems() {
                     className="flex items-center gap-4 rounded-lg bg-surface-100 py-2 transition-colors hover:bg-surface-200"
                   >
                     <div className="flex h-6 w-6 items-center justify-center rounded-sm bg-surface-100 border">
-                      <EntityTypeIcon type={item.type} />
+                      {item.type === 'sql' ? (
+                        <SqlSnippetSourceIcon source={item.metadata?.sqlSource} />
+                      ) : (
+                        <EntityTypeIcon type={item.type} />
+                      )}
                     </div>
                     <div className="flex flex-1 gap-5 items-center">
                       <span className="text-sm text-foreground">

--- a/apps/studio/components/layouts/Tabs/SortableTab.tsx
+++ b/apps/studio/components/layouts/Tabs/SortableTab.tsx
@@ -6,6 +6,7 @@ import { useMemo } from 'react'
 import { cn, TabsTrigger_Shadcn_ } from 'ui'
 
 import { useEditorType } from '../editors/EditorsLayout.hooks'
+import { SqlSnippetSourceIcon } from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import { EntityTypeIcon } from '@/components/ui/EntityTypeIcon'
 import { useQuerySchemaState } from '@/hooks/misc/useSchemaQueryState'
 import { useTabsStateSnapshot, type Tab } from '@/state/tabs'
@@ -84,7 +85,11 @@ export const SortableTab = ({
         )}
         {...listeners}
       >
-        <EntityTypeIcon type={tab.type} />
+        {tab.type === 'sql' ? (
+          <SqlSnippetSourceIcon source={tab.metadata?.sqlSource} />
+        ) : (
+          <EntityTypeIcon type={tab.type} />
+        )}
         <div className="flex items-center gap-0">
           <AnimatePresence mode="popLayout" initial>
             {shouldShowSchema && (

--- a/apps/studio/components/layouts/Tabs/TabPreview.tsx
+++ b/apps/studio/components/layouts/Tabs/TabPreview.tsx
@@ -1,5 +1,6 @@
 import { motion } from 'framer-motion'
 
+import { SqlSnippetSourceIcon } from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import { EntityTypeIcon } from '@/components/ui/EntityTypeIcon'
 import { useTabsStateSnapshot } from '@/state/tabs'
 
@@ -17,7 +18,11 @@ export const TabPreview = ({ tab }: { tab: string }) => {
       animate={{ opacity: 0.7 }}
       className="flex relative items-center gap-2 px-3 text-xs bg-dash-sidebar dark:bg-surface-100 shadow-lg rounded-xs h-10"
     >
-      <EntityTypeIcon type={tabData.type} />
+      {tabData.type === 'sql' ? (
+        <SqlSnippetSourceIcon source={tabData.metadata?.sqlSource} />
+      ) : (
+        <EntityTypeIcon type={tabData.type} />
+      )}
       <span>{tabData.label || 'Untitled'}</span>
       <div className="absolute w-full top-0 left-0 right-0 h-px bg-foreground-muted" />
     </motion.div>

--- a/apps/studio/components/ui/DatabaseSelector.tsx
+++ b/apps/studio/components/ui/DatabaseSelector.tsx
@@ -39,6 +39,7 @@ interface DatabaseSelectorProps {
   className?: string
   align?: 'start' | 'end'
   isForm?: boolean
+  showLabel?: boolean
 }
 
 export const DatabaseSelector = ({
@@ -50,6 +51,7 @@ export const DatabaseSelector = ({
   align = 'end',
   className,
   isForm = false,
+  showLabel = !isForm,
 }: DatabaseSelectorProps) => {
   const router = useRouter()
   const { ref: projectRef } = useParams()
@@ -84,7 +86,7 @@ export const DatabaseSelector = ({
     <Popover open={open} onOpenChange={setOpen} modal={false}>
       <PopoverTrigger asChild>
         <div className={cn('flex cursor-pointer', className)}>
-          {!isForm && (
+          {showLabel && (
             <span className="flex items-center text-foreground-lighter px-3 rounded-lg rounded-r-none text-xs border border-button border-r-0">
               Source
             </span>
@@ -96,7 +98,7 @@ export const DatabaseSelector = ({
             {...buttonProps}
             className={cn(
               'justify-start',
-              !isForm && 'rounded-l-none',
+              showLabel && 'rounded-l-none',
               variant === 'connected-on-right' && 'rounded-r-none',
               variant === 'connected-on-left' && 'rounded-l-none border-l-0',
               variant === 'connected-on-both' && 'rounded-none border-x-0',

--- a/apps/studio/components/ui/DatabaseSelector.tsx
+++ b/apps/studio/components/ui/DatabaseSelector.tsx
@@ -1,33 +1,12 @@
 import { useParams } from 'common'
 import { noop } from 'lodash'
-import { Check, ChevronDown, Loader2, Plus } from 'lucide-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { parseAsBoolean, useQueryState } from 'nuqs'
+import { ChevronDown, Loader2 } from 'lucide-react'
 import { useEffect, useState } from 'react'
-import {
-  Button,
-  ButtonProps,
-  cn,
-  Command,
-  CommandGroup,
-  CommandItem,
-  CommandList,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  ScrollArea,
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from 'ui'
+import { Button, ButtonProps, cn, Popover, PopoverContent, PopoverTrigger } from 'ui'
 
-import { Markdown } from '@/components/interfaces/Markdown'
-import { REPLICA_STATUS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
+import { DatabaseSelectorMenuContent } from './DatabaseSelectorMenuContent'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { formatDatabaseID, formatDatabaseRegion } from '@/data/read-replicas/replicas.utils'
-import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import { IS_PLATFORM } from '@/lib/constants'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
 interface DatabaseSelectorProps {
@@ -53,29 +32,20 @@ export const DatabaseSelector = ({
   isForm = false,
   showLabel = !isForm,
 }: DatabaseSelectorProps) => {
-  const router = useRouter()
   const { ref: projectRef } = useParams()
   const [open, setOpen] = useState(false)
-  const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
-
-  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
 
   const state = useDatabaseSelectorStateSnapshot()
   const selectedDatabaseId = _selectedDatabaseId ?? state.selectedDatabaseId
 
   const { data, isPending: isLoading, isSuccess } = useReadReplicasQuery({ projectRef })
   const databases = data ?? []
-  const sortedDatabases = databases
-    .sort((a, b) => (a.inserted_at > b.inserted_at ? 1 : 0))
-    .sort((database) => (database.identifier === projectRef ? -1 : 0))
 
   const selectedDatabase = databases.find((db) => db.identifier === selectedDatabaseId)
   const selectedDatabaseRegion = formatDatabaseRegion(selectedDatabase?.region ?? '')
   const formattedDatabaseId = formatDatabaseID(selectedDatabaseId ?? '')
 
   const selectedAdditionalOption = additionalOptions.find((x) => x.id === selectedDatabaseId)
-
-  const newReplicaURL = `/project/${projectRef}/database/replication?type=Read+Replica`
 
   useEffect(() => {
     if (_selectedDatabaseId && !isForm) state.setSelectedDatabaseId(_selectedDatabaseId)
@@ -111,7 +81,7 @@ export const DatabaseSelector = ({
               <>
                 <span className="capitalize">
                   {isLoading || selectedDatabase?.identifier === projectRef
-                    ? 'Primary database'
+                    ? 'Primary'
                     : 'Read replica'}
                 </span>{' '}
                 {isSuccess && selectedDatabase?.identifier !== projectRef && (
@@ -125,123 +95,13 @@ export const DatabaseSelector = ({
         </div>
       </PopoverTrigger>
       <PopoverContent className="p-0 w-64" side="bottom" align={align}>
-        <Command>
-          <CommandList>
-            {additionalOptions.length > 0 && (
-              <CommandGroup className="border-b">
-                {additionalOptions.map((option) => (
-                  <CommandItem
-                    key={option.id}
-                    value={option.id}
-                    className="cursor-pointer w-full"
-                    onSelect={() => {
-                      if (!isForm) state.setSelectedDatabaseId(option.id)
-                      setOpen(false)
-                      onSelectId(option.id)
-                    }}
-                    onClick={() => {
-                      if (!isForm) state.setSelectedDatabaseId(option.id)
-                      setOpen(false)
-                      onSelectId(option.id)
-                    }}
-                  >
-                    <div className="w-full flex items-center justify-between">
-                      <p>{option.name}</p>
-                      {option.id === selectedDatabaseId && <Check size={14} />}
-                    </div>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            )}
-            <CommandGroup>
-              <ScrollArea className={(databases || []).length > 7 ? 'h-[210px]' : ''}>
-                {sortedDatabases?.map((database) => {
-                  const region = formatDatabaseRegion(database.region)
-                  const id = formatDatabaseID(database.identifier)
-
-                  if (database.status !== 'ACTIVE_HEALTHY') {
-                    const status = [
-                      REPLICA_STATUS.INIT_READ_REPLICA,
-                      REPLICA_STATUS.COMING_UP,
-                    ].includes(database.status)
-                      ? 'coming up'
-                      : 'not healthy'
-
-                    return (
-                      <Tooltip key={database.identifier}>
-                        <TooltipTrigger asChild>
-                          <div className="px-2 py-1.5 w-full flex items-center justify-between">
-                            <p className="text-xs text-foreground-lighter">
-                              Read replica ({region} - {id})
-                            </p>
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent side="right" className="w-80">
-                          <Markdown
-                            className="text-xs text-foreground"
-                            content={`Replica unable to accept requests as its ${status}. [View infrastructure settings](/project/${projectRef}/settings/infrastructure) for more information.`}
-                          />
-                        </TooltipContent>
-                      </Tooltip>
-                    )
-                  }
-
-                  return (
-                    <CommandItem
-                      key={database.identifier}
-                      value={database.identifier}
-                      className="cursor-pointer w-full"
-                      onSelect={() => {
-                        if (!isForm) state.setSelectedDatabaseId(database.identifier)
-                        setOpen(false)
-                        onSelectId(database.identifier)
-                      }}
-                      onClick={() => {
-                        if (!isForm) state.setSelectedDatabaseId(database.identifier)
-                        setOpen(false)
-                        onSelectId(database.identifier)
-                      }}
-                    >
-                      <div className="w-full flex items-center justify-between">
-                        <p>
-                          {database.identifier === projectRef
-                            ? 'Primary database'
-                            : `Read replica (${region} - ${id})`}
-                        </p>
-                        {database.identifier === selectedDatabaseId && <Check size={16} />}
-                      </div>
-                    </CommandItem>
-                  )
-                })}
-              </ScrollArea>
-            </CommandGroup>
-            {IS_PLATFORM && infrastructureReadReplicas && (
-              <CommandGroup className="border-t">
-                <CommandItem
-                  className="cursor-pointer w-full"
-                  onSelect={() => {
-                    setOpen(false)
-                    router.push(newReplicaURL)
-                  }}
-                  onClick={() => setOpen(false)}
-                >
-                  <Link
-                    href={newReplicaURL}
-                    onClick={async () => {
-                      setOpen(false)
-                      // [Joshen] This is used in the Connect UI which is available across all pages
-                      setShowConnect(false)
-                    }}
-                    className="w-full flex items-center gap-2"
-                  >
-                    <Plus size={14} strokeWidth={1.5} />
-                    <p>Create a new read replica</p>
-                  </Link>
-                </CommandItem>
-              </CommandGroup>
-            )}
-          </CommandList>
-        </Command>
+        <DatabaseSelectorMenuContent
+          selectedDatabaseId={selectedDatabaseId}
+          additionalOptions={additionalOptions}
+          onSelectId={onSelectId}
+          onAfterSelect={() => setOpen(false)}
+          isForm={isForm}
+        />
       </PopoverContent>
     </Popover>
   )

--- a/apps/studio/components/ui/DatabaseSelectorMenuContent.tsx
+++ b/apps/studio/components/ui/DatabaseSelectorMenuContent.tsx
@@ -1,0 +1,166 @@
+import { useParams } from 'common'
+import { noop } from 'lodash'
+import { Check, Plus } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { parseAsBoolean, useQueryState } from 'nuqs'
+import {
+  Command,
+  CommandGroup,
+  CommandItem,
+  CommandList,
+  ScrollArea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from 'ui'
+
+import { Markdown } from '@/components/interfaces/Markdown'
+import { REPLICA_STATUS } from '@/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.constants'
+import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
+import { formatDatabaseID, formatDatabaseRegion } from '@/data/read-replicas/replicas.utils'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+import { IS_PLATFORM } from '@/lib/constants'
+import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
+
+interface DatabaseSelectorMenuContentProps {
+  selectedDatabaseId?: string
+  additionalOptions?: { id: string; name: string }[]
+  onSelectId?: (id: string) => void
+  onAfterSelect?: () => void
+  isForm?: boolean
+}
+
+export const DatabaseSelectorMenuContent = ({
+  selectedDatabaseId: _selectedDatabaseId,
+  additionalOptions = [],
+  onSelectId = noop,
+  onAfterSelect,
+  isForm = false,
+}: DatabaseSelectorMenuContentProps) => {
+  const router = useRouter()
+  const { ref: projectRef } = useParams()
+  const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
+
+  const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
+
+  const state = useDatabaseSelectorStateSnapshot()
+  const selectedDatabaseId = _selectedDatabaseId ?? state.selectedDatabaseId
+
+  const { data } = useReadReplicasQuery({ projectRef })
+  const databases = data ?? []
+  const sortedDatabases = databases
+    .sort((a, b) => (a.inserted_at > b.inserted_at ? 1 : 0))
+    .sort((database) => (database.identifier === projectRef ? -1 : 0))
+
+  const newReplicaURL = `/project/${projectRef}/database/replication?type=Read+Replica`
+
+  const handleSelect = (id: string) => {
+    if (!isForm) state.setSelectedDatabaseId(id)
+    onAfterSelect?.()
+    onSelectId(id)
+  }
+
+  return (
+    <Command>
+      <CommandList>
+        {additionalOptions.length > 0 && (
+          <CommandGroup className="border-b">
+            {additionalOptions.map((option) => (
+              <CommandItem
+                key={option.id}
+                value={option.id}
+                className="cursor-pointer w-full"
+                onSelect={() => handleSelect(option.id)}
+                onClick={() => handleSelect(option.id)}
+              >
+                <div className="w-full flex items-center justify-between">
+                  <p>{option.name}</p>
+                  {option.id === selectedDatabaseId && <Check size={14} />}
+                </div>
+              </CommandItem>
+            ))}
+          </CommandGroup>
+        )}
+        <CommandGroup>
+          <ScrollArea className={(databases || []).length > 7 ? 'h-[210px]' : ''}>
+            {sortedDatabases?.map((database) => {
+              const region = formatDatabaseRegion(database.region)
+              const id = formatDatabaseID(database.identifier)
+
+              if (database.status !== 'ACTIVE_HEALTHY') {
+                const status = [
+                  REPLICA_STATUS.INIT_READ_REPLICA,
+                  REPLICA_STATUS.COMING_UP,
+                ].includes(database.status)
+                  ? 'coming up'
+                  : 'not healthy'
+
+                return (
+                  <Tooltip key={database.identifier}>
+                    <TooltipTrigger asChild>
+                      <div className="px-2 py-1.5 w-full flex items-center justify-between">
+                        <p className="text-xs text-foreground-lighter">
+                          Read replica ({region} - {id})
+                        </p>
+                      </div>
+                    </TooltipTrigger>
+                    <TooltipContent side="right" className="w-80">
+                      <Markdown
+                        className="text-xs text-foreground"
+                        content={`Replica unable to accept requests as its ${status}. [View infrastructure settings](/project/${projectRef}/settings/infrastructure) for more information.`}
+                      />
+                    </TooltipContent>
+                  </Tooltip>
+                )
+              }
+
+              return (
+                <CommandItem
+                  key={database.identifier}
+                  value={database.identifier}
+                  className="cursor-pointer w-full"
+                  onSelect={() => handleSelect(database.identifier)}
+                  onClick={() => handleSelect(database.identifier)}
+                >
+                  <div className="w-full flex items-center justify-between">
+                    <p>
+                      {database.identifier === projectRef
+                        ? 'Primary'
+                        : `Read replica (${region} - ${id})`}
+                    </p>
+                    {database.identifier === selectedDatabaseId && <Check size={16} />}
+                  </div>
+                </CommandItem>
+              )
+            })}
+          </ScrollArea>
+        </CommandGroup>
+        {IS_PLATFORM && infrastructureReadReplicas && (
+          <CommandGroup className="border-t">
+            <CommandItem
+              className="cursor-pointer w-full"
+              onSelect={() => {
+                onAfterSelect?.()
+                router.push(newReplicaURL)
+              }}
+              onClick={() => onAfterSelect?.()}
+            >
+              <Link
+                href={newReplicaURL}
+                onClick={async () => {
+                  onAfterSelect?.()
+                  setShowConnect(false)
+                }}
+                className="w-full flex items-center gap-2"
+              >
+                <Plus size={14} strokeWidth={1.5} />
+                <p>Create a new read replica</p>
+              </Link>
+            </CommandItem>
+          </CommandGroup>
+        )}
+      </CommandList>
+    </Command>
+  )
+}

--- a/apps/studio/data/logs/execute-log-sql-mutation.ts
+++ b/apps/studio/data/logs/execute-log-sql-mutation.ts
@@ -1,0 +1,46 @@
+import { useMutation } from '@tanstack/react-query'
+
+import { executeAnalyticsSql } from './execute-analytics-sql'
+import { logsAllEndpointUrl } from './logs-endpoint'
+import type { SafeLogSqlFragment } from './safe-analytics-sql'
+import type { Logs } from '@/components/interfaces/Settings/Logs/Logs.types'
+import type { ResponseError, UseCustomMutationOptions } from '@/types'
+
+export type ExecuteLogSqlVariables = {
+  projectRef: string
+  sql: SafeLogSqlFragment
+  iso_timestamp_start: string
+  iso_timestamp_end: string
+  useOtel?: boolean
+}
+
+export async function executeLogSql({
+  projectRef,
+  sql,
+  iso_timestamp_start,
+  iso_timestamp_end,
+  useOtel = false,
+}: ExecuteLogSqlVariables) {
+  return executeAnalyticsSql({
+    projectRef,
+    endpoint: logsAllEndpointUrl(useOtel),
+    sql,
+    iso_timestamp_start,
+    iso_timestamp_end,
+    method: 'get',
+  }) as Promise<Logs>
+}
+
+export type ExecuteLogSqlData = Awaited<ReturnType<typeof executeLogSql>>
+export type ExecuteLogSqlError = ResponseError
+
+export const useExecuteLogSqlMutation = ({
+  ...options
+}: Omit<
+  UseCustomMutationOptions<ExecuteLogSqlData, ExecuteLogSqlError, ExecuteLogSqlVariables>,
+  'mutationFn'
+> = {}) =>
+  useMutation<ExecuteLogSqlData, ExecuteLogSqlError, ExecuteLogSqlVariables>({
+    mutationFn: (args) => executeLogSql(args),
+    ...options,
+  })

--- a/apps/studio/data/logs/safe-analytics-sql.ts
+++ b/apps/studio/data/logs/safe-analytics-sql.ts
@@ -50,6 +50,7 @@
  * Never cast arbitrary strings to this type.
  */
 export type SafeLogSqlFragment = string & { readonly __safeLogSqlFragmentBrand: never }
+export type UntrustedLogSqlFragment = string & { readonly __untrustedLogSqlFragmentBrand: never }
 
 type LogSqlFragmentSeparator =
   | ','
@@ -90,6 +91,22 @@ export function safeSql(
  */
 function rawSql(sql: string): SafeLogSqlFragment {
   return sql as SafeLogSqlFragment
+}
+
+/**
+ * Marks raw log SQL as user-controlled input. This does not make the SQL safe to execute; it only
+ * makes the trust boundary explicit at call sites that receive text from an editor, URL, or LLM.
+ */
+export function untrustedLogSql(sql: string): UntrustedLogSqlFragment {
+  return sql as UntrustedLogSqlFragment
+}
+
+/**
+ * Accepts a complete untrusted log-SQL statement for execution after a deliberate user action.
+ * Do not use this for string fragments that will be composed into a larger analytics query.
+ */
+export function acceptUntrustedLogSql(sql: UntrustedLogSqlFragment): SafeLogSqlFragment {
+  return rawSql(sql)
 }
 
 /** Joins already-safe log-SQL fragments with a fixed structural separator. */

--- a/apps/studio/lib/api/snippets.utils.ts
+++ b/apps/studio/lib/api/snippets.utils.ts
@@ -25,7 +25,7 @@ export const SnippetSchema = z.object({
     sql: z.string(),
     content_id: z.string(),
     schema_version: z.literal('1.0'),
-    source: z.union([z.literal('project'), z.literal('logs')]).optional(),
+    source: z.union([z.literal('database'), z.literal('logs')]).optional(),
     logDateRange: z
       .object({
         to: z.string(),
@@ -96,7 +96,7 @@ const buildSnippet = (
       sql: content,
       content_id: uuidv4(),
       schema_version: '1.0',
-      source: 'project',
+      source: 'database',
     },
     visibility: 'user',
     project_id: 1,

--- a/apps/studio/lib/api/snippets.utils.ts
+++ b/apps/studio/lib/api/snippets.utils.ts
@@ -25,6 +25,15 @@ export const SnippetSchema = z.object({
     sql: z.string(),
     content_id: z.string(),
     schema_version: z.literal('1.0'),
+    source: z.union([z.literal('project'), z.literal('logs')]).optional(),
+    logDateRange: z
+      .object({
+        to: z.string(),
+        from: z.string(),
+        isHelper: z.boolean().optional(),
+        text: z.string().optional(),
+      })
+      .optional(),
   }),
   visibility: z.union([
     z.literal('user'),
@@ -87,6 +96,7 @@ const buildSnippet = (
       sql: content,
       content_id: uuidv4(),
       schema_version: '1.0',
+      source: 'project',
     },
     visibility: 'user',
     project_id: 1,

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -13,6 +13,7 @@ import {
 import { readPersistedDraftSqlTab } from '@/components/interfaces/SQLEditor/draftSqlTabStorage.utils'
 import { SQLEditor } from '@/components/interfaces/SQLEditor/SQLEditor'
 import { generateSnippetTitle } from '@/components/interfaces/SQLEditor/SQLEditor.constants'
+import { getSqlSnippetSource } from '@/components/interfaces/SQLEditor/SQLEditorSource.utils'
 import DefaultLayout from '@/components/layouts/DefaultLayout'
 import { EditorBaseLayout } from '@/components/layouts/editors/EditorBaseLayout'
 import { useEditorType } from '@/components/layouts/editors/EditorsLayout.hooks'
@@ -151,6 +152,7 @@ const SqlEditor: NextPageWithLayout = () => {
 
     const tabId = createTabId('sql', { id })
     const snippet = allSnippets.find((x) => x.id === id)
+    const sqlSource = snippet ? getSqlSnippetSource(snippet) : (persistedDraft?.source ?? 'project')
 
     tabs.addTab({
       id: tabId,
@@ -160,6 +162,7 @@ const SqlEditor: NextPageWithLayout = () => {
         sqlId: id,
         name: snippet?.name ?? persistedDraft?.name,
         isDraft: isDraftId,
+        sqlSource,
       },
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/studio/pages/project/[ref]/sql/[id].tsx
+++ b/apps/studio/pages/project/[ref]/sql/[id].tsx
@@ -152,7 +152,9 @@ const SqlEditor: NextPageWithLayout = () => {
 
     const tabId = createTabId('sql', { id })
     const snippet = allSnippets.find((x) => x.id === id)
-    const sqlSource = snippet ? getSqlSnippetSource(snippet) : (persistedDraft?.source ?? 'project')
+    const sqlSource = snippet
+      ? getSqlSnippetSource(snippet)
+      : (persistedDraft?.source ?? 'database')
 
     tabs.addTab({
       id: tabId,

--- a/apps/studio/state/sql-editor-v2.test.ts
+++ b/apps/studio/state/sql-editor-v2.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { sqlEditorState, type SnippetWithContent } from './sql-editor-v2'
+import { readPersistedDraftSqlTab } from '@/components/interfaces/SQLEditor/draftSqlTabStorage.utils'
+import { createSqlSnippetSkeletonV2 } from '@/components/interfaces/SQLEditor/SQLEditor.utils'
+
+const PROJECT_REF = 'test-project'
+const LOG_DATE_RANGE = {
+  from: '2026-06-15T00:00:00.000Z',
+  to: '2026-06-15T01:00:00.000Z',
+  isHelper: true,
+  text: 'Last hour',
+}
+
+function resetState() {
+  for (const key of Object.keys(sqlEditorState.snippets)) delete sqlEditorState.snippets[key]
+  for (const key of Object.keys(sqlEditorState.results)) delete sqlEditorState.results[key]
+  for (const key of Object.keys(sqlEditorState.explainResults))
+    delete sqlEditorState.explainResults[key]
+  for (const key of Object.keys(sqlEditorState.savingStates))
+    delete sqlEditorState.savingStates[key]
+  sqlEditorState.needsSaving.clear()
+  localStorage.clear()
+}
+
+function seedSnippet({
+  id,
+  isDraft = false,
+}: {
+  id: string
+  isDraft?: boolean
+}): SnippetWithContent {
+  const snippet = createSqlSnippetSkeletonV2({
+    idOverride: id,
+    name: `Snippet ${id}`,
+    sql: 'select 1',
+    owner_id: 1,
+    project_id: 1,
+  })
+  if (isDraft) snippet.isDraftTab = true
+  sqlEditorState.addSnippet({ projectRef: PROJECT_REF, snippet })
+  return snippet
+}
+
+describe('sqlEditorState source + log date range', () => {
+  beforeEach(() => {
+    resetState()
+  })
+
+  describe('setSnippetSource', () => {
+    it('updates a saved snippet and queues it for saving', () => {
+      seedSnippet({ id: 'saved-1' })
+
+      sqlEditorState.setSnippetSource({ id: 'saved-1', source: 'logs' })
+
+      expect(sqlEditorState.snippets['saved-1'].snippet.content?.source).toBe('logs')
+      expect(sqlEditorState.needsSaving.get('saved-1')).toBe(true)
+    })
+
+    it('updates a draft and persists to local storage without queuing for DB save', () => {
+      seedSnippet({ id: 'draft-1', isDraft: true })
+
+      sqlEditorState.setSnippetSource({ id: 'draft-1', source: 'logs' })
+
+      expect(sqlEditorState.snippets['draft-1'].snippet.content?.source).toBe('logs')
+      expect(sqlEditorState.needsSaving.has('draft-1')).toBe(false)
+      expect(readPersistedDraftSqlTab(PROJECT_REF, 'draft-1')).toMatchObject({ source: 'logs' })
+    })
+
+    it('is a no-op when the snippet does not exist', () => {
+      expect(() => sqlEditorState.setSnippetSource({ id: 'missing', source: 'logs' })).not.toThrow()
+      expect(sqlEditorState.needsSaving.has('missing')).toBe(false)
+    })
+  })
+
+  describe('setSnippetLogDateRange', () => {
+    it('updates a saved snippet and queues it for saving', () => {
+      seedSnippet({ id: 'saved-2' })
+
+      sqlEditorState.setSnippetLogDateRange({ id: 'saved-2', logDateRange: LOG_DATE_RANGE })
+
+      expect(sqlEditorState.snippets['saved-2'].snippet.content?.logDateRange).toEqual(
+        LOG_DATE_RANGE
+      )
+      expect(sqlEditorState.needsSaving.get('saved-2')).toBe(true)
+    })
+
+    it('updates a draft and persists to local storage without queuing for DB save', () => {
+      seedSnippet({ id: 'draft-2', isDraft: true })
+
+      sqlEditorState.setSnippetLogDateRange({ id: 'draft-2', logDateRange: LOG_DATE_RANGE })
+
+      expect(sqlEditorState.needsSaving.has('draft-2')).toBe(false)
+      expect(readPersistedDraftSqlTab(PROJECT_REF, 'draft-2')).toMatchObject({
+        logDateRange: LOG_DATE_RANGE,
+      })
+    })
+  })
+
+  describe('draft persistence in updateSnippet / setSql', () => {
+    it('updateSnippet on a draft persists locally and never queues for DB save', () => {
+      seedSnippet({ id: 'draft-3', isDraft: true })
+
+      sqlEditorState.updateSnippet({
+        id: 'draft-3',
+        snippet: { name: 'Renamed draft' },
+        skipSave: false,
+      })
+
+      expect(sqlEditorState.needsSaving.has('draft-3')).toBe(false)
+      expect(readPersistedDraftSqlTab(PROJECT_REF, 'draft-3')).toMatchObject({
+        name: 'Renamed draft',
+      })
+    })
+
+    it('setSql on a draft persists locally and never queues for DB save', () => {
+      seedSnippet({ id: 'draft-4', isDraft: true })
+
+      sqlEditorState.setSql({ id: 'draft-4', sql: 'select 42' })
+
+      expect(sqlEditorState.needsSaving.has('draft-4')).toBe(false)
+      expect(readPersistedDraftSqlTab(PROJECT_REF, 'draft-4')).toMatchObject({ sql: 'select 42' })
+    })
+  })
+})

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -53,7 +53,7 @@ function persistDraftSnippet(stateSnippet: StateSnippet) {
   persistDraftSqlTab(projectRef, snippet.id, {
     sql: snippet.content.unchecked_sql,
     name: snippet.name,
-    source: snippet.content.source ?? 'project',
+    source: snippet.content.source ?? 'database',
     logDateRange: snippet.content.logDateRange,
   })
 }

--- a/apps/studio/state/sql-editor-v2.ts
+++ b/apps/studio/state/sql-editor-v2.ts
@@ -46,6 +46,18 @@ function isDraftSqlTabId(id: string) {
   return sqlEditorState.snippets[id]?.snippet?.isDraftTab === true
 }
 
+function persistDraftSnippet(stateSnippet: StateSnippet) {
+  const { snippet, projectRef } = stateSnippet
+  if (!snippet.id || !snippet.content) return
+
+  persistDraftSqlTab(projectRef, snippet.id, {
+    sql: snippet.content.unchecked_sql,
+    name: snippet.name,
+    source: snippet.content.source ?? 'project',
+    logDateRange: snippet.content.logDateRange,
+  })
+}
+
 export const sqlEditorState = proxy({
   // ========================================================================
   // ## Data properties within the store
@@ -155,6 +167,10 @@ export const sqlEditorState = proxy({
         ...sqlEditorState.snippets[id].snippet,
         ...snippet,
       }
+      if (isDraftSqlTabId(id)) {
+        persistDraftSnippet(sqlEditorState.snippets[id])
+        return
+      }
       if (!skipSave && !isDraftSqlTabId(id)) sqlEditorState.needsSaving.set(id, true)
     }
   },
@@ -198,14 +214,48 @@ export const sqlEditorState = proxy({
       // survives reloads, and never queue them for the async DB save.
       if (isDraftSqlTabId(id)) {
         const stateSnippet = sqlEditorState.snippets[id]
-        if (stateSnippet) {
-          persistDraftSqlTab(stateSnippet.projectRef, id, { sql, name: snippet.name })
-        }
+        if (stateSnippet) persistDraftSnippet(stateSnippet)
         return
       }
 
       if (!skipSave) sqlEditorState.needsSaving.set(id, shouldInvalidate)
     }
+  },
+
+  setSnippetSource: ({ id, source }: { id: string; source: SqlSnippets.Source }) => {
+    const snippet = sqlEditorState.snippets[id]?.snippet
+    if (!snippet?.content) return
+
+    snippet.content.source = source
+
+    if (isDraftSqlTabId(id)) {
+      const stateSnippet = sqlEditorState.snippets[id]
+      if (stateSnippet) persistDraftSnippet(stateSnippet)
+      return
+    }
+
+    sqlEditorState.needsSaving.set(id, true)
+  },
+
+  setSnippetLogDateRange: ({
+    id,
+    logDateRange,
+  }: {
+    id: string
+    logDateRange: SqlSnippets.LogDateRange
+  }) => {
+    const snippet = sqlEditorState.snippets[id]?.snippet
+    if (!snippet?.content) return
+
+    snippet.content.logDateRange = logDateRange
+
+    if (isDraftSqlTabId(id)) {
+      const stateSnippet = sqlEditorState.snippets[id]
+      if (stateSnippet) persistDraftSnippet(stateSnippet)
+      return
+    }
+
+    sqlEditorState.needsSaving.set(id, true)
   },
 
   /**

--- a/apps/studio/state/tabs.tsx
+++ b/apps/studio/state/tabs.tsx
@@ -6,6 +6,7 @@ import { proxy, subscribe, useSnapshot } from 'valtio'
 
 import { buildTableEditorUrl } from '@/components/grid/SupabaseGrid.utils'
 import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
+import type { SqlSnippets } from '@/types'
 
 export const editorEntityTypes = {
   table: ['r', 'v', 'm', 'f', 'p'],
@@ -36,6 +37,7 @@ export interface Tab {
     name?: string
     tableId?: number
     sqlId?: string
+    sqlSource?: SqlSnippets.Source
     scrollTop?: number
     /** Marks a SQL tab as an unsaved draft so it can be hidden from the saved-snippets nav and restored from local storage */
     isDraft?: boolean
@@ -57,6 +59,7 @@ export interface RecentItem {
     name?: string
     tableId?: number
     sqlId?: string
+    sqlSource?: SqlSnippets.Source
     isDraft?: boolean
   }
 }

--- a/apps/studio/styles/monaco.css
+++ b/apps/studio/styles/monaco.css
@@ -25,6 +25,7 @@
 .monaco-diff-editor {
   --vscode-editor-background: hsl(var(--background-dash-sidebar)) !important;
   --vscode-editorGutter-background: hsl(var(--background-dash-sidebar)) !important;
+  --vscode-focusBorder: transparent !important;
 }
 
 .gutter {

--- a/apps/studio/types/userContent.ts
+++ b/apps/studio/types/userContent.ts
@@ -26,6 +26,15 @@ export interface UserContentMap {
 }
 
 export namespace SqlSnippets {
+  export type Source = 'project' | 'logs'
+
+  export type LogDateRange = {
+    to: string
+    from: string
+    isHelper?: boolean
+    text?: string
+  }
+
   /**
    * To be stored in the database: public.user_content.content
    * In this case there is only one thing to store, but it's good to
@@ -42,6 +51,12 @@ export namespace SqlSnippets {
 
     // we can add some versioning to this schema in case we need to change the format.
     schema_version: string
+
+    // Determines which execution backend the editor should use.
+    source?: Source
+
+    // Logs-specific execution settings. Only used when source is "logs".
+    logDateRange?: LogDateRange
 
     chart?: {
       type: 'bar' | 'line'

--- a/apps/studio/types/userContent.ts
+++ b/apps/studio/types/userContent.ts
@@ -26,7 +26,7 @@ export interface UserContentMap {
 }
 
 export namespace SqlSnippets {
-  export type Source = 'project' | 'logs'
+  export type Source = 'database' | 'logs'
 
   export type LogDateRange = {
     to: string


### PR DESCRIPTION
<img width="1512" height="861" alt="image" src="https://github.com/user-attachments/assets/f3815330-ac3d-43cd-94fc-f9a995b9f7a4" />

<img width="1512" height="861" alt="image" src="https://github.com/user-attachments/assets/1311e708-864d-4484-a85d-dfed8c372921" />

Adds "Logs" as a data source within the SQL Editor which covers the old logs explorer as people move towards the unified logging experience. This will also play nicely with our custom reports.

**Note: This PR requires https://github.com/supabase/supabase/pull/46922 to be merged first**