### PR TITLE
feat(studio): TanStack project routes + page wiring (stack 5/6, from #46424)

### DIFF
--- a/apps/studio/api/server.js
+++ b/apps/studio/api/server.js
@@ -1,0 +1,25 @@
+// STUDIO_FRAMEWORK gates whether this function actually serves the TanStack
+// SSR handler. Vercel auto-detects every file under /api as a Function
+// regardless of the framework preset (vercel.com/docs/functions), so we
+// can't keep this file from being deployed in the Next.js prod build — we
+// just make it inert when the env var is unset.
+const isTanstack = process.env.STUDIO_FRAMEWORK === 'tanstack'
+
+// Computed path keeps `dist/server/server.js` out of Vercel's function
+// bundler's static analysis. In the Next.js prod deploy the `dist/` tree
+// doesn't exist, but Vercel still bundles this file because it lives under
+// `api/`. With the .join() the bundler treats the import as runtime-only
+// and the missing dist/ isn't a build error. In TanStack mode the SSR
+// bundle is shipped into the function via the `functions['api/server.js']
+// .includeFiles` config in vercel.ts.
+const tanstackEntry = ['..', 'dist', 'server', 'server.js'].join('/')
+
+const handler = isTanstack
+  ? (await import(tanstackEntry)).default
+  : { fetch: () => new Response('Not Found', { status: 404 }) }
+
+// Vercel's Web API handler convention: export an object with `fetch(request)`.
+// TanStack's server build is already shaped that way — default-export it
+// verbatim and Vercel hands us a real Web Request.
+// eslint-disable-next-line no-restricted-exports
+export default handler

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
@@ -1,12 +1,11 @@
 import { useParams } from 'common'
 import dynamic from 'next/dynamic'
 import Link from 'next/link'
-import { useMemo, useRef } from 'react'
+import { useMemo, useRef, type ComponentType } from 'react'
 import { Button } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
-import { connectSchema } from './connect.schema'
 import type {
   ConnectionStringPooler,
   ConnectState,
@@ -129,6 +128,27 @@ function useConnectionStringPooler(deploymentMode: DeploymentMode): ConnectionSt
   )
 }
 
+// Vite needs `import.meta.glob` to statically discover the step content
+// modules because the `${filePath}` template can span multiple directory
+// segments (`flask/supabasepy`, `steps/shadcn/explore`, ...) which Vite's
+// dynamic-import-vars plugin can't analyze. Skip the glob on the SSR bundle
+// — Vite replaces `import.meta.env.SSR` at build time and tree-shakes the
+// call so the 37 content modules stay out of the server graph (pulling them
+// in reshuffles chunks enough to surface latent circular-dep bugs in
+// unrelated modules). Next/webpack doesn't know about `import.meta.glob`
+// either; the try/catch lets that branch fall through to the webpack-friendly
+// `import()` below.
+let contentModules: Record<string, () => Promise<unknown>> = {}
+if (!import.meta.env?.SSR) {
+  try {
+    contentModules = import.meta.glob('./content/**/content.{tsx,ts}')
+  } catch {
+    // webpack build: import.meta.glob is undefined, keep empty map
+  }
+}
+
+type StepContentModule = { default: ComponentType<StepContentProps> }
+
 /**
  * Dynamically loads and renders a content component from the content directory.
  * All step content uses this unified loader - no built-in component registry needed.
@@ -151,7 +171,16 @@ function StepContent({
 
   // Dynamically import the content component
   const ContentComponent = useMemo(() => {
-    return dynamic<StepContentProps>(() => import(`./content/${filePath}/content`), {
+    const viteLoader =
+      contentModules[`./content/${filePath}/content.tsx`] ??
+      contentModules[`./content/${filePath}/content.ts`]
+
+    const loader = viteLoader
+      ? (viteLoader as () => Promise<StepContentModule>)
+      : () =>
+          import(/* @vite-ignore */ `./content/${filePath}/content`) as Promise<StepContentModule>
+
+    return dynamic<StepContentProps>(loader, {
       loading: () => (
         <div className="p-4 min-h-[200px]">
           <GenericSkeletonLoader />
@@ -196,11 +225,6 @@ export function ConnectStepsSection({ steps, state, projectKeys }: ConnectStepsS
 
   const showSelfHostedMcpNotice = deploymentMode.isSelfHosted && state.mode === 'mcp'
 
-  const customPrompt = useMemo(
-    () => connectSchema.modes.find((m) => m.id === state.mode)?.prompt,
-    [state.mode]
-  )
-
   if (steps.length === 0) return null
 
   return (
@@ -244,7 +268,7 @@ export function ConnectStepsSection({ steps, state, projectKeys }: ConnectStepsS
           />
         )}
 
-        <CopyPromptAdmonition stepsContainerRef={stepsContainerRef} customPrompt={customPrompt} />
+        <CopyPromptAdmonition stepsContainerRef={stepsContainerRef} />
 
         <div className="mt-6" ref={stepsContainerRef}>
           {steps.map((step, index) => (

--- a/apps/studio/pages/org/_/[[...routeSlug]].tsx
+++ b/apps/studio/pages/org/_/[[...routeSlug]].tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import { useRouter } from 'next/router'
 import { cn } from 'ui'
 
+import { parseCatchAllRoute } from '@/compat/next/router'
 import {
   Header,
   LoadingCardView,
@@ -20,7 +21,10 @@ import { buildStudioPageTitle } from '@/lib/page-title'
 const GenericOrganizationPage: NextPage = () => {
   const router = useRouter()
   const { appTitle } = useCustomContent(['app:title'])
-  const { routeSlug, ...queryParams } = router.query
+  // Normalise the catch-all path across Next (`routeSlug: string[]`) and
+  // TanStack (`_splat: string`) so downstream URL building (buildOrgUrl)
+  // keeps working — see parseCatchAllRoute.
+  const { segments: routeSlug, queryParams } = parseCatchAllRoute(router.query, 'routeSlug')
   const queryString =
     Object.keys(queryParams).length > 0
       ? new URLSearchParams(queryParams as Record<string, string>).toString()

--- a/apps/studio/pages/project/[ref]/branches/index.tsx
+++ b/apps/studio/pages/project/[ref]/branches/index.tsx
@@ -3,7 +3,7 @@ import { useParams } from 'common'
 import { partition } from 'lodash'
 import { MessageCircle } from 'lucide-react'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useState, type PropsWithChildren } from 'react'
 import { toast } from 'sonner'
 import { Button } from 'ui'
 
@@ -189,73 +189,74 @@ const BranchesPage: NextPageWithLayout = () => {
   )
 }
 
-BranchesPage.getLayout = (page) => {
-  const BranchesPageWrapper = () => {
-    const snap = useAppStateSnapshot()
-    const { can: canCreateBranches } = useAsyncCheckPermissions(
-      PermissionAction.CREATE,
-      'preview_branches',
-      {
-        resource: { is_default: false },
-      }
-    )
+// Hoisted out of `getLayout` so the TanStack route can import it
+// directly. Same shape and identical body as before — accepts the page
+// content as `children` instead of capturing it from a closure.
+export const BranchesPageWrapper = ({ children }: PropsWithChildren) => {
+  const snap = useAppStateSnapshot()
+  const { can: canCreateBranches } = useAsyncCheckPermissions(
+    PermissionAction.CREATE,
+    'preview_branches',
+    {
+      resource: { is_default: false },
+    }
+  )
 
-    const primaryActions = (
-      <ButtonTooltip
-        variant="primary"
-        disabled={!canCreateBranches}
-        onClick={() => snap.setShowCreateBranchModal(true)}
-        tooltip={{
-          content: {
-            side: 'bottom',
-            text: !canCreateBranches
-              ? 'You need additional permissions to create branches'
-              : undefined,
-          },
-        }}
+  const primaryActions = (
+    <ButtonTooltip
+      variant="primary"
+      disabled={!canCreateBranches}
+      onClick={() => snap.setShowCreateBranchModal(true)}
+      tooltip={{
+        content: {
+          side: 'bottom',
+          text: !canCreateBranches
+            ? 'You need additional permissions to create branches'
+            : undefined,
+        },
+      }}
+    >
+      Create branch
+    </ButtonTooltip>
+  )
+
+  const secondaryActions = (
+    <div className="flex items-center gap-x-2">
+      <Button
+        asChild
+        variant="text"
+        icon={<MessageCircle className="text-muted" strokeWidth={1} />}
       >
-        Create branch
-      </ButtonTooltip>
-    )
-
-    const secondaryActions = (
-      <div className="flex items-center gap-x-2">
-        <Button
-          asChild
-          variant="text"
-          icon={<MessageCircle className="text-muted" strokeWidth={1} />}
+        <a
+          target="_blank"
+          rel="noreferrer"
+          href="https://github.com/orgs/supabase/discussions/18937"
         >
-          <a
-            target="_blank"
-            rel="noreferrer"
-            href="https://github.com/orgs/supabase/discussions/18937"
-          >
-            Branching feedback
-          </a>
-        </Button>
-        <DocsButton href={`${DOCS_URL}/guides/platform/branching`} />
-      </div>
-    )
-
-    return (
-      <PageLayout
-        title="Branches"
-        subtitle="Manage your database preview branches and deployments"
-        primaryActions={primaryActions}
-        secondaryActions={secondaryActions}
-      >
-        {page}
-      </PageLayout>
-    )
-  }
+          Branching feedback
+        </a>
+      </Button>
+      <DocsButton href={`${DOCS_URL}/guides/platform/branching`} />
+    </div>
+  )
 
   return (
-    <DefaultLayout>
-      <BranchLayout>
-        <BranchesPageWrapper />
-      </BranchLayout>
-    </DefaultLayout>
+    <PageLayout
+      title="Branches"
+      subtitle="Manage your database preview branches and deployments"
+      primaryActions={primaryActions}
+      secondaryActions={secondaryActions}
+    >
+      {children}
+    </PageLayout>
   )
 }
+
+BranchesPage.getLayout = (page) => (
+  <DefaultLayout>
+    <BranchLayout>
+      <BranchesPageWrapper>{page}</BranchesPageWrapper>
+    </BranchLayout>
+  </DefaultLayout>
+)
 
 export default BranchesPage

--- a/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
+++ b/apps/studio/pages/project/[ref]/branches/merge-requests.tsx
@@ -300,7 +300,7 @@ const MergeRequestsPage: NextPageWithLayout = () => {
   )
 }
 
-const MergeRequestsPageWrapper = ({ children }: PropsWithChildren<{}>) => {
+export const MergeRequestsPageWrapper = ({ children }: PropsWithChildren<{}>) => {
   const router = useRouter()
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()

--- a/apps/studio/pages/project/[ref]/functions/index.tsx
+++ b/apps/studio/pages/project/[ref]/functions/index.tsx
@@ -2,7 +2,7 @@ import { useFlag, useParams } from 'common'
 import { ExternalLink, RefreshCw, Search, X } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { parseAsString, parseAsStringLiteral, useQueryState } from 'nuqs'
-import React, { useMemo, useRef } from 'react'
+import React, { useMemo, useRef, type PropsWithChildren } from 'react'
 import { Button, Card, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'ui'
 import { Admonition } from 'ui-patterns'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -231,41 +231,45 @@ const EdgeFunctionsPage: NextPageWithLayout = () => {
   )
 }
 
-EdgeFunctionsPage.getLayout = (page: React.ReactElement) => {
-  return (
-    <DefaultLayout>
-      <EdgeFunctionsLayout title="Edge Functions">
-        <div className="w-full min-h-full flex flex-col items-stretch">
-          <PageHeader size="large">
-            <PageHeaderMeta>
-              <PageHeaderSummary>
-                <PageHeaderTitle>Edge Functions</PageHeaderTitle>
-                <PageHeaderDescription>
-                  Run server-side logic close to your users
-                </PageHeaderDescription>
-              </PageHeaderSummary>
-              <PageHeaderAside>
-                <DocsButton href={`${DOCS_URL}/guides/functions`} />
-                <Button asChild variant="default" icon={<ExternalLink />}>
-                  <a
-                    target="_blank"
-                    rel="noreferrer"
-                    href="https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions"
-                  >
-                    Examples
-                  </a>
-                </Button>
-                {IS_PLATFORM && <DeployEdgeFunctionButton />}
-              </PageHeaderAside>
-            </PageHeaderMeta>
-          </PageHeader>
+// Hoisted out of `getLayout` so the TanStack route can import it
+// directly. Same body — accepts the page content as `children`.
+export const EdgeFunctionsIndexPageWrapper = ({ children }: PropsWithChildren) => (
+  <>
+    <div className="w-full min-h-full flex flex-col items-stretch">
+      <PageHeader size="large">
+        <PageHeaderMeta>
+          <PageHeaderSummary>
+            <PageHeaderTitle>Edge Functions</PageHeaderTitle>
+            <PageHeaderDescription>Run server-side logic close to your users</PageHeaderDescription>
+          </PageHeaderSummary>
+          <PageHeaderAside>
+            <DocsButton href={`${DOCS_URL}/guides/functions`} />
+            <Button asChild variant="default" icon={<ExternalLink />}>
+              <a
+                target="_blank"
+                rel="noreferrer"
+                href="https://github.com/supabase/supabase/tree/master/examples/edge-functions/supabase/functions"
+              >
+                Examples
+              </a>
+            </Button>
+            {IS_PLATFORM && <DeployEdgeFunctionButton />}
+          </PageHeaderAside>
+        </PageHeaderMeta>
+      </PageHeader>
 
-          {page}
-        </div>
-      </EdgeFunctionsLayout>
-      <TerminalInstructionsDialog />
-    </DefaultLayout>
-  )
-}
+      {children}
+    </div>
+    <TerminalInstructionsDialog />
+  </>
+)
+
+EdgeFunctionsPage.getLayout = (page: React.ReactElement) => (
+  <DefaultLayout>
+    <EdgeFunctionsLayout title="Edge Functions">
+      <EdgeFunctionsIndexPageWrapper>{page}</EdgeFunctionsIndexPageWrapper>
+    </EdgeFunctionsLayout>
+  </DefaultLayout>
+)
 
 export default EdgeFunctionsPage

--- a/apps/studio/pages/project/[ref]/functions/secrets.tsx
+++ b/apps/studio/pages/project/[ref]/functions/secrets.tsx
@@ -1,3 +1,4 @@
+import type { PropsWithChildren } from 'react'
 import { Admonition } from 'ui-patterns/admonition'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
@@ -91,27 +92,29 @@ const SecretsPage: NextPageWithLayout = () => {
   )
 }
 
-SecretsPage.getLayout = (page) => {
-  return (
-    <DefaultLayout>
-      <EdgeFunctionsLayout title="Secrets">
-        <div className="w-full min-h-full flex flex-col items-stretch">
-          <PageHeader size="large">
-            <PageHeaderMeta>
-              <PageHeaderSummary>
-                <PageHeaderTitle>Edge Function Secrets</PageHeaderTitle>
-                <PageHeaderDescription>
-                  Manage encrypted values for your functions
-                </PageHeaderDescription>
-              </PageHeaderSummary>
-            </PageHeaderMeta>
-          </PageHeader>
+// Hoisted out of `getLayout` so the TanStack route can import it
+// directly. Same body — accepts the page content as `children`.
+export const SecretsPageWrapper = ({ children }: PropsWithChildren) => (
+  <div className="w-full min-h-full flex flex-col items-stretch">
+    <PageHeader size="large">
+      <PageHeaderMeta>
+        <PageHeaderSummary>
+          <PageHeaderTitle>Edge Function Secrets</PageHeaderTitle>
+          <PageHeaderDescription>Manage encrypted values for your functions</PageHeaderDescription>
+        </PageHeaderSummary>
+      </PageHeaderMeta>
+    </PageHeader>
 
-          {page}
-        </div>
-      </EdgeFunctionsLayout>
-    </DefaultLayout>
-  )
-}
+    {children}
+  </div>
+)
+
+SecretsPage.getLayout = (page) => (
+  <DefaultLayout>
+    <EdgeFunctionsLayout title="Secrets">
+      <SecretsPageWrapper>{page}</SecretsPageWrapper>
+    </EdgeFunctionsLayout>
+  </DefaultLayout>
+)
 
 export default SecretsPage

--- a/apps/studio/pages/project/[ref]/logs/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/index.tsx
@@ -26,29 +26,29 @@ export const LogPage: NextPageWithLayout = () => {
 
   if (!logsEnabled) {
     return (
-      <DefaultLayout>
-        <ProjectLayout browserTitle={{ section: 'Logs' }}>
-          <UnknownInterface urlBack={`/project/${ref}`} />
-        </ProjectLayout>
-      </DefaultLayout>
+      <ProjectLayout browserTitle={{ section: 'Logs' }}>
+        <UnknownInterface urlBack={`/project/${ref}`} />
+      </ProjectLayout>
     )
   }
 
   if (isUnifiedLogsEnabled) {
     return (
-      <DefaultLayout>
-        {/* Omit the generic product segment here; project/org context already makes the route clear. */}
-        <ProjectLayout browserTitle={{ section: 'Unified Logs' }}>
-          <UnifiedLogs />
-        </ProjectLayout>
-      </DefaultLayout>
+      // Omit the generic product segment here; project/org context already makes the route clear.
+      <ProjectLayout browserTitle={{ section: 'Unified Logs' }}>
+        <UnifiedLogs />
+      </ProjectLayout>
     )
   }
 
   return null
 }
 
-// Don't use getLayout since we're handling layouts conditionally within the component
-LogPage.getLayout = (page) => page
+// DefaultLayout lives at the framework wrapper level, not in the page
+// body — both runtimes provide it externally (Next via `getLayout`,
+// TanStack via the parent `routes/project/$ref.tsx` shell). Wrapping it
+// inline would double-mount its SidebarProvider/ProjectContextProvider
+// chain under TanStack since the shell already supplies one.
+LogPage.getLayout = (page) => <DefaultLayout>{page}</DefaultLayout>
 
 export default LogPage

--- a/apps/studio/pages/project/_/[[...routeSlug]].tsx
+++ b/apps/studio/pages/project/_/[[...routeSlug]].tsx
@@ -15,6 +15,7 @@ import {
 } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns'
 
+import { parseCatchAllRoute } from '@/compat/next/router'
 import {
   Header,
   LoadingCardView,
@@ -35,7 +36,10 @@ import { withAuth } from '@/hooks/misc/withAuth'
 const GenericProjectPage: NextPage = () => {
   const router = useRouter()
   const { slug } = useParams()
-  const { routeSlug, ...queryParams } = router.query
+  // Normalise the catch-all path across Next (`routeSlug: string[]`) and
+  // TanStack (`_splat: string`) so downstream URL building
+  // (urlRewriterFactory) keeps working — see parseCatchAllRoute.
+  const { segments: routeSlug, queryParams } = parseCatchAllRoute(router.query, 'routeSlug')
 
   const { lastVisitedOrganization } = useLastVisitedOrganization()
 

--- a/apps/studio/routeTree.gen.ts
+++ b/apps/studio/routeTree.gen.ts
@@ -9,6 +9,22 @@
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
 import { Route as rootRouteImport } from './routes/__root'
+import { Route as VerifyEmailRouteImport } from './routes/verify-email'
+import { Route as RedeemRouteImport } from './routes/redeem'
+import { Route as MaintenanceRouteImport } from './routes/maintenance'
+import { Route as LogoutRouteImport } from './routes/logout'
+import { Route as JoinRouteImport } from './routes/join'
+import { Route as ClaimProjectRouteImport } from './routes/claim-project'
+import { Route as AwsMarketplaceOnboardingRouteImport } from './routes/aws-marketplace-onboarding'
+import { Route as AuthorizeRouteImport } from './routes/authorize'
+import { Route as AuthRouteImport } from './routes/_auth'
+import { Route as AppRouteImport } from './routes/_app'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as ProjectChar91_Char93RouteImport } from './routes/project.[_]'
+import { Route as ProjectRefRouteImport } from './routes/project/$ref'
+import { Route as OrgChar91_Char93RouteImport } from './routes/org.[_]'
+import { Route as NewSlugRouteImport } from './routes/new/$slug'
+import { Route as IntegrationsVercelRouteImport } from './routes/integrations/vercel'
 import { Route as ApiStatusOverrideRouteImport } from './routes/api/status-override'
 import { Route as ApiParseQueryRouteImport } from './routes/api/parse-query'
 import { Route as ApiIncidentStatusRouteImport } from './routes/api/incident-status'
@@ -32,10 +48,29 @@ import { Route as AuthForgotPasswordRouteImport } from './routes/_auth/forgot-pa
 import { Route as AppOrganizationsRouteImport } from './routes/_app/organizations'
 import { Route as AppOrgRouteImport } from './routes/_app/org'
 import { Route as AppAccountRouteImport } from './routes/_app/account'
+import { Route as ProjectRefIndexRouteImport } from './routes/project/$ref/index'
 import { Route as ApiMcpIndexRouteImport } from './routes/api/mcp/index'
 import { Route as ApiConnectIndexRouteImport } from './routes/api/connect/index'
 import { Route as AppOrgIndexRouteImport } from './routes/_app/org/index'
 import { Route as AppNewIndexRouteImport } from './routes/_app/new/index'
+import { Route as ProjectChar91_Char93SplatRouteImport } from './routes/project.[_].$'
+import { Route as ProjectRefStorageRouteImport } from './routes/project/$ref/storage'
+import { Route as ProjectRefSqlRouteImport } from './routes/project/$ref/sql'
+import { Route as ProjectRefSettingsRouteImport } from './routes/project/$ref/settings'
+import { Route as ProjectRefRealtimeRouteImport } from './routes/project/$ref/realtime'
+import { Route as ProjectRefObservabilityRouteImport } from './routes/project/$ref/observability'
+import { Route as ProjectRefMergeRouteImport } from './routes/project/$ref/merge'
+import { Route as ProjectRefLogsRouteImport } from './routes/project/$ref/logs'
+import { Route as ProjectRefIntegrationsRouteImport } from './routes/project/$ref/integrations'
+import { Route as ProjectRefFunctionsRouteImport } from './routes/project/$ref/functions'
+import { Route as ProjectRefEditorRouteImport } from './routes/project/$ref/editor'
+import { Route as ProjectRefDatabaseRouteImport } from './routes/project/$ref/database'
+import { Route as ProjectRefBranchesRouteImport } from './routes/project/$ref/branches'
+import { Route as ProjectRefAuthRouteImport } from './routes/project/$ref/auth'
+import { Route as ProjectRefAdvisorsRouteImport } from './routes/project/$ref/advisors'
+import { Route as OrgChar91_Char93SplatRouteImport } from './routes/org.[_].$'
+import { Route as IntegrationsVercelInstallRouteImport } from './routes/integrations/vercel/install'
+import { Route as IntegrationsGithubAuthorizeRouteImport } from './routes/integrations/github/authorize'
 import { Route as ApiPlatformDeploymentModeRouteImport } from './routes/api/platform/deployment-mode'
 import { Route as ApiIntegrationsStripeSyncRouteImport } from './routes/api/integrations/stripe-sync'
 import { Route as ApiEdgeFunctionsTestRouteImport } from './routes/api/edge-functions/test'
@@ -47,11 +82,94 @@ import { Route as AppSupportLinkRouteImport } from './routes/_app/support/link'
 import { Route as AppAccountSecurityRouteImport } from './routes/_app/account/security'
 import { Route as AppAccountMeRouteImport } from './routes/_app/account/me'
 import { Route as AppAccountAuditRouteImport } from './routes/_app/account/audit'
+import { Route as ProjectRefSqlIndexRouteImport } from './routes/project/$ref/sql/index'
+import { Route as ProjectRefObservabilityIndexRouteImport } from './routes/project/$ref/observability/index'
+import { Route as ProjectRefLogsIndexRouteImport } from './routes/project/$ref/logs/index'
+import { Route as ProjectRefIntegrationsIndexRouteImport } from './routes/project/$ref/integrations/index'
+import { Route as ProjectRefFunctionsIndexRouteImport } from './routes/project/$ref/functions/index'
+import { Route as ProjectRefEditorIndexRouteImport } from './routes/project/$ref/editor/index'
+import { Route as ProjectRefBranchesIndexRouteImport } from './routes/project/$ref/branches/index'
+import { Route as ProjectRefApiIndexRouteImport } from './routes/project/$ref/api/index'
 import { Route as ApiPlatformProjectsIndexRouteImport } from './routes/api/platform/projects/index'
 import { Route as ApiPlatformProfileIndexRouteImport } from './routes/api/platform/profile/index'
 import { Route as ApiPlatformOrganizationsIndexRouteImport } from './routes/api/platform/organizations/index'
 import { Route as AppOrgSlugIndexRouteImport } from './routes/_app/org/$slug/index'
 import { Route as AppAccountTokensIndexRouteImport } from './routes/_app/account/tokens/index'
+import { Route as ProjectRefStorageS3RouteImport } from './routes/project/$ref/storage/s3'
+import { Route as ProjectRefSqlTemplatesRouteImport } from './routes/project/$ref/sql/templates'
+import { Route as ProjectRefSqlExamplesRouteImport } from './routes/project/$ref/sql/examples'
+import { Route as ProjectRefSqlIdRouteImport } from './routes/project/$ref/sql/$id'
+import { Route as ProjectRefSettingsLogDrainsRouteImport } from './routes/project/$ref/settings/log-drains'
+import { Route as ProjectRefSettingsIntegrationsRouteImport } from './routes/project/$ref/settings/integrations'
+import { Route as ProjectRefSettingsInfrastructureRouteImport } from './routes/project/$ref/settings/infrastructure'
+import { Route as ProjectRefSettingsGeneralRouteImport } from './routes/project/$ref/settings/general'
+import { Route as ProjectRefSettingsDashboardRouteImport } from './routes/project/$ref/settings/dashboard'
+import { Route as ProjectRefSettingsComputeAndDiskRouteImport } from './routes/project/$ref/settings/compute-and-disk'
+import { Route as ProjectRefSettingsApiKeysRouteImport } from './routes/project/$ref/settings/api-keys'
+import { Route as ProjectRefSettingsApiRouteImport } from './routes/project/$ref/settings/api'
+import { Route as ProjectRefSettingsAddonsRouteImport } from './routes/project/$ref/settings/addons'
+import { Route as ProjectRefRealtimeSettingsRouteImport } from './routes/project/$ref/realtime/settings'
+import { Route as ProjectRefRealtimePoliciesRouteImport } from './routes/project/$ref/realtime/policies'
+import { Route as ProjectRefRealtimeInspectorRouteImport } from './routes/project/$ref/realtime/inspector'
+import { Route as ProjectRefObservabilityStorageRouteImport } from './routes/project/$ref/observability/storage'
+import { Route as ProjectRefObservabilityRealtimeRouteImport } from './routes/project/$ref/observability/realtime'
+import { Route as ProjectRefObservabilityQueryPerformanceRouteImport } from './routes/project/$ref/observability/query-performance'
+import { Route as ProjectRefObservabilityQueryInsightsRouteImport } from './routes/project/$ref/observability/query-insights'
+import { Route as ProjectRefObservabilityPostgrestRouteImport } from './routes/project/$ref/observability/postgrest'
+import { Route as ProjectRefObservabilityEdgeFunctionsRouteImport } from './routes/project/$ref/observability/edge-functions'
+import { Route as ProjectRefObservabilityDatabaseRouteImport } from './routes/project/$ref/observability/database'
+import { Route as ProjectRefObservabilityAuthRouteImport } from './routes/project/$ref/observability/auth'
+import { Route as ProjectRefObservabilityApiOverviewRouteImport } from './routes/project/$ref/observability/api-overview'
+import { Route as ProjectRefObservabilityIdRouteImport } from './routes/project/$ref/observability/$id'
+import { Route as ProjectRefLogsStorageLogsRouteImport } from './routes/project/$ref/logs/storage-logs'
+import { Route as ProjectRefLogsReplicationLogsRouteImport } from './routes/project/$ref/logs/replication-logs'
+import { Route as ProjectRefLogsRealtimeLogsRouteImport } from './routes/project/$ref/logs/realtime-logs'
+import { Route as ProjectRefLogsPostgrestLogsRouteImport } from './routes/project/$ref/logs/postgrest-logs'
+import { Route as ProjectRefLogsPostgresLogsRouteImport } from './routes/project/$ref/logs/postgres-logs'
+import { Route as ProjectRefLogsPoolerLogsRouteImport } from './routes/project/$ref/logs/pooler-logs'
+import { Route as ProjectRefLogsPgcronLogsRouteImport } from './routes/project/$ref/logs/pgcron-logs'
+import { Route as ProjectRefLogsPgUpgradeLogsRouteImport } from './routes/project/$ref/logs/pg-upgrade-logs'
+import { Route as ProjectRefLogsEdgeLogsRouteImport } from './routes/project/$ref/logs/edge-logs'
+import { Route as ProjectRefLogsEdgeFunctionsLogsRouteImport } from './routes/project/$ref/logs/edge-functions-logs'
+import { Route as ProjectRefLogsDedicatedPoolerLogsRouteImport } from './routes/project/$ref/logs/dedicated-pooler-logs'
+import { Route as ProjectRefLogsCronLogsRouteImport } from './routes/project/$ref/logs/cron-logs'
+import { Route as ProjectRefLogsAuthLogsRouteImport } from './routes/project/$ref/logs/auth-logs'
+import { Route as ProjectRefFunctionsSecretsRouteImport } from './routes/project/$ref/functions/secrets'
+import { Route as ProjectRefFunctionsNewRouteImport } from './routes/project/$ref/functions/new'
+import { Route as ProjectRefFunctionsFunctionSlugRouteImport } from './routes/project/$ref/functions/$functionSlug'
+import { Route as ProjectRefEditorNewRouteImport } from './routes/project/$ref/editor/new'
+import { Route as ProjectRefEditorIdRouteImport } from './routes/project/$ref/editor/$id'
+import { Route as ProjectRefDatabaseTypesRouteImport } from './routes/project/$ref/database/types'
+import { Route as ProjectRefDatabaseTriggersRouteImport } from './routes/project/$ref/database/triggers'
+import { Route as ProjectRefDatabaseSettingsRouteImport } from './routes/project/$ref/database/settings'
+import { Route as ProjectRefDatabaseSchemasRouteImport } from './routes/project/$ref/database/schemas'
+import { Route as ProjectRefDatabaseRolesRouteImport } from './routes/project/$ref/database/roles'
+import { Route as ProjectRefDatabaseMigrationsRouteImport } from './routes/project/$ref/database/migrations'
+import { Route as ProjectRefDatabaseIndexesRouteImport } from './routes/project/$ref/database/indexes'
+import { Route as ProjectRefDatabaseFunctionsRouteImport } from './routes/project/$ref/database/functions'
+import { Route as ProjectRefDatabaseExtensionsRouteImport } from './routes/project/$ref/database/extensions'
+import { Route as ProjectRefDatabaseColumnPrivilegesRouteImport } from './routes/project/$ref/database/column-privileges'
+import { Route as ProjectRefBranchesMergeRequestsRouteImport } from './routes/project/$ref/branches/merge-requests'
+import { Route as ProjectRefAuthUsersRouteImport } from './routes/project/$ref/auth/users'
+import { Route as ProjectRefAuthUrlConfigurationRouteImport } from './routes/project/$ref/auth/url-configuration'
+import { Route as ProjectRefAuthThirdPartyRouteImport } from './routes/project/$ref/auth/third-party'
+import { Route as ProjectRefAuthSmtpRouteImport } from './routes/project/$ref/auth/smtp'
+import { Route as ProjectRefAuthSessionsRouteImport } from './routes/project/$ref/auth/sessions'
+import { Route as ProjectRefAuthRateLimitsRouteImport } from './routes/project/$ref/auth/rate-limits'
+import { Route as ProjectRefAuthProvidersRouteImport } from './routes/project/$ref/auth/providers'
+import { Route as ProjectRefAuthProtectionRouteImport } from './routes/project/$ref/auth/protection'
+import { Route as ProjectRefAuthPoliciesRouteImport } from './routes/project/$ref/auth/policies'
+import { Route as ProjectRefAuthPerformanceRouteImport } from './routes/project/$ref/auth/performance'
+import { Route as ProjectRefAuthPasskeysRouteImport } from './routes/project/$ref/auth/passkeys'
+import { Route as ProjectRefAuthOverviewRouteImport } from './routes/project/$ref/auth/overview'
+import { Route as ProjectRefAuthOauthServerRouteImport } from './routes/project/$ref/auth/oauth-server'
+import { Route as ProjectRefAuthOauthAppsRouteImport } from './routes/project/$ref/auth/oauth-apps'
+import { Route as ProjectRefAuthMfaRouteImport } from './routes/project/$ref/auth/mfa'
+import { Route as ProjectRefAuthHooksRouteImport } from './routes/project/$ref/auth/hooks'
+import { Route as ProjectRefAuthAuditLogsRouteImport } from './routes/project/$ref/auth/audit-logs'
+import { Route as ProjectRefAdvisorsSecurityRouteImport } from './routes/project/$ref/advisors/security'
+import { Route as ProjectRefAdvisorsRulesRouteImport } from './routes/project/$ref/advisors/rules'
+import { Route as ProjectRefAdvisorsPerformanceRouteImport } from './routes/project/$ref/advisors/performance'
 import { Route as ApiPlatformTelemetryEventRouteImport } from './routes/api/platform/telemetry/event'
 import { Route as ApiPlatformIntegrationsSlugRouteImport } from './routes/api/platform/integrations/$slug'
 import { Route as ApiAiSqlTitleV2RouteImport } from './routes/api/ai/sql/title-v2'
@@ -76,9 +194,49 @@ import { Route as AppOrgSlugBillingRouteImport } from './routes/_app/org/$slug/b
 import { Route as AppOrgSlugAuditRouteImport } from './routes/_app/org/$slug/audit'
 import { Route as AppOrgSlugAppsRouteImport } from './routes/_app/org/$slug/apps'
 import { Route as AppAccountTokensScopedRouteImport } from './routes/_app/account/tokens/scoped'
+import { Route as ProjectRefStorageVectorsIndexRouteImport } from './routes/project/$ref/storage/vectors/index'
+import { Route as ProjectRefStorageFilesIndexRouteImport } from './routes/project/$ref/storage/files/index'
+import { Route as ProjectRefStorageAnalyticsIndexRouteImport } from './routes/project/$ref/storage/analytics/index'
+import { Route as ProjectRefSettingsWebhooksIndexRouteImport } from './routes/project/$ref/settings/webhooks/index'
+import { Route as ProjectRefSettingsJwtIndexRouteImport } from './routes/project/$ref/settings/jwt/index'
+import { Route as ProjectRefSettingsApiKeysIndexRouteImport } from './routes/project/$ref/settings/api-keys/index'
+import { Route as ProjectRefLogsExplorerIndexRouteImport } from './routes/project/$ref/logs/explorer/index'
+import { Route as ProjectRefIntegrationsIdIndexRouteImport } from './routes/project/$ref/integrations/$id/index'
+import { Route as ProjectRefFunctionsFunctionSlugIndexRouteImport } from './routes/project/$ref/functions/$functionSlug/index'
+import { Route as ProjectRefDatabaseTriggersIndexRouteImport } from './routes/project/$ref/database/triggers/index'
+import { Route as ProjectRefDatabaseTablesIndexRouteImport } from './routes/project/$ref/database/tables/index'
+import { Route as ProjectRefDatabaseReplicationIndexRouteImport } from './routes/project/$ref/database/replication/index'
+import { Route as ProjectRefDatabasePublicationsIndexRouteImport } from './routes/project/$ref/database/publications/index'
+import { Route as ProjectRefAuthTemplatesIndexRouteImport } from './routes/project/$ref/auth/templates/index'
 import { Route as ApiPlatformProjectsRefIndexRouteImport } from './routes/api/platform/projects/$ref/index'
 import { Route as AppOrgSlugWebhooksIndexRouteImport } from './routes/_app/org/$slug/webhooks/index'
 import { Route as AppOrgSlugPrivateAppsIndexRouteImport } from './routes/_app/org/$slug/private-apps/index'
+import { Route as ProjectRefStorageFilesSettingsRouteImport } from './routes/project/$ref/storage/files/settings'
+import { Route as ProjectRefStorageFilesPoliciesRouteImport } from './routes/project/$ref/storage/files/policies'
+import { Route as ProjectRefSettingsWebhooksEndpointIdRouteImport } from './routes/project/$ref/settings/webhooks/$endpointId'
+import { Route as ProjectRefSettingsJwtLegacyRouteImport } from './routes/project/$ref/settings/jwt/legacy'
+import { Route as ProjectRefSettingsBillingUsageRouteImport } from './routes/project/$ref/settings/billing/usage'
+import { Route as ProjectRefSettingsApiKeysLegacyRouteImport } from './routes/project/$ref/settings/api-keys/legacy'
+import { Route as ProjectRefLogsExplorerTemplatesRouteImport } from './routes/project/$ref/logs/explorer/templates'
+import { Route as ProjectRefLogsExplorerSavedRouteImport } from './routes/project/$ref/logs/explorer/saved'
+import { Route as ProjectRefLogsExplorerRecentRouteImport } from './routes/project/$ref/logs/explorer/recent'
+import { Route as ProjectRefFunctionsFunctionSlugLogsRouteImport } from './routes/project/$ref/functions/$functionSlug/logs'
+import { Route as ProjectRefFunctionsFunctionSlugInvocationsRouteImport } from './routes/project/$ref/functions/$functionSlug/invocations'
+import { Route as ProjectRefFunctionsFunctionSlugDetailsRouteImport } from './routes/project/$ref/functions/$functionSlug/details'
+import { Route as ProjectRefFunctionsFunctionSlugCodeRouteImport } from './routes/project/$ref/functions/$functionSlug/code'
+import { Route as ProjectRefDatabaseTriggersEventRouteImport } from './routes/project/$ref/database/triggers/event'
+import { Route as ProjectRefDatabaseTriggersDataRouteImport } from './routes/project/$ref/database/triggers/data'
+import { Route as ProjectRefDatabaseTablesIdRouteImport } from './routes/project/$ref/database/tables/$id'
+import { Route as ProjectRefDatabaseReplicationPipelineIdRouteImport } from './routes/project/$ref/database/replication/$pipelineId'
+import { Route as ProjectRefDatabasePublicationsIdRouteImport } from './routes/project/$ref/database/publications/$id'
+import { Route as ProjectRefDatabaseBackupsScheduledRouteImport } from './routes/project/$ref/database/backups/scheduled'
+import { Route as ProjectRefDatabaseBackupsRestoreToNewProjectRouteImport } from './routes/project/$ref/database/backups/restore-to-new-project'
+import { Route as ProjectRefDatabaseBackupsPitrRouteImport } from './routes/project/$ref/database/backups/pitr'
+import { Route as ProjectRefAuthTemplatesTemplateIdRouteImport } from './routes/project/$ref/auth/templates/$templateId'
+import { Route as ProjectRefAdvisorsRulesSecurityRouteImport } from './routes/project/$ref/advisors/rules/security'
+import { Route as ProjectRefAdvisorsRulesPerformanceRouteImport } from './routes/project/$ref/advisors/rules/performance'
+import { Route as IntegrationsVercelSlugMarketplaceChooseProjectRouteImport } from './routes/integrations/vercel/$slug/marketplace/choose-project'
+import { Route as IntegrationsVercelSlugDeployButtonNewProjectRouteImport } from './routes/integrations/vercel/$slug/deploy-button/new-project'
 import { Route as ApiV1ProjectsRefApiKeysRouteImport } from './routes/api/v1/projects/$ref/api-keys'
 import { Route as ApiPlatformPropsOrgSlugRouteImport } from './routes/api/platform/props/org/$slug'
 import { Route as ApiPlatformProjectsRefSettingsRouteImport } from './routes/api/platform/projects/$ref/settings'
@@ -105,6 +263,7 @@ import { Route as ApiPlatformAuthRefMagiclinkRouteImport } from './routes/api/pl
 import { Route as ApiPlatformAuthRefInviteRouteImport } from './routes/api/platform/auth/$ref/invite'
 import { Route as AuthPartnersStripeProjectsLoginRouteImport } from './routes/_auth/partners/stripe/projects/login'
 import { Route as AppOrgSlugWebhooksEndpointIdRouteImport } from './routes/_app/org/$slug/webhooks/$endpointId'
+import { Route as ProjectRefIntegrationsIdPageIdIndexRouteImport } from './routes/project/$ref/integrations/$id/$pageId/index'
 import { Route as ApiV1ProjectsRefFunctionsIndexRouteImport } from './routes/api/v1/projects/$ref/functions/index'
 import { Route as ApiPlatformStorageRefVectorBucketsIndexRouteImport } from './routes/api/platform/storage/$ref/vector-buckets/index'
 import { Route as ApiPlatformStorageRefBucketsIndexRouteImport } from './routes/api/platform/storage/$ref/buckets/index'
@@ -113,6 +272,10 @@ import { Route as ApiPlatformProjectsRefContentIndexRouteImport } from './routes
 import { Route as ApiPlatformProjectsRefConfigIndexRouteImport } from './routes/api/platform/projects/$ref/config/index'
 import { Route as ApiPlatformPgMetaRefQueryIndexRouteImport } from './routes/api/platform/pg-meta/$ref/query/index'
 import { Route as ApiPlatformAuthRefUsersIndexRouteImport } from './routes/api/platform/auth/$ref/users/index'
+import { Route as ProjectRefStorageVectorsBucketsBucketIdRouteImport } from './routes/project/$ref/storage/vectors/buckets/$bucketId'
+import { Route as ProjectRefStorageFilesBucketsBucketIdRouteImport } from './routes/project/$ref/storage/files/buckets/$bucketId'
+import { Route as ProjectRefStorageAnalyticsBucketsBucketIdRouteImport } from './routes/project/$ref/storage/analytics/buckets/$bucketId'
+import { Route as ProjectRefDatabaseReplicationReplicaReplicaIdRouteImport } from './routes/project/$ref/database/replication/replica/$replicaId'
 import { Route as ApiV1ProjectsRefTypesTypescriptRouteImport } from './routes/api/v1/projects/$ref/types/typescript'
 import { Route as ApiV1ProjectsRefDatabaseMigrationsRouteImport } from './routes/api/v1/projects/$ref/database/migrations'
 import { Route as ApiV1ProjectsRefApiKeysIdRouteImport } from './routes/api/v1/projects/$ref/api-keys/$id'
@@ -125,6 +288,7 @@ import { Route as ApiPlatformProjectsRefApiGraphqlRouteImport } from './routes/a
 import { Route as ApiPlatformProjectsRefApiKeysTemporaryRouteImport } from './routes/api/platform/projects/$ref/api-keys/temporary'
 import { Route as ApiPlatformProjectsRefAnalyticsLogDrainsRouteImport } from './routes/api/platform/projects/$ref/analytics/log-drains'
 import { Route as ApiPlatformOrganizationsSlugBillingSubscriptionRouteImport } from './routes/api/platform/organizations/$slug/billing/subscription'
+import { Route as ProjectRefIntegrationsIdPageIdChildIdIndexRouteImport } from './routes/project/$ref/integrations/$id/$pageId/$childId/index'
 import { Route as ApiV1ProjectsRefFunctionsSlugIndexRouteImport } from './routes/api/v1/projects/$ref/functions/$slug/index'
 import { Route as ApiPlatformStorageRefVectorBucketsIdIndexRouteImport } from './routes/api/platform/storage/$ref/vector-buckets/$id/index'
 import { Route as ApiPlatformStorageRefBucketsIdIndexRouteImport } from './routes/api/platform/storage/$ref/buckets/$id/index'
@@ -150,6 +314,85 @@ import { Route as ApiPlatformStorageRefBucketsIdObjectsMoveRouteImport } from '.
 import { Route as ApiPlatformStorageRefBucketsIdObjectsListRouteImport } from './routes/api/platform/storage/$ref/buckets/$id/objects/list'
 import { Route as ApiPlatformStorageRefBucketsIdObjectsDownloadRouteImport } from './routes/api/platform/storage/$ref/buckets/$id/objects/download'
 
+const VerifyEmailRoute = VerifyEmailRouteImport.update({
+  id: '/verify-email',
+  path: '/verify-email',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const RedeemRoute = RedeemRouteImport.update({
+  id: '/redeem',
+  path: '/redeem',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MaintenanceRoute = MaintenanceRouteImport.update({
+  id: '/maintenance',
+  path: '/maintenance',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const LogoutRoute = LogoutRouteImport.update({
+  id: '/logout',
+  path: '/logout',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const JoinRoute = JoinRouteImport.update({
+  id: '/join',
+  path: '/join',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ClaimProjectRoute = ClaimProjectRouteImport.update({
+  id: '/claim-project',
+  path: '/claim-project',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AwsMarketplaceOnboardingRoute =
+  AwsMarketplaceOnboardingRouteImport.update({
+    id: '/aws-marketplace-onboarding',
+    path: '/aws-marketplace-onboarding',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const AuthorizeRoute = AuthorizeRouteImport.update({
+  id: '/authorize',
+  path: '/authorize',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthRoute = AuthRouteImport.update({
+  id: '/_auth',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AppRoute = AppRouteImport.update({
+  id: '/_app',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectChar91_Char93Route = ProjectChar91_Char93RouteImport.update({
+  id: '/project/_',
+  path: '/project/_',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProjectRefRoute = ProjectRefRouteImport.update({
+  id: '/project/$ref',
+  path: '/project/$ref',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const OrgChar91_Char93Route = OrgChar91_Char93RouteImport.update({
+  id: '/org/_',
+  path: '/org/_',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const NewSlugRoute = NewSlugRouteImport.update({
+  id: '/new/$slug',
+  path: '/new/$slug',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const IntegrationsVercelRoute = IntegrationsVercelRouteImport.update({
+  id: '/integrations/vercel',
+  path: '/integrations/vercel',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiStatusOverrideRoute = ApiStatusOverrideRouteImport.update({
   id: '/api/status-override',
   path: '/api/status-override',
@@ -213,59 +456,64 @@ const ApiCheckCnameRoute = ApiCheckCnameRouteImport.update({
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthSignUpRoute = AuthSignUpRouteImport.update({
-  id: '/_auth/sign-up',
+  id: '/sign-up',
   path: '/sign-up',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthSignInSsoRoute = AuthSignInSsoRouteImport.update({
-  id: '/_auth/sign-in-sso',
+  id: '/sign-in-sso',
   path: '/sign-in-sso',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthSignInPartnerRoute = AuthSignInPartnerRouteImport.update({
-  id: '/_auth/sign-in-partner',
+  id: '/sign-in-partner',
   path: '/sign-in-partner',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthSignInMfaRoute = AuthSignInMfaRouteImport.update({
-  id: '/_auth/sign-in-mfa',
+  id: '/sign-in-mfa',
   path: '/sign-in-mfa',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthSignInRoute = AuthSignInRouteImport.update({
-  id: '/_auth/sign-in',
+  id: '/sign-in',
   path: '/sign-in',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthResetPasswordRoute = AuthResetPasswordRouteImport.update({
-  id: '/_auth/reset-password',
+  id: '/reset-password',
   path: '/reset-password',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthForgotPasswordMfaRoute = AuthForgotPasswordMfaRouteImport.update({
-  id: '/_auth/forgot-password-mfa',
+  id: '/forgot-password-mfa',
   path: '/forgot-password-mfa',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AuthForgotPasswordRoute = AuthForgotPasswordRouteImport.update({
-  id: '/_auth/forgot-password',
+  id: '/forgot-password',
   path: '/forgot-password',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AppOrganizationsRoute = AppOrganizationsRouteImport.update({
-  id: '/_app/organizations',
+  id: '/organizations',
   path: '/organizations',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AppRoute,
 } as any)
 const AppOrgRoute = AppOrgRouteImport.update({
-  id: '/_app/org',
+  id: '/org',
   path: '/org',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AppRoute,
 } as any)
 const AppAccountRoute = AppAccountRouteImport.update({
-  id: '/_app/account',
+  id: '/account',
   path: '/account',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AppRoute,
+} as any)
+const ProjectRefIndexRoute = ProjectRefIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ProjectRefRoute,
 } as any)
 const ApiMcpIndexRoute = ApiMcpIndexRouteImport.update({
   id: '/api/mcp/',
@@ -283,10 +531,103 @@ const AppOrgIndexRoute = AppOrgIndexRouteImport.update({
   getParentRoute: () => AppOrgRoute,
 } as any)
 const AppNewIndexRoute = AppNewIndexRouteImport.update({
-  id: '/_app/new/',
+  id: '/new/',
   path: '/new/',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AppRoute,
 } as any)
+const ProjectChar91_Char93SplatRoute =
+  ProjectChar91_Char93SplatRouteImport.update({
+    id: '/$',
+    path: '/$',
+    getParentRoute: () => ProjectChar91_Char93Route,
+  } as any)
+const ProjectRefStorageRoute = ProjectRefStorageRouteImport.update({
+  id: '/storage',
+  path: '/storage',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefSqlRoute = ProjectRefSqlRouteImport.update({
+  id: '/sql',
+  path: '/sql',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefSettingsRoute = ProjectRefSettingsRouteImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefRealtimeRoute = ProjectRefRealtimeRouteImport.update({
+  id: '/realtime',
+  path: '/realtime',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefObservabilityRoute = ProjectRefObservabilityRouteImport.update({
+  id: '/observability',
+  path: '/observability',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefMergeRoute = ProjectRefMergeRouteImport.update({
+  id: '/merge',
+  path: '/merge',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefLogsRoute = ProjectRefLogsRouteImport.update({
+  id: '/logs',
+  path: '/logs',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefIntegrationsRoute = ProjectRefIntegrationsRouteImport.update({
+  id: '/integrations',
+  path: '/integrations',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefFunctionsRoute = ProjectRefFunctionsRouteImport.update({
+  id: '/functions',
+  path: '/functions',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefEditorRoute = ProjectRefEditorRouteImport.update({
+  id: '/editor',
+  path: '/editor',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefDatabaseRoute = ProjectRefDatabaseRouteImport.update({
+  id: '/database',
+  path: '/database',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefBranchesRoute = ProjectRefBranchesRouteImport.update({
+  id: '/branches',
+  path: '/branches',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefAuthRoute = ProjectRefAuthRouteImport.update({
+  id: '/auth',
+  path: '/auth',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const ProjectRefAdvisorsRoute = ProjectRefAdvisorsRouteImport.update({
+  id: '/advisors',
+  path: '/advisors',
+  getParentRoute: () => ProjectRefRoute,
+} as any)
+const OrgChar91_Char93SplatRoute = OrgChar91_Char93SplatRouteImport.update({
+  id: '/$',
+  path: '/$',
+  getParentRoute: () => OrgChar91_Char93Route,
+} as any)
+const IntegrationsVercelInstallRoute =
+  IntegrationsVercelInstallRouteImport.update({
+    id: '/install',
+    path: '/install',
+    getParentRoute: () => IntegrationsVercelRoute,
+  } as any)
+const IntegrationsGithubAuthorizeRoute =
+  IntegrationsGithubAuthorizeRouteImport.update({
+    id: '/integrations/github/authorize',
+    path: '/integrations/github/authorize',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiPlatformDeploymentModeRoute =
   ApiPlatformDeploymentModeRouteImport.update({
     id: '/api/platform/deployment-mode',
@@ -315,19 +656,19 @@ const ApiAiDocsRoute = ApiAiDocsRouteImport.update({
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthCliLoginRoute = AuthCliLoginRouteImport.update({
-  id: '/_auth/cli/login',
+  id: '/cli/login',
   path: '/cli/login',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AuthRoute,
 } as any)
 const AppSupportNewRoute = AppSupportNewRouteImport.update({
-  id: '/_app/support/new',
+  id: '/support/new',
   path: '/support/new',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AppRoute,
 } as any)
 const AppSupportLinkRoute = AppSupportLinkRouteImport.update({
-  id: '/_app/support/link',
+  id: '/support/link',
   path: '/support/link',
-  getParentRoute: () => rootRouteImport,
+  getParentRoute: () => AppRoute,
 } as any)
 const AppAccountSecurityRoute = AppAccountSecurityRouteImport.update({
   id: '/security',
@@ -343,6 +684,49 @@ const AppAccountAuditRoute = AppAccountAuditRouteImport.update({
   id: '/audit',
   path: '/audit',
   getParentRoute: () => AppAccountRoute,
+} as any)
+const ProjectRefSqlIndexRoute = ProjectRefSqlIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ProjectRefSqlRoute,
+} as any)
+const ProjectRefObservabilityIndexRoute =
+  ProjectRefObservabilityIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefLogsIndexRoute = ProjectRefLogsIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ProjectRefLogsRoute,
+} as any)
+const ProjectRefIntegrationsIndexRoute =
+  ProjectRefIntegrationsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ProjectRefIntegrationsRoute,
+  } as any)
+const ProjectRefFunctionsIndexRoute =
+  ProjectRefFunctionsIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ProjectRefFunctionsRoute,
+  } as any)
+const ProjectRefEditorIndexRoute = ProjectRefEditorIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ProjectRefEditorRoute,
+} as any)
+const ProjectRefBranchesIndexRoute = ProjectRefBranchesIndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => ProjectRefBranchesRoute,
+} as any)
+const ProjectRefApiIndexRoute = ProjectRefApiIndexRouteImport.update({
+  id: '/api/',
+  path: '/api/',
+  getParentRoute: () => ProjectRefRoute,
 } as any)
 const ApiPlatformProjectsIndexRoute =
   ApiPlatformProjectsIndexRouteImport.update({
@@ -371,6 +755,431 @@ const AppAccountTokensIndexRoute = AppAccountTokensIndexRouteImport.update({
   path: '/tokens/',
   getParentRoute: () => AppAccountRoute,
 } as any)
+const ProjectRefStorageS3Route = ProjectRefStorageS3RouteImport.update({
+  id: '/s3',
+  path: '/s3',
+  getParentRoute: () => ProjectRefStorageRoute,
+} as any)
+const ProjectRefSqlTemplatesRoute = ProjectRefSqlTemplatesRouteImport.update({
+  id: '/templates',
+  path: '/templates',
+  getParentRoute: () => ProjectRefSqlRoute,
+} as any)
+const ProjectRefSqlExamplesRoute = ProjectRefSqlExamplesRouteImport.update({
+  id: '/examples',
+  path: '/examples',
+  getParentRoute: () => ProjectRefSqlRoute,
+} as any)
+const ProjectRefSqlIdRoute = ProjectRefSqlIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => ProjectRefSqlRoute,
+} as any)
+const ProjectRefSettingsLogDrainsRoute =
+  ProjectRefSettingsLogDrainsRouteImport.update({
+    id: '/log-drains',
+    path: '/log-drains',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsIntegrationsRoute =
+  ProjectRefSettingsIntegrationsRouteImport.update({
+    id: '/integrations',
+    path: '/integrations',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsInfrastructureRoute =
+  ProjectRefSettingsInfrastructureRouteImport.update({
+    id: '/infrastructure',
+    path: '/infrastructure',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsGeneralRoute =
+  ProjectRefSettingsGeneralRouteImport.update({
+    id: '/general',
+    path: '/general',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsDashboardRoute =
+  ProjectRefSettingsDashboardRouteImport.update({
+    id: '/dashboard',
+    path: '/dashboard',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsComputeAndDiskRoute =
+  ProjectRefSettingsComputeAndDiskRouteImport.update({
+    id: '/compute-and-disk',
+    path: '/compute-and-disk',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsApiKeysRoute =
+  ProjectRefSettingsApiKeysRouteImport.update({
+    id: '/api-keys',
+    path: '/api-keys',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsApiRoute = ProjectRefSettingsApiRouteImport.update({
+  id: '/api',
+  path: '/api',
+  getParentRoute: () => ProjectRefSettingsRoute,
+} as any)
+const ProjectRefSettingsAddonsRoute =
+  ProjectRefSettingsAddonsRouteImport.update({
+    id: '/addons',
+    path: '/addons',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefRealtimeSettingsRoute =
+  ProjectRefRealtimeSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => ProjectRefRealtimeRoute,
+  } as any)
+const ProjectRefRealtimePoliciesRoute =
+  ProjectRefRealtimePoliciesRouteImport.update({
+    id: '/policies',
+    path: '/policies',
+    getParentRoute: () => ProjectRefRealtimeRoute,
+  } as any)
+const ProjectRefRealtimeInspectorRoute =
+  ProjectRefRealtimeInspectorRouteImport.update({
+    id: '/inspector',
+    path: '/inspector',
+    getParentRoute: () => ProjectRefRealtimeRoute,
+  } as any)
+const ProjectRefObservabilityStorageRoute =
+  ProjectRefObservabilityStorageRouteImport.update({
+    id: '/storage',
+    path: '/storage',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityRealtimeRoute =
+  ProjectRefObservabilityRealtimeRouteImport.update({
+    id: '/realtime',
+    path: '/realtime',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityQueryPerformanceRoute =
+  ProjectRefObservabilityQueryPerformanceRouteImport.update({
+    id: '/query-performance',
+    path: '/query-performance',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityQueryInsightsRoute =
+  ProjectRefObservabilityQueryInsightsRouteImport.update({
+    id: '/query-insights',
+    path: '/query-insights',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityPostgrestRoute =
+  ProjectRefObservabilityPostgrestRouteImport.update({
+    id: '/postgrest',
+    path: '/postgrest',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityEdgeFunctionsRoute =
+  ProjectRefObservabilityEdgeFunctionsRouteImport.update({
+    id: '/edge-functions',
+    path: '/edge-functions',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityDatabaseRoute =
+  ProjectRefObservabilityDatabaseRouteImport.update({
+    id: '/database',
+    path: '/database',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityAuthRoute =
+  ProjectRefObservabilityAuthRouteImport.update({
+    id: '/auth',
+    path: '/auth',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityApiOverviewRoute =
+  ProjectRefObservabilityApiOverviewRouteImport.update({
+    id: '/api-overview',
+    path: '/api-overview',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefObservabilityIdRoute =
+  ProjectRefObservabilityIdRouteImport.update({
+    id: '/$id',
+    path: '/$id',
+    getParentRoute: () => ProjectRefObservabilityRoute,
+  } as any)
+const ProjectRefLogsStorageLogsRoute =
+  ProjectRefLogsStorageLogsRouteImport.update({
+    id: '/storage-logs',
+    path: '/storage-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsReplicationLogsRoute =
+  ProjectRefLogsReplicationLogsRouteImport.update({
+    id: '/replication-logs',
+    path: '/replication-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsRealtimeLogsRoute =
+  ProjectRefLogsRealtimeLogsRouteImport.update({
+    id: '/realtime-logs',
+    path: '/realtime-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsPostgrestLogsRoute =
+  ProjectRefLogsPostgrestLogsRouteImport.update({
+    id: '/postgrest-logs',
+    path: '/postgrest-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsPostgresLogsRoute =
+  ProjectRefLogsPostgresLogsRouteImport.update({
+    id: '/postgres-logs',
+    path: '/postgres-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsPoolerLogsRoute =
+  ProjectRefLogsPoolerLogsRouteImport.update({
+    id: '/pooler-logs',
+    path: '/pooler-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsPgcronLogsRoute =
+  ProjectRefLogsPgcronLogsRouteImport.update({
+    id: '/pgcron-logs',
+    path: '/pgcron-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsPgUpgradeLogsRoute =
+  ProjectRefLogsPgUpgradeLogsRouteImport.update({
+    id: '/pg-upgrade-logs',
+    path: '/pg-upgrade-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsEdgeLogsRoute = ProjectRefLogsEdgeLogsRouteImport.update({
+  id: '/edge-logs',
+  path: '/edge-logs',
+  getParentRoute: () => ProjectRefLogsRoute,
+} as any)
+const ProjectRefLogsEdgeFunctionsLogsRoute =
+  ProjectRefLogsEdgeFunctionsLogsRouteImport.update({
+    id: '/edge-functions-logs',
+    path: '/edge-functions-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsDedicatedPoolerLogsRoute =
+  ProjectRefLogsDedicatedPoolerLogsRouteImport.update({
+    id: '/dedicated-pooler-logs',
+    path: '/dedicated-pooler-logs',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsCronLogsRoute = ProjectRefLogsCronLogsRouteImport.update({
+  id: '/cron-logs',
+  path: '/cron-logs',
+  getParentRoute: () => ProjectRefLogsRoute,
+} as any)
+const ProjectRefLogsAuthLogsRoute = ProjectRefLogsAuthLogsRouteImport.update({
+  id: '/auth-logs',
+  path: '/auth-logs',
+  getParentRoute: () => ProjectRefLogsRoute,
+} as any)
+const ProjectRefFunctionsSecretsRoute =
+  ProjectRefFunctionsSecretsRouteImport.update({
+    id: '/secrets',
+    path: '/secrets',
+    getParentRoute: () => ProjectRefFunctionsRoute,
+  } as any)
+const ProjectRefFunctionsNewRoute = ProjectRefFunctionsNewRouteImport.update({
+  id: '/new',
+  path: '/new',
+  getParentRoute: () => ProjectRefFunctionsRoute,
+} as any)
+const ProjectRefFunctionsFunctionSlugRoute =
+  ProjectRefFunctionsFunctionSlugRouteImport.update({
+    id: '/$functionSlug',
+    path: '/$functionSlug',
+    getParentRoute: () => ProjectRefFunctionsRoute,
+  } as any)
+const ProjectRefEditorNewRoute = ProjectRefEditorNewRouteImport.update({
+  id: '/new',
+  path: '/new',
+  getParentRoute: () => ProjectRefEditorRoute,
+} as any)
+const ProjectRefEditorIdRoute = ProjectRefEditorIdRouteImport.update({
+  id: '/$id',
+  path: '/$id',
+  getParentRoute: () => ProjectRefEditorRoute,
+} as any)
+const ProjectRefDatabaseTypesRoute = ProjectRefDatabaseTypesRouteImport.update({
+  id: '/types',
+  path: '/types',
+  getParentRoute: () => ProjectRefDatabaseRoute,
+} as any)
+const ProjectRefDatabaseTriggersRoute =
+  ProjectRefDatabaseTriggersRouteImport.update({
+    id: '/triggers',
+    path: '/triggers',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseSettingsRoute =
+  ProjectRefDatabaseSettingsRouteImport.update({
+    id: '/settings',
+    path: '/settings',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseSchemasRoute =
+  ProjectRefDatabaseSchemasRouteImport.update({
+    id: '/schemas',
+    path: '/schemas',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseRolesRoute = ProjectRefDatabaseRolesRouteImport.update({
+  id: '/roles',
+  path: '/roles',
+  getParentRoute: () => ProjectRefDatabaseRoute,
+} as any)
+const ProjectRefDatabaseMigrationsRoute =
+  ProjectRefDatabaseMigrationsRouteImport.update({
+    id: '/migrations',
+    path: '/migrations',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseIndexesRoute =
+  ProjectRefDatabaseIndexesRouteImport.update({
+    id: '/indexes',
+    path: '/indexes',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseFunctionsRoute =
+  ProjectRefDatabaseFunctionsRouteImport.update({
+    id: '/functions',
+    path: '/functions',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseExtensionsRoute =
+  ProjectRefDatabaseExtensionsRouteImport.update({
+    id: '/extensions',
+    path: '/extensions',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseColumnPrivilegesRoute =
+  ProjectRefDatabaseColumnPrivilegesRouteImport.update({
+    id: '/column-privileges',
+    path: '/column-privileges',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefBranchesMergeRequestsRoute =
+  ProjectRefBranchesMergeRequestsRouteImport.update({
+    id: '/merge-requests',
+    path: '/merge-requests',
+    getParentRoute: () => ProjectRefBranchesRoute,
+  } as any)
+const ProjectRefAuthUsersRoute = ProjectRefAuthUsersRouteImport.update({
+  id: '/users',
+  path: '/users',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthUrlConfigurationRoute =
+  ProjectRefAuthUrlConfigurationRouteImport.update({
+    id: '/url-configuration',
+    path: '/url-configuration',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
+const ProjectRefAuthThirdPartyRoute =
+  ProjectRefAuthThirdPartyRouteImport.update({
+    id: '/third-party',
+    path: '/third-party',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
+const ProjectRefAuthSmtpRoute = ProjectRefAuthSmtpRouteImport.update({
+  id: '/smtp',
+  path: '/smtp',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthSessionsRoute = ProjectRefAuthSessionsRouteImport.update({
+  id: '/sessions',
+  path: '/sessions',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthRateLimitsRoute =
+  ProjectRefAuthRateLimitsRouteImport.update({
+    id: '/rate-limits',
+    path: '/rate-limits',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
+const ProjectRefAuthProvidersRoute = ProjectRefAuthProvidersRouteImport.update({
+  id: '/providers',
+  path: '/providers',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthProtectionRoute =
+  ProjectRefAuthProtectionRouteImport.update({
+    id: '/protection',
+    path: '/protection',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
+const ProjectRefAuthPoliciesRoute = ProjectRefAuthPoliciesRouteImport.update({
+  id: '/policies',
+  path: '/policies',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthPerformanceRoute =
+  ProjectRefAuthPerformanceRouteImport.update({
+    id: '/performance',
+    path: '/performance',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
+const ProjectRefAuthPasskeysRoute = ProjectRefAuthPasskeysRouteImport.update({
+  id: '/passkeys',
+  path: '/passkeys',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthOverviewRoute = ProjectRefAuthOverviewRouteImport.update({
+  id: '/overview',
+  path: '/overview',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthOauthServerRoute =
+  ProjectRefAuthOauthServerRouteImport.update({
+    id: '/oauth-server',
+    path: '/oauth-server',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
+const ProjectRefAuthOauthAppsRoute = ProjectRefAuthOauthAppsRouteImport.update({
+  id: '/oauth-apps',
+  path: '/oauth-apps',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthMfaRoute = ProjectRefAuthMfaRouteImport.update({
+  id: '/mfa',
+  path: '/mfa',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthHooksRoute = ProjectRefAuthHooksRouteImport.update({
+  id: '/hooks',
+  path: '/hooks',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAuthAuditLogsRoute = ProjectRefAuthAuditLogsRouteImport.update({
+  id: '/audit-logs',
+  path: '/audit-logs',
+  getParentRoute: () => ProjectRefAuthRoute,
+} as any)
+const ProjectRefAdvisorsSecurityRoute =
+  ProjectRefAdvisorsSecurityRouteImport.update({
+    id: '/security',
+    path: '/security',
+    getParentRoute: () => ProjectRefAdvisorsRoute,
+  } as any)
+const ProjectRefAdvisorsRulesRoute = ProjectRefAdvisorsRulesRouteImport.update({
+  id: '/rules',
+  path: '/rules',
+  getParentRoute: () => ProjectRefAdvisorsRoute,
+} as any)
+const ProjectRefAdvisorsPerformanceRoute =
+  ProjectRefAdvisorsPerformanceRouteImport.update({
+    id: '/performance',
+    path: '/performance',
+    getParentRoute: () => ProjectRefAdvisorsRoute,
+  } as any)
 const ApiPlatformTelemetryEventRoute =
   ApiPlatformTelemetryEventRouteImport.update({
     id: '/api/platform/telemetry/event',
@@ -493,6 +1302,90 @@ const AppAccountTokensScopedRoute = AppAccountTokensScopedRouteImport.update({
   path: '/tokens/scoped',
   getParentRoute: () => AppAccountRoute,
 } as any)
+const ProjectRefStorageVectorsIndexRoute =
+  ProjectRefStorageVectorsIndexRouteImport.update({
+    id: '/vectors/',
+    path: '/vectors/',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefStorageFilesIndexRoute =
+  ProjectRefStorageFilesIndexRouteImport.update({
+    id: '/files/',
+    path: '/files/',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefStorageAnalyticsIndexRoute =
+  ProjectRefStorageAnalyticsIndexRouteImport.update({
+    id: '/analytics/',
+    path: '/analytics/',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefSettingsWebhooksIndexRoute =
+  ProjectRefSettingsWebhooksIndexRouteImport.update({
+    id: '/webhooks/',
+    path: '/webhooks/',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsJwtIndexRoute =
+  ProjectRefSettingsJwtIndexRouteImport.update({
+    id: '/jwt/',
+    path: '/jwt/',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsApiKeysIndexRoute =
+  ProjectRefSettingsApiKeysIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ProjectRefSettingsApiKeysRoute,
+  } as any)
+const ProjectRefLogsExplorerIndexRoute =
+  ProjectRefLogsExplorerIndexRouteImport.update({
+    id: '/explorer/',
+    path: '/explorer/',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefIntegrationsIdIndexRoute =
+  ProjectRefIntegrationsIdIndexRouteImport.update({
+    id: '/$id/',
+    path: '/$id/',
+    getParentRoute: () => ProjectRefIntegrationsRoute,
+  } as any)
+const ProjectRefFunctionsFunctionSlugIndexRoute =
+  ProjectRefFunctionsFunctionSlugIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ProjectRefFunctionsFunctionSlugRoute,
+  } as any)
+const ProjectRefDatabaseTriggersIndexRoute =
+  ProjectRefDatabaseTriggersIndexRouteImport.update({
+    id: '/',
+    path: '/',
+    getParentRoute: () => ProjectRefDatabaseTriggersRoute,
+  } as any)
+const ProjectRefDatabaseTablesIndexRoute =
+  ProjectRefDatabaseTablesIndexRouteImport.update({
+    id: '/tables/',
+    path: '/tables/',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseReplicationIndexRoute =
+  ProjectRefDatabaseReplicationIndexRouteImport.update({
+    id: '/replication/',
+    path: '/replication/',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabasePublicationsIndexRoute =
+  ProjectRefDatabasePublicationsIndexRouteImport.update({
+    id: '/publications/',
+    path: '/publications/',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefAuthTemplatesIndexRoute =
+  ProjectRefAuthTemplatesIndexRouteImport.update({
+    id: '/templates/',
+    path: '/templates/',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
 const ApiPlatformProjectsRefIndexRoute =
   ApiPlatformProjectsRefIndexRouteImport.update({
     id: '/api/platform/projects/$ref/',
@@ -509,6 +1402,162 @@ const AppOrgSlugPrivateAppsIndexRoute =
     id: '/$slug/private-apps/',
     path: '/$slug/private-apps/',
     getParentRoute: () => AppOrgRoute,
+  } as any)
+const ProjectRefStorageFilesSettingsRoute =
+  ProjectRefStorageFilesSettingsRouteImport.update({
+    id: '/files/settings',
+    path: '/files/settings',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefStorageFilesPoliciesRoute =
+  ProjectRefStorageFilesPoliciesRouteImport.update({
+    id: '/files/policies',
+    path: '/files/policies',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefSettingsWebhooksEndpointIdRoute =
+  ProjectRefSettingsWebhooksEndpointIdRouteImport.update({
+    id: '/webhooks/$endpointId',
+    path: '/webhooks/$endpointId',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsJwtLegacyRoute =
+  ProjectRefSettingsJwtLegacyRouteImport.update({
+    id: '/jwt/legacy',
+    path: '/jwt/legacy',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsBillingUsageRoute =
+  ProjectRefSettingsBillingUsageRouteImport.update({
+    id: '/billing/usage',
+    path: '/billing/usage',
+    getParentRoute: () => ProjectRefSettingsRoute,
+  } as any)
+const ProjectRefSettingsApiKeysLegacyRoute =
+  ProjectRefSettingsApiKeysLegacyRouteImport.update({
+    id: '/legacy',
+    path: '/legacy',
+    getParentRoute: () => ProjectRefSettingsApiKeysRoute,
+  } as any)
+const ProjectRefLogsExplorerTemplatesRoute =
+  ProjectRefLogsExplorerTemplatesRouteImport.update({
+    id: '/explorer/templates',
+    path: '/explorer/templates',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsExplorerSavedRoute =
+  ProjectRefLogsExplorerSavedRouteImport.update({
+    id: '/explorer/saved',
+    path: '/explorer/saved',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefLogsExplorerRecentRoute =
+  ProjectRefLogsExplorerRecentRouteImport.update({
+    id: '/explorer/recent',
+    path: '/explorer/recent',
+    getParentRoute: () => ProjectRefLogsRoute,
+  } as any)
+const ProjectRefFunctionsFunctionSlugLogsRoute =
+  ProjectRefFunctionsFunctionSlugLogsRouteImport.update({
+    id: '/logs',
+    path: '/logs',
+    getParentRoute: () => ProjectRefFunctionsFunctionSlugRoute,
+  } as any)
+const ProjectRefFunctionsFunctionSlugInvocationsRoute =
+  ProjectRefFunctionsFunctionSlugInvocationsRouteImport.update({
+    id: '/invocations',
+    path: '/invocations',
+    getParentRoute: () => ProjectRefFunctionsFunctionSlugRoute,
+  } as any)
+const ProjectRefFunctionsFunctionSlugDetailsRoute =
+  ProjectRefFunctionsFunctionSlugDetailsRouteImport.update({
+    id: '/details',
+    path: '/details',
+    getParentRoute: () => ProjectRefFunctionsFunctionSlugRoute,
+  } as any)
+const ProjectRefFunctionsFunctionSlugCodeRoute =
+  ProjectRefFunctionsFunctionSlugCodeRouteImport.update({
+    id: '/code',
+    path: '/code',
+    getParentRoute: () => ProjectRefFunctionsFunctionSlugRoute,
+  } as any)
+const ProjectRefDatabaseTriggersEventRoute =
+  ProjectRefDatabaseTriggersEventRouteImport.update({
+    id: '/event',
+    path: '/event',
+    getParentRoute: () => ProjectRefDatabaseTriggersRoute,
+  } as any)
+const ProjectRefDatabaseTriggersDataRoute =
+  ProjectRefDatabaseTriggersDataRouteImport.update({
+    id: '/data',
+    path: '/data',
+    getParentRoute: () => ProjectRefDatabaseTriggersRoute,
+  } as any)
+const ProjectRefDatabaseTablesIdRoute =
+  ProjectRefDatabaseTablesIdRouteImport.update({
+    id: '/tables/$id',
+    path: '/tables/$id',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseReplicationPipelineIdRoute =
+  ProjectRefDatabaseReplicationPipelineIdRouteImport.update({
+    id: '/replication/$pipelineId',
+    path: '/replication/$pipelineId',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabasePublicationsIdRoute =
+  ProjectRefDatabasePublicationsIdRouteImport.update({
+    id: '/publications/$id',
+    path: '/publications/$id',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseBackupsScheduledRoute =
+  ProjectRefDatabaseBackupsScheduledRouteImport.update({
+    id: '/backups/scheduled',
+    path: '/backups/scheduled',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseBackupsRestoreToNewProjectRoute =
+  ProjectRefDatabaseBackupsRestoreToNewProjectRouteImport.update({
+    id: '/backups/restore-to-new-project',
+    path: '/backups/restore-to-new-project',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefDatabaseBackupsPitrRoute =
+  ProjectRefDatabaseBackupsPitrRouteImport.update({
+    id: '/backups/pitr',
+    path: '/backups/pitr',
+    getParentRoute: () => ProjectRefDatabaseRoute,
+  } as any)
+const ProjectRefAuthTemplatesTemplateIdRoute =
+  ProjectRefAuthTemplatesTemplateIdRouteImport.update({
+    id: '/templates/$templateId',
+    path: '/templates/$templateId',
+    getParentRoute: () => ProjectRefAuthRoute,
+  } as any)
+const ProjectRefAdvisorsRulesSecurityRoute =
+  ProjectRefAdvisorsRulesSecurityRouteImport.update({
+    id: '/security',
+    path: '/security',
+    getParentRoute: () => ProjectRefAdvisorsRulesRoute,
+  } as any)
+const ProjectRefAdvisorsRulesPerformanceRoute =
+  ProjectRefAdvisorsRulesPerformanceRouteImport.update({
+    id: '/performance',
+    path: '/performance',
+    getParentRoute: () => ProjectRefAdvisorsRulesRoute,
+  } as any)
+const IntegrationsVercelSlugMarketplaceChooseProjectRoute =
+  IntegrationsVercelSlugMarketplaceChooseProjectRouteImport.update({
+    id: '/$slug/marketplace/choose-project',
+    path: '/$slug/marketplace/choose-project',
+    getParentRoute: () => IntegrationsVercelRoute,
+  } as any)
+const IntegrationsVercelSlugDeployButtonNewProjectRoute =
+  IntegrationsVercelSlugDeployButtonNewProjectRouteImport.update({
+    id: '/$slug/deploy-button/new-project',
+    path: '/$slug/deploy-button/new-project',
+    getParentRoute: () => IntegrationsVercelRoute,
   } as any)
 const ApiV1ProjectsRefApiKeysRoute = ApiV1ProjectsRefApiKeysRouteImport.update({
   id: '/api/v1/projects/$ref/api-keys',
@@ -653,15 +1702,21 @@ const ApiPlatformAuthRefInviteRoute =
   } as any)
 const AuthPartnersStripeProjectsLoginRoute =
   AuthPartnersStripeProjectsLoginRouteImport.update({
-    id: '/_auth/partners/stripe/projects/login',
+    id: '/partners/stripe/projects/login',
     path: '/partners/stripe/projects/login',
-    getParentRoute: () => rootRouteImport,
+    getParentRoute: () => AuthRoute,
   } as any)
 const AppOrgSlugWebhooksEndpointIdRoute =
   AppOrgSlugWebhooksEndpointIdRouteImport.update({
     id: '/$slug/webhooks/$endpointId',
     path: '/$slug/webhooks/$endpointId',
     getParentRoute: () => AppOrgRoute,
+  } as any)
+const ProjectRefIntegrationsIdPageIdIndexRoute =
+  ProjectRefIntegrationsIdPageIdIndexRouteImport.update({
+    id: '/$id/$pageId/',
+    path: '/$id/$pageId/',
+    getParentRoute: () => ProjectRefIntegrationsRoute,
   } as any)
 const ApiV1ProjectsRefFunctionsIndexRoute =
   ApiV1ProjectsRefFunctionsIndexRouteImport.update({
@@ -710,6 +1765,30 @@ const ApiPlatformAuthRefUsersIndexRoute =
     id: '/api/platform/auth/$ref/users/',
     path: '/api/platform/auth/$ref/users/',
     getParentRoute: () => rootRouteImport,
+  } as any)
+const ProjectRefStorageVectorsBucketsBucketIdRoute =
+  ProjectRefStorageVectorsBucketsBucketIdRouteImport.update({
+    id: '/vectors/buckets/$bucketId',
+    path: '/vectors/buckets/$bucketId',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefStorageFilesBucketsBucketIdRoute =
+  ProjectRefStorageFilesBucketsBucketIdRouteImport.update({
+    id: '/files/buckets/$bucketId',
+    path: '/files/buckets/$bucketId',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefStorageAnalyticsBucketsBucketIdRoute =
+  ProjectRefStorageAnalyticsBucketsBucketIdRouteImport.update({
+    id: '/analytics/buckets/$bucketId',
+    path: '/analytics/buckets/$bucketId',
+    getParentRoute: () => ProjectRefStorageRoute,
+  } as any)
+const ProjectRefDatabaseReplicationReplicaReplicaIdRoute =
+  ProjectRefDatabaseReplicationReplicaReplicaIdRouteImport.update({
+    id: '/replication/replica/$replicaId',
+    path: '/replication/replica/$replicaId',
+    getParentRoute: () => ProjectRefDatabaseRoute,
   } as any)
 const ApiV1ProjectsRefTypesTypescriptRoute =
   ApiV1ProjectsRefTypesTypescriptRouteImport.update({
@@ -782,6 +1861,12 @@ const ApiPlatformOrganizationsSlugBillingSubscriptionRoute =
     id: '/api/platform/organizations/$slug/billing/subscription',
     path: '/api/platform/organizations/$slug/billing/subscription',
     getParentRoute: () => rootRouteImport,
+  } as any)
+const ProjectRefIntegrationsIdPageIdChildIdIndexRoute =
+  ProjectRefIntegrationsIdPageIdChildIdIndexRouteImport.update({
+    id: '/$id/$pageId/$childId/',
+    path: '/$id/$pageId/$childId/',
+    getParentRoute: () => ProjectRefIntegrationsRoute,
   } as any)
 const ApiV1ProjectsRefFunctionsSlugIndexRoute =
   ApiV1ProjectsRefFunctionsSlugIndexRouteImport.update({
@@ -929,6 +2014,15 @@ const ApiPlatformStorageRefBucketsIdObjectsDownloadRoute =
   } as any)
 
 export interface FileRoutesByFullPath {
+  '/': typeof IndexRoute
+  '/authorize': typeof AuthorizeRoute
+  '/aws-marketplace-onboarding': typeof AwsMarketplaceOnboardingRoute
+  '/claim-project': typeof ClaimProjectRoute
+  '/join': typeof JoinRoute
+  '/logout': typeof LogoutRoute
+  '/maintenance': typeof MaintenanceRoute
+  '/redeem': typeof RedeemRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/account': typeof AppAccountRouteWithChildren
   '/org': typeof AppOrgRouteWithChildren
   '/organizations': typeof AppOrganizationsRoute
@@ -952,6 +2046,11 @@ export interface FileRoutesByFullPath {
   '/api/incident-status': typeof ApiIncidentStatusRoute
   '/api/parse-query': typeof ApiParseQueryRoute
   '/api/status-override': typeof ApiStatusOverrideRoute
+  '/integrations/vercel': typeof IntegrationsVercelRouteWithChildren
+  '/new/$slug': typeof NewSlugRoute
+  '/org/_': typeof OrgChar91_Char93RouteWithChildren
+  '/project/$ref': typeof ProjectRefRouteWithChildren
+  '/project/_': typeof ProjectChar91_Char93RouteWithChildren
   '/account/audit': typeof AppAccountAuditRoute
   '/account/me': typeof AppAccountMeRoute
   '/account/security': typeof AppAccountSecurityRoute
@@ -963,10 +2062,29 @@ export interface FileRoutesByFullPath {
   '/api/edge-functions/test': typeof ApiEdgeFunctionsTestRoute
   '/api/integrations/stripe-sync': typeof ApiIntegrationsStripeSyncRoute
   '/api/platform/deployment-mode': typeof ApiPlatformDeploymentModeRoute
+  '/integrations/github/authorize': typeof IntegrationsGithubAuthorizeRoute
+  '/integrations/vercel/install': typeof IntegrationsVercelInstallRoute
+  '/org/_/$': typeof OrgChar91_Char93SplatRoute
+  '/project/$ref/advisors': typeof ProjectRefAdvisorsRouteWithChildren
+  '/project/$ref/auth': typeof ProjectRefAuthRouteWithChildren
+  '/project/$ref/branches': typeof ProjectRefBranchesRouteWithChildren
+  '/project/$ref/database': typeof ProjectRefDatabaseRouteWithChildren
+  '/project/$ref/editor': typeof ProjectRefEditorRouteWithChildren
+  '/project/$ref/functions': typeof ProjectRefFunctionsRouteWithChildren
+  '/project/$ref/integrations': typeof ProjectRefIntegrationsRouteWithChildren
+  '/project/$ref/logs': typeof ProjectRefLogsRouteWithChildren
+  '/project/$ref/merge': typeof ProjectRefMergeRoute
+  '/project/$ref/observability': typeof ProjectRefObservabilityRouteWithChildren
+  '/project/$ref/realtime': typeof ProjectRefRealtimeRouteWithChildren
+  '/project/$ref/settings': typeof ProjectRefSettingsRouteWithChildren
+  '/project/$ref/sql': typeof ProjectRefSqlRouteWithChildren
+  '/project/$ref/storage': typeof ProjectRefStorageRouteWithChildren
+  '/project/_/$': typeof ProjectChar91_Char93SplatRoute
   '/new/': typeof AppNewIndexRoute
   '/org/': typeof AppOrgIndexRoute
   '/api/connect/': typeof ApiConnectIndexRoute
   '/api/mcp/': typeof ApiMcpIndexRoute
+  '/project/$ref/': typeof ProjectRefIndexRoute
   '/account/tokens/scoped': typeof AppAccountTokensScopedRoute
   '/org/$slug/apps': typeof AppOrgSlugAppsRoute
   '/org/$slug/audit': typeof AppOrgSlugAuditRoute
@@ -991,11 +2109,94 @@ export interface FileRoutesByFullPath {
   '/api/ai/sql/title-v2': typeof ApiAiSqlTitleV2Route
   '/api/platform/integrations/$slug': typeof ApiPlatformIntegrationsSlugRoute
   '/api/platform/telemetry/event': typeof ApiPlatformTelemetryEventRoute
+  '/project/$ref/advisors/performance': typeof ProjectRefAdvisorsPerformanceRoute
+  '/project/$ref/advisors/rules': typeof ProjectRefAdvisorsRulesRouteWithChildren
+  '/project/$ref/advisors/security': typeof ProjectRefAdvisorsSecurityRoute
+  '/project/$ref/auth/audit-logs': typeof ProjectRefAuthAuditLogsRoute
+  '/project/$ref/auth/hooks': typeof ProjectRefAuthHooksRoute
+  '/project/$ref/auth/mfa': typeof ProjectRefAuthMfaRoute
+  '/project/$ref/auth/oauth-apps': typeof ProjectRefAuthOauthAppsRoute
+  '/project/$ref/auth/oauth-server': typeof ProjectRefAuthOauthServerRoute
+  '/project/$ref/auth/overview': typeof ProjectRefAuthOverviewRoute
+  '/project/$ref/auth/passkeys': typeof ProjectRefAuthPasskeysRoute
+  '/project/$ref/auth/performance': typeof ProjectRefAuthPerformanceRoute
+  '/project/$ref/auth/policies': typeof ProjectRefAuthPoliciesRoute
+  '/project/$ref/auth/protection': typeof ProjectRefAuthProtectionRoute
+  '/project/$ref/auth/providers': typeof ProjectRefAuthProvidersRoute
+  '/project/$ref/auth/rate-limits': typeof ProjectRefAuthRateLimitsRoute
+  '/project/$ref/auth/sessions': typeof ProjectRefAuthSessionsRoute
+  '/project/$ref/auth/smtp': typeof ProjectRefAuthSmtpRoute
+  '/project/$ref/auth/third-party': typeof ProjectRefAuthThirdPartyRoute
+  '/project/$ref/auth/url-configuration': typeof ProjectRefAuthUrlConfigurationRoute
+  '/project/$ref/auth/users': typeof ProjectRefAuthUsersRoute
+  '/project/$ref/branches/merge-requests': typeof ProjectRefBranchesMergeRequestsRoute
+  '/project/$ref/database/column-privileges': typeof ProjectRefDatabaseColumnPrivilegesRoute
+  '/project/$ref/database/extensions': typeof ProjectRefDatabaseExtensionsRoute
+  '/project/$ref/database/functions': typeof ProjectRefDatabaseFunctionsRoute
+  '/project/$ref/database/indexes': typeof ProjectRefDatabaseIndexesRoute
+  '/project/$ref/database/migrations': typeof ProjectRefDatabaseMigrationsRoute
+  '/project/$ref/database/roles': typeof ProjectRefDatabaseRolesRoute
+  '/project/$ref/database/schemas': typeof ProjectRefDatabaseSchemasRoute
+  '/project/$ref/database/settings': typeof ProjectRefDatabaseSettingsRoute
+  '/project/$ref/database/triggers': typeof ProjectRefDatabaseTriggersRouteWithChildren
+  '/project/$ref/database/types': typeof ProjectRefDatabaseTypesRoute
+  '/project/$ref/editor/$id': typeof ProjectRefEditorIdRoute
+  '/project/$ref/editor/new': typeof ProjectRefEditorNewRoute
+  '/project/$ref/functions/$functionSlug': typeof ProjectRefFunctionsFunctionSlugRouteWithChildren
+  '/project/$ref/functions/new': typeof ProjectRefFunctionsNewRoute
+  '/project/$ref/functions/secrets': typeof ProjectRefFunctionsSecretsRoute
+  '/project/$ref/logs/auth-logs': typeof ProjectRefLogsAuthLogsRoute
+  '/project/$ref/logs/cron-logs': typeof ProjectRefLogsCronLogsRoute
+  '/project/$ref/logs/dedicated-pooler-logs': typeof ProjectRefLogsDedicatedPoolerLogsRoute
+  '/project/$ref/logs/edge-functions-logs': typeof ProjectRefLogsEdgeFunctionsLogsRoute
+  '/project/$ref/logs/edge-logs': typeof ProjectRefLogsEdgeLogsRoute
+  '/project/$ref/logs/pg-upgrade-logs': typeof ProjectRefLogsPgUpgradeLogsRoute
+  '/project/$ref/logs/pgcron-logs': typeof ProjectRefLogsPgcronLogsRoute
+  '/project/$ref/logs/pooler-logs': typeof ProjectRefLogsPoolerLogsRoute
+  '/project/$ref/logs/postgres-logs': typeof ProjectRefLogsPostgresLogsRoute
+  '/project/$ref/logs/postgrest-logs': typeof ProjectRefLogsPostgrestLogsRoute
+  '/project/$ref/logs/realtime-logs': typeof ProjectRefLogsRealtimeLogsRoute
+  '/project/$ref/logs/replication-logs': typeof ProjectRefLogsReplicationLogsRoute
+  '/project/$ref/logs/storage-logs': typeof ProjectRefLogsStorageLogsRoute
+  '/project/$ref/observability/$id': typeof ProjectRefObservabilityIdRoute
+  '/project/$ref/observability/api-overview': typeof ProjectRefObservabilityApiOverviewRoute
+  '/project/$ref/observability/auth': typeof ProjectRefObservabilityAuthRoute
+  '/project/$ref/observability/database': typeof ProjectRefObservabilityDatabaseRoute
+  '/project/$ref/observability/edge-functions': typeof ProjectRefObservabilityEdgeFunctionsRoute
+  '/project/$ref/observability/postgrest': typeof ProjectRefObservabilityPostgrestRoute
+  '/project/$ref/observability/query-insights': typeof ProjectRefObservabilityQueryInsightsRoute
+  '/project/$ref/observability/query-performance': typeof ProjectRefObservabilityQueryPerformanceRoute
+  '/project/$ref/observability/realtime': typeof ProjectRefObservabilityRealtimeRoute
+  '/project/$ref/observability/storage': typeof ProjectRefObservabilityStorageRoute
+  '/project/$ref/realtime/inspector': typeof ProjectRefRealtimeInspectorRoute
+  '/project/$ref/realtime/policies': typeof ProjectRefRealtimePoliciesRoute
+  '/project/$ref/realtime/settings': typeof ProjectRefRealtimeSettingsRoute
+  '/project/$ref/settings/addons': typeof ProjectRefSettingsAddonsRoute
+  '/project/$ref/settings/api': typeof ProjectRefSettingsApiRoute
+  '/project/$ref/settings/api-keys': typeof ProjectRefSettingsApiKeysRouteWithChildren
+  '/project/$ref/settings/compute-and-disk': typeof ProjectRefSettingsComputeAndDiskRoute
+  '/project/$ref/settings/dashboard': typeof ProjectRefSettingsDashboardRoute
+  '/project/$ref/settings/general': typeof ProjectRefSettingsGeneralRoute
+  '/project/$ref/settings/infrastructure': typeof ProjectRefSettingsInfrastructureRoute
+  '/project/$ref/settings/integrations': typeof ProjectRefSettingsIntegrationsRoute
+  '/project/$ref/settings/log-drains': typeof ProjectRefSettingsLogDrainsRoute
+  '/project/$ref/sql/$id': typeof ProjectRefSqlIdRoute
+  '/project/$ref/sql/examples': typeof ProjectRefSqlExamplesRoute
+  '/project/$ref/sql/templates': typeof ProjectRefSqlTemplatesRoute
+  '/project/$ref/storage/s3': typeof ProjectRefStorageS3Route
   '/account/tokens/': typeof AppAccountTokensIndexRoute
   '/org/$slug/': typeof AppOrgSlugIndexRoute
   '/api/platform/organizations/': typeof ApiPlatformOrganizationsIndexRoute
   '/api/platform/profile/': typeof ApiPlatformProfileIndexRoute
   '/api/platform/projects/': typeof ApiPlatformProjectsIndexRoute
+  '/project/$ref/api/': typeof ProjectRefApiIndexRoute
+  '/project/$ref/branches/': typeof ProjectRefBranchesIndexRoute
+  '/project/$ref/editor/': typeof ProjectRefEditorIndexRoute
+  '/project/$ref/functions/': typeof ProjectRefFunctionsIndexRoute
+  '/project/$ref/integrations/': typeof ProjectRefIntegrationsIndexRoute
+  '/project/$ref/logs/': typeof ProjectRefLogsIndexRoute
+  '/project/$ref/observability/': typeof ProjectRefObservabilityIndexRoute
+  '/project/$ref/sql/': typeof ProjectRefSqlIndexRoute
   '/org/$slug/webhooks/$endpointId': typeof AppOrgSlugWebhooksEndpointIdRoute
   '/partners/stripe/projects/login': typeof AuthPartnersStripeProjectsLoginRoute
   '/api/platform/auth/$ref/invite': typeof ApiPlatformAuthRefInviteRoute
@@ -1022,9 +2223,49 @@ export interface FileRoutesByFullPath {
   '/api/platform/projects/$ref/settings': typeof ApiPlatformProjectsRefSettingsRoute
   '/api/platform/props/org/$slug': typeof ApiPlatformPropsOrgSlugRoute
   '/api/v1/projects/$ref/api-keys': typeof ApiV1ProjectsRefApiKeysRouteWithChildren
+  '/integrations/vercel/$slug/deploy-button/new-project': typeof IntegrationsVercelSlugDeployButtonNewProjectRoute
+  '/integrations/vercel/$slug/marketplace/choose-project': typeof IntegrationsVercelSlugMarketplaceChooseProjectRoute
+  '/project/$ref/advisors/rules/performance': typeof ProjectRefAdvisorsRulesPerformanceRoute
+  '/project/$ref/advisors/rules/security': typeof ProjectRefAdvisorsRulesSecurityRoute
+  '/project/$ref/auth/templates/$templateId': typeof ProjectRefAuthTemplatesTemplateIdRoute
+  '/project/$ref/database/backups/pitr': typeof ProjectRefDatabaseBackupsPitrRoute
+  '/project/$ref/database/backups/restore-to-new-project': typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
+  '/project/$ref/database/backups/scheduled': typeof ProjectRefDatabaseBackupsScheduledRoute
+  '/project/$ref/database/publications/$id': typeof ProjectRefDatabasePublicationsIdRoute
+  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRoute
+  '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
+  '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
+  '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
+  '/project/$ref/functions/$functionSlug/code': typeof ProjectRefFunctionsFunctionSlugCodeRoute
+  '/project/$ref/functions/$functionSlug/details': typeof ProjectRefFunctionsFunctionSlugDetailsRoute
+  '/project/$ref/functions/$functionSlug/invocations': typeof ProjectRefFunctionsFunctionSlugInvocationsRoute
+  '/project/$ref/functions/$functionSlug/logs': typeof ProjectRefFunctionsFunctionSlugLogsRoute
+  '/project/$ref/logs/explorer/recent': typeof ProjectRefLogsExplorerRecentRoute
+  '/project/$ref/logs/explorer/saved': typeof ProjectRefLogsExplorerSavedRoute
+  '/project/$ref/logs/explorer/templates': typeof ProjectRefLogsExplorerTemplatesRoute
+  '/project/$ref/settings/api-keys/legacy': typeof ProjectRefSettingsApiKeysLegacyRoute
+  '/project/$ref/settings/billing/usage': typeof ProjectRefSettingsBillingUsageRoute
+  '/project/$ref/settings/jwt/legacy': typeof ProjectRefSettingsJwtLegacyRoute
+  '/project/$ref/settings/webhooks/$endpointId': typeof ProjectRefSettingsWebhooksEndpointIdRoute
+  '/project/$ref/storage/files/policies': typeof ProjectRefStorageFilesPoliciesRoute
+  '/project/$ref/storage/files/settings': typeof ProjectRefStorageFilesSettingsRoute
   '/org/$slug/private-apps/': typeof AppOrgSlugPrivateAppsIndexRoute
   '/org/$slug/webhooks/': typeof AppOrgSlugWebhooksIndexRoute
   '/api/platform/projects/$ref/': typeof ApiPlatformProjectsRefIndexRoute
+  '/project/$ref/auth/templates/': typeof ProjectRefAuthTemplatesIndexRoute
+  '/project/$ref/database/publications/': typeof ProjectRefDatabasePublicationsIndexRoute
+  '/project/$ref/database/replication/': typeof ProjectRefDatabaseReplicationIndexRoute
+  '/project/$ref/database/tables/': typeof ProjectRefDatabaseTablesIndexRoute
+  '/project/$ref/database/triggers/': typeof ProjectRefDatabaseTriggersIndexRoute
+  '/project/$ref/functions/$functionSlug/': typeof ProjectRefFunctionsFunctionSlugIndexRoute
+  '/project/$ref/integrations/$id/': typeof ProjectRefIntegrationsIdIndexRoute
+  '/project/$ref/logs/explorer/': typeof ProjectRefLogsExplorerIndexRoute
+  '/project/$ref/settings/api-keys/': typeof ProjectRefSettingsApiKeysIndexRoute
+  '/project/$ref/settings/jwt/': typeof ProjectRefSettingsJwtIndexRoute
+  '/project/$ref/settings/webhooks/': typeof ProjectRefSettingsWebhooksIndexRoute
+  '/project/$ref/storage/analytics/': typeof ProjectRefStorageAnalyticsIndexRoute
+  '/project/$ref/storage/files/': typeof ProjectRefStorageFilesIndexRoute
+  '/project/$ref/storage/vectors/': typeof ProjectRefStorageVectorsIndexRoute
   '/api/platform/organizations/$slug/billing/subscription': typeof ApiPlatformOrganizationsSlugBillingSubscriptionRoute
   '/api/platform/projects/$ref/analytics/log-drains': typeof ApiPlatformProjectsRefAnalyticsLogDrainsRouteWithChildren
   '/api/platform/projects/$ref/api-keys/temporary': typeof ApiPlatformProjectsRefApiKeysTemporaryRoute
@@ -1037,6 +2278,10 @@ export interface FileRoutesByFullPath {
   '/api/v1/projects/$ref/api-keys/$id': typeof ApiV1ProjectsRefApiKeysIdRoute
   '/api/v1/projects/$ref/database/migrations': typeof ApiV1ProjectsRefDatabaseMigrationsRoute
   '/api/v1/projects/$ref/types/typescript': typeof ApiV1ProjectsRefTypesTypescriptRoute
+  '/project/$ref/database/replication/replica/$replicaId': typeof ProjectRefDatabaseReplicationReplicaReplicaIdRoute
+  '/project/$ref/storage/analytics/buckets/$bucketId': typeof ProjectRefStorageAnalyticsBucketsBucketIdRoute
+  '/project/$ref/storage/files/buckets/$bucketId': typeof ProjectRefStorageFilesBucketsBucketIdRoute
+  '/project/$ref/storage/vectors/buckets/$bucketId': typeof ProjectRefStorageVectorsBucketsBucketIdRoute
   '/api/platform/auth/$ref/users/': typeof ApiPlatformAuthRefUsersIndexRoute
   '/api/platform/pg-meta/$ref/query/': typeof ApiPlatformPgMetaRefQueryIndexRoute
   '/api/platform/projects/$ref/config/': typeof ApiPlatformProjectsRefConfigIndexRoute
@@ -1045,6 +2290,7 @@ export interface FileRoutesByFullPath {
   '/api/platform/storage/$ref/buckets/': typeof ApiPlatformStorageRefBucketsIndexRoute
   '/api/platform/storage/$ref/vector-buckets/': typeof ApiPlatformStorageRefVectorBucketsIndexRoute
   '/api/v1/projects/$ref/functions/': typeof ApiV1ProjectsRefFunctionsIndexRoute
+  '/project/$ref/integrations/$id/$pageId/': typeof ProjectRefIntegrationsIdPageIdIndexRoute
   '/api/platform/auth/$ref/users/$id/factors': typeof ApiPlatformAuthRefUsersIdFactorsRoute
   '/api/platform/projects/$ref/analytics/endpoints/$name': typeof ApiPlatformProjectsRefAnalyticsEndpointsNameRoute
   '/api/platform/projects/$ref/analytics/log-drains/$uuid': typeof ApiPlatformProjectsRefAnalyticsLogDrainsUuidRoute
@@ -1058,6 +2304,7 @@ export interface FileRoutesByFullPath {
   '/api/platform/storage/$ref/buckets/$id/': typeof ApiPlatformStorageRefBucketsIdIndexRoute
   '/api/platform/storage/$ref/vector-buckets/$id/': typeof ApiPlatformStorageRefVectorBucketsIdIndexRoute
   '/api/v1/projects/$ref/functions/$slug/': typeof ApiV1ProjectsRefFunctionsSlugIndexRoute
+  '/project/$ref/integrations/$id/$pageId/$childId/': typeof ProjectRefIntegrationsIdPageIdChildIdIndexRoute
   '/api/platform/storage/$ref/buckets/$id/objects/download': typeof ApiPlatformStorageRefBucketsIdObjectsDownloadRoute
   '/api/platform/storage/$ref/buckets/$id/objects/list': typeof ApiPlatformStorageRefBucketsIdObjectsListRoute
   '/api/platform/storage/$ref/buckets/$id/objects/move': typeof ApiPlatformStorageRefBucketsIdObjectsMoveRoute
@@ -1071,6 +2318,15 @@ export interface FileRoutesByFullPath {
   '/api/v1/projects/$ref/config/auth/signing-keys/': typeof ApiV1ProjectsRefConfigAuthSigningKeysIndexRoute
 }
 export interface FileRoutesByTo {
+  '/': typeof IndexRoute
+  '/authorize': typeof AuthorizeRoute
+  '/aws-marketplace-onboarding': typeof AwsMarketplaceOnboardingRoute
+  '/claim-project': typeof ClaimProjectRoute
+  '/join': typeof JoinRoute
+  '/logout': typeof LogoutRoute
+  '/maintenance': typeof MaintenanceRoute
+  '/redeem': typeof RedeemRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/account': typeof AppAccountRouteWithChildren
   '/organizations': typeof AppOrganizationsRoute
   '/forgot-password': typeof AuthForgotPasswordRoute
@@ -1093,6 +2349,10 @@ export interface FileRoutesByTo {
   '/api/incident-status': typeof ApiIncidentStatusRoute
   '/api/parse-query': typeof ApiParseQueryRoute
   '/api/status-override': typeof ApiStatusOverrideRoute
+  '/integrations/vercel': typeof IntegrationsVercelRouteWithChildren
+  '/new/$slug': typeof NewSlugRoute
+  '/org/_': typeof OrgChar91_Char93RouteWithChildren
+  '/project/_': typeof ProjectChar91_Char93RouteWithChildren
   '/account/audit': typeof AppAccountAuditRoute
   '/account/me': typeof AppAccountMeRoute
   '/account/security': typeof AppAccountSecurityRoute
@@ -1104,10 +2364,22 @@ export interface FileRoutesByTo {
   '/api/edge-functions/test': typeof ApiEdgeFunctionsTestRoute
   '/api/integrations/stripe-sync': typeof ApiIntegrationsStripeSyncRoute
   '/api/platform/deployment-mode': typeof ApiPlatformDeploymentModeRoute
+  '/integrations/github/authorize': typeof IntegrationsGithubAuthorizeRoute
+  '/integrations/vercel/install': typeof IntegrationsVercelInstallRoute
+  '/org/_/$': typeof OrgChar91_Char93SplatRoute
+  '/project/$ref/advisors': typeof ProjectRefAdvisorsRouteWithChildren
+  '/project/$ref/auth': typeof ProjectRefAuthRouteWithChildren
+  '/project/$ref/database': typeof ProjectRefDatabaseRouteWithChildren
+  '/project/$ref/merge': typeof ProjectRefMergeRoute
+  '/project/$ref/realtime': typeof ProjectRefRealtimeRouteWithChildren
+  '/project/$ref/settings': typeof ProjectRefSettingsRouteWithChildren
+  '/project/$ref/storage': typeof ProjectRefStorageRouteWithChildren
+  '/project/_/$': typeof ProjectChar91_Char93SplatRoute
   '/new': typeof AppNewIndexRoute
   '/org': typeof AppOrgIndexRoute
   '/api/connect': typeof ApiConnectIndexRoute
   '/api/mcp': typeof ApiMcpIndexRoute
+  '/project/$ref': typeof ProjectRefIndexRoute
   '/account/tokens/scoped': typeof AppAccountTokensScopedRoute
   '/org/$slug/apps': typeof AppOrgSlugAppsRoute
   '/org/$slug/audit': typeof AppOrgSlugAuditRoute
@@ -1132,11 +2404,91 @@ export interface FileRoutesByTo {
   '/api/ai/sql/title-v2': typeof ApiAiSqlTitleV2Route
   '/api/platform/integrations/$slug': typeof ApiPlatformIntegrationsSlugRoute
   '/api/platform/telemetry/event': typeof ApiPlatformTelemetryEventRoute
+  '/project/$ref/advisors/performance': typeof ProjectRefAdvisorsPerformanceRoute
+  '/project/$ref/advisors/rules': typeof ProjectRefAdvisorsRulesRouteWithChildren
+  '/project/$ref/advisors/security': typeof ProjectRefAdvisorsSecurityRoute
+  '/project/$ref/auth/audit-logs': typeof ProjectRefAuthAuditLogsRoute
+  '/project/$ref/auth/hooks': typeof ProjectRefAuthHooksRoute
+  '/project/$ref/auth/mfa': typeof ProjectRefAuthMfaRoute
+  '/project/$ref/auth/oauth-apps': typeof ProjectRefAuthOauthAppsRoute
+  '/project/$ref/auth/oauth-server': typeof ProjectRefAuthOauthServerRoute
+  '/project/$ref/auth/overview': typeof ProjectRefAuthOverviewRoute
+  '/project/$ref/auth/passkeys': typeof ProjectRefAuthPasskeysRoute
+  '/project/$ref/auth/performance': typeof ProjectRefAuthPerformanceRoute
+  '/project/$ref/auth/policies': typeof ProjectRefAuthPoliciesRoute
+  '/project/$ref/auth/protection': typeof ProjectRefAuthProtectionRoute
+  '/project/$ref/auth/providers': typeof ProjectRefAuthProvidersRoute
+  '/project/$ref/auth/rate-limits': typeof ProjectRefAuthRateLimitsRoute
+  '/project/$ref/auth/sessions': typeof ProjectRefAuthSessionsRoute
+  '/project/$ref/auth/smtp': typeof ProjectRefAuthSmtpRoute
+  '/project/$ref/auth/third-party': typeof ProjectRefAuthThirdPartyRoute
+  '/project/$ref/auth/url-configuration': typeof ProjectRefAuthUrlConfigurationRoute
+  '/project/$ref/auth/users': typeof ProjectRefAuthUsersRoute
+  '/project/$ref/branches/merge-requests': typeof ProjectRefBranchesMergeRequestsRoute
+  '/project/$ref/database/column-privileges': typeof ProjectRefDatabaseColumnPrivilegesRoute
+  '/project/$ref/database/extensions': typeof ProjectRefDatabaseExtensionsRoute
+  '/project/$ref/database/functions': typeof ProjectRefDatabaseFunctionsRoute
+  '/project/$ref/database/indexes': typeof ProjectRefDatabaseIndexesRoute
+  '/project/$ref/database/migrations': typeof ProjectRefDatabaseMigrationsRoute
+  '/project/$ref/database/roles': typeof ProjectRefDatabaseRolesRoute
+  '/project/$ref/database/schemas': typeof ProjectRefDatabaseSchemasRoute
+  '/project/$ref/database/settings': typeof ProjectRefDatabaseSettingsRoute
+  '/project/$ref/database/types': typeof ProjectRefDatabaseTypesRoute
+  '/project/$ref/editor/$id': typeof ProjectRefEditorIdRoute
+  '/project/$ref/editor/new': typeof ProjectRefEditorNewRoute
+  '/project/$ref/functions/new': typeof ProjectRefFunctionsNewRoute
+  '/project/$ref/functions/secrets': typeof ProjectRefFunctionsSecretsRoute
+  '/project/$ref/logs/auth-logs': typeof ProjectRefLogsAuthLogsRoute
+  '/project/$ref/logs/cron-logs': typeof ProjectRefLogsCronLogsRoute
+  '/project/$ref/logs/dedicated-pooler-logs': typeof ProjectRefLogsDedicatedPoolerLogsRoute
+  '/project/$ref/logs/edge-functions-logs': typeof ProjectRefLogsEdgeFunctionsLogsRoute
+  '/project/$ref/logs/edge-logs': typeof ProjectRefLogsEdgeLogsRoute
+  '/project/$ref/logs/pg-upgrade-logs': typeof ProjectRefLogsPgUpgradeLogsRoute
+  '/project/$ref/logs/pgcron-logs': typeof ProjectRefLogsPgcronLogsRoute
+  '/project/$ref/logs/pooler-logs': typeof ProjectRefLogsPoolerLogsRoute
+  '/project/$ref/logs/postgres-logs': typeof ProjectRefLogsPostgresLogsRoute
+  '/project/$ref/logs/postgrest-logs': typeof ProjectRefLogsPostgrestLogsRoute
+  '/project/$ref/logs/realtime-logs': typeof ProjectRefLogsRealtimeLogsRoute
+  '/project/$ref/logs/replication-logs': typeof ProjectRefLogsReplicationLogsRoute
+  '/project/$ref/logs/storage-logs': typeof ProjectRefLogsStorageLogsRoute
+  '/project/$ref/observability/$id': typeof ProjectRefObservabilityIdRoute
+  '/project/$ref/observability/api-overview': typeof ProjectRefObservabilityApiOverviewRoute
+  '/project/$ref/observability/auth': typeof ProjectRefObservabilityAuthRoute
+  '/project/$ref/observability/database': typeof ProjectRefObservabilityDatabaseRoute
+  '/project/$ref/observability/edge-functions': typeof ProjectRefObservabilityEdgeFunctionsRoute
+  '/project/$ref/observability/postgrest': typeof ProjectRefObservabilityPostgrestRoute
+  '/project/$ref/observability/query-insights': typeof ProjectRefObservabilityQueryInsightsRoute
+  '/project/$ref/observability/query-performance': typeof ProjectRefObservabilityQueryPerformanceRoute
+  '/project/$ref/observability/realtime': typeof ProjectRefObservabilityRealtimeRoute
+  '/project/$ref/observability/storage': typeof ProjectRefObservabilityStorageRoute
+  '/project/$ref/realtime/inspector': typeof ProjectRefRealtimeInspectorRoute
+  '/project/$ref/realtime/policies': typeof ProjectRefRealtimePoliciesRoute
+  '/project/$ref/realtime/settings': typeof ProjectRefRealtimeSettingsRoute
+  '/project/$ref/settings/addons': typeof ProjectRefSettingsAddonsRoute
+  '/project/$ref/settings/api': typeof ProjectRefSettingsApiRoute
+  '/project/$ref/settings/compute-and-disk': typeof ProjectRefSettingsComputeAndDiskRoute
+  '/project/$ref/settings/dashboard': typeof ProjectRefSettingsDashboardRoute
+  '/project/$ref/settings/general': typeof ProjectRefSettingsGeneralRoute
+  '/project/$ref/settings/infrastructure': typeof ProjectRefSettingsInfrastructureRoute
+  '/project/$ref/settings/integrations': typeof ProjectRefSettingsIntegrationsRoute
+  '/project/$ref/settings/log-drains': typeof ProjectRefSettingsLogDrainsRoute
+  '/project/$ref/sql/$id': typeof ProjectRefSqlIdRoute
+  '/project/$ref/sql/examples': typeof ProjectRefSqlExamplesRoute
+  '/project/$ref/sql/templates': typeof ProjectRefSqlTemplatesRoute
+  '/project/$ref/storage/s3': typeof ProjectRefStorageS3Route
   '/account/tokens': typeof AppAccountTokensIndexRoute
   '/org/$slug': typeof AppOrgSlugIndexRoute
   '/api/platform/organizations': typeof ApiPlatformOrganizationsIndexRoute
   '/api/platform/profile': typeof ApiPlatformProfileIndexRoute
   '/api/platform/projects': typeof ApiPlatformProjectsIndexRoute
+  '/project/$ref/api': typeof ProjectRefApiIndexRoute
+  '/project/$ref/branches': typeof ProjectRefBranchesIndexRoute
+  '/project/$ref/editor': typeof ProjectRefEditorIndexRoute
+  '/project/$ref/functions': typeof ProjectRefFunctionsIndexRoute
+  '/project/$ref/integrations': typeof ProjectRefIntegrationsIndexRoute
+  '/project/$ref/logs': typeof ProjectRefLogsIndexRoute
+  '/project/$ref/observability': typeof ProjectRefObservabilityIndexRoute
+  '/project/$ref/sql': typeof ProjectRefSqlIndexRoute
   '/org/$slug/webhooks/$endpointId': typeof AppOrgSlugWebhooksEndpointIdRoute
   '/partners/stripe/projects/login': typeof AuthPartnersStripeProjectsLoginRoute
   '/api/platform/auth/$ref/invite': typeof ApiPlatformAuthRefInviteRoute
@@ -1163,9 +2515,49 @@ export interface FileRoutesByTo {
   '/api/platform/projects/$ref/settings': typeof ApiPlatformProjectsRefSettingsRoute
   '/api/platform/props/org/$slug': typeof ApiPlatformPropsOrgSlugRoute
   '/api/v1/projects/$ref/api-keys': typeof ApiV1ProjectsRefApiKeysRouteWithChildren
+  '/integrations/vercel/$slug/deploy-button/new-project': typeof IntegrationsVercelSlugDeployButtonNewProjectRoute
+  '/integrations/vercel/$slug/marketplace/choose-project': typeof IntegrationsVercelSlugMarketplaceChooseProjectRoute
+  '/project/$ref/advisors/rules/performance': typeof ProjectRefAdvisorsRulesPerformanceRoute
+  '/project/$ref/advisors/rules/security': typeof ProjectRefAdvisorsRulesSecurityRoute
+  '/project/$ref/auth/templates/$templateId': typeof ProjectRefAuthTemplatesTemplateIdRoute
+  '/project/$ref/database/backups/pitr': typeof ProjectRefDatabaseBackupsPitrRoute
+  '/project/$ref/database/backups/restore-to-new-project': typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
+  '/project/$ref/database/backups/scheduled': typeof ProjectRefDatabaseBackupsScheduledRoute
+  '/project/$ref/database/publications/$id': typeof ProjectRefDatabasePublicationsIdRoute
+  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRoute
+  '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
+  '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
+  '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
+  '/project/$ref/functions/$functionSlug/code': typeof ProjectRefFunctionsFunctionSlugCodeRoute
+  '/project/$ref/functions/$functionSlug/details': typeof ProjectRefFunctionsFunctionSlugDetailsRoute
+  '/project/$ref/functions/$functionSlug/invocations': typeof ProjectRefFunctionsFunctionSlugInvocationsRoute
+  '/project/$ref/functions/$functionSlug/logs': typeof ProjectRefFunctionsFunctionSlugLogsRoute
+  '/project/$ref/logs/explorer/recent': typeof ProjectRefLogsExplorerRecentRoute
+  '/project/$ref/logs/explorer/saved': typeof ProjectRefLogsExplorerSavedRoute
+  '/project/$ref/logs/explorer/templates': typeof ProjectRefLogsExplorerTemplatesRoute
+  '/project/$ref/settings/api-keys/legacy': typeof ProjectRefSettingsApiKeysLegacyRoute
+  '/project/$ref/settings/billing/usage': typeof ProjectRefSettingsBillingUsageRoute
+  '/project/$ref/settings/jwt/legacy': typeof ProjectRefSettingsJwtLegacyRoute
+  '/project/$ref/settings/webhooks/$endpointId': typeof ProjectRefSettingsWebhooksEndpointIdRoute
+  '/project/$ref/storage/files/policies': typeof ProjectRefStorageFilesPoliciesRoute
+  '/project/$ref/storage/files/settings': typeof ProjectRefStorageFilesSettingsRoute
   '/org/$slug/private-apps': typeof AppOrgSlugPrivateAppsIndexRoute
   '/org/$slug/webhooks': typeof AppOrgSlugWebhooksIndexRoute
   '/api/platform/projects/$ref': typeof ApiPlatformProjectsRefIndexRoute
+  '/project/$ref/auth/templates': typeof ProjectRefAuthTemplatesIndexRoute
+  '/project/$ref/database/publications': typeof ProjectRefDatabasePublicationsIndexRoute
+  '/project/$ref/database/replication': typeof ProjectRefDatabaseReplicationIndexRoute
+  '/project/$ref/database/tables': typeof ProjectRefDatabaseTablesIndexRoute
+  '/project/$ref/database/triggers': typeof ProjectRefDatabaseTriggersIndexRoute
+  '/project/$ref/functions/$functionSlug': typeof ProjectRefFunctionsFunctionSlugIndexRoute
+  '/project/$ref/integrations/$id': typeof ProjectRefIntegrationsIdIndexRoute
+  '/project/$ref/logs/explorer': typeof ProjectRefLogsExplorerIndexRoute
+  '/project/$ref/settings/api-keys': typeof ProjectRefSettingsApiKeysIndexRoute
+  '/project/$ref/settings/jwt': typeof ProjectRefSettingsJwtIndexRoute
+  '/project/$ref/settings/webhooks': typeof ProjectRefSettingsWebhooksIndexRoute
+  '/project/$ref/storage/analytics': typeof ProjectRefStorageAnalyticsIndexRoute
+  '/project/$ref/storage/files': typeof ProjectRefStorageFilesIndexRoute
+  '/project/$ref/storage/vectors': typeof ProjectRefStorageVectorsIndexRoute
   '/api/platform/organizations/$slug/billing/subscription': typeof ApiPlatformOrganizationsSlugBillingSubscriptionRoute
   '/api/platform/projects/$ref/analytics/log-drains': typeof ApiPlatformProjectsRefAnalyticsLogDrainsRouteWithChildren
   '/api/platform/projects/$ref/api-keys/temporary': typeof ApiPlatformProjectsRefApiKeysTemporaryRoute
@@ -1178,6 +2570,10 @@ export interface FileRoutesByTo {
   '/api/v1/projects/$ref/api-keys/$id': typeof ApiV1ProjectsRefApiKeysIdRoute
   '/api/v1/projects/$ref/database/migrations': typeof ApiV1ProjectsRefDatabaseMigrationsRoute
   '/api/v1/projects/$ref/types/typescript': typeof ApiV1ProjectsRefTypesTypescriptRoute
+  '/project/$ref/database/replication/replica/$replicaId': typeof ProjectRefDatabaseReplicationReplicaReplicaIdRoute
+  '/project/$ref/storage/analytics/buckets/$bucketId': typeof ProjectRefStorageAnalyticsBucketsBucketIdRoute
+  '/project/$ref/storage/files/buckets/$bucketId': typeof ProjectRefStorageFilesBucketsBucketIdRoute
+  '/project/$ref/storage/vectors/buckets/$bucketId': typeof ProjectRefStorageVectorsBucketsBucketIdRoute
   '/api/platform/auth/$ref/users': typeof ApiPlatformAuthRefUsersIndexRoute
   '/api/platform/pg-meta/$ref/query': typeof ApiPlatformPgMetaRefQueryIndexRoute
   '/api/platform/projects/$ref/config': typeof ApiPlatformProjectsRefConfigIndexRoute
@@ -1186,6 +2582,7 @@ export interface FileRoutesByTo {
   '/api/platform/storage/$ref/buckets': typeof ApiPlatformStorageRefBucketsIndexRoute
   '/api/platform/storage/$ref/vector-buckets': typeof ApiPlatformStorageRefVectorBucketsIndexRoute
   '/api/v1/projects/$ref/functions': typeof ApiV1ProjectsRefFunctionsIndexRoute
+  '/project/$ref/integrations/$id/$pageId': typeof ProjectRefIntegrationsIdPageIdIndexRoute
   '/api/platform/auth/$ref/users/$id/factors': typeof ApiPlatformAuthRefUsersIdFactorsRoute
   '/api/platform/projects/$ref/analytics/endpoints/$name': typeof ApiPlatformProjectsRefAnalyticsEndpointsNameRoute
   '/api/platform/projects/$ref/analytics/log-drains/$uuid': typeof ApiPlatformProjectsRefAnalyticsLogDrainsUuidRoute
@@ -1199,6 +2596,7 @@ export interface FileRoutesByTo {
   '/api/platform/storage/$ref/buckets/$id': typeof ApiPlatformStorageRefBucketsIdIndexRoute
   '/api/platform/storage/$ref/vector-buckets/$id': typeof ApiPlatformStorageRefVectorBucketsIdIndexRoute
   '/api/v1/projects/$ref/functions/$slug': typeof ApiV1ProjectsRefFunctionsSlugIndexRoute
+  '/project/$ref/integrations/$id/$pageId/$childId': typeof ProjectRefIntegrationsIdPageIdChildIdIndexRoute
   '/api/platform/storage/$ref/buckets/$id/objects/download': typeof ApiPlatformStorageRefBucketsIdObjectsDownloadRoute
   '/api/platform/storage/$ref/buckets/$id/objects/list': typeof ApiPlatformStorageRefBucketsIdObjectsListRoute
   '/api/platform/storage/$ref/buckets/$id/objects/move': typeof ApiPlatformStorageRefBucketsIdObjectsMoveRoute
@@ -1213,6 +2611,17 @@ export interface FileRoutesByTo {
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/_app': typeof AppRouteWithChildren
+  '/_auth': typeof AuthRouteWithChildren
+  '/authorize': typeof AuthorizeRoute
+  '/aws-marketplace-onboarding': typeof AwsMarketplaceOnboardingRoute
+  '/claim-project': typeof ClaimProjectRoute
+  '/join': typeof JoinRoute
+  '/logout': typeof LogoutRoute
+  '/maintenance': typeof MaintenanceRoute
+  '/redeem': typeof RedeemRoute
+  '/verify-email': typeof VerifyEmailRoute
   '/_app/account': typeof AppAccountRouteWithChildren
   '/_app/org': typeof AppOrgRouteWithChildren
   '/_app/organizations': typeof AppOrganizationsRoute
@@ -1236,6 +2645,11 @@ export interface FileRoutesById {
   '/api/incident-status': typeof ApiIncidentStatusRoute
   '/api/parse-query': typeof ApiParseQueryRoute
   '/api/status-override': typeof ApiStatusOverrideRoute
+  '/integrations/vercel': typeof IntegrationsVercelRouteWithChildren
+  '/new/$slug': typeof NewSlugRoute
+  '/org/_': typeof OrgChar91_Char93RouteWithChildren
+  '/project/$ref': typeof ProjectRefRouteWithChildren
+  '/project/_': typeof ProjectChar91_Char93RouteWithChildren
   '/_app/account/audit': typeof AppAccountAuditRoute
   '/_app/account/me': typeof AppAccountMeRoute
   '/_app/account/security': typeof AppAccountSecurityRoute
@@ -1247,10 +2661,29 @@ export interface FileRoutesById {
   '/api/edge-functions/test': typeof ApiEdgeFunctionsTestRoute
   '/api/integrations/stripe-sync': typeof ApiIntegrationsStripeSyncRoute
   '/api/platform/deployment-mode': typeof ApiPlatformDeploymentModeRoute
+  '/integrations/github/authorize': typeof IntegrationsGithubAuthorizeRoute
+  '/integrations/vercel/install': typeof IntegrationsVercelInstallRoute
+  '/org/_/$': typeof OrgChar91_Char93SplatRoute
+  '/project/$ref/advisors': typeof ProjectRefAdvisorsRouteWithChildren
+  '/project/$ref/auth': typeof ProjectRefAuthRouteWithChildren
+  '/project/$ref/branches': typeof ProjectRefBranchesRouteWithChildren
+  '/project/$ref/database': typeof ProjectRefDatabaseRouteWithChildren
+  '/project/$ref/editor': typeof ProjectRefEditorRouteWithChildren
+  '/project/$ref/functions': typeof ProjectRefFunctionsRouteWithChildren
+  '/project/$ref/integrations': typeof ProjectRefIntegrationsRouteWithChildren
+  '/project/$ref/logs': typeof ProjectRefLogsRouteWithChildren
+  '/project/$ref/merge': typeof ProjectRefMergeRoute
+  '/project/$ref/observability': typeof ProjectRefObservabilityRouteWithChildren
+  '/project/$ref/realtime': typeof ProjectRefRealtimeRouteWithChildren
+  '/project/$ref/settings': typeof ProjectRefSettingsRouteWithChildren
+  '/project/$ref/sql': typeof ProjectRefSqlRouteWithChildren
+  '/project/$ref/storage': typeof ProjectRefStorageRouteWithChildren
+  '/project/_/$': typeof ProjectChar91_Char93SplatRoute
   '/_app/new/': typeof AppNewIndexRoute
   '/_app/org/': typeof AppOrgIndexRoute
   '/api/connect/': typeof ApiConnectIndexRoute
   '/api/mcp/': typeof ApiMcpIndexRoute
+  '/project/$ref/': typeof ProjectRefIndexRoute
   '/_app/account/tokens/scoped': typeof AppAccountTokensScopedRoute
   '/_app/org/$slug/apps': typeof AppOrgSlugAppsRoute
   '/_app/org/$slug/audit': typeof AppOrgSlugAuditRoute
@@ -1275,11 +2708,94 @@ export interface FileRoutesById {
   '/api/ai/sql/title-v2': typeof ApiAiSqlTitleV2Route
   '/api/platform/integrations/$slug': typeof ApiPlatformIntegrationsSlugRoute
   '/api/platform/telemetry/event': typeof ApiPlatformTelemetryEventRoute
+  '/project/$ref/advisors/performance': typeof ProjectRefAdvisorsPerformanceRoute
+  '/project/$ref/advisors/rules': typeof ProjectRefAdvisorsRulesRouteWithChildren
+  '/project/$ref/advisors/security': typeof ProjectRefAdvisorsSecurityRoute
+  '/project/$ref/auth/audit-logs': typeof ProjectRefAuthAuditLogsRoute
+  '/project/$ref/auth/hooks': typeof ProjectRefAuthHooksRoute
+  '/project/$ref/auth/mfa': typeof ProjectRefAuthMfaRoute
+  '/project/$ref/auth/oauth-apps': typeof ProjectRefAuthOauthAppsRoute
+  '/project/$ref/auth/oauth-server': typeof ProjectRefAuthOauthServerRoute
+  '/project/$ref/auth/overview': typeof ProjectRefAuthOverviewRoute
+  '/project/$ref/auth/passkeys': typeof ProjectRefAuthPasskeysRoute
+  '/project/$ref/auth/performance': typeof ProjectRefAuthPerformanceRoute
+  '/project/$ref/auth/policies': typeof ProjectRefAuthPoliciesRoute
+  '/project/$ref/auth/protection': typeof ProjectRefAuthProtectionRoute
+  '/project/$ref/auth/providers': typeof ProjectRefAuthProvidersRoute
+  '/project/$ref/auth/rate-limits': typeof ProjectRefAuthRateLimitsRoute
+  '/project/$ref/auth/sessions': typeof ProjectRefAuthSessionsRoute
+  '/project/$ref/auth/smtp': typeof ProjectRefAuthSmtpRoute
+  '/project/$ref/auth/third-party': typeof ProjectRefAuthThirdPartyRoute
+  '/project/$ref/auth/url-configuration': typeof ProjectRefAuthUrlConfigurationRoute
+  '/project/$ref/auth/users': typeof ProjectRefAuthUsersRoute
+  '/project/$ref/branches/merge-requests': typeof ProjectRefBranchesMergeRequestsRoute
+  '/project/$ref/database/column-privileges': typeof ProjectRefDatabaseColumnPrivilegesRoute
+  '/project/$ref/database/extensions': typeof ProjectRefDatabaseExtensionsRoute
+  '/project/$ref/database/functions': typeof ProjectRefDatabaseFunctionsRoute
+  '/project/$ref/database/indexes': typeof ProjectRefDatabaseIndexesRoute
+  '/project/$ref/database/migrations': typeof ProjectRefDatabaseMigrationsRoute
+  '/project/$ref/database/roles': typeof ProjectRefDatabaseRolesRoute
+  '/project/$ref/database/schemas': typeof ProjectRefDatabaseSchemasRoute
+  '/project/$ref/database/settings': typeof ProjectRefDatabaseSettingsRoute
+  '/project/$ref/database/triggers': typeof ProjectRefDatabaseTriggersRouteWithChildren
+  '/project/$ref/database/types': typeof ProjectRefDatabaseTypesRoute
+  '/project/$ref/editor/$id': typeof ProjectRefEditorIdRoute
+  '/project/$ref/editor/new': typeof ProjectRefEditorNewRoute
+  '/project/$ref/functions/$functionSlug': typeof ProjectRefFunctionsFunctionSlugRouteWithChildren
+  '/project/$ref/functions/new': typeof ProjectRefFunctionsNewRoute
+  '/project/$ref/functions/secrets': typeof ProjectRefFunctionsSecretsRoute
+  '/project/$ref/logs/auth-logs': typeof ProjectRefLogsAuthLogsRoute
+  '/project/$ref/logs/cron-logs': typeof ProjectRefLogsCronLogsRoute
+  '/project/$ref/logs/dedicated-pooler-logs': typeof ProjectRefLogsDedicatedPoolerLogsRoute
+  '/project/$ref/logs/edge-functions-logs': typeof ProjectRefLogsEdgeFunctionsLogsRoute
+  '/project/$ref/logs/edge-logs': typeof ProjectRefLogsEdgeLogsRoute
+  '/project/$ref/logs/pg-upgrade-logs': typeof ProjectRefLogsPgUpgradeLogsRoute
+  '/project/$ref/logs/pgcron-logs': typeof ProjectRefLogsPgcronLogsRoute
+  '/project/$ref/logs/pooler-logs': typeof ProjectRefLogsPoolerLogsRoute
+  '/project/$ref/logs/postgres-logs': typeof ProjectRefLogsPostgresLogsRoute
+  '/project/$ref/logs/postgrest-logs': typeof ProjectRefLogsPostgrestLogsRoute
+  '/project/$ref/logs/realtime-logs': typeof ProjectRefLogsRealtimeLogsRoute
+  '/project/$ref/logs/replication-logs': typeof ProjectRefLogsReplicationLogsRoute
+  '/project/$ref/logs/storage-logs': typeof ProjectRefLogsStorageLogsRoute
+  '/project/$ref/observability/$id': typeof ProjectRefObservabilityIdRoute
+  '/project/$ref/observability/api-overview': typeof ProjectRefObservabilityApiOverviewRoute
+  '/project/$ref/observability/auth': typeof ProjectRefObservabilityAuthRoute
+  '/project/$ref/observability/database': typeof ProjectRefObservabilityDatabaseRoute
+  '/project/$ref/observability/edge-functions': typeof ProjectRefObservabilityEdgeFunctionsRoute
+  '/project/$ref/observability/postgrest': typeof ProjectRefObservabilityPostgrestRoute
+  '/project/$ref/observability/query-insights': typeof ProjectRefObservabilityQueryInsightsRoute
+  '/project/$ref/observability/query-performance': typeof ProjectRefObservabilityQueryPerformanceRoute
+  '/project/$ref/observability/realtime': typeof ProjectRefObservabilityRealtimeRoute
+  '/project/$ref/observability/storage': typeof ProjectRefObservabilityStorageRoute
+  '/project/$ref/realtime/inspector': typeof ProjectRefRealtimeInspectorRoute
+  '/project/$ref/realtime/policies': typeof ProjectRefRealtimePoliciesRoute
+  '/project/$ref/realtime/settings': typeof ProjectRefRealtimeSettingsRoute
+  '/project/$ref/settings/addons': typeof ProjectRefSettingsAddonsRoute
+  '/project/$ref/settings/api': typeof ProjectRefSettingsApiRoute
+  '/project/$ref/settings/api-keys': typeof ProjectRefSettingsApiKeysRouteWithChildren
+  '/project/$ref/settings/compute-and-disk': typeof ProjectRefSettingsComputeAndDiskRoute
+  '/project/$ref/settings/dashboard': typeof ProjectRefSettingsDashboardRoute
+  '/project/$ref/settings/general': typeof ProjectRefSettingsGeneralRoute
+  '/project/$ref/settings/infrastructure': typeof ProjectRefSettingsInfrastructureRoute
+  '/project/$ref/settings/integrations': typeof ProjectRefSettingsIntegrationsRoute
+  '/project/$ref/settings/log-drains': typeof ProjectRefSettingsLogDrainsRoute
+  '/project/$ref/sql/$id': typeof ProjectRefSqlIdRoute
+  '/project/$ref/sql/examples': typeof ProjectRefSqlExamplesRoute
+  '/project/$ref/sql/templates': typeof ProjectRefSqlTemplatesRoute
+  '/project/$ref/storage/s3': typeof ProjectRefStorageS3Route
   '/_app/account/tokens/': typeof AppAccountTokensIndexRoute
   '/_app/org/$slug/': typeof AppOrgSlugIndexRoute
   '/api/platform/organizations/': typeof ApiPlatformOrganizationsIndexRoute
   '/api/platform/profile/': typeof ApiPlatformProfileIndexRoute
   '/api/platform/projects/': typeof ApiPlatformProjectsIndexRoute
+  '/project/$ref/api/': typeof ProjectRefApiIndexRoute
+  '/project/$ref/branches/': typeof ProjectRefBranchesIndexRoute
+  '/project/$ref/editor/': typeof ProjectRefEditorIndexRoute
+  '/project/$ref/functions/': typeof ProjectRefFunctionsIndexRoute
+  '/project/$ref/integrations/': typeof ProjectRefIntegrationsIndexRoute
+  '/project/$ref/logs/': typeof ProjectRefLogsIndexRoute
+  '/project/$ref/observability/': typeof ProjectRefObservabilityIndexRoute
+  '/project/$ref/sql/': typeof ProjectRefSqlIndexRoute
   '/_app/org/$slug/webhooks/$endpointId': typeof AppOrgSlugWebhooksEndpointIdRoute
   '/_auth/partners/stripe/projects/login': typeof AuthPartnersStripeProjectsLoginRoute
   '/api/platform/auth/$ref/invite': typeof ApiPlatformAuthRefInviteRoute
@@ -1306,9 +2822,49 @@ export interface FileRoutesById {
   '/api/platform/projects/$ref/settings': typeof ApiPlatformProjectsRefSettingsRoute
   '/api/platform/props/org/$slug': typeof ApiPlatformPropsOrgSlugRoute
   '/api/v1/projects/$ref/api-keys': typeof ApiV1ProjectsRefApiKeysRouteWithChildren
+  '/integrations/vercel/$slug/deploy-button/new-project': typeof IntegrationsVercelSlugDeployButtonNewProjectRoute
+  '/integrations/vercel/$slug/marketplace/choose-project': typeof IntegrationsVercelSlugMarketplaceChooseProjectRoute
+  '/project/$ref/advisors/rules/performance': typeof ProjectRefAdvisorsRulesPerformanceRoute
+  '/project/$ref/advisors/rules/security': typeof ProjectRefAdvisorsRulesSecurityRoute
+  '/project/$ref/auth/templates/$templateId': typeof ProjectRefAuthTemplatesTemplateIdRoute
+  '/project/$ref/database/backups/pitr': typeof ProjectRefDatabaseBackupsPitrRoute
+  '/project/$ref/database/backups/restore-to-new-project': typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
+  '/project/$ref/database/backups/scheduled': typeof ProjectRefDatabaseBackupsScheduledRoute
+  '/project/$ref/database/publications/$id': typeof ProjectRefDatabasePublicationsIdRoute
+  '/project/$ref/database/replication/$pipelineId': typeof ProjectRefDatabaseReplicationPipelineIdRoute
+  '/project/$ref/database/tables/$id': typeof ProjectRefDatabaseTablesIdRoute
+  '/project/$ref/database/triggers/data': typeof ProjectRefDatabaseTriggersDataRoute
+  '/project/$ref/database/triggers/event': typeof ProjectRefDatabaseTriggersEventRoute
+  '/project/$ref/functions/$functionSlug/code': typeof ProjectRefFunctionsFunctionSlugCodeRoute
+  '/project/$ref/functions/$functionSlug/details': typeof ProjectRefFunctionsFunctionSlugDetailsRoute
+  '/project/$ref/functions/$functionSlug/invocations': typeof ProjectRefFunctionsFunctionSlugInvocationsRoute
+  '/project/$ref/functions/$functionSlug/logs': typeof ProjectRefFunctionsFunctionSlugLogsRoute
+  '/project/$ref/logs/explorer/recent': typeof ProjectRefLogsExplorerRecentRoute
+  '/project/$ref/logs/explorer/saved': typeof ProjectRefLogsExplorerSavedRoute
+  '/project/$ref/logs/explorer/templates': typeof ProjectRefLogsExplorerTemplatesRoute
+  '/project/$ref/settings/api-keys/legacy': typeof ProjectRefSettingsApiKeysLegacyRoute
+  '/project/$ref/settings/billing/usage': typeof ProjectRefSettingsBillingUsageRoute
+  '/project/$ref/settings/jwt/legacy': typeof ProjectRefSettingsJwtLegacyRoute
+  '/project/$ref/settings/webhooks/$endpointId': typeof ProjectRefSettingsWebhooksEndpointIdRoute
+  '/project/$ref/storage/files/policies': typeof ProjectRefStorageFilesPoliciesRoute
+  '/project/$ref/storage/files/settings': typeof ProjectRefStorageFilesSettingsRoute
   '/_app/org/$slug/private-apps/': typeof AppOrgSlugPrivateAppsIndexRoute
   '/_app/org/$slug/webhooks/': typeof AppOrgSlugWebhooksIndexRoute
   '/api/platform/projects/$ref/': typeof ApiPlatformProjectsRefIndexRoute
+  '/project/$ref/auth/templates/': typeof ProjectRefAuthTemplatesIndexRoute
+  '/project/$ref/database/publications/': typeof ProjectRefDatabasePublicationsIndexRoute
+  '/project/$ref/database/replication/': typeof ProjectRefDatabaseReplicationIndexRoute
+  '/project/$ref/database/tables/': typeof ProjectRefDatabaseTablesIndexRoute
+  '/project/$ref/database/triggers/': typeof ProjectRefDatabaseTriggersIndexRoute
+  '/project/$ref/functions/$functionSlug/': typeof ProjectRefFunctionsFunctionSlugIndexRoute
+  '/project/$ref/integrations/$id/': typeof ProjectRefIntegrationsIdIndexRoute
+  '/project/$ref/logs/explorer/': typeof ProjectRefLogsExplorerIndexRoute
+  '/project/$ref/settings/api-keys/': typeof ProjectRefSettingsApiKeysIndexRoute
+  '/project/$ref/settings/jwt/': typeof ProjectRefSettingsJwtIndexRoute
+  '/project/$ref/settings/webhooks/': typeof ProjectRefSettingsWebhooksIndexRoute
+  '/project/$ref/storage/analytics/': typeof ProjectRefStorageAnalyticsIndexRoute
+  '/project/$ref/storage/files/': typeof ProjectRefStorageFilesIndexRoute
+  '/project/$ref/storage/vectors/': typeof ProjectRefStorageVectorsIndexRoute
   '/api/platform/organizations/$slug/billing/subscription': typeof ApiPlatformOrganizationsSlugBillingSubscriptionRoute
   '/api/platform/projects/$ref/analytics/log-drains': typeof ApiPlatformProjectsRefAnalyticsLogDrainsRouteWithChildren
   '/api/platform/projects/$ref/api-keys/temporary': typeof ApiPlatformProjectsRefApiKeysTemporaryRoute
@@ -1321,6 +2877,10 @@ export interface FileRoutesById {
   '/api/v1/projects/$ref/api-keys/$id': typeof ApiV1ProjectsRefApiKeysIdRoute
   '/api/v1/projects/$ref/database/migrations': typeof ApiV1ProjectsRefDatabaseMigrationsRoute
   '/api/v1/projects/$ref/types/typescript': typeof ApiV1ProjectsRefTypesTypescriptRoute
+  '/project/$ref/database/replication/replica/$replicaId': typeof ProjectRefDatabaseReplicationReplicaReplicaIdRoute
+  '/project/$ref/storage/analytics/buckets/$bucketId': typeof ProjectRefStorageAnalyticsBucketsBucketIdRoute
+  '/project/$ref/storage/files/buckets/$bucketId': typeof ProjectRefStorageFilesBucketsBucketIdRoute
+  '/project/$ref/storage/vectors/buckets/$bucketId': typeof ProjectRefStorageVectorsBucketsBucketIdRoute
   '/api/platform/auth/$ref/users/': typeof ApiPlatformAuthRefUsersIndexRoute
   '/api/platform/pg-meta/$ref/query/': typeof ApiPlatformPgMetaRefQueryIndexRoute
   '/api/platform/projects/$ref/config/': typeof ApiPlatformProjectsRefConfigIndexRoute
@@ -1329,6 +2889,7 @@ export interface FileRoutesById {
   '/api/platform/storage/$ref/buckets/': typeof ApiPlatformStorageRefBucketsIndexRoute
   '/api/platform/storage/$ref/vector-buckets/': typeof ApiPlatformStorageRefVectorBucketsIndexRoute
   '/api/v1/projects/$ref/functions/': typeof ApiV1ProjectsRefFunctionsIndexRoute
+  '/project/$ref/integrations/$id/$pageId/': typeof ProjectRefIntegrationsIdPageIdIndexRoute
   '/api/platform/auth/$ref/users/$id/factors': typeof ApiPlatformAuthRefUsersIdFactorsRoute
   '/api/platform/projects/$ref/analytics/endpoints/$name': typeof ApiPlatformProjectsRefAnalyticsEndpointsNameRoute
   '/api/platform/projects/$ref/analytics/log-drains/$uuid': typeof ApiPlatformProjectsRefAnalyticsLogDrainsUuidRoute
@@ -1342,6 +2903,7 @@ export interface FileRoutesById {
   '/api/platform/storage/$ref/buckets/$id/': typeof ApiPlatformStorageRefBucketsIdIndexRoute
   '/api/platform/storage/$ref/vector-buckets/$id/': typeof ApiPlatformStorageRefVectorBucketsIdIndexRoute
   '/api/v1/projects/$ref/functions/$slug/': typeof ApiV1ProjectsRefFunctionsSlugIndexRoute
+  '/project/$ref/integrations/$id/$pageId/$childId/': typeof ProjectRefIntegrationsIdPageIdChildIdIndexRoute
   '/api/platform/storage/$ref/buckets/$id/objects/download': typeof ApiPlatformStorageRefBucketsIdObjectsDownloadRoute
   '/api/platform/storage/$ref/buckets/$id/objects/list': typeof ApiPlatformStorageRefBucketsIdObjectsListRoute
   '/api/platform/storage/$ref/buckets/$id/objects/move': typeof ApiPlatformStorageRefBucketsIdObjectsMoveRoute
@@ -1357,6 +2919,15 @@ export interface FileRoutesById {
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
+    | '/'
+    | '/authorize'
+    | '/aws-marketplace-onboarding'
+    | '/claim-project'
+    | '/join'
+    | '/logout'
+    | '/maintenance'
+    | '/redeem'
+    | '/verify-email'
     | '/account'
     | '/org'
     | '/organizations'
@@ -1380,6 +2951,11 @@ export interface FileRouteTypes {
     | '/api/incident-status'
     | '/api/parse-query'
     | '/api/status-override'
+    | '/integrations/vercel'
+    | '/new/$slug'
+    | '/org/_'
+    | '/project/$ref'
+    | '/project/_'
     | '/account/audit'
     | '/account/me'
     | '/account/security'
@@ -1391,10 +2967,29 @@ export interface FileRouteTypes {
     | '/api/edge-functions/test'
     | '/api/integrations/stripe-sync'
     | '/api/platform/deployment-mode'
+    | '/integrations/github/authorize'
+    | '/integrations/vercel/install'
+    | '/org/_/$'
+    | '/project/$ref/advisors'
+    | '/project/$ref/auth'
+    | '/project/$ref/branches'
+    | '/project/$ref/database'
+    | '/project/$ref/editor'
+    | '/project/$ref/functions'
+    | '/project/$ref/integrations'
+    | '/project/$ref/logs'
+    | '/project/$ref/merge'
+    | '/project/$ref/observability'
+    | '/project/$ref/realtime'
+    | '/project/$ref/settings'
+    | '/project/$ref/sql'
+    | '/project/$ref/storage'
+    | '/project/_/$'
     | '/new/'
     | '/org/'
     | '/api/connect/'
     | '/api/mcp/'
+    | '/project/$ref/'
     | '/account/tokens/scoped'
     | '/org/$slug/apps'
     | '/org/$slug/audit'
@@ -1419,11 +3014,94 @@ export interface FileRouteTypes {
     | '/api/ai/sql/title-v2'
     | '/api/platform/integrations/$slug'
     | '/api/platform/telemetry/event'
+    | '/project/$ref/advisors/performance'
+    | '/project/$ref/advisors/rules'
+    | '/project/$ref/advisors/security'
+    | '/project/$ref/auth/audit-logs'
+    | '/project/$ref/auth/hooks'
+    | '/project/$ref/auth/mfa'
+    | '/project/$ref/auth/oauth-apps'
+    | '/project/$ref/auth/oauth-server'
+    | '/project/$ref/auth/overview'
+    | '/project/$ref/auth/passkeys'
+    | '/project/$ref/auth/performance'
+    | '/project/$ref/auth/policies'
+    | '/project/$ref/auth/protection'
+    | '/project/$ref/auth/providers'
+    | '/project/$ref/auth/rate-limits'
+    | '/project/$ref/auth/sessions'
+    | '/project/$ref/auth/smtp'
+    | '/project/$ref/auth/third-party'
+    | '/project/$ref/auth/url-configuration'
+    | '/project/$ref/auth/users'
+    | '/project/$ref/branches/merge-requests'
+    | '/project/$ref/database/column-privileges'
+    | '/project/$ref/database/extensions'
+    | '/project/$ref/database/functions'
+    | '/project/$ref/database/indexes'
+    | '/project/$ref/database/migrations'
+    | '/project/$ref/database/roles'
+    | '/project/$ref/database/schemas'
+    | '/project/$ref/database/settings'
+    | '/project/$ref/database/triggers'
+    | '/project/$ref/database/types'
+    | '/project/$ref/editor/$id'
+    | '/project/$ref/editor/new'
+    | '/project/$ref/functions/$functionSlug'
+    | '/project/$ref/functions/new'
+    | '/project/$ref/functions/secrets'
+    | '/project/$ref/logs/auth-logs'
+    | '/project/$ref/logs/cron-logs'
+    | '/project/$ref/logs/dedicated-pooler-logs'
+    | '/project/$ref/logs/edge-functions-logs'
+    | '/project/$ref/logs/edge-logs'
+    | '/project/$ref/logs/pg-upgrade-logs'
+    | '/project/$ref/logs/pgcron-logs'
+    | '/project/$ref/logs/pooler-logs'
+    | '/project/$ref/logs/postgres-logs'
+    | '/project/$ref/logs/postgrest-logs'
+    | '/project/$ref/logs/realtime-logs'
+    | '/project/$ref/logs/replication-logs'
+    | '/project/$ref/logs/storage-logs'
+    | '/project/$ref/observability/$id'
+    | '/project/$ref/observability/api-overview'
+    | '/project/$ref/observability/auth'
+    | '/project/$ref/observability/database'
+    | '/project/$ref/observability/edge-functions'
+    | '/project/$ref/observability/postgrest'
+    | '/project/$ref/observability/query-insights'
+    | '/project/$ref/observability/query-performance'
+    | '/project/$ref/observability/realtime'
+    | '/project/$ref/observability/storage'
+    | '/project/$ref/realtime/inspector'
+    | '/project/$ref/realtime/policies'
+    | '/project/$ref/realtime/settings'
+    | '/project/$ref/settings/addons'
+    | '/project/$ref/settings/api'
+    | '/project/$ref/settings/api-keys'
+    | '/project/$ref/settings/compute-and-disk'
+    | '/project/$ref/settings/dashboard'
+    | '/project/$ref/settings/general'
+    | '/project/$ref/settings/infrastructure'
+    | '/project/$ref/settings/integrations'
+    | '/project/$ref/settings/log-drains'
+    | '/project/$ref/sql/$id'
+    | '/project/$ref/sql/examples'
+    | '/project/$ref/sql/templates'
+    | '/project/$ref/storage/s3'
     | '/account/tokens/'
     | '/org/$slug/'
     | '/api/platform/organizations/'
     | '/api/platform/profile/'
     | '/api/platform/projects/'
+    | '/project/$ref/api/'
+    | '/project/$ref/branches/'
+    | '/project/$ref/editor/'
+    | '/project/$ref/functions/'
+    | '/project/$ref/integrations/'
+    | '/project/$ref/logs/'
+    | '/project/$ref/observability/'
+    | '/project/$ref/sql/'
     | '/org/$slug/webhooks/$endpointId'
     | '/partners/stripe/projects/login'
     | '/api/platform/auth/$ref/invite'
@@ -1450,9 +3128,49 @@ export interface FileRouteTypes {
     | '/api/platform/projects/$ref/settings'
     | '/api/platform/props/org/$slug'
     | '/api/v1/projects/$ref/api-keys'
+    | '/integrations/vercel/$slug/deploy-button/new-project'
+    | '/integrations/vercel/$slug/marketplace/choose-project'
+    | '/project/$ref/advisors/rules/performance'
+    | '/project/$ref/advisors/rules/security'
+    | '/project/$ref/auth/templates/$templateId'
+    | '/project/$ref/database/backups/pitr'
+    | '/project/$ref/database/backups/restore-to-new-project'
+    | '/project/$ref/database/backups/scheduled'
+    | '/project/$ref/database/publications/$id'
+    | '/project/$ref/database/replication/$pipelineId'
+    | '/project/$ref/database/tables/$id'
+    | '/project/$ref/database/triggers/data'
+    | '/project/$ref/database/triggers/event'
+    | '/project/$ref/functions/$functionSlug/code'
+    | '/project/$ref/functions/$functionSlug/details'
+    | '/project/$ref/functions/$functionSlug/invocations'
+    | '/project/$ref/functions/$functionSlug/logs'
+    | '/project/$ref/logs/explorer/recent'
+    | '/project/$ref/logs/explorer/saved'
+    | '/project/$ref/logs/explorer/templates'
+    | '/project/$ref/settings/api-keys/legacy'
+    | '/project/$ref/settings/billing/usage'
+    | '/project/$ref/settings/jwt/legacy'
+    | '/project/$ref/settings/webhooks/$endpointId'
+    | '/project/$ref/storage/files/policies'
+    | '/project/$ref/storage/files/settings'
     | '/org/$slug/private-apps/'
     | '/org/$slug/webhooks/'
     | '/api/platform/projects/$ref/'
+    | '/project/$ref/auth/templates/'
+    | '/project/$ref/database/publications/'
+    | '/project/$ref/database/replication/'
+    | '/project/$ref/database/tables/'
+    | '/project/$ref/database/triggers/'
+    | '/project/$ref/functions/$functionSlug/'
+    | '/project/$ref/integrations/$id/'
+    | '/project/$ref/logs/explorer/'
+    | '/project/$ref/settings/api-keys/'
+    | '/project/$ref/settings/jwt/'
+    | '/project/$ref/settings/webhooks/'
+    | '/project/$ref/storage/analytics/'
+    | '/project/$ref/storage/files/'
+    | '/project/$ref/storage/vectors/'
     | '/api/platform/organizations/$slug/billing/subscription'
     | '/api/platform/projects/$ref/analytics/log-drains'
     | '/api/platform/projects/$ref/api-keys/temporary'
@@ -1465,6 +3183,10 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/api-keys/$id'
     | '/api/v1/projects/$ref/database/migrations'
     | '/api/v1/projects/$ref/types/typescript'
+    | '/project/$ref/database/replication/replica/$replicaId'
+    | '/project/$ref/storage/analytics/buckets/$bucketId'
+    | '/project/$ref/storage/files/buckets/$bucketId'
+    | '/project/$ref/storage/vectors/buckets/$bucketId'
     | '/api/platform/auth/$ref/users/'
     | '/api/platform/pg-meta/$ref/query/'
     | '/api/platform/projects/$ref/config/'
@@ -1473,6 +3195,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets/'
     | '/api/platform/storage/$ref/vector-buckets/'
     | '/api/v1/projects/$ref/functions/'
+    | '/project/$ref/integrations/$id/$pageId/'
     | '/api/platform/auth/$ref/users/$id/factors'
     | '/api/platform/projects/$ref/analytics/endpoints/$name'
     | '/api/platform/projects/$ref/analytics/log-drains/$uuid'
@@ -1486,6 +3209,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets/$id/'
     | '/api/platform/storage/$ref/vector-buckets/$id/'
     | '/api/v1/projects/$ref/functions/$slug/'
+    | '/project/$ref/integrations/$id/$pageId/$childId/'
     | '/api/platform/storage/$ref/buckets/$id/objects/download'
     | '/api/platform/storage/$ref/buckets/$id/objects/list'
     | '/api/platform/storage/$ref/buckets/$id/objects/move'
@@ -1499,6 +3223,15 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/config/auth/signing-keys/'
   fileRoutesByTo: FileRoutesByTo
   to:
+    | '/'
+    | '/authorize'
+    | '/aws-marketplace-onboarding'
+    | '/claim-project'
+    | '/join'
+    | '/logout'
+    | '/maintenance'
+    | '/redeem'
+    | '/verify-email'
     | '/account'
     | '/organizations'
     | '/forgot-password'
@@ -1521,6 +3254,10 @@ export interface FileRouteTypes {
     | '/api/incident-status'
     | '/api/parse-query'
     | '/api/status-override'
+    | '/integrations/vercel'
+    | '/new/$slug'
+    | '/org/_'
+    | '/project/_'
     | '/account/audit'
     | '/account/me'
     | '/account/security'
@@ -1532,10 +3269,22 @@ export interface FileRouteTypes {
     | '/api/edge-functions/test'
     | '/api/integrations/stripe-sync'
     | '/api/platform/deployment-mode'
+    | '/integrations/github/authorize'
+    | '/integrations/vercel/install'
+    | '/org/_/$'
+    | '/project/$ref/advisors'
+    | '/project/$ref/auth'
+    | '/project/$ref/database'
+    | '/project/$ref/merge'
+    | '/project/$ref/realtime'
+    | '/project/$ref/settings'
+    | '/project/$ref/storage'
+    | '/project/_/$'
     | '/new'
     | '/org'
     | '/api/connect'
     | '/api/mcp'
+    | '/project/$ref'
     | '/account/tokens/scoped'
     | '/org/$slug/apps'
     | '/org/$slug/audit'
@@ -1560,11 +3309,91 @@ export interface FileRouteTypes {
     | '/api/ai/sql/title-v2'
     | '/api/platform/integrations/$slug'
     | '/api/platform/telemetry/event'
+    | '/project/$ref/advisors/performance'
+    | '/project/$ref/advisors/rules'
+    | '/project/$ref/advisors/security'
+    | '/project/$ref/auth/audit-logs'
+    | '/project/$ref/auth/hooks'
+    | '/project/$ref/auth/mfa'
+    | '/project/$ref/auth/oauth-apps'
+    | '/project/$ref/auth/oauth-server'
+    | '/project/$ref/auth/overview'
+    | '/project/$ref/auth/passkeys'
+    | '/project/$ref/auth/performance'
+    | '/project/$ref/auth/policies'
+    | '/project/$ref/auth/protection'
+    | '/project/$ref/auth/providers'
+    | '/project/$ref/auth/rate-limits'
+    | '/project/$ref/auth/sessions'
+    | '/project/$ref/auth/smtp'
+    | '/project/$ref/auth/third-party'
+    | '/project/$ref/auth/url-configuration'
+    | '/project/$ref/auth/users'
+    | '/project/$ref/branches/merge-requests'
+    | '/project/$ref/database/column-privileges'
+    | '/project/$ref/database/extensions'
+    | '/project/$ref/database/functions'
+    | '/project/$ref/database/indexes'
+    | '/project/$ref/database/migrations'
+    | '/project/$ref/database/roles'
+    | '/project/$ref/database/schemas'
+    | '/project/$ref/database/settings'
+    | '/project/$ref/database/types'
+    | '/project/$ref/editor/$id'
+    | '/project/$ref/editor/new'
+    | '/project/$ref/functions/new'
+    | '/project/$ref/functions/secrets'
+    | '/project/$ref/logs/auth-logs'
+    | '/project/$ref/logs/cron-logs'
+    | '/project/$ref/logs/dedicated-pooler-logs'
+    | '/project/$ref/logs/edge-functions-logs'
+    | '/project/$ref/logs/edge-logs'
+    | '/project/$ref/logs/pg-upgrade-logs'
+    | '/project/$ref/logs/pgcron-logs'
+    | '/project/$ref/logs/pooler-logs'
+    | '/project/$ref/logs/postgres-logs'
+    | '/project/$ref/logs/postgrest-logs'
+    | '/project/$ref/logs/realtime-logs'
+    | '/project/$ref/logs/replication-logs'
+    | '/project/$ref/logs/storage-logs'
+    | '/project/$ref/observability/$id'
+    | '/project/$ref/observability/api-overview'
+    | '/project/$ref/observability/auth'
+    | '/project/$ref/observability/database'
+    | '/project/$ref/observability/edge-functions'
+    | '/project/$ref/observability/postgrest'
+    | '/project/$ref/observability/query-insights'
+    | '/project/$ref/observability/query-performance'
+    | '/project/$ref/observability/realtime'
+    | '/project/$ref/observability/storage'
+    | '/project/$ref/realtime/inspector'
+    | '/project/$ref/realtime/policies'
+    | '/project/$ref/realtime/settings'
+    | '/project/$ref/settings/addons'
+    | '/project/$ref/settings/api'
+    | '/project/$ref/settings/compute-and-disk'
+    | '/project/$ref/settings/dashboard'
+    | '/project/$ref/settings/general'
+    | '/project/$ref/settings/infrastructure'
+    | '/project/$ref/settings/integrations'
+    | '/project/$ref/settings/log-drains'
+    | '/project/$ref/sql/$id'
+    | '/project/$ref/sql/examples'
+    | '/project/$ref/sql/templates'
+    | '/project/$ref/storage/s3'
     | '/account/tokens'
     | '/org/$slug'
     | '/api/platform/organizations'
     | '/api/platform/profile'
     | '/api/platform/projects'
+    | '/project/$ref/api'
+    | '/project/$ref/branches'
+    | '/project/$ref/editor'
+    | '/project/$ref/functions'
+    | '/project/$ref/integrations'
+    | '/project/$ref/logs'
+    | '/project/$ref/observability'
+    | '/project/$ref/sql'
     | '/org/$slug/webhooks/$endpointId'
     | '/partners/stripe/projects/login'
     | '/api/platform/auth/$ref/invite'
@@ -1591,9 +3420,49 @@ export interface FileRouteTypes {
     | '/api/platform/projects/$ref/settings'
     | '/api/platform/props/org/$slug'
     | '/api/v1/projects/$ref/api-keys'
+    | '/integrations/vercel/$slug/deploy-button/new-project'
+    | '/integrations/vercel/$slug/marketplace/choose-project'
+    | '/project/$ref/advisors/rules/performance'
+    | '/project/$ref/advisors/rules/security'
+    | '/project/$ref/auth/templates/$templateId'
+    | '/project/$ref/database/backups/pitr'
+    | '/project/$ref/database/backups/restore-to-new-project'
+    | '/project/$ref/database/backups/scheduled'
+    | '/project/$ref/database/publications/$id'
+    | '/project/$ref/database/replication/$pipelineId'
+    | '/project/$ref/database/tables/$id'
+    | '/project/$ref/database/triggers/data'
+    | '/project/$ref/database/triggers/event'
+    | '/project/$ref/functions/$functionSlug/code'
+    | '/project/$ref/functions/$functionSlug/details'
+    | '/project/$ref/functions/$functionSlug/invocations'
+    | '/project/$ref/functions/$functionSlug/logs'
+    | '/project/$ref/logs/explorer/recent'
+    | '/project/$ref/logs/explorer/saved'
+    | '/project/$ref/logs/explorer/templates'
+    | '/project/$ref/settings/api-keys/legacy'
+    | '/project/$ref/settings/billing/usage'
+    | '/project/$ref/settings/jwt/legacy'
+    | '/project/$ref/settings/webhooks/$endpointId'
+    | '/project/$ref/storage/files/policies'
+    | '/project/$ref/storage/files/settings'
     | '/org/$slug/private-apps'
     | '/org/$slug/webhooks'
     | '/api/platform/projects/$ref'
+    | '/project/$ref/auth/templates'
+    | '/project/$ref/database/publications'
+    | '/project/$ref/database/replication'
+    | '/project/$ref/database/tables'
+    | '/project/$ref/database/triggers'
+    | '/project/$ref/functions/$functionSlug'
+    | '/project/$ref/integrations/$id'
+    | '/project/$ref/logs/explorer'
+    | '/project/$ref/settings/api-keys'
+    | '/project/$ref/settings/jwt'
+    | '/project/$ref/settings/webhooks'
+    | '/project/$ref/storage/analytics'
+    | '/project/$ref/storage/files'
+    | '/project/$ref/storage/vectors'
     | '/api/platform/organizations/$slug/billing/subscription'
     | '/api/platform/projects/$ref/analytics/log-drains'
     | '/api/platform/projects/$ref/api-keys/temporary'
@@ -1606,6 +3475,10 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/api-keys/$id'
     | '/api/v1/projects/$ref/database/migrations'
     | '/api/v1/projects/$ref/types/typescript'
+    | '/project/$ref/database/replication/replica/$replicaId'
+    | '/project/$ref/storage/analytics/buckets/$bucketId'
+    | '/project/$ref/storage/files/buckets/$bucketId'
+    | '/project/$ref/storage/vectors/buckets/$bucketId'
     | '/api/platform/auth/$ref/users'
     | '/api/platform/pg-meta/$ref/query'
     | '/api/platform/projects/$ref/config'
@@ -1614,6 +3487,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets'
     | '/api/platform/storage/$ref/vector-buckets'
     | '/api/v1/projects/$ref/functions'
+    | '/project/$ref/integrations/$id/$pageId'
     | '/api/platform/auth/$ref/users/$id/factors'
     | '/api/platform/projects/$ref/analytics/endpoints/$name'
     | '/api/platform/projects/$ref/analytics/log-drains/$uuid'
@@ -1627,6 +3501,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets/$id'
     | '/api/platform/storage/$ref/vector-buckets/$id'
     | '/api/v1/projects/$ref/functions/$slug'
+    | '/project/$ref/integrations/$id/$pageId/$childId'
     | '/api/platform/storage/$ref/buckets/$id/objects/download'
     | '/api/platform/storage/$ref/buckets/$id/objects/list'
     | '/api/platform/storage/$ref/buckets/$id/objects/move'
@@ -1640,6 +3515,17 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/config/auth/signing-keys'
   id:
     | '__root__'
+    | '/'
+    | '/_app'
+    | '/_auth'
+    | '/authorize'
+    | '/aws-marketplace-onboarding'
+    | '/claim-project'
+    | '/join'
+    | '/logout'
+    | '/maintenance'
+    | '/redeem'
+    | '/verify-email'
     | '/_app/account'
     | '/_app/org'
     | '/_app/organizations'
@@ -1663,6 +3549,11 @@ export interface FileRouteTypes {
     | '/api/incident-status'
     | '/api/parse-query'
     | '/api/status-override'
+    | '/integrations/vercel'
+    | '/new/$slug'
+    | '/org/_'
+    | '/project/$ref'
+    | '/project/_'
     | '/_app/account/audit'
     | '/_app/account/me'
     | '/_app/account/security'
@@ -1674,10 +3565,29 @@ export interface FileRouteTypes {
     | '/api/edge-functions/test'
     | '/api/integrations/stripe-sync'
     | '/api/platform/deployment-mode'
+    | '/integrations/github/authorize'
+    | '/integrations/vercel/install'
+    | '/org/_/$'
+    | '/project/$ref/advisors'
+    | '/project/$ref/auth'
+    | '/project/$ref/branches'
+    | '/project/$ref/database'
+    | '/project/$ref/editor'
+    | '/project/$ref/functions'
+    | '/project/$ref/integrations'
+    | '/project/$ref/logs'
+    | '/project/$ref/merge'
+    | '/project/$ref/observability'
+    | '/project/$ref/realtime'
+    | '/project/$ref/settings'
+    | '/project/$ref/sql'
+    | '/project/$ref/storage'
+    | '/project/_/$'
     | '/_app/new/'
     | '/_app/org/'
     | '/api/connect/'
     | '/api/mcp/'
+    | '/project/$ref/'
     | '/_app/account/tokens/scoped'
     | '/_app/org/$slug/apps'
     | '/_app/org/$slug/audit'
@@ -1702,11 +3612,94 @@ export interface FileRouteTypes {
     | '/api/ai/sql/title-v2'
     | '/api/platform/integrations/$slug'
     | '/api/platform/telemetry/event'
+    | '/project/$ref/advisors/performance'
+    | '/project/$ref/advisors/rules'
+    | '/project/$ref/advisors/security'
+    | '/project/$ref/auth/audit-logs'
+    | '/project/$ref/auth/hooks'
+    | '/project/$ref/auth/mfa'
+    | '/project/$ref/auth/oauth-apps'
+    | '/project/$ref/auth/oauth-server'
+    | '/project/$ref/auth/overview'
+    | '/project/$ref/auth/passkeys'
+    | '/project/$ref/auth/performance'
+    | '/project/$ref/auth/policies'
+    | '/project/$ref/auth/protection'
+    | '/project/$ref/auth/providers'
+    | '/project/$ref/auth/rate-limits'
+    | '/project/$ref/auth/sessions'
+    | '/project/$ref/auth/smtp'
+    | '/project/$ref/auth/third-party'
+    | '/project/$ref/auth/url-configuration'
+    | '/project/$ref/auth/users'
+    | '/project/$ref/branches/merge-requests'
+    | '/project/$ref/database/column-privileges'
+    | '/project/$ref/database/extensions'
+    | '/project/$ref/database/functions'
+    | '/project/$ref/database/indexes'
+    | '/project/$ref/database/migrations'
+    | '/project/$ref/database/roles'
+    | '/project/$ref/database/schemas'
+    | '/project/$ref/database/settings'
+    | '/project/$ref/database/triggers'
+    | '/project/$ref/database/types'
+    | '/project/$ref/editor/$id'
+    | '/project/$ref/editor/new'
+    | '/project/$ref/functions/$functionSlug'
+    | '/project/$ref/functions/new'
+    | '/project/$ref/functions/secrets'
+    | '/project/$ref/logs/auth-logs'
+    | '/project/$ref/logs/cron-logs'
+    | '/project/$ref/logs/dedicated-pooler-logs'
+    | '/project/$ref/logs/edge-functions-logs'
+    | '/project/$ref/logs/edge-logs'
+    | '/project/$ref/logs/pg-upgrade-logs'
+    | '/project/$ref/logs/pgcron-logs'
+    | '/project/$ref/logs/pooler-logs'
+    | '/project/$ref/logs/postgres-logs'
+    | '/project/$ref/logs/postgrest-logs'
+    | '/project/$ref/logs/realtime-logs'
+    | '/project/$ref/logs/replication-logs'
+    | '/project/$ref/logs/storage-logs'
+    | '/project/$ref/observability/$id'
+    | '/project/$ref/observability/api-overview'
+    | '/project/$ref/observability/auth'
+    | '/project/$ref/observability/database'
+    | '/project/$ref/observability/edge-functions'
+    | '/project/$ref/observability/postgrest'
+    | '/project/$ref/observability/query-insights'
+    | '/project/$ref/observability/query-performance'
+    | '/project/$ref/observability/realtime'
+    | '/project/$ref/observability/storage'
+    | '/project/$ref/realtime/inspector'
+    | '/project/$ref/realtime/policies'
+    | '/project/$ref/realtime/settings'
+    | '/project/$ref/settings/addons'
+    | '/project/$ref/settings/api'
+    | '/project/$ref/settings/api-keys'
+    | '/project/$ref/settings/compute-and-disk'
+    | '/project/$ref/settings/dashboard'
+    | '/project/$ref/settings/general'
+    | '/project/$ref/settings/infrastructure'
+    | '/project/$ref/settings/integrations'
+    | '/project/$ref/settings/log-drains'
+    | '/project/$ref/sql/$id'
+    | '/project/$ref/sql/examples'
+    | '/project/$ref/sql/templates'
+    | '/project/$ref/storage/s3'
     | '/_app/account/tokens/'
     | '/_app/org/$slug/'
     | '/api/platform/organizations/'
     | '/api/platform/profile/'
     | '/api/platform/projects/'
+    | '/project/$ref/api/'
+    | '/project/$ref/branches/'
+    | '/project/$ref/editor/'
+    | '/project/$ref/functions/'
+    | '/project/$ref/integrations/'
+    | '/project/$ref/logs/'
+    | '/project/$ref/observability/'
+    | '/project/$ref/sql/'
     | '/_app/org/$slug/webhooks/$endpointId'
     | '/_auth/partners/stripe/projects/login'
     | '/api/platform/auth/$ref/invite'
@@ -1733,9 +3726,49 @@ export interface FileRouteTypes {
     | '/api/platform/projects/$ref/settings'
     | '/api/platform/props/org/$slug'
     | '/api/v1/projects/$ref/api-keys'
+    | '/integrations/vercel/$slug/deploy-button/new-project'
+    | '/integrations/vercel/$slug/marketplace/choose-project'
+    | '/project/$ref/advisors/rules/performance'
+    | '/project/$ref/advisors/rules/security'
+    | '/project/$ref/auth/templates/$templateId'
+    | '/project/$ref/database/backups/pitr'
+    | '/project/$ref/database/backups/restore-to-new-project'
+    | '/project/$ref/database/backups/scheduled'
+    | '/project/$ref/database/publications/$id'
+    | '/project/$ref/database/replication/$pipelineId'
+    | '/project/$ref/database/tables/$id'
+    | '/project/$ref/database/triggers/data'
+    | '/project/$ref/database/triggers/event'
+    | '/project/$ref/functions/$functionSlug/code'
+    | '/project/$ref/functions/$functionSlug/details'
+    | '/project/$ref/functions/$functionSlug/invocations'
+    | '/project/$ref/functions/$functionSlug/logs'
+    | '/project/$ref/logs/explorer/recent'
+    | '/project/$ref/logs/explorer/saved'
+    | '/project/$ref/logs/explorer/templates'
+    | '/project/$ref/settings/api-keys/legacy'
+    | '/project/$ref/settings/billing/usage'
+    | '/project/$ref/settings/jwt/legacy'
+    | '/project/$ref/settings/webhooks/$endpointId'
+    | '/project/$ref/storage/files/policies'
+    | '/project/$ref/storage/files/settings'
     | '/_app/org/$slug/private-apps/'
     | '/_app/org/$slug/webhooks/'
     | '/api/platform/projects/$ref/'
+    | '/project/$ref/auth/templates/'
+    | '/project/$ref/database/publications/'
+    | '/project/$ref/database/replication/'
+    | '/project/$ref/database/tables/'
+    | '/project/$ref/database/triggers/'
+    | '/project/$ref/functions/$functionSlug/'
+    | '/project/$ref/integrations/$id/'
+    | '/project/$ref/logs/explorer/'
+    | '/project/$ref/settings/api-keys/'
+    | '/project/$ref/settings/jwt/'
+    | '/project/$ref/settings/webhooks/'
+    | '/project/$ref/storage/analytics/'
+    | '/project/$ref/storage/files/'
+    | '/project/$ref/storage/vectors/'
     | '/api/platform/organizations/$slug/billing/subscription'
     | '/api/platform/projects/$ref/analytics/log-drains'
     | '/api/platform/projects/$ref/api-keys/temporary'
@@ -1748,6 +3781,10 @@ export interface FileRouteTypes {
     | '/api/v1/projects/$ref/api-keys/$id'
     | '/api/v1/projects/$ref/database/migrations'
     | '/api/v1/projects/$ref/types/typescript'
+    | '/project/$ref/database/replication/replica/$replicaId'
+    | '/project/$ref/storage/analytics/buckets/$bucketId'
+    | '/project/$ref/storage/files/buckets/$bucketId'
+    | '/project/$ref/storage/vectors/buckets/$bucketId'
     | '/api/platform/auth/$ref/users/'
     | '/api/platform/pg-meta/$ref/query/'
     | '/api/platform/projects/$ref/config/'
@@ -1756,6 +3793,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets/'
     | '/api/platform/storage/$ref/vector-buckets/'
     | '/api/v1/projects/$ref/functions/'
+    | '/project/$ref/integrations/$id/$pageId/'
     | '/api/platform/auth/$ref/users/$id/factors'
     | '/api/platform/projects/$ref/analytics/endpoints/$name'
     | '/api/platform/projects/$ref/analytics/log-drains/$uuid'
@@ -1769,6 +3807,7 @@ export interface FileRouteTypes {
     | '/api/platform/storage/$ref/buckets/$id/'
     | '/api/platform/storage/$ref/vector-buckets/$id/'
     | '/api/v1/projects/$ref/functions/$slug/'
+    | '/project/$ref/integrations/$id/$pageId/$childId/'
     | '/api/platform/storage/$ref/buckets/$id/objects/download'
     | '/api/platform/storage/$ref/buckets/$id/objects/list'
     | '/api/platform/storage/$ref/buckets/$id/objects/move'
@@ -1783,17 +3822,17 @@ export interface FileRouteTypes {
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  AppAccountRoute: typeof AppAccountRouteWithChildren
-  AppOrgRoute: typeof AppOrgRouteWithChildren
-  AppOrganizationsRoute: typeof AppOrganizationsRoute
-  AuthForgotPasswordRoute: typeof AuthForgotPasswordRoute
-  AuthForgotPasswordMfaRoute: typeof AuthForgotPasswordMfaRoute
-  AuthResetPasswordRoute: typeof AuthResetPasswordRoute
-  AuthSignInRoute: typeof AuthSignInRoute
-  AuthSignInMfaRoute: typeof AuthSignInMfaRoute
-  AuthSignInPartnerRoute: typeof AuthSignInPartnerRoute
-  AuthSignInSsoRoute: typeof AuthSignInSsoRoute
-  AuthSignUpRoute: typeof AuthSignUpRoute
+  IndexRoute: typeof IndexRoute
+  AppRoute: typeof AppRouteWithChildren
+  AuthRoute: typeof AuthRouteWithChildren
+  AuthorizeRoute: typeof AuthorizeRoute
+  AwsMarketplaceOnboardingRoute: typeof AwsMarketplaceOnboardingRoute
+  ClaimProjectRoute: typeof ClaimProjectRoute
+  JoinRoute: typeof JoinRoute
+  LogoutRoute: typeof LogoutRoute
+  MaintenanceRoute: typeof MaintenanceRoute
+  RedeemRoute: typeof RedeemRoute
+  VerifyEmailRoute: typeof VerifyEmailRoute
   ApiCheckCnameRoute: typeof ApiCheckCnameRoute
   ApiCliReleaseVersionRoute: typeof ApiCliReleaseVersionRoute
   ApiEnabledFeaturesOverridesRoute: typeof ApiEnabledFeaturesOverridesRoute
@@ -1806,15 +3845,17 @@ export interface RootRouteChildren {
   ApiIncidentStatusRoute: typeof ApiIncidentStatusRoute
   ApiParseQueryRoute: typeof ApiParseQueryRoute
   ApiStatusOverrideRoute: typeof ApiStatusOverrideRoute
-  AppSupportLinkRoute: typeof AppSupportLinkRoute
-  AppSupportNewRoute: typeof AppSupportNewRoute
-  AuthCliLoginRoute: typeof AuthCliLoginRoute
+  IntegrationsVercelRoute: typeof IntegrationsVercelRouteWithChildren
+  NewSlugRoute: typeof NewSlugRoute
+  OrgChar91_Char93Route: typeof OrgChar91_Char93RouteWithChildren
+  ProjectRefRoute: typeof ProjectRefRouteWithChildren
+  ProjectChar91_Char93Route: typeof ProjectChar91_Char93RouteWithChildren
   ApiAiDocsRoute: typeof ApiAiDocsRoute
   ApiContentGraphqlRoute: typeof ApiContentGraphqlRoute
   ApiEdgeFunctionsTestRoute: typeof ApiEdgeFunctionsTestRoute
   ApiIntegrationsStripeSyncRoute: typeof ApiIntegrationsStripeSyncRoute
   ApiPlatformDeploymentModeRoute: typeof ApiPlatformDeploymentModeRoute
-  AppNewIndexRoute: typeof AppNewIndexRoute
+  IntegrationsGithubAuthorizeRoute: typeof IntegrationsGithubAuthorizeRoute
   ApiConnectIndexRoute: typeof ApiConnectIndexRoute
   ApiMcpIndexRoute: typeof ApiMcpIndexRoute
   ApiAiCodeCompleteRoute: typeof ApiAiCodeCompleteRoute
@@ -1833,7 +3874,6 @@ export interface RootRouteChildren {
   ApiPlatformOrganizationsIndexRoute: typeof ApiPlatformOrganizationsIndexRoute
   ApiPlatformProfileIndexRoute: typeof ApiPlatformProfileIndexRoute
   ApiPlatformProjectsIndexRoute: typeof ApiPlatformProjectsIndexRoute
-  AuthPartnersStripeProjectsLoginRoute: typeof AuthPartnersStripeProjectsLoginRoute
   ApiPlatformAuthRefInviteRoute: typeof ApiPlatformAuthRefInviteRoute
   ApiPlatformAuthRefMagiclinkRoute: typeof ApiPlatformAuthRefMagiclinkRoute
   ApiPlatformAuthRefOtpRoute: typeof ApiPlatformAuthRefOtpRoute
@@ -1905,6 +3945,118 @@ export interface RootRouteChildren {
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/verify-email': {
+      id: '/verify-email'
+      path: '/verify-email'
+      fullPath: '/verify-email'
+      preLoaderRoute: typeof VerifyEmailRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/redeem': {
+      id: '/redeem'
+      path: '/redeem'
+      fullPath: '/redeem'
+      preLoaderRoute: typeof RedeemRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/maintenance': {
+      id: '/maintenance'
+      path: '/maintenance'
+      fullPath: '/maintenance'
+      preLoaderRoute: typeof MaintenanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/logout': {
+      id: '/logout'
+      path: '/logout'
+      fullPath: '/logout'
+      preLoaderRoute: typeof LogoutRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/join': {
+      id: '/join'
+      path: '/join'
+      fullPath: '/join'
+      preLoaderRoute: typeof JoinRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/claim-project': {
+      id: '/claim-project'
+      path: '/claim-project'
+      fullPath: '/claim-project'
+      preLoaderRoute: typeof ClaimProjectRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/aws-marketplace-onboarding': {
+      id: '/aws-marketplace-onboarding'
+      path: '/aws-marketplace-onboarding'
+      fullPath: '/aws-marketplace-onboarding'
+      preLoaderRoute: typeof AwsMarketplaceOnboardingRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/authorize': {
+      id: '/authorize'
+      path: '/authorize'
+      fullPath: '/authorize'
+      preLoaderRoute: typeof AuthorizeRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_auth': {
+      id: '/_auth'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AuthRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/_app': {
+      id: '/_app'
+      path: ''
+      fullPath: '/'
+      preLoaderRoute: typeof AppRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/project/_': {
+      id: '/project/_'
+      path: '/project/_'
+      fullPath: '/project/_'
+      preLoaderRoute: typeof ProjectChar91_Char93RouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/project/$ref': {
+      id: '/project/$ref'
+      path: '/project/$ref'
+      fullPath: '/project/$ref'
+      preLoaderRoute: typeof ProjectRefRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/org/_': {
+      id: '/org/_'
+      path: '/org/_'
+      fullPath: '/org/_'
+      preLoaderRoute: typeof OrgChar91_Char93RouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/new/$slug': {
+      id: '/new/$slug'
+      path: '/new/$slug'
+      fullPath: '/new/$slug'
+      preLoaderRoute: typeof NewSlugRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/integrations/vercel': {
+      id: '/integrations/vercel'
+      path: '/integrations/vercel'
+      fullPath: '/integrations/vercel'
+      preLoaderRoute: typeof IntegrationsVercelRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/status-override': {
       id: '/api/status-override'
       path: '/api/status-override'
@@ -1994,77 +4146,84 @@ declare module '@tanstack/react-router' {
       path: '/sign-up'
       fullPath: '/sign-up'
       preLoaderRoute: typeof AuthSignUpRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/sign-in-sso': {
       id: '/_auth/sign-in-sso'
       path: '/sign-in-sso'
       fullPath: '/sign-in-sso'
       preLoaderRoute: typeof AuthSignInSsoRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/sign-in-partner': {
       id: '/_auth/sign-in-partner'
       path: '/sign-in-partner'
       fullPath: '/sign-in-partner'
       preLoaderRoute: typeof AuthSignInPartnerRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/sign-in-mfa': {
       id: '/_auth/sign-in-mfa'
       path: '/sign-in-mfa'
       fullPath: '/sign-in-mfa'
       preLoaderRoute: typeof AuthSignInMfaRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/sign-in': {
       id: '/_auth/sign-in'
       path: '/sign-in'
       fullPath: '/sign-in'
       preLoaderRoute: typeof AuthSignInRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/reset-password': {
       id: '/_auth/reset-password'
       path: '/reset-password'
       fullPath: '/reset-password'
       preLoaderRoute: typeof AuthResetPasswordRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/forgot-password-mfa': {
       id: '/_auth/forgot-password-mfa'
       path: '/forgot-password-mfa'
       fullPath: '/forgot-password-mfa'
       preLoaderRoute: typeof AuthForgotPasswordMfaRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_auth/forgot-password': {
       id: '/_auth/forgot-password'
       path: '/forgot-password'
       fullPath: '/forgot-password'
       preLoaderRoute: typeof AuthForgotPasswordRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_app/organizations': {
       id: '/_app/organizations'
       path: '/organizations'
       fullPath: '/organizations'
       preLoaderRoute: typeof AppOrganizationsRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AppRoute
     }
     '/_app/org': {
       id: '/_app/org'
       path: '/org'
       fullPath: '/org'
       preLoaderRoute: typeof AppOrgRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AppRoute
     }
     '/_app/account': {
       id: '/_app/account'
       path: '/account'
       fullPath: '/account'
       preLoaderRoute: typeof AppAccountRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/project/$ref/': {
+      id: '/project/$ref/'
+      path: '/'
+      fullPath: '/project/$ref/'
+      preLoaderRoute: typeof ProjectRefIndexRouteImport
+      parentRoute: typeof ProjectRefRoute
     }
     '/api/mcp/': {
       id: '/api/mcp/'
@@ -2092,6 +4251,132 @@ declare module '@tanstack/react-router' {
       path: '/new'
       fullPath: '/new/'
       preLoaderRoute: typeof AppNewIndexRouteImport
+      parentRoute: typeof AppRoute
+    }
+    '/project/_/$': {
+      id: '/project/_/$'
+      path: '/$'
+      fullPath: '/project/_/$'
+      preLoaderRoute: typeof ProjectChar91_Char93SplatRouteImport
+      parentRoute: typeof ProjectChar91_Char93Route
+    }
+    '/project/$ref/storage': {
+      id: '/project/$ref/storage'
+      path: '/storage'
+      fullPath: '/project/$ref/storage'
+      preLoaderRoute: typeof ProjectRefStorageRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/sql': {
+      id: '/project/$ref/sql'
+      path: '/sql'
+      fullPath: '/project/$ref/sql'
+      preLoaderRoute: typeof ProjectRefSqlRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/settings': {
+      id: '/project/$ref/settings'
+      path: '/settings'
+      fullPath: '/project/$ref/settings'
+      preLoaderRoute: typeof ProjectRefSettingsRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/realtime': {
+      id: '/project/$ref/realtime'
+      path: '/realtime'
+      fullPath: '/project/$ref/realtime'
+      preLoaderRoute: typeof ProjectRefRealtimeRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/observability': {
+      id: '/project/$ref/observability'
+      path: '/observability'
+      fullPath: '/project/$ref/observability'
+      preLoaderRoute: typeof ProjectRefObservabilityRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/merge': {
+      id: '/project/$ref/merge'
+      path: '/merge'
+      fullPath: '/project/$ref/merge'
+      preLoaderRoute: typeof ProjectRefMergeRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/logs': {
+      id: '/project/$ref/logs'
+      path: '/logs'
+      fullPath: '/project/$ref/logs'
+      preLoaderRoute: typeof ProjectRefLogsRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/integrations': {
+      id: '/project/$ref/integrations'
+      path: '/integrations'
+      fullPath: '/project/$ref/integrations'
+      preLoaderRoute: typeof ProjectRefIntegrationsRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/functions': {
+      id: '/project/$ref/functions'
+      path: '/functions'
+      fullPath: '/project/$ref/functions'
+      preLoaderRoute: typeof ProjectRefFunctionsRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/editor': {
+      id: '/project/$ref/editor'
+      path: '/editor'
+      fullPath: '/project/$ref/editor'
+      preLoaderRoute: typeof ProjectRefEditorRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/database': {
+      id: '/project/$ref/database'
+      path: '/database'
+      fullPath: '/project/$ref/database'
+      preLoaderRoute: typeof ProjectRefDatabaseRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/branches': {
+      id: '/project/$ref/branches'
+      path: '/branches'
+      fullPath: '/project/$ref/branches'
+      preLoaderRoute: typeof ProjectRefBranchesRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/auth': {
+      id: '/project/$ref/auth'
+      path: '/auth'
+      fullPath: '/project/$ref/auth'
+      preLoaderRoute: typeof ProjectRefAuthRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/project/$ref/advisors': {
+      id: '/project/$ref/advisors'
+      path: '/advisors'
+      fullPath: '/project/$ref/advisors'
+      preLoaderRoute: typeof ProjectRefAdvisorsRouteImport
+      parentRoute: typeof ProjectRefRoute
+    }
+    '/org/_/$': {
+      id: '/org/_/$'
+      path: '/$'
+      fullPath: '/org/_/$'
+      preLoaderRoute: typeof OrgChar91_Char93SplatRouteImport
+      parentRoute: typeof OrgChar91_Char93Route
+    }
+    '/integrations/vercel/install': {
+      id: '/integrations/vercel/install'
+      path: '/install'
+      fullPath: '/integrations/vercel/install'
+      preLoaderRoute: typeof IntegrationsVercelInstallRouteImport
+      parentRoute: typeof IntegrationsVercelRoute
+    }
+    '/integrations/github/authorize': {
+      id: '/integrations/github/authorize'
+      path: '/integrations/github/authorize'
+      fullPath: '/integrations/github/authorize'
+      preLoaderRoute: typeof IntegrationsGithubAuthorizeRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/platform/deployment-mode': {
@@ -2134,21 +4419,21 @@ declare module '@tanstack/react-router' {
       path: '/cli/login'
       fullPath: '/cli/login'
       preLoaderRoute: typeof AuthCliLoginRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_app/support/new': {
       id: '/_app/support/new'
       path: '/support/new'
       fullPath: '/support/new'
       preLoaderRoute: typeof AppSupportNewRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AppRoute
     }
     '/_app/support/link': {
       id: '/_app/support/link'
       path: '/support/link'
       fullPath: '/support/link'
       preLoaderRoute: typeof AppSupportLinkRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AppRoute
     }
     '/_app/account/security': {
       id: '/_app/account/security'
@@ -2170,6 +4455,62 @@ declare module '@tanstack/react-router' {
       fullPath: '/account/audit'
       preLoaderRoute: typeof AppAccountAuditRouteImport
       parentRoute: typeof AppAccountRoute
+    }
+    '/project/$ref/sql/': {
+      id: '/project/$ref/sql/'
+      path: '/'
+      fullPath: '/project/$ref/sql/'
+      preLoaderRoute: typeof ProjectRefSqlIndexRouteImport
+      parentRoute: typeof ProjectRefSqlRoute
+    }
+    '/project/$ref/observability/': {
+      id: '/project/$ref/observability/'
+      path: '/'
+      fullPath: '/project/$ref/observability/'
+      preLoaderRoute: typeof ProjectRefObservabilityIndexRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/logs/': {
+      id: '/project/$ref/logs/'
+      path: '/'
+      fullPath: '/project/$ref/logs/'
+      preLoaderRoute: typeof ProjectRefLogsIndexRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/integrations/': {
+      id: '/project/$ref/integrations/'
+      path: '/'
+      fullPath: '/project/$ref/integrations/'
+      preLoaderRoute: typeof ProjectRefIntegrationsIndexRouteImport
+      parentRoute: typeof ProjectRefIntegrationsRoute
+    }
+    '/project/$ref/functions/': {
+      id: '/project/$ref/functions/'
+      path: '/'
+      fullPath: '/project/$ref/functions/'
+      preLoaderRoute: typeof ProjectRefFunctionsIndexRouteImport
+      parentRoute: typeof ProjectRefFunctionsRoute
+    }
+    '/project/$ref/editor/': {
+      id: '/project/$ref/editor/'
+      path: '/'
+      fullPath: '/project/$ref/editor/'
+      preLoaderRoute: typeof ProjectRefEditorIndexRouteImport
+      parentRoute: typeof ProjectRefEditorRoute
+    }
+    '/project/$ref/branches/': {
+      id: '/project/$ref/branches/'
+      path: '/'
+      fullPath: '/project/$ref/branches/'
+      preLoaderRoute: typeof ProjectRefBranchesIndexRouteImport
+      parentRoute: typeof ProjectRefBranchesRoute
+    }
+    '/project/$ref/api/': {
+      id: '/project/$ref/api/'
+      path: '/api'
+      fullPath: '/project/$ref/api/'
+      preLoaderRoute: typeof ProjectRefApiIndexRouteImport
+      parentRoute: typeof ProjectRefRoute
     }
     '/api/platform/projects/': {
       id: '/api/platform/projects/'
@@ -2205,6 +4546,531 @@ declare module '@tanstack/react-router' {
       fullPath: '/account/tokens/'
       preLoaderRoute: typeof AppAccountTokensIndexRouteImport
       parentRoute: typeof AppAccountRoute
+    }
+    '/project/$ref/storage/s3': {
+      id: '/project/$ref/storage/s3'
+      path: '/s3'
+      fullPath: '/project/$ref/storage/s3'
+      preLoaderRoute: typeof ProjectRefStorageS3RouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/sql/templates': {
+      id: '/project/$ref/sql/templates'
+      path: '/templates'
+      fullPath: '/project/$ref/sql/templates'
+      preLoaderRoute: typeof ProjectRefSqlTemplatesRouteImport
+      parentRoute: typeof ProjectRefSqlRoute
+    }
+    '/project/$ref/sql/examples': {
+      id: '/project/$ref/sql/examples'
+      path: '/examples'
+      fullPath: '/project/$ref/sql/examples'
+      preLoaderRoute: typeof ProjectRefSqlExamplesRouteImport
+      parentRoute: typeof ProjectRefSqlRoute
+    }
+    '/project/$ref/sql/$id': {
+      id: '/project/$ref/sql/$id'
+      path: '/$id'
+      fullPath: '/project/$ref/sql/$id'
+      preLoaderRoute: typeof ProjectRefSqlIdRouteImport
+      parentRoute: typeof ProjectRefSqlRoute
+    }
+    '/project/$ref/settings/log-drains': {
+      id: '/project/$ref/settings/log-drains'
+      path: '/log-drains'
+      fullPath: '/project/$ref/settings/log-drains'
+      preLoaderRoute: typeof ProjectRefSettingsLogDrainsRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/integrations': {
+      id: '/project/$ref/settings/integrations'
+      path: '/integrations'
+      fullPath: '/project/$ref/settings/integrations'
+      preLoaderRoute: typeof ProjectRefSettingsIntegrationsRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/infrastructure': {
+      id: '/project/$ref/settings/infrastructure'
+      path: '/infrastructure'
+      fullPath: '/project/$ref/settings/infrastructure'
+      preLoaderRoute: typeof ProjectRefSettingsInfrastructureRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/general': {
+      id: '/project/$ref/settings/general'
+      path: '/general'
+      fullPath: '/project/$ref/settings/general'
+      preLoaderRoute: typeof ProjectRefSettingsGeneralRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/dashboard': {
+      id: '/project/$ref/settings/dashboard'
+      path: '/dashboard'
+      fullPath: '/project/$ref/settings/dashboard'
+      preLoaderRoute: typeof ProjectRefSettingsDashboardRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/compute-and-disk': {
+      id: '/project/$ref/settings/compute-and-disk'
+      path: '/compute-and-disk'
+      fullPath: '/project/$ref/settings/compute-and-disk'
+      preLoaderRoute: typeof ProjectRefSettingsComputeAndDiskRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/api-keys': {
+      id: '/project/$ref/settings/api-keys'
+      path: '/api-keys'
+      fullPath: '/project/$ref/settings/api-keys'
+      preLoaderRoute: typeof ProjectRefSettingsApiKeysRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/api': {
+      id: '/project/$ref/settings/api'
+      path: '/api'
+      fullPath: '/project/$ref/settings/api'
+      preLoaderRoute: typeof ProjectRefSettingsApiRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/addons': {
+      id: '/project/$ref/settings/addons'
+      path: '/addons'
+      fullPath: '/project/$ref/settings/addons'
+      preLoaderRoute: typeof ProjectRefSettingsAddonsRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/realtime/settings': {
+      id: '/project/$ref/realtime/settings'
+      path: '/settings'
+      fullPath: '/project/$ref/realtime/settings'
+      preLoaderRoute: typeof ProjectRefRealtimeSettingsRouteImport
+      parentRoute: typeof ProjectRefRealtimeRoute
+    }
+    '/project/$ref/realtime/policies': {
+      id: '/project/$ref/realtime/policies'
+      path: '/policies'
+      fullPath: '/project/$ref/realtime/policies'
+      preLoaderRoute: typeof ProjectRefRealtimePoliciesRouteImport
+      parentRoute: typeof ProjectRefRealtimeRoute
+    }
+    '/project/$ref/realtime/inspector': {
+      id: '/project/$ref/realtime/inspector'
+      path: '/inspector'
+      fullPath: '/project/$ref/realtime/inspector'
+      preLoaderRoute: typeof ProjectRefRealtimeInspectorRouteImport
+      parentRoute: typeof ProjectRefRealtimeRoute
+    }
+    '/project/$ref/observability/storage': {
+      id: '/project/$ref/observability/storage'
+      path: '/storage'
+      fullPath: '/project/$ref/observability/storage'
+      preLoaderRoute: typeof ProjectRefObservabilityStorageRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/realtime': {
+      id: '/project/$ref/observability/realtime'
+      path: '/realtime'
+      fullPath: '/project/$ref/observability/realtime'
+      preLoaderRoute: typeof ProjectRefObservabilityRealtimeRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/query-performance': {
+      id: '/project/$ref/observability/query-performance'
+      path: '/query-performance'
+      fullPath: '/project/$ref/observability/query-performance'
+      preLoaderRoute: typeof ProjectRefObservabilityQueryPerformanceRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/query-insights': {
+      id: '/project/$ref/observability/query-insights'
+      path: '/query-insights'
+      fullPath: '/project/$ref/observability/query-insights'
+      preLoaderRoute: typeof ProjectRefObservabilityQueryInsightsRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/postgrest': {
+      id: '/project/$ref/observability/postgrest'
+      path: '/postgrest'
+      fullPath: '/project/$ref/observability/postgrest'
+      preLoaderRoute: typeof ProjectRefObservabilityPostgrestRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/edge-functions': {
+      id: '/project/$ref/observability/edge-functions'
+      path: '/edge-functions'
+      fullPath: '/project/$ref/observability/edge-functions'
+      preLoaderRoute: typeof ProjectRefObservabilityEdgeFunctionsRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/database': {
+      id: '/project/$ref/observability/database'
+      path: '/database'
+      fullPath: '/project/$ref/observability/database'
+      preLoaderRoute: typeof ProjectRefObservabilityDatabaseRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/auth': {
+      id: '/project/$ref/observability/auth'
+      path: '/auth'
+      fullPath: '/project/$ref/observability/auth'
+      preLoaderRoute: typeof ProjectRefObservabilityAuthRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/api-overview': {
+      id: '/project/$ref/observability/api-overview'
+      path: '/api-overview'
+      fullPath: '/project/$ref/observability/api-overview'
+      preLoaderRoute: typeof ProjectRefObservabilityApiOverviewRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/observability/$id': {
+      id: '/project/$ref/observability/$id'
+      path: '/$id'
+      fullPath: '/project/$ref/observability/$id'
+      preLoaderRoute: typeof ProjectRefObservabilityIdRouteImport
+      parentRoute: typeof ProjectRefObservabilityRoute
+    }
+    '/project/$ref/logs/storage-logs': {
+      id: '/project/$ref/logs/storage-logs'
+      path: '/storage-logs'
+      fullPath: '/project/$ref/logs/storage-logs'
+      preLoaderRoute: typeof ProjectRefLogsStorageLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/replication-logs': {
+      id: '/project/$ref/logs/replication-logs'
+      path: '/replication-logs'
+      fullPath: '/project/$ref/logs/replication-logs'
+      preLoaderRoute: typeof ProjectRefLogsReplicationLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/realtime-logs': {
+      id: '/project/$ref/logs/realtime-logs'
+      path: '/realtime-logs'
+      fullPath: '/project/$ref/logs/realtime-logs'
+      preLoaderRoute: typeof ProjectRefLogsRealtimeLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/postgrest-logs': {
+      id: '/project/$ref/logs/postgrest-logs'
+      path: '/postgrest-logs'
+      fullPath: '/project/$ref/logs/postgrest-logs'
+      preLoaderRoute: typeof ProjectRefLogsPostgrestLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/postgres-logs': {
+      id: '/project/$ref/logs/postgres-logs'
+      path: '/postgres-logs'
+      fullPath: '/project/$ref/logs/postgres-logs'
+      preLoaderRoute: typeof ProjectRefLogsPostgresLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/pooler-logs': {
+      id: '/project/$ref/logs/pooler-logs'
+      path: '/pooler-logs'
+      fullPath: '/project/$ref/logs/pooler-logs'
+      preLoaderRoute: typeof ProjectRefLogsPoolerLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/pgcron-logs': {
+      id: '/project/$ref/logs/pgcron-logs'
+      path: '/pgcron-logs'
+      fullPath: '/project/$ref/logs/pgcron-logs'
+      preLoaderRoute: typeof ProjectRefLogsPgcronLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/pg-upgrade-logs': {
+      id: '/project/$ref/logs/pg-upgrade-logs'
+      path: '/pg-upgrade-logs'
+      fullPath: '/project/$ref/logs/pg-upgrade-logs'
+      preLoaderRoute: typeof ProjectRefLogsPgUpgradeLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/edge-logs': {
+      id: '/project/$ref/logs/edge-logs'
+      path: '/edge-logs'
+      fullPath: '/project/$ref/logs/edge-logs'
+      preLoaderRoute: typeof ProjectRefLogsEdgeLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/edge-functions-logs': {
+      id: '/project/$ref/logs/edge-functions-logs'
+      path: '/edge-functions-logs'
+      fullPath: '/project/$ref/logs/edge-functions-logs'
+      preLoaderRoute: typeof ProjectRefLogsEdgeFunctionsLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/dedicated-pooler-logs': {
+      id: '/project/$ref/logs/dedicated-pooler-logs'
+      path: '/dedicated-pooler-logs'
+      fullPath: '/project/$ref/logs/dedicated-pooler-logs'
+      preLoaderRoute: typeof ProjectRefLogsDedicatedPoolerLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/cron-logs': {
+      id: '/project/$ref/logs/cron-logs'
+      path: '/cron-logs'
+      fullPath: '/project/$ref/logs/cron-logs'
+      preLoaderRoute: typeof ProjectRefLogsCronLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/auth-logs': {
+      id: '/project/$ref/logs/auth-logs'
+      path: '/auth-logs'
+      fullPath: '/project/$ref/logs/auth-logs'
+      preLoaderRoute: typeof ProjectRefLogsAuthLogsRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/functions/secrets': {
+      id: '/project/$ref/functions/secrets'
+      path: '/secrets'
+      fullPath: '/project/$ref/functions/secrets'
+      preLoaderRoute: typeof ProjectRefFunctionsSecretsRouteImport
+      parentRoute: typeof ProjectRefFunctionsRoute
+    }
+    '/project/$ref/functions/new': {
+      id: '/project/$ref/functions/new'
+      path: '/new'
+      fullPath: '/project/$ref/functions/new'
+      preLoaderRoute: typeof ProjectRefFunctionsNewRouteImport
+      parentRoute: typeof ProjectRefFunctionsRoute
+    }
+    '/project/$ref/functions/$functionSlug': {
+      id: '/project/$ref/functions/$functionSlug'
+      path: '/$functionSlug'
+      fullPath: '/project/$ref/functions/$functionSlug'
+      preLoaderRoute: typeof ProjectRefFunctionsFunctionSlugRouteImport
+      parentRoute: typeof ProjectRefFunctionsRoute
+    }
+    '/project/$ref/editor/new': {
+      id: '/project/$ref/editor/new'
+      path: '/new'
+      fullPath: '/project/$ref/editor/new'
+      preLoaderRoute: typeof ProjectRefEditorNewRouteImport
+      parentRoute: typeof ProjectRefEditorRoute
+    }
+    '/project/$ref/editor/$id': {
+      id: '/project/$ref/editor/$id'
+      path: '/$id'
+      fullPath: '/project/$ref/editor/$id'
+      preLoaderRoute: typeof ProjectRefEditorIdRouteImport
+      parentRoute: typeof ProjectRefEditorRoute
+    }
+    '/project/$ref/database/types': {
+      id: '/project/$ref/database/types'
+      path: '/types'
+      fullPath: '/project/$ref/database/types'
+      preLoaderRoute: typeof ProjectRefDatabaseTypesRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/triggers': {
+      id: '/project/$ref/database/triggers'
+      path: '/triggers'
+      fullPath: '/project/$ref/database/triggers'
+      preLoaderRoute: typeof ProjectRefDatabaseTriggersRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/settings': {
+      id: '/project/$ref/database/settings'
+      path: '/settings'
+      fullPath: '/project/$ref/database/settings'
+      preLoaderRoute: typeof ProjectRefDatabaseSettingsRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/schemas': {
+      id: '/project/$ref/database/schemas'
+      path: '/schemas'
+      fullPath: '/project/$ref/database/schemas'
+      preLoaderRoute: typeof ProjectRefDatabaseSchemasRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/roles': {
+      id: '/project/$ref/database/roles'
+      path: '/roles'
+      fullPath: '/project/$ref/database/roles'
+      preLoaderRoute: typeof ProjectRefDatabaseRolesRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/migrations': {
+      id: '/project/$ref/database/migrations'
+      path: '/migrations'
+      fullPath: '/project/$ref/database/migrations'
+      preLoaderRoute: typeof ProjectRefDatabaseMigrationsRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/indexes': {
+      id: '/project/$ref/database/indexes'
+      path: '/indexes'
+      fullPath: '/project/$ref/database/indexes'
+      preLoaderRoute: typeof ProjectRefDatabaseIndexesRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/functions': {
+      id: '/project/$ref/database/functions'
+      path: '/functions'
+      fullPath: '/project/$ref/database/functions'
+      preLoaderRoute: typeof ProjectRefDatabaseFunctionsRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/extensions': {
+      id: '/project/$ref/database/extensions'
+      path: '/extensions'
+      fullPath: '/project/$ref/database/extensions'
+      preLoaderRoute: typeof ProjectRefDatabaseExtensionsRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/column-privileges': {
+      id: '/project/$ref/database/column-privileges'
+      path: '/column-privileges'
+      fullPath: '/project/$ref/database/column-privileges'
+      preLoaderRoute: typeof ProjectRefDatabaseColumnPrivilegesRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/branches/merge-requests': {
+      id: '/project/$ref/branches/merge-requests'
+      path: '/merge-requests'
+      fullPath: '/project/$ref/branches/merge-requests'
+      preLoaderRoute: typeof ProjectRefBranchesMergeRequestsRouteImport
+      parentRoute: typeof ProjectRefBranchesRoute
+    }
+    '/project/$ref/auth/users': {
+      id: '/project/$ref/auth/users'
+      path: '/users'
+      fullPath: '/project/$ref/auth/users'
+      preLoaderRoute: typeof ProjectRefAuthUsersRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/url-configuration': {
+      id: '/project/$ref/auth/url-configuration'
+      path: '/url-configuration'
+      fullPath: '/project/$ref/auth/url-configuration'
+      preLoaderRoute: typeof ProjectRefAuthUrlConfigurationRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/third-party': {
+      id: '/project/$ref/auth/third-party'
+      path: '/third-party'
+      fullPath: '/project/$ref/auth/third-party'
+      preLoaderRoute: typeof ProjectRefAuthThirdPartyRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/smtp': {
+      id: '/project/$ref/auth/smtp'
+      path: '/smtp'
+      fullPath: '/project/$ref/auth/smtp'
+      preLoaderRoute: typeof ProjectRefAuthSmtpRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/sessions': {
+      id: '/project/$ref/auth/sessions'
+      path: '/sessions'
+      fullPath: '/project/$ref/auth/sessions'
+      preLoaderRoute: typeof ProjectRefAuthSessionsRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/rate-limits': {
+      id: '/project/$ref/auth/rate-limits'
+      path: '/rate-limits'
+      fullPath: '/project/$ref/auth/rate-limits'
+      preLoaderRoute: typeof ProjectRefAuthRateLimitsRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/providers': {
+      id: '/project/$ref/auth/providers'
+      path: '/providers'
+      fullPath: '/project/$ref/auth/providers'
+      preLoaderRoute: typeof ProjectRefAuthProvidersRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/protection': {
+      id: '/project/$ref/auth/protection'
+      path: '/protection'
+      fullPath: '/project/$ref/auth/protection'
+      preLoaderRoute: typeof ProjectRefAuthProtectionRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/policies': {
+      id: '/project/$ref/auth/policies'
+      path: '/policies'
+      fullPath: '/project/$ref/auth/policies'
+      preLoaderRoute: typeof ProjectRefAuthPoliciesRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/performance': {
+      id: '/project/$ref/auth/performance'
+      path: '/performance'
+      fullPath: '/project/$ref/auth/performance'
+      preLoaderRoute: typeof ProjectRefAuthPerformanceRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/passkeys': {
+      id: '/project/$ref/auth/passkeys'
+      path: '/passkeys'
+      fullPath: '/project/$ref/auth/passkeys'
+      preLoaderRoute: typeof ProjectRefAuthPasskeysRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/overview': {
+      id: '/project/$ref/auth/overview'
+      path: '/overview'
+      fullPath: '/project/$ref/auth/overview'
+      preLoaderRoute: typeof ProjectRefAuthOverviewRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/oauth-server': {
+      id: '/project/$ref/auth/oauth-server'
+      path: '/oauth-server'
+      fullPath: '/project/$ref/auth/oauth-server'
+      preLoaderRoute: typeof ProjectRefAuthOauthServerRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/oauth-apps': {
+      id: '/project/$ref/auth/oauth-apps'
+      path: '/oauth-apps'
+      fullPath: '/project/$ref/auth/oauth-apps'
+      preLoaderRoute: typeof ProjectRefAuthOauthAppsRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/mfa': {
+      id: '/project/$ref/auth/mfa'
+      path: '/mfa'
+      fullPath: '/project/$ref/auth/mfa'
+      preLoaderRoute: typeof ProjectRefAuthMfaRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/hooks': {
+      id: '/project/$ref/auth/hooks'
+      path: '/hooks'
+      fullPath: '/project/$ref/auth/hooks'
+      preLoaderRoute: typeof ProjectRefAuthHooksRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/auth/audit-logs': {
+      id: '/project/$ref/auth/audit-logs'
+      path: '/audit-logs'
+      fullPath: '/project/$ref/auth/audit-logs'
+      preLoaderRoute: typeof ProjectRefAuthAuditLogsRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/advisors/security': {
+      id: '/project/$ref/advisors/security'
+      path: '/security'
+      fullPath: '/project/$ref/advisors/security'
+      preLoaderRoute: typeof ProjectRefAdvisorsSecurityRouteImport
+      parentRoute: typeof ProjectRefAdvisorsRoute
+    }
+    '/project/$ref/advisors/rules': {
+      id: '/project/$ref/advisors/rules'
+      path: '/rules'
+      fullPath: '/project/$ref/advisors/rules'
+      preLoaderRoute: typeof ProjectRefAdvisorsRulesRouteImport
+      parentRoute: typeof ProjectRefAdvisorsRoute
+    }
+    '/project/$ref/advisors/performance': {
+      id: '/project/$ref/advisors/performance'
+      path: '/performance'
+      fullPath: '/project/$ref/advisors/performance'
+      preLoaderRoute: typeof ProjectRefAdvisorsPerformanceRouteImport
+      parentRoute: typeof ProjectRefAdvisorsRoute
     }
     '/api/platform/telemetry/event': {
       id: '/api/platform/telemetry/event'
@@ -2374,6 +5240,104 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof AppAccountTokensScopedRouteImport
       parentRoute: typeof AppAccountRoute
     }
+    '/project/$ref/storage/vectors/': {
+      id: '/project/$ref/storage/vectors/'
+      path: '/vectors'
+      fullPath: '/project/$ref/storage/vectors/'
+      preLoaderRoute: typeof ProjectRefStorageVectorsIndexRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/storage/files/': {
+      id: '/project/$ref/storage/files/'
+      path: '/files'
+      fullPath: '/project/$ref/storage/files/'
+      preLoaderRoute: typeof ProjectRefStorageFilesIndexRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/storage/analytics/': {
+      id: '/project/$ref/storage/analytics/'
+      path: '/analytics'
+      fullPath: '/project/$ref/storage/analytics/'
+      preLoaderRoute: typeof ProjectRefStorageAnalyticsIndexRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/settings/webhooks/': {
+      id: '/project/$ref/settings/webhooks/'
+      path: '/webhooks'
+      fullPath: '/project/$ref/settings/webhooks/'
+      preLoaderRoute: typeof ProjectRefSettingsWebhooksIndexRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/jwt/': {
+      id: '/project/$ref/settings/jwt/'
+      path: '/jwt'
+      fullPath: '/project/$ref/settings/jwt/'
+      preLoaderRoute: typeof ProjectRefSettingsJwtIndexRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/api-keys/': {
+      id: '/project/$ref/settings/api-keys/'
+      path: '/'
+      fullPath: '/project/$ref/settings/api-keys/'
+      preLoaderRoute: typeof ProjectRefSettingsApiKeysIndexRouteImport
+      parentRoute: typeof ProjectRefSettingsApiKeysRoute
+    }
+    '/project/$ref/logs/explorer/': {
+      id: '/project/$ref/logs/explorer/'
+      path: '/explorer'
+      fullPath: '/project/$ref/logs/explorer/'
+      preLoaderRoute: typeof ProjectRefLogsExplorerIndexRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/integrations/$id/': {
+      id: '/project/$ref/integrations/$id/'
+      path: '/$id'
+      fullPath: '/project/$ref/integrations/$id/'
+      preLoaderRoute: typeof ProjectRefIntegrationsIdIndexRouteImport
+      parentRoute: typeof ProjectRefIntegrationsRoute
+    }
+    '/project/$ref/functions/$functionSlug/': {
+      id: '/project/$ref/functions/$functionSlug/'
+      path: '/'
+      fullPath: '/project/$ref/functions/$functionSlug/'
+      preLoaderRoute: typeof ProjectRefFunctionsFunctionSlugIndexRouteImport
+      parentRoute: typeof ProjectRefFunctionsFunctionSlugRoute
+    }
+    '/project/$ref/database/triggers/': {
+      id: '/project/$ref/database/triggers/'
+      path: '/'
+      fullPath: '/project/$ref/database/triggers/'
+      preLoaderRoute: typeof ProjectRefDatabaseTriggersIndexRouteImport
+      parentRoute: typeof ProjectRefDatabaseTriggersRoute
+    }
+    '/project/$ref/database/tables/': {
+      id: '/project/$ref/database/tables/'
+      path: '/tables'
+      fullPath: '/project/$ref/database/tables/'
+      preLoaderRoute: typeof ProjectRefDatabaseTablesIndexRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/replication/': {
+      id: '/project/$ref/database/replication/'
+      path: '/replication'
+      fullPath: '/project/$ref/database/replication/'
+      preLoaderRoute: typeof ProjectRefDatabaseReplicationIndexRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/publications/': {
+      id: '/project/$ref/database/publications/'
+      path: '/publications'
+      fullPath: '/project/$ref/database/publications/'
+      preLoaderRoute: typeof ProjectRefDatabasePublicationsIndexRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/auth/templates/': {
+      id: '/project/$ref/auth/templates/'
+      path: '/templates'
+      fullPath: '/project/$ref/auth/templates/'
+      preLoaderRoute: typeof ProjectRefAuthTemplatesIndexRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
     '/api/platform/projects/$ref/': {
       id: '/api/platform/projects/$ref/'
       path: '/api/platform/projects/$ref'
@@ -2394,6 +5358,188 @@ declare module '@tanstack/react-router' {
       fullPath: '/org/$slug/private-apps/'
       preLoaderRoute: typeof AppOrgSlugPrivateAppsIndexRouteImport
       parentRoute: typeof AppOrgRoute
+    }
+    '/project/$ref/storage/files/settings': {
+      id: '/project/$ref/storage/files/settings'
+      path: '/files/settings'
+      fullPath: '/project/$ref/storage/files/settings'
+      preLoaderRoute: typeof ProjectRefStorageFilesSettingsRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/storage/files/policies': {
+      id: '/project/$ref/storage/files/policies'
+      path: '/files/policies'
+      fullPath: '/project/$ref/storage/files/policies'
+      preLoaderRoute: typeof ProjectRefStorageFilesPoliciesRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/settings/webhooks/$endpointId': {
+      id: '/project/$ref/settings/webhooks/$endpointId'
+      path: '/webhooks/$endpointId'
+      fullPath: '/project/$ref/settings/webhooks/$endpointId'
+      preLoaderRoute: typeof ProjectRefSettingsWebhooksEndpointIdRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/jwt/legacy': {
+      id: '/project/$ref/settings/jwt/legacy'
+      path: '/jwt/legacy'
+      fullPath: '/project/$ref/settings/jwt/legacy'
+      preLoaderRoute: typeof ProjectRefSettingsJwtLegacyRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/billing/usage': {
+      id: '/project/$ref/settings/billing/usage'
+      path: '/billing/usage'
+      fullPath: '/project/$ref/settings/billing/usage'
+      preLoaderRoute: typeof ProjectRefSettingsBillingUsageRouteImport
+      parentRoute: typeof ProjectRefSettingsRoute
+    }
+    '/project/$ref/settings/api-keys/legacy': {
+      id: '/project/$ref/settings/api-keys/legacy'
+      path: '/legacy'
+      fullPath: '/project/$ref/settings/api-keys/legacy'
+      preLoaderRoute: typeof ProjectRefSettingsApiKeysLegacyRouteImport
+      parentRoute: typeof ProjectRefSettingsApiKeysRoute
+    }
+    '/project/$ref/logs/explorer/templates': {
+      id: '/project/$ref/logs/explorer/templates'
+      path: '/explorer/templates'
+      fullPath: '/project/$ref/logs/explorer/templates'
+      preLoaderRoute: typeof ProjectRefLogsExplorerTemplatesRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/explorer/saved': {
+      id: '/project/$ref/logs/explorer/saved'
+      path: '/explorer/saved'
+      fullPath: '/project/$ref/logs/explorer/saved'
+      preLoaderRoute: typeof ProjectRefLogsExplorerSavedRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/logs/explorer/recent': {
+      id: '/project/$ref/logs/explorer/recent'
+      path: '/explorer/recent'
+      fullPath: '/project/$ref/logs/explorer/recent'
+      preLoaderRoute: typeof ProjectRefLogsExplorerRecentRouteImport
+      parentRoute: typeof ProjectRefLogsRoute
+    }
+    '/project/$ref/functions/$functionSlug/logs': {
+      id: '/project/$ref/functions/$functionSlug/logs'
+      path: '/logs'
+      fullPath: '/project/$ref/functions/$functionSlug/logs'
+      preLoaderRoute: typeof ProjectRefFunctionsFunctionSlugLogsRouteImport
+      parentRoute: typeof ProjectRefFunctionsFunctionSlugRoute
+    }
+    '/project/$ref/functions/$functionSlug/invocations': {
+      id: '/project/$ref/functions/$functionSlug/invocations'
+      path: '/invocations'
+      fullPath: '/project/$ref/functions/$functionSlug/invocations'
+      preLoaderRoute: typeof ProjectRefFunctionsFunctionSlugInvocationsRouteImport
+      parentRoute: typeof ProjectRefFunctionsFunctionSlugRoute
+    }
+    '/project/$ref/functions/$functionSlug/details': {
+      id: '/project/$ref/functions/$functionSlug/details'
+      path: '/details'
+      fullPath: '/project/$ref/functions/$functionSlug/details'
+      preLoaderRoute: typeof ProjectRefFunctionsFunctionSlugDetailsRouteImport
+      parentRoute: typeof ProjectRefFunctionsFunctionSlugRoute
+    }
+    '/project/$ref/functions/$functionSlug/code': {
+      id: '/project/$ref/functions/$functionSlug/code'
+      path: '/code'
+      fullPath: '/project/$ref/functions/$functionSlug/code'
+      preLoaderRoute: typeof ProjectRefFunctionsFunctionSlugCodeRouteImport
+      parentRoute: typeof ProjectRefFunctionsFunctionSlugRoute
+    }
+    '/project/$ref/database/triggers/event': {
+      id: '/project/$ref/database/triggers/event'
+      path: '/event'
+      fullPath: '/project/$ref/database/triggers/event'
+      preLoaderRoute: typeof ProjectRefDatabaseTriggersEventRouteImport
+      parentRoute: typeof ProjectRefDatabaseTriggersRoute
+    }
+    '/project/$ref/database/triggers/data': {
+      id: '/project/$ref/database/triggers/data'
+      path: '/data'
+      fullPath: '/project/$ref/database/triggers/data'
+      preLoaderRoute: typeof ProjectRefDatabaseTriggersDataRouteImport
+      parentRoute: typeof ProjectRefDatabaseTriggersRoute
+    }
+    '/project/$ref/database/tables/$id': {
+      id: '/project/$ref/database/tables/$id'
+      path: '/tables/$id'
+      fullPath: '/project/$ref/database/tables/$id'
+      preLoaderRoute: typeof ProjectRefDatabaseTablesIdRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/replication/$pipelineId': {
+      id: '/project/$ref/database/replication/$pipelineId'
+      path: '/replication/$pipelineId'
+      fullPath: '/project/$ref/database/replication/$pipelineId'
+      preLoaderRoute: typeof ProjectRefDatabaseReplicationPipelineIdRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/publications/$id': {
+      id: '/project/$ref/database/publications/$id'
+      path: '/publications/$id'
+      fullPath: '/project/$ref/database/publications/$id'
+      preLoaderRoute: typeof ProjectRefDatabasePublicationsIdRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/backups/scheduled': {
+      id: '/project/$ref/database/backups/scheduled'
+      path: '/backups/scheduled'
+      fullPath: '/project/$ref/database/backups/scheduled'
+      preLoaderRoute: typeof ProjectRefDatabaseBackupsScheduledRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/backups/restore-to-new-project': {
+      id: '/project/$ref/database/backups/restore-to-new-project'
+      path: '/backups/restore-to-new-project'
+      fullPath: '/project/$ref/database/backups/restore-to-new-project'
+      preLoaderRoute: typeof ProjectRefDatabaseBackupsRestoreToNewProjectRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/database/backups/pitr': {
+      id: '/project/$ref/database/backups/pitr'
+      path: '/backups/pitr'
+      fullPath: '/project/$ref/database/backups/pitr'
+      preLoaderRoute: typeof ProjectRefDatabaseBackupsPitrRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
+    }
+    '/project/$ref/auth/templates/$templateId': {
+      id: '/project/$ref/auth/templates/$templateId'
+      path: '/templates/$templateId'
+      fullPath: '/project/$ref/auth/templates/$templateId'
+      preLoaderRoute: typeof ProjectRefAuthTemplatesTemplateIdRouteImport
+      parentRoute: typeof ProjectRefAuthRoute
+    }
+    '/project/$ref/advisors/rules/security': {
+      id: '/project/$ref/advisors/rules/security'
+      path: '/security'
+      fullPath: '/project/$ref/advisors/rules/security'
+      preLoaderRoute: typeof ProjectRefAdvisorsRulesSecurityRouteImport
+      parentRoute: typeof ProjectRefAdvisorsRulesRoute
+    }
+    '/project/$ref/advisors/rules/performance': {
+      id: '/project/$ref/advisors/rules/performance'
+      path: '/performance'
+      fullPath: '/project/$ref/advisors/rules/performance'
+      preLoaderRoute: typeof ProjectRefAdvisorsRulesPerformanceRouteImport
+      parentRoute: typeof ProjectRefAdvisorsRulesRoute
+    }
+    '/integrations/vercel/$slug/marketplace/choose-project': {
+      id: '/integrations/vercel/$slug/marketplace/choose-project'
+      path: '/$slug/marketplace/choose-project'
+      fullPath: '/integrations/vercel/$slug/marketplace/choose-project'
+      preLoaderRoute: typeof IntegrationsVercelSlugMarketplaceChooseProjectRouteImport
+      parentRoute: typeof IntegrationsVercelRoute
+    }
+    '/integrations/vercel/$slug/deploy-button/new-project': {
+      id: '/integrations/vercel/$slug/deploy-button/new-project'
+      path: '/$slug/deploy-button/new-project'
+      fullPath: '/integrations/vercel/$slug/deploy-button/new-project'
+      preLoaderRoute: typeof IntegrationsVercelSlugDeployButtonNewProjectRouteImport
+      parentRoute: typeof IntegrationsVercelRoute
     }
     '/api/v1/projects/$ref/api-keys': {
       id: '/api/v1/projects/$ref/api-keys'
@@ -2568,7 +5714,7 @@ declare module '@tanstack/react-router' {
       path: '/partners/stripe/projects/login'
       fullPath: '/partners/stripe/projects/login'
       preLoaderRoute: typeof AuthPartnersStripeProjectsLoginRouteImport
-      parentRoute: typeof rootRouteImport
+      parentRoute: typeof AuthRoute
     }
     '/_app/org/$slug/webhooks/$endpointId': {
       id: '/_app/org/$slug/webhooks/$endpointId'
@@ -2576,6 +5722,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/org/$slug/webhooks/$endpointId'
       preLoaderRoute: typeof AppOrgSlugWebhooksEndpointIdRouteImport
       parentRoute: typeof AppOrgRoute
+    }
+    '/project/$ref/integrations/$id/$pageId/': {
+      id: '/project/$ref/integrations/$id/$pageId/'
+      path: '/$id/$pageId'
+      fullPath: '/project/$ref/integrations/$id/$pageId/'
+      preLoaderRoute: typeof ProjectRefIntegrationsIdPageIdIndexRouteImport
+      parentRoute: typeof ProjectRefIntegrationsRoute
     }
     '/api/v1/projects/$ref/functions/': {
       id: '/api/v1/projects/$ref/functions/'
@@ -2632,6 +5785,34 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/platform/auth/$ref/users/'
       preLoaderRoute: typeof ApiPlatformAuthRefUsersIndexRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/project/$ref/storage/vectors/buckets/$bucketId': {
+      id: '/project/$ref/storage/vectors/buckets/$bucketId'
+      path: '/vectors/buckets/$bucketId'
+      fullPath: '/project/$ref/storage/vectors/buckets/$bucketId'
+      preLoaderRoute: typeof ProjectRefStorageVectorsBucketsBucketIdRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/storage/files/buckets/$bucketId': {
+      id: '/project/$ref/storage/files/buckets/$bucketId'
+      path: '/files/buckets/$bucketId'
+      fullPath: '/project/$ref/storage/files/buckets/$bucketId'
+      preLoaderRoute: typeof ProjectRefStorageFilesBucketsBucketIdRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/storage/analytics/buckets/$bucketId': {
+      id: '/project/$ref/storage/analytics/buckets/$bucketId'
+      path: '/analytics/buckets/$bucketId'
+      fullPath: '/project/$ref/storage/analytics/buckets/$bucketId'
+      preLoaderRoute: typeof ProjectRefStorageAnalyticsBucketsBucketIdRouteImport
+      parentRoute: typeof ProjectRefStorageRoute
+    }
+    '/project/$ref/database/replication/replica/$replicaId': {
+      id: '/project/$ref/database/replication/replica/$replicaId'
+      path: '/replication/replica/$replicaId'
+      fullPath: '/project/$ref/database/replication/replica/$replicaId'
+      preLoaderRoute: typeof ProjectRefDatabaseReplicationReplicaReplicaIdRouteImport
+      parentRoute: typeof ProjectRefDatabaseRoute
     }
     '/api/v1/projects/$ref/types/typescript': {
       id: '/api/v1/projects/$ref/types/typescript'
@@ -2716,6 +5897,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/api/platform/organizations/$slug/billing/subscription'
       preLoaderRoute: typeof ApiPlatformOrganizationsSlugBillingSubscriptionRouteImport
       parentRoute: typeof rootRouteImport
+    }
+    '/project/$ref/integrations/$id/$pageId/$childId/': {
+      id: '/project/$ref/integrations/$id/$pageId/$childId/'
+      path: '/$id/$pageId/$childId'
+      fullPath: '/project/$ref/integrations/$id/$pageId/$childId/'
+      preLoaderRoute: typeof ProjectRefIntegrationsIdPageIdChildIdIndexRouteImport
+      parentRoute: typeof ProjectRefIntegrationsRoute
     }
     '/api/v1/projects/$ref/functions/$slug/': {
       id: '/api/v1/projects/$ref/functions/$slug/'
@@ -2947,6 +6135,588 @@ const AppOrgRouteChildren: AppOrgRouteChildren = {
 const AppOrgRouteWithChildren =
   AppOrgRoute._addFileChildren(AppOrgRouteChildren)
 
+interface AppRouteChildren {
+  AppAccountRoute: typeof AppAccountRouteWithChildren
+  AppOrgRoute: typeof AppOrgRouteWithChildren
+  AppOrganizationsRoute: typeof AppOrganizationsRoute
+  AppSupportLinkRoute: typeof AppSupportLinkRoute
+  AppSupportNewRoute: typeof AppSupportNewRoute
+  AppNewIndexRoute: typeof AppNewIndexRoute
+}
+
+const AppRouteChildren: AppRouteChildren = {
+  AppAccountRoute: AppAccountRouteWithChildren,
+  AppOrgRoute: AppOrgRouteWithChildren,
+  AppOrganizationsRoute: AppOrganizationsRoute,
+  AppSupportLinkRoute: AppSupportLinkRoute,
+  AppSupportNewRoute: AppSupportNewRoute,
+  AppNewIndexRoute: AppNewIndexRoute,
+}
+
+const AppRouteWithChildren = AppRoute._addFileChildren(AppRouteChildren)
+
+interface AuthRouteChildren {
+  AuthForgotPasswordRoute: typeof AuthForgotPasswordRoute
+  AuthForgotPasswordMfaRoute: typeof AuthForgotPasswordMfaRoute
+  AuthResetPasswordRoute: typeof AuthResetPasswordRoute
+  AuthSignInRoute: typeof AuthSignInRoute
+  AuthSignInMfaRoute: typeof AuthSignInMfaRoute
+  AuthSignInPartnerRoute: typeof AuthSignInPartnerRoute
+  AuthSignInSsoRoute: typeof AuthSignInSsoRoute
+  AuthSignUpRoute: typeof AuthSignUpRoute
+  AuthCliLoginRoute: typeof AuthCliLoginRoute
+  AuthPartnersStripeProjectsLoginRoute: typeof AuthPartnersStripeProjectsLoginRoute
+}
+
+const AuthRouteChildren: AuthRouteChildren = {
+  AuthForgotPasswordRoute: AuthForgotPasswordRoute,
+  AuthForgotPasswordMfaRoute: AuthForgotPasswordMfaRoute,
+  AuthResetPasswordRoute: AuthResetPasswordRoute,
+  AuthSignInRoute: AuthSignInRoute,
+  AuthSignInMfaRoute: AuthSignInMfaRoute,
+  AuthSignInPartnerRoute: AuthSignInPartnerRoute,
+  AuthSignInSsoRoute: AuthSignInSsoRoute,
+  AuthSignUpRoute: AuthSignUpRoute,
+  AuthCliLoginRoute: AuthCliLoginRoute,
+  AuthPartnersStripeProjectsLoginRoute: AuthPartnersStripeProjectsLoginRoute,
+}
+
+const AuthRouteWithChildren = AuthRoute._addFileChildren(AuthRouteChildren)
+
+interface IntegrationsVercelRouteChildren {
+  IntegrationsVercelInstallRoute: typeof IntegrationsVercelInstallRoute
+  IntegrationsVercelSlugDeployButtonNewProjectRoute: typeof IntegrationsVercelSlugDeployButtonNewProjectRoute
+  IntegrationsVercelSlugMarketplaceChooseProjectRoute: typeof IntegrationsVercelSlugMarketplaceChooseProjectRoute
+}
+
+const IntegrationsVercelRouteChildren: IntegrationsVercelRouteChildren = {
+  IntegrationsVercelInstallRoute: IntegrationsVercelInstallRoute,
+  IntegrationsVercelSlugDeployButtonNewProjectRoute:
+    IntegrationsVercelSlugDeployButtonNewProjectRoute,
+  IntegrationsVercelSlugMarketplaceChooseProjectRoute:
+    IntegrationsVercelSlugMarketplaceChooseProjectRoute,
+}
+
+const IntegrationsVercelRouteWithChildren =
+  IntegrationsVercelRoute._addFileChildren(IntegrationsVercelRouteChildren)
+
+interface OrgChar91_Char93RouteChildren {
+  OrgChar91_Char93SplatRoute: typeof OrgChar91_Char93SplatRoute
+}
+
+const OrgChar91_Char93RouteChildren: OrgChar91_Char93RouteChildren = {
+  OrgChar91_Char93SplatRoute: OrgChar91_Char93SplatRoute,
+}
+
+const OrgChar91_Char93RouteWithChildren =
+  OrgChar91_Char93Route._addFileChildren(OrgChar91_Char93RouteChildren)
+
+interface ProjectRefAdvisorsRulesRouteChildren {
+  ProjectRefAdvisorsRulesPerformanceRoute: typeof ProjectRefAdvisorsRulesPerformanceRoute
+  ProjectRefAdvisorsRulesSecurityRoute: typeof ProjectRefAdvisorsRulesSecurityRoute
+}
+
+const ProjectRefAdvisorsRulesRouteChildren: ProjectRefAdvisorsRulesRouteChildren =
+  {
+    ProjectRefAdvisorsRulesPerformanceRoute:
+      ProjectRefAdvisorsRulesPerformanceRoute,
+    ProjectRefAdvisorsRulesSecurityRoute: ProjectRefAdvisorsRulesSecurityRoute,
+  }
+
+const ProjectRefAdvisorsRulesRouteWithChildren =
+  ProjectRefAdvisorsRulesRoute._addFileChildren(
+    ProjectRefAdvisorsRulesRouteChildren,
+  )
+
+interface ProjectRefAdvisorsRouteChildren {
+  ProjectRefAdvisorsPerformanceRoute: typeof ProjectRefAdvisorsPerformanceRoute
+  ProjectRefAdvisorsRulesRoute: typeof ProjectRefAdvisorsRulesRouteWithChildren
+  ProjectRefAdvisorsSecurityRoute: typeof ProjectRefAdvisorsSecurityRoute
+}
+
+const ProjectRefAdvisorsRouteChildren: ProjectRefAdvisorsRouteChildren = {
+  ProjectRefAdvisorsPerformanceRoute: ProjectRefAdvisorsPerformanceRoute,
+  ProjectRefAdvisorsRulesRoute: ProjectRefAdvisorsRulesRouteWithChildren,
+  ProjectRefAdvisorsSecurityRoute: ProjectRefAdvisorsSecurityRoute,
+}
+
+const ProjectRefAdvisorsRouteWithChildren =
+  ProjectRefAdvisorsRoute._addFileChildren(ProjectRefAdvisorsRouteChildren)
+
+interface ProjectRefAuthRouteChildren {
+  ProjectRefAuthAuditLogsRoute: typeof ProjectRefAuthAuditLogsRoute
+  ProjectRefAuthHooksRoute: typeof ProjectRefAuthHooksRoute
+  ProjectRefAuthMfaRoute: typeof ProjectRefAuthMfaRoute
+  ProjectRefAuthOauthAppsRoute: typeof ProjectRefAuthOauthAppsRoute
+  ProjectRefAuthOauthServerRoute: typeof ProjectRefAuthOauthServerRoute
+  ProjectRefAuthOverviewRoute: typeof ProjectRefAuthOverviewRoute
+  ProjectRefAuthPasskeysRoute: typeof ProjectRefAuthPasskeysRoute
+  ProjectRefAuthPerformanceRoute: typeof ProjectRefAuthPerformanceRoute
+  ProjectRefAuthPoliciesRoute: typeof ProjectRefAuthPoliciesRoute
+  ProjectRefAuthProtectionRoute: typeof ProjectRefAuthProtectionRoute
+  ProjectRefAuthProvidersRoute: typeof ProjectRefAuthProvidersRoute
+  ProjectRefAuthRateLimitsRoute: typeof ProjectRefAuthRateLimitsRoute
+  ProjectRefAuthSessionsRoute: typeof ProjectRefAuthSessionsRoute
+  ProjectRefAuthSmtpRoute: typeof ProjectRefAuthSmtpRoute
+  ProjectRefAuthThirdPartyRoute: typeof ProjectRefAuthThirdPartyRoute
+  ProjectRefAuthUrlConfigurationRoute: typeof ProjectRefAuthUrlConfigurationRoute
+  ProjectRefAuthUsersRoute: typeof ProjectRefAuthUsersRoute
+  ProjectRefAuthTemplatesTemplateIdRoute: typeof ProjectRefAuthTemplatesTemplateIdRoute
+  ProjectRefAuthTemplatesIndexRoute: typeof ProjectRefAuthTemplatesIndexRoute
+}
+
+const ProjectRefAuthRouteChildren: ProjectRefAuthRouteChildren = {
+  ProjectRefAuthAuditLogsRoute: ProjectRefAuthAuditLogsRoute,
+  ProjectRefAuthHooksRoute: ProjectRefAuthHooksRoute,
+  ProjectRefAuthMfaRoute: ProjectRefAuthMfaRoute,
+  ProjectRefAuthOauthAppsRoute: ProjectRefAuthOauthAppsRoute,
+  ProjectRefAuthOauthServerRoute: ProjectRefAuthOauthServerRoute,
+  ProjectRefAuthOverviewRoute: ProjectRefAuthOverviewRoute,
+  ProjectRefAuthPasskeysRoute: ProjectRefAuthPasskeysRoute,
+  ProjectRefAuthPerformanceRoute: ProjectRefAuthPerformanceRoute,
+  ProjectRefAuthPoliciesRoute: ProjectRefAuthPoliciesRoute,
+  ProjectRefAuthProtectionRoute: ProjectRefAuthProtectionRoute,
+  ProjectRefAuthProvidersRoute: ProjectRefAuthProvidersRoute,
+  ProjectRefAuthRateLimitsRoute: ProjectRefAuthRateLimitsRoute,
+  ProjectRefAuthSessionsRoute: ProjectRefAuthSessionsRoute,
+  ProjectRefAuthSmtpRoute: ProjectRefAuthSmtpRoute,
+  ProjectRefAuthThirdPartyRoute: ProjectRefAuthThirdPartyRoute,
+  ProjectRefAuthUrlConfigurationRoute: ProjectRefAuthUrlConfigurationRoute,
+  ProjectRefAuthUsersRoute: ProjectRefAuthUsersRoute,
+  ProjectRefAuthTemplatesTemplateIdRoute:
+    ProjectRefAuthTemplatesTemplateIdRoute,
+  ProjectRefAuthTemplatesIndexRoute: ProjectRefAuthTemplatesIndexRoute,
+}
+
+const ProjectRefAuthRouteWithChildren = ProjectRefAuthRoute._addFileChildren(
+  ProjectRefAuthRouteChildren,
+)
+
+interface ProjectRefBranchesRouteChildren {
+  ProjectRefBranchesMergeRequestsRoute: typeof ProjectRefBranchesMergeRequestsRoute
+  ProjectRefBranchesIndexRoute: typeof ProjectRefBranchesIndexRoute
+}
+
+const ProjectRefBranchesRouteChildren: ProjectRefBranchesRouteChildren = {
+  ProjectRefBranchesMergeRequestsRoute: ProjectRefBranchesMergeRequestsRoute,
+  ProjectRefBranchesIndexRoute: ProjectRefBranchesIndexRoute,
+}
+
+const ProjectRefBranchesRouteWithChildren =
+  ProjectRefBranchesRoute._addFileChildren(ProjectRefBranchesRouteChildren)
+
+interface ProjectRefDatabaseTriggersRouteChildren {
+  ProjectRefDatabaseTriggersDataRoute: typeof ProjectRefDatabaseTriggersDataRoute
+  ProjectRefDatabaseTriggersEventRoute: typeof ProjectRefDatabaseTriggersEventRoute
+  ProjectRefDatabaseTriggersIndexRoute: typeof ProjectRefDatabaseTriggersIndexRoute
+}
+
+const ProjectRefDatabaseTriggersRouteChildren: ProjectRefDatabaseTriggersRouteChildren =
+  {
+    ProjectRefDatabaseTriggersDataRoute: ProjectRefDatabaseTriggersDataRoute,
+    ProjectRefDatabaseTriggersEventRoute: ProjectRefDatabaseTriggersEventRoute,
+    ProjectRefDatabaseTriggersIndexRoute: ProjectRefDatabaseTriggersIndexRoute,
+  }
+
+const ProjectRefDatabaseTriggersRouteWithChildren =
+  ProjectRefDatabaseTriggersRoute._addFileChildren(
+    ProjectRefDatabaseTriggersRouteChildren,
+  )
+
+interface ProjectRefDatabaseRouteChildren {
+  ProjectRefDatabaseColumnPrivilegesRoute: typeof ProjectRefDatabaseColumnPrivilegesRoute
+  ProjectRefDatabaseExtensionsRoute: typeof ProjectRefDatabaseExtensionsRoute
+  ProjectRefDatabaseFunctionsRoute: typeof ProjectRefDatabaseFunctionsRoute
+  ProjectRefDatabaseIndexesRoute: typeof ProjectRefDatabaseIndexesRoute
+  ProjectRefDatabaseMigrationsRoute: typeof ProjectRefDatabaseMigrationsRoute
+  ProjectRefDatabaseRolesRoute: typeof ProjectRefDatabaseRolesRoute
+  ProjectRefDatabaseSchemasRoute: typeof ProjectRefDatabaseSchemasRoute
+  ProjectRefDatabaseSettingsRoute: typeof ProjectRefDatabaseSettingsRoute
+  ProjectRefDatabaseTriggersRoute: typeof ProjectRefDatabaseTriggersRouteWithChildren
+  ProjectRefDatabaseTypesRoute: typeof ProjectRefDatabaseTypesRoute
+  ProjectRefDatabaseBackupsPitrRoute: typeof ProjectRefDatabaseBackupsPitrRoute
+  ProjectRefDatabaseBackupsRestoreToNewProjectRoute: typeof ProjectRefDatabaseBackupsRestoreToNewProjectRoute
+  ProjectRefDatabaseBackupsScheduledRoute: typeof ProjectRefDatabaseBackupsScheduledRoute
+  ProjectRefDatabasePublicationsIdRoute: typeof ProjectRefDatabasePublicationsIdRoute
+  ProjectRefDatabaseReplicationPipelineIdRoute: typeof ProjectRefDatabaseReplicationPipelineIdRoute
+  ProjectRefDatabaseTablesIdRoute: typeof ProjectRefDatabaseTablesIdRoute
+  ProjectRefDatabasePublicationsIndexRoute: typeof ProjectRefDatabasePublicationsIndexRoute
+  ProjectRefDatabaseReplicationIndexRoute: typeof ProjectRefDatabaseReplicationIndexRoute
+  ProjectRefDatabaseTablesIndexRoute: typeof ProjectRefDatabaseTablesIndexRoute
+  ProjectRefDatabaseReplicationReplicaReplicaIdRoute: typeof ProjectRefDatabaseReplicationReplicaReplicaIdRoute
+}
+
+const ProjectRefDatabaseRouteChildren: ProjectRefDatabaseRouteChildren = {
+  ProjectRefDatabaseColumnPrivilegesRoute:
+    ProjectRefDatabaseColumnPrivilegesRoute,
+  ProjectRefDatabaseExtensionsRoute: ProjectRefDatabaseExtensionsRoute,
+  ProjectRefDatabaseFunctionsRoute: ProjectRefDatabaseFunctionsRoute,
+  ProjectRefDatabaseIndexesRoute: ProjectRefDatabaseIndexesRoute,
+  ProjectRefDatabaseMigrationsRoute: ProjectRefDatabaseMigrationsRoute,
+  ProjectRefDatabaseRolesRoute: ProjectRefDatabaseRolesRoute,
+  ProjectRefDatabaseSchemasRoute: ProjectRefDatabaseSchemasRoute,
+  ProjectRefDatabaseSettingsRoute: ProjectRefDatabaseSettingsRoute,
+  ProjectRefDatabaseTriggersRoute: ProjectRefDatabaseTriggersRouteWithChildren,
+  ProjectRefDatabaseTypesRoute: ProjectRefDatabaseTypesRoute,
+  ProjectRefDatabaseBackupsPitrRoute: ProjectRefDatabaseBackupsPitrRoute,
+  ProjectRefDatabaseBackupsRestoreToNewProjectRoute:
+    ProjectRefDatabaseBackupsRestoreToNewProjectRoute,
+  ProjectRefDatabaseBackupsScheduledRoute:
+    ProjectRefDatabaseBackupsScheduledRoute,
+  ProjectRefDatabasePublicationsIdRoute: ProjectRefDatabasePublicationsIdRoute,
+  ProjectRefDatabaseReplicationPipelineIdRoute:
+    ProjectRefDatabaseReplicationPipelineIdRoute,
+  ProjectRefDatabaseTablesIdRoute: ProjectRefDatabaseTablesIdRoute,
+  ProjectRefDatabasePublicationsIndexRoute:
+    ProjectRefDatabasePublicationsIndexRoute,
+  ProjectRefDatabaseReplicationIndexRoute:
+    ProjectRefDatabaseReplicationIndexRoute,
+  ProjectRefDatabaseTablesIndexRoute: ProjectRefDatabaseTablesIndexRoute,
+  ProjectRefDatabaseReplicationReplicaReplicaIdRoute:
+    ProjectRefDatabaseReplicationReplicaReplicaIdRoute,
+}
+
+const ProjectRefDatabaseRouteWithChildren =
+  ProjectRefDatabaseRoute._addFileChildren(ProjectRefDatabaseRouteChildren)
+
+interface ProjectRefEditorRouteChildren {
+  ProjectRefEditorIdRoute: typeof ProjectRefEditorIdRoute
+  ProjectRefEditorNewRoute: typeof ProjectRefEditorNewRoute
+  ProjectRefEditorIndexRoute: typeof ProjectRefEditorIndexRoute
+}
+
+const ProjectRefEditorRouteChildren: ProjectRefEditorRouteChildren = {
+  ProjectRefEditorIdRoute: ProjectRefEditorIdRoute,
+  ProjectRefEditorNewRoute: ProjectRefEditorNewRoute,
+  ProjectRefEditorIndexRoute: ProjectRefEditorIndexRoute,
+}
+
+const ProjectRefEditorRouteWithChildren =
+  ProjectRefEditorRoute._addFileChildren(ProjectRefEditorRouteChildren)
+
+interface ProjectRefFunctionsFunctionSlugRouteChildren {
+  ProjectRefFunctionsFunctionSlugCodeRoute: typeof ProjectRefFunctionsFunctionSlugCodeRoute
+  ProjectRefFunctionsFunctionSlugDetailsRoute: typeof ProjectRefFunctionsFunctionSlugDetailsRoute
+  ProjectRefFunctionsFunctionSlugInvocationsRoute: typeof ProjectRefFunctionsFunctionSlugInvocationsRoute
+  ProjectRefFunctionsFunctionSlugLogsRoute: typeof ProjectRefFunctionsFunctionSlugLogsRoute
+  ProjectRefFunctionsFunctionSlugIndexRoute: typeof ProjectRefFunctionsFunctionSlugIndexRoute
+}
+
+const ProjectRefFunctionsFunctionSlugRouteChildren: ProjectRefFunctionsFunctionSlugRouteChildren =
+  {
+    ProjectRefFunctionsFunctionSlugCodeRoute:
+      ProjectRefFunctionsFunctionSlugCodeRoute,
+    ProjectRefFunctionsFunctionSlugDetailsRoute:
+      ProjectRefFunctionsFunctionSlugDetailsRoute,
+    ProjectRefFunctionsFunctionSlugInvocationsRoute:
+      ProjectRefFunctionsFunctionSlugInvocationsRoute,
+    ProjectRefFunctionsFunctionSlugLogsRoute:
+      ProjectRefFunctionsFunctionSlugLogsRoute,
+    ProjectRefFunctionsFunctionSlugIndexRoute:
+      ProjectRefFunctionsFunctionSlugIndexRoute,
+  }
+
+const ProjectRefFunctionsFunctionSlugRouteWithChildren =
+  ProjectRefFunctionsFunctionSlugRoute._addFileChildren(
+    ProjectRefFunctionsFunctionSlugRouteChildren,
+  )
+
+interface ProjectRefFunctionsRouteChildren {
+  ProjectRefFunctionsFunctionSlugRoute: typeof ProjectRefFunctionsFunctionSlugRouteWithChildren
+  ProjectRefFunctionsNewRoute: typeof ProjectRefFunctionsNewRoute
+  ProjectRefFunctionsSecretsRoute: typeof ProjectRefFunctionsSecretsRoute
+  ProjectRefFunctionsIndexRoute: typeof ProjectRefFunctionsIndexRoute
+}
+
+const ProjectRefFunctionsRouteChildren: ProjectRefFunctionsRouteChildren = {
+  ProjectRefFunctionsFunctionSlugRoute:
+    ProjectRefFunctionsFunctionSlugRouteWithChildren,
+  ProjectRefFunctionsNewRoute: ProjectRefFunctionsNewRoute,
+  ProjectRefFunctionsSecretsRoute: ProjectRefFunctionsSecretsRoute,
+  ProjectRefFunctionsIndexRoute: ProjectRefFunctionsIndexRoute,
+}
+
+const ProjectRefFunctionsRouteWithChildren =
+  ProjectRefFunctionsRoute._addFileChildren(ProjectRefFunctionsRouteChildren)
+
+interface ProjectRefIntegrationsRouteChildren {
+  ProjectRefIntegrationsIndexRoute: typeof ProjectRefIntegrationsIndexRoute
+  ProjectRefIntegrationsIdIndexRoute: typeof ProjectRefIntegrationsIdIndexRoute
+  ProjectRefIntegrationsIdPageIdIndexRoute: typeof ProjectRefIntegrationsIdPageIdIndexRoute
+  ProjectRefIntegrationsIdPageIdChildIdIndexRoute: typeof ProjectRefIntegrationsIdPageIdChildIdIndexRoute
+}
+
+const ProjectRefIntegrationsRouteChildren: ProjectRefIntegrationsRouteChildren =
+  {
+    ProjectRefIntegrationsIndexRoute: ProjectRefIntegrationsIndexRoute,
+    ProjectRefIntegrationsIdIndexRoute: ProjectRefIntegrationsIdIndexRoute,
+    ProjectRefIntegrationsIdPageIdIndexRoute:
+      ProjectRefIntegrationsIdPageIdIndexRoute,
+    ProjectRefIntegrationsIdPageIdChildIdIndexRoute:
+      ProjectRefIntegrationsIdPageIdChildIdIndexRoute,
+  }
+
+const ProjectRefIntegrationsRouteWithChildren =
+  ProjectRefIntegrationsRoute._addFileChildren(
+    ProjectRefIntegrationsRouteChildren,
+  )
+
+interface ProjectRefLogsRouteChildren {
+  ProjectRefLogsAuthLogsRoute: typeof ProjectRefLogsAuthLogsRoute
+  ProjectRefLogsCronLogsRoute: typeof ProjectRefLogsCronLogsRoute
+  ProjectRefLogsDedicatedPoolerLogsRoute: typeof ProjectRefLogsDedicatedPoolerLogsRoute
+  ProjectRefLogsEdgeFunctionsLogsRoute: typeof ProjectRefLogsEdgeFunctionsLogsRoute
+  ProjectRefLogsEdgeLogsRoute: typeof ProjectRefLogsEdgeLogsRoute
+  ProjectRefLogsPgUpgradeLogsRoute: typeof ProjectRefLogsPgUpgradeLogsRoute
+  ProjectRefLogsPgcronLogsRoute: typeof ProjectRefLogsPgcronLogsRoute
+  ProjectRefLogsPoolerLogsRoute: typeof ProjectRefLogsPoolerLogsRoute
+  ProjectRefLogsPostgresLogsRoute: typeof ProjectRefLogsPostgresLogsRoute
+  ProjectRefLogsPostgrestLogsRoute: typeof ProjectRefLogsPostgrestLogsRoute
+  ProjectRefLogsRealtimeLogsRoute: typeof ProjectRefLogsRealtimeLogsRoute
+  ProjectRefLogsReplicationLogsRoute: typeof ProjectRefLogsReplicationLogsRoute
+  ProjectRefLogsStorageLogsRoute: typeof ProjectRefLogsStorageLogsRoute
+  ProjectRefLogsIndexRoute: typeof ProjectRefLogsIndexRoute
+  ProjectRefLogsExplorerRecentRoute: typeof ProjectRefLogsExplorerRecentRoute
+  ProjectRefLogsExplorerSavedRoute: typeof ProjectRefLogsExplorerSavedRoute
+  ProjectRefLogsExplorerTemplatesRoute: typeof ProjectRefLogsExplorerTemplatesRoute
+  ProjectRefLogsExplorerIndexRoute: typeof ProjectRefLogsExplorerIndexRoute
+}
+
+const ProjectRefLogsRouteChildren: ProjectRefLogsRouteChildren = {
+  ProjectRefLogsAuthLogsRoute: ProjectRefLogsAuthLogsRoute,
+  ProjectRefLogsCronLogsRoute: ProjectRefLogsCronLogsRoute,
+  ProjectRefLogsDedicatedPoolerLogsRoute:
+    ProjectRefLogsDedicatedPoolerLogsRoute,
+  ProjectRefLogsEdgeFunctionsLogsRoute: ProjectRefLogsEdgeFunctionsLogsRoute,
+  ProjectRefLogsEdgeLogsRoute: ProjectRefLogsEdgeLogsRoute,
+  ProjectRefLogsPgUpgradeLogsRoute: ProjectRefLogsPgUpgradeLogsRoute,
+  ProjectRefLogsPgcronLogsRoute: ProjectRefLogsPgcronLogsRoute,
+  ProjectRefLogsPoolerLogsRoute: ProjectRefLogsPoolerLogsRoute,
+  ProjectRefLogsPostgresLogsRoute: ProjectRefLogsPostgresLogsRoute,
+  ProjectRefLogsPostgrestLogsRoute: ProjectRefLogsPostgrestLogsRoute,
+  ProjectRefLogsRealtimeLogsRoute: ProjectRefLogsRealtimeLogsRoute,
+  ProjectRefLogsReplicationLogsRoute: ProjectRefLogsReplicationLogsRoute,
+  ProjectRefLogsStorageLogsRoute: ProjectRefLogsStorageLogsRoute,
+  ProjectRefLogsIndexRoute: ProjectRefLogsIndexRoute,
+  ProjectRefLogsExplorerRecentRoute: ProjectRefLogsExplorerRecentRoute,
+  ProjectRefLogsExplorerSavedRoute: ProjectRefLogsExplorerSavedRoute,
+  ProjectRefLogsExplorerTemplatesRoute: ProjectRefLogsExplorerTemplatesRoute,
+  ProjectRefLogsExplorerIndexRoute: ProjectRefLogsExplorerIndexRoute,
+}
+
+const ProjectRefLogsRouteWithChildren = ProjectRefLogsRoute._addFileChildren(
+  ProjectRefLogsRouteChildren,
+)
+
+interface ProjectRefObservabilityRouteChildren {
+  ProjectRefObservabilityIdRoute: typeof ProjectRefObservabilityIdRoute
+  ProjectRefObservabilityApiOverviewRoute: typeof ProjectRefObservabilityApiOverviewRoute
+  ProjectRefObservabilityAuthRoute: typeof ProjectRefObservabilityAuthRoute
+  ProjectRefObservabilityDatabaseRoute: typeof ProjectRefObservabilityDatabaseRoute
+  ProjectRefObservabilityEdgeFunctionsRoute: typeof ProjectRefObservabilityEdgeFunctionsRoute
+  ProjectRefObservabilityPostgrestRoute: typeof ProjectRefObservabilityPostgrestRoute
+  ProjectRefObservabilityQueryInsightsRoute: typeof ProjectRefObservabilityQueryInsightsRoute
+  ProjectRefObservabilityQueryPerformanceRoute: typeof ProjectRefObservabilityQueryPerformanceRoute
+  ProjectRefObservabilityRealtimeRoute: typeof ProjectRefObservabilityRealtimeRoute
+  ProjectRefObservabilityStorageRoute: typeof ProjectRefObservabilityStorageRoute
+  ProjectRefObservabilityIndexRoute: typeof ProjectRefObservabilityIndexRoute
+}
+
+const ProjectRefObservabilityRouteChildren: ProjectRefObservabilityRouteChildren =
+  {
+    ProjectRefObservabilityIdRoute: ProjectRefObservabilityIdRoute,
+    ProjectRefObservabilityApiOverviewRoute:
+      ProjectRefObservabilityApiOverviewRoute,
+    ProjectRefObservabilityAuthRoute: ProjectRefObservabilityAuthRoute,
+    ProjectRefObservabilityDatabaseRoute: ProjectRefObservabilityDatabaseRoute,
+    ProjectRefObservabilityEdgeFunctionsRoute:
+      ProjectRefObservabilityEdgeFunctionsRoute,
+    ProjectRefObservabilityPostgrestRoute:
+      ProjectRefObservabilityPostgrestRoute,
+    ProjectRefObservabilityQueryInsightsRoute:
+      ProjectRefObservabilityQueryInsightsRoute,
+    ProjectRefObservabilityQueryPerformanceRoute:
+      ProjectRefObservabilityQueryPerformanceRoute,
+    ProjectRefObservabilityRealtimeRoute: ProjectRefObservabilityRealtimeRoute,
+    ProjectRefObservabilityStorageRoute: ProjectRefObservabilityStorageRoute,
+    ProjectRefObservabilityIndexRoute: ProjectRefObservabilityIndexRoute,
+  }
+
+const ProjectRefObservabilityRouteWithChildren =
+  ProjectRefObservabilityRoute._addFileChildren(
+    ProjectRefObservabilityRouteChildren,
+  )
+
+interface ProjectRefRealtimeRouteChildren {
+  ProjectRefRealtimeInspectorRoute: typeof ProjectRefRealtimeInspectorRoute
+  ProjectRefRealtimePoliciesRoute: typeof ProjectRefRealtimePoliciesRoute
+  ProjectRefRealtimeSettingsRoute: typeof ProjectRefRealtimeSettingsRoute
+}
+
+const ProjectRefRealtimeRouteChildren: ProjectRefRealtimeRouteChildren = {
+  ProjectRefRealtimeInspectorRoute: ProjectRefRealtimeInspectorRoute,
+  ProjectRefRealtimePoliciesRoute: ProjectRefRealtimePoliciesRoute,
+  ProjectRefRealtimeSettingsRoute: ProjectRefRealtimeSettingsRoute,
+}
+
+const ProjectRefRealtimeRouteWithChildren =
+  ProjectRefRealtimeRoute._addFileChildren(ProjectRefRealtimeRouteChildren)
+
+interface ProjectRefSettingsApiKeysRouteChildren {
+  ProjectRefSettingsApiKeysLegacyRoute: typeof ProjectRefSettingsApiKeysLegacyRoute
+  ProjectRefSettingsApiKeysIndexRoute: typeof ProjectRefSettingsApiKeysIndexRoute
+}
+
+const ProjectRefSettingsApiKeysRouteChildren: ProjectRefSettingsApiKeysRouteChildren =
+  {
+    ProjectRefSettingsApiKeysLegacyRoute: ProjectRefSettingsApiKeysLegacyRoute,
+    ProjectRefSettingsApiKeysIndexRoute: ProjectRefSettingsApiKeysIndexRoute,
+  }
+
+const ProjectRefSettingsApiKeysRouteWithChildren =
+  ProjectRefSettingsApiKeysRoute._addFileChildren(
+    ProjectRefSettingsApiKeysRouteChildren,
+  )
+
+interface ProjectRefSettingsRouteChildren {
+  ProjectRefSettingsAddonsRoute: typeof ProjectRefSettingsAddonsRoute
+  ProjectRefSettingsApiRoute: typeof ProjectRefSettingsApiRoute
+  ProjectRefSettingsApiKeysRoute: typeof ProjectRefSettingsApiKeysRouteWithChildren
+  ProjectRefSettingsComputeAndDiskRoute: typeof ProjectRefSettingsComputeAndDiskRoute
+  ProjectRefSettingsDashboardRoute: typeof ProjectRefSettingsDashboardRoute
+  ProjectRefSettingsGeneralRoute: typeof ProjectRefSettingsGeneralRoute
+  ProjectRefSettingsInfrastructureRoute: typeof ProjectRefSettingsInfrastructureRoute
+  ProjectRefSettingsIntegrationsRoute: typeof ProjectRefSettingsIntegrationsRoute
+  ProjectRefSettingsLogDrainsRoute: typeof ProjectRefSettingsLogDrainsRoute
+  ProjectRefSettingsBillingUsageRoute: typeof ProjectRefSettingsBillingUsageRoute
+  ProjectRefSettingsJwtLegacyRoute: typeof ProjectRefSettingsJwtLegacyRoute
+  ProjectRefSettingsWebhooksEndpointIdRoute: typeof ProjectRefSettingsWebhooksEndpointIdRoute
+  ProjectRefSettingsJwtIndexRoute: typeof ProjectRefSettingsJwtIndexRoute
+  ProjectRefSettingsWebhooksIndexRoute: typeof ProjectRefSettingsWebhooksIndexRoute
+}
+
+const ProjectRefSettingsRouteChildren: ProjectRefSettingsRouteChildren = {
+  ProjectRefSettingsAddonsRoute: ProjectRefSettingsAddonsRoute,
+  ProjectRefSettingsApiRoute: ProjectRefSettingsApiRoute,
+  ProjectRefSettingsApiKeysRoute: ProjectRefSettingsApiKeysRouteWithChildren,
+  ProjectRefSettingsComputeAndDiskRoute: ProjectRefSettingsComputeAndDiskRoute,
+  ProjectRefSettingsDashboardRoute: ProjectRefSettingsDashboardRoute,
+  ProjectRefSettingsGeneralRoute: ProjectRefSettingsGeneralRoute,
+  ProjectRefSettingsInfrastructureRoute: ProjectRefSettingsInfrastructureRoute,
+  ProjectRefSettingsIntegrationsRoute: ProjectRefSettingsIntegrationsRoute,
+  ProjectRefSettingsLogDrainsRoute: ProjectRefSettingsLogDrainsRoute,
+  ProjectRefSettingsBillingUsageRoute: ProjectRefSettingsBillingUsageRoute,
+  ProjectRefSettingsJwtLegacyRoute: ProjectRefSettingsJwtLegacyRoute,
+  ProjectRefSettingsWebhooksEndpointIdRoute:
+    ProjectRefSettingsWebhooksEndpointIdRoute,
+  ProjectRefSettingsJwtIndexRoute: ProjectRefSettingsJwtIndexRoute,
+  ProjectRefSettingsWebhooksIndexRoute: ProjectRefSettingsWebhooksIndexRoute,
+}
+
+const ProjectRefSettingsRouteWithChildren =
+  ProjectRefSettingsRoute._addFileChildren(ProjectRefSettingsRouteChildren)
+
+interface ProjectRefSqlRouteChildren {
+  ProjectRefSqlIdRoute: typeof ProjectRefSqlIdRoute
+  ProjectRefSqlExamplesRoute: typeof ProjectRefSqlExamplesRoute
+  ProjectRefSqlTemplatesRoute: typeof ProjectRefSqlTemplatesRoute
+  ProjectRefSqlIndexRoute: typeof ProjectRefSqlIndexRoute
+}
+
+const ProjectRefSqlRouteChildren: ProjectRefSqlRouteChildren = {
+  ProjectRefSqlIdRoute: ProjectRefSqlIdRoute,
+  ProjectRefSqlExamplesRoute: ProjectRefSqlExamplesRoute,
+  ProjectRefSqlTemplatesRoute: ProjectRefSqlTemplatesRoute,
+  ProjectRefSqlIndexRoute: ProjectRefSqlIndexRoute,
+}
+
+const ProjectRefSqlRouteWithChildren = ProjectRefSqlRoute._addFileChildren(
+  ProjectRefSqlRouteChildren,
+)
+
+interface ProjectRefStorageRouteChildren {
+  ProjectRefStorageS3Route: typeof ProjectRefStorageS3Route
+  ProjectRefStorageFilesPoliciesRoute: typeof ProjectRefStorageFilesPoliciesRoute
+  ProjectRefStorageFilesSettingsRoute: typeof ProjectRefStorageFilesSettingsRoute
+  ProjectRefStorageAnalyticsIndexRoute: typeof ProjectRefStorageAnalyticsIndexRoute
+  ProjectRefStorageFilesIndexRoute: typeof ProjectRefStorageFilesIndexRoute
+  ProjectRefStorageVectorsIndexRoute: typeof ProjectRefStorageVectorsIndexRoute
+  ProjectRefStorageAnalyticsBucketsBucketIdRoute: typeof ProjectRefStorageAnalyticsBucketsBucketIdRoute
+  ProjectRefStorageFilesBucketsBucketIdRoute: typeof ProjectRefStorageFilesBucketsBucketIdRoute
+  ProjectRefStorageVectorsBucketsBucketIdRoute: typeof ProjectRefStorageVectorsBucketsBucketIdRoute
+}
+
+const ProjectRefStorageRouteChildren: ProjectRefStorageRouteChildren = {
+  ProjectRefStorageS3Route: ProjectRefStorageS3Route,
+  ProjectRefStorageFilesPoliciesRoute: ProjectRefStorageFilesPoliciesRoute,
+  ProjectRefStorageFilesSettingsRoute: ProjectRefStorageFilesSettingsRoute,
+  ProjectRefStorageAnalyticsIndexRoute: ProjectRefStorageAnalyticsIndexRoute,
+  ProjectRefStorageFilesIndexRoute: ProjectRefStorageFilesIndexRoute,
+  ProjectRefStorageVectorsIndexRoute: ProjectRefStorageVectorsIndexRoute,
+  ProjectRefStorageAnalyticsBucketsBucketIdRoute:
+    ProjectRefStorageAnalyticsBucketsBucketIdRoute,
+  ProjectRefStorageFilesBucketsBucketIdRoute:
+    ProjectRefStorageFilesBucketsBucketIdRoute,
+  ProjectRefStorageVectorsBucketsBucketIdRoute:
+    ProjectRefStorageVectorsBucketsBucketIdRoute,
+}
+
+const ProjectRefStorageRouteWithChildren =
+  ProjectRefStorageRoute._addFileChildren(ProjectRefStorageRouteChildren)
+
+interface ProjectRefRouteChildren {
+  ProjectRefAdvisorsRoute: typeof ProjectRefAdvisorsRouteWithChildren
+  ProjectRefAuthRoute: typeof ProjectRefAuthRouteWithChildren
+  ProjectRefBranchesRoute: typeof ProjectRefBranchesRouteWithChildren
+  ProjectRefDatabaseRoute: typeof ProjectRefDatabaseRouteWithChildren
+  ProjectRefEditorRoute: typeof ProjectRefEditorRouteWithChildren
+  ProjectRefFunctionsRoute: typeof ProjectRefFunctionsRouteWithChildren
+  ProjectRefIntegrationsRoute: typeof ProjectRefIntegrationsRouteWithChildren
+  ProjectRefLogsRoute: typeof ProjectRefLogsRouteWithChildren
+  ProjectRefMergeRoute: typeof ProjectRefMergeRoute
+  ProjectRefObservabilityRoute: typeof ProjectRefObservabilityRouteWithChildren
+  ProjectRefRealtimeRoute: typeof ProjectRefRealtimeRouteWithChildren
+  ProjectRefSettingsRoute: typeof ProjectRefSettingsRouteWithChildren
+  ProjectRefSqlRoute: typeof ProjectRefSqlRouteWithChildren
+  ProjectRefStorageRoute: typeof ProjectRefStorageRouteWithChildren
+  ProjectRefIndexRoute: typeof ProjectRefIndexRoute
+  ProjectRefApiIndexRoute: typeof ProjectRefApiIndexRoute
+}
+
+const ProjectRefRouteChildren: ProjectRefRouteChildren = {
+  ProjectRefAdvisorsRoute: ProjectRefAdvisorsRouteWithChildren,
+  ProjectRefAuthRoute: ProjectRefAuthRouteWithChildren,
+  ProjectRefBranchesRoute: ProjectRefBranchesRouteWithChildren,
+  ProjectRefDatabaseRoute: ProjectRefDatabaseRouteWithChildren,
+  ProjectRefEditorRoute: ProjectRefEditorRouteWithChildren,
+  ProjectRefFunctionsRoute: ProjectRefFunctionsRouteWithChildren,
+  ProjectRefIntegrationsRoute: ProjectRefIntegrationsRouteWithChildren,
+  ProjectRefLogsRoute: ProjectRefLogsRouteWithChildren,
+  ProjectRefMergeRoute: ProjectRefMergeRoute,
+  ProjectRefObservabilityRoute: ProjectRefObservabilityRouteWithChildren,
+  ProjectRefRealtimeRoute: ProjectRefRealtimeRouteWithChildren,
+  ProjectRefSettingsRoute: ProjectRefSettingsRouteWithChildren,
+  ProjectRefSqlRoute: ProjectRefSqlRouteWithChildren,
+  ProjectRefStorageRoute: ProjectRefStorageRouteWithChildren,
+  ProjectRefIndexRoute: ProjectRefIndexRoute,
+  ProjectRefApiIndexRoute: ProjectRefApiIndexRoute,
+}
+
+const ProjectRefRouteWithChildren = ProjectRefRoute._addFileChildren(
+  ProjectRefRouteChildren,
+)
+
+interface ProjectChar91_Char93RouteChildren {
+  ProjectChar91_Char93SplatRoute: typeof ProjectChar91_Char93SplatRoute
+}
+
+const ProjectChar91_Char93RouteChildren: ProjectChar91_Char93RouteChildren = {
+  ProjectChar91_Char93SplatRoute: ProjectChar91_Char93SplatRoute,
+}
+
+const ProjectChar91_Char93RouteWithChildren =
+  ProjectChar91_Char93Route._addFileChildren(ProjectChar91_Char93RouteChildren)
+
 interface ApiV1ProjectsRefApiKeysRouteChildren {
   ApiV1ProjectsRefApiKeysIdRoute: typeof ApiV1ProjectsRefApiKeysIdRoute
 }
@@ -2977,17 +6747,17 @@ const ApiPlatformProjectsRefAnalyticsLogDrainsRouteWithChildren =
   )
 
 const rootRouteChildren: RootRouteChildren = {
-  AppAccountRoute: AppAccountRouteWithChildren,
-  AppOrgRoute: AppOrgRouteWithChildren,
-  AppOrganizationsRoute: AppOrganizationsRoute,
-  AuthForgotPasswordRoute: AuthForgotPasswordRoute,
-  AuthForgotPasswordMfaRoute: AuthForgotPasswordMfaRoute,
-  AuthResetPasswordRoute: AuthResetPasswordRoute,
-  AuthSignInRoute: AuthSignInRoute,
-  AuthSignInMfaRoute: AuthSignInMfaRoute,
-  AuthSignInPartnerRoute: AuthSignInPartnerRoute,
-  AuthSignInSsoRoute: AuthSignInSsoRoute,
-  AuthSignUpRoute: AuthSignUpRoute,
+  IndexRoute: IndexRoute,
+  AppRoute: AppRouteWithChildren,
+  AuthRoute: AuthRouteWithChildren,
+  AuthorizeRoute: AuthorizeRoute,
+  AwsMarketplaceOnboardingRoute: AwsMarketplaceOnboardingRoute,
+  ClaimProjectRoute: ClaimProjectRoute,
+  JoinRoute: JoinRoute,
+  LogoutRoute: LogoutRoute,
+  MaintenanceRoute: MaintenanceRoute,
+  RedeemRoute: RedeemRoute,
+  VerifyEmailRoute: VerifyEmailRoute,
   ApiCheckCnameRoute: ApiCheckCnameRoute,
   ApiCliReleaseVersionRoute: ApiCliReleaseVersionRoute,
   ApiEnabledFeaturesOverridesRoute: ApiEnabledFeaturesOverridesRoute,
@@ -3000,15 +6770,17 @@ const rootRouteChildren: RootRouteChildren = {
   ApiIncidentStatusRoute: ApiIncidentStatusRoute,
   ApiParseQueryRoute: ApiParseQueryRoute,
   ApiStatusOverrideRoute: ApiStatusOverrideRoute,
-  AppSupportLinkRoute: AppSupportLinkRoute,
-  AppSupportNewRoute: AppSupportNewRoute,
-  AuthCliLoginRoute: AuthCliLoginRoute,
+  IntegrationsVercelRoute: IntegrationsVercelRouteWithChildren,
+  NewSlugRoute: NewSlugRoute,
+  OrgChar91_Char93Route: OrgChar91_Char93RouteWithChildren,
+  ProjectRefRoute: ProjectRefRouteWithChildren,
+  ProjectChar91_Char93Route: ProjectChar91_Char93RouteWithChildren,
   ApiAiDocsRoute: ApiAiDocsRoute,
   ApiContentGraphqlRoute: ApiContentGraphqlRoute,
   ApiEdgeFunctionsTestRoute: ApiEdgeFunctionsTestRoute,
   ApiIntegrationsStripeSyncRoute: ApiIntegrationsStripeSyncRoute,
   ApiPlatformDeploymentModeRoute: ApiPlatformDeploymentModeRoute,
-  AppNewIndexRoute: AppNewIndexRoute,
+  IntegrationsGithubAuthorizeRoute: IntegrationsGithubAuthorizeRoute,
   ApiConnectIndexRoute: ApiConnectIndexRoute,
   ApiMcpIndexRoute: ApiMcpIndexRoute,
   ApiAiCodeCompleteRoute: ApiAiCodeCompleteRoute,
@@ -3027,7 +6799,6 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlatformOrganizationsIndexRoute: ApiPlatformOrganizationsIndexRoute,
   ApiPlatformProfileIndexRoute: ApiPlatformProfileIndexRoute,
   ApiPlatformProjectsIndexRoute: ApiPlatformProjectsIndexRoute,
-  AuthPartnersStripeProjectsLoginRoute: AuthPartnersStripeProjectsLoginRoute,
   ApiPlatformAuthRefInviteRoute: ApiPlatformAuthRefInviteRoute,
   ApiPlatformAuthRefMagiclinkRoute: ApiPlatformAuthRefMagiclinkRoute,
   ApiPlatformAuthRefOtpRoute: ApiPlatformAuthRefOtpRoute,

--- a/apps/studio/routes/_app.tsx
+++ b/apps/studio/routes/_app.tsx
@@ -1,0 +1,33 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import { AppLayout } from '@/components/layouts/AppLayout/AppLayout'
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
+
+export const Route = createFileRoute('/_app')({
+  component: AppShell,
+})
+
+function AppShell() {
+  // useMatches() without `select` returns a fresh array on every router
+  // tick — even when the matched leaf hasn't changed — and re-renders the
+  // entire shell subtree. Use the `select` form so we only re-render when
+  // the values we actually consume change.
+  const headerTitle = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as { defaultLayoutHeaderTitle?: string } | undefined)
+        ?.defaultLayoutHeaderTitle,
+  })
+  const hideMobileMenu = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as { hideMobileMenu?: boolean } | undefined)
+        ?.hideMobileMenu,
+  })
+
+  return (
+    <AppLayout>
+      <DefaultLayout headerTitle={headerTitle} hideMobileMenu={hideMobileMenu}>
+        <Outlet />
+      </DefaultLayout>
+    </AppLayout>
+  )
+}

--- a/apps/studio/routes/_auth.tsx
+++ b/apps/studio/routes/_auth.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import { AuthenticationLayout } from '@/components/layouts/AuthenticationLayout'
+
+export const Route = createFileRoute('/_auth')({
+  component: AuthShell,
+})
+
+function AuthShell() {
+  return (
+    <AuthenticationLayout>
+      <Outlet />
+    </AuthenticationLayout>
+  )
+}

--- a/apps/studio/routes/authorize.tsx
+++ b/apps/studio/routes/authorize.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import APIAuthorizationPage from '@/pages/authorize'
+
+export const Route = createFileRoute('/authorize')({
+  component: Authorize,
+})
+
+function Authorize() {
+  return <APIAuthorizationPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/aws-marketplace-onboarding.tsx
+++ b/apps/studio/routes/aws-marketplace-onboarding.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AwsMarketplaceOnboardingPage from '@/pages/aws-marketplace-onboarding'
+
+export const Route = createFileRoute('/aws-marketplace-onboarding')({
+  component: AwsMarketplaceOnboardingRoute,
+})
+
+function AwsMarketplaceOnboardingRoute() {
+  return <AwsMarketplaceOnboardingPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/claim-project.tsx
+++ b/apps/studio/routes/claim-project.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute } from '@tanstack/react-router'
+import Head from 'next/head'
+
+import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
+import ClaimProjectPage from '@/pages/claim-project'
+
+export const Route = createFileRoute('/claim-project')({
+  component: ClaimProject,
+})
+
+function ClaimProject() {
+  const { appTitle } = useCustomContent(['app:title'])
+
+  return (
+    <>
+      <Head>
+        <title>{`Claim project | ${appTitle ?? 'Supabase'}`}</title>
+      </Head>
+      <main className="flex flex-col w-full min-h-screen overflow-y-auto">
+        <ClaimProjectPage dehydratedState={undefined} />
+      </main>
+    </>
+  )
+}

--- a/apps/studio/routes/index.tsx
+++ b/apps/studio/routes/index.tsx
@@ -1,0 +1,24 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+import { IS_PLATFORM } from '@/lib/constants'
+
+// `/` is never rendered — it always redirects. Mirrors the Next.js
+// `redirects()` rules in next.config.ts: platform sends users to `/org`
+// (or `/new/new-project` when deep-linked with `?next=new-project`),
+// self-hosted sends them straight to `/project/default`.
+export const Route = createFileRoute('/')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    next: typeof search.next === 'string' ? search.next : undefined,
+  }),
+  beforeLoad: ({ search }) => {
+    // `href` instead of `to` because these targets aren't in the TanStack
+    // routeTree yet — they're still on the Next.js pages side during the
+    // migration. Swap to `to` once `/org`, `/new/new-project`, and
+    // `/project/default` are migrated.
+    if (IS_PLATFORM) {
+      if (search.next === 'new-project') throw redirect({ href: '/new/new-project' })
+      throw redirect({ href: '/org' })
+    }
+    throw redirect({ href: '/project/default' })
+  },
+})

--- a/apps/studio/routes/integrations/github/authorize.tsx
+++ b/apps/studio/routes/integrations/github/authorize.tsx
@@ -1,0 +1,13 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import GitHubIntegrationAuthorize from '@/pages/integrations/github/authorize'
+
+export const Route = createFileRoute('/integrations/github/authorize')({
+  component: GitHubAuthorizeRoute,
+})
+
+// Placed at top-level — the Next page has no getLayout (renders bare),
+// so adding AppLayout/DefaultLayout via _app would be a behaviour change.
+function GitHubAuthorizeRoute() {
+  return <GitHubIntegrationAuthorize />
+}

--- a/apps/studio/routes/integrations/vercel.tsx
+++ b/apps/studio/routes/integrations/vercel.tsx
@@ -1,0 +1,19 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import VercelIntegrationWindowLayout from '@/components/layouts/IntegrationsLayout/VercelIntegrationWindowLayout'
+
+export const Route = createFileRoute('/integrations/vercel')({
+  component: VercelIntegrationShell,
+})
+
+// Placed at top-level rather than under _app — Next getLayout for all
+// three leaves only wraps in VercelIntegrationWindowLayout (no AppLayout
+// or DefaultLayout), so adding _app's chrome here would be a behaviour
+// change.
+function VercelIntegrationShell() {
+  return (
+    <VercelIntegrationWindowLayout>
+      <Outlet />
+    </VercelIntegrationWindowLayout>
+  )
+}

--- a/apps/studio/routes/integrations/vercel/$slug/deploy-button/new-project.tsx
+++ b/apps/studio/routes/integrations/vercel/$slug/deploy-button/new-project.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import VercelIntegration from '@/pages/integrations/vercel/[slug]/deploy-button/new-project'
+
+export const Route = createFileRoute('/integrations/vercel/$slug/deploy-button/new-project')({
+  component: VercelDeployButtonNewProjectRoute,
+})
+
+function VercelDeployButtonNewProjectRoute() {
+  return <VercelIntegration dehydratedState={undefined} />
+}

--- a/apps/studio/routes/integrations/vercel/$slug/marketplace/choose-project.tsx
+++ b/apps/studio/routes/integrations/vercel/$slug/marketplace/choose-project.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import VercelIntegration from '@/pages/integrations/vercel/[slug]/marketplace/choose-project'
+
+export const Route = createFileRoute('/integrations/vercel/$slug/marketplace/choose-project')({
+  component: VercelChooseProjectRoute,
+})
+
+function VercelChooseProjectRoute() {
+  return <VercelIntegration dehydratedState={undefined} />
+}

--- a/apps/studio/routes/integrations/vercel/install.tsx
+++ b/apps/studio/routes/integrations/vercel/install.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import VercelIntegration from '@/pages/integrations/vercel/install'
+
+export const Route = createFileRoute('/integrations/vercel/install')({
+  component: VercelInstallRoute,
+})
+
+function VercelInstallRoute() {
+  return <VercelIntegration dehydratedState={undefined} />
+}

--- a/apps/studio/routes/join.tsx
+++ b/apps/studio/routes/join.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { cn } from 'ui'
+
+import JoinOrganizationPage from '@/pages/join'
+
+export const Route = createFileRoute('/join')({
+  component: Join,
+})
+
+function Join() {
+  return (
+    <div
+      className={cn(
+        'flex h-full min-h-screen bg-studio',
+        'w-full flex-col place-items-center',
+        'items-center justify-center gap-8 px-5'
+      )}
+    >
+      <JoinOrganizationPage dehydratedState={undefined} />
+    </div>
+  )
+}

--- a/apps/studio/routes/logout.tsx
+++ b/apps/studio/routes/logout.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import LogoutPage from '@/pages/logout'
+
+export const Route = createFileRoute('/logout')({
+  component: Logout,
+})
+
+function Logout() {
+  return <LogoutPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/maintenance.tsx
+++ b/apps/studio/routes/maintenance.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+import { cn } from 'ui'
+
+import MaintenancePage from '@/pages/maintenance'
+
+export const Route = createFileRoute('/maintenance')({
+  component: Maintenance,
+})
+
+function Maintenance() {
+  return (
+    <div
+      className={cn(
+        'flex h-full min-h-screen bg-studio',
+        'w-full flex-col place-items-center',
+        'items-center justify-center gap-8 px-5'
+      )}
+    >
+      <MaintenancePage dehydratedState={undefined} />
+    </div>
+  )
+}

--- a/apps/studio/routes/new/$slug.tsx
+++ b/apps/studio/routes/new/$slug.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
+import { PageLayout } from '@/components/layouts/PageLayout/PageLayout'
+import Wizard from '@/pages/new/[slug]'
+
+export const Route = createFileRoute('/new/$slug')({
+  component: NewProjectRoute,
+})
+
+// Placed at top-level rather than under _app — the Next getLayout omits
+// AppLayout, and uses PageLayout (not WizardLayout) inside DefaultLayout.
+function NewProjectRoute() {
+  return (
+    <DefaultLayout hideMobileMenu headerTitle="New project">
+      <PageLayout>
+        <Wizard dehydratedState={undefined} />
+      </PageLayout>
+    </DefaultLayout>
+  )
+}

--- a/apps/studio/routes/org.[_].$.tsx
+++ b/apps/studio/routes/org.[_].$.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import GenericOrganizationPage from '@/pages/org/_/[[...routeSlug]]'
+
+export const Route = createFileRoute('/org/_/$')({
+  component: OrgWildcardSplatRoute,
+})
+
+// Matches `/org/_/...`. TanStack exposes the trailing path as the
+// `_splat` param; the underlying Next page normalises it back to the
+// `routeSlug: string[]` shape it originally consumed.
+//
+// Naming delta: `org.[_].$.tsx` (path-as-filename) rather than
+// `org/[_]/$.tsx` (nested directory) — see `org.[_].tsx` for the full
+// rationale; in short, the directory + index.tsx form trips a
+// router-generator bug that strips the escaped `_` segment when the
+// last segment isn't escaped.
+function OrgWildcardSplatRoute() {
+  return <GenericOrganizationPage />
+}

--- a/apps/studio/routes/org.[_].tsx
+++ b/apps/studio/routes/org.[_].tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import GenericOrganizationPage from '@/pages/org/_/[[...routeSlug]]'
+
+export const Route = createFileRoute('/org/_')({
+  component: OrgWildcardIndexRoute,
+})
+
+// Matches `/org/_` exactly. The companion splat route at
+// `org.[_].$.tsx` handles `/org/_/...`.
+//
+// `[_]` is TanStack's escape syntax for a literal underscore in the URL
+// (otherwise an unescaped `_` segment is treated as a pathless layout).
+//
+// Naming delta: this is `org.[_].tsx`, not `org/[_]/index.tsx`, to side-
+// step a router-generator bug — when an index.tsx's path has a bracket-
+// escaped *parent* segment, `originalRoutePath` gets wiped wholesale and
+// the escape info is lost (getRouteNodes.js:132 sets originalRoutePath
+// to `/`). The path-as-filename form keeps the last segment non-index,
+// so the bug branch is skipped.
+function OrgWildcardIndexRoute() {
+  return <GenericOrganizationPage />
+}

--- a/apps/studio/routes/project.[_].$.tsx
+++ b/apps/studio/routes/project.[_].$.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import GenericProjectPage from '@/pages/project/_/[[...routeSlug]]'
+
+export const Route = createFileRoute('/project/_/$')({
+  component: ProjectWildcardSplatRoute,
+})
+
+// Matches `/project/_/...`. TanStack exposes the trailing path as the
+// `_splat` param; the underlying Next page normalises it back to the
+// `routeSlug: string[]` shape it originally consumed.
+//
+// Naming delta: `project.[_].$.tsx` (path-as-filename) rather than
+// `project/[_]/$.tsx` (nested directory) — see `org.[_].tsx` for the
+// full rationale; in short, the directory + index.tsx form trips a
+// router-generator bug that strips the escaped `_` segment when the
+// last segment isn't escaped.
+function ProjectWildcardSplatRoute() {
+  return <GenericProjectPage />
+}

--- a/apps/studio/routes/project.[_].tsx
+++ b/apps/studio/routes/project.[_].tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import GenericProjectPage from '@/pages/project/_/[[...routeSlug]]'
+
+export const Route = createFileRoute('/project/_')({
+  component: ProjectWildcardIndexRoute,
+})
+
+// Matches `/project/_` exactly. The companion splat route at
+// `project.[_].$.tsx` handles `/project/_/...`. See `org.[_].tsx` for
+// why this is named with the path-as-filename form rather than
+// `project/[_]/index.tsx`.
+function ProjectWildcardIndexRoute() {
+  return <GenericProjectPage />
+}

--- a/apps/studio/routes/project/$ref.tsx
+++ b/apps/studio/routes/project/$ref.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import { DefaultLayout } from '@/components/layouts/DefaultLayout'
+
+export const Route = createFileRoute('/project/$ref')({
+  component: ProjectShell,
+})
+
+function ProjectShell() {
+  return (
+    <DefaultLayout>
+      <Outlet />
+    </DefaultLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/advisors.tsx
+++ b/apps/studio/routes/project/$ref/advisors.tsx
@@ -1,0 +1,37 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import AdvisorsLayout from '@/components/layouts/AdvisorsLayout/AdvisorsLayout'
+
+export const Route = createFileRoute('/project/$ref/advisors')({
+  component: AdvisorsShell,
+})
+
+type AdvisorsStaticData = {
+  advisorsLayoutTitle?: string
+  // The `advisors/rules` sub-shell wraps in its own <AdvisorsLayout>
+  // (mirroring the existing AdvisorRulesLayout component). Without
+  // opting out here we'd double-wrap.
+  skipAdvisorsLayout?: boolean
+}
+
+function AdvisorsShell() {
+  // Scan the whole match chain — `skipAdvisorsLayout` is set on the
+  // sub-shell route, not on the leaf. Same pattern as functions.tsx.
+  const skip = useMatches({
+    select: (matches) =>
+      matches.some((m) => (m.staticData as AdvisorsStaticData | undefined)?.skipAdvisorsLayout),
+  })
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as AdvisorsStaticData | undefined)
+        ?.advisorsLayoutTitle ?? '',
+  })
+
+  if (skip) return <Outlet />
+
+  return (
+    <AdvisorsLayout title={title}>
+      <Outlet />
+    </AdvisorsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/advisors/performance.tsx
+++ b/apps/studio/routes/project/$ref/advisors/performance.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AdvisorsPerformancePage from '@/pages/project/[ref]/advisors/performance'
+
+export const Route = createFileRoute('/project/$ref/advisors/performance')({
+  component: AdvisorsPerformanceRoute,
+  staticData: {
+    advisorsLayoutTitle: 'Linter',
+  },
+})
+
+function AdvisorsPerformanceRoute() {
+  return <AdvisorsPerformancePage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/advisors/rules.tsx
+++ b/apps/studio/routes/project/$ref/advisors/rules.tsx
@@ -1,0 +1,57 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+
+import { useIsAdvisorRulesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import AdvisorsLayout from '@/components/layouts/AdvisorsLayout/AdvisorsLayout'
+import { PageLayout } from '@/components/layouts/PageLayout/PageLayout'
+import { FeaturePreviewBadge } from '@/components/ui/FeaturePreviewBadge'
+
+export const Route = createFileRoute('/project/$ref/advisors/rules')({
+  component: AdvisorRulesShell,
+  // Opt out of the parent advisors.tsx shell's <AdvisorsLayout> wrap
+  // — we render our own with no title, plus a PageLayout tab strip,
+  // mirroring the existing AdvisorRulesLayout component.
+  staticData: {
+    skipAdvisorsLayout: true,
+  },
+})
+
+// Body inlined from `components/layouts/AdvisorsLayout/AdvisorRulesLayout.tsx`
+// minus its outer <DefaultLayout> wrap (already provided by the
+// `routes/project/$ref.tsx` shell). The Next-side AdvisorRulesLayout
+// keeps working unchanged for the pages router; we duplicate the
+// PageLayout config here so the TanStack route can re-use the same
+// title + nav + feature-preview badge without coupling to the
+// component's DefaultLayout-wrapping shape.
+function AdvisorRulesShell() {
+  const { ref } = useParams()
+  const isAdvisorRulesEnabled = useIsAdvisorRulesEnabled()
+
+  return (
+    <AdvisorsLayout>
+      <PageLayout
+        title={
+          <span className="flex items-center gap-x-4">
+            Advisor Settings
+            {isAdvisorRulesEnabled && (
+              <FeaturePreviewBadge featureKey={LOCAL_STORAGE_KEYS.UI_PREVIEW_ADVISOR_RULES} />
+            )}
+          </span>
+        }
+        subtitle="Disable specific advisor categories or rules"
+        navigationItems={[
+          {
+            label: 'Security',
+            href: `/project/${ref}/advisors/rules/security`,
+          },
+          {
+            label: 'Performance',
+            href: `/project/${ref}/advisors/rules/performance`,
+          },
+        ]}
+      >
+        <Outlet />
+      </PageLayout>
+    </AdvisorsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/advisors/rules/performance.tsx
+++ b/apps/studio/routes/project/$ref/advisors/rules/performance.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AdvisorPerformanceRulesPage from '@/pages/project/[ref]/advisors/rules/performance'
+
+export const Route = createFileRoute('/project/$ref/advisors/rules/performance')({
+  component: AdvisorRulesPerformanceRoute,
+})
+
+function AdvisorRulesPerformanceRoute() {
+  return <AdvisorPerformanceRulesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/advisors/rules/security.tsx
+++ b/apps/studio/routes/project/$ref/advisors/rules/security.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AdvisorSecurityRulesPage from '@/pages/project/[ref]/advisors/rules/security'
+
+export const Route = createFileRoute('/project/$ref/advisors/rules/security')({
+  component: AdvisorRulesSecurityRoute,
+})
+
+function AdvisorRulesSecurityRoute() {
+  return <AdvisorSecurityRulesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/advisors/security.tsx
+++ b/apps/studio/routes/project/$ref/advisors/security.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AdvisorsSecurityPage from '@/pages/project/[ref]/advisors/security'
+
+export const Route = createFileRoute('/project/$ref/advisors/security')({
+  component: AdvisorsSecurityRoute,
+  staticData: {
+    advisorsLayoutTitle: 'Linter',
+  },
+})
+
+function AdvisorsSecurityRoute() {
+  return <AdvisorsSecurityPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/api/index.tsx
+++ b/apps/studio/routes/project/$ref/api/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ApiDocsRedirect from '@/pages/project/[ref]/api/index'
+
+export const Route = createFileRoute('/project/$ref/api/')({
+  component: ProjectApiIndexRoute,
+})
+
+function ProjectApiIndexRoute() {
+  return <ApiDocsRedirect dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth.tsx
+++ b/apps/studio/routes/project/$ref/auth.tsx
@@ -1,0 +1,40 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import AuthLayout from '@/components/layouts/AuthLayout/AuthLayout'
+
+export const Route = createFileRoute('/project/$ref/auth')({
+  component: AuthShell,
+})
+
+function AuthShell() {
+  // Read the two staticData fields via `select` so the shell only re-renders
+  // when the actual selected values change. See routes/_app.tsx for why the
+  // bare `useMatches()` form is unsafe here.
+  const skipAuthLayout = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as { skipAuthLayout?: boolean } | undefined)
+        ?.skipAuthLayout ?? false,
+  })
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as { authLayoutTitle?: string } | undefined)
+        ?.authLayoutTitle ?? '',
+  })
+
+  // Some auth leaves wrap themselves in a sub-layout that internally already
+  // includes <AuthLayout> (AuthProvidersLayout, AuthEmailsLayout, and pages
+  // like third-party that inline that wrapping). Those routes set
+  // `staticData.skipAuthLayout: true` and render their own Outlet chain;
+  // otherwise we'd double-wrap with AuthLayout (and AuthLayout pulls in
+  // withAuth + ProjectLayout, so a double-wrap is observable beyond just
+  // visual nesting).
+  if (skipAuthLayout) {
+    return <Outlet />
+  }
+
+  return (
+    <AuthLayout title={title}>
+      <Outlet />
+    </AuthLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/auth/audit-logs.tsx
+++ b/apps/studio/routes/project/$ref/auth/audit-logs.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AuditLogsPage from '@/pages/project/[ref]/auth/audit-logs'
+
+export const Route = createFileRoute('/project/$ref/auth/audit-logs')({
+  component: AuthAuditLogsRoute,
+  staticData: {
+    authLayoutTitle: 'Audit Logs',
+  },
+})
+
+function AuthAuditLogsRoute() {
+  return <AuditLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/hooks.tsx
+++ b/apps/studio/routes/project/$ref/auth/hooks.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import Hooks from '@/pages/project/[ref]/auth/hooks'
+
+export const Route = createFileRoute('/project/$ref/auth/hooks')({
+  component: AuthHooksRoute,
+  staticData: {
+    authLayoutTitle: 'Auth Hooks',
+  },
+})
+
+function AuthHooksRoute() {
+  return <Hooks dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/mfa.tsx
+++ b/apps/studio/routes/project/$ref/auth/mfa.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import MfaPage from '@/pages/project/[ref]/auth/mfa'
+
+export const Route = createFileRoute('/project/$ref/auth/mfa')({
+  component: AuthMfaRoute,
+  staticData: {
+    authLayoutTitle: 'Multi-Factor',
+  },
+})
+
+function AuthMfaRoute() {
+  return <MfaPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/oauth-apps.tsx
+++ b/apps/studio/routes/project/$ref/auth/oauth-apps.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import OAuthApps from '@/pages/project/[ref]/auth/oauth-apps'
+
+export const Route = createFileRoute('/project/$ref/auth/oauth-apps')({
+  component: AuthOAuthAppsRoute,
+  staticData: {
+    authLayoutTitle: 'OAuth Apps',
+  },
+})
+
+function AuthOAuthAppsRoute() {
+  return <OAuthApps dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/oauth-server.tsx
+++ b/apps/studio/routes/project/$ref/auth/oauth-server.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import OAuthServerPage from '@/pages/project/[ref]/auth/oauth-server'
+
+export const Route = createFileRoute('/project/$ref/auth/oauth-server')({
+  component: AuthOAuthServerRoute,
+  staticData: {
+    authLayoutTitle: 'OAuth Server',
+  },
+})
+
+function AuthOAuthServerRoute() {
+  return <OAuthServerPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/overview.tsx
+++ b/apps/studio/routes/project/$ref/auth/overview.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AuthOverview from '@/pages/project/[ref]/auth/overview'
+
+export const Route = createFileRoute('/project/$ref/auth/overview')({
+  component: AuthOverviewRoute,
+  staticData: {
+    authLayoutTitle: 'Overview',
+  },
+})
+
+function AuthOverviewRoute() {
+  return <AuthOverview dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/passkeys.tsx
+++ b/apps/studio/routes/project/$ref/auth/passkeys.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PasskeysPage from '@/pages/project/[ref]/auth/passkeys'
+
+export const Route = createFileRoute('/project/$ref/auth/passkeys')({
+  component: AuthPasskeysRoute,
+  staticData: {
+    authLayoutTitle: 'Passkeys',
+  },
+})
+
+function AuthPasskeysRoute() {
+  return <PasskeysPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/performance.tsx
+++ b/apps/studio/routes/project/$ref/auth/performance.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PerformancePage from '@/pages/project/[ref]/auth/performance'
+
+export const Route = createFileRoute('/project/$ref/auth/performance')({
+  component: AuthPerformanceRoute,
+  staticData: {
+    authLayoutTitle: 'Performance',
+  },
+})
+
+function AuthPerformanceRoute() {
+  return <PerformancePage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/policies.tsx
+++ b/apps/studio/routes/project/$ref/auth/policies.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AuthPoliciesPage from '@/pages/project/[ref]/auth/policies'
+
+export const Route = createFileRoute('/project/$ref/auth/policies')({
+  component: AuthPoliciesRoute,
+  staticData: {
+    authLayoutTitle: 'Policies',
+  },
+})
+
+function AuthPoliciesRoute() {
+  return <AuthPoliciesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/protection.tsx
+++ b/apps/studio/routes/project/$ref/auth/protection.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProtectionPage from '@/pages/project/[ref]/auth/protection'
+
+export const Route = createFileRoute('/project/$ref/auth/protection')({
+  component: AuthProtectionRoute,
+  staticData: {
+    authLayoutTitle: 'Attack Protection',
+  },
+})
+
+function AuthProtectionRoute() {
+  return <ProtectionPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/providers.tsx
+++ b/apps/studio/routes/project/$ref/auth/providers.tsx
@@ -1,0 +1,22 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AuthProvidersLayout } from '@/components/layouts/AuthLayout/AuthProvidersLayout'
+import ProvidersPage from '@/pages/project/[ref]/auth/providers'
+
+export const Route = createFileRoute('/project/$ref/auth/providers')({
+  component: AuthProvidersRoute,
+  // AuthProvidersLayout wraps in <AuthLayout> internally; the auth.tsx
+  // shell skips its own AuthLayout wrap so we don't double-wrap (and
+  // double withAuth + ProjectLayout).
+  staticData: {
+    skipAuthLayout: true,
+  },
+})
+
+function AuthProvidersRoute() {
+  return (
+    <AuthProvidersLayout>
+      <ProvidersPage dehydratedState={undefined} />
+    </AuthProvidersLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/auth/rate-limits.tsx
+++ b/apps/studio/routes/project/$ref/auth/rate-limits.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import RateLimitsPage from '@/pages/project/[ref]/auth/rate-limits'
+
+export const Route = createFileRoute('/project/$ref/auth/rate-limits')({
+  component: AuthRateLimitsRoute,
+  staticData: {
+    authLayoutTitle: 'Rate Limits',
+  },
+})
+
+function AuthRateLimitsRoute() {
+  return <RateLimitsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/sessions.tsx
+++ b/apps/studio/routes/project/$ref/auth/sessions.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import SessionsPage from '@/pages/project/[ref]/auth/sessions'
+
+export const Route = createFileRoute('/project/$ref/auth/sessions')({
+  component: AuthSessionsRoute,
+  staticData: {
+    authLayoutTitle: 'Sessions',
+  },
+})
+
+function AuthSessionsRoute() {
+  return <SessionsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/smtp.tsx
+++ b/apps/studio/routes/project/$ref/auth/smtp.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AuthEmailsLayout } from '@/components/layouts/AuthLayout/AuthEmailsLayout'
+import SmtpPage from '@/pages/project/[ref]/auth/smtp'
+
+export const Route = createFileRoute('/project/$ref/auth/smtp')({
+  component: AuthSmtpRoute,
+  // AuthEmailsLayout wraps in <AuthLayout> internally; opt out of the
+  // auth.tsx shell wrap to avoid double-wrapping.
+  staticData: {
+    skipAuthLayout: true,
+  },
+})
+
+function AuthSmtpRoute() {
+  return (
+    <AuthEmailsLayout>
+      <SmtpPage dehydratedState={undefined} />
+    </AuthEmailsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/auth/templates/$templateId.tsx
+++ b/apps/studio/routes/project/$ref/auth/templates/$templateId.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import TemplatePage from '@/pages/project/[ref]/auth/templates/[templateId]'
+
+export const Route = createFileRoute('/project/$ref/auth/templates/$templateId')({
+  component: AuthTemplateDetailRoute,
+  staticData: {
+    authLayoutTitle: 'Emails',
+  },
+})
+
+function AuthTemplateDetailRoute() {
+  return <TemplatePage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/templates/index.tsx
+++ b/apps/studio/routes/project/$ref/auth/templates/index.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { AuthEmailsLayout } from '@/components/layouts/AuthLayout/AuthEmailsLayout'
+import TemplatesPage from '@/pages/project/[ref]/auth/templates/index'
+
+export const Route = createFileRoute('/project/$ref/auth/templates/')({
+  component: AuthTemplatesIndexRoute,
+  // AuthEmailsLayout wraps in <AuthLayout> internally; opt out of the
+  // auth.tsx shell wrap to avoid double-wrapping. Sibling
+  // templates/$templateId.tsx does NOT use AuthEmailsLayout, so we
+  // can't share a templates.tsx sub-shell — each leaf wraps itself.
+  staticData: {
+    skipAuthLayout: true,
+  },
+})
+
+function AuthTemplatesIndexRoute() {
+  return (
+    <AuthEmailsLayout>
+      <TemplatesPage dehydratedState={undefined} />
+    </AuthEmailsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/auth/third-party.tsx
+++ b/apps/studio/routes/project/$ref/auth/third-party.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ThirdPartyPage from '@/pages/project/[ref]/auth/third-party'
+
+export const Route = createFileRoute('/project/$ref/auth/third-party')({
+  component: AuthThirdPartyRoute,
+  // The page body wraps itself in <AuthProvidersLayout>, which already
+  // includes <AuthLayout>. Tell the auth.tsx shell to skip its own
+  // AuthLayout wrap so we don't double-wrap (and double withAuth +
+  // ProjectLayout).
+  staticData: {
+    skipAuthLayout: true,
+  },
+})
+
+function AuthThirdPartyRoute() {
+  return <ThirdPartyPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/url-configuration.tsx
+++ b/apps/studio/routes/project/$ref/auth/url-configuration.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import URLConfiguration from '@/pages/project/[ref]/auth/url-configuration'
+
+export const Route = createFileRoute('/project/$ref/auth/url-configuration')({
+  component: AuthUrlConfigurationRoute,
+  staticData: {
+    authLayoutTitle: 'URL Configuration',
+  },
+})
+
+function AuthUrlConfigurationRoute() {
+  return <URLConfiguration dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/auth/users.tsx
+++ b/apps/studio/routes/project/$ref/auth/users.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import UsersPage from '@/pages/project/[ref]/auth/users'
+
+export const Route = createFileRoute('/project/$ref/auth/users')({
+  component: AuthUsersRoute,
+  staticData: {
+    authLayoutTitle: 'Users',
+  },
+})
+
+function AuthUsersRoute() {
+  return <UsersPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/branches.tsx
+++ b/apps/studio/routes/project/$ref/branches.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import BranchLayout from '@/components/layouts/BranchLayout/BranchLayout'
+
+export const Route = createFileRoute('/project/$ref/branches')({
+  component: BranchesShell,
+})
+
+// BranchLayout sibling-file shell. Each leaf renders its own per-page
+// PageLayout (different titles + primary/secondary actions); we keep
+// that wrapping in the leaf route files via the page-side
+// `*PageWrapper` exports rather than trying to share PageLayout in the
+// shell — the shell deliberately stops at BranchLayout.
+function BranchesShell() {
+  return (
+    <BranchLayout>
+      <Outlet />
+    </BranchLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/branches/index.tsx
+++ b/apps/studio/routes/project/$ref/branches/index.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import BranchesPage, { BranchesPageWrapper } from '@/pages/project/[ref]/branches/index'
+
+export const Route = createFileRoute('/project/$ref/branches/')({
+  component: BranchesIndexRoute,
+})
+
+function BranchesIndexRoute() {
+  return (
+    <BranchesPageWrapper>
+      <BranchesPage dehydratedState={undefined} />
+    </BranchesPageWrapper>
+  )
+}

--- a/apps/studio/routes/project/$ref/branches/merge-requests.tsx
+++ b/apps/studio/routes/project/$ref/branches/merge-requests.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import MergeRequestsPage, {
+  MergeRequestsPageWrapper,
+} from '@/pages/project/[ref]/branches/merge-requests'
+
+export const Route = createFileRoute('/project/$ref/branches/merge-requests')({
+  component: MergeRequestsRoute,
+})
+
+function MergeRequestsRoute() {
+  return (
+    <MergeRequestsPageWrapper>
+      <MergeRequestsPage dehydratedState={undefined} />
+    </MergeRequestsPageWrapper>
+  )
+}

--- a/apps/studio/routes/project/$ref/database.tsx
+++ b/apps/studio/routes/project/$ref/database.tsx
@@ -1,0 +1,31 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import DatabaseLayout from '@/components/layouts/DatabaseLayout/DatabaseLayout'
+
+export const Route = createFileRoute('/project/$ref/database')({
+  component: DatabaseShell,
+})
+
+function DatabaseShell() {
+  // useMatches() returns a fresh array reference on every router tick, which
+  // re-renders the shell (and its subtree, e.g. DatabaseLayout → ProjectLayout
+  // → the route content) even when the leaf staticData hasn't changed. The
+  // `select` form lets TanStack compare the selected value (a string) and
+  // only re-render when it actually changes — required to keep heavy children
+  // like ReactFlow stable, otherwise their internal compose-refs chain runs
+  // setRef → setState every render and trips React's max-update-depth.
+  const title = useMatches({
+    select: (matches) => {
+      const leaf = matches[matches.length - 1]?.staticData as
+        | { databaseLayoutTitle?: string }
+        | undefined
+      return leaf?.databaseLayoutTitle ?? ''
+    },
+  })
+
+  return (
+    <DatabaseLayout title={title}>
+      <Outlet />
+    </DatabaseLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/database/backups/pitr.tsx
+++ b/apps/studio/routes/project/$ref/database/backups/pitr.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabasePhysicalBackups from '@/pages/project/[ref]/database/backups/pitr'
+
+export const Route = createFileRoute('/project/$ref/database/backups/pitr')({
+  component: DatabaseBackupsPitrRoute,
+  staticData: {
+    databaseLayoutTitle: 'Backups',
+  },
+})
+
+function DatabaseBackupsPitrRoute() {
+  return <DatabasePhysicalBackups dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/backups/restore-to-new-project.tsx
+++ b/apps/studio/routes/project/$ref/database/backups/restore-to-new-project.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import RestoreToNewProjectPage from '@/pages/project/[ref]/database/backups/restore-to-new-project'
+
+export const Route = createFileRoute('/project/$ref/database/backups/restore-to-new-project')({
+  component: DatabaseBackupsRestoreToNewProjectRoute,
+  staticData: {
+    databaseLayoutTitle: 'Backups',
+  },
+})
+
+function DatabaseBackupsRestoreToNewProjectRoute() {
+  return <RestoreToNewProjectPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/backups/scheduled.tsx
+++ b/apps/studio/routes/project/$ref/database/backups/scheduled.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseScheduledBackups from '@/pages/project/[ref]/database/backups/scheduled'
+
+export const Route = createFileRoute('/project/$ref/database/backups/scheduled')({
+  component: DatabaseBackupsScheduledRoute,
+  staticData: {
+    databaseLayoutTitle: 'Backups',
+  },
+})
+
+function DatabaseBackupsScheduledRoute() {
+  return <DatabaseScheduledBackups dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/column-privileges.tsx
+++ b/apps/studio/routes/project/$ref/database/column-privileges.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PrivilegesPage from '@/pages/project/[ref]/database/column-privileges'
+
+export const Route = createFileRoute('/project/$ref/database/column-privileges')({
+  component: DatabaseColumnPrivilegesRoute,
+  staticData: {
+    databaseLayoutTitle: 'Column Privileges',
+  },
+})
+
+function DatabaseColumnPrivilegesRoute() {
+  return <PrivilegesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/extensions.tsx
+++ b/apps/studio/routes/project/$ref/database/extensions.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseExtensions from '@/pages/project/[ref]/database/extensions'
+
+export const Route = createFileRoute('/project/$ref/database/extensions')({
+  component: DatabaseExtensionsRoute,
+  staticData: {
+    databaseLayoutTitle: 'Extensions',
+  },
+})
+
+function DatabaseExtensionsRoute() {
+  return <DatabaseExtensions dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/functions.tsx
+++ b/apps/studio/routes/project/$ref/database/functions.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseFunctionsPage from '@/pages/project/[ref]/database/functions'
+
+export const Route = createFileRoute('/project/$ref/database/functions')({
+  component: DatabaseFunctionsRoute,
+  staticData: {
+    databaseLayoutTitle: 'Functions',
+  },
+})
+
+function DatabaseFunctionsRoute() {
+  return <DatabaseFunctionsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/indexes.tsx
+++ b/apps/studio/routes/project/$ref/database/indexes.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import IndexesPage from '@/pages/project/[ref]/database/indexes'
+
+export const Route = createFileRoute('/project/$ref/database/indexes')({
+  component: DatabaseIndexesRoute,
+  staticData: {
+    databaseLayoutTitle: 'Indexes',
+  },
+})
+
+function DatabaseIndexesRoute() {
+  return <IndexesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/migrations.tsx
+++ b/apps/studio/routes/project/$ref/database/migrations.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import MigrationsPage from '@/pages/project/[ref]/database/migrations'
+
+export const Route = createFileRoute('/project/$ref/database/migrations')({
+  component: DatabaseMigrationsRoute,
+  staticData: {
+    databaseLayoutTitle: 'Migrations',
+  },
+})
+
+function DatabaseMigrationsRoute() {
+  return <MigrationsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/publications/$id.tsx
+++ b/apps/studio/routes/project/$ref/database/publications/$id.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabasePublications from '@/pages/project/[ref]/database/publications/[id]'
+
+export const Route = createFileRoute('/project/$ref/database/publications/$id')({
+  component: DatabasePublicationDetailRoute,
+  staticData: {
+    databaseLayoutTitle: 'Publications',
+  },
+})
+
+function DatabasePublicationDetailRoute() {
+  return <DatabasePublications dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/publications/index.tsx
+++ b/apps/studio/routes/project/$ref/database/publications/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabasePublications from '@/pages/project/[ref]/database/publications/index'
+
+export const Route = createFileRoute('/project/$ref/database/publications/')({
+  component: DatabasePublicationsIndexRoute,
+  staticData: {
+    databaseLayoutTitle: 'Publications',
+  },
+})
+
+function DatabasePublicationsIndexRoute() {
+  return <DatabasePublications dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/replication/$pipelineId.tsx
+++ b/apps/studio/routes/project/$ref/database/replication/$pipelineId.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseReplicationPage from '@/pages/project/[ref]/database/replication/[pipelineId]'
+
+export const Route = createFileRoute('/project/$ref/database/replication/$pipelineId')({
+  component: DatabaseReplicationPipelineRoute,
+  staticData: {
+    databaseLayoutTitle: 'Replication',
+  },
+})
+
+function DatabaseReplicationPipelineRoute() {
+  return <DatabaseReplicationPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/replication/index.tsx
+++ b/apps/studio/routes/project/$ref/database/replication/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseReplicationPage from '@/pages/project/[ref]/database/replication/index'
+
+export const Route = createFileRoute('/project/$ref/database/replication/')({
+  component: DatabaseReplicationIndexRoute,
+  staticData: {
+    databaseLayoutTitle: 'Replication',
+  },
+})
+
+function DatabaseReplicationIndexRoute() {
+  return <DatabaseReplicationPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/replication/replica/$replicaId.tsx
+++ b/apps/studio/routes/project/$ref/database/replication/replica/$replicaId.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseReadReplicaPage from '@/pages/project/[ref]/database/replication/replica/[replicaId]'
+
+export const Route = createFileRoute('/project/$ref/database/replication/replica/$replicaId')({
+  component: DatabaseReplicationReplicaRoute,
+  staticData: {
+    databaseLayoutTitle: 'Replication',
+  },
+})
+
+function DatabaseReplicationReplicaRoute() {
+  return <DatabaseReadReplicaPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/roles.tsx
+++ b/apps/studio/routes/project/$ref/database/roles.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseRoles from '@/pages/project/[ref]/database/roles'
+
+export const Route = createFileRoute('/project/$ref/database/roles')({
+  component: DatabaseRolesRoute,
+  staticData: {
+    databaseLayoutTitle: 'Roles',
+  },
+})
+
+function DatabaseRolesRoute() {
+  return <DatabaseRoles dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/schemas.tsx
+++ b/apps/studio/routes/project/$ref/database/schemas.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import SchemasPage from '@/pages/project/[ref]/database/schemas'
+
+export const Route = createFileRoute('/project/$ref/database/schemas')({
+  component: SchemasRoute,
+  staticData: {
+    databaseLayoutTitle: 'Schema Visualizer',
+  },
+})
+
+function SchemasRoute() {
+  return <SchemasPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/settings.tsx
+++ b/apps/studio/routes/project/$ref/database/settings.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseSettings from '@/pages/project/[ref]/database/settings'
+
+export const Route = createFileRoute('/project/$ref/database/settings')({
+  component: DatabaseSettingsRoute,
+  staticData: {
+    databaseLayoutTitle: 'Settings',
+  },
+})
+
+function DatabaseSettingsRoute() {
+  return <DatabaseSettings dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/tables/$id.tsx
+++ b/apps/studio/routes/project/$ref/database/tables/$id.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseTables from '@/pages/project/[ref]/database/tables/[id]'
+
+export const Route = createFileRoute('/project/$ref/database/tables/$id')({
+  component: DatabaseTableDetailRoute,
+  staticData: {
+    databaseLayoutTitle: 'Tables',
+  },
+})
+
+function DatabaseTableDetailRoute() {
+  return <DatabaseTables dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/tables/index.tsx
+++ b/apps/studio/routes/project/$ref/database/tables/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseTables from '@/pages/project/[ref]/database/tables/index'
+
+export const Route = createFileRoute('/project/$ref/database/tables/')({
+  component: DatabaseTablesIndexRoute,
+  staticData: {
+    databaseLayoutTitle: 'Tables',
+  },
+})
+
+function DatabaseTablesIndexRoute() {
+  return <DatabaseTables dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/triggers.tsx
+++ b/apps/studio/routes/project/$ref/database/triggers.tsx
@@ -1,0 +1,39 @@
+import { PermissionAction } from '@supabase/shared-types/out/constants'
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import { PageLayout } from '@/components/layouts/PageLayout/PageLayout'
+import NoPermission from '@/components/ui/NoPermission'
+import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+
+export const Route = createFileRoute('/project/$ref/database/triggers')({
+  component: TriggersShell,
+  staticData: {
+    databaseLayoutTitle: 'Triggers',
+  },
+})
+
+function TriggersShell() {
+  const { ref } = Route.useParams()
+  const { can: canReadTriggers, isSuccess: isPermissionsLoaded } = useAsyncCheckPermissions(
+    PermissionAction.TENANT_SQL_ADMIN_READ,
+    'triggers'
+  )
+
+  if (isPermissionsLoaded && !canReadTriggers) {
+    return <NoPermission isFullPage resourceText="view database triggers" />
+  }
+
+  return (
+    <PageLayout
+      title="Database Triggers"
+      subtitle="Execute actions automatically when database events occur"
+      size="large"
+      navigationItems={[
+        { label: 'Data', href: `/project/${ref}/database/triggers/data` },
+        { label: 'Event', href: `/project/${ref}/database/triggers/event` },
+      ]}
+    >
+      <Outlet />
+    </PageLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/database/triggers/data.tsx
+++ b/apps/studio/routes/project/$ref/database/triggers/data.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import TriggersDataPage from '@/pages/project/[ref]/database/triggers/data'
+
+export const Route = createFileRoute('/project/$ref/database/triggers/data')({
+  component: TriggersDataRoute,
+})
+
+function TriggersDataRoute() {
+  return <TriggersDataPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/triggers/event.tsx
+++ b/apps/studio/routes/project/$ref/database/triggers/event.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import TriggersSchemaPage from '@/pages/project/[ref]/database/triggers/event'
+
+export const Route = createFileRoute('/project/$ref/database/triggers/event')({
+  component: TriggersEventRoute,
+})
+
+function TriggersEventRoute() {
+  return <TriggersSchemaPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/triggers/index.tsx
+++ b/apps/studio/routes/project/$ref/database/triggers/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseTriggersIndexPage from '@/pages/project/[ref]/database/triggers/index'
+
+export const Route = createFileRoute('/project/$ref/database/triggers/')({
+  component: DatabaseTriggersIndexRoute,
+})
+
+function DatabaseTriggersIndexRoute() {
+  return <DatabaseTriggersIndexPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/database/types.tsx
+++ b/apps/studio/routes/project/$ref/database/types.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseEnumeratedTypes from '@/pages/project/[ref]/database/types'
+
+export const Route = createFileRoute('/project/$ref/database/types')({
+  component: DatabaseTypesRoute,
+  staticData: {
+    databaseLayoutTitle: 'Enumerated Types',
+  },
+})
+
+function DatabaseTypesRoute() {
+  return <DatabaseEnumeratedTypes dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/editor.tsx
+++ b/apps/studio/routes/project/$ref/editor.tsx
@@ -1,0 +1,34 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import { EditorBaseLayout } from '@/components/layouts/editors/EditorBaseLayout'
+import { TableEditorLayout } from '@/components/layouts/TableEditorLayout/TableEditorLayout'
+import { TableEditorMenu } from '@/components/layouts/TableEditorLayout/TableEditorMenu'
+
+export const Route = createFileRoute('/project/$ref/editor')({
+  component: TableEditorShell,
+})
+
+// All three editor leaves (index, $id, new) share identical layout
+// wrapping in the Next pages router (DefaultLayout > EditorBaseLayout >
+// TableEditorLayout). DefaultLayout is provided by the parent
+// `routes/project/$ref.tsx` shell, so this file only adds the
+// editor-specific layers.
+//
+// Note on the ProjectLayoutWithAuth chain: EditorBaseLayout always
+// wraps in <ProjectLayoutWithAuth>. TableEditorLayout *also* wraps in
+// one — but only on its no-permission path; the happy path returns
+// `<>{children}<SaveQueueActionBar/></>` so no double-wrap occurs in
+// normal use. Mirrors current Next behaviour exactly.
+function TableEditorShell() {
+  return (
+    <EditorBaseLayout
+      productMenu={<TableEditorMenu />}
+      product="Table Editor"
+      productMenuClassName="overflow-y-hidden"
+    >
+      <TableEditorLayout>
+        <Outlet />
+      </TableEditorLayout>
+    </EditorBaseLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/editor/$id.tsx
+++ b/apps/studio/routes/project/$ref/editor/$id.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import TableEditorPage from '@/pages/project/[ref]/editor/[id]'
+
+export const Route = createFileRoute('/project/$ref/editor/$id')({
+  component: TableEditorDetailRoute,
+})
+
+function TableEditorDetailRoute() {
+  return <TableEditorPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/editor/index.tsx
+++ b/apps/studio/routes/project/$ref/editor/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import TableEditorPage from '@/pages/project/[ref]/editor/index'
+
+export const Route = createFileRoute('/project/$ref/editor/')({
+  component: TableEditorIndexRoute,
+})
+
+function TableEditorIndexRoute() {
+  return <TableEditorPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/editor/new.tsx
+++ b/apps/studio/routes/project/$ref/editor/new.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import EditorNewPage from '@/pages/project/[ref]/editor/new'
+
+export const Route = createFileRoute('/project/$ref/editor/new')({
+  component: TableEditorNewRoute,
+})
+
+function TableEditorNewRoute() {
+  return <EditorNewPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/functions.tsx
+++ b/apps/studio/routes/project/$ref/functions.tsx
@@ -1,0 +1,41 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import EdgeFunctionsLayout from '@/components/layouts/EdgeFunctionsLayout/EdgeFunctionsLayout'
+
+export const Route = createFileRoute('/project/$ref/functions')({
+  component: FunctionsShell,
+})
+
+type FunctionsStaticData = {
+  functionsLayoutTitle?: string
+  // The $functionSlug routes wrap themselves in <EdgeFunctionDetailsLayout>,
+  // which already renders <EdgeFunctionsLayout> internally. Without
+  // opting out here we'd double-wrap.
+  skipFunctionsLayout?: boolean
+}
+
+function FunctionsShell() {
+  // `skipFunctionsLayout` is set on the $functionSlug sub-shell's
+  // staticData, not on the leaf — so checking only the leaf misses it
+  // and we end up double-wrapping (`functions.tsx` adds
+  // EdgeFunctionsLayout, then the sub-shell's EdgeFunctionDetailsLayout
+  // wraps EdgeFunctionsLayout again internally → duplicated sidebar).
+  // Scan the whole match chain instead.
+  const skip = useMatches({
+    select: (matches) =>
+      matches.some((m) => (m.staticData as FunctionsStaticData | undefined)?.skipFunctionsLayout),
+  })
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as FunctionsStaticData | undefined)
+        ?.functionsLayoutTitle ?? '',
+  })
+
+  if (skip) return <Outlet />
+
+  return (
+    <EdgeFunctionsLayout title={title}>
+      <Outlet />
+    </EdgeFunctionsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/functions/$functionSlug.tsx
+++ b/apps/studio/routes/project/$ref/functions/$functionSlug.tsx
@@ -1,0 +1,27 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import EdgeFunctionDetailsLayout from '@/components/layouts/EdgeFunctionsLayout/EdgeFunctionDetailsLayout'
+
+export const Route = createFileRoute('/project/$ref/functions/$functionSlug')({
+  component: FunctionDetailsShell,
+  // EdgeFunctionDetailsLayout already wraps <EdgeFunctionsLayout>
+  // internally. Tell the parent functions.tsx shell to skip its own
+  // EdgeFunctionsLayout wrap so we don't double-wrap.
+  staticData: {
+    skipFunctionsLayout: true,
+  },
+})
+
+function FunctionDetailsShell() {
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as { edgeFunctionDetailsTitle?: string } | undefined)
+        ?.edgeFunctionDetailsTitle ?? '',
+  })
+
+  return (
+    <EdgeFunctionDetailsLayout title={title}>
+      <Outlet />
+    </EdgeFunctionDetailsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/functions/$functionSlug/code.tsx
+++ b/apps/studio/routes/project/$ref/functions/$functionSlug/code.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import CodePage from '@/pages/project/[ref]/functions/[functionSlug]/code'
+
+export const Route = createFileRoute('/project/$ref/functions/$functionSlug/code')({
+  component: FunctionCodeRoute,
+  staticData: {
+    edgeFunctionDetailsTitle: 'Code',
+  },
+})
+
+function FunctionCodeRoute() {
+  return <CodePage />
+}

--- a/apps/studio/routes/project/$ref/functions/$functionSlug/details.tsx
+++ b/apps/studio/routes/project/$ref/functions/$functionSlug/details.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import FunctionDetailsPage from '@/pages/project/[ref]/functions/[functionSlug]/details'
+
+export const Route = createFileRoute('/project/$ref/functions/$functionSlug/details')({
+  component: FunctionDetailsRoute,
+  staticData: {
+    edgeFunctionDetailsTitle: 'Settings',
+  },
+})
+
+function FunctionDetailsRoute() {
+  return <FunctionDetailsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/functions/$functionSlug/index.tsx
+++ b/apps/studio/routes/project/$ref/functions/$functionSlug/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import FunctionOverviewPage from '@/pages/project/[ref]/functions/[functionSlug]/index'
+
+export const Route = createFileRoute('/project/$ref/functions/$functionSlug/')({
+  component: FunctionOverviewRoute,
+  staticData: {
+    edgeFunctionDetailsTitle: 'Overview',
+  },
+})
+
+function FunctionOverviewRoute() {
+  return <FunctionOverviewPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/functions/$functionSlug/invocations.tsx
+++ b/apps/studio/routes/project/$ref/functions/$functionSlug/invocations.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import FunctionInvocationsPage from '@/pages/project/[ref]/functions/[functionSlug]/invocations'
+
+export const Route = createFileRoute('/project/$ref/functions/$functionSlug/invocations')({
+  component: FunctionInvocationsRoute,
+  staticData: {
+    edgeFunctionDetailsTitle: 'Invocations',
+  },
+})
+
+function FunctionInvocationsRoute() {
+  return <FunctionInvocationsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/functions/$functionSlug/logs.tsx
+++ b/apps/studio/routes/project/$ref/functions/$functionSlug/logs.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import FunctionLogsPage from '@/pages/project/[ref]/functions/[functionSlug]/logs'
+
+export const Route = createFileRoute('/project/$ref/functions/$functionSlug/logs')({
+  component: FunctionLogsRoute,
+  staticData: {
+    edgeFunctionDetailsTitle: 'Logs',
+  },
+})
+
+function FunctionLogsRoute() {
+  return <FunctionLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/functions/index.tsx
+++ b/apps/studio/routes/project/$ref/functions/index.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import EdgeFunctionsPage, {
+  EdgeFunctionsIndexPageWrapper,
+} from '@/pages/project/[ref]/functions/index'
+
+export const Route = createFileRoute('/project/$ref/functions/')({
+  component: FunctionsIndexRoute,
+  staticData: {
+    functionsLayoutTitle: 'Edge Functions',
+  },
+})
+
+function FunctionsIndexRoute() {
+  return (
+    <EdgeFunctionsIndexPageWrapper>
+      <EdgeFunctionsPage dehydratedState={undefined} />
+    </EdgeFunctionsIndexPageWrapper>
+  )
+}

--- a/apps/studio/routes/project/$ref/functions/new.tsx
+++ b/apps/studio/routes/project/$ref/functions/new.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import NewFunctionPage from '@/pages/project/[ref]/functions/new'
+
+export const Route = createFileRoute('/project/$ref/functions/new')({
+  component: FunctionsNewRoute,
+  staticData: {
+    functionsLayoutTitle: 'New',
+  },
+})
+
+function FunctionsNewRoute() {
+  return <NewFunctionPage />
+}

--- a/apps/studio/routes/project/$ref/functions/secrets.tsx
+++ b/apps/studio/routes/project/$ref/functions/secrets.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import SecretsPage, { SecretsPageWrapper } from '@/pages/project/[ref]/functions/secrets'
+
+export const Route = createFileRoute('/project/$ref/functions/secrets')({
+  component: FunctionsSecretsRoute,
+  staticData: {
+    functionsLayoutTitle: 'Secrets',
+  },
+})
+
+function FunctionsSecretsRoute() {
+  return (
+    <SecretsPageWrapper>
+      <SecretsPage dehydratedState={undefined} />
+    </SecretsPageWrapper>
+  )
+}

--- a/apps/studio/routes/project/$ref/index.tsx
+++ b/apps/studio/routes/project/$ref/index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { ProjectLayoutWithAuth } from '@/components/layouts/ProjectLayout'
+import HomePage from '@/pages/project/[ref]/index'
+
+export const Route = createFileRoute('/project/$ref/')({
+  component: ProjectHomeRoute,
+})
+
+function ProjectHomeRoute() {
+  return (
+    <ProjectLayoutWithAuth>
+      <HomePage dehydratedState={undefined} />
+    </ProjectLayoutWithAuth>
+  )
+}

--- a/apps/studio/routes/project/$ref/integrations.tsx
+++ b/apps/studio/routes/project/$ref/integrations.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import { ProjectIntegrationsLayout } from '@/components/layouts/ProjectIntegrationsLayout'
+
+export const Route = createFileRoute('/project/$ref/integrations')({
+  component: IntegrationsShell,
+})
+
+function IntegrationsShell() {
+  return (
+    <ProjectIntegrationsLayout>
+      <Outlet />
+    </ProjectIntegrationsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/integrations/$id/$pageId/$childId/index.tsx
+++ b/apps/studio/routes/project/$ref/integrations/$id/$pageId/$childId/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import IntegrationPage from '@/pages/project/[ref]/integrations/[id]/[pageId]/[childId]/index'
+
+export const Route = createFileRoute('/project/$ref/integrations/$id/$pageId/$childId/')({
+  component: IntegrationChildIdRoute,
+})
+
+function IntegrationChildIdRoute() {
+  return <IntegrationPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/integrations/$id/$pageId/index.tsx
+++ b/apps/studio/routes/project/$ref/integrations/$id/$pageId/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import IntegrationPage from '@/pages/project/[ref]/integrations/[id]/[pageId]/index'
+
+export const Route = createFileRoute('/project/$ref/integrations/$id/$pageId/')({
+  component: IntegrationPageIdRoute,
+})
+
+function IntegrationPageIdRoute() {
+  return <IntegrationPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/integrations/$id/index.tsx
+++ b/apps/studio/routes/project/$ref/integrations/$id/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import IntegrationPage from '@/pages/project/[ref]/integrations/[id]/index'
+
+export const Route = createFileRoute('/project/$ref/integrations/$id/')({
+  component: IntegrationIdRoute,
+})
+
+function IntegrationIdRoute() {
+  return <IntegrationPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/integrations/index.tsx
+++ b/apps/studio/routes/project/$ref/integrations/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import IntegrationsPage from '@/pages/project/[ref]/integrations/index'
+
+export const Route = createFileRoute('/project/$ref/integrations/')({
+  component: IntegrationsIndexRoute,
+})
+
+function IntegrationsIndexRoute() {
+  return <IntegrationsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs.tsx
+++ b/apps/studio/routes/project/$ref/logs.tsx
@@ -1,0 +1,35 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import LogsLayout from '@/components/layouts/LogsLayout/LogsLayout'
+
+export const Route = createFileRoute('/project/$ref/logs')({
+  component: LogsShell,
+})
+
+type LogsStaticData = {
+  logsLayoutTitle?: string
+  // `logs/index` handles its own ProjectLayout-wrapped content
+  // (UnifiedLogs view or no-permission interface) and only needs the
+  // parent project shell's DefaultLayout — not LogsLayout. Opt out.
+  skipLogsLayout?: boolean
+}
+
+function LogsShell() {
+  const skip = useMatches({
+    select: (matches) =>
+      matches.some((m) => (m.staticData as LogsStaticData | undefined)?.skipLogsLayout),
+  })
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as LogsStaticData | undefined)?.logsLayoutTitle ??
+      '',
+  })
+
+  if (skip) return <Outlet />
+
+  return (
+    <LogsLayout title={title}>
+      <Outlet />
+    </LogsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/logs/auth-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/auth-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AuthLogsPage from '@/pages/project/[ref]/logs/auth-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/auth-logs')({
+  component: AuthLogsRoute,
+  staticData: { logsLayoutTitle: 'Auth Logs' },
+})
+
+function AuthLogsRoute() {
+  return <AuthLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/cron-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/cron-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import CronLogsPage from '@/pages/project/[ref]/logs/cron-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/cron-logs')({
+  component: CronLogsRoute,
+  staticData: { logsLayoutTitle: 'Cron Logs' },
+})
+
+function CronLogsRoute() {
+  return <CronLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/dedicated-pooler-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/dedicated-pooler-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DedicatedPoolerLogsPage from '@/pages/project/[ref]/logs/dedicated-pooler-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/dedicated-pooler-logs')({
+  component: DedicatedPoolerLogsRoute,
+  staticData: { logsLayoutTitle: 'Dedicated Pooler Logs' },
+})
+
+function DedicatedPoolerLogsRoute() {
+  return <DedicatedPoolerLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/edge-functions-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/edge-functions-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import EdgeFunctionsLogsPage from '@/pages/project/[ref]/logs/edge-functions-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/edge-functions-logs')({
+  component: EdgeFunctionsLogsRoute,
+  staticData: { logsLayoutTitle: 'Edge Functions Logs' },
+})
+
+function EdgeFunctionsLogsRoute() {
+  return <EdgeFunctionsLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/edge-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/edge-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import EdgeLogsPage from '@/pages/project/[ref]/logs/edge-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/edge-logs')({
+  component: EdgeLogsRoute,
+  staticData: { logsLayoutTitle: 'Edge Logs' },
+})
+
+function EdgeLogsRoute() {
+  return <EdgeLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/explorer/index.tsx
+++ b/apps/studio/routes/project/$ref/logs/explorer/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import LogsExplorerPage from '@/pages/project/[ref]/logs/explorer/index'
+
+export const Route = createFileRoute('/project/$ref/logs/explorer/')({
+  component: LogsExplorerIndexRoute,
+  staticData: { logsLayoutTitle: 'Explorer' },
+})
+
+function LogsExplorerIndexRoute() {
+  return <LogsExplorerPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/explorer/recent.tsx
+++ b/apps/studio/routes/project/$ref/logs/explorer/recent.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import LogsRecentPage from '@/pages/project/[ref]/logs/explorer/recent'
+
+export const Route = createFileRoute('/project/$ref/logs/explorer/recent')({
+  component: LogsExplorerRecentRoute,
+  staticData: { logsLayoutTitle: 'Recent' },
+})
+
+function LogsExplorerRecentRoute() {
+  return <LogsRecentPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/explorer/saved.tsx
+++ b/apps/studio/routes/project/$ref/logs/explorer/saved.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import LogsSavedPage from '@/pages/project/[ref]/logs/explorer/saved'
+
+export const Route = createFileRoute('/project/$ref/logs/explorer/saved')({
+  component: LogsExplorerSavedRoute,
+  staticData: { logsLayoutTitle: 'Saved' },
+})
+
+function LogsExplorerSavedRoute() {
+  return <LogsSavedPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/explorer/templates.tsx
+++ b/apps/studio/routes/project/$ref/logs/explorer/templates.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import LogsTemplatesPage from '@/pages/project/[ref]/logs/explorer/templates'
+
+export const Route = createFileRoute('/project/$ref/logs/explorer/templates')({
+  component: LogsExplorerTemplatesRoute,
+  staticData: { logsLayoutTitle: 'Templates' },
+})
+
+function LogsExplorerTemplatesRoute() {
+  return <LogsTemplatesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/index.tsx
+++ b/apps/studio/routes/project/$ref/logs/index.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import LogPage from '@/pages/project/[ref]/logs/index'
+
+export const Route = createFileRoute('/project/$ref/logs/')({
+  component: LogsIndexRoute,
+  staticData: {
+    // Page body wraps in its own <ProjectLayout> conditionally; LogsLayout
+    // is not appropriate here.
+    skipLogsLayout: true,
+  },
+})
+
+function LogsIndexRoute() {
+  return <LogPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/pg-upgrade-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/pg-upgrade-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PgUpgradeLogsPage from '@/pages/project/[ref]/logs/pg-upgrade-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/pg-upgrade-logs')({
+  component: PgUpgradeLogsRoute,
+  staticData: { logsLayoutTitle: 'Postgres Version Upgrade' },
+})
+
+function PgUpgradeLogsRoute() {
+  return <PgUpgradeLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/pgcron-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/pgcron-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PgCronLogsPage from '@/pages/project/[ref]/logs/pgcron-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/pgcron-logs')({
+  component: PgCronLogsRoute,
+  staticData: { logsLayoutTitle: 'PgCron Logs' },
+})
+
+function PgCronLogsRoute() {
+  return <PgCronLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/pooler-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/pooler-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PoolerLogsPage from '@/pages/project/[ref]/logs/pooler-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/pooler-logs')({
+  component: PoolerLogsRoute,
+  staticData: { logsLayoutTitle: 'Pooler Logs' },
+})
+
+function PoolerLogsRoute() {
+  return <PoolerLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/postgres-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/postgres-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PostgresLogsPage from '@/pages/project/[ref]/logs/postgres-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/postgres-logs')({
+  component: PostgresLogsRoute,
+  staticData: { logsLayoutTitle: 'Postgres Logs' },
+})
+
+function PostgresLogsRoute() {
+  return <PostgresLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/postgrest-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/postgrest-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PostgrestLogsPage from '@/pages/project/[ref]/logs/postgrest-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/postgrest-logs')({
+  component: PostgrestLogsRoute,
+  staticData: { logsLayoutTitle: 'Postgrest Logs' },
+})
+
+function PostgrestLogsRoute() {
+  return <PostgrestLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/realtime-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/realtime-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import RealtimeLogsPage from '@/pages/project/[ref]/logs/realtime-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/realtime-logs')({
+  component: RealtimeLogsRoute,
+  staticData: { logsLayoutTitle: 'Realtime Logs' },
+})
+
+function RealtimeLogsRoute() {
+  return <RealtimeLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/replication-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/replication-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ReplicationLogsPage from '@/pages/project/[ref]/logs/replication-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/replication-logs')({
+  component: ReplicationLogsRoute,
+  staticData: { logsLayoutTitle: 'Replication Logs' },
+})
+
+function ReplicationLogsRoute() {
+  return <ReplicationLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/logs/storage-logs.tsx
+++ b/apps/studio/routes/project/$ref/logs/storage-logs.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import StorageLogsPage from '@/pages/project/[ref]/logs/storage-logs'
+
+export const Route = createFileRoute('/project/$ref/logs/storage-logs')({
+  component: StorageLogsRoute,
+  staticData: { logsLayoutTitle: 'Storage Logs' },
+})
+
+function StorageLogsRoute() {
+  return <StorageLogsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/merge.tsx
+++ b/apps/studio/routes/project/$ref/merge.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import { ProjectLayoutWithAuth } from '@/components/layouts/ProjectLayout'
+import MergePage from '@/pages/project/[ref]/merge'
+
+export const Route = createFileRoute('/project/$ref/merge')({
+  component: ProjectMergeRoute,
+})
+
+function ProjectMergeRoute() {
+  return (
+    <ProjectLayoutWithAuth>
+      <MergePage dehydratedState={undefined} />
+    </ProjectLayoutWithAuth>
+  )
+}

--- a/apps/studio/routes/project/$ref/observability.tsx
+++ b/apps/studio/routes/project/$ref/observability.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import ObservabilityLayout from '@/components/layouts/ObservabilityLayout/ObservabilityLayout'
+
+export const Route = createFileRoute('/project/$ref/observability')({
+  component: ObservabilityShell,
+})
+
+function ObservabilityShell() {
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as { observabilityLayoutTitle?: string } | undefined)
+        ?.observabilityLayoutTitle ?? '',
+  })
+
+  return (
+    <ObservabilityLayout title={title}>
+      <Outlet />
+    </ObservabilityLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/observability/$id.tsx
+++ b/apps/studio/routes/project/$ref/observability/$id.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ObservabilityReportPage from '@/pages/project/[ref]/observability/[id]'
+
+export const Route = createFileRoute('/project/$ref/observability/$id')({
+  component: ObservabilityReportRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Report',
+  },
+})
+
+function ObservabilityReportRoute() {
+  return <ObservabilityReportPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/api-overview.tsx
+++ b/apps/studio/routes/project/$ref/observability/api-overview.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ApiReport from '@/pages/project/[ref]/observability/api-overview'
+
+export const Route = createFileRoute('/project/$ref/observability/api-overview')({
+  component: ObservabilityApiOverviewRoute,
+  staticData: {
+    observabilityLayoutTitle: 'API Gateway',
+  },
+})
+
+function ObservabilityApiOverviewRoute() {
+  return <ApiReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/auth.tsx
+++ b/apps/studio/routes/project/$ref/observability/auth.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AuthReport from '@/pages/project/[ref]/observability/auth'
+
+export const Route = createFileRoute('/project/$ref/observability/auth')({
+  component: ObservabilityAuthRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Auth',
+  },
+})
+
+function ObservabilityAuthRoute() {
+  return <AuthReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/database.tsx
+++ b/apps/studio/routes/project/$ref/observability/database.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import DatabaseReport from '@/pages/project/[ref]/observability/database'
+
+export const Route = createFileRoute('/project/$ref/observability/database')({
+  component: ObservabilityDatabaseRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Database',
+  },
+})
+
+function ObservabilityDatabaseRoute() {
+  return <DatabaseReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/edge-functions.tsx
+++ b/apps/studio/routes/project/$ref/observability/edge-functions.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import EdgeFunctionsReportV2 from '@/pages/project/[ref]/observability/edge-functions'
+
+export const Route = createFileRoute('/project/$ref/observability/edge-functions')({
+  component: ObservabilityEdgeFunctionsRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Edge Functions',
+  },
+})
+
+function ObservabilityEdgeFunctionsRoute() {
+  return <EdgeFunctionsReportV2 dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/index.tsx
+++ b/apps/studio/routes/project/$ref/observability/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import UserReportPage from '@/pages/project/[ref]/observability/index'
+
+export const Route = createFileRoute('/project/$ref/observability/')({
+  component: ObservabilityIndexRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Overview',
+  },
+})
+
+function ObservabilityIndexRoute() {
+  return <UserReportPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/postgrest.tsx
+++ b/apps/studio/routes/project/$ref/observability/postgrest.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import PostgRESTReport from '@/pages/project/[ref]/observability/postgrest'
+
+export const Route = createFileRoute('/project/$ref/observability/postgrest')({
+  component: ObservabilityPostgRESTRoute,
+  staticData: {
+    observabilityLayoutTitle: 'PostgREST',
+  },
+})
+
+function ObservabilityPostgRESTRoute() {
+  return <PostgRESTReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/query-insights.tsx
+++ b/apps/studio/routes/project/$ref/observability/query-insights.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import QueryInsightsReport from '@/pages/project/[ref]/observability/query-insights'
+
+export const Route = createFileRoute('/project/$ref/observability/query-insights')({
+  component: ObservabilityQueryInsightsRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Query insights',
+  },
+})
+
+function ObservabilityQueryInsightsRoute() {
+  return <QueryInsightsReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/query-performance.tsx
+++ b/apps/studio/routes/project/$ref/observability/query-performance.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import QueryPerformanceReport from '@/pages/project/[ref]/observability/query-performance'
+
+export const Route = createFileRoute('/project/$ref/observability/query-performance')({
+  component: ObservabilityQueryPerformanceRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Query Performance',
+  },
+})
+
+function ObservabilityQueryPerformanceRoute() {
+  return <QueryPerformanceReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/realtime.tsx
+++ b/apps/studio/routes/project/$ref/observability/realtime.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import RealtimeReport from '@/pages/project/[ref]/observability/realtime'
+
+export const Route = createFileRoute('/project/$ref/observability/realtime')({
+  component: ObservabilityRealtimeRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Realtime',
+  },
+})
+
+function ObservabilityRealtimeRoute() {
+  return <RealtimeReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/observability/storage.tsx
+++ b/apps/studio/routes/project/$ref/observability/storage.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import StorageReport from '@/pages/project/[ref]/observability/storage'
+
+export const Route = createFileRoute('/project/$ref/observability/storage')({
+  component: ObservabilityStorageRoute,
+  staticData: {
+    observabilityLayoutTitle: 'Storage',
+  },
+})
+
+function ObservabilityStorageRoute() {
+  return <StorageReport dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/realtime.tsx
+++ b/apps/studio/routes/project/$ref/realtime.tsx
@@ -1,0 +1,23 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import RealtimeLayout from '@/components/layouts/RealtimeLayout/RealtimeLayout'
+
+export const Route = createFileRoute('/project/$ref/realtime')({
+  component: RealtimeShell,
+})
+
+function RealtimeShell() {
+  // `select` form: only re-render when the selected title changes. See
+  // routes/_app.tsx for the full rationale.
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as { realtimeLayoutTitle?: string } | undefined)
+        ?.realtimeLayoutTitle ?? '',
+  })
+
+  return (
+    <RealtimeLayout title={title}>
+      <Outlet />
+    </RealtimeLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/realtime/inspector.tsx
+++ b/apps/studio/routes/project/$ref/realtime/inspector.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import InspectorPage from '@/pages/project/[ref]/realtime/inspector'
+
+export const Route = createFileRoute('/project/$ref/realtime/inspector')({
+  component: RealtimeInspectorRoute,
+  staticData: {
+    realtimeLayoutTitle: 'Realtime Inspector',
+  },
+})
+
+function RealtimeInspectorRoute() {
+  return <InspectorPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/realtime/policies.tsx
+++ b/apps/studio/routes/project/$ref/realtime/policies.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import RealtimePoliciesPage from '@/pages/project/[ref]/realtime/policies'
+
+export const Route = createFileRoute('/project/$ref/realtime/policies')({
+  component: RealtimePoliciesRoute,
+  staticData: {
+    realtimeLayoutTitle: 'Policies',
+  },
+})
+
+function RealtimePoliciesRoute() {
+  return <RealtimePoliciesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/realtime/settings.tsx
+++ b/apps/studio/routes/project/$ref/realtime/settings.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import RealtimeSettingsPage from '@/pages/project/[ref]/realtime/settings'
+
+export const Route = createFileRoute('/project/$ref/realtime/settings')({
+  component: RealtimeSettingsRoute,
+  staticData: {
+    realtimeLayoutTitle: 'Realtime Settings',
+  },
+})
+
+function RealtimeSettingsRoute() {
+  return <RealtimeSettingsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings.tsx
+++ b/apps/studio/routes/project/$ref/settings.tsx
@@ -1,0 +1,34 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import SettingsLayout from '@/components/layouts/ProjectSettingsLayout/SettingsLayout'
+
+export const Route = createFileRoute('/project/$ref/settings')({
+  component: SettingsShell,
+})
+
+type SettingsStaticData = {
+  settingsLayoutTitle?: string
+  // settings/api is a redirect-only page; skip the SettingsLayout wrap
+  // so we don't render the sidebar around a `return null`.
+  skipSettingsLayout?: boolean
+}
+
+function SettingsShell() {
+  const skip = useMatches({
+    select: (matches) =>
+      matches.some((m) => (m.staticData as SettingsStaticData | undefined)?.skipSettingsLayout),
+  })
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as SettingsStaticData | undefined)
+        ?.settingsLayoutTitle ?? '',
+  })
+
+  if (skip) return <Outlet />
+
+  return (
+    <SettingsLayout title={title}>
+      <Outlet />
+    </SettingsLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/settings/addons.tsx
+++ b/apps/studio/routes/project/$ref/settings/addons.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProjectAddons from '@/pages/project/[ref]/settings/addons'
+
+export const Route = createFileRoute('/project/$ref/settings/addons')({
+  component: SettingsAddonsRoute,
+  staticData: { settingsLayoutTitle: 'Add-ons' },
+})
+
+function SettingsAddonsRoute() {
+  return <ProjectAddons dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/api-keys.tsx
+++ b/apps/studio/routes/project/$ref/settings/api-keys.tsx
@@ -1,0 +1,21 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import ApiKeysLayout from '@/components/layouts/APIKeys/APIKeysLayout'
+
+export const Route = createFileRoute('/project/$ref/settings/api-keys')({
+  component: ApiKeysShell,
+})
+
+// Sub-shell mirroring the existing pages-router pattern: both
+// api-keys/index and api-keys/legacy wrap their content in
+// <SettingsLayout title=...><ApiKeysLayout>{page}</ApiKeysLayout></SettingsLayout>.
+// The parent settings.tsx shell handles SettingsLayout (title via the
+// leaf's `settingsLayoutTitle` staticData); this sub-shell adds the
+// ApiKeysLayout tab strip both leaves share.
+function ApiKeysShell() {
+  return (
+    <ApiKeysLayout>
+      <Outlet />
+    </ApiKeysLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/settings/api-keys/index.tsx
+++ b/apps/studio/routes/project/$ref/settings/api-keys/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ApiKeysNewPage from '@/pages/project/[ref]/settings/api-keys/index'
+
+export const Route = createFileRoute('/project/$ref/settings/api-keys/')({
+  component: SettingsApiKeysIndexRoute,
+  staticData: { settingsLayoutTitle: 'API Keys' },
+})
+
+function SettingsApiKeysIndexRoute() {
+  return <ApiKeysNewPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/api-keys/legacy.tsx
+++ b/apps/studio/routes/project/$ref/settings/api-keys/legacy.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ApiKeysLegacyPage from '@/pages/project/[ref]/settings/api-keys/legacy'
+
+export const Route = createFileRoute('/project/$ref/settings/api-keys/legacy')({
+  component: SettingsApiKeysLegacyRoute,
+  staticData: { settingsLayoutTitle: 'API Keys (Legacy)' },
+})
+
+function SettingsApiKeysLegacyRoute() {
+  return <ApiKeysLegacyPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/api.tsx
+++ b/apps/studio/routes/project/$ref/settings/api.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ApiSettings from '@/pages/project/[ref]/settings/api'
+
+export const Route = createFileRoute('/project/$ref/settings/api')({
+  component: SettingsApiRoute,
+  // Page is a useEffect redirect that returns null; SettingsLayout
+  // (the sidebar shell) shouldn't render around it.
+  staticData: { skipSettingsLayout: true },
+})
+
+function SettingsApiRoute() {
+  return <ApiSettings dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/billing/usage.tsx
+++ b/apps/studio/routes/project/$ref/settings/billing/usage.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProjectBillingUsage from '@/pages/project/[ref]/settings/billing/usage'
+
+export const Route = createFileRoute('/project/$ref/settings/billing/usage')({
+  component: SettingsBillingUsageRoute,
+  staticData: { settingsLayoutTitle: 'Usage' },
+})
+
+function SettingsBillingUsageRoute() {
+  return <ProjectBillingUsage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/compute-and-disk.tsx
+++ b/apps/studio/routes/project/$ref/settings/compute-and-disk.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ComputeAndDiskPage from '@/pages/project/[ref]/settings/compute-and-disk'
+
+export const Route = createFileRoute('/project/$ref/settings/compute-and-disk')({
+  component: SettingsComputeAndDiskRoute,
+  staticData: { settingsLayoutTitle: 'Compute and Disk' },
+})
+
+function SettingsComputeAndDiskRoute() {
+  return <ComputeAndDiskPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/dashboard.tsx
+++ b/apps/studio/routes/project/$ref/settings/dashboard.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import Preferences from '@/pages/project/[ref]/settings/dashboard'
+
+export const Route = createFileRoute('/project/$ref/settings/dashboard')({
+  component: SettingsDashboardRoute,
+  staticData: { settingsLayoutTitle: 'General' },
+})
+
+function SettingsDashboardRoute() {
+  return <Preferences dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/general.tsx
+++ b/apps/studio/routes/project/$ref/settings/general.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProjectSettings from '@/pages/project/[ref]/settings/general'
+
+export const Route = createFileRoute('/project/$ref/settings/general')({
+  component: SettingsGeneralRoute,
+  staticData: { settingsLayoutTitle: 'General' },
+})
+
+function SettingsGeneralRoute() {
+  return <ProjectSettings dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/infrastructure.tsx
+++ b/apps/studio/routes/project/$ref/settings/infrastructure.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProjectInfrastructure from '@/pages/project/[ref]/settings/infrastructure'
+
+export const Route = createFileRoute('/project/$ref/settings/infrastructure')({
+  component: SettingsInfrastructureRoute,
+  staticData: { settingsLayoutTitle: 'Infrastructure' },
+})
+
+function SettingsInfrastructureRoute() {
+  return <ProjectInfrastructure dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/integrations.tsx
+++ b/apps/studio/routes/project/$ref/settings/integrations.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProjectSettingsIntegrations from '@/pages/project/[ref]/settings/integrations'
+
+export const Route = createFileRoute('/project/$ref/settings/integrations')({
+  component: SettingsIntegrationsRoute,
+  staticData: { settingsLayoutTitle: 'Integrations' },
+})
+
+function SettingsIntegrationsRoute() {
+  return <ProjectSettingsIntegrations dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/jwt/index.tsx
+++ b/apps/studio/routes/project/$ref/settings/jwt/index.tsx
@@ -1,0 +1,20 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import JWTKeysLayout from '@/components/layouts/JWTKeys/JWTKeysLayout'
+import JWTSigningKeysPage from '@/pages/project/[ref]/settings/jwt/index'
+
+export const Route = createFileRoute('/project/$ref/settings/jwt/')({
+  component: SettingsJwtIndexRoute,
+  staticData: { settingsLayoutTitle: 'JWT Keys' },
+})
+
+// Inline the JWTKeysLayout wrap here rather than via a `settings/jwt.tsx`
+// sub-shell — jwt/legacy doesn't use JWTKeysLayout, so a shared
+// sub-shell would wrap legacy in the wrong layout.
+function SettingsJwtIndexRoute() {
+  return (
+    <JWTKeysLayout>
+      <JWTSigningKeysPage dehydratedState={undefined} />
+    </JWTKeysLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/settings/jwt/legacy.tsx
+++ b/apps/studio/routes/project/$ref/settings/jwt/legacy.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import JWTKeysLegacyPage from '@/pages/project/[ref]/settings/jwt/legacy'
+
+export const Route = createFileRoute('/project/$ref/settings/jwt/legacy')({
+  component: SettingsJwtLegacyRoute,
+  staticData: { settingsLayoutTitle: 'JWT Keys (Legacy)' },
+})
+
+function SettingsJwtLegacyRoute() {
+  return <JWTKeysLegacyPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/log-drains.tsx
+++ b/apps/studio/routes/project/$ref/settings/log-drains.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import LogDrainsSettings from '@/pages/project/[ref]/settings/log-drains'
+
+export const Route = createFileRoute('/project/$ref/settings/log-drains')({
+  component: SettingsLogDrainsRoute,
+  staticData: { settingsLayoutTitle: 'Log Drains' },
+})
+
+function SettingsLogDrainsRoute() {
+  return <LogDrainsSettings dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/webhooks/$endpointId.tsx
+++ b/apps/studio/routes/project/$ref/settings/webhooks/$endpointId.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProjectWebhookEndpointSettings from '@/pages/project/[ref]/settings/webhooks/[endpointId]'
+
+export const Route = createFileRoute('/project/$ref/settings/webhooks/$endpointId')({
+  component: SettingsWebhooksEndpointRoute,
+  staticData: { settingsLayoutTitle: 'Webhooks' },
+})
+
+function SettingsWebhooksEndpointRoute() {
+  return <ProjectWebhookEndpointSettings dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/settings/webhooks/index.tsx
+++ b/apps/studio/routes/project/$ref/settings/webhooks/index.tsx
@@ -1,0 +1,12 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import ProjectWebhooksSettings from '@/pages/project/[ref]/settings/webhooks/index'
+
+export const Route = createFileRoute('/project/$ref/settings/webhooks/')({
+  component: SettingsWebhooksIndexRoute,
+  staticData: { settingsLayoutTitle: 'Webhooks' },
+})
+
+function SettingsWebhooksIndexRoute() {
+  return <ProjectWebhooksSettings dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/sql.tsx
+++ b/apps/studio/routes/project/$ref/sql.tsx
@@ -1,0 +1,29 @@
+import { createFileRoute, Outlet } from '@tanstack/react-router'
+
+import { EditorBaseLayout } from '@/components/layouts/editors/EditorBaseLayout'
+import SQLEditorLayout from '@/components/layouts/SQLEditorLayout/SQLEditorLayout'
+import { SQLEditorMenu } from '@/components/layouts/SQLEditorLayout/SQLEditorMenu'
+
+export const Route = createFileRoute('/project/$ref/sql')({
+  component: SQLEditorShell,
+})
+
+// Twin of routes/project/$ref/editor.tsx — all four sql/* leaves share
+// identical layout wrapping (`<DefaultLayout><EditorBaseLayout productMenu>
+// <SQLEditorLayout>{page}</SQLEditorLayout></EditorBaseLayout>`), so the
+// shell hardcodes the props with no staticData overrides. DefaultLayout
+// is provided by the parent `routes/project/$ref.tsx` shell.
+//
+// EditorBaseLayout wraps in <ProjectLayoutWithAuth>; SQLEditorLayout adds
+// its own `withAuth` HOC but doesn't add another ProjectLayout — so no
+// double-render concerns, only doubled auth check (a no-op when already
+// authenticated).
+function SQLEditorShell() {
+  return (
+    <EditorBaseLayout productMenu={<SQLEditorMenu />} product="SQL Editor">
+      <SQLEditorLayout>
+        <Outlet />
+      </SQLEditorLayout>
+    </EditorBaseLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/sql/$id.tsx
+++ b/apps/studio/routes/project/$ref/sql/$id.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import SqlEditor from '@/pages/project/[ref]/sql/[id]'
+
+export const Route = createFileRoute('/project/$ref/sql/$id')({
+  component: SQLEditorDetailRoute,
+})
+
+function SQLEditorDetailRoute() {
+  return <SqlEditor dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/sql/examples.tsx
+++ b/apps/studio/routes/project/$ref/sql/examples.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import SqlExamples from '@/pages/project/[ref]/sql/examples'
+
+export const Route = createFileRoute('/project/$ref/sql/examples')({
+  component: SqlExamplesRoute,
+})
+
+function SqlExamplesRoute() {
+  return <SqlExamples dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/sql/index.tsx
+++ b/apps/studio/routes/project/$ref/sql/index.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import SQLEditorIndexPage from '@/pages/project/[ref]/sql/index'
+
+export const Route = createFileRoute('/project/$ref/sql/')({
+  component: SQLEditorIndexRoute,
+})
+
+function SQLEditorIndexRoute() {
+  return <SQLEditorIndexPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/sql/templates.tsx
+++ b/apps/studio/routes/project/$ref/sql/templates.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import SqlTemplates from '@/pages/project/[ref]/sql/templates'
+
+export const Route = createFileRoute('/project/$ref/sql/templates')({
+  component: SQLTemplatesRoute,
+})
+
+function SQLTemplatesRoute() {
+  return <SqlTemplates dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage.tsx
+++ b/apps/studio/routes/project/$ref/storage.tsx
@@ -1,0 +1,61 @@
+import { createFileRoute, Outlet, useMatches } from '@tanstack/react-router'
+
+import { StorageBucketsLayout } from '@/components/layouts/StorageLayout/StorageBucketsLayout'
+import StorageLayout from '@/components/layouts/StorageLayout/StorageLayout'
+
+export const Route = createFileRoute('/project/$ref/storage')({
+  component: StorageShell,
+})
+
+type StorageStaticData = {
+  storageLayoutTitle?: string
+  // Most storage leaves wrap in <StorageBucketsLayout> (the bucket-tab
+  // sub-nav). Bucket detail pages (files/analytics/vectors $bucketId) skip
+  // it and render a full-bleed bucket UI under StorageLayout only.
+  skipStorageBucketsLayout?: boolean
+  // Inner-layout overrides — used by /storage/s3 which passes its own
+  // title and hides the subtitle. Most leaves leave these undefined.
+  storageBucketsLayoutTitle?: string
+  storageBucketsLayoutHideSubtitle?: boolean
+}
+
+function StorageShell() {
+  // `select` form across each field — only re-render when the specific
+  // value changes. See routes/_app.tsx for the full rationale.
+  const title = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as StorageStaticData | undefined)
+        ?.storageLayoutTitle ?? '',
+  })
+  const skipBuckets = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as StorageStaticData | undefined)
+        ?.skipStorageBucketsLayout ?? false,
+  })
+  const bucketsTitle = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as StorageStaticData | undefined)
+        ?.storageBucketsLayoutTitle,
+  })
+  const bucketsHideSubtitle = useMatches({
+    select: (matches) =>
+      (matches[matches.length - 1]?.staticData as StorageStaticData | undefined)
+        ?.storageBucketsLayoutHideSubtitle ?? false,
+  })
+
+  if (skipBuckets) {
+    return (
+      <StorageLayout title={title}>
+        <Outlet />
+      </StorageLayout>
+    )
+  }
+
+  return (
+    <StorageLayout title={title}>
+      <StorageBucketsLayout title={bucketsTitle} hideSubtitle={bucketsHideSubtitle}>
+        <Outlet />
+      </StorageBucketsLayout>
+    </StorageLayout>
+  )
+}

--- a/apps/studio/routes/project/$ref/storage/analytics/buckets/$bucketId.tsx
+++ b/apps/studio/routes/project/$ref/storage/analytics/buckets/$bucketId.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import AnalyticsBucketPage from '@/pages/project/[ref]/storage/analytics/buckets/[bucketId]'
+
+export const Route = createFileRoute('/project/$ref/storage/analytics/buckets/$bucketId')({
+  component: StorageAnalyticsBucketRoute,
+  staticData: {
+    storageLayoutTitle: 'Buckets',
+    skipStorageBucketsLayout: true,
+  },
+})
+
+function StorageAnalyticsBucketRoute() {
+  return <AnalyticsBucketPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/analytics/index.tsx
+++ b/apps/studio/routes/project/$ref/storage/analytics/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import StorageAnalyticsPage from '@/pages/project/[ref]/storage/analytics/index'
+
+export const Route = createFileRoute('/project/$ref/storage/analytics/')({
+  component: StorageAnalyticsIndexRoute,
+  staticData: {
+    storageLayoutTitle: 'Analytics',
+  },
+})
+
+function StorageAnalyticsIndexRoute() {
+  return <StorageAnalyticsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/files/buckets/$bucketId.tsx
+++ b/apps/studio/routes/project/$ref/storage/files/buckets/$bucketId.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import BucketPage from '@/pages/project/[ref]/storage/files/buckets/[bucketId]'
+
+export const Route = createFileRoute('/project/$ref/storage/files/buckets/$bucketId')({
+  component: StorageFilesBucketRoute,
+  // Bucket detail pages skip StorageBucketsLayout — they render the
+  // bucket UI full-bleed under StorageLayout only.
+  staticData: {
+    storageLayoutTitle: 'Buckets',
+    skipStorageBucketsLayout: true,
+  },
+})
+
+function StorageFilesBucketRoute() {
+  return <BucketPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/files/index.tsx
+++ b/apps/studio/routes/project/$ref/storage/files/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import StorageFilesPage from '@/pages/project/[ref]/storage/files/index'
+
+export const Route = createFileRoute('/project/$ref/storage/files/')({
+  component: StorageFilesIndexRoute,
+  staticData: {
+    storageLayoutTitle: 'Files',
+  },
+})
+
+function StorageFilesIndexRoute() {
+  return <StorageFilesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/files/policies.tsx
+++ b/apps/studio/routes/project/$ref/storage/files/policies.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import FilesPoliciesPage from '@/pages/project/[ref]/storage/files/policies'
+
+export const Route = createFileRoute('/project/$ref/storage/files/policies')({
+  component: StorageFilesPoliciesRoute,
+  staticData: {
+    storageLayoutTitle: 'Policies',
+  },
+})
+
+function StorageFilesPoliciesRoute() {
+  return <FilesPoliciesPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/files/settings.tsx
+++ b/apps/studio/routes/project/$ref/storage/files/settings.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import FilesSettingsPage from '@/pages/project/[ref]/storage/files/settings'
+
+export const Route = createFileRoute('/project/$ref/storage/files/settings')({
+  component: StorageFilesSettingsRoute,
+  staticData: {
+    storageLayoutTitle: 'Settings',
+  },
+})
+
+function StorageFilesSettingsRoute() {
+  return <FilesSettingsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/s3.tsx
+++ b/apps/studio/routes/project/$ref/storage/s3.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import S3SettingsPage from '@/pages/project/[ref]/storage/s3'
+
+export const Route = createFileRoute('/project/$ref/storage/s3')({
+  component: StorageS3Route,
+  staticData: {
+    storageLayoutTitle: 'S3 Configuration',
+    storageBucketsLayoutTitle: 'S3 Configuration',
+    storageBucketsLayoutHideSubtitle: true,
+  },
+})
+
+function StorageS3Route() {
+  return <S3SettingsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/vectors/buckets/$bucketId.tsx
+++ b/apps/studio/routes/project/$ref/storage/vectors/buckets/$bucketId.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import VectorsBucketPage from '@/pages/project/[ref]/storage/vectors/buckets/[bucketId]'
+
+export const Route = createFileRoute('/project/$ref/storage/vectors/buckets/$bucketId')({
+  component: StorageVectorsBucketRoute,
+  staticData: {
+    storageLayoutTitle: 'Buckets',
+    skipStorageBucketsLayout: true,
+  },
+})
+
+function StorageVectorsBucketRoute() {
+  return <VectorsBucketPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/project/$ref/storage/vectors/index.tsx
+++ b/apps/studio/routes/project/$ref/storage/vectors/index.tsx
@@ -1,0 +1,14 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import StorageVectorsPage from '@/pages/project/[ref]/storage/vectors/index'
+
+export const Route = createFileRoute('/project/$ref/storage/vectors/')({
+  component: StorageVectorsIndexRoute,
+  staticData: {
+    storageLayoutTitle: 'Vectors',
+  },
+})
+
+function StorageVectorsIndexRoute() {
+  return <StorageVectorsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/redeem.tsx
+++ b/apps/studio/routes/redeem.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import RedeemCreditsPage from '@/pages/redeem'
+
+export const Route = createFileRoute('/redeem')({
+  component: RedeemRoute,
+})
+
+function RedeemRoute() {
+  return <RedeemCreditsPage dehydratedState={undefined} />
+}

--- a/apps/studio/routes/verify-email.tsx
+++ b/apps/studio/routes/verify-email.tsx
@@ -1,0 +1,11 @@
+import { createFileRoute } from '@tanstack/react-router'
+
+import VerifyEmailPage from '@/pages/verify-email'
+
+export const Route = createFileRoute('/verify-email')({
+  component: VerifyEmailRoute,
+})
+
+function VerifyEmailRoute() {
+  return <VerifyEmailPage dehydratedState={undefined} />
+}


### PR DESCRIPTION
**Stack 5/6** of the TanStack Start migration (#46424) — the bulk. Stacked on **#47113** (S4).

> [!NOTE]
> The route files are thin wrappers rendering the existing pages-router page components via the compat shims. The 9 non-route files are the minimal `pages/`/component edits those routes depend on (see below) — all verified Next-safe by a full Next build.

## What's in this PR
- **~164 route files** under `routes/_app/project/$ref/**` + the `/org/_`, `/project/_` catch-alls — every product surface (database, editor, sql, auth, storage, functions, realtime, logs, observability, advisors, settings, branches…).
- **9 supporting edits:**
  - hoist `BranchesPageWrapper` / `EdgeFunctionsIndexPageWrapper` out of `getLayout` so routes can import them (no behaviour change on Next),
  - move `DefaultLayout` to the root for the logs page,
  - `ConnectStepsSection` `import.meta.glob` for Vite content-module discovery (no-op on Next/webpack),
  - the `/org/_`, `/project/_` catch-alls, `api/server.js`.
- `routeTree.gen.ts` — regenerated for the full set; **byte-identical to the migration branch** now that all routes are present.

## Review tip
Route files are uniform wrappers — skim them. The 9 non-route edits are the real review surface.

## Verification
On top of S1–S4: `studio` typecheck ✓, lint (0 errors) ✓, **Next build ✓ (181/181 static pages)**.
