### PR TITLE
fix: preserve queued table row identity

### DIFF
--- a/apps/studio/components/grid/hooks/useTableRowOperations.ts
+++ b/apps/studio/components/grid/hooks/useTableRowOperations.ts
@@ -18,6 +18,7 @@ import type { TableRowsData } from '@/data/table-rows/table-rows-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useGetImpersonatedRoleState } from '@/state/role-impersonation-state'
 import { useTableEditorStateSnapshot } from '@/state/table-editor'
+import type { QueuedOperation } from '@/state/table-editor-operation-queue.types'
 import type { Dictionary } from '@/types'
 
 export interface EditCellParams {
@@ -64,6 +65,8 @@ export function useTableRowOperations() {
   const { data: project } = useSelectedProjectQuery()
   const tableEditorSnap = useTableEditorStateSnapshot()
   const getImpersonatedRoleState = useGetImpersonatedRoleState()
+  const queuedOperations = tableEditorSnap.operationQueue
+    .operations as unknown as readonly QueuedOperation[]
 
   // Non-queue mutation for cell edits with optimistic updates
   const { mutateAsync: mutateUpdateTableRow, isPending: isEditPending } = useTableRowUpdateMutation(
@@ -123,6 +126,7 @@ export function useTableRowOperations() {
       if (isQueueEnabled) {
         queueCellEditWithOptimisticUpdate({
           queueOperation: tableEditorSnap.queueOperation,
+          operations: queuedOperations,
           tableId: params.tableId,
           table: params.table,
           row: params.row,
@@ -149,7 +153,14 @@ export function useTableRowOperations() {
       })
       params.onSuccess?.()
     },
-    [isQueueEnabled, project, tableEditorSnap, mutateUpdateTableRow, getImpersonatedRoleState]
+    [
+      isQueueEnabled,
+      project,
+      tableEditorSnap,
+      queuedOperations,
+      mutateUpdateTableRow,
+      getImpersonatedRoleState,
+    ]
   )
 
   const updateRow = useCallback(
@@ -159,6 +170,7 @@ export function useTableRowOperations() {
         for (const columnName of Object.keys(params.payload)) {
           queueCellEditWithOptimisticUpdate({
             queueOperation: tableEditorSnap.queueOperation,
+            operations: queuedOperations,
             tableId: params.tableId,
             table: params.table,
             row: params.row,
@@ -185,7 +197,14 @@ export function useTableRowOperations() {
       })
       params.onSuccess?.()
     },
-    [isQueueEnabled, project, tableEditorSnap, mutateUpdateTableRow, getImpersonatedRoleState]
+    [
+      isQueueEnabled,
+      project,
+      tableEditorSnap,
+      queuedOperations,
+      mutateUpdateTableRow,
+      getImpersonatedRoleState,
+    ]
   )
 
   const addRow = useCallback(
@@ -225,6 +244,7 @@ export function useTableRowOperations() {
         queueRowDeletesWithOptimisticUpdate({
           rows: params.rows,
           table: params.table,
+          operations: queuedOperations,
           queueOperation: tableEditorSnap.queueOperation,
           projectRef: project?.ref,
         })
@@ -239,7 +259,7 @@ export function useTableRowOperations() {
         callback: params.callback,
       })
     },
-    [isQueueEnabled, project, tableEditorSnap]
+    [isQueueEnabled, project, tableEditorSnap, queuedOperations]
   )
 
   return {

--- a/apps/studio/components/grid/hooks/useTableRowOperations.ts
+++ b/apps/studio/components/grid/hooks/useTableRowOperations.ts
@@ -18,7 +18,6 @@ import type { TableRowsData } from '@/data/table-rows/table-rows-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useGetImpersonatedRoleState } from '@/state/role-impersonation-state'
 import { useTableEditorStateSnapshot } from '@/state/table-editor'
-import type { QueuedOperation } from '@/state/table-editor-operation-queue.types'
 import type { Dictionary } from '@/types'
 
 export interface EditCellParams {
@@ -65,8 +64,7 @@ export function useTableRowOperations() {
   const { data: project } = useSelectedProjectQuery()
   const tableEditorSnap = useTableEditorStateSnapshot()
   const getImpersonatedRoleState = useGetImpersonatedRoleState()
-  const queuedOperations = tableEditorSnap.operationQueue
-    .operations as unknown as readonly QueuedOperation[]
+  const queuedOperations = tableEditorSnap.operationQueue.operations
 
   // Non-queue mutation for cell edits with optimistic updates
   const { mutateAsync: mutateUpdateTableRow, isPending: isEditPending } = useTableRowUpdateMutation(

--- a/apps/studio/components/grid/utils/queueOperationUtils.test.ts
+++ b/apps/studio/components/grid/utils/queueOperationUtils.test.ts
@@ -1,16 +1,21 @@
 import { describe, expect, test } from 'vitest'
 
-import type { SupaRow } from '../types'
+import type { PendingAddRow, SupaRow } from '../types'
 import {
   formatGridDataWithOperationValues,
   generateTableChangeKey,
+  getOriginalRowIdentifiersForQueuedOperation,
+  queueRowDeletesWithOptimisticUpdate,
   rowMatchesIdentifiers,
 } from './queueOperationUtils'
+import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
+import type { Entity } from '@/data/table-editor/table-editor-types'
 import {
   QueuedOperationType,
   type NewAddRowOperation,
   type NewDeleteRowOperation,
   type NewEditCellContentOperation,
+  type NewQueuedOperation,
   type QueuedOperation,
 } from '@/state/table-editor-operation-queue.types'
 
@@ -149,6 +154,170 @@ describe('rowMatchesIdentifiers', () => {
   test('should not match with undefined values in row', () => {
     const result = rowMatchesIdentifiers({ id: undefined, name: 'test' }, { id: 1 })
     expect(result).toBe(false)
+  })
+})
+
+describe('getOriginalRowIdentifiersForQueuedOperation', () => {
+  const table = {
+    id: 1,
+    entity_type: ENTITY_TYPE.TABLE,
+    primary_keys: [{ name: 'id' }],
+  } as unknown as Entity
+
+  test('keeps row identifiers unchanged when there are no queued primary key edits', () => {
+    const result = getOriginalRowIdentifiersForQueuedOperation({
+      operations: [],
+      tableId: 1,
+      table,
+      rowIdentifiers: { id: 2 },
+    })
+
+    expect(result).toEqual({ id: 2 })
+  })
+
+  test('returns original identifiers after a queued primary key edit', () => {
+    const operations: QueuedOperation[] = [
+      {
+        id: 'edit_cell_content:1:id:id:1',
+        tableId: 1,
+        timestamp: Date.now(),
+        type: QueuedOperationType.EDIT_CELL_CONTENT,
+        payload: {
+          rowIdentifiers: { id: 1 },
+          columnName: 'id',
+          oldValue: 1,
+          newValue: 2,
+          table,
+        },
+      },
+    ]
+
+    const result = getOriginalRowIdentifiersForQueuedOperation({
+      operations,
+      tableId: 1,
+      table,
+      rowIdentifiers: { id: 2 },
+    })
+
+    expect(result).toEqual({ id: 1 })
+  })
+
+  test('handles multiple queued primary key edits for composite identifiers', () => {
+    const compositeTable = {
+      id: 1,
+      entity_type: ENTITY_TYPE.TABLE,
+      primary_keys: [{ name: 'tenant_id' }, { name: 'user_id' }],
+    } as unknown as Entity
+    const operations: QueuedOperation[] = [
+      {
+        id: 'edit_cell_content:1:tenant_id:tenant_id:a|user_id:1',
+        tableId: 1,
+        timestamp: Date.now(),
+        type: QueuedOperationType.EDIT_CELL_CONTENT,
+        payload: {
+          rowIdentifiers: { tenant_id: 'a', user_id: 1 },
+          columnName: 'tenant_id',
+          oldValue: 'a',
+          newValue: 'b',
+          table: compositeTable,
+        },
+      },
+      {
+        id: 'edit_cell_content:1:user_id:tenant_id:a|user_id:1',
+        tableId: 1,
+        timestamp: Date.now(),
+        type: QueuedOperationType.EDIT_CELL_CONTENT,
+        payload: {
+          rowIdentifiers: { tenant_id: 'a', user_id: 1 },
+          columnName: 'user_id',
+          oldValue: 1,
+          newValue: 2,
+          table: compositeTable,
+        },
+      },
+    ]
+
+    const result = getOriginalRowIdentifiersForQueuedOperation({
+      operations,
+      tableId: 1,
+      table: compositeTable,
+      rowIdentifiers: { tenant_id: 'b', user_id: 2 },
+    })
+
+    expect(result).toEqual({ tenant_id: 'a', user_id: 1 })
+  })
+
+  test('leaves pending row temp identifiers unchanged', () => {
+    const result = getOriginalRowIdentifiersForQueuedOperation({
+      operations: [],
+      tableId: 1,
+      table,
+      rowIdentifiers: { __tempId: '-1', id: 2 },
+    })
+
+    expect(result).toEqual({ __tempId: '-1', id: 2 })
+  })
+})
+
+describe('queueRowDeletesWithOptimisticUpdate', () => {
+  const table = {
+    id: 1,
+    entity_type: ENTITY_TYPE.TABLE,
+    primary_keys: [{ name: 'id' }],
+  } as unknown as Entity
+
+  test('queues delete with original identifiers after a primary key edit', () => {
+    const queuedOperations: NewQueuedOperation[] = []
+    const operations: QueuedOperation[] = [
+      {
+        id: 'edit_cell_content:1:id:id:1',
+        tableId: 1,
+        timestamp: Date.now(),
+        type: QueuedOperationType.EDIT_CELL_CONTENT,
+        payload: {
+          rowIdentifiers: { id: 1 },
+          columnName: 'id',
+          oldValue: 1,
+          newValue: 2,
+          table,
+        },
+      },
+    ]
+
+    queueRowDeletesWithOptimisticUpdate({
+      rows: [{ idx: 0, id: 2, name: 'Alice' }],
+      table,
+      operations,
+      queueOperation: (operation) => queuedOperations.push(operation),
+      projectRef: 'project-ref',
+    })
+
+    expect(queuedOperations).toHaveLength(1)
+    expect(queuedOperations[0]).toMatchObject({
+      type: QueuedOperationType.DELETE_ROW,
+      payload: {
+        rowIdentifiers: { id: 1 },
+      },
+    })
+  })
+
+  test('queues pending row delete with temp identifier', () => {
+    const queuedOperations: NewQueuedOperation[] = []
+
+    queueRowDeletesWithOptimisticUpdate({
+      rows: [{ idx: -1, __tempId: '-1', id: 10, name: 'Draft' } as PendingAddRow],
+      table,
+      queueOperation: (operation) => queuedOperations.push(operation),
+      projectRef: 'project-ref',
+    })
+
+    expect(queuedOperations).toHaveLength(1)
+    expect(queuedOperations[0]).toMatchObject({
+      type: QueuedOperationType.DELETE_ROW,
+      payload: {
+        rowIdentifiers: { id: 10, __tempId: '-1' },
+      },
+    })
   })
 })
 

--- a/apps/studio/components/grid/utils/queueOperationUtils.ts
+++ b/apps/studio/components/grid/utils/queueOperationUtils.ts
@@ -1,3 +1,5 @@
+import type { INTERNAL_Snapshot as Snapshot } from 'valtio/vanilla'
+
 import { isPendingAddRow, PendingAddRow, SupaRow } from '../types'
 import { isTableLike, type Entity } from '@/data/table-editor/table-editor-types'
 import {
@@ -7,6 +9,8 @@ import {
   QueuedOperationType,
 } from '@/state/table-editor-operation-queue.types'
 import type { Dictionary } from '@/types'
+
+type QueuedOperationSnapshot = Snapshot<QueuedOperation>
 
 interface EditCellKeyOperation extends Omit<
   EditCellContentOperation,
@@ -60,7 +64,7 @@ export function rowMatchesIdentifiers(
 }
 
 function getQueuedCurrentRowIdentifiers(
-  operations: readonly QueuedOperation[],
+  operations: readonly QueuedOperationSnapshot[],
   tableId: number,
   primaryKeyNames: string[],
   originalIdentifiers: Dictionary<unknown>
@@ -90,7 +94,7 @@ export function getOriginalRowIdentifiersForQueuedOperation({
   table,
   rowIdentifiers,
 }: {
-  operations: readonly QueuedOperation[]
+  operations: readonly QueuedOperationSnapshot[]
   tableId: number
   table: Entity
   rowIdentifiers: Dictionary<unknown>
@@ -104,17 +108,16 @@ export function getOriginalRowIdentifiersForQueuedOperation({
     return rowIdentifiers
   }
 
-  const existingOriginalIdentifiers = operations
-    .filter((operation) => {
-      return (
-        operation.tableId === tableId &&
-        operation.type === QueuedOperationType.EDIT_CELL_CONTENT &&
-        primaryKeyNames.includes(operation.payload.columnName)
-      )
-    })
-    .map((operation) => operation.payload.rowIdentifiers)
+  for (const operation of operations) {
+    if (
+      operation.tableId !== tableId ||
+      operation.type !== QueuedOperationType.EDIT_CELL_CONTENT ||
+      !primaryKeyNames.includes(operation.payload.columnName)
+    ) {
+      continue
+    }
 
-  for (const originalIdentifiers of existingOriginalIdentifiers) {
+    const originalIdentifiers = operation.payload.rowIdentifiers
     const currentIdentifiers = getQueuedCurrentRowIdentifiers(
       operations,
       tableId,
@@ -136,7 +139,7 @@ export function removeRow(rows: SupaRow[], rowIdentifiers: Dictionary<unknown>):
 
 interface QueueCellEditParams {
   queueOperation: (operation: NewQueuedOperation) => void
-  operations?: readonly QueuedOperation[]
+  operations?: readonly QueuedOperationSnapshot[]
   tableId: number
   table: Entity
   row: SupaRow
@@ -269,7 +272,7 @@ export const formatGridDataWithOperationValues = ({
 interface QueueRowDeletesParams {
   rows: SupaRow[]
   table: Entity
-  operations?: readonly QueuedOperation[]
+  operations?: readonly QueuedOperationSnapshot[]
   queueOperation: (operation: NewQueuedOperation) => void
   projectRef: string | undefined
 }

--- a/apps/studio/components/grid/utils/queueOperationUtils.ts
+++ b/apps/studio/components/grid/utils/queueOperationUtils.ts
@@ -59,12 +59,84 @@ export function rowMatchesIdentifiers(
   return identifierEntries.every(([key, value]) => row[key] === value)
 }
 
+function getQueuedCurrentRowIdentifiers(
+  operations: readonly QueuedOperation[],
+  tableId: number,
+  primaryKeyNames: string[],
+  originalIdentifiers: Dictionary<unknown>
+): Dictionary<unknown> {
+  const currentIdentifiers = { ...originalIdentifiers }
+
+  operations.forEach((operation) => {
+    if (operation.tableId !== tableId || operation.type !== QueuedOperationType.EDIT_CELL_CONTENT) {
+      return
+    }
+
+    if (!primaryKeyNames.includes(operation.payload.columnName)) {
+      return
+    }
+
+    if (rowMatchesIdentifiers(operation.payload.rowIdentifiers, originalIdentifiers)) {
+      currentIdentifiers[operation.payload.columnName] = operation.payload.newValue
+    }
+  })
+
+  return currentIdentifiers
+}
+
+export function getOriginalRowIdentifiersForQueuedOperation({
+  operations,
+  tableId,
+  table,
+  rowIdentifiers,
+}: {
+  operations: readonly QueuedOperation[]
+  tableId: number
+  table: Entity
+  rowIdentifiers: Dictionary<unknown>
+}): Dictionary<unknown> {
+  if (rowIdentifiers.__tempId !== undefined || !isTableLike(table)) {
+    return rowIdentifiers
+  }
+
+  const primaryKeyNames = table.primary_keys.map((primaryKey) => primaryKey.name)
+  if (primaryKeyNames.length === 0) {
+    return rowIdentifiers
+  }
+
+  const existingOriginalIdentifiers = operations
+    .filter((operation) => {
+      return (
+        operation.tableId === tableId &&
+        operation.type === QueuedOperationType.EDIT_CELL_CONTENT &&
+        primaryKeyNames.includes(operation.payload.columnName)
+      )
+    })
+    .map((operation) => operation.payload.rowIdentifiers)
+
+  for (const originalIdentifiers of existingOriginalIdentifiers) {
+    const currentIdentifiers = getQueuedCurrentRowIdentifiers(
+      operations,
+      tableId,
+      primaryKeyNames,
+      originalIdentifiers
+    )
+
+    if (rowMatchesIdentifiers(currentIdentifiers, rowIdentifiers)) {
+      return originalIdentifiers
+    }
+  }
+
+  return rowIdentifiers
+}
+
 export function removeRow(rows: SupaRow[], rowIdentifiers: Dictionary<unknown>): SupaRow[] {
   return rows.filter((row) => !rowMatchesIdentifiers(row, rowIdentifiers))
 }
 
 interface QueueCellEditParams {
   queueOperation: (operation: NewQueuedOperation) => void
+  operations?: readonly QueuedOperation[]
   tableId: number
   table: Entity
   row: SupaRow
@@ -77,6 +149,7 @@ interface QueueCellEditParams {
 
 export function queueCellEditWithOptimisticUpdate({
   queueOperation,
+  operations = [],
   tableId,
   table,
   row,
@@ -87,7 +160,14 @@ export function queueCellEditWithOptimisticUpdate({
   enumArrayColumns,
 }: QueueCellEditParams) {
   // Updated row identifiers to include __tempId for pending add rows so edits merge into ADD_ROW operation
-  const rowIdentifiers: Dictionary<unknown> = { ...callerRowIdentifiers }
+  const rowIdentifiers: Dictionary<unknown> = {
+    ...getOriginalRowIdentifiersForQueuedOperation({
+      operations,
+      tableId,
+      table,
+      rowIdentifiers: callerRowIdentifiers,
+    }),
+  }
   if (isPendingAddRow(row)) {
     rowIdentifiers.__tempId = row.__tempId
   }
@@ -189,6 +269,7 @@ export const formatGridDataWithOperationValues = ({
 interface QueueRowDeletesParams {
   rows: SupaRow[]
   table: Entity
+  operations?: readonly QueuedOperation[]
   queueOperation: (operation: NewQueuedOperation) => void
   projectRef: string | undefined
 }
@@ -200,6 +281,7 @@ interface QueueRowDeletesParams {
 export function queueRowDeletesWithOptimisticUpdate({
   rows,
   table,
+  operations = [],
   queueOperation,
   projectRef,
 }: QueueRowDeletesParams): void {
@@ -221,10 +303,23 @@ export function queueRowDeletesWithOptimisticUpdate({
   }
 
   for (const row of rows) {
-    const rowIdentifiers: Record<string, unknown> = {}
+    let rowIdentifiers: Record<string, unknown> = {}
     table.primary_keys.forEach((pk) => {
       rowIdentifiers[pk.name] = row[pk.name]
     })
+
+    rowIdentifiers = {
+      ...getOriginalRowIdentifiersForQueuedOperation({
+        operations,
+        tableId: table.id,
+        table,
+        rowIdentifiers,
+      }),
+    }
+
+    if (isPendingAddRow(row)) {
+      rowIdentifiers.__tempId = row.__tempId
+    }
 
     queueOperation({
       type: QueuedOperationType.DELETE_ROW,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Fixes #47318. In Studio's batched table edit mode, editing primary key values can cause later queued edits or deletes for the same row to use the optimistic primary key values instead of the original row identifiers. Deleting a newly added pending row can also miss the pending-row identity needed to cancel the queued add.

## What is the new behavior?

Queued row edits and deletes now resolve the original database row identifiers when primary key edits are already pending. Pending added rows continue to use their temporary row identifier so deleting them cancels the queued add/edit operations instead of creating an invalid delete.

## Additional context

Validation performed:

- Focused Vitest queue utility tests: 57 tests passed.
- Prettier check passed for the touched files.
- git diff --check passed.

Note: full Studio typecheck was not used as the final gate locally because the default run exceeded the Node heap, and a larger-heap run surfaced existing unrelated API test mock typing errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of queued cell edits and row deletions when primary-key values change before actions are applied.
  * Ensures edits/deletes correctly match the intended rows, including for composite primary keys.
  * More robust handling of pending rows that use temporary identifiers during optimistic updates.
  * Optimistic queued operations now stay consistent with any previously queued primary-key edits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->