### PR TITLE
Studio: Add quickstarts instruments example to dashboard examples

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.queries.ts
@@ -1600,4 +1600,37 @@ grant execute on function public.custom_access_token_hook to supabase_auth_admin
 revoke execute on function public.custom_access_token_hook from authenticated, anon, public;
     `,
   },
+  {
+    id: 30,
+    type: 'quickstart',
+    title: 'Instruments',
+    description:
+      'Create an instruments table with sample data and Row Level Security, as used in the framework quickstarts.',
+    sql: `
+-- Create the table
+create table instruments (
+  id bigint primary key generated always as identity,
+  name text not null
+);
+
+-- Insert sample data into the table
+insert into instruments (name)
+values
+  ('violin'),
+  ('viola'),
+  ('cello');
+
+-- Grant the privileges the role needs, which is read access
+grant select on public.instruments to anon;
+
+-- Enable row level security for the table
+alter table instruments enable row level security;
+
+-- Create a policy to allow the anon role to read from the instruments table
+create policy "public can read instruments"
+on public.instruments
+for select to anon
+using (true);
+`.trim(),
+  },
 ]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

Adds a new SQL example to the SQL editor to make following quickstarts easier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new SQL quickstart template called **“Instruments”**.
  * The template helps users create a sample `instruments` table, add example rows, and set up read access with row-level security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->