### PR TITLE
chore: add audit logs drains to documentation

### DIFF
--- a/apps/docs/content/guides/security/platform-audit-logs.mdx
+++ b/apps/docs/content/guides/security/platform-audit-logs.mdx
@@ -3,7 +3,9 @@ title: 'Platform Audit Logs'
 description: 'Monitor and track organization member activities via platform API or dashboard.'
 ---
 
-Any [Platform API](/docs/reference/api/introduction) or [dashboard](/dashboard) actions performed by organization members are logged automatically for auditing and security purposes. This includes actions such as creating a new project, inviting members, modifying an edge function or changing project settings.
+This topic covers how to view and stream Platform Audit Logs for your organization.
+
+Any [Platform API](/docs/reference/api/introduction) or [dashboard](/dashboard) actions performed by organization members are logged automatically for auditing and security purposes. This includes actions such as creating a new project, inviting members, modifying an edge function or changing project settings. You can view these logs in the dashboard or stream them to an external destination using [Audit Log Drains](#accessing-audit-log-drains).
 
 Besides Platform Audit Logs, Supabase Auth also provides [Auth Audit Logs](/docs/guides/auth/audit-logs) to monitor authentication-related activities within your projects.
 
@@ -42,13 +44,9 @@ For each audit log, you can see additional details by clicking on the log entry:
 
 Each Supabase user account also has access to [Account Audit logs](/dashboard/account/audit) which displays these logs for only the associated user account.
 
-## Audit Log Drains
+## Accessing Audit Log Drains
 
-Audit Log Drains let you stream platform audit log events to an external destination in real time. This is useful for centralizing security monitoring in a SIEM or custom log aggregation pipeline.
-
-Audit Log Drains can be configured under your [organization's audit log drains](/dashboard/org/_/audit-log-drains).
-
-For setup instructions and supported destinations, see the [Log Drains guide](/docs/guides/telemetry/log-drains).
+Audit Log Drains can be configured under your [organization's audit log drains](/dashboard/org/_/audit-log-drains). For setup instructions and supported destinations, see the [Log Drains guide](/docs/guides/telemetry/log-drains).
 
 ## Limitations
 

--- a/apps/docs/content/guides/security/platform-audit-logs.mdx
+++ b/apps/docs/content/guides/security/platform-audit-logs.mdx
@@ -42,8 +42,15 @@ For each audit log, you can see additional details by clicking on the log entry:
 
 Each Supabase user account also has access to [Account Audit logs](/dashboard/account/audit) which displays these logs for only the associated user account.
 
+## Audit Log Drains
+
+Audit Log Drains let you stream platform audit log events to an external destination in real time. This is useful for centralizing security monitoring in a SIEM or custom log aggregation pipeline.
+
+Audit Log Drains can be configured under your [organization's audit log drains](/dashboard/org/_/audit-log-drains). 
+
+For setup instructions and supported destinations, see the [Log Drains guide](/docs/guides/telemetry/log-drains).
+
 ## Limitations
 
 - There is currently no way to export the logs via dashboard
-- There is currently no way to set up a log drain of platform audit logs
 - Retention periods depend on your plan

--- a/apps/docs/content/guides/security/platform-audit-logs.mdx
+++ b/apps/docs/content/guides/security/platform-audit-logs.mdx
@@ -46,7 +46,7 @@ Each Supabase user account also has access to [Account Audit logs](/dashboard/ac
 
 Audit Log Drains let you stream platform audit log events to an external destination in real time. This is useful for centralizing security monitoring in a SIEM or custom log aggregation pipeline.
 
-Audit Log Drains can be configured under your [organization's audit log drains](/dashboard/org/_/audit-log-drains). 
+Audit Log Drains can be configured under your [organization's audit log drains](/dashboard/org/_/audit-log-drains).
 
 For setup instructions and supported destinations, see the [Log Drains guide](/docs/guides/telemetry/log-drains).
 

--- a/supa-mdx-lint/Rule001HeadingCase.toml
+++ b/supa-mdx-lint/Rule001HeadingCase.toml
@@ -15,6 +15,7 @@ may_uppercase = [
     "Apache Spark",
     "Apple",
     "Assistant",
+    "Audit Log Drains?",
     "Audit Logs?",
     "Auth",
     "Auth API Gateway",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

missing mention of the audit logs drains

## What is the new behavior?

add audit logs drains info

## Additional context

<img width="942" height="396" alt="CleanShot 2026-06-22 at 18 10 06" src="https://github.com/user-attachments/assets/7ca29e42-3d18-4a6a-9e2e-e9a274f393f4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new **“Accessing Audit Log Drains”** section explaining how to stream platform audit log events in real time using **Audit Log Drains**, including where to configure this in the dashboard.
  * Updated the guide’s introduction to reference external streaming via Audit Log Drains.
  * Revised the **“Limitations”** section to remove the prior note about lacking drain setup, while retaining the dashboard-export limitation and the plan-based retention information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->