### PR TITLE
chore(telemetry): align event interface names with action strings

### DIFF
--- a/apps/studio/hooks/ui/useCsvFileDrop.ts
+++ b/apps/studio/hooks/ui/useCsvFileDrop.ts
@@ -1,4 +1,4 @@
-import { type ImportDataFileAddedEvent } from 'common/telemetry-constants'
+import { type ImportDataDropzoneFileAddedEvent } from 'common/telemetry-constants'
 import { useCallback, useState, type DragEvent } from 'react'
 
 import { flagInvalidFileImport } from '@/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.utils'
@@ -6,7 +6,7 @@ import { flagInvalidFileImport } from '@/components/interfaces/TableGridEditor/S
 interface UseCsvFileDropOptions {
   enabled: boolean
   onFileDropped: (file: File) => void
-  onTelemetryEvent?: (eventName: ImportDataFileAddedEvent['action']) => void
+  onTelemetryEvent?: (eventName: ImportDataDropzoneFileAddedEvent['action']) => void
 }
 
 interface UseCsvFileDropReturn {

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -23,7 +23,7 @@ export const TABLE_EVENT_ACTIONS = {
 } as const satisfies {
   TableCreated: TableCreatedEvent['action']
   TableDataAdded: TableDataAddedEvent['action']
-  TableRLSEnabled: TableRLSEnabledEvent['action']
+  TableRLSEnabled: TableRlsEnabledEvent['action']
 }
 
 export type TableEventAction = (typeof TABLE_EVENT_ACTIONS)[keyof typeof TABLE_EVENT_ACTIONS]
@@ -782,7 +782,7 @@ export interface AssistantEditInSqlEditorClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/reports/{id}
  */
-export interface CustomReportAddSQLBlockClickedEvent {
+export interface CustomReportAddSqlBlockClickedEvent {
   action: 'custom_report_add_sql_block_clicked'
   groups: TelemetryGroups
 }
@@ -794,7 +794,7 @@ export interface CustomReportAddSQLBlockClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/reports/{id}
  */
-export interface CustomReportAssistantSQLBlockAddedEvent {
+export interface CustomReportAssistantSqlBlockAddedEvent {
   action: 'custom_report_assistant_sql_block_added'
   groups: TelemetryGroups
 }
@@ -821,7 +821,7 @@ export interface DocsFeedbackClickedEvent {
  * @group Events
  * @source docs
  */
-export interface CopyAsMarkdownEvent {
+export interface CopyAsMarkdownClickedEvent {
   action: 'copy_as_markdown_clicked'
 }
 
@@ -831,7 +831,7 @@ export interface CopyAsMarkdownEvent {
  * @group Events
  * @source docs
  */
-export interface AskAIEvent {
+export interface AskAiClickedEvent {
   action: 'ask_ai_clicked'
   properties: {
     agent: 'chatgpt' | 'claude'
@@ -844,7 +844,7 @@ export interface AskAIEvent {
  * @group Events
  * @source docs
  */
-export interface DocsRecommendation404ClickedEvent {
+export interface Docs404RecommendationClickedEvent {
   action: 'docs_404_recommendation_clicked'
   properties: {
     /**
@@ -925,7 +925,7 @@ export interface WwwPricingPlanCtaClickedEvent {
  * @source www
  * @page /events/*
  */
-export interface EventPageCtaClickedEvent {
+export interface WwwEventPageCtaClickedEvent {
   action: 'www_event_page_cta_clicked'
   properties: {
     /**
@@ -942,7 +942,7 @@ export interface EventPageCtaClickedEvent {
  * @source www
  * @page /
  */
-export interface HomepageGitHubButtonClickedEvent {
+export interface HomepageGithubButtonClickedEvent {
   action: 'homepage_github_button_clicked'
 }
 
@@ -1141,7 +1141,7 @@ export interface ImportDataButtonClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/editor
  */
-export interface ImportDataFileAddedEvent {
+export interface ImportDataDropzoneFileAddedEvent {
   action: 'import_data_dropzone_file_added'
   groups: TelemetryGroups
 }
@@ -1248,7 +1248,7 @@ export interface ReportsDatabaseGrafanaBannerClickedEvent {
  * @source studio
  * @page /observability/*
  */
-export interface MetricsAPIBannerCtaButtonClickedEvent {
+export interface MetricsApiBannerCtaButtonClickedEvent {
   action: 'metrics_api_banner_cta_button_clicked'
   groups: TelemetryGroups
 }
@@ -1260,7 +1260,7 @@ export interface MetricsAPIBannerCtaButtonClickedEvent {
  * @source studio
  * @page /observability/*
  */
-export interface MetricsAPIBannerDismissButtonClickedEvent {
+export interface MetricsApiBannerDismissButtonClickedEvent {
   action: 'metrics_api_banner_dismiss_button_clicked'
   groups: TelemetryGroups
 }
@@ -2153,7 +2153,7 @@ export interface TableDataAddedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/editor or /dashboard/project/{ref}/sql
  */
-export interface TableRLSEnabledEvent {
+export interface TableRlsEnabledEvent {
   action: 'table_rls_enabled'
   properties: {
     /**
@@ -2179,7 +2179,7 @@ export interface TableRLSEnabledEvent {
  * @source studio
  * @page /dashboard/project/{ref}/editor
  */
-export interface RLSGeneratePoliciesClickedEvent {
+export interface RlsGeneratePoliciesClickedEvent {
   action: 'rls_generate_policies_clicked'
   groups: TelemetryGroups
 }
@@ -2191,7 +2191,7 @@ export interface RLSGeneratePoliciesClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/editor
  */
-export interface RLSGeneratedPolicyRemovedEvent {
+export interface RlsGeneratedPolicyRemovedEvent {
   action: 'rls_generated_policy_removed'
   groups: TelemetryGroups
 }
@@ -2203,7 +2203,7 @@ export interface RLSGeneratedPolicyRemovedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/editor
  */
-export interface RLSGeneratedPoliciesCreatedEvent {
+export interface RlsGeneratedPoliciesCreatedEvent {
   action: 'rls_generated_policies_created'
   groups: TelemetryGroups
 }
@@ -2696,7 +2696,7 @@ export interface AdvisorAssistantButtonClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/observability/query-performance
  */
-export interface QueryPerformanceAIExplanationButtonClickedEvent {
+export interface QueryPerformanceExplainWithAiButtonClickedEvent {
   action: 'query_performance_explain_with_ai_button_clicked'
   groups: TelemetryGroups
 }
@@ -3425,7 +3425,7 @@ export interface HeaderLocalVersionPopoverOpenedEvent {
  * @group Events
  * @source studio
  */
-export interface RLSTesterRunQueryClickedEvent {
+export interface RlsTesterRunQueryClickedEvent {
   action: 'rls_tester_run_query_clicked'
   properties: { type: 'raw' | 'inferred' }
   groups: Partial<TelemetryGroups>
@@ -3478,19 +3478,19 @@ export type TelemetryEvent =
   | AssistantEditInSqlEditorClickedEvent
   | AssistantMessageRatingSubmittedEvent
   | DocsFeedbackClickedEvent
-  | CopyAsMarkdownEvent
-  | AskAIEvent
-  | DocsRecommendation404ClickedEvent
+  | CopyAsMarkdownClickedEvent
+  | AskAiClickedEvent
+  | Docs404RecommendationClickedEvent
   | HomepageFrameworkQuickstartClickedEvent
   | HomepageProductCardClickedEvent
   | WwwPricingPlanCtaClickedEvent
-  | EventPageCtaClickedEvent
-  | HomepageGitHubButtonClickedEvent
+  | WwwEventPageCtaClickedEvent
+  | HomepageGithubButtonClickedEvent
   | HomepageDiscordButtonClickedEvent
   | HomepageCustomerStoryCardClickedEvent
   | HomepageProjectTemplateCardClickedEvent
-  | CustomReportAddSQLBlockClickedEvent
-  | CustomReportAssistantSQLBlockAddedEvent
+  | CustomReportAddSqlBlockClickedEvent
+  | CustomReportAssistantSqlBlockAddedEvent
   | OpenSourceRepoCardClickedEvent
   | StartProjectButtonClickedEvent
   | SeeDocumentationButtonClickedEvent
@@ -3499,7 +3499,7 @@ export type TelemetryEvent =
   | HelpButtonClickedEvent
   | ExampleProjectCardClickedEvent
   | ImportDataButtonClickedEvent
-  | ImportDataFileAddedEvent
+  | ImportDataDropzoneFileAddedEvent
   | ImportDataAddedEvent
   | SendFeedbackButtonClickedEvent
   | SqlEditorQueryRunButtonClickedEvent
@@ -3512,8 +3512,8 @@ export type TelemetryEvent =
   | StudioBillingCancelSubscriptionClickedEvent
   | StudioPricingSidePanelOpenedEvent
   | ReportsDatabaseGrafanaBannerClickedEvent
-  | MetricsAPIBannerCtaButtonClickedEvent
-  | MetricsAPIBannerDismissButtonClickedEvent
+  | MetricsApiBannerCtaButtonClickedEvent
+  | MetricsApiBannerDismissButtonClickedEvent
   | UnifiedLogsBannerCtaButtonClickedEvent
   | UnifiedLogsBannerDismissButtonClickedEvent
   | IndexAdvisorEnableButtonClickedEvent
@@ -3563,10 +3563,10 @@ export type TelemetryEvent =
   | HipaaRequestButtonClickedEvent
   | TableCreatedEvent
   | TableDataAddedEvent
-  | TableRLSEnabledEvent
-  | RLSGeneratePoliciesClickedEvent
-  | RLSGeneratedPolicyRemovedEvent
-  | RLSGeneratedPoliciesCreatedEvent
+  | TableRlsEnabledEvent
+  | RlsGeneratePoliciesClickedEvent
+  | RlsGeneratedPolicyRemovedEvent
+  | RlsGeneratedPoliciesCreatedEvent
   | AuthUsersSearchSubmittedEvent
   | CommandMenuOpenedEvent
   | CommandMenuClosedEvent
@@ -3581,7 +3581,7 @@ export type TelemetryEvent =
   | AuditLogDrainRemovedEvent
   | AdvisorDetailOpenedEvent
   | AdvisorAssistantButtonClickedEvent
-  | QueryPerformanceAIExplanationButtonClickedEvent
+  | QueryPerformanceExplainWithAiButtonClickedEvent
   | AiPromptCopiedEvent
   | AiAssistantDropdownButtonClickedEvent
   | AiExternalToolClickedEvent
@@ -3626,4 +3626,4 @@ export type TelemetryEvent =
   | HeaderUserDropdownOpenedEvent
   | HeaderLocalDropdownOpenedEvent
   | HeaderLocalVersionPopoverOpenedEvent
-  | RLSTesterRunQueryClickedEvent
+  | RlsTesterRunQueryClickedEvent


### PR DESCRIPTION
## Summary

Aligns 16 telemetry event interface identifiers in `packages/common/telemetry-constants.ts` so each interface name equals the PascalCase of its `action` string (`PascalCase(action) + Event`). This is a follow-up to the GROWTH-798 audit (#45964), which fixed the `action` strings and several interface names but left these 16 identifiers mismatched. I renamed identifiers only: every `action` string is untouched, so there is zero impact on PostHog event names or historical data.

Before this change, 176/192 interfaces matched the convention. This brings it to 192/192.

## Changes

Structural renames (interface name was dropping or reordering words vs the action):
- `AskAIEvent` to `AskAiClickedEvent`
- `CopyAsMarkdownEvent` to `CopyAsMarkdownClickedEvent`
- `DocsRecommendation404ClickedEvent` to `Docs404RecommendationClickedEvent` (from #46990)
- `EventPageCtaClickedEvent` to `WwwEventPageCtaClickedEvent` (completes the interface side of GROWTH-798 HIGH #1)
- `ImportDataFileAddedEvent` to `ImportDataDropzoneFileAddedEvent` (also updates the consumer `apps/studio/hooks/ui/useCsvFileDrop.ts`)
- `QueryPerformanceAIExplanationButtonClickedEvent` to `QueryPerformanceExplainWithAiButtonClickedEvent`

Initialism casing (normalized to the file-majority lowercase transform; `Sql` 9:2, `Api` 3:2, `Ai` 6:2):
- `CustomReportAddSQLBlockClickedEvent` to `CustomReportAddSqlBlockClickedEvent`
- `CustomReportAssistantSQLBlockAddedEvent` to `CustomReportAssistantSqlBlockAddedEvent`
- `HomepageGitHubButtonClickedEvent` to `HomepageGithubButtonClickedEvent`
- `MetricsAPIBannerCtaButtonClickedEvent` to `MetricsApiBannerCtaButtonClickedEvent`
- `MetricsAPIBannerDismissButtonClickedEvent` to `MetricsApiBannerDismissButtonClickedEvent`
- `TableRLSEnabledEvent` to `TableRlsEnabledEvent`
- `RLSGeneratePoliciesClickedEvent` to `RlsGeneratePoliciesClickedEvent`
- `RLSGeneratedPolicyRemovedEvent` to `RlsGeneratedPolicyRemovedEvent`
- `RLSGeneratedPoliciesCreatedEvent` to `RlsGeneratedPoliciesCreatedEvent`
- `RLSTesterRunQueryClickedEvent` to `RlsTesterRunQueryClickedEvent`

## Testing

Type-only change, no runtime or PostHog behavior to exercise. Verified that all 192 interfaces now match `PascalCase(action) + Event` (0 mismatches), the `TelemetryEvent` union has no duplicates, no old identifier names remain anywhere in the repo, and the one external consumer (`useCsvFileDrop.ts`) still resolves via its `['action']` indexed access since the action strings are unchanged.

## Linear

- fixes GROWTH-928


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal telemetry infrastructure for consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->