### PR TITLE
chore(docs) Resolve 'simple' style warnings where applicable

### DIFF
--- a/apps/docs/content/_partials/database_setup.mdx
+++ b/apps/docs/content/_partials/database_setup.mdx
@@ -1,6 +1,6 @@
 ## Project setup
 
-Let's create a new Postgres database. This is as simple as starting a new Project in Supabase:
+To create a new Postgres database, start a new Project in Supabase:
 
 1. [Create a new project](https://database.new/) in the Supabase dashboard.
 1. Enter your project details. Remember to store your password somewhere safe.

--- a/apps/docs/content/_partials/kotlin_project_setup.mdx
+++ b/apps/docs/content/_partials/kotlin_project_setup.mdx
@@ -1,6 +1,6 @@
 ## Project setup
 
-Before we start building we're going to set up our Database and API. This is as simple as starting a new Project in Supabase and then creating a "schema" inside the database.
+Before building, you must set up your Database and API with a new Project in Supabase and then creating a "schema" inside the database.
 
 ### Create a project
 

--- a/apps/docs/content/_partials/kotlin_project_setup.mdx
+++ b/apps/docs/content/_partials/kotlin_project_setup.mdx
@@ -1,6 +1,6 @@
 ## Project setup
 
-Before building, you must set up your Database and API with a new Project in Supabase and then creating a "schema" inside the database.
+Before building, you must set up your Database and API with a new Project in Supabase and then create a "schema" inside the database.
 
 ### Create a project
 

--- a/apps/docs/content/_partials/metrics_access.mdx
+++ b/apps/docs/content/_partials/metrics_access.mdx
@@ -25,7 +25,7 @@ className="rounded-lg border border-foreground/10 bg-surface-100 text-foreground
     - **Username**: `service_role`
     - **Password**: a **Secret API key** (`sb_secret_...`). You can create/copy it in [**Project Settings → API Keys**](/dashboard/project/_/settings/api-keys). For more context, see [Understanding API keys](/docs/guides/getting-started/api-keys).
 
-    Testing locally is as simple as running `curl` with your Secret API key:
+    To testing locally, run `curl` with your Secret API key:
 
     ```bash
     curl <project-url>/customer/v1/privileged/metrics \

--- a/apps/docs/content/_partials/metrics_access.mdx
+++ b/apps/docs/content/_partials/metrics_access.mdx
@@ -25,7 +25,7 @@ className="rounded-lg border border-foreground/10 bg-surface-100 text-foreground
     - **Username**: `service_role`
     - **Password**: a **Secret API key** (`sb_secret_...`). You can create/copy it in [**Project Settings → API Keys**](/dashboard/project/_/settings/api-keys). For more context, see [Understanding API keys](/docs/guides/getting-started/api-keys).
 
-    To testing locally, run `curl` with your Secret API key:
+    To test locally, run `curl` with your Secret API key:
 
     ```bash
     curl <project-url>/customer/v1/privileged/metrics \

--- a/apps/docs/content/guides/ai-tools/byo-mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/byo-mcp.mdx
@@ -218,6 +218,8 @@ After this step, you have a fully deployed MCP server accessible from anywhere. 
 
 You can find ready-to-use MCP server implementations here:
 
+
+{/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
 - [Simple MCP server](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/mcp/simple-mcp-server) - Unauthenticated example
 
 ## Resources

--- a/apps/docs/content/guides/ai-tools/byo-mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/byo-mcp.mdx
@@ -218,8 +218,8 @@ After this step, you have a fully deployed MCP server accessible from anywhere. 
 
 You can find ready-to-use MCP server implementations here:
 
-
 {/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
+
 - [Simple MCP server](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/mcp/simple-mcp-server) - Unauthenticated example
 
 ## Resources

--- a/apps/docs/content/guides/ai-tools/byo-mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/byo-mcp.mdx
@@ -218,7 +218,7 @@ After this step, you have a fully deployed MCP server accessible from anywhere. 
 
 You can find ready-to-use MCP server implementations here:
 
-- [Basic MCP server](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/mcp/simple-mcp-server) - Unauthenticated example
+- [Simple MCP server](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/mcp/simple-mcp-server) - Unauthenticated example
 
 ## Resources
 

--- a/apps/docs/content/guides/ai-tools/byo-mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/byo-mcp.mdx
@@ -75,7 +75,7 @@ const server = new McpServer({
   version: '0.1.0',
 })
 
-// Register a simple addition tool
+// Register an addition tool
 server.registerTool(
   'add',
   {
@@ -218,7 +218,7 @@ After this step, you have a fully deployed MCP server accessible from anywhere. 
 
 You can find ready-to-use MCP server implementations here:
 
-- [Simple MCP server](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/mcp/simple-mcp-server) - Basic unauthenticated example
+- [Basic MCP server](https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions/mcp/simple-mcp-server) - Unauthenticated example
 
 ## Resources
 

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -109,8 +109,8 @@ Check out all of the AI [templates and examples](https://github.com/supabase/sup
   <div className="col-span-4">
     <Link href="/guides/ai/examples/building-chatgpt-plugins" passHref>
       <GlassPanel title="OpenAI">
-        OpenAI is an AI research and deployment company. Supabase provides a way to use
-        OpenAI in your applications.
+        OpenAI is an AI research and deployment company. Supabase provides a way to use OpenAI in
+        your applications.
       </GlassPanel>
     </Link>
   </div>
@@ -125,8 +125,8 @@ Check out all of the AI [templates and examples](https://github.com/supabase/sup
   <div className="col-span-4">
     <Link href="/guides/ai/hugging-face" passHref>
       <GlassPanel title="Hugging Face">
-        Hugging Face is an open-source provider of NLP technologies. Supabase provides a way
-        to use Hugging Face's models in your applications.
+        Hugging Face is an open-source provider of NLP technologies. Supabase provides a way to use
+        Hugging Face's models in your applications.
       </GlassPanel>
     </Link>
   </div>

--- a/apps/docs/content/guides/ai.mdx
+++ b/apps/docs/content/guides/ai.mdx
@@ -109,7 +109,7 @@ Check out all of the AI [templates and examples](https://github.com/supabase/sup
   <div className="col-span-4">
     <Link href="/guides/ai/examples/building-chatgpt-plugins" passHref>
       <GlassPanel title="OpenAI">
-        OpenAI is an AI research and deployment company. Supabase provides a simple way to use
+        OpenAI is an AI research and deployment company. Supabase provides a way to use
         OpenAI in your applications.
       </GlassPanel>
     </Link>
@@ -125,7 +125,7 @@ Check out all of the AI [templates and examples](https://github.com/supabase/sup
   <div className="col-span-4">
     <Link href="/guides/ai/hugging-face" passHref>
       <GlassPanel title="Hugging Face">
-        Hugging Face is an open-source provider of NLP technologies. Supabase provides a simple way
+        Hugging Face is an open-source provider of NLP technologies. Supabase provides a way
         to use Hugging Face's models in your applications.
       </GlassPanel>
     </Link>

--- a/apps/docs/content/guides/ai/engineering-for-scale.mdx
+++ b/apps/docs/content/guides/ai/engineering-for-scale.mdx
@@ -8,7 +8,7 @@ sidebar_label: 'Engineering for Scale'
 
 Content sources for vectors can be extremely large. As you grow you should run your Vector workloads across several secondary databases (sometimes called "pods"), which allows each collection to scale independently.
 
-## Small workloads
+## Small workloads [#simple-workloads]
 
 For small workloads, you can typically store your data in a single database.
 

--- a/apps/docs/content/guides/ai/engineering-for-scale.mdx
+++ b/apps/docs/content/guides/ai/engineering-for-scale.mdx
@@ -8,9 +8,9 @@ sidebar_label: 'Engineering for Scale'
 
 Content sources for vectors can be extremely large. As you grow you should run your Vector workloads across several secondary databases (sometimes called "pods"), which allows each collection to scale independently.
 
-## Simple workloads
+## Small workloads
 
-For small workloads, it's typical to store your data in a single database.
+For small workloads, you can typically store your data in a single database.
 
 If you've used [Vecs](/docs/guides/ai/vecs-python-client) to create 3 different collections, you can expose collections to your web or mobile application using [views](/docs/guides/database/tables#views):
 

--- a/apps/docs/content/guides/ai/examples/building-chatgpt-plugins.mdx
+++ b/apps/docs/content/guides/ai/examples/building-chatgpt-plugins.mdx
@@ -20,7 +20,7 @@ It allows ChatGPT to dynamically pull relevant information into conversations fr
 
 ## Example: Chat with Postgres docs
 
-Let’s build an example where we can “ask ChatGPT questions” about the Postgres documentation. Although ChatGPT already knows about the Postgres documentation because it is publicly available, this is a simple example which demonstrates how to work with PDF files.
+Let’s build an example where we can “ask ChatGPT questions” about the Postgres documentation. Although ChatGPT already knows about the Postgres documentation because it is publicly available, this is a basic example which demonstrates how to work with PDF files.
 
 This plugin requires several steps:
 

--- a/apps/docs/content/guides/ai/keyword-search.mdx
+++ b/apps/docs/content/guides/ai/keyword-search.mdx
@@ -8,7 +8,7 @@ sidebar_label: 'Keyword search'
 
 Keyword search involves locating documents or records that contain specific words or phrases, primarily based on the exact match between the search terms and the text within the data. It differs from [semantic search](/docs/guides/ai/semantic-search), which interprets the meaning behind the query to provide results that are contextually related, even if the exact words aren't present in the text. Semantic search considers synonyms, intent, and natural language nuances to provide a more nuanced approach to information retrieval.
 
-In Postgres, keyword search is implemented using [full-text search](/docs/guides/database/full-text-search). It supports indexing and text analysis for data retrieval, focusing on records that match the search criteria. Postgres' full-text search extends beyond simple keyword matching to address linguistic nuances, making it effective for applications that require precise text queries.
+In Postgres, keyword search is implemented using [full-text search](/docs/guides/database/full-text-search). It supports indexing and text analysis for data retrieval, focusing on records that match the search criteria. Postgres' full-text search extends beyond keyword matching to address linguistic nuances, making it effective for applications that require precise text queries.
 
 ## When and why to use keyword search
 

--- a/apps/docs/content/guides/ai/langchain.mdx
+++ b/apps/docs/content/guides/ai/langchain.mdx
@@ -108,7 +108,7 @@ export const run = async () => {
 }
 ```
 
-### Basic metadata filtering
+### Basic metadata filtering [#simple-metadata-filtering]
 
 Given the above `match_documents` Postgres function, you can also pass a filter parameter to only return documents with a specific metadata field value. This filter parameter is a JSON object, and the `match_documents` function will use the Postgres JSONB Containment operator `@>` to filter documents by the metadata field values you specify. See details on the [Postgres JSONB Containment operator](https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT) for more information.
 

--- a/apps/docs/content/guides/ai/langchain.mdx
+++ b/apps/docs/content/guides/ai/langchain.mdx
@@ -108,7 +108,7 @@ export const run = async () => {
 }
 ```
 
-### Simple metadata filtering
+### Basic metadata filtering
 
 Given the above `match_documents` Postgres function, you can also pass a filter parameter to only return documents with a specific metadata field value. This filter parameter is a JSON object, and the `match_documents` function will use the Postgres JSONB Containment operator `@>` to filter documents by the metadata field values you specify. See details on the [Postgres JSONB Containment operator](https://www.postgresql.org/docs/current/datatype-json.html#JSON-CONTAINMENT) for more information.
 

--- a/apps/docs/content/guides/ai/rag-with-permissions.mdx
+++ b/apps/docs/content/guides/ai/rag-with-permissions.mdx
@@ -231,7 +231,7 @@ order by document_sections.embedding <#> embedding;
 
 {/* supa-mdx-lint-disable-next-line Rule004ExcludeWords */}
 
-You might be tempted to discard RLS completely and simply filter by user within the `where` clause. Though this will work, we recommend RLS as a general best practice since RLS is always applied even as new queries and application logic is introduced in the future.
+You might be tempted to discard RLS completely and filter by user within the `where` clause. Though this will work, we recommend RLS as a general best practice since RLS is always applied even as new queries and application logic is introduced in the future.
 
 </Admonition>
 

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -127,7 +127,7 @@ Unenrolling a factor will downgrade the assurance level from `aal2` to `aal1` on
 
 ```tsx
 /**
- * UnenrollMFA shows a simple table with the list of factors together with a button to unenroll.
+ * UnenrollMFA shows a table with the list of factors together with a button to unenroll.
  * When a user types in the factorId of the factor that they wish to unenroll and clicks unenroll
  * the corresponding factor will be unenrolled.
  */

--- a/apps/docs/content/guides/auth/auth-mfa/totp.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa/totp.mdx
@@ -75,7 +75,7 @@ Below is an example that creates a new `EnrollMFA` component that illustrates th
 
 ```tsx
 /**
- * EnrollMFA shows a simple enrollment dialog. When shown on screen it calls
+ * EnrollMFA shows an enrollment dialog. When shown on screen it calls
  * the `enroll` API. Each time a user clicks the Enable button it calls the
  * `challenge` and `verify` APIs to check if the code provided by the user is
  * valid.

--- a/apps/docs/content/guides/auth/auth-smtp.mdx
+++ b/apps/docs/content/guides/auth/auth-smtp.mdx
@@ -13,7 +13,7 @@ If you're using Supabase Auth with the following configuration:
 
 You will need to set up a custom SMTP server to handle the delivery of messages to your users.
 
-To get you started and let you explore and set up email message templates for your application, Supabase provides a simple SMTP server for all projects. This server imposes a few important restrictions and is not meant for production use.
+To get you started and let you explore and set up email message templates for your application, Supabase provides an SMTP server for all projects. This server imposes a few important restrictions and is not meant for production use.
 
 **Send messages only to pre-authorized addresses.**
 

--- a/apps/docs/content/guides/auth/server-side.mdx
+++ b/apps/docs/content/guides/auth/server-side.mdx
@@ -15,7 +15,7 @@ Make sure to use the PKCE flow instructions where those differ from the implicit
 
 ## `@supabase/ssr`
 
-We have developed an [`@supabase/ssr`](https://www.npmjs.com/package/@supabase/ssr) package to make setting up the Supabase client as simple as possible. This package is currently in beta. Adoption is recommended but be aware that the API is still unstable and may have breaking changes in the future.
+We have developed an [`@supabase/ssr`](https://www.npmjs.com/package/@supabase/ssr) package for setting up the Supabase client. This package is currently in beta. Adoption is recommended but be aware that the API is still unstable and may have breaking changes in the future.
 
 ## Framework quickstarts
 

--- a/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
@@ -35,7 +35,7 @@ Choose one of these Vercel Deploy Templates which use our [Vercel Deploy Integra
       passHref
     >
       <GlassPanel title="Kysely" hasLightIcon={true} background={false} showIconBg={true}>
-        Simple Next.js template that uses Supabase as the database and Kysely as the query builder.
+        Basic Next.js template that uses Supabase as the database and Kysely as the query builder.
       </GlassPanel>
     </Link>
   </div>

--- a/apps/docs/content/guides/database/extensions/http.mdx
+++ b/apps/docs/content/guides/database/extensions/http.mdx
@@ -88,7 +88,7 @@ A successful call to a web URL from the `http` extension returns a record with t
 
 ## Examples
 
-### Simple `GET` example
+### Basic `GET` example
 
 ```sql
 select
@@ -97,7 +97,7 @@ from
   extensions.http_get('https://jsonplaceholder.typicode.com/todos/1');
 ```
 
-### Simple `POST` example
+### Basic `POST` example
 
 ```sql
 select

--- a/apps/docs/content/guides/database/extensions/http.mdx
+++ b/apps/docs/content/guides/database/extensions/http.mdx
@@ -97,7 +97,7 @@ from
   extensions.http_get('https://jsonplaceholder.typicode.com/todos/1');
 ```
 
-### Basic `POST` example
+### Basic `POST` example [#simple-post-example]
 
 ```sql
 select

--- a/apps/docs/content/guides/database/extensions/http.mdx
+++ b/apps/docs/content/guides/database/extensions/http.mdx
@@ -88,7 +88,7 @@ A successful call to a web URL from the `http` extension returns a record with t
 
 ## Examples
 
-### Basic `GET` example
+### Basic `GET` example [#simple-get-example]
 
 ```sql
 select

--- a/apps/docs/content/guides/database/extensions/hypopg.mdx
+++ b/apps/docs/content/guides/database/extensions/hypopg.mdx
@@ -45,7 +45,7 @@ It's good practice to create the extension within a separate schema (like `exten
 
 ### Speeding up a query
 
-Given the following table and a simple query to select from the table by `id`:
+Given the following table and a basic query to select from the table by `id`:
 
 {/* prettier-ignore */}
 ```sql

--- a/apps/docs/content/guides/database/extensions/postgis.mdx
+++ b/apps/docs/content/guides/database/extensions/postgis.mdx
@@ -9,7 +9,7 @@ tocVideo: 'agFsGDJxjwA'
 
 ## Overview
 
-While you may be able to store simple lat/long geographic coordinates as a set of decimals, it does not scale very well when you try to query through a large data set. PostGIS comes with special data types that are efficient, and indexable for high scalability.
+While you may be able to store lat/long geographic coordinates as a set of decimals, it does not scale very well when you try to query through a large data set. PostGIS comes with special data types that are efficient, and indexable for high scalability.
 
 The additional data types that PostGIS provides include [Point](https://postgis.net/docs/using_postgis_dbmanagement.html#Point), [Polygon](https://postgis.net/docs/using_postgis_dbmanagement.html#Polygon), [LineString](https://postgis.net/docs/using_postgis_dbmanagement.html#LineString), and many more to represent different types of geographical data. In this guide, we will mainly focus on how to interact with `Point` type, which represents a single set of latitude and longitude. If you are interested in digging deeper, you can learn more about different data types on the [data management section of PostGIS docs](https://postgis.net/docs/using_postgis_dbmanagement.html).
 
@@ -47,7 +47,7 @@ drop extension if exists postgis;
 
 ## Examples
 
-Now that we are ready to get started with PostGIS, let’s create a table and see how we can utilize PostGIS for some typical use cases. Let’s imagine we are creating a simple restaurant-searching app.
+Now that we are ready to get started with PostGIS, let’s create a table and see how we can utilize PostGIS for some typical use cases. Let's imagine we are creating a basic restaurant-searching app.
 
 Let’s create our table. Each row represents a restaurant with its location stored in `location` column as a `Point` type.
 

--- a/apps/docs/content/guides/database/extensions/postgis.mdx
+++ b/apps/docs/content/guides/database/extensions/postgis.mdx
@@ -47,7 +47,7 @@ drop extension if exists postgis;
 
 ## Examples
 
-Now that we are ready to get started with PostGIS, let’s create a table and see how we can utilize PostGIS for some typical use cases. Let's imagine we are creating a basic restaurant-searching app.
+Now that we are ready to get started with PostGIS, let’s create a table and see how we can use PostGIS for some typical use cases. Let's imagine we are creating a basic restaurant-searching app.
 
 Let’s create our table. Each row represents a restaurant with its location stored in `location` column as a `Point` type.
 

--- a/apps/docs/content/guides/database/extensions/postgis.mdx
+++ b/apps/docs/content/guides/database/extensions/postgis.mdx
@@ -47,7 +47,7 @@ drop extension if exists postgis;
 
 ## Examples
 
-Now that we are ready to get started with PostGIS, let’s create a table and see how we can use PostGIS for some typical use cases. Let's imagine we are creating a basic restaurant-searching app.
+Now that we are ready to get started with PostGIS, let’s create a table and see how we can use PostGIS for some typical use cases. Imagine we are creating a basic restaurant-searching app.
 
 Let’s create our table. Each row represents a restaurant with its location stored in `location` column as a `Point` type.
 

--- a/apps/docs/content/guides/database/extensions/timescaledb.mdx
+++ b/apps/docs/content/guides/database/extensions/timescaledb.mdx
@@ -60,7 +60,7 @@ It's good practice to create the extension within a separate schema (like `exten
 
 ## Usage
 
-To demonstrate how `timescaledb` works, let's consider a simple example where we have a table that stores temperature data from different sensors. We will create a table named "temperatures" and store data for two sensors.
+To demonstrate how `timescaledb` works, let's consider a basic example where we have a table that stores temperature data from different sensors. We will create a table named "temperatures" and store data for two sensors.
 
 First we create a hypertable, which is a virtual table that is partitioned into chunks based on time intervals. The hypertable acts as a proxy for the actual table and makes it easy to query and manage time-series data.
 

--- a/apps/docs/content/guides/database/extensions/timescaledb.mdx
+++ b/apps/docs/content/guides/database/extensions/timescaledb.mdx
@@ -60,7 +60,7 @@ It's good practice to create the extension within a separate schema (like `exten
 
 ## Usage
 
-To demonstrate how `timescaledb` works, let's consider a basic example where we have a table that stores temperature data from different sensors. We will create a table named "temperatures" and store data for two sensors.
+To demonstrate how `timescaledb` works, consider a basic example where we have a table that stores temperature data from different sensors. We will create a table named "temperatures" and store data for two sensors.
 
 First we create a hypertable, which is a virtual table that is partitioned into chunks based on time intervals. The hypertable acts as a proxy for the actual table and makes it easy to query and manage time-series data.
 

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -30,7 +30,7 @@ and run the SQL queries yourself.
 3. Enter the SQL to create or replace your Database function.
 4. Click "Run" or cmd+enter (ctrl+enter).
 
-## Basic functions
+## Basic functions [#simple-functions]
 
 Let's create a basic Database Function which returns a string "hello world".
 

--- a/apps/docs/content/guides/database/functions.mdx
+++ b/apps/docs/content/guides/database/functions.mdx
@@ -30,7 +30,7 @@ and run the SQL queries yourself.
 3. Enter the SQL to create or replace your Database function.
 4. Click "Run" or cmd+enter (ctrl+enter).
 
-## Simple functions
+## Basic functions
 
 Let's create a basic Database Function which returns a string "hello world".
 
@@ -53,7 +53,7 @@ At it's most basic a function has the following parts:
 2. `returns text`: The type of data that the function returns. If it returns nothing, you can `returns void`.
 3. `language sql`: The language used inside the function body. This can also be a procedural language: `plpgsql`, `plpython`, etc.
 4. `as $$`: The function wrapper. Anything enclosed inside the `$$` symbols will be part of the function body.
-5. `select 'hello world';`: A simple function body. The final `select` statement inside a function body will be returned if there are no statements following it.
+5. `select 'hello world';`: A basic function body. The final `select` statement inside a function body will be returned if there are no statements following it.
 6. `$$;`: The closing symbols of the function wrapper.
 
 </details>
@@ -290,7 +290,7 @@ data = supabase.rpc('get_planets').eq('id', 1).execute()
 
 ## Passing parameters
 
-Let's create a Function to insert a new planet into the `planets` table and return the new ID. Note that this time we're using the `plpgsql` language.
+Create a function to insert a new planet into the `planets` table and return the new ID. Note that this time we're using the `plpgsql` language.
 
 ```sql
 create or replace function add_planet(name text)

--- a/apps/docs/content/guides/database/partitions.mdx
+++ b/apps/docs/content/guides/database/partitions.mdx
@@ -105,7 +105,7 @@ There is no real threshold to determine when you should use partitions. Partitio
 
 ## Examples
 
-Here are simple examples for each of the partitioning types in Postgres.
+Here are basic examples for each of the partitioning types in Postgres.
 
 ### Range partitioning
 

--- a/apps/docs/content/guides/database/postgres/indexes.mdx
+++ b/apps/docs/content/guides/database/postgres/indexes.mdx
@@ -53,7 +53,7 @@ Seq Scan on persons  (cost=0.00..22.75 rows=x width=y)
 Filter: (age = 32)
 ```
 
-To add a simple B-Tree index you can run:
+To add a basic B-Tree index you can run:
 
 ```sql
 create index idx_persons_age on persons (age);

--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -92,7 +92,7 @@ You must define the "data type" when you create a column.
 
 ### Data types
 
-Every column is a predefined type. Postgres provides many [default types](https://www.postgresql.org/docs/current/datatype.html), and you can even design your own (or use extensions) if the default types don't fit your needs. You can use any data type that Postgres supports via the SQL editor. We only support a subset of these in the Table Editor in an effort to keep the experience simple for people with less experience with databases.
+Every column is a predefined type. Postgres provides many [default types](https://www.postgresql.org/docs/current/datatype.html), and you can even design your own (or use extensions) if the default types don't fit your needs. You can use any data type that Postgres supports via the SQL editor. We only support a subset of these in the Table Editor in an effort to keep the experience focused for people with less experience with databases.
 
 <details>
 <summary>Show/Hide default data types</summary>

--- a/apps/docs/content/guides/database/testing.mdx
+++ b/apps/docs/content/guides/database/testing.mdx
@@ -34,7 +34,7 @@ touch ./supabase/tests/database/hello_world.test.sql
 
 All `sql` files use [pgTAP](/docs/guides/database/extensions/pgtap) as the test runner.
 
-Let's write a simple test to check that our `auth.users` table has an ID column. Open `hello_world.test.sql` and add the following code:
+Let's write a test to check that our `auth.users` table has an ID column. Open `hello_world.test.sql` and add the following code:
 
 ```sql
 begin;

--- a/apps/docs/content/guides/database/testing.mdx
+++ b/apps/docs/content/guides/database/testing.mdx
@@ -34,7 +34,7 @@ touch ./supabase/tests/database/hello_world.test.sql
 
 All `sql` files use [pgTAP](/docs/guides/database/extensions/pgtap) as the test runner.
 
-Let's write a test to check that our `auth.users` table has an ID column. Open `hello_world.test.sql` and add the following code:
+Write a test to check that our `auth.users` table has an ID column. Open `hello_world.test.sql` and add the following code:
 
 ```sql
 begin;

--- a/apps/docs/content/guides/deployment.mdx
+++ b/apps/docs/content/guides/deployment.mdx
@@ -4,11 +4,11 @@ title: Deployment & Branching
 
 Deploying your app makes it live and accessible to users. Most apps have at least two environments: a production environment for users and one or more staging or preview environments for development.
 
-Supabase provides flexible options for both simple and advanced deployment workflows.
+Supabase provides flexible options for deployment workflows of various complexity.
 
 ## Recommended workflow
 
-The simplest way to deploy your Supabase project is with GitHub (recommended, but not required):
+You can deploy your Supabase project with GitHub:
 
 1. Develop locally using the [Supabase CLI](/docs/guides/local-development)
 2. Push changes to your GitHub repository
@@ -41,7 +41,7 @@ You can automate deployments using:
 
 ### Is GitHub required?
 
-No. GitHub integration is recommended for the simplest setup, but you can deploy using the [Supabase CLI](/docs/guides/local-development) in your own CI/CD pipeline without connecting a GitHub repository.
+No. GitHub integration is recommended, but you can deploy using the [Supabase CLI](/docs/guides/local-development) in your own CI/CD pipeline without connecting a GitHub repository.
 
 ### Do you need a paid plan?
 

--- a/apps/docs/content/guides/deployment/shared-responsibility-model.mdx
+++ b/apps/docs/content/guides/deployment/shared-responsibility-model.mdx
@@ -69,7 +69,7 @@ If your application architecture relies on such integrations, you should monitor
 
 ## You choose your level of comfort with Postgres
 
-Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you just want to treat Postgres like a basic table-store, that’s perfectly fine.
+Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you want to treat Postgres like a basic table-store, that’s perfectly fine.
 
 ## You are in control of your database
 

--- a/apps/docs/content/guides/deployment/shared-responsibility-model.mdx
+++ b/apps/docs/content/guides/deployment/shared-responsibility-model.mdx
@@ -69,7 +69,7 @@ If your application architecture relies on such integrations, you should monitor
 
 ## You choose your level of comfort with Postgres
 
-Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you just want to treat Postgres like a simple table-store, that’s perfectly fine.
+Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you just want to treat Postgres like a basic table-store, that’s perfectly fine.
 
 ## You are in control of your database
 

--- a/apps/docs/content/guides/functions.mdx
+++ b/apps/docs/content/guides/functions.mdx
@@ -25,7 +25,7 @@ Edge Functions are server-side TypeScript functions, distributed globally at the
 
 ## Quick technical notes
 
-- **Runtime:** Supabase Edge Runtime (Deno compatible runtime with TypeScript first). Functions are simple `.ts` files that export a handler.
+- **Runtime:** Supabase Edge Runtime (Deno compatible runtime with TypeScript first). Functions are `.ts` files that export a handler.
 - **Local dev parity:** Use Supabase CLI for a local runtime similar to production for faster iteration (`supabase functions serve` command).
 - **Global deployment:** Deploy your Edge Functions via Supabase Dashboard, CLI or MCP.
 - **Cold starts & concurrency:** cold starts are possible — design for short-lived, idempotent operations. Heavy long-running jobs should be moved to [background workers](/docs/guides/functions/background-tasks).

--- a/apps/docs/content/guides/functions/architecture.mdx
+++ b/apps/docs/content/guides/functions/architecture.mdx
@@ -24,7 +24,7 @@ To illustrate how edge functions operate, consider a photo-sharing app where use
 - **Why Edge Functions?**:
   - They handle compute-intensive tasks without burdening the client device or the database.
   - Execution happens server-side but at the edge, ensuring speed and scalability.
-  - Developers define the function in a simple JavaScript file within the Supabase functions directory.
+  - Developers define the function in a JavaScript file within the Supabase functions directory.
 
 This example highlights edge functions as lightweight, on-demand code snippets that integrate seamlessly with Supabase services like Storage and Auth.
 

--- a/apps/docs/content/guides/functions/examples/discord-bot.mdx
+++ b/apps/docs/content/guides/functions/examples/discord-bot.mdx
@@ -45,10 +45,11 @@ This will register a Slash Command named `hello` that accepts a parameter named 
 // Sift is a small routing library that abstracts away details like starting a
 // listener on a port, and provides a function (serve) that has an API
 // to invoke a function for a specific path.
-import { json, serve, validateRequest } from 'https://deno.land/x/sift@0.6.0/mod.ts'
+
 // TweetNaCl is a cryptography library that we use to verify requests
 // from Discord.
 import nacl from 'https://cdn.skypack.dev/tweetnacl@v1.0.3?dts'
+import { json, serve, validateRequest } from 'https://deno.land/x/sift@0.6.0/mod.ts'
 
 enum DiscordCommandType {
   Ping = 1,

--- a/apps/docs/content/guides/functions/examples/discord-bot.mdx
+++ b/apps/docs/content/guides/functions/examples/discord-bot.mdx
@@ -43,7 +43,7 @@ This will register a Slash Command named `hello` that accepts a parameter named 
 
 ```ts index.ts
 // Sift is a small routing library that abstracts away details like starting a
-// listener on a port, and provides a simple function (serve) that has an API
+// listener on a port, and provides a function (serve) that has an API
 // to invoke a function for a specific path.
 import { json, serve, validateRequest } from 'https://deno.land/x/sift@0.6.0/mod.ts'
 // TweetNaCl is a cryptography library that we use to verify requests

--- a/apps/docs/content/guides/functions/examples/mcp-server-mcp-lite.mdx
+++ b/apps/docs/content/guides/functions/examples/mcp-server-mcp-lite.mdx
@@ -21,7 +21,7 @@ This combination offers several advantages:
 - **Direct database access**: Connect directly to your Supabase Postgres
 - **Minimal footprint**: mcp-lite has zero runtime dependencies
 - **Full type safety**: TypeScript support in Deno
-- **Simple deployment**: One command to production
+- **Basic deployment**: One command to production
 
 ## Prerequisites
 

--- a/apps/docs/content/guides/functions/recursive-functions.mdx
+++ b/apps/docs/content/guides/functions/recursive-functions.mdx
@@ -256,7 +256,7 @@ export async function save(data: any) {
 
 ```typescript
 // supabase/functions/process-data/index.ts
-import { validate, transform, save } from '../_shared/transform.ts'
+import { save, transform, validate } from '../_shared/transform.ts'
 
 Deno.serve(async (req) => {
   const data = await req.json()
@@ -284,7 +284,7 @@ async function processWithDelay(items: any[]) {
 
 | Pattern                         | Budget consumption | Recommendation    |
 | ------------------------------- | ------------------ | ----------------- |
-| Basic chain (A to B to C)      | Low                | Generally safe    |
+| Basic chain (A to B to C)       | Low                | Generally safe    |
 | Fan-out (A to B, C, D, E)       | Moderate           | Limit concurrency |
 | Deep recursion (A to A to A...) | High               | Set max depth     |
 | Unbounded loops                 | Very high          | Avoid, use queues |

--- a/apps/docs/content/guides/functions/recursive-functions.mdx
+++ b/apps/docs/content/guides/functions/recursive-functions.mdx
@@ -284,7 +284,7 @@ async function processWithDelay(items: any[]) {
 
 | Pattern                         | Budget consumption | Recommendation    |
 | ------------------------------- | ------------------ | ----------------- |
-| Simple chain (A to B to C)      | Low                | Generally safe    |
+| Basic chain (A to B to C)      | Low                | Generally safe    |
 | Fan-out (A to B, C, D, E)       | Moderate           | Limit concurrency |
 | Deep recursion (A to A to A...) | High               | Set max depth     |
 | Unbounded loops                 | Very high          | Avoid, use queues |

--- a/apps/docs/content/guides/functions/routing.mdx
+++ b/apps/docs/content/guides/functions/routing.mdx
@@ -27,7 +27,7 @@ To combine multiple endpoints into a single Edge Function, you can use web appli
 
 ## Basic routing example
 
-Here's a simple hello world example using some popular web frameworks:
+Here's a basic hello world example using some popular web frameworks:
 
 <Tabs
   scrollable

--- a/apps/docs/content/guides/functions/unit-test.mdx
+++ b/apps/docs/content/guides/functions/unit-test.mdx
@@ -65,7 +65,7 @@ const testClientCreation = async () => {
   if (!supabaseUrl) throw new Error('supabaseUrl is required.')
   if (!supabaseKey) throw new Error('supabaseKey is required.')
 
-  // Test a simple query to the database
+  // Test a query to the database
   const { data: table_data, error: table_error } = await client
     .from('my_table')
     .select('*')

--- a/apps/docs/content/guides/functions/wasm.mdx
+++ b/apps/docs/content/guides/functions/wasm.mdx
@@ -20,7 +20,7 @@ For example, libraries like [magick-wasm](/docs/guides/functions/examples/image-
 
 ### Writing a Wasm module
 
-You can use different languages and SDKs to write Wasm modules. For this tutorial, we will write a simple Wasm module in Rust that adds two numbers.
+You can use different languages and SDKs to write Wasm modules. For this tutorial, we will write a basic Wasm module in Rust that adds two numbers.
 
 <Admonition type="note">
 

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -89,7 +89,7 @@ Never expose your secret keys publicly. Your data is at risk. **Do not:**
 - Never use in a browser, even on `localhost`.
 - Do not pass in URLs or query params, as these are often logged.
 - Be careful passing them in request headers without prior log sanitization.
-- Take extra care logging even potentially **invalid API keys**. Simple typos might reveal the real key in the future.
+- Take extra care logging even potentially **invalid API keys**. Typos might reveal the real key in the future.
 - Reveal, copy, use or manipulate on hardware devices without full disk encryption and which you do not directly own or control (such as public computers, friend's laptop, etc.)
 
 Ensure you handle them with care and using [secure coding practices](https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/stable-en/).

--- a/apps/docs/content/guides/getting-started/architecture.mdx
+++ b/apps/docs/content/guides/getting-started/architecture.mdx
@@ -4,7 +4,7 @@ description: 'Supabase design and architecture'
 tocVideo: 'T-qAtAKjqwc'
 ---
 
-Supabase is open source. We choose open source tools which are scalable and make them simple to use.
+Supabase is open source. We choose open source tools which are scalable and make them approachable.
 
 Supabase is not a 1-to-1 mapping of Firebase. While we are building many of the features that Firebase offers, we are not going about it the same way:
 our technological choices are quite different; everything we use is open source; and wherever possible, we use and support existing tools rather than developing from scratch.
@@ -13,7 +13,7 @@ Most notably, we use Postgres rather than a NoSQL store. This choice was deliber
 
 ## Choose your comfort level
 
-Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you just want to treat Postgres like a simple table-store, that’s perfectly fine.
+Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you just want to treat Postgres like a basic table-store, that’s perfectly fine.
 
 ## Architecture
 

--- a/apps/docs/content/guides/getting-started/architecture.mdx
+++ b/apps/docs/content/guides/getting-started/architecture.mdx
@@ -13,7 +13,7 @@ Most notably, we use Postgres rather than a NoSQL store. This choice was deliber
 
 ## Choose your comfort level
 
-Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you just want to treat Postgres like a basic table-store, that’s perfectly fine.
+Our goal at Supabase is to make _all_ of Postgres easy to use. That doesn’t mean you have to use all of it. If you’re a Postgres veteran, you’ll probably love the tools that we offer. If you’ve never used Postgres before, then start smaller and grow into it. If you want to treat Postgres like a basic table-store, that’s perfectly fine.
 
 ## Architecture
 

--- a/apps/docs/content/guides/getting-started/features.mdx
+++ b/apps/docs/content/guides/getting-started/features.mdx
@@ -128,7 +128,7 @@ Helpers for implementing user authentication in popular server-side languages an
 
 ### File storage
 
-Supabase Storage makes it simple to store and serve files. [Docs](/docs/guides/storage).
+Supabase Storage helps you store and serve files. [Docs](/docs/guides/storage).
 
 ### Content Delivery Network
 

--- a/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/laravel.mdx
@@ -29,7 +29,7 @@ hideToc: true
   <StepHikeCompact.Step step={2}>
     <StepHikeCompact.Details title="Install the Authentication template">
 
-    Install [Laravel Breeze](https://laravel.com/docs/10.x/starter-kits#laravel-breeze), a simple implementation of all of Laravel's [authentication features](https://laravel.com/docs/10.x/authentication).
+    Install [Laravel Breeze](https://laravel.com/docs/10.x/starter-kits#laravel-breeze), a basic implementation of all of Laravel's [authentication features](https://laravel.com/docs/10.x/authentication).
 
     </StepHikeCompact.Details>
 

--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -112,7 +112,7 @@ hideToc: true
   <StepHikeCompact.Step step={6}>
     <StepHikeCompact.Details title="Query data from the app">
 
-    Use `load` method to fetch the data server-side and display the query results as a simple list.
+    Use `load` method to fetch the data server-side and display the query results as a list.
 
     Create `+page.server.js` file in the `src/routes` directory with the following code.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-redwoodjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-redwoodjs.mdx
@@ -28,7 +28,7 @@ Important: When this guide refers to "API," that means the Supabase API and when
 
 The **`api side`** is an implementation of a GraphQL API. The business logic is organized into "services" that represent their own internal API and can be called both from external GraphQL requests and other internal services.
 
-The **`web side`** is built with React. Redwood's router makes it simple to map URL paths to React "Page" components (and automatically code-split your app on each route).
+The **`web side`** is built with React. Redwood's router lets you map URL paths to React "Page" components (and automatically code-split your app on each route).
 Pages may contain a "Layout" component to wrap content. They also contain "Cells" and regular React components.
 Cells allow you to declaratively manage the lifecycle of a component that fetches and displays data.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-redwoodjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-redwoodjs.mdx
@@ -249,8 +249,8 @@ Now, update the `Auth.js` component to contain:
 <$CodeTabs>
 
 ```jsx name=/web/src/components/Auth/Auth.js
-import { useState } from 'react'
 import { useAuth } from '@redwoodjs/auth'
+import { useState } from 'react'
 
 const Auth = () => {
   const { logIn } = useAuth()
@@ -326,8 +326,8 @@ And then update the file to contain:
 <$CodeTabs>
 
 ```jsx name=web/src/components/Account/Account.js
-import { useState, useEffect } from 'react'
 import { useAuth } from '@redwoodjs/auth'
+import { useEffect, useState } from 'react'
 
 const Account = () => {
   const { client: supabase, currentUser, logOut } = useAuth()
@@ -464,7 +464,6 @@ With all the components in place, update your `HomePage` page to use them:
 ```jsx name=web/src/pages/HomePage/HomePage.js
 import { useAuth } from '@redwoodjs/auth'
 import { MetaTags } from '@redwoodjs/web'
-
 import Account from 'src/components/Account'
 import Auth from 'src/components/Auth'
 
@@ -511,8 +510,8 @@ Now, update your Avatar component to contain the following widget:
 <$CodeTabs>
 
 ```jsx name=web/src/components/Avatar/Avatar.js
-import { useEffect, useState } from 'react'
 import { useAuth } from '@redwoodjs/auth'
+import { useEffect, useState } from 'react'
 
 const Avatar = ({ url, size, onUpload }) => {
   const { client: supabase } = useAuth()

--- a/apps/docs/content/guides/integrations/partner-integration-guide.mdx
+++ b/apps/docs/content/guides/integrations/partner-integration-guide.mdx
@@ -9,12 +9,12 @@ This guide assumes you have already followed [the Build a Supabase Integration g
 
 When a Supabase user clicks the **Install Integration** button in the Dashboard, they are redirected to your system to begin the OAuth flow. You can implement this redirect in one of two ways:
 
-- **[Simple redirect](#method-1-simple-redirect)**: Easier to build, but your system cannot verify that the incoming user was sent by Supabase.
+- **[Redirect](#method-1-redirect)**: Easier to build, but your system cannot verify that the incoming user was sent by Supabase.
 - **[Signed redirect](#method-2-signed-redirect)**: More work to build, but cryptographically verifies that the redirect originated from Supabase. **Recommended for production integrations.**
 
 Pick the method that fits your security requirements, then follow the matching section below.
 
-## Method 1: Simple redirect
+## Method 1: Redirect
 
 In this method, you implement a single `GET` endpoint. Supabase redirects the user to this endpoint when they click **Install Integration**, and your endpoint kicks off the OAuth flow.
 

--- a/apps/docs/content/guides/integrations/vercel-marketplace.mdx
+++ b/apps/docs/content/guides/integrations/vercel-marketplace.mdx
@@ -58,7 +58,7 @@ These variables ensure your applications can connect securely to the database an
 
 ## Studio support
 
-Accessing Supabase Studio is simple through the Vercel dashboard. You can open Supabase Studio from either the Integration installation page or the Vercel Storage page.
+Open Supabase Studio from the Vercel dashboard. You can access it from either the Integration installation page or the Vercel Storage page.
 Depending on your entry point, you'll either land on the Supabase dashboard homepage or be redirected to the corresponding Supabase Project.
 
 Supabase Studio provides tools such as:

--- a/apps/docs/content/guides/local-development/cli/testing-and-linting.mdx
+++ b/apps/docs/content/guides/local-development/cli/testing-and-linting.mdx
@@ -44,7 +44,7 @@ By default, Mailpit is available at [localhost:54324](http://localhost:54324) wh
 
 ### Going into production
 
-The "default" email provided by Supabase is only for development purposes. It is [heavily restricted](/docs/guides/platform/going-into-prod#auth-rate-limits) to ensure that it is not used for spam. Before going into production, you must configure your own email provider. This is as simple as enabling a new SMTP credentials in your [project settings](/dashboard/project/_/auth/smtp).
+The "default" email provided by Supabase is only for development purposes. It is [heavily restricted](/docs/guides/platform/going-into-prod#auth-rate-limits) to ensure that it is not used for spam. Before going into production, configure your own email provider by enabling SMTP credentials in your [project settings](/dashboard/project/_/auth/smtp).
 
 ## Linting your database
 

--- a/apps/docs/content/guides/local-development/testing/overview.mdx
+++ b/apps/docs/content/guides/local-development/testing/overview.mdx
@@ -17,12 +17,12 @@ Testing is a critical part of database development, especially when working with
 - Functions and procedures
 - Data integrity
 
-This example demonstrates setting up and testing RLS policies for a simple todo application:
+This example demonstrates setting up and testing RLS policies for a basic todo application:
 
 1. Create a test table with RLS enabled:
 
    ```sql
-   -- Create a simple todos table
+   -- Create a todos table
    create table todos (
    id uuid primary key default gen_random_uuid(),
    task text not null,

--- a/apps/docs/content/guides/local-development/testing/pgtap-extended.mdx
+++ b/apps/docs/content/guides/local-development/testing/pgtap-extended.mdx
@@ -83,7 +83,7 @@ The test helpers package provides several advantages over writing raw pgTAP test
 
 ## Schema-wide Row Level Security testing
 
-When working with Row Level Security, it's crucial to ensure that RLS is enabled on all tables that need it. Create a simple test to verify RLS is enabled across an entire schema:
+When working with Row Level Security, it's crucial to ensure that RLS is enabled on all tables that need it. Create a basic test to verify RLS is enabled across an entire schema:
 
 ```sql
 begin;
@@ -112,7 +112,7 @@ This setup file should contain:
 
 1. All shared extensions and dependencies
 2. Common test utilities
-3. A simple always green test to verify the setup
+3. A basic always-green test to verify the setup
 
 Here's an example setup file:
 

--- a/apps/docs/content/guides/platform.mdx
+++ b/apps/docs/content/guides/platform.mdx
@@ -5,7 +5,7 @@ description: 'Getting started with the Supabase Platform.'
 sidebar_label: 'Overview'
 ---
 
-Supabase is a hosted platform which makes it very simple to get started without needing to manage any infrastructure.
+Supabase is a hosted platform that allows you to get started without needing to manage any infrastructure.
 
 Visit [supabase.com/dashboard](/dashboard) and sign in to start creating projects.
 

--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -153,7 +153,7 @@ Binary payloads (`ArrayBuffer` / `ArrayBufferView`) are received automatically f
     // Join a room/topic. Can be anything except for 'realtime'.
     const myChannel = supabase.channel('test-channel')
 
-    // Simple function to log any messages we receive
+    // Function to log any messages we receive
     function messageReceived(payload) {
       console.log(payload)
     }
@@ -176,7 +176,7 @@ Binary payloads (`ArrayBuffer` / `ArrayBufferView`) are received automatically f
     ```dart
     final myChannel = supabase.channel('test-channel');
 
-    // Simple function to log any messages we receive
+    // Log any messages we receive
     void messageReceived(payload) {
       print(payload);
     }
@@ -241,7 +241,7 @@ Binary payloads (`ArrayBuffer` / `ArrayBufferView`) are received automatically f
     # Join a room/topic. Can be anything except for 'realtime'.
     my_channel = supabase.channel('test-channel')
 
-    # Simple function to log any messages we receive
+    # Function to log any messages we receive
     def message_received(payload):
       print(f"Broadcast received: {payload}")
 

--- a/apps/docs/content/guides/realtime/protocol.mdx
+++ b/apps/docs/content/guides/realtime/protocol.mdx
@@ -35,7 +35,7 @@ Messages can be serialized in different formats. The Realtime protocol supports 
 
 ## 1.0.0
 
-Version 1.0.0 is extremely simple. It uses JSON as the serialization format for messages. The underlying WebSocket messages are all text frames.
+Version 1.0.0 is minimal. It uses JSON as the serialization format for messages. The underlying WebSocket messages are all text frames.
 
 Messages contain the following fields:
 

--- a/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
+++ b/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
@@ -73,6 +73,7 @@ Finally, on the client side, listen to the topic `topic:<record_id>` to receive 
 
 ```js
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
 // ---cut---
@@ -129,6 +130,7 @@ You can use the `INSERT` event to stream all new rows.
 ```js
 // @noImplicitAny: false
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
 // ---cut---
@@ -152,6 +154,7 @@ You can use the `UPDATE` event to stream all updated rows.
 ```js
 // @noImplicitAny: false
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
 // ---cut---

--- a/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
+++ b/apps/docs/content/guides/realtime/subscribing-to-database-changes.mdx
@@ -90,7 +90,7 @@ const changes = supabase
 
 ## Using Postgres Changes
 
-Postgres Changes are simple to use, but have some [limitations](/docs/guides/realtime/postgres-changes#limitations) as your application scales. We recommend using Broadcast for most use cases.
+Postgres Changes require minimal setup, but have some [limitations](/docs/guides/realtime/postgres-changes#limitations) as your application scales. We recommend using Broadcast for most use cases.
 
 <div className="video-container">
   <iframe

--- a/apps/docs/content/guides/resources/glossary.mdx
+++ b/apps/docs/content/guides/resources/glossary.mdx
@@ -70,7 +70,7 @@ There are three generally accepted password hashing functions: Argon2, bcrypt an
 
 ## Password strength
 
-Password strength is a measurement of how difficult a password is to guess. Simple measurement includes calculating the number of possibilities given the types of characters used in the password. For example a password of only letters has fewer variations than ones with letters and digits. Better measurements include strategies such as looking for similarity to words, phrases or already known passwords.
+Password strength is a measurement of how difficult a password is to guess. Basic measurement includes calculating the number of possibilities given the types of characters used in the password. For example a password of only letters has fewer variations than ones with letters and digits. Better measurements include strategies such as looking for similarity to words, phrases or already known passwords.
 
 ## PKCE
 

--- a/apps/docs/content/guides/security.mdx
+++ b/apps/docs/content/guides/security.mdx
@@ -6,7 +6,7 @@ sidebar_label: 'Overview'
 hideToc: true
 ---
 
-Supabase is a hosted platform which makes it very simple to get started without needing to manage any infrastructure. The hosted platform comes with many security and compliance controls managed by Supabase.
+Supabase is a hosted platform that allows you to get started without needing to manage any infrastructure. The hosted platform comes with many security and compliance controls managed by Supabase.
 
 # Compliance
 

--- a/apps/docs/content/guides/security.mdx
+++ b/apps/docs/content/guides/security.mdx
@@ -6,7 +6,7 @@ sidebar_label: 'Overview'
 hideToc: true
 ---
 
-Supabase is a hosted platform that allows you to get started without needing to manage any infrastructure. The hosted platform comes with many security and compliance controls managed by Supabase.
+Supabase is a hosted platform to get you started without needing to manage any infrastructure yourself. The hosted platform comes with many security and compliance controls managed by Supabase.
 
 # Compliance
 

--- a/apps/docs/content/guides/self-hosting/self-hosted-envoy.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-envoy.mdx
@@ -274,7 +274,7 @@ This guide does not cover Envoy's route, filter, and cluster reference. See the 
 
 Envoy exposes an admin interface on `127.0.0.1:9901` inside the container, with endpoints like `/ready`, `/clusters`, `/stats`, and `/config_dump`. The standard `envoyproxy/envoy` image is minimal (no `curl` or `wget`), so the admin endpoints are not reachable via `docker exec` without adding tooling.
 
-The simplest way to query the admin interface during debugging is to run a short-lived `curl` container that joins the same network namespace as `supabase-envoy`:
+You can query the admin interface during debugging by running a short-lived `curl` container that joins the same network namespace as `supabase-envoy`:
 
 ```sh
 docker run --rm --network container:supabase-envoy curlimages/curl http://127.0.0.1:9901/clusters

--- a/apps/docs/content/guides/storage/uploads/standard-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/standard-uploads.mdx
@@ -123,6 +123,7 @@ If you want to overwrite a file on a specific path you can set the `upsert` opti
 
 ```javascript
 import { createClient } from '@supabase/supabase-js'
+
 const file = new Blob()
 
 // ---cut---
@@ -222,6 +223,7 @@ By default, Storage will assume the content type of an asset from the file exten
 
 ```javascript
 import { createClient } from '@supabase/supabase-js'
+
 const file = new Blob()
 
 // ---cut---

--- a/apps/docs/content/guides/storage/uploads/standard-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/standard-uploads.mdx
@@ -10,7 +10,7 @@ sidebar_label: 'Uploads'
 
 The standard file upload method is ideal for small files that are not larger than 6MB.
 
-It uses the traditional `multipart/form-data` format. You can implement it with the supabase-js SDK. Here's an example of how to upload a file using the standard upload method:
+You implement file uploads with the supabase-js SDK using the traditional `multipart/form-data` format. Here's an example of how to upload a file using the standard upload method:
 
 <Admonition type="note">
 

--- a/apps/docs/content/guides/storage/uploads/standard-uploads.mdx
+++ b/apps/docs/content/guides/storage/uploads/standard-uploads.mdx
@@ -10,7 +10,7 @@ sidebar_label: 'Uploads'
 
 The standard file upload method is ideal for small files that are not larger than 6MB.
 
-It uses the traditional `multipart/form-data` format and is simple to implement using the supabase-js SDK. Here's an example of how to upload a file using the standard upload method:
+It uses the traditional `multipart/form-data` format. You can implement it with the supabase-js SDK. Here's an example of how to upload a file using the standard upload method:
 
 <Admonition type="note">
 

--- a/apps/docs/content/guides/telemetry/logs.mdx
+++ b/apps/docs/content/guides/telemetry/logs.mdx
@@ -8,7 +8,7 @@ The Supabase Platform includes a Logs Explorer that allows log tracing and debug
 
 ## Product logs
 
-Supabase provides a logging interface specific to each product. You can use simple regular expressions for keywords and patterns to search log event messages. You can also export and download the log events matching your query as a spreadsheet.
+Supabase provides a logging interface specific to each product. You can use regular expressions for keywords and patterns to search log event messages. You can also export and download the log events matching your query as a spreadsheet.
 
 {/* <!-- To update screenshots, ensure that at least one log line is selected to display the metadata. Can use meme.town as an example. --> */}
 

--- a/apps/docs/content/troubleshooting/error-index-row-size-exceeds-btree-version-4-maximum-for-index-LMmoeU.mdx
+++ b/apps/docs/content/troubleshooting/error-index-row-size-exceeds-btree-version-4-maximum-for-index-LMmoeU.mdx
@@ -36,7 +36,7 @@ This can be if the index is built on text, JSON column etc. It's not prohibited 
 
 One of the measures of index efficiency is the ratio of index entries to the width of all possible values space for this datatype. If we have say 100000 distinct values of int32 in the index then the ratio is 1/40000. If we have text with length of 2704 bytes (maximum for B-tree index) we can hardly imagine the number of distinct values that gives us even a comparable ratio. That said indexing of that long values stores much redundancy in the index.
 
-The solution is simple: use some king of hashing to transfer the values to much narrower space. I.e. md5. The solution is simple, you build a functional index (=index by expression):
+The solution: use some kind of hashing to transfer the values to much narrower space. I.e. md5. Build a functional index (=index by expression):
 
 ```sql
 create index on table_name (MD5(column_name));

--- a/apps/docs/content/troubleshooting/how-to-migrate-from-supabase-auth-helpers-to-ssr-package-5NRunM.mdx
+++ b/apps/docs/content/troubleshooting/how-to-migrate-from-supabase-auth-helpers-to-ssr-package-5NRunM.mdx
@@ -99,7 +99,7 @@ export async function updateSession(request: NextRequest) {
   )
 
   // Do not run code between createServerClient and
-  // supabase.auth.getClaims(). A simple mistake could make it very hard to debug
+  // supabase.auth.getClaims(). A basic mistake could make it very hard to debug
   // issues with users being randomly logged out.
 
   // IMPORTANT: If you remove getClaims() and you use server-side rendering

--- a/apps/docs/content/troubleshooting/http-api-issues.mdx
+++ b/apps/docs/content/troubleshooting/http-api-issues.mdx
@@ -21,7 +21,7 @@ Symptoms of HTTP API issues include:
 
 The most common class of issues that causes HTTP timeouts and 5xx response codes is the under-provisioning of resources for your project. This can cause your project to be unable to service the traffic it is receiving.
 
-Each Supabase project is provisioned with [segregated compute resources](../platform/compute-add-ons). This allows the project to serve unlimited requests, as long as they can be handled using the resources that have been provisioned. Complex queries, or queries that process larger amounts of data, will require higher amounts of resources. As such, the amount of resources that can handle a high volume of simple queries (or queries involving small amounts of data), will likely be unable to handle a similar volume of complex queries.
+Each Supabase project is provisioned with [segregated compute resources](../platform/compute-add-ons). This allows the project to serve unlimited requests, as long as they can be handled using the resources that have been provisioned. Complex queries, or queries that process larger amounts of data, will require higher amounts of resources. As such, the amount of resources that can handle a high volume of basic queries (or queries involving small amounts of data), will likely be unable to handle a similar volume of complex queries.
 
 You can view the resource utilization of your Supabase Project using the [reports in the Dashboard](/dashboard/project/_/observability/database).
 

--- a/apps/docs/content/troubleshooting/pkce-flow-errors-cannot-parse-response-or-zgotmplz-in-magic-link-emails-433665.mdx
+++ b/apps/docs/content/troubleshooting/pkce-flow-errors-cannot-parse-response-or-zgotmplz-in-magic-link-emails-433665.mdx
@@ -61,7 +61,7 @@ Now that your `SITE_URL` is correctly set to a web domain, you can safely use th
 
 This is the most crucial step to resolve both the broken PKCE handshake and the email link scanner issues.
 
-- **Create a Web Callback Page**: Develop a simple web page on your `SITE_URL` (e.g., `https://example.com/auth/callback`). This page will be the initial destination when the user clicks the magic link in the email.
+- **Create a Web Callback Page**: Create a web page on your `SITE_URL` (e.g., `https://example.com/auth/callback`). This page is the initial destination when the user clicks the magic link in the email.
 - **Add a User-Initiated Button**: On this callback page, include a button or explicit action that the user _must_ click to proceed. For example, a button labeled "Verify & Open App."
   - **Why this is essential**:
     - It prevents email link scanners from automatically triggering the final deep link, ensuring the one-time token is not consumed prematurely.

--- a/apps/docs/content/troubleshooting/prisma-error-management-Cm5P_o.mdx
+++ b/apps/docs/content/troubleshooting/prisma-error-management-Cm5P_o.mdx
@@ -103,7 +103,7 @@ grant "prisma" to "postgres";
 
 ### Keep it safe!
 
-Use a strong password for Prisma. Bitwarden provides a free and simple [password generator](https://bitwarden.com/password-generator/) that can make one for you.
+Use a strong password for Prisma. Bitwarden provides a free [password generator](https://bitwarden.com/password-generator/) that can make one for you.
 
 If you need to change it later, you can use the below SQL:
 

--- a/apps/docs/content/troubleshooting/realtime-heartbeat-messages.mdx
+++ b/apps/docs/content/troubleshooting/realtime-heartbeat-messages.mdx
@@ -161,7 +161,7 @@ If the worker fails to start, check:
 
 ### Show connection status to users
 
-Display connection status with a simple indicator:
+Display connection status with an indicator:
 
 ```tsx
 import { useState, useEffect } from 'react'

--- a/apps/docs/content/troubleshooting/realtime-heartbeat-messages.mdx
+++ b/apps/docs/content/troubleshooting/realtime-heartbeat-messages.mdx
@@ -28,8 +28,8 @@ Without heartbeats, your application might appear connected while being unable t
 You can monitor heartbeat lifecycle events using the `onHeartbeat` method:
 
 ```tsx
-import { useEffect } from 'react'
 import { createClient } from '@supabase/supabase-js'
+import { useEffect } from 'react'
 
 function MyComponent() {
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
@@ -72,8 +72,8 @@ If you're seeing frequent `timeout` status in your heartbeat callback:
 The client automatically attempts reconnection with exponential backoff (1s, 2s, 5s, 10s). If you need to manually reconnect:
 
 ```tsx
-import { useState, useEffect } from 'react'
 import { createClient } from '@supabase/supabase-js'
+import { useEffect, useState } from 'react'
 
 function ConnectionStatus() {
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
@@ -164,8 +164,8 @@ If the worker fails to start, check:
 Display connection status with an indicator:
 
 ```tsx
-import { useState, useEffect } from 'react'
 import { createClient } from '@supabase/supabase-js'
+import { useEffect, useState } from 'react'
 
 function ConnectionIndicator() {
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)
@@ -196,9 +196,9 @@ function ConnectionIndicator() {
 Ensure connection is active when user opens your app:
 
 ```tsx
+import { createClient } from '@supabase/supabase-js'
 import { useEffect } from 'react'
 import { AppState } from 'react-native'
-import { createClient } from '@supabase/supabase-js'
 
 function App() {
   const supabase = createClient(SUPABASE_URL, SUPABASE_KEY)

--- a/apps/docs/content/troubleshooting/soft-deletes-with-supabase-js.mdx
+++ b/apps/docs/content/troubleshooting/soft-deletes-with-supabase-js.mdx
@@ -103,6 +103,6 @@ await supabase.from('items').update({ deleted_at: null }).eq('id', 123)
 
 ## Conclusion
 
-Soft deletes are easy to implement with Supabase and Postgres. By combining a `deleted_at` column with views, you can cleanly separate active and deleted records, keeping your application logic simple and maintainable.
+Soft deletes are easy to implement with Supabase and Postgres. By combining a `deleted_at` column with views, you can cleanly separate active and deleted records, keeping your application logic clean and maintainable.
 
 This approach provides the flexibility of retaining data for audits or recovery while keeping your app's interface clean and efficient. Start using soft deletes in your Supabase projects today!


### PR DESCRIPTION
Contributes to DOCS-1052

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Resolves MDX linting errors related to "simple" where it applies.
There was a couple cases that did not apply. For example, a product with "Simple" in the name.

These changes are made in context, either by removing or using a more descriptive synonym like "minimal" or "basic".

## Tophatting

1. Read each of the diffs.
2. See that the text still makes sense in context.

For extra due diligence, you can run `pnpm lint:mdx` locally and see the 'simple' errors that remain and whether they are worth addressing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated many guide, tutorial, and troubleshooting pages with clearer “basic”/“minimal” wording across setup steps, local testing instructions, security cautions, and RLS guidance.
  * Refined headings, example descriptions, and inline comments for consistency (including deployment, MCP, metrics API, and search/function phrasing).
  * Improved readability with small snippet formatting tweaks (whitespace plus import/comment ordering) and added a self-hosting debugging note for Envoy admin endpoints via a short-lived `curl` container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->