### PR TITLE
Prettify account identities for custom providers

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
@@ -52,6 +52,7 @@ export const AccountIdentities = () => {
   const router = useRouter()
 
   const { data, isPending: isLoading, isSuccess } = useProfileIdentitiesQuery()
+  console.log(data)
 
   const enabledProviders = useEnabledIdentityProviders()
   const connectableExternalProviders = useMemo(
@@ -142,8 +143,8 @@ export const AccountIdentities = () => {
           {isSuccess && (
             <div className="divide-y">
               {identities.map((identity) => {
-                const { identity_id, provider } = identity
-                const username = identity.identity_data?.user_name
+                const { identity_id, identity_data, provider } = identity
+                const username = identity_data?.user_name
                 const providerDisplay = getProviderDisplay(provider)
                 const providerName = providerDisplay.displayName
                 const configuredProvider = getConfiguredExternalProvider(provider)

--- a/apps/studio/lib/external-identity-providers.ts
+++ b/apps/studio/lib/external-identity-providers.ts
@@ -70,6 +70,14 @@ export function getProviderDisplay(provider: string): IdentityProviderDisplay {
     }
   }
 
+  if (provider.startsWith('custom:')) {
+    return {
+      id: provider,
+      displayName: provider.replace('custom:', ''),
+      iconPath: `${BASE_PATH}/img/icons/saml-icon.svg`,
+    }
+  }
+
   if (provider.startsWith('sso')) {
     return {
       id: provider,


### PR DESCRIPTION
## Context

Super tiny improvement - just strips away `custom:` from the identity name for rendering in the UI