### PR TITLE
fix: formatCompactNumber correctly displays 1.0M instead of 1000.0k for values near 1,000,000

### DIFF
--- a/apps/studio/components/ui/DataTable/DataTable.utils.ts
+++ b/apps/studio/components/ui/DataTable/DataTable.utils.ts
@@ -7,7 +7,8 @@ export function formatCompactNumber(value: number) {
   if (value >= 100 && value < 1000) {
     return value.toString() // Keep the number as is if it's in the hundreds
   } else if (value >= 1000 && value < 1000000) {
-    return (value / 1000).toFixed(1) + 'k' // Convert to 'k' for thousands
+    const kValue = (value / 1000).toFixed(1)
+    return kValue === '1000.0' ? '1.0M' : kValue + 'k' // formatCompactNumber correctly displays 1.0M instead of 1000.0k for values near 1,000,000
   } else if (value >= 1000000) {
     return (value / 1000000).toFixed(1) + 'M' // Convert to 'M' for millions
   } else {


### PR DESCRIPTION
## Bug Fix

Fixes #47165

## Problem
When a value like 999,999 was passed to `formatCompactNumber`, the `.toFixed(1)` 
rounding would produce `1000.0k` instead of the correct `1.0M`.

## Root Cause
The `else if (value >= 1000 && value < 1000000)` branch used `.toFixed(1)` which 
rounds up values like 999,999 to 1000.0 before appending 'k', bypassing the million check.

## Fix
Added a check: if the rounded k value equals '1000.0', return '1.0M' instead.

## Before
- Input: 999,999 → Output: `1000.0k` 

## After  
- Input: 999,999 → Output: `1.0M` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved number formatting in data tables to correctly display large numbers in compact notation (e.g., "1.0M" instead of "1000.0k").

<!-- end of auto-generated comment: release notes by coderabbit.ai -->