### PR TITLE
chore: Handle AuthProviders component for md output

### DIFF
--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -13,6 +13,7 @@ import { mdxjs } from 'micromark-extension-mdxjs'
 
 import { getInternalLinkBaseUrl, prefixInternalLinks } from './internal-links'
 import { Admonition } from './markdown-schema/Admonition'
+import { AuthProviders } from './markdown-schema/AuthProviders'
 import { ComputeDiskLimitsTable } from './markdown-schema/ComputeDiskLimitsTable'
 import { Link } from './markdown-schema/Link'
 import { MetricsStackCards } from './markdown-schema/MetricsStackCards'
@@ -133,6 +134,7 @@ function applySchema(parent: Parent, schema: ComponentSchema): void {
  */
 const SCHEMA: ComponentSchema = {
   Admonition,
+  AuthProviders,
   ComputeDiskLimitsTable,
   Link,
   Price,

--- a/apps/docs/internals/markdown-schema/AuthProviders.ts
+++ b/apps/docs/internals/markdown-schema/AuthProviders.ts
@@ -1,0 +1,10 @@
+import authProviders from '../../data/authProviders'
+import { withDocsBasePath } from '../internal-links'
+
+export const AuthProviders = ({ props }: { props: Record<string, unknown> }): string => {
+  const type = String(props.type ?? '')
+  return authProviders
+    .filter((p) => p.authType === type)
+    .map((p) => `- [${p.name}](${withDocsBasePath(p.href)})`)
+    .join('\n')
+}


### PR DESCRIPTION
In this PR:
 - Added alternative for `AuthProviders` React component to improve the simplified markdown output on our build pipeline.
 
 Reuses the exact authProviders data the React component imports — no duplication. Filter by type prop ("social" / "phone"), emit a list with `- [name](href)`. `withDocsBasePath` prefixes `/docs` the same way the Link handler does, so hrefs in the generated markdown look identical to existing in-doc links.

Wired into SCHEMA in internals/generate-guides-markdown.ts.
 
**How to test**

 - Open `/docs/guides/auth.md` route both on supabase.com and in the Preview of this deployment.
 - Notice the markdown content under the `Providers` section.
 - Production currently shows empty content under the phone and social providers.
 - Preview should show a list with providers in link format as displayed in the screenshot below.
 
 
<img width="803" height="647" alt="Screenshot 2026-06-19 at 13 42 53" src="https://github.com/user-attachments/assets/eb40667b-b4fa-4f45-b89e-d8079e2f65d9" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Documentation system now supports displaying available authentication providers with direct links, improving discoverability of supported auth methods and integration resources.

* **Documentation**
  * Extended the guide generation pipeline to recognize and render authentication provider information within documentation content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->