### PR TITLE
fix(cron): display timestamps in UTC FE-3570

### DIFF
--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.test.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.test.tsx
@@ -1,0 +1,73 @@
+import { screen } from '@testing-library/dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { render } from '@/tests/helpers'
+import { CronJobTableCell } from './CronJobTableCell'
+
+vi.mock('@/data/database-cron-jobs/database-cron-job-run-mutation', () => ({
+  useDatabaseCronJobRunCommandMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/data/database-cron-jobs/database-cron-jobs-toggle-mutation', () => ({
+  useDatabaseCronJobToggleMutation: () => ({ mutate: vi.fn(), isPending: false }),
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({ data: { ref: 'test-ref' } }),
+}))
+
+vi.mock('nuqs', () => ({
+  parseAsString: { withDefault: () => null },
+  useQueryState: () => ['', vi.fn()],
+}))
+
+const TEST_TIMESTAMP = '2026-06-15T09:25:00.000Z'
+
+const baseRow = {
+  jobid: 1,
+  jobname: 'test-job',
+  schedule: '*/5 * * * *',
+  latest_run: TEST_TIMESTAMP,
+  status: 'succeeded',
+  active: true,
+  command: 'SELECT 1',
+}
+
+describe('CronJobTableCell timestamp display', () => {
+  it('renders latest_run in UTC', () => {
+    render(
+      <CronJobTableCell
+        col={{ id: 'latest_run', name: 'Last run' }}
+        row={baseRow}
+        onSelectEdit={vi.fn()}
+        onSelectDelete={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/\(UTC\)/)).toBeInTheDocument()
+  })
+
+  it('renders next_run in UTC', () => {
+    render(
+      <CronJobTableCell
+        col={{ id: 'next_run', name: 'Next run' }}
+        row={baseRow}
+        onSelectEdit={vi.fn()}
+        onSelectDelete={vi.fn()}
+      />
+    )
+    expect(screen.getByText(/\(UTC\)/)).toBeInTheDocument()
+  })
+
+  it('shows a dash when latest_run is absent', () => {
+    const { container } = render(
+      <CronJobTableCell
+        col={{ id: 'latest_run', name: 'Last run' }}
+        row={{ ...baseRow, latest_run: undefined }}
+        onSelectEdit={vi.fn()}
+        onSelectDelete={vi.fn()}
+      />
+    )
+    expect(container.querySelector('svg')).toBeInTheDocument()
+    expect(screen.queryByText(/\(UTC\)/)).toBeNull()
+  })
+})

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobTableCell.tsx
@@ -256,7 +256,8 @@ export const CronJobTableCell = ({
             ) : (
               <TimestampInfo
                 utcTimestamp={formattedValue}
-                labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
+                displayAs="utc"
+                labelFormat="DD MMM YYYY HH:mm:ss [(UTC)]"
                 className="font-sans text-xs"
               />
             )

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -470,17 +470,20 @@ describe('formatDate', () => {
     expect(formatDate('not-a-date')).toBe('Invalid Date')
   })
 
-  it('displays time in UTC regardless of system timezone', () => {
-    // 2026-06-15T09:25:00Z is 09:25 in UTC; the output must include 'UTC'
-    const result = formatDate('2026-06-15T09:25:00.000Z')
-    expect(result).toContain('UTC')
+  it('returns Invalid Date for an empty string', () => {
+    expect(formatDate('')).toBe('Invalid Date')
   })
 
-  it('formats the correct UTC hour, not local', () => {
-    // 2026-01-01T00:30:00Z is midnight UTC; any local-timezone rendering
-    // in a UTC+N zone would produce a different hour or even a different day.
-    const result = formatDate('2026-01-01T00:30:00.000Z')
-    expect(result).toContain('UTC')
+  it('formats a UTC timestamp to the exact UTC hour and minute', () => {
+    // Any local-timezone renderer in UTC+N would produce hour 11 or later
+    // for this input; the only correct UTC answer is 09:25.
+    expect(formatDate('2026-06-15T09:25:00.000Z')).toBe('15 Jun 2026, 09:25:00 UTC')
+  })
+
+  it('formats a near-midnight UTC timestamp without rolling the day', () => {
+    // 2026-01-01T00:30:00Z is 00:30 on Jan 1 in UTC.
+    // A UTC+5 renderer would produce Dec 31 at 19:30 — the wrong day entirely.
+    expect(formatDate('2026-01-01T00:30:00.000Z')).toBe('01 Jan 2026, 00:30:00 UTC')
   })
 })
 

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.test.ts
@@ -4,7 +4,9 @@ import { cronPattern, secondsPattern } from './CronJobs.constants'
 import {
   buildCronCreateQuery,
   buildCronUpdateQuery,
+  calculateDuration,
   formatCronJobColumns,
+  formatDate,
   parseCronJobCommand,
 } from './CronJobs.utils'
 
@@ -460,6 +462,43 @@ describe('parseCronJobCommand', () => {
     it(`should match the regex for a cronPattern with "${description}"`, () => {
       expect(command).toMatch(cronPattern)
     })
+  })
+})
+
+describe('formatDate', () => {
+  it('returns Invalid Date for a non-date string', () => {
+    expect(formatDate('not-a-date')).toBe('Invalid Date')
+  })
+
+  it('displays time in UTC regardless of system timezone', () => {
+    // 2026-06-15T09:25:00Z is 09:25 in UTC; the output must include 'UTC'
+    const result = formatDate('2026-06-15T09:25:00.000Z')
+    expect(result).toContain('UTC')
+  })
+
+  it('formats the correct UTC hour, not local', () => {
+    // 2026-01-01T00:30:00Z is midnight UTC; any local-timezone rendering
+    // in a UTC+N zone would produce a different hour or even a different day.
+    const result = formatDate('2026-01-01T00:30:00.000Z')
+    expect(result).toContain('UTC')
+  })
+})
+
+describe('calculateDuration', () => {
+  it('returns milliseconds for sub-second durations', () => {
+    expect(calculateDuration('2026-06-15T09:25:00.000Z', '2026-06-15T09:25:00.500Z')).toBe('500ms')
+  })
+
+  it('returns seconds for durations under a minute', () => {
+    expect(calculateDuration('2026-06-15T09:25:00.000Z', '2026-06-15T09:25:05.000Z')).toBe('5.0s')
+  })
+
+  it('returns minutes for durations of a minute or more', () => {
+    expect(calculateDuration('2026-06-15T09:25:00.000Z', '2026-06-15T09:27:00.000Z')).toBe('2.0m')
+  })
+
+  it('returns Invalid Date for unparseable inputs', () => {
+    expect(calculateDuration('bad', 'also-bad')).toBe('Invalid Date')
   })
 })
 

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
@@ -256,13 +256,14 @@ export function formatDate(dateString: string): string {
   }
   const options: Intl.DateTimeFormatOptions = {
     year: 'numeric',
-    month: 'short', // Use 'long' for full month name
+    month: 'short',
     day: '2-digit',
     hour: '2-digit',
     minute: '2-digit',
     second: '2-digit',
-    hour12: false, // Use 12-hour format if preferred
-    timeZoneName: 'short', // Optional: to include timezone
+    hour12: false,
+    timeZone: 'UTC',
+    timeZoneName: 'short',
   }
   return date.toLocaleString(undefined, options)
 }

--- a/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/CronJobs.utils.tsx
@@ -1,7 +1,11 @@
 import { keyword, literal, safeSql, type SafeSqlFragment } from '@supabase/pg-meta/src/pg-format'
 import { toString as CronToString } from 'cronstrue'
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
 import { Column } from 'react-data-grid'
 import { cn } from 'ui'
+
+dayjs.extend(utc)
 
 import { CronJobType } from './CreateCronJobSheet/CreateCronJobSheet.constants'
 import { CRON_TABLE_COLUMNS, HTTPHeader, secondsPattern } from './CronJobs.constants'
@@ -250,22 +254,10 @@ export function calculateDuration(start: string, end: string): string {
 }
 
 export function formatDate(dateString: string): string {
-  const date = new Date(dateString)
-  if (isNaN(date.getTime())) {
-    return 'Invalid Date'
-  }
-  const options: Intl.DateTimeFormatOptions = {
-    year: 'numeric',
-    month: 'short',
-    day: '2-digit',
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-    hour12: false,
-    timeZone: 'UTC',
-    timeZoneName: 'short',
-  }
-  return date.toLocaleString(undefined, options)
+  if (!dateString) return 'Invalid Date'
+  const parsed = dayjs.utc(dateString)
+  if (!parsed.isValid()) return 'Invalid Date'
+  return parsed.format('DD MMM YYYY, HH:mm:ss [UTC]')
 }
 
 export function isSecondsFormat(schedule: string): boolean {

--- a/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.test.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.test.tsx
@@ -1,0 +1,71 @@
+import { screen } from '@testing-library/dom'
+import { describe, expect, it, vi } from 'vitest'
+
+import { render } from '@/tests/helpers'
+import { PreviousRunsTab } from './PreviousRunsTab'
+
+const TEST_START = '2026-06-15T09:25:00.000Z'
+const TEST_END = '2026-06-15T09:25:05.000Z'
+
+// Replace the virtualized DataGrid with a plain renderer so renderCell
+// functions are exercised without needing real DOM dimensions.
+vi.mock('react-data-grid', () => ({
+  default: ({ rows, columns }: any) => (
+    <div>
+      {rows.map((row: any, rowIdx: number) =>
+        columns.map((col: any) => (
+          <div key={`${rowIdx}-${String(col.key)}`}>{col.renderCell?.({ row })}</div>
+        ))
+      )}
+    </div>
+  ),
+  Row: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('common', () => ({
+  useParams: () => ({ childId: '1' }),
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({
+    data: { ref: 'test-ref', connectionString: 'test-conn' },
+  }),
+}))
+
+vi.mock('@/data/database-cron-jobs/database-cron-jobs-runs-infinite-query', () => ({
+  useCronJobRunsInfiniteQuery: () => ({
+    data: {
+      pages: [
+        [
+          {
+            runid: 1,
+            job_pid: 123,
+            jobid: 1,
+            start_time: TEST_START,
+            end_time: TEST_END,
+            return_message: null,
+            status: 'succeeded',
+          },
+        ],
+      ],
+    },
+    isPending: false,
+    isFetching: false,
+    isFetchingNextPage: false,
+    hasNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}))
+
+vi.mock('@/hooks/misc/useInfiniteScroll', () => ({
+  useInfiniteScroll: () => vi.fn(),
+}))
+
+describe('PreviousRunsTab timestamp display', () => {
+  it('renders start_time and end_time columns in UTC', () => {
+    render(<PreviousRunsTab />)
+    // Both start_time and end_time should show timestamps ending in (UTC)
+    const utcLabels = screen.getAllByText(/\(UTC\)/)
+    expect(utcLabels.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/CronJobs/PreviousRunsTab.tsx
@@ -134,7 +134,8 @@ const columns = cronJobColumns.map((col) => {
             <div className="flex items-center">
               <TimestampInfo
                 utcTimestamp={formattedValue}
-                labelFormat="DD MMM YYYY HH:mm:ss (ZZ)"
+                displayAs="utc"
+                labelFormat="DD MMM YYYY HH:mm:ss [(UTC)]"
                 className="text-xs"
               />
             </div>


### PR DESCRIPTION
## Problem

Cron job timestamps in the Jobs list and Job History tabs were displayed in the browser's local timezone with no way to switch to UTC. This made it harder to correlate cron runs with server logs and alerts, which are always in UTC.

## Fix

- Pass `displayAs="utc"` and `labelFormat="DD MMM YYYY HH:mm:ss [(UTC)]"` to the `TimestampInfo` component in `CronJobTableCell` (Jobs list) and `PreviousRunsTab` (Job History).
- Rewrote `formatDate` in `CronJobs.utils.tsx` to use `dayjs.utc` instead of `toLocaleString`, making the output deterministic across all locales.
- Added component render tests for both tables asserting timestamps show `(UTC)`, and unit tests for `formatDate` asserting exact UTC hour and minute values.

## How to test

- Navigate to Dashboard > Integrations > Cron > Jobs tab.
- Observe the "Last run" and "Next run" columns: timestamps should read e.g. `15 Jun 2026 09:25:00 (UTC)`.
- Hover over any timestamp to confirm the tooltip still shows local timezone and relative time rows.
- Open a job and go to the Job History tab.
- Confirm "Start Time" and "End Time" columns also show `(UTC)`.
- Switch your system or browser timezone to something other than UTC and reload; the primary label should remain in UTC.