### PR TITLE
[FE-3682] feat(studio): warn on Vercel preview/dev env var sync

### DIFF
--- a/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelIntegrationConnectionForm.tsx
+++ b/apps/studio/components/interfaces/Settings/Integrations/VercelIntegration/VercelIntegrationConnectionForm.tsx
@@ -1,6 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod'
 import Link from 'next/link'
-import { useForm } from 'react-hook-form'
+import { useState } from 'react'
+import { useForm, useWatch } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
   Alert,
@@ -16,9 +17,13 @@ import {
   Input,
   Switch,
 } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
 import { FormActions } from '@/components/ui/Forms/FormActions'
+import { InlineLink } from '@/components/ui/InlineLink'
 import type {
   EnvironmentTargets,
   Integration,
@@ -26,6 +31,7 @@ import type {
 } from '@/data/integrations/integrations.types'
 import { useVercelConnectionUpdateMutation } from '@/data/integrations/vercel-connection-update-mutate'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 
 const VercelIntegrationConnectionForm = ({
@@ -40,6 +46,8 @@ const VercelIntegrationConnectionForm = ({
   // NOTE(kamil): Ignore sync targets for Vercel Marketplace as it's not synchronized using integration,
   // but through a separate marketplace mechanism. It's not theoretically necessary, but we might have some stale data.
   const { data: org } = useSelectedOrganizationQuery()
+  const { data: project } = useSelectedProjectQuery()
+  const isBranchingEnabled = project?.is_branch_enabled === true
   const envSyncTargets =
     org?.managed_by === 'vercel-marketplace' ? [] : (connection.env_sync_targets ?? [])
 
@@ -60,32 +68,56 @@ const VercelIntegrationConnectionForm = ({
     },
   })
 
+  const [showConfirmation, setShowConfirmation] = useState(false)
+  const [pendingValues, setPendingValues] = useState<z.infer<typeof FormSchema> | null>(null)
+
   const { mutate: updateVercelConnection, isPending } = useVercelConnectionUpdateMutation({
     onSuccess: () => {
       form.reset(form.getValues())
+      setShowConfirmation(false)
+      setPendingValues(null)
       toast.success(`Updated Vercel connection`)
     },
   })
 
-  function onSubmit(data: z.infer<typeof FormSchema>) {
-    const {
-      environmentVariablesProduction,
-      environmentVariablesPreview,
-      environmentVariablesDevelopment,
-    } = data
+  // Syncing the `preview` or `development` target sends this project's production credentials
+  // (anon and service role keys, database connection strings) to those Vercel environments. Watch
+  // the toggles so we can warn inline and gate the save behind a confirmation.
+  const [syncPreview, syncDevelopment] = useWatch({
+    control: form.control,
+    name: ['environmentVariablesPreview', 'environmentVariablesDevelopment'],
+  })
+  const isSyncingNonProdEnvs = syncPreview || syncDevelopment
 
-    const envSyncTargets: string[] = []
+  const selectedNonProdTargets: string[] = []
+  if (pendingValues?.environmentVariablesPreview) selectedNonProdTargets.push('Preview')
+  if (pendingValues?.environmentVariablesDevelopment) selectedNonProdTargets.push('Development')
 
-    if (environmentVariablesProduction) envSyncTargets.push('production')
-    if (environmentVariablesPreview) envSyncTargets.push('preview')
-    if (environmentVariablesDevelopment) envSyncTargets.push('development')
+  function performUpdate(data: z.infer<typeof FormSchema>) {
+    const targets: EnvironmentTargets[] = []
+
+    if (data.environmentVariablesProduction) targets.push('production')
+    if (data.environmentVariablesPreview) targets.push('preview')
+    if (data.environmentVariablesDevelopment) targets.push('development')
 
     updateVercelConnection({
       id: connection.id,
-      envSyncTargets: envSyncTargets as EnvironmentTargets[],
+      envSyncTargets: targets,
       publicEnvVarPrefix: data.publicEnvVarPrefix?.trim(),
       organizationIntegrationId: integration.id,
     })
+  }
+
+  function onSubmit(data: z.infer<typeof FormSchema>) {
+    // Always confirm when Preview/Development sync is enabled to discourage leaking production
+    // credentials into preview deployments and steer users toward Branching instead.
+    if (data.environmentVariablesPreview || data.environmentVariablesDevelopment) {
+      setPendingValues(data)
+      setShowConfirmation(true)
+      return
+    }
+
+    performUpdate(data)
   }
 
   const vercelConnectionFormId = `vercel-connection-form-${connection.id}`
@@ -119,76 +151,127 @@ const VercelIntegrationConnectionForm = ({
               </Alert>
             ) : (
               <div>
-                <h5 className="text-foreground ">
-                  Sync environment variables for selected target environments
-                </h5>
+                <div className="space-y-1 mb-4">
+                  <h5 className="text-foreground">Sync environment variables to Vercel</h5>
+                  <p className="text-sm text-foreground-light">
+                    Choose which Vercel environments receive this project&apos;s{' '}
+                    <span className="text-foreground">production</span> credentials. Most projects
+                    only need <code>production</code>.
+                  </p>
+                  <p className="text-sm text-foreground-light">
+                    With{' '}
+                    <InlineLink href={`/project/${project?.ref}/branches`}>Branching</InlineLink>{' '}
+                    enabled, leave Preview and Development off: Branching gives each preview branch
+                    its own database and syncs those credentials to your Vercel Preview deployments.
+                  </p>
+                </div>
 
-                <FormField
-                  control={form.control}
-                  name="environmentVariablesProduction"
-                  render={({ field }) => (
-                    <FormItem className="space-y-0 flex gap-x-4">
-                      <FormControl>
-                        <Switch
-                          disabled={disabled}
-                          className="mt-1"
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                      <div>
-                        <FormLabel className="!text">Production</FormLabel>
-                        <FormDescription className="text-xs text-foreground-lighter">
-                          Sync environment variables for <code>production</code> environment.
-                        </FormDescription>
-                      </div>
-                    </FormItem>
+                <div className="space-y-4">
+                  <FormField
+                    control={form.control}
+                    name="environmentVariablesProduction"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        layout="flex-row-reverse"
+                        label="Production"
+                        description={
+                          <>
+                            Syncs to the Vercel <code>production</code> env.
+                          </>
+                        }
+                      >
+                        <FormControl>
+                          <Switch
+                            disabled={disabled}
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="environmentVariablesPreview"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        layout="flex-row-reverse"
+                        label="Preview"
+                        description={
+                          <>
+                            Syncs to the Vercel <code>preview</code> env.
+                          </>
+                        }
+                      >
+                        <FormControl>
+                          <Switch
+                            disabled={disabled}
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="environmentVariablesDevelopment"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        layout="flex-row-reverse"
+                        label="Development"
+                        description={
+                          <>
+                            Syncs to the Vercel <code>development</code> env.
+                          </>
+                        }
+                      >
+                        <FormControl>
+                          <Switch
+                            disabled={disabled}
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+
+                  {isSyncingNonProdEnvs && (
+                    <Admonition
+                      type="warning"
+                      title={
+                        isBranchingEnabled
+                          ? 'Not recommended with Branching'
+                          : 'These environments will use production credentials'
+                      }
+                    >
+                      <p>
+                        Preview and Development sync your production credentials, including the
+                        service role key and database password, to those Vercel environments.
+                      </p>
+                      {isBranchingEnabled ? (
+                        <p>
+                          <InlineLink href={`/project/${project?.ref}/branches`}>
+                            Branching
+                          </InlineLink>{' '}
+                          already provisions isolated credentials for each preview branch. With
+                          Preview enabled, deployments use production credentials until a branch
+                          finishes provisioning, which can affect production data. We recommend
+                          leaving Preview and Development off.
+                        </p>
+                      ) : (
+                        <p>
+                          To give preview deployments their own isolated credentials, use{' '}
+                          <InlineLink href={`/project/${project?.ref}/branches`}>
+                            Branching
+                          </InlineLink>{' '}
+                          instead.
+                        </p>
+                      )}
+                    </Admonition>
                   )}
-                />
-                <FormField
-                  control={form.control}
-                  name="environmentVariablesPreview"
-                  render={({ field }) => (
-                    <FormItem className="space-y-0 flex gap-x-4">
-                      <FormControl>
-                        <Switch
-                          disabled={disabled}
-                          className="mt-1"
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                      <div>
-                        <FormLabel className="!text">Preview</FormLabel>
-                        <FormDescription className="text-xs text-foreground-lighter">
-                          Sync environment variables for <code>preview</code> environment.
-                        </FormDescription>
-                      </div>
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name="environmentVariablesDevelopment"
-                  render={({ field }) => (
-                    <FormItem className="space-y-0 flex gap-x-4">
-                      <FormControl>
-                        <Switch
-                          disabled={disabled}
-                          className="mt-1"
-                          checked={field.value}
-                          onCheckedChange={field.onChange}
-                        />
-                      </FormControl>
-                      <div>
-                        <FormLabel className="!text">Development</FormLabel>
-                        <FormDescription className="text-xs text-foreground-lighter">
-                          Sync environment variables for <code>development</code> environment.
-                        </FormDescription>
-                      </div>
-                    </FormItem>
-                  )}
-                />
+                </div>
               </div>
             )}
           </div>
@@ -268,6 +351,49 @@ const VercelIntegrationConnectionForm = ({
           />
         </div>
       </form>
+
+      <ConfirmationModal
+        visible={showConfirmation}
+        variant="warning"
+        size="medium"
+        loading={isPending}
+        title="Sync production credentials?"
+        confirmLabel="Sync credentials"
+        confirmLabelLoading="Saving"
+        onCancel={() => {
+          setShowConfirmation(false)
+          setPendingValues(null)
+        }}
+        onConfirm={() => {
+          if (pendingValues) performUpdate(pendingValues)
+        }}
+        alert={{
+          title: 'These environments will use production credentials',
+          description:
+            'Including the project ref, API URL, anon and service role keys, and database connection strings.',
+        }}
+      >
+        <div className="space-y-3 text-sm text-foreground-light">
+          <p>
+            This syncs your production credentials to the{' '}
+            <span className="text-foreground">{selectedNonProdTargets.join(' and ')}</span>{' '}
+            environment{selectedNonProdTargets.length > 1 ? 's' : ''} of your connected Vercel
+            project.
+          </p>
+          {isBranchingEnabled ? (
+            <p>
+              Branching already provisions isolated credentials for each preview branch. With this
+              enabled, deployments use production credentials until a branch finishes provisioning,
+              which can affect production data. We recommend leaving it off.
+            </p>
+          ) : (
+            <p>
+              To use isolated credentials for preview deployments instead, enable{' '}
+              <InlineLink href={`/project/${project?.ref}/branches`}>Branching</InlineLink>.
+            </p>
+          )}
+        </div>
+      </ConfirmationModal>
     </Form>
   )
 }


### PR DESCRIPTION
Clarifies what the Vercel environment-variable sync toggles actually do and guards the risky path. Enabling Preview/Development sync pushes this project's **production** credentials into those Vercel environments — previously this wasn't clear, so users expected isolated preview deployments and were surprised when previews hit production.

Addresses **FE-3682** (support case SU-385292).

**Changed:**
- Reworded the sync section: a single heading + intro that makes clear the toggles sync this project's production credentials to the selected Vercel environments, and that most projects only need `production`.
- Recommend Branching for preview isolation, linking to the in-dashboard branches page (`/project/<ref>/branches`) instead of docs.
- Switched the toggle rows to `FormItemLayout` (`flex-row-reverse`) for consistent layout/spacing; descriptions now clarify these are the **Vercel** environments.

**Added:**
- Inline `Admonition` warning when Preview/Development sync is enabled, with branching-aware copy (a "Not recommended with Branching" variant when Branching is on, explaining production creds are used until a branch finishes provisioning).
- Confirmation dialog before saving whenever Preview/Development sync is on, naming exactly which credentials get exposed (project ref, API URL, anon + service role keys, DB connection strings). Production-only saves skip the dialog.

## Screenshots



<img width="707" height="630" alt="Screenshot 2026-06-25 at 6 43 23 PM" src="https://github.com/user-attachments/assets/30d45527-5a48-44c2-bdb7-2e576f5e4c7d" />

**Default state (production only)**



<img width="704" height="786" alt="Screenshot 2026-06-25 at 6 43 46 PM" src="https://github.com/user-attachments/assets/75a12f65-99d0-4aad-9360-a7a6e6c91ca1" />

**Preview + Development enabled — inline warning (no Branching)**



<img width="535" height="373" alt="Screenshot 2026-06-25 at 6 44 18 PM" src="https://github.com/user-attachments/assets/29d75804-fa93-402b-8cee-1faedd0ac9c7" />

**Confirmation dialog (no Branching)**



<img width="705" height="824" alt="Screenshot 2026-06-25 at 6 48 09 PM" src="https://github.com/user-attachments/assets/c3f7bf97-7c6e-4be4-9a5b-90d422b03f81" />

**Inline warning — Branching enabled**



<img width="530" height="415" alt="Screenshot 2026-06-25 at 6 48 20 PM" src="https://github.com/user-attachments/assets/a5ede69e-6186-488e-bf1e-49007b231201" />

**Confirmation dialog — Branching enabled**

## To test

- Open a project's **Integrations → Vercel** settings with a connected Vercel project (the project-scoped connection form).
- Toggle **Preview** and/or **Development** on → inline warning appears; toggle both off → it disappears.
- On a project with **Branching enabled**, confirm the warning shows the "Not recommended with Branching" variant.
- Click **Save** with Preview/Dev on → confirmation dialog appears naming the credentials. **Cancel** aborts (no save), **Sync credentials** saves.
- Save with **only Production** on → no dialog, saves directly.
- Confirm the **Branching** links navigate to `/project/<ref>/branches`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a confirmation step before syncing Preview or Development environment variables.
  * Improved the sync settings UI with clearer descriptions and a warning message when these environments are enabled.
  * Made the sync flow aware of project branching status, with guidance that adapts to the project setup.

* **Bug Fixes**
  * Improved the save flow so successful updates now reset the form, close the dialog, and show a success message consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->