### PR TITLE
feat(replication): Render errors as markdown and improve publication loading

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.ts
@@ -15,11 +15,12 @@ import {
   IcebergDestinationConfig,
   SnowflakeDestinationConfig,
 } from '@/data/replication/create-destination-pipeline-mutation'
+import { type ValidationFailure } from '@/data/replication/validate-destination-mutation'
 import {
   type CreateS3AccessKeyCredentialVariables,
   type S3AccessKeyCreateData,
 } from '@/data/storage/s3-access-key-create-mutation'
-import { ResponseError } from '@/types'
+import { type ResponseError } from '@/types'
 
 const normalizeOptionalString = (value?: string) => {
   const trimmed = value?.trim()
@@ -334,4 +335,23 @@ export const buildDestinationConfig = async ({
   }
 
   return destinationConfig
+}
+
+const getValidationFailureKey = (failure: ValidationFailure) =>
+  JSON.stringify([failure.failure_type, failure.name, failure.reason])
+
+const getSortedValidationFailureKeys = (failures: ValidationFailure[]) =>
+  failures.map(getValidationFailureKey).sort((a, b) => a.localeCompare(b))
+
+export const areValidationFailuresEqual = (
+  previousFailures: ValidationFailure[],
+  nextFailures: ValidationFailure[]
+) => {
+  const previousKeys = getSortedValidationFailureKeys(previousFailures)
+  const nextKeys = getSortedValidationFailureKeys(nextFailures)
+
+  return (
+    previousKeys.length === nextKeys.length &&
+    previousKeys.every((key, index) => key === nextKeys[index])
+  )
 }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationPanelFields.tsx
@@ -883,7 +883,7 @@ export const AnalyticsBucketFields = ({
                 <Button
                   variant="default"
                   icon={showSecretAccessKey ? <Eye /> : <EyeOff />}
-                  className="w-7 absolute right-6 top-[4px]"
+                  className="w-7 absolute right-1 top-[4px]"
                   onClick={() => setShowSecretAccessKey(!showSecretAccessKey)}
                 />
               </FormItemLayout>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationSelection.tsx
@@ -24,13 +24,10 @@ export const PublicationSelection = ({
   const { ref: projectRef } = useParams()
   const { publicationName } = form.watch()
 
-  const {
-    data: publications = [],
-    isPending: isLoadingPublications,
-    isFetching: isFetchingPublications,
-    isSuccess: isSuccessPublications,
-    refetch: refetchPublications,
-  } = useReplicationPublicationsQuery({ projectRef, sourceId })
+  const { data: publications, isSuccess: isSuccessPublications } = useReplicationPublicationsQuery({
+    projectRef,
+    sourceId,
+  })
 
   const publicationNames = useMemo(() => publications?.map((pub) => pub.name) ?? [], [publications])
   const isSelectedPublicationMissing =
@@ -48,14 +45,8 @@ export const PublicationSelection = ({
         >
           <FormControl>
             <PublicationsComboBox
-              publications={publications}
-              isLoadingPublications={isLoadingPublications || isFetchingPublications}
               field={field}
-              onOpen={() => {
-                if (projectRef && sourceId) {
-                  void refetchPublications()
-                }
-              }}
+              sourceId={sourceId}
               onNewPublicationClick={() => onSelectNewPublication()}
             />
           </FormControl>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationSelection.tsx
@@ -27,7 +27,9 @@ export const PublicationSelection = ({
   const {
     data: publications = [],
     isPending: isLoadingPublications,
+    isFetching: isFetchingPublications,
     isSuccess: isSuccessPublications,
+    refetch: refetchPublications,
   } = useReplicationPublicationsQuery({ projectRef, sourceId })
 
   const publicationNames = useMemo(() => publications?.map((pub) => pub.name) ?? [], [publications])
@@ -47,8 +49,13 @@ export const PublicationSelection = ({
           <FormControl>
             <PublicationsComboBox
               publications={publications}
-              isLoadingPublications={isLoadingPublications}
+              isLoadingPublications={isLoadingPublications || isFetchingPublications}
               field={field}
+              onOpen={() => {
+                if (projectRef && sourceId) {
+                  void refetchPublications()
+                }
+              }}
               onNewPublicationClick={() => onSelectNewPublication()}
             />
           </FormControl>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationsComboBox.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationsComboBox.tsx
@@ -65,8 +65,11 @@ export const PublicationsComboBox = ({
       onOpenChange={(open) => {
         setDropdownOpen(open)
         if (open) {
-          refetchPublications()
+          if (typeof projectRef !== 'undefined' && typeof sourceId !== 'undefined') {
+            refetchPublications()
+          }
         }
+
         if (!open && field?.onBlur) {
           field.onBlur()
         }

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationsComboBox.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationsComboBox.tsx
@@ -18,24 +18,28 @@ import {
   ScrollArea,
 } from 'ui'
 
+import type { DestinationPanelSchemaType } from './DestinationForm.schema'
 import type { ReplicationPublication } from '@/data/replication/publications-query'
 
 interface PublicationsComboBoxProps {
   publications: ReplicationPublication[]
   isLoadingPublications: boolean
+  onOpen: () => void
   onNewPublicationClick: () => void
-  field: ControllerRenderProps<any, 'publicationName'>
+  field: ControllerRenderProps<DestinationPanelSchemaType, 'publicationName'>
 }
 
 export const PublicationsComboBox = ({
   publications,
   isLoadingPublications,
+  onOpen,
   onNewPublicationClick,
   field,
 }: PublicationsComboBoxProps) => {
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [selectedPublication, setSelectedPublication] = useState<string>(field?.value || '')
   const [searchTerm, setSearchTerm] = useState('')
+  const showLoadingState = isLoadingPublications && publications.length === 0
 
   function handlePublicationSelect(pub: string) {
     setSelectedPublication(pub)
@@ -53,6 +57,9 @@ export const PublicationsComboBox = ({
       open={dropdownOpen}
       onOpenChange={(open) => {
         setDropdownOpen(open)
+        if (open) {
+          onOpen()
+        }
         if (!open && field?.onBlur) {
           field.onBlur()
         }
@@ -66,7 +73,13 @@ export const PublicationsComboBox = ({
             'w-full [&>span]:w-full text-left',
             !selectedPublication && 'text-foreground-muted'
           )}
-          iconRight={<ChevronsUpDown className="text-foreground-muted" strokeWidth={2} size={14} />}
+          iconRight={
+            showLoadingState ? (
+              <Loader2 className="text-foreground-muted animate-spin" strokeWidth={2} size={14} />
+            ) : (
+              <ChevronsUpDown className="text-foreground-muted" strokeWidth={2} size={14} />
+            )
+          }
           name={field.name}
           onBlur={field.onBlur}
         >
@@ -83,7 +96,7 @@ export const PublicationsComboBox = ({
           />
           <CommandList>
             <CommandEmpty>
-              {isLoadingPublications ? (
+              {showLoadingState ? (
                 <div className="flex items-center gap-2 text-center justify-center">
                   <Loader2 size={12} className="animate-spin" />
                   Loading...
@@ -94,7 +107,7 @@ export const PublicationsComboBox = ({
             </CommandEmpty>
 
             <CommandGroup>
-              {publications.length === 0 && (
+              {publications.length === 0 && !showLoadingState && (
                 <div className="text-foreground-lighter text-xs py-3 px-2 space-y-0.5">
                   <p>No publications available</p>
                   <p className="text-foreground-muted">Publications with no tables are hidden</p>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationsComboBox.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/PublicationsComboBox.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'common'
 import { Check, ChevronsUpDown, Loader2, Plus } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { ControllerRenderProps } from 'react-hook-form'
@@ -19,26 +20,32 @@ import {
 } from 'ui'
 
 import type { DestinationPanelSchemaType } from './DestinationForm.schema'
-import type { ReplicationPublication } from '@/data/replication/publications-query'
+import { useReplicationPublicationsQuery } from '@/data/replication/publications-query'
 
 interface PublicationsComboBoxProps {
-  publications: ReplicationPublication[]
-  isLoadingPublications: boolean
-  onOpen: () => void
-  onNewPublicationClick: () => void
+  sourceId?: number
   field: ControllerRenderProps<DestinationPanelSchemaType, 'publicationName'>
+  onNewPublicationClick: () => void
 }
 
 export const PublicationsComboBox = ({
-  publications,
-  isLoadingPublications,
-  onOpen,
-  onNewPublicationClick,
+  sourceId,
   field,
+  onNewPublicationClick,
 }: PublicationsComboBoxProps) => {
+  const { ref: projectRef } = useParams()
+
+  const [searchTerm, setSearchTerm] = useState('')
   const [dropdownOpen, setDropdownOpen] = useState(false)
   const [selectedPublication, setSelectedPublication] = useState<string>(field?.value || '')
-  const [searchTerm, setSearchTerm] = useState('')
+
+  const {
+    data: publications = [],
+    isPending,
+    isFetching,
+    refetch: refetchPublications,
+  } = useReplicationPublicationsQuery({ projectRef, sourceId })
+  const isLoadingPublications = isPending || isFetching
   const showLoadingState = isLoadingPublications && publications.length === 0
 
   function handlePublicationSelect(pub: string) {
@@ -58,7 +65,7 @@ export const PublicationsComboBox = ({
       onOpenChange={(open) => {
         setDropdownOpen(open)
         if (open) {
-          onOpen()
+          refetchPublications()
         }
         if (!open && field?.onBlur) {
           field.onBlur()

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationFailuresSection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationFailuresSection.tsx
@@ -1,6 +1,7 @@
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Badge, Card } from 'ui'
 import { Admonition } from 'ui-patterns'
 
+import { Markdown } from '@/components/interfaces/Markdown'
 import type { ValidationFailure } from '@/data/replication/validate-destination-mutation'
 
 interface ValidationFailuresSectionProps {
@@ -52,9 +53,9 @@ export const ValidationFailuresSection = ({
                 </p>
               </AccordionTrigger>
               <AccordionContent className="px-3">
-                <p className="whitespace-pre-wrap text-sm">
-                  {failure.reason.replaceAll('\n\n', '\n')}
-                </p>
+                <Markdown className="text-sm text-foreground-light [&>p]:mb-0!">
+                  {failure.reason}
+                </Markdown>
               </AccordionContent>
             </AccordionItem>
           ))}

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationFailuresSection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationFailuresSection.tsx
@@ -53,7 +53,7 @@ export const ValidationFailuresSection = ({
                 </p>
               </AccordionTrigger>
               <AccordionContent className="px-3">
-                <Markdown className="text-sm text-foreground-light [&>p]:mb-0!">
+                <Markdown className="text-sm text-foreground-light [&>p]:mb-2!">
                   {failure.reason}
                 </Markdown>
               </AccordionContent>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationWarningsDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationWarningsDialog.tsx
@@ -33,7 +33,7 @@ export const ValidationWarningsDialog = ({
           <AlertDialogTitle>
             {hasWarnings
               ? `Create destination with ${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}?`
-              : 'Create destination?'}
+              : 'Confirm to create destination'}
           </AlertDialogTitle>
           <AlertDialogDescription>
             {hasWarnings

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationWarningsDialog.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/ValidationWarningsDialog.tsx
@@ -24,27 +24,32 @@ export const ValidationWarningsDialog = ({
   onOpenChange,
   onConfirm,
 }: ValidationWarningsDialogProps) => {
+  const hasWarnings = warningCount > 0
+
   return (
     <AlertDialog open={open} onOpenChange={onOpenChange}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>
-            Create destination with {warningCount} {warningCount === 1 ? 'warning' : 'warnings'}?
+            {hasWarnings
+              ? `Create destination with ${warningCount} ${warningCount === 1 ? 'warning' : 'warnings'}?`
+              : 'Create destination?'}
           </AlertDialogTitle>
           <AlertDialogDescription>
-            Replication can start, but the warnings listed above may affect how some changes are
-            applied downstream. Review them before proceeding.
+            {hasWarnings
+              ? 'Replication can start, but the warnings listed above may affect how some changes are applied downstream. Review them before proceeding.'
+              : 'No validation issues were found. Confirm to create the destination and start replication.'}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
           <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
           <AlertDialogAction
-            variant="warning"
+            variant={hasWarnings ? 'warning' : 'primary'}
             disabled={isLoading}
             loading={isLoading}
             onClick={onConfirm}
           >
-            Proceed to create
+            {hasWarnings ? 'Proceed to create' : 'Create destination'}
           </AlertDialogAction>
         </AlertDialogFooter>
       </AlertDialogContent>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -67,6 +67,25 @@ import { type ResponseError } from '@/types'
 
 const formId = 'destination-editor'
 
+const getValidationFailureKey = (failure: ValidationFailure) =>
+  JSON.stringify([failure.failure_type, failure.name, failure.reason])
+
+const getSortedValidationFailureKeys = (failures: ValidationFailure[]) =>
+  failures.map(getValidationFailureKey).sort((a, b) => a.localeCompare(b))
+
+const areValidationFailuresEqual = (
+  previousFailures: ValidationFailure[],
+  nextFailures: ValidationFailure[]
+) => {
+  const previousKeys = getSortedValidationFailureKeys(previousFailures)
+  const nextKeys = getSortedValidationFailureKeys(nextFailures)
+
+  return (
+    previousKeys.length === nextKeys.length &&
+    previousKeys.every((key, index) => key === nextKeys[index])
+  )
+}
+
 interface DestinationFormProps {
   selectedType: DestinationType
   visible: boolean
@@ -356,6 +375,10 @@ export const DestinationForm = ({
     if (editMode) {
       return existingDestination?.enabled ? 'Apply and restart' : 'Apply and start'
     } else {
+      if (hasRunValidation && validationWarnings.length > 0 && !hasValidationFailures) {
+        return 'Create and start anyway'
+      }
+
       return 'Create and start'
     }
   }
@@ -537,28 +560,36 @@ export const DestinationForm = ({
 
   const onSubmit = async (data: z.infer<typeof FormSchema>) => {
     if (!editMode) {
-      if (!hasRunValidation || isValidating || hasValidationFailures) {
-        const validationResult = await validateConfiguration(data)
-        if (!validationResult.canContinue) {
-          // Critical failures shown inline — stop so user can fix them
-          return
-        }
-        if (validationResult.warnings.length > 0) {
-          // Warnings shown inline — stop so user can review, then re-submit to confirm
-          return
-        }
-        await submitPipeline(data)
+      const previousValidationFailures = allValidationFailures
+      const previousWarnings = previousValidationFailures.filter(
+        (f) => f.failure_type === 'warning'
+      )
+      const previousFailuresAreOnlyWarnings =
+        hasRunValidation &&
+        previousValidationFailures.length > 0 &&
+        previousValidationFailures.every((f) => f.failure_type === 'warning')
+
+      const validationResult = await validateConfiguration(data)
+      if (!validationResult.canContinue) {
+        // Critical failures shown inline — stop so user can fix them
         return
       }
 
-      // Validation already passed; warnings are visible inline — ask user to confirm
-      if (validationWarnings.length > 0) {
-        setPendingFormValues(data)
-        setShowValidationWarningsDialog(true)
+      if (validationResult.warnings.length > 0) {
+        if (
+          previousFailuresAreOnlyWarnings &&
+          areValidationFailuresEqual(previousWarnings, validationResult.warnings)
+        ) {
+          setPendingFormValues(data)
+          setShowValidationWarningsDialog(true)
+        }
+        // Warnings are shown inline. The user can submit again to confirm if unchanged.
         return
       }
 
-      await submitPipeline(data)
+      // Validation passed cleanly — still ask for confirmation before creating the pipeline.
+      setPendingFormValues(data)
+      setShowValidationWarningsDialog(true)
       return
     }
 
@@ -569,7 +600,6 @@ export const DestinationForm = ({
     setShowValidationWarningsDialog(open)
     if (!open) {
       setPendingFormValues(null)
-      setHasRunValidation(false)
     }
   }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -566,10 +566,14 @@ export const DestinationForm = ({
 
       // Open the confirmation dialog when validation is clean, or when warnings are unchanged on
       // resubmit. New/changed warnings are shown inline so the user can review and submit again.
-      if (hasWarnings && warningsUnchanged) {
-        setPendingFormValues(data)
-        setShowValidationWarningsDialog(true)
-        return
+      if (hasWarnings) {
+        if (warningsUnchanged) {
+          setPendingFormValues(data)
+          setShowValidationWarningsDialog(true)
+          return
+        } else {
+          return
+        }
       }
     }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -570,10 +570,8 @@ export const DestinationForm = ({
         if (warningsUnchanged) {
           setPendingFormValues(data)
           setShowValidationWarningsDialog(true)
-          return
-        } else {
-          return
         }
+        return
       }
     }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -20,6 +20,7 @@ import { AdvancedSettings } from './AdvancedSettings'
 import { CREATE_NEW_NAMESPACE } from './DestinationForm.constants'
 import { DestinationPanelFormSchema as FormSchema } from './DestinationForm.schema'
 import {
+  areValidationFailuresEqual,
   buildDestinationConfig,
   buildDestinationConfigForValidation,
   getDucklakeValidationIssues,
@@ -66,25 +67,6 @@ import {
 import { type ResponseError } from '@/types'
 
 const formId = 'destination-editor'
-
-const getValidationFailureKey = (failure: ValidationFailure) =>
-  JSON.stringify([failure.failure_type, failure.name, failure.reason])
-
-const getSortedValidationFailureKeys = (failures: ValidationFailure[]) =>
-  failures.map(getValidationFailureKey).sort((a, b) => a.localeCompare(b))
-
-const areValidationFailuresEqual = (
-  previousFailures: ValidationFailure[],
-  nextFailures: ValidationFailure[]
-) => {
-  const previousKeys = getSortedValidationFailureKeys(previousFailures)
-  const nextKeys = getSortedValidationFailureKeys(nextFailures)
-
-  return (
-    previousKeys.length === nextKeys.length &&
-    previousKeys.every((key, index) => key === nextKeys[index])
-  )
-}
 
 interface DestinationFormProps {
   selectedType: DestinationType
@@ -200,11 +182,13 @@ export const DestinationForm = ({
   const { mutateAsync: createDestinationPipeline, isPending: creatingDestinationPipeline } =
     useCreateDestinationPipelineMutation({
       onSuccess: () => form.reset(defaultValues),
+      onError: () => {},
     })
 
   const { mutateAsync: updateDestinationPipeline, isPending: updatingDestinationPipeline } =
     useUpdateDestinationPipelineMutation({
       onSuccess: () => form.reset(defaultValues),
+      onError: () => {},
     })
 
   const { mutateAsync: startPipeline, isPending: startingPipeline } = useStartPipelineMutation()
@@ -575,22 +559,18 @@ export const DestinationForm = ({
         return
       }
 
-      if (validationResult.warnings.length > 0) {
-        if (
-          previousFailuresAreOnlyWarnings &&
-          areValidationFailuresEqual(previousWarnings, validationResult.warnings)
-        ) {
-          setPendingFormValues(data)
-          setShowValidationWarningsDialog(true)
-        }
-        // Warnings are shown inline. The user can submit again to confirm if unchanged.
+      const hasWarnings = validationResult.warnings.length > 0
+      const warningsUnchanged =
+        previousFailuresAreOnlyWarnings &&
+        areValidationFailuresEqual(previousWarnings, validationResult.warnings)
+
+      // Open the confirmation dialog when validation is clean, or when warnings are unchanged on
+      // resubmit. New/changed warnings are shown inline so the user can review and submit again.
+      if (hasWarnings && warningsUnchanged) {
+        setPendingFormValues(data)
+        setShowValidationWarningsDialog(true)
         return
       }
-
-      // Validation passed cleanly — still ask for confirmation before creating the pipeline.
-      setPendingFormValues(data)
-      setShowValidationWarningsDialog(true)
-      return
     }
 
     await submitPipeline(data)

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationTypeSelection.tsx
@@ -144,12 +144,12 @@ export const DestinationTypeSelection = () => {
       labelOptional="Destination type cannot be changed after creation"
       description={
         selectedOption?.isAlpha && (
-          <p className="text-sm text-foreground-light mb-1">
+          <span className="text-sm text-foreground-light mb-1">
             This destination type is in alpha and may change while we iterate.{' '}
             <InlineLink href="https://github.com/orgs/supabase/discussions/39416">
               Leave feedback
             </InlineLink>
-          </p>
+          </span>
         )
       }
     >

--- a/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/ReadReplicas/ReadReplicaRow.tsx
@@ -122,7 +122,7 @@ export const ReadReplicaRow = ({ replica, onUpdateReplica }: ReadReplicaRow) => 
               </Link>
             </Button>
             <DropdownMenu>
-              <DropdownMenuTrigger>
+              <DropdownMenuTrigger asChild>
                 <Button variant="default" icon={<MoreVertical />} className="w-7" />
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-52">


### PR DESCRIPTION
This PR improves the rendering of validation failures as markdown and also improves the publication loading which is now triggered also when the dialog is opened, this was it allows a refresh without having to close the destination dialog. In addition, it improves the UX around the handling of warnings and critical errors.

### Screenshots

<img width="774" height="371" alt="image" src="https://github.com/user-attachments/assets/049947ee-b31d-4854-b494-e280a038b247" />

<img width="775" height="510" alt="image" src="https://github.com/user-attachments/assets/051abde4-18d3-4a95-871d-b60af1f3bd16" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved replication publications loading/empty states with clearer spinner messaging and automatic refresh when opening the selection.
  * Updated publication selection so loading state is handled consistently without extra default fallbacks.

* **User Experience**
  * Rendered validation failure reasons using shared Markdown formatting for improved readability.
  * Enhanced the validation warnings dialog (warning vs non-warning titles, descriptions, and actions) and refined the create flow for warnings-only scenarios.
  * Minor UI tweaks to help text, dropdown behavior, and a secret field toggle positioning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->