### PR TITLE
fix(studio): strip one-shot content param from SQL editor URL

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -259,7 +259,15 @@ const MonacoEditor = ({
           project_id: project?.id,
         })
         snapV2.addSnippet({ projectRef: ref, snippet })
-        router.push(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
+        // When the editor was seeded from a `content` deep-link, replace rather
+        // than push. The caller navigated to `/sql/new?content=...` (a long,
+        // one-shot URL); replacing collapses it out of history so Back returns to
+        // the originating page instead of a wasted step that re-seeds the snippet.
+        if (router.query.content) {
+          router.replace(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
+        } else {
+          router.push(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
+        }
       }
       setValue(value)
     }

--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -263,7 +263,7 @@ const MonacoEditor = ({
         // than push. The caller navigated to `/sql/new?content=...` (a long,
         // one-shot URL); replacing collapses it out of history so Back returns to
         // the originating page instead of a wasted step that re-seeds the snippet.
-        if (router.query.content) {
+        if (router.query.content !== undefined) {
           router.replace(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
         } else {
           router.push(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When you open the SQL editor with prefilled SQL via `/sql/new?content=<sql>`, the editor seeds its contents from the `content` query param, then navigates to the newly created snippet with `router.push`.

That leaves the (often very long) `/sql/new?content=...` URL in the browser history. Pressing Back returns to that URL instead of the page you came from. It is a wasted step, and it re-seeds and recreates a fresh snippet.

This affects every entry point that opens the SQL editor with prefilled SQL, such as the table definition "Open in SQL Editor" button, create index, and the SQL command menu.

## What is the new behavior?

When the editor is seeded from a `content` deep link, the navigation to the new snippet uses `router.replace` instead of `router.push`. This collapses the one-shot `/sql/new?content=...` URL out of the history. 

Back now returns straight to the page you came from, with no wasted step and no duplicate snippet. Normal new query creation (no `content` param) is unchanged.

## To test

1. Open any table in the Table Editor, switch to the Definition view, and click "Open in SQL Editor". Any deep link with prefilled SQL works. You can also visit `/project/<ref>/sql/new?content=SELECT%201` directly.
2. Confirm the SQL editor opens with the SQL prefilled, and the URL no longer contains `?content=`.
3. Press the browser Back button.
4. You return straight to the previous page in a single Back.

Before this fix, the first Back landed on `/sql/new?content=...` and recreated a snippet, and only a second Back reached the page you came from.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation behavior in SQL Editor when creating snippets from imported content, resulting in more efficient routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->