### PR TITLE
fix(studio): clarify OTP auth rate limit copy

### DIFF
--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.constants.ts
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.constants.ts
@@ -1,0 +1,9 @@
+export const AUTH_RATE_LIMIT_FIELD_COPY = {
+  RATE_LIMIT_OTP: {
+    label: 'Rate limit for OTP requests',
+    description:
+      'Number of OTP and magic link requests that can be sent per hour from your project',
+    unit: 'requests/h',
+    showHourlyEstimate: false,
+  },
+} as const

--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -35,6 +35,7 @@ import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 import * as z from 'zod'
 
 import { isSmtpEnabled } from '../SmtpForm/SmtpForm.utils'
+import { AUTH_RATE_LIMIT_FIELD_COPY } from './RateLimits.constants'
 import AlertError from '@/components/ui/AlertError'
 import { InlineLink } from '@/components/ui/InlineLink'
 import NoPermission from '@/components/ui/NoPermission'
@@ -502,8 +503,8 @@ export const RateLimits = () => {
                     render={({ field }) => (
                       <FormItemLayout
                         layout="flex-row-reverse"
-                        label="Rate limit for sign-ups and sign-ins"
-                        description="Number of sign-up and sign-in requests that can be made in a 5 minute interval per IP address (excludes anonymous users)"
+                        label={AUTH_RATE_LIMIT_FIELD_COPY.RATE_LIMIT_OTP.label}
+                        description={AUTH_RATE_LIMIT_FIELD_COPY.RATE_LIMIT_OTP.description}
                       >
                         <Tooltip>
                           <TooltipTrigger asChild>
@@ -516,7 +517,9 @@ export const RateLimits = () => {
                                   disabled={!canUpdateConfig}
                                 />
                                 <InputGroupAddon align="inline-end">
-                                  <InputGroupText>requests/5 min</InputGroupText>
+                                  <InputGroupText>
+                                    {AUTH_RATE_LIMIT_FIELD_COPY.RATE_LIMIT_OTP.unit}
+                                  </InputGroupText>
                                 </InputGroupAddon>
                               </InputGroup>
                             </FormControl>
@@ -533,11 +536,12 @@ export const RateLimits = () => {
                             </TooltipContent>
                           )}
                         </Tooltip>
-                        {rateLimitForm.watch('RATE_LIMIT_OTP') > 0 && (
-                          <p className="text-foreground-lighter text-sm mt-2">
-                            {rateLimitForm.watch('RATE_LIMIT_OTP') * 12} requests per hour
-                          </p>
-                        )}
+                        {AUTH_RATE_LIMIT_FIELD_COPY.RATE_LIMIT_OTP.showHourlyEstimate &&
+                          rateLimitForm.watch('RATE_LIMIT_OTP') > 0 && (
+                            <p className="text-foreground-lighter text-sm mt-2">
+                              {rateLimitForm.watch('RATE_LIMIT_OTP') * 12} requests per hour
+                            </p>
+                          )}
                       </FormItemLayout>
                     )}
                   />

--- a/apps/studio/tests/components/Auth/RateLimits.constants.test.ts
+++ b/apps/studio/tests/components/Auth/RateLimits.constants.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest'
+
+import { AUTH_RATE_LIMIT_FIELD_COPY } from '@/components/interfaces/Auth/RateLimits/RateLimits.constants'
+
+describe('Auth rate limit field copy', () => {
+  it('describes RATE_LIMIT_OTP as OTP requests, not sign-ups or sign-ins', () => {
+    const otpCopy = AUTH_RATE_LIMIT_FIELD_COPY.RATE_LIMIT_OTP
+
+    expect(otpCopy.label).toBe('Rate limit for OTP requests')
+    expect(otpCopy.description).toContain('OTP and magic link requests')
+    expect(`${otpCopy.label} ${otpCopy.description}`).not.toMatch(/sign-?ups?|sign-?ins?/i)
+  })
+
+  it('uses the per-hour unit for RATE_LIMIT_OTP', () => {
+    expect(AUTH_RATE_LIMIT_FIELD_COPY.RATE_LIMIT_OTP.unit).toBe('requests/h')
+    expect(AUTH_RATE_LIMIT_FIELD_COPY.RATE_LIMIT_OTP.showHourlyEstimate).toBe(false)
+  })
+})


### PR DESCRIPTION
## What\n\nClarifies the Studio Auth rate limit field backed by `RATE_LIMIT_OTP` so it no longer claims to control sign-up and sign-in requests. The field now describes OTP and magic link requests, uses the per-hour unit, and hides the incorrect 5-minute hourly estimate.\n\nRefs #41947\n\n## Verification\n\n- `pnpm --filter studio exec vitest --run tests/components/Auth/RateLimits.constants.test.ts`\n- `pnpm exec prettier --check apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx apps/studio/components/interfaces/Auth/RateLimits/RateLimits.constants.ts apps/studio/tests/components/Auth/RateLimits.constants.test.ts`\n- `pnpm --filter studio exec eslint components/interfaces/Auth/RateLimits/RateLimits.tsx components/interfaces/Auth/RateLimits/RateLimits.constants.ts tests/components/Auth/RateLimits.constants.test.ts`