### PR TITLE
Add Capstart to framework quickstarts

### DIFF
--- a/apps/docs/content/guides/getting-started.mdx
+++ b/apps/docs/content/guides/getting-started.mdx
@@ -96,6 +96,17 @@ hideToc: true
       data from a React app.
     </GlassPanel>
   </Link>
+  <Link href="https://capstart.dev/docs/installation#capstart-boilerplate" passHref className="col-span-4">
+    <GlassPanel
+      title="Capstart"
+      span="col-span-6"
+      background={false}
+      icon="/docs/img/icons/react-icon"
+    >
+      Start a mobile app with Capacitor, React, Supabase Auth, and shadcn/ui, with
+      iOS and Android projects already configured.
+    </GlassPanel>
+  </Link>
   <Link href="/guides/getting-started/quickstarts/nextjs" passHref className="col-span-4">
     <GlassPanel
       title="Next.js"


### PR DESCRIPTION
Adds Capstart to the Framework quickstarts list as a Capacitor, React, Supabase Auth, and shadcn/ui starter.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Capstart framework quickstart card to the getting started guide, providing quick access to framework installation documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->