### PR TITLE
fix(studio): fix GraphiQL editor layout, gutter bleed and spacing

### DIFF
--- a/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx
@@ -8,7 +8,7 @@ import { useParams } from 'common'
 import { GraphiQL, HISTORY_PLUGIN } from 'graphiql'
 import { User as IconUser } from 'lucide-react'
 import { useTheme } from 'next-themes'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState, type RefObject } from 'react'
 import { toast } from 'sonner'
 import { LogoLoader } from 'ui'
 
@@ -71,24 +71,39 @@ const GraphiQLMonacoTheme = ({ resolvedTheme }: { resolvedTheme: 'dark' | 'light
  * - `glyphMargin` reserves an empty column to the left of the line numbers (same gutter
  *   background), giving them left breathing room.
  *
- * `onDidCreateEditor` covers editors that GraphiQL mounts after Monaco loads.
+ * GraphiQL shares the global Monaco instance with the rest of Studio (the SQL editor etc.),
+ * so we must scope `updateOptions` to editors that live inside the GraphiQL container —
+ * `monaco.editor.getEditors()`/`onDidCreateEditor()` see every editor in the app, and
+ * applying these options globally would shift the SQL editor's layout too. Filtering by
+ * container also means there's nothing to revert on unmount: we never touch other editors.
  */
-const GraphiQLEditorOptions = () => {
+const GraphiQLEditorOptions = ({
+  containerRef,
+}: {
+  containerRef: RefObject<HTMLDivElement | null>
+}) => {
   const { monaco } = useMonaco()
 
   useEffect(() => {
     if (!monaco) return
     const options = { padding: { top: 16, bottom: 16 }, glyphMargin: true }
-    monaco.editor.getEditors().forEach((editor) => editor.updateOptions(options))
-    const disposable = monaco.editor.onDidCreateEditor((editor) => editor.updateOptions(options))
+    const applyToGraphiQLEditor = (editor: ReturnType<typeof monaco.editor.getEditors>[number]) => {
+      if (containerRef.current?.contains(editor.getContainerDomNode())) {
+        editor.updateOptions(options)
+      }
+    }
+
+    monaco.editor.getEditors().forEach(applyToGraphiQLEditor)
+    const disposable = monaco.editor.onDidCreateEditor(applyToGraphiQLEditor)
 
     return () => disposable.dispose()
-  }, [monaco])
+  }, [monaco, containerRef])
 
   return null
 }
 
 export const GraphiQLTab = () => {
+  const editorContainerRef = useRef<HTMLDivElement>(null)
   const { resolvedTheme } = useTheme()
   const { ref: projectRef } = useParams()
   const currentTheme = resolvedTheme?.includes('dark') ? 'dark' : 'light'
@@ -174,7 +189,7 @@ export const GraphiQLTab = () => {
   return (
     <div className="flex flex-col h-full">
       <GraphiQLMonacoTheme resolvedTheme={currentTheme} />
-      <GraphiQLEditorOptions />
+      <GraphiQLEditorOptions containerRef={editorContainerRef} />
       {notice === 'opt-in' && (
         <IntrospectionDisabledNotice
           schema={DEFAULT_INTROSPECTION_SCHEMA}
@@ -189,7 +204,7 @@ export const GraphiQLTab = () => {
           onDisabled={handleIntrospectionChanged}
         />
       )}
-      <div className="flex-1 min-h-0">
+      <div ref={editorContainerRef} className="flex-1 min-h-0">
         <GraphiQL
           key={graphiqlKey}
           fetcher={fetcher}

--- a/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/GraphQL/GraphiQLTab.tsx
@@ -59,6 +59,35 @@ const GraphiQLMonacoTheme = ({ resolvedTheme }: { resolvedTheme: 'dark' | 'light
   return null
 }
 
+/**
+ * Inset the editor content from the container edges without floating the scroll shadow.
+ *
+ * Monaco anchors its `.scroll-decoration` (the shadow shown when scrolled) to the editor's
+ * top edge and absolutely positions the line numbers at the gutter's left edge, so container
+ * padding can't move either — it would just push the whole editor (shadow included) inward.
+ * Instead use Monaco's own options:
+ * - `padding` insets the content top/bottom while leaving the shadow pinned to the top, so
+ *   `.graphiql-query-editor` can stay full-bleed (`p-0`) for a flush shadow.
+ * - `glyphMargin` reserves an empty column to the left of the line numbers (same gutter
+ *   background), giving them left breathing room.
+ *
+ * `onDidCreateEditor` covers editors that GraphiQL mounts after Monaco loads.
+ */
+const GraphiQLEditorOptions = () => {
+  const { monaco } = useMonaco()
+
+  useEffect(() => {
+    if (!monaco) return
+    const options = { padding: { top: 16, bottom: 16 }, glyphMargin: true }
+    monaco.editor.getEditors().forEach((editor) => editor.updateOptions(options))
+    const disposable = monaco.editor.onDidCreateEditor((editor) => editor.updateOptions(options))
+
+    return () => disposable.dispose()
+  }, [monaco])
+
+  return null
+}
+
 export const GraphiQLTab = () => {
   const { resolvedTheme } = useTheme()
   const { ref: projectRef } = useParams()
@@ -145,6 +174,7 @@ export const GraphiQLTab = () => {
   return (
     <div className="flex flex-col h-full">
       <GraphiQLMonacoTheme resolvedTheme={currentTheme} />
+      <GraphiQLEditorOptions />
       {notice === 'opt-in' && (
         <IntrospectionDisabledNotice
           schema={DEFAULT_INTROSPECTION_SCHEMA}

--- a/apps/studio/components/interfaces/Integrations/GraphQL/graphiql.module.css
+++ b/apps/studio/components/interfaces/Integrations/GraphQL/graphiql.module.css
@@ -34,6 +34,27 @@
   border-left: 0;
 }
 
+/* Restore Monaco's intended clipping of the editor body. Monaco renders the gutter as an
+ * oversized, scroll-offset `.margin` (absolutely positioned, opaque background) and relies
+ * on `.overflow-guard { overflow: hidden }` to clip it to the editor box. Here the guard
+ * ends up `overflow: visible` via an inline style Monaco's layout sets at runtime, so the
+ * white gutter escapes the editor and paints over the page above it. An inline style beats
+ * any external selector regardless of specificity, so `!important` is required to win — it
+ * is not a specificity shortcut here. Scoped to `.root` so the SQL editor's Monaco is
+ * untouched. Autocomplete/hover popups live in `.overflowingContentWidgets` (a sibling of
+ * `.overflow-guard`), so they are not clipped. */
+.root :global(.monaco-editor .overflow-guard) {
+  @apply !overflow-hidden;
+}
+
+/* Drop GraphiQL's default 16px padding around the query editor so the editor sits flush to
+ * its container. This keeps Monaco's scroll shadow (`.scroll-decoration`, pinned to the
+ * editor's top edge) full-bleed instead of floating inset. The content's own breathing room
+ * is restored via Monaco's `padding`/`glyphMargin` options in GraphiQLTab.tsx. */
+.root :global(.graphiql-query-editor) {
+  @apply p-0;
+}
+
 /* Lift the response panel above the editor surface so the two read as separate panes.
  * The token differs per theme because the editor sits at a different baseline lightness
  * in each (~12% L in dark, ~94% L in light), so a single surface token can't lift it

--- a/apps/studio/components/interfaces/Integrations/Integration/LegacyIntegrationPage.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/LegacyIntegrationPage.tsx
@@ -135,7 +135,7 @@ const LegacyIntegrationPage = () => {
         )}
       </PageHeader>
 
-      <div className="mx-auto w-full">{content}</div>
+      <div className="flex-1 min-h-0 mx-auto w-full">{content}</div>
     </>
   )
 }

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceDetail.tsx
@@ -175,7 +175,9 @@ export const MarketplaceDetail = () => {
             <CustomPageComponent />
           </div>
         ) : (
-          <CustomPageComponent />
+          <div className="flex-1 min-h-0">
+            <CustomPageComponent />
+          </div>
         )
       ) : null}
     </>


### PR DESCRIPTION
Fixes three GraphiQL/integrations layout issues introduced by the Marketplace layout change (#45856), which dropped the height passthrough on the integration page content wrapper.

**Changed:**
- **Full-height integration pages** — the content wrapper had no height, so GraphiQL's `h-full` editor collapsed instead of filling the page. Added `flex-1 min-h-0` to the wrapper in both the legacy (`LegacyIntegrationPage`) and marketplace (`MarketplaceDetail`) render paths.
- **GraphiQL gutter bleed** — Monaco's `.overflow-guard` was ending up `overflow: visible` (an inline style Monaco sets at runtime), so the oversized opaque line-number gutter escaped the editor and painted over the page above it. Re-asserted the clip, scoped to GraphiQL so the SQL editor is untouched.
- **GraphiQL editor spacing** — removed GraphiQL's default 16px query-editor padding so the scroll shadow sits flush, and restored the content's breathing room via Monaco's own `padding` (top/bottom) and `glyphMargin` (line-number left inset) options, which leave the scroll shadow pinned to the top edge.

Before:
<img width="2056" height="814" alt="Screenshot 2026-06-26 at 5 27 24 PM" src="https://github.com/user-attachments/assets/573856bf-2bfb-4bf2-9dd7-59c29b423ec9" />

## To test

- Open a project → **Integrations → GraphiQL** (the `graphiql` tab). The editor should fill the full page height.
- Scroll the query editor — the scroll shadow should sit flush at the top edge, not float inset, and the white gutter should not bleed over the page header above.
- Confirm line numbers have left padding and content has top/bottom padding.
- Trigger autocomplete in the editor — the suggestion popup should still appear (not clipped by the gutter `overflow: hidden`).
- Toggle the **Marketplace** feature preview (Account dropdown → Feature Previews) and re-check the GraphiQL page in both states, since it renders through two different page components.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the GraphQL in-browser editor layout to prevent the editor gutter from overlapping surrounding content.
  * Removed unnecessary query-editor padding so scrolling and shadow effects display correctly in the available space.
  * Ensured Monaco editor spacing/settings are applied consistently to both existing and newly created editors.
  * Fixed full-height sizing for integration pages so content stays correctly constrained and doesn’t collapse or overflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->