### PR TITLE
fix(studio): polish editor tab styling

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -904,7 +904,7 @@ export const SQLEditor = () => {
           <ResizablePanel defaultSize="50" maxSize="70">
             <div className="grow overflow-y-auto border-b h-full">
               {isLoading ? (
-                <div className="flex h-full w-full items-center justify-center">
+                <div className="flex h-full w-full items-center justify-center bg-surface-100">
                   <Loader2 className="animate-spin text-brand" />
                 </div>
               ) : (

--- a/apps/studio/components/layouts/Tabs/SortableTab.tsx
+++ b/apps/studio/components/layouts/Tabs/SortableTab.tsx
@@ -60,7 +60,7 @@ export const SortableTab = ({
       layoutId={tab.id}
       transition={{ duration: 0.045 }}
       animate={{ opacity: isDragging ? 0 : 1 }}
-      className={cn('flex items-center h-(--header-height) first-of-type:border-l')}
+      className={cn('flex items-center h-(--header-height)', index === 0 && 'border-l')}
     >
       <TabsTrigger_Shadcn_
         value={tab.id}
@@ -78,6 +78,7 @@ export const SortableTab = ({
           'data-[state=active]:bg-dash-sidebar dark:data-[state=active]:bg-surface-100',
           'border-b border-default',
           'data-[state=active]:border-b-background-dash-sidebar dark:data-[state=active]:border-b-background-surface-100',
+          'transition-none',
           'relative group h-full',
           'hover:bg-surface-300 dark:hover:bg-surface-100',
           tab.isPreview && 'italic font-light' // Optional: style preview tabs differently
@@ -120,7 +121,7 @@ export const SortableTab = ({
         >
           <X size={12} className="text-foreground-light" />
         </span>
-        <div className="absolute w-full top-0 left-0 right-0 h-px bg-foreground opacity-0 group-data-[state=active]:opacity-100" />
+        <div className="absolute w-full top-0 left-0 right-0 h-0.5 bg-foreground opacity-0 group-data-[state=active]:opacity-100" />
       </TabsTrigger_Shadcn_>
       {index < openTabs.length && (
         <div role="separator" className="h-full w-px bg-border" key={`separator-${tab.id}`} />

--- a/apps/studio/components/layouts/Tabs/Tabs.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.tsx
@@ -187,10 +187,12 @@ export const EditorTabs = () => {
                 'flex items-center gap-2 px-3 text-xs',
                 'bg-dash-sidebar/50 dark:bg-surface-100/50',
                 'data-[state=active]:bg-dash-sidebar dark:data-[state=active]:bg-surface-100',
-                'relative group h-full border-t-2 border-b-0!',
+                'relative group h-full',
+                'border-b border-default data-[state=active]:border-b-background-dash-sidebar dark:data-[state=active]:border-b-background-surface-100',
                 'hover:bg-surface-300 dark:hover:bg-surface-100'
               )}
             >
+              <div className="absolute top-0 left-0 right-0 w-full h-0.5 bg-foreground opacity-0 group-data-[state=active]:opacity-100" />
               <Plus size={16} strokeWidth={1.5} className={'text-foreground-lighter'} />
               <div className="flex items-center gap-0">
                 <span>New</span>
@@ -201,7 +203,7 @@ export const EditorTabs = () => {
                   e.preventDefault()
                   e.stopPropagation()
                 }}
-                className="ml-1 opacity-0 group-hover:opacity-100 hover:bg-200 rounded-xs cursor-pointer"
+                className="ml-1 opacity-0 group-hover:opacity-100 hover:bg-200 rounded-xs cursor-pointer p-0.5"
                 onMouseDown={(e) => {
                   e.preventDefault()
                   e.stopPropagation()
@@ -220,23 +222,26 @@ export const EditorTabs = () => {
 
           <AnimatePresence initial={false}>
             {!hasNewTab && (
-              <motion.button
-                className="flex items-center justify-center w-10 min-h-(--header-height) hover:bg-surface-100 shrink-0 border-b"
-                onClick={() =>
-                  router.push(
-                    `/project/${router.query.ref}/${editor === 'table' ? 'editor' : 'sql'}/new?skip=true`
-                  )
-                }
-                initial={{ opacity: 0, scale: 0.8, x: -10 }}
-                animate={{ opacity: 1, scale: 1, x: 0 }}
-                transition={{ duration: 0.2 }}
-              >
-                <Plus
-                  size={16}
-                  strokeWidth={1.5}
-                  className="text-foreground-lighter hover:text-foreground-light"
-                />
-              </motion.button>
+              <div className="relative flex h-full shrink-0">
+                <motion.button
+                  className="flex h-full w-10 items-center justify-center border-b border-b-transparent hover:bg-surface-100"
+                  onClick={() =>
+                    router.push(
+                      `/project/${router.query.ref}/${editor === 'table' ? 'editor' : 'sql'}/new?skip=true`
+                    )
+                  }
+                  initial={{ opacity: 0, scale: 0.8, x: -10 }}
+                  animate={{ opacity: 1, scale: 1, x: 0 }}
+                  transition={{ duration: 0.2 }}
+                >
+                  <Plus
+                    size={16}
+                    strokeWidth={1.5}
+                    className="text-foreground-lighter hover:text-foreground-light"
+                  />
+                </motion.button>
+                <div className="pointer-events-none absolute bottom-0 left-0 right-0 h-px bg-border" />
+              </div>
             )}
           </AnimatePresence>
           <div className="grow h-full border-b pr-6" />


### PR DESCRIPTION
## What kind of change does this PR introduce?

this pr is a proposal to polish the SQL table editor tabs and fix border and styling glitches that show up when adding, switching + navigating between tabs

## What is the current behavior?

working with editor tabs a few border + styling issues appear:
- doubled left border between tabs, when creating and filling up a new SQL query in the editor
- animated bottom border on tab switch (from new empty to previous).
- active tab top border and the "+" have minor inconsistencies (thickness, shift)

## What is the new behavior?

- doubled left border is gone
- active top indicator is consistent with active tab styling (2px)
- "+" icon stays vertically aligned

| state | preview |
| -------|------|
| before | <video src="https://github.com/user-attachments/assets/a78e668e-233b-46a1-984e-d6471b9cd5a2" /> |
| after | <video src="https://github.com/user-attachments/assets/4e3ea0a1-c06f-491c-a98c-fa3206800462" /> | 

| state | preview |
| -------|------|
| before | <img width="579" height="186" alt="image" src="https://github.com/user-attachments/assets/727104a6-2c34-4a58-8757-7ab8c51c9649" /> |
| after | <img width="579" height="186" alt="image" src="https://github.com/user-attachments/assets/248ec731-f79c-4941-9845-8c4354532a27" /> |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated SQL editor loading state background styling
  * Refined tab component styling for borders, transitions, and underline heights
  * Enhanced "New" tab appearance with highlight element and improved close button
  * Improved "add new tab" button styling with divider element

<!-- end of auto-generated comment: release notes by coderabbit.ai -->