### PR TITLE
fix: Bug: Navigation race condition in SignInPartner causing unintended redirects on unmount

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
@@ -9,6 +9,8 @@ export const SignInPartner = () => {
   const router = useRouter()
 
   useEffect(() => {
+    let isMounted = true
+
     ;(async () => {
       const params = new URLSearchParams(window.location.hash.substring(1))
 
@@ -21,12 +23,18 @@ export const SignInPartner = () => {
         try {
           await auth.signInWithIdToken({ provider: partner, token })
         } finally {
-          router.replace({ pathname: '/sign-in-mfa' })
+          if (isMounted) {
+            router.replace({ pathname: '/sign-in-mfa' })
+          }
         }
-      } else {
+      } else if (isMounted) {
         router.replace({ pathname: '/sign-in' })
       }
     })()
+
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   return (


### PR DESCRIPTION
Implemented and committed the fix.

What changed:
- Updated `apps/studio/components/interfaces/SignIn/SignInPartner.tsx`
- Added an `isMounted` lifecycle guard inside the `useEffect`
- Wrapped both `router.replace()` calls so they only run while the component is still mounted
- Added cleanup to set `isMounted = false` on unmount

Verification:
- Installed required Node.js 22 and project dependencies with `pnpm install --frozen-lockfile`
- Ran Studio type checking successfully:

```bash
pnpm --filter studio typecheck
```

Commit created:
```bash
0eee4e859d fix(studio): guard partner sign-in redirects
```

Limitations:
- I verified via typecheck/build tooling, not a browser-level manual Slow 3G reproduction.

Fixes #46593


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of the sign-in process by preventing routing logic from executing after the component unmounts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->