### PR TITLE
docs: tighten custom schema grant guidance

### DIFF
--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -41,6 +41,10 @@ GRANT ALL ON ALL TABLES IN SCHEMA myschema TO service_role;
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA myschema TO authenticated;
 GRANT ALL ON ALL SEQUENCES IN SCHEMA myschema TO service_role;
 
+-- PostgreSQL grants EXECUTE on new functions to PUBLIC by default.
+-- Revoke that default first if you want function access to stay opt-in.
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres REVOKE EXECUTE ON FUNCTIONS FROM PUBLIC;
+
 -- Grant EXECUTE only on routines that should be callable through the Data API.
 -- For example:
 -- GRANT EXECUTE ON FUNCTION myschema.your_function() TO authenticated;
@@ -52,7 +56,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT USAGE, SELEC
 ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON SEQUENCES TO service_role;
 ```
 
-If you already applied broader grants from an older setup, revoke them before switching to narrower access. Also note that `ALTER DEFAULT PRIVILEGES FOR ROLE postgres` applies only to objects created by `postgres`; repeat it for any other roles that create tables, views, functions, or sequences in this schema.
+If you already applied broader grants from an older setup, revoke them before switching to narrower access. If you already created functions that should not be callable by client-facing roles, revoke `EXECUTE` on those functions and then grant it back explicitly where needed. Also note that `ALTER DEFAULT PRIVILEGES FOR ROLE postgres` applies only to objects created by `postgres`; repeat it for any other roles that create tables, views, functions, or sequences in this schema.
 
 For more guidance on grants, RLS, and exposed views or functions, see [Securing your API](/docs/guides/api/securing-your-api) and [Row Level Security](/docs/guides/database/postgres/row-level-security).
 

--- a/apps/docs/content/guides/api/using-custom-schemas.mdx
+++ b/apps/docs/content/guides/api/using-custom-schemas.mdx
@@ -21,15 +21,40 @@ You can expose custom database schemas - to do so you need to follow these steps
 1. Go to [API settings](/dashboard/project/_/settings/api) and add your custom schema to "Exposed schemas".
 2. Run the following SQL, substituting `myschema` with your schema name:
 
+<Admonition type="danger">
+
+Grant only the privileges each role needs. Once a schema is exposed, broad grants to `anon` or `authenticated` can make every table, routine, or sequence in that schema reachable through the Data API. Enable RLS on exposed tables before granting access to client-facing roles, and review any views or functions you expose carefully.
+
+</Admonition>
+
+This example keeps anonymous access read-only, allows signed-in users to read and write, and reserves broader access for trusted server-side code using the service role:
+
 ```sql
 GRANT USAGE ON SCHEMA myschema TO anon, authenticated, service_role;
-GRANT ALL ON ALL TABLES IN SCHEMA myschema TO anon, authenticated, service_role;
-GRANT ALL ON ALL ROUTINES IN SCHEMA myschema TO anon, authenticated, service_role;
-GRANT ALL ON ALL SEQUENCES IN SCHEMA myschema TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON TABLES TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON ROUTINES TO anon, authenticated, service_role;
-ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON SEQUENCES TO anon, authenticated, service_role;
+
+-- Tables
+GRANT SELECT ON ALL TABLES IN SCHEMA myschema TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA myschema TO authenticated;
+GRANT ALL ON ALL TABLES IN SCHEMA myschema TO service_role;
+
+-- Sequences
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA myschema TO authenticated;
+GRANT ALL ON ALL SEQUENCES IN SCHEMA myschema TO service_role;
+
+-- Grant EXECUTE only on routines that should be callable through the Data API.
+-- For example:
+-- GRANT EXECUTE ON FUNCTION myschema.your_function() TO authenticated;
+
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT SELECT ON TABLES TO anon;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON TABLES TO service_role;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA myschema GRANT ALL ON SEQUENCES TO service_role;
 ```
+
+If you already applied broader grants from an older setup, revoke them before switching to narrower access. Also note that `ALTER DEFAULT PRIVILEGES FOR ROLE postgres` applies only to objects created by `postgres`; repeat it for any other roles that create tables, views, functions, or sequences in this schema.
+
+For more guidance on grants, RLS, and exposed views or functions, see [Securing your API](/docs/guides/api/securing-your-api) and [Row Level Security](/docs/guides/database/postgres/row-level-security).
 
 Now you can access these schemas from data APIs:
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update.

## What is the current behavior?

The custom schema guide shows a least-privilege example now, but it still leaves out PostgreSQL's default `EXECUTE` grant to `PUBLIC` for newly created functions. That makes the opt-in guidance for routines incomplete.

## What is the new behavior?

The guide now tells readers to revoke the global default `EXECUTE` privilege for functions created by `postgres` before relying on function-by-function grants. It also adds a note about revoking `EXECUTE` on existing functions before re-granting access explicitly.

## Additional context

This follows up on review feedback in the PR thread and keeps the routines guidance aligned with the rest of the least-privilege example.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API guide to recommend narrower, role-based database permissions.
  * Added a warning about avoiding broad access for public-facing roles and reminding readers to enable row-level security.
  * Clarified that functions are now opt-in for API access, with guidance to grant access only where needed.
  * Added notes on tightening existing permissions and how default privileges apply to newly created objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->