### PR TITLE
chore: add feature flag to pretty explain

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -30,6 +30,7 @@ export type MonacoEditorProps = {
   autoFocus?: boolean
   executeQuery: () => void
   executeExplainQuery: () => void
+  showExplainAction?: boolean
   prettifyQuery: () => void
   onHasSelection: (value: boolean) => void
   onMount?: (editor: IStandaloneCodeEditor) => void
@@ -53,6 +54,7 @@ const MonacoEditor = ({
   className,
   executeQuery,
   executeExplainQuery,
+  showExplainAction = true,
   prettifyQuery,
   onHasSelection,
   onPrompt,
@@ -145,16 +147,18 @@ const MonacoEditor = ({
       },
     })
 
-    editor.addAction({
-      id: 'run-explain-query',
-      label: 'Run EXPLAIN ANALYZE',
-      keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter],
-      contextMenuGroupId: 'operation',
-      contextMenuOrder: 1,
-      run: () => {
-        executeExplainQueryRef.current()
-      },
-    })
+    if (showExplainAction) {
+      editor.addAction({
+        id: 'run-explain-query',
+        label: 'Run EXPLAIN ANALYZE',
+        keybindings: [monaco.KeyMod.CtrlCmd | monaco.KeyMod.Shift | monaco.KeyCode.Enter],
+        contextMenuGroupId: 'operation',
+        contextMenuOrder: 1,
+        run: () => {
+          executeExplainQueryRef.current()
+        },
+      })
+    }
 
     editor.addAction({
       id: 'save-query',

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -120,6 +120,9 @@ export const SQLEditor = () => {
   const databaseSelectorState = useDatabaseSelectorStateSnapshot()
   const { aiOptInLevel } = useOrgAiOptInLevel()
   const showPrettyExplain = useFlag('ShowPrettyExplain')
+  
+  // [Ali] Kill switch to hide the SQL Editor Explain tab and its entry points
+  const disablePrettyExplain = useFlag('DisablePrettyExplainOnSqlEditor')
 
   const {
     sourceSqlDiff,
@@ -223,7 +226,7 @@ export const SQLEditor = () => {
       if (id) {
         snapV2.addResult(id, data.result, vars.autoLimit)
 
-        if (showPrettyExplain && isExplainQuery(data.result)) {
+        if (!disablePrettyExplain && showPrettyExplain && isExplainQuery(data.result)) {
           snapV2.addExplainResult(id, data.result)
           setActiveUtilityTab('explain')
         } else if (activeUtilityTab === 'explain') {
@@ -535,6 +538,7 @@ export const SQLEditor = () => {
   ])
 
   useShortcut(SHORTCUT_IDS.SQL_EDITOR_EXPLAIN, executeExplainQuery, {
+    enabled: !disablePrettyExplain,
     registerInCommandMenu: true,
   })
 
@@ -958,6 +962,7 @@ export const SQLEditor = () => {
                       monacoRef={monacoRef}
                       executeQuery={executeQuery}
                       executeExplainQuery={executeExplainQuery}
+                      showExplainAction={!disablePrettyExplain}
                       prettifyQuery={prettifyQuery}
                       onHasSelection={setHasSelection}
                       onMount={onMount}
@@ -1022,6 +1027,7 @@ export const SQLEditor = () => {
                 prettifyQuery={prettifyQuery}
                 executeQuery={executeQueryFromButton}
                 executeExplainQuery={executeExplainQuery}
+                showExplainTab={!disablePrettyExplain}
                 onDebug={onDebug}
                 buildDebugPrompt={buildDebugPrompt}
                 activeTab={activeUtilityTab}

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -120,7 +120,7 @@ export const SQLEditor = () => {
   const databaseSelectorState = useDatabaseSelectorStateSnapshot()
   const { aiOptInLevel } = useOrgAiOptInLevel()
   const showPrettyExplain = useFlag('ShowPrettyExplain')
-  
+
   // [Ali] Kill switch to hide the SQL Editor Explain tab and its entry points
   const disablePrettyExplain = useFlag('DisablePrettyExplainOnSqlEditor')
 

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/UtilityPanel.tsx
@@ -22,6 +22,7 @@ export type UtilityPanelProps = {
   prettifyQuery: () => void
   executeQuery: () => void
   executeExplainQuery: () => void
+  showExplainTab?: boolean
   onDebug: () => void
   buildDebugPrompt: () => string
   activeTab?: string
@@ -47,6 +48,7 @@ export const UtilityPanel = ({
   prettifyQuery,
   executeQuery,
   executeExplainQuery,
+  showExplainTab = true,
   onDebug,
   buildDebugPrompt,
   activeTab = 'results',
@@ -136,9 +138,11 @@ export const UtilityPanel = ({
           <TabsTrigger_Shadcn_ className="py-3 text-xs" value="results">
             <span className="translate-y-px">Results</span>
           </TabsTrigger_Shadcn_>
-          <TabsTrigger_Shadcn_ className="py-3 text-xs" value="explain">
-            <span className="translate-y-px">Explain</span>
-          </TabsTrigger_Shadcn_>
+          {showExplainTab && (
+            <TabsTrigger_Shadcn_ className="py-3 text-xs" value="explain">
+              <span className="translate-y-px">Explain</span>
+            </TabsTrigger_Shadcn_>
+          )}
           <TabsTrigger_Shadcn_ className="py-3 text-xs" value="chart">
             <span className="translate-y-px">Chart</span>
           </TabsTrigger_Shadcn_>
@@ -177,9 +181,11 @@ export const UtilityPanel = ({
         />
       </TabsContent_Shadcn_>
 
-      <TabsContent_Shadcn_ asChild value="explain" className="mt-0 grow">
-        <UtilityTabExplain id={id} isExecuting={isExplainExecuting} />
-      </TabsContent_Shadcn_>
+      {showExplainTab && (
+        <TabsContent_Shadcn_ asChild value="explain" className="mt-0 grow">
+          <UtilityTabExplain id={id} isExecuting={isExplainExecuting} />
+        </TabsContent_Shadcn_>
+      )}
 
       <TabsContent_Shadcn_ asChild value="chart" className="mt-0 grow">
         <ChartConfig results={result} config={chartConfig} onConfigChange={onConfigChange} />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Put Pretty Explain behind a feature flag for experimentation purposes 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * SQL Editor now supports optional feature controls to conditionally disable “Explain” functionality. When disabled via configuration, the “Explain” tab and its entry points are hidden, the EXPLAIN ANALYZE keyboard shortcut (Ctrl/Cmd+Shift+Enter) is disabled, and any automatic post-run switch to the Explain tab for EXPLAIN-like queries is prevented. This also reduces unnecessary mounting of Explain UI content when turned off.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->