### PR TITLE
chore: Add org slug and project ref as tags to the Sentry data

### DIFF
--- a/apps/studio/lib/telemetry.test.tsx
+++ b/apps/studio/lib/telemetry.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   useUser: vi.fn(),
   useOrganizationsQuery: vi.fn(),
   setUser: vi.fn(),
+  setTag: vi.fn(),
 }))
 
 vi.mock('common', async (importOriginal) => {
@@ -36,6 +37,7 @@ vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
 
 vi.mock('@sentry/nextjs', () => ({
   setUser: (...args: unknown[]) => mocks.setUser(...args),
+  setTag: (...args: unknown[]) => mocks.setTag(...args),
 }))
 
 const USER_ID = 'user-abc-123'
@@ -50,6 +52,7 @@ describe('Telemetry — posthog identify mirroring', () => {
     mocks.useUser.mockReset()
     mocks.useOrganizationsQuery.mockReset()
     mocks.setUser.mockReset()
+    mocks.setTag.mockReset()
   })
 
   it('fires identify with both org_count and signup_timestamp when user and orgs are loaded', async () => {

--- a/apps/studio/lib/telemetry.tsx
+++ b/apps/studio/lib/telemetry.tsx
@@ -59,8 +59,8 @@ export function Telemetry() {
     }
 
     // Tag Sentry events with the current project ref and customer org slug so backend/
-    // frontend errors can be filtered by project / org without a PostHog join. Passing a
-    // null value clears the tag, so stale values don't leak across navigation.
+    // frontend errors can be filtered by project / org. Passing a null value clears
+    // the tag, so stale values don't leak across navigation.
     Sentry.setTag('project_ref', projectRef ?? null)
     Sentry.setTag('org_slug', organization?.slug ?? null)
   }, [user?.id, projectRef, organization?.slug])

--- a/apps/studio/lib/telemetry.tsx
+++ b/apps/studio/lib/telemetry.tsx
@@ -5,7 +5,6 @@ import { useConsentToast } from 'ui-patterns/consent'
 
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
-import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { API_URL, IS_PLATFORM } from '@/lib/constants'
 
 export function Telemetry() {

--- a/apps/studio/lib/telemetry.tsx
+++ b/apps/studio/lib/telemetry.tsx
@@ -1,10 +1,11 @@
 import * as Sentry from '@sentry/nextjs'
-import { PageTelemetry, posthogClient, useUser } from 'common'
+import { PageTelemetry, posthogClient, useParams, useUser } from 'common'
 import { useEffect, useRef } from 'react'
 import { useConsentToast } from 'ui-patterns/consent'
 
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { API_URL, IS_PLATFORM } from '@/lib/constants'
 
 export function Telemetry() {
@@ -18,6 +19,9 @@ export function Telemetry() {
   const { data: organization } = useSelectedOrganizationQuery()
 
   const user = useUser()
+
+  // Project ref from the URL params, mirroring the backend's `request.params.ref`
+  const { ref: projectRef } = useParams()
 
   // Mirror the user's org-list length into a PostHog person property so feature
   // flags and analytics can segment by current org membership. signup_timestamp
@@ -50,12 +54,16 @@ export function Telemetry() {
 
   useEffect(() => {
     // don't set the sentry user id if the user hasn't logged in (so that Sentry errors show null user id instead of anonymous id)
-    if (!user?.id) {
-      return
+    if (user?.id) {
+      Sentry.setUser({ id: user.id })
     }
 
-    Sentry.setUser({ id: user.id })
-  }, [user?.id])
+    // Tag Sentry events with the current project ref and customer org slug so backend/
+    // frontend errors can be filtered by project / org without a PostHog join. Passing a
+    // null value clears the tag, so stale values don't leak across navigation.
+    Sentry.setTag('project_ref', projectRef ?? null)
+    Sentry.setTag('org_slug', organization?.slug ?? null)
+  }, [user?.id, projectRef, organization?.slug])
 
   return (
     <PageTelemetry


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced telemetry to include the active project reference and selected organization on events.
  * Cleared and re-applied project and organization tags when navigating to prevent stale tagging.
  * Only applies user identification when user account details are available.
* **Tests**
  * Updated telemetry tests to cover the additional tagging behavior by extending Sentry mocks accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->