### PR TITLE
chore(self-hosted): set DB_ENC_KEY from env

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -61,6 +61,9 @@ DASHBOARD_PASSWORD=this_password_is_insecure_and_should_be_updated
 # Used by Realtime and Supavisor
 SECRET_KEY_BASE=UpNVntn3cDxHJpq99YMc1T1AQgQpc8kfYTuRgBiYa15BLrx8etQoXz3gZv1/u2oq
 
+# Encryption key for realtime tenant information, must be 16 characters
+REALTIME_DB_ENC_KEY=supabaserealtime
+
 # Used by Supavisor
 VAULT_ENC_KEY=your-32-character-encryption-key
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -312,7 +312,7 @@ services:
       DB_PASSWORD: ${POSTGRES_PASSWORD}
       DB_NAME: ${POSTGRES_DB}
       DB_AFTER_CONNECT_QUERY: 'SET search_path TO _realtime'
-      DB_ENC_KEY: supabaserealtime
+      DB_ENC_KEY: ${REALTIME_DB_ENC_KEY:-supabaserealtime}
 
       # Legacy symmetric HS256 key
       API_JWT_SECRET: ${JWT_SECRET}

--- a/docker/utils/generate-keys.sh
+++ b/docker/utils/generate-keys.sh
@@ -62,6 +62,7 @@ service_role_key=$(gen_token "$service_role_payload")
 
 secret_key_base=$(gen_base64 48)
 vault_enc_key=$(gen_hex 16)
+realtime_db_enc_key=$(gen_hex 8)
 pg_meta_crypto_key=$(gen_base64 24)
 
 logflare_public_access_token=$(gen_base64 24)
@@ -82,6 +83,7 @@ echo "SERVICE_ROLE_KEY=${service_role_key}"
 echo ""
 echo "SECRET_KEY_BASE=${secret_key_base}"
 echo "VAULT_ENC_KEY=${vault_enc_key}"
+echo "REALTIME_DB_ENC_KEY=${realtime_db_enc_key}"
 echo "PG_META_CRYPTO_KEY=${pg_meta_crypto_key}"
 echo "LOGFLARE_PUBLIC_ACCESS_TOKEN=${logflare_public_access_token}"
 echo "LOGFLARE_PRIVATE_ACCESS_TOKEN=${logflare_private_access_token}"
@@ -132,4 +134,5 @@ sed \
     -e "s|^MINIO_ROOT_PASSWORD=.*$|MINIO_ROOT_PASSWORD=${minio_root_password}|" \
     -e "s|^POSTGRES_PASSWORD=.*$|POSTGRES_PASSWORD=${postgres_password}|" \
     -e "s|^DASHBOARD_PASSWORD=.*$|DASHBOARD_PASSWORD=${dashboard_password}|" \
+    -e "s|^REALTIME_DB_ENC_KEY=.*$|REALTIME_DB_ENC_KEY=${realtime_db_enc_key}|" \
     .env


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

defaults update

## What is the current behavior?

hard-codes the DB_ENC_KEY. 

## What is the new behavior?

Sets the value from the environment and supports generating it. Defaults back to the hardcoded value to support existing deployments where data may already be encrypted with this key.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring the Realtime encryption key via environment settings (with a safe default when unset).
  * Key generation now includes the new Realtime encryption value to improve setup and maintenance.
* **Chores**
  * Updated the example environment file and container configuration to use the new configurable value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->