### PR TITLE
chore(docs): gitignore extracted public/docs/ markdown

### DIFF
--- a/apps/docs/.gitignore
+++ b/apps/docs/.gitignore
@@ -32,6 +32,7 @@ public/llms/
 # Generated guide and reference markdown files
 public/markdown/
 public/docs.tar.gz
+public/docs/
 
 # Copied examples folder
 /examples/


### PR DESCRIPTION
Resolves GROWTH-932

## What

Adds `public/docs/` to `apps/docs/.gitignore`.

## Why

The docs build extracts `public/docs.tar.gz` into `public/docs/`, producing ~530 generated `.md` files. The tarball is already gitignored, but the extracted directory was not. So after any docs build those 530 files show up as untracked, and they're easy to stage by accident (I had 72 sitting staged in my working copy, which is what sent me down this path). They never belong in a commit: the tarball is the committed source of truth, and `public/docs/` is just its extraction.

Today the only thing keeping this quiet for some of us is a personal `.git/info/exclude` entry, which every contributor has to discover and add on their own. This moves the ignore into the committed gitignore so nobody has to.

## Verification

```
$ git check-ignore -v apps/docs/public/docs/guides/ai.md
apps/docs/.gitignore:35:public/docs/    apps/docs/public/docs/guides/ai.md

$ git check-ignore -v apps/docs/public/docs.tar.gz
apps/docs/.gitignore:34:public/docs.tar.gz    apps/docs/public/docs.tar.gz
```

Extracted files now match the new rule; the tarball stays ignored. No tracked files are affected (nothing under `public/docs/` is committed on `master`).
