### PR TITLE
Fix button styles

### DIFF
--- a/apps/www/pages/careers.tsx
+++ b/apps/www/pages/careers.tsx
@@ -131,7 +131,7 @@ const CareerPage = ({ jobs, placeholderJob, contributors }: CareersPageProps) =>
           <p className="text-sm md:text-base text-foreground-lighter max-w-sm sm:max-w-md md:max-w-lg mx-auto">
             Explore remote opportunities and join our team to help us achieve it.
           </p>
-          <Button asChild variant="primary" className="mt-4 mx-auto w-fit">
+          <Button asChild variant="primary" className="mt-4">
             <Link href="#positions">Open positions</Link>
           </Button>
         </header>

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -209,7 +209,7 @@ export interface ButtonProps
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     // omit 'disabled' as it is included in HTMLButtonElement
     Omit<ButtonVariantProps, 'disabled'>,
-    Omit<LoadingVariantProps, 'type'> {
+    LoadingVariantProps {
   asChild?: boolean
   variant?: ButtonVariantProps['variant']
   icon?: React.ReactNode

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -11,7 +11,7 @@ import { cn } from '../../lib/utils/cn'
 export type ButtonVariantProps = VariantProps<typeof buttonVariants>
 const buttonVariants = cva(
   `relative
-  flex items-center justify-center
+  inline-flex items-center justify-center
   cursor-pointer
   space-x-2
   text-center
@@ -165,7 +165,7 @@ const IconContainerVariants = cva('inline-flex items-center justify-center shrin
       xxlarge: '[&_svg]:h-[30px] [&_svg]:w-[30px]',
       xxxlarge: '[&_svg]:h-[42px] [&_svg]:w-[42px]',
     },
-    type: {
+    variant: {
       primary: 'text-brand-600',
       default: 'text-foreground-lighter',
       secondary: 'text-border-muted',
@@ -183,7 +183,7 @@ const IconContainerVariants = cva('inline-flex items-center justify-center shrin
 export type LoadingVariantProps = VariantProps<typeof loadingVariants>
 const loadingVariants = cva('', {
   variants: {
-    type: {
+    variant: {
       primary: 'text-brand-600',
       default: 'text-foreground-lighter',
       secondary: 'text-border-muted',
@@ -258,10 +258,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         {...props}
         disabled={disabled}
         tabIndex={computedTabIndex}
-        className={cn(
-          buttonVariants({ variant: variant, size, disabled, block, rounded }),
-          className
-        )}
+        className={cn(buttonVariants({ variant, size, disabled, block, rounded }), className)}
         onClick={(e) => {
           // [Joshen] Prevents redirecting if Button is used with a link-based child element
           if (disabled) return e.preventDefault()
@@ -275,21 +272,17 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
               undefined,
               showIcon &&
                 (loading ? (
-                  <div className={cn(IconContainerVariants({ size, type: variant }))}>
-                    <Loader2 className={cn(loadingVariants({ loading, type: variant }))} />
+                  <div className={cn(IconContainerVariants({ size, variant }))}>
+                    <Loader2 className={cn(loadingVariants({ loading, variant }))} />
                   </div>
                 ) : _iconLeft ? (
-                  <div className={cn(IconContainerVariants({ size, type: variant }))}>
-                    {_iconLeft}
-                  </div>
+                  <div className={cn(IconContainerVariants({ size, variant }))}>{_iconLeft}</div>
                 ) : null),
               children.props.children && (
                 <span className={'truncate'}>{children.props.children}</span>
               ),
               iconRight && !loading && (
-                <div className={cn(IconContainerVariants({ size, type: variant }))}>
-                  {iconRight}
-                </div>
+                <div className={cn(IconContainerVariants({ size, variant }))}>{iconRight}</div>
               )
             )
           ) : null
@@ -297,17 +290,15 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           <>
             {showIcon &&
               (loading ? (
-                <div className={cn(IconContainerVariants({ size, type: variant }))}>
-                  <Loader2 className={cn(loadingVariants({ loading, type: variant }))} />
+                <div className={cn(IconContainerVariants({ size, variant }))}>
+                  <Loader2 className={cn(loadingVariants({ loading, variant }))} />
                 </div>
               ) : _iconLeft ? (
-                <div className={cn(IconContainerVariants({ size, type: variant }))}>
-                  {_iconLeft}
-                </div>
+                <div className={cn(IconContainerVariants({ size, variant }))}>{_iconLeft}</div>
               ) : null)}{' '}
             {children && <span className={'truncate'}>{children}</span>}{' '}
             {iconRight && !loading && (
-              <div className={cn(IconContainerVariants({ size, type: variant }))}>{iconRight}</div>
+              <div className={cn(IconContainerVariants({ size, variant }))}>{iconRight}</div>
             )}
           </>
         )}


### PR DESCRIPTION
## Problem

When we restored the `Button` focus styles in [46800](https://github.com/supabase/supabase/pull/46800/changes#diff-97973c54c2ac5270cf2d68e8f372365341693c8ae9d540ed62e0f614bfe92cf0L16), we removed the wrong duplicate `display` property (`inline-flex` instead of `flex`). This made some buttons take up as much space as available on some pages:

<img width="2992" height="1628" alt="image" src="https://github.com/user-attachments/assets/63943b27-10de-453a-ac96-51b3dbff633d" />

<img width="1216" height="952" alt="image" src="https://github.com/user-attachments/assets/24aa02c4-66b0-4c34-a3d4-39c4c74fec7a" />

## Solution

Use `inline-flex` instead of `flex` (it's one or the other, cannot be both).

<img width="1277" height="566" alt="image" src="https://github.com/user-attachments/assets/4add0aff-7afc-4e8f-9b57-16f93be99689" />

<img width="756" height="493" alt="image" src="https://github.com/user-attachments/assets/b3f8c8ec-4e89-40f1-b14b-10a141887370" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated button layout rendering to use `inline-flex` instead of `flex`, improving how buttons align within inline contexts.
  * Refreshed button icon/loading styling configuration (including icon container and loader behavior) to keep visual states consistent.
  * Adjusted the “Open positions” primary button spacing on the careers page, changing its alignment to better match the header layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->