### PR TITLE
chore: remove SECURITY.md in favor of org-wide policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,1 +1,0 @@
-apps/docs/public/.well-known/security.txt


### PR DESCRIPTION
## What

Removes this repo's `SECURITY.md` so it inherits the organization-wide security policy maintained centrally in `supabase/.github`.

References supabase/.github#20

## Why

The security policy is being consolidated into a single org-wide default (`supabase/.github`) instead of being duplicated across every repository. GitHub serves that default as the "Security policy" for any repo that doesn't define its own, so this file is now redundant.

## Note

Please do not merge until supabase/.github#20 is merged, otherwise this repo would briefly show no security policy.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the public security contact file previously available at the `.well-known/security.txt` path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->