### PR TITLE
fix(billing): clicking outside downgrade modal closes it

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -2,14 +2,15 @@ import { MinusCircle, PauseCircle } from 'lucide-react'
 import { useMemo } from 'react'
 import { plans as subscriptionsPlans } from 'shared-data/plans'
 import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
+  Button,
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogSectionSeparator,
+  DialogTitle,
 } from 'ui'
 import { Admonition } from 'ui-patterns'
 
@@ -96,96 +97,93 @@ export const DowngradeModal = ({
   )
 
   return (
-    <AlertDialog open={visible} onOpenChange={onClose}>
-      <AlertDialogContent size="large">
-        <AlertDialogHeader>
-          <AlertDialogTitle>{`Confirm to downgrade to ${selectedPlan?.name} plan`}</AlertDialogTitle>
-          <AlertDialogDescription asChild>
-            <div>
-              <div className="flex flex-col space-y-2">
-                <Admonition
-                  type="warning"
-                  title="Downgrading to the Free Plan will lead to reductions in your organization's quota"
-                  description="If you're already past the limits of the Free Plan, your projects could become
+    <Dialog open={visible} onOpenChange={onClose}>
+      <DialogContent size="large">
+        <DialogHeader>
+          <DialogTitle>{`Confirm to downgrade to ${selectedPlan?.name} plan`}</DialogTitle>
+        </DialogHeader>
+        <DialogSectionSeparator />
+        <div className="px-5 py-4 text-foreground-light">
+          <div className="flex flex-col space-y-2">
+            <Admonition
+              type="warning"
+              title="Downgrading to the Free Plan will lead to reductions in your organization's quota"
+              description="If you're already past the limits of the Free Plan, your projects could become
                   unresponsive or enter read only mode."
-                />
+            />
 
-                {((previousProjectAddons.length ?? 0) > 0 || hasInstancesOnMicro) && (
-                  <Admonition type="warning" title="Projects affected by the downgrade">
-                    <ul className="space-y-1 max-h-[100px] overflow-y-auto">
-                      {previousProjectAddons.map((project) => (
-                        <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
-                      ))}
+            {((previousProjectAddons.length ?? 0) > 0 || hasInstancesOnMicro) && (
+              <Admonition type="warning" title="Projects affected by the downgrade">
+                <ul className="space-y-1 max-h-[100px] overflow-y-auto">
+                  {previousProjectAddons.map((project) => (
+                    <ProjectDowngradeListItem key={project.ref} projectAddon={project} />
+                  ))}
 
-                      {projects
-                        .filter((it) => {
-                          const computeSize = getComputeSize(it)
-                          return computeSize === 'micro'
-                        })
-                        .map((project) => (
-                          <li className="list-disc ml-6" key={project.ref}>
-                            {project.name}: Compute will be downgraded. Project will also{' '}
-                            <span className="font-bold">need to be restarted</span>.
-                          </li>
-                        ))}
-                    </ul>
-                  </Admonition>
-                )}
+                  {projects
+                    .filter((it) => {
+                      const computeSize = getComputeSize(it)
+                      return computeSize === 'micro'
+                    })
+                    .map((project) => (
+                      <li className="list-disc ml-6" key={project.ref}>
+                        {project.name}: Compute will be downgraded. Project will also{' '}
+                        <span className="font-bold">need to be restarted</span>.
+                      </li>
+                    ))}
+                </ul>
+              </Admonition>
+            )}
+          </div>
+
+          {hasPostCutoffProjects && (
+            <Admonition
+              type="warning"
+              className="mt-2"
+              title="Any custom email templates will be reset"
+              description="Downgrading will reset your custom email templates to their defaults. You won’t be able to edit them unless you set up custom SMTP after downgrading."
+            />
+          )}
+
+          <ul className="mt-4 space-y-5 text-sm">
+            <li className="flex items-center gap-3">
+              <PauseCircle size={18} />
+              <span>Projects will be paused after a week of inactivity</span>
+            </li>
+
+            <li className="flex items-center gap-3 mb-2">
+              <MinusCircle size={18} />
+              <span>Add ons from all projects under this organization will be removed.</span>
+            </li>
+
+            <li className="flex gap-3">
+              <div>
+                <strong>Before you downgrade to the {selectedPlan?.name} plan, consider:</strong>
+                <ul className="space-y-2 mt-2">
+                  <li className="list-disc ml-6 text-foreground-light">
+                    Your projects no longer require their respective add-ons.
+                  </li>
+                  <li className="list-disc ml-6 text-foreground-light">
+                    Your resource consumption are well within the {selectedPlan?.name} plan's quota.
+                  </li>
+                  <li className="list-disc ml-6 text-foreground-light">
+                    Alternatively, you may also transfer projects across organizations.
+                  </li>
+                </ul>
               </div>
+            </li>
+          </ul>
 
-              {hasPostCutoffProjects && (
-                <Admonition
-                  type="warning"
-                  className="mt-2"
-                  title="Any custom email templates will be reset"
-                  description="Downgrading will reset your custom email templates to their defaults. You won’t be able to edit them unless you set up custom SMTP after downgrading."
-                />
-              )}
-
-              <ul className="mt-4 space-y-5 text-sm">
-                <li className="flex items-center gap-3">
-                  <PauseCircle size={18} />
-                  <span>Projects will be paused after a week of inactivity</span>
-                </li>
-
-                <li className="flex items-center gap-3 mb-2">
-                  <MinusCircle size={18} />
-                  <span>Add ons from all projects under this organization will be removed.</span>
-                </li>
-
-                <li className="flex gap-3">
-                  <div>
-                    <strong>
-                      Before you downgrade to the {selectedPlan?.name} plan, consider:
-                    </strong>
-                    <ul className="space-y-2 mt-2">
-                      <li className="list-disc ml-6 text-foreground-light">
-                        Your projects no longer require their respective add-ons.
-                      </li>
-                      <li className="list-disc ml-6 text-foreground-light">
-                        Your resource consumption are well within the {selectedPlan?.name} plan's
-                        quota.
-                      </li>
-                      <li className="list-disc ml-6 text-foreground-light">
-                        Alternatively, you may also transfer projects across organizations.
-                      </li>
-                    </ul>
-                  </div>
-                </li>
-              </ul>
-
-              {subscription?.billing_via_partner === true &&
-                subscription.billing_partner === 'fly' && (
-                  <p className="mt-4 text-sm">
-                    Your organization will be downgraded at the end of your current billing cycle.
-                  </p>
-                )}
-            </div>
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction
+          {subscription?.billing_via_partner === true && subscription.billing_partner === 'fly' && (
+            <p className="mt-4 text-sm">
+              Your organization will be downgraded at the end of your current billing cycle.
+            </p>
+          )}
+        </div>
+        <DialogFooter>
+          <Button variant={'default'} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
             disabled={confirmDisabled ?? false}
             variant="warning"
             onClick={(e) => {
@@ -194,9 +192,9 @@ export const DowngradeModal = ({
             }}
           >
             Confirm
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   )
 }

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -98,7 +98,7 @@ export const DowngradeModal = ({
     <Dialog open={visible} onOpenChange={onClose}>
       <DialogContent size="large">
         <DialogHeader>
-          <DialogTitle>{`Confirm to downgrade to ${selectedPlan?.name} plan`}</DialogTitle>
+          <DialogTitle>Confirm to downgrade to {selectedPlan?.name} plan</DialogTitle>
         </DialogHeader>
         <DialogSectionSeparator />
         <div className="px-5 py-4 text-foreground-light">

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/DowngradeModal.tsx
@@ -4,9 +4,7 @@ import { plans as subscriptionsPlans } from 'shared-data/plans'
 import {
   Button,
   Dialog,
-  DialogClose,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogSectionSeparator,


### PR DESCRIPTION
Replaced the `DowngradeModal`'s `AlertDialog` with a normal `Dialog`, since `AlertDialog` won't close if you click outside the modal by design.


Left is current PR, right is staging:
<img width="1600" height="537" alt="Screenshot 2026-06-18 at 10 07 46" src="https://github.com/user-attachments/assets/ce1bcc17-d1c9-4fcd-ad3b-f2fcfd8824f6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the downgrade confirmation modal to use the newer dialog component set and layout.
  * Preserved the same downgrade warnings, checklist content, and billing notice.
  * Kept existing confirm/cancel behavior, including disabled-state handling for the confirm action.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->