### PR TITLE
fix(studio): close delete bucket modal immediately after deletion

### DIFF
--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -31,6 +31,9 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
 
   const { mutate: deleteBucket, isPending: isDeletingBucket } = useBucketDeleteMutation({
     onSuccess: async () => {
+      // Close the modal and navigate away as soon as the bucket itself is deleted, so
+      // policy cleanup below (which can be slow) doesn't hold the loading state or block
+      // the success feedback.
       toast.success(`Successfully deleted bucket ${bucket.id}`)
       onClose()
       if (bucketId) router.push(`/project/${projectRef}/storage/files`)

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -27,11 +27,14 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
     schema: 'storage',
   })
 
-  const { mutateAsync: deletePolicy, isPending: isDeletingPolicies } =
-    useDatabasePolicyDeleteMutation()
+  const { mutateAsync: deletePolicy } = useDatabasePolicyDeleteMutation()
 
   const { mutate: deleteBucket, isPending: isDeletingBucket } = useBucketDeleteMutation({
     onSuccess: async () => {
+      toast.success(`Successfully deleted bucket ${bucket.id}`)
+      onClose()
+      if (bucketId) router.push(`/project/${projectRef}/storage/files`)
+
       if (!project) return console.error('Project is required')
 
       // Clean up policies from the corresponding bucket that was deleted
@@ -42,20 +45,18 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
         return policyBucket === bucket.name
       })
 
+      if (bucketPolicies.length === 0) return
+
       try {
         await Promise.all(
           bucketPolicies.map((policy) =>
             deletePolicy({
-              projectRef: project?.ref,
-              connectionString: project?.connectionString,
+              projectRef: project.ref,
+              connectionString: project.connectionString,
               originalPolicy: policy,
             })
           )
         )
-
-        toast.success(`Successfully deleted bucket ${bucket.id}`)
-        if (!!bucketId) router.push(`/project/${projectRef}/storage/files`)
-        onClose()
       } catch (error) {
         toast.success(
           `Successfully deleted bucket ${bucket.id}. However, there was a problem deleting the policies tied to the bucket. Please review them in the storage policies section`
@@ -76,7 +77,7 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
       size="medium"
       variant="destructive"
       title={`Delete bucket “${bucket.id}”`}
-      loading={isDeletingBucket || isDeletingPolicies}
+      loading={isDeletingBucket}
       confirmPlaceholder="Type bucket name"
       confirmString={bucket.id}
       confirmLabel="Delete bucket"

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -49,15 +49,13 @@ export const useBucketDeleteMutation = ({
 
       const deletedBucketQueryKey = storageKeys.bucket(projectRef, id)
       await queryClient.cancelQueries({ queryKey: deletedBucketQueryKey })
-      queryClient.removeQueries({
-        queryKey: deletedBucketQueryKey,
-      })
+      queryClient.removeQueries({ queryKey: deletedBucketQueryKey })
 
       await onSuccess?.(data, variables, context)
 
-      void queryClient.invalidateQueries({
-        queryKey: [...storageKeys.buckets(projectRef), 'list'],
-      })
+      // Fire-and-forget: only the bucket list needs refreshing, and it shouldn't block
+      // onSuccess (modal close/navigation) above.
+      void queryClient.invalidateQueries({ queryKey: storageKeys.bucketsList(projectRef) })
     },
     async onError(data, variables, context) {
       if (onError === undefined) {

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -57,10 +57,11 @@ export const useBucketDeleteMutation = ({
           query.queryKey[3] === id,
       })
 
-      await queryClient.invalidateQueries({
+      await onSuccess?.(data, variables, context)
+
+      void queryClient.invalidateQueries({
         queryKey: [...storageKeys.buckets(projectRef), 'list'],
       })
-      await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {
       if (onError === undefined) {

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -45,8 +45,21 @@ export const useBucketDeleteMutation = ({
   return useMutation<BucketDeleteData, ResponseError, BucketDeleteVariables>({
     mutationFn: (vars) => deleteBucket(vars),
     async onSuccess(data, variables, context) {
-      const { projectRef } = variables
-      await queryClient.invalidateQueries({ queryKey: storageKeys.buckets(projectRef) })
+      const { projectRef, id } = variables
+
+      const deletedBucketQueryKey = storageKeys.bucket(projectRef, id)
+      await queryClient.cancelQueries({ queryKey: deletedBucketQueryKey })
+      queryClient.removeQueries({
+        predicate: (query) =>
+          query.queryKey[0] === 'projects' &&
+          query.queryKey[1] === projectRef &&
+          query.queryKey[2] === 'buckets' &&
+          query.queryKey[3] === id,
+      })
+
+      await queryClient.invalidateQueries({
+        queryKey: [...storageKeys.buckets(projectRef), 'list'],
+      })
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {

--- a/apps/studio/data/storage/bucket-delete-mutation.ts
+++ b/apps/studio/data/storage/bucket-delete-mutation.ts
@@ -50,11 +50,7 @@ export const useBucketDeleteMutation = ({
       const deletedBucketQueryKey = storageKeys.bucket(projectRef, id)
       await queryClient.cancelQueries({ queryKey: deletedBucketQueryKey })
       queryClient.removeQueries({
-        predicate: (query) =>
-          query.queryKey[0] === 'projects' &&
-          query.queryKey[1] === projectRef &&
-          query.queryKey[2] === 'buckets' &&
-          query.queryKey[3] === id,
+        queryKey: deletedBucketQueryKey,
       })
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -227,6 +227,10 @@ export const useBucketInfoQueryPreferCached = (bucketId?: string, projectRef?: s
 
 const shouldRetryBucketsQuery = (failureCount: number, error: unknown) => {
   if (error instanceof ResponseError) {
+    if (error.code === 404) {
+      return false
+    }
+
     if (
       error.message.includes('Missing tenant config') ||
       error.message.includes('Project has no active API keys')

--- a/apps/studio/data/storage/buckets-query.ts
+++ b/apps/studio/data/storage/buckets-query.ts
@@ -227,6 +227,7 @@ export const useBucketInfoQueryPreferCached = (bucketId?: string, projectRef?: s
 
 const shouldRetryBucketsQuery = (failureCount: number, error: unknown) => {
   if (error instanceof ResponseError) {
+    // If the bucket doesn't exist or was deleted, don't retry — it will never succeed.
     if (error.code === 404) {
       return false
     }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

When deleting Storage bucket:

After a successful `DELETE`, `useBucketDeleteMutation` called: `await queryClient.invalidateQueries({ queryKey: storageKeys.buckets(projectRef) })`

That prefix matches both the bucket list and the individual bucket query for the current page (`useSelectedBucket`). React Query immediately refetches the just-deleted bucket → 404 → retried up to 3 times.

Because that `await` ran before the modal's `onSuccess`, the whole chain was blocked:

- Modal stayed open (no `onClose()` yet)
- Success toast was delayed until the refetch/retry loop finished
- If the modal is closed manually, the background work eventually completes and the toast appears late
- Policy cleanup also ran before closing the modal, which could extend the loading state further on buckets with storage policies

Fix:

- Remove the deleted bucket from cache and only invalidate bucket list queries (not the individual bucket query)
- Close the modal, show the toast, and navigate away immediately; policy cleanup runs afterward in the background
- Don't retry bucket queries on 404 (defensive, in case a stale refetch still happens).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Bucket deletion flow now immediately shows success, closes the dialog, and returns to the storage view after the delete completes—without waiting on policy cleanup.
  * Policy cleanup after deletion is now conditional and shows a clearer message if policy removal fails.
  * Storage UI caching is cleaned up more precisely for the deleted bucket to reduce stale results.
  * Bucket list loading retries no longer repeat when a not-found (404) error occurs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->