### PR TITLE
feat(studio): shared High Availability disabled hook and UI primitives

### DIFF
--- a/apps/studio/components/ui/HighAvailability/HighAvailabilityDisabledEmptyState.tsx
+++ b/apps/studio/components/ui/HighAvailability/HighAvailabilityDisabledEmptyState.tsx
@@ -1,0 +1,32 @@
+import type { LucideIcon } from 'lucide-react'
+import { Server } from 'lucide-react'
+import type { ReactNode } from 'react'
+import { cn } from 'ui'
+import { EmptyStatePresentational } from 'ui-patterns'
+
+const DEFAULT_TITLE = 'This feature is unavailable on High Availability projects'
+const DEFAULT_DESCRIPTION =
+  "We're working to bring this feature to High Availability projects. Contact support if this is blocking your work."
+
+interface HighAvailabilityDisabledEmptyStateProps {
+  title?: string
+  description?: ReactNode
+  icon?: LucideIcon | ReactNode
+  className?: string
+}
+
+export function HighAvailabilityDisabledEmptyState({
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+  icon = Server,
+  className,
+}: HighAvailabilityDisabledEmptyStateProps) {
+  return (
+    <EmptyStatePresentational
+      icon={icon}
+      title={title}
+      description={description}
+      className={cn('w-full max-w-md mx-auto', className)}
+    />
+  )
+}

--- a/apps/studio/components/ui/HighAvailability/HighAvailabilityDisabledSectionNotice.tsx
+++ b/apps/studio/components/ui/HighAvailability/HighAvailabilityDisabledSectionNotice.tsx
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react'
+import { Admonition } from 'ui-patterns/admonition'
+
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
+
+const DEFAULT_TITLE = 'This feature is unavailable on High Availability projects'
+const DEFAULT_DESCRIPTION =
+  "We're working to bring this feature to High Availability projects. Contact support if this is blocking your work."
+
+interface HighAvailabilityDisabledSectionNoticeProps {
+  title?: string
+  description?: ReactNode
+}
+
+export function HighAvailabilityDisabledSectionNotice({
+  title = DEFAULT_TITLE,
+  description = DEFAULT_DESCRIPTION,
+}: HighAvailabilityDisabledSectionNoticeProps) {
+  const { isHighAvailability } = useHighAvailability()
+
+  if (!isHighAvailability) return null
+
+  return (
+    <Admonition type="default" title={title}>
+      <p className="text-sm text-foreground-light">{description}</p>
+    </Admonition>
+  )
+}

--- a/apps/studio/hooks/misc/useHighAvailability.constants.ts
+++ b/apps/studio/hooks/misc/useHighAvailability.constants.ts
@@ -1,0 +1,5 @@
+export const MULTIGRES_SCHEMA_NAME = 'multigres'
+
+export function resolveHighAvailability(project?: { high_availability?: boolean | null }) {
+  return project?.high_availability ?? false
+}

--- a/apps/studio/hooks/misc/useHighAvailability.ts
+++ b/apps/studio/hooks/misc/useHighAvailability.ts
@@ -1,0 +1,25 @@
+import { MULTIGRES_SCHEMA_NAME, resolveHighAvailability } from './useHighAvailability.constants'
+import { useSelectedProjectQuery } from './useSelectedProject'
+
+export { MULTIGRES_SCHEMA_NAME, resolveHighAvailability }
+
+export function useHighAvailability() {
+  const { data: project, isPending } = useSelectedProjectQuery()
+
+  const isHighAvailability = resolveHighAvailability(project)
+
+  return {
+    isHighAvailability,
+    isHighAvailabilityDisabled: !isHighAvailability,
+    isPending,
+  }
+}
+
+export function filterSchemasForHighAvailability<T extends { name: string }>(
+  schemas: T[],
+  isHighAvailability: boolean
+) {
+  if (!isHighAvailability) return schemas
+
+  return schemas.filter((schema) => schema.name !== MULTIGRES_SCHEMA_NAME)
+}


### PR DESCRIPTION
Add generic building blocks for blocking features on High Availability projects:

- useHighAvailability hook: HA state only (isHighAvailability, isPending)
- HighAvailabilityDisabledEmptyState (full-page empty state)
- HighAvailabilityDisabledSectionNotice (in-section admonition)

The components carry a generic default title/description; consuming pages pass their own copy via props. HA state is read from the project's high_availability flag (same source as the High Availability badge on the project home page).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer messaging for features that aren’t available in High Availability projects.
  * Introduced a standard High Availability status check to help the app adapt what it shows.
* **Bug Fixes**
  * Hid non-applicable schema options when High Availability is enabled, reducing confusion in selection lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->