### PR TITLE
fix: preserve psql

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -194,14 +194,11 @@ function DirectConnectionContent({ state, deploymentMode }: StepContentProps) {
     if (!temporaryDatabasePassword) return redactedConnectionString
 
     if (connectionType === 'psql') {
-      return `psql "${buildConnectionStringWithPassword(
-        safeConnectionString,
-        temporaryDatabasePassword
-      )}"`
+      return redactedConnectionString
     }
 
     return buildConnectionStringWithPassword(redactedConnectionString, temporaryDatabasePassword)
-  }, [connectionType, redactedConnectionString, safeConnectionString, temporaryDatabasePassword])
+  }, [connectionType, redactedConnectionString, temporaryDatabasePassword])
 
   const trackCopy = () => {
     const typeConfig = DATABASE_CONNECTION_TYPES.find((t) => t.id === connectionType)


### PR DESCRIPTION
- closes https://github.com/supabase/supabase/issues/47023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Modified how connection strings are generated for psql database connections when temporary passwords are in use. Psql connections now return a redacted connection string format instead of directly embedding the temporary credentials in the connection command itself. Other connection types continue using standard password-inclusive connection strings to maintain full compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->