### PR TITLE
fix(ci): skip AWS ECR auth on fork PRs in studio e2e workflow

### DIFF
--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -86,13 +86,13 @@ jobs:
 
       # Authenticate with AWS ECR to avoid rate limiting
       - name: configure aws credentials
-        if: steps.filter.outputs.studio == 'true'
+        if: steps.filter.outputs.studio == 'true' && !github.event.pull_request.head.repo.fork
         uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # v2.2.0
         with:
           role-to-assume: ${{ secrets.PROD_AWS_ROLE }}
           aws-region: us-east-1
       - uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2.2.0
-        if: steps.filter.outputs.studio == 'true'
+        if: steps.filter.outputs.studio == 'true' && !github.event.pull_request.head.repo.fork
         with:
           registry: public.ecr.aws
 


### PR DESCRIPTION
## Problem

The Selfhosted Studio E2E Tests workflow fails on community (fork) PRs at the **configure aws credentials** step with:

> Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers

GitHub does not pass repository secrets to workflows triggered by `pull_request` from a fork (a deliberate security measure). So on fork PRs:

- `${{ secrets.PROD_AWS_ROLE }}` evaluates to an empty string, and
- the OIDC `id-token` token isn't available either,

so `aws-actions/configure-aws-credentials` falls through its entire provider chain and errors out, failing the job.

## Fix

Guard the AWS credential + ECR login steps with `!github.event.pull_request.head.repo.fork`, the same pattern already used by the Playwright comment step in this workflow. These steps only exist to authenticate with AWS ECR to avoid Docker pull rate limiting, so on fork PRs we simply skip them and pull from `public.ecr.aws` anonymously, letting the e2e tests run instead of erroring out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CI/CD pipeline security configuration to better safeguard authentication credentials during external contributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->