### PR TITLE
feat(studio): add redirect and toasts to feature previews

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -1,7 +1,9 @@
 import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import { ExternalLink, Eye, EyeOff, FlaskConical } from 'lucide-react'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
 import { ReactNode } from 'react'
+import { toast } from 'sonner'
 import {
   Badge,
   Button,
@@ -14,6 +16,9 @@ import {
   DialogSectionSeparator,
   DialogTitle,
   ScrollArea,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from 'ui'
 import {
   Select,
@@ -51,6 +56,7 @@ const FEATURE_PREVIEW_KEY_TO_CONTENT: {
 }
 
 export const FeaturePreviewModal = () => {
+  const router = useRouter()
   const { ref } = useParams()
   const featurePreviews = useFeaturePreviews()
   const {
@@ -78,18 +84,40 @@ export const FeaturePreviewModal = () => {
     allFeaturePreviews[0]
   const isSelectedFeatureEnabled = flags[selectedFeature?.key]
 
+  const selectedFeatureRoute = selectedFeature?.getRoute?.(ref)
+  const hasRoute = selectedFeatureRoute !== undefined && ref !== undefined
+
   const toggleFeature = () => {
     if (!selectedFeature) return
+
+    const isEnabling = !isSelectedFeatureEnabled
 
     if (selectedFeature.key === LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER) {
       dismissBanner('rls-tester-banner')
       setIsDismissedRlsTesterBanner(true)
     }
 
-    onUpdateFlag(selectedFeature.key, !isSelectedFeatureEnabled)
-    track(isSelectedFeatureEnabled ? 'feature_preview_disabled' : 'feature_preview_enabled', {
+    onUpdateFlag(selectedFeature.key, isEnabling)
+    track(isEnabling ? 'feature_preview_enabled' : 'feature_preview_disabled', {
       feature: selectedFeature.key,
     })
+
+    if (!isEnabling) {
+      toast(`${selectedFeature.name} disabled`)
+      return
+    }
+
+    toggleFeaturePreviewModal(false)
+    if (hasRoute) {
+      router.push(selectedFeatureRoute)
+      toast.success(`${selectedFeature.name} enabled`, {
+        description: "We've taken you to where you can try it out.",
+      })
+    } else {
+      toast.success(`${selectedFeature.name} enabled`, {
+        description: "It's now active across the dashboard.",
+      })
+    }
   }
 
   return (
@@ -167,9 +195,24 @@ export const FeaturePreviewModal = () => {
                         </Link>
                       </Button>
                     )}
-                    <Button variant="default" onClick={() => toggleFeature()}>
-                      {isSelectedFeatureEnabled ? 'Disable' : 'Enable'} feature
-                    </Button>
+                    {isSelectedFeatureEnabled ? (
+                      <Button variant="default" onClick={() => toggleFeature()}>
+                        Disable feature
+                      </Button>
+                    ) : (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <Button variant="default" onClick={() => toggleFeature()}>
+                            Enable feature
+                          </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom" className="max-w-64 text-center">
+                          {hasRoute
+                            ? 'Enables the feature and takes you to where you can try it out'
+                            : 'Enables this preview across the dashboard'}
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
                   </div>
                 </div>
                 <div className="overflow-y-scroll pt-3 pb-4">

--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -1,4 +1,5 @@
 import { LOCAL_STORAGE_KEYS, useFlag } from 'common'
+import { useMemo } from 'react'
 
 export type FeaturePreview = {
   key: string
@@ -24,85 +25,89 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
   const platformWebhooksEnabled = useFlag('platformWebhooks')
   const jitDbAccessEnabled = useFlag('jitDbAccess')
 
-  return [
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER,
-      name: 'RLS Tester',
-      discussionsUrl: 'https://github.com/orgs/supabase/discussions/45233',
-      enabled: true,
-      isNew: true,
-      isPlatformOnly: false,
-      isDefaultOptIn: false,
-      getRoute: (ref?: string) => `/project/${ref}/auth/policies`,
-    },
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS,
-      name: 'Updated Logs interface',
-      discussionsUrl: 'https://github.com/orgs/supabase/discussions/37234',
-      enabled: isUnifiedLogsPreviewAvailable,
-      isNew: true,
-      isPlatformOnly: true,
-      isDefaultOptIn: false,
-      getRoute: (ref?: string) => `/project/${ref}/logs`,
-    },
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_ADVISOR_RULES,
-      name: 'Disable Advisor rules',
-      discussionsUrl: undefined,
-      enabled: true,
-      isNew: false,
-      isPlatformOnly: true,
-      isDefaultOptIn: false,
-      getRoute: (ref?: string) => `/project/${ref}/advisors/rules`,
-    },
+  return useMemo(
+    () =>
+      [
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_RLS_TESTER,
+          name: 'RLS Tester',
+          discussionsUrl: 'https://github.com/orgs/supabase/discussions/45233',
+          enabled: true,
+          isNew: true,
+          isPlatformOnly: false,
+          isDefaultOptIn: false,
+          getRoute: (ref?: string) => `/project/${ref}/auth/policies`,
+        },
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS,
+          name: 'Updated Logs interface',
+          discussionsUrl: 'https://github.com/orgs/supabase/discussions/37234',
+          enabled: isUnifiedLogsPreviewAvailable,
+          isNew: true,
+          isPlatformOnly: true,
+          isDefaultOptIn: false,
+          getRoute: (ref?: string) => `/project/${ref}/logs`,
+        },
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_ADVISOR_RULES,
+          name: 'Disable Advisor rules',
+          discussionsUrl: undefined,
+          enabled: true,
+          isNew: false,
+          isPlatformOnly: true,
+          isDefaultOptIn: false,
+          getRoute: (ref?: string) => `/project/${ref}/advisors/rules`,
+        },
 
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PG_DELTA_DIFF,
-      name: 'PG Delta Diff',
-      discussionsUrl: undefined,
-      isNew: false,
-      isPlatformOnly: true,
-      isDefaultOptIn: true,
-      enabled: pgDeltaDiffEnabled,
-    },
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PLATFORM_WEBHOOKS,
-      name: 'Platform webhooks',
-      discussionsUrl: undefined,
-      isNew: true,
-      isPlatformOnly: true,
-      isDefaultOptIn: false,
-      enabled: platformWebhooksEnabled,
-      getRoute: (ref?: string) => `/project/${ref}/settings/webhooks`,
-    },
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_JIT_DB_ACCESS,
-      name: 'Temporary access',
-      discussionsUrl: undefined,
-      isNew: true,
-      isPlatformOnly: true,
-      isDefaultOptIn: false,
-      enabled: jitDbAccessEnabled,
-      getRoute: (ref?: string) => `/project/${ref}/database/settings`,
-    },
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_CLS,
-      name: 'Column-level privileges',
-      discussionsUrl: 'https://github.com/orgs/supabase/discussions/20295',
-      enabled: true,
-      isNew: false,
-      isPlatformOnly: false,
-      isDefaultOptIn: false,
-      getRoute: (ref?: string) => `/project/${ref}/database/column-privileges`,
-    },
-    {
-      key: LOCAL_STORAGE_KEYS.UI_PREVIEW_MARKETPLACE,
-      name: 'Integrations layout',
-      discussionsUrl: undefined,
-      enabled: true,
-      isNew: true,
-      isPlatformOnly: false,
-      isDefaultOptIn: true,
-    },
-  ].sort((a, b) => Number(b.isNew) - Number(a.isNew))
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PG_DELTA_DIFF,
+          name: 'PG Delta Diff',
+          discussionsUrl: undefined,
+          isNew: false,
+          isPlatformOnly: true,
+          isDefaultOptIn: true,
+          enabled: pgDeltaDiffEnabled,
+        },
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_PLATFORM_WEBHOOKS,
+          name: 'Platform webhooks',
+          discussionsUrl: undefined,
+          isNew: true,
+          isPlatformOnly: true,
+          isDefaultOptIn: false,
+          enabled: platformWebhooksEnabled,
+          getRoute: (ref?: string) => `/project/${ref}/settings/webhooks`,
+        },
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_JIT_DB_ACCESS,
+          name: 'Temporary access',
+          discussionsUrl: undefined,
+          isNew: true,
+          isPlatformOnly: true,
+          isDefaultOptIn: false,
+          enabled: jitDbAccessEnabled,
+          getRoute: (ref?: string) => `/project/${ref}/database/settings`,
+        },
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_CLS,
+          name: 'Column-level privileges',
+          discussionsUrl: 'https://github.com/orgs/supabase/discussions/20295',
+          enabled: true,
+          isNew: false,
+          isPlatformOnly: false,
+          isDefaultOptIn: false,
+          getRoute: (ref?: string) => `/project/${ref}/database/column-privileges`,
+        },
+        {
+          key: LOCAL_STORAGE_KEYS.UI_PREVIEW_MARKETPLACE,
+          name: 'Integrations layout',
+          discussionsUrl: undefined,
+          enabled: true,
+          isNew: true,
+          isPlatformOnly: false,
+          isDefaultOptIn: true,
+        },
+      ].sort((a, b) => Number(b.isNew) - Number(a.isNew)),
+    [isUnifiedLogsPreviewAvailable, pgDeltaDiffEnabled, platformWebhooksEnabled, jitDbAccessEnabled]
+  )
 }

--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -11,6 +11,11 @@ export type FeaturePreview = {
   isDefaultOptIn: boolean
   /** Visibility in the feature preview modal (For feature flagging a feature preview) */
   enabled: boolean
+  /**
+   * Where to send the user after enabling, to try the feature out. Omit if the
+   * feature has no single destination (e.g. a global layout change).
+   */
+  getRoute?: (ref?: string) => string
 }
 
 export const useFeaturePreviews = (): FeaturePreview[] => {
@@ -28,6 +33,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
       isNew: true,
       isPlatformOnly: false,
       isDefaultOptIn: false,
+      getRoute: (ref?: string) => `/project/${ref}/auth/policies`,
     },
     {
       key: LOCAL_STORAGE_KEYS.UI_PREVIEW_UNIFIED_LOGS,
@@ -37,6 +43,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
       isNew: true,
       isPlatformOnly: true,
       isDefaultOptIn: false,
+      getRoute: (ref?: string) => `/project/${ref}/logs`,
     },
     {
       key: LOCAL_STORAGE_KEYS.UI_PREVIEW_ADVISOR_RULES,
@@ -46,6 +53,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
       isNew: false,
       isPlatformOnly: true,
       isDefaultOptIn: false,
+      getRoute: (ref?: string) => `/project/${ref}/advisors/rules`,
     },
 
     {
@@ -65,6 +73,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
       isPlatformOnly: true,
       isDefaultOptIn: false,
       enabled: platformWebhooksEnabled,
+      getRoute: (ref?: string) => `/project/${ref}/settings/webhooks`,
     },
     {
       key: LOCAL_STORAGE_KEYS.UI_PREVIEW_JIT_DB_ACCESS,
@@ -74,6 +83,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
       isPlatformOnly: true,
       isDefaultOptIn: false,
       enabled: jitDbAccessEnabled,
+      getRoute: (ref?: string) => `/project/${ref}/database/settings`,
     },
     {
       key: LOCAL_STORAGE_KEYS.UI_PREVIEW_CLS,
@@ -83,6 +93,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
       isNew: false,
       isPlatformOnly: false,
       isDefaultOptIn: false,
+      getRoute: (ref?: string) => `/project/${ref}/database/column-privileges`,
     },
     {
       key: LOCAL_STORAGE_KEYS.UI_PREVIEW_MARKETPLACE,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a redirect and/or toast depending if there is one for when a feature is enabled via the Feature Preview dialog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feature previews now support route-aware enabling: when a dedicated configuration page exists, enabling a feature preview automatically navigates there; otherwise it keeps the standard dashboard activation flow.
  * Feature preview controls now show contextual tooltips (including guidance based on availability), making it clearer when and how a preview can be enabled or disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->