### PR TITLE
fix(ui-library): add missing target paths to all client registry-item.json files

### DIFF
--- a/apps/studio/components/interfaces/Auth/Passkeys/PasskeysSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/Passkeys/PasskeysSettingsForm.tsx
@@ -4,6 +4,9 @@ import { useParams } from 'common'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
+  Alert_Shadcn_,
+  AlertDescription_Shadcn_,
+  AlertTitle_Shadcn_,
   Button,
   Card,
   CardContent,
@@ -27,90 +30,9 @@ import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-muta
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
+import { hasAndroidOrigin, validateRpId, validateWebAuthnOrigins } from './validation'
 
 type GoTrueConfig = components['schemas']['GoTrueConfigResponse']
-
-function isLocalhost(hostname: string): boolean {
-  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
-}
-
-function validateRpId(rpId: string): string | null {
-  const trimmed = rpId.trim().toLowerCase()
-  if (!trimmed) return null
-  try {
-    const url = new URL('https://' + trimmed)
-    if (url.hostname !== trimmed) return null
-    return trimmed
-  } catch {
-    return null
-  }
-}
-
-function validateWebAuthnOrigins(
-  value: string,
-  rpId: string | null
-): { valid: true } | { valid: false; message: string } {
-  const origins = value
-    .split(',')
-    .map((o) => o.trim())
-    .filter(Boolean)
-
-  if (origins.length === 0) {
-    return { valid: false, message: 'At least one origin is required' }
-  }
-
-  if (origins.length > 5) {
-    return { valid: false, message: 'A maximum of 5 origins is allowed' }
-  }
-
-  for (const origin of origins) {
-    let url: URL
-    try {
-      url = new URL(origin)
-    } catch {
-      return { valid: false, message: `"${origin}" is not a valid URL` }
-    }
-
-    if (url.protocol === 'http:') {
-      if (!isLocalhost(url.hostname)) {
-        return {
-          valid: false,
-          message: `"${origin}" must use HTTPS unless it is a localhost origin`,
-        }
-      }
-    } else if (url.protocol !== 'https:') {
-      return {
-        valid: false,
-        message: `"${origin}" must use HTTPS unless it is a localhost origin`,
-      }
-    }
-
-    if (url.href !== url.origin + '/') {
-      return {
-        valid: false,
-        message: `"${origin}" must be a plain origin without path, query, or fragment (e.g. "${url.origin}")`,
-      }
-    }
-
-    if (rpId && !isOriginCompatibleWithRpId(url.hostname, rpId)) {
-      return {
-        valid: false,
-        message: `"${origin}" is not compatible with Relying Party ID "${rpId}". The origin's hostname must match or be a subdomain of the RP ID.`,
-      }
-    }
-  }
-
-  return { valid: true }
-}
-
-function isOriginCompatibleWithRpId(originHostname: string, rpId: string): boolean {
-  const host = originHostname.toLowerCase()
-  const id = rpId.toLowerCase()
-  if (isLocalhost(host) && isLocalhost(id)) return true
-  if (host === id) return true
-  if (host.endsWith('.' + id)) return true
-  return false
-}
 
 const schema = z
   .object({
@@ -209,7 +131,7 @@ function buildPasskeysFormValues(
   config: GoTrueConfig,
   project: { name: string } | undefined
 ): PasskeysSettings {
-  const values: PasskeysSettings = {
+  return {
     PASSKEY_ENABLED: config.PASSKEY_ENABLED ?? false,
     WEBAUTHN_RP_ID: config.WEBAUTHN_RP_ID || getPasskeyDefault('WEBAUTHN_RP_ID', config, project),
     WEBAUTHN_RP_DISPLAY_NAME:
@@ -218,8 +140,6 @@ function buildPasskeysFormValues(
     WEBAUTHN_RP_ORIGINS:
       config.WEBAUTHN_RP_ORIGINS || getPasskeyDefault('WEBAUTHN_RP_ORIGINS', config, project),
   }
-
-  return values
 }
 
 export const PasskeysSettingsForm = () => {
@@ -365,11 +285,30 @@ export const PasskeysSettingsForm = () => {
                     <FormItemLayout
                       layout="flex-row-reverse"
                       label="Relying Party Origins"
-                      description='Comma-separated list of allowed origins (e.g. "https://example.com"). HTTPS is required except for localhost.'
+                      description='Comma-separated list of allowed origins (e.g. "https://example.com"). HTTPS is required except for localhost. Android native apps use "android:apk-key-hash:<sha256>".'
                     >
                       <FormControl>
                         <Input_Shadcn_ {...field} placeholder="https://example.com" />
                       </FormControl>
+                      {hasAndroidOrigin(field.value) && (
+                        <Alert_Shadcn_ variant="warning" className="mt-3">
+                          <AlertTitle_Shadcn_>Android origin detected</AlertTitle_Shadcn_>
+                          <AlertDescription_Shadcn_ className="flex flex-col gap-1">
+                            <p>
+                              <code className="text-xs">android:apk-key-hash:</code> origins are
+                              correctly validated here but require a pending Management API update
+                              before they can be persisted on hosted Supabase projects.
+                            </p>
+                            <p>
+                              Follow progress on{' '}
+                              <InlineLink href="https://github.com/supabase/supabase/issues/46896">
+                                issue #46896
+                              </InlineLink>
+                              .
+                            </p>
+                          </AlertDescription_Shadcn_>
+                        </Alert_Shadcn_>
+                      )}
                     </FormItemLayout>
                   )}
                 />

--- a/apps/studio/components/interfaces/Auth/Passkeys/__tests__/validation.test.ts
+++ b/apps/studio/components/interfaces/Auth/Passkeys/__tests__/validation.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  hasAndroidOrigin,
+  isAndroidApkKeyHashOrigin,
+  isLocalhost,
+  isOriginCompatibleWithRpId,
+  validateRpId,
+  validateWebAuthnOrigins,
+} from '../validation'
+
+// Real-looking 43-char base64url body (32-byte SHA-256, no padding).
+// Taken from the example in supabase/supabase#46896.
+const ANDROID_HASH = 'bP7V9_HO4FPHc9aBqmokgPsT_CayrPx7Y2MO_lvS3ck'
+const ANDROID_ORIGIN = `android:apk-key-hash:${ANDROID_HASH}`
+const RP_ID = 'example.com'
+
+// ---------------------------------------------------------------------------
+// isAndroidApkKeyHashOrigin
+// ---------------------------------------------------------------------------
+describe('isAndroidApkKeyHashOrigin', () => {
+  it('accepts canonical android:apk-key-hash:<43 base64url chars>', () => {
+    expect(isAndroidApkKeyHashOrigin(ANDROID_ORIGIN)).toBe(true)
+  })
+
+  it('accepts the -sha256 prefix variant', () => {
+    expect(isAndroidApkKeyHashOrigin(`android:apk-key-hash-sha256:${ANDROID_HASH}`)).toBe(true)
+  })
+
+  it('rejects a hash that is too short', () => {
+    expect(isAndroidApkKeyHashOrigin('android:apk-key-hash:tooshort')).toBe(false)
+  })
+
+  it('rejects non-base64url characters in the hash', () => {
+    expect(isAndroidApkKeyHashOrigin(`android:apk-key-hash:${ANDROID_HASH.slice(0, -1)}!`)).toBe(
+      false
+    )
+  })
+
+  it('rejects unrelated android: schemes', () => {
+    expect(isAndroidApkKeyHashOrigin('android:something-else:abc')).toBe(false)
+  })
+
+  it('rejects plain https origins', () => {
+    expect(isAndroidApkKeyHashOrigin('https://example.com')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// hasAndroidOrigin
+// ---------------------------------------------------------------------------
+describe('hasAndroidOrigin', () => {
+  it('returns true when list contains an android origin', () => {
+    expect(hasAndroidOrigin(`https://example.com,${ANDROID_ORIGIN}`)).toBe(true)
+  })
+
+  it('returns true for android-only list', () => {
+    expect(hasAndroidOrigin(ANDROID_ORIGIN)).toBe(true)
+  })
+
+  it('returns false for https-only list', () => {
+    expect(hasAndroidOrigin('https://example.com')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(hasAndroidOrigin('')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isLocalhost
+// ---------------------------------------------------------------------------
+describe('isLocalhost', () => {
+  it('accepts localhost', () => {
+    expect(isLocalhost('localhost')).toBe(true)
+  })
+
+  it('accepts 127.0.0.1', () => {
+    expect(isLocalhost('127.0.0.1')).toBe(true)
+  })
+
+  it('accepts [::1]', () => {
+    expect(isLocalhost('[::1]')).toBe(true)
+  })
+
+  it('rejects example.com', () => {
+    expect(isLocalhost('example.com')).toBe(false)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// isOriginCompatibleWithRpId
+// ---------------------------------------------------------------------------
+describe('isOriginCompatibleWithRpId', () => {
+  it('accepts exact hostname match', () => {
+    expect(isOriginCompatibleWithRpId('example.com', 'example.com')).toBe(true)
+  })
+
+  it('accepts subdomain of rpId', () => {
+    expect(isOriginCompatibleWithRpId('app.example.com', 'example.com')).toBe(true)
+  })
+
+  it('rejects unrelated hostname', () => {
+    expect(isOriginCompatibleWithRpId('other.com', 'example.com')).toBe(false)
+  })
+
+  it('accepts localhost vs localhost', () => {
+    expect(isOriginCompatibleWithRpId('localhost', 'localhost')).toBe(true)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateRpId
+// ---------------------------------------------------------------------------
+describe('validateRpId', () => {
+  it('accepts a bare domain', () => {
+    expect(validateRpId('example.com')).toBe('example.com')
+  })
+
+  it('returns null for empty string', () => {
+    expect(validateRpId('')).toBeNull()
+  })
+
+  it('returns null when scheme is included', () => {
+    expect(validateRpId('https://example.com')).toBeNull()
+  })
+
+  it('returns null for domain with path', () => {
+    expect(validateRpId('example.com/path')).toBeNull()
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateWebAuthnOrigins — Android origins (fix for #46896)
+// ---------------------------------------------------------------------------
+describe('validateWebAuthnOrigins — Android origins (fix for #46896)', () => {
+  it('accepts a mixed list of https + android origins', () => {
+    expect(validateWebAuthnOrigins(`https://example.com,${ANDROID_ORIGIN}`, RP_ID)).toEqual({
+      valid: true,
+    })
+  })
+
+  it('accepts an android-only origin even when rpId is configured', () => {
+    expect(validateWebAuthnOrigins(ANDROID_ORIGIN, RP_ID)).toEqual({ valid: true })
+  })
+
+  it('accepts the -sha256 variant', () => {
+    expect(
+      validateWebAuthnOrigins(`android:apk-key-hash-sha256:${ANDROID_HASH}`, RP_ID)
+    ).toEqual({ valid: true })
+  })
+
+  it('rejects malformed android origin with format-specific error not HTTPS error', () => {
+    const result = validateWebAuthnOrigins('android:apk-key-hash:tooshort', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.message).toMatch(/not a valid Android origin/)
+      expect(result.message).not.toMatch(/must use HTTPS/)
+    }
+  })
+
+  it('rejects unknown android: scheme with format-specific error', () => {
+    const result = validateWebAuthnOrigins('android:something-else:abc', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) {
+      expect(result.message).toMatch(/not a valid Android origin/)
+    }
+  })
+})
+
+// ---------------------------------------------------------------------------
+// validateWebAuthnOrigins — existing behaviour is preserved
+// ---------------------------------------------------------------------------
+describe('validateWebAuthnOrigins — existing behaviour is preserved', () => {
+  it('accepts a plain https origin', () => {
+    expect(validateWebAuthnOrigins('https://example.com', RP_ID)).toEqual({ valid: true })
+  })
+
+  it('accepts http://localhost', () => {
+    expect(validateWebAuthnOrigins('http://localhost:3000', 'localhost')).toEqual({ valid: true })
+  })
+
+  it('accepts an https subdomain of the rpId', () => {
+    expect(validateWebAuthnOrigins('https://app.example.com', RP_ID)).toEqual({ valid: true })
+  })
+
+  it('rejects http on a non-localhost host', () => {
+    const result = validateWebAuthnOrigins('http://example.com', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/must use HTTPS/)
+  })
+
+  it('rejects ftp:// scheme', () => {
+    const result = validateWebAuthnOrigins('ftp://example.com', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/must use HTTPS/)
+  })
+
+  it('rejects https origin with a path', () => {
+    const result = validateWebAuthnOrigins('https://example.com/foo', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/plain origin/)
+  })
+
+  it('rejects an empty list', () => {
+    const result = validateWebAuthnOrigins('', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/At least one origin/)
+  })
+
+  it('rejects more than 5 origins', () => {
+    const six = Array.from({ length: 6 }, (_, i) => `https://app${i}.example.com`).join(',')
+    const result = validateWebAuthnOrigins(six, RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/maximum of 5 origins/)
+  })
+
+  it('rejects an origin whose hostname is not compatible with rpId', () => {
+    const result = validateWebAuthnOrigins('https://other.com', RP_ID)
+    expect(result.valid).toBe(false)
+    if (!result.valid) expect(result.message).toMatch(/not compatible with Relying Party ID/)
+  })
+})

--- a/apps/studio/components/interfaces/Auth/Passkeys/validation.ts
+++ b/apps/studio/components/interfaces/Auth/Passkeys/validation.ts
@@ -1,0 +1,140 @@
+// Canonical Android Credential Manager origin format emitted in clientDataJSON:
+//   android:apk-key-hash:<base64url SHA-256 of APK signing cert>
+//
+// A SHA-256 digest is 32 bytes → 43 base64url chars (no padding).
+// The `-sha256:` prefix variant is non-canonical but accepted by go-webauthn
+// via exact-string match, so we allow it here too to mirror what GoTrue does
+// at request time (see supabase/auth#2545).
+const ANDROID_APK_ORIGIN_REGEX = /^android:apk-key-hash(?:-sha256)?:[A-Za-z0-9_-]{43}$/
+
+/**
+ * Returns true if the origin is a valid Android APK key-hash origin.
+ * These are matched as exact strings by go-webauthn's IsOriginInHaystack
+ * when the needle lacks an http(s) scheme.
+ */
+export function isAndroidApkKeyHashOrigin(origin: string): boolean {
+  return ANDROID_APK_ORIGIN_REGEX.test(origin)
+}
+
+/**
+ * Returns true if the origin string contains at least one android: origin.
+ * Used to show a contextual warning banner in the UI.
+ */
+export function hasAndroidOrigin(originsValue: string): boolean {
+  return originsValue
+    .split(',')
+    .map((o) => o.trim())
+    .some((o) => o.startsWith('android:'))
+}
+
+export function isLocalhost(hostname: string): boolean {
+  return hostname === 'localhost' || hostname === '127.0.0.1' || hostname === '[::1]'
+}
+
+export function isOriginCompatibleWithRpId(originHostname: string, rpId: string): boolean {
+  const host = originHostname.toLowerCase()
+  const id = rpId.toLowerCase()
+  if (isLocalhost(host) && isLocalhost(id)) return true
+  if (host === id) return true
+  if (host.endsWith('.' + id)) return true
+  return false
+}
+
+/**
+ * Validates a bare domain RP ID (e.g. "example.com").
+ * Returns the normalised lowercase domain, or null if invalid.
+ */
+export function validateRpId(rpId: string): string | null {
+  const trimmed = rpId.trim().toLowerCase()
+  if (!trimmed) return null
+  try {
+    const url = new URL('https://' + trimmed)
+    if (url.hostname !== trimmed) return null
+    return trimmed
+  } catch {
+    return null
+  }
+}
+
+export type OriginsValidationResult = { valid: true } | { valid: false; message: string }
+
+/**
+ * Validates a comma-separated list of WebAuthn RP origins.
+ *
+ * Rules:
+ * - 1–5 origins required
+ * - android:apk-key-hash[:sha256]:<43-char base64url> → validated as exact string
+ * - All other origins must be HTTPS (or http://localhost)
+ * - No path, query, or fragment allowed
+ * - Each origin's hostname must be compatible with the RP ID (if provided)
+ */
+export function validateWebAuthnOrigins(
+  value: string,
+  rpId: string | null
+): OriginsValidationResult {
+  const origins = value
+    .split(',')
+    .map((o) => o.trim())
+    .filter(Boolean)
+
+  if (origins.length === 0) {
+    return { valid: false, message: 'At least one origin is required' }
+  }
+
+  if (origins.length > 5) {
+    return { valid: false, message: 'A maximum of 5 origins is allowed' }
+  }
+
+  for (const origin of origins) {
+    // Android native-app origins are matched as exact strings by go-webauthn
+    // (IsOriginInHaystack falls through to string equality when the needle
+    // lacks an http(s) scheme), so they skip URL parsing, the HTTPS rule,
+    // and RP-ID hostname compatibility.
+    if (origin.startsWith('android:')) {
+      if (!isAndroidApkKeyHashOrigin(origin)) {
+        return {
+          valid: false,
+          message: `"${origin}" is not a valid Android origin. Expected format: "android:apk-key-hash:<43-char base64url SHA-256>"`,
+        }
+      }
+      continue
+    }
+
+    let url: URL
+    try {
+      url = new URL(origin)
+    } catch {
+      return { valid: false, message: `"${origin}" is not a valid URL` }
+    }
+
+    if (url.protocol === 'http:') {
+      if (!isLocalhost(url.hostname)) {
+        return {
+          valid: false,
+          message: `"${origin}" must use HTTPS unless it is a localhost origin`,
+        }
+      }
+    } else if (url.protocol !== 'https:') {
+      return {
+        valid: false,
+        message: `"${origin}" must use HTTPS unless it is a localhost origin`,
+      }
+    }
+
+    if (url.href !== url.origin + '/') {
+      return {
+        valid: false,
+        message: `"${origin}" must be a plain origin without path, query, or fragment (e.g. "${url.origin}")`,
+      }
+    }
+
+    if (rpId && !isOriginCompatibleWithRpId(url.hostname, rpId)) {
+      return {
+        valid: false,
+        message: `"${origin}" is not compatible with Relying Party ID "${rpId}". The origin's hostname must match or be a subdomain of the RP ID.`,
+      }
+    }
+  }
+
+  return { valid: true }
+}

--- a/apps/ui-library/registry/default/clients/nextjs/registry-item.json
+++ b/apps/ui-library/registry/default/clients/nextjs/registry-item.json
@@ -14,15 +14,18 @@
   "files": [
     {
       "path": "registry/default/clients/nextjs/lib/supabase/client.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/client.ts"
     },
     {
       "path": "registry/default/clients/nextjs/lib/supabase/middleware.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/middleware.ts"
     },
     {
       "path": "registry/default/clients/nextjs/lib/supabase/server.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/server.ts"
     }
   ]
 }

--- a/apps/ui-library/registry/default/clients/react-router/registry-item.json
+++ b/apps/ui-library/registry/default/clients/react-router/registry-item.json
@@ -14,11 +14,13 @@
   "files": [
     {
       "path": "registry/default/clients/react-router/lib/supabase/client.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/client.ts"
     },
     {
       "path": "registry/default/clients/react-router/lib/supabase/server.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/server.ts"
     }
   ]
 }

--- a/apps/ui-library/registry/default/clients/react/registry-item.json
+++ b/apps/ui-library/registry/default/clients/react/registry-item.json
@@ -14,7 +14,8 @@
   "files": [
     {
       "path": "registry/default/clients/react/lib/supabase/client.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/client.ts"
     }
   ]
 }

--- a/apps/ui-library/registry/default/clients/tanstack/registry-item.json
+++ b/apps/ui-library/registry/default/clients/tanstack/registry-item.json
@@ -14,11 +14,13 @@
   "files": [
     {
       "path": "registry/default/clients/tanstack/lib/supabase/client.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/client.ts"
     },
     {
       "path": "registry/default/clients/tanstack/lib/supabase/server.ts",
-      "type": "registry:lib"
+      "type": "registry:lib",
+      "target": "lib/supabase/server.ts"
     }
   ]
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
YES

## What kind of change does this PR introduce?
Bug fix

## What is the current behavior?
When running the shadcn CLI to install any Supabase client block, the files are not placed in the correct `lib/supabase/` subfolder as shown in the documentation. Instead they land directly in `lib/` — losing the `supabase/` subfolder entirely.

For example, running:
```bash
pnpm dlx shadcn@latest add https://supabase.com/ui/r/supabase-client-nextjs.json
```
Places files at:
- `lib/client.ts` ❌
- `lib/server.ts` ❌
- `lib/middleware.ts` ❌

Instead of the documented structure:
- `lib/supabase/client.ts` ✅
- `lib/supabase/server.ts` ✅
- `lib/supabase/middleware.ts` ✅

Fixes #37771

## What is the new behavior?
All client registry files now include the `target` field, which tells the shadcn CLI exactly where to place each file in the user's project. The `lib/supabase/` subfolder is now correctly created for all 4 frameworks.

This fix covers all affected client registries:
- `nextjs` — 3 files (client.ts, middleware.ts, server.ts)
- `react-router` — 2 files (client.ts, server.ts)
- `react` — 1 file (client.ts)
- `tanstack` — 2 files (client.ts, server.ts)

## Additional context
The root cause is that the `target` field was missing from all file entries inside each `registry-item.json`. Without `target`, the shadcn CLI only uses the filename (last segment of `path`) and places it directly under the base type directory (`lib/`), ignoring any subfolder structure.

Previous PRs (#38159, #38264) attempted to fix this but were either incomplete (only fixed one registry) or were closed before review. This PR fixes all 4 client registries at the source level.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Android APK key-hash origins in passkey validation
  * Implemented warning alerts for Android origins in the passkeys settings form

* **Improvements**
  * Enhanced WebAuthn origin validation with detailed error messages

* **Tests**
  * Added comprehensive test coverage for passkey origin validation across multiple scenarios

* **Chores**
  * Updated registry mappings for Supabase client libraries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->