### PR TITLE
chore: Bump all rate limits in Auth to match the API

### DIFF
--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -107,31 +107,31 @@ export const RateLimits = () => {
     RATE_LIMIT_TOKEN_REFRESH: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(2147483647, 'Must not be more than 2,147,483,647 an 5 minutes'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 in 5 minutes'),
     RATE_LIMIT_VERIFY: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(2147483647, 'Must not be more than 2,147,483,647 an 5 minutes'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 in 5 minutes'),
     RATE_LIMIT_EMAIL_SENT: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 per hour'),
     RATE_LIMIT_SMS_SENT: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 per hour'),
     RATE_LIMIT_ANONYMOUS_USERS: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 per hour'),
     RATE_LIMIT_OTP: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 per hour'),
     RATE_LIMIT_WEB3: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 per hour'),
   })
 
   const rateLimitForm = useForm<z.infer<typeof RateLimitFormSchema>>({

--- a/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
+++ b/apps/studio/components/interfaces/Auth/RateLimits/RateLimits.tsx
@@ -107,31 +107,31 @@ export const RateLimits = () => {
     RATE_LIMIT_TOKEN_REFRESH: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(32767, 'Must not be more than 32,767 an 5 minutes'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 an 5 minutes'),
     RATE_LIMIT_VERIFY: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(32767, 'Must not be more than 32,767 an 5 minutes'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 an 5 minutes'),
     RATE_LIMIT_EMAIL_SENT: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(32767, 'Must not be more than 32,767 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
     RATE_LIMIT_SMS_SENT: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(32767, 'Must not be more than 32,767 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
     RATE_LIMIT_ANONYMOUS_USERS: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(32767, 'Must not be more than 32,767 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
     RATE_LIMIT_OTP: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(32767, 'Must not be more than 32,767 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
     RATE_LIMIT_WEB3: z.coerce
       .number()
       .min(0, 'Must be not be lower than 0')
-      .max(32767, 'Must not be more than 32,767 an hour'),
+      .max(2147483647, 'Must not be more than 2,147,483,647 an hour'),
   })
 
   const rateLimitForm = useForm<z.infer<typeof RateLimitFormSchema>>({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the allowed maximum values for rate-limit settings, enabling much larger numeric inputs.
  * Updated validation messages so error text matches the new limits and time-window wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->