### PR TITLE
docs: update PostgreSQL upgrading guide

### DIFF
--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -52,7 +52,7 @@ If you are upgrading from a significantly older version, you will need to consid
 
 1. Make sure to discuss with your teams a suitable maintenance window as upgrading involves downtime, this will be crucial for minimising the impact.
 2. For smaller databases, we recommend taking a logical backup of the data using [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) utility. This is to ensure you have sufficient backup before upgrading.
-3. For larger databases, ensure that a recent backup is in the [Backups](https://supabase.com/dashboard/project/_/database/backups/scheduled) page in the Dashboard.
+3. For larger databases, ensure that a recent backup is in the [Backups](/dashboard/project/_/database/backups/scheduled) page in the Dashboard.
 4. Reduce the size of the data and the number of objects in the database. The time to upgrade highly depends on these factors, and can influence downtime. For example: Archiving data which is not actively used, dropping unused indexes, running vacuum etc. See the [Inspect](/docs/reference/cli/supabase-inspect-db) command in the Supabase CLI for a detailed report on space that can be gained, as well as the [pg_repack](/docs/guides/database/extensions/pg_repack) documentation.
 
 ## Post-upgrade best practices

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -8,7 +8,7 @@ For scaling your compute size, refer to the [Compute and Disk page](/docs/guides
 
 ## How we upgrade
 
-The process remains the same for PostgreSQL major and minor version upgrades, as other features and services are also upgraded at the same time.
+The process remains the same for Postgres major and minor version upgrades, as other features and services are also upgraded at the same time.
 
 <Admonition type="note">
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -98,7 +98,7 @@ Starting from 2024-06-24, when a project is paused, users then have a 90-day win
 
 The 90-day window allows Supabase to introduce platform changes that may not be backwards compatible with older backups. Unlike active projects, static backups can't be updated to accommodate such changes.
 
-During the 90-day restore window a paused project can be restored to the platform with a single button click from [Studio's dashboard page](https://supabase.com/dashboard/projects).
+During the 90-day restore window a paused project can be restored to the platform with a single button click from [Studio's dashboard page](/dashboard/projects).
 
 <Image
   alt="Project Paused: 90 Days Remaining"

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -2,59 +2,44 @@
 title: Upgrading
 ---
 
-Supabase ships fast and we endeavor to add all new features to existing projects wherever possible. In some cases, access to new features require upgrading or migrating your Supabase project.
+Supabase ships fast and we endeavor to add all new features to existing projects wherever possible. In some cases, access to new features require upgrading or migrating your Supabase project. It is recommended to upgrade PostgreSQL version to get access to the latest features and fixes.
 
-<Admonition type="tip">
+For scaling your compute size, refer to the [Compute and Disk page](/docs/guides/platform/compute-and-disk).
 
-This guide refers to upgrading the Postgres version of your Supabase Project. For scaling your compute size, refer to the [Compute and Disk page](/docs/guides/platform/compute-and-disk).
+## How we upgrade
 
-</Admonition>
-
-You can upgrade your project using in-place upgrades or by pausing and restoring your project.
-
-## In-place upgrades
+The process remains the same for PostgreSQL major and minor version upgrades, as other features and services are also upgraded at the same time.
 
 <Admonition type="note">
 
-For security purposes, passwords for custom roles are not backed up and, following a restore, they would need to be reset. See [here](/docs/guides/platform/backups#daily-backups) for more details
+Free projects will move to the latest minor version when their paused project is restored. Paid projects can't be paused.
 
 </Admonition>
 
-In-place upgrades uses `pg_upgrade`. For projects larger than 1GB, this method is generally faster than a pause and restore cycle, and the speed advantage grows with the size of the database.
+The upgrade process is as follows:
 
-1. Plan for an appropriate downtime window, and ensure you have reviewed the [caveats](#caveats) section of this document before executing the upgrade.
-1. Use the "Upgrade project" button on the [Infrastructure](/dashboard/project/_/settings/infrastructure) section of your dashboard.
+1. Use the "Upgrade project" button on the [Infrastructure](https://supabase.com/dashboard/project/_/settings/infrastructure) section of your dashboard.
+2. An estimate of the time to upgrade is shown and anything that needs to be addressed before you are eligible to upgrade is shown as a warning. Ensure you have reviewed the [caveats](#caveats) section of this document before executing the upgrade.
+3. Your project is taken offline and the Dashboard shows the upgrade status.
+4. Behind the scenes, a new instance is created running the latest version of Supabase.
+5. Your data is copied to the new instance and upgraded using `pg_upgrade`.
+6. If the upgrade should fail, your original database would be brought back up online and be able to service requests.
+7. When the upgrade succeeds, a [basebackup](https://www.postgresql.org/docs/current/app-pgbasebackup.html) is taken and, once complete, your project is available in the Dashboard.
 
-Additionally, if the upgrade should fail, your original database would be brought back up online and be able to service requests.
+A Supabase project is deployed with a GP3 disk type by default, which will give ~100Mbps when upgrading. Changing the [disk type (or increasing IOPS/Throughput)](/docs/guides/platform/compute-and-disk) will reduce the time to upgrade.
 
-As a rough rule of thumb, pg_upgrade operates at ~100MBps (when executing an upgrade on your data). Using the size of your database, you can use this metric to derive an approximate sense of the downtime window necessary for the upgrade. During this window, you should plan for your database and associated services to be unavailable.
+Using the size of your database, you can use this metric to derive an approximation of the downtime window necessary for the upgrade. During this window, you should plan for your database and associated services to be unavailable.
 
-## Pause and restore
+## Upgrade pre-requisites
 
-<Admonition type="note">
+When upgrading, a notification will inform you about what is blocking the upgrade process. You need to follow the pre-requisites for the upgrade to successfully complete:
 
-We recommend using the In-place upgrade method, as it is faster, and more reliable. Additionally, only Free-tier projects are eligible to use the Pause and Restore method.
+1. Projects with read-replicas can't be upgraded. You need to delete the replicas and re-create them after upgrade completes.
+2. `pg_upgrade` does not support upgrading of databases containing `reg*` data types referencing system OIDs. You need to modify the data to not use `reg*` data types before upgrade.
+3. Logical replication slots must be dropped.
+4. Deprecated/unsupported extensions must be dropped. Extensions can have dependencies, make sure you backup that data to restore it after the upgrade, with the updated extension version.
 
-</Admonition>
-
-When you pause and restore a project, the restored database includes the latest features. **This method includes downtime**, so be aware that your project will be inaccessible for a short period of time.
-
-1. On the [General Settings](/dashboard/project/_/settings/general) page in the Dashboard, click **Pause project**. You will be redirected to the home screen in the meantime.
-1. After this, click **Restore project**. Your project will be restored from the [physical backup](/guides/platform/backups). You should receive an email once the restoration is complete.
-
-Pausing and restoring project will take some time depending on how much data your database has. If the restore process fails, [contact Supabase support](/dashboard/support/new?projectRef=) to bring your project back online.
-
-## Caveats
-
-Regardless of the upgrade method, a few caveats apply:
-
-### Logical replication
-
-If you are using logical replication, the replication slots will not be preserved by the upgrade process. You will need to manually recreate them after the upgrade with the method `pg_create_logical_replication_slot`. Refer to the Postgres docs on [Replication Management Functions](https://www.postgresql.org/docs/current/functions-admin.html#FUNCTIONS-REPLICATION) for more details about the method.
-
-### Breaking changes
-
-Newer versions of services can break functionality or change the performance characteristics you rely on. If your project is eligible for an upgrade, you will be able to find your current service versions from within [the Supabase dashboard](/dashboard/project/_/settings/infrastructure).
+Newer versions of services can break functionality or change the performance characteristics you rely on. If your project is eligible for an upgrade, you will be able to find your current service versions from within [the Supabase dashboard](https://supabase.com/dashboard/project/_/settings/infrastructure).
 
 Breaking changes are generally only present in major version upgrades of Postgres and PostgREST. You can find their respective release notes at:
 
@@ -63,70 +48,22 @@ Breaking changes are generally only present in major version upgrades of Postgre
 
 If you are upgrading from a significantly older version, you will need to consider the release notes for any intermediary releases as well.
 
-### Time limits
+## Pre-upgrade best practices
 
-Starting from 2024-06-24, when a project is paused, users then have a 90-day window to restore the project on the platform from within Supabase Studio.
+1. Make sure to discuss with your teams a suitable maintenance window as upgrading involves downtime, this will be crucial for minimising the impact.
+2. For smaller databases, we recommend taking a logical backup of the data using [pg_dump](https://www.postgresql.org/docs/current/app-pgdump.html) utility. This is to ensure you have sufficient backup before upgrading.
+3. For larger databases, ensure that a recent backup is in the [Backups](https://supabase.com/dashboard/project/_/database/backups/scheduled) page in the Dashboard.
+4. Reduce the size of the data and the number of objects in the database. The time to upgrade highly depends on these factors, and can influence downtime. For example: Archiving data which is not actively used, dropping unused indexes, running vacuum etc. See the [Inspect](/docs/reference/cli/supabase-inspect-db) command in the Supabase CLI for a detailed report on space that can be gained, as well as the [pg_repack](/docs/guides/database/extensions/pg_repack) documentation.
 
-The 90-day window allows Supabase to introduce platform changes that may not be backwards compatible with older backups. Unlike active projects, static backups can't be updated to accommodate such changes.
+## Post-upgrade best practices
 
-During the 90-day restore window a paused project can be restored to the platform with a single button click from [Studio's dashboard page](/dashboard/projects).
+1. Supabase performs extensive pre- and post-upgrade validations to ensure that the database has been correctly upgraded. However, you should plan for your own application-level validations, as there might be changes you might not have anticipated, and this should be budgeted for when planning your downtime window.
+2. Analyze logs for any new slow-running queries that may have emerged post-upgrade. This is possible due to the change in data structure during upgrade.
+3. Verify extension versions, and look for the extensions you need to upgrade.
 
-<Image
+## Caveats
 
-alt="Project Paused: 90 Days Remaining"
-width={962}
-height={386}
-src="/docs/img/guides/platform/paused-90-day.png"
-/>
-
-After the 90-day restore window, you can download your project's backup file, and Storage objects from the project dashboard. You can restore the data in the following ways:
-
-- [Restore a backup to a new Supabase project](/docs/guides/platform/migrating-within-supabase/dashboard-restore)
-- [Restore a backup locally](/docs/guides/local-development/restoring-downloaded-backup)
-
-<Image
-
-alt="Project Paused: 90 Days Remaining"
-src="/docs/img/guides/platform/paused-dl-backup.png"
-width={495}
-height={306}
-/>
-
-If you upgrade to a paid plan while your project is paused within the 90-day restore window, any expired one-click restore options are reenabled. Since the backup was taken outside the backwards compatibility window, it may fail to restore. If you have a problem restoring your backup after upgrading, contact [Support](/support).
-
-<Image
-
-alt="Project Paused: 90 Days Remaining"
-src="/docs/img/guides/platform/paused-paid-tier.png"
-width={962}
-height={385}
-/>
-
-### Disk sizing
-
-When upgrading, the Supabase platform will "right-size" your disk based on the current size of the database. For example, if your database is 100GB in size, and you have a 200GB disk, the upgrade will reduce the disk size to 120GB (1.2x the size of your database).
-
-### Objects dependent on Postgres extensions
-
-In-place upgrades do not support upgrading of databases containing reg\* data types referencing system OIDs.
-If you have created any objects that depend on the following extensions, you will need to recreate them after the upgrade.
-
-### `pg_cron` records
-
-[pg_cron](https://github.com/citusdata/pg_cron#viewing-job-run-details) does not automatically clean up historical records. This can lead to extremely large `cron.job_run_details` tables if the records are not regularly pruned; you should clean unnecessary records from this table prior to an upgrade.
-
-During an in-place upgrade, the `pg_cron` extension gets dropped and recreated. Prior to this process, the `cron.job_run_details` table is duplicated to avoid losing historical logs. The instantaneous disk pressure created by duplicating an extremely large details table can cause at best unnecessary performance degradation, or at worst, upgrade process failures.
-
-### Extensions
-
-In-place upgrades do not currently support upgrading of databases using extensions older than the following versions:
-
-- TimescaleDB 2.16.1
-- plv8 3.1.10
-
-To upgrade to a newer version of Postgres, you will need to drop the extensions before the upgrade, and recreate them after the upgrade.
-
-#### Authentication method changes - deprecating md5 in favor of scram-sha-256
+### Custom roles with md5 passwords
 
 The md5 hashing method has [known weaknesses](https://en.wikipedia.org/wiki/MD5#Security) that make it unsuitable for cryptography.
 As such, we are deprecating md5 in favor of [scram-sha-256](https://www.postgresql.org/docs/current/auth-password.html), which is the default and most secure authentication method used in the latest Postgres versions.
@@ -151,9 +88,45 @@ ALTER ROLE <role_name> WITH PASSWORD '<password>';
 
 As part of the upgrade process, maintenance operations such as [vacuuming](https://www.postgresql.org/docs/current/routine-vacuuming.html#ROUTINE-VACUUMING) are also executed. This can result in a reduction in the reported database size.
 
-### Post-upgrade validation
+### Disk sizing
 
-Supabase performs extensive pre- and post-upgrade validations to ensure that the database has been correctly upgraded. However, you should plan for your own application-level validations, as there might be changes you might not have anticipated, and this should be budgeted for when planning your downtime window.
+When upgrading, the Supabase platform will "right-size" your disk based on the current size of the database. For example, if your database is 100GB in size, and you have a 200GB disk, the upgrade will reduce the disk size to 120GB (1.2x the size of your database).
+
+### Time limits
+
+Starting from 2024-06-24, when a project is paused, users then have a 90-day window to restore the project on the platform from within Supabase Studio.
+
+The 90-day window allows Supabase to introduce platform changes that may not be backwards compatible with older backups. Unlike active projects, static backups can't be updated to accommodate such changes.
+
+During the 90-day restore window a paused project can be restored to the platform with a single button click from [Studio's dashboard page](https://supabase.com/dashboard/projects).
+
+<Image
+  alt="Project Paused: 90 Days Remaining"
+  width={962}
+  height={386}
+  src="/docs/img/guides/platform/paused-90-day.png"
+/>
+
+After the 90-day restore window, you can download your project's backup file, and Storage objects from the project dashboard. You can restore the data in the following ways:
+
+- [Restore a backup to a new Supabase project](/docs/guides/platform/migrating-within-supabase/dashboard-restore)
+- [Restore a backup locally](/docs/guides/local-development/restoring-downloaded-backup)
+
+<Image
+  alt="Project Paused: Download Backup"
+  src="/docs/img/guides/platform/paused-dl-backup.png"
+  width={495}
+  height={306}
+/>
+
+If you upgrade to a paid plan while your project is paused within the 90-day restore window, any expired one-click restore options are reenabled. Since the backup was taken outside the backwards compatibility window, it may fail to restore. If you have a problem restoring your backup after upgrading, contact [Support](https://supabase.com/support).
+
+<Image
+  alt="Project Paused: Paid Tier Restore"
+  src="/docs/img/guides/platform/paused-paid-tier.png"
+  width={962}
+  height={385}
+/>
 
 ## Specific upgrade notes
 
@@ -167,11 +140,21 @@ In projects using Postgres 17, the following extensions are deprecated:
 - `timescaledb`
 - `pgjwt`
 
-Projects planning to upgrade from Postgres 15 to Postgres 17 need to first disable these extensions in the [Supabase Dashboard](/dashboard/project/_/database/extensions).
+Projects planning to upgrade from Postgres 15 to Postgres 17 need to first disable these extensions in the [Supabase Dashboard](https://supabase.com/dashboard/project/_/database/extensions).
 
-`pgjwt` was enabled by default on every Supabase project up until Postgres 17. If you weren’t explicitly using `pgjwt` in your project, it’s most likely safe to disable.
+<Admonition type="tip">
+
+`pgjwt` was enabled by default on every Supabase project up until Postgres 17. If you weren't explicitly using `pgjwt` in your project, it's most likely safe to disable.
+
+</Admonition>
 
 Existing projects on lower versions of Postgres are not impacted, and the extensions will continue to be supported on projects using Postgres 15, until the end of life of Postgres 15 on the Supabase platform.
+
+### `pg_cron` usage
+
+[pg_cron](https://github.com/citusdata/pg_cron#viewing-job-run-details) does not automatically clean up historical records. This can lead to extremely large `cron.job_run_details` tables if the records are not regularly pruned; you should clean unnecessary records from this table prior to an upgrade.
+
+During the supabase project upgrade, the `pg_cron` extension gets dropped and recreated. Prior to this process, the `cron.job_run_details` table is duplicated to avoid losing historical logs. The instantaneous disk pressure created by duplicating an extremely large details table can cause at best unnecessary performance degradation, or at worst, upgrade process failures.
 
 ### Upgrading to pg_graphql 1.6.0
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -154,7 +154,7 @@ Existing projects on lower versions of Postgres are not impacted, and the extens
 
 [pg_cron](https://github.com/citusdata/pg_cron#viewing-job-run-details) does not automatically clean up historical records. This can lead to extremely large `cron.job_run_details` tables if the records are not regularly pruned; you should clean unnecessary records from this table prior to an upgrade.
 
-During the supabase project upgrade, the `pg_cron` extension gets dropped and recreated. Prior to this process, the `cron.job_run_details` table is duplicated to avoid losing historical logs. The instantaneous disk pressure created by duplicating an extremely large details table can cause at best unnecessary performance degradation, or at worst, upgrade process failures.
+During the Supabase project upgrade, the `pg_cron` extension gets dropped and recreated. Prior to this process, the `cron.job_run_details` table is duplicated to avoid losing historical logs. The instantaneous disk pressure created by duplicating an extremely large details table can cause at best unnecessary performance degradation, or at worst, upgrade process failures.
 
 ### Upgrading to pg_graphql 1.6.0
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -152,9 +152,9 @@ Existing projects on lower versions of Postgres are not impacted, and the extens
 
 ### `pg_cron` usage
 
-[pg_cron](https://github.com/citusdata/pg_cron#viewing-job-run-details) does not automatically clean up historical records. This can lead to extremely large `cron.job_run_details` tables if the records are not regularly pruned; you should clean unnecessary records from this table prior to an upgrade.
+[pg_cron](https://github.com/citusdata/pg_cron#viewing-job-run-details) does not automatically clean up historical records. This can lead to extremely large `cron.job_run_details` tables if the records are not regularly pruned; you should clean unnecessary records from this table before an upgrade.
 
-During the Supabase project upgrade, the `pg_cron` extension gets dropped and recreated. Prior to this process, the `cron.job_run_details` table is duplicated to avoid losing historical logs. The instantaneous disk pressure created by duplicating an extremely large details table can cause at best unnecessary performance degradation, or at worst, upgrade process failures.
+During the Supabase project upgrade, the `pg_cron` extension gets dropped and recreated. Before this process, the `cron.job_run_details` table is duplicated to avoid losing historical logs. The instantaneous disk pressure created by duplicating an extremely large details table can cause at best unnecessary performance degradation, or at worst, upgrade process failures.
 
 ### Upgrading to pg_graphql 1.6.0
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -2,7 +2,7 @@
 title: Upgrading
 ---
 
-Supabase ships fast and we endeavor to add all new features to existing projects wherever possible. In some cases, access to new features require upgrading or migrating your Supabase project. It is recommended to upgrade Postgres version to get access to the latest features and fixes.
+Supabase ships fast and we try to add all new features to existing projects wherever possible. In some cases, access to new features require upgrading or migrating your Supabase project. It is recommended to upgrade Postgres version to get access to the latest features and fixes.
 
 For scaling your compute size, refer to the [Compute and Disk page](/docs/guides/platform/compute-and-disk).
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -140,7 +140,7 @@ In projects using Postgres 17, the following extensions are deprecated:
 - `timescaledb`
 - `pgjwt`
 
-Projects planning to upgrade from Postgres 15 to Postgres 17 need to first disable these extensions in the [Supabase Dashboard](https://supabase.com/dashboard/project/_/database/extensions).
+Projects planning to upgrade from Postgres 15 to Postgres 17 need to first disable these extensions in the [Supabase Dashboard](/dashboard/project/_/database/extensions).
 
 <Admonition type="tip">
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -2,7 +2,7 @@
 title: Upgrading
 ---
 
-Supabase ships fast and we endeavor to add all new features to existing projects wherever possible. In some cases, access to new features require upgrading or migrating your Supabase project. It is recommended to upgrade PostgreSQL version to get access to the latest features and fixes.
+Supabase ships fast and we endeavor to add all new features to existing projects wherever possible. In some cases, access to new features require upgrading or migrating your Supabase project. It is recommended to upgrade Postgres version to get access to the latest features and fixes.
 
 For scaling your compute size, refer to the [Compute and Disk page](/docs/guides/platform/compute-and-disk).
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -18,7 +18,7 @@ Free projects will move to the latest minor version when their paused project is
 
 The upgrade process is as follows:
 
-1. Use the "Upgrade project" button on the [Infrastructure](https://supabase.com/dashboard/project/_/settings/infrastructure) section of your dashboard.
+1. Use the "Upgrade project" button on the [Infrastructure](/dashboard/project/_/settings/infrastructure) section of your dashboard.
 2. An estimate of the time to upgrade is shown and anything that needs to be addressed before you are eligible to upgrade is shown as a warning. Ensure you have reviewed the [caveats](#caveats) section of this document before executing the upgrade.
 3. Your project is taken offline and the Dashboard shows the upgrade status.
 4. Behind the scenes, a new instance is created running the latest version of Supabase.

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -39,7 +39,7 @@ When upgrading, a notification will inform you about what is blocking the upgrad
 3. Logical replication slots must be dropped.
 4. Deprecated/unsupported extensions must be dropped. Extensions can have dependencies, make sure you backup that data to restore it after the upgrade, with the updated extension version.
 
-Newer versions of services can break functionality or change the performance characteristics you rely on. If your project is eligible for an upgrade, you will be able to find your current service versions from within [the Supabase dashboard](https://supabase.com/dashboard/project/_/settings/infrastructure).
+Newer versions of services can break functionality or change the performance characteristics you rely on. If your project is eligible for an upgrade, you will be able to find your current service versions from within [the Supabase dashboard](/dashboard/project/_/settings/infrastructure).
 
 Breaking changes are generally only present in major version upgrades of Postgres and PostgREST. You can find their respective release notes at:
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -24,7 +24,7 @@ The upgrade process is as follows:
 4. Behind the scenes, a new instance is created running the latest version of Supabase.
 5. Your data is copied to the new instance and upgraded using `pg_upgrade`.
 6. If the upgrade should fail, your original database would be brought back up online and be able to service requests.
-7. When the upgrade succeeds, a [basebackup](https://www.postgresql.org/docs/current/app-pgbasebackup.html) is taken and, once complete, your project is available in the Dashboard.
+7. When the upgrade succeeds, a [pg_basebackup](https://www.postgresql.org/docs/current/app-pgbasebackup.html) is taken and, once complete, your project is available in the Dashboard.
 
 A Supabase project is deployed with a GP3 disk type by default, which will give ~100Mbps when upgrading. Changing the [disk type (or increasing IOPS/Throughput)](/docs/guides/platform/compute-and-disk) will reduce the time to upgrade.
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -119,7 +119,7 @@ After the 90-day restore window, you can download your project's backup file, an
   height={306}
 />
 
-If you upgrade to a paid plan while your project is paused within the 90-day restore window, any expired one-click restore options are reenabled. Since the backup was taken outside the backwards compatibility window, it may fail to restore. If you have a problem restoring your backup after upgrading, contact [Support](https://supabase.com/support).
+If you upgrade to a paid plan while your project is paused within the 90-day restore window, any expired one-click restore options are reenabled. Since the backup was taken outside the backwards compatibility window, it may fail to restore. If you have a problem restoring your backup after upgrading, contact [Support](/support).
 
 <Image
   alt="Project Paused: Paid Tier Restore"

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -325,6 +325,7 @@ allow_list = [
     "PagerDuty",
     "PGAudit",
     "PGroonga",
+    "pg_basebackup",
     "PgBouncer",
     "pgjwt",
     "PHI",


### PR DESCRIPTION
Committer: Divya Sharma <divya.sharma@supabase.io>

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

Current doc link : https://github.com/supabase/supabase/blob/master/apps/docs/content/guides/platform/upgrading.mdx

## What is the new behavior?

Changed the doc to reflect the upgrade process

## Additional context

- Added pre-upgrade and post-upgrade best practices
- Document upgrade pre-requisites
- Re-arranged the sections 
- removed outdated info


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured the database upgrade guide into a unified, end-to-end “How we upgrade” step-by-step flow, including dashboard upgrade status, new instance creation, data upgrading, rollback behavior, and completion steps
  * Expanded upgrade prerequisites with clearer eligibility blockers (read replicas, `pg_upgrade` limitations, logical replication slot handling, and removal of deprecated/unsupported extensions)
  * Added pre-upgrade and post-upgrade best practices, plus reorganized caveats and updated timing/downtime/restore-window guidance (including Free vs Paid project behavior)
  * Refreshed Postgres 17 notes, including deprecated extension handling and new `pg_cron` upgrade implications
<!-- end of auto-generated comment: release notes by coderabbit.ai -->