### PR TITLE
chore: prepare CODEOWNERS for group renaming

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,4 +19,4 @@
 /apps/studio/components/interfaces/Organization/Documents/          @supabase/security
 /apps/studio/pages/new/index.tsx                                    @supabase/security
 
-/packages/shared-data/compute-disk-limits.ts @supabase/infra
+/packages/shared-data/compute-disk-limits.ts @supabase/infra @supabase/platform


### PR DESCRIPTION
This PR updates CODEOWNERS to prepare for renaming infrastructure teams:

- supabase/infra → supabase/platform

The new group names are added alongside the old ones. Once the GitHub teams are renamed, a follow-up PR will remove the old group references at the bottom of the file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated repository code ownership configuration to expand the set of teams responsible for a shared disk-limits component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->