### PR TITLE
fix(logs): load saved query content from api instead of stale url param FE-3733

### DIFF
--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -411,7 +411,7 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   useEffect(() => {
     if (search) {
       setEditorValue(search)
-    } else if (q) {
+    } else if (q && !queryId) {
       setEditorValue(q)
       setSearch(q)
     } else if (!queryId) {
@@ -419,6 +419,13 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
       editorRef.current?.setValue(PLACEHOLDER_QUERY)
     }
   }, [q, search, queryId, setSearch, PLACEHOLDER_QUERY])
+
+  const querySql = (query?.content as LogSqlSnippets.Content | undefined)?.sql
+  useEffect(() => {
+    if (!queryId || !querySql || search) return
+    setEditorValue(querySql)
+    editorRef.current?.setValue(querySql)
+  }, [queryId, querySql, search])
 
   useEffect(() => {
     // prevents overwriting when the user selects a helper.

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -408,24 +408,21 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
     }))
   }
 
+  const querySql = (query?.content as LogSqlSnippets.Content | undefined)?.sql
   useEffect(() => {
     if (search) {
       setEditorValue(search)
     } else if (q && !queryId) {
       setEditorValue(q)
       setSearch(q)
+    } else if (queryId && querySql) {
+      setEditorValue(querySql)
+      editorRef.current?.setValue(querySql)
     } else if (!queryId) {
       setEditorValue(PLACEHOLDER_QUERY)
       editorRef.current?.setValue(PLACEHOLDER_QUERY)
     }
-  }, [q, search, queryId, setSearch, PLACEHOLDER_QUERY])
-
-  const querySql = (query?.content as LogSqlSnippets.Content | undefined)?.sql
-  useEffect(() => {
-    if (!queryId || !querySql || search) return
-    setEditorValue(querySql)
-    editorRef.current?.setValue(querySql)
-  }, [queryId, querySql, search])
+  }, [q, search, queryId, querySql, setSearch, PLACEHOLDER_QUERY])
 
   useEffect(() => {
     // prevents overwriting when the user selects a helper.


### PR DESCRIPTION
## Problem

Refreshing the browser while viewing a saved log query loads stale query content. The sidebar navigation link embeds the SQL in the `q` URL param at the time it is rendered. When the query is updated and saved, the URL still holds the old SQL. On refresh, the editor initialises from that stale `q` param instead of fetching the latest content from the API.

## Fix

When a `queryId` is present in the URL, the `q` param is now ignored for initialising the editor. Instead, a new effect populates the editor from the API response once `useContentQuery` resolves. If the user previously ran a modified query (stored in the `search`/`s` param), that takes precedence over the saved content, preserving existing behaviour.

## How to test

- Open Logs Explorer and create a new query, save it as "test".
- Change the query content, click "Save query" to update it.
- Refresh the browser.
- Expected: the editor shows the updated query content, not the old content.
- Navigate away and back, then refresh again.
- Expected: the updated content still loads correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the logs explorer so that selecting a saved query reliably loads its SQL into the editor.
  * Updated behavior so URL query text no longer overwrites the editor contents when a saved query is selected.
  * Ensured editor content is preserved when searching, preventing unexpected replacements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->