### PR TITLE
fix(billing): clarify averaged usage messaging

### DIFF
--- a/apps/docs/content/guides/platform/billing-faq.mdx
+++ b/apps/docs/content/guides/platform/billing-faq.mdx
@@ -96,11 +96,11 @@ We currently do not support annual plans officially. However, you can do a [cred
 
 #### What will happen when I exceed the Free Plan quota?
 
-You will be notified when you exceed the Free Plan quota. It is important to take action at this point. If you continue to exceed the limits without reducing your usage, service restrictions will apply. To avoid service restrictions, you have two options: reduce your usage or upgrade to a paid plan. Learn more about restrictions in the [Fair Use Policy](#fair-use-policy) section.
+You will be notified when you exceed the Free Plan quota. It is important to take action at this point. If you continue to exceed the limits, service restrictions will apply. To avoid service restrictions, you can [manage your usage](/docs/guides/platform/manage-your-usage) or upgrade to a paid plan. Learn more about restrictions in the [Fair Use Policy](#fair-use-policy) section.
 
 #### What will happen when I exceed the Pro Plan quota and have the spend cap on?
 
-You will be notified when you exceed your Pro Plan quota. To unblock yourself, you can toggle off your spend cap in your [organization's billing settings](/dashboard/org/_/billing) to pay for over-usage beyond the Pro plans limits. If you continue to exceed the limits without reducing your usage or turning off the spend cap, restrictions will apply. Learn more about restrictions in the [Fair Use Policy](#fair-use-policy) section.
+You will be notified when you exceed your Pro Plan quota. To unblock yourself, you can toggle off your spend cap in your [organization's billing settings](/dashboard/org/_/billing) to pay for over-usage beyond the Pro plans limits. If you continue to exceed the limits without managing your usage or turning off the spend cap, restrictions will apply. Learn more about restrictions in the [Fair Use Policy](#fair-use-policy) section.
 
 #### How do I scale beyond the limits of my Pro Plan?
 

--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -114,6 +114,14 @@ Free Plan projects enter [read-only](#read-only-mode) mode when your **database 
 - [Upgrade to the Pro Plan](/dashboard/org/_/billing) to increase the database size quota. [Disable the Spend Cap](https://app.supabase.com/org/_/billing?panel=costControl) if you want your Pro instance to auto-scale beyond the 8 GB disk size limit.
 - [Disable read-only mode](#disabling-read-only-mode) and reduce your database size.
 
+### Fair Use database size restriction
+
+Separate from the per-project read-only mode above, your organization can be placed under a [Fair Use](/docs/guides/platform/billing-faq#fair-use-policy) service restriction (requests return a `402` status code) when its database size exceeds the plan quota. This quota is evaluated **per organization**, summing the database size across all of your projects.
+
+Importantly, it is based on the **average daily database size over the billing period**, not the live size. Reducing your database size does not immediately lift the restriction: the average stays elevated until enough lower-usage days accumulate, and it effectively resets when your billing cycle rolls over. This is why a project that is well under the limit today can still be restricted, as its average across the period is still over.
+
+To resolve it, upgrade your plan or disable your Spend Cap to lift the restriction immediately. Otherwise, reduce your database size and wait for the new billing cycle, at which point the average restarts from your current size.
+
 ### Read-only mode
 
 In some cases Supabase may put your database into read-only mode to prevent your database from exceeding the billing or disk limitations.

--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -114,7 +114,7 @@ Free Plan projects enter [read-only](#read-only-mode) mode when your **database 
 - [Upgrade to the Pro Plan](/dashboard/org/_/billing) to increase the database size quota. [Disable the Spend Cap](https://app.supabase.com/org/_/billing?panel=costControl) if you want your Pro instance to auto-scale beyond the 8 GB disk size limit.
 - [Disable read-only mode](#disabling-read-only-mode) and reduce your database size.
 
-### Fair Use database size restriction
+### Fair use database size restriction
 
 Separate from the per-project read-only mode above, your organization can be placed under a [Fair Use](/docs/guides/platform/billing-faq#fair-use-policy) service restriction (requests return a `402` status code) when its database size exceeds the plan quota. This quota is evaluated **per organization**, summing the database size across all of your projects.
 

--- a/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/egress.mdx
@@ -63,6 +63,12 @@ Cached and uncached egress have independent quotas and independent pricing. Cach
 
 Egress is charged by gigabyte. Charges apply only for usage exceeding your subscription plan's quota. This quota is called the Unified Egress Quota because it can be used across all services (Database, Auth, Storage etc.).
 
+<Admonition type="note">
+
+Egress accumulates over the billing cycle and resets at the start of the next cycle. Usage that has already been served cannot be reduced retroactively, so the optimizations below lower future egress only. If your organization is restricted for egress, the restriction clears at the start of the next billing cycle, or immediately if you upgrade your plan or disable your Spend Cap.
+
+</Admonition>
+
 ### Usage on your invoice
 
 Usage is shown as "Egress GB" and "Cached Egress GB" on your invoice.

--- a/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
+++ b/apps/docs/content/guides/platform/manage-your-usage/storage-size.mdx
@@ -12,6 +12,8 @@ You are charged for the total size of all assets in your buckets.
 Storage size is charged by Gigabyte-Hours (GB-Hrs). 1 GB-Hr represents the use of 1 GB of storage for 1 hour.
 For example, storing 10 GB of data for 5 hours results in 50 GB-Hrs (10 GB × 5 hours).
 
+Because usage is measured in GB-Hrs, your Storage size for quota and billing is effectively the average across the billing period, not the live size. For example, storing 20 GB for the first half of the month and 0 GB for the second half averages to 10 GB. This means reducing storage late in the cycle lowers the average only gradually, so it may not immediately clear a restriction until the next billing cycle begins.
+
 ### Usage on your invoice
 
 Usage is shown as "Storage Size GB-Hrs" on your invoice.

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Restriction.tsx
@@ -147,9 +147,10 @@ export const Restriction = () => {
               <span className="text-foreground">
                 {dayjs(org.restriction_data['grace_period_end']).format('DD MMM, YYYY')}
               </span>
-              . Fair Use Policy applies now. Stay below your plan's quota or{' '}
-              {org.plan.id === 'free' ? 'upgrade your plan' : 'disable spend cap'} if you expect to
-              exceed it. If you exceed your quota, requests will respond with a 402 status code.
+              . Fair Use Policy applies now. If your organization is over its quota, your projects
+              can be restricted and requests will respond with a 402 status code.{' '}
+              {org.plan.id === 'free' ? 'Upgrade your plan' : 'Disable spend cap'} if you expect to
+              exceed your plan's quota.
             </p>
             <div className="flex items-center gap-x-2 mt-3">
               <Button key="upgrade-button" asChild variant="default">
@@ -187,9 +188,9 @@ export const Restriction = () => {
               serve requests and will respond with a 402 status code. You have exceeded your plan's
               quota{violationLabels && ` ${violationLabels}`}.{' '}
               {org.plan.id === 'free' ? 'Upgrade your plan' : 'Disable spend cap'} to lift
-              restrictions immediately, or wait until your quota refills at the start of your next
-              billing period. Note that there may be a short delay after your billing period resets
-              before restrictions are fully lifted.
+              restrictions immediately, or wait until the start of your next billing period. Note
+              that there may be a short delay after your billing period resets before restrictions
+              are fully lifted.
             </p>
             <div className="flex items-center gap-x-2 mt-3">
               <Button key="upgrade-button" asChild variant="default">

--- a/apps/studio/components/interfaces/Organization/restriction.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.tsx
@@ -12,8 +12,11 @@ export const RESTRICTION_MESSAGES = {
       return (
         <>
           You have a grace period until{' '}
-          <TimestampInfo className="text-sm" utcTimestamp={date} label={label} /> to bring usage
-          back under quota. <InlineLink href={`/org/${slug}/usage`}>Review usage</InlineLink>
+          <TimestampInfo className="text-sm" utcTimestamp={date} label={label} />. After that, your
+          projects will be restricted while your organization is over quota.{' '}
+          <InlineLink href={`/org/${slug}/usage`}>Review usage</InlineLink> or{' '}
+          <InlineLink href={`/org/${slug}/billing`}>manage your plan</InlineLink> to avoid
+          restrictions.
         </>
       )
     },


### PR DESCRIPTION
## Summary
Fixes misleading in-product copy and docs about how usage restrictions resolve, for the averaged-metric case behind a rise in DB size restriction tickets. Database and storage size are enforced on the billing-period average (not live size), and egress is cumulative and can't be reduced retroactively, so the previous "reduce your usage to avoid restriction" framing set the wrong expectation. A customer can drop their DB to 50 MB and still be restricted because the period average is still over.

## Changes
- Studio: reworded the grace-period header banner (`restriction.constants.tsx`) to warn that projects will be restricted after the grace period and point to usage + billing, instead of "bring usage back under quota". Generalized the grace-period-over and restricted alert prose in `Restriction.tsx` so it is no longer wrong for averaged metrics ("stay below your quota" / "quota refills" removed).
- Docs: `billing-faq.mdx` now says "manage your usage" instead of "reduce your usage". `egress.mdx` notes egress is cumulative within the cycle and can't be reduced retroactively. `storage-size.mdx` explains GB-Hrs is the average over the billing period. `database-size.mdx` adds a "Fair Use database size restriction" section explaining the per-org, averaged quota (distinct from the per-project read-only mode).

## Testing
Copy and docs only, no logic changes. To verify on the Vercel preview:
- Docs pages render correctly: egress, storage-size, database-size (new section), billing-faq.
- Studio restriction banner/alert copy reads correctly for the grace_period, grace_period_over, and restricted states (org-level restriction_status driven).

## Linear
- Part of GROWTH-930


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated “Quotas and spend caps” guidance for Free and Pro plan exceedance, including immediate actions and revised restriction triggers.
  * Added “Fair use database size restriction” details (including 402 behavior), how the quota is calculated, and when restrictions reset.
  * Clarified that egress and storage charges accumulate across the billing cycle and clear only at the next cycle (with gradual lifting after reductions).

* **Improvements**
  * Refreshed restriction alert copy to emphasize upgrading and/or disabling Spend Cap, and clarified timing for when restrictions lift (“start of your next billing period”).
  * Added grace-period end time and actionable links to usage and billing pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->