### PR TITLE
feat(studio): track unified logs cta variant and auto-dismiss on explore

### DIFF
--- a/apps/studio/components/ui/BannerStack/Banners/BannerUnifiedLogs.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerUnifiedLogs.tsx
@@ -52,7 +52,11 @@ export const BannerUnifiedLogs = () => {
             <Button type="default" size="tiny" asChild>
               <Link
                 href={`/project/${ref}/logs`}
-                onClick={() => track('unified_logs_banner_cta_button_clicked')}
+                onClick={() => {
+                  track('unified_logs_banner_cta_button_clicked', { is_enabled: true })
+                  setIsDismissed(true)
+                  dismissBanner('unified-logs-banner')
+                }}
               >
                 Explore Unified Logs
               </Link>
@@ -62,7 +66,7 @@ export const BannerUnifiedLogs = () => {
               type="default"
               size="tiny"
               onClick={() => {
-                track('unified_logs_banner_cta_button_clicked')
+                track('unified_logs_banner_cta_button_clicked', { is_enabled: false })
                 selectFeaturePreview(LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS)
               }}
             >

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1254,6 +1254,9 @@ export interface MetricsAPIBannerDismissButtonClickedEvent {
  */
 export interface UnifiedLogsBannerCtaButtonClickedEvent {
   action: 'unified_logs_banner_cta_button_clicked'
+  properties: {
+    is_enabled: boolean
+  }
   groups: TelemetryGroups
 }
 


### PR DESCRIPTION
## Summary
The Unified Logs promo banner (shipped in #46847) had two telemetry/UX gaps I found while auditing the weekly PostHog event review. Its CTA fired one event for two different user paths with no way to tell them apart, and clicking "Explore" left the banner in place. This adds an `is_enabled` property to the CTA event and auto-dismisses the banner on the Explore path.

## Changes
- Add `is_enabled: boolean` to `unified_logs_banner_cta_button_clicked`. It is `true` when the user is already enabled and the button navigates to the logs page ("Explore"), and `false` when not enabled and the button opens the feature-preview modal ("Enable"). The two cohorts are now queryable independently, which is what makes the CTA data usable for measuring adoption.
- Auto-dismiss the banner when an already-enabled user clicks "Explore". Previously only the X button dismissed it, so an Explore click left the banner showing on the next project page load. Scoped to the Explore path on purpose: the not-enabled path only opens a preview modal (it does not enable), so dismissing there would hide the banner from users who never enabled.

## Testing
Behavior to verify on the Vercel preview:
- [x] Enabled user clicks "Explore Unified Logs": navigates to the logs page, banner does not reappear on the next project page load, CTA event fires with `is_enabled` true.
- [x] Non-enabled user clicks "Enable Unified Logs": preview modal opens, banner is still present after closing the modal, CTA event fires with `is_enabled` false.
- [x] X button: banner dismissed as before, dismiss event fires.

Out of scope on purpose: no impression event (it would fire on every banner render, low-millions of events per month for one banner), so true click-through rate stays unmeasurable for now.

## Linear
- fixes GROWTH-925


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Unified Logs banner now intelligently updates behavior based on feature state.
  * When enabled, exploring the feature automatically dismisses the banner.
  * When disabled, the enable action opens the feature preview flow.
  * Enhanced tracking for banner interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->