### PR TITLE
fix(studio): align /authorize invalid and edge states with interstitial UI

### DIFF
--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Invalid.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Invalid.tsx
@@ -1,5 +1,9 @@
+import Link from 'next/link'
 import type { ReactNode } from 'react'
-import { Card, CardContent, CardHeader } from 'ui'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns'
+
+import { InterstitialLayout, SupabaseLogo } from '@/components/layouts/InterstitialLayout'
 
 export interface ApiAuthorizationInvalidScreenProps {
   missingParameters: Array<string>
@@ -9,20 +13,24 @@ export function ApiAuthorizationInvalidScreen({
   missingParameters,
 }: ApiAuthorizationInvalidScreenProps): ReactNode {
   const isPlural = missingParameters.length > 1
-  const paragraphFontClass = 'text-sm text-muted-foreground'
 
   return (
-    <Card>
-      <CardHeader>Missing parameters</CardHeader>
-      <CardContent className="flex flex-col gap-2">
-        <p className={paragraphFontClass}>
-          Cannot authorize this request because the URL is missing the following parameter
-          {isPlural ? 's' : ''}: {missingParameters.join(', ')}.
-        </p>
-        <p className={paragraphFontClass}>
-          If you followed a link here, please check the link and try again.
-        </p>
-      </CardContent>
-    </Card>
+    <InterstitialLayout
+      logo={<SupabaseLogo />}
+      title="Missing authorization link"
+      description="This authorization request cannot be completed"
+    >
+      <div className="flex flex-col gap-3 px-6 pb-6">
+        <Admonition
+          type="warning"
+          description={`Retry the authorization request from the requesting app. The URL is missing parameter${
+            isPlural ? 's' : ''
+          }: ${missingParameters.join(', ')}.`}
+        />
+        <Button type="default" block asChild>
+          <Link href="/">Back to dashboard</Link>
+        </Button>
+      </div>
+    </InterstitialLayout>
   )
 }

--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Valid.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Valid.tsx
@@ -193,7 +193,9 @@ export function ApiAuthorizationValidScreen({
     ? buildStudioPageTitle({ section: `Authorize ${effectiveRequester.name}`, brand: 'Supabase' })
     : undefined
 
-  if (!effectiveRequester) return null
+  if (!effectiveRequester) {
+    return <ApiAuthorizationErrorScreen error={undefined} />
+  }
 
   if (isApproved) {
     const approvedOrganization =

--- a/apps/studio/pages/authorize.tsx
+++ b/apps/studio/pages/authorize.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 
 import { ApiAuthorizationScreen } from '@/components/interfaces/ApiAuthorization/ApiAuthorization'
+import { ApiAuthorizationLoadingScreen } from '@/components/interfaces/ApiAuthorization/ApiAuthorization.Loading'
 import { withAuth } from '@/hooks/misc/withAuth'
 import { buildStudioPageTitle } from '@/lib/page-title'
 import type { NextPageWithLayout } from '@/types'
@@ -15,7 +16,14 @@ const APIAuthorizationPage: NextPageWithLayout = () => {
   const { auth_id, organization_slug } = useParams()
 
   if (!routerReady) {
-    return null
+    return (
+      <>
+        <Head>
+          <title>{PAGE_TITLE}</title>
+        </Head>
+        <ApiAuthorizationLoadingScreen />
+      </>
+    )
   }
 
   return (

--- a/apps/studio/tests/components/ApiAuthorization.test.tsx
+++ b/apps/studio/tests/components/ApiAuthorization.test.tsx
@@ -122,10 +122,12 @@ function renderScreen(props: Partial<ApiAuthorizationScreenProps> = {}) {
 
 describe('ApiAuthorizationScreen', () => {
   describe('when auth_id is missing', () => {
-    test('renders invalid screen when auth_id is undefined', () => {
+    test('renders invalid interstitial when auth_id is undefined', () => {
       renderScreen({ auth_id: undefined })
-      expect(screen.getByText('Missing parameters')).toBeInTheDocument()
+      expect(screen.getByText('Missing authorization link')).toBeInTheDocument()
       expect(screen.getByText(/auth_id/)).toBeInTheDocument()
+      expect(screen.getByAltText('Supabase')).toBeInTheDocument()
+      expect(screen.getByRole('link', { name: 'Back to dashboard' })).toHaveAttribute('href', '/')
     })
   })
 
@@ -148,6 +150,17 @@ describe('ApiAuthorizationScreen', () => {
         method: 'get',
         path: '/platform/oauth/authorizations/:id',
         response: () => HttpResponse.json<APIErrorBody>({ message: 'Not found' }, { status: 404 }),
+      })
+      renderScreen()
+      await screen.findByText('Unable to load authorization')
+    })
+
+    test('renders error screen when authorization query returns no requester', async () => {
+      mockOrgsEndpoint()
+      addAPIMock({
+        method: 'get',
+        path: '/platform/oauth/authorizations/:id',
+        response: () => HttpResponse.json(null),
       })
       renderScreen()
       await screen.findByText('Unable to load authorization')

--- a/apps/studio/tests/components/ApiAuthorization.test.tsx
+++ b/apps/studio/tests/components/ApiAuthorization.test.tsx
@@ -160,7 +160,10 @@ describe('ApiAuthorizationScreen', () => {
       addAPIMock({
         method: 'get',
         path: '/platform/oauth/authorizations/:id',
-        response: () => HttpResponse.json(null),
+        response: () =>
+          HttpResponse.json<GetOAuthAuthorizationResponse>(
+            null as unknown as GetOAuthAuthorizationResponse
+          ),
       })
       renderScreen()
       await screen.findByText('Unable to load authorization')

--- a/apps/studio/tests/pages/authorize.test.tsx
+++ b/apps/studio/tests/pages/authorize.test.tsx
@@ -1,0 +1,48 @@
+import { screen } from '@testing-library/react'
+import { describe, expect, test, vi } from 'vitest'
+
+import type { ProfileContextType } from '@/lib/profile'
+import APIAuthorizationPage from '@/pages/authorize'
+import { customRender } from '@/tests/lib/custom-render'
+
+vi.mock('@/hooks/misc/withAuth', () => ({
+  withAuth: (Component: React.ComponentType) => Component,
+}))
+
+const routerPushMock = vi.fn()
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({
+    isReady: false,
+    push: routerPushMock,
+    query: {},
+  }),
+}))
+
+const DEFAULT_PROFILE_CONTEXT: ProfileContextType = {
+  profile: {
+    id: 1,
+    auth0_id: 'auth0|test',
+    gotrue_id: 'gotrue-test',
+    username: 'testuser',
+    primary_email: 'test@example.com',
+    first_name: null,
+    last_name: null,
+    mobile: null,
+    is_alpha_user: false,
+    is_sso_user: false,
+    disabled_features: [],
+    free_project_limit: null,
+  },
+  error: null,
+  isLoading: false,
+  isError: false,
+  isSuccess: true,
+}
+
+describe('APIAuthorizationPage', () => {
+  test('renders loading interstitial while router is not ready', () => {
+    customRender(<APIAuthorizationPage />, { profileContext: DEFAULT_PROFILE_CONTEXT })
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/tests/pages/authorize.test.tsx
+++ b/apps/studio/tests/pages/authorize.test.tsx
@@ -42,7 +42,9 @@ const DEFAULT_PROFILE_CONTEXT: ProfileContextType = {
 
 describe('APIAuthorizationPage', () => {
   test('renders loading interstitial while router is not ready', () => {
-    customRender(<APIAuthorizationPage />, { profileContext: DEFAULT_PROFILE_CONTEXT })
+    customRender(<APIAuthorizationPage dehydratedState={{}} />, {
+      profileContext: DEFAULT_PROFILE_CONTEXT,
+    })
     expect(screen.getByText('Loading...')).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / UI polish

## What is the current behavior?

Visiting `/authorize` without an `auth_id` renders a bare `Card` outside the shared Connect interstitial — no centered layout, no Supabase logo, inconsistent with every other `/authorize` state (loading, error, form, approved). 

Two edge cases also produce poor UX: a blank flash while `router.isReady` is false, and a silent empty page when the authorization query succeeds but returns no requester.

## What is the new behavior?

- **Missing `auth_id`**: `ApiAuthorizationInvalidScreen` now uses `InterstitialLayout` with `SupabaseLogo`, a user-facing title ("Missing authorization link"), warning admonition, and "Back to dashboard" — matching the error screen and CLI missing-params pattern.
- **Router not ready**: `authorize.tsx` shows `ApiAuthorizationLoadingScreen` instead of `null`.
- **Empty requester**: `ApiAuthorization.Valid.tsx` renders `ApiAuthorizationErrorScreen` instead of returning `null`.

Tests updated in `ApiAuthorization.test.tsx`; added `authorize.test.tsx` for router-not-ready loading.

| Before | After |
| --- | --- |
| <img width="524" height="455" alt="Authorize API Access  Supabase-DCB404EC-7D65-4DD1-A6E0-B720DC765DA7" src="https://github.com/user-attachments/assets/8d2b68fc-e008-4145-aa74-3154a883083c" /> | <img width="524" height="455" alt="Authorize API Access  Supabase-6B642066-D0BE-4EDC-A186-A0290B4B5634" src="https://github.com/user-attachments/assets/b04bee93-6b23-411f-8e36-9a0fff8a975d" /> |

## To test

Please do a visual check on `http://localhost:8082/authorize` (no `auth_id` or other parameters).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the UI and copy shown when the authorization link is missing.
  * Updated behavior to show an explicit error screen when authorization requester data is unavailable.
* **New Features**
  * Added a loading state for the authorization page while router parameters are initializing.
* **Tests**
  * Updated component expectations for the missing authorization and “unable to load” scenarios.
  * Added a page test to verify the loading message when the router is not ready.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->