### PR TITLE
fix(studio): map email template anchors to docs

### DIFF
--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.test.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest'
+
+import { EMAIL_TEMPLATE_DOCS_ANCHORS } from './EmailTemplates.constants'
+import { AUTH_TEMPLATE_TYPES, type AuthTemplateType } from './EmailTemplates.types'
+
+/** Docs section headings from customizing-email-templates.mdx */
+const DOCS_HEADINGS: Record<AuthTemplateType, string> = {
+  CONFIRMATION: 'auth.email.template.confirmation',
+  INVITE: 'auth.email.template.invite',
+  MAGIC_LINK: 'auth.email.template.magic_link',
+  EMAIL_CHANGE: 'auth.email.template.email_change',
+  RECOVERY: 'auth.email.template.recovery',
+  REAUTHENTICATION: 'auth.email.template.reauthentication',
+  PASSWORD_CHANGED_NOTIFICATION: 'auth.email.notification.password_changed',
+  EMAIL_CHANGED_NOTIFICATION: 'auth.email.notification.email_changed',
+  PHONE_CHANGED_NOTIFICATION: 'auth.email.notification.phone_changed',
+  IDENTITY_LINKED_NOTIFICATION: 'auth.email.notification.identity_linked',
+  IDENTITY_UNLINKED_NOTIFICATION: 'auth.email.notification.identity_unlinked',
+  MFA_FACTOR_ENROLLED_NOTIFICATION: 'auth.email.notification.mfa_factor_enrolled',
+  MFA_FACTOR_UNENROLLED_NOTIFICATION: 'auth.email.notification.mfa_factor_unenrolled',
+}
+
+/** Matches github-slugger / rehype-slug output for these dot-separated config paths. */
+function docsHeadingToAnchor(heading: string) {
+  return heading.replace(/\./g, '').toLowerCase()
+}
+
+describe('EmailTemplates.constants: EMAIL_TEMPLATE_DOCS_ANCHORS', () => {
+  it('covers every auth template type', () => {
+    expect(Object.keys(EMAIL_TEMPLATE_DOCS_ANCHORS).sort()).toEqual([...AUTH_TEMPLATE_TYPES].sort())
+  })
+
+  it.each(AUTH_TEMPLATE_TYPES)('matches docs heading slug for %s', (templateType) => {
+    const expectedAnchor = docsHeadingToAnchor(DOCS_HEADINGS[templateType])
+
+    expect(EMAIL_TEMPLATE_DOCS_ANCHORS[templateType]).toBe(expectedAnchor)
+  })
+})

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.test.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.test.ts
@@ -20,9 +20,16 @@ const DOCS_HEADINGS: Record<AuthTemplateType, string> = {
   MFA_FACTOR_UNENROLLED_NOTIFICATION: 'auth.email.notification.mfa_factor_unenrolled',
 }
 
-/** Matches github-slugger / rehype-slug output for these dot-separated config paths. */
+/**
+ * Matches docs `Heading` anchor generation in
+ * packages/ui/src/components/CustomHTMLElements/CustomHTMLElements.utils.ts
+ */
 function docsHeadingToAnchor(heading: string) {
-  return heading.replace(/\./g, '').toLowerCase()
+  return heading
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9- ]/g, '')
+    .replace(/[ ]/g, '-')
 }
 
 describe('EmailTemplates.constants: EMAIL_TEMPLATE_DOCS_ANCHORS', () => {

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.ts
@@ -1,5 +1,26 @@
-import { AUTH_TEMPLATE_TYPES, type AuthTemplateResetType } from './EmailTemplates.types'
+import {
+  AUTH_TEMPLATE_TYPES,
+  type AuthTemplateResetType,
+  type AuthTemplateType,
+} from './EmailTemplates.types'
 import { getAuthTemplateType } from './EmailTemplates.utils'
 
 export const AUTH_TEMPLATE_RESET_TYPES: AuthTemplateResetType[] =
   AUTH_TEMPLATE_TYPES.map(getAuthTemplateType)
+
+/** Docs heading anchors for customizing-email-templates.mdx (github-slugger output). */
+export const EMAIL_TEMPLATE_DOCS_ANCHORS = {
+  CONFIRMATION: 'authemailtemplateconfirmation',
+  INVITE: 'authemailtemplateinvite',
+  MAGIC_LINK: 'authemailtemplatemagic_link',
+  EMAIL_CHANGE: 'authemailtemplateemail_change',
+  RECOVERY: 'authemailtemplaterecovery',
+  REAUTHENTICATION: 'authemailtemplatereauthentication',
+  PASSWORD_CHANGED_NOTIFICATION: 'authemailnotificationpassword_changed',
+  EMAIL_CHANGED_NOTIFICATION: 'authemailnotificationemail_changed',
+  PHONE_CHANGED_NOTIFICATION: 'authemailnotificationphone_changed',
+  IDENTITY_LINKED_NOTIFICATION: 'authemailnotificationidentity_linked',
+  IDENTITY_UNLINKED_NOTIFICATION: 'authemailnotificationidentity_unlinked',
+  MFA_FACTOR_ENROLLED_NOTIFICATION: 'authemailnotificationmfa_factor_enrolled',
+  MFA_FACTOR_UNENROLLED_NOTIFICATION: 'authemailnotificationmfa_factor_unenrolled',
+} as const satisfies Record<AuthTemplateType, string>

--- a/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.ts
+++ b/apps/studio/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants.ts
@@ -8,19 +8,19 @@ import { getAuthTemplateType } from './EmailTemplates.utils'
 export const AUTH_TEMPLATE_RESET_TYPES: AuthTemplateResetType[] =
   AUTH_TEMPLATE_TYPES.map(getAuthTemplateType)
 
-/** Docs heading anchors for customizing-email-templates.mdx (github-slugger output). */
+/** Docs heading anchors for customizing-email-templates.mdx (ui Heading slugify output). */
 export const EMAIL_TEMPLATE_DOCS_ANCHORS = {
   CONFIRMATION: 'authemailtemplateconfirmation',
   INVITE: 'authemailtemplateinvite',
-  MAGIC_LINK: 'authemailtemplatemagic_link',
-  EMAIL_CHANGE: 'authemailtemplateemail_change',
+  MAGIC_LINK: 'authemailtemplatemagiclink',
+  EMAIL_CHANGE: 'authemailtemplateemailchange',
   RECOVERY: 'authemailtemplaterecovery',
   REAUTHENTICATION: 'authemailtemplatereauthentication',
-  PASSWORD_CHANGED_NOTIFICATION: 'authemailnotificationpassword_changed',
-  EMAIL_CHANGED_NOTIFICATION: 'authemailnotificationemail_changed',
-  PHONE_CHANGED_NOTIFICATION: 'authemailnotificationphone_changed',
-  IDENTITY_LINKED_NOTIFICATION: 'authemailnotificationidentity_linked',
-  IDENTITY_UNLINKED_NOTIFICATION: 'authemailnotificationidentity_unlinked',
-  MFA_FACTOR_ENROLLED_NOTIFICATION: 'authemailnotificationmfa_factor_enrolled',
-  MFA_FACTOR_UNENROLLED_NOTIFICATION: 'authemailnotificationmfa_factor_unenrolled',
+  PASSWORD_CHANGED_NOTIFICATION: 'authemailnotificationpasswordchanged',
+  EMAIL_CHANGED_NOTIFICATION: 'authemailnotificationemailchanged',
+  PHONE_CHANGED_NOTIFICATION: 'authemailnotificationphonechanged',
+  IDENTITY_LINKED_NOTIFICATION: 'authemailnotificationidentitylinked',
+  IDENTITY_UNLINKED_NOTIFICATION: 'authemailnotificationidentityunlinked',
+  MFA_FACTOR_ENROLLED_NOTIFICATION: 'authemailnotificationmfafactorenrolled',
+  MFA_FACTOR_UNENROLLED_NOTIFICATION: 'authemailnotificationmfafactorunenrolled',
 } as const satisfies Record<AuthTemplateType, string>

--- a/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
+++ b/apps/studio/pages/project/[ref]/auth/templates/[templateId].tsx
@@ -37,6 +37,7 @@ import * as z from 'zod'
 
 import { TEMPLATES_SCHEMAS } from '@/components/interfaces/Auth/EmailTemplates/AuthTemplatesValidation'
 import { CustomEmailTemplateRestrictionAdmonition } from '@/components/interfaces/Auth/EmailTemplates/CustomEmailTemplateRestrictionAdmonition'
+import { EMAIL_TEMPLATE_DOCS_ANCHORS } from '@/components/interfaces/Auth/EmailTemplates/EmailTemplates.constants'
 import {
   isCustomEmailTemplateEditingRestricted,
   isCustomEmailTemplateRestrictionStatusKnown,
@@ -105,10 +106,6 @@ const RedirectToTemplates = () => {
     templateId && typeof templateId === 'string'
       ? TEMPLATES_SCHEMAS.find((template) => slugifyTitle(template.title) === templateId)
       : null
-
-  // Convert templateId slug to one lowercase word to match docs anchor tag
-  const templateIdForDocs =
-    typeof templateId === 'string' ? templateId.replace(/-/g, '').toLowerCase() : ''
 
   // Determine if this is a security notification template
   const isSecurityTemplate = template?.misc?.emailTemplateType === 'security'
@@ -205,7 +202,7 @@ const RedirectToTemplates = () => {
           </PageHeaderSummary>
           <PageHeaderAside>
             <DocsButton
-              href={`${DOCS_URL}/guides/local-development/customizing-email-templates#${isSecurityTemplate ? 'security' : 'auth'}emailtemplate${templateIdForDocs}`}
+              href={`${DOCS_URL}/guides/local-development/customizing-email-templates#${EMAIL_TEMPLATE_DOCS_ANCHORS[template.id]}`}
             />
           </PageHeaderAside>
         </PageHeaderMeta>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix. Resolves FE-3469.

## What is the current behavior?

On auth email template pages, the Docs button builds anchor hashes from the Studio URL slug (derived from user-facing titles), not from canonical template IDs.

E.g. **Reset password** links to `#authemailtemplateresetpassword`, but the docs section is `#authemailtemplaterecovery`.

12 of 13 templates had broken Docs links.

## What is the new behavior?

Docs links use an explicit `EMAIL_TEMPLATE_DOCS_ANCHORS` map keyed by `template.id`, matching the anchors in [customizing-email-templates.mdx](https://supabase.com/docs/guides/local-development/customizing-email-templates).

Examples:
- Reset password → `#authemailtemplaterecovery`
- Magic link or OTP → `#authemailtemplatemagic_link`
- Password changed → `#authemailnotificationpassword_changed`

Dashboard URL slugs (`reset-password`, etc.) are unchanged.

## Additional context

- Added `EMAIL_TEMPLATE_DOCS_ANCHORS` in `EmailTemplates.constants.ts` with `satisfies Record<AuthTemplateType, string>` for exhaustiveness
- Added `EmailTemplates.constants.test.ts` to verify all template types are covered and anchors match docs heading paths

**Test plan**
- [x] `pnpm --filter studio test EmailTemplates.constants`
- [ ] Spot-check Docs button on Reset password, Magic link or OTP, and Password changed templates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added automated checks to ensure every authentication email template has the correct documentation anchor mapping.

* **Chores**
  * Updated the documentation link behavior for email templates to use a consistent, predefined anchor mapping—improving reliability and maintainability of the docs button.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->