### PR TITLE
fix(studio): make the DataTable date-range filter inclusive of its bounds

### DIFF
--- a/apps/studio/components/ui/DataTable/DataTable.utils.test.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { inDateRange } from './DataTable.utils'
+
+const rowWith = (date: Date | string) => ({ getValue: () => date }) as any
+
+describe('inDateRange', () => {
+  // Built from local components so the same-day (local) check is timezone-stable.
+  const start = new Date(2024, 0, 10, 0, 0, 0)
+  const end = new Date(2024, 0, 20, 0, 0, 0)
+
+  it('includes a timestamp on the start boundary', () => {
+    expect(inDateRange(rowWith(start), 'ts', [start, end], () => {})).toBe(true)
+  })
+
+  it('includes a timestamp on the end boundary', () => {
+    expect(inDateRange(rowWith(end), 'ts', [start, end], () => {})).toBe(true)
+  })
+
+  it('includes a timestamp inside the range', () => {
+    const mid = new Date(2024, 0, 15, 12, 0, 0)
+    expect(inDateRange(rowWith(mid), 'ts', [start, end], () => {})).toBe(true)
+  })
+
+  it('excludes a timestamp before the start', () => {
+    const before = new Date(2024, 0, 9, 23, 59, 59)
+    expect(inDateRange(rowWith(before), 'ts', [start, end], () => {})).toBe(false)
+  })
+
+  it('excludes a timestamp after the end', () => {
+    const after = new Date(2024, 0, 20, 0, 0, 1)
+    expect(inDateRange(rowWith(after), 'ts', [start, end], () => {})).toBe(false)
+  })
+
+  it('matches the same day when no end is provided', () => {
+    const sameDay = new Date(2024, 0, 10, 18, 30, 0)
+    expect(inDateRange(rowWith(sameDay), 'ts', [start], () => {})).toBe(true)
+  })
+
+  it('returns false for an invalid date', () => {
+    expect(inDateRange(rowWith('not-a-date'), 'ts', [start, end], () => {})).toBe(false)
+  })
+})

--- a/apps/studio/components/ui/DataTable/DataTable.utils.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.utils.ts
@@ -44,7 +44,9 @@ export const inDateRange: FilterFn<any> = (row, columnId, value) => {
   // if no end date, check if it's the same day
   if (!end) return isSameDay(date, start)
 
-  return isAfter(date, start) && isBefore(date, end)
+  // inclusive range: a row whose timestamp lands exactly on the start or end
+  // boundary belongs in the range (isAfter/isBefore are strict comparisons)
+  return !isBefore(date, start) && !isAfter(date, end)
 }
 
 inDateRange.autoRemove = (val: any) => !Array.isArray(val) || !val.length || !isArrayOfDates(val)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`inDateRange` in `apps/studio/components/ui/DataTable/DataTable.utils.ts` is the filter function behind the DataTable date-range picker (used by Unified Logs, etc.). It compares with strict bounds:

```ts
return isAfter(date, start) && isBefore(date, end)
```

`date-fns` `isAfter` / `isBefore` are strict (`>` / `<`), so a row whose timestamp lands exactly on the selected start or end boundary is excluded. A log written at the exact start (or end) of a chosen window silently disappears from the filtered results.

## What is the new behavior?

The bounds are inclusive:

```ts
return !isBefore(date, start) && !isAfter(date, end)
```

so a timestamp equal to the start or end is kept. Inside/outside/no-end behavior is unchanged.

## Additional context

Adds `DataTable.utils.test.ts` covering the start boundary, end boundary, inside, before-start, after-end, no-end same-day, and invalid-date cases. The two boundary tests fail against the previous strict comparison and pass with this change. `prettier --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed date range filtering to properly include start and end dates in filter results.

* **Tests**
  * Added comprehensive test coverage for date range filtering functionality, validating boundary behavior and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->