### PR TITLE
Fire load more slightly before reaching the bottom of the page

### DIFF
--- a/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableInfinite.tsx
@@ -52,15 +52,17 @@ export function DataTableInfinite<TData, TValue, TMeta>({
 
   const onScroll = useCallback(
     (e: UIEvent<HTMLElement>) => {
+      // Trigger fetching slightly before reaching the very bottom for a smoother experience
+      const BOTTOM_BUFFER_PX = 300
       const onPageBottom =
         Math.ceil(e.currentTarget.scrollTop + e.currentTarget.clientHeight) >=
-        e.currentTarget.scrollHeight
+        e.currentTarget.scrollHeight - BOTTOM_BUFFER_PX
 
-      if (onPageBottom && !isFetching && totalRows > totalRowsFetched) {
+      if (onPageBottom && !isFetching && hasNextPage) {
         fetchNextPage()
       }
     },
-    [fetchNextPage, isFetching, totalRows, totalRowsFetched]
+    [fetchNextPage, isFetching, hasNextPage]
   )
 
   useShortcut(


### PR DESCRIPTION
## Context

JFYI the originally problem from the ticket was that unified logs wasn't loading more automatically when scrolling to the bottom

However, I can't reproduce that issue as it seems to be working as intended. But opting to triggering the load more when scrolling slightly before hitting the bottom of the page for a smoother UX

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized infinite-scroll behavior in data tables by refining when the loading trigger activates. Content now begins loading earlier as users scroll, rather than waiting until reaching the absolute bottom of the table. This responsive adjustment improves overall performance and user experience when navigating through tables with large datasets, reducing perceived delays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->