### PR TITLE
fix(studio): track homepage service-card clicks

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
@@ -135,6 +135,7 @@ export const ProjectUsageSection = () => {
       {
         key: 'realtime',
         title: 'Realtime requests',
+        href: `/project/${projectRef}/realtime/inspector`,
         route: '/logs/realtime-logs',
         enabled: true,
       },

--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsageSectionDeltas.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsageSectionDeltas.tsx
@@ -76,6 +76,7 @@ export const ProjectUsageSectionDeltas = () => {
       {
         key: 'functions',
         title: 'Edge Functions',
+        href: `/project/${projectRef}/functions`,
         route: '/logs/edge-functions-logs',
         enabled: true,
       },
@@ -96,12 +97,14 @@ export const ProjectUsageSectionDeltas = () => {
       {
         key: 'realtime',
         title: 'Realtime',
+        href: `/project/${projectRef}/realtime/inspector`,
         route: '/logs/realtime-logs',
         enabled: true,
       },
       {
         key: 'data_api',
         title: 'API Gateway',
+        href: `/project/${projectRef}/integrations/data_api/overview`,
         route: '/logs/edge-logs',
         enabled: dataApiEnabled,
       },


### PR DESCRIPTION
## Summary

The homepage usage section fired `home_project_usage_service_clicked` for only 3 of its 6 service cards. `functions`, `realtime`, and `data_api` logged zero clicks over the last 30 days, while `home_project_usage_chart_clicked` confirmed real traffic on those same surfaces (realtime 3,928, data_api 968, functions 59). The cause: the `track(...)` call lives inside a `<Link>` that only renders when a service card has an `href`. Those three cards only had a `route` (used by the chart-bar handler), so their titles rendered as plain text with no link and nothing to fire the event on.

I added the missing `href`s so all six titles route through the existing `<Link onClick={track}>` path, restoring navigation + tracking parity with db/auth/storage. This also makes those three titles clickable for the first time (they were previously dead text).

## Changes

- Add `href` to the `functions`, `realtime`, and `data_api` cards in `ProjectUsageSectionDeltas.tsx` (functions to the Edge Functions page, realtime to the Realtime inspector, data_api to the Data API overview)
- Add `href` to the `realtime` card in the flag-off fallback `ProjectUsageSection.tsx`

Routes were verified against the actual page directories and the project left-nav. The legacy `/project/{ref}/api` path is a redirect, so data_api points at the canonical `/integrations/data_api/overview`.

## Testing

To verify on the Vercel preview (project home page, both with and without the `newHomepageUsageDeltas` flag):

- [x] Click the **Edge Functions**, **Realtime**, and **API Gateway** card titles: each navigates to its feature page and fires `home_project_usage_service_clicked` with the matching `service_type` (check PostHog live events / network tab)
- [x] db / auth / storage titles still navigate and track as before
- [x] Chart-bar clicks unchanged: still fire `home_project_usage_chart_clicked`

Verified locally: the three new routes resolve to real pages, and tracking reuses the same proven Link path as db/auth/storage.

## Linear

- fixes GROWTH-933


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service card titles on the project dashboard are now interactive links that navigate directly to their corresponding tools and interfaces. Realtime requests, Functions, and API Gateway cards can now be accessed with a single click from the project overview, improving navigation efficiency and reducing the time needed to access frequently used features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->