### PR TITLE
docs: clarify Kakao individual Biz app setup

### DIFF
--- a/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
@@ -77,7 +77,9 @@ If you don't need an email address (or `account_email` isn't available for your 
 
 <Admonition type="tip">
 
-In the Kakao Developers Portal, the "account_email" consent item is only available for apps that are registered as "Biz App". To convert your app to a "Biz App", go to **App Settings** > **App** > **General**, and complete the required fields in the **Business Information** section.
+In the Kakao Developers Portal, the "account_email" consent item is only available for apps that are registered as a Biz app. If you have a business registration number, go to **App Settings** > **App** > **General** > **Business information** and register it there.
+
+Individual developers can also [switch to a Biz app](https://developers.kakao.com/docs/en/app-setting/app#business-information) without a business registration number. The app owner must complete Kakao account identification, accept the Kakao Business terms, and may need to upload an app icon before the individual conversion option appears.
 
 </Admonition>
 


### PR DESCRIPTION
﻿## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update.

## What is the current behavior?

The Kakao Auth guide says `account_email` requires a Biz app and points business owners to **App Settings** > **App** > **General** > **Business information**, but it does not explain Kakao's supported individual-developer Biz app conversion path.

This leaves issue #36878 unresolved for individual developers who do not have a business registration number.

## What is the new behavior?

Clarifies that:

- Business owners can register a business registration number in Kakao Developers.
- Individual developers can also switch to a Biz app without a business registration number.
- The app owner must complete Kakao account identification, accept Kakao Business terms, and may need an app icon before the individual conversion option appears.

Fixes #36878.

## Additional context

Evidence checked before opening:

- Issue #36878 is open, unassigned, and labeled `bug`, `documentation`, `auth`, `external-issue`.
- A Supabase contributor said a docs PR for this issue was welcome in https://github.com/supabase/supabase/issues/36878#issuecomment-3042542885.
- The only prior matching PR, #37051, is closed and unmerged.
- Kakao's current official App Settings docs say individual developers without a business registration number can switch to a Biz app after owner identification and Kakao Business terms consent: https://developers.kakao.com/docs/en/app-setting/app#business-information.

Local validation:

- `pnpm exec prettier --check apps/docs/content/guides/auth/social-login/auth-kakao.mdx`
- `git diff --check`
- `rg -n "Individual developers can also|Kakao Business terms|business registration number|Business information" apps/docs/content/guides/auth/social-login/auth-kakao.mdx`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Kakao Auth guide updated with clarified information on `account_email` consent item availability for Biz apps and comprehensive setup instructions for both business-registered applications and individual developers converting to Biz app status, including identification and terms completion steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->