### PR TITLE
fix: avoid showing navigation item as disabled while loading

### DIFF
--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -159,6 +159,7 @@ export function SideBarNavLink({
   route,
   active,
   onClick,
+  isLoading,
   ...props
 }: {
   route: Route
@@ -183,6 +184,7 @@ export function SideBarNavLink({
   const buttonProps = {
     disabled: route.disabled,
     isActive: active,
+    isLoading,
     className: cn('text-sm', sidebarBehaviour === 'open' ? 'px-2!' : ''),
     size: 'default' as const,
     onClick: onClick,
@@ -237,7 +239,7 @@ const ActiveDot = ({ hasErrors, hasWarnings }: { hasErrors: boolean; hasWarnings
 const ProjectLinks = () => {
   const router = useRouter()
   const { ref } = useParams()
-  const { data: project } = useSelectedProjectQuery()
+  const { data: project, isPending: isProjectPending } = useSelectedProjectQuery()
   const { securityLints, errorLints } = useLints()
   const showReports = useIsFeatureEnabled('reports:all')
   const showLogs = useIsFeatureEnabled('logs:all')
@@ -295,6 +297,7 @@ const ProjectLinks = () => {
             key={`tools-routes-${i}`}
             route={route}
             active={activeRoute === route.key}
+            isLoading={isProjectPending}
           />
         ))}
       </SidebarGroup>
@@ -305,6 +308,7 @@ const ProjectLinks = () => {
             key={`product-routes-${i}`}
             route={route}
             active={activeRoute === route.key}
+            isLoading={isProjectPending}
           />
         ))}
       </SidebarGroup>
@@ -320,12 +324,22 @@ const ProjectLinks = () => {
                     hasWarnings={securityLints.length > 0}
                   />
                 )}
-                <SideBarNavLink key={route.key} route={route} active={activeRoute === route.key} />
+                <SideBarNavLink
+                  key={route.key}
+                  route={route}
+                  active={activeRoute === route.key}
+                  isLoading={isProjectPending}
+                />
               </div>
             )
           } else {
             return (
-              <SideBarNavLink key={route.key} route={route} active={activeRoute === route.key} />
+              <SideBarNavLink
+                key={route.key}
+                route={route}
+                active={activeRoute === route.key}
+                isLoading={isProjectPending}
+              />
             )
           }
         })}
@@ -338,6 +352,7 @@ const ProjectLinks = () => {
             key={`settings-routes-${i}`}
             route={route}
             active={activeRoute === route.key}
+            isLoading={isProjectPending}
           />
         ))}
       </SidebarGroup>

--- a/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
+++ b/apps/studio/components/layouts/ProjectSettingsLayout/SettingsMenu.utils.tsx
@@ -10,7 +10,7 @@ import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 
 export const useGenerateSettingsMenu = () => {
   const { ref } = useParams()
-  const { data: project } = useSelectedProjectQuery()
+  const { data: project, isPending } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
   const showDashboardPreferences = useFlag('dashboardPreferences')
 
@@ -112,6 +112,7 @@ export const useGenerateSettingsMenu = () => {
           url: `/project/${ref}/settings/compute-and-disk`,
           items: [],
           disabled: !isProjectActive,
+          isLoading: isPending,
           shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_COMPUTE_AND_DISK,
         },
         {
@@ -120,6 +121,7 @@ export const useGenerateSettingsMenu = () => {
           url: `/project/${ref}/settings/infrastructure`,
           items: [],
           disabled: !isProjectActive,
+          isLoading: isPending,
           shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_INFRASTRUCTURE,
         },
 
@@ -129,6 +131,7 @@ export const useGenerateSettingsMenu = () => {
           url: `/project/${ref}/settings/integrations`,
           items: [],
           disabled: !isProjectActive,
+          isLoading: isPending,
           shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_INTEGRATIONS,
         },
         ...(platformWebhooksEnabled
@@ -139,6 +142,7 @@ export const useGenerateSettingsMenu = () => {
                 url: `/project/${ref}/settings/webhooks`,
                 items: [],
                 disabled: !isProjectActive,
+                isLoading: isPending,
                 shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_WEBHOOKS,
               },
             ]
@@ -150,6 +154,7 @@ export const useGenerateSettingsMenu = () => {
           url: `/project/${ref}/settings/api-keys`,
           items: [],
           disabled: !isProjectActive,
+          isLoading: isPending,
           shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_API_KEYS,
         },
         {
@@ -160,6 +165,7 @@ export const useGenerateSettingsMenu = () => {
             : `/project/${ref}/settings/jwt/signing-keys`,
           items: [],
           disabled: !isProjectActive,
+          isLoading: isPending,
           shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_JWT_KEYS,
         },
 
@@ -171,6 +177,7 @@ export const useGenerateSettingsMenu = () => {
                 url: `/project/${ref}/settings/log-drains`,
                 items: [],
                 disabled: !isProjectActive,
+                isLoading: isPending,
                 shortcutId: SHORTCUT_IDS.NAV_PROJECT_SETTINGS_LOG_DRAINS,
               },
             ]
@@ -205,6 +212,7 @@ export const useGenerateSettingsMenu = () => {
           items: [],
           rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
           disabled: !isProjectActive,
+          isLoading: isPending,
         },
         {
           name: 'Vault',
@@ -214,6 +222,7 @@ export const useGenerateSettingsMenu = () => {
           rightIcon: <ArrowUpRight strokeWidth={1} className="h-4 w-4" />,
           label: 'Beta',
           disabled: !isProjectActive,
+          isLoading: isPending,
         },
       ],
     },

--- a/apps/studio/components/ui/ProductMenu/ProductMenu.types.ts
+++ b/apps/studio/components/ui/ProductMenu/ProductMenu.types.ts
@@ -30,6 +30,7 @@ export interface ProductMenuGroupItem {
   childItems?: ProductMenuGroupItem[]
   pages?: string[]
   shortcutId?: ShortcutId
+  isLoading?: boolean
 }
 
 /**

--- a/apps/studio/components/ui/ProductMenu/ProductMenuItem.tsx
+++ b/apps/studio/components/ui/ProductMenu/ProductMenuItem.tsx
@@ -19,7 +19,17 @@ export const ProductMenuItem = ({
   hoverText = '',
   onClick,
 }: ProductMenuItemProps) => {
-  const { name = '', url = '', icon, rightIcon, isExternal, label, disabled, shortcutId } = item
+  const {
+    name = '',
+    url = '',
+    icon,
+    rightIcon,
+    isExternal,
+    label,
+    disabled,
+    shortcutId,
+    isLoading,
+  } = item
 
   const menuItem = (
     <Menu.Item icon={icon} active={isActive} onClick={onClick}>
@@ -44,6 +54,12 @@ export const ProductMenuItem = ({
       </div>
     </Menu.Item>
   )
+
+  // When data necessary to check whether an item should be disabled is not yet available, override the styles to avoid
+  // showing the disabled state just for a moment
+  if (isLoading) {
+    return <div className="pointer-events-none">{menuItem}</div>
+  }
 
   if (disabled) {
     return <div className="opacity-50 pointer-events-none">{menuItem}</div>

--- a/packages/ui/src/components/shadcn/ui/sidebar.tsx
+++ b/packages/ui/src/components/shadcn/ui/sidebar.tsx
@@ -521,6 +521,13 @@ const sidebarMenuButtonVariants = cva(
         true: 'group-data-[collapsible=icon]:size-8! group-data-[collapsible=icon]:pl-1.5! group-data-[collapsible=icon]:pr-2!',
         false: '',
       },
+      isLoading: {
+        // When data necessary to check whether an item should be disabled is not yet available, override the styles to avoid
+        // showing the disabled state just for a moment
+        true: 'disabled:opacity-100 aria-disabled:opacity-100',
+        // If the item is not loading, fallback to the default styles so that disabled state is handled properly
+        false: '',
+      },
     },
     defaultVariants: {
       variant: 'default',
@@ -537,6 +544,7 @@ const SidebarMenuButton = React.forwardRef<
     isActive?: boolean
     tooltip?: string | React.ComponentProps<typeof TooltipContent>
     hasIcon?: boolean
+    isLoading?: boolean
   } & VariantProps<typeof sidebarMenuButtonVariants>
 >(
   (
@@ -546,6 +554,7 @@ const SidebarMenuButton = React.forwardRef<
       variant = 'default',
       size = 'default',
       hasIcon = true,
+      isLoading = false,
       tooltip,
       className,
       ...props
@@ -570,7 +579,7 @@ const SidebarMenuButton = React.forwardRef<
         data-active={isActive}
         data-has-icon={hasIcon}
         tabIndex={computedTabIndex}
-        className={cn(sidebarMenuButtonVariants({ variant, size, hasIcon }), className)}
+        className={cn(sidebarMenuButtonVariants({ variant, size, hasIcon, isLoading }), className)}
         {...props}
       />
     )


### PR DESCRIPTION
## Problem

On pages that needs to check conditions for which data is loaded asynchronously, the navigation links in the sidebar appear disabled for a split second:
<img width="1394" height="1636" alt="image" src="https://github.com/user-attachments/assets/0681966d-676d-4c8c-8bd4-852dcf93ddb7" />

## Solution

Check whether the required data is loading and override the styles so that the links are still disabled to avoid errors but appear as normal.

## How to test

- Open the project setting page
- Check the styles of the sidebar items carefully while it load (might require to refresh a few times to be sure)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Navigation buttons, menu items, and settings menus now display loading states while project data is being fetched, providing visual feedback and preventing interaction during data loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->