### PR TITLE
feat(studio): marketplace preview listings

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -1,9 +1,9 @@
-import { FeatureFlagContext, IS_PLATFORM, useFlag } from 'common'
+import { FeatureFlagContext, getFlags, IS_PLATFORM, useFlag, useUser } from 'common'
 import { fullImageUrl } from 'common/marketplace-client'
 import { Boxes } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
-import { useContext, useMemo } from 'react'
+import { useContext, useEffect, useMemo, useState } from 'react'
 import { cn } from 'ui'
 
 import { INTEGRATIONS, Loading, type IntegrationDefinition } from './Integrations.constants'
@@ -38,6 +38,18 @@ function isForeignDataWrapper(integration: MarketplaceIntegration) {
   return integration.categories.some((c) => c?.slug === 'foreign-data-wrapper')
 }
 
+function parsePreviewListingsFlag(flagVal: string | false): (slug: string) => boolean {
+  if (flagVal === false) {
+    return (_slug) => false
+  }
+  const slugs = flagVal.split(",").map((s) => s.trim())
+  if (slugs.includes('*')) {
+    return (_slug) => true
+  } else {
+    return (slug) => slugs.includes(slug)
+  }
+}
+
 /**
  * [Joshen] Returns a combination of
  * - Marketplace integrations retrieved remotely (Only if feature flag enabled)
@@ -48,18 +60,21 @@ export const useAvailableIntegrations = () => {
   const isMarketplaceEnabled = useIsMarketplaceEnabled()
   const { integrationsWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
 
-  const grafanaEnabled = useFlag('grafanaDashboardIntegrationEnabled')
-  const resendEnabled = useFlag('resendDashboardIntegrationEnabled')
-  const aikidoEnabled = useFlag('aikidoDashboardIntegrationEnabled')
-  const dopplerEnabled = useFlag('dopplerDashboardIntegrationEnabled')
-
   const { data: cliData } = useCLIReleaseVersionQuery()
   const isCLI = !!cliData?.current
 
-  const { data, error } = useMarketplaceIntegrationsQuery({ enabled: isMarketplaceEnabled })
-  const isPending = IS_PLATFORM && (!hasLoaded || (isMarketplaceEnabled && !data && !error))
-  const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!data && !error)))
+  const { data: marketplaceData, error } = useMarketplaceIntegrationsQuery({ enabled: isMarketplaceEnabled })
+  const isPending = IS_PLATFORM && (!hasLoaded || (isMarketplaceEnabled && !marketplaceData && !error))
+  const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!marketplaceData && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
+
+  console.log(marketplaceData)
+
+  const previewListingsEnabled = useFlag<string>('previewMarketplaceListings')
+  const isPreviewEnabled = useMemo(() => parsePreviewListingsFlag(previewListingsEnabled), [previewListingsEnabled])
+
+  const enabledMarketplaceListings = useMemo(() => (marketplaceData ?? []).filter((integration) => (integration.review_status === 'approved' || (integration.review_status === 'preview' && isPreviewEnabled(integration.slug)))),
+    [marketplaceData, isPreviewEnabled])
 
   // [Joshen] Format marketplace integrations into existing ones for now
   // Likely that we might need to change, but can look into separately
@@ -67,8 +82,8 @@ export const useAvailableIntegrations = () => {
   // hardcoded studio wrappers below as content overrides.
   const marketplaceIntegrations: IntegrationDefinition[] = useMemo(
     () =>
-      (data ?? [])
-        ?.filter((integration) => !isForeignDataWrapper(integration))
+      enabledMarketplaceListings
+        .filter((integration) => !isForeignDataWrapper(integration))
         .map((integration) => {
           const {
             id: listingId,
@@ -143,19 +158,19 @@ export const useAvailableIntegrations = () => {
             },
           }
         }),
-    [data]
+    [enabledMarketplaceListings]
   )
 
   // Marketplace wrapper listings keyed by their studio-equivalent id
   // (marketplace uses dash-separated slugs, studio uses underscore-separated ids).
   const marketplaceWrappers = useMemo(() => {
     const map: Record<string, MarketplaceIntegration> = {}
-    ;(data ?? []).forEach((integration) => {
-      if (!isForeignDataWrapper(integration)) return
-      map[integration.slug.replaceAll('-', '_')] = integration
-    })
+      ; enabledMarketplaceListings.forEach((integration) => {
+        if (!isForeignDataWrapper(integration)) return
+        map[integration.slug.replaceAll('-', '_')] = integration
+      })
     return map
-  }, [data])
+  }, [enabledMarketplaceListings])
 
   // [Joshen] Existing integrations that are defined within studio
   // Available integrations are all integrations that can be installed. If an integration can't be installed (needed
@@ -211,24 +226,9 @@ export const useAvailableIntegrations = () => {
   }, [integrationsWrappers, isCLI, marketplaceWrappers])
 
   const dataWithMarketplace = useMemo(() => {
-    const flagGatedIds: Record<string, boolean> = {
-      grafana: grafanaEnabled,
-      resend: resendEnabled,
-      aikido: aikidoEnabled,
-      doppler: dopplerEnabled,
-    }
-
     return [...marketplaceIntegrations, ...allIntegrations]
-      .filter((integration) => flagGatedIds[integration.id] !== false)
       .sort((a, b) => a.name.localeCompare(b.name))
-  }, [
-    marketplaceIntegrations,
-    allIntegrations,
-    grafanaEnabled,
-    resendEnabled,
-    aikidoEnabled,
-    dopplerEnabled,
-  ])
+  }, [marketplaceIntegrations, allIntegrations])
 
   return {
     data: dataWithMarketplace,

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -1,9 +1,9 @@
-import { FeatureFlagContext, getFlags, IS_PLATFORM, useFlag, useUser } from 'common'
+import { FeatureFlagContext, IS_PLATFORM, useFlag } from 'common'
 import { fullImageUrl } from 'common/marketplace-client'
 import { Boxes } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import Image from 'next/image'
-import { useContext, useEffect, useMemo, useState } from 'react'
+import { useContext, useMemo } from 'react'
 import { cn } from 'ui'
 
 import { INTEGRATIONS, Loading, type IntegrationDefinition } from './Integrations.constants'

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -1,4 +1,10 @@
-import { FeatureFlagContext, IS_PLATFORM, useFlag } from 'common'
+import {
+  FeatureFlagContext,
+  FeatureFlagContextType,
+  IS_PLATFORM,
+  useFeatureFlags,
+  useFlag,
+} from 'common'
 import { fullImageUrl } from 'common/marketplace-client'
 import { Boxes } from 'lucide-react'
 import dynamic from 'next/dynamic'
@@ -38,16 +44,15 @@ function isForeignDataWrapper(integration: MarketplaceIntegration) {
   return integration.categories.some((c) => c?.slug === 'foreign-data-wrapper')
 }
 
-function parsePreviewListingsFlag(flagVal: string | false): (slug: string) => boolean {
-  if (flagVal === false) {
-    return (_slug) => false
-  }
-  const slugs = flagVal.split(',').map((s) => s.trim())
-  if (slugs.includes('*')) {
-    return (_slug) => true
-  } else {
-    return (slug) => slugs.includes(slug)
-  }
+/**
+ * We use per-listing feature flags with a templated naming convention in order to independently
+ * enable previews for users where the global `previewMarketplaceListingsEnabled` flag is not set.
+ * This will let us make previews available to partner users and beta testers and then independently
+ * roll each one out to a wider audience.
+ */
+const isPreviewEnabled = (featureFlags: FeatureFlagContextType, listingSlug: string) => {
+  const flagName = `${listingSlug}DashboardIntegrationEnabled`
+  return (featureFlags.configcat[flagName] ?? false) as boolean
 }
 
 /**
@@ -72,20 +77,20 @@ export const useAvailableIntegrations = () => {
     !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!marketplaceData && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
 
-  const previewListingsEnabled = useFlag<string>('previewMarketplaceListings')
-  const isPreviewEnabled = useMemo(
-    () => parsePreviewListingsFlag(previewListingsEnabled),
-    [previewListingsEnabled]
-  )
+  // This flag can globally enable preview listings for all partners for a given user (i.e. for Supabase users)
+  const previewAllListingsEnabled = useFlag<boolean>('previewMarketplaceListingsEnabled')
+
+  const featureFlags = useFeatureFlags()
 
   const enabledMarketplaceListings = useMemo(
     () =>
       (marketplaceData ?? []).filter(
         (integration) =>
           integration.review_status === 'approved' ||
-          (integration.review_status === 'preview' && isPreviewEnabled(integration.slug))
+          (integration.review_status === 'preview' &&
+            (previewAllListingsEnabled || isPreviewEnabled(featureFlags, integration.slug)))
       ),
-    [marketplaceData, isPreviewEnabled]
+    [marketplaceData, previewAllListingsEnabled, featureFlags]
   )
 
   // [Joshen] Format marketplace integrations into existing ones for now

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -42,7 +42,7 @@ function parsePreviewListingsFlag(flagVal: string | false): (slug: string) => bo
   if (flagVal === false) {
     return (_slug) => false
   }
-  const slugs = flagVal.split(",").map((s) => s.trim())
+  const slugs = flagVal.split(',').map((s) => s.trim())
   if (slugs.includes('*')) {
     return (_slug) => true
   } else {
@@ -63,16 +63,30 @@ export const useAvailableIntegrations = () => {
   const { data: cliData } = useCLIReleaseVersionQuery()
   const isCLI = !!cliData?.current
 
-  const { data: marketplaceData, error } = useMarketplaceIntegrationsQuery({ enabled: isMarketplaceEnabled })
-  const isPending = IS_PLATFORM && (!hasLoaded || (isMarketplaceEnabled && !marketplaceData && !error))
-  const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!marketplaceData && !error)))
+  const { data: marketplaceData, error } = useMarketplaceIntegrationsQuery({
+    enabled: isMarketplaceEnabled,
+  })
+  const isPending =
+    IS_PLATFORM && (!hasLoaded || (isMarketplaceEnabled && !marketplaceData && !error))
+  const isSuccess =
+    !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!marketplaceData && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
 
   const previewListingsEnabled = useFlag<string>('previewMarketplaceListings')
-  const isPreviewEnabled = useMemo(() => parsePreviewListingsFlag(previewListingsEnabled), [previewListingsEnabled])
+  const isPreviewEnabled = useMemo(
+    () => parsePreviewListingsFlag(previewListingsEnabled),
+    [previewListingsEnabled]
+  )
 
-  const enabledMarketplaceListings = useMemo(() => (marketplaceData ?? []).filter((integration) => (integration.review_status === 'approved' || (integration.review_status === 'preview' && isPreviewEnabled(integration.slug)))),
-    [marketplaceData, isPreviewEnabled])
+  const enabledMarketplaceListings = useMemo(
+    () =>
+      (marketplaceData ?? []).filter(
+        (integration) =>
+          integration.review_status === 'approved' ||
+          (integration.review_status === 'preview' && isPreviewEnabled(integration.slug))
+      ),
+    [marketplaceData, isPreviewEnabled]
+  )
 
   // [Joshen] Format marketplace integrations into existing ones for now
   // Likely that we might need to change, but can look into separately
@@ -163,10 +177,10 @@ export const useAvailableIntegrations = () => {
   // (marketplace uses dash-separated slugs, studio uses underscore-separated ids).
   const marketplaceWrappers = useMemo(() => {
     const map: Record<string, MarketplaceIntegration> = {}
-      ; enabledMarketplaceListings.forEach((integration) => {
-        if (!isForeignDataWrapper(integration)) return
-        map[integration.slug.replaceAll('-', '_')] = integration
-      })
+    enabledMarketplaceListings.forEach((integration) => {
+      if (!isForeignDataWrapper(integration)) return
+      map[integration.slug.replaceAll('-', '_')] = integration
+    })
     return map
   }, [enabledMarketplaceListings])
 
@@ -224,8 +238,9 @@ export const useAvailableIntegrations = () => {
   }, [integrationsWrappers, isCLI, marketplaceWrappers])
 
   const dataWithMarketplace = useMemo(() => {
-    return [...marketplaceIntegrations, ...allIntegrations]
-      .sort((a, b) => a.name.localeCompare(b.name))
+    return [...marketplaceIntegrations, ...allIntegrations].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    )
   }, [marketplaceIntegrations, allIntegrations])
 
   return {

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -68,8 +68,6 @@ export const useAvailableIntegrations = () => {
   const isSuccess = !IS_PLATFORM || (hasLoaded && (!isMarketplaceEnabled || (!!marketplaceData && !error)))
   const isError = IS_PLATFORM && isMarketplaceEnabled && !!error
 
-  console.log(marketplaceData)
-
   const previewListingsEnabled = useFlag<string>('previewMarketplaceListings')
   const isPreviewEnabled = useMemo(() => parsePreviewListingsFlag(previewListingsEnabled), [previewListingsEnabled])
 

--- a/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/useAvailableIntegrations.tsx
@@ -45,28 +45,17 @@ function isForeignDataWrapper(integration: MarketplaceIntegration) {
 }
 
 /**
- * We use per-listing feature flags with a templated naming convention in order to independently
- * enable previews for users where the global `previewMarketplaceListingsEnabled` flag is not set.
- * This will let us make previews available to partner users and beta testers and then independently
- * roll each one out to a wider audience.
+ * Use per-listing feature flags with a templated naming convention in order to independently
+ * enable/disable previews for users where the global `previewMarketplaceListingsEnabled` flag is not set.
  */
 const isPreviewEnabled = (featureFlags: FeatureFlagContextType, listingSlug: string) => {
   const flagName = `${listingSlug}DashboardIntegrationEnabled`
   return (featureFlags.configcat[flagName] ?? false) as boolean
 }
 
-/**
- * [Joshen] Returns a combination of
- * - Marketplace integrations retrieved remotely (Only if feature flag enabled)
- * - Existing integrations that are defined within studio
- */
-export const useAvailableIntegrations = () => {
+const useMarketplaceListings = () => {
   const { hasLoaded } = useContext(FeatureFlagContext)
   const isMarketplaceEnabled = useIsMarketplaceEnabled()
-  const { integrationsWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
-
-  const { data: cliData } = useCLIReleaseVersionQuery()
-  const isCLI = !!cliData?.current
 
   const { data: marketplaceData, error } = useMarketplaceIntegrationsQuery({
     enabled: isMarketplaceEnabled,
@@ -82,7 +71,7 @@ export const useAvailableIntegrations = () => {
 
   const featureFlags = useFeatureFlags()
 
-  const enabledMarketplaceListings = useMemo(
+  const enabledListings = useMemo(
     () =>
       (marketplaceData ?? []).filter(
         (integration) =>
@@ -93,13 +82,35 @@ export const useAvailableIntegrations = () => {
     [marketplaceData, previewAllListingsEnabled, featureFlags]
   )
 
+  return { isPending, isSuccess, isError, data: enabledListings, error }
+}
+
+/**
+ * [Joshen] Returns a combination of
+ * - Marketplace integrations retrieved remotely (Only if feature flag enabled)
+ * - Existing integrations that are defined within studio
+ */
+export const useAvailableIntegrations = () => {
+  const { integrationsWrappers } = useIsFeatureEnabled(['integrations:wrappers'])
+
+  const { data: cliData } = useCLIReleaseVersionQuery()
+  const isCLI = !!cliData?.current
+
+  const {
+    isPending,
+    isSuccess,
+    isError,
+    data: marketplaceListings,
+    error,
+  } = useMarketplaceListings()
+
   // [Joshen] Format marketplace integrations into existing ones for now
   // Likely that we might need to change, but can look into separately
   // Wrappers from marketplace are excluded here — they are merged into the
   // hardcoded studio wrappers below as content overrides.
   const marketplaceIntegrations: IntegrationDefinition[] = useMemo(
     () =>
-      enabledMarketplaceListings
+      marketplaceListings
         .filter((integration) => !isForeignDataWrapper(integration))
         .map((integration) => {
           const {
@@ -175,19 +186,19 @@ export const useAvailableIntegrations = () => {
             },
           }
         }),
-    [enabledMarketplaceListings]
+    [marketplaceListings]
   )
 
   // Marketplace wrapper listings keyed by their studio-equivalent id
   // (marketplace uses dash-separated slugs, studio uses underscore-separated ids).
   const marketplaceWrappers = useMemo(() => {
     const map: Record<string, MarketplaceIntegration> = {}
-    enabledMarketplaceListings.forEach((integration) => {
+    marketplaceListings.forEach((integration) => {
       if (!isForeignDataWrapper(integration)) return
       map[integration.slug.replaceAll('-', '_')] = integration
     })
     return map
-  }, [enabledMarketplaceListings])
+  }, [marketplaceListings])
 
   // [Joshen] Existing integrations that are defined within studio
   // Available integrations are all integrations that can be installed. If an integration can't be installed (needed

--- a/apps/studio/data/marketplace/integrations-query.ts
+++ b/apps/studio/data/marketplace/integrations-query.ts
@@ -1,16 +1,16 @@
 import { useQuery } from '@tanstack/react-query'
-import { createMarketplaceClient, type Listing } from 'common/marketplace-client'
+import { createMarketplaceClient, type MarketplaceListing } from 'common/marketplace-client'
 
 import { marketplaceIntegrationsKeys } from './keys'
 import { handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
-export type MarketplaceIntegration = Listing
+export type MarketplaceIntegration = MarketplaceListing
 
 export async function getMarketplaceIntegrations(signal?: AbortSignal) {
   const marketplaceClient = createMarketplaceClient()
   let query = marketplaceClient
-    .from('listings')
+    .from('marketplace_listings')
     .select('*')
     .not('published_in_marketplace_at', 'is', null)
   if (signal) query = query.abortSignal(signal)

--- a/packages/common/marketplace-client.ts
+++ b/packages/common/marketplace-client.ts
@@ -33,12 +33,31 @@ export type Database = MergeDeep<
             listing_logo: string
           }
         }
+        marketplace_listings: {
+          Row: {
+            // add a type for the JSON structure
+            categories: Category[]
+            // These all come from non-nullable columns but all view columns are inferred as nullable.
+            // See https://github.com/orgs/supabase/discussions/14151
+            featured: boolean
+            partner_name: string
+            built_by: string
+            slug: string
+            title: string
+            description: string
+            content: string
+            website_url: string
+            documentation_url: string
+            listing_logo: string
+          }
+        }
       }
     }
   }
 >
 
 export type Listing = Database['public']['Views']['listings']['Row']
+export type MarketplaceListing = Database['public']['Views']['marketplace_listings']['Row']
 
 export const createMarketplaceClient = () => {
   const API_URL = process.env.NEXT_PUBLIC_MARKETPLACE_API_URL || ''

--- a/packages/common/marketplace.types.ts
+++ b/packages/common/marketplace.types.ts
@@ -1,10 +1,4 @@
-export type Json =
-  | string
-  | number
-  | boolean
-  | null
-  | { [key: string]: Json | undefined }
-  | Json[]
+export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
 
 export type Database = {
   public: {
@@ -46,13 +40,13 @@ export type Database = {
           id: string | null
           images: string[] | null
           installation_identification_method:
-            | "secret_key_prefix"
-            | "edge_function_secret_name"
-            | "integration_status"
-            | "oauth_authorization"
+            | 'secret_key_prefix'
+            | 'edge_function_secret_name'
+            | 'integration_status'
+            | 'oauth_authorization'
             | null
           installation_url: string | null
-          installation_url_type: "get" | "post" | null
+          installation_url_type: 'get' | 'post' | null
           listing_logo: string | null
           listing_tsv: unknown
           marketplace_url: string | null
@@ -71,11 +65,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "listings_partner_id_fkey"
-            columns: ["partner_id"]
+            foreignKeyName: 'listings_partner_id_fkey'
+            columns: ['partner_id']
             isOneToOne: false
-            referencedRelation: "partners"
-            referencedColumns: ["id"]
+            referencedRelation: 'partners'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -91,13 +85,13 @@ export type Database = {
           id: string | null
           images: string[] | null
           installation_identification_method:
-            | "secret_key_prefix"
-            | "edge_function_secret_name"
-            | "integration_status"
-            | "oauth_authorization"
+            | 'secret_key_prefix'
+            | 'edge_function_secret_name'
+            | 'integration_status'
+            | 'oauth_authorization'
             | null
           installation_url: string | null
-          installation_url_type: "get" | "post" | null
+          installation_url_type: 'get' | 'post' | null
           listing_logo: string | null
           oauth_app_id: string | null
           partner_id: string | null
@@ -105,13 +99,7 @@ export type Database = {
           partner_name: string | null
           partner_slug: string | null
           published_in_marketplace_at: string | null
-          review_status:
-            | "draft"
-            | "pending"
-            | "approved"
-            | "rejected"
-            | "preview"
-            | null
+          review_status: 'draft' | 'pending' | 'approved' | 'rejected' | 'preview' | null
           secret_key_prefix: string | null
           slug: string | null
           title: string | null
@@ -120,11 +108,11 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: "listings_partner_id_fkey"
-            columns: ["partner_id"]
+            foreignKeyName: 'listings_partner_id_fkey'
+            columns: ['partner_id']
             isOneToOne: false
-            referencedRelation: "partners"
-            referencedColumns: ["id"]
+            referencedRelation: 'partners'
+            referencedColumns: ['id']
           },
         ]
       }
@@ -137,7 +125,7 @@ export type Database = {
           name: string | null
           num_of_employees: number | null
           slug: string | null
-          type: "technology" | "expert" | null
+          type: 'technology' | 'expert' | null
           website: string | null
         }
         Insert: {
@@ -148,7 +136,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: "technology" | "expert" | null
+          type?: 'technology' | 'expert' | null
           website?: string | null
         }
         Update: {
@@ -159,7 +147,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: "technology" | "expert" | null
+          type?: 'technology' | 'expert' | null
           website?: string | null
         }
         Relationships: []
@@ -171,7 +159,7 @@ export type Database = {
           listing_slug: string | null
           partner_links: Json | null
           project_ref: string | null
-          status: "installing" | "ready" | "error" | null
+          status: 'installing' | 'ready' | 'error' | null
           updated_at: string | null
           user_alert: Json | null
           version: string | null
@@ -191,33 +179,31 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
+type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
+    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])
-    ? (DefaultSchema["Tables"] &
-        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -226,23 +212,23 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -251,23 +237,23 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema["Tables"]
+    | keyof DefaultSchema['Tables']
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
-    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
+    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -276,36 +262,36 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema["Enums"]
+    | keyof DefaultSchema['Enums']
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
-    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
+    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema["CompositeTypes"]
+    | keyof DefaultSchema['CompositeTypes']
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
-    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
+    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
     : never
 
 export const Constants = {
@@ -313,4 +299,3 @@ export const Constants = {
     Enums: {},
   },
 } as const
-

--- a/packages/common/marketplace.types.ts
+++ b/packages/common/marketplace.types.ts
@@ -1,4 +1,10 @@
-export type Json = string | number | boolean | null | { [key: string]: Json | undefined } | Json[]
+export type Json =
+  | string
+  | number
+  | boolean
+  | null
+  | { [key: string]: Json | undefined }
+  | Json[]
 
 export type Database = {
   public: {
@@ -40,13 +46,13 @@ export type Database = {
           id: string | null
           images: string[] | null
           installation_identification_method:
-            | 'secret_key_prefix'
-            | 'edge_function_secret_name'
-            | 'integration_status'
-            | 'oauth_authorization'
+            | "secret_key_prefix"
+            | "edge_function_secret_name"
+            | "integration_status"
+            | "oauth_authorization"
             | null
           installation_url: string | null
-          installation_url_type: 'get' | 'post' | null
+          installation_url_type: "get" | "post" | null
           listing_logo: string | null
           listing_tsv: unknown
           marketplace_url: string | null
@@ -65,11 +71,60 @@ export type Database = {
         }
         Relationships: [
           {
-            foreignKeyName: 'listings_partner_id_fkey'
-            columns: ['partner_id']
+            foreignKeyName: "listings_partner_id_fkey"
+            columns: ["partner_id"]
             isOneToOne: false
-            referencedRelation: 'partners'
-            referencedColumns: ['id']
+            referencedRelation: "partners"
+            referencedColumns: ["id"]
+          },
+        ]
+      }
+      marketplace_listings: {
+        Row: {
+          built_by: string | null
+          categories: Json | null
+          content: string | null
+          description: string | null
+          documentation_url: string | null
+          edge_function_secret_name: string | null
+          featured: boolean | null
+          id: string | null
+          images: string[] | null
+          installation_identification_method:
+            | "secret_key_prefix"
+            | "edge_function_secret_name"
+            | "integration_status"
+            | "oauth_authorization"
+            | null
+          installation_url: string | null
+          installation_url_type: "get" | "post" | null
+          listing_logo: string | null
+          oauth_app_id: string | null
+          partner_id: string | null
+          partner_logo: string | null
+          partner_name: string | null
+          partner_slug: string | null
+          published_in_marketplace_at: string | null
+          review_status:
+            | "draft"
+            | "pending"
+            | "approved"
+            | "rejected"
+            | "preview"
+            | null
+          secret_key_prefix: string | null
+          slug: string | null
+          title: string | null
+          website_url: string | null
+          youtube_id: string | null
+        }
+        Relationships: [
+          {
+            foreignKeyName: "listings_partner_id_fkey"
+            columns: ["partner_id"]
+            isOneToOne: false
+            referencedRelation: "partners"
+            referencedColumns: ["id"]
           },
         ]
       }
@@ -82,7 +137,7 @@ export type Database = {
           name: string | null
           num_of_employees: number | null
           slug: string | null
-          type: 'technology' | 'expert' | null
+          type: "technology" | "expert" | null
           website: string | null
         }
         Insert: {
@@ -93,7 +148,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: 'technology' | 'expert' | null
+          type?: "technology" | "expert" | null
           website?: string | null
         }
         Update: {
@@ -104,7 +159,7 @@ export type Database = {
           name?: string | null
           num_of_employees?: number | null
           slug?: string | null
-          type?: 'technology' | 'expert' | null
+          type?: "technology" | "expert" | null
           website?: string | null
         }
         Relationships: []
@@ -116,7 +171,7 @@ export type Database = {
           listing_slug: string | null
           partner_links: Json | null
           project_ref: string | null
-          status: 'installing' | 'ready' | 'error' | null
+          status: "installing" | "ready" | "error" | null
           updated_at: string | null
           user_alert: Json | null
           version: string | null
@@ -136,31 +191,33 @@ export type Database = {
   }
 }
 
-type DatabaseWithoutInternals = Omit<Database, '__InternalSupabase'>
+type DatabaseWithoutInternals = Omit<Database, "__InternalSupabase">
 
-type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, 'public'>]
+type DefaultSchema = DatabaseWithoutInternals[Extract<keyof Database, "public">]
 
 export type Tables<
   DefaultSchemaTableNameOrOptions extends
-    | keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
+    | keyof (DefaultSchema["Tables"] & DefaultSchema["Views"])
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])
+    ? keyof (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+        DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'] &
-      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Views'])[TableName] extends {
+  ? (DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"] &
+      DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Views"])[TableName] extends {
       Row: infer R
     }
     ? R
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema['Tables'] & DefaultSchema['Views'])
-    ? (DefaultSchema['Tables'] & DefaultSchema['Views'])[DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])
+    ? (DefaultSchema["Tables"] &
+        DefaultSchema["Views"])[DefaultSchemaTableNameOrOptions] extends {
         Row: infer R
       }
       ? R
@@ -169,23 +226,23 @@ export type Tables<
 
 export type TablesInsert<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Insert: infer I
     }
     ? I
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Insert: infer I
       }
       ? I
@@ -194,23 +251,23 @@ export type TablesInsert<
 
 export type TablesUpdate<
   DefaultSchemaTableNameOrOptions extends
-    | keyof DefaultSchema['Tables']
+    | keyof DefaultSchema["Tables"]
     | { schema: keyof DatabaseWithoutInternals },
   TableName extends DefaultSchemaTableNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"]
     : never = never,
 > = DefaultSchemaTableNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions['schema']]['Tables'][TableName] extends {
+  ? DatabaseWithoutInternals[DefaultSchemaTableNameOrOptions["schema"]]["Tables"][TableName] extends {
       Update: infer U
     }
     ? U
     : never
-  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema['Tables']
-    ? DefaultSchema['Tables'][DefaultSchemaTableNameOrOptions] extends {
+  : DefaultSchemaTableNameOrOptions extends keyof DefaultSchema["Tables"]
+    ? DefaultSchema["Tables"][DefaultSchemaTableNameOrOptions] extends {
         Update: infer U
       }
       ? U
@@ -219,36 +276,36 @@ export type TablesUpdate<
 
 export type Enums<
   DefaultSchemaEnumNameOrOptions extends
-    | keyof DefaultSchema['Enums']
+    | keyof DefaultSchema["Enums"]
     | { schema: keyof DatabaseWithoutInternals },
   EnumName extends DefaultSchemaEnumNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums']
+    ? keyof DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"]
     : never = never,
 > = DefaultSchemaEnumNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions['schema']]['Enums'][EnumName]
-  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema['Enums']
-    ? DefaultSchema['Enums'][DefaultSchemaEnumNameOrOptions]
+  ? DatabaseWithoutInternals[DefaultSchemaEnumNameOrOptions["schema"]]["Enums"][EnumName]
+  : DefaultSchemaEnumNameOrOptions extends keyof DefaultSchema["Enums"]
+    ? DefaultSchema["Enums"][DefaultSchemaEnumNameOrOptions]
     : never
 
 export type CompositeTypes<
   PublicCompositeTypeNameOrOptions extends
-    | keyof DefaultSchema['CompositeTypes']
+    | keyof DefaultSchema["CompositeTypes"]
     | { schema: keyof DatabaseWithoutInternals },
   CompositeTypeName extends PublicCompositeTypeNameOrOptions extends {
     schema: keyof DatabaseWithoutInternals
   }
-    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes']
+    ? keyof DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"]
     : never = never,
 > = PublicCompositeTypeNameOrOptions extends {
   schema: keyof DatabaseWithoutInternals
 }
-  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions['schema']]['CompositeTypes'][CompositeTypeName]
-  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema['CompositeTypes']
-    ? DefaultSchema['CompositeTypes'][PublicCompositeTypeNameOrOptions]
+  ? DatabaseWithoutInternals[PublicCompositeTypeNameOrOptions["schema"]]["CompositeTypes"][CompositeTypeName]
+  : PublicCompositeTypeNameOrOptions extends keyof DefaultSchema["CompositeTypes"]
+    ? DefaultSchema["CompositeTypes"][PublicCompositeTypeNameOrOptions]
     : never
 
 export const Constants = {
@@ -256,3 +313,4 @@ export const Constants = {
     Enums: {},
   },
 } as const
+


### PR DESCRIPTION
Updates the Studio integrations marketplace to support the new marketplace-specific database view and `preview` status introduced in https://github.com/supabase/marketplace/pull/123.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Marketplace integrations now support preview availability controlled by a global feature flag plus per-listing eligibility rules.

* **Improvements**
  * Marketplace listings are filtered by review status: approved listings always appear; preview listings appear only when enabled.
  * Enabled listings now drive both marketplace availability and wrapper/mapping, preserving existing studio keying.
  * Marketplace integration results are now built from the marketplace-specific dataset, and previously hidden marketplace integrations are no longer filtered individually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->