### PR TITLE
fix(docs) Apply Quickstart friction log feedback

### DIFF
--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -41,7 +41,7 @@ When your Supabase project is up and running, create a table for your data. You 
 
 <Admonition type="note">
 
-Use snake_case for table names. For example, use `friction_log` instead of `Friction log`. Postgres stores unquoted names in lowercase.
+Supabase recommends using snake_case for table names. For example, use `my_table` instead of `My table`. 
 
 </Admonition>
 
@@ -78,12 +78,12 @@ This example insert uses a table named `instruments`. Replace `<your-table>` wit
 
 Run the following example SQL:
 
-</StepHikeCompact.Details>
+</StepHikeCompact.Details:way>
 
 <StepHikeCompact.Code>
 
     ```sql SQL_EDITOR
-    -- Example only.
+    -- Example: insert sample data into the table
     insert into instruments (name)
     values
       ('violin'),

--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -9,7 +9,8 @@ Alternatively, you can create a project using the Management API:
 <StepHikeCompact.Code>
 
 ```bash
-# First, get your access token from https://supabase.com/dashboard/account/tokens
+# First, get your access token from
+# https://supabase.com/dashboard/account/tokens
 export SUPABASE_ACCESS_TOKEN="your-access-token"
 
 # List your organizations to get the organization ID
@@ -32,11 +33,11 @@ curl -X POST https://api.supabase.com/v1/projects \
 
 <StepHikeCompact.Details>
 
-When your Supabase project is up and running, create an example `instruments` table. You can use the Table Editor or the SQL Editor.
+When your Supabase project is up and running, create a table for your data. You can use the Table Editor or the SQL Editor.
 
-**Table Editor:** Open the [**Table Editor**](/dashboard/project/_/editor). Create a table named `instruments` and insert sample rows. Open [**Integrations > Data API**](/dashboard/project/_/integrations/data_api/settings) and expose the table. To expose future tables in `public` automatically, enable **Default privileges for new entities**.
+**Table Editor:** Open the [**Table Editor**](/dashboard/project/_/editor). Create a table and add columns. Open [**Integrations > Data API**](/dashboard/project/_/integrations/data_api/settings) and expose the table. To expose future tables in `public` automatically, enable **Default privileges for new entities**.
 
-**SQL Editor:** Run the snippet below in your project's [SQL Editor](/dashboard/project/_/sql/new). The snippet creates the example `instruments` table with sample data.
+**SQL Editor:** Run the SQL snippets in your project's [SQL Editor](/dashboard/project/_/sql/new).
 
 <Admonition type="note">
 
@@ -44,48 +45,80 @@ Use snake_case for table names. For example, use `friction_log` instead of `Fric
 
 </Admonition>
 
-Run the snippets below regardless of the method you use. The snippets grant read access, enable [Row Level Security](/docs/guides/database/postgres/row-level-security), and add a policy. The Data API does not return rows until a Row Level Security policy allows access. This step applies even if you create the table in the Table Editor.
+Run the SQL snippets regardless of the method you use. The snippets grant read access, enable [Row Level Security](/docs/guides/database/postgres/row-level-security), and add a policy. The Data API does not return rows until a Row Level Security policy allows access. This step applies even if you create the table in the Table Editor.
 
-If you use a different table name, replace `instruments` in the snippets below.
+Replace the following:
+
+- `<your-table>`: your table name in snake_case
+
+</StepHikeCompact.Details>
+
+<StepHikeCompact.Details>
+
+Run the following SQL to create your table:
 
 </StepHikeCompact.Details>
 
 <StepHikeCompact.Code>
 
     ```sql SQL_EDITOR
-    -- Create the example table. Skip this section if you already created the table in the Table Editor.
-    create table instruments (
+    -- Omit the following statement if you already created the table in the
+    -- Table Editor.
+    create table <your-table> (
       id bigint primary key generated always as identity,
       name text not null
     );
-
-    -- Insert sample data into the table
-    insert into instruments (name)
-    values
-      ('violin'),
-      ('viola'),
-      ('cello');
-
-    -- Grant read access to API roles
-    grant select on public.instruments to anon, authenticated;
-
-    -- Enable row level security for the table
-    alter table instruments enable row level security;
     ```
 
 </StepHikeCompact.Code>
 
 <StepHikeCompact.Details>
 
-Create a Row Level Security policy that allows reads from the `instruments` table. The policy applies to anonymous users and users who sign in. This matters if your app uses the pre-configured auth from the `with-supabase` template.
+This example insert uses a table named `instruments`. Replace `<your-table>` with `instruments` in the other snippets if you use this example. Skip this section if you already have data in your table or you use a different table name.
+
+Run the following example SQL:
 
 </StepHikeCompact.Details>
 
 <StepHikeCompact.Code>
 
     ```sql SQL_EDITOR
-    create policy "public can read instruments"
-    on public.instruments
+    -- Example only.
+    insert into instruments (name)
+    values
+      ('violin'),
+      ('viola'),
+      ('cello');
+    ```
+
+</StepHikeCompact.Code>
+
+<StepHikeCompact.Details>
+
+Run the following SQL to grant read access and enable Row Level Security:
+
+</StepHikeCompact.Details>
+
+<StepHikeCompact.Code>
+
+    ```sql SQL_EDITOR
+    grant select on public.<your-table> to anon, authenticated;
+    alter table <your-table> enable row level security;
+    ```
+
+</StepHikeCompact.Code>
+
+<StepHikeCompact.Details>
+
+Run the following SQL to create a Row Level Security policy. The policy applies to anonymous users and users who sign in.
+
+</StepHikeCompact.Details>
+
+<StepHikeCompact.Code>
+
+    ```sql SQL_EDITOR
+    create policy "Allow public read access"
+    on public.<your-table>
     for select
     using (true);
     ```

--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -16,7 +16,7 @@ export SUPABASE_ACCESS_TOKEN="your-access-token"
 curl -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   https://api.supabase.com/v1/organizations
 
-# Create a new project (replace <org-id> with your organization ID)
+# Create a new project. Replace <org-id> with your organization ID.
 curl -X POST https://api.supabase.com/v1/projects \
   -H "Authorization: Bearer $SUPABASE_ACCESS_TOKEN" \
   -H "Content-Type: application/json" \
@@ -32,18 +32,28 @@ curl -X POST https://api.supabase.com/v1/projects \
 
 <StepHikeCompact.Details>
 
-When your project is up and running, go to the [**Table Editor**](/dashboard/project/_/editor) section of the Dashboard, create a new table and insert some data. Then in the [**Integrations > Data API**](/dashboard/project/_/integrations/data_api/settings) section of the Dashboard, expose the specific tables or functions you want to access. To automatically grant access for new tables and functions in `public`, enable **Default privileges for new entities**.
+When your Supabase project is up and running, create an example `instruments` table. You can use the Table Editor or the SQL Editor.
 
-Alternatively, you can run the following snippet in your project's [SQL Editor](/dashboard/project/_/sql/new).
+**Table Editor:** Open the [**Table Editor**](/dashboard/project/_/editor). Create a table named `instruments` and insert sample rows. Open [**Integrations > Data API**](/dashboard/project/_/integrations/data_api/settings) and expose the table. To expose future tables in `public` automatically, enable **Default privileges for new entities**.
 
-This creates an `instruments` table with some sample data, sets a secure baseline by setting only the privileges each Postgres role needs, and adds [Row Level Security (RLS)](/docs/guides/database/postgres/row-level-security) for enhanced security for database data by default.
+**SQL Editor:** Run the snippet below in your project's [SQL Editor](/dashboard/project/_/sql/new). The snippet creates the example `instruments` table with sample data.
+
+<Admonition type="note">
+
+Use snake_case for table names. For example, use `friction_log` instead of `Friction log`. Postgres stores unquoted names in lowercase.
+
+</Admonition>
+
+Run the snippets below regardless of the method you use. The snippets grant read access, enable [Row Level Security](/docs/guides/database/postgres/row-level-security), and add a policy. The Data API does not return rows until a Row Level Security policy allows access. This step applies even if you create the table in the Table Editor.
+
+If you use a different table name, replace `instruments` in the snippets below.
 
 </StepHikeCompact.Details>
 
 <StepHikeCompact.Code>
 
     ```sql SQL_EDITOR
-    -- Create the table
+    -- Create the example table. Skip this section if you already created the table in the Table Editor.
     create table instruments (
       id bigint primary key generated always as identity,
       name text not null
@@ -56,8 +66,8 @@ This creates an `instruments` table with some sample data, sets a secure baselin
       ('viola'),
       ('cello');
 
-    -- Grant the privileges the role needs, which is read access
-    grant select on public.instruments to anon;
+    -- Grant read access to API roles
+    grant select on public.instruments to anon, authenticated;
 
     -- Enable row level security for the table
     alter table instruments enable row level security;
@@ -67,17 +77,16 @@ This creates an `instruments` table with some sample data, sets a secure baselin
 
 <StepHikeCompact.Details>
 
-Create an RLS policy to make the data in your table publicly readable:
+Create a Row Level Security policy that allows reads from the `instruments` table. The policy applies to anonymous users and users who sign in. This matters if your app uses the pre-configured auth from the `with-supabase` template.
 
 </StepHikeCompact.Details>
 
 <StepHikeCompact.Code>
 
     ```sql SQL_EDITOR
-    -- Create a policy to allow the anon role to read from the instruments table
     create policy "public can read instruments"
     on public.instruments
-    for select to anon
+    for select
     using (true);
     ```
 

--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Use Supabase with Next.js'
-subtitle: 'Learn how to create a Supabase project, add some sample data, and query from a Next.js app.'
+subtitle: 'Learn how to create a Supabase project, connect a Next.js app, and query your database.'
 breadcrumb: 'Framework Quickstarts'
 hideToc: true
 ---
@@ -27,7 +27,9 @@ hideToc: true
 
     <$Partial path="uiLibCta.mdx" />
 
-</StepHikeCompact.Details>
+    Run the following command to create a Next.js app:
+
+    </StepHikeCompact.Details>
 
     <StepHikeCompact.Code>
 
@@ -42,11 +44,12 @@ hideToc: true
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-    Rename `.env.example` to `.env.local`. Set your Supabase connection variables in the file:
+    Rename `.env.example` to `.env.local`.
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="publishable" />
 
+    Add the following variables to `.env.local`:
 
     </StepHikeCompact.Details>
 
@@ -70,7 +73,14 @@ hideToc: true
   <StepHikeCompact.Step step={4}>
     <StepHikeCompact.Details title="Query Supabase data from Next.js">
 
-    Create `app/instruments/page.tsx` as an example. The page queries the `instruments` table from step 1 and renders the results.
+    Create a page at `app/<your-page-path>/page.tsx`. The page queries your table and renders the results.
+
+    Replace the following:
+
+    - `<your-page-path>`: the route for your page
+    - `<your-table>`: the table name from step 1
+
+    The following code queries your table and renders the results:
 
     </StepHikeCompact.Details>
 
@@ -78,31 +88,33 @@ hideToc: true
 
     <$CodeTabs>
 
-      ```ts name=app/instruments/page.tsx
+      ```ts name=app/<your-page-path>/page.tsx
       import { createClient } from "@/lib/supabase/server";
       import { Suspense } from "react";
 
-      async function InstrumentsData() {
+      async function TableData() {
         const supabase = await createClient();
-        const { data: instruments, error } = await supabase.from("instruments").select();
+        const { data, error } = await supabase
+          .from("<your-table>")
+          .select();
 
         if (error) {
           return (
             <p>
-              Error loading instruments: {error.message}. Verify that the table exists. Verify that
-              the table name matches your query. Verify that Row Level Security policies allow
-              access for your role.
+              Error loading data: {error.message}. Verify that the table
+              exists. Verify that the table name matches your query. Verify
+              that Row Level Security policies allow access for your role.
             </p>
           );
         }
 
-        return <pre>{JSON.stringify(instruments, null, 2)}</pre>;
+        return <pre>{JSON.stringify(data, null, 2)}</pre>;
       }
 
-      export default function Instruments() {
+      export default function Page() {
         return (
-          <Suspense fallback={<div>Loading instruments...</div>}>
-            <InstrumentsData />
+          <Suspense fallback={<div>Loading...</div>}>
+            <TableData />
           </Suspense>
         );
       }
@@ -117,7 +129,7 @@ hideToc: true
   <StepHikeCompact.Step step={5}>
     <StepHikeCompact.Details title="Start the app">
 
-    Run the development server. Open http://localhost:3000/instruments in a browser. The page shows the list of instruments.
+    Run the following command to start the development server:
 
     </StepHikeCompact.Details>
 
@@ -128,6 +140,12 @@ hideToc: true
       ```
 
     </StepHikeCompact.Code>
+
+    <StepHikeCompact.Details>
+
+    Open http://localhost:3000/<your-page-path> in a browser. The page shows your query results.
+
+    </StepHikeCompact.Details>
 
   </StepHikeCompact.Step>
 

--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -17,10 +17,13 @@ hideToc: true
 
     <StepHikeCompact.Details title="Create a Next.js app">
 
-    Use the `create-next-app` command and the `with-supabase` template, to create a Next.js app pre-configured with:
-    - [Cookie-based Auth](/docs/guides/auth/server-side/creating-a-client?queryGroups=package-manager&package-manager=npm&queryGroups=framework&framework=nextjs&queryGroups=environment&environment=server)
-    - [TypeScript](https://www.typescriptlang.org/)
-    - [Tailwind CSS](https://tailwindcss.com/)
+    Create a Next.js app from the `with-supabase` template. The template includes cookie-based [Auth](/docs/guides/auth/server-side/creating-a-client?queryGroups=package-manager&package-manager=npm&queryGroups=framework&framework=nextjs&queryGroups=environment&environment=server), TypeScript, and Tailwind CSS.
+
+    <Admonition type="note">
+
+    If you already have a Next.js app, skip this step. [Add Supabase to your existing app](/docs/guides/auth/server-side/creating-a-client?queryGroups=package-manager&package-manager=npm&queryGroups=framework&framework=nextjs&queryGroups=environment&environment=server) instead.
+
+    </Admonition>
 
     <$Partial path="uiLibCta.mdx" />
 
@@ -29,7 +32,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash
-      npx create-next-app -e with-supabase
+      npx create-next-app my-app --example with-supabase
       ```
 
     </StepHikeCompact.Code>
@@ -39,7 +42,7 @@ hideToc: true
   <StepHikeCompact.Step step={3}>
     <StepHikeCompact.Details title="Declare Supabase Environment Variables">
 
-    Rename `.env.example` to `.env.local` and populate with your Supabase connection variables:
+    Rename `.env.example` to `.env.local`. Set your Supabase connection variables in the file:
 
     <ProjectConfigVariables variable="url" />
     <ProjectConfigVariables variable="publishable" />
@@ -67,9 +70,7 @@ hideToc: true
   <StepHikeCompact.Step step={4}>
     <StepHikeCompact.Details title="Query Supabase data from Next.js">
 
-    Create a new file at `app/instruments/page.tsx` and populate with the following.
-
-    This selects all the rows from the `instruments` table in Supabase and render them on the page.
+    Create `app/instruments/page.tsx` as an example. The page queries the `instruments` table from step 1 and renders the results.
 
     </StepHikeCompact.Details>
 
@@ -83,7 +84,17 @@ hideToc: true
 
       async function InstrumentsData() {
         const supabase = await createClient();
-        const { data: instruments } = await supabase.from("instruments").select();
+        const { data: instruments, error } = await supabase.from("instruments").select();
+
+        if (error) {
+          return (
+            <p>
+              Error loading instruments: {error.message}. Verify that the table exists. Verify that
+              the table name matches your query. Verify that Row Level Security policies allow
+              access for your role.
+            </p>
+          );
+        }
 
         return <pre>{JSON.stringify(instruments, null, 2)}</pre>;
       }
@@ -106,7 +117,7 @@ hideToc: true
   <StepHikeCompact.Step step={5}>
     <StepHikeCompact.Details title="Start the app">
 
-    Run the development server, go to http://localhost:3000/instruments in a browser and you should see the list of instruments.
+    Run the development server. Open http://localhost:3000/instruments in a browser. The page shows the list of instruments.
 
     </StepHikeCompact.Details>
 
@@ -124,6 +135,7 @@ hideToc: true
 
 ## Next steps
 
-- Set up [Auth](/docs/guides/auth) for your app
+- Learn how to [manage tables and data](/docs/guides/database/tables) from your app
 - [Insert more data](/docs/guides/database/import-data) into your database
 - Upload and serve static files using [Storage](/docs/guides/storage)
+- Customize the [pre-configured auth](/docs/guides/auth/server-side/creating-a-client?queryGroups=package-manager&package-manager=npm&queryGroups=framework&framework=nextjs&queryGroups=environment&environment=server) in the template

--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -27,6 +27,10 @@ hideToc: true
 
     <$Partial path="uiLibCta.mdx" />
 
+    Replace the following:
+
+    - `<your-app>`: the name of your Next.js app
+
     Run the following command to create a Next.js app:
 
     </StepHikeCompact.Details>
@@ -34,7 +38,7 @@ hideToc: true
     <StepHikeCompact.Code>
 
       ```bash
-      npx create-next-app my-app --example with-supabase
+      npx create-next-app <your-app> --example with-supabase
       ```
 
     </StepHikeCompact.Code>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Problem

For my Dogfooding project, I walked through out Onboarding docs with Next.js and logged every moment of friction.

See below for everything I noted:


### 1 — Confusing
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** Step 2 was so long that I spaced out and had to read it several times.

### 3 — Took incorrect action
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** I already had a Next.js app running. I misunderstood here "When your project is up and running...".

### 4 — Inaccessible
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** Typescript is linking to an external source. Not indicated and I also think not necessary, since Next.js is not our product.

### 5 — Confusing
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** "Create an RLS policy to make the data in your table publicly readable:" is only using the example, which was optional. What if I was using the interface up to this point?

### 6 — Confusing
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** Do not know what the npx command does in full. `-e` could use the verbose name `--example` for clarity to make clear that this is spinning up a next app with a Supabase template. Also, the my-app can go after

### 7 — Misleading
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** app/instruments/page.tsx is an example, but it is not clear. Instead of requiring the reader to infer it is an example, state it is an example each time.

### 8 — Inability to debug
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** In the page.tsx template example, if the query fails (wrong table name, RLS, missing table), you'll see null with no explanation. A better template would explain what's wrong.

### 9 — Missing convention
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** I gave my table a two-word name in Supabase, "Friction log", which I realize now is fragile.

### 10 — Blocker
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** I was logged in, so I was not able to see the table with 'anon'. I didn't know the issue for awhile.

### 11 — Unhelpful
- **Location:** https://supabase.com/docs/guides/getting-started/quickstarts/nextjs
- **Description:** I found "Set up Auth for your app" unhelpful because the getting-started *already* has auth set up out of the box, so the instructions appear duplicated to me. What I really wanted to do was learn how I could manipulate my tables with my app, which none of the next steps state. A more helpful Next Steps might be "Tables and Data"

### 12 — Inconsistent
- **Location:** https://supabase.com/docs/guides/api/rest/generating-types
- **Description:** Generating types using Supabase section should be in procedure format (numbered list).

### 13 — Took incorrect action
- **Location:** https://supabase.com/docs/guides/api/rest/generating-types
- **Description:** I was missing the step `npx supabase link` before running the gen types script. The local development one didn't work.