### PR TITLE
fix(studio): use publishable key for edge function tests

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -37,15 +37,14 @@ import * as z from 'zod'
 
 import { HTTP_METHODS } from './EdgeFunctionDetails.constants'
 import { ErrorWithStatus, ResponseData } from './EdgeFunctionDetails.types'
+import { buildEdgeFunctionTestHeaders } from './EdgeFunctionTesterSheet.utils'
 import { RoleImpersonationPopover } from '@/components/interfaces/RoleImpersonationSelector/RoleImpersonationPopover'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
-import { useSessionAccessTokenQuery } from '@/data/auth/session-access-token-query'
 import { useProjectPostgrestConfigQuery } from '@/data/config/project-postgrest-config-query'
 import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-query'
 import { useEdgeFunctionTestMutation } from '@/data/edge-functions/edge-function-test-mutation'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import { IS_PLATFORM } from '@/lib/constants'
 import { prettifyJSON } from '@/lib/helpers'
 import { getRoleImpersonationJWT } from '@/lib/role-impersonation'
 import { useTrack } from '@/lib/telemetry/track'
@@ -103,10 +102,9 @@ const EdgeFunctionTesterSheetContent = ({ visible, onClose }: EdgeFunctionTester
 
   const { can: canReadAPIKeys } = useAsyncCheckPermissions(PermissionAction.SECRETS_READ, '*')
   const { data: apiKeysData } = useAPIKeys({ projectRef }, { enabled: canReadAPIKeys })
-  const { serviceKey } = apiKeysData ?? {}
+  const { publishableKey, serviceKey } = apiKeysData ?? {}
   const { data: config } = useProjectPostgrestConfigQuery({ projectRef })
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const { data: accessToken } = useSessionAccessTokenQuery({ enabled: IS_PLATFORM })
 
   const track = useTrack()
   const { mutate: testEdgeFunction, isPending } = useEdgeFunctionTestMutation({
@@ -233,14 +231,12 @@ const EdgeFunctionTesterSheetContent = ({ visible, onClose }: EdgeFunctionTester
       url: finalUrl,
       method: values.method,
       body: values.body,
-      headers: {
-        ...(accessToken && {
-          Authorization: `Bearer ${accessToken}`,
-        }),
-        'x-test-authorization': testAuthorization ?? `Bearer ${serviceKey?.api_key}`,
-        'Content-Type': 'application/json',
-        ...customHeaders,
-      },
+      headers: buildEdgeFunctionTestHeaders({
+        publishableKey,
+        serviceKey,
+        testAuthorization,
+        customHeaders,
+      }),
     })
   }
 

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.utils.ts
@@ -13,6 +13,14 @@ export function buildEdgeFunctionTestHeaders({
   testAuthorization,
   customHeaders,
 }: BuildEdgeFunctionTestHeadersArgs) {
+  const normalizedCustomHeaders = Object.entries(customHeaders).reduce(
+    (headers, [key, value]) => {
+      headers[key.toLowerCase() === 'x-test-authorization' ? 'x-test-authorization' : key] = value
+      return headers
+    },
+    {} as Record<string, string>
+  )
+
   const generatedHeaders: Record<string, string> = {
     'Content-Type': 'application/json',
   }
@@ -21,7 +29,7 @@ export function buildEdgeFunctionTestHeaders({
     generatedHeaders.apikey = publishableKey.api_key
   }
 
-  const hasCustomAuthorization = Object.keys(customHeaders).some(
+  const hasCustomAuthorization = Object.keys(normalizedCustomHeaders).some(
     (key) => key.toLowerCase() === 'authorization' || key.toLowerCase() === 'x-test-authorization'
   )
 
@@ -35,6 +43,6 @@ export function buildEdgeFunctionTestHeaders({
 
   return {
     ...generatedHeaders,
-    ...customHeaders,
+    ...normalizedCustomHeaders,
   }
 }

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.utils.ts
@@ -1,0 +1,40 @@
+import type { APIKey } from '@/data/api-keys/api-keys-query'
+
+interface BuildEdgeFunctionTestHeadersArgs {
+  publishableKey?: APIKey
+  serviceKey?: APIKey
+  testAuthorization?: string
+  customHeaders: Record<string, string>
+}
+
+export function buildEdgeFunctionTestHeaders({
+  publishableKey,
+  serviceKey,
+  testAuthorization,
+  customHeaders,
+}: BuildEdgeFunctionTestHeadersArgs) {
+  const generatedHeaders: Record<string, string> = {
+    'Content-Type': 'application/json',
+  }
+
+  if (publishableKey?.api_key) {
+    generatedHeaders.apikey = publishableKey.api_key
+  }
+
+  const hasCustomAuthorization = Object.keys(customHeaders).some(
+    (key) => key.toLowerCase() === 'authorization' || key.toLowerCase() === 'x-test-authorization'
+  )
+
+  if (!hasCustomAuthorization) {
+    if (testAuthorization) {
+      generatedHeaders['x-test-authorization'] = testAuthorization
+    } else if (!publishableKey?.api_key && serviceKey?.api_key) {
+      generatedHeaders['x-test-authorization'] = `Bearer ${serviceKey.api_key}`
+    }
+  }
+
+  return {
+    ...generatedHeaders,
+    ...customHeaders,
+  }
+}

--- a/apps/studio/tests/components/Functions/EdgeFunctionTesterSheet.utils.test.ts
+++ b/apps/studio/tests/components/Functions/EdgeFunctionTesterSheet.utils.test.ts
@@ -90,6 +90,23 @@ describe('EdgeFunctionTesterSheet.utils: buildEdgeFunctionTestHeaders', () => {
     expect(headers['x-test-authorization']).toBeUndefined()
   })
 
+  it('normalizes manually entered x-test-authorization casing before sending to the API route', () => {
+    const headers = buildEdgeFunctionTestHeaders({
+      publishableKey,
+      serviceKey,
+      testAuthorization: 'Bearer impersonated-role-token',
+      customHeaders: {
+        'X-Test-Authorization': 'Bearer manual-token',
+      },
+    })
+
+    expect(headers).toMatchObject({
+      apikey: 'sb_publishable_project_key',
+      'x-test-authorization': 'Bearer manual-token',
+    })
+    expect(headers['X-Test-Authorization']).toBeUndefined()
+  })
+
   it('keeps the legacy service role fallback when a publishable key is unavailable', () => {
     const headers = buildEdgeFunctionTestHeaders({
       publishableKey: undefined,

--- a/apps/studio/tests/components/Functions/EdgeFunctionTesterSheet.utils.test.ts
+++ b/apps/studio/tests/components/Functions/EdgeFunctionTesterSheet.utils.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildEdgeFunctionTestHeaders } from '@/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.utils'
+import type { APIKey } from '@/data/api-keys/api-keys-query'
+
+const publishableKey: APIKey = {
+  api_key: 'sb_publishable_project_key',
+  id: 'publishable',
+  inserted_at: '2026-01-01T00:00:00Z',
+  name: 'publishable',
+  type: 'publishable',
+}
+
+const serviceKey: APIKey = {
+  api_key: 'legacy-service-role-jwt',
+  hash: 'hash',
+  id: 'service_role',
+  inserted_at: '2026-01-01T00:00:00Z',
+  name: 'service_role',
+  prefix: 'prefix',
+  secret_jwt_template: { role: 'service_role' },
+  type: 'secret',
+}
+
+describe('EdgeFunctionTesterSheet.utils: buildEdgeFunctionTestHeaders', () => {
+  it('uses the publishable key as apikey without forwarding a legacy service-role JWT', () => {
+    const headers = buildEdgeFunctionTestHeaders({
+      publishableKey,
+      serviceKey,
+      testAuthorization: undefined,
+      customHeaders: {},
+    })
+
+    expect(headers).toMatchObject({
+      apikey: 'sb_publishable_project_key',
+      'Content-Type': 'application/json',
+    })
+    expect(headers.Authorization).toBeUndefined()
+    expect(headers['x-test-authorization']).toBeUndefined()
+  })
+
+  it('keeps explicit role impersonation authorization ahead of the publishable-key default', () => {
+    const headers = buildEdgeFunctionTestHeaders({
+      publishableKey,
+      serviceKey,
+      testAuthorization: 'Bearer impersonated-role-token',
+      customHeaders: {},
+    })
+
+    expect(headers).toMatchObject({
+      apikey: 'sb_publishable_project_key',
+      'x-test-authorization': 'Bearer impersonated-role-token',
+    })
+  })
+
+  it('allows custom headers to override generated headers for manual testing', () => {
+    const headers = buildEdgeFunctionTestHeaders({
+      publishableKey,
+      serviceKey,
+      testAuthorization: undefined,
+      customHeaders: {
+        apikey: 'manual-api-key',
+        Authorization: 'Bearer manual-token',
+        'x-extra-header': 'value',
+      },
+    })
+
+    expect(headers).toMatchObject({
+      apikey: 'manual-api-key',
+      Authorization: 'Bearer manual-token',
+      'x-extra-header': 'value',
+    })
+    expect(headers['x-test-authorization']).toBeUndefined()
+  })
+
+  it('treats lower-case authorization as a manual override', () => {
+    const headers = buildEdgeFunctionTestHeaders({
+      publishableKey,
+      serviceKey,
+      testAuthorization: undefined,
+      customHeaders: {
+        authorization: 'Bearer manual-token',
+      },
+    })
+
+    expect(headers).toMatchObject({
+      apikey: 'sb_publishable_project_key',
+      authorization: 'Bearer manual-token',
+    })
+    expect(headers['x-test-authorization']).toBeUndefined()
+  })
+
+  it('keeps the legacy service role fallback when a publishable key is unavailable', () => {
+    const headers = buildEdgeFunctionTestHeaders({
+      publishableKey: undefined,
+      serviceKey,
+      testAuthorization: undefined,
+      customHeaders: {},
+    })
+
+    expect(headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'x-test-authorization': 'Bearer legacy-service-role-jwt',
+    })
+    expect(headers.apikey).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary
- Use the project publishable key as the default `apikey` header when testing Edge Functions from Studio.
- Stop forwarding the legacy service-role JWT through `x-test-authorization` when a publishable key is available.
- Keep explicit role impersonation and manual authorization headers working, with a legacy service-role fallback for projects without publishable keys.

Fixes #42755

## Test plan
- `pnpm --filter studio exec vitest --run tests/components/Functions/EdgeFunctionTesterSheet.utils.test.ts`
- `pnpm --filter studio exec eslint components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.utils.ts tests/components/Functions/EdgeFunctionTesterSheet.utils.test.ts` (passes with one pre-existing `no-explicit-any` warning in `EdgeFunctionTesterSheet.tsx`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed authorization handling in edge function testing, replacing session-based authentication with a more reliable API key-based approach.

* **New Features**
  * Enhanced custom header support for edge function tests, allowing headers to override defaults while maintaining proper normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->