### PR TITLE
Ensure that fetching policies is filtered by schema in table editor and auth policies page

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -101,10 +101,14 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
   const showHeaderActions = snap.selectedRows.size === 0
 
   const projectRef = project?.ref
-  const { data } = useDatabasePoliciesQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
+  const { data } = useDatabasePoliciesQuery(
+    {
+      projectRef: project?.ref,
+      connectionString: project?.connectionString,
+      schema: table.schema,
+    },
+    { enabled: !!table }
+  )
   const policies = (data ?? []).filter(
     (policy) => policy.schema === table.schema && policy.table === table.name
   )

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -165,7 +165,7 @@ export const useSetProjectStatus = () => {
   }) => {
     // Org projects infinite query
     if (slug) {
-      queryClient.setQueriesData<{ pageParams: any; pages: OrgProjectsResponse[] } | undefined>(
+      queryClient.setQueriesData<{ pages: OrgProjectsResponse[] } | undefined>(
         { queryKey: projectKeys.infiniteListByOrg(slug) },
         (old) => {
           if (!old) return old
@@ -186,7 +186,7 @@ export const useSetProjectStatus = () => {
     }
 
     // Projects infinite query
-    queryClient.setQueriesData<{ pageParams: any; pages: OrgProjectsResponse[] } | undefined>(
+    queryClient.setQueriesData<{ pages: OrgProjectsResponse[] } | undefined>(
       { queryKey: projectKeys.infiniteList() },
       (old) => {
         if (!old) return old

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -116,6 +116,7 @@ export const useProjectDetailQuery = <TData = ProjectDetailData>(
 
 export function prefetchProjectDetail(client: QueryClient, { ref }: ProjectDetailVariables) {
   return client.fetchQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps
     queryKey: projectKeys.detail(ref),
     queryFn: ({ signal }) => getProjectDetail({ ref }, signal, undefined, client),
   })

--- a/apps/studio/pages/project/[ref]/auth/policies.tsx
+++ b/apps/studio/pages/project/[ref]/auth/policies.tsx
@@ -34,6 +34,7 @@ import { RLSTesterSheet } from '@/components/interfaces/Auth/RLSTester/RLSTester
 import AuthLayout from '@/components/layouts/AuthLayout/AuthLayout'
 import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import { getExposedSchemas } from '@/components/layouts/ProjectNeedsSecuring/ProjectNeedsSecuring.utils'
 import { AlertError } from '@/components/ui/AlertError'
 import { AutoEnableRLSNotice } from '@/components/ui/AutoEnableRLSNotice'
 import { BannerRlsTester } from '@/components/ui/BannerStack/Banners/BannerRlsTester'
@@ -114,7 +115,10 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
 
   const { ref: projectRef } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const { data: postgrestConfig } = useProjectPostgrestConfigQuery({ projectRef: project?.ref })
+  const { data: dbSchema } = useProjectPostgrestConfigQuery(
+    { projectRef: project?.ref },
+    { select: ({ db_schema }) => db_schema }
+  )
 
   const isInlineEditorEnabled = useIsInlineEditorEnabled()
   const rlsTesterEnabled = useIsRLSTesterEnabled()
@@ -167,6 +171,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
   } = useDatabasePoliciesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
+    schema,
   })
   const selectedPolicyToEdit = policies.find((policy) => policy.id.toString() === selectedIdToEdit)
 
@@ -186,13 +191,7 @@ const AuthPoliciesPage: NextPageWithLayout = () => {
     () => getTableFilterState(tables ?? [], policies ?? [], searchString),
     [tables, policies, searchString]
   )
-  const exposedSchemas = useMemo(() => {
-    if (!postgrestConfig?.db_schema) return []
-    return postgrestConfig.db_schema
-      .split(',')
-      .map((schema) => schema.trim())
-      .filter((schema) => schema.length > 0)
-  }, [postgrestConfig?.db_schema])
+  const exposedSchemas = getExposedSchemas(dbSchema)
 
   const { can: canReadPolicies, isSuccess: isPermissionsLoaded } = useAsyncCheckPermissions(
     PermissionAction.TENANT_SQL_ADMIN_READ,


### PR DESCRIPTION
## Context

We're currently fetching _all_ database policies when landing on the Table Editor which is unnecessarily since only the table in view matters in that moment.

## Changes involved

- Ensure that fetching policies is filtered by the current schema in the table editor to avoid fetching all policies in the DB
- ^ Applied the same fix on the Auth Policies page as well since it faces the same issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database policy fetching so it respects the currently selected schema and won’t run when the table context is missing.
  * Enhanced project status updates by aligning cached updates with the infinite-list query structure.
* **Refactor**
  * Streamlined auth policy schema handling by deriving exposed schemas via shared utilities and requesting only the needed configuration field for subsequent policy queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->