### PR TITLE
chore: Handle SharedData component for md output

### DIFF
--- a/apps/docs/components/SharedData.tsx
+++ b/apps/docs/components/SharedData.tsx
@@ -1,6 +1,7 @@
-import { at } from 'lodash-es'
 import { ReactNode } from 'react'
 import { config, logConstants } from 'shared-data'
+
+import { resolveSharedDataPath } from './SharedData.utils'
 
 const sharedData = {
   config,
@@ -25,12 +26,10 @@ function SharedData({
   data: keyof typeof sharedData
   children: ((selectedData: (typeof sharedData)[keyof typeof sharedData]) => ReactNode) | string
 }) {
-  let selectedData = sharedData[data] as any
-  return typeof children === 'string'
-    ? ((typeof (selectedData = at(selectedData, [children])[0]) === 'object'
-        ? `${selectedData.value ?? ''} ${selectedData.unit ?? ''}`.trim()
-        : selectedData) as unknown as ReactNode)
-    : children(selectedData)
+  if (typeof children === 'string') {
+    return resolveSharedDataPath(sharedData[data], children) as ReactNode
+  }
+  return children(sharedData[data])
 }
 
 export { SharedData }

--- a/apps/docs/components/SharedData.utils.ts
+++ b/apps/docs/components/SharedData.utils.ts
@@ -1,0 +1,19 @@
+import { at } from 'lodash-es'
+
+/**
+ * Resolves a dot/bracket path within a shared-data dataset. If the resolved
+ * value is an object with `value`/`unit` fields, returns `${value} ${unit}`
+ * (trimmed); otherwise returns the resolved primitive as-is.
+ *
+ * Pure: no `shared-data` import. Callers supply the dataset so this util can
+ * be reused by the React `<SharedData>` component (Next.js bundle) and by the
+ * build-time markdown-schema handler (tsx) without each having to navigate
+ * `shared-data`'s ESM/CJS interop independently.
+ */
+export function resolveSharedDataPath(dataset: unknown, path: string): string | number | undefined {
+  const selected = at(dataset as any, [path])[0]
+  if (typeof selected === 'object' && selected !== null) {
+    return `${(selected as any).value ?? ''} ${(selected as any).unit ?? ''}`.trim()
+  }
+  return selected
+}

--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -13,6 +13,7 @@ import { mdxjs } from 'micromark-extension-mdxjs'
 
 import { getInternalLinkBaseUrl, prefixInternalLinks } from './internal-links'
 import { Admonition } from './markdown-schema/Admonition'
+import { ComputeDiskLimitsTable } from './markdown-schema/ComputeDiskLimitsTable'
 import { Link } from './markdown-schema/Link'
 import { MetricsStackCards } from './markdown-schema/MetricsStackCards'
 import { Panel } from './markdown-schema/Panel'
@@ -132,6 +133,7 @@ function applySchema(parent: Parent, schema: ComponentSchema): void {
  */
 const SCHEMA: ComponentSchema = {
   Admonition,
+  ComputeDiskLimitsTable,
   Link,
   Price,
   GlassPanel: Panel,

--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -16,9 +16,10 @@ import { Admonition } from './markdown-schema/Admonition'
 import { Link } from './markdown-schema/Link'
 import { MetricsStackCards } from './markdown-schema/MetricsStackCards'
 import { Panel } from './markdown-schema/Panel'
+import { Price } from './markdown-schema/Price'
+import { SharedData } from './markdown-schema/SharedData'
 import { StepHike } from './markdown-schema/StepHike'
 import { TabPanel } from './markdown-schema/TabPanel'
-import { Price } from './markdown-schema/Price'
 
 const PARTIALS_DIR = path.join(process.cwd(), 'content', '_partials')
 
@@ -138,6 +139,7 @@ const SCHEMA: ComponentSchema = {
   ...StepHike,
   TabPanel,
   MetricsStackCards,
+  SharedData,
 }
 
 async function generateOne(filePath: string, linkBaseUrl: string): Promise<string> {

--- a/apps/docs/internals/markdown-schema/ComputeDiskLimitsTable.ts
+++ b/apps/docs/internals/markdown-schema/ComputeDiskLimitsTable.ts
@@ -1,0 +1,29 @@
+import { createRequire } from 'node:module'
+
+// tsx's ESM loader can't pick up named exports from the `shared-data` package
+// (CJS, no `"type": "module"`). Load via `createRequire` for CJS interop —
+// this file only runs in the build script, never in the Next.js bundle.
+const {
+  COMPUTE_BASELINE_IOPS,
+  COMPUTE_BASELINE_THROUGHPUT,
+  COMPUTE_DISK,
+  COMPUTE_MAX_IOPS,
+  COMPUTE_MAX_THROUGHPUT,
+} = createRequire(import.meta.url)('shared-data') as {
+  COMPUTE_BASELINE_IOPS: Record<string, number>
+  COMPUTE_BASELINE_THROUGHPUT: Record<string, number>
+  COMPUTE_DISK: Record<string, { name: string }>
+  COMPUTE_MAX_IOPS: Record<string, number>
+  COMPUTE_MAX_THROUGHPUT: Record<string, number>
+}
+
+export const ComputeDiskLimitsTable = (): string => `
+| Compute Instance | Baseline Throughput (MB/s) | Max Throughput (MB/s) | Baseline IOPS | Max IOPS |
+| --- | --- | --- | --- | --- |
+${Object.entries(COMPUTE_DISK)
+  .map(
+    ([key, value]) =>
+      `| ${value.name} | ${COMPUTE_BASELINE_THROUGHPUT[key]?.toLocaleString()} MB/s | ${COMPUTE_MAX_THROUGHPUT[key]?.toLocaleString()} MB/s | ${COMPUTE_BASELINE_IOPS[key]?.toLocaleString()} IOPS | ${COMPUTE_MAX_IOPS[key]?.toLocaleString()} IOPS |`
+  )
+  .join('\n')}
+`

--- a/apps/docs/internals/markdown-schema/SharedData.ts
+++ b/apps/docs/internals/markdown-schema/SharedData.ts
@@ -1,0 +1,46 @@
+import { createRequire } from 'node:module'
+
+import { resolveSharedDataPath } from '../../components/SharedData.utils'
+
+// tsx's ESM loader can't pick up named exports from the `shared-data` package
+// (CJS, no `"type": "module"`). Load via `createRequire` to use CJS interop —
+// this file only runs in the build script, never in the Next.js bundle.
+const { config, logConstants } = createRequire(import.meta.url)('shared-data')
+
+type Field = { path: string; type: string }
+type Schema = { name: string; fields: Field[] }
+
+const sharedData: Record<string, unknown> = { config, logConstants }
+
+const renderLogConstants = (data: { schemas: Schema[] }): string =>
+  data.schemas
+    .map(
+      (s) =>
+        `#### ${s.name}\n${[...s.fields]
+          .sort((a, b) => a.path.localeCompare(b.path))
+          .map((f) => ` - \`${f.path}\`, \`${f.type}\``)
+          .join('\n')}`
+    )
+    .join('\n\n')
+
+export const SharedData = ({
+  props,
+  children,
+}: {
+  props: Record<string, unknown>
+  children: string
+}): string => {
+  const dataset = sharedData[String(props.data ?? '')]
+  if (!dataset) return children
+
+  // String-path pattern: `<SharedData data="config">a.b.c</SharedData>`.
+  const value = resolveSharedDataPath(dataset, children.trim())
+  if (value != null) return String(value)
+
+  // Render-function pattern: `<SharedData data="logConstants">{(d) => …}`.
+  // The schema walker strips the MDX expression children before this handler
+  // runs, and we can't evaluate the function statically anyway — hardcode the
+  // markdown for the only dataset that uses this form today.
+  if (props.data === 'logConstants') return renderLogConstants(dataset as { schemas: Schema[] })
+  return ''
+}


### PR DESCRIPTION
Handle the `SharedData` component.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized shared-data path resolution for docs rendering, improving consistency in how values (including units) are displayed.
  * Updated markdown generation so `SharedData` blocks are handled by the docs schema renderer.
* **Documentation**
  * Generated guide markdown now includes correctly rendered log-schema constants and compute disk limits tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->