### PR TITLE
fix(studio): correct self-hosted snippet store sync on move/rename

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MoveQueryModal.tsx
@@ -37,6 +37,7 @@ import {
 } from 'ui'
 import * as z from 'zod'
 
+import { getSelfHostedSnippetStoreSyncPlan } from './self-hosted-snippet-store.utils'
 import { getContentById } from '@/data/content/content-id-query'
 import { useContentUpsertMutation } from '@/data/content/content-upsert-mutation'
 import { useSQLSnippetFolderCreateMutation } from '@/data/content/sql-folder-create-mutation'
@@ -60,7 +61,7 @@ interface MoveQueryModalProps {
  */
 
 export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryModalProps) => {
-  const { ref } = useParams()
+  const { ref, id: activeSnippetId } = useParams()
   const snapV2 = useSqlEditorV2StateSnapshot()
   const tabsSnap = useTabsStateSnapshot()
   const router = useRouter()
@@ -125,11 +126,14 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
       let folderId = selectedId
 
       if (selectedId === 'new-folder' && 'name' in values) {
-        const { id } = await createFolder({
+        const createdFolder = await createFolder({
           projectRef: ref,
           name: values.name,
         })
-        folderId = id
+        folderId = createdFolder.id
+        if (!IS_PLATFORM) {
+          snapV2.addFolder({ projectRef: ref, folder: createdFolder })
+        }
       }
 
       await Promise.all(
@@ -166,19 +170,32 @@ export const MoveQueryModal = ({ visible, snippets = [], onClose }: MoveQueryMod
                 skipSave: true,
               })
             } else if (movedSnippet) {
-              // On selfhosted, we need to update the state with the moved snippet because the snippet depends on the
-              // folder_id the moved snippet has a different id than the original snippet.
+              const targetFolderId = selectedId === 'root' ? null : folderId
+              const syncPlan = getSelfHostedSnippetStoreSyncPlan({
+                previousId: snippet.id,
+                nextSnippetId: movedSnippet.id,
+                isViewingSnippet: activeSnippetId === snippet.id,
+                hasOldTab: tabsSnap.hasTab(createTabId('sql', { id: snippet.id })),
+              })
 
-              // remove the old snippet from the state without saving to API
-              snapV2.removeSnippet(snippet.id, true)
+              if (syncPlan.action === 'replace') {
+                snapV2.addSnippet({ projectRef: ref, snippet: movedSnippet })
 
-              snapV2.addSnippet({ projectRef: ref, snippet: movedSnippet })
+                if (syncPlan.shouldNavigate) {
+                  await router.replace(`/project/${ref}/sql/${syncPlan.nextSnippetId}`)
+                }
 
-              // remove the tab for the old snippet if the snippet was open. Moving can also happen when the tab is not open.
-              const tabId = createTabId('sql', { id: snippet.id })
-              if (tabsSnap.hasTab(tabId)) {
-                tabsSnap.removeTab(tabId)
-                await router.push(`/project/${ref}/sql/${movedSnippet.id}`)
+                if (syncPlan.shouldRemoveOldTab) {
+                  tabsSnap.removeTab(createTabId('sql', { id: syncPlan.previousId }))
+                }
+
+                snapV2.removeSnippet(syncPlan.previousId, true)
+              } else {
+                snapV2.updateSnippet({
+                  id: snippet.id,
+                  snippet: { ...movedSnippet, folder_id: targetFolderId },
+                  skipSave: true,
+                })
               }
             }
           }

--- a/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/RenameQueryModal.tsx
@@ -23,6 +23,7 @@ import {
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import * as z from 'zod'
 
+import { getSelfHostedSnippetStoreSyncPlan } from './self-hosted-snippet-store.utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useCheckOpenAIKeyQuery } from '@/data/ai/check-api-key-query'
 import { useSqlTitleGenerateMutation } from '@/data/ai/sql-title-mutation'
@@ -56,7 +57,7 @@ export const RenameQueryModal = ({
   onCancel,
   onComplete,
 }: RenameQueryModalProps) => {
-  const { ref } = useParams()
+  const { ref, id: activeSnippetId } = useParams()
   const router = useRouter()
 
   const snapV2 = useSqlEditorV2StateSnapshot()
@@ -129,19 +130,28 @@ export const RenameQueryModal = ({
         const tabId = createTabId('sql', { id })
         tabsSnap.updateTab(tabId, { label: name })
       } else if (changedSnippet) {
-        // In self-hosted, the snippet also updates the id when renaming it. This code is to ensure the previous snippet
-        // is removed, new one is added, tab state is updated and the router is updated.
+        const syncPlan = getSelfHostedSnippetStoreSyncPlan({
+          previousId: id,
+          nextSnippetId: changedSnippet.id,
+          isViewingSnippet: activeSnippetId === id,
+          hasOldTab: tabsSnap.hasTab(createTabId('sql', { id })),
+        })
 
-        // remove the old snippet from the state without saving to API
-        snapV2.removeSnippet(id, true)
+        if (syncPlan.action === 'replace') {
+          snapV2.addSnippet({ projectRef: ref, snippet: changedSnippet })
 
-        snapV2.addSnippet({ projectRef: ref, snippet: changedSnippet })
+          if (syncPlan.shouldNavigate) {
+            await router.replace(`/project/${ref}/sql/${syncPlan.nextSnippetId}`)
+          }
 
-        // remove the tab for the old snippet if the snippet was open. Renaming can also happen when the tab is not open.
-        const tabId = createTabId('sql', { id })
-        if (tabsSnap.hasTab(tabId)) {
-          tabsSnap.removeTab(tabId)
-          await router.push(`/project/${ref}/sql/${changedSnippet.id}`)
+          if (syncPlan.shouldRemoveOldTab) {
+            tabsSnap.removeTab(createTabId('sql', { id: syncPlan.previousId }))
+          }
+
+          snapV2.removeSnippet(syncPlan.previousId, true)
+        } else {
+          snapV2.renameSnippet({ id, name, description })
+          tabsSnap.updateTab(createTabId('sql', { id: syncPlan.snippetId }), { label: name })
         }
       }
 

--- a/apps/studio/components/interfaces/SQLEditor/self-hosted-snippet-store.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/self-hosted-snippet-store.utils.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  getSelfHostedSnippetStoreAction,
+  getSelfHostedSnippetStoreSyncPlan,
+} from './self-hosted-snippet-store.utils'
+
+describe('getSelfHostedSnippetStoreAction', () => {
+  it('returns replace when the snippet id changes (rename name or move folder)', () => {
+    expect(getSelfHostedSnippetStoreAction('old-id', 'new-id')).toBe('replace')
+  })
+
+  it('returns update when the snippet id is unchanged (e.g. description-only rename)', () => {
+    expect(getSelfHostedSnippetStoreAction('same-id', 'same-id')).toBe('update')
+  })
+})
+
+describe('getSelfHostedSnippetStoreSyncPlan', () => {
+  it('replace + viewing + open tab: navigate and remove old tab, never update-in-place', () => {
+    expect(
+      getSelfHostedSnippetStoreSyncPlan({
+        previousId: 'old-id',
+        nextSnippetId: 'new-id',
+        isViewingSnippet: true,
+        hasOldTab: true,
+      })
+    ).toEqual({
+      action: 'replace',
+      previousId: 'old-id',
+      nextSnippetId: 'new-id',
+      shouldNavigate: true,
+      shouldRemoveOldTab: true,
+    })
+  })
+
+  it('replace + not viewing: skip navigation and tab removal', () => {
+    expect(
+      getSelfHostedSnippetStoreSyncPlan({
+        previousId: 'old-id',
+        nextSnippetId: 'new-id',
+        isViewingSnippet: false,
+        hasOldTab: false,
+      })
+    ).toEqual({
+      action: 'replace',
+      previousId: 'old-id',
+      nextSnippetId: 'new-id',
+      shouldNavigate: false,
+      shouldRemoveOldTab: false,
+    })
+  })
+
+  it('replace + has tab but not viewing: remove old tab, skip navigation', () => {
+    expect(
+      getSelfHostedSnippetStoreSyncPlan({
+        previousId: 'old-id',
+        nextSnippetId: 'new-id',
+        isViewingSnippet: false,
+        hasOldTab: true,
+      })
+    ).toEqual({
+      action: 'replace',
+      previousId: 'old-id',
+      nextSnippetId: 'new-id',
+      shouldNavigate: false,
+      shouldRemoveOldTab: true,
+    })
+  })
+
+  it('same id (description-only rename): update in place, no navigation or tab teardown', () => {
+    expect(
+      getSelfHostedSnippetStoreSyncPlan({
+        previousId: 'same-id',
+        nextSnippetId: 'same-id',
+        isViewingSnippet: true,
+        hasOldTab: true,
+      })
+    ).toEqual({
+      action: 'update',
+      snippetId: 'same-id',
+    })
+  })
+})

--- a/apps/studio/components/interfaces/SQLEditor/self-hosted-snippet-store.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/self-hosted-snippet-store.utils.ts
@@ -1,0 +1,56 @@
+/**
+ * Self-hosted snippets derive their id from folder + filename. When an upsert
+ * returns the same id, addSnippet is a no-op and removeSnippet would wipe the
+ * store entry — use in-place update instead of replace (add/nav/remove).
+ */
+export type SelfHostedSnippetStoreAction = 'replace' | 'update'
+
+export type SelfHostedSnippetStoreSyncPlan =
+  | {
+      action: 'replace'
+      previousId: string
+      nextSnippetId: string
+      /** Navigate to nextSnippetId when the user is viewing the moved/renamed snippet. */
+      shouldNavigate: boolean
+      /** Remove the tab keyed on previousId after a successful replace. */
+      shouldRemoveOldTab: boolean
+    }
+  | {
+      action: 'update'
+      snippetId: string
+    }
+
+export function getSelfHostedSnippetStoreAction(
+  previousId: string,
+  nextSnippetId: string
+): SelfHostedSnippetStoreAction {
+  return previousId !== nextSnippetId ? 'replace' : 'update'
+}
+
+/**
+ * Pure orchestration for self-hosted move/rename store + navigation updates.
+ * Modals apply the returned plan against Valtio/tabs/router.
+ */
+export function getSelfHostedSnippetStoreSyncPlan({
+  previousId,
+  nextSnippetId,
+  isViewingSnippet,
+  hasOldTab,
+}: {
+  previousId: string
+  nextSnippetId: string
+  isViewingSnippet: boolean
+  hasOldTab: boolean
+}): SelfHostedSnippetStoreSyncPlan {
+  if (getSelfHostedSnippetStoreAction(previousId, nextSnippetId) === 'replace') {
+    return {
+      action: 'replace',
+      previousId,
+      nextSnippetId,
+      shouldNavigate: isViewingSnippet,
+      shouldRemoveOldTab: hasOldTab,
+    }
+  }
+
+  return { action: 'update', snippetId: previousId }
+}

--- a/apps/studio/data/content/content-remap.test.ts
+++ b/apps/studio/data/content/content-remap.test.ts
@@ -1,0 +1,79 @@
+import { untrustedSql } from '@supabase/pg-meta'
+import { describe, expect, it } from 'vitest'
+
+import { remapSqlContentField, remapSqlContentFields, unmapSqlContentField } from './content-remap'
+
+const SQL_SNIPPET = {
+  id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+  type: 'sql' as const,
+  name: 'My query',
+  content: {
+    sql: 'SELECT 1',
+    content_id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    schema_version: '1.0',
+  },
+}
+
+describe('remapSqlContentField', () => {
+  it('remaps content.sql to content.unchecked_sql for SQL snippets', () => {
+    const result = remapSqlContentField(SQL_SNIPPET)
+
+    expect(result.content).toEqual({
+      content_id: SQL_SNIPPET.content.content_id,
+      schema_version: '1.0',
+      unchecked_sql: untrustedSql('SELECT 1'),
+    })
+    expect(result.content).not.toHaveProperty('sql')
+  })
+
+  it('leaves non-SQL content types unchanged', () => {
+    const report = { id: '1', type: 'report' as const, content: { foo: 'bar' } }
+
+    expect(remapSqlContentField(report)).toBe(report)
+  })
+
+  it('leaves SQL snippets without a content field unchanged', () => {
+    const snippet = { id: '1', type: 'sql' as const, name: 'No content' }
+
+    expect(remapSqlContentField(snippet)).toBe(snippet)
+  })
+
+  it('leaves SQL snippets whose content has no sql field unchanged', () => {
+    const snippet = {
+      id: '1',
+      type: 'sql' as const,
+      content: { content_id: '1', schema_version: '1.0', unchecked_sql: untrustedSql('x') },
+    }
+
+    expect(remapSqlContentField(snippet)).toBe(snippet)
+  })
+})
+
+describe('remapSqlContentFields', () => {
+  it('remaps every SQL snippet in a list', () => {
+    const items = [SQL_SNIPPET, { id: '2', type: 'report' as const }]
+
+    const result = remapSqlContentFields(items)
+    const remappedSql = result.find((item) => item.type === 'sql')
+
+    expect(remappedSql && 'content' in remappedSql && remappedSql.content).toMatchObject({
+      unchecked_sql: untrustedSql('SELECT 1'),
+    })
+    expect(result[1]).toBe(items[1])
+  })
+})
+
+describe('unmapSqlContentField', () => {
+  it('remaps content.unchecked_sql back to content.sql for the API', () => {
+    const snippet = remapSqlContentField(SQL_SNIPPET)
+
+    const result = unmapSqlContentField(snippet)
+
+    expect(result.content).toEqual({
+      content_id: SQL_SNIPPET.content.content_id,
+      schema_version: '1.0',
+      sql: untrustedSql('SELECT 1'),
+    })
+    expect(result.content).not.toHaveProperty('unchecked_sql')
+  })
+})

--- a/apps/studio/data/content/content-upsert-mutation.test.ts
+++ b/apps/studio/data/content/content-upsert-mutation.test.ts
@@ -1,0 +1,60 @@
+import { untrustedSql } from '@supabase/pg-meta'
+import { HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { upsertContent } from './content-upsert-mutation'
+import { addAPIMock } from '@/tests/lib/msw'
+
+const SNIPPET_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+
+describe('upsertContent', () => {
+  it('remaps content.sql to unchecked_sql in the upsert response', async () => {
+    addAPIMock({
+      method: 'put',
+      path: '/platform/projects/:ref/content',
+      response: async ({ request }) => {
+        const body = (await request.json()) as { id: string; name: string; type: string }
+        return HttpResponse.json({
+          id: SNIPPET_ID,
+          type: 'sql',
+          name: body.name,
+          description: '',
+          favorite: false,
+          folder_id: 'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13',
+          inserted_at: '2024-01-01T00:00:00.000Z',
+          updated_at: '2024-01-01T00:00:00.000Z',
+          visibility: 'user',
+          owner_id: 1,
+          project_id: 1,
+          content: {
+            sql: 'SELECT 1',
+            content_id: SNIPPET_ID,
+            schema_version: '1.0',
+          },
+        })
+      },
+    })
+
+    const result = await upsertContent({
+      projectRef: 'default',
+      payload: {
+        id: SNIPPET_ID,
+        type: 'sql',
+        name: 'Moved query',
+        visibility: 'user',
+        project_id: 1,
+        owner_id: 1,
+        folder_id: 'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13',
+        content: {
+          content_id: SNIPPET_ID,
+          schema_version: '1.0',
+          unchecked_sql: untrustedSql('SELECT 1'),
+        },
+      },
+    })
+
+    expect(result?.status).toBe('saved')
+    expect(result?.content?.unchecked_sql).toBeDefined()
+    expect(result?.content).not.toHaveProperty('sql')
+  })
+})

--- a/apps/studio/data/content/content-upsert-mutation.ts
+++ b/apps/studio/data/content/content-upsert-mutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { Content } from './content-query'
-import { unmapSqlContentField } from './content-remap'
+import { remapSqlContentField, unmapSqlContentField } from './content-remap'
 import { contentKeys } from './keys'
 import type { Snippet, SnippetWithContent } from './sql-folders-query'
 import type { components } from '@/data/api'
@@ -35,7 +35,7 @@ export async function upsertContent(
   const snippet = data as Snippet | null
   // The upsert response is a snippet freshly persisted to the database, so it
   // carries status 'saved' as it crosses into the app — same as the queries.
-  return snippet === null ? null : { ...snippet, status: 'saved' }
+  return snippet === null ? null : { ...remapSqlContentField(snippet), status: 'saved' }
 }
 
 export type UpsertContentData = Awaited<ReturnType<typeof upsertContent>>
@@ -61,6 +61,7 @@ export const useContentUpsertMutation = ({
         await Promise.all([
           queryClient.invalidateQueries({ queryKey: contentKeys.allContentLists(projectRef) }),
           queryClient.invalidateQueries({ queryKey: contentKeys.infiniteList(projectRef) }),
+          queryClient.invalidateQueries({ queryKey: contentKeys.folders(projectRef) }),
         ])
       }
       await onSuccess?.(data, variables, context)

--- a/apps/studio/state/sql-editor/sql-editor-lifecycle.test.ts
+++ b/apps/studio/state/sql-editor/sql-editor-lifecycle.test.ts
@@ -1,8 +1,10 @@
+import { untrustedSql } from '@supabase/pg-meta'
 import { describe, expect, it } from 'vitest'
 
 import {
   folderStatusOnSaveStart,
   hasUnsavedChanges,
+  hasUsableSnippetContent,
   isFolderEditing,
   isFolderSaving,
   isNewFolder,
@@ -15,6 +17,7 @@ import {
   type FolderStatus,
 } from './sql-editor-lifecycle'
 import type { SnippetStatus } from '@/data/content/snippet-status'
+import type { SqlSnippets } from '@/types'
 
 const NEVER_PERSISTED: Array<SnippetStatus> = ['new', 'new_saving', 'new_save_failed']
 const PERSISTED: Array<SnippetStatus> = ['saved', 'unsaved', 'saving', 'save_failed']
@@ -184,5 +187,40 @@ describe('folderStatusOnSaveStart', () => {
   it('moves a persisted folder to saving', () => {
     expect(folderStatusOnSaveStart('editing')).toBe('saving')
     expect(folderStatusOnSaveStart('idle')).toBe('saving')
+  })
+})
+
+describe('hasUsableSnippetContent', () => {
+  const usableContent: SqlSnippets.Content = {
+    content_id: 'snippet-1',
+    schema_version: '1.0',
+    unchecked_sql: untrustedSql('SELECT 1'),
+  }
+
+  it('is false when content is missing', () => {
+    expect(hasUsableSnippetContent(undefined)).toBe(false)
+  })
+
+  it('is false for unmapped API content that only has sql', () => {
+    const unmapped = {
+      content_id: 'snippet-1',
+      schema_version: '1.0',
+      sql: 'SELECT 1',
+    } as unknown as SqlSnippets.Content
+
+    expect(hasUsableSnippetContent(unmapped)).toBe(false)
+  })
+
+  it('is true when unchecked_sql is defined, even if empty', () => {
+    expect(
+      hasUsableSnippetContent({
+        ...usableContent,
+        unchecked_sql: untrustedSql(''),
+      })
+    ).toBe(true)
+  })
+
+  it('is true when unchecked_sql holds SQL text', () => {
+    expect(hasUsableSnippetContent(usableContent)).toBe(true)
   })
 })

--- a/apps/studio/state/sql-editor/sql-editor-lifecycle.ts
+++ b/apps/studio/state/sql-editor/sql-editor-lifecycle.ts
@@ -1,4 +1,14 @@
 import type { SnippetStatus } from '@/data/content/snippet-status'
+import type { SqlSnippets } from '@/types'
+
+/**
+ * True when snippet content is loaded in the frontend shape (has `unchecked_sql`).
+ * Unmapped API payloads may carry `content.sql` instead — those are not usable by
+ * the editor and should be replaced when fresher content arrives.
+ */
+export function hasUsableSnippetContent(content: SqlSnippets.Content | undefined): boolean {
+  return content !== undefined && content.unchecked_sql !== undefined
+}
 
 /**
  * True when the snippet has never been successfully written to the database.

--- a/apps/studio/state/sql-editor/sql-editor-state.ts
+++ b/apps/studio/state/sql-editor/sql-editor-state.ts
@@ -4,7 +4,11 @@ import { toast } from 'sonner'
 import { proxy, ref, snapshot, useSnapshot } from 'valtio'
 import { devtools, proxyMap } from 'valtio/utils'
 
-import { folderStatusOnSaveStart, isNewFolder } from './sql-editor-lifecycle'
+import {
+  folderStatusOnSaveStart,
+  hasUsableSnippetContent,
+  isNewFolder,
+} from './sql-editor-lifecycle'
 import type { StateSnippet, StateSnippetFolder } from './types'
 import type { QueryPlanRow } from '@/components/interfaces/ExplainVisualizer/ExplainVisualizer.types'
 import { DiffType } from '@/components/interfaces/SQLEditor/SQLEditor.types'
@@ -126,7 +130,7 @@ export const sqlEditorState = proxy({
   setSnippet: (projectRef: string, snippet: SnippetWithContent) => {
     let storedSnippet = sqlEditorState.snippets[snippet.id]
     if (storedSnippet) {
-      if (!storedSnippet.snippet.content) {
+      if (!hasUsableSnippetContent(storedSnippet.snippet.content)) {
         storedSnippet.snippet.content = snippet.content
       }
     } else {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

On self-hosted/CLI Studio, snippet ids are derived from folder + filename, so most renames and moves return a **new id**. The store sync did add-new then remove-old - but `addSnippet` is a no-op when the id already exists (`sql-editor-state.ts`). So a rename that keeps the id (e.g. **description-only**) hit the no-op add, then `removeSnippet` wiped the entry → **blank editor**. The old ordering also removed the snippet before navigating, briefly pointing the URL at a dead id (spinner).

- Extract the decision into a pure `getSelfHostedSnippetStoreSyncPlan` (`self-hosted-snippet-store.utils.ts`):
  - **`replace`** (id changed): add new → navigate (if viewing) → remove old tab → remove old snippet
  - **`update`** (id unchanged): update in place via `renameSnippet`/`updateSnippet`; no add/remove
- Wire both `MoveQueryModal` and `RenameQueryModal` to apply the plan
- Remap the upsert response (`content.sql` → `unchecked_sql`) - the PUT response is consumed directly on move/rename - and invalidate the `folders` query so the sidebar tree refreshes
- Guard `setSnippet` with `hasUsableSnippetContent` so unmapped (`sql`-only) content isn't treated as already loaded

### Tests

Unit tests for the sync-plan decision matrix, the upsert-response remap (MSW), `hasUsableSnippetContent`, and the content remap helpers.

### Notes

- The sync logic is behind `!IS_PLATFORM`; the upsert remap and folder invalidation are no-op/defensive there
- Supersedes an attempt for a fix in PR https://github.com/supabase/supabase/pull/47359
- Depends on PR #47403
