### PR TITLE
fix(docs): functions error codes into Debugging section and link references

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1727,6 +1727,10 @@ export const functions: NavMenuConstant = {
           url: '/guides/functions/logging' as `/${string}`,
         },
         {
+          name: 'Error codes',
+          url: '/guides/functions/error-codes' as `/${string}`,
+        },
+        {
           name: 'Troubleshooting',
           url: '/guides/functions/troubleshooting' as `/${string}`,
         },
@@ -1743,10 +1747,6 @@ export const functions: NavMenuConstant = {
         {
           name: 'Status codes',
           url: '/guides/functions/status-codes' as `/${string}`,
-        },
-        {
-          name: 'Error codes',
-          url: '/guides/functions/error-codes' as `/${string}`,
         },
         {
           name: 'Recursive/Nested function calls',

--- a/apps/docs/content/guides/functions/status-codes.mdx
+++ b/apps/docs/content/guides/functions/status-codes.mdx
@@ -7,6 +7,14 @@ subtitle: 'Understand HTTP status codes returned by Edge Functions to properly d
 
 {/* supa-mdx-lint-disable Rule001HeadingCase */}
 
+When invoking an Edge Function, the response may return a variety of HTTP status codes. The most common status codes are listed below.
+
+<Admonition type="note">
+
+Error responses may also include an `sb-error-code` header that identifies the specific error condition. See [Error Codes](/docs/guides/functions/error-codes) for a complete list of error codes and their meanings.
+
+</Admonition>
+
 ## Success Responses
 
 ### 2XX Success


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update

## What is the new behavior?

Moving the new `error-codes` page to "Debugging" section.
Adding link reference to it under `status-codes` page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reorganized Error Codes guide navigation to the Debugging section for improved discoverability
  * Enhanced status codes guide with details on HTTP status codes and error response headers in Edge Functions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->