### PR TITLE
fix(www): call ScrollProgress hooks unconditionally to prevent crash

### DIFF
--- a/apps/www/components/ScrollProgress.tsx
+++ b/apps/www/components/ScrollProgress.tsx
@@ -8,27 +8,29 @@ const ScrollProgress = () => {
   const pathname = usePathname()
 
   const isBlogPost = pathname?.includes('/blog/')
-  if (!isBlogPost) return null
-
-  const handleScroll = () => {
-    if (typeof document === 'undefined') return null
-    const article = document?.querySelector('article')
-    if (!article) return null
-    const { top, height } = (article as any)?.getBoundingClientRect()
-    let scrollDistance = -top
-    let progressPercentage =
-      (scrollDistance / (height - document.documentElement.clientHeight)) * 100
-    setProgressPercentage(progressPercentage)
-  }
 
   useEffect(() => {
+    if (!isBlogPost) return
+
+    const handleScroll = () => {
+      const article = document.querySelector('article')
+      if (!article) return
+      const { top, height } = article.getBoundingClientRect()
+      const scrollDistance = -top
+      const nextPercentage =
+        (scrollDistance / (height - document.documentElement.clientHeight)) * 100
+      setProgressPercentage(nextPercentage)
+    }
+
     window.addEventListener('scroll', handleScroll)
     return () => {
       window.removeEventListener('scroll', handleScroll)
     }
-  }, [])
+  }, [isBlogPost])
 
-  let isActive = progressPercentage <= 100
+  if (!isBlogPost) return null
+
+  const isActive = progressPercentage <= 100
 
   return (
     <div className="h-[2px] w-full flex justify-start relative">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`ScrollProgress` calls its hooks conditionally. The early `return null` for non-blog routes sits **above** the `useEffect`:

```tsx
const isBlogPost = pathname?.includes('/blog/')
if (!isBlogPost) return null   // bails out before the hook below

// ...
useEffect(() => { ... }, [])   // only runs on blog routes
```

So a blog route renders `useState` + `usePathname` + `useEffect` (3 hooks), while a non-blog route renders only `useState` + `usePathname` (2 hooks).

This component is mounted in the global nav (`components/Nav/index.tsx`), which persists across client-side navigation. The same instance therefore re-renders with a changing `pathname`, and the hook count changes between renders. React then throws:

> Rendered fewer hooks than expected. This may be caused by an accidental early return statement.

i.e. navigating from a blog post (`/blog/...`) to any non-blog page crashes the render. It also violates the Rules of Hooks — `eslint-plugin-react-hooks` flags it:

```
react-hooks/rules-of-hooks: React Hook "useEffect" is called conditionally.
React Hooks must be called in the exact same order in every component render.
```

## What is the new behavior?

The `useEffect` is now always called, and the `return null` guard moved below it. The blog-only logic lives inside the effect (`if (!isBlogPost) return`), with `isBlogPost` in the dependency array so the scroll listener attaches/detaches as the route changes. The scroll handler moved inside the effect (it only depends on `setProgressPercentage`), and the redundant `typeof document` guard / `as any` cast were dropped since the effect only runs client-side.

Hook order is now stable across every render, the listener is correctly scoped to blog routes, and the eslint warning is gone.

## Additional context

`react`/`usePathname`/`useState` imports unchanged. Behaviour on blog pages is identical; the fix only removes the conditional-hook crash on navigation away from a post.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scroll progress tracking now only activates on blog post pages, significantly reducing unnecessary processing on other site sections
  * Component refinement prevents scroll monitoring from running on non-blog pages for improved performance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->