### PR TITLE
test(e2e): assert grid cell text with web-first toHaveText

### DIFF
--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -564,7 +564,6 @@ testRunner('table editor', () => {
     await page.getByRole('button', { name: 'Sorted by 1 rule' }).click()
 
     // Verify sorted row content asc lexicographically for strings
-    await page.waitForTimeout(500)
     await expect(page.getByRole('gridcell').nth(3)).toHaveText('123')
     await expect(page.getByRole('gridcell').nth(8)).toHaveText('456')
     await expect(page.getByRole('gridcell').nth(13)).toHaveText('789')

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -314,9 +314,9 @@ testRunner('table editor', () => {
     }
 
     // verify row content
-    expect(await page.getByRole('gridcell').nth(3).textContent()).toBe('789')
-    expect(await page.getByRole('gridcell').nth(8).textContent()).toBe('456')
-    expect(await page.getByRole('gridcell').nth(13).textContent()).toBe('123')
+    await expect(page.getByRole('gridcell').nth(3)).toHaveText('789')
+    await expect(page.getByRole('gridcell').nth(8)).toHaveText('456')
+    await expect(page.getByRole('gridcell').nth(13)).toHaveText('123')
 
     // edit table (rename table, rename column name)
     await page
@@ -565,9 +565,9 @@ testRunner('table editor', () => {
 
     // Verify sorted row content asc lexicographically for strings
     await page.waitForTimeout(500)
-    expect(await page.getByRole('gridcell').nth(3).textContent()).toBe('123')
-    expect(await page.getByRole('gridcell').nth(8).textContent()).toBe('456')
-    expect(await page.getByRole('gridcell').nth(13).textContent()).toBe('789')
+    await expect(page.getByRole('gridcell').nth(3)).toHaveText('123')
+    await expect(page.getByRole('gridcell').nth(8)).toHaveText('456')
+    await expect(page.getByRole('gridcell').nth(13)).toHaveText('789')
   })
 
   test('column actions works as expected', async ({ page, ref }) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (test reliability). No production code change.

## What is the current behavior?

The Table Editor e2e spec (`e2e/studio/features/table-editor.spec.ts`) verifies inserted and sorted row values with one-shot reads:

```ts
expect(await page.getByRole('gridcell').nth(n).textContent()).toBe(value)
```

`textContent()` reads the cell exactly once with no retry, so the assertion can run before the grid finishes rendering the inserted row or applying the sort. The sort test currently masks this race with a hard-coded `await page.waitForTimeout(500)`. These six reads are the sole verification of row content in their tests, so the race lands on the exact behavior the tests are meant to guarantee.

## What is the new behavior?

The six reads use the web-first matcher:

```ts
await expect(page.getByRole('gridcell').nth(n)).toHaveText(value)
```

`toHaveText` auto-retries until the cell settles, removing the render/sort race and matching the auto-retrying `toContainText` already used elsewhere in this file. Because the matcher now waits for the grid to render, the `await page.waitForTimeout(500)` in the sort test (which sat after the sort API response was already awaited) is redundant and is removed. No selectors, row data, or test structure change.

## Additional context

Found while reviewing the test suite with [e2e-skills/e2e-reviewer](https://github.com/voidmatcha/e2e-skills#skill-2-e2e-reviewer--quality-review).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated table editor end-to-end assertions to use Playwright’s native text matchers for more reliable verification of grid row content and the results after sorting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->