### PR TITLE
fix(studio): escape filename when building duplicate-name RegExp in Storage Explorer

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.test.ts
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.test.ts
@@ -265,6 +265,36 @@ describe('sanitizeNameForDuplicateInColumn', () => {
       )
     })
 
+    it('counts existing duplicates correctly when the name contains regex-special characters', () => {
+      // `a+b` contains `+`, a regex quantifier. Without escaping, the generated
+      // pattern fails to match `a+b (1).txt`, so the count is wrong and the
+      // function returns `a+b (1).txt` - a name that already exists.
+      const state = makeState([[{ name: 'a+b.txt' }, { name: 'a+b (1).txt' }]])
+      expect(sanitizeNameForDuplicateInColumn(state, { name: 'a+b.txt', autofix: true })).toBe(
+        'a+b (2).txt'
+      )
+    })
+
+    it('does not throw when the name contains an unbalanced parenthesis', () => {
+      // `file(.txt` passes validateFolderName but, unescaped, produces an
+      // invalid RegExp (unterminated group) that throws.
+      const state = makeState([[{ name: 'file(.txt' }]])
+      expect(() =>
+        sanitizeNameForDuplicateInColumn(state, { name: 'file(.txt', autofix: true })
+      ).not.toThrow()
+      expect(sanitizeNameForDuplicateInColumn(state, { name: 'file(.txt', autofix: true })).toBe(
+        'file( (1).txt'
+      )
+    })
+
+    it('does not match across the literal extension dot', () => {
+      // The extension separator must be a literal dot, not "any character".
+      const state = makeState([[{ name: 'file.txt' }, { name: 'file (1)Xtxt' }]])
+      expect(sanitizeNameForDuplicateInColumn(state, { name: 'file.txt', autofix: true })).toBe(
+        'file (1).txt'
+      )
+    })
+
     it('treats the whole name as the extension when there is no dot (existing behaviour)', () => {
       // NOTE: the function splits on '.' and always treats the last segment as the
       // extension, so a dotless name produces " (1).myfile" rather than "myfile (1)".

--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.tsx
@@ -1,3 +1,4 @@
+import { escapeRegExp } from 'lodash'
 import { toast } from 'sonner'
 import { copyToClipboard } from 'ui'
 
@@ -99,7 +100,14 @@ export function sanitizeNameForDuplicateInColumn(
       const fileName = fileNameSegments.slice(0, fileNameSegments.length - 1).join('.')
       const fileExt = fileNameSegments[fileNameSegments.length - 1]
 
-      const dupeNameRegex = new RegExp(`${fileName} \\([-0-9]+\\)${fileExt ? '.' + fileExt : ''}$`)
+      // Escape the user-controlled name/extension before interpolating into a
+      // RegExp. Storage object keys may contain regex-special characters (e.g.
+      // `(`, `)`, `+`, `*`, `?`) which would otherwise corrupt the pattern -
+      // producing an incorrect duplicate count (and thus a name that already
+      // exists) or, for unbalanced parens, throwing a SyntaxError.
+      const dupeNameRegex = new RegExp(
+        `${escapeRegExp(fileName)} \\([-0-9]+\\)${fileExt ? '\\.' + escapeRegExp(fileExt) : ''}$`
+      )
       const itemsWithSameNameInColumn = currentColumnItems.filter((item) =>
         item.name.match(dupeNameRegex)
       )


### PR DESCRIPTION
## What

`sanitizeNameForDuplicateInColumn` (Storage Explorer autofix) interpolated the raw object key into a `RegExp` to count existing `name (N)` duplicates. Storage object keys allow regex-special characters (`validObjectKeyRegex` permits `( ) + * ? $ .` etc.), so the pattern could be corrupted.

This escapes `fileName`/`fileExt` with lodash `escapeRegExp` before building the pattern, and uses a literal `\.` for the extension separator.

## Why

Two reproducible failure modes (both verified by replicating the exact line in Node):

1. **Wrong count → returns an already-existing name.** A column with `a+b.txt` and `a+b (1).txt`, uploading another `a+b.txt`: the pattern `/a+b \([-0-9]+\).txt$/` treats `a+` as a quantifier, so the existing duplicate isn't counted and the function returns `a+b (1).txt` — re-introducing the collision autofix is meant to resolve. Now returns `a+b (2).txt`.
2. **Uncaught `SyntaxError` → crash.** A name with an unbalanced paren like `file(.txt` (which passes `validateFolderName`) produced an invalid RegExp and threw, crashing the duplicate-upload/rename flow. Now handled.

Closes #47163.

## Tests

Extends `StorageExplorer.utils.test.ts` with: regex-special-character counting, no-throw on unbalanced paren, and literal-extension-dot matching. Existing cases are unchanged.

> Note: the vitest suite wasn't run locally (workspace deps aren't bootstrapped in my environment); the exact regex behavior and all new/existing cases were verified via Node, and CI will run the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file names containing special characters (such as `+` and parentheses) when detecting and sanitizing duplicate files in Storage Explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->