### PR TITLE
Joshen/fe 3685 show a timestamp for failed restart messages in the

### DIFF
--- a/apps/studio/components/ui/AdvisorPanel/AdvisorPanelHeader.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/AdvisorPanelHeader.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, X } from 'lucide-react'
 import { Badge } from 'ui'
+import { TimestampInfo } from 'ui-patterns'
 
 import type { AdvisorItem } from './AdvisorPanel.types'
 import {
@@ -20,16 +21,9 @@ interface AdvisorPanelHeaderProps {
 export const AdvisorPanelHeader = ({ selectedItem, onBack, onClose }: AdvisorPanelHeaderProps) => {
   const displayTitle = selectedItem ? getAdvisorPanelItemDisplayTitle(selectedItem) : undefined
   const secondaryText = selectedItem ? getAdvisorItemSecondaryText(selectedItem) : undefined
-  const metadataText = selectedItem
-    ? (secondaryText ??
-      (selectedItem.createdAt ? formatItemDate(selectedItem.createdAt) : undefined))
-    : undefined
-  // Only capitalize date strings (e.g. "a few seconds ago"); entity strings
-  // like "public.users" must not be case-altered.
-  const metadataCapitalize =
-    selectedItem !== undefined &&
-    secondaryText === undefined &&
-    selectedItem.createdAt !== undefined
+  const createdAt = selectedItem?.createdAt
+
+  const metadataCapitalize = selectedItem !== undefined && secondaryText === undefined
 
   return (
     <div className="border-b px-4 py-3 flex items-center gap-3">
@@ -43,13 +37,19 @@ export const AdvisorPanelHeader = ({ selectedItem, onBack, onClose }: AdvisorPan
       <div className="flex items-center gap-2 overflow-hidden flex-1">
         <div className="flex-1 flex flex-col">
           <span className="heading-default">{displayTitle}</span>
-          {metadataText && (
+          {selectedItem?.source !== 'notification' && secondaryText ? (
             <span
               className={`text-xs text-foreground-light${metadataCapitalize ? ' capitalize-sentence' : ''}`}
             >
-              {metadataText}
+              {secondaryText}
             </span>
-          )}
+          ) : createdAt ? (
+            <TimestampInfo
+              className="w-fit capitalize-sentence"
+              utcTimestamp={createdAt}
+              label={formatItemDate(createdAt)}
+            />
+          ) : null}
         </div>
         {selectedItem && (
           <Badge variant={severityBadgeVariants[selectedItem.severity]}>

--- a/apps/studio/components/ui/AdvisorPanel/NotificationDetail.tsx
+++ b/apps/studio/components/ui/AdvisorPanel/NotificationDetail.tsx
@@ -40,13 +40,17 @@ export const NotificationDetail = ({ notification, onUpdateStatus }: Notificatio
               <Link
                 title={organization.name}
                 href={`/org/${organization.slug}/general`}
-                className="text-link"
+                className="text-sm text-link"
               >
                 {organization.name}
               </Link>
             )}
             {project !== undefined && (
-              <Link title={project.name} href={`/project/${project.ref}`} className="text-link">
+              <Link
+                title={project.name}
+                href={`/project/${project.ref}`}
+                className="text-sm text-link"
+              >
                 {project.name}
               </Link>
             )}


### PR DESCRIPTION
## Context

For notifications which affect a specific project, there's currently no indication of when the notification was created at all, so this PR addresses that

## Changes involved
- For notifications, show created at timestamp in header description
  - Was previously showing project ref if present in notification metadata, but it's repeated information as the affected project is mentioned in the context section
  - It'll still show the project ref in the list view, change is only in the detail view (after clicking on a notification)

### Before
<img width="400" alt="image" src="https://github.com/user-attachments/assets/e8ce247c-afa4-46df-832f-856d34ce82fd" />
<img width="400" alt="image" src="https://github.com/user-attachments/assets/2e0a6c8a-3bb4-4c05-ae13-36b8a92e7ff0" />

### After
No change for notifications list view

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e741b607-c5ef-4cd0-9985-5957f2b52bfc" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how advisor panel details are displayed, ensuring timestamps and secondary text appear in the right situations.
  * Hidden metadata when no relevant information is available, reducing clutter in the panel.
  
* **Style**
  * Updated a link layout in notification details for cleaner, more consistent formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->