### PR TITLE
test: Skip snapshot test for the moment

### DIFF
--- a/apps/docs/scripts/build-reference-content.test.ts
+++ b/apps/docs/scripts/build-reference-content.test.ts
@@ -15,8 +15,13 @@ import { collectReferenceContent } from './build-reference-content'
  * doesn't collapse deep / cyclic structures (typeSpec contains
  * self-referencing builder types) into `[Object]` placeholders — which would
  * make param renames, signature changes, and JSDoc edits invisible.
+ *
+ * ---
+ *
+ * Update on Jun 30th, 2026. Skipping this until we figure out a better way to
+ * avoid downloaded typedoc files to block build on unrelated PRs.
  */
-describe('build-reference-content — javascript/v2', () => {
+describe.skip('build-reference-content — javascript/v2', () => {
   it('matches snapshot', async () => {
     const { bySlug, flat, sections, functionsList, typeSpec } = await collectReferenceContent(
       'javascript',


### PR DESCRIPTION
In this PR:
 - We are skipping snapshot tests for now. The reasoning is, if an SDK release changes the snapshot, builds can download the resulting typedoc but builds would fail because snapshots need to be manually updated. We need to sit down and re-think this. For now, we are unblocking builds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Skipped a documentation reference-content test suite to prevent unrelated build failures from blocking progress.
  * Added a note explaining why the suite is currently disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->