### PR TITLE
Prevent refetch on focus and reconnect for /query requests that failed due to statement timeouts

### DIFF
--- a/apps/studio/data/query-client.ts
+++ b/apps/studio/data/query-client.ts
@@ -20,6 +20,16 @@ const SKIP_RETRY_PATHNAME_MATCHERS = [
 
 export const MAX_RETRY_FAILURE_COUNT = 3
 
+function isQueryEndpointStatementTimeout(error: unknown) {
+  const PG_META_QUERY_PATHNAME_MATCHER = match('/platform/pg-meta/:ref/query')
+  return (
+    error instanceof ResponseError &&
+    !!error.requestPathname &&
+    !!PG_META_QUERY_PATHNAME_MATCHER(error.requestPathname) &&
+    !!error.message?.includes('canceling statement due to statement timeout')
+  )
+}
+
 let queryClient: QueryClient | undefined
 
 export function getQueryClient() {
@@ -70,6 +80,17 @@ export function getQueryClient() {
 
             // react-query default: doubles, starting at 1000ms, with each attempt, but will not exceed 30 seconds
             return Math.min(1000 * 2 ** failureCount, 30000)
+          },
+          refetchOnWindowFocus(query) {
+            // [Joshen] Opting to not refetch a /query request that failed due to a statement
+            // timeout, presumably that it'll just run into the same issue. Can however be overriden
+            // on a per case basis on each individual query hook
+            if (isQueryEndpointStatementTimeout(query.state.error)) return false
+            return true
+          },
+          refetchOnReconnect(query) {
+            if (isQueryEndpointStatementTimeout(query.state.error)) return false
+            return true
           },
         },
       },

--- a/apps/studio/data/sql/execute-sql-mutation.ts
+++ b/apps/studio/data/sql/execute-sql-mutation.ts
@@ -158,8 +158,7 @@ export async function executeSql<T = any>(
     }
 
     const key =
-      queryKey?.filter((seg) => typeof seg === 'string' || typeof seg === 'number').join('-') ??
-      undefined
+      queryKey?.filter((seg) => typeof seg === 'string' || typeof seg === 'number').join('-') ?? ''
     const result = await post('/platform/pg-meta/{ref}/query', {
       ...options,
       body: { query: sql, disable_statement_timeout: isStatementTimeoutDisabled },

--- a/apps/studio/data/sql/execute-sql-mutation.ts
+++ b/apps/studio/data/sql/execute-sql-mutation.ts
@@ -158,7 +158,8 @@ export async function executeSql<T = any>(
     }
 
     const key =
-      queryKey?.filter((seg) => typeof seg === 'string' || typeof seg === 'number').join('-') ?? ''
+      queryKey?.filter((seg) => typeof seg === 'string' || typeof seg === 'number').join('-') ??
+      undefined
     const result = await post('/platform/pg-meta/{ref}/query', {
       ...options,
       body: { query: sql, disable_statement_timeout: isStatementTimeoutDisabled },


### PR DESCRIPTION
## Context

As per PR title - prevents refetch on focus and reconnect for /query requests that failed due to statement timeouts, presumably that those requests will run into the same problem either way so this minimizes unnecessary impact to the database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of statement timeouts to prevent automatic retry attempts after window focus or reconnection.
  * Enhanced query execution request identification for better query tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->