### PR TITLE
feat: Add Server lib to connect w/ ability to copy env

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/Connect.types.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/Connect.types.ts
@@ -57,7 +57,7 @@ export type ConditionalValue<T> =
 // Schema Types - Modes
 // ============================================================================
 
-export const CONNECT_MODES = ['framework', 'direct', 'orm', 'mcp'] as const
+export const CONNECT_MODES = ['framework', 'direct', 'orm', 'mcp', 'server'] as const
 export type ConnectMode = (typeof CONNECT_MODES)[number]
 
 export interface ModeDefinition {

--- a/apps/studio/components/interfaces/ConnectSheet/Connect.types.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/Connect.types.ts
@@ -65,6 +65,7 @@ export interface ModeDefinition {
   label: string
   description: string
   icon?: string
+  prompt?: string
   fields: string[] // References to field IDs
 }
 

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectConfigSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Cable, Database, Sparkles } from 'lucide-react'
+import { Box, Cable, Database, Server, Sparkles } from 'lucide-react'
 import {
   cn,
   RadioGroupStacked,
@@ -27,6 +27,7 @@ const MODE_ICONS: Record<string, React.ReactNode> = {
   direct: <Database size={16} strokeWidth={1.5} />,
   orm: <Cable size={16} strokeWidth={1.5} />,
   mcp: <Sparkles size={16} strokeWidth={1.5} />,
+  server: <Server size={16} strokeWidth={1.5} />,
 }
 
 interface ConnectConfigSectionProps {
@@ -244,7 +245,10 @@ interface ModeSelectorProps {
 
 export function ModeSelector({ modes, selected, onChange }: ModeSelectorProps) {
   return (
-    <div className="grid grid-cols-4 rounded-lg border overflow-hidden">
+    <div
+      className="grid rounded-lg border overflow-hidden"
+      style={{ gridTemplateColumns: `repeat(${modes.length}, minmax(0, 1fr))` }}
+    >
       {modes.map((mode) => (
         <button
           key={mode.id}

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectSheet.tsx
@@ -222,14 +222,16 @@ export const ConnectSheet = () => {
             />
           </div>
 
-          <div className="border-b p-8">
-            <ConnectConfigSection
-              state={state}
-              activeFields={activeFields}
-              onFieldChange={handleFieldChange}
-              getFieldOptions={getFieldOptions}
-            />
-          </div>
+          {activeFields.length > 0 && (
+            <div className="border-b p-8">
+              <ConnectConfigSection
+                state={state}
+                activeFields={activeFields}
+                onFieldChange={handleFieldChange}
+                getFieldOptions={getFieldOptions}
+              />
+            </div>
+          )}
 
           <ConnectStepsSection steps={resolvedSteps} state={state} projectKeys={projectKeys} />
         </div>

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
@@ -6,6 +6,7 @@ import { Button } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
+import { connectSchema } from './connect.schema'
 import type {
   ConnectionStringPooler,
   ConnectState,
@@ -195,6 +196,11 @@ export function ConnectStepsSection({ steps, state, projectKeys }: ConnectStepsS
 
   const showSelfHostedMcpNotice = deploymentMode.isSelfHosted && state.mode === 'mcp'
 
+  const customPrompt = useMemo(
+    () => connectSchema.modes.find((m) => m.id === state.mode)?.prompt,
+    [state.mode]
+  )
+
   if (steps.length === 0) return null
 
   return (
@@ -238,7 +244,7 @@ export function ConnectStepsSection({ steps, state, projectKeys }: ConnectStepsS
           />
         )}
 
-        <CopyPromptAdmonition stepsContainerRef={stepsContainerRef} />
+        <CopyPromptAdmonition stepsContainerRef={stepsContainerRef} customPrompt={customPrompt} />
 
         <div className="mt-6" ref={stepsContainerRef}>
           {steps.map((step, index) => (

--- a/apps/studio/components/interfaces/ConnectSheet/CopyPromptAdmonition.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/CopyPromptAdmonition.tsx
@@ -6,6 +6,8 @@ import { BASE_PATH } from '@/lib/constants'
 
 interface CopyPromptAdmonitionProps {
   stepsContainerRef: RefObject<HTMLDivElement | null>
+  /** When set, the Copy prompt button uses this verbatim instead of scraping the steps. */
+  customPrompt?: string
 }
 
 const normalizeTextLines = (value: string) => {
@@ -123,9 +125,12 @@ export const buildConnectPrompt = (stepsContainer: HTMLElement | null) => {
   return promptContent
 }
 
-export function CopyPromptAdmonition({ stepsContainerRef }: CopyPromptAdmonitionProps) {
+export function CopyPromptAdmonition({
+  stepsContainerRef,
+  customPrompt,
+}: CopyPromptAdmonitionProps) {
   const handleCopyPrompt = () => {
-    return buildConnectPrompt(stepsContainerRef.current)
+    return customPrompt ?? buildConnectPrompt(stepsContainerRef.current)
   }
 
   return (

--- a/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
@@ -190,6 +190,14 @@ const skillsInstallStep: StepDefinition = {
   content: 'steps/skills-install',
 }
 
+const serverSkillsInstallStep: StepDefinition = {
+  id: 'install-skills',
+  title: 'Install the Supabase Server skill (Optional)',
+  description:
+    'Gives AI coding tools ready-made instructions for building APIs with @supabase/server.',
+  content: 'steps/skills-install',
+}
+
 // ============================================================================
 // Mode Prompts
 // ============================================================================
@@ -440,7 +448,7 @@ export const connectSchema: ConnectSchema = {
           DEFAULT: [mcpConfigureStep, skillsInstallStep],
         },
       },
-      server: [serverInstallStep, serverEnvStep, skillsInstallStep],
+      server: [serverInstallStep, serverEnvStep, serverSkillsInstallStep],
       DEFAULT: [skillsInstallStep],
     },
   },

--- a/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
@@ -166,6 +166,22 @@ const ormConfigureStep: StepDefinition = {
   content: '{{orm}}',
 }
 
+const serverInstallStep: StepDefinition = {
+  id: 'server-install',
+  title: 'Install package',
+  description:
+    'Add @supabase/server to your project. On Supabase Edge Functions you can import it directly — no install needed.',
+  content: 'server/install',
+}
+
+const serverEnvStep: StepDefinition = {
+  id: 'server-env',
+  title: 'Set environment variables',
+  description:
+    'Copy these into your environment. On Supabase Edge Functions they are injected automatically.',
+  content: 'server/env',
+}
+
 const skillsInstallStep: StepDefinition = {
   id: 'install-skills',
   title: 'Install Agent Skills (Optional)',
@@ -206,6 +222,12 @@ export const connectSchema: ConnectSchema = {
       label: 'MCP',
       description: 'Connect your agent',
       fields: ['mcpClient', 'mcpReadonly', 'mcpFeatures'],
+    },
+    {
+      id: 'server',
+      label: 'Server',
+      description: '@supabase/server',
+      fields: [],
     },
   ],
 
@@ -386,6 +408,7 @@ export const connectSchema: ConnectSchema = {
           DEFAULT: [mcpConfigureStep, skillsInstallStep],
         },
       },
+      server: [serverInstallStep, serverEnvStep, skillsInstallStep],
       DEFAULT: [skillsInstallStep],
     },
   },

--- a/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
@@ -170,7 +170,7 @@ const serverInstallStep: StepDefinition = {
   id: 'server-install',
   title: 'Install package',
   description:
-    'Add @supabase/server to your project. On Supabase Edge Functions you can import it directly — no install needed.',
+    'Add @supabase/server to your backend or API framework of choice. On Supabase Edge Functions you can import it directly, no install needed.',
   content: 'server/install',
 }
 
@@ -178,7 +178,7 @@ const serverEnvStep: StepDefinition = {
   id: 'server-env',
   title: 'Set environment variables',
   description:
-    'Copy these into your environment. On Supabase Edge Functions they are injected automatically.',
+    'Copy these into your environment so you can verify users and use the client/admin supabase-js library from the context of your handler. On Supabase Edge Functions they are injected automatically.',
   content: 'server/env',
 }
 

--- a/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
@@ -191,6 +191,37 @@ const skillsInstallStep: StepDefinition = {
 }
 
 // ============================================================================
+// Mode Prompts
+// ============================================================================
+
+// Agent-ready prompt for the Server mode. Intentionally omits the project's
+// actual keys — the secret should never be pasted into an LLM prompt; users
+// copy the real values from the env step.
+const serverConnectPrompt = `Set up the @supabase/server SDK in this project.
+
+Install it:
+npm install @supabase/server
+
+It reads these environment variables (copy the real values from the Supabase dashboard's Connect dialog — never commit the secret key):
+- SUPABASE_URL
+- SUPABASE_PUBLISHABLE_KEY
+- SUPABASE_SECRET_KEY
+- SUPABASE_JWKS_URL (used to verify user JWTs)
+
+Create request handlers with \`withSupabase\` from "@supabase/server". It validates auth and provides an RLS-scoped client (\`ctx.supabase\`) and an admin client that bypasses RLS (\`ctx.supabaseAdmin\`). Example:
+
+import { withSupabase } from "@supabase/server"
+
+export default {
+  fetch: withSupabase({ auth: "user" }, async (_req, ctx) => {
+    const { data } = await ctx.supabase.from("todos").select()
+    return Response.json(data)
+  }),
+}
+
+Auth modes: "user" (valid JWT), "publishable" (publishable key), "secret" (secret key), "none". On Supabase Edge Functions these env vars are injected automatically; for non-"user" auth modes, set \`verify_jwt = false\` for the function in supabase/config.toml.`
+
+// ============================================================================
 // Main Schema
 // ============================================================================
 
@@ -204,6 +235,13 @@ export const connectSchema: ConnectSchema = {
       label: 'Framework',
       description: 'Use a client library',
       fields: ['framework', 'frameworkVariant', 'library', 'frameworkUi'],
+    },
+    {
+      id: 'server',
+      label: 'Server',
+      description: '@supabase/server',
+      fields: [],
+      prompt: serverConnectPrompt,
     },
     {
       id: 'direct',
@@ -222,12 +260,6 @@ export const connectSchema: ConnectSchema = {
       label: 'MCP',
       description: 'Connect your agent',
       fields: ['mcpClient', 'mcpReadonly', 'mcpFeatures'],
-    },
-    {
-      id: 'server',
-      label: 'Server',
-      description: '@supabase/server',
-      fields: [],
     },
   ],
 

--- a/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/connect.schema.ts
@@ -239,7 +239,7 @@ export const connectSchema: ConnectSchema = {
     {
       id: 'server',
       label: 'Server',
-      description: '@supabase/server',
+      description: 'Build APIs',
       fields: [],
       prompt: serverConnectPrompt,
     },

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/common/EnvRow.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/common/EnvRow.tsx
@@ -1,0 +1,19 @@
+export function EnvRow({
+  name,
+  value,
+  children,
+}: {
+  name: string
+  value: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="flex items-center gap-x-2 px-4 py-2.5 font-mono text-sm">
+      <span className="shrink-0 text-foreground-lighter">{name}=</span>
+      <span className="flex-1 truncate text-foreground" title={value}>
+        {value}
+      </span>
+      <div className="flex items-center gap-x-1">{children}</div>
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/common/SecretRow.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/common/SecretRow.tsx
@@ -1,0 +1,64 @@
+import { Eye, EyeOff } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button, cn, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
+import { ConnectServerEnvSecret, SERVER_ENV_VARS } from '../../../useConnectServerEnv'
+import { EnvRow } from './EnvRow'
+import CopyButton from '@/components/ui/CopyButton'
+
+export interface SecretEnvRowProps {
+  secret: ConnectServerEnvSecret
+}
+
+export function SecretEnvRow({ secret }: SecretEnvRowProps) {
+  const isDisabled = !secret.exists || !secret.canReveal
+
+  const onToggle = () => {
+    secret.toggle().catch(() => toast.error('Failed to reveal secret API key'))
+  }
+
+  const onCopy = async () => {
+    try {
+      return await secret.getValue()
+    } catch {
+      toast.error('Failed to copy secret API key')
+      return ''
+    }
+  }
+
+  const revealTooltip = !secret.exists
+    ? 'No secret key found for this project'
+    : !secret.canReveal
+      ? 'You need additional permissions to reveal secret API keys'
+      : secret.isRevealed
+        ? 'Hide secret key'
+        : 'Reveal secret key'
+
+  return (
+    <EnvRow name={SERVER_ENV_VARS.secretKey} value={secret.displayValue}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Button
+            variant="default"
+            size="tiny"
+            className={cn('px-1.5', isDisabled && 'opacity-50')}
+            aria-label={secret.isRevealed ? 'Hide secret key' : 'Reveal secret key'}
+            loading={secret.isRevealed && secret.isRevealing}
+            icon={secret.isRevealed ? <EyeOff strokeWidth={2} /> : <Eye strokeWidth={2} />}
+            onClick={onToggle}
+            disabled={isDisabled}
+          />
+        </TooltipTrigger>
+        <TooltipContent side="bottom">{revealTooltip}</TooltipContent>
+      </Tooltip>
+      <CopyButton
+        variant="default"
+        size="tiny"
+        iconOnly
+        aria-label="Copy secret key"
+        asyncText={onCopy}
+        disabled={isDisabled}
+      />
+    </EnvRow>
+  )
+}

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/env/content.test.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/env/content.test.tsx
@@ -1,0 +1,199 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { components } from 'api-types'
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import ServerEnvContent from './content'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+type ApiKeyResponse = components['schemas']['ApiKeyResponse']
+type ProjectSettingsResponse = components['schemas']['ProjectSettingsResponse']
+
+const { mockUseAsyncCheckPermissions } = vi.hoisted(() => ({
+  mockUseAsyncCheckPermissions: vi.fn(),
+}))
+vi.mock('@/hooks/misc/useCheckPermissions', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/hooks/misc/useCheckPermissions')>()),
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+// CopyButton writes via copyToClipboard from 'ui'. Stub just that export
+const { mockCopyToClipboard } = vi.hoisted(() => ({ mockCopyToClipboard: vi.fn() }))
+vi.mock('ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('ui')>()),
+  copyToClipboard: mockCopyToClipboard,
+}))
+
+const PROJECT_ENDPOINT = 'default.supabase.co'
+const PROJECT_URL = `https://${PROJECT_ENDPOINT}`
+const JWKS_URL = `${PROJECT_URL}/auth/v1/.well-known/jwks.json`
+const PUBLISHABLE_KEY = 'sb_publishable_abcdefghijklmnop'
+
+// The list endpoint returns the first 15 chars for a secret key; reveal-by-id
+// returns the full value.
+const SECRET_MASKED = 'sb_secret_abcde'
+const SECRET_FULL = 'sb_secret_abcdefghijklmnopqrstuv'
+
+function mockProjectSettings() {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref/settings',
+    response: () =>
+      HttpResponse.json<ProjectSettingsResponse>({
+        app_config: {
+          db_schema: 'public',
+          endpoint: PROJECT_ENDPOINT,
+          storage_endpoint: `storage.${PROJECT_ENDPOINT}`,
+        },
+        cloud_provider: 'AWS',
+        db_dns_name: PROJECT_ENDPOINT,
+        db_host: PROJECT_ENDPOINT,
+        db_ip_addr_config: 'ipv4',
+        db_name: 'postgres',
+        db_port: 5432,
+        db_user: 'postgres',
+        inserted_at: '2025-02-16T22:24:42.115195',
+        name: 'default',
+        ref: 'default',
+        region: 'us-east-1',
+        ssl_enforced: true,
+        status: 'ACTIVE_HEALTHY',
+      }),
+  })
+}
+
+function mockApiKeysList() {
+  addAPIMock({
+    method: 'get',
+    path: '/v1/projects/:ref/api-keys',
+    response: () =>
+      HttpResponse.json<ApiKeyResponse[]>([
+        {
+          id: 'pub-id',
+          name: 'default',
+          type: 'publishable',
+          api_key: PUBLISHABLE_KEY,
+          prefix: 'sb_publishable_',
+        },
+        {
+          id: 'secret-id',
+          name: 'default',
+          type: 'secret',
+          api_key: SECRET_MASKED,
+          prefix: 'sb_secret_',
+        },
+      ]),
+  })
+}
+
+function mockRevealSecret() {
+  addAPIMock({
+    method: 'get',
+    path: '/v1/projects/:ref/api-keys/:id',
+    response: () =>
+      HttpResponse.json<ApiKeyResponse>({
+        id: 'secret-id',
+        name: 'default',
+        type: 'secret',
+        api_key: SECRET_FULL,
+        prefix: 'sb_secret_',
+      }),
+  })
+}
+
+describe('ServerEnvContent', () => {
+  beforeEach(() => {
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true, isLoading: false, isSuccess: true })
+    mockCopyToClipboard.mockClear()
+  })
+
+  it('renders the project URL, publishable key, JWKS URL, and a masked secret', async () => {
+    mockProjectSettings()
+    mockApiKeysList()
+
+    customRender(<ServerEnvContent />)
+
+    expect(await screen.findByText(PROJECT_URL)).toBeInTheDocument()
+    expect(await screen.findByText(PUBLISHABLE_KEY)).toBeInTheDocument()
+    expect(screen.getByText(JWKS_URL)).toBeInTheDocument()
+
+    expect(screen.queryByText(SECRET_FULL)).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Reveal secret key' })).toBeEnabled()
+  })
+
+  it('reveals the full secret key when the reveal button is clicked', async () => {
+    mockProjectSettings()
+    mockApiKeysList()
+    mockRevealSecret()
+
+    customRender(<ServerEnvContent />)
+
+    await screen.findByText(PUBLISHABLE_KEY)
+    fireEvent.click(screen.getByRole('button', { name: 'Reveal secret key' }))
+
+    expect(await screen.findByText(SECRET_FULL)).toBeInTheDocument()
+  })
+
+  it('copies the full secret key (revealing it on demand)', async () => {
+    mockProjectSettings()
+    mockApiKeysList()
+    mockRevealSecret()
+
+    customRender(<ServerEnvContent />)
+
+    // The copy button is disabled until the api-keys load (secret exists).
+    await screen.findByText(PUBLISHABLE_KEY)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy secret key' }))
+
+    await waitFor(() => expect(mockCopyToClipboard).toHaveBeenCalledTimes(1))
+    await expect(Promise.resolve(mockCopyToClipboard.mock.calls[0][0])).resolves.toBe(SECRET_FULL)
+  })
+
+  it('copies the full .env, with the secret revealed, via "Copy all variables"', async () => {
+    mockProjectSettings()
+    mockApiKeysList()
+    mockRevealSecret()
+
+    customRender(<ServerEnvContent />)
+
+    // Wait for keys to load so buildEnv has real values.
+    await screen.findByText(PUBLISHABLE_KEY)
+    fireEvent.click(screen.getByRole('button', { name: 'Copy all variables' }))
+
+    await waitFor(() => expect(mockCopyToClipboard).toHaveBeenCalledTimes(1))
+    const copied = await Promise.resolve(mockCopyToClipboard.mock.calls[0][0])
+    expect(copied).toContain(`SUPABASE_URL=${PROJECT_URL}`)
+    expect(copied).toContain(`SUPABASE_PUBLISHABLE_KEY=${PUBLISHABLE_KEY}`)
+    expect(copied).toContain(`SUPABASE_SECRET_KEY=${SECRET_FULL}`)
+    expect(copied).toContain(`SUPABASE_JWKS_URL=${JWKS_URL}`)
+  })
+
+  describe('without service_api_keys permission', () => {
+    beforeEach(() => {
+      mockUseAsyncCheckPermissions.mockReturnValue({
+        can: false,
+        isLoading: false,
+        isSuccess: true,
+      })
+    })
+
+    it('still shows the public URL/JWKS but gates the keys and disables the secret', async () => {
+      mockProjectSettings()
+
+      customRender(<ServerEnvContent />)
+
+      // Public, settings-derived values are still available.
+      expect(await screen.findByText(PROJECT_URL)).toBeInTheDocument()
+      expect(screen.getByText(JWKS_URL)).toBeInTheDocument()
+
+      // Keys can't be read, so they fall back to placeholders...
+      expect(screen.getByText('your-publishable-key')).toBeInTheDocument()
+      expect(screen.getByText('your-secret-key')).toBeInTheDocument()
+
+      // ...and the secret's reveal/copy controls are disabled.
+      expect(screen.getByRole('button', { name: 'Reveal secret key' })).toBeDisabled()
+      expect(screen.getByRole('button', { name: 'Copy secret key' })).toBeDisabled()
+    })
+  })
+})

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/env/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/env/content.tsx
@@ -1,0 +1,80 @@
+import { useParams } from 'common'
+import Link from 'next/link'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns'
+
+import { EnvRow } from '../common/EnvRow'
+import { SecretEnvRow } from '../common/SecretRow'
+import {
+  SERVER_ENV_VARS,
+  useConnectServerEnv,
+} from '@/components/interfaces/ConnectSheet/useConnectServerEnv'
+import CopyButton from '@/components/ui/CopyButton'
+
+function ServerEnvContent() {
+  const { ref } = useParams()
+  const { apiUrl, publishableKey, jwksUrl, secret, buildEnv } = useConnectServerEnv()
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <div className="overflow-hidden rounded-lg border bg-surface-100">
+        <div className="flex items-center justify-between border-b bg-surface-200 px-4 py-2">
+          <span className="font-mono text-xs text-foreground-light">.env</span>
+          <CopyButton
+            variant="default"
+            size="tiny"
+            asyncText={buildEnv}
+            aria-label="Copy all variables"
+          />
+        </div>
+        <div className="divide-y">
+          <EnvRow name={SERVER_ENV_VARS.url} value={apiUrl}>
+            <CopyButton
+              variant="default"
+              size="tiny"
+              iconOnly
+              aria-label="Copy project URL"
+              text={apiUrl}
+            />
+          </EnvRow>
+          <EnvRow name={SERVER_ENV_VARS.publishableKey} value={publishableKey}>
+            <CopyButton
+              variant="default"
+              size="tiny"
+              iconOnly
+              aria-label="Copy publishable key"
+              text={publishableKey}
+            />
+          </EnvRow>
+          <SecretEnvRow secret={secret} />
+          <EnvRow name={SERVER_ENV_VARS.jwksUrl} value={jwksUrl}>
+            <CopyButton
+              variant="default"
+              size="tiny"
+              iconOnly
+              aria-label="Copy JWKS URL"
+              text={jwksUrl}
+            />
+          </EnvRow>
+        </div>
+      </div>
+
+      <Admonition
+        variant="default"
+        title="On Supabase Edge Functions these are injected automatically"
+        description="No setup is needed for Edge Functions. For other runtimes, copy the values above into your environment — SUPABASE_JWKS_URL is used to verify user JWTs. Need a secret key? Create or manage them in API Keys settings."
+        actions={
+          ref
+            ? [
+                <Button asChild key="api-keys" variant="default">
+                  <Link href={`/project/${ref}/settings/api-keys`}>View API keys</Link>
+                </Button>,
+              ]
+            : undefined
+        }
+      />
+    </div>
+  )
+}
+
+export default ServerEnvContent

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/env/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/env/content.tsx
@@ -62,7 +62,7 @@ function ServerEnvContent() {
       <Admonition
         variant="default"
         title="On Supabase Edge Functions these are injected automatically"
-        description="No setup is needed for Edge Functions. For other runtimes, copy the values above into your environment — SUPABASE_JWKS_URL is used to verify user JWTs. Need a secret key? Create or manage them in API Keys settings."
+        description="No setup is needed for Edge Functions. For other runtimes, copy the values above into your environment. Need a secret key? Create or manage them in API Keys settings."
         actions={
           ref
             ? [

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
@@ -5,11 +5,10 @@ import CopyButton from '@/components/ui/CopyButton'
 const INSTALL_OPTIONS = [
   { name: 'npm', command: 'npm install @supabase/server' },
   { name: 'pnpm', command: 'pnpm add @supabase/server' },
+  { name: 'bun', command: 'bun add @supabase/server'},
   { name: 'Deno', command: 'import { withSupabase } from "npm:@supabase/server"' },
 ]
 
-// A single install command is short, so render a compact tabbed row rather than
-// MultipleCodeBlock, which reserves a fixed ~288px height meant for multi-line files.
 function ServerInstallContent() {
   return (
     <Tabs_Shadcn_ defaultValue="npm" className="overflow-hidden rounded-lg border">

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
@@ -1,25 +1,51 @@
-import { MultipleCodeBlock } from 'ui-patterns/MultipleCodeBlock'
+import { Tabs_Shadcn_, TabsContent_Shadcn_, TabsList_Shadcn_, TabsTrigger_Shadcn_ } from 'ui'
 
+import CopyButton from '@/components/ui/CopyButton'
+
+const INSTALL_OPTIONS = [
+  { name: 'npm', command: 'npm install @supabase/server' },
+  { name: 'pnpm', command: 'pnpm add @supabase/server' },
+  { name: 'Deno', command: 'import { withSupabase } from "npm:@supabase/server"' },
+]
+
+// A single install command is short, so render a compact tabbed row rather than
+// MultipleCodeBlock, which reserves a fixed ~288px height meant for multi-line files.
 function ServerInstallContent() {
-  const files = [
-    {
-      name: 'npm',
-      language: 'bash',
-      code: 'npm install @supabase/server',
-    },
-    {
-      name: 'pnpm',
-      language: 'bash',
-      code: 'pnpm add @supabase/server',
-    },
-    {
-      name: 'Deno',
-      language: 'ts',
-      code: `import { withSupabase } from "npm:@supabase/server"`,
-    },
-  ]
-
-  return <MultipleCodeBlock files={files} />
+  return (
+    <Tabs_Shadcn_ defaultValue="npm" className="overflow-hidden rounded-lg border">
+      <TabsList_Shadcn_ className="gap-5 border-0 border-b bg-surface-75 px-4">
+        {INSTALL_OPTIONS.map((option) => (
+          <TabsTrigger_Shadcn_
+            key={option.name}
+            value={option.name}
+            className="px-0 py-2.5 text-xs data-[state=active]:bg-transparent"
+          >
+            {option.name}
+          </TabsTrigger_Shadcn_>
+        ))}
+      </TabsList_Shadcn_>
+      {INSTALL_OPTIONS.map((option) => (
+        <TabsContent_Shadcn_
+          key={option.name}
+          value={option.name}
+          className="m-0 data-[state=inactive]:hidden"
+        >
+          <div className="flex items-center gap-x-2 bg-surface-75 px-4 py-3">
+            <code className="flex-1 overflow-x-auto whitespace-nowrap font-mono text-sm text-foreground-light">
+              {option.command}
+            </code>
+            <CopyButton
+              variant="default"
+              size="tiny"
+              iconOnly
+              text={option.command}
+              aria-label={`Copy ${option.name} command`}
+            />
+          </div>
+        </TabsContent_Shadcn_>
+      ))}
+    </Tabs_Shadcn_>
+  )
 }
 
 export default ServerInstallContent

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
@@ -5,7 +5,7 @@ import CopyButton from '@/components/ui/CopyButton'
 const INSTALL_OPTIONS = [
   { name: 'npm', command: 'npm install @supabase/server' },
   { name: 'pnpm', command: 'pnpm add @supabase/server' },
-  { name: 'bun', command: 'bun add @supabase/server'},
+  { name: 'bun', command: 'bun add @supabase/server' },
   { name: 'Deno', command: 'import { withSupabase } from "npm:@supabase/server"' },
 ]
 

--- a/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/server/install/content.tsx
@@ -1,0 +1,25 @@
+import { MultipleCodeBlock } from 'ui-patterns/MultipleCodeBlock'
+
+function ServerInstallContent() {
+  const files = [
+    {
+      name: 'npm',
+      language: 'bash',
+      code: 'npm install @supabase/server',
+    },
+    {
+      name: 'pnpm',
+      language: 'bash',
+      code: 'pnpm add @supabase/server',
+    },
+    {
+      name: 'Deno',
+      language: 'ts',
+      code: `import { withSupabase } from "npm:@supabase/server"`,
+    },
+  ]
+
+  return <MultipleCodeBlock files={files} />
+}
+
+export default ServerInstallContent

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/skills-install/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/skills-install/content.tsx
@@ -4,13 +4,16 @@ import { Button, copyToClipboard } from 'ui'
 
 import type { StepContentProps } from '@/components/interfaces/ConnectSheet/Connect.types'
 
-const SKILLS_COMMAND = 'npx skills add supabase/agent-skills'
+const DEFAULT_SKILLS_COMMAND = 'npx skills add supabase/agent-skills'
+const SERVER_SKILLS_COMMAND = 'npx skills add supabase/server'
 
-function SkillsInstallContent(_props: StepContentProps) {
+function SkillsInstallContent({ state }: StepContentProps) {
   const [copyLabel, setCopyLabel] = useState('Copy')
 
+  const skillsCommand = state.mode === 'server' ? SERVER_SKILLS_COMMAND : DEFAULT_SKILLS_COMMAND
+
   const handleCopy = () => {
-    copyToClipboard(SKILLS_COMMAND, () => {
+    copyToClipboard(skillsCommand, () => {
       setCopyLabel('Copied')
       setTimeout(() => setCopyLabel('Copy'), 2000)
     })
@@ -19,7 +22,7 @@ function SkillsInstallContent(_props: StepContentProps) {
   return (
     <div className="relative group">
       <div className="bg-surface-75 border rounded-lg p-3 pr-20 font-mono text-sm text-foreground-light overflow-x-auto">
-        <code>{SKILLS_COMMAND}</code>
+        <code>{skillsCommand}</code>
       </div>
       <div className="absolute right-2 top-1/2 -translate-y-1/2">
         <Button

--- a/apps/studio/components/interfaces/ConnectSheet/useAvailableConnectModes.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/useAvailableConnectModes.ts
@@ -17,6 +17,7 @@ export function useAvailableConnectModes(): ConnectMode[] {
   return useMemo(() => {
     const allModes: { id: ConnectMode; enabled: boolean }[] = [
       { id: 'framework', enabled: showAppFrameworks || showMobileFrameworks },
+      { id: 'server', enabled: true },
       { id: 'direct', enabled: true },
       { id: 'orm', enabled: showOrms },
       { id: 'mcp', enabled: true },

--- a/apps/studio/components/interfaces/ConnectSheet/useConnectServerEnv.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/useConnectServerEnv.ts
@@ -1,0 +1,144 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { useParams } from 'common'
+import { useCallback, useEffect, useState } from 'react'
+
+import { useRevealedSecret } from '@/components/interfaces/APIKeys/useRevealedSecret'
+import { useAPIKeys } from '@/data/api-keys/api-keys-query'
+import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
+import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+
+const AUTO_HIDE_MS = 10_000
+const SECRET_MASK = '••••••••••••••••••••'
+
+export const SERVER_ENV_VARS = {
+  url: 'SUPABASE_URL',
+  publishableKey: 'SUPABASE_PUBLISHABLE_KEY',
+  secretKey: 'SUPABASE_SECRET_KEY',
+  jwksUrl: 'SUPABASE_JWKS_URL',
+} as const
+
+const JWKS_DISCOVERY_PATH = '/auth/v1/.well-known/jwks.json'
+
+export interface ConnectServerEnvSecret {
+  exists: boolean
+  canReveal: boolean
+  isRevealed: boolean
+  isRevealing: boolean
+  maskedValue: string
+  displayValue: string
+  toggle: () => Promise<void>
+  getValue: () => Promise<string>
+}
+
+export interface UseConnectServerEnvResult {
+  isLoading: boolean
+  apiUrl: string
+  publishableKey: string
+
+  // Public JWKS discovery endpoint, used to verify user JWTs.
+  jwksUrl: string
+  secret: ConnectServerEnvSecret
+
+  // Builds the full .env text, revealing the secret key on demand.
+  buildEnv: () => Promise<string>
+}
+
+
+export function useConnectServerEnv(): UseConnectServerEnvResult {
+  const { ref: projectRef } = useParams()
+
+  const { can: canReadAPIKeys, isLoading: isLoadingPermission } = useAsyncCheckPermissions(
+    PermissionAction.READ,
+    'service_api_keys'
+  )
+
+  const { data: apiUrl, isPending: isLoadingUrl } = useProjectApiUrl({ projectRef })
+  const { data: keys, isLoading: isLoadingKeys } = useAPIKeys(
+    { projectRef },
+    { enabled: canReadAPIKeys }
+  )
+
+  const canReveal = canReadAPIKeys
+
+  const resolvedUrl = apiUrl || 'your-project-url'
+  const publishableKey = keys?.publishableKey?.api_key ?? keys?.anonKey?.api_key ?? ''
+  const secretKey = keys?.secretKey
+
+  const jwksUrl = apiUrl
+    ? new URL(JWKS_DISCOVERY_PATH, apiUrl).href
+    : `your-project-url${JWKS_DISCOVERY_PATH}`
+
+  const {
+    data: revealedSecret,
+    isLoading: isRevealing,
+    reveal,
+    clear,
+  } = useRevealedSecret({ projectRef, id: secretKey?.id })
+
+  const [isRevealed, setIsRevealed] = useState(false)
+
+  useEffect(() => {
+    if (!isRevealed || !revealedSecret) return
+    const timer = setTimeout(() => {
+      setIsRevealed(false)
+      clear()
+    }, AUTO_HIDE_MS)
+    return () => clearTimeout(timer)
+  }, [isRevealed, revealedSecret, clear])
+
+  const maskedValue = secretKey?.api_key
+    ? `${secretKey.api_key.slice(0, 15)}${SECRET_MASK}`
+    : 'your-secret-key'
+
+  const toggle = useCallback(async () => {
+    if (!secretKey || !canReveal) return
+    if (isRevealed) {
+      setIsRevealed(false)
+      clear()
+    } else {
+      setIsRevealed(true)
+      try {
+        await reveal()
+      } catch {
+        setIsRevealed(false)
+        throw new Error('Failed to reveal secret API key')
+      }
+    }
+  }, [secretKey, canReveal, isRevealed, clear, reveal])
+
+  const getSecretValue = useCallback(async () => {
+    if (!secretKey || !canReveal) return 'your-secret-key'
+    if (revealedSecret) return revealedSecret
+    const value = await reveal()
+    if (!isRevealed) clear()
+    return value ?? 'your-secret-key'
+  }, [secretKey, canReveal, revealedSecret, reveal, isRevealed, clear])
+
+  const buildEnv = useCallback(async () => {
+    const secretValue = await getSecretValue()
+    return [
+      `${SERVER_ENV_VARS.url}=${resolvedUrl}`,
+      `${SERVER_ENV_VARS.publishableKey}=${publishableKey || 'your-publishable-key'}`,
+      `${SERVER_ENV_VARS.secretKey}=${secretValue}`,
+      `${SERVER_ENV_VARS.jwksUrl}=${jwksUrl}`,
+    ].join('\n')
+  }, [resolvedUrl, publishableKey, jwksUrl, getSecretValue])
+
+  return {
+    isLoading: isLoadingUrl || isLoadingKeys || isLoadingPermission,
+    apiUrl: resolvedUrl,
+    publishableKey: publishableKey || 'your-publishable-key',
+    jwksUrl,
+    secret: {
+      exists: !!secretKey,
+      canReveal,
+      isRevealed,
+      isRevealing,
+      maskedValue,
+      displayValue: isRevealed && revealedSecret ? revealedSecret : maskedValue,
+      toggle,
+      getValue: getSecretValue,
+    },
+    buildEnv,
+  }
+}

--- a/apps/studio/components/interfaces/ConnectSheet/useConnectServerEnv.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/useConnectServerEnv.ts
@@ -43,7 +43,6 @@ export interface UseConnectServerEnvResult {
   buildEnv: () => Promise<string>
 }
 
-
 export function useConnectServerEnv(): UseConnectServerEnvResult {
   const { ref: projectRef } = useParams()
 

--- a/apps/studio/components/interfaces/ProjectHome/ConnectSection.config.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ConnectSection.config.tsx
@@ -1,4 +1,4 @@
-import { Box, Cable, Database, KeyRound, Sparkles } from 'lucide-react'
+import { Box, Cable, Database, KeyRound, Server, Sparkles } from 'lucide-react'
 import type { ReactNode } from 'react'
 
 import type { ConnectMode } from '../ConnectSheet/Connect.types'
@@ -20,6 +20,13 @@ export const CONNECT_ACTIONS: ConnectAction[] = [
     heading: 'Framework',
     subheading: 'Use a client library',
     icon: <Box size={16} strokeWidth={1.5} />,
+  },
+  {
+    id: 'server',
+    mode: 'server',
+    heading: 'Server',
+    subheading: '@supabase/server',
+    icon: <Server size={16} strokeWidth={1.5} />,
   },
   {
     id: 'direct',

--- a/apps/studio/components/interfaces/ProjectHome/ConnectSection.config.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ConnectSection.config.tsx
@@ -25,7 +25,7 @@ export const CONNECT_ACTIONS: ConnectAction[] = [
     id: 'server',
     mode: 'server',
     heading: 'Server',
-    subheading: '@supabase/server',
+    subheading: 'Build APIs',
     icon: <Server size={16} strokeWidth={1.5} />,
   },
   {

--- a/apps/studio/components/interfaces/ProjectHome/ConnectSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ConnectSection.tsx
@@ -72,7 +72,7 @@ export const ConnectSection = () => {
         </div>
 
         <CardContent className="relative z-10 p-0">
-          <div className="grid grid-cols-1 xl:grid-cols-5 divide-y xl:divide-y-0 xl:divide-x border-muted">
+          <div className="grid grid-cols-1 xl:grid-cols-6 divide-y xl:divide-y-0 xl:divide-x border-muted">
             {availableActions.map((action) => (
               <button
                 key={action.id}

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1997,7 +1997,7 @@ export interface HomeConnectActionClickedEvent {
     /**
      * The connect action/tile that was clicked
      */
-    mode: 'framework' | 'direct' | 'orm' | 'mcp' | 'api_keys'
+    mode: 'framework' | 'direct' | 'orm' | 'mcp' | 'server' | 'api_keys'
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Introduced a new library called Superbase/Server. To help developers using third party API frameworks, we want to make it easier than ever to install and use as needed.
- One click copy
- Custom prompt to get started
- Validated API key permissions to ensure we don't leak secrets to other users in your org/project

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added a **Server** connection mode end-to-end, including mode-specific prompting and steps for installing **`@supabase/server`** and setting required variables.
- Added a server **.env** panel with per-variable copy, **“Copy all variables”**, and permission-aware secret reveal/copy.

## Improvements
- Updated connection UI layouts (mode selector grid and conditional config section).
- Improved prompt copying to use mode-specific prompt text when available.

## Tests
- Added UI tests for server env rendering, secret reveal/copy, **copy-all** behavior, and permission-restricted scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->