### PR TITLE
fix: Studio misclassifies http:// auth hooks as Postgres hooks

### DIFF
--- a/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/CreateHookSheet.tsx
@@ -79,11 +79,11 @@ const FormSchema = z
   })
   .superRefine((data, ctx) => {
     if (data.selectedType === 'https') {
-      if (!data.httpsValues.url.startsWith('https://')) {
+      if (!data.httpsValues.url.startsWith('http://') && !data.httpsValues.url.startsWith('https://')) {
         ctx.addIssue({
           path: ['httpsValues', 'url'],
           code: z.ZodIssueCode.custom,
-          message: 'The URL must start with https://',
+          message: 'The URL must start with http:// or https://',
         })
       }
       if (!data.httpsValues.secret) {
@@ -360,8 +360,8 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
                           value="https"
                           id="https"
                           key="https"
-                          label="HTTPS"
-                          description="Used to call any HTTPS endpoint."
+                          label="HTTP"
+                          description="Used to call any HTTP endpoint."
                         />
                       </RadioGroupStacked>
                     </FormControl>
@@ -462,7 +462,7 @@ revoke execute on function ${ident(schema)}.${ident(functionName)} from authenti
                     render={({ field }) => (
                       <FormItemLayout
                         label="URL"
-                        description="Supabase Auth will send a HTTPS POST request to this URL each time the hook is triggered."
+                        description="Supabase Auth will send an HTTP POST request to this URL each time the hook is triggered."
                       >
                         <FormControl>
                           <Input {...field} />

--- a/apps/studio/components/interfaces/Auth/Hooks/HookCard.tsx
+++ b/apps/studio/components/interfaces/Auth/Hooks/HookCard.tsx
@@ -67,7 +67,7 @@ export const HookCard = ({ hook, onSelect }: HookCardProps) => {
             <div className="flex flex-col w-full space-y-2">
               <div className="flex flex-row items-center">
                 <span className="text-foreground-light w-20">type</span>
-                <span className="text-foreground">HTTPS endpoint</span>
+                <span className="text-foreground">HTTP endpoint</span>
               </div>
               <div className="flex flex-row items-center">
                 <label htmlFor="url" className="text-foreground-light w-20">

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+
+import { extractMethod, isValidHook } from './hooks.utils'
+import { HOOKS_DEFINITIONS, type Hook } from './hooks.constants'
+
+describe('Auth Hooks utils', () => {
+  test('treats the documented self-hosted Send Email HTTP URI as an HTTP hook', () => {
+    const uri = 'http://host.docker.internal:54321/functions/v1/email_sender'
+    const secret = 'v1,whsec_test'
+
+    const method = extractMethod(uri, secret)
+
+    expect(method).toEqual({ type: 'https', url: uri, secret })
+    expect(method).not.toMatchObject({ type: 'postgres', schema: 'functions', functionName: 'v1' })
+
+    const hook: Hook = {
+      ...HOOKS_DEFINITIONS[0],
+      enabled: true,
+      method,
+    }
+    expect(isValidHook(hook)).toBe(true)
+  })
+
+  test('treats HTTPS URIs as HTTP hooks', () => {
+    const uri = 'https://example.com/auth-hook'
+    const secret = 'v1,whsec_test'
+
+    expect(extractMethod(uri, secret)).toEqual({ type: 'https', url: uri, secret })
+  })
+
+  test('treats pg-functions URIs as Postgres hooks', () => {
+    expect(extractMethod('pg-functions://postgres/public/custom_access_token')).toEqual({
+      type: 'postgres',
+      schema: 'public',
+      functionName: 'custom_access_token',
+    })
+  })
+})

--- a/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
+++ b/apps/studio/components/interfaces/Auth/Hooks/hooks.utils.ts
@@ -8,7 +8,7 @@ export const extractMethod = (
 ):
   | { type: 'postgres'; schema: string; functionName: string }
   | { type: 'https'; url: string; secret: string } => {
-  if (uri.startsWith('https')) {
+  if (uri.startsWith('http://') || uri.startsWith('https://')) {
     return { type: 'https', url: uri, secret: secret || '' }
   } else {
     const [_proto, _x, _db, schema, functionName] = (uri || '').split('/')
@@ -26,7 +26,9 @@ export const isValidHook = (h: Hook) => {
     (h.method.type === 'postgres' &&
       h.method.schema.length > 0 &&
       h.method.functionName.length > 0) ||
-    (h.method.type === 'https' && h.method.url.startsWith('https') && h.method.secret.length > 0)
+    (h.method.type === 'https' &&
+      (h.method.url.startsWith('http://') || h.method.url.startsWith('https://')) &&
+      h.method.secret.length > 0)
   )
 }
 


### PR DESCRIPTION
Implemented and committed the fix.

What changed:
- Updated auth hook URI classification so both `http://` and `https://` URLs are treated as HTTP hooks instead of falling through to Postgres parsing.
- Updated hook validity checks to accept both HTTP and HTTPS URLs with secrets.
- Updated the create/edit hook form validation to allow `http://` URLs.
- Adjusted UI copy from HTTPS-only wording to HTTP endpoint wording.
- Added regression tests covering:
  - The documented self-hosted Send Email URL: `http://host.docker.internal:54321/functions/v1/email_sender`
  - HTTPS hook URLs
  - `pg-functions://` Postgres hook URLs

Verified:
- Ran targeted Vitest test:
  - `pnpm --filter studio exec vitest --run components/interfaces/Auth/Hooks/hooks.utils.test.ts`
- Ran Studio TypeScript check:
  - `pnpm --filter studio exec tsc --noEmit --pretty false`

Commit:
- `2854545e9e fix(studio): support HTTP auth hook URLs`

Fixes #46950


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Authentication hooks now support both HTTP and HTTPS webhook URLs instead of HTTPS only. Updated UI labels and validation accordingly.

* **Tests**
  * Added test coverage for webhook utility parsing and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->