### PR TITLE
Remove old redirect links in database section

### DIFF
--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
@@ -1,16 +1,12 @@
 import { useParams } from 'common'
 import { ArrowUpRight } from 'lucide-react'
 
-import {
-  useIsColumnLevelPrivilegesEnabled,
-  useIsMarketplaceEnabled,
-} from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import { useIsColumnLevelPrivilegesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useIsETLPrivateAlpha } from '@/components/interfaces/Database/Replication/useIsETLPrivateAlpha'
 import type {
   ProductMenuGroup,
   ProductMenuGroupItem,
 } from '@/components/ui/ProductMenu/ProductMenu.types'
-import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useProjectAddonsQuery } from '@/data/subscriptions/project-addons-query'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -23,30 +19,19 @@ export const useGenerateDatabaseMenu = (): ProductMenuGroup[] => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
 
-  const {
-    databaseReplication: showPgReplicate,
-    databaseRoles: showRoles,
-    integrationsWrappers: showWrappers,
-  } = useIsFeatureEnabled(['database:replication', 'database:roles', 'integrations:wrappers'])
+  const { databaseReplication: showPgReplicate, databaseRoles: showRoles } = useIsFeatureEnabled([
+    'database:replication',
+    'database:roles',
+    'integrations:wrappers',
+  ])
 
-  const { data } = useDatabaseExtensionsQuery({
-    projectRef: project?.ref,
-    connectionString: project?.connectionString,
-  })
   const { data: addons } = useProjectAddonsQuery({ projectRef: project?.ref })
 
-  const pgNetExtensionExists = (data ?? []).some((ext) => ext.name === 'pg_net')
   const pitrEnabled = addons?.selected_addons.some((addon) => addon.type === 'pitr') ?? false
   const columnLevelPrivileges = useIsColumnLevelPrivilegesEnabled()
   const enablePgReplicate = useIsETLPrivateAlpha()
 
   const getDatabaseURL = (path: string) => `/project/${ref}/database/${path}`
-
-  // In the new marketplace revamped page the `category=wrapper` query param has
-  // changed to `type=wrapper`. So fix this link below based on which version is
-  // the user viewing.
-  const isMarketplaceEnabled = useIsMarketplaceEnabled()
-  const wrappersLinkParamName = isMarketplaceEnabled ? 'type' : 'category'
 
   return [
     {
@@ -154,42 +139,7 @@ export const useGenerateDatabaseMenu = (): ProductMenuGroup[] => {
           url: getDatabaseURL('migrations'),
           shortcutId: SHORTCUT_IDS.NAV_DATABASE_MIGRATIONS,
         },
-        showWrappers && {
-          name: 'Wrappers',
-          key: 'wrappers',
-          url: `/project/${ref}/integrations?${wrappersLinkParamName}=wrapper`,
-          rightIcon: ExternalLinkIcon,
-        },
-        pgNetExtensionExists && {
-          name: 'Database Webhooks',
-          key: 'hooks',
-          url: `/project/${ref}/integrations/webhooks/overview`,
-          rightIcon: ExternalLinkIcon,
-        },
       ].filter(Boolean) as ProductMenuGroupItem[],
-    },
-    {
-      title: 'Tools',
-      items: [
-        {
-          name: 'Security Advisor',
-          key: 'security-advisor',
-          url: `/project/${ref}/advisors/security`,
-          rightIcon: ExternalLinkIcon,
-        },
-        {
-          name: 'Performance Advisor',
-          key: 'performance-advisor',
-          url: `/project/${ref}/advisors/performance`,
-          rightIcon: ExternalLinkIcon,
-        },
-        {
-          name: 'Query Performance',
-          key: 'query-performance',
-          url: `/project/${ref}/observability/query-performance`,
-          rightIcon: ExternalLinkIcon,
-        },
-      ],
     },
   ]
 }


### PR DESCRIPTION
## Context

Just cleans up a couple of old redirect links from the Database section

<img width="267" height="654" alt="image" src="https://github.com/user-attachments/assets/e3c7befe-e121-4588-8530-56d55907b058" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified the database menu and removed two options that are no longer shown: **Wrappers** and **Database Webhooks**.
  * Updated the menu layout so the **Platform** section ends with the currently available items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->