### PR TITLE
Remove custom label for SignInWithExternalProvider

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInWithExternalProvider.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInWithExternalProvider.tsx
@@ -17,14 +17,9 @@ import { auth, buildPathWithParams } from '@/lib/gotrue'
 
 interface SignInWithExternalProviderProps {
   provider: ExternalIdentityProviderConfig
-  /** Overrides the default "Continue with {provider}" button label (e.g. a focused "Continue"). */
-  label?: string
 }
 
-export const SignInWithExternalProvider = ({
-  provider,
-  label,
-}: SignInWithExternalProviderProps) => {
+export const SignInWithExternalProvider = ({ provider }: SignInWithExternalProviderProps) => {
   const [loading, setLoading] = useState(false)
   const [, setLastSignInUsed] = useLastSignIn()
 
@@ -64,7 +59,7 @@ export const SignInWithExternalProvider = ({
         variant="outline"
         loading={loading}
       >
-        {label ?? `Continue with ${provider.displayName}`}
+        Continue with {provider.displayName}
       </Button>
     </LastSignInWrapper>
   )

--- a/apps/studio/pages/sign-in.tsx
+++ b/apps/studio/pages/sign-in.tsx
@@ -95,7 +95,7 @@ const SignInPage: NextPageWithLayout = () => {
 
     return (
       <div className="flex flex-col gap-5">
-        <SignInWithExternalProvider provider={focusProvider} label="Continue" />
+        <SignInWithExternalProvider provider={focusProvider} />
         {hasOtherOptions &&
           (showOtherOptions ? (
             renderAuthOptions(otherProviders, 'bg-surface-100')

--- a/apps/studio/pages/sign-up.tsx
+++ b/apps/studio/pages/sign-up.tsx
@@ -56,7 +56,7 @@ const SignUpPage: NextPageWithLayout = () => {
 
     return (
       <div className="flex flex-col gap-5">
-        <SignInWithExternalProvider provider={focusProvider} label="Continue" />
+        <SignInWithExternalProvider provider={focusProvider} />
         {showOtherOptions ? (
           renderAuthOptions(otherProviders, 'bg-surface-100')
         ) : (


### PR DESCRIPTION
## Context

Tiny UI nudge to just use the full "Continue with ___" text in the `SignInWithExternalProvider` UI (can repro by adding a `?method=` param in the URL on the sign in page)

### Before
<img width="520" height="692" alt="image" src="https://github.com/user-attachments/assets/f120ade1-8b82-459d-9d82-99027a86bdfd" />


### After
<img width="469" height="669" alt="image" src="https://github.com/user-attachments/assets/7076132a-dee5-40d0-a261-d357808b92b0" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized the external authentication provider button text across sign-in and sign-up flows. The primary provider option now consistently displays **“Continue with [provider name]”**, including the focused-provider paths, ensuring uniform labeling instead of relying on caller-provided overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->