### PR TITLE
Fix Studio auth hook parsing for http URIs

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -32,7 +32,12 @@ import { InfoTooltip } from 'ui-patterns/info-tooltip'
 import * as z from 'zod'
 
 import { Hook, HOOK_DEFINITION_TITLE, HOOKS_DEFINITIONS } from './hooks.constants'
-import { extractMethod, getRevokePermissionStatements, isValidHook } from './hooks.utils'
+import {
+  extractMethod,
+  getRevokePermissionStatements,
+  isHttpHookUrl,
+  isValidHook,
+} from './hooks.utils'
 import { convertArgumentTypes } from '@/components/interfaces/Database/Functions/Functions.utils'
 import { DiscardChangesConfirmationDialog } from '@/components/ui-patterns/Dialogs/DiscardChangesConfirmationDialog'
 import CodeEditor from '@/components/ui/CodeEditor/CodeEditor'
@@ -67,8 +72,8 @@ const FormSchema = z
   .object({
     hookType: z.string(),
     enabled: z.boolean(),
-    selectedType: z.union([z.literal('https'), z.literal('postgres')]),
-    httpsValues: z.object({
+    selectedType: z.union([z.literal('http'), z.literal('postgres')]),
+    httpValues: z.object({
       url: z.string(),
       secret: z.string(),
     }),
@@ -78,17 +83,17 @@ const FormSchema = z
     }),
   })
   .superRefine((data, ctx) => {
-    if (data.selectedType === 'https') {
-      if (!data.httpsValues.url.startsWith('https://')) {
+    if (data.selectedType === 'http') {
+      if (!isHttpHookUrl(data.httpValues.url)) {
         ctx.addIssue({
-          path: ['httpsValues', 'url'],
+          path: ['httpValues', 'url'],
           code: z.ZodIssueCode.custom,
-          message: 'The URL must start with https://',
+          message: 'The URL must start with http:// or https://',
         })
       }
-      if (!data.httpsValues.secret) {
+      if (!data.httpValues.secret) {
         ctx.addIssue({
-          path: ['httpsValues', 'secret'],
+          path: ['httpValues', 'secret'],
           code: z.ZodIssueCode.custom,
           message: 'Missing secret value',
         })
@@ -153,7 +158,7 @@ export const CreateHookSheet = ({
       hookType: title || '',
       enabled: true,
       selectedType: 'postgres',
-      httpsValues: {
+      httpValues: {
         url: '',
         secret: '',
       },
@@ -239,13 +244,13 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
     if (values.selectedType === 'postgres') {
       url = `pg-functions://postgres/${values.postgresValues.schema}/${values.postgresValues.functionName}`
     } else {
-      url = values.httpsValues.url
+      url = values.httpValues.url
     }
 
     const payload = {
       [enabledLabel]: values.enabled,
       [uriLabel]: url,
-      [secretsLabel]: values.selectedType === 'https' ? values.httpsValues.secret : null,
+      [secretsLabel]: values.selectedType === 'http' ? values.httpValues.secret : null,
     }
 
     updateAuthHooks({ projectRef: projectRef!, config: payload })
@@ -263,9 +268,9 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
           hookType: definition.title,
           enabled: isCreating ? true : authConfig?.[definition.enabledKey],
           selectedType: values.type,
-          httpsValues: {
-            url: (values.type === 'https' && values.url) || '',
-            secret: (values.type === 'https' && values.secret) || '',
+          httpValues: {
+            url: (values.type === 'http' && values.url) || '',
+            secret: (values.type === 'http' && values.secret) || '',
           },
           postgresValues: {
             schema: (values.type === 'postgres' && values.schema) || 'public',
@@ -277,7 +282,7 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
           hookType: title || '',
           enabled: true,
           selectedType: 'postgres',
-          httpsValues: {
+          httpValues: {
             url: '',
             secret: '',
           },
@@ -357,11 +362,11 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
                           description="Used to call a Postgres function."
                         />
                         <RadioGroupStackedItem
-                          value="https"
-                          id="https"
-                          key="https"
-                          label="HTTPS"
-                          description="Used to call any HTTPS endpoint."
+                          value="http"
+                          id="http"
+                          key="http"
+                          label="HTTP"
+                          description="Used to call any HTTP or HTTPS endpoint."
                         />
                       </RadioGroupStacked>
                     </FormControl>
@@ -453,13 +458,13 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
               ) : (
                 <div className="flex flex-col gap-4 px-5">
                   <FormField
-                    key="httpsValues.url"
+                    key="httpValues.url"
                     control={form.control}
-                    name="httpsValues.url"
+                    name="httpValues.url"
                     render={({ field }) => (
                       <FormItemLayout
                         label="URL"
-                        description="Supabase Auth will send a HTTPS POST request to this URL each time the hook is triggered."
+                        description="Supabase Auth will send an HTTP POST request to this URL each time the hook is triggered."
                       >
                         <FormControl>
                           <Input {...field} />
@@ -468,9 +473,9 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
                     )}
                   />
                   <FormField
-                    key="httpsValues.secret"
+                    key="httpValues.secret"
                     control={form.control}
-                    name="httpsValues.secret"
+                    name="httpValues.secret"
                     render={({ field }) => (
                       <FormItemLayout
                         label="Secret"
@@ -497,7 +502,7 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
                               className="rounded-l-none text-xs"
                               onClick={() => {
                                 const authHookSecret = generateAuthHookSecret()
-                                form.setValue('httpsValues.secret', authHookSecret, {
+                                form.setValue('httpValues.secret', authHookSecret, {
                                   shouldDirty: true,
                                 })
                               }}

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.constants.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.constants.ts
@@ -79,5 +79,5 @@ export interface Hook {
   docSlug: string
   method:
     | { type: 'postgres'; schema: string; functionName: string }
-    | { type: 'https'; url: string; secret: string }
+    | { type: 'http'; url: string; secret: string }
 }

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { extractMethod, isHttpHookUrl, isValidHook } from './hooks.utils'
+
+describe('hooks.utils', () => {
+  it('classifies the documented self-hosted send email hook as an HTTP hook', () => {
+    expect(
+      extractMethod(
+        'http://host.docker.internal:54321/functions/v1/email_sender',
+        'v1,whsec_example'
+      )
+    ).toEqual({
+      type: 'http',
+      url: 'http://host.docker.internal:54321/functions/v1/email_sender',
+      secret: 'v1,whsec_example',
+    })
+  })
+
+  it('accepts both http and https hook URLs', () => {
+    expect(isHttpHookUrl('http://host.docker.internal:54321/functions/v1/email_sender')).toBe(true)
+    expect(isHttpHookUrl('https://example.com/hooks/send-email')).toBe(true)
+    expect(isHttpHookUrl('pg-functions://postgres/public/send_email')).toBe(false)
+  })
+
+  it('treats HTTP hooks with a secret as valid hooks', () => {
+    expect(
+      isValidHook({
+        id: 'send-email',
+        title: 'Send Email hook',
+        subtitle: '',
+        entitlementKey: 'HOOK_SEND_EMAIL',
+        enabled: true,
+        enabledKey: 'HOOK_SEND_EMAIL_ENABLED',
+        uriKey: 'HOOK_SEND_EMAIL_URI',
+        secretsKey: 'HOOK_SEND_EMAIL_SECRETS',
+        docSlug: 'send-email-hook',
+        method: {
+          type: 'http',
+          url: 'http://host.docker.internal:54321/functions/v1/email_sender',
+          secret: 'v1,whsec_example',
+        },
+      })
+    ).toBe(true)
+  })
+})

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.test.ts
@@ -16,10 +16,35 @@ describe('hooks.utils', () => {
     })
   })
 
+  it('classifies https hook URLs as HTTP hooks too', () => {
+    expect(extractMethod('https://example.com/hooks/send-email', 'v1,whsec_example')).toEqual({
+      type: 'http',
+      url: 'https://example.com/hooks/send-email',
+      secret: 'v1,whsec_example',
+    })
+  })
+
   it('accepts both http and https hook URLs', () => {
     expect(isHttpHookUrl('http://host.docker.internal:54321/functions/v1/email_sender')).toBe(true)
     expect(isHttpHookUrl('https://example.com/hooks/send-email')).toBe(true)
     expect(isHttpHookUrl('pg-functions://postgres/public/send_email')).toBe(false)
+  })
+
+  it('keeps Postgres hook URIs on the postgres branch', () => {
+    expect(extractMethod('pg-functions://postgres/public/custom_access_token_hook')).toEqual({
+      type: 'postgres',
+      schema: 'public',
+      functionName: 'custom_access_token_hook',
+    })
+  })
+
+  it('falls back to an empty postgres hook for blank URIs without throwing', () => {
+    expect(() => extractMethod('')).not.toThrow()
+    expect(extractMethod('')).toEqual({
+      type: 'postgres',
+      schema: '',
+      functionName: '',
+    })
   })
 
   it('treats HTTP hooks with a secret as valid hooks', () => {

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
@@ -2,14 +2,17 @@ import { ident, safeSql, type SafeSqlFragment } from '@supabase/pg-meta/src/pg-f
 
 import { Hook } from './hooks.constants'
 
+export const isHttpHookUrl = (uri: string) =>
+  uri.startsWith('http://') || uri.startsWith('https://')
+
 export const extractMethod = (
   uri: string,
   secret?: string
 ):
   | { type: 'postgres'; schema: string; functionName: string }
-  | { type: 'https'; url: string; secret: string } => {
-  if (uri.startsWith('https')) {
-    return { type: 'https', url: uri, secret: secret || '' }
+  | { type: 'http'; url: string; secret: string } => {
+  if (isHttpHookUrl(uri)) {
+    return { type: 'http', url: uri, secret: secret || '' }
   } else {
     const [_proto, _x, _db, schema, functionName] = (uri || '').split('/')
 
@@ -26,7 +29,7 @@ export const isValidHook = (h: Hook) => {
     (h.method.type === 'postgres' &&
       h.method.schema.length > 0 &&
       h.method.functionName.length > 0) ||
-    (h.method.type === 'https' && h.method.url.startsWith('https') && h.method.secret.length > 0)
+    (h.method.type === 'http' && isHttpHookUrl(h.method.url) && h.method.secret.length > 0)
   )
 }
 

--- a/apps/studio/components/interfaces/RoleImpersonationSelector/UserImpersonationSelector.tsx
+++ b/apps/studio/components/interfaces/RoleImpersonationSelector/UserImpersonationSelector.tsx
@@ -107,9 +107,9 @@ export const UserImpersonationSelector = () => {
       return updated.slice(0, 5)
     })
 
-    if (customAccessTokenHookDetails?.type === 'https') {
+    if (customAccessTokenHookDetails?.type === 'http') {
       toast.info(
-        'Please note that HTTPS custom access token hooks are not yet supported in the dashboard.'
+        'Please note that HTTP custom access token hooks are not yet supported in the dashboard.'
       )
     }
 


### PR DESCRIPTION
Closes #46950

Studio currently treats any auth hook URI that does not start with `https` as a Postgres hook. That breaks the documented self-hosted Send Email example and can rewrite or revoke the wrong target.

This patch treats both `http://` and `https://` as HTTP hooks, keeps those URLs intact in the hook editor, renames the editor option from `HTTPS` to `HTTP`, and updates the custom access token warning to match the broader hook type.

The Postgres path stays unchanged. Postgres URIs still use the existing parser and still generate the same grant and revoke SQL.

Testing

From `apps/studio`:
`npm exec --yes pnpm@10.24.0 exec vitest run components/interfaces/Auth/Hooks/hooks.utils.test.ts --reporter verbose`
`npm exec --yes pnpm@10.24.0 exec prettier --check ./components/interfaces/Auth/Hooks/CreateHookSheet.tsx ./components/interfaces/Auth/Hooks/hooks.constants.ts ./components/interfaces/Auth/Hooks/hooks.utils.ts ./components/interfaces/Auth/Hooks/hooks.utils.test.ts ./components/interfaces/RoleImpersonationSelector/UserImpersonationSelector.tsx`
`./node_modules/.bin/tsc --noEmit -p tsconfig.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated URL-based authentication hooks to use **HTTP** (instead of HTTPS) consistently across validation, form inputs, and submitted payloads, including URL detection for both `http://` and `https://` and correct secret handling/generation.

* **Bug Fixes**
  * Adjusted the impersonation info message to show correctly for **HTTP** custom access token hooks.

* **Tests**
  * Expanded unit tests to cover HTTP/HTTPS URL classification, validation behavior, and edge cases for hook extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->