### PR TITLE
fix(studio): allow newlines in SMS OTP template and update types

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/AuthProvidersForm.types.ts
@@ -14,7 +14,7 @@ export interface Provider {
   properties: {
     [x: string]: {
       title: string
-      type: 'boolean' | 'string' | 'select' | 'number'
+      type: 'boolean' | 'string' | 'select' | 'number' | 'multiline-string' | 'datetime'
       enum: Enum[]
       show: {
         key: string

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -101,7 +101,10 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
           if (isDoubleNegative) {
             values[key] = !(config as any)[key]
           } else {
-            const configValue = (config as any)[key]
+            let configValue = (config as any)[key]
+            if (key === 'SMS_TEMPLATE' && typeof configValue === 'string') {
+              configValue = configValue.replace(/\\n/g, '\n')
+            }
             values[key] = configValue
               ? configValue
               : provider.properties[key].type === 'boolean'


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #6435 

Currently, users who had previously configured their SMS templates when the input field was a single-line input might have escaped newline sequences (like `\n` or `\\n`) stored directly in their configuration database. When the field was upgraded to a multiline textarea, these escaped newlines were not converted back to real newlines, causing the form to load literal `\n` characters in the editor instead of actual line breaks.

Additionally, the TypeScript types for the `Provider` interface did not include `'multiline-string'` or `'datetime'` in the union type of `properties` types.

## What is the new behavior?

1. **Escaped Newline Conversion on Load:** The configuration loading logic in `getValuesForProvider` within `ProviderForm.tsx` now checks for the `SMS_TEMPLATE` key. If present, it replaces literal `\\n` sequences with actual newlines (`\n`) before initializing the form. This ensures that the textarea renders actual newlines and saves actual newlines to the database.
2. **TypeScript Type Union Sync:** Updated `AuthProvidersForm.types.ts` to add `'multiline-string'` and `'datetime'` to the `type` union within the provider configuration schema.

## How was this tested?

1. **Type Checking:** 
   Ran `pnpm typecheck` in `apps/studio` successfully to verify typescript compilation.
2. **Unit Tests:**
   Ran vitest unit tests in `apps/studio` specifically for the `Auth` interface components:
   `pnpm test components/interfaces/Auth`
   All tests passed successfully with no regressions.

## Tradeoffs or Open Questions

- We restricted the conversion of escaped newlines specifically to the `SMS_TEMPLATE` field. If other multiline-string settings are introduced in the future that also need migration of literal `\n` symbols, we could generalise this logic to look at the field's schema `type === 'multiline-string'` rather than check the field name explicitly. However, keeping the migration check restricted to `SMS_TEMPLATE` is currently the safest approach to minimize unintended side effects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiline-string and datetime field types in authentication provider configuration.

* **Bug Fixes**
  * Fixed SMS template configuration to properly display newlines when loading settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->