### PR TITLE
bug: table editor default value background color

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/Column.tsx
@@ -269,7 +269,7 @@ export const Column = ({
             size="small"
             value={column.defaultValue ?? ''}
             disabled={column.format.includes('int') && column.isIdentity}
-            className={`rounded-sm bg-surface-100 lg:gap-0 ${
+            className={`rounded-sm lg:gap-0 ${
               column.format.includes('int') && column.isIdentity ? 'opacity-50' : ''
             }`}
             suggestions={suggestions}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > Table Editor > New/Edit Table

## What is the current behavior?

The `Default Value` has a white background and not matching the same styling:

<img width="776" height="837" alt="Screenshot 2026-06-18 at 13 20 12" src="https://github.com/user-attachments/assets/b48674d9-20cd-409a-8e9f-387d4fe9f87a" />


## What is the new behavior?

Input matches the other styling:

<img width="776" height="837" alt="Screenshot 2026-06-18 at 13 20 25" src="https://github.com/user-attachments/assets/30cef35a-cab7-4141-bc9c-851e0881d8cb" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated styling for input fields in the table column editor to provide a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->