### PR TITLE
chore(studio): updated the email not confirmed error message

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -108,7 +108,7 @@ export const SignInForm = () => {
 
       if (error.message.toLowerCase() === 'email not confirmed') {
         return toast.error(
-          'Account has not been verified, please check the link sent to your email',
+          'Your account has not been verified. Please check the verification link sent to your email. If you have not received the email or the link has expired, please sign up again to request a new verification link.',
           { id: toastId }
         )
       }


### PR DESCRIPTION
Updated the error message in the toast users get when they try to sign in but do not have their email address verified. This should reduce the support tickets we get asking to resend the verification email.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

<img width="842" height="176" alt="image" src="https://github.com/user-attachments/assets/e76590ad-960a-4527-91a3-0b717da3f335" />

## What is the new behavior?

<img width="842" height="332" alt="image" src="https://github.com/user-attachments/assets/2422c2fe-0988-4241-877e-dbb0896ceb3b" />

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for sign-in failures due to unconfirmed email addresses. Users now receive clearer, more detailed guidance regarding email verification and expired link instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->