### PR TITLE
fix: expanded editor shortcut

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar.tsx
@@ -1,5 +1,5 @@
 import { noop } from 'lodash'
-import { PropsWithChildren, useCallback, useState } from 'react'
+import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
 import { Button, KeyboardShortcut } from 'ui'
 
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
@@ -52,6 +52,28 @@ export const ActionBar = ({
   }, [isRunning, loading, disableApply, hideApply, formId, applyFunction, onSelectApply])
 
   useShortcut(SHORTCUT_IDS.ACTION_BAR_SAVE, handleSave, { enabled: visible })
+
+  useEffect(() => {
+    if (!visible) return
+
+    const handleKeydown = (event: KeyboardEvent) => {
+      if (
+        !(event.metaKey || event.ctrlKey) ||
+        event.altKey ||
+        event.shiftKey ||
+        event.key.toLowerCase() !== 'enter'
+      ) {
+        return
+      }
+
+      event.preventDefault()
+      event.stopPropagation()
+      handleSave()
+    }
+
+    window.addEventListener('keydown', handleKeydown, true)
+    return () => window.removeEventListener('keydown', handleKeydown, true)
+  }, [visible, handleSave])
 
   return (
     <div className="flex w-full items-center gap-3 border-t border-default px-3 py-4">

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar.tsx
@@ -1,5 +1,5 @@
 import { noop } from 'lodash'
-import { PropsWithChildren, useCallback, useEffect, useState } from 'react'
+import { PropsWithChildren, useCallback, useState } from 'react'
 import { Button, KeyboardShortcut } from 'ui'
 
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
@@ -52,28 +52,6 @@ export const ActionBar = ({
   }, [isRunning, loading, disableApply, hideApply, formId, applyFunction, onSelectApply])
 
   useShortcut(SHORTCUT_IDS.ACTION_BAR_SAVE, handleSave, { enabled: visible })
-
-  useEffect(() => {
-    if (!visible) return
-
-    const handleKeydown = (event: KeyboardEvent) => {
-      if (
-        !(event.metaKey || event.ctrlKey) ||
-        event.altKey ||
-        event.shiftKey ||
-        event.key.toLowerCase() !== 'enter'
-      ) {
-        return
-      }
-
-      event.preventDefault()
-      event.stopPropagation()
-      handleSave()
-    }
-
-    window.addEventListener('keydown', handleKeydown, true)
-    return () => window.removeEventListener('keydown', handleKeydown, true)
-  }, [visible, handleSave])
 
   return (
     <div className="flex w-full items-center gap-3 border-t border-default px-3 py-4">

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
@@ -61,16 +61,19 @@ export const JsonEditor = ({
 
   const { mutate: getCellValue, isPending, isSuccess, reset } = useGetCellValueMutation()
 
-  const validateJSON = useCallback(async (resolve: () => void) => {
-    try {
-      const newJsonStr = removeJSONTrailingComma(jsonStr)
-      const minifiedJSON = minifyJSON(newJsonStr)
-      if (onSaveJSON) onSaveJSON(minifiedJSON, resolve)
-    } catch (error: any) {
-      resolve()
-      toast.error('JSON seems to have an invalid structure.')
-    }
-  }, [jsonStr, onSaveJSON])
+  const validateJSON = useCallback(
+    async (nextValue: string, resolve: () => void) => {
+      try {
+        const newJsonStr = removeJSONTrailingComma(nextValue)
+        const minifiedJSON = minifyJSON(newJsonStr)
+        if (onSaveJSON) onSaveJSON(minifiedJSON, resolve)
+      } catch (error: any) {
+        resolve()
+        toast.error('JSON seems to have an invalid structure.')
+      }
+    },
+    [onSaveJSON]
+  )
 
   const handleEditorMount: OnMount = useCallback(
     (editor, monaco) => {
@@ -80,7 +83,7 @@ export const JsonEditor = ({
         id: 'save-value',
         label: 'Save value',
         keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.Enter],
-        run: () => validateJSON(() => undefined),
+        run: () => validateJSON(editor.getValue(), () => undefined),
       })
     },
     [readOnly, validateJSON]
@@ -181,7 +184,7 @@ export const JsonEditor = ({
           closePanel={onClose}
           backButtonLabel={backButtonLabel}
           applyButtonLabel={applyButtonLabel}
-          applyFunction={readOnly ? undefined : validateJSON}
+          applyFunction={readOnly ? undefined : (resolve) => validateJSON(jsonStr, resolve)}
         />
       }
     >

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
@@ -1,3 +1,4 @@
+import type { OnMount } from '@monaco-editor/react'
 import { MAX_CHARACTERS } from '@supabase/pg-meta/src/query/table-row-query'
 import { useParams } from 'common'
 import { AlignLeft } from 'lucide-react'
@@ -60,7 +61,7 @@ export const JsonEditor = ({
 
   const { mutate: getCellValue, isPending, isSuccess, reset } = useGetCellValueMutation()
 
-  const validateJSON = async (resolve: () => void) => {
+  const validateJSON = useCallback(async (resolve: () => void) => {
     try {
       const newJsonStr = removeJSONTrailingComma(jsonStr)
       const minifiedJSON = minifyJSON(newJsonStr)
@@ -69,7 +70,21 @@ export const JsonEditor = ({
       resolve()
       toast.error('JSON seems to have an invalid structure.')
     }
-  }
+  }, [jsonStr, onSaveJSON])
+
+  const handleEditorMount: OnMount = useCallback(
+    (editor, monaco) => {
+      if (readOnly) return
+
+      editor.addAction({
+        id: 'save-value',
+        label: 'Save value',
+        keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.Enter],
+        run: () => validateJSON(() => undefined),
+      })
+    },
+    [readOnly, validateJSON]
+  )
 
   const prettify = () => {
     const res = prettifyJSON(jsonStr)
@@ -179,6 +194,7 @@ export const JsonEditor = ({
               language="json"
               value={(jsonStr ?? '').toString()}
               onInputChange={(val) => setJsonStr(val ?? '')}
+              onMount={handleEditorMount}
             />
           </div>
         ) : (

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.tsx
@@ -1,3 +1,4 @@
+import type { OnMount } from '@monaco-editor/react'
 import { MAX_CHARACTERS } from '@supabase/pg-meta/src/query/table-row-query'
 import { useParams } from 'common'
 import { useCallback, useEffect, useState } from 'react'
@@ -77,9 +78,23 @@ export const TextEditor = ({
     )
   }
 
-  const saveValue = (resolve: () => void) => {
+  const saveValue = useCallback((resolve: () => void) => {
     if (onSaveField) onSaveField(strValue, resolve)
-  }
+  }, [onSaveField, strValue])
+
+  const handleEditorMount: OnMount = useCallback(
+    (editor, monaco) => {
+      if (readOnly) return
+
+      editor.addAction({
+        id: 'save-value',
+        label: 'Save value',
+        keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.Enter],
+        run: () => saveValue(() => undefined),
+      })
+    },
+    [readOnly, saveValue]
+  )
 
   useEffect(() => {
     if (visible) {
@@ -134,6 +149,7 @@ export const TextEditor = ({
               language="markdown"
               value={strValue ?? ''}
               onInputChange={(val) => setStrValue(val ?? '')}
+              onMount={handleEditorMount}
             />
           </div>
         ) : (

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.tsx
@@ -78,9 +78,12 @@ export const TextEditor = ({
     )
   }
 
-  const saveValue = useCallback((resolve: () => void) => {
-    if (onSaveField) onSaveField(strValue, resolve)
-  }, [onSaveField, strValue])
+  const saveValue = useCallback(
+    (nextValue: string, resolve: () => void) => {
+      if (onSaveField) onSaveField(nextValue, resolve)
+    },
+    [onSaveField]
+  )
 
   const handleEditorMount: OnMount = useCallback(
     (editor, monaco) => {
@@ -90,7 +93,7 @@ export const TextEditor = ({
         id: 'save-value',
         label: 'Save value',
         keybindings: [monaco.KeyMod.CtrlCmd + monaco.KeyCode.Enter],
-        run: () => saveValue(() => undefined),
+        run: () => saveValue(editor.getValue(), () => undefined),
       })
     },
     [readOnly, saveValue]
@@ -136,7 +139,7 @@ export const TextEditor = ({
           closePanel={onClose}
           backButtonLabel="Cancel"
           applyButtonLabel="Save value"
-          applyFunction={readOnly ? undefined : saveValue}
+          applyFunction={readOnly ? undefined : (resolve) => saveValue(strValue, resolve)}
         />
       }
     >


### PR DESCRIPTION
## TL;DR 
fixes `Cmd/Ctrl+Enter` in the expanded editor by wiring the save shortcut directly to monaco...

## ref:
- closes https://github.com/supabase/supabase/issues/47368

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Ctrl/Cmd+Enter shortcut in both the JSON and text editors to trigger validation and save actions.
* **Bug Fixes**
  * Improved editor reliability by standardizing how editor actions are wired and executed after mounting.
* **Performance**
  * Reduced unnecessary re-renders by memoizing the shared save/validation handlers used by the editor and the action bar.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->