### PR TITLE
fix(logs): quote numeric pipeline_id in otel etl logs filter

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
@@ -589,6 +589,25 @@ describe('OTEL filter translation', () => {
         100"
     `)
   })
+
+  it('quotes a numeric etl pipeline_id so it compares as a string', () => {
+    expect(fmt(genDefaultQueryOtel(LogsTableName.ETL, { pipeline_id: 42 }))).toMatchInlineSnapshot(`
+      "-- Logs Preview Query (otel) ['etl_replication_logs']
+      select
+        id,
+        timestamp,
+        event_message
+      from
+        logs
+      where
+        source = 'etl_replication_logs'
+        and (log_attributes['pipeline_id'] = '42')
+      order by
+        timestamp desc
+      limit
+        100"
+    `)
+  })
 })
 
 describe('otelTimestampToMicros', () => {

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.test.ts
@@ -591,7 +591,10 @@ describe('OTEL filter translation', () => {
   })
 
   it('quotes a numeric etl pipeline_id so it compares as a string', () => {
-    expect(fmt(genDefaultQueryOtel(LogsTableName.ETL, { pipeline_id: 42 }))).toMatchInlineSnapshot(`
+    // The replication "View logs" link puts pipeline_id in the `f` param as a
+    // number; JSON.parse keeps it numeric, so model that path here.
+    const filters = JSON.parse('{ "pipeline_id": 42 }')
+    expect(fmt(genDefaultQueryOtel(LogsTableName.ETL, filters))).toMatchInlineSnapshot(`
       "-- Logs Preview Query (otel) ['etl_replication_logs']
       select
         id,

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.otel.ts
@@ -102,7 +102,9 @@ const SUPAVISOR_FILTERS: Record<string, SqlFilterEntry> = {
 }
 const ETL_FILTERS: Record<string, SqlFilterEntry> = {
   ...COMMON_FILTERS,
-  pipeline_id: (value: string | number) => safeSql`${attr('pipeline_id')} = ${lit(value)}`,
+  // pipeline_id arrives as a number, but log_attributes values are strings, so
+  // compare as a string. A numeric literal here is a ClickHouse type error.
+  pipeline_id: (value: string | number) => safeSql`${attr('pipeline_id')} = ${lit(String(value))}`,
 }
 
 const col = (key: string, alias: SafeLogSqlFragment): SafeLogSqlFragment =>


### PR DESCRIPTION
## Problem

Opening replication/ETL logs via the "View logs" button on a pipeline details view fails with "Error executing ClickHouse query" on the OTEL logs path.

The button links to `/logs/replication-logs?f={"pipeline_id": <id>}`, and `pipelineId` is a number (`Number(_pipelineId)` in ReplicationPipelineStatus, typed `number` in PipelineStatus). The OTEL ETL filter emitted that value as an unquoted numeric literal:

```sql
WHERE source = 'etl_replication_logs' AND (log_attributes['pipeline_id'] = 123)
```

`log_attributes` is a `Map(String, String)`, so comparing its string value to a number is a type error in ClickHouse, which surfaces as the generic "Error executing ClickHouse query".

## Fix

Coerce the value to a string in the OTEL ETL `pipeline_id` filter so it always compares string-to-string:

```sql
WHERE source = 'etl_replication_logs' AND (log_attributes['pipeline_id'] = '123')
```

- OTEL-only change. The legacy BigQuery path (a numeric `pipeline_id` column) is left untouched and still compares as a number.
- The existing unit test only passed a string `'42'`, which hid the bug. Added a numeric `42` case that would emit the unquoted literal without the fix.

## How to test

- Open a project with an ETL/replication destination, go to the pipeline details view, and click "View logs".
- Expected result: the logs load instead of showing "Error executing ClickHouse query".
- Run the unit tests: `pnpm test:studio` (or target `Logs.utils.otel.test.ts`).
- Expected result: the new test "quotes a numeric etl pipeline_id so it compares as a string" passes, asserting `log_attributes['pipeline_id'] = '42'`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filtering for ETL logs so `pipeline_id` values are consistently treated as text, including numeric inputs.
  * Improved matching behavior when using the pipeline filter, helping ensure results appear as expected.
* **Tests**
  * Updated and expanded test coverage for pipeline ID filtering to verify the corrected SQL output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->