### PR TITLE
feat: Add error state to charts

### DIFF
--- a/apps/design-system/registry/default/block/chart-composed-states.tsx
+++ b/apps/design-system/registry/default/block/chart-composed-states.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { BarChart2, ExternalLink } from 'lucide-react'
-import { Badge } from 'ui'
+import { Badge, CriticalIcon } from 'ui'
 import {
   Chart,
   ChartActions,
@@ -41,6 +41,35 @@ export default function ChartComposedStates() {
             <ChartActions actions={actions} />
           </ChartHeader>
           <ChartContent loadingState={<ChartLoadingState />}>My chart here...</ChartContent>
+        </ChartCard>
+      </Chart>
+
+      <Chart isErrored={true}>
+        <ChartCard>
+          <ChartHeader>
+            <ChartTitle tooltip="This is a tooltip">Response Errors</ChartTitle>
+            <ChartActions actions={actions} />
+          </ChartHeader>
+          <ChartContent
+            isEmpty={true}
+            errorState={
+              <ChartEmptyState
+                icon={<CriticalIcon />}
+                title="Some error happened"
+                description="Error happened why trying to fetch data. Please try again later."
+              />
+            }
+            emptyState={
+              <ChartEmptyState
+                icon={<BarChart2 size={20} />}
+                title="No data to show"
+                description="It may take up to 24 hours for data to refresh"
+              />
+            }
+            loadingState={<ChartLoadingState />}
+          >
+            My chart here...
+          </ChartContent>
         </ChartCard>
       </Chart>
 

--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
@@ -3,15 +3,16 @@ import dayjs from 'dayjs'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
-import { Card, CardContent, CardHeader, CardTitle, Loading } from 'ui'
+import { Card, CardContent, CardHeader, CardTitle, CriticalIcon, Loading } from 'ui'
 import { Row } from 'ui-patterns'
+import { ChartEmptyState } from 'ui-patterns/Chart'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
 
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import { ChartIntervalDropdown } from '@/components/ui/Logs/ChartIntervalDropdown'
 import { CHART_INTERVALS } from '@/components/ui/Logs/logs.utils'
 import { UsageApiCounts, useProjectLogStatsQuery } from '@/data/analytics/project-log-stats-query'
-import { useFillTimeseriesSorted } from '@/hooks/analytics/useFillTimeseriesSorted'
+import { fillTimeseriesSorted } from '@/hooks/analytics/useFillTimeseriesSorted'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -71,33 +72,41 @@ export const ProjectUsageSection = () => {
   }, [selectedInterval])
 
   // Use V1 data fetching
-  const { data: logStatsData, isPending: isLoading } = useProjectLogStatsQuery({
-    projectRef,
-    interval,
-  })
+  const {
+    data: filledCharts,
+    isPending: isLoading,
+    error,
+  } = useProjectLogStatsQuery(
+    {
+      projectRef,
+      interval,
+    },
+    {
+      select: (data) => {
+        // Calculate date range for gap filling
+        const startDateLocal = dayjs().subtract(
+          selectedInterval.startValue,
+          selectedInterval.startUnit as dayjs.ManipulateType
+        )
+        const endDateLocal = dayjs()
 
-  // Calculate date range for gap filling
-  const startDateLocal = dayjs().subtract(
-    selectedInterval.startValue,
-    selectedInterval.startUnit as dayjs.ManipulateType
+        return fillTimeseriesSorted({
+          data: data.result,
+          timestampKey: 'timestamp',
+          valueKey: [
+            'total_auth_requests',
+            'total_rest_requests',
+            'total_storage_requests',
+            'total_realtime_requests',
+          ],
+          defaultValue: 0,
+          startDate: startDateLocal.toISOString(),
+          endDate: endDateLocal.toISOString(),
+          minPointsToFill: 5,
+        })
+      },
+    }
   )
-  const endDateLocal = dayjs()
-
-  // Fill gaps in timeseries data
-  const { data: filledCharts } = useFillTimeseriesSorted({
-    data: logStatsData?.result ?? [],
-    timestampKey: 'timestamp',
-    valueKey: [
-      'total_auth_requests',
-      'total_rest_requests',
-      'total_storage_requests',
-      'total_realtime_requests',
-    ],
-    defaultValue: 0,
-    startDate: startDateLocal.toISOString(),
-    endDate: endDateLocal.toISOString(),
-    minPointsToFill: 5,
-  })
 
   const serviceBase: ServiceEntry[] = useMemo(
     () => [
@@ -147,7 +156,7 @@ export const ProjectUsageSection = () => {
 
         // Transform V1 data to LogsBarChart format
         // Since V1 doesn't have error/warning breakdown, we show everything as "ok"
-        const transformedData: LogsBarChartDatum[] = (filledCharts || []).map((item) => ({
+        const transformedData: LogsBarChartDatum[] = (filledCharts?.data || []).map((item) => ({
           timestamp: item.timestamp,
           error_count: 0,
           warning_count: 0,
@@ -162,10 +171,10 @@ export const ProjectUsageSection = () => {
           data: transformedData,
           total,
           isLoading,
-          error: null,
+          error: error || filledCharts?.error || null,
         }
       }),
-    [serviceBase, filledCharts, isLoading]
+    [serviceBase, filledCharts, isLoading, error]
   )
 
   const handleBarClick =
@@ -239,6 +248,7 @@ export const ProjectUsageSection = () => {
                 <LogsBarChart
                   isFullHeight
                   data={s.data}
+                  error={s.error}
                   DateTimeFormat={datetimeFormat}
                   onBarClick={handleBarClick(s.route, s.key)}
                   hideZeroValues={true}
@@ -253,6 +263,13 @@ export const ProjectUsageSection = () => {
                       label: 'Requests',
                     },
                   }}
+                  ErrorState={
+                    <ChartEmptyState
+                      icon={<CriticalIcon />}
+                      title="Failed to get project's usage api counts"
+                      description="Please try again later."
+                    />
+                  }
                   EmptyState={
                     <NoDataPlaceholder
                       size="small"

--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
@@ -3,7 +3,7 @@ import dayjs from 'dayjs'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
-import { Card, CardContent, CardHeader, CardTitle, CriticalIcon, Loading } from 'ui'
+import { Card, CardContent, CardHeader, CardTitle, Loading, WarningIcon } from 'ui'
 import { Row } from 'ui-patterns'
 import { ChartEmptyState } from 'ui-patterns/Chart'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
@@ -105,6 +105,7 @@ export const ProjectUsageSection = () => {
           minPointsToFill: 5,
         })
       },
+      refetchOnWindowFocus: false,
     }
   )
 
@@ -265,9 +266,9 @@ export const ProjectUsageSection = () => {
                   }}
                   ErrorState={
                     <ChartEmptyState
-                      icon={<CriticalIcon />}
-                      title="Failed to get project's usage api counts"
-                      description="Please try again later."
+                      icon={<WarningIcon />}
+                      title="Failed to load project usage"
+                      description="Check our Status Page or try again later."
                     />
                   }
                   EmptyState={

--- a/apps/studio/hooks/analytics/useFillTimeseriesSorted.ts
+++ b/apps/studio/hooks/analytics/useFillTimeseriesSorted.ts
@@ -67,6 +67,23 @@ export function hasValidTimestamp<T extends Datum>(data: T[], timestampKey: stri
 export const useFillTimeseriesSorted = <T extends Datum = Datum>(
   options: FillTimeseriesOptions<T>
 ): FillTimeseriesResult<T> => {
+  return useMemo(() => {
+    return fillTimeseriesSorted(options)
+  }, [
+    JSON.stringify(options.data),
+    options.timestampKey,
+    JSON.stringify(options.valueKey),
+    options.defaultValue,
+    options.startDate,
+    options.endDate,
+    options.minPointsToFill,
+    options.interval,
+  ])
+}
+
+export const fillTimeseriesSorted = <T extends Datum = Datum>(
+  options: FillTimeseriesOptions<T>
+): FillTimeseriesResult<T> => {
   const {
     data,
     timestampKey,
@@ -78,50 +95,39 @@ export const useFillTimeseriesSorted = <T extends Datum = Datum>(
     interval,
   } = options
 
-  return useMemo(() => {
-    // Early return if no valid timestamp
-    if (!hasValidTimestamp(data, timestampKey)) {
-      return {
-        data,
-        error: null,
-        isError: false,
-      }
+  // Early return if no valid timestamp
+  if (!hasValidTimestamp(data, timestampKey)) {
+    return {
+      data,
+      error: null,
+      isError: false,
     }
+  }
 
-    try {
-      const filled = fillTimeseries(
-        data,
-        timestampKey,
-        valueKey,
-        defaultValue,
-        startDate,
-        endDate,
-        minPointsToFill,
-        interval
-      ) as T[]
+  try {
+    const filled = fillTimeseries(
+      data,
+      timestampKey,
+      valueKey,
+      defaultValue,
+      startDate,
+      endDate,
+      minPointsToFill,
+      interval
+    ) as T[]
 
-      const sorted = sortByTimestamp(filled, timestampKey)
+    const sorted = sortByTimestamp(filled, timestampKey)
 
-      return {
-        data: sorted,
-        error: null,
-        isError: false,
-      }
-    } catch (error: unknown) {
-      return {
-        data: [],
-        error: error instanceof Error ? error : new Error(String(error)),
-        isError: true,
-      }
+    return {
+      data: sorted,
+      error: null,
+      isError: false,
     }
-  }, [
-    JSON.stringify(data),
-    timestampKey,
-    JSON.stringify(valueKey),
-    defaultValue,
-    startDate,
-    endDate,
-    minPointsToFill,
-    interval,
-  ])
+  } catch (error: unknown) {
+    return {
+      data: [],
+      error: error instanceof Error ? error : new Error(String(error)),
+      isError: true,
+    }
+  }
 }

--- a/packages/ui-patterns/src/Chart/index.tsx
+++ b/packages/ui-patterns/src/Chart/index.tsx
@@ -43,11 +43,13 @@ export type ChartConfig = {
 interface ChartContextValue {
   isLoading?: boolean
   isDisabled?: boolean
+  isErrored?: boolean
 }
 
 const ChartContext = React.createContext<ChartContextValue>({
   isLoading: false,
   isDisabled: false,
+  isErrored: false,
 })
 
 export const useChart = () => {
@@ -59,15 +61,19 @@ interface ChartProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode
   isLoading?: boolean
   isDisabled?: boolean
+  isErrored?: boolean
   className?: string
 }
 
 const chartTableClasses = `[&_tr]:border-b [&_tr]:border-border [&_thead_tr]:bg-transparent! [&_thead_th]:py-2! [&_thead_th]:!px-card [&_thead_th]:h-auto [&_tbody_td]:py-2.5 [&_tbody_td]:px-card [&_tbody_td]:text-xs [&_table]:mb-1 [&_table]:border-b [&_table]:border-border`
 
 const Chart = React.forwardRef<HTMLDivElement, ChartProps>(
-  ({ children, isLoading = false, isDisabled = false, className, ...props }, ref) => {
+  (
+    { children, isLoading = false, isDisabled = false, isErrored = false, className, ...props },
+    ref
+  ) => {
     return (
-      <ChartContext.Provider value={{ isLoading, isDisabled }}>
+      <ChartContext.Provider value={{ isLoading, isDisabled, isErrored }}>
         <div ref={ref} className={cn('relative w-full', className)} {...props}>
           {children}
         </div>
@@ -306,6 +312,7 @@ interface ChartContentProps extends React.HTMLAttributes<HTMLDivElement> {
   isEmpty?: boolean
   emptyState?: React.ReactNode
   loadingState?: React.ReactNode
+  errorState?: React.ReactNode
   disabledState?: React.ReactNode
   disabledActions?: ChartAction[]
 }
@@ -318,19 +325,22 @@ const ChartContent = React.forwardRef<HTMLDivElement, ChartContentProps>(
       isEmpty = false,
       emptyState,
       loadingState,
+      errorState,
       disabledState,
       disabledActions,
       ...props
     },
     ref
   ) => {
-    const { isLoading, isDisabled } = useChart()
+    const { isLoading, isDisabled, isErrored } = useChart()
     let content: React.ReactNode
 
     if (isDisabled) {
       content = disabledState
     } else if (isLoading) {
       content = loadingState
+    } else if (isErrored) {
+      content = errorState
     } else if (isEmpty) {
       content = emptyState
     } else {

--- a/packages/ui-patterns/src/LogsBarChart/index.tsx
+++ b/packages/ui-patterns/src/LogsBarChart/index.tsx
@@ -26,8 +26,10 @@ type LogsBarChartDatum = {
 
 export const LogsBarChart = ({
   data,
+  error,
   onBarClick,
   EmptyState,
+  ErrorState,
   DateTimeFormat = 'MMM D, YYYY, hh:mma',
   isFullHeight = false,
   chartConfig,
@@ -36,8 +38,10 @@ export const LogsBarChart = ({
   hideXAxis = false,
 }: {
   data: LogsBarChartDatum[]
+  error?: unknown | null
   onBarClick?: (datum: LogsBarChartDatum, tooltipData?: CategoricalChartState) => void
   EmptyState?: ReactNode
+  ErrorState?: ReactNode
   DateTimeFormat?: string
   isFullHeight?: boolean
   chartConfig?: ChartConfig
@@ -46,6 +50,11 @@ export const LogsBarChart = ({
   hideXAxis?: boolean
 }) => {
   const [focusDataIndex, setFocusDataIndex] = useState<number | null>(null)
+
+  if (error) {
+    if (ErrorState) return ErrorState
+    return null
+  }
 
   if (data.length === 0) {
     if (EmptyState) return EmptyState


### PR DESCRIPTION
This PR adds an error state to the usage charts on the Project home page.

<img width="1708" height="471" alt="Screenshot 2026-06-16 at 18 10 20" src="https://github.com/user-attachments/assets/cba87dad-5e23-4cd1-b787-0ea699445d7f" />

I also added an error state to the charts in the [design system](https://design-system-git-feat-chart-error-state-supabase.vercel.app/design-system/docs/ui-patterns/charts#chart-states).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **New Features**
  * Chart components can now render dedicated error states (with custom error messaging) when data fails to load or process.
  * Project usage charts now show a clear “Failed to load project usage” message when usage metrics can’t be retrieved.

* **Bug Fixes**
  * Improved timeseries gap-filling and sorting reliability, with safer handling when timestamp data is missing or processing fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->