### PR TITLE
fix(studio): polish interstitial logo contrast and redirect text

### DIFF
--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Form.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Form.tsx
@@ -309,7 +309,7 @@ function FormFooter({
       </Button>
       {redirectUrl && (
         <div className="mt-3 border-t border-muted pt-5">
-          <p className="text-center text-xs text-foreground-lighter">
+          <p className="text-center text-xs text-foreground-lighter text-balance">
             Authorizing will redirect you to <span className="text-foreground">{redirectUrl}</span>
           </p>
         </div>

--- a/apps/studio/components/layouts/InterstitialLayout.tsx
+++ b/apps/studio/components/layouts/InterstitialLayout.tsx
@@ -123,7 +123,7 @@ export const PartnerLogo = ({ src, alt }: { src: string; alt: string }) => (
 
 /** Supabase symbol (not the wordmark) rendered inset inside a LogoBox. */
 export const SupabaseLogo = () => (
-  <LogoBox className="bg-white">
+  <LogoBox className="bg-surface-75">
     <img alt="Supabase" src={`${BASE_PATH}/img/supabase-logo.svg`} className="size-7" />
   </LogoBox>
 )

--- a/apps/studio/components/layouts/InterstitialLayout.tsx
+++ b/apps/studio/components/layouts/InterstitialLayout.tsx
@@ -123,7 +123,7 @@ export const PartnerLogo = ({ src, alt }: { src: string; alt: string }) => (
 
 /** Supabase symbol (not the wordmark) rendered inset inside a LogoBox. */
 export const SupabaseLogo = () => (
-  <LogoBox>
+  <LogoBox className="bg-white">
     <img alt="Supabase" src={`${BASE_PATH}/img/supabase-logo.svg`} className="size-7" />
   </LogoBox>
 )


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / UI polish. Resolves DEPR-597.

## What is the current behavior?

In shared Connect / interstitial surfaces, partner logos in `LogoPair` often have baked-in backgrounds (e.g. Figma white, Cursor black, CLI `bg-black`), while `SupabaseLogo` uses the default `LogoBox` `bg-muted` and can look washed out in dark mode. 

The OAuth redirect footnote on `/authorize` also lacked `text-balance`, unlike other interstitial footnotes.

## What is the new behavior?

- `SupabaseLogo` now uses `bg-surface-75` on its `LogoBox` for better contrast alongside partner logos in light and dark mode, without the harsh fixed-white pairing on flows like CLI login.
- The `/authorize` redirect footnote uses `text-balance` for cleaner wrapping of long redirect URLs.

| Before | After |
| --- | --- |
| <img width="524" height="455" alt="Authorize CLI  Supabase-206F0310-3508-41F6-8255-6840FD1DFB21" src="https://github.com/user-attachments/assets/86a41a79-4074-4263-abba-e9db97dd1f9d" /> | <img width="524" height="455" alt="Authorize CLI  Supabase-25A580E2-5353-4CA4-BDA7-C6953154A5FE" src="https://github.com/user-attachments/assets/83046770-f9fc-4648-b7c4-428423510f53" /> |