### PR TITLE
fix(www): detach community slider hover listeners instead of leaking them

### DIFF
--- a/apps/www/components/Sections/CommunitySlider.tsx
+++ b/apps/www/components/Sections/CommunitySlider.tsx
@@ -92,16 +92,20 @@ const CommunitySlider = () => {
   }, [width])
 
   useEffect(() => {
-    if (!ref.current || !swiperInstance?.autoplay) return
+    const el = ref.current
+    if (!el || !swiperInstance?.autoplay) return
 
-    ref.current?.addEventListener('mouseover', () => swiperInstance?.autoplay?.stop())
-    ref.current?.addEventListener('mouseleave', () => swiperInstance?.autoplay?.start())
+    const stopAutoplay = () => swiperInstance?.autoplay?.stop()
+    const startAutoplay = () => swiperInstance?.autoplay?.start()
+
+    el.addEventListener('mouseover', stopAutoplay)
+    el.addEventListener('mouseleave', startAutoplay)
 
     return () => {
-      ref.current?.removeEventListener('mouseover', () => swiperInstance?.autoplay?.stop())
-      ref.current?.removeEventListener('mouseleave', () => swiperInstance?.autoplay?.start())
+      el.removeEventListener('mouseover', stopAutoplay)
+      el.removeEventListener('mouseleave', startAutoplay)
     }
-  }, [ref.current, swiperInstance?.autoplay])
+  }, [swiperInstance?.autoplay])
 
   const Card = (card: CardInterface) => (
     <div className="bg-surface-100 hover:border-strong border-overlay rounded-2xl border p-6 drop-shadow-xs flex flex-col gap-4">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In `apps/www/components/Sections/CommunitySlider.tsx` the hover handlers are registered and removed with separate inline arrow functions:

```ts
ref.current?.addEventListener('mouseover', () => swiperInstance?.autoplay?.stop())
ref.current?.addEventListener('mouseleave', () => swiperInstance?.autoplay?.start())

return () => {
  ref.current?.removeEventListener('mouseover', () => swiperInstance?.autoplay?.stop())
  ref.current?.removeEventListener('mouseleave', () => swiperInstance?.autoplay?.start())
}
```

Each `removeEventListener` gets a brand-new function reference, which never equals the one passed to `addEventListener`, so nothing is removed. The effect depends on `swiperInstance?.autoplay`, so every time that changes the cleanup fails to detach and another pair of `mouseover`/`mouseleave` listeners is stacked on the slider node, all firing autoplay stop/start.

## What is the new behavior?

The two handlers are hoisted into stable `const`s so `addEventListener` and `removeEventListener` share the same reference and the listeners are actually detached on cleanup. `ref.current` is captured into a local `el` at effect run time so cleanup operates on the same node.

## Additional context

`ref.current` is also removed from the dependency array: a ref is stable and reading `ref.current` in deps does not track mutations, so it added nothing. Behavior (autoplay pausing on hover, resuming on leave) is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed community slider autoplay behavior to properly pause and resume on mouse hover interactions.

* **Refactor**
  * Improved event listener management for enhanced reliability and cleaner code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->