### PR TITLE
fix(www): clear the CountUp animation interval on unmount

### DIFF
--- a/apps/www/components/CountUp.tsx
+++ b/apps/www/components/CountUp.tsx
@@ -19,29 +19,10 @@ const CountUp = (props: Props) => {
   useEffect(() => {
     let frame = 0
     const totalFrames = Math.round(duration / frameDuration)
+    let counter: ReturnType<typeof setInterval> | undefined
 
-    async function handleScroll() {
-      const reference = document.getElementById(referenceElId)
-      if (reference && !animTriggered) {
-        const yOffset = reference.getBoundingClientRect().top - window.innerHeight + 20
-        if (yOffset <= 0) {
-          setAnimTriggered(true)
-          setCount(0)
-          const counter = setInterval(() => {
-            frame++
-            const progress = easeOutQuad(frame / totalFrames)
-            setCount(countTo * progress)
-
-            if (frame === totalFrames) clearInterval(counter)
-          }, frameDuration)
-        }
-      }
-    }
-
-    if (triggerAnimOnScroll) {
-      window.addEventListener('scroll', handleScroll, { passive: true })
-    } else {
-      const counter = setInterval(() => {
+    function startCounting() {
+      counter = setInterval(() => {
         frame++
         const progress = easeOutQuad(frame / totalFrames)
         setCount(countTo * progress)
@@ -50,8 +31,27 @@ const CountUp = (props: Props) => {
       }, frameDuration)
     }
 
+    async function handleScroll() {
+      const reference = document.getElementById(referenceElId)
+      if (reference && !animTriggered) {
+        const yOffset = reference.getBoundingClientRect().top - window.innerHeight + 20
+        if (yOffset <= 0) {
+          setAnimTriggered(true)
+          setCount(0)
+          startCounting()
+        }
+      }
+    }
+
+    if (triggerAnimOnScroll) {
+      window.addEventListener('scroll', handleScroll, { passive: true })
+    } else {
+      startCounting()
+    }
+
     return () => {
       if (triggerAnimOnScroll) window.removeEventListener('scroll', handleScroll)
+      if (counter) clearInterval(counter)
     }
   }, [animTriggered])
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

In `apps/www/components/CountUp.tsx` the `setInterval` that drives the number animation is assigned to a `const counter` declared inside the branch that starts it -- once in the `else` branch, once inside the async `handleScroll`:

```ts
} else {
  const counter = setInterval(() => { ... if (frame === totalFrames) clearInterval(counter) }, frameDuration)
}

return () => {
  if (triggerAnimOnScroll) window.removeEventListener('scroll', handleScroll)
}
```

The cleanup has no reference to `counter`, so it can only ever remove the scroll listener. If the component unmounts before the animation reaches its final frame (or the effect re-runs when `animTriggered` changes), the interval keeps running, calls `setCount` on an unmounted component, and is never cleared. On pages that render many `CountUp` values this leaks one interval per instance.

## What is the new behavior?

The interval id is hoisted to the effect scope through a shared `startCounting` helper used by both the scroll and non-scroll paths, and the cleanup clears it. The existing self-clearing `clearInterval` on the final frame is kept, so finished animations behave exactly as before.

## Additional context

The helper also removes the duplicated interval body that previously existed in both branches.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the CountUp component's animation performance through internal logic improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->