### PR TITLE
chore: added small padding to support form

### DIFF
--- a/apps/studio/components/interfaces/Support/Success.tsx
+++ b/apps/studio/components/interfaces/Support/Success.tsx
@@ -43,7 +43,7 @@ export const Success = ({
   ) : null
 
   return (
-    <div className="flex w-full flex-col items-center gap-4 px-4 pt-4 text-center">
+    <div className="flex w-full flex-col items-center gap-4 px-4 pt-4 pb-8 text-center">
       <Check strokeWidth={1.5} size={24} className="text-brand" />
 
       <div className="flex max-w-[620px] flex-col items-center gap-2">

--- a/apps/studio/components/interfaces/Support/Success.tsx
+++ b/apps/studio/components/interfaces/Support/Success.tsx
@@ -43,7 +43,7 @@ export const Success = ({
   ) : null
 
   return (
-    <div className="flex w-full flex-col items-center gap-4 px-4 pt-4 pb-8 text-center">
+    <div className="flex w-full flex-col items-center gap-4 px-4 py-4 text-center">
       <Check strokeWidth={1.5} size={24} className="text-brand" />
 
       <div className="flex max-w-[620px] flex-col items-center gap-2">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Support form is a bit cramped when submitted, this is to fix that 

**Before**
<img width="1248" height="580" alt="image" src="https://github.com/user-attachments/assets/dfbf6d1c-6a07-4b1b-b7a6-90bb87c37aaa" />

**After**
<img width="697" height="430" alt="image" src="https://github.com/user-attachments/assets/2baeca9f-fee3-4c42-a50b-07d9617cc36e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined vertical padding in the success confirmation message for improved spacing and visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->