### PR TITLE
fix(www): detach the resize listener that was actually attached in Globe

### DIFF
--- a/apps/www/components/Globe.tsx
+++ b/apps/www/components/Globe.tsx
@@ -56,7 +56,7 @@ const Globe = () => {
     })
     setTimeout(() => (canvasRef.current.style.opacity = '0.8'), 10)
     return () => {
-      window.removeEventListener('resize', onResize)
+      window.removeEventListener('resize', debouncedResize)
       cobe.destroy()
     }
   }, [resolvedTheme])


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In `apps/www/components/Globe.tsx` the resize listener is registered with the debounced wrapper:

```ts
const debouncedResize = debounce(onResize, 10)
window.addEventListener('resize', debouncedResize)
```

but the cleanup tries to remove a different function:

```ts
window.removeEventListener('resize', onResize)
```

`removeEventListener` matches listeners by reference, and `onResize` was never the function that got added, so the listener is never detached. The effect depends on `resolvedTheme`, so it re-runs (and adds a fresh `debouncedResize`) on every theme change while none of the old ones are removed. The handlers accumulate on `window`.

## What is the new behavior?

Cleanup removes the same `debouncedResize` reference that was added, so the listener is detached on unmount and on each theme change. No leftover resize handlers.

## Additional context

One-line change; `debouncedResize` is already in the effect closure so it is reachable from the cleanup.