### PR TITLE
fix(studio): allow multiline MFA phone template

### DIFF
--- a/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/MfaAuthSettingsForm/MfaAuthSettingsForm.tsx
@@ -25,6 +25,7 @@ import {
   SelectTrigger,
   SelectValue,
   Switch,
+  Textarea,
   WarningIcon,
 } from 'ui'
 import { GenericSkeletonLoader } from 'ui-patterns'
@@ -542,9 +543,10 @@ export const MfaAuthSettingsForm = () => {
                         description="To format the OTP code use `{{ .Code }}`"
                       >
                         <FormControl>
-                          <Input
-                            type="text"
+                          <Textarea
                             {...field}
+                            rows={4}
+                            className="resize-none"
                             disabled={!canUpdateConfig || !hasAccessToMFA}
                             data-1p-ignore // 1Password
                             data-lpignore="true" // LastPass


### PR DESCRIPTION
## What changed

Switches the MFA phone verification message field from a single-line `Input` to the shared `Textarea` component.

## Why

Phone/MFA templates can include formatting such as newlines for SMS/WebOTP-style messages. The SMS provider template path already supports multiline input through a textarea, but the MFA phone verification message field still rendered as a single-line input.

## Impact

Users editing MFA phone verification messages in Studio can enter and review multiline template content more naturally. Existing form state, validation, permissions, and password-manager ignore attributes are preserved.

## Validation

- Inspected current Studio auth form implementation on `master`
- Confirmed the change is scoped to the MFA phone template field

I did not run the Studio test suite in this clean shallow clone because dependencies are not installed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Updated the SMS MFA phone verification message field to support multi-line text.
  * Increased the visible editing area for longer verification messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->