### PR TITLE
docs(i18n): remove outdated alpha/beta status section from Hindi README

### DIFF
--- a/i18n/README.hi.md
+++ b/i18n/README.hi.md
@@ -19,6 +19,7 @@
   - [x] डेटाबेस फ़ंक्शंस। [प्रलेखन](https://supabase.com/docs/guides/database/functions)
   - [x] एज फ़ंक्शंस। [प्रलेखन](https://supabase.com/docs/guides/functions)
 - [x] भंडारण। [प्रलेखन](https://supabase.com/docs/guides/storage)
+- [x] AI + वेक्टर/एम्बेडिंग्स टूलकिट। [Docs](https://supabase.com/docs/guides/ai)
 - [x] डैशबोर्ड।
 
 ![सुपाबेस का डैशबोर्ड।](https://raw.githubusercontent.com/supabase/supabase/master/apps/www/public/images/github/supabase-dashboard.png)
@@ -36,14 +37,6 @@
 - [ई-मेल समर्थन](https://supabase.com/docs/support#business-support)। आपके डेटाबेस और इंफ़्रास्ट्रक्चर के साथ समस्याएं के लिए उचित है।
 - [डिस्कॉर्ड](https://discord.supabase.com/)। अपने प्रोजेक्ट्स शेयर करने के लिए और हमारी सुपाबेस समुदाय के साथ बातचीत करने के लिए उचित है।
 
-## स्थिति
-
-- [x] अल्फा: हम चुनिंदा ग्राहकों के साथ सुपरबास का परीक्षण कर रहे हैं
-- [x] सार्वजनिक अल्फा: कोई भी [supabase.com/dashboard](https://supabase.com/dashboard) के जरिए शामिल हो सकता है। लेकिन हम पर आसान हो जाओ, कुछ मोड़ हैं।
-- [x] सार्वजनिक बीटा: अधिकांश गैर-एंटरप्राइज़ उपयोग-मामलों के लिए पर्याप्त स्थिर
-- [ ] सार्वजनिक: उत्पादन-तैयार
-
-हम इस समय सार्वजनिक बीटा में हैं। प्रमुख अद्यतन की सूचना पाने के लिए इस रेपो का "रिलीज़" देखें।
 
 <kbd><img src="https://raw.githubusercontent.com/supabase/supabase/d5f7f413ab356dc1a92075cb3cee4e40a957d5b1/web/static/watch-repo.gif" alt="इस रेपो को देखें"/></kbd>
 


### PR DESCRIPTION
The Hindi README still had the Alpha/Public Alpha/Public Beta status  checklist and the line saying Supabase is "currently in public beta."  This section no longer exists in the current English README since  Supabase has been production-ready for a while. Removed it to keep  the translation in sync.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Hindi README with a completed checklist item for the AI + vector/embeddings toolkit, including its documentation link.
  * Removed the separate readiness/status section that listed launch milestones and public beta notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->