### PR TITLE
Cleaned up the Perplexity webinar landing page

### DIFF
--- a/apps/www/_events/2026-06-25-supabase-perplexity-small-businesses.mdx
+++ b/apps/www/_events/2026-06-25-supabase-perplexity-small-businesses.mdx
@@ -10,7 +10,7 @@ meta_description: >-
   and more. Registered attendees get complimentary Perplexity Enterprise Pro and
   Computer credits.
 type: webinar
-onDemand: false
+onDemand: true
 date: '2026-06-25T09:00:00.000-07:00'
 timezone: America/Los_Angeles
 duration: 45 mins
@@ -24,9 +24,9 @@ company:
 categories:
   - webinar
 main_cta:
-  url: 'https://www.youtube.com/watch?v=MxGNtNpZJFM'
+  url: '#recording'
   target: _self
-  label: Watch the Recording
+  label: Watch the recording
 speakers: 'natalie_roberge,david_dalmaso'
 ---
 
@@ -38,14 +38,12 @@ Supabase is where a lot of growing businesses already keep their most important 
 
 Perplexity Computer makes that possible: the work that used to take a small army of operators now happens in a single workflow, running directly on top of the data you already have in Supabase.
 
-In this session, Natalie Roberge, Customer Solutions Architect from Supabase and David Dalmaso, Member of Technical Staff, from Perplexity will walk through what a growing business actually looks like when it runs on Perplexity Computer and Supabase together.
-
-**Registered attendees will receive complimentary Perplexity Enterprise Pro and Computer credits.**
+In this session, Natalie Roberge, Customer Solutions Architect from Supabase and David Dalmaso, Member of Technical Staff, from Perplexity walk through what a growing business actually looks like when it runs on Perplexity Computer and Supabase together.
 
 <div className="video-container mb-8" id="recording">
   <iframe
     className="w-full"
-    src="https://www.youtube.com/watch?v=MxGNtNpZJFM"
+    src="https://www.youtube-nocookie.com/embed/MxGNtNpZJFM"
     title="Workflows That Scale: Supabase + Perplexity Computer for small businesses"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
     allowFullScreen
@@ -64,5 +62,3 @@ In this session, Natalie Roberge, Customer Solutions Architect from Supabase and
 - Go from market signals to a campaign brief, stored in Supabase so your marketing team can find and build on it
 
 You'll leave with a clear picture of what it looks like to run a lean, high-leverage business on Supabase and Perplexity Computer and the first workflows to try with your own data.
-
-Plus, bring your questions for the live Q&A. Can't make it? We'll send you the recording.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixes the landing page for a webinar:

- Set on demand to true
- Changed verbiage to reflect that the webinar has already happend
- Changed the webinar CTA buttons to link to an on-page anchor instead of off-site

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the event page to highlight the on-demand recording and direct visitors to the recording section.
  * Switched the embedded video to a privacy-enhanced playback format.

* **Content Updates**
  * Shortened and refined the session description.
  * Removed outdated attendee incentive and live Q&A messaging to match the new webinar flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->