### PR TITLE
Joshen/fe 3595 read replica migration warning is prominent on

### DIFF
--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureConfiguration/InstanceConfiguration.tsx
@@ -67,7 +67,7 @@ const InstanceConfigurationUI = ({ diagramOnly = false }: InstanceConfigurationU
 
   const isAws = useIsAwsCloudProvider()
   const { infrastructureReadReplicas } = useIsFeatureEnabled(['infrastructure:read_replicas'])
-  const newReplicaURL = `/project/${projectRef}/database/replication?type=Read+Replica`
+  const newReplicaURL = `/project/${projectRef}/database/replication?destinationType=Read+Replica`
 
   const [view, setView] = useState<'flow' | 'map'>('flow')
   const [showDeleteAllModal, setShowDeleteAllModal] = useState(false)

--- a/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
+++ b/apps/studio/components/interfaces/Settings/Infrastructure/InfrastructureInfo.tsx
@@ -1,8 +1,6 @@
 import { useParams } from 'common'
-import Link from 'next/link'
 import {
   Badge,
-  Button,
   Input,
   InputGroup,
   InputGroupAddon,
@@ -21,7 +19,6 @@ import {
   ValidationErrorsWarning,
   ValidationWarningsAdmonition,
 } from './UpgradeWarnings'
-import { NoticeBar } from '@/components/interfaces/DiskManagement/ui/NoticeBar'
 import {
   ScaffoldContainer,
   ScaffoldDivider,
@@ -40,15 +37,12 @@ export const InfrastructureInfo = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
 
-  const {
-    projectAuthAll: authEnabled,
-    projectSettingsDatabaseUpgrades: showDatabaseUpgrades,
-    databaseReplication: showReplication,
-  } = useIsFeatureEnabled([
-    'project_auth:all',
-    'project_settings:database_upgrades',
-    'database:replication',
-  ])
+  const { projectAuthAll: authEnabled, projectSettingsDatabaseUpgrades: showDatabaseUpgrades } =
+    useIsFeatureEnabled([
+      'project_auth:all',
+      'project_settings:database_upgrades',
+      'database:replication',
+    ])
 
   const {
     data,
@@ -90,26 +84,6 @@ export const InfrastructureInfo = () => {
   return (
     <>
       <ScaffoldDivider />
-
-      {project?.cloud_provider !== 'FLY' && showReplication && (
-        <ScaffoldContainer>
-          <ScaffoldSection isFullWidth>
-            <NoticeBar
-              visible={true}
-              type="default"
-              title="Management of read replicas has moved"
-              description="Read replicas is now managed under Replication in the Database section."
-              actions={
-                <Button variant="default" asChild>
-                  <Link href={`/project/${ref}/database/replication`} className="no-underline!">
-                    Go to Replication
-                  </Link>
-                </Button>
-              }
-            />
-          </ScaffoldSection>
-        </ScaffoldContainer>
-      )}
 
       <ScaffoldContainer>
         <ScaffoldSection>

--- a/apps/studio/components/ui/DatabaseSelector.tsx
+++ b/apps/studio/components/ui/DatabaseSelector.tsx
@@ -73,7 +73,7 @@ export const DatabaseSelector = ({
 
   const selectedAdditionalOption = additionalOptions.find((x) => x.id === selectedDatabaseId)
 
-  const newReplicaURL = `/project/${projectRef}/database/replication?type=Read+Replica`
+  const newReplicaURL = `/project/${projectRef}/database/replication?destinationType=Read+Replica`
 
   useEffect(() => {
     if (_selectedDatabaseId && !isForm) state.setSelectedDatabaseId(_selectedDatabaseId)
@@ -213,6 +213,7 @@ export const DatabaseSelector = ({
                 })}
               </ScrollArea>
             </CommandGroup>
+
             {IS_PLATFORM && infrastructureReadReplicas && (
               <CommandGroup className="border-t">
                 <CommandItem


### PR DESCRIPTION
## Context

Opting to remove the "Read replicas has moved" notice in Project Settings -> Infrastructure

Also fixes URLs to new replica in `InstanceConfiguration` and `DatabaseSelector` - query parameter was changed from `type` to `destinationType`, so fix ensures that the create replica panel opens after getting navigated to database/replication

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated read replica deployment navigation parameters for consistency across the infrastructure configuration interface.
  * Removed outdated notice message regarding read replica functionality relocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->