### PR TITLE
Add recording to Perplexity webinar page

### DIFF
--- a/apps/www/_events/2026-06-25-supabase-perplexity-small-businesses.mdx
+++ b/apps/www/_events/2026-06-25-supabase-perplexity-small-businesses.mdx
@@ -24,9 +24,9 @@ company:
 categories:
   - webinar
 main_cta:
-  url: 'https://attendee.gotowebinar.com/register/2836535946334786656'
-  target: _blank
-  label: Register now
+  url: 'https://www.youtube.com/watch?v=MxGNtNpZJFM'
+  target: _self
+  label: Watch the Recording
 speakers: 'natalie_roberge,david_dalmaso'
 ---
 
@@ -42,7 +42,17 @@ In this session, Natalie Roberge, Customer Solutions Architect from Supabase and
 
 **Registered attendees will receive complimentary Perplexity Enterprise Pro and Computer credits.**
 
-### What we'll cover
+<div className="video-container mb-8" id="recording">
+  <iframe
+    className="w-full"
+    src="https://www.youtube.com/watch?v=MxGNtNpZJFM"
+    title="Workflows That Scale: Supabase + Perplexity Computer for small businesses"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  />
+</div>
+
+### Key takeaways
 
 - Using Supabase as the backend for all AI / Computer workflows to help democratize data
 - How anyone on your team can run Perplexity Computer workflows autonomously, with Supabase as the consistent data layer that ties everything together across tools, teams, and systems.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add recording / change CTA

## What is the current behavior?

It links to the GoToWebinar page.

## What is the new behavior?

It will now link to the on-demand recording :)

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the event page to feature a watchable recording instead of a registration link.
  * Added an embedded video section and a new “Key takeaways” area for easier recap.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->