### PR TITLE
fix(studio): restore email template source editor height

### DIFF
--- a/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
+++ b/apps/studio/components/ui/CodeEditor/CodeEditor.tsx
@@ -264,7 +264,9 @@ export const CodeEditor = ({
         // rule flips it to `position: absolute` (which happens after visiting GraphiQL, since it
         // injects a second copy of Monaco's CSS onto the shared instance). Without an explicit
         // height, an absolutely-positioned wrapper collapses to 0 and Monaco lays out at ~5px.
-        className={cn(className, 'monaco-editor', 'h-full')}
+        // Order matters: `h-full` is a default, so a caller-supplied height in `className`
+        // (e.g. `h-96`) wins via tailwind-merge instead of being clobbered.
+        className={cn('monaco-editor', 'h-full', className)}
         wrapperProps={{ className: wrapperClassName }}
         value={value ?? undefined}
         language={language}


### PR DESCRIPTION
## What

Restores the email template **source editor** height, which had collapsed to a single line.

## Root cause

Earlier today, #47339 ("prevent Monaco editor collapse after visiting GraphiQL") appended `h-full` to the shared `CodeEditor`:

```ts
className={cn(className, 'monaco-editor', 'h-full')}
```

`cn` is `twMerge(clsx(...))`. tailwind-merge resolves conflicting height utilities by keeping the **last** one, so the trailing `h-full` clobbered any caller-supplied height. The email template editor (`TemplateEditor.tsx`) passes `h-96`, and its wrapper has no explicit height — so `h-full` resolved to 0 and the editor collapsed to a single line.

## Fix

Reorder so `h-full` is a default that a caller's height wins over:

```ts
className={cn('monaco-editor', 'h-full', className)}
```

- Email editor passes `h-96` → comes last → wins → 384px height restored.
- Callers that set no height (GraphiQL, etc.) → `h-full` still applies → #47339 fix preserved.

## Testing

- [ ] Email template source editor renders at full height again
- [ ] GraphiQL → editor navigation still does not collapse

Fixes FE-3728


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editor sizing so custom height classes are respected instead of being overridden by the default full-height styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->