### PR TITLE
Chore/marketplace feature preview to show only if flag true

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -24,6 +24,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
   const pgDeltaDiffEnabled = useFlag('pgdeltaDiff')
   const platformWebhooksEnabled = useFlag('platformWebhooks')
   const jitDbAccessEnabled = useFlag('jitDbAccess')
+  const isMarketplaceEnabled = useFlag('marketplaceIntegrations')
 
   return useMemo(
     () =>
@@ -102,12 +103,18 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
           key: LOCAL_STORAGE_KEYS.UI_PREVIEW_MARKETPLACE,
           name: 'Integrations layout',
           discussionsUrl: undefined,
-          enabled: true,
+          enabled: isMarketplaceEnabled,
           isNew: true,
           isPlatformOnly: false,
           isDefaultOptIn: true,
         },
       ].sort((a, b) => Number(b.isNew) - Number(a.isNew)),
-    [isUnifiedLogsPreviewAvailable, pgDeltaDiffEnabled, platformWebhooksEnabled, jitDbAccessEnabled]
+    [
+      isUnifiedLogsPreviewAvailable,
+      pgDeltaDiffEnabled,
+      platformWebhooksEnabled,
+      jitDbAccessEnabled,
+      isMarketplaceEnabled,
+    ]
   )
 }

--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -105,8 +105,9 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
           discussionsUrl: undefined,
           enabled: isMarketplaceEnabled,
           isNew: true,
-          isPlatformOnly: false,
-          isDefaultOptIn: true,
+          isPlatformOnly: true,
+          isDefaultOptIn: false,
+          getRoute: (ref?: string) => `/project/${ref}/integrations`,
         },
       ].sort((a, b) => Number(b.isNew) - Number(a.isNew)),
     [


### PR DESCRIPTION
## Context

Marketplace integrations feature preview is currently showing up in the feature preview modal irregardless - it should be flagged against the config cat flag

Also added the `getRoute` param for it, and also set `isPlatformOnly` to true and `isDefaultOptIn` to false

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Integrations layout" feature preview controlled by a feature flag. Users can now access integrations functionality through this dedicated preview item. The feature is marked as new, platform-exclusive, and available for user opt-in, directing users to their project's integrations page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->