### PR TITLE
fix: self hosted cmdk organizations

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/OrgProjectSwitcher.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/OrgProjectSwitcher.tsx
@@ -79,7 +79,7 @@ export function useConfigureOrganizationCommand() {
         },
       ],
     },
-    { deps: [organizations], enabled: !!organizations && organizations.length > 0 }
+    { deps: [organizations], enabled: IS_PLATFORM && !!organizations && organizations.length > 0 }
   )
 
   useRegisterCommands(
@@ -93,6 +93,6 @@ export function useConfigureOrganizationCommand() {
         icon: () => <Building />,
       },
     ],
-    { enabled: !!organizations && organizations.length > 0 }
+    { enabled: IS_PLATFORM && !!organizations && organizations.length > 0 }
   )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Supabase Studio > CMD K

## What is the current behavior?

When on self hosted and using CMD K the organization options are available.

## What is the new behavior?

Organization options now hidden on self hosted/local

## Additional context

Closes #40106 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the organization switcher and related command entry to appear only when the platform-specific conditions are met, helping prevent it from showing up in unsupported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->