### PR TITLE
docs: add Nuxt/SolidStart server routes, fix stale getClaims docs

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -609,7 +609,7 @@ export default defineEventHandler(async (event) => {
     }
   )
 
-  await supabase.auth.getUser()
+  await supabase.auth.getClaims()
 
   return { ok: true }
 })

--- a/apps/docs/content/guides/getting-started/tutorials/with-nuxt-3.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nuxt-3.mdx
@@ -360,3 +360,43 @@ And then open the browser to [localhost:3000](http://localhost:3000) and you sho
 ![Supabase Nuxt 3](/docs/img/supabase-vue-3-demo.png)
 
 At this stage you have a fully functional application!
+
+## Add a server route
+
+So far the app authenticates the user on the client. For protected API endpoints or server-rendered data, you need a server route that verifies the session.
+
+[`@supabase/server`](https://supabase.github.io/server/) handles the full flow through a single middleware: it validates the JWT locally (using your project's asymmetric signing keys, no round-trip to the Auth server), attaches an RLS-scoped Supabase client and the user's claims to the request, and rejects unauthenticated requests with a 401 before your handler runs.
+
+```bash
+npm install @supabase/server
+```
+
+<$CodeTabs>
+
+```typescript name=server/api/profile.get.ts
+import { withSupabase } from '@supabase/server/adapters/h3'
+import { defineHandler } from 'h3'
+
+export default defineHandler({
+  middleware: [withSupabase({ auth: 'user' })],
+  handler: async (event) => {
+    const { supabase, userClaims } = event.context.supabaseContext
+
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('username, website, avatar_url')
+      .eq('id', userClaims.sub)
+      .single()
+
+    if (error) {
+      throw createError({ statusCode: 500, statusMessage: error.message })
+    }
+
+    return data
+  },
+})
+```
+
+</$CodeTabs>
+
+For an unauthenticated route, pass `auth: 'none'`. For app-wide auth, register `withSupabase({ auth: 'user' })` as a Nuxt server middleware at `server/middleware/supabase.ts` instead. See the [h3/Nuxt adapter docs](https://supabase.github.io/server/adapters/h3) for typing, route overrides, and the full API.

--- a/apps/docs/content/guides/getting-started/tutorials/with-nuxt-3.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nuxt-3.mdx
@@ -18,7 +18,7 @@ If you get stuck while working through this guide, you can find the [full exampl
 
 ## Building the app
 
-Let's start building the Vue 3 app from scratch.
+Start building the Vue 3 app from scratch.
 
 ### Initialize a Nuxt 3 app
 
@@ -30,7 +30,7 @@ npx nuxi init nuxt-user-management
 cd nuxt-user-management
 ```
 
-Then let's install the only additional dependency: [Nuxt Supabase](https://supabase.nuxtjs.org/). We only need to import Nuxt Supabase as a dev dependency.
+Then install the only additional dependency: [Nuxt Supabase](https://supabase.nuxtjs.org/). We only need to import Nuxt Supabase as a dev dependency.
 
 ```bash
 npm install @nuxtjs/supabase --save-dev
@@ -73,7 +73,7 @@ export default defineNuxtConfig({
 
 ### Set up Auth component
 
-Let's set up a Vue component to manage logins and sign ups. We'll use Magic Links, so users can sign in with their email without using passwords.
+Set up a Vue component to manage logins and sign ups. We'll use Magic Links, so users can sign in with their email without using passwords.
 
 <$CodeTabs>
 
@@ -128,7 +128,7 @@ To access the user information, use the composable [`useSupabaseUser`](https://s
 ### Account component
 
 After a user is signed in we can allow them to edit their profile details and manage their account.
-Let's create a new component for that called `Account.vue`.
+Create a new component for that called `Account.vue`.
 
 <$CodeTabs>
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-nuxt-3.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nuxt-3.mdx
@@ -385,7 +385,7 @@ export default defineHandler({
     const { data, error } = await supabase
       .from('profiles')
       .select('username, website, avatar_url')
-      .eq('id', userClaims.sub)
+      .eq('id', userClaims.id)
       .single()
 
     if (error) {

--- a/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-solidjs.mdx
@@ -151,3 +151,47 @@ And then open the browser to [localhost:3000](http://localhost:3000) and you sho
 ![Supabase SolidJS](/docs/img/supabase-solidjs-demo.png)
 
 At this stage you have a fully functional application!
+
+## Add a server route (SolidStart)
+
+The example above is client-only. If you migrate the app to [SolidStart](https://start.solidjs.com/) for server-side rendering and API routes, you can add protected server endpoints with [`@supabase/server`](https://supabase.github.io/server/).
+
+`createSupabaseContext` validates the incoming request's JWT locally (using your project's asymmetric signing keys, no round-trip to the Auth server), scopes a Supabase client to the authenticated user via RLS, and exposes the user's claims, all from a single call inside your SolidStart API route handler.
+
+```bash
+npm install @supabase/server
+```
+
+<$CodeTabs>
+
+```typescript name=src/routes/api/profile.ts
+import type { APIEvent } from '@solidjs/start/server'
+import { createSupabaseContext } from '@supabase/server'
+
+export async function GET({ request }: APIEvent) {
+  const { data: ctx, error } = await createSupabaseContext(request, {
+    auth: 'user',
+  })
+
+  if (error) {
+    return Response.json({ message: error.message, code: error.code }, { status: error.status })
+  }
+
+  const { supabase, userClaims } = ctx
+  const { data, error: queryError } = await supabase
+    .from('profiles')
+    .select('username, website, avatar_url')
+    .eq('id', userClaims.id)
+    .single()
+
+  if (queryError) {
+    return Response.json({ message: queryError.message }, { status: 500 })
+  }
+
+  return Response.json(data)
+}
+```
+
+</$CodeTabs>
+
+To make a route public, swap `auth: 'user'` for `auth: 'none'`. For app-wide authentication via SolidStart middleware, or for the full `@supabase/server` API, see the [getting started guide](https://supabase.github.io/server/getting-started).

--- a/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -78,7 +78,7 @@ meta="name=src/hooks.server.ts"
 
 <$Partial path="get_session_warning.mdx" />
 {/* TODO: Change when adding JS autoconversion */}
-As this tutorial uses TypeScript the compiler complains about `event.locals.supabase` and `event.locals.safeGetSession`, you can fix this by updating the `src/app.d.ts` with the content below:
+As this tutorial uses TypeScript the compiler complains about `event.locals.supabase`. You can fix this by updating the `src/app.d.ts` with the content below:
 
 <$CodeTabs>
 

--- a/supa-mdx-lint/Rule001HeadingCase.toml
+++ b/supa-mdx-lint/Rule001HeadingCase.toml
@@ -213,6 +213,7 @@ may_uppercase = [
     "Slack Developers?",
     "Social Login",
     "SolidJS",
+    "SolidStart",
     "Spend Cap",
     "Spotify",
     "Spotify Developers?",

--- a/supa-mdx-lint/Rule003Spelling.toml
+++ b/supa-mdx-lint/Rule003Spelling.toml
@@ -377,6 +377,7 @@ allow_list = [
     "Solana",
     "Sonatype",
     "SolidJS",
+    "SolidStart",
     "Spotify",
     "Sqitch",
     "Supabase",


### PR DESCRIPTION
Resolves four docs gaps surfaced in #40985.

The Nuxt SSR example in `creating-a-client.mdx` now uses `getClaims()` instead of `getUser()`, matching the file's own guidance at `:253`. The SvelteKit tutorial drops a stale `event.locals.safeGetSession` reference whose linked `app.d.ts` no longer declares one. The Nuxt and SolidJS tutorials each gain a new server-route section using `@supabase/server` (h3 adapter for Nuxt, `createSupabaseContext` for SolidStart), addressing the original complaint that those tutorials had no server setup at all.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced Nuxt 3 getting-started tutorial with new guidance on adding server routes, validating auth sessions, and using Supabase middleware for protected (and optional public) endpoints.
  * Updated the Nuxt Server route Supabase SSR example to validate authentication using token claims during server-side refresh.
  * Added a SolidJS → SolidStart SSR/API migration section, including an example protected profile route and how to make it public.
  * Refined SvelteKit tutorial wording around TypeScript-related session handling and updated terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->