### PR TITLE
fix(docs) Format MDX note in one paragraph

### DIFF
--- a/apps/docs/lib/mdx/plugins/remarkAdmonition.test.ts
+++ b/apps/docs/lib/mdx/plugins/remarkAdmonition.test.ts
@@ -1,0 +1,59 @@
+import { fromDocsMarkdown } from '~/features/directives/utils.server'
+import type { Content, Paragraph, Root } from 'mdast'
+import { gfmToMarkdown } from 'mdast-util-gfm'
+import type { MdxJsxFlowElement } from 'mdast-util-mdx'
+import { mdxToMarkdown } from 'mdast-util-mdx'
+import { toMarkdown } from 'mdast-util-to-markdown'
+import { describe, expect, it } from 'vitest'
+
+import remarkMkDocsAdmonition from './remarkAdmonition'
+
+function transformAndSerialize(markdown: string) {
+  const mdast = fromDocsMarkdown(markdown)
+  const transformed = remarkMkDocsAdmonition()(mdast)
+  const output = toMarkdown(transformed, { extensions: [mdxToMarkdown(), gfmToMarkdown()] })
+  const reparsed = fromDocsMarkdown(output)
+  return { transformed, output, reparsed }
+}
+
+function getAdmonition(root: Root): MdxJsxFlowElement {
+  const node = root.children[0]
+  expect(node.type).toBe('mdxJsxFlowElement')
+  return node as MdxJsxFlowElement
+}
+
+function getParagraph(node: Content): Paragraph {
+  expect(node.type).toBe('paragraph')
+  return node as Paragraph
+}
+
+describe('remarkMkDocsAdmonition', () => {
+  it('wraps inline admonition content in a single paragraph', () => {
+    const markdown = `!!! note "About Authentication"
+ HubSpot deprecated their legacy API Keys in November 2022. The \`api_key\` option in this wrapper accepts a **Private App Access Token**, which is HubSpot's recommended authentication method. See [HubSpot Private Apps](https://developers.hubspot.com/docs/guides/apps/private-apps/overview) for setup instructions.`
+
+    const { transformed, reparsed } = transformAndSerialize(markdown)
+
+    const admonition = getAdmonition(transformed)
+    expect(admonition.children).toHaveLength(1)
+    getParagraph(admonition.children[0])
+
+    const reparsedAdmonition = getAdmonition(reparsed)
+    expect(reparsedAdmonition.children).toHaveLength(1)
+    getParagraph(reparsedAdmonition.children[0])
+  })
+
+  it('keeps indented sibling blocks as separate children', () => {
+    const markdown = `!!! note
+
+    First indented paragraph.
+
+    Second indented paragraph.`
+
+    const { transformed } = transformAndSerialize(markdown)
+
+    const admonition = getAdmonition(transformed)
+    expect(admonition.children.length).toBeGreaterThanOrEqual(2)
+    expect(admonition.children.every((child) => child.type === 'paragraph')).toBe(true)
+  })
+})

--- a/apps/docs/lib/mdx/plugins/remarkAdmonition.ts
+++ b/apps/docs/lib/mdx/plugins/remarkAdmonition.ts
@@ -1,4 +1,4 @@
-import type { Content, Paragraph, Root } from 'mdast'
+import type { BlockContent, Content, Paragraph, Root } from 'mdast'
 import type { MdxJsxFlowElement } from 'mdast-util-mdx'
 import type { AdmonitionProps } from 'ui-patterns/admonition'
 import type { Node } from 'unist'
@@ -41,7 +41,7 @@ const remarkMkDocsAdmonition = function () {
         })
 
         // Wrap inline content in a single paragraph so MDX does not emit one <p> per node.
-        const children: Content[] = [
+        const children: MdxJsxFlowElement['children'] = [
           ...(inlineChildren.length > 0
             ? [{ type: 'paragraph' as const, children: inlineChildren }]
             : []),
@@ -88,7 +88,12 @@ const remarkMkDocsAdmonition = function () {
  *
  * Splices the discovered siblings out of the original parent and returns them.
  */
-function extractLinkedSiblings(parent: Root, node: Node, index: number, indentAmount = 4) {
+function extractLinkedSiblings(
+  parent: Root,
+  node: Node,
+  index: number,
+  indentAmount = 4
+): BlockContent[] {
   const { column } = node.position?.start || { column: 0 }
 
   let nextSibling: Content
@@ -98,7 +103,7 @@ function extractLinkedSiblings(parent: Root, node: Node, index: number, indentAm
     nextSibling = parent.children[++i]
   } while (nextSibling?.position && nextSibling.position.start.column === column + indentAmount)
 
-  return parent.children.splice(index + 1, i - index - 1)
+  return parent.children.splice(index + 1, i - index - 1) as BlockContent[]
 }
 
 /**

--- a/apps/docs/lib/mdx/plugins/remarkAdmonition.ts
+++ b/apps/docs/lib/mdx/plugins/remarkAdmonition.ts
@@ -35,7 +35,18 @@ const remarkMkDocsAdmonition = function () {
         // Extract sibling nodes that should be linked to this admonition
         const siblingsToNest = extractLinkedSiblings(parent, paragraph, index)
 
-        const children: any[] = [...paragraph.children, ...siblingsToNest]
+        const inlineChildren = paragraph.children.filter((child) => {
+          if (child.type === 'text') return child.value.trim().length > 0
+          return true
+        })
+
+        // Wrap inline content in a single paragraph so MDX does not emit one <p> per node.
+        const children: Content[] = [
+          ...(inlineChildren.length > 0
+            ? [{ type: 'paragraph' as const, children: inlineChildren }]
+            : []),
+          ...siblingsToNest,
+        ]
 
         // Generate a Supabase Admonition JSX element
         const admonitionElement: MdxJsxFlowElement = {


### PR DESCRIPTION
Closes DOCS-994

<img width="784" height="171" alt="Screenshot 2026-06-17 at 3 50 27 PM" src="https://github.com/user-attachments/assets/4ff4afc4-2bc8-4a71-95d8-655171b317b6" />



## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Problem

The formatting for `!!! note` breaks out multiple nodes when using `code notation`. 

## Fix

This PR formats the `Annotation` MDX component so that it groups the components into one paragraph rather than multiple.

It also includes a test file, using the example given in the Linear issue.

## Tophatting

1. Go to [Hubspot](https://docs-git-docs-format-note-p-supabase.vercel.app/docs/guides/database/extensions/wrappers/hubspot) in preview.
2. See that the note is formatted correctly. Compare to production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a Vitest suite to verify admonition transformation and round-trip markdown parsing, including inline wrapping and preservation of multiple indented content blocks.
* **Bug Fixes**
  * Improved admonition rendering so inline admonition content is grouped into a single paragraph and whitespace-only text is ignored.
  * When admonitions include multiple sibling blocks, those blocks are kept as separate paragraph children for consistent output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->