### PR TITLE
fix(a11y): add tooltip to SQL Editor new query button

### DIFF
--- a/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
+++ b/apps/studio/components/layouts/SQLEditorLayout/SQLEditorMenu.tsx
@@ -22,6 +22,7 @@ import {
   InnerSideBarFilterSortDropdownItem,
 } from 'ui-patterns/InnerSideMenu'
 
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { SearchList } from './SQLEditorNavV2/SearchList'
 import { SQLEditorNav } from './SQLEditorNavV2/SQLEditorNav'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
@@ -136,11 +137,12 @@ export const SQLEditorMenu = () => {
           </InnerSideBarFilters>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
+              <ButtonTooltip
                 data-testid="sql-editor-new-query-button"
                 variant="default"
                 icon={<Plus className="text-foreground" />}
                 className="w-[26px]"
+                tooltip={{ content: { text: 'New query' } }}
               />
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" side="bottom" className="w-48">


### PR DESCRIPTION

The `+` button in the SQL Editor sidebar had no tooltip, making its purpose unclear to new users.

Replaced `Button` with `ButtonTooltip` following the same pattern used in #44526.

Relates to #44524


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltip to the "New query" button in SQL Editor menu for improved user guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->