### PR TITLE
chore: add CI job to validate `ui-patterns` exports

### DIFF
--- a/.github/workflows/ui-patterns-tests.yml
+++ b/.github/workflows/ui-patterns-tests.yml
@@ -44,7 +44,7 @@ jobs:
         run: |
           pnpm --filter ui-patterns gen:exports
           if ! git diff --ignore-space-at-eol --exit-code --quiet packages/ui-patterns/package.json then
-            echo "Detected uncommitted changes after build. See status below:"
+            echo "Detected uncommitted changes after build. Run pnpm --filter ui-patterns gen:exports to fix it."
             git diff
             exit 1
           fi

--- a/.github/workflows/ui-patterns-tests.yml
+++ b/.github/workflows/ui-patterns-tests.yml
@@ -40,5 +40,13 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
+      - name: Validate exports
+        run: |
+          pnpm --filter ui-patterns generate
+          if ! git diff --ignore-space-at-eol --exit-code --quiet specific-file.ts then
+            echo "Detected uncommitted changes after build. See status below:"
+            git diff
+            exit 1
+          fi
       - name: Run tests
         run: pnpm run test:ui-patterns

--- a/.github/workflows/ui-patterns-tests.yml
+++ b/.github/workflows/ui-patterns-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Validate exports
         run: |
           pnpm --filter ui-patterns generate
-          if ! git diff --ignore-space-at-eol --exit-code --quiet specific-file.ts then
+          if ! git diff --ignore-space-at-eol --exit-code --quiet packages/ui-patterns/package.json then
             echo "Detected uncommitted changes after build. See status below:"
             git diff
             exit 1

--- a/.github/workflows/ui-patterns-tests.yml
+++ b/.github/workflows/ui-patterns-tests.yml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Validate exports
         run: |
-          pnpm --filter ui-patterns generate
+          pnpm --filter ui-patterns gen:exports
           if ! git diff --ignore-space-at-eol --exit-code --quiet packages/ui-patterns/package.json then
             echo "Detected uncommitted changes after build. See status below:"
             git diff


### PR DESCRIPTION
## Problem

`ui-patterns` exports its components under a subpath (see its `package.json`). This is easy to forget when adding a new component.

## Solution

Add a CI job that validate the exports are corrects

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a new “Validate exports” step to the UI patterns pipeline to verify that generated exports stay synchronized.
  * If the generation results differ from the current package state, the workflow prints the differences and fails to prevent stale or out-of-sync artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->