### PR TITLE
fix(studio): formatCompactNumber rolls over to "M" instead of rendering "1000.0k"

### DIFF
--- a/apps/studio/components/ui/DataTable/DataTable.utils.test.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+
+import { formatCompactNumber } from './DataTable.utils'
+
+describe('formatCompactNumber', () => {
+  test('returns numbers below 1000 as-is', () => {
+    expect(formatCompactNumber(0)).toBe('0')
+    expect(formatCompactNumber(99)).toBe('99')
+    expect(formatCompactNumber(100)).toBe('100')
+    expect(formatCompactNumber(999)).toBe('999')
+  })
+
+  test('formats thousands with a "k" suffix', () => {
+    expect(formatCompactNumber(1000)).toBe('1.0k')
+    expect(formatCompactNumber(1500)).toBe('1.5k')
+    expect(formatCompactNumber(15310)).toBe('15.3k')
+  })
+
+  test('formats millions with an "M" suffix', () => {
+    expect(formatCompactNumber(1000000)).toBe('1.0M')
+    expect(formatCompactNumber(1500000)).toBe('1.5M')
+  })
+
+  // Regression: values that round up to 1000.0k were rendered as "1000.0k"
+  // instead of being promoted to "1.0M".
+  test('promotes values that round up to 1000k into millions', () => {
+    expect(formatCompactNumber(999999)).toBe('1.0M')
+    expect(formatCompactNumber(999950)).toBe('1.0M')
+  })
+
+  test('does not promote values that round down below 1000k', () => {
+    expect(formatCompactNumber(999949)).toBe('999.9k')
+  })
+
+  test('boundary between thousands and the rounding guard', () => {
+    expect(formatCompactNumber(999900)).toBe('999.9k')
+  })
+})

--- a/apps/studio/components/ui/DataTable/DataTable.utils.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.utils.ts
@@ -4,14 +4,18 @@ import { isAfter, isBefore, isSameDay } from 'date-fns'
 import { LEVELS } from './DataTable.constants'
 
 export function formatCompactNumber(value: number) {
-  if (value >= 100 && value < 1000) {
-    return value.toString() // Keep the number as is if it's in the hundreds
-  } else if (value >= 1000 && value < 1000000) {
-    return (value / 1000).toFixed(1) + 'k' // Convert to 'k' for thousands
-  } else if (value >= 1000000) {
+  if (value >= 1000000) {
     return (value / 1000000).toFixed(1) + 'M' // Convert to 'M' for millions
+  } else if (value >= 1000) {
+    const thousands = value / 1000
+    // Guard against rounding up into the next magnitude (e.g. 999,999 -> "1000.0k").
+    // Once the rounded value reaches 1000k, promote it to millions instead.
+    if (thousands.toFixed(1) === '1000.0') {
+      return (value / 1000000).toFixed(1) + 'M'
+    }
+    return thousands.toFixed(1) + 'k' // Convert to 'k' for thousands
   } else {
-    return value.toString() // Optionally handle numbers less than 100 if needed
+    return value.toString() // Keep the number as is if it's less than a thousand
   }
 }
 


### PR DESCRIPTION
## What

`formatCompactNumber` (DataTable utils) checked magnitude ranges before rounding, so a thousands value that rounds up to `1000.0` rendered as `"1000.0k"` instead of `"1.0M"`. This checks millions first and promotes any thousands value that rounds to `"1000.0"` into the millions branch.

## Why

```js
formatCompactNumber(999999) // "1000.0k"  -> should be "1.0M"
formatCompactNumber(999950) // "1000.0k"  -> should be "1.0M"
formatCompactNumber(999949) // "999.9k"   (unchanged, correct)
```

Any value in `[999950, 999999]` hit the thousands branch (`value < 1000000`), then `(value / 1000).toFixed(1)` rounded to `"1000.0"`. The function is user-visible: it formats row-count labels in the DataTable toolbar (`X of Y row(s)`), `DataTableInfinite`, and filter checkbox counts.

Closes #47165.

## Tests

Adds `DataTable.utils.test.ts` covering sub-1000 pass-through, thousands, millions, the rollover boundary (`999999`/`999950` → `"1.0M"`), and the non-promotion boundary (`999949`/`999900` → `"999.9k"`).

> Note: the vitest suite wasn't run locally (workspace deps aren't bootstrapped in my environment); behavior was verified via Node against the original and fixed implementations, and CI will run the suite.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced numeric value formatting in data tables to ensure accurate display of large numbers, particularly fixing edge cases where values near magnitude boundaries were rendering incorrectly.

* **Tests**
  * Added comprehensive test coverage for numeric formatting behavior at boundary conditions and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->