### PR TITLE
Remove errorneous class name on global file size limit form input

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageSettings/StorageSettings.tsx
@@ -335,7 +335,6 @@ export const StorageSettings = () => {
                                 hideMessage
                                 layout="flex-row-reverse"
                                 label="Global file size limit"
-                                className="[&>div]:md:w-1/2 [&>div]:xl:w-2/5 [&>div>div]:w-full [&>div]:min-w-100"
                                 description={
                                   <>
                                     Restrict the size of files uploaded across all buckets.{' '}


### PR DESCRIPTION
## Context

Storage settings "Global file size limit" field goes off the card on smaller viewports
<img width="1592" height="1258" alt="image" src="https://github.com/user-attachments/assets/bdc58ff1-f54a-4e09-adc8-79c8a1a0b3f1" />

Just removes a className on the FormItemLayout that's causing it - have verified that doesn't cause other issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the layout configuration of the Global file size limit field in Storage Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->