### PR TITLE
fix(www): center "Open positions" button on careers page

### DIFF
--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -131,7 +131,7 @@ const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) =>
           <p className="text-sm md:text-base text-foreground-lighter max-w-sm sm:max-w-md md:max-w-lg mx-auto">
             Explore remote opportunities and join our team to help us achieve it.
           </p>
-          <Button asChild variant="primary" className="mt-4">
+          <Button asChild variant="primary" className="mt-4 mx-auto w-fit">
             <Link href="#positions">Open positions</Link>
           </Button>
         </header>


### PR DESCRIPTION
before

<img width="1360" height="564" alt="Screenshot 2026-06-17 at 11 30 45" src="https://github.com/user-attachments/assets/69516e92-0c3d-42ad-b893-2d6ffdf9e9f8" />

after

<img width="1351" height="596" alt="Screenshot 2026-06-17 at 11 31 29" src="https://github.com/user-attachments/assets/8c78e4c5-f46b-4419-87bd-d689982c3f5b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined the visual presentation of the "Open positions" call-to-action button on the careers page with improved spacing and layout alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->