### PR TITLE
fix(assistant): prevent parallel approval-required tool calls

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage as MessageType } from '@ai-sdk/react'
 import { useChat } from '@ai-sdk/react'
-import { isToolUIPart, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
 import { useParams, useSearchParamsShallow } from 'common/hooks'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -39,6 +39,7 @@ import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useOrgAiOptInLevel } from '@/hooks/misc/useOrgOptedIntoAi'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { getParallelApprovalIdsToReject } from '@/lib/ai/message-utils'
 import {
   DEFAULT_ASSISTANT_BASE_MODEL_ID,
   defaultAssistantModelId,
@@ -368,23 +369,13 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
 
   useEffect(() => {
     // Approval-required tools can't run in parallel. Auto-deny extras so the model reissues them sequentially.
-    const lastMessage = chatMessages.findLast((m) => m.role === 'assistant')
-    if (!lastMessage) return
-
-    const pendingApprovals = (lastMessage.parts ?? []).filter(
-      (part) => isToolUIPart(part) && part.state === 'approval-requested'
-    )
-    if (pendingApprovals.length <= 1) return
-
-    for (const part of pendingApprovals.slice(1)) {
-      if (isToolUIPart(part)) {
-        addToolApprovalResponse?.({
-          id: part.approval.id,
-          approved: false,
-          reason:
-            'Only one approval-required tool call is allowed per turn. Please reissue this tool call after the current one completes.',
-        })
-      }
+    for (const id of getParallelApprovalIdsToReject(chatMessages)) {
+      addToolApprovalResponse?.({
+        id,
+        approved: false,
+        reason:
+          'Only one approval-required tool call is allowed per turn. Please reissue this tool call after the current one completes.',
+      })
     }
   }, [chatMessages, addToolApprovalResponse])
 

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage as MessageType } from '@ai-sdk/react'
 import { useChat } from '@ai-sdk/react'
-import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
+import { isToolUIPart, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
 import { useParams, useSearchParamsShallow } from 'common/hooks'
 import { AnimatePresence, motion } from 'framer-motion'
@@ -365,6 +365,28 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
       setIsResubmitting(false)
     }
   }, [isResubmitting, chatStatus, error])
+
+  useEffect(() => {
+    // Approval-required tools can't run in parallel. Auto-deny extras so the model reissues them sequentially.
+    const lastMessage = chatMessages.findLast((m) => m.role === 'assistant')
+    if (!lastMessage) return
+
+    const pendingApprovals = (lastMessage.parts ?? []).filter(
+      (part) => isToolUIPart(part) && part.state === 'approval-requested'
+    )
+    if (pendingApprovals.length <= 1) return
+
+    for (const part of pendingApprovals.slice(1)) {
+      if (isToolUIPart(part)) {
+        addToolApprovalResponse?.({
+          id: part.approval.id,
+          approved: false,
+          reason:
+            'Only one approval-required tool call is allowed per turn. Please reissue this tool call after the current one completes.',
+        })
+      }
+    }
+  }, [chatMessages, addToolApprovalResponse])
 
   useEffect(() => {
     setValue(snap.initialInput || '')

--- a/apps/studio/lib/ai/message-utils.test.ts
+++ b/apps/studio/lib/ai/message-utils.test.ts
@@ -1,7 +1,81 @@
-import type { UIMessage } from 'ai'
+import type { DynamicToolUIPart, UIMessage } from 'ai'
 import { describe, expect, it } from 'vitest'
 
-import { prepareMessagesForAPI } from './message-utils'
+import { getParallelApprovalIdsToReject, prepareMessagesForAPI } from './message-utils'
+
+const makeApprovalPart = (id: string): DynamicToolUIPart => ({
+  type: 'dynamic-tool',
+  toolName: 'test_tool',
+  toolCallId: id,
+  state: 'approval-requested',
+  input: {},
+  approval: { id },
+})
+
+const makeResultPart = (id: string): DynamicToolUIPart => ({
+  type: 'dynamic-tool',
+  toolName: 'test_tool',
+  toolCallId: id,
+  state: 'output-available',
+  input: {},
+  output: {},
+})
+
+describe('getParallelApprovalIdsToReject', () => {
+  it('returns [] for empty messages', () => {
+    expect(getParallelApprovalIdsToReject([])).toEqual([])
+  })
+
+  it('returns [] when there are no assistant messages', () => {
+    const messages: UIMessage[] = [{ id: '1', role: 'user', parts: [] }]
+    expect(getParallelApprovalIdsToReject(messages)).toEqual([])
+  })
+
+  it('returns [] when last assistant message has no pending approvals', () => {
+    const messages: UIMessage[] = [{ id: '1', role: 'assistant', parts: [makeResultPart('r1')] }]
+    expect(getParallelApprovalIdsToReject(messages)).toEqual([])
+  })
+
+  it('returns [] when there is only one pending approval', () => {
+    const messages: UIMessage[] = [{ id: '1', role: 'assistant', parts: [makeApprovalPart('a1')] }]
+    expect(getParallelApprovalIdsToReject(messages)).toEqual([])
+  })
+
+  it('returns all but the first id when there are multiple pending approvals', () => {
+    const messages: UIMessage[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [makeApprovalPart('a1'), makeApprovalPart('a2'), makeApprovalPart('a3')],
+      },
+    ]
+    expect(getParallelApprovalIdsToReject(messages)).toEqual(['a2', 'a3'])
+  })
+
+  it('only inspects the last assistant message', () => {
+    const messages: UIMessage[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [makeApprovalPart('old1'), makeApprovalPart('old2')],
+      },
+      { id: '2', role: 'user', parts: [] },
+      { id: '3', role: 'assistant', parts: [makeApprovalPart('new1')] },
+    ]
+    expect(getParallelApprovalIdsToReject(messages)).toEqual([])
+  })
+
+  it('ignores non-approval tool parts', () => {
+    const messages: UIMessage[] = [
+      {
+        id: '1',
+        role: 'assistant',
+        parts: [makeResultPart('r1'), makeApprovalPart('a1'), makeApprovalPart('a2')],
+      },
+    ]
+    expect(getParallelApprovalIdsToReject(messages)).toEqual(['a2'])
+  })
+})
 
 describe('prepareMessagesForAPI', () => {
   it('should limit messages to last 7 entries', () => {

--- a/apps/studio/lib/ai/message-utils.ts
+++ b/apps/studio/lib/ai/message-utils.ts
@@ -1,4 +1,4 @@
-import type { UIMessage } from 'ai'
+import { isToolUIPart, type UIMessage } from 'ai'
 
 /**
  * Prepares messages for API transmission by cleaning and limiting history
@@ -22,4 +22,18 @@ export function prepareMessagesForAPI(messages: UIMessage[]): UIMessage[] {
   })
 
   return cleanedMessages
+}
+
+/**
+ * Returns approval IDs to auto-deny when the model issues multiple approval-required
+ * tool calls in the same turn — all but the first, so the model reissues them sequentially.
+ */
+export function getParallelApprovalIdsToReject(messages: UIMessage[]): string[] {
+  const lastMessage = messages.findLast((m) => m.role === 'assistant')
+  if (!lastMessage) return []
+
+  const pendingIds = (lastMessage.parts ?? []).flatMap((part) =>
+    isToolUIPart(part) && part.state === 'approval-requested' ? [part.approval.id] : []
+  )
+  return pendingIds.slice(1)
 }

--- a/apps/studio/lib/ai/prompts.ts
+++ b/apps/studio/lib/ai/prompts.ts
@@ -733,7 +733,7 @@ export const CHAT_PROMPT = `
 - On execution error, explain succinctly and attempt to correct if possible, validating each outcome briefly (1–2 lines) after execution.
 - If a user skips execution, acknowledge and suggest alternatives.
 - Use markdown code blocks (\`\`\`sql\`\`\`) for illustrative SQL only if requested by the user or when providing non-executable examples.
-- Execute multiple queries separately via \`execute_sql\` and briefly validate outcomes.
+- Never call \`execute_sql\` or \`deploy_edge_function\` in parallel within the same step. Each requires user approval, so issue one per step and wait for its result before calling the next.
 - After execution, summarize outcomes concisely without duplicating results, as the client will present these.
 ## Edge Functions
 - Deploy Edge Functions by calling \`deploy_edge_function\` directly with \`name\` and \`code\`; the client handles confirmation and result presentation.


### PR DESCRIPTION
Addresses the issue of parallel tool approvals freezing Assistant and causing UX ambiguity around what happens if only part of multiple dependent invocations is approved.

Two layers at which this is addressed:
1.  Tightens prompt to clarify approval tools must be issued one per step, not in parallel.
2. In case something slips past the prompt, this also auto-denies all but the first `approval-required` tool call when the model issues multiple in the same step, so the model is forced to reissue them sequentially.


**Demo**

The following chats demo me explicitly asking Assistant to run those approval-gated tools in parallel, and the Assistant correctly invokes them sequentially instead.

| Parallel `execute_sql` request | Parallel `deploy_edge_function` request |
|--------|--------|
| <img width="1820" height="4240" alt="CleanShot 2026-06-16 at 16 20 23@2x" src="https://github.com/user-attachments/assets/3ddad61d-24d6-4e5b-8572-c261755f3a03" /> | <img width="1738" height="2726" alt="CleanShot 2026-06-16 at 16 22 59@2x" src="https://github.com/user-attachments/assets/77a0aa20-e3cb-4061-b270-ab2a96d1e64a" /> | 


As shown in [this trace](https://www.braintrust.dev/app/supabase.io/p/Assistant/trace?object_type=project_logs&object_id=5a8d02e5-b3b6-40cc-ba76-ecee286478f4&r=a3a37857-95df-4a95-a5a8-818ea305b2a5&s=a3a37857-95df-4a95-a5a8-818ea305b2a5), parallel tool calls are still allowed for context gathering tools that don't require approval:

<img width="1051" height="517" alt="CleanShot 2026-06-16 at 16 25 42@2x" src="https://github.com/user-attachments/assets/00d208b1-6131-4b8e-910e-e92fd2a79a5b" />


Closes AI-803

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Approval-required operations are now processed sequentially rather than in parallel within the AI Assistant.

* **Tests**
  * Added comprehensive test coverage for the parallel approval prevention logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->