### PR TITLE
fix(studio): preserve session and redirect to MFA when AAL elevation is needed

### DIFF
--- a/apps/studio/hooks/misc/withAuth.tsx
+++ b/apps/studio/hooks/misc/withAuth.tsx
@@ -67,13 +67,18 @@ export function withAuth<T>(
     const isLoggedIn = Boolean(session)
     const isFinishedLoading = !isLoading && !isAALLoading
 
+    const isCorrectLevel = options.useHighestAAL
+      ? aalData?.currentLevel === aalData?.nextLevel
+      : true
+    const needsMfaElevation = isLoggedIn && !isCorrectLevel
+
     const redirectToSignIn = useCallback(() => {
       let pathname = location.pathname
       if (BASE_PATH) {
         pathname = pathname.replace(BASE_PATH, '')
       }
 
-      if (pathname === '/sign-in') {
+      if (pathname === '/sign-in' || pathname === '/sign-in-mfa') {
         // If the user is already on the sign in page, we don't need to redirect them
         return
       }
@@ -81,11 +86,19 @@ export function withAuth<T>(
       const searchParams = new URLSearchParams(location.search)
       searchParams.set('returnTo', pathname)
 
+      if (needsMfaElevation) {
+        // Session is valid at AAL1 but needs to be elevated to AAL2. Preserve the session
+        // and send the user to the MFA challenge — typically the IdP-initiated SSO path,
+        // where the user lands directly on /dashboard without going through /sign-in-mfa.
+        router.push(`/sign-in-mfa?${searchParams.toString()}`)
+        return
+      }
+
       // Sign out before redirecting to sign in page incase the user is stuck in a loading state
       signOut().finally(() => {
         router.push(`/sign-in?${searchParams.toString()}`)
       })
-    }, [router, signOut])
+    }, [router, signOut, needsMfaElevation])
 
     useEffect(() => {
       if (!isFinishedLoading) {
@@ -105,10 +118,6 @@ export function withAuth<T>(
         }
       }
     }, [isFinishedLoading, router, redirectToSignIn])
-
-    const isCorrectLevel = options.useHighestAAL
-      ? aalData?.currentLevel === aalData?.nextLevel
-      : true
 
     const shouldRedirect = isFinishedLoading && (!isLoggedIn || !isCorrectLevel)
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`withAuth` calls `signOut()` and redirects to `/sign-in` whenever the current AAL is below the required level. For IdP-initiated SSO logins — where the user lands directly on `/dashboard` rather than passing through `/sign-in-mfa` — this destroys the valid AAL1 session that was just established. Subsequent mgmt-api requests then return 401 Unauthorized, and the user is dumped on `/sign-in` with no way to recover except restarting the SSO flow (which loops them back to the same state).

The platform already returns an actionable `403 Insufficient AAL: MFA required` on the first mgmt-api request, but the dashboard does not capture it.

## What is the new behavior?

`withAuth` now distinguishes between "not logged in" and "needs AAL elevation":

- **Logged in but AAL1** → `router.push('/sign-in-mfa?returnTo=…')`, session preserved. The existing `/sign-in-mfa` page picks up the session, renders the MFA form, and bounces the user to `returnTo` after a successful challenge.
- **Not logged in** → unchanged: `signOut()` then redirect to `/sign-in?returnTo=…`.
- `/sign-in-mfa` is also added to the "already there, do nothing" guard so the user isn't re-redirected mid-challenge.

This relies on the gotrue client's local AAL state via `useAuthenticatorAssuranceLevelQuery`, which fires before any mgmt-api request, so no fetcher-level error parsing is needed.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-factor authentication (MFA) elevation flow to preserve user sessions instead of forcing sign-out and requiring users to restart sign-in.
  * Fixed unnecessary redirects when users are already on sign-in pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->