### PR TITLE
chore: Login to Docker Hub in e2e CI workflow to avoid rate limiting

### DIFF
--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -83,6 +83,13 @@ jobs:
         if: steps.filter.outputs.studio == 'true'
         run: rm -rf supabase && pnpm exec supabase init && mkdir supabase/functions
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+        if: steps.filter.outputs.studio == 'true'
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
       - name: Pre-start diagnostics
         run: |
           docker ps -a

--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -83,12 +83,17 @@ jobs:
         if: steps.filter.outputs.studio == 'true'
         run: rm -rf supabase && pnpm exec supabase init && mkdir supabase/functions
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
+      # Authenticate with AWS ECR to avoid rate limiting
+      - name: configure aws credentials
+        if: steps.filter.outputs.studio == 'true'
+        uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
+        with:
+          role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
+          aws-region: us-east-1
+      - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
         if: steps.filter.outputs.studio == 'true'
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: public.ecr.aws
 
       - name: Pre-start diagnostics
         run: |

--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -23,7 +23,8 @@ jobs:
       tests_ran: ${{ steps.filter.outputs.studio == 'true' }}
 
     permissions:
-      contents: write
+      contents: read
+      id-token: write
     env:
       OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
 


### PR DESCRIPTION
## Problem

As the e2e workflow starts the Supabase CLI, it downloads all our images from the AWS ECR for every run. This makes many anonymous pulls that are rate limited.

## Solution

Authenticate on AWS ECR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Chores
* Updated the Studio E2E test workflow to include AWS ECR authentication. The workflow now uses tightened job permissions and conditionally authenticates with AWS and Docker registries to reliably pull required container images while improving security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->