### PR TITLE
fix: make mfa lockout risk clear in dashboard

### DIFF
--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs'
-import { AlertCircle } from 'lucide-react'
 import { useState } from 'react'
-import { Alert, AlertDescription, AlertTitle, Button } from 'ui'
+import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 

--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs'
 import { AlertCircle } from 'lucide-react'
 import { useState } from 'react'
 import { Alert, AlertDescription, AlertTitle, Button } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { AddNewFactorModal } from './AddNewFactorModal'
@@ -29,15 +30,12 @@ export const TOTPFactors = () => {
           {isSuccess && (
             <>
               {data.totp.length === 1 && (
-                <Alert variant="default" className="mb-2">
-                  <AlertCircle className="h-4 w-4" />
-                  <AlertTitle>
-                    We recommend configuring two authenticator apps across different devices
-                  </AlertTitle>
-                  <AlertDescription className="flex flex-col gap-3">
-                    The two authenticator apps will serve as a backup for each other.
-                  </AlertDescription>
-                </Alert>
+                <Admonition
+                  type="warning"
+                  layout="horizontal"
+                  title="We recommend configuring two authenticator apps across different devices"
+                  description="The two authenticator apps will serve as a backup for each other."
+                />
               )}
               <div>
                 {data.totp.map((factor) => {


### PR DESCRIPTION
## Problem

Lots of users are getting locked out of their accounts, with no way to get back in.

The current warning after setting up an MFA is not visible enough:
<img width="1484" height="836" alt="image" src="https://github.com/user-attachments/assets/944093f0-b912-4eb9-9955-a012be1a5248" />

## Solution

First part of the solution is to make the warning more visible:
<img width="1612" height="930" alt="image" src="https://github.com/user-attachments/assets/06d334dc-ee6a-4bf3-a8b3-3d4282a275b7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the two-factor authentication setup warning to use a clearer warning style and horizontal layout.
  * Improved the guidance shown when only one authenticator app is configured, making the message easier to read.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->