### PR TITLE
Remove monaco outline

### DIFF
--- a/apps/studio/styles/monaco.css
+++ b/apps/studio/styles/monaco.css
@@ -25,6 +25,7 @@
 .monaco-diff-editor {
   --vscode-editor-background: hsl(var(--background-dash-sidebar)) !important;
   --vscode-editorGutter-background: hsl(var(--background-dash-sidebar)) !important;
+  outline: none !important;
 }
 
 .gutter {


### PR DESCRIPTION
Removes an always on clipped outline in editor. Will look at focus styles as part of editor refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the code editor styling to provide a cleaner visual presentation by refining outline properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->