### PR TITLE
Make mfa lockout risk clear in dashboard

### DIFF
--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -28,14 +28,6 @@ export const TOTPFactors = () => {
           )}
           {isSuccess && (
             <>
-              {data.totp.length === 1 && (
-                <Admonition
-                  type="warning"
-                  layout="horizontal"
-                  title="We recommend configuring two authenticator apps across different devices"
-                  description="The two authenticator apps will serve as a backup for each other."
-                />
-              )}
               <div>
                 {data.totp.map((factor) => {
                   return (

--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -1,7 +1,6 @@
 import dayjs from 'dayjs'
 import { useState } from 'react'
 import { Button } from 'ui'
-import { Admonition } from 'ui-patterns/admonition'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { AddNewFactorModal } from './AddNewFactorModal'

--- a/apps/studio/pages/account/security.tsx
+++ b/apps/studio/pages/account/security.tsx
@@ -46,22 +46,8 @@ const Security: NextPageWithLayout = () => {
             className="mt-8"
             type="danger"
             layout="horizontal"
-            title="Important: You can get permanently locked out"
-            description={
-              <>
-                <p>
-                  If you lose access to your authenticator app and don't have a second method set
-                  up,{' '}
-                  <strong className="text-destructive">
-                    you will lose access to your account.
-                  </strong>
-                </p>
-                <p>
-                  We strongly recommend adding another factor of authentication on another device
-                  right now.
-                </p>
-              </>
-            }
+            title="Avoid being locked out"
+            description="Add a backup sign-in method now. Otherwise, losing access to your authenticator app will permanently lock you out of your account."
           />
         )}
         <Card className="mt-8">

--- a/apps/studio/pages/account/security.tsx
+++ b/apps/studio/pages/account/security.tsx
@@ -1,5 +1,6 @@
 import { Lock } from 'lucide-react'
 import { Badge, Card, CardContent, CardHeader } from 'ui'
+import { Admonition } from 'ui-patterns'
 import { PageContainer } from 'ui-patterns/PageContainer'
 import {
   PageHeader,
@@ -40,6 +41,26 @@ const Security: NextPageWithLayout = () => {
         </PageHeaderMeta>
       </PageHeader>
       <PageContainer size="small">
+        {data?.totp.length === 1 && (
+          <Admonition
+            className="mt-8"
+            type="danger"
+            layout="horizontal"
+            title="Important: You can get permanently locked out"
+            description={
+              <>
+                <p>
+                  If you lose access to your authenticator app and don't have a second method set
+                  up,{' '}
+                  <strong className="text-destructive">
+                    you will lose access to your account.
+                  </strong>
+                </p>
+                <p>We strongly recommend adding authentication on a second device right now.</p>
+              </>
+            }
+          />
+        )}
         <Card className="mt-8">
           <CardHeader className="py-3 flex flex-row items-center justify-between">
             <div className="flex flex-row gap-4 items-center py-1 mb-0">

--- a/apps/studio/pages/account/security.tsx
+++ b/apps/studio/pages/account/security.tsx
@@ -56,7 +56,7 @@ const Security: NextPageWithLayout = () => {
                     you will lose access to your account.
                   </strong>
                 </p>
-                <p>We strongly recommend adding authentication on a second device right now.</p>
+                <p>We strongly recommend adding another factor of authentication on another device right now.</p>
               </>
             }
           />

--- a/apps/studio/pages/account/security.tsx
+++ b/apps/studio/pages/account/security.tsx
@@ -56,7 +56,10 @@ const Security: NextPageWithLayout = () => {
                     you will lose access to your account.
                   </strong>
                 </p>
-                <p>We strongly recommend adding another factor of authentication on another device right now.</p>
+                <p>
+                  We strongly recommend adding another factor of authentication on another device
+                  right now.
+                </p>
               </>
             }
           />


### PR DESCRIPTION
## Problem

#47330 is not enough. We want the alert to really catch users attention

## Solution

<img width="1670" height="1138" alt="image" src="https://github.com/user-attachments/assets/3dab5145-2abf-4213-a591-45116eeacb6a" />
<img width="1634" height="1048" alt="image" src="https://github.com/user-attachments/assets/c70ac8cc-2af0-4778-a68b-3ea9ea8f8166" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Consolidated the “permanently locked out” MFA warning so it appears only on the account security page when exactly one authenticator app is configured.
  * Removed the duplicate warning from the authenticator factor list to ensure the alert is shown in a single, consistent location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->