### PR TITLE
fix: cmdk search

### DIFF
--- a/packages/pg-meta/src/sql/studio/database/tables-paginated.ts
+++ b/packages/pg-meta/src/sql/studio/database/tables-paginated.ts
@@ -42,6 +42,7 @@ export const getTablesPaginatedSql = ({
         : safeSql`and (
             c.relname ilike ${literal(`%${escapeIlikeLiteral(nameFilter)}%`)}
             or nc.nspname ilike ${literal(`%${escapeIlikeLiteral(nameFilter)}%`)}
+            or (nc.nspname || '.' || c.relname) ilike ${literal(`%${escapeIlikeLiteral(nameFilter)}%`)}
           )`
       : safeSql``
 

--- a/packages/pg-meta/test/sql/studio/tables-paginated.test.ts
+++ b/packages/pg-meta/test/sql/studio/tables-paginated.test.ts
@@ -308,6 +308,41 @@ withTestDatabase(
 )
 
 withTestDatabase(
+  'nameFilter matches fully-qualified schema.table names when no schema filter is set',
+  async ({ executeQuery }) => {
+    await executeQuery(`
+      create schema if not exists cmdk_regression;
+      create table cmdk_regression.repro_table (id bigint primary key);
+    `)
+
+    const baseSql = getTablesPaginatedSql({
+      limit: 100,
+      afterOid: 0,
+      nameFilter: 'cmdk_regression.repro_table',
+    })
+    const baseRows = await executeQuery<Row[]>(baseSql)
+
+    expect(baseRows.map((r) => ({ schema: r.schema, name: r.name }))).toContainEqual({
+      schema: 'cmdk_regression',
+      name: 'repro_table',
+    })
+
+    const withColumnsSql = getTablesPaginatedSql({
+      limit: 100,
+      afterOid: 0,
+      includeColumns: true,
+      nameFilter: 'cmdk_regression.repro_table',
+    })
+    const withColumnsRows = await executeQuery<Row[]>(withColumnsSql)
+
+    expect(withColumnsRows.map((r) => ({ schema: r.schema, name: r.name }))).toContainEqual({
+      schema: 'cmdk_regression',
+      name: 'repro_table',
+    })
+  }
+)
+
+withTestDatabase(
   'nameFilter escapes LIKE wildcards so they match literally',
   async ({ executeQuery }) => {
     await executeQuery(`


### PR DESCRIPTION
- closes https://github.com/supabase/supabase/issues/47033

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Table search now matches fully-qualified table names (e.g., `schema.table`) when no specific schema is selected, enabling searches to work seamlessly across all schemas.

* **Tests**
  * Added comprehensive test coverage validating schema-qualified table name matching in search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->