### PR TITLE
fix: Disable generate snippet title feature when the org has disabled AI features

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
@@ -64,7 +64,7 @@ export const RenameQueryModal = ({
   const isSQLSnippet = snippet.type === 'sql'
 
   // Orgs on HIPAA plans or that have disabled AI should not have access to Supabase AI
-  const { aiOptInLevel } = useOrgAiOptInLevel()
+  const { aiOptInLevel, isHipaaProjectDisallowed } = useOrgAiOptInLevel()
   const isAiOptedOut = aiOptInLevel === 'disabled'
 
   const { id, name, description } = snippet
@@ -191,29 +191,36 @@ export const RenameQueryModal = ({
                 )}
               />
               <div className="flex w-full justify-end mt-2">
-                {!isAiOptedOut && (
-                  <ButtonTooltip
-                    type="default"
-                    onClick={() => generateTitle()}
-                    size="tiny"
-                    disabled={isTitleGenerationLoading || !isApiKeySet}
-                    tooltip={{
-                      content: {
-                        side: 'bottom',
-                        text: isApiKeySet
-                          ? undefined
-                          : 'Add your "OPENAI_API_KEY" to your environment variables to use this feature.',
-                      },
-                    }}
-                  >
-                    <div className="flex items-center gap-1">
-                      <div className="scale-75">
-                        <AiIconAnimation loading={isTitleGenerationLoading} />
-                      </div>
-                      <span>Rename with Supabase AI</span>
+                <ButtonTooltip
+                  type="default"
+                  onClick={() => generateTitle()}
+                  size="tiny"
+                  disabled={
+                    isTitleGenerationLoading ||
+                    !isApiKeySet ||
+                    isHipaaProjectDisallowed ||
+                    isAiOptedOut
+                  }
+                  tooltip={{
+                    content: {
+                      side: 'bottom',
+                      text: isHipaaProjectDisallowed
+                        ? 'This feature is not available for HIPAA projects.'
+                        : isAiOptedOut
+                          ? 'Your organization has opted out of AI features.'
+                          : isApiKeySet
+                            ? undefined
+                            : 'Add your "OPENAI_API_KEY" to your environment variables to use this feature.',
+                    },
+                  }}
+                >
+                  <div className="flex items-center gap-1">
+                    <div className="scale-75">
+                      <AiIconAnimation loading={isTitleGenerationLoading} />
                     </div>
-                  </ButtonTooltip>
-                )}
+                    <span>Rename with Supabase AI</span>
+                  </div>
+                </ButtonTooltip>
               </div>
               <FormField
                 control={form.control}

--- a/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
@@ -23,11 +23,9 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
-import { subscriptionHasHipaaAddon } from '../Billing/Subscription/Subscription.utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useCheckOpenAIKeyQuery } from '@/data/ai/check-api-key-query'
 import { useSqlTitleGenerateMutation } from '@/data/ai/sql-title-mutation'
-import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 import { getContentById } from '@/data/content/content-id-query'
 import {
   UpsertContentPayload,
@@ -35,8 +33,7 @@ import {
 } from '@/data/content/content-upsert-mutation'
 import { Snippet } from '@/data/content/sql-folders-query'
 import type { SqlSnippet } from '@/data/content/sql-snippets-query'
-import { useOrgSubscriptionQuery } from '@/data/subscriptions/org-subscription-query'
-import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useOrgAiOptInLevel } from '@/hooks/misc/useOrgOptedIntoAi'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
 import { createTabId, useTabsStateSnapshot } from '@/state/tabs'
@@ -61,19 +58,14 @@ export const RenameQueryModal = ({
 }: RenameQueryModalProps) => {
   const { ref } = useParams()
   const router = useRouter()
-  const { data: organization } = useSelectedOrganizationQuery()
 
   const snapV2 = useSqlEditorV2StateSnapshot()
   const tabsSnap = useTabsStateSnapshot()
-  const { data: subscription } = useOrgSubscriptionQuery(
-    { orgSlug: organization?.slug },
-    { enabled: visible }
-  )
   const isSQLSnippet = snippet.type === 'sql'
-  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
 
-  // Customers on HIPAA plans should not have access to Supabase AI
-  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
+  // Orgs on HIPAA plans or that have disabled AI should not have access to Supabase AI
+  const { aiOptInLevel } = useOrgAiOptInLevel()
+  const isAiOptedOut = aiOptInLevel === 'disabled'
 
   const { id, name, description } = snippet
 
@@ -199,7 +191,7 @@ export const RenameQueryModal = ({
                 )}
               />
               <div className="flex w-full justify-end mt-2">
-                {!hasHipaaAddon && (
+                {!isAiOptedOut && (
                   <ButtonTooltip
                     type="default"
                     onClick={() => generateTitle()}

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -118,7 +118,7 @@ export const SQLEditor = () => {
   const snapV2 = useSqlEditorV2StateSnapshot()
   const getImpersonatedRoleState = useGetImpersonatedRoleState()
   const databaseSelectorState = useDatabaseSelectorStateSnapshot()
-  const { isHipaaProjectDisallowed } = useOrgAiOptInLevel()
+  const { aiOptInLevel } = useOrgAiOptInLevel()
   const showPrettyExplain = useFlag('ShowPrettyExplain')
 
   const {
@@ -392,7 +392,9 @@ export const SQLEditor = () => {
       }
 
       if (
-        !isHipaaProjectDisallowed &&
+        // Don't auto-generate a title when the org has disabled AI or is a HIPAA project,
+        // as that would silently forward the query to the AI provider without consent
+        aiOptInLevel !== 'disabled' &&
         snippet?.snippet.name.startsWith(untitledSnippetTitle) &&
         IS_PLATFORM
       ) {
@@ -440,7 +442,7 @@ export const SQLEditor = () => {
       id,
       isExecuting,
       project,
-      isHipaaProjectDisallowed,
+      aiOptInLevel,
       execute,
       getImpersonatedRoleState,
       setAiTitle,

--- a/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
+++ b/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
@@ -1,4 +1,3 @@
-import { useParams } from 'common'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -15,14 +14,11 @@ import {
   Label,
 } from 'ui'
 
-import { subscriptionHasHipaaAddon } from '@/components/interfaces/Billing/Subscription/Subscription.utils'
 import { generateSnippetTitle } from '@/components/interfaces/SQLEditor/SQLEditor.constants'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useCheckOpenAIKeyQuery } from '@/data/ai/check-api-key-query'
 import { useSqlTitleGenerateMutation } from '@/data/ai/sql-title-mutation'
-import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
-import { useOrgSubscriptionQuery } from '@/data/subscriptions/org-subscription-query'
-import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useOrgAiOptInLevel } from '@/hooks/misc/useOrgOptedIntoAi'
 
 interface SaveSnippetDialogProps {
   open: boolean
@@ -32,19 +28,15 @@ interface SaveSnippetDialogProps {
 }
 
 export const SaveSnippetDialog = ({ open, sql, onOpenChange, onSave }: SaveSnippetDialogProps) => {
-  const { ref } = useParams()
-  const { data: organization } = useSelectedOrganizationQuery()
-  const { data: subscription } = useOrgSubscriptionQuery(
-    { orgSlug: organization?.slug },
-    { enabled: open }
-  )
-  const { data: projectSettings } = useProjectSettingsV2Query({ projectRef: ref })
   const { data: check } = useCheckOpenAIKeyQuery()
 
   const [name, setName] = useState(generateSnippetTitle())
 
   const isApiKeySet = !!check?.hasKey
-  const hasHipaaAddon = subscriptionHasHipaaAddon(subscription) && projectSettings?.is_sensitive
+
+  // Orgs on HIPAA plans or that have disabled AI should not have access to Supabase AI
+  const { aiOptInLevel } = useOrgAiOptInLevel()
+  const isAiOptedOut = aiOptInLevel === 'disabled'
 
   const { mutate: generateTitle, isPending: isGenerating } = useSqlTitleGenerateMutation({
     onSuccess: ({ title }) => setName(title),
@@ -83,7 +75,7 @@ export const SaveSnippetDialog = ({ open, sql, onOpenChange, onSave }: SaveSnipp
               }}
             />
           </div>
-          {!hasHipaaAddon && (
+          {!isAiOptedOut && (
             <div className="flex justify-end">
               <ButtonTooltip
                 type="default"

--- a/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
+++ b/apps/studio/components/ui/EditorPanel/SaveSnippetDialog.tsx
@@ -35,7 +35,7 @@ export const SaveSnippetDialog = ({ open, sql, onOpenChange, onSave }: SaveSnipp
   const isApiKeySet = !!check?.hasKey
 
   // Orgs on HIPAA plans or that have disabled AI should not have access to Supabase AI
-  const { aiOptInLevel } = useOrgAiOptInLevel()
+  const { aiOptInLevel, isHipaaProjectDisallowed } = useOrgAiOptInLevel()
   const isAiOptedOut = aiOptInLevel === 'disabled'
 
   const { mutate: generateTitle, isPending: isGenerating } = useSqlTitleGenerateMutation({
@@ -75,31 +75,33 @@ export const SaveSnippetDialog = ({ open, sql, onOpenChange, onSave }: SaveSnipp
               }}
             />
           </div>
-          {!isAiOptedOut && (
-            <div className="flex justify-end">
-              <ButtonTooltip
-                type="default"
-                size="tiny"
-                disabled={isGenerating || !isApiKeySet}
-                onClick={() => generateTitle({ sql })}
-                tooltip={{
-                  content: {
-                    side: 'bottom',
-                    text: isApiKeySet
-                      ? undefined
-                      : 'Add your "OPENAI_API_KEY" to your environment variables to use this feature.',
-                  },
-                }}
-              >
-                <div className="flex items-center gap-1">
-                  <div className="scale-75">
-                    <AiIconAnimation loading={isGenerating} />
-                  </div>
-                  <span>Generate with AI</span>
+          <div className="flex justify-end">
+            <ButtonTooltip
+              type="default"
+              size="tiny"
+              disabled={isGenerating || !isApiKeySet || isHipaaProjectDisallowed || isAiOptedOut}
+              onClick={() => generateTitle({ sql })}
+              tooltip={{
+                content: {
+                  side: 'bottom',
+                  text: isHipaaProjectDisallowed
+                    ? 'This feature is not available for HIPAA projects.'
+                    : isAiOptedOut
+                      ? 'Your organization has opted out of AI features.'
+                      : isApiKeySet
+                        ? undefined
+                        : 'Add your "OPENAI_API_KEY" to your environment variables to use this feature.',
+                },
+              }}
+            >
+              <div className="flex items-center gap-1">
+                <div className="scale-75">
+                  <AiIconAnimation loading={isGenerating} />
                 </div>
-              </ButtonTooltip>
-            </div>
-          )}
+                <span>Generate with AI</span>
+              </div>
+            </ButtonTooltip>
+          </div>
         </DialogSection>
         <DialogSectionSeparator />
         <DialogFooter className="px-5 py-4">

--- a/apps/studio/data/ai/sql-title-mutation.ts
+++ b/apps/studio/data/ai/sql-title-mutation.ts
@@ -5,16 +5,16 @@ import { constructHeaders, fetchHandler } from '@/data/fetchers'
 import { BASE_PATH } from '@/lib/constants'
 import { ResponseError, UseCustomMutationOptions } from '@/types'
 
-export type SqlTitleGenerateResponse = {
+type SqlTitleGenerateResponse = {
   title: string
   description: string
 }
 
-export type SqlTitleGenerateVariables = {
+type SqlTitleGenerateVariables = {
   sql: string
 }
 
-export async function generateSqlTitle({ sql }: SqlTitleGenerateVariables) {
+async function generateSqlTitle({ sql }: SqlTitleGenerateVariables) {
   const url = `${BASE_PATH}/api/ai/sql/title-v2`
 
   const headers = await constructHeaders({ 'Content-Type': 'application/json' })
@@ -50,9 +50,6 @@ export const useSqlTitleGenerateMutation = ({
 > = {}) => {
   return useMutation<SqlTitleGenerateData, ResponseError, SqlTitleGenerateVariables>({
     mutationFn: (vars) => generateSqlTitle(vars),
-    async onSuccess(data, variables, context) {
-      await onSuccess?.(data, variables, context)
-    },
     async onError(data, variables, context) {
       if (onError === undefined) {
         toast.error(`Failed to generate title: ${data.message}`)


### PR DESCRIPTION
This PR disabled generating snippet titles when running and disables the "generate titles" buttons in Rename Snippet and Save Snippet dialogs (which is accessed through the side SQL Editor).

How to test:
1. Disable AI for an org.
2. Try to run a new snippet, it shouldn't be renamed automatically.
3. Right click it, click Rename. The "generate title" in the dialog should be disabled with a reason in a tooltip.
4. Open the side SQL Editor, write "select 1", click Save snippet. The "generate title" in the dialog should be disabled.

Testing the same flows for HIPAA projects should say `This feature is not available for HIPAA projects.`

<img width="715" height="833" alt="Screenshot 2026-06-15 at 23 02 15" src="https://github.com/user-attachments/assets/f9b68f2f-5a5a-4a66-bd0d-9245f4e2f78e" />
<img width="948" height="845" alt="Screenshot 2026-06-15 at 23 02 01" src="https://github.com/user-attachments/assets/b0c9a90e-6cc1-4262-a246-88617cec41dc" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI feature availability is now gated by organization-level AI opt-in settings instead of subscription-based HIPAA add-ons.

* **Bug Fixes**
  * Updated "Generate with AI" buttons to display disabled state with contextual messaging (missing API key, organization AI opt-out, HIPAA project restriction, or generation in progress).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->