### PR TITLE
fix: swift tutorial deprecated APIs and missing await

### DIFF
--- a/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-swift.mdx
@@ -547,7 +547,7 @@ struct AppView: View {
       }
     }
     .task {
-      for await state in supabase.auth.authStateChanges {
+      for await state in await supabase.auth.authStateChanges {
         if [.initialSession, .signedIn, .signedOut].contains(state.event) {
           isAuthenticated = state.session != nil
         }

--- a/examples/user-management/swift-user-management/swift-user-management/ProfileView.swift
+++ b/examples/user-management/swift-user-management/swift-user-management/ProfileView.swift
@@ -96,7 +96,7 @@ struct ProfileView: View {
     do {
       let currentUser = try await supabase.auth.session.user
 
-      let profile: Profile = try await supabase.database
+      let profile: Profile = try await supabase
         .from("profiles")
         .select()
         .eq("id", value: currentUser.id)
@@ -133,7 +133,7 @@ struct ProfileView: View {
           avatarURL: imageURL
         )
 
-        try await supabase.database
+        try await supabase
           .from("profiles")
           .update(updatedProfile)
           .eq("id", value: currentUser.id)
@@ -167,8 +167,8 @@ struct ProfileView: View {
     try await supabase.storage
       .from("avatars")
       .upload(
-        path: filePath,
-        file: data,
+        filePath,
+        data: data,
         options: FileOptions(contentType: "image/jpeg")
       )
 


### PR DESCRIPTION
hopped into the Swift/SwiftUI tutorial and noticed a few things that slipped through the earlier fix:

the `await` on `authStateChanges` was missing from the AppView code snippet — without it the code won't compile with recent supabase-swift versions. also the example project was still using `supabase.database.from()` (deprecated) and the old `path:/file:` upload params.

closes #33242


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Swift getting-started guide so its authentication example follows the correct async pattern.
  * Adjusted the Swift user management example to use the current profile update and avatar upload flow, helping profile edits and image uploads work more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->