### PR TITLE
fix(logs): map metadata.function_id override to otel attribute key

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
@@ -570,6 +570,30 @@ describe('OTEL filter translation', () => {
     `)
   })
 
+  it('drops the metadata root from an override key for function logs', () => {
+    expect(fmt(genDefaultQueryOtel(LogsTableName.FUNCTIONS, { 'metadata.function_id': 'abc-123' })))
+      .toMatchInlineSnapshot(`
+      "-- Logs Preview Query (otel) ['function_logs']
+      select
+        id,
+        timestamp,
+        event_message,
+        log_attributes['event_type'] as event_type,
+        log_attributes['function_id'] as function_id,
+        log_attributes['execution_id'] as execution_id,
+        log_attributes['level'] as level
+      from
+        logs
+      where
+        source = 'function_logs'
+        and (log_attributes['function_id'] = 'abc-123')
+      order by
+        timestamp desc
+      limit
+        100"
+    `)
+  })
+
   it('translates the etl pipeline_id filter', () => {
     expect(fmt(genDefaultQueryOtel(LogsTableName.ETL, { pipeline_id: '42' })))
       .toMatchInlineSnapshot(`

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
@@ -299,6 +299,33 @@ describe('genChartQueryOtel', () => {
     `)
   })
 
+  it('filters the function logs chart by the metadata.function_id override key', () => {
+    expect(
+      fmt(genChartQueryOtel(LogsTableName.FUNCTIONS, params, { 'metadata.function_id': 'abc-123' }))
+    ).toMatchInlineSnapshot(`
+      "-- Logs Chart Query (otel) ['function_logs']
+      select
+        toStartOfMinute (timestamp) as timestamp,
+        countIf (
+          not (
+            (log_attributes['level'] in ('error', 'fatal'))
+            or (log_attributes['level'] = 'warning')
+          )
+        ) as ok_count,
+        countIf (log_attributes['level'] in ('error', 'fatal')) as error_count,
+        countIf (log_attributes['level'] = 'warning') as warning_count
+      from
+        logs
+      where
+        source = 'function_logs'
+        and (log_attributes['function_id'] = 'abc-123')
+      group by
+        timestamp
+      order by
+        timestamp asc"
+    `)
+  })
+
   it('buckets by hour for ranges longer than 12 hours', () => {
     expect(
       fmt(

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
@@ -223,8 +223,11 @@ const resolveUnknownOtelClause = (dotKey: string, value: unknown): SafeLogSqlFra
   if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
     return null
   }
+  // OTEL drops the `metadata` root that BigQuery filter keys carry, so a
+  // `metadata.function_id` override maps to `log_attributes['function_id']`.
+  const attrKey = dotKey.startsWith('metadata.') ? dotKey.slice('metadata.'.length) : dotKey
   try {
-    return safeSql`${attr(dotKey)} = ${lit(value)}`
+    return safeSql`${attr(attrKey)} = ${lit(value)}`
   } catch {
     return null
   }


### PR DESCRIPTION
## Problem

Individual edge function logs are broken on the OTEL logs path. The logs chart for a single function filters by the `metadata.function_id` override key passed from the function logs page. On the OTEL path this key has no filter template, so it falls through to the unknown-clause resolver and is emitted verbatim as `log_attributes['metadata.function_id']`. OTEL drops the `metadata` root, so the live attribute key is just `function_id`. The filter matched nothing and the chart came back empty.

Generated before:

```sql
WHERE source = 'function_logs' AND (log_attributes['metadata.function_id'] = '...')
```

## Fix

Strip a leading `metadata.` prefix in the OTEL unknown-clause resolver (`resolveUnknownOtelClause`). The same BigQuery-style override key now resolves to `log_attributes['function_id']`, matching the working invocations query. This is the documented OTEL convention (the `metadata` root is always dropped), so it also covers any other `metadata.*` override keys.

Generated after:

```sql
WHERE source = 'function_logs' AND (log_attributes['function_id'] = '...')
```

## How to test

- Enable the OTEL logs path and open an edge function's Logs tab for a project with recent invocations.
- Confirm the logs chart renders ok/warning/error buckets instead of an empty chart.
- Run the unit tests: `pnpm test:studio` (or target `Logs.utils.otel.test.ts`).
- Expected result: the new test "drops the metadata root from an override key for function logs" passes, asserting the generated SQL uses `log_attributes['function_id']`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OTEL filter handling so keys that include the `metadata.` prefix are translated correctly for log searches.
  * Filters like `metadata.function_id` now generate the expected log-attribute predicates, improving Function logs matching.
* **Tests**
  * Added/updated inline snapshot coverage to verify SQL generation for metadata-based log filter overrides in both chart and preview queries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->