### PR TITLE
fix: api docs not found

### DIFF
--- a/apps/studio/components/interfaces/Integrations/DataApi/DocView.tsx
+++ b/apps/studio/components/interfaces/Integrations/DataApi/DocView.tsx
@@ -1,4 +1,7 @@
 import { useParams } from 'common'
+import { useRouter } from 'next/router'
+import { useEffect } from 'react'
+import { toast } from 'sonner'
 
 import type { ShowApiKey } from '../../Docs/Docs.types'
 import { GeneralContent } from '@/components/interfaces/Docs/GeneralContent'
@@ -16,6 +19,7 @@ interface DocViewProps {
 }
 
 export const DocView = ({ selectedLang, selectedApiKey }: DocViewProps) => {
+  const router = useRouter()
   const { ref: projectRef, page, resource, rpc } = useParams()
 
   const { data: settings, error: settingsError } = useProjectSettingsV2Query({ projectRef })
@@ -30,6 +34,27 @@ export const DocView = ({ selectedLang, selectedApiKey }: DocViewProps) => {
   const PAGE_KEY = resource || rpc || page || 'index'
 
   const { resources, rpcs } = buildEntityMaps(paths)
+
+  const resourceMissing = !!resource && !(resource in resources)
+  const rpcMissing = !!rpc && !(rpc in rpcs)
+
+  useEffect(() => {
+    const isSchemaReady = !isLoading && !!jsonSchema && !settingsError && !jsonSchemaError
+    if (!isSchemaReady || !projectRef) return
+    if (resourceMissing || rpcMissing) {
+      toast.error(`${resourceMissing ? 'table/view' : 'function'} could not be found`)
+      router.replace(`/project/${projectRef}/integrations/data_api/docs`)
+    }
+  }, [
+    isLoading,
+    jsonSchema,
+    settingsError,
+    jsonSchemaError,
+    projectRef,
+    resourceMissing,
+    rpcMissing,
+    router,
+  ])
 
   if (settingsError || jsonSchemaError) {
     return <DocViewError error={settingsError || jsonSchemaError} />


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > Integrations > Data API > [Docs](https://supabase.com/dashboard/project/_/integrations/data_api/docs)

## What is the current behavior?

Going to a route that does not exist the user just gets a blank page and no warning.

## What is the new behavior?

User now gets redirected back to the intro docs page and and error toast appears

## Additional context

Closes #34721


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of invalid Data API documentation links.
  * If a requested table, view, or function can’t be found after loading, users now see an error message and are redirected back to the main Data API docs page.
  * This helps prevent blank or broken documentation views when route parameters are incorrect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->