### PR TITLE
feat(unified-logs): restore card-style sidebar banners

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogsBanner.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogsBanner.tsx
@@ -1,5 +1,5 @@
 import { CircleHelpIcon, Undo2 } from 'lucide-react'
-import { Button, cn } from 'ui'
+import { Badge, Button, cn } from 'ui'
 
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 
@@ -18,37 +18,40 @@ export function UnifiedLogsBanner({
   onSwitchBack,
   className,
 }: UnifiedLogsBannerProps) {
-  const stripClassName = cn(
-    'flex items-center justify-between gap-3 border-b border-border px-4 py-3',
+  const cardClassName = cn(
+    'rounded-lg border p-4 space-y-3 text-left',
+    'bg-muted/10 border-border/50',
     className
   )
 
   if (variant === 'utility') {
     return (
-      <div className={stripClassName}>
-        <div className="min-w-0 space-y-0.5">
-          <p className="truncate text-xs font-medium text-foreground">Go back to old logs</p>
-          <p className="truncate text-xs text-foreground-light">Use the traditional interface</p>
+      <div className={cn('rounded-lg border px-4 py-3', 'bg-muted/10 border-border/50', className)}>
+        <div className="flex items-center justify-between gap-3">
+          <p className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">
+            Go back to old logs
+          </p>
+          <ButtonTooltip
+            variant="default"
+            className="shrink-0 px-1.5"
+            icon={<Undo2 />}
+            onClick={onSwitchBack}
+            tooltip={{ content: { side: 'bottom', text: 'Switch back' } }}
+          />
         </div>
-        <ButtonTooltip
-          variant="default"
-          className="shrink-0 px-1.5"
-          icon={<Undo2 />}
-          onClick={onSwitchBack}
-          tooltip={{ content: { side: 'bottom', text: 'Switch back' } }}
-        />
       </div>
     )
   }
 
   return (
-    <div className={stripClassName}>
-      <p className="min-w-0 flex-1 truncate text-xs font-medium text-foreground">
-        Try Unified Logs
-      </p>
-      <div className="flex shrink-0 items-center gap-x-2">
-        <Button size="tiny" variant="default" onClick={onEnable}>
-          Enable
+    <div className={cardClassName}>
+      <div className="flex justify-start">
+        <Badge variant="success">New</Badge>
+      </div>
+      <h3 className="font-medium text-sm text-foreground">Introducing unified logs</h3>
+      <div className="flex justify-start items-start gap-x-2">
+        <Button variant="default" onClick={onEnable}>
+          Enable preview
         </Button>
         <ButtonTooltip
           variant="default"

--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -243,6 +243,7 @@ export function LogsSidebarMenuV2() {
       {isUnifiedLogsEligible && (
         <UnifiedLogsBanner
           variant="promo"
+          className="mx-4 mt-4"
           onEnable={() => {
             enableUnifiedLogs()
             router.push(`/project/${ref}/logs`)

--- a/apps/studio/components/ui/DataTable/FilterSideBar.tsx
+++ b/apps/studio/components/ui/DataTable/FilterSideBar.tsx
@@ -75,7 +75,11 @@ export function FilterSideBar({
       </div>
 
       {isUnifiedLogsEligible && (
-        <UnifiedLogsBanner variant="utility" onSwitchBack={handleGoBackToOldLogs} />
+        <UnifiedLogsBanner
+          variant="utility"
+          className="mx-4 mt-4"
+          onSwitchBack={handleGoBackToOldLogs}
+        />
       )}
 
       <div className="flex-1 p-2 sm:overflow-y-scroll">


### PR DESCRIPTION
## Problem

When [#46812](https://github.com/supabase/supabase/pull/46812) was scoped down to "sidebar visual changes only", Kemal's UI redesign of the Unified Logs sidebar banners was unintentionally reverted back to the older full-bleed strip layout. The shared `UnifiedLogsBanner` component survived, but his actual visual design did not.

This PR brings back just Kemal's banner UI changes, with nothing else from that branch.

## Changes

- **promo variant** (`LogsSidebarMenuV2`): bordered card with a "New" badge, an "Introducing unified logs" heading, and an "Enable preview" button + "More information" tooltip button
- **utility variant** (`FilterSideBar`): bordered card for the "Go back to old logs" action with a "Switch back" tooltip button
- Restore the `mx-4 mt-4` placement in both consumers

Adapted to the current `Button` `variant` API (the original used the now-removed `type` prop).

## Testing

- `pnpm lint --filter=studio`
- Visual check of the Logs sidebar for an account eligible for Unified Logs (promo card) and one already on Unified Logs (utility card)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "New" badge indicator to the logs interface.

* **Style**
  * Redesigned the unified logs banner with a new card-based layout.
  * Updated the "Go back to old logs" option with improved visual presentation and tooltip guidance.
  * Adjusted spacing and alignment of the banner component for better visual hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->