### PR TITLE
test(pg-meta): add studio SQL and self-hosted constants coverage

### DIFF
--- a/apps/studio/lib/api/self-hosted/constants.test.ts
+++ b/apps/studio/lib/api/self-hosted/constants.test.ts
@@ -103,6 +103,21 @@ describe('api/self-hosted/constants', () => {
     })
   })
 
+  describe('DEFAULT_EXPOSED_SCHEMAS', () => {
+    it('should use PGRST_DB_SCHEMAS when set', async () => {
+      vi.stubEnv('PGRST_DB_SCHEMAS', 'public,storage,custom')
+      const { DEFAULT_EXPOSED_SCHEMAS } = await import('./constants')
+      expect(DEFAULT_EXPOSED_SCHEMAS).toBe('public,storage,custom')
+    })
+
+    it('should default to public, storage, and graphql_public', async () => {
+      vi.unstubAllEnvs()
+      vi.resetModules()
+      const { DEFAULT_EXPOSED_SCHEMAS } = await import('./constants')
+      expect(DEFAULT_EXPOSED_SCHEMAS).toBe('public,storage,graphql_public')
+    })
+  })
+
   describe('AUTH_JWT_SECRET', () => {
     it('should use AUTH_JWT_SECRET when set', async () => {
       vi.stubEnv('AUTH_JWT_SECRET', 'custom-jwt-secret-32-chars-long-xyz')

--- a/packages/pg-meta/test/sql/studio/index-advisor.test.ts
+++ b/packages/pg-meta/test/sql/studio/index-advisor.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { getTableIndexAdvisorSql } from '../../../src/sql/studio/advisor/index-advisor'
+
+describe('getTableIndexAdvisorSql', () => {
+  it('includes schema and table in table-matching regex patterns', () => {
+    const sql = getTableIndexAdvisorSql('public', 'orders')
+
+    expect(sql).toContain('index_advisor')
+    expect(sql).toContain('pg_stat_statements')
+    expect(sql).toContain('(^|[^a-z0-9_$])public[.]orders($|[^a-z0-9_$])')
+    expect(sql).toContain('(^|[^a-z0-9_$])from[[:space:]]+orders($|[^a-z0-9_$])')
+    expect(sql).toContain('(^|[^a-z0-9_$])join[[:space:]]+orders($|[^a-z0-9_$])')
+  })
+
+  it('escapes regex metacharacters in schema and table names', () => {
+    const sql = getTableIndexAdvisorSql('my.schema', 'orders+items')
+
+    expect(sql).toContain('my\\\\.schema')
+    expect(sql).toContain('orders\\\\+items')
+  })
+
+  it('limits analysis to top 5 queries', () => {
+    const sql = getTableIndexAdvisorSql('public', 'users')
+
+    expect(sql).toContain('limit 5')
+  })
+})

--- a/packages/pg-meta/test/sql/studio/lints.test.ts
+++ b/packages/pg-meta/test/sql/studio/lints.test.ts
@@ -1,6 +1,26 @@
 import { describe, expect, it } from 'vitest'
 
-import { enrichLintsQuery, safeSql } from '../../../src'
+import { enrichLintsQuery, getLintsSQL, safeSql } from '../../../src'
+
+describe('getLintsSQL', () => {
+  it('embeds docsUrl in remediation links', () => {
+    const docsUrl = 'https://supabase.com/docs'
+    const sql = getLintsSQL({ docsUrl })
+
+    expect(sql).toContain(
+      `'${docsUrl}/guides/database/database-linter?lint=0001_unindexed_foreign_keys'`
+    )
+    expect(sql).toContain(
+      `'${docsUrl}/guides/database/database-linter?lint=0024_permissive_rls_policy'`
+    )
+  })
+
+  it('resets search_path before running lints', () => {
+    const sql = getLintsSQL({ docsUrl: 'https://supabase.com/docs' })
+
+    expect(sql).toMatch(/^set local search_path = '';/)
+  })
+})
 
 describe('enrichLintsQuery', () => {
   const dummyQuery = safeSql`SELECT 1`


### PR DESCRIPTION
## Summary
- Add unit tests for `getTableIndexAdvisorSql` in `@supabase/pg-meta` (regex escaping and query shape)
- Add unit tests for `getLintsSQL` docsUrl wiring and search_path reset
- Add self-hosted `DEFAULT_EXPOSED_SCHEMAS` tests for `PGRST_DB_SCHEMAS` docker/CLI env wiring

## Test plan
- [x] `cd packages/pg-meta && test/run-tests.sh pnpm exec vitest run test/sql/studio/index-advisor.test.ts test/sql/studio/lints.test.ts`
- [x] `cd apps/studio && pnpm exec vitest run lib/api/self-hosted/constants.test.ts`
- [x] Local stack via `pnpm setup:cli`