### PR TITLE
ci: restore contents write for mgmt api docs token

### DIFF
--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -49,6 +49,7 @@ jobs:
           client-id: ${{ vars.GH_AUTOFIX_APP_CLIENT_ID }}
           private-key: ${{ secrets.GH_AUTOFIX_PRIVATE_KEY }}
           permission-pull-requests: write
+          permission-contents: write
 
       - name: Create pull request
         uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES sir

## What kind of change does this PR introduce?

This PR fixes an issue with our automated documentation update:

The implicit `contents: write` it previously inherited from the App installation.
This led to the weekly mgmt api docs job failing with a 403 once the upstream spec changed.
Add `permission-contents: write` so the token can push the branch again.

Refs: https://github.com/supabase/supabase/pull/46454
Refs: https://github.com/supabase/supabase/actions/workflows/docs-mgmt-api-update.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD automation workflow to improve deployment reliability and documentation update processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->