### PR TITLE
test(studio): cover SQL content remap and upsert response remap

### DIFF
--- a/apps/studio/data/content/content-remap.test.ts
+++ b/apps/studio/data/content/content-remap.test.ts
@@ -1,0 +1,103 @@
+import { untrustedSql } from '@supabase/pg-meta'
+import { describe, expect, it } from 'vitest'
+
+import { remapSqlContentField, remapSqlContentFields, unmapSqlContentField } from './content-remap'
+
+const SQL_SNIPPET = {
+  id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+  type: 'sql' as const,
+  name: 'My query',
+  content: {
+    sql: 'SELECT 1',
+    content_id: 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11',
+    schema_version: '1.0',
+  },
+}
+
+describe('remapSqlContentField', () => {
+  it('remaps content.sql to content.unchecked_sql for SQL snippets', () => {
+    const result = remapSqlContentField(SQL_SNIPPET)
+
+    expect(result.content).toEqual({
+      content_id: SQL_SNIPPET.content.content_id,
+      schema_version: '1.0',
+      unchecked_sql: untrustedSql('SELECT 1'),
+    })
+    expect(result.content).not.toHaveProperty('sql')
+  })
+
+  it('leaves non-SQL content types unchanged', () => {
+    const report = { id: '1', type: 'report' as const, content: { foo: 'bar' } }
+
+    expect(remapSqlContentField(report)).toBe(report)
+  })
+
+  it('leaves SQL snippets without a content field unchanged', () => {
+    const snippet = { id: '1', type: 'sql' as const, name: 'No content' }
+
+    expect(remapSqlContentField(snippet)).toBe(snippet)
+  })
+
+  it('leaves SQL snippets whose content has no sql field unchanged', () => {
+    const snippet = {
+      id: '1',
+      type: 'sql' as const,
+      content: { content_id: '1', schema_version: '1.0', unchecked_sql: untrustedSql('x') },
+    }
+
+    expect(remapSqlContentField(snippet)).toBe(snippet)
+  })
+})
+
+describe('remapSqlContentFields', () => {
+  it('remaps every SQL snippet in a list', () => {
+    const items = [SQL_SNIPPET, { id: '2', type: 'report' as const }]
+
+    const result = remapSqlContentFields(items)
+    const remappedSql = result.find((item) => item.type === 'sql')
+
+    expect(remappedSql && 'content' in remappedSql && remappedSql.content).toMatchObject({
+      unchecked_sql: untrustedSql('SELECT 1'),
+    })
+    expect(result[1]).toBe(items[1])
+  })
+})
+
+describe('unmapSqlContentField', () => {
+  it('remaps content.unchecked_sql back to content.sql for the API', () => {
+    const snippet = remapSqlContentField(SQL_SNIPPET)
+
+    const result = unmapSqlContentField(snippet)
+
+    expect(result.content).toEqual({
+      content_id: SQL_SNIPPET.content.content_id,
+      schema_version: '1.0',
+      sql: untrustedSql('SELECT 1'),
+    })
+    expect(result.content).not.toHaveProperty('unchecked_sql')
+  })
+
+  it('leaves non-SQL content types unchanged', () => {
+    const report = { id: '1', type: 'report' as const, content: { foo: 'bar' } }
+
+    expect(unmapSqlContentField(report)).toBe(report)
+  })
+
+  it('leaves SQL snippets whose content has no unchecked_sql field unchanged', () => {
+    const snippet = {
+      id: '1',
+      type: 'sql' as const,
+      content: { content_id: '1', schema_version: '1.0', sql: 'SELECT 1' },
+    }
+
+    expect(unmapSqlContentField(snippet)).toBe(snippet)
+  })
+})
+
+describe('remap/unmap round-trip', () => {
+  it('returns the original content shape after remap then unmap', () => {
+    const result = unmapSqlContentField(remapSqlContentField(SQL_SNIPPET))
+
+    expect(result.content).toEqual(SQL_SNIPPET.content)
+  })
+})

--- a/apps/studio/data/content/content-upsert-mutation.test.ts
+++ b/apps/studio/data/content/content-upsert-mutation.test.ts
@@ -1,0 +1,75 @@
+import { untrustedSql } from '@supabase/pg-meta'
+import { HttpResponse } from 'msw'
+import { describe, expect, it } from 'vitest'
+
+import { upsertContent } from './content-upsert-mutation'
+import { addAPIMock } from '@/tests/lib/msw'
+
+const SNIPPET_ID = 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11'
+const FOLDER_ID = 'c2eebc99-9c0b-4ef8-bb6d-6bb9bd380a13'
+
+const payload = {
+  id: SNIPPET_ID,
+  type: 'sql' as const,
+  name: 'Moved query',
+  visibility: 'user' as const,
+  project_id: 1,
+  owner_id: 1,
+  folder_id: FOLDER_ID,
+  content: {
+    content_id: SNIPPET_ID,
+    schema_version: '1.0',
+    unchecked_sql: untrustedSql('SELECT 1'),
+  },
+}
+
+describe('upsertContent', () => {
+  it('remaps content.sql to unchecked_sql in the upsert response', async () => {
+    // Self-hosted (and the management API) persist + return the SQL body under `content.sql`;
+    // the editor reads `content.unchecked_sql`. Move/rename consume this response directly, so it
+    // must be remapped — otherwise the editor renders blank until a refetch.
+    addAPIMock({
+      method: 'put',
+      path: '/platform/projects/:ref/content',
+      response: async ({ request }) => {
+        const body = (await request.json()) as { id: string; name: string; type: string }
+        return HttpResponse.json({
+          id: SNIPPET_ID,
+          type: 'sql',
+          name: body.name,
+          description: '',
+          favorite: false,
+          folder_id: FOLDER_ID,
+          inserted_at: '2024-01-01T00:00:00.000Z',
+          updated_at: '2024-01-01T00:00:00.000Z',
+          visibility: 'user',
+          owner_id: 1,
+          project_id: 1,
+          content: {
+            sql: 'SELECT 1',
+            content_id: SNIPPET_ID,
+            schema_version: '1.0',
+          },
+        })
+      },
+    })
+
+    const result = await upsertContent({ projectRef: 'default', payload })
+
+    expect(result?.status).toBe('saved')
+    expect(result?.content?.unchecked_sql).toEqual(untrustedSql('SELECT 1'))
+    expect(result?.content).not.toHaveProperty('sql')
+  })
+
+  it('returns null when the API responds with no snippet', async () => {
+    addAPIMock({
+      method: 'put',
+      path: '/platform/projects/:ref/content',
+      response: () => HttpResponse.json(null),
+    })
+
+    const result = await upsertContent({ projectRef: 'default', payload })
+
+    expect(result).toBeNull()
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds unit coverage for the `content.sql` <-> `content.unchecked_sql` remap that self-hosted SQL snippets depend on.

The API persists and returns the SQL body under `content.sql`, while the editor reads `content.unchecked_sql`; `content-remap.ts` bridges the two and is used at every read/write boundary (6 files). Cover the following:
- `content-remap.ts`'s helpers had **no direct tests**.
- The upsert-response remap added in **#47409** was **unguarded** - a refactor removing that one line would silently bring back the "snippet blank after move/rename" bug on self-hosted, with no test failing.

### New tests

- **`content-remap.test.ts`** - `remapSqlContentField` / `remapSqlContentFields` / `unmapSqlContentField`: happy paths, the "leave unchanged" guards (non-SQL, no `content`, missing field), and a remap→unmap round-trip invariant.
- **`content-upsert-mutation.test.ts`** - MSW test asserting `upsertContent` remaps the PUT response (`content.sql` → `unchecked_sql`), plus the `null`-response passthrough.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for SQL content field remapping and unmapping behavior.
  * Verified SQL content is preserved through round-trip handling, while non-SQL or incomplete content stays unchanged.
  * Added coverage for content upsert responses, including SQL field normalization and handling of empty responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->