### PR TITLE
feat(docs) h1 dynamically generates anchors

### DIFF
--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -10,7 +10,7 @@ import { SerializeOptions } from '~/types/next-mdx-remote-serialize'
 import { ExternalLink } from 'lucide-react'
 import { type ReactNode } from 'react'
 import ReactMarkdown from 'react-markdown'
-import { cn } from 'ui'
+import { cn, Heading } from 'ui'
 
 const EDIT_LINK_SYMBOL = Symbol('edit link')
 interface EditLink {
@@ -97,9 +97,9 @@ const GuideTemplate = ({
             id="sb-docs-guide-main-article"
             className="prose max-w-none"
           >
-            <h1 className="mb-0 [&>p]:m-0">
+            <Heading tag="h1" className="mb-0 [&>p]:m-0">
               <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
-            </h1>
+            </Heading>
             {meta?.subtitle && (
               <h2 className="mt-3 text-xl text-foreground-light">
                 <ReactMarkdown>{meta.subtitle}</ReactMarkdown>

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -100,6 +100,11 @@ const components = {
   TabPanel,
   InfoTooltip,
   a: MdxAnchor,
+  h1: (props: any) => (
+    <Heading tag="h1" {...props}>
+      {props.children}
+    </Heading>
+  ),
   h2: (props: any) => (
     <Heading tag="h2" {...props}>
       {props.children}

--- a/apps/docs/features/ui/guide/GuideHeader.tsx
+++ b/apps/docs/features/ui/guide/GuideHeader.tsx
@@ -1,6 +1,8 @@
 'use client'
 
 import ReactMarkdown from 'react-markdown'
+import { Heading } from 'ui'
+
 import { useGuide } from './Guide'
 
 interface GuideHeaderProps {
@@ -12,9 +14,9 @@ export function GuideHeader({ className }: GuideHeaderProps) {
 
   return (
     <div className={className}>
-      <h1 className="mb-0 [&>p]:m-0">
+      <Heading tag="h1" className="mb-0 [&>p]:m-0">
         <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
-      </h1>
+      </Heading>
       {meta?.subtitle && (
         <h2 className="mt-3 text-xl text-foreground-light">
           <ReactMarkdown>{meta.subtitle}</ReactMarkdown>


### PR DESCRIPTION
Closes DOCS-875

<img width="1875" height="431" alt="Screenshot 2026-06-17 at 12 26 00 PM" src="https://github.com/user-attachments/assets/e09eed1b-68c4-4872-8d60-7303e766d0d9" />


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Swaps h1 for the UI `Heading` component in our Mdx and Guide templates so that we get its benefits.

This includes dynamic anchor links.

## What is the current behavior?

No anchor links on docs h1s.

## What is the new behavior?

Anchor links now included in docs h1s.
Does not include home page.

## Additional context

The original request was to also **add h1s to the sidebar.** In a page like [Backup and Restore using the CLI](https://supabase.com/docs/guides/platform/migrating-within-supabase/backup-restore).

However, I do not recommend this behavior because the standard convention is to have only one h1 per page.
Instead, I recommend demoting the h1s to h2s, the h2s to h3s, and so on.

## Tophatting

To review changes:
1. Preview any docs page from this PR.
2. Right click and **Inspect element** of the main header.
3. See an `id=` present.
4. Follow the same steps on the live site and see `id` is not present on the h1.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized heading rendering across documentation templates for improved consistency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->