### PR TITLE
fix(docs): remove redundant icons

### DIFF
--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -1,11 +1,10 @@
 import { isFeatureEnabled } from 'common'
 import { type Metadata, type ResolvingMetadata } from 'next'
 import Link from 'next/link'
-import { cn, IconBackground } from 'ui'
+import { cn } from 'ui'
 import { IconPanel } from 'ui-patterns/IconPanel'
 import { TextLink } from 'ui-patterns/TextLink'
 
-import MenuIconPicker from '@/components/Navigation/NavigationMenu/MenuIconPicker'
 import { MIGRATION_PAGES } from '@/components/Navigation/NavigationMenu/NavigationMenu.constants'
 import { GlassPanelWithIconPicker } from '@/features/ui/GlassPanelWithIconPicker'
 import { IconPanelWithIconPicker } from '@/features/ui/IconPanelWithIconPicker'
@@ -325,9 +324,9 @@ const HomePage = () => (
 
       <div className="flex flex-col gap-6 py-12 border-b">
         <div className="col-span-4 flex flex-col gap-1 [&_h2]:m-0 [&_h3]:m-0">
-          <h3 id="additional-resources" className="group scroll-mt-24">
+          <h2 id="additional-resources" className="group scroll-mt-24">
             Additional resources
-          </h3>
+          </h2>
         </div>
 
         <ul className="grid grid-cols-12 gap-6 not-prose">
@@ -354,14 +353,11 @@ const HomePage = () => (
           <div className="col-span-4 flex flex-col gap-1 [&_h2]:m-0 [&_h3]:m-0">
             <div className="md:max-w-xs 2xl:max-w-none">
               <div className="flex items-center gap-3 mb-3 text-brand-600">
-                <IconBackground>
-                  <MenuIconPicker icon="self-hosting" width={18} height={18} />
-                </IconBackground>
-                <h3 id="self-hosting" className="group scroll-mt-24">
+                <h2 id="self-hosting" className="group scroll-mt-24">
                   Self-Hosting
-                </h3>
+                </h2>
               </div>
-              <p className="text-foreground-light text-sm">
+              <p className="text-foreground-light text-sm m-0 p-0">
                 Get started with self-hosting Supabase.
               </p>
               <TextLink

--- a/apps/docs/app/page.tsx
+++ b/apps/docs/app/page.tsx
@@ -323,8 +323,8 @@ const HomePage = () => (
       )}
 
       <div className="flex flex-col gap-6 py-12 border-b">
-        <div className="col-span-4 flex flex-col gap-1 [&_h2]:m-0 [&_h3]:m-0">
-          <h2 id="additional-resources" className="group scroll-mt-24">
+        <div className="col-span-4 flex flex-col gap-1">
+          <h2 id="additional-resources" className="group scroll-mt-24 m-0">
             Additional resources
           </h2>
         </div>
@@ -350,10 +350,10 @@ const HomePage = () => (
       </div>
       {isFeatureEnabled('docs:full_getting_started') && (
         <div className="flex flex-col lg:grid grid-cols-12 gap-6 py-12">
-          <div className="col-span-4 flex flex-col gap-1 [&_h2]:m-0 [&_h3]:m-0">
+          <div className="col-span-4 flex flex-col gap-1">
             <div className="md:max-w-xs 2xl:max-w-none">
               <div className="flex items-center gap-3 mb-3 text-brand-600">
-                <h2 id="self-hosting" className="group scroll-mt-24">
+                <h2 id="self-hosting" className="group scroll-mt-24 m-0">
                   Self-Hosting
                 </h2>
               </div>

--- a/apps/docs/components/HomePageCover.tsx
+++ b/apps/docs/components/HomePageCover.tsx
@@ -2,10 +2,10 @@
 
 // End of third-party imports
 import { isFeatureEnabled, useBreakpoint } from 'common'
-import { ChevronRight, Play, Sparkles } from 'lucide-react'
+import { ChevronRight, Sparkles } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Link from 'next/link'
-import { cn, IconBackground } from 'ui'
+import { cn } from 'ui'
 import { IconPanel } from 'ui-patterns/IconPanel'
 
 import { getCustomContent } from '../lib/custom-content/getCustomContent'
@@ -127,15 +127,12 @@ const HomePageCover = (props) => {
     >
       <div className="col-span-full flex flex-col md:flex-row xl:flex-col justify-between gap-3">
         <div className="md:max-w-xs shrink w-fit xl:max-w-none">
-          <div className="flex items-center gap-3 mb-3">
-            <IconBackground>
-              <Play aria-hidden="true" className="text-brand-600 w-4" strokeWidth={2} />
-            </IconBackground>
-            <h2 className="text-2xl m-0 text-foreground">Getting Started</h2>
+          <div className="flex flex-col gap-1 mb-3">
+            <h2 className="text-2xl text-foreground">Getting Started</h2>
+            <p className="text-foreground-light text-sm">
+              Set up and connect a database in just a few minutes.
+            </p>
           </div>
-          <p className="text-foreground-light text-sm">
-            Set up and connect a database in just a few minutes.
-          </p>
         </div>
         <div className="shrink-0">
           <div className="flex flex-wrap md:grid md:grid-cols-5 gap-2 sm:gap-3">


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI fix. Resolves DOCS-1051.

## What is the current behavior?

Two unnecessary icons on docs homepage add more confusion than help.

## What is the new behavior?

Removed and tightened surrounding spacing + rhythm.

| Before | After |
| --- | --- |
| <img width="1339" height="703" alt="Supabase Docs-5A137B99-AC36-4A59-85D9-B581307FFE6D" src="https://github.com/user-attachments/assets/b1a1c2c7-3882-455d-93d6-799079bef209" /> | <img width="1339" height="703" alt="Supabase Docs-1220594B-29B1-48B0-B976-39CCFB009857" src="https://github.com/user-attachments/assets/87a2501a-d6a4-4a1e-a73e-cf870c7170db" /> |
|  <img width="1339" height="703" alt="Supabase Docs-23849B84-EE41-45EB-A585-BEE71AB8FFB2" src="https://github.com/user-attachments/assets/517fe19a-8022-4276-822d-952f3c094005" /> | <img width="1339" height="703" alt="Supabase Docs-B5A3344F-32DD-4A49-B7DF-E5B10C8CDD13" src="https://github.com/user-attachments/assets/045a46fe-6e8c-4268-8212-602b95868b66" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Simplified documentation page header and section visuals by removing icon-accented wrappers and using cleaner text-based layouts.

* **Accessibility / Content**
  * Updated section heading hierarchy for improved structure (e.g., “Additional resources” and “Self-Hosting”) by promoting headings while keeping existing context and styling.
  * Refreshed the “Getting Started” section to be text-focused without the prior play icon treatment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->