### PR TITLE
fix: Fix troubleshooting frontmatter validation

### DIFF
--- a/apps/docs/content/troubleshooting/postgrest-error-400-column-example_tableexample_column-does-not-exist-when-using-or-operators-46ff23.mdx
+++ b/apps/docs/content/troubleshooting/postgrest-error-400-column-example_tableexample_column-does-not-exist-when-using-or-operators-46ff23.mdx
@@ -6,7 +6,6 @@ keywords = [ "postgrest", "column does not exist" ]
 [[errors]]
 http_status_code = 400
 message = "column example_table.example_column does not exist"
-
 ---
 
 If you receive a `400` error with the message `column example_table.example_column does not exist` only on mutation requests (`PATCH`, `POST`, `DELETE`) — while `SELECT` queries on the same column work fine — this is a known bug in PostgREST versions before 14.4 ([issue #3707](https://github.com/PostgREST/postgrest/issues/3707)).

--- a/apps/docs/features/docs/Troubleshooting.utils.common.mjs
+++ b/apps/docs/features/docs/Troubleshooting.utils.common.mjs
@@ -61,6 +61,7 @@ export const TroubleshootingSchema = z
       z.enum([
         'ai',
         'ai-tools',
+        'api',
         'auth',
         'branching',
         'cli',
@@ -129,12 +130,10 @@ export async function getAllTroubleshootingEntriesInternal() {
 
     const parseResult = validateTroubleshootingMetadata(frontmatter)
     if ('error' in parseResult) {
-      console.error(
-        `Error validating troubleshooting metadata\nEntry:%O\nError:%O`,
-        frontmatter,
-        parseResult.error
+      throw Error(
+        `Error validating troubleshooting metadata for ${filePath}`,
+        { cause: parseResult.error }
       )
-      return null
     }
 
     const mdxTree = fromMarkdown(content, {


### PR DESCRIPTION
In this PR:
 - Add missing supported `api` in valid topics for troubleshooting.
 - Throw error when culprit troubleshooting guide is added with invalid schema in metadata.
 - Clean production error logs.
 
 **Current behavior:**
 When wrong metadata was present the build would still pass. We want builds to fail when content is not valid. Also, it would pollute build logs even when passing.
 
 **New behavior:**
Wrong metadata now breaks build on _preview_. Build fails. Production logs now stay clean when build passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated PostgREST error troubleshooting documentation.
  * Added new API troubleshooting topic category.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->