### PR TITLE
Add method post to all auth forms

### DIFF
--- a/apps/studio/components/interfaces/SignIn/ForgotPasswordWizard.tsx
+++ b/apps/studio/components/interfaces/SignIn/ForgotPasswordWizard.tsx
@@ -76,6 +76,7 @@ const ConfirmResetCodeForm = ({ email }: { email: string }) => {
     <Form {...codeForm}>
       <form
         id="code-input-form"
+        method="POST"
         className="flex flex-col pt-4 space-y-4"
         onSubmit={codeForm.handleSubmit(onCodeEntered)}
       >
@@ -148,6 +149,7 @@ const ForgotPasswordForm = ({ onSuccess }: { onSuccess: (email: string) => void 
     <Form {...forgotPasswordForm}>
       <form
         id="forgot-password-form"
+        method="POST"
         className="flex flex-col pt-4 space-y-4"
         onSubmit={forgotPasswordForm.handleSubmit(onForgotPassword)}
       >

--- a/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
@@ -76,7 +76,11 @@ export const ResetPasswordForm = () => {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onResetPassword)} className="space-y-4 pt-4">
+      <form
+        method="POST"
+        onSubmit={form.handleSubmit(onResetPassword)}
+        className="space-y-4 pt-4"
+      >
         {requireCurrentPassword && (
           <FormField
             control={form.control}

--- a/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/ResetPasswordForm.tsx
@@ -76,11 +76,7 @@ export const ResetPasswordForm = () => {
 
   return (
     <Form {...form}>
-      <form
-        method="POST"
-        onSubmit={form.handleSubmit(onResetPassword)}
-        className="space-y-4 pt-4"
-      >
+      <form method="POST" onSubmit={form.handleSubmit(onResetPassword)} className="space-y-4 pt-4">
         {requireCurrentPassword && (
           <FormField
             control={form.control}

--- a/apps/studio/components/interfaces/SignIn/SignInForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInForm.tsx
@@ -121,7 +121,12 @@ export const SignInForm = () => {
 
   return (
     <Form {...form}>
-      <form id={formId} className="flex flex-col gap-4" onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        id={formId}
+        method="POST"
+        className="flex flex-col gap-4"
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
         {authError && <AlertError error={authError} subject="Error while signing in" />}
         <FormField
           key="email"

--- a/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInMfaForm.tsx
@@ -128,7 +128,12 @@ export const SignInMfaForm = ({ context = 'sign-in' }: SignInMfaFormProps) => {
 
       {isSuccessFactors && (
         <Form {...form}>
-          <form id={formId} className="flex flex-col gap-4" onSubmit={form.handleSubmit(onSubmit)}>
+          <form
+            id={formId}
+            method="POST"
+            className="flex flex-col gap-4"
+            onSubmit={form.handleSubmit(onSubmit)}
+          >
             <FormField
               key="code"
               name="code"

--- a/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInSSOForm.tsx
@@ -73,7 +73,12 @@ export const SignInSSOForm = () => {
 
   return (
     <Form {...form}>
-      <form id={formId} className="flex flex-col gap-4" onSubmit={form.handleSubmit(onSubmit)}>
+      <form
+        id={formId}
+        method="POST"
+        className="flex flex-col gap-4"
+        onSubmit={form.handleSubmit(onSubmit)}
+      >
         <FormField
           key="email"
           name="email"

--- a/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -151,6 +151,7 @@ export const SignUpForm = () => {
         <Form {...form}>
           <form
             id={formId}
+            method="POST"
             className="flex flex-col gap-4"
             onSubmit={form.handleSubmit(onSubmit, (errors) =>
               trackFunnelError('signup', classifyValidationError('signup', errors), 'form')


### PR DESCRIPTION
## Context

Adds `method=post` to all auth related forms on the dashboard (sign in, forget password, etc)

## To test
- [ ] Minimally ensure that logging in via email password still works as expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sign-in, sign-up, MFA, SSO, reset password, and forgot password forms now explicitly submit using **POST** for more consistent authentication behavior.
* **Style**
  * Reformatted authentication form markup (e.g., multiline JSX attributes) to improve readability and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->