### PR TITLE
fix(studio): hide throughput row on review modal for io2

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.hooks.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.hooks.ts
@@ -120,7 +120,6 @@ export function useDiskManagementReviewChanges(
 
   // --- Derived predicates ---
 
-  const storageTypeBefore = (form.formState.defaultValues?.storageType ?? '') as DiskType
   const storageTypeAfter = form.getValues('storageType') as DiskType
 
   // Show hero whenever any line-item price actually changes, not just compute
@@ -132,12 +131,14 @@ export function useDiskManagementReviewChanges(
   // Show cooldown warning whenever any disk attribute that enforces the 4-hour lock changes
   const anyDiskAttributeChange = hasIOPSChanges || hasStorageTypeChanges || hasTotalSizeChanges
 
-  // Show throughput row whenever either the before or after storage type is GP3
-  // (covers GP3→IO2 where the throughput charge drops to zero)
+  // Throughput is only a user-configurable, separately-billed attribute for GP3. For IO2 it is
+  // derived from provisioned IOPS (0.256 MiB/s per IOPS) and isn't surfaced as its own value, so
+  // the form clears it to 0 — rendering a misleading "→ 0 MB/s". Only show the row when the
+  // resulting storage type is GP3; any GP3→IO2 throughput price delta still lands in the total.
   const showThroughputRow =
     !isAwsK8sProject &&
     !isAwsNimbus &&
-    (storageTypeBefore === 'gp3' || storageTypeAfter === 'gp3') &&
+    storageTypeAfter === 'gp3' &&
     (hasThroughputChanges || hasStorageTypeChanges)
 
   const hasAnyBreakdownRows =


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

When a user selects IO2 on compute upgrade, the `0/MB` isn't quite correct, whilst the costa delta of $0 is correct. We will hide the row as it adds noise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed disk management UI to correctly display the throughput configuration row only when selecting GP3 storage type, ensuring the interface accurately reflects available options for the selected storage type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->