### PR TITLE
fix: invalidate permissions cache on org invite acceptance

### DIFF
--- a/apps/studio/data/organization-members/organization-invitation-accept-mutation.ts
+++ b/apps/studio/data/organization-members/organization-invitation-accept-mutation.ts
@@ -3,6 +3,7 @@ import { toast } from 'sonner'
 
 import { handleError, post } from '@/data/fetchers'
 import { invalidateOrganizationsQuery } from '@/data/organizations/organizations-query'
+import { invalidatePermissionsQuery } from '@/data/permissions/permissions-query'
 import { useInvalidateProjectsInfiniteQuery } from '@/data/projects/org-projects-infinite-query'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
 
@@ -47,8 +48,11 @@ export const useOrganizationAcceptInvitationMutation = ({
   >({
     mutationFn: (vars) => acceptOrganizationInvitation(vars),
     async onSuccess(data, variables, context) {
-      await invalidateOrganizationsQuery(queryClient)
-      await invalidateProjectsQuery()
+      await Promise.all([
+        invalidateOrganizationsQuery(queryClient),
+        invalidateProjectsQuery(),
+        invalidatePermissionsQuery(queryClient),
+      ])
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/permissions/permissions-query.ts
+++ b/apps/studio/data/permissions/permissions-query.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query'
+import { useQuery, type QueryClient } from '@tanstack/react-query'
 import { useIsLoggedIn } from 'common'
 
 import { permissionKeys } from './keys'
@@ -43,4 +43,8 @@ export const usePermissionsQuery = <TData = PermissionsData>({
     enabled: IS_PLATFORM && enabled && isLoggedIn,
     staleTime: 5 * 60 * 1000,
   })
+}
+
+export function invalidatePermissionsQuery(client: QueryClient) {
+  return client.invalidateQueries({ queryKey: permissionKeys.list() })
 }


### PR DESCRIPTION
- Add `invalidatePermissionsQuery` helper to `permissions-query.ts`
- Invalidate it alongside organizations and projects in `useOrganizationAcceptInvitationMutation`'s `onSuccess`, so permissions are refetched before the redirect to the org.

## Testing

1. Invite a user to an org.
2. Accept the invite via the invite link.
3. Navigate to the org's Billing page.
4. Verify the Subscription and Cost Control sections load without "you need additional permissions" errors (no manual reload needed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where user permissions were not properly synchronized after accepting organization invitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->