### PR TITLE
fix(studio): make upload ETA independent of file order

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.test.ts
@@ -7,6 +7,7 @@ import {
 } from '@/components/interfaces/Storage/Storage.constants'
 import type { StorageItem } from '@/components/interfaces/Storage/Storage.types'
 import {
+  calculateTotalRemainingTime,
   getPathAlongFoldersToIndex,
   getPathAlongOpenedFolders,
   sanitizeNameForDuplicateInColumn,
@@ -274,5 +275,33 @@ describe('sanitizeNameForDuplicateInColumn', () => {
         ' (1).myfile'
       )
     })
+  })
+})
+
+describe('calculateTotalRemainingTime', () => {
+  const progress = (remainingBytes: number, remainingTime: number) => ({
+    percentage: 0,
+    elapsed: 0,
+    uploadSpeed: 0,
+    remainingBytes,
+    remainingTime,
+  })
+
+  it('returns 0 when there are no remaining bytes', () => {
+    expect(calculateTotalRemainingTime([])).toBe(0)
+    expect(calculateTotalRemainingTime([progress(0, 30)])).toBe(0)
+  })
+
+  it('weights each remaining time by its share of the total remaining bytes', () => {
+    // equal bytes, 10s and 20s left -> 0.5 * 10 + 0.5 * 20 = 15
+    expect(calculateTotalRemainingTime([progress(100, 10), progress(100, 20)])).toBeCloseTo(15)
+  })
+
+  it('does not depend on the order of the uploads', () => {
+    // bytes 100 / 300 -> weights 0.25 / 0.75 -> 0.25 * 10 + 0.75 * 20 = 17.5
+    const forward = calculateTotalRemainingTime([progress(100, 10), progress(300, 20)])
+    const reversed = calculateTotalRemainingTime([progress(300, 20), progress(100, 10)])
+    expect(forward).toBeCloseTo(reversed)
+    expect(forward).toBeCloseTo(17.5)
   })
 })

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.tsx
@@ -142,19 +142,20 @@ export const formatTime = (seconds: number) => {
 }
 
 export const calculateTotalRemainingTime = (progresses: UploadProgress[]) => {
-  let totalRemainingTime = 0
-  let totalRemainingBytes = 0
+  const totalRemainingBytes = progresses.reduce((sum, progress) => sum + progress.remainingBytes, 0)
+  if (totalRemainingBytes === 0) {
+    return 0
+  }
 
-  progresses.forEach((progress) => {
-    totalRemainingBytes += progress.remainingBytes
-    if (totalRemainingBytes === 0) {
-      return
-    }
-    const weight = progress.remainingBytes / totalRemainingBytes
-    totalRemainingTime += weight * progress.remainingTime
-  })
-
-  return totalRemainingTime
+  // Weight each upload's remaining time by its share of the total remaining
+  // bytes. The weights must divide by the final total, not a running prefix
+  // sum, or the result depends on iteration order (the first upload would get
+  // weight 1 and dominate the estimate).
+  return progresses.reduce(
+    (total, progress) =>
+      total + (progress.remainingBytes / totalRemainingBytes) * progress.remainingTime,
+    0
+  )
 }
 
 export const formatFolderItems = (items: StorageObject[] = [], prefix?: string): StorageItem[] => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`calculateTotalRemainingTime` (`apps/studio/.../StorageExplorer/StorageExplorer.utils.tsx`) drives the combined "time remaining" estimate shown while several files upload at once. It weights each upload's remaining time by its share of the remaining bytes, but divides by a **running prefix sum**:

```ts
progresses.forEach((progress) => {
  totalRemainingBytes += progress.remainingBytes
  if (totalRemainingBytes === 0) return
  const weight = progress.remainingBytes / totalRemainingBytes // running total
  totalRemainingTime += weight * progress.remainingTime
})
```

Because the denominator grows as it iterates, the first upload always gets weight `1`, later uploads get less than their fair share, and the weights do not sum to `1`. The estimate is wrong and depends on the order of the uploads — e.g. for `[100B/10s, 300B/20s]` it returns `25`, but reversed it returns `22.5`, whereas the correct bytes-weighted average is `17.5`.

## What is the new behavior?

Sum the total remaining bytes first, then take the bytes-weighted average of the remaining times:

```ts
const totalRemainingBytes = progresses.reduce((s, p) => s + p.remainingBytes, 0)
if (totalRemainingBytes === 0) return 0
return progresses.reduce(
  (t, p) => t + (p.remainingBytes / totalRemainingBytes) * p.remainingTime,
  0
)
```

The weights now sum to `1` and the result is order-independent (`17.5` for the example above). The empty / zero-bytes case still returns `0`. The weighted-average model is unchanged; only the denominator bug is fixed.

## Additional context

Adds tests for the zero case, the weighted average, and order independence (the latter two fail against the previous running-sum version). `prettier --check` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of remaining upload time estimates by fixing calculation logic that could vary based on upload order.

* **Tests**
  * Added comprehensive test suite for upload time estimation, covering edge cases and order independence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->