### PR TITLE
chore: Add self-hosted label to documentation

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,11 @@ documentation:
   - changed-files:
       - any-glob-to-any-file: 'apps/docs/**/*'
 
+# Add 'self-hosted' to any change in the self-hosting docs
+self-hosted:
+  - changed-files:
+      - any-glob-to-any-file: 'apps/docs/content/guides/self-hosting/**/*'
+
 # Add 'api-deploy-required' to any change in packages/api-types/types
 api-deploy-required:
   - changed-files:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub workflow configuration for improved pull request management and categorization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->