### PR TITLE
chore: delete `Button` `alternative` deprecated variant

### DIFF
--- a/apps/design-system/registry/default/example/switch-form.tsx
+++ b/apps/design-system/registry/default/example/switch-form.tsx
@@ -83,7 +83,7 @@ export default function SwitchForm() {
             />
           </div>
         </div>
-        <Button type="submit" variant="alternative">
+        <Button type="submit" variant="primary">
           Submit
         </Button>
       </form>

--- a/apps/design-system/registry/default/example/textarea-form.tsx
+++ b/apps/design-system/registry/default/example/textarea-form.tsx
@@ -65,7 +65,7 @@ export default function TextareaForm() {
             </FormItem>
           )}
         />
-        <Button type="submit" variant="alternative">
+        <Button type="submit" variant="primary">
           Submit
         </Button>
       </form>

--- a/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/LogTable.tsx
@@ -512,7 +512,7 @@ export const LogTable = ({
         )}
         <Button
           title="run-logs-query"
-          variant={hasEditorValue ? 'primary' : 'alternative'}
+          variant="primary"
           disabled={!hasEditorValue}
           onClick={onRun}
           iconRight={<Play size={12} />}

--- a/apps/studio/components/interfaces/Settings/Logs/RecentQueriesItem.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/RecentQueriesItem.tsx
@@ -23,7 +23,7 @@ const RecentQueriesItem: React.FC<Props> = ({ item }) => {
       </Table.td>
       <Table.td className="text-right">
         <Button
-          variant="alternative"
+          variant="primary"
           iconRight={<Play size={10} />}
           onClick={() =>
             router.push(`/project/${ref}/logs/explorer?q=${encodeURIComponent(item.sql)}`)

--- a/apps/www/components/LaunchWeek/11/Releases/LW11Header.tsx
+++ b/apps/www/components/LaunchWeek/11/Releases/LW11Header.tsx
@@ -34,7 +34,7 @@ const LW11Header = ({ className }: { className?: string }) => {
           . <br className="hidden sm:block" /> Join us in this major milestone and explore{' '}
           <br className="hidden sm:block" /> the exciting features that come with it.
         </p>
-        <Button asChild size="small" variant="alternative">
+        <Button asChild size="small" variant="primary">
           <Link href="/ga">Read full announcement</Link>
         </Button>
       </SectionContainer>

--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -58,17 +58,6 @@ const buttonVariants = cva(
           data-[state=open]:border-foreground-lighter
           data-[state=open]:outline-border-strong
         `,
-        /** @deprecated use 'primary' instead */
-        alternative: `
-          text-foreground
-          bg-brand-400 hover:bg-brand-500
-          border-brand-500
-          focus-visible:border-brand-500
-          focus-visible:outline-brand-600
-          data-[state=open]:bg-brand-500
-          data-[state=open]:border-brand-500
-          data-[state=open]:outline-brand-600
-        `,
         outline: `
           text-foreground
           bg-transparent


### PR DESCRIPTION
## Problem

The `alternative` variant for `<Button>` has been deprecated but is still used in a few places.

## Solution

- Migrate usages to the recommended `primary` variant
- Delete the `alternative` variant 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated several buttons across forms, logs, recent queries, and release headers to use the primary visual style.
  * Button styling is now more consistent throughout the app, with a cleaner default emphasis for key actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->