### PR TITLE
docs: tighten custom schema grant guidance

### DIFF
--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -21,15 +21,40 @@ You can expose custom database schemas - to do so you need to follow these steps
 1. Go to [API settings](/dashboard/project/_/settings/api) and add your custom schema to "Exposed schemas".
 2. Run the following SQL, substituting `myschema` with your schema name:
 
+<Admonition type="danger">
+
+Grant only the privileges each role needs. Once a schema is exposed, broad grants to `anon` or `authenticated` can make every table, routine, or sequence in that schema reachable through the Data API. Enable RLS on exposed tables before granting access to client-facing roles, and review any views or functions you expose carefully.
+
+</Admonition>
+
+This example keeps anonymous access read-only, allows signed-in users to read and write, and reserves broader access for trusted server-side code using the service role:
+
 ```sql
 GRANT USAGE ON SCHEMA myschema TO anon, authenticated, service_role;
-GRANT ALL ON ALL TABLES IN SCHEMA myschema TO anon, authenticated, service_role;
-GRANT ALL ON ALL ROUTINES IN SCHEMA myschema TO anon, authenticated, service_role;
-GRANT ALL ON ALL SEQUENCES IN SCHEMA myschema TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON TABLES TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON ROUTINES TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+
+-- Tables
+GRANT SELECT ON ALL TABLES IN SCHEMA myschema TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA myschema TO authenticated;
+GRANT ALL ON ALL TABLES IN SCHEMA myschema TO service_role;
+
+-- Sequences
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA myschema TO authenticated;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA myschema TO service_role;
+
+-- Grant EXECUTE only on routines that should be callable through the Data API.
+-- For example:
+-- GRANT EXECUTE ON FUNCTION myschema.your_function() TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT SELECT ON TABLES TO anon;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON SEQUENCES TO service_role;
 ```
+
+If you already applied broader grants from an older setup, revoke them before switching to narrower access. Also note that `ALTER DEFAULT PRIVILEGES FOR ROLE postgres` applies only to objects created by `postgres`; repeat it for any other roles that create tables, views, functions, or sequences in this schema.
+
+For more guidance on grants, RLS, and exposed views or functions, see [Securing your API](/docs/guides/api/securing-your-api) and [Row Level Security](/docs/guides/database/postgres/row-level-security).
 
 Now you can access these schemas from data APIs:
 


### PR DESCRIPTION
## Summary
- replace the broad custom schema grant example with a least-privilege version
- add a warning about exposing schemas before RLS and access rules are in place
- note that default privileges only cover objects created by the specified role

## Why
The custom schema guide still showed blanket grants for tables, routines, and sequences, which felt out of step with the newer Data API and RLS guidance elsewhere in the docs. This update keeps the example practical while steering readers toward narrower defaults.

## Testing
- git diff --check
- manual review of the updated MDX section


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for exposing custom schemas with stronger security recommendations.
  * Added a warning to use least-privilege access, enable row-level security on exposed tables, and review exposed views and routines carefully.
  * Replaced the broad permission example with more precise access rules for read, write, and service access.
  * Added notes about granting access to specific routines, setting default permissions for new objects, and revoking older broad grants before switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->