### PR TITLE
chore: Migrate recharts to v3

### DIFF
--- a/apps/studio/components/interfaces/Organization/Usage/UsageChartTooltips.tsx
+++ b/apps/studio/components/interfaces/Organization/Usage/UsageChartTooltips.tsx
@@ -1,4 +1,4 @@
-import type { Payload, ValueType } from 'recharts/types/component/DefaultTooltipContent'
+import type { TooltipPayloadEntry as Payload, TooltipValueType as ValueType } from 'recharts'
 import { cn } from 'ui'
 
 import { Attribute, COLOR_MAP } from './Usage.constants'
@@ -35,7 +35,7 @@ export const SingleAttributeTooltipContent = ({
 
 export interface MultiAttributeTooltipContentProps {
   attributes: Attribute[]
-  values: Payload<ValueType, string | number>[]
+  values: ReadonlyArray<Payload<ValueType, string | number>>
   isAfterToday: boolean
   tooltipFormatter?: (value: any) => any
   unit: 'bytes' | 'percentage' | 'absolute' | 'hours' | 'gigabytes'

--- a/apps/studio/components/interfaces/QueryInsights/QueryInsightsChart/QueryInsightsChartTooltip.tsx
+++ b/apps/studio/components/interfaces/QueryInsights/QueryInsightsChart/QueryInsightsChartTooltip.tsx
@@ -1,11 +1,14 @@
 import dayjs from 'dayjs'
-import type { TooltipProps } from 'recharts'
+import type { TooltipContentProps } from 'recharts'
 
 import { formatDuration } from '../QueryInsightsTable/QueryInsightsTable.utils'
 import { isTimeMetric } from './QueryInsightsChart.utils'
 import { guessLocalTimezone } from '@/lib/dayjs'
 
-export const QueryInsightsChartTooltip = ({ active, payload }: TooltipProps<number, string>) => {
+export const QueryInsightsChartTooltip = ({
+  active,
+  payload,
+}: Partial<TooltipContentProps<number, string>>) => {
   if (!active || !payload?.length) return null
 
   const time = payload[0]?.payload?.time

--- a/apps/studio/components/ui/Charts/BarChart.tsx
+++ b/apps/studio/components/ui/Charts/BarChart.tsx
@@ -9,7 +9,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import type { CategoricalChartState } from 'recharts/types/chart/types'
+import type { MouseHandlerDataParam } from 'recharts'
 
 import { ChartHeader } from './ChartHeader'
 import type { CommonChartProps, Datum } from './Charts.types'
@@ -24,7 +24,7 @@ export interface BarChartProps<D = Datum> extends CommonChartProps<D> {
   xAxisKey: string
   customDateFormat?: string
   displayDateInUtc?: boolean
-  onBarClick?: (datum: D, tooltipData?: CategoricalChartState) => void
+  onBarClick?: (datum: D, tooltipData?: MouseHandlerDataParam) => void
   emptyStateMessage?: string
   showLegend?: boolean
   xAxisIsDate?: boolean
@@ -159,8 +159,9 @@ function BarChart<D extends Datum = Datum>({
             clearHover()
           }}
           onClick={(tooltipData) => {
-            const datum = tooltipData?.activePayload?.[0]?.payload
-            if (onBarClick) onBarClick(datum, tooltipData)
+            const index = tooltipData?.activeTooltipIndex
+            const datum = index != null ? transformedData[Number(index)] : undefined
+            if (onBarClick && datum) onBarClick(datum, tooltipData)
           }}
         >
           {showLegend && <Legend />}

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -14,7 +14,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import { CategoricalChartState } from 'recharts/types/chart/types'
+import type { MouseHandlerDataParam } from 'recharts'
 import { cn } from 'ui'
 
 import { ChartHeader } from './ChartHeader'
@@ -52,7 +52,7 @@ export interface ComposedChartProps<D = Datum> extends CommonChartProps<D> {
   yAxisKey: string
   xAxisKey: string
   displayDateInUtc?: boolean
-  onBarClick?: (datum: Datum, tooltipData?: CategoricalChartState) => void
+  onBarClick?: (datum: Datum, tooltipData?: MouseHandlerDataParam) => void
   emptyStateMessage?: string
   showLegend?: boolean
   xAxisIsDate?: boolean
@@ -469,29 +469,31 @@ export function ComposedChart({
           style={{ cursor: 'crosshair' }}
           onMouseMove={({ activeLabel, activeTooltipIndex }) => {
             if (activeTooltipIndex === undefined || activeTooltipIndex === null) return
+            const index = Number(activeTooltipIndex)
 
             setIsActiveHoveredChart(true)
-            if (activeTooltipIndex !== focusDataIndex) {
-              setFocusDataIndex(activeTooltipIndex)
+            if (index !== focusDataIndex) {
+              setFocusDataIndex(index)
             }
 
-            setHover(activeTooltipIndex)
+            setHover(index)
 
             const activeTimestamp =
-              data[activeTooltipIndex]?.[xAxisKey] ?? data[activeTooltipIndex]?.timestamp
+              data[index]?.[xAxisKey] ?? data[index]?.timestamp
             chartHighlight?.handleMouseMove({
               activeLabel: activeTimestamp?.toString(),
-              coordinates: activeLabel,
+              coordinates: activeLabel?.toString(),
             })
           }}
           onMouseDown={({ activeLabel, activeTooltipIndex }) => {
             if (activeTooltipIndex === undefined || activeTooltipIndex === null) return
+            const index = Number(activeTooltipIndex)
 
             const activeTimestamp =
-              data[activeTooltipIndex]?.[xAxisKey] ?? data[activeTooltipIndex]?.timestamp
+              data[index]?.[xAxisKey] ?? data[index]?.timestamp
             chartHighlight?.handleMouseDown({
               activeLabel: activeTimestamp?.toString(),
-              coordinates: activeLabel,
+              coordinates: activeLabel?.toString(),
             })
           }}
           onMouseUp={chartHighlight?.handleMouseUp}
@@ -502,8 +504,9 @@ export function ComposedChart({
             clearHover()
           }}
           onClick={(tooltipData) => {
-            const datum = tooltipData?.activePayload?.[0]?.payload
-            if (onBarClick) onBarClick(datum, tooltipData)
+            const index = tooltipData?.activeTooltipIndex
+            const datum = index != null ? displayData[Number(index)] : undefined
+            if (onBarClick && datum) onBarClick(datum, tooltipData)
           }}
         >
           {showGrid && <CartesianGrid stroke={CHART_COLORS.AXIS} />}
@@ -627,6 +630,7 @@ export function ComposedChart({
               showTooltip && !showHighlightActions ? (
                 <CustomTooltip
                   {...props}
+                  payload={props.payload ? [...props.payload] : undefined}
                   data={data}
                   format={format}
                   isPercentage={isPercentage}

--- a/apps/studio/components/ui/Charts/PortalChartTooltip.tsx
+++ b/apps/studio/components/ui/Charts/PortalChartTooltip.tsx
@@ -1,17 +1,14 @@
 import { useIsomorphicLayoutEffect } from 'common'
 import { ComponentProps, RefObject, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
-import type { TooltipProps } from 'recharts'
-import type { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent'
 import { ChartTooltipContent, cn } from 'ui'
 
 const TOOLTIP_OFFSET = 16
 const VIEWPORT_MARGIN = 8
 
-type PortalChartTooltipProps = Omit<ComponentProps<typeof ChartTooltipContent>, 'content'> &
-  Pick<TooltipProps<ValueType, NameType>, 'active' | 'coordinate' | 'payload'> & {
-    chartRef: RefObject<HTMLElement | null>
-  }
+type PortalChartTooltipProps = Omit<ComponentProps<typeof ChartTooltipContent>, 'content'> & {
+  chartRef: RefObject<HTMLElement | null>
+}
 
 export const PortalChartTooltip = ({ chartRef, className, ...props }: PortalChartTooltipProps) => {
   const { active, coordinate, payload } = props

--- a/apps/studio/components/ui/Charts/StackedBarChart.tsx
+++ b/apps/studio/components/ui/Charts/StackedBarChart.tsx
@@ -188,7 +188,7 @@ const StackedBarChart: React.FC<Props> = ({
                 const index = percentagesStackedData.findIndex(
                   (pStack) => pStack === props.payload!
                 )
-                const val = stackedData[index][name]
+                const val = stackedData[index][name as string]
                 const percentage = precisionFormatter(Number(value) * 100, 1) + '%'
                 return `${percentage} (${val}${suffix})`
               }

--- a/apps/studio/components/ui/Charts/useChartHighlight.tsx
+++ b/apps/studio/components/ui/Charts/useChartHighlight.tsx
@@ -14,7 +14,11 @@ export interface ChartHighlight {
   popoverPosition: { x: number; y: number } | null
   handleMouseDown: (e: ChartHighlightMouseEvent) => void
   handleMouseMove: (e: ChartHighlightMouseEvent) => void
-  handleMouseUp: (e: { chartX?: number; chartY?: number }) => void
+  handleMouseUp: (e: {
+    activeCoordinate?: { x: number; y: number } | null
+    chartX?: number
+    chartY?: number
+  }) => void
   clearHighlight: () => void
 }
 
@@ -64,20 +68,19 @@ export function useChartHighlight(): ChartHighlight {
     }
   }
 
-  const handleMouseUp = (e: unknown) => {
+  const handleMouseUp = (e: {
+    activeCoordinate?: { x: number; y: number } | null
+    chartX?: number
+    chartY?: number
+  }) => {
     if (!isSelecting) return
     setIsSelecting(false)
     setInitialPoint(undefined)
 
-    if (
-      typeof e === 'object' &&
-      e !== null &&
-      'chartX' in e &&
-      'chartY' in e &&
-      typeof e.chartX === 'number' &&
-      typeof e.chartY === 'number'
-    ) {
-      setPopoverPosition({ x: e.chartX, y: e.chartY })
+    const x = e?.activeCoordinate?.x ?? e?.chartX
+    const y = e?.activeCoordinate?.y ?? e?.chartY
+    if (typeof x === 'number' && typeof y === 'number') {
+      setPopoverPosition({ x, y })
     }
   }
 

--- a/apps/studio/components/ui/DataTable/TimelineChart.tsx
+++ b/apps/studio/components/ui/DataTable/TimelineChart.tsx
@@ -103,11 +103,13 @@ export function TimelineChart<TChart extends BaseChartSchema>({
           margin={{ top: 0, left: 0, right: 0, bottom: 0 }}
           onMouseDown={({ activeLabel, activeTooltipIndex }) => {
             if (activeTooltipIndex === undefined || activeTooltipIndex === null) return
-            chartHighlight.handleMouseDown({ activeLabel, coordinates: activeLabel })
+            const label = activeLabel?.toString()
+            chartHighlight.handleMouseDown({ activeLabel: label, coordinates: label })
           }}
           onMouseMove={({ activeLabel, activeTooltipIndex }) => {
             if (activeTooltipIndex === undefined || activeTooltipIndex === null) return
-            chartHighlight.handleMouseMove({ activeLabel, coordinates: activeLabel })
+            const label = activeLabel?.toString()
+            chartHighlight.handleMouseMove({ activeLabel: label, coordinates: label })
           }}
           onMouseUp={chartHighlight.handleMouseUp}
           style={{ cursor: 'crosshair' }}

--- a/apps/ui-library/registry/default/components/ui/chart.tsx
+++ b/apps/ui-library/registry/default/components/ui/chart.tsx
@@ -97,7 +97,8 @@ const ChartTooltip = RechartsPrimitive.Tooltip
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-    React.ComponentProps<'div'> & {
+    React.ComponentProps<'div'> &
+    Partial<Pick<RechartsPrimitive.TooltipContentProps, 'payload' | 'label' | 'coordinate'>> & {
       hideLabel?: boolean
       hideIndicator?: boolean
       indicator?: 'line' | 'dot' | 'dashed'
@@ -174,7 +175,7 @@ const ChartTooltipContent = React.forwardRef<
 
             return (
               <div
-                key={item.dataKey}
+                key={`${item.dataKey ?? index}`}
                 className={cn(
                   'flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground',
                   indicator === 'dot' && 'items-center'
@@ -240,7 +241,7 @@ const ChartLegend = RechartsPrimitive.Legend
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<'div'> &
-    Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
+    Pick<RechartsPrimitive.DefaultLegendContentProps, 'payload' | 'verticalAlign'> & {
       hideIcon?: boolean
       nameKey?: string
     }

--- a/packages/ui-patterns/src/Chart/charts/chart-bar.tsx
+++ b/packages/ui-patterns/src/Chart/charts/chart-bar.tsx
@@ -12,7 +12,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import type { CategoricalChartState } from 'recharts/types/chart/types'
+import type { MouseHandlerDataParam } from 'recharts'
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, cn } from 'ui'
 
 const CHART_COLORS = {
@@ -47,7 +47,7 @@ export interface ChartBarProps {
   data: ChartBarTick[]
   dataKey: string
   config?: ChartConfig
-  onBarClick?: (datum: ChartBarTick, tooltipData?: CategoricalChartState) => void
+  onBarClick?: (datum: ChartBarTick, tooltipData?: MouseHandlerDataParam) => void
   DateTimeFormat?: string
   isFullHeight?: boolean
   className?: string
@@ -172,8 +172,9 @@ export const ChartBar = ({
             }
           }}
           onClick={(tooltipData) => {
-            const datum = tooltipData?.activePayload?.[0]?.payload
-            if (onBarClick) onBarClick(datum, tooltipData)
+            const index = tooltipData?.activeTooltipIndex
+            const datum = index != null ? data[Number(index)] : undefined
+            if (onBarClick && datum) onBarClick(datum, tooltipData)
           }}
         >
           {showGrid && <CartesianGrid vertical={false} stroke={CHART_COLORS.AXIS} />}
@@ -189,7 +190,7 @@ export const ChartBar = ({
             content={
               <ChartTooltipContent
                 className="text-foreground-light -mt-5"
-                labelFormatter={(v: string) => dayjs(v).format(DateTimeFormat)}
+                labelFormatter={(v) => dayjs(v as string).format(DateTimeFormat)}
               />
             }
           />

--- a/packages/ui-patterns/src/Chart/charts/chart-line.tsx
+++ b/packages/ui-patterns/src/Chart/charts/chart-line.tsx
@@ -12,7 +12,7 @@ import {
   XAxis,
   YAxis,
 } from 'recharts'
-import type { CategoricalChartState } from 'recharts/types/chart/types'
+import type { MouseHandlerDataParam } from 'recharts'
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, cn } from 'ui'
 
 const CHART_COLORS = {
@@ -57,7 +57,7 @@ export interface ChartLineProps {
   dataKeys?: string[]
   config?: ChartConfig
   tooltipDetails?: (datum: ChartLineTick, key: string, value: unknown) => ReactNode
-  onLineClick?: (datum: ChartLineTick, tooltipData?: CategoricalChartState) => void
+  onLineClick?: (datum: ChartLineTick, tooltipData?: MouseHandlerDataParam) => void
   DateTimeFormat?: string
   isFullHeight?: boolean
   className?: string
@@ -197,8 +197,9 @@ export const ChartLine = ({
             }
           }}
           onClick={(tooltipData) => {
-            const datum = tooltipData?.activePayload?.[0]?.payload
-            if (onLineClick) onLineClick(datum, tooltipData)
+            const index = tooltipData?.activeTooltipIndex
+            const datum = index != null ? data[Number(index)] : undefined
+            if (onLineClick && datum) onLineClick(datum, tooltipData)
           }}
         >
           {showGrid && <CartesianGrid vertical={false} stroke={CHART_COLORS.AXIS} />}
@@ -214,7 +215,7 @@ export const ChartLine = ({
             content={
               <ChartTooltipContent
                 className="text-foreground-light -mt-5"
-                labelFormatter={(v: string) => dayjs(v).format(DateTimeFormat)}
+                labelFormatter={(v) => dayjs(v as string).format(DateTimeFormat)}
                 formatter={(value, name, item) => {
                   const key = String(item.dataKey || name || dataKey)
                   const itemConfig = chartConfig[key]

--- a/packages/ui-patterns/src/Chart/index.tsx
+++ b/packages/ui-patterns/src/Chart/index.tsx
@@ -12,7 +12,7 @@ import {
   Bar,
   BarChart,
   Tooltip as RechartsTooltip,
-  TooltipProps as RechartsTooltipProps,
+  TooltipContentProps as RechartsTooltipProps,
   ResponsiveContainer,
   XAxis,
   YAxis,
@@ -543,7 +543,7 @@ const ChartValueDifferential = React.forwardRef<HTMLDivElement, ChartValueDiffer
 )
 ChartValueDifferential.displayName = 'ChartValueDifferential'
 
-const ChartSparklineTooltip = ({ active, payload, label }: RechartsTooltipProps<any, any>) => {
+const ChartSparklineTooltip = ({ active, payload, label }: Partial<RechartsTooltipProps<any, any>>) => {
   if (!active || !payload || !payload.length) return null
 
   const formatTimestamp = (timestamp: string) => {
@@ -562,7 +562,7 @@ const ChartSparklineTooltip = ({ active, payload, label }: RechartsTooltipProps<
           {formatTimestamp(payload[0].payload.timestamp)}
         </div>
       )}
-      <div>{payload[0].value.toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
+      <div>{payload[0].value?.toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
     </div>
   )
 }

--- a/packages/ui-patterns/src/LogsBarChart/index.tsx
+++ b/packages/ui-patterns/src/LogsBarChart/index.tsx
@@ -3,7 +3,7 @@
 import dayjs from 'dayjs'
 import { ReactNode, useState } from 'react'
 import { Bar, Cell, BarChart as RechartBarChart, XAxis, YAxis } from 'recharts'
-import type { CategoricalChartState } from 'recharts/types/chart/types'
+import type { MouseHandlerDataParam } from 'recharts'
 import { ChartConfig, ChartContainer, ChartTooltip, ChartTooltipContent, cn } from 'ui'
 
 const CHART_COLORS = {
@@ -39,7 +39,7 @@ export const LogsBarChart = ({
 }: {
   data: LogsBarChartDatum[]
   error?: unknown | null
-  onBarClick?: (datum: LogsBarChartDatum, tooltipData?: CategoricalChartState) => void
+  onBarClick?: (datum: LogsBarChartDatum, tooltipData?: MouseHandlerDataParam) => void
   EmptyState?: ReactNode
   ErrorState?: ReactNode
   DateTimeFormat?: string
@@ -91,8 +91,9 @@ export const LogsBarChart = ({
           }}
           onMouseLeave={() => setFocusDataIndex(null)}
           onClick={(tooltipData) => {
-            const datum = tooltipData?.activePayload?.[0]?.payload
-            if (onBarClick) onBarClick(datum, tooltipData)
+            const index = tooltipData?.activeTooltipIndex
+            const datum = index != null ? data[Number(index)] : undefined
+            if (onBarClick && datum) onBarClick(datum, tooltipData)
           }}
         >
           <YAxis
@@ -133,7 +134,7 @@ export const LogsBarChart = ({
                   payload={filteredPayload}
                   label={props.label}
                   className="text-foreground-light -mt-5 transition-none!"
-                  labelFormatter={(v: string) => dayjs(v).format(DateTimeFormat)}
+                  labelFormatter={(v) => dayjs(v as string).format(DateTimeFormat)}
                 />
               )
             }}

--- a/packages/ui-patterns/src/MetricCard/index.tsx
+++ b/packages/ui-patterns/src/MetricCard/index.tsx
@@ -9,7 +9,7 @@ import {
   Area,
   AreaChart,
   Tooltip as RechartsTooltip,
-  TooltipProps as RechartsTooltipProps,
+  TooltipContentProps as RechartsTooltipProps,
   ResponsiveContainer,
 } from 'recharts'
 import {
@@ -204,7 +204,7 @@ const MetricCardDifferential = React.forwardRef<HTMLDivElement, MetricCardDiffer
 
 MetricCardDifferential.displayName = 'MetricCardDifferential'
 
-const SparklineTooltip = ({ active, payload, label }: RechartsTooltipProps<any, any>) => {
+const SparklineTooltip = ({ active, payload, label }: Partial<RechartsTooltipProps<any, any>>) => {
   if (!active || !payload || !payload.length) return null
 
   const formatTimestamp = (timestamp: string) => {
@@ -223,7 +223,7 @@ const SparklineTooltip = ({ active, payload, label }: RechartsTooltipProps<any, 
           {formatTimestamp(payload[0].payload.timestamp)}
         </div>
       )}
-      <div>{payload[0].value.toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
+      <div>{payload[0].value?.toLocaleString(undefined, { maximumFractionDigits: 0 })}</div>
     </div>
   )
 }

--- a/packages/ui/src/components/shadcn/ui/chart.tsx
+++ b/packages/ui/src/components/shadcn/ui/chart.tsx
@@ -97,7 +97,8 @@ const ChartTooltip = RechartsPrimitive.Tooltip
 const ChartTooltipContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
-    React.ComponentProps<'div'> & {
+    React.ComponentProps<'div'> &
+    Partial<Pick<RechartsPrimitive.TooltipContentProps, 'payload' | 'label' | 'coordinate'>> & {
       hideLabel?: boolean
       hideIndicator?: boolean
       indicator?: 'line' | 'dot' | 'dashed'
@@ -176,7 +177,7 @@ const ChartTooltipContent = React.forwardRef<
 
             return (
               <div
-                key={item.dataKey}
+                key={`${item.dataKey ?? index}`}
                 className={cn(
                   'flex w-full items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-foreground-muted',
                   indicator === 'dot' && 'items-center'
@@ -246,7 +247,7 @@ const ChartLegend = RechartsPrimitive.Legend
 const ChartLegendContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<'div'> &
-    Pick<RechartsPrimitive.LegendProps, 'payload' | 'verticalAlign'> & {
+    Pick<RechartsPrimitive.DefaultLegendContentProps, 'payload' | 'verticalAlign'> & {
       hideIcon?: boolean
       nameKey?: string
     }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -27,7 +27,7 @@ catalog:
   radix-ui: ^1.4.3
   react: ^19.2.6
   react-dom: ^19.2.6
-  recharts: ^2.15.4
+  recharts: ^3.8.1
   tailwindcss: ^4.2.4
   tsx: ^4.22.0
   typescript: ~6.0.0


### PR DESCRIPTION
Updates all recharts imports and usages for compatibility with v3.\n\n- Replace CategoricalChartState with MouseHandlerDataParam\n- Replace TooltipProps with TooltipContentProps (Partial wrapper)\n- Replace activePayload?.[0]?.payload with activeTooltipIndex lookups\n- Add Partial wrappers for TooltipContentProps in chart component props\n- Use DefaultLegendContentProps instead of LegendProps\n- Bump catalog entry in pnpm-workspace.yaml to ^3.8.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated recharts library to v3.8.1.

* **Refactor**
  * Improved tooltip interactions and chart data handling. Enhanced type safety for chart click event handlers and refined coordinate passing for more reliable user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->