### PR TITLE
Allow forward slashes for branch names

### DIFF
--- a/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
+++ b/apps/studio/components/interfaces/BranchManagement/CreateBranchModal.tsx
@@ -93,8 +93,8 @@ export const CreateBranchModal = () => {
       .string()
       .min(1, 'Branch name cannot be empty')
       .refine(
-        (val) => /^[a-zA-Z0-9\-_]+$/.test(val),
-        'Branch name can only contain alphanumeric characters, hyphens, and underscores.'
+        (val) => /^[a-zA-Z0-9\-_/]+$/.test(val),
+        'Only letters, numbers, hyphens, underscores, and forward slashes are allowed.'
       )
       .refine(
         (val) => (branches ?? []).every((branch) => branch.name !== val),
@@ -105,7 +105,7 @@ export const CreateBranchModal = () => {
   })
 
   const form = useForm<z.infer<typeof FormSchema>>({
-    mode: 'onSubmit',
+    mode: 'onChange',
     reValidateMode: 'onBlur',
     resolver: zodResolver(FormSchema),
     defaultValues: { branchName: '', gitBranchName: '', withData: false },
@@ -307,7 +307,7 @@ export const CreateBranchModal = () => {
                 control={form.control}
                 name="branchName"
                 render={({ field }) => (
-                  <FormItemLayout label="Preview Branch Name">
+                  <FormItemLayout label="Preview branch name">
                     <FormControl>
                       <Input
                         {...field}


### PR DESCRIPTION
## Context

Allows forward slashes for branch names

Also fixes validation behaviour in the form, as currently the error shows up `onSubmit`, but the button is disabled until the form state is valid, so the error never shows up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended branch naming rules to support forward slashes and additional special characters, allowing more flexible branch names.
  * Enhanced form validation to provide real-time feedback as you type.

* **Style**
  * Refined form field label text formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->