### PR TITLE
Fix feature preview URL for disable advisor rules

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -57,7 +57,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
           isNew: false,
           isPlatformOnly: true,
           isDefaultOptIn: false,
-          getRoute: (ref?: string) => `/project/${ref}/advisors/rules`,
+          getRoute: (ref?: string) => `/project/${ref}/advisors/rules/security`,
         },
 
         {


### PR DESCRIPTION
## Context

Tiny one - just fixes the URL for the disable advisor rules feature preview

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation in the Advisor feature to direct users to the security rules section more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->