### PR TITLE
fix(docs): use default connection string

### DIFF
--- a/examples/edge-functions/supabase/functions/postgres-on-the-edge/index.ts
+++ b/examples/edge-functions/supabase/functions/postgres-on-the-edge/index.ts
@@ -1,17 +1,7 @@
 import { Pool } from 'jsr:@db/postgres@^0'
 
 // Create a database pool with one connection.
-const pool = new Pool(
-  {
-    tls: { enabled: false },
-    database: 'postgres',
-    hostname: Deno.env.get('DB_HOSTNAME'),
-    user: Deno.env.get('DB_USER'),
-    port: 6543,
-    password: Deno.env.get('DB_PASSWORD'),
-  },
-  1
-)
+const pool = new Pool(Deno.env.get('SUPABASE_DB_URL')!, 1)
 
 export default {
   fetch: async (_req) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

docs update, ...

## What is the current behavior?

Current docs suggest to use `DB_USER` and other params to create the `Pool` but these secrets are not automatically created, which requires extra steps from user side.

## What is the new behavior?

Use the default `SUPABASE_DB_URL` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified database connection initialization in the Supabase edge function by leveraging environment configuration, reducing manual setup complexity while maintaining the same functionality and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->