### PR TITLE
fix(logs): load saved query content from api instead of stale url param FE-3733

### DIFF
--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -328,11 +328,18 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   useEffect(() => {
     if (search) {
       setEditorValue(search)
-    } else if (q) {
+    } else if (q && !queryId) {
       setEditorValue(q)
       setSearch(q)
     }
-  }, [q, search, setSearch])
+  }, [q, queryId, search, setSearch])
+
+  const querySql = (query?.content as LogSqlSnippets.Content | undefined)?.sql
+  useEffect(() => {
+    if (!queryId || !querySql || search) return
+    setEditorValue(querySql)
+    editorRef.current?.setValue(querySql)
+  }, [queryId, querySql, search])
 
   useEffect(() => {
     if (!useOtelEndpoint || q || search || queryId) return


### PR DESCRIPTION
## Problem

Refreshing the browser while viewing a saved log query loads stale query content. The sidebar navigation link embeds the SQL in the `q` URL param at the time it is rendered. When the query is updated and saved, the URL still holds the old SQL. On refresh, the editor initialises from that stale `q` param instead of fetching the latest content from the API.

## Fix

When a `queryId` is present in the URL, the `q` param is now ignored for initialising the editor. Instead, a new effect populates the editor from the API response once `useContentQuery` resolves. If the user previously ran a modified query (stored in the `search`/`s` param), that takes precedence over the saved content, preserving existing behaviour.

## How to test

- Open Logs Explorer and create a new query, save it as "test".
- Change the query content, click "Save query" to update it.
- Refresh the browser.
- Expected: the editor shows the updated query content, not the old content.
- Navigate away and back, then refresh again.
- Expected: the updated content still loads correctly.