### PR TITLE
fix(www): show one partner addendum

### DIFF
--- a/apps/www/pages/legal/partner-resources/program-addenda/index.tsx
+++ b/apps/www/pages/legal/partner-resources/program-addenda/index.tsx
@@ -44,24 +44,18 @@ export default function ProgramAddendaPage({ addenda }: { addenda: AddendumSumma
         <h2>Current addenda</h2>
         <p>Additional partner-type addenda will be added as the program expands.</p>
         <div className="divide-y divide-border">
-          {addenda.flatMap((item) =>
-            item.versions.map((v) => (
-              <div key={`${item.slug}-${v.id}`} className="flex items-center gap-3 py-4">
-                <FileText size={15} className="shrink-0 text-foreground-muted" />
-                <Link
-                  href={v.href}
-                  className="text-foreground-light transition-colors hover:text-foreground hover:underline"
-                >
-                  {item.title}
-                </Link>
-                {v.isLatest ? (
-                  <Badge variant="success">Effective {v.effectiveDate}</Badge>
-                ) : (
-                  <Badge>{v.effectiveDate}</Badge>
-                )}
-              </div>
-            ))
-          )}
+          {addenda.map((item) => (
+            <div key={item.slug} className="flex items-center gap-3 py-4">
+              <FileText size={15} className="shrink-0 text-foreground-muted" />
+              <Link
+                href={item.href}
+                className="text-foreground-light transition-colors hover:text-foreground hover:underline"
+              >
+                {item.title}
+              </Link>
+              <Badge>Effective {item.versions[0].effectiveDate}</Badge>
+            </div>
+          ))}
         </div>
       </SectionContainer>
     </DefaultLayout>


### PR DESCRIPTION
Show only latest partner addendum in index page.

## Before
<img width="896" height="459" alt="Screenshot 2026-06-17 at 00 19 26" src="https://github.com/user-attachments/assets/083606f8-88cd-48e2-9410-2c9671e16e67" />

## After
<img width="910" height="420" alt="Screenshot 2026-06-17 at 00 18 44" src="https://github.com/user-attachments/assets/aefc5947-44af-4a1c-b601-7cf466044daf" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined the partner program addenda list display by consolidating entries and improving the presentation of effective dates for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->