### PR TITLE
docs: note cron.log_statement requires a database restart

### DIFF
--- a/apps/docs/content/guides/database/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/database/custom-postgres-config.mdx
@@ -153,6 +153,8 @@ Use the examples below with `supabase --experimental --project-ref <project-ref>
 
 Some Postgres settings are configurable through the [Management API](/docs/reference/api/v1-update-postgres-config) but not the CLI. These include logging settings such as `log_connections`. See [Postgres connection logging](/docs/guides/platform/postgres-connection-logging) for details.
 
+`cron.log_statement` (which logs each [pg_cron](/docs/guides/database/extensions/pg_cron) job statement before it runs) is also Management API only. It is a `postmaster`-context parameter, so updating it **requires a database restart** to take effect.
+
 #### Managing Postgres configuration with the CLI
 
 To start:


### PR DESCRIPTION
## What

Documents that `cron.log_statement` is a Management-API-configurable Postgres parameter that **requires a database restart** to take effect.

## Why

While aligning the platform's `RESTART_REQUIRED_KEYS` with `pg_settings.context` (supabase/platform#34691), `cron.log_statement` surfaced as a parameter that:
- is accepted by the Management API `PUT /v1/projects/{ref}/config/database/postgres` endpoint (it's in the request schema), so project Owners/Admins can set it — though it's **not** exposed via the CLI;
- is registered by pg_cron as `PGC_POSTMASTER` (context `postmaster`), so it only takes effect after a restart.

It wasn't documented anywhere user-facing (it only appeared in the auto-generated OpenAPI spec). This adds a short note in the "Management API only parameters" section so the restart requirement is discoverable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VaRQMeVMf4g5biiYPoZHLW)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the database configuration guide to include `cron.log_statement` in the list of Management API-only parameters.
  * Clarified that this setting requires a database restart before changes take effect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->