### PR TITLE
Unified logs - exclude realtime logs that start with billing metrics

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -124,6 +124,13 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(sql).not.toContain("event_message NOT LIKE 'connection received%'")
     })
 
+    it("always excludes Realtime's 'Billing metrics:' log lines", () => {
+      const sql = getUnifiedLogsQuery(withFilters('log_type:eq:realtime'))
+      expect(sql).toContain(
+        "(source != 'realtime_logs' OR NOT startsWith(event_message, 'Billing metrics:'))"
+      )
+    })
+
     it('does not emit subqueries or CTEs (rejected by the OTEL endpoint)', () => {
       const sql = getUnifiedLogsQuery(baseSearch)
       expect(sql).not.toMatch(/WITH\s+\w+\s+AS\s*\(/i)
@@ -169,6 +176,17 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       const logTypeWhere = whereOfBranchContaining(sql, `'log_type'`)
       expect(logTypeWhere).not.toContain(`NOT LIKE '%/rest/%'`)
     })
+
+    it("excludes Realtime's 'Billing metrics:' log lines from every count scan", () => {
+      const sql = getLogsCountQuery(baseSearch)
+      const scans = sql.split(/\bUNION ALL\b/)
+      expect(scans.length).toBeGreaterThan(1)
+      for (const scan of scans) {
+        expect(scan).toContain(
+          "(source != 'realtime_logs' OR NOT startsWith(event_message, 'Billing metrics:'))"
+        )
+      }
+    })
   })
 
   describe('getLogsChartQuery', () => {
@@ -197,6 +215,13 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       const sql = getLogsChartQuery(baseSearch)
       expect(sql).toContain(
         `if(source = 'auth_logs', log_attributes['status'], log_attributes['response.status_code'])`
+      )
+    })
+
+    it("excludes Realtime's 'Billing metrics:' log lines from the chart", () => {
+      const sql = getLogsChartQuery(withFilters('log_type:eq:realtime'))
+      expect(sql).toContain(
+        "(source != 'realtime_logs' OR NOT startsWith(event_message, 'Billing metrics:'))"
       )
     })
   })

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -264,6 +264,15 @@ const rowProjection = (): SafeLogSqlFragment => safeSql`
     null AS logs
 `
 
+/**
+ * Excludes Realtime's periodic `Billing metrics:` log lines, which are internal
+ * bookkeeping noise rather than user-facing events. Always applied (no toggle)
+ * and shared by every query via `buildBaseWhere`, so the row, chart and sidebar
+ * facet counts all agree. The `source != 'realtime_logs'` guard makes it a
+ * no-op for every other log type.
+ */
+const REALTIME_BILLING_METRICS_FILTER: SafeLogSqlFragment = safeSql`(source != 'realtime_logs' OR NOT startsWith(event_message, 'Billing metrics:'))`
+
 const buildBaseWhere = (
   search: QuerySearchParamsType,
   excludeField?: string
@@ -292,6 +301,8 @@ const buildBaseWhere = (
     }
   }
 
+  parts.push(REALTIME_BILLING_METRICS_FILTER)
+
   return parts
 }
 
@@ -309,6 +320,7 @@ const connectionLogsFilter = (search: QuerySearchParamsType): SafeLogSqlFragment
     event_message NOT LIKE 'connection authorized%'
   ))`
 }
+
 
 /**
  * Unified logs row query — flat SELECT, no subquery wrapper.

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -321,7 +321,6 @@ const connectionLogsFilter = (search: QuerySearchParamsType): SafeLogSqlFragment
   ))`
 }
 
-
 /**
  * Unified logs row query — flat SELECT, no subquery wrapper.
  */


### PR DESCRIPTION
## Context

As per PR title

JFYI though I'm not exactly sure how to test this without some example logs in a project that fits this criteria 😕 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Realtime "Billing metrics:" log entries are now excluded from the unified logs view, including chart queries and sidebar facet counts, providing a cleaner log display focused on relevant user activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->