### PR TITLE
feat(logs): validate log explorer queries client-side with ClickHouse parser

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
@@ -217,6 +217,27 @@ const OTEL_SOURCES: Record<LogsTableName, OtelSourceDescriptor> = {
   [LogsTableName.PG_UPGRADE]: { source: 'pg_upgrade_logs' },
 }
 
+// The single ClickHouse table backing every OTEL log source. Individual sources
+// are selected with the `source` column rather than separate tables.
+export const OTEL_LOGS_TABLE = 'logs'
+
+// Columns that exist on the `logs` table directly. Everything else lives in the
+// `log_attributes` map and is read via log_attributes['key'].
+export const OTEL_LOG_COLUMNS = [
+  'id',
+  'timestamp',
+  'event_message',
+  'source',
+  'severity_text',
+  'log_attributes',
+] as const
+
+// Valid values for the `source` column, derived from the source descriptors so
+// the two never drift apart.
+export const KNOWN_OTEL_SOURCES = Array.from(
+  new Set(Object.values(OTEL_SOURCES).map((desc) => desc.source))
+).sort()
+
 // Fallback for filter keys with no template: `log_attributes[key] = value`.
 // Drops the clause on non-scalar or un-encodable input.
 const resolveUnknownOtelClause = (dotKey: string, value: unknown): SafeLogSqlFragment | null => {

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.validation.otel.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.validation.otel.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateOtelLogQuery } from './Logs.validation.otel'
+
+const errorMessages = (sql: string) => validateOtelLogQuery(sql).errors.map((e) => e.message)
+const warningMessages = (sql: string) => validateOtelLogQuery(sql).warnings.map((w) => w.message)
+
+describe('validateOtelLogQuery - empty input', () => {
+  it('returns no issues for empty or whitespace queries', () => {
+    expect(validateOtelLogQuery('')).toEqual({ errors: [], warnings: [] })
+    expect(validateOtelLogQuery('   \n  ')).toEqual({ errors: [], warnings: [] })
+  })
+
+  it('ignores trailing semicolons after a valid query', () => {
+    expect(validateOtelLogQuery('select 1;;')).toEqual({ errors: [], warnings: [] })
+  })
+})
+
+describe('validateOtelLogQuery - valid SELECTs', () => {
+  it('accepts the default OTEL query', () => {
+    const result = validateOtelLogQuery(
+      "select timestamp, event_message, log_attributes from logs where source = 'edge_logs' order by timestamp desc limit 5"
+    )
+    expect(result.errors).toEqual([])
+    expect(result.warnings).toEqual([])
+  })
+
+  it('accepts log_attributes subscript access and aggregates', () => {
+    const result = validateOtelLogQuery(
+      "select timestamp, log_attributes['request.method'] as method, count(*) as c from logs where source = 'edge_logs' group by timestamp, method"
+    )
+    expect(result.errors).toEqual([])
+    expect(result.warnings).toEqual([])
+  })
+
+  it('accepts WITH / CTE queries (unlike the BigQuery endpoint)', () => {
+    const result = validateOtelLogQuery(
+      "with errors as (select event_message from logs where source = 'postgres_logs') select * from errors"
+    )
+    expect(result.errors).toEqual([])
+  })
+})
+
+describe('validateOtelLogQuery - statement allow-list', () => {
+  it.each([
+    ['insert into logs values (1)', 'INSERT'],
+    ['drop table logs', 'DROP'],
+    ['truncate table logs', 'TRUNCATE'],
+    ['alter table logs delete where 1', 'ALTER'],
+    ['create table t (id UInt64) engine = Memory', 'CREATE'],
+    ['system reload config', 'SYSTEM'],
+  ])('rejects %s as %s', (sql, label) => {
+    const messages = errorMessages(sql)
+    expect(messages).toHaveLength(1)
+    expect(messages[0]).toContain(`${label} statements are not supported`)
+  })
+
+  it('rejects a SELECT followed by a destructive statement', () => {
+    expect(errorMessages('select 1; drop table logs').join(' ')).toContain(
+      'DROP statements are not supported'
+    )
+  })
+
+  it('rejects multiple statements even when both are SELECTs', () => {
+    expect(errorMessages('select 1; select 2')).toEqual([
+      'Only a single query can be run at a time. Remove the extra statements separated by ";".',
+    ])
+  })
+
+  it('does not emit schema warnings for a rejected query', () => {
+    expect(validateOtelLogQuery('drop table not_a_source').warnings).toEqual([])
+  })
+})
+
+describe('validateOtelLogQuery - syntax errors', () => {
+  it('reports a syntax error with a position', () => {
+    const { errors } = validateOtelLogQuery('select foo bar baz )(')
+    expect(errors).toHaveLength(1)
+    expect(errors[0].message).toContain('Syntax error')
+    expect(errors[0].line).toBe(1)
+    expect(typeof errors[0].column).toBe('number')
+  })
+})
+
+describe('validateOtelLogQuery - schema hints', () => {
+  it('warns when querying a source name as a table', () => {
+    const warnings = warningMessages('select event_message from edge_logs')
+    expect(warnings.some((w) => w.includes('Logs live in the "logs" table'))).toBe(true)
+  })
+
+  it('warns on an unknown source value', () => {
+    const warnings = warningMessages("select event_message from logs where source = 'edge_log'")
+    expect(warnings.some((w) => w.includes('Unknown log source "edge_log"'))).toBe(true)
+  })
+
+  it('does not warn on a known source value', () => {
+    const warnings = warningMessages("select event_message from logs where source = 'auth_logs'")
+    expect(warnings).toEqual([])
+  })
+
+  it('warns on unknown sources inside an IN list but not known ones', () => {
+    const warnings = warningMessages(
+      "select event_message from logs where source in ('edge_logs', 'bogus_logs')"
+    )
+    expect(warnings.some((w) => w.includes('"bogus_logs"'))).toBe(true)
+    expect(warnings.some((w) => w.includes('"edge_logs"'))).toBe(false)
+  })
+
+  it('does not warn on unknown values inside a NOT IN exclusion', () => {
+    const warnings = warningMessages(
+      "select event_message from logs where source not in ('edge_logs', 'bogus_logs')"
+    )
+    expect(warnings).toEqual([])
+  })
+
+  it('does not flag a CTE named after a source as a table', () => {
+    const warnings = warningMessages(
+      "with edge_logs as (select event_message from logs where source = 'postgres_logs') select * from edge_logs"
+    )
+    expect(warnings).toEqual([])
+  })
+
+  it('warns on an unknown column and suggests log_attributes', () => {
+    const warnings = warningMessages("select foo from logs where source = 'edge_logs'")
+    expect(warnings.some((w) => w.includes('Unknown column "foo"'))).toBe(true)
+    expect(warnings.some((w) => w.includes("log_attributes['foo']"))).toBe(true)
+  })
+
+  it('does not flag query aliases referenced elsewhere', () => {
+    const warnings = warningMessages(
+      "select timestamp as ts, count(*) as total from logs where source = 'edge_logs' group by ts order by total"
+    )
+    expect(warnings).toEqual([])
+  })
+
+  it('does not flag known base columns', () => {
+    const warnings = warningMessages(
+      'select id, timestamp, event_message, source, severity_text, log_attributes from logs'
+    )
+    expect(warnings).toEqual([])
+  })
+})

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.validation.otel.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.validation.otel.ts
@@ -1,0 +1,236 @@
+import { findNodes, parse, ParseError, type Statement } from '@clickhouse/parser'
+
+import { KNOWN_OTEL_SOURCES, OTEL_LOG_COLUMNS, OTEL_LOGS_TABLE } from './Logs.utils.otel'
+
+// Client-side validation for the ClickHouse-backed (OTEL) log explorer. Parses
+// the query with @clickhouse/parser so we can (1) surface syntax errors, (2)
+// reject anything that isn't a read-only SELECT before it reaches the endpoint,
+// and (3) hint at schema mistakes (unknown sources/columns) without blocking.
+
+export interface LogQueryIssue {
+  message: string
+  // 1-based position of the problem in the query, when the parser knows it.
+  line?: number
+  column?: number
+}
+
+export interface LogQueryValidation {
+  errors: LogQueryIssue[]
+  warnings: LogQueryIssue[]
+}
+
+const EMPTY: LogQueryValidation = { errors: [], warnings: [] }
+
+// Statement kinds that only read data. Anything else (INSERT, ALTER, DROP,
+// CREATE, SYSTEM, ...) is rejected.
+const READ_ONLY_STATEMENT_KINDS = new Set(['select', 'union', 'intersect'])
+
+// Readable labels for the statement kinds we reject, so the error names the
+// operation the user actually wrote.
+const STATEMENT_LABELS: Record<string, string> = {
+  insert: 'INSERT',
+  update: 'UPDATE',
+  delete: 'DELETE',
+  drop: 'DROP',
+  truncate: 'TRUNCATE',
+  rename: 'RENAME',
+  optimize: 'OPTIMIZE',
+  attach: 'ATTACH',
+  detach: 'DETACH',
+  system: 'SYSTEM',
+  grant: 'GRANT',
+  kill: 'KILL',
+  set: 'SET',
+  use: 'USE',
+  explain: 'EXPLAIN',
+  describe: 'DESCRIBE',
+  show: 'SHOW',
+}
+
+const labelForKind = (kind: string): string => {
+  if (STATEMENT_LABELS[kind]) return STATEMENT_LABELS[kind]
+  if (kind.startsWith('create')) return 'CREATE'
+  if (kind.startsWith('alter')) return 'ALTER'
+  return kind.toUpperCase()
+}
+
+const isStringIdentifier = (value: unknown): value is string => typeof value === 'string'
+
+const toParseIssue = (error: unknown): LogQueryIssue => {
+  const message = error instanceof Error ? error.message : 'Could not parse query.'
+  if (error instanceof ParseError && error.location) {
+    return {
+      message: `Syntax error: ${message}`,
+      line: error.location.start.line,
+      column: error.location.start.column,
+    }
+  }
+  return { message: `Syntax error: ${message}` }
+}
+
+// `FROM edge_logs` is a common mistake carried over from the BigQuery explorer,
+// where each source was its own table. Point users at the single `logs` table.
+// Names introduced by WITH ... AS (...) clauses. They appear as table and
+// column references in the AST but aren't real schema objects, so the source
+// and column checks below must ignore them.
+const collectCteNames = (statements: Statement[]): Set<string> => {
+  const names = new Set<string>()
+  for (const cte of findNodes(statements, 'cteSubquery')) {
+    if (isStringIdentifier(cte.name)) names.add(cte.name)
+  }
+  for (const cte of findNodes(statements, 'cteExpr')) {
+    if (isStringIdentifier(cte.name)) names.add(cte.name)
+  }
+  return names
+}
+
+const checkSourceTables = (statements: Statement[], cteNames: Set<string>): LogQueryIssue[] => {
+  const issues: LogQueryIssue[] = []
+  for (const ref of findNodes(statements, 'tableRef')) {
+    if (
+      isStringIdentifier(ref.table) &&
+      !cteNames.has(ref.table) &&
+      KNOWN_OTEL_SOURCES.includes(ref.table)
+    ) {
+      issues.push({
+        message: `Logs live in the "${OTEL_LOGS_TABLE}" table. Use "FROM ${OTEL_LOGS_TABLE} WHERE source = '${ref.table}'" instead of "FROM ${ref.table}".`,
+        line: ref.location?.start.line,
+        column: ref.location?.start.column,
+      })
+    }
+  }
+  return issues
+}
+
+const isSourceColumn = (node: unknown): boolean => {
+  if (!node || typeof node !== 'object') return false
+  const ref = node as { kind?: string; parts?: unknown[] }
+  return (
+    ref.kind === 'columnRef' &&
+    Array.isArray(ref.parts) &&
+    ref.parts.length === 1 &&
+    ref.parts[0] === 'source'
+  )
+}
+
+const stringLiteralValue = (node: unknown): string | null => {
+  if (!node || typeof node !== 'object') return null
+  const literal = node as { kind?: string; type?: string; value?: unknown }
+  if (
+    literal.kind === 'literal' &&
+    literal.type === 'String' &&
+    typeof literal.value === 'string'
+  ) {
+    return literal.value
+  }
+  return null
+}
+
+// Warn when a `source = '...'` / `source IN (...)` filter compares against a
+// value that isn't a known source, so typos surface before an empty result.
+const checkSourceValues = (statements: Statement[]): LogQueryIssue[] => {
+  const issues: LogQueryIssue[] = []
+  const flagged = new Set<string>()
+
+  const flag = (node: unknown) => {
+    const value = stringLiteralValue(node)
+    if (value === null || KNOWN_OTEL_SOURCES.includes(value) || flagged.has(value)) return
+    flagged.add(value)
+    issues.push({
+      message: `Unknown log source "${value}". Known sources: ${KNOWN_OTEL_SOURCES.join(', ')}.`,
+    })
+  }
+
+  for (const expr of findNodes(statements, 'binaryExpr')) {
+    if (expr.op !== '=') continue
+    if (isSourceColumn(expr.left)) flag(expr.right)
+    if (isSourceColumn(expr.right)) flag(expr.left)
+  }
+
+  for (const expr of findNodes(statements, 'inExpr')) {
+    // `source NOT IN (...)` excludes values, so an unknown one isn't a typo.
+    if (expr.negated || !isSourceColumn(expr.expr) || !Array.isArray(expr.values)) continue
+    for (const value of expr.values) flag(value)
+  }
+
+  return issues
+}
+
+// Warn on bare column references that aren't real columns on the `logs` table.
+// Aliases defined in the query are allowed, and qualified/multi-part references
+// are skipped to avoid false positives on joins, subqueries and tuples.
+const checkColumns = (statements: Statement[], cteNames: Set<string>): LogQueryIssue[] => {
+  const issues: LogQueryIssue[] = []
+
+  const aliases = new Set<string>()
+  for (const alias of findNodes(statements, 'alias')) {
+    if (isStringIdentifier(alias.alias)) aliases.add(alias.alias)
+  }
+
+  const known = new Set<string>(OTEL_LOG_COLUMNS)
+  for (const name of cteNames) known.add(name)
+  const flagged = new Set<string>()
+
+  for (const ref of findNodes(statements, 'columnRef')) {
+    if (ref.parts.length !== 1) continue
+    const name = ref.parts[0]
+    if (!isStringIdentifier(name)) continue
+    if (known.has(name) || aliases.has(name) || flagged.has(name)) continue
+    flagged.add(name)
+    issues.push({
+      message: `Unknown column "${name}". Available columns: ${OTEL_LOG_COLUMNS.join(', ')}. Read custom fields with log_attributes['${name}'].`,
+      line: ref.location?.start.line,
+      column: ref.location?.start.column,
+    })
+  }
+
+  return issues
+}
+
+const collectSchemaWarnings = (statements: Statement[]): LogQueryIssue[] => {
+  const cteNames = collectCteNames(statements)
+  return [
+    ...checkSourceTables(statements, cteNames),
+    ...checkSourceValues(statements),
+    ...checkColumns(statements, cteNames),
+  ]
+}
+
+export function validateOtelLogQuery(sql: string): LogQueryValidation {
+  const trimmed = (sql ?? '').trim()
+  if (!trimmed) return EMPTY
+
+  let statements: Statement[]
+  try {
+    statements = parse(trimmed)
+  } catch (error) {
+    return { errors: [toParseIssue(error)], warnings: [] }
+  }
+
+  // Trailing semicolons parse to no-op `empty` statements; ignore them so a
+  // stray ";" doesn't read as an unsupported statement.
+  const realStatements = statements.filter((statement) => statement.kind !== 'empty')
+  if (realStatements.length === 0) return EMPTY
+
+  const errors: LogQueryIssue[] = []
+
+  if (realStatements.length > 1) {
+    errors.push({
+      message:
+        'Only a single query can be run at a time. Remove the extra statements separated by ";".',
+    })
+  }
+
+  for (const statement of realStatements) {
+    if (!READ_ONLY_STATEMENT_KINDS.has(statement.kind)) {
+      errors.push({
+        message: `Only SELECT queries are allowed in the log explorer. ${labelForKind(statement.kind)} statements are not supported.`,
+      })
+    }
+  }
+
+  // Once the query is rejected, schema hints would just be noise.
+  if (errors.length > 0) return { errors, warnings: [] }
+
+  return { errors, warnings: collectSchemaWarnings(realStatements) }
+}

--- a/apps/studio/hooks/analytics/useLogsQuery.tsx
+++ b/apps/studio/hooks/analytics/useLogsQuery.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query'
 import { IS_PLATFORM } from 'common'
-import { Dispatch, SetStateAction, useEffect, useState } from 'react'
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react'
 
 import {
   EXPLORER_DATEPICKER_HELPERS,
@@ -10,11 +10,16 @@ import type {
   LogData,
   Logs,
   LogsEndpointParams,
+  LogsWarning,
 } from '@/components/interfaces/Settings/Logs/Logs.types'
 import {
   checkForILIKEClause,
   checkForWithClause,
 } from '@/components/interfaces/Settings/Logs/Logs.utils'
+import {
+  validateOtelLogQuery,
+  type LogQueryIssue,
+} from '@/components/interfaces/Settings/Logs/Logs.validation.otel'
 import { get } from '@/data/fetchers'
 import { logsAllEndpointUrl } from '@/data/logs/logs-endpoint'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
@@ -30,7 +35,14 @@ export interface LogsQueryHook {
   runQuery: () => void
   setParams: Dispatch<SetStateAction<LogsEndpointParams>>
   enabled?: boolean
+  validationWarnings: LogsWarning[]
 }
+
+// Append the parser's 1-based position to an issue message when it has one.
+const describeIssue = (issue: LogQueryIssue): string =>
+  issue.line !== undefined && issue.column !== undefined
+    ? `${issue.message} (line ${issue.line}, column ${issue.column})`
+    : issue.message
 
 export const useLogsQuery = (
   projectRef: string,
@@ -62,7 +74,17 @@ export const useLogsQuery = (
     }))
   }, [initialParams.sql, initialParams.iso_timestamp_start, initialParams.iso_timestamp_end])
 
-  const _enabled = enabled && typeof projectRef !== 'undefined' && Boolean(params.sql)
+  // The ClickHouse-backed OTEL endpoint gets full client-side parsing: syntax
+  // checks, a read-only statement allow-list, and schema hints. The BigQuery
+  // endpoint keeps its lighter regex checks below.
+  const validation = useMemo(
+    () => (useOtel ? validateOtelLogQuery(params.sql || '') : { errors: [], warnings: [] }),
+    [useOtel, params.sql]
+  )
+  const hasBlockingError = validation.errors.length > 0
+
+  const _enabled =
+    enabled && typeof projectRef !== 'undefined' && Boolean(params.sql) && !hasBlockingError
 
   const usesWith = checkForWithClause(params.sql || '')
   const usesILIKE = checkForILIKEClause(params.sql || '')
@@ -115,6 +137,17 @@ export const useLogsQuery = (
       }
     }
   }
+
+  // A blocked OTEL query never hits the endpoint, so surface the parser's
+  // verdict as the error instead.
+  if (useOtel && hasBlockingError) {
+    error = { message: describeIssue(validation.errors[0]) }
+  }
+
+  const validationWarnings: LogsWarning[] = validation.warnings.map((warning) => ({
+    text: describeIssue(warning),
+  }))
+
   const changeQuery = (newQuery = '') => {
     setParams((prev) => ({ ...prev, sql: newQuery }))
   }
@@ -136,6 +169,7 @@ export const useLogsQuery = (
     changeQuery,
     runQuery: () => refetch(),
     setParams,
+    validationWarnings,
   }
 }
 export default useLogsQuery

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -45,6 +45,7 @@
     "@ai-sdk/provider-utils": "^4.0.19",
     "@ai-sdk/react": "^3.0.118",
     "@aws-sdk/credential-providers": "^3.1041.0",
+    "@clickhouse/parser": "0.2.1",
     "@dagrejs/dagre": "^1.0.4",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^9.0.0",

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -137,6 +137,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
     error,
     isLoading: logsLoading,
     setParams,
+    validationWarnings,
   } = useLogsQuery(
     projectRef,
     {
@@ -399,7 +400,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
             onSelectSource={handleInsertSource}
             templates={allTemplates.filter((template) => template.mode === 'custom')}
             onSelectTemplate={onSelectTemplate}
-            warnings={warnings}
+            warnings={warnings.concat(validationWarnings)}
           />
           <ShimmerLine active={isLoading} />
           <CodeEditor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -884,6 +884,9 @@ importers:
       '@aws-sdk/credential-providers':
         specifier: ^3.1041.0
         version: 3.1041.0
+      '@clickhouse/parser':
+        specifier: 0.2.1
+        version: 0.2.1
       '@dagrejs/dagre':
         specifier: ^1.0.4
         version: 1.0.4
@@ -3336,6 +3339,9 @@ packages:
   '@clack/prompts@1.5.0':
     resolution: {integrity: sha512-wKh+wTjmrUoUdkZg8KpJO5X+p9PWV+KE9mePseq9UYWkukgTKsGS47RRL2HstwVcvDQH+PenrPJWII8+MfiiyA==}
     engines: {node: '>= 20.12.0'}
+
+  '@clickhouse/parser@0.2.1':
+    resolution: {integrity: sha512-Si87lKbiTuSF/eOthsT7vjPz6hXBpVEkBaeE0ay7G1WwbO8x6x0VnXWvelyrBYqPgD5xk145tTiog1tNKWBE0w==}
 
   '@cloudflare/kv-asset-handler@0.4.2':
     resolution: {integrity: sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==}
@@ -18586,6 +18592,10 @@ snapshots:
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
+
+  '@clickhouse/parser@0.2.1':
+    dependencies:
+      zod: 4.4.3
 
   '@cloudflare/kv-asset-handler@0.4.2': {}
 


### PR DESCRIPTION
## Problem

The ClickHouse-backed (OTEL) log explorer sent whatever SQL the user typed straight to the analytics endpoint. Typos, non-SELECT statements, and schema mistakes (wrong source, unknown columns) only failed server-side, with errors that were hard to act on.

## Fix

Parse the query client-side with `@clickhouse/parser` when the OTEL endpoint is active, in a new pure, unit-tested helper (`Logs.validation.otel.ts`):

- Blocking errors (the request is not sent): syntax errors (with line/column), and any statement that is not a read-only SELECT (INSERT, ALTER, DROP, CREATE, SYSTEM, multiple statements, etc).
- Non-blocking warnings (shown in the existing query-panel warnings): unknown `source` values, unknown columns (suggesting `log_attributes['...']`), and querying a source name as a table.

CTE names and query aliases are excluded from the schema checks to avoid false positives, and `source NOT IN (...)` exclusions are not flagged. The BigQuery path keeps its existing regex checks unchanged.

## How to test

- Enable the OTEL log explorer endpoint and open Logs > Explorer.
- Run `select timestamp, event_message, log_attributes from logs where source = 'edge_logs' limit 5`: runs normally, no warnings.
- Run `drop table logs` or `insert into logs values (1)`: blocked with an "Only SELECT queries are allowed" error; no request is sent.
- Run `select foo bar baz)(`: blocked with a syntax error including line/column.
- Run `select foo from logs where source = 'edge_log'`: runs, but the warnings badge flags the unknown source `edge_log` and the unknown column `foo` (suggesting `log_attributes['foo']`).
- Run `select event_message from edge_logs`: warns to query `from logs where source = 'edge_logs'` instead.
- Unit tests: `pnpm --filter studio test Logs.validation.otel`.