### PR TITLE
chore: update docs for temporary access alpha

### DIFF
--- a/apps/docs/content/guides/platform/temporary-access.mdx
+++ b/apps/docs/content/guides/platform/temporary-access.mdx
@@ -97,6 +97,12 @@ curl -X PUT "https://api.supabase.com/v1/projects/$PROJECT_REF/database/jit" \
 
 ## Using temporary access
 
+<Admonition type="note">
+
+This feature does not work with IPv6 Transaction pooler (pgbouncer). Direct connections and connections through the IPv4 connection pooler are fully supported.
+
+</Admonition>
+
 To log in to the database using temporary access, existing connection strings can be used and only the password needs to be changed to the user's API or dashboard token.
 
 For example, if a user has been authorized to assume the `postgres` role:
@@ -111,8 +117,8 @@ Connecting via the shared connection pooler requires the addition of a new conne
 
 ```
 # directly in the URI
-psql 'postgres://postgres.{project-ref}:sbp_111222333aaabbbccc@aws-1-us-west-1.pooler.supabase.com:5432/postgres?options=-c%20jit%3don'
+psql 'postgres://postgres.{project-ref}:sbp_111222333aaabbbccc@aws-1-us-west-1.pooler.supabase.com:5432/postgres?options=-c%20jit%3dtrue'
 
 # or as a connection info string
-psql "host=aws-1-us-west-1.pooler.supabase.com user=postgres.{project-ref} options='-c jit=on'"
+psql "host=aws-1-us-west-1.pooler.supabase.com user=postgres.{project-ref} options='-c jit=true'"
 ```

--- a/apps/docs/content/guides/platform/temporary-access.mdx
+++ b/apps/docs/content/guides/platform/temporary-access.mdx
@@ -99,7 +99,7 @@ curl -X PUT "https://api.supabase.com/v1/projects/$PROJECT_REF/database/jit" \
 
 <Admonition type="note">
 
-This feature does not work with IPv6 Transaction pooler (pgbouncer). Direct connections and connections through the IPv4 connection pooler are fully supported.
+This feature does not work with IPv6 Transaction pooler (PgBouncer). Direct connections and connections through the IPv4 connection pooler are fully supported.
 
 </Admonition>
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## Additional context

Small errata fix and adds note about pgbouncer not being supported

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified temporary access guidance: it works with direct connections and IPv4 pooler connections, but not with the IPv6 transaction pooler.
  * Updated the example connection options to use `jit=true` for temporary access setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->