### PR TITLE
docs(realtime): broadcast replay retention limits - REAL-874

### DIFF
--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -1042,6 +1042,12 @@ You can configure replay with the following options:
 - **`since`** (Required): The epoch timestamp in milliseconds (for example, `1697472000000`), specifying the earliest point from which messages should be retrieved.
 - **`limit`** (Optional): The number of messages to return. This must be a positive integer, with a maximum value of 25.
 
+<Admonition type="note">
+
+Message retention is capped at 72 hours. A `since` value older than 72h skips older messages. See [Realtime Limits](/docs/guides/realtime/limits) for details.
+
+</Admonition>
+
 <Tabs
   scrollable
   size="small"

--- a/apps/docs/content/guides/realtime/broadcast.mdx
+++ b/apps/docs/content/guides/realtime/broadcast.mdx
@@ -1044,7 +1044,7 @@ You can configure replay with the following options:
 
 <Admonition type="note">
 
-Message retention is capped at 72 hours. A `since` value older than 72h skips older messages. See [Realtime Limits](/docs/guides/realtime/limits) for details.
+Messages are stored in daily partitions, and partitions older than 72 hours are dropped. Because whole days are removed at once, a message stays available for at least 72 hours and at most 4 days, depending on the time of day it was sent. Setting `since` further back than the retained window does not recover deleted messages. See [Realtime Limits](/docs/guides/realtime/limits) for details.
 
 </Admonition>
 

--- a/apps/docs/content/guides/realtime/limits.mdx
+++ b/apps/docs/content/guides/realtime/limits.mdx
@@ -26,6 +26,8 @@ Upgrade your plan to increase your limits. Without a spend cap, or on an Enterpr
 | **Presence calls per client, per 30 seconds**                                       | 5        | 5        | 5                  | 5        | 5          |
 | **Broadcast payload size**                                                          | 256 KB   | 3,000 KB | 3,000 KB           | 3,000 KB | 3,000+ KB  |
 | **Postgres change payload size ([**read more**](#postgres-changes-payload-limit))** | 1,024 KB | 1,024 KB | 1,024 KB           | 1,024 KB | 1,024+ KB  |
+| **Broadcast replay retention ([**read more**](/docs/guides/realtime/broadcast#broadcast-replay))** | 72 hours | 72 hours | 72 hours | 72 hours | 72 hours |
+| **Broadcast replay messages per request**                                           | 25       | 25       | 25                 | 25       | 25         |
 
 Beyond the Free and Pro Plan you can customize your limits by [contacting support](/dashboard/support/new).
 

--- a/apps/docs/content/guides/realtime/limits.mdx
+++ b/apps/docs/content/guides/realtime/limits.mdx
@@ -15,19 +15,19 @@ Upgrade your plan to increase your limits. Without a spend cap, or on an Enterpr
 
 ## Limits by plan
 
-|                                                                                     | Free     | Pro      | Pro (no spend cap) | Team     | Enterprise |
-| ----------------------------------------------------------------------------------- | -------- | -------- | ------------------ | -------- | ---------- |
-| **Concurrent connections**                                                          | 200      | 500      | 10,000             | 10,000   | 10,000+    |
-| **Messages per second**                                                             | 100      | 500      | 2,500              | 2,500    | 2,500+     |
-| **Channel joins per second**                                                        | 100      | 500      | 2,500              | 2,500    | 2,500+     |
-| **Channels per connection**                                                         | 100      | 100      | 100                | 100      | 100+       |
-| **Presence keys per object**                                                        | 10       | 10       | 10                 | 10       | 10+        |
-| **Presence messages per second**                                                    | 20       | 50       | 1,000              | 1,000    | 1,000+     |
-| **Presence calls per client, per 30 seconds**                                       | 5        | 5        | 5                  | 5        | 5          |
-| **Broadcast payload size**                                                          | 256 KB   | 3,000 KB | 3,000 KB           | 3,000 KB | 3,000+ KB  |
-| **Postgres change payload size ([**read more**](#postgres-changes-payload-limit))** | 1,024 KB | 1,024 KB | 1,024 KB           | 1,024 KB | 1,024+ KB  |
-| **Broadcast replay retention ([**read more**](/docs/guides/realtime/broadcast#broadcast-replay))** | 72 hours | 72 hours | 72 hours | 72 hours | 72 hours |
-| **Broadcast replay messages per request**                                           | 25       | 25       | 25                 | 25       | 25         |
+|                                                                                                    | Free     | Pro      | Pro (no spend cap) | Team     | Enterprise |
+| -------------------------------------------------------------------------------------------------- | -------- | -------- | ------------------ | -------- | ---------- |
+| **Concurrent connections**                                                                         | 200      | 500      | 10,000             | 10,000   | 10,000+    |
+| **Messages per second**                                                                            | 100      | 500      | 2,500              | 2,500    | 2,500+     |
+| **Channel joins per second**                                                                       | 100      | 500      | 2,500              | 2,500    | 2,500+     |
+| **Channels per connection**                                                                        | 100      | 100      | 100                | 100      | 100+       |
+| **Presence keys per object**                                                                       | 10       | 10       | 10                 | 10       | 10+        |
+| **Presence messages per second**                                                                   | 20       | 50       | 1,000              | 1,000    | 1,000+     |
+| **Presence calls per client, per 30 seconds**                                                      | 5        | 5        | 5                  | 5        | 5          |
+| **Broadcast payload size**                                                                         | 256 KB   | 3,000 KB | 3,000 KB           | 3,000 KB | 3,000+ KB  |
+| **Postgres change payload size ([**read more**](#postgres-changes-payload-limit))**                | 1,024 KB | 1,024 KB | 1,024 KB           | 1,024 KB | 1,024+ KB  |
+| **Broadcast replay retention ([**read more**](/docs/guides/realtime/broadcast#broadcast-replay))** | 72 hours | 72 hours | 72 hours           | 72 hours | 72 hours   |
+| **Broadcast replay messages per request**                                                          | 25       | 25       | 25                 | 25       | 25         |
 
 Beyond the Free and Pro Plan you can customize your limits by [contacting support](/dashboard/support/new).
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs to expose current Realtime Broadcast Replay limits.

--

Fixes REAL-874



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how broadcast replay storage retention works, including the daily-partition behavior and that replays are dropped after 72 hours (messages are available for at least 72 hours and up to ~4 days depending on send time).
  * Updated the “Limits by plan” table with broadcast replay retention (72 hours) and broadcast replay messages per request (25) across all plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->