### PR TITLE
chore(studio): use admonition for auto-enable RLS notice

### DIFF
--- a/apps/studio/components/interfaces/Database/Triggers/EventTriggersList/EventTriggers.constants.ts
+++ b/apps/studio/components/interfaces/Database/Triggers/EventTriggersList/EventTriggers.constants.ts
@@ -16,6 +16,7 @@ EXECUTE FUNCTION event_trigger_fn();
 `
 
 export const AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL = safeSql`
+-- Event trigger: ensure_rls
 CREATE OR REPLACE FUNCTION rls_auto_enable()
 RETURNS EVENT_TRIGGER
 LANGUAGE plpgsql

--- a/apps/studio/components/ui/AutoEnableRLSNotice.tsx
+++ b/apps/studio/components/ui/AutoEnableRLSNotice.tsx
@@ -5,8 +5,6 @@ import { useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import {
   Button,
-  Card,
-  CardContent,
   Dialog,
   DialogContent,
   DialogDescription,
@@ -17,6 +15,7 @@ import {
   DialogTitle,
   DialogTrigger,
 } from 'ui'
+import { Admonition } from 'ui-patterns/admonition'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import { AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL } from '@/components/interfaces/Database/Triggers/EventTriggersList/EventTriggers.constants'
@@ -60,21 +59,13 @@ export const AutoEnableRLSNotice = ({ iconOnly }: { iconOnly?: boolean }) => {
   }
 
   return (
-    <Card>
-      <CardContent className="flex items-center justify-between">
-        <div className="flex items-center gap-x-4">
-          <div className="rounded-lg bg-surface-300 text-foreground-light w-10 h-10 flex items-center justify-center">
-            <ShieldCheck size={18} />
-          </div>
-          <div className="text-sm">
-            <p>Auto-enable RLS for new tables</p>
-            <p className="text-foreground-lighter">
-              Create an event trigger that enables Row Level Security on all new tables
-            </p>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-x-2">
+    <Admonition
+      type="note"
+      layout="horizontal"
+      title="Auto-enable RLS for new tables"
+      description="We recommend creating an event trigger that enables Row Level Security on all new tables."
+      actions={
+        <>
           <CreateEnsureRLSTriggerDialog />
           <ButtonTooltip
             icon={<X />}
@@ -83,9 +74,9 @@ export const AutoEnableRLSNotice = ({ iconOnly }: { iconOnly?: boolean }) => {
             tooltip={{ content: { side: 'bottom', text: 'Minimize' } }}
             onClick={() => setIsMinimized(true)}
           />
-        </div>
-      </CardContent>
-    </Card>
+        </>
+      }
+    />
   )
 }
 
@@ -131,7 +122,7 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
             tooltip={{ content: { side: 'bottom', text: 'Auto-enable RLS for new tables' } }}
           />
         ) : (
-          <Button variant="primary">Learn more</Button>
+          <Button variant="default">Learn more</Button>
         )}
       </DialogTrigger>
       <DialogContent size="large">

--- a/apps/studio/components/ui/AutoEnableRLSNotice.tsx
+++ b/apps/studio/components/ui/AutoEnableRLSNotice.tsx
@@ -61,17 +61,17 @@ export const AutoEnableRLSNotice = ({ iconOnly }: { iconOnly?: boolean }) => {
   return (
     <Admonition
       type="note"
-      layout="horizontal"
-      title="Auto-enable RLS for new tables"
-      description="We recommend creating an event trigger that enables Row Level Security on all new tables."
+      layout="responsive"
+      title="Automatically enable RLS on new tables"
+      description="Protect future tables by automatically enabling Row Level Security whenever a table is created."
       actions={
         <>
           <CreateEnsureRLSTriggerDialog />
           <ButtonTooltip
             icon={<X />}
             variant="text"
-            className="w-7"
-            tooltip={{ content: { side: 'bottom', text: 'Minimize' } }}
+            className="w-6"
+            tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
             onClick={() => setIsMinimized(true)}
           />
         </>
@@ -122,36 +122,38 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
             tooltip={{ content: { side: 'bottom', text: 'Auto-enable RLS for new tables' } }}
           />
         ) : (
-          <Button variant="default">Learn more</Button>
+          <Button variant="default">Set up trigger</Button>
         )}
       </DialogTrigger>
       <DialogContent size="large">
         <DialogHeader>
-          <DialogTitle>Automatically enable RLS for newly created tables</DialogTitle>
-          <DialogDescription>Secure your data using Postgres Row Level Security</DialogDescription>
+          <DialogTitle>Automatically enable RLS for new tables</DialogTitle>
+          <DialogDescription>
+            Protect future tables with a built-in database trigger.
+          </DialogDescription>
         </DialogHeader>
 
         <DialogSectionSeparator />
 
         <DialogSection className="text-sm flex flex-col gap-y-2">
           <p>
-            Tables in exposed schemas (default being the{' '}
-            <code className="text-code-inline">public</code> schema) are accessible to anyone.
-            Hence, we highly recommend enabling RLS on all such tables.
+            We recommend enabling Row Level Security (RLS) on all tables in exposed schemas, such as{' '}
+            <code className="text-code-inline">public</code>. This trigger automatically enables RLS
+            whenever a new table is created.
           </p>
-          <p>
-            You can set up a database trigger to enable RLS automatically on all new tables with the
-            following SQL:
-          </p>
+          <p>Review the SQL below before creating the trigger.</p>
         </DialogSection>
 
-        <CodeBlock language="sql" className="language-sql px-0 border-x-0 rounded-none h-64">
+        <CodeBlock
+          language="sql"
+          className="language-sql px-0 border-x-0 border-b-0 rounded-none h-64"
+        >
           {AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL.trim()}
         </CodeBlock>
 
         <DialogFooter>
           <Button variant="default" disabled={isCreating} onClick={() => setOpen(false)}>
-            Close
+            Cancel
           </Button>
           <ButtonTooltip
             disabled={!canCreateTriggers}
@@ -166,7 +168,7 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
               },
             }}
           >
-            Create ensure_rls trigger
+            Create trigger
           </ButtonTooltip>
         </DialogFooter>
       </DialogContent>

--- a/apps/studio/components/ui/AutoEnableRLSNotice.tsx
+++ b/apps/studio/components/ui/AutoEnableRLSNotice.tsx
@@ -128,7 +128,7 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
       </DialogTrigger>
       <DialogContent size="large">
         <DialogHeader>
-          <DialogTitle>Automatically enable Row Level Security (RLS) for new tables</DialogTitle>
+          <DialogTitle>Automatically enable RLS for new tables</DialogTitle>
           <DialogDescription>
             Protect future tables with a built-in database trigger.
           </DialogDescription>
@@ -138,14 +138,13 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
 
         <DialogSection className="text-sm flex flex-col gap-y-2">
           <p>
-            Tables in exposed schemas, such as <code className="text-code-inline">public</code>, are
-            reachable through your project's API. We recommend enabling RLS on these tables so that
-            access is governed by policies you define — otherwise anyone with your publishable key
-            can read and write their contents.
+            Tables in exposed schemas such as <code className="text-code-inline">public</code> are
+            reachable through your project’s API. Enable Row Level Security (RLS) on these tables so
+            access is governed by the policies you define, not just the project API key.
           </p>
           <p>
-            The trigger below automatically enables RLS whenever a new table is created. Review the
-            SQL before creating it:
+            This trigger automatically enables RLS whenever a new table is created. Review the SQL
+            before creating it:
           </p>
         </DialogSection>
 

--- a/apps/studio/components/ui/AutoEnableRLSNotice.tsx
+++ b/apps/studio/components/ui/AutoEnableRLSNotice.tsx
@@ -72,6 +72,7 @@ export const AutoEnableRLSNotice = ({ iconOnly }: { iconOnly?: boolean }) => {
             variant="text"
             className="w-6"
             tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
+            aria-label="Dismiss RLS notice"
             onClick={() => setIsMinimized(true)}
           />
         </>

--- a/apps/studio/components/ui/AutoEnableRLSNotice.tsx
+++ b/apps/studio/components/ui/AutoEnableRLSNotice.tsx
@@ -62,8 +62,8 @@ export const AutoEnableRLSNotice = ({ iconOnly }: { iconOnly?: boolean }) => {
     <Admonition
       type="note"
       layout="responsive"
-      title="Automatically enable RLS on new tables"
-      description="Protect future tables by automatically enabling Row Level Security whenever a table is created."
+      title="Automatically enable Row Level Security (RLS) on new tables"
+      description="Protect future tables by automatically enabling RLS whenever a table is created."
       actions={
         <>
           <CreateEnsureRLSTriggerDialog />
@@ -128,7 +128,7 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
       </DialogTrigger>
       <DialogContent size="large">
         <DialogHeader>
-          <DialogTitle>Automatically enable RLS for new tables</DialogTitle>
+          <DialogTitle>Automatically enable Row Level Security (RLS) for new tables</DialogTitle>
           <DialogDescription>
             Protect future tables with a built-in database trigger.
           </DialogDescription>
@@ -138,11 +138,15 @@ const CreateEnsureRLSTriggerDialog = ({ iconOnly }: { iconOnly?: boolean }) => {
 
         <DialogSection className="text-sm flex flex-col gap-y-2">
           <p>
-            We recommend enabling Row Level Security (RLS) on all tables in exposed schemas, such as{' '}
-            <code className="text-code-inline">public</code>. This trigger automatically enables RLS
-            whenever a new table is created.
+            Tables in exposed schemas, such as <code className="text-code-inline">public</code>, are
+            reachable through your project's API. We recommend enabling RLS on these tables so that
+            access is governed by policies you define — otherwise anyone with your publishable key
+            can read and write their contents.
           </p>
-          <p>Review the SQL below before creating the trigger.</p>
+          <p>
+            The trigger below automatically enables RLS whenever a new table is created. Review the
+            SQL before creating it:
+          </p>
         </DialogSection>
 
         <CodeBlock


### PR DESCRIPTION
## What kind of change does this PR introduce?

Chore. UI polish for the auto-enable RLS notice.

## What is the current behavior?

Auto-enable RLS is shown in a card with a shield icon and a primary "Learn more" button. The setup dialog uses longer copy and labels like "Close" / "Create ensure_rls trigger".

## What is the new behavior?

- Banner uses a responsive note `Admonition` instead of a card.
- Clearer copy: title, description, and dialog body tightened around protecting future tables.
- Actions: "Set up trigger" (default), "Cancel", "Create trigger"; dismiss tooltip updated.
- Code block border tweak in the dialog; SQL template gets a short identifying comment.

| Before | After |
| --- | --- |
| <img width="1106" height="747" alt="Tables  Database  temp-stripe  wksp_6UXXrF9W8SK9CCKdlRh8Uts  Supabase-17201C2A-C57A-4AFE-BA79-591920BBEB8D" src="https://github.com/user-attachments/assets/f7977ef1-b9c2-4064-b779-b32bdbcc4214" /> | <img width="1106" height="747" alt="Tables  Database  temp-stripe  wksp_6UXXrF9W8SK9CCKdlRh8Uts  Supabase-48D740A2-0814-41FE-AE92-F86F1C6C4397" src="https://github.com/user-attachments/assets/7168cd82-5563-4718-94e3-1ffb4fa690c1" /> |
| <img width="1106" height="747" alt="Tables  Database  temp-stripe  wksp_6UXXrF9W8SK9CCKdlRh8Uts  Supabase-7FC76297-7640-440E-B4BF-34ECA51F652B" src="https://github.com/user-attachments/assets/0b38711e-c6af-4d15-a4d5-d98db28bce20" /> | <img width="1106" height="747" alt="Tables  Database  temp-stripe  wksp_6UXXrF9W8SK9CCKdlRh8Uts  Supabase-E98B2F86-E19C-4F5B-988F-DAC40E1B845D" src="https://github.com/user-attachments/assets/01fa3b62-af2b-447d-bd17-b92e86064285" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **UI Improvements**
  * Refreshed the RLS notice banner with updated wording and a cleaner alert-style presentation.
  * Improved the trigger setup dialog copy, including title/description text and updated button labels.
  * Updated the trigger creation tooltip/action wording for clearer guidance.
* **Documentation**
  * Added a small inline label comment to the generated auto-enable RLS event trigger SQL for easier readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->