### PR TITLE
fix(studio): rename auth hook card HTTP label

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/HookCard.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/HookCard.tsx
@@ -67,7 +67,7 @@ export const HookCard = ({ hook, onSelect }: HookCardProps) => {
             <div className="flex flex-col w-full space-y-2">
               <div className="flex flex-row items-center">
                 <span className="text-foreground-light w-20">type</span>
-                <span className="text-foreground">HTTPS endpoint</span>
+                <span className="text-foreground">HTTP endpoint</span>
               </div>
               <div className="flex flex-row items-center">
                 <label htmlFor="url" className="text-foreground-light w-20">


### PR DESCRIPTION
Follow-up to #46950 and #46951.

This changes one leftover auth hook card label from `HTTPS endpoint` to `HTTP endpoint` so the Studio copy matches the broader HTTP hook type.

No behavior changes.

Testing

Not run, copy-only change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a label in hook details that previously displayed "HTTPS endpoint" to now correctly show "HTTP endpoint".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->