### PR TITLE
refactor: permission-safe integration data via result adapter

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/InstallOAuthIntegrationButton.tsx
@@ -3,18 +3,22 @@ import { useMemo } from 'react'
 import { toast } from 'sonner'
 import { Button } from 'ui'
 
-import { isOAuthInstalled, useProjectOAuthIntegrationData } from '../../../Landing/Landing.utils'
+import { isOAuthInstalled, type ProjectOAuthIntegrationData } from '../../../Landing/Landing.utils'
 import type { IntegrationDefinition } from '@/components/interfaces/Integrations/Landing/Integrations.constants'
 import { useInstallOAuthIntegrationMutation } from '@/data/marketplace/install-oauth-integration-mutation'
 
 interface InstallOAuthIntegrationButtonProps {
   integration: IntegrationDefinition
+  data: ProjectOAuthIntegrationData
+  isLoading: boolean
 }
 
-export function InstallOAuthIntegrationButton({ integration }: InstallOAuthIntegrationButtonProps) {
+export function InstallOAuthIntegrationButton({
+  integration,
+  data,
+  isLoading,
+}: InstallOAuthIntegrationButtonProps) {
   const { ref: projectRef } = useParams()
-
-  const { data, isLoading } = useProjectOAuthIntegrationData(projectRef)
 
   const { mutate: installOAuthIntegration, isPending: isInstalling } =
     useInstallOAuthIntegrationMutation({

--- a/apps/studio/components/interfaces/Integrations/Integration/LegacyIntegrationPage.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/LegacyIntegrationPage.tsx
@@ -41,6 +41,8 @@ const LegacyIntegrationPage = () => {
     integration,
     isAvailableLoading,
     isInstalledLoading,
+    isIntegrationStatusLoading,
+    oauthIntegrationData,
     tabs,
     Component,
   } = useIntegrationDetail()
@@ -117,7 +119,11 @@ const LegacyIntegrationPage = () => {
             </PageHeaderSummary>
 
             {integration?.type === 'oauth' && (
-              <InstallOAuthIntegrationButton integration={integration} />
+              <InstallOAuthIntegrationButton
+                integration={integration}
+                data={oauthIntegrationData}
+                isLoading={isIntegrationStatusLoading}
+              />
             )}
           </PageHeaderMeta>
         )}

--- a/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
@@ -1,5 +1,4 @@
 import { parseSchemaComment } from '@stripe/sync-engine/supabase'
-import { useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
 
 import { type WrapperMeta } from '../Wrappers/Wrappers.types'
@@ -9,19 +8,17 @@ import {
   isInstalled as checkIsInstalled,
   findStripeSchema,
 } from '@/components/interfaces/Integrations/templates/StripeSyncEngine/stripe-sync-status'
-import { getAPIKeys, type APIKey } from '@/data/api-keys/api-keys-query'
-import { apiKeysKeys } from '@/data/api-keys/keys'
-import { getProjectAuthConfig, ProjectAuthConfigData } from '@/data/auth/auth-config-query'
-import { authKeys } from '@/data/auth/keys'
+import { useAPIKeysQuery, type APIKey } from '@/data/api-keys/api-keys-query'
+import { ProjectAuthConfigData, useAuthConfigQuery } from '@/data/auth/auth-config-query'
 import { type DatabaseExtension } from '@/data/database-extensions/database-extensions-query'
 import { type Schema } from '@/data/database/schemas-query'
 import { type FDW } from '@/data/fdw/fdws-query'
-import { AuthorizedApp, getAuthorizedApps } from '@/data/oauth/authorized-apps-query'
-import { oauthAppKeys } from '@/data/oauth/keys'
-import { getIntegrations, IntegrationStatus } from '@/data/partners/integration-status-query'
-import { partnersKeys } from '@/data/partners/keys'
-import { secretsKeys } from '@/data/secrets/keys'
-import { getSecrets, type ProjectSecret } from '@/data/secrets/secrets-query'
+import { AuthorizedApp, useAuthorizedAppsQuery } from '@/data/oauth/authorized-apps-query'
+import {
+  IntegrationStatus,
+  usePartnerIntegrationsQuery,
+} from '@/data/partners/integration-status-query'
+import { useSecretsQuery, type ProjectSecret } from '@/data/secrets/secrets-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { ResponseError } from '@/types'
 
@@ -31,7 +28,7 @@ export const isStripeSyncEngineInstalled = (schemas: Schema[]) => {
   return checkIsInstalled(parsedSchema.status)
 }
 
-type ProjectOAuthIntegrationData = {
+export type ProjectOAuthIntegrationData = {
   apiKeys: APIKey[]
   edgeFunctionSecrets: ProjectSecret[]
   authConfig: ProjectAuthConfigData | null
@@ -39,40 +36,20 @@ type ProjectOAuthIntegrationData = {
   oauthApps: AuthorizedApp[]
 }
 
+const isPermissionError = (error: unknown): error is ResponseError =>
+  error instanceof ResponseError && error.code === 403
+
 /**
- * Wraps a query in error-handling code that suppresses 403 errors, for graceful degradation of the marketplace UI
- * for users in roles that don't have access to certain resources.
- * TODO: Consider surfacing permission errors in query results so the Settings tab can differentiate between
- *       missing resources and ones the user doesn't have permission to see.
+ * Reinterprets a 403 from an existing query as a fallback value, for graceful degradation of the
+ * marketplace UI for users in roles that don't have access to certain resources.
  */
-function usePermissionSafeQuery<T>({
-  queryKey,
-  queryFn,
-  defaultVal,
-  enabled = true,
-}: {
-  queryKey: readonly (string | boolean | undefined)[]
-  queryFn: (opts: { signal?: AbortSignal }) => Promise<T>
-  defaultVal: T
-  enabled: boolean
-}) {
-  return useQuery({
-    // Callers should pass in the queryKey used by the standard data hook, as the shared prefix
-    // will let this new query also be invalidated in response to user actions.
-    queryKey: [...queryKey, 'permission-safe'],
-    queryFn: async (opts) => {
-      try {
-        return await queryFn(opts)
-      } catch (error) {
-        if (error instanceof ResponseError && error.code === 403) {
-          return defaultVal
-        } else {
-          throw error
-        }
-      }
-    },
-    enabled,
-  })
+function permissionSafeData<TData, TDefault>(
+  data: TData | undefined,
+  error: ResponseError | null,
+  defaultVal: TDefault
+): TData | TDefault {
+  if (isPermissionError(error)) return defaultVal
+  return data ?? defaultVal
 }
 
 /**
@@ -91,66 +68,54 @@ export const useProjectOAuthIntegrationData = (
 } => {
   const { data: org } = useSelectedOrganizationQuery({ enabled })
   const queries = {
-    apiKeys: usePermissionSafeQuery({
-      queryKey: apiKeysKeys.list(projectRef, false),
-      queryFn: ({ signal }) => getAPIKeys({ projectRef, reveal: false }, signal),
-      defaultVal: [],
-      enabled: enabled && !!projectRef,
-    }),
-    edgeFunctionSecrets: usePermissionSafeQuery({
-      queryKey: secretsKeys.list(projectRef),
-      queryFn: ({ signal }) => getSecrets({ projectRef }, signal),
-      defaultVal: [],
-      enabled: enabled && !!projectRef,
-    }),
-    authConfig: usePermissionSafeQuery({
-      queryKey: authKeys.authConfig(projectRef),
-      queryFn: ({ signal }) => getProjectAuthConfig({ projectRef }, signal),
-      defaultVal: null,
-      enabled: enabled && !!projectRef,
-    }),
-    partnerIntegrations: usePermissionSafeQuery({
-      queryKey: partnersKeys.getIntegrations(projectRef),
-      queryFn: ({ signal }) => getIntegrations({ projectRef }, signal),
-      defaultVal: [],
-      enabled: enabled && !!projectRef,
-    }),
-    oauthApps: usePermissionSafeQuery({
-      queryKey: oauthAppKeys.authorizedApps(org?.slug),
-      queryFn: ({ signal }) => getAuthorizedApps({ slug: org?.slug }, signal),
-      defaultVal: [],
-      enabled: enabled && !!org,
-    }),
+    apiKeys: useAPIKeysQuery({ projectRef, reveal: false }, { enabled }),
+    edgeFunctionSecrets: useSecretsQuery({ projectRef }, { enabled }),
+    authConfig: useAuthConfigQuery({ projectRef }, { enabled }),
+    partnerIntegrations: usePartnerIntegrationsQuery({ projectRef }, { enabled }),
+    oauthApps: useAuthorizedAppsQuery({ slug: org?.slug }, { enabled: enabled && !!org }),
   }
 
-  // memoize to prevent object creation from triggering a re-render when the result data is used
-  // as a dependency.
   const data = useMemo(() => {
     return {
-      apiKeys: queries.apiKeys.data ?? [],
-      edgeFunctionSecrets: queries.edgeFunctionSecrets.data ?? [],
-      authConfig: queries.authConfig.data ?? null,
-      partnerIntegrations: queries.partnerIntegrations.data ?? [],
-      oauthApps: queries.oauthApps.data ?? [],
+      apiKeys: permissionSafeData(queries.apiKeys.data, queries.apiKeys.error, []),
+      edgeFunctionSecrets: permissionSafeData(
+        queries.edgeFunctionSecrets.data,
+        queries.edgeFunctionSecrets.error,
+        []
+      ),
+      authConfig: permissionSafeData(queries.authConfig.data, queries.authConfig.error, null),
+      partnerIntegrations: permissionSafeData(
+        queries.partnerIntegrations.data,
+        queries.partnerIntegrations.error,
+        []
+      ),
+      oauthApps: permissionSafeData(queries.oauthApps.data, queries.oauthApps.error, []),
     }
   }, [
     queries.apiKeys.data,
+    queries.apiKeys.error,
     queries.edgeFunctionSecrets.data,
+    queries.edgeFunctionSecrets.error,
     queries.authConfig.data,
+    queries.authConfig.error,
     queries.partnerIntegrations.data,
+    queries.partnerIntegrations.error,
     queries.oauthApps.data,
+    queries.oauthApps.error,
   ])
+
+  // A 403 is intentionally handled (the resource degrades to its fallback), so it should not
+  // surface as an error to consumers, and a query that 403s still counts as "settled".
+  const queryList = Object.values(queries)
+  const unhandledErrors = queryList.map((q) => q.error).filter((e) => !!e && !isPermissionError(e))
 
   return {
     data,
-    error:
-      Object.values(queries)
-        .map((q) => q.error)
-        .find((e) => !!e) || null,
-    isError: Object.values(queries).some((x) => x.isError),
-    isLoading: Object.values(queries).some((x) => x.isLoading),
-    isPending: Object.values(queries).some((x) => x.isPending),
-    isSuccess: Object.values(queries).every((x) => x.isSuccess),
+    error: unhandledErrors[0] ?? null,
+    isError: unhandledErrors.length > 0,
+    isLoading: queryList.some((q) => q.isLoading),
+    isPending: queryList.some((q) => q.isPending),
+    isSuccess: queryList.every((q) => q.isSuccess || isPermissionError(q.error)),
   }
 }
 

--- a/apps/studio/components/interfaces/Integrations/Landing/MarketplaceDetail.test.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/MarketplaceDetail.test.tsx
@@ -1,0 +1,139 @@
+import { HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+
+import { MarketplaceDetail } from '@/components/interfaces/Integrations/Marketplace/MarketplaceDetail'
+import { type components } from '@/data/api'
+import { type APIKey } from '@/data/api-keys/api-keys-query'
+import { type ProjectSecret } from '@/data/secrets/secrets-query'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock, type APIErrorBody } from '@/tests/lib/msw'
+import { routerMock } from '@/tests/lib/route-mock'
+
+// The OAuth-apps query overrides its return type to `AuthorizedApp`, but the wire response (and so
+// the MSW resolver) is the raw OpenAPI `OAuthAppResponse`. Build fixtures against the API shape.
+type OAuthAppResponse = components['schemas']['OAuthAppResponse']
+type PartnerIntegrationListResponse = components['schemas']['PartnerIntegrationListResponse']
+
+const STABLE_PARAMS = { ref: 'default', id: 'grafana', pageId: 'overview' }
+const STABLE_PROJECT = { data: { ref: 'default', connectionString: 'postgres://x' } }
+const STABLE_ORG = { data: { slug: 'acme' } }
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, useParams: () => STABLE_PARAMS }
+})
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => STABLE_PROJECT,
+}))
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: () => STABLE_ORG,
+}))
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return { ...actual, IS_PLATFORM: true }
+})
+
+const STABLE_INTEGRATIONS = [
+  {
+    id: 'grafana',
+    name: 'Grafana',
+    type: 'oauth',
+    source: 'Partner',
+    description: 'Grafana',
+    content: 'Grafana overview content',
+    docsUrl: null,
+    siteUrl: null,
+    author: { name: 'Grafana Labs' },
+    oauthAppId: 'grafana-app',
+    icon: () => null,
+    navigate: () => null,
+    navigation: [{ route: 'overview', label: 'Overview' }],
+  },
+]
+const STABLE_EMPTY_ARR = [] as unknown[]
+vi.mock('@/components/interfaces/Integrations/Landing/useAvailableIntegrations', () => ({
+  useAvailableIntegrations: () => ({
+    data: STABLE_INTEGRATIONS,
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+  }),
+}))
+vi.mock('@/data/fdw/fdws-query', () => ({
+  useFDWsQuery: () => ({
+    data: STABLE_EMPTY_ARR,
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+  }),
+}))
+vi.mock('@/data/database-extensions/database-extensions-query', () => ({
+  useDatabaseExtensionsQuery: () => ({
+    data: STABLE_EMPTY_ARR,
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+  }),
+}))
+vi.mock('@/data/database/schemas-query', () => ({
+  useSchemasQuery: () => ({
+    data: STABLE_EMPTY_ARR,
+    isPending: false,
+    isSuccess: true,
+    isError: false,
+    error: null,
+  }),
+}))
+
+let authConfigRequests = 0
+const mockProjectResources = () => {
+  authConfigRequests = 0
+  addAPIMock({
+    method: 'get',
+    path: '/v1/projects/:ref/api-keys',
+    response: () => HttpResponse.json<APIKey[]>([]),
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/v1/projects/:ref/secrets',
+    response: () => HttpResponse.json<ProjectSecret[]>([]),
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/auth/:ref/config',
+    // A role without permission to read auth config - this is the scenario
+    // useProjectOAuthIntegrationData tolerates by falling back to `null`.
+    response: () => {
+      authConfigRequests++
+      return HttpResponse.json<APIErrorBody>({ message: 'forbidden' }, { status: 403 })
+    },
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/integrations/partners/:ref',
+    response: () => HttpResponse.json<PartnerIntegrationListResponse>({ integrations: [] }),
+  })
+  addAPIMock({
+    method: 'get',
+    path: '/platform/organizations/:slug/oauth/apps',
+    response: () => HttpResponse.json<OAuthAppResponse[]>([]),
+  })
+}
+
+describe('MarketplaceDetail', () => {
+  test('a permission-denied resource does not put the page into an endless refetch loop', async () => {
+    mockProjectResources()
+    routerMock.setCurrentUrl('/project/default/integrations/grafana/overview')
+
+    customRender(<MarketplaceDetail />)
+
+    // Let any queries settle, plus a few ticks to catch a refetch loop if one exists.
+    await new Promise((resolve) => setTimeout(resolve, 300))
+
+    // A settled 403 should only ever be fetched once (the initial attempt) - not retried
+    // in an endless mount/unmount cycle driven by its own `isLoading` flag.
+    expect(authConfigRequests).toBeLessThanOrEqual(1)
+  })
+})

--- a/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/useIntegrationDetail.ts
@@ -157,6 +157,7 @@ export const useIntegrationDetail = () => {
     isAvailableLoading,
     isInstalledLoading,
     isIntegrationStatusLoading,
+    oauthIntegrationData: projectData,
     Component,
   }
 }

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -36,6 +36,7 @@ export const MarketplaceDetail = () => {
     isAvailableLoading,
     isInstalledLoading,
     isIntegrationStatusLoading,
+    oauthIntegrationData,
     Component,
   } = useIntegrationDetail()
 
@@ -75,7 +76,13 @@ export const MarketplaceDetail = () => {
   const renderInstallAction = () => {
     switch (installActionType) {
       case 'oauth':
-        return <InstallOAuthIntegrationButton integration={integration} />
+        return (
+          <InstallOAuthIntegrationButton
+            integration={integration}
+            data={oauthIntegrationData}
+            isLoading={isIntegrationStatusLoading}
+          />
+        )
       case 'add-wrapper':
         return (
           <AddWrapperButton

--- a/apps/studio/data/api-keys/api-keys-query.ts
+++ b/apps/studio/data/api-keys/api-keys-query.ts
@@ -51,7 +51,7 @@ interface APIKeysVariables {
 
 export type APIKey = LegacyKeys | SecretKeys | PublishableKeys
 
-export async function getAPIKeys({ projectRef, reveal }: APIKeysVariables, signal?: AbortSignal) {
+async function getAPIKeys({ projectRef, reveal }: APIKeysVariables, signal?: AbortSignal) {
   if (!projectRef) throw new Error('projectRef is required')
 
   const { data, error } = await get(`/v1/projects/{ref}/api-keys`, {

--- a/apps/studio/data/oauth/authorized-apps-query.ts
+++ b/apps/studio/data/oauth/authorized-apps-query.ts
@@ -18,12 +18,11 @@ export type AuthorizedApp = {
   authorized_at: string
 }
 
-export async function getAuthorizedApps({ slug }: AuthorizedAppsVariables, signal?: AbortSignal) {
+export async function getAuthorizedApps({ slug }: AuthorizedAppsVariables) {
   if (!slug) throw new Error('Organization slug is required')
 
   const { data, error } = await get('/platform/organizations/{slug}/oauth/apps', {
     params: { path: { slug }, query: { type: 'authorized' } },
-    signal,
   })
 
   if (error) handleError(error)
@@ -42,7 +41,7 @@ export const useAuthorizedAppsQuery = <TData = AuthorizedAppsData>(
 ) =>
   useQuery<AuthorizedAppsData, AuthorizedAppsError, TData>({
     queryKey: oauthAppKeys.authorizedApps(slug),
-    queryFn: ({ signal }) => getAuthorizedApps({ slug }, signal),
+    queryFn: () => getAuthorizedApps({ slug }),
     enabled: enabled && typeof slug !== 'undefined',
     ...options,
   })

--- a/apps/studio/data/partners/integration-status-query.ts
+++ b/apps/studio/data/partners/integration-status-query.ts
@@ -12,7 +12,7 @@ export type IntegrationVariables = {
 export type IntegrationStatus =
   components['schemas']['PartnerIntegrationListResponse']['integrations'][0]
 
-export async function getIntegrations({ projectRef }: IntegrationVariables, signal?: AbortSignal) {
+async function getIntegrations({ projectRef }: IntegrationVariables, signal?: AbortSignal) {
   if (!projectRef) throw new Error('Project ref is required')
 
   const { data, error } = await get(`/platform/integrations/partners/{ref}`, {


### PR DESCRIPTION
Follow-up to #47272, targeting that branch.

## Why

The current approach issues a *parallel* query per resource under a `'permission-safe'` cache key (using direct fetchers), which:

- **Double-fetches** every resource — the same endpoint is now requested under both the standard key (used elsewhere in Studio) and the `'permission-safe'` key, so there's no dedup.
- **Duplicates the data layer** — it re-imports the fetchers, rebuilds query keys, and re-derives `enabled` guards (the source of the readiness-guard issue CodeRabbit flagged).

## What

Treat the 403→fallback as a *reinterpretation of the existing query result*, not a separate fetch:

- The standard hooks (`useAPIKeysQuery`, `useSecretsQuery`, `useAuthConfigQuery`, `usePartnerIntegrationsQuery`, `useAuthorizedAppsQuery`) are reused as-is. Same cache key, single fetch, full dedup with the rest of Studio.
- A small `permissionSafeData(data, error, defaultVal)` adapter swaps in the fallback when `error` is a 403. It takes the stabilized `data`/`error` fields (not the whole query object) so the `useMemo` deps match the closure.
- The aggregated `error`/`isError`/`isSuccess` flags treat a handled 403 as non-error / settled.
- The cache stays truthful: a 403 is still an error for every *other* consumer of that key — only this hook opts into degrading. 
- Reverts the now-unnecessary data-layer churn: `getAPIKeys`/`getIntegrations` exports and the `authorized-apps` signal change.