### PR TITLE
chore: migrate `Tabs` to Shadcn new component

### DIFF
--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/SpreadsheetImport/SpreadsheetImport.tsx
@@ -2,7 +2,13 @@ import type { PGTable } from '@supabase/pg-meta'
 import { noop } from 'lodash'
 import { useCallback, type ChangeEvent, type DragEvent } from 'react'
 import { toast } from 'sonner'
-import { SidePanel, Tabs } from 'ui'
+import {
+  SidePanel,
+  Tabs_Shadcn_ as Tabs,
+  TabsContent_Shadcn_ as TabsContent,
+  TabsList_Shadcn_ as TabsList,
+  TabsTrigger_Shadcn_ as TabsTrigger,
+} from 'ui'
 
 import { ActionBar } from '../ActionBar'
 import type { ImportContent } from '../TableEditor/TableEditor.types'
@@ -112,8 +118,12 @@ export const SpreadsheetImport = ({
     >
       <SidePanel.Content>
         <div className="pt-6">
-          <Tabs block type="pills" activeId={tab} onChange={handleSwitchTab}>
-            <Tabs.Panel id="fileUpload" label="Upload CSV">
+          <Tabs value={tab} onValueChange={handleSwitchTab}>
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="fileUpload">Upload CSV</TabsTrigger>
+              <TabsTrigger value="pasteText">Paste text</TabsTrigger>
+            </TabsList>
+            <TabsContent value="fileUpload">
               <SpreadsheetFileDropZone
                 file={hasAttachedFile(state) ? state.file : undefined}
                 parseProgress={
@@ -122,13 +132,13 @@ export const SpreadsheetImport = ({
                 onUploadFile={handleUploadFile}
                 onRemoveFile={handleRemoveFile}
               />
-            </Tabs.Panel>
-            <Tabs.Panel id="pasteText" label="Paste text">
+            </TabsContent>
+            <TabsContent value="pasteText">
               <SpreadsheetInputZone
                 text={hasAttachedText(state) ? state.text : ''}
                 onInputChange={handleInputText}
               />
-            </Tabs.Panel>
+            </TabsContent>
           </Tabs>
         </div>
       </SidePanel.Content>


### PR DESCRIPTION
## Problem

`Tabs` is deprecated in favour of the Shadcn `Tabs` component currently suffixed with `_Shadcn_`

## Solution

Migrate the only studio usage

Before:
<img width="662" height="396" alt="image" src="https://github.com/user-attachments/assets/62f36e98-6754-4362-9375-f2a45bd8028e" />

After:
<img width="666" height="434" alt="image" src="https://github.com/user-attachments/assets/a96f9e61-7420-4e77-a60a-a5db54b0e3d6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated the spreadsheet import panel to use a refreshed tab interface with clearer “Upload CSV” and “Paste text” options.
  * Improved the layout of the import flow so each tab’s content is displayed more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->