### PR TITLE
fix(studio): remove Enterprise-only notice from unified logs preview

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/UnifiedLogsPreview.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/UnifiedLogsPreview.tsx
@@ -13,10 +13,6 @@ export const UnifiedLogsPreview = () => {
         Experience our enhanced Logs interface with improved filtering, real-time updates, and a
         unified view across all your services. Built for better performance and easier debugging.
       </p>
-      <p className="text-foreground-light text-sm mb-4">
-        This interface is only available for organizations on the Enterprise plan.
-      </p>
-
       <Image
         alt="new-logs-preview"
         src={`${BASE_PATH}/img/previews/new-logs-preview.png`}


### PR DESCRIPTION
## Problem

The unified logs feature preview displayed a message saying the interface was only available for Enterprise plan organizations. The feature is now available to all plans, making this notice inaccurate and potentially confusing.

## Fix

Removed the paragraph containing the Enterprise-only restriction notice from the unified logs preview component.

## How to test

1. Open Studio and navigate to any project
2. Open the Feature Previews panel
3. Find the "Unified Logs" preview entry
4. Confirm the Enterprise restriction notice is no longer shown
5. Expected result: only the description and screenshot are visible, with no plan restriction text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refreshed Unified Logs interface description to emphasize enhanced capabilities including improved filtering, real-time updates, and a unified view across services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->