### PR TITLE
fix: snippet content missing after move or rename

### DIFF
--- a/apps/studio/data/content/content-upsert-mutation.ts
+++ b/apps/studio/data/content/content-upsert-mutation.ts
@@ -2,7 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { toast } from 'sonner'
 
 import type { Content } from './content-query'
-import { unmapSqlContentField } from './content-remap'
+import { remapSqlContentField, unmapSqlContentField } from './content-remap'
 import { contentKeys } from './keys'
 import type { Snippet, SnippetWithContent } from './sql-folders-query'
 import type { components } from '@/data/api'
@@ -33,9 +33,7 @@ export async function upsertContent(
   if (error) handleError(error)
 
   const snippet = data as Snippet | null
-  // The upsert response is a snippet freshly persisted to the database, so it
-  // carries status 'saved' as it crosses into the app — same as the queries.
-  return snippet === null ? null : { ...snippet, status: 'saved' }
+  return snippet === null ? null : { ...remapSqlContentField(snippet), status: 'saved' }
 }
 
 export type UpsertContentData = Awaited<ReturnType<typeof upsertContent>>


### PR DESCRIPTION
Snippet content was wiped blank after a move or rename (until dashboard refreshed) because it depended on the API returning the new content, but the API returns under the `content` field, not the `unchecked_sql` field that is expected. Added a `remapSqlContentField` remap to fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the saved content response so snippet fields are mapped consistently before being returned.
  * Kept the saved status unchanged while updating the returned data shape for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->