### PR TITLE
Changed order that CLI flags are applied in

### DIFF
--- a/apps/docs/content/guides/database/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/database/custom-postgres-config.mdx
@@ -161,7 +161,7 @@ To update Postgres configurations, use the [`postgres config`](/docs/reference/c
 ```bash
 supabase --experimental \
 postgres-config update --config shared_buffers=250MB \
---project-ref <project-ref> 
+--project-ref <project-ref>
 ```
 
 By default, the CLI will merge any provided config overrides with any existing ones. The `--replace-existing-overrides` flag can be used to instead force all existing overrides to be replaced with the ones being provided:
@@ -170,7 +170,7 @@ By default, the CLI will merge any provided config overrides with any existing o
 supabase --experimental \
 postgres-config update --config max_parallel_workers=3 \
 --replace-existing-overrides \
---project-ref <project-ref> 
+--project-ref <project-ref>
 ```
 
 To delete specific configuration overrides, use the `postgres-config delete` command:

--- a/apps/docs/content/guides/database/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/database/custom-postgres-config.mdx
@@ -160,25 +160,25 @@ To update Postgres configurations, use the [`postgres config`](/docs/reference/c
 
 ```bash
 supabase --experimental \
---project-ref <project-ref> \
-postgres-config update --config shared_buffers=250MB
+postgres-config update --config shared_buffers=250MB \
+--project-ref <project-ref> 
 ```
 
 By default, the CLI will merge any provided config overrides with any existing ones. The `--replace-existing-overrides` flag can be used to instead force all existing overrides to be replaced with the ones being provided:
 
 ```bash
 supabase --experimental \
---project-ref <project-ref> \
 postgres-config update --config max_parallel_workers=3 \
---replace-existing-overrides
+--replace-existing-overrides \
+--project-ref <project-ref> 
 ```
 
 To delete specific configuration overrides, use the `postgres-config delete` command:
 
 ```bash
 supabase --experimental \
---project-ref <project-ref> \
-postgres-config delete --config shared_buffers,work_mem
+postgres-config delete --config shared_buffers,work_mem \
+--project-ref <project-ref>
 ```
 
 By default, CLI v2 (≥ 2.0.0) checks the parameter’s context and requests the correct action (reload or restart):


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

A bug causes the CLI to fail when the `--project-ref` flag is not applied last in the chain

## What is the new behavior?

Moved it to the end of the chain

## Additional context

Slack:
- https://supabase.slack.com/archives/C02BJ2239GA/p1781816645742719

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CLI command examples for managing Postgres configuration, including corrected parameter ordering and improved line formatting for the related `postgres-config` update/delete commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->