### PR TITLE
fix(www): preserve arguments on debounce trailing edge

### DIFF
--- a/apps/www/lib/helpers.test.ts
+++ b/apps/www/lib/helpers.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { debounce } from './helpers'
+
+describe('debounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('invokes the trailing call with the arguments from the most recent call', () => {
+    const spy = vi.fn()
+    const debounced = debounce(spy, 100)
+
+    debounced('a')
+    debounced('b')
+
+    vi.advanceTimersByTime(100)
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith('b')
+  })
+
+  it('forwards all arguments to a single trailing invocation', () => {
+    const spy = vi.fn()
+    const debounced = debounce(spy, 50)
+
+    debounced(1, 2, 3)
+
+    vi.advanceTimersByTime(50)
+
+    expect(spy).toHaveBeenCalledWith(1, 2, 3)
+  })
+
+  it('passes the latest arguments on the leading edge as well', () => {
+    const spy = vi.fn()
+    const debounced = debounce(spy, 100, { leading: true, trailing: false })
+
+    debounced('first')
+
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(spy).toHaveBeenCalledWith('first')
+  })
+
+  it('does not invoke after cancel()', () => {
+    const spy = vi.fn()
+    const debounced = debounce(spy, 100)
+
+    debounced('x')
+    debounced.cancel()
+
+    vi.advanceTimersByTime(100)
+
+    expect(spy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/www/lib/helpers.tsx
+++ b/apps/www/lib/helpers.tsx
@@ -131,12 +131,16 @@ export const debounce = <T extends (...args: any[]) => any>(
   pending: () => boolean
 } => {
   let timeoutId: ReturnType<typeof setTimeout> | undefined
+  let lastArgs: Parameters<T> | undefined
   let lastCallTime: number | undefined
   let lastInvokeTime = 0
 
   const { leading = false, trailing = true } = options
 
-  function invokeFunc(time: number, ...args: Parameters<T>) {
+  function invokeFunc(time: number) {
+    const args = lastArgs ?? ([] as unknown as Parameters<T>)
+
+    lastArgs = undefined
     lastInvokeTime = time
     func.apply(null, args)
   }
@@ -149,10 +153,10 @@ export const debounce = <T extends (...args: any[]) => any>(
     clearTimeout(id)
   }
 
-  function leadingEdge(time: number, ...args: Parameters<T>) {
+  function leadingEdge(time: number) {
     lastInvokeTime = time
     timeoutId = startTimer(timerExpired, wait)
-    return leading ? invokeFunc(time, ...args) : undefined
+    return leading ? invokeFunc(time) : undefined
   }
 
   function remainingWait(time: number) {
@@ -186,10 +190,12 @@ export const debounce = <T extends (...args: any[]) => any>(
   function trailingEdge(time: number) {
     timeoutId = undefined
 
-    if (trailing) {
-      // For trailing edge, we don't have the original arguments, so we call without them
-      return invokeFunc(time, ...([] as any))
+    // Only invoke if we have pending arguments captured from a debounced call.
+    if (trailing && lastArgs !== undefined) {
+      return invokeFunc(time)
     }
+
+    lastArgs = undefined
   }
 
   function cancel() {
@@ -197,6 +203,7 @@ export const debounce = <T extends (...args: any[]) => any>(
       cancelTimer(timeoutId)
     }
     lastInvokeTime = 0
+    lastArgs = undefined
     lastCallTime = undefined
     timeoutId = undefined
   }
@@ -213,15 +220,16 @@ export const debounce = <T extends (...args: any[]) => any>(
     const time = Date.now()
     const isInvoking = shouldInvoke(time)
 
+    lastArgs = args
     lastCallTime = time
 
     if (isInvoking) {
       if (timeoutId === undefined) {
-        return leadingEdge(lastCallTime, ...args)
+        return leadingEdge(lastCallTime)
       }
       if (trailing) {
         timeoutId = startTimer(timerExpired, wait)
-        return invokeFunc(lastCallTime, ...args)
+        return invokeFunc(lastCallTime)
       }
     }
     if (timeoutId === undefined) {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`debounce` in `apps/www/lib/helpers.tsx` is a vanilla replacement for lodash's `debounce`, but it drops the call arguments on the trailing edge. The trailing invocation was hard-coded to pass nothing:

```tsx
function trailingEdge(time: number) {
  timeoutId = undefined
  if (trailing) {
    // For trailing edge, we don't have the original arguments, so we call without them
    return invokeFunc(time, ...([] as any))
  }
}
```

With the default options (`leading: false, trailing: true`) the function is only ever invoked on the trailing edge, so a debounced callback that reads its arguments receives `undefined` instead of the most recent call's arguments. For example:

```tsx
const onChange = debounce((value: string) => search(value), 300)
onChange('hello') // 300ms later, search() is called with undefined, not 'hello'
```

This diverges from the lodash behaviour the helper is meant to match (lodash invokes the trailing edge with the arguments from the latest call).

## What is the new behavior?

The most recent call's arguments are captured in `lastArgs` and forwarded to whichever edge actually invokes the function. The trailing edge now only fires when there are pending arguments, and `cancel()` clears them. Leading-edge and immediate-invoke paths reuse the same captured arguments, so behaviour is unchanged there.

Added `apps/www/lib/helpers.test.ts` covering the trailing-edge argument forwarding, multiple-call coalescing (latest args win), the leading-edge path, and `cancel()`. The two argument-forwarding tests fail against the previous implementation and pass with this change.

## Additional context

`this` binding is unchanged from the previous implementation (the function was already invoked with `null` as the context). The change is scoped to argument forwarding. `pnpm --filter www test`, lint, and prettier pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for the debounce utility, verifying behavior with leading invocations, trailing invocations, argument forwarding, and cancellation functionality to ensure reliability.

* **Refactor**
  * Enhanced debounce utility implementation with improved argument capture and state management, resulting in more consistent and predictable behavior across various usage scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->