### PR TITLE
fix(studio): resize handle double border

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -396,7 +396,7 @@ const EdgeFunctionTesterSheetContent = ({ visible, onClose }: EdgeFunctionTester
               </ResizablePanel>
               <ResizableHandle withHandle />
               <ResizablePanel defaultSize="41" minSize="41" maxSize="83">
-                <div className="h-full bg-surface-100 border-t flex-1 flex flex-col overflow-hidden">
+                <div className="h-full bg-surface-100 flex-1 flex flex-col overflow-hidden">
                   {response ? (
                     <div className="h-full bg-surface-100 flex flex-col overflow-hidden">
                       {error ? (

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -902,7 +902,7 @@ export const SQLEditor = () => {
           autoSaveId={LOCAL_STORAGE_KEYS.SQL_EDITOR_SPLIT_SIZE}
         >
           <ResizablePanel defaultSize="50" maxSize="70">
-            <div className="grow overflow-y-auto border-b h-full">
+            <div className="grow overflow-y-auto h-full">
               {isLoading ? (
                 <div className="flex h-full w-full items-center justify-center">
                   <Loader2 className="animate-spin text-brand" />

--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -464,7 +464,7 @@ export const LogTable = ({
   const logsExplorerTableHeader = (
     <div
       className={cn(
-        'flex w-full items-center justify-between border-t bg-surface-100 px-5 py-2',
+        'flex w-full items-center justify-between bg-surface-100 px-5 py-2',
         className,
         { hidden: !showHeader }
       )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

this pr is a fix proposal regarding the double border rendered, in order to remove panel border and rely solely on the `ResizableHandle` one

## What is the current behavior?

as `ResizableHandle` already renders a 1px divider line between panels, the following elements also carried their own making it a doubled border:
- SQL Editor
- Logs Explorer
- Edge Function Tester

## What is the new behavior?

| state | Edge Function Tester |
| -------|------|
| before | <img width="501" height="186" alt="image" src="https://github.com/user-attachments/assets/ce216414-afe7-4bc5-9bff-f80466e4f825" /> |
| after | <img width="501" height="186" alt="image" src="https://github.com/user-attachments/assets/340fcbb4-30d6-4a73-9f00-6c26e430f736" /> | 

## To test

Visit:

1. SQL Editor: `/project/default/sql/new`
2. Logs Explorer: `/project/default/logs/explorer`
3. Edge Function Tester: `/project/<ref>/functions` and click `Test` from a deployed function


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed top border styling from response panels, editor containers, and log table headers for a streamlined visual presentation across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->