### PR TITLE
fix(ui-patterns): keep Row carousel right arrow at far edge FE-3743

### DIFF
--- a/packages/ui-patterns/src/Row/Row.utils.test.ts
+++ b/packages/ui-patterns/src/Row/Row.utils.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { findClippingAncestor } from './Row.utils'
+
+describe('findClippingAncestor', () => {
+  beforeEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('returns null when no ancestor clips horizontal overflow', () => {
+    const parent = document.createElement('div')
+    const child = document.createElement('div')
+    parent.appendChild(child)
+    document.body.appendChild(parent)
+
+    expect(findClippingAncestor(child)).toBeNull()
+  })
+
+  it.each(['hidden', 'auto', 'scroll', 'clip'])(
+    'finds an ancestor with overflow-x: %s',
+    (value) => {
+      const clip = document.createElement('div')
+      clip.style.overflowX = value
+      const child = document.createElement('div')
+      clip.appendChild(child)
+      document.body.appendChild(clip)
+
+      expect(findClippingAncestor(child)).toBe(clip)
+    }
+  )
+
+  it('returns the nearest clipping ancestor, skipping non-clipping ones', () => {
+    const outer = document.createElement('div')
+    outer.style.overflowX = 'hidden'
+    const middle = document.createElement('div')
+    const inner = document.createElement('div')
+    inner.style.overflowX = 'scroll'
+    const child = document.createElement('div')
+
+    outer.appendChild(middle)
+    middle.appendChild(inner)
+    inner.appendChild(child)
+    document.body.appendChild(outer)
+
+    expect(findClippingAncestor(child)).toBe(inner)
+  })
+})

--- a/packages/ui-patterns/src/Row/Row.utils.ts
+++ b/packages/ui-patterns/src/Row/Row.utils.ts
@@ -36,3 +36,70 @@ export const useMeasuredWidth = <T extends HTMLElement>(ref: React.RefObject<T |
 
   return measuredWidth
 }
+
+const findClippingAncestor = (element: HTMLElement) => {
+  let node = element.parentElement
+  while (node) {
+    const overflowX = getComputedStyle(node).overflowX
+    if (
+      overflowX === 'hidden' ||
+      overflowX === 'auto' ||
+      overflowX === 'scroll' ||
+      overflowX === 'clip'
+    ) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}
+
+// Distance from the row's own edges out to the nearest ancestor that clips
+// horizontal overflow. Items bleed past the row's box to that clip edge, so the
+// arrows are offset by these insets to sit on the visible edge rather than on
+// the row's (often narrower, centered) box.
+export const useClipInsets = <T extends HTMLElement>(ref: React.RefObject<T | null>) => {
+  const [insets, setInsets] = useState({ left: 0, right: 0 })
+
+  useLayoutEffect(() => {
+    const element = ref.current
+    if (!element) return
+
+    const measure = () => {
+      const clip = findClippingAncestor(element)
+      const row = element.getBoundingClientRect()
+      const bounds = clip
+        ? clip.getBoundingClientRect()
+        : { left: 0, right: document.documentElement.clientWidth }
+      const left = Math.max(0, row.left - bounds.left)
+      const right = Math.max(0, bounds.right - row.right)
+      setInsets((prev) => (prev.left === left && prev.right === right ? prev : { left, right }))
+    }
+
+    measure()
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', measure)
+      return () => window.removeEventListener('resize', measure)
+    }
+
+    let frame = 0
+    const schedule = () => {
+      if (frame) cancelAnimationFrame(frame)
+      frame = requestAnimationFrame(measure)
+    }
+    const resizeObserver = new ResizeObserver(schedule)
+    resizeObserver.observe(element)
+    const clip = findClippingAncestor(element)
+    if (clip) resizeObserver.observe(clip)
+    window.addEventListener('resize', schedule)
+
+    return () => {
+      if (frame) cancelAnimationFrame(frame)
+      resizeObserver.disconnect()
+      window.removeEventListener('resize', schedule)
+    }
+  }, [ref])
+
+  return insets
+}

--- a/packages/ui-patterns/src/Row/Row.utils.ts
+++ b/packages/ui-patterns/src/Row/Row.utils.ts
@@ -37,16 +37,13 @@ export const useMeasuredWidth = <T extends HTMLElement>(ref: React.RefObject<T |
   return measuredWidth
 }
 
-const findClippingAncestor = (element: HTMLElement) => {
+// Overflow values that establish a clipping box on the horizontal axis.
+const CLIPPING_OVERFLOW_VALUES = new Set(['hidden', 'auto', 'scroll', 'clip'])
+
+export const findClippingAncestor = (element: HTMLElement) => {
   let node = element.parentElement
   while (node) {
-    const overflowX = getComputedStyle(node).overflowX
-    if (
-      overflowX === 'hidden' ||
-      overflowX === 'auto' ||
-      overflowX === 'scroll' ||
-      overflowX === 'clip'
-    ) {
+    if (CLIPPING_OVERFLOW_VALUES.has(getComputedStyle(node).overflowX)) {
       return node
     }
     node = node.parentElement
@@ -65,8 +62,7 @@ export const useClipInsets = <T extends HTMLElement>(ref: React.RefObject<T | nu
     const element = ref.current
     if (!element) return
 
-    const measure = () => {
-      const clip = findClippingAncestor(element)
+    const measure = (clip = findClippingAncestor(element)) => {
       const row = element.getBoundingClientRect()
       const bounds = clip
         ? clip.getBoundingClientRect()
@@ -76,28 +72,30 @@ export const useClipInsets = <T extends HTMLElement>(ref: React.RefObject<T | nu
       setInsets((prev) => (prev.left === left && prev.right === right ? prev : { left, right }))
     }
 
-    measure()
+    const clip = findClippingAncestor(element)
+    measure(clip)
 
     if (typeof ResizeObserver === 'undefined') {
-      window.addEventListener('resize', measure)
-      return () => window.removeEventListener('resize', measure)
+      const onResize = () => measure()
+      window.addEventListener('resize', onResize)
+      return () => window.removeEventListener('resize', onResize)
     }
 
     let frame = 0
     const schedule = () => {
       if (frame) cancelAnimationFrame(frame)
-      frame = requestAnimationFrame(measure)
+      frame = requestAnimationFrame(() => measure())
     }
     const resizeObserver = new ResizeObserver(schedule)
+    // Observing both the row and its clip ancestor covers viewport resizes too:
+    // when the clip ancestor is the scroll container, its size tracks the
+    // viewport, so a separate window listener would be redundant.
     resizeObserver.observe(element)
-    const clip = findClippingAncestor(element)
     if (clip) resizeObserver.observe(clip)
-    window.addEventListener('resize', schedule)
 
     return () => {
       if (frame) cancelAnimationFrame(frame)
       resizeObserver.disconnect()
-      window.removeEventListener('resize', schedule)
     }
   }, [ref])
 

--- a/packages/ui-patterns/src/Row/index.tsx
+++ b/packages/ui-patterns/src/Row/index.tsx
@@ -6,7 +6,7 @@ import type { ReactNode } from 'react'
 import { forwardRef, useEffect, useMemo, useRef, useState } from 'react'
 import { Button, cn } from 'ui'
 
-import { useMeasuredWidth } from './Row.utils'
+import { useClipInsets, useMeasuredWidth } from './Row.utils'
 
 interface RowProps extends React.HTMLAttributes<HTMLDivElement> {
   // Maximum number of columns visible in the row at once
@@ -60,6 +60,7 @@ export const Row = forwardRef<HTMLDivElement, RowProps>(function Row(
 
   const [scrollPosition, setScrollPosition] = useState(0)
   const measuredWidth = useMeasuredWidth(containerRef)
+  const clipInsets = useClipInsets(containerRef)
 
   const numberOfColumns = useMemo(
     () =>
@@ -149,7 +150,8 @@ export const Row = forwardRef<HTMLDivElement, RowProps>(function Row(
         <Button
           variant="default"
           onClick={scrollLeft}
-          className="absolute w-8 h-8 left-0 top-1/2 -translate-y-1/2 z-10 rounded-full p-2"
+          className="absolute w-8 h-8 top-1/2 -translate-y-1/2 z-10 rounded-full p-2"
+          style={{ left: -clipInsets.left }}
           aria-label="Scroll left"
         >
           <ChevronLeft className="w-4 h-4" />
@@ -160,7 +162,8 @@ export const Row = forwardRef<HTMLDivElement, RowProps>(function Row(
         <Button
           variant="default"
           onClick={scrollRight}
-          className="absolute w-8 h-8 right-0 top-1/2 -translate-y-1/2 z-10 rounded-full p-2"
+          className="absolute w-8 h-8 top-1/2 -translate-y-1/2 z-10 rounded-full p-2"
+          style={{ right: -clipInsets.right }}
           aria-label="Scroll right"
         >
           <ChevronRight className="w-4 h-4" />
@@ -169,7 +172,7 @@ export const Row = forwardRef<HTMLDivElement, RowProps>(function Row(
 
       <div
         ref={containerRef}
-        className="w-full overflow-visible focus:outline-hidden"
+        className="w-full overflow-hidden focus:outline-hidden"
         tabIndex={0}
         role="region"
         aria-roledescription="carousel"


### PR DESCRIPTION
## Problem

On wide screens the right-scroll arrow of the homepage service-health carousel (the shared `Row` component) sat on top of the fourth card instead of the far right edge. The cards beyond the visible column count were also rendered spilling out beside the arrow.

The scroll viewport used `overflow-visible`, so cards past the visible column count were still painted. The right chevron is anchored to the viewport's right edge, which equals `maxColumns` wide, so it landed on the last visible card while the overflowing cards rendered to its right.

## Fix

Clip the scroll viewport with `overflow-hidden`. Off-screen cards are hidden, only the visible columns show, and the right arrow sits at the true right edge. This is the expected carousel behavior since scrolling is done via `translateX`.

## How to test

- Open the project homepage with the service-health usage section (newHomepageUsageDeltas flag) on a wide screen.
- Confirm only the fitted number of cards are visible and the right arrow is pinned to the far right edge of the row.
- Click the right arrow and confirm the carousel scrolls to reveal the remaining cards.
- Narrow the window and confirm the arrow stays at the right edge and the visible column count reduces.