### PR TITLE
refactor(replication): do not fetch secrets from APIs and enable partial update on API

### DIFF
--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/AnalyticsBucket.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/AnalyticsBucket.utils.ts
@@ -14,6 +14,11 @@ export type AnalyticsBucketValidationIssue = {
   message: string
 }
 
+type AnalyticsBucketValidationOptions = {
+  secretsOptional?: boolean
+  storedS3AccessKeyId?: string
+}
+
 // Fields that are always required regardless of the namespace / access key selections.
 const ANALYTICS_BUCKET_REQUIRED_FIELDS: AnalyticsBucketValidationIssue[] = [
   { path: 'warehouseName', message: 'Bucket is required' },
@@ -23,7 +28,7 @@ const ANALYTICS_BUCKET_REQUIRED_FIELDS: AnalyticsBucketValidationIssue[] = [
 
 export const getAnalyticsBucketValidationIssues = (
   data: Pick<DestinationPanelSchemaType, AnalyticsBucketFieldPath>,
-  options: { secretsOptional?: boolean } = {}
+  options: AnalyticsBucketValidationOptions = {}
 ): AnalyticsBucketValidationIssue[] => {
   const requiredFields = options.secretsOptional
     ? ANALYTICS_BUCKET_REQUIRED_FIELDS.filter(({ path }) => path !== 's3AccessKeyId')
@@ -51,10 +56,17 @@ export const getAnalyticsBucketValidationIssues = (
     issues.push({ path: 's3AccessKeyId', message: 'S3 Access Key ID is required' })
   }
 
+  const currentS3AccessKeyId = data.s3AccessKeyId?.trim()
+  const storedS3AccessKeyId = options.storedS3AccessKeyId?.trim()
+  const hasChangedStoredS3AccessKey =
+    options.secretsOptional &&
+    !!currentS3AccessKeyId &&
+    currentS3AccessKeyId !== storedS3AccessKeyId
+
   // Creating a new key generates the secret later, so only require it for existing keys.
   if (
     data.s3AccessKeyId !== CREATE_NEW_KEY &&
-    (!options.secretsOptional || data.s3AccessKeyId?.trim().length) &&
+    (!options.secretsOptional || hasChangedStoredS3AccessKey) &&
     !data.s3SecretAccessKey?.trim().length
   ) {
     issues.push({ path: 's3SecretAccessKey', message: 'S3 Secret Access Key is required' })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/AnalyticsBucket.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/AnalyticsBucket.utils.ts
@@ -22,9 +22,13 @@ const ANALYTICS_BUCKET_REQUIRED_FIELDS: AnalyticsBucketValidationIssue[] = [
 ]
 
 export const getAnalyticsBucketValidationIssues = (
-  data: Pick<DestinationPanelSchemaType, AnalyticsBucketFieldPath>
+  data: Pick<DestinationPanelSchemaType, AnalyticsBucketFieldPath>,
+  options: { secretsOptional?: boolean } = {}
 ): AnalyticsBucketValidationIssue[] => {
-  const issues = ANALYTICS_BUCKET_REQUIRED_FIELDS.filter(({ path }) => !data[path]?.trim().length)
+  const requiredFields = options.secretsOptional
+    ? ANALYTICS_BUCKET_REQUIRED_FIELDS.filter(({ path }) => path !== 's3AccessKeyId')
+    : ANALYTICS_BUCKET_REQUIRED_FIELDS
+  const issues = requiredFields.filter(({ path }) => !data[path]?.trim().length)
 
   const isCreatingNewNamespace = data.namespace === CREATE_NEW_NAMESPACE
   const hasValidNamespace =
@@ -39,8 +43,20 @@ export const getAnalyticsBucketValidationIssues = (
     )
   }
 
+  if (
+    options.secretsOptional &&
+    data.s3SecretAccessKey?.trim().length &&
+    !data.s3AccessKeyId?.trim().length
+  ) {
+    issues.push({ path: 's3AccessKeyId', message: 'S3 Access Key ID is required' })
+  }
+
   // Creating a new key generates the secret later, so only require it for existing keys.
-  if (data.s3AccessKeyId !== CREATE_NEW_KEY && !data.s3SecretAccessKey?.trim().length) {
+  if (
+    data.s3AccessKeyId !== CREATE_NEW_KEY &&
+    (!options.secretsOptional || data.s3AccessKeyId?.trim().length) &&
+    !data.s3SecretAccessKey?.trim().length
+  ) {
     issues.push({ path: 's3SecretAccessKey', message: 'S3 Secret Access Key is required' })
   }
 

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/Fields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/AnalyticsBucket/Fields.tsx
@@ -20,7 +20,11 @@ import { Admonition } from 'ui-patterns/admonition'
 import { Input as PasswordInput } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
-import { CREATE_NEW_KEY, CREATE_NEW_NAMESPACE } from '../DestinationForm.constants'
+import {
+  CREATE_NEW_KEY,
+  CREATE_NEW_NAMESPACE,
+  STORED_SECRET_PLACEHOLDER,
+} from '../DestinationForm.constants'
 import type { DestinationPanelSchemaType } from '../DestinationForm.schema'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
@@ -38,12 +42,27 @@ import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
  * Ideal scenario: Just select an access key ID, we then apply the secret access key in the PATCH request, so FE has no
  * context of the secret access key at any point
  */
+const getS3AccessKeyTriggerLabel = ({
+  value,
+  editMode,
+}: {
+  value: string | undefined
+  editMode: boolean
+}) => {
+  if (value === CREATE_NEW_KEY) return 'Create a new key'
+  if (!value) return editMode ? STORED_SECRET_PLACEHOLDER : 'Select an access key ID'
+
+  return value
+}
+
 export const AnalyticsBucketFields = ({
   form,
+  editMode,
   setIsFormInteracting,
   onSelectNewBucket,
 }: {
   form: UseFormReturn<DestinationPanelSchemaType>
+  editMode: boolean
   setIsFormInteracting: (value: boolean) => void
   onSelectNewBucket: () => void
 }) => {
@@ -262,19 +281,23 @@ export const AnalyticsBucketFields = ({
               layout="horizontal"
               label="Catalog Token"
               description={
-                <>
-                  Automatically retrieved from your project's{' '}
-                  <InlineLink href={`/project/${projectRef}/settings/api-keys`}>
-                    service role key
-                  </InlineLink>
-                </>
+                editMode ? (
+                  'Stored catalog token is hidden and kept automatically.'
+                ) : (
+                  <>
+                    Automatically retrieved from your project's{' '}
+                    <InlineLink href={`/project/${projectRef}/settings/api-keys`}>
+                      service role key
+                    </InlineLink>
+                  </>
+                )
               }
             >
               <PasswordInput
                 disabled
                 value={field.value}
                 type={showCatalogToken ? 'text' : 'password'}
-                placeholder="Auto-populated"
+                placeholder={editMode ? STORED_SECRET_PLACEHOLDER : 'Auto-populated'}
                 actions={
                   serviceApiKey ? (
                     <div className="flex items-center justify-center">
@@ -356,11 +379,7 @@ export const AnalyticsBucketFields = ({
                 <FormControl>
                   <Select value={field.value} onValueChange={field.onChange}>
                     <SelectTrigger>
-                      {field.value === CREATE_NEW_KEY
-                        ? 'Create a new key'
-                        : (field.value ?? '').length === 0
-                          ? 'Select an access key ID'
-                          : field.value}
+                      {getS3AccessKeyTriggerLabel({ value: field.value, editMode })}
                     </SelectTrigger>
                     <SelectContent>
                       <SelectGroup>
@@ -392,14 +411,20 @@ export const AnalyticsBucketFields = ({
                 layout="horizontal"
                 label="S3 Secret Access Key"
                 className="relative"
-                description="The secret key corresponding to your selected access key ID."
+                description={
+                  editMode
+                    ? 'Stored secret access key is hidden. Enter a new secret to replace it.'
+                    : 'The secret key corresponding to your selected access key ID.'
+                }
               >
                 <FormControl>
                   <Input
                     {...field}
                     type={showSecretAccessKey ? 'text' : 'password'}
                     value={field.value ?? ''}
-                    placeholder="Provide the secret access key"
+                    placeholder={
+                      editMode ? STORED_SECRET_PLACEHOLDER : 'Provide the secret access key'
+                    }
                   />
                 </FormControl>
                 <Button

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/BigQuery.utils.ts
@@ -14,6 +14,11 @@ const BIGQUERY_REQUIRED_FIELDS: { path: BigQueryFieldPath; message: string }[] =
 ]
 
 export const getBigQueryValidationIssues = (
-  data: Pick<DestinationPanelSchemaType, BigQueryFieldPath>
+  data: Pick<DestinationPanelSchemaType, BigQueryFieldPath>,
+  options: { secretsOptional?: boolean } = {}
 ): BigQueryValidationIssue[] =>
-  BIGQUERY_REQUIRED_FIELDS.filter(({ path }) => !data[path]?.trim().length)
+  BIGQUERY_REQUIRED_FIELDS.filter(({ path }) => {
+    if (options.secretsOptional && path === 'serviceAccountKey') return false
+
+    return !data[path]?.trim().length
+  })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/Fields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/BigQuery/Fields.tsx
@@ -2,9 +2,16 @@ import type { UseFormReturn } from 'react-hook-form'
 import { FormControl, FormField, Input, TextArea } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
+import { STORED_SECRET_PLACEHOLDER } from '../DestinationForm.constants'
 import type { DestinationPanelSchemaType } from '../DestinationForm.schema'
 
-export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
+export const BigQueryFields = ({
+  form,
+  editMode,
+}: {
+  form: UseFormReturn<DestinationPanelSchemaType>
+  editMode: boolean
+}) => {
   return (
     <div className="flex flex-col gap-y-6 p-5">
       <p className="text-sm font-medium text-foreground">BigQuery settings</p>
@@ -48,14 +55,22 @@ export const BigQueryFields = ({ form }: { form: UseFormReturn<DestinationPanelS
             <FormItemLayout
               layout="horizontal"
               label="Service Account Key"
-              description="Service account credentials JSON for authenticating with BigQuery"
+              description={
+                editMode
+                  ? 'Stored credentials are hidden. Enter new credentials to replace them.'
+                  : 'Service account credentials JSON for authenticating with BigQuery'
+              }
             >
               <FormControl>
                 <TextArea
                   {...field}
                   rows={5}
                   maxLength={5000}
-                  placeholder='{"type": "service_account", "project_id": "...", ...}'
+                  placeholder={
+                    editMode
+                      ? STORED_SECRET_PLACEHOLDER
+                      : '{"type": "service_account", "project_id": "...", ...}'
+                  }
                   className="font-mono text-xs"
                 />
               </FormControl>

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.constants.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.constants.ts
@@ -3,3 +3,5 @@ export const CREATE_NEW_KEY = 'create-new'
 
 // Hardcoded value for `namespace` field in the form to indicate creating a new namespace
 export const CREATE_NEW_NAMESPACE = 'create-new-namespace'
+
+export const STORED_SECRET_PLACEHOLDER = '••••••••••••••••'

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
@@ -157,6 +157,42 @@ describe('DestinationForm.utils DuckLake', () => {
     ])
   })
 
+  it('allows omitted DuckLake secrets in edit mode', () => {
+    const issues = getDucklakeValidationIssues(
+      {
+        ducklakeCatalogUrl: '',
+        ducklakeDataPath: 's3://bucket/path',
+        ducklakeS3AccessKeyId: '',
+        ducklakeS3SecretAccessKey: '',
+        ducklakeS3Region: 'eu-west-1',
+        ducklakeS3Endpoint: 's3.example.com',
+        ducklakeMetadataSchema: '',
+      },
+      { secretsOptional: true }
+    )
+
+    expect(issues).toEqual([])
+  })
+
+  it('requires both DuckLake S3 key fields when replacing one secret in edit mode', () => {
+    const issues = getDucklakeValidationIssues(
+      {
+        ducklakeCatalogUrl: '',
+        ducklakeDataPath: 's3://bucket/path',
+        ducklakeS3AccessKeyId: 'access-key',
+        ducklakeS3SecretAccessKey: '',
+        ducklakeS3Region: 'eu-west-1',
+        ducklakeS3Endpoint: 's3.example.com',
+        ducklakeMetadataSchema: '',
+      },
+      { secretsOptional: true }
+    )
+
+    expect(issues).toEqual([
+      { path: 'ducklakeS3SecretAccessKey', message: 'S3 Secret Access Key is required' },
+    ])
+  })
+
   it('treats whitespace-only values as missing', () => {
     const issues = getDucklakeValidationIssues({
       ducklakeCatalogUrl: '   ',
@@ -387,6 +423,21 @@ describe('DestinationForm.utils Snowflake', () => {
       { path: 'snowflakeSchema', message: 'Schema is required' },
     ])
   })
+
+  it('allows an omitted Snowflake private key in edit mode', () => {
+    const issues = getSnowflakeValidationIssues(
+      {
+        snowflakeAccountId: 'MYORG-MYACCOUNT',
+        snowflakeUser: 'PIPELINES_USER',
+        snowflakePrivateKey: '',
+        snowflakeDatabase: 'ANALYTICS',
+        snowflakeSchema: 'PUBLIC',
+      },
+      { secretsOptional: true }
+    )
+
+    expect(issues).toEqual([])
+  })
 })
 
 describe('DestinationForm.utils BigQuery', () => {
@@ -424,6 +475,19 @@ describe('DestinationForm.utils BigQuery', () => {
       datasetId: 'my_dataset',
       serviceAccountKey: '{ "type": "service_account" }',
     })
+
+    expect(issues).toEqual([])
+  })
+
+  it('allows an omitted BigQuery service account key in edit mode', () => {
+    const issues = getBigQueryValidationIssues(
+      {
+        projectId: 'my-project',
+        datasetId: 'my_dataset',
+        serviceAccountKey: '',
+      },
+      { secretsOptional: true }
+    )
 
     expect(issues).toEqual([])
   })
@@ -492,6 +556,40 @@ describe('DestinationForm.utils Analytics Bucket', () => {
     })
 
     expect(issues).toEqual([])
+  })
+
+  it('allows omitted S3 key fields in edit mode', () => {
+    const issues = getAnalyticsBucketValidationIssues(
+      {
+        warehouseName: 'bucket',
+        namespace: 'analytics',
+        newNamespaceName: '',
+        s3Region: 'us-east-1',
+        s3AccessKeyId: '',
+        s3SecretAccessKey: '',
+      },
+      { secretsOptional: true }
+    )
+
+    expect(issues).toEqual([])
+  })
+
+  it('requires an S3 secret when replacing an Analytics Bucket key in edit mode', () => {
+    const issues = getAnalyticsBucketValidationIssues(
+      {
+        warehouseName: 'bucket',
+        namespace: 'analytics',
+        newNamespaceName: '',
+        s3Region: 'us-east-1',
+        s3AccessKeyId: 'key',
+        s3SecretAccessKey: '',
+      },
+      { secretsOptional: true }
+    )
+
+    expect(issues).toEqual([
+      { path: 's3SecretAccessKey', message: 'S3 Secret Access Key is required' },
+    ])
   })
 
   it('returns no issues for a complete configuration', () => {

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DestinationForm.utils.test.ts
@@ -574,6 +574,22 @@ describe('DestinationForm.utils Analytics Bucket', () => {
     expect(issues).toEqual([])
   })
 
+  it('allows an omitted S3 secret for an unchanged Analytics Bucket key in edit mode', () => {
+    const issues = getAnalyticsBucketValidationIssues(
+      {
+        warehouseName: 'bucket',
+        namespace: 'analytics',
+        newNamespaceName: '',
+        s3Region: 'us-east-1',
+        s3AccessKeyId: 'stored-key',
+        s3SecretAccessKey: '',
+      },
+      { secretsOptional: true, storedS3AccessKeyId: 'stored-key' }
+    )
+
+    expect(issues).toEqual([])
+  })
+
   it('requires an S3 secret when replacing an Analytics Bucket key in edit mode', () => {
     const issues = getAnalyticsBucketValidationIssues(
       {
@@ -581,10 +597,10 @@ describe('DestinationForm.utils Analytics Bucket', () => {
         namespace: 'analytics',
         newNamespaceName: '',
         s3Region: 'us-east-1',
-        s3AccessKeyId: 'key',
+        s3AccessKeyId: 'new-key',
         s3SecretAccessKey: '',
       },
-      { secretsOptional: true }
+      { secretsOptional: true, storedS3AccessKeyId: 'stored-key' }
     )
 
     expect(issues).toEqual([

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/DuckLake.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/DuckLake.utils.ts
@@ -2,7 +2,7 @@ import { type DestinationPanelSchemaType } from '../DestinationForm.schema'
 import { DUCKLAKE_MODE_SUPABASE } from './DuckLake.constants'
 
 export type DucklakeApiConfig = {
-  catalog_url: string
+  catalog_url?: string
   data_path: string
   pool_size?: number
   s3_access_key_id?: string
@@ -69,6 +69,12 @@ const DUCKLAKE_CUSTOM_REQUIRED_FIELDS: DucklakeValidationIssue[] = [
   { path: 'ducklakeS3Endpoint', message: 'S3 Endpoint is required' },
 ]
 
+const DUCKLAKE_CUSTOM_SECRET_FIELDS = new Set<DucklakeFieldPath>([
+  'ducklakeCatalogUrl',
+  'ducklakeS3AccessKeyId',
+  'ducklakeS3SecretAccessKey',
+])
+
 // Catalog metadata schema is optional, but must be a valid Postgres identifier when set.
 const METADATA_SCHEMA_PATTERN = /^[A-Za-z0-9_]+$/
 const METADATA_SCHEMA_ISSUE: DucklakeValidationIssue = {
@@ -82,7 +88,8 @@ const getMissingRequiredFieldIssues = (
 ) => requiredFields.filter(({ path }) => !data[path]?.trim().length)
 
 export const getDucklakeValidationIssues = (
-  data: DucklakeValidationData
+  data: DucklakeValidationData,
+  options: { secretsOptional?: boolean } = {}
 ): DucklakeValidationIssue[] => {
   if (data.ducklakeMode === DUCKLAKE_MODE_SUPABASE) {
     const issues = getMissingRequiredFieldIssues(data, DUCKLAKE_SUPABASE_REQUIRED_FIELDS)
@@ -94,7 +101,32 @@ export const getDucklakeValidationIssues = (
     return issues
   }
 
-  const issues = getMissingRequiredFieldIssues(data, DUCKLAKE_CUSTOM_REQUIRED_FIELDS)
+  const requiredFields = options.secretsOptional
+    ? DUCKLAKE_CUSTOM_REQUIRED_FIELDS.filter(({ path }) => !DUCKLAKE_CUSTOM_SECRET_FIELDS.has(path))
+    : DUCKLAKE_CUSTOM_REQUIRED_FIELDS
+  const issues = getMissingRequiredFieldIssues(data, requiredFields)
+
+  if (
+    options.secretsOptional &&
+    data.ducklakeS3SecretAccessKey?.trim().length &&
+    !data.ducklakeS3AccessKeyId?.trim().length
+  ) {
+    issues.push({
+      path: 'ducklakeS3AccessKeyId',
+      message: 'S3 Access Key ID is required',
+    })
+  }
+
+  if (
+    options.secretsOptional &&
+    data.ducklakeS3AccessKeyId?.trim().length &&
+    !data.ducklakeS3SecretAccessKey?.trim().length
+  ) {
+    issues.push({
+      path: 'ducklakeS3SecretAccessKey',
+      message: 'S3 Secret Access Key is required',
+    })
+  }
 
   // Format checks only apply once a value is present; missing values are already flagged above.
   if (

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/Fields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/DuckLake/Fields.tsx
@@ -26,6 +26,7 @@ import { Admonition } from 'ui-patterns/admonition'
 import { Input as PasswordInput } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
+import { STORED_SECRET_PLACEHOLDER } from '../DestinationForm.constants'
 import type { DestinationPanelSchemaType } from '../DestinationForm.schema'
 import {
   DUCKLAKE_MODE_CUSTOM,
@@ -358,7 +359,13 @@ const DuckLakeSupabaseFields = ({ form }: { form: UseFormReturn<DestinationPanel
   )
 }
 
-const DuckLakeCustomFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
+const DuckLakeCustomFields = ({
+  form,
+  editMode,
+}: {
+  form: UseFormReturn<DestinationPanelSchemaType>
+  editMode: boolean
+}) => {
   const [showCatalogUrl, setShowCatalogUrl] = useState(false)
   const [showSecretAccessKey, setShowSecretAccessKey] = useState(false)
 
@@ -379,13 +386,21 @@ const DuckLakeCustomFields = ({ form }: { form: UseFormReturn<DestinationPanelSc
             <FormItemLayout
               layout="horizontal"
               label="Catalog URL"
-              description="A PostgreSQL connection string for the DuckLake catalog"
+              description={
+                editMode
+                  ? 'Stored catalog URL is hidden. Enter a new URL to replace it.'
+                  : 'A PostgreSQL connection string for the DuckLake catalog'
+              }
             >
               <FormControl>
                 <PasswordInput
                   value={field.value ?? ''}
                   type={showCatalogUrl ? 'text' : 'password'}
-                  placeholder="postgres://user:pass@host:5432/ducklake_catalog"
+                  placeholder={
+                    editMode
+                      ? STORED_SECRET_PLACEHOLDER
+                      : 'postgres://user:pass@host:5432/ducklake_catalog'
+                  }
                   onChange={(event) => field.onChange(event.target.value)}
                   actions={
                     <div className="flex items-center justify-center">
@@ -462,10 +477,18 @@ const DuckLakeCustomFields = ({ form }: { form: UseFormReturn<DestinationPanelSc
             <FormItemLayout
               layout="horizontal"
               label="S3 Access Key ID"
-              description="Required access key ID for the object storage provider"
+              description={
+                editMode
+                  ? 'Stored access key ID is hidden. Enter a new key ID to replace it.'
+                  : 'Required access key ID for the object storage provider'
+              }
             >
               <FormControl>
-                <Input {...field} placeholder="my-access-key" value={field.value ?? ''} />
+                <Input
+                  {...field}
+                  placeholder={editMode ? STORED_SECRET_PLACEHOLDER : 'my-access-key'}
+                  value={field.value ?? ''}
+                />
               </FormControl>
             </FormItemLayout>
           )}
@@ -478,14 +501,18 @@ const DuckLakeCustomFields = ({ form }: { form: UseFormReturn<DestinationPanelSc
             <FormItemLayout
               layout="horizontal"
               label="S3 Secret Access Key"
-              description="Required secret access key for the object storage provider"
+              description={
+                editMode
+                  ? 'Stored secret access key is hidden. Enter a new secret to replace it.'
+                  : 'Required secret access key for the object storage provider'
+              }
               className="relative"
             >
               <FormControl>
                 <Input
                   {...field}
                   type={showSecretAccessKey ? 'text' : 'password'}
-                  placeholder="my-secret-key"
+                  placeholder={editMode ? STORED_SECRET_PLACEHOLDER : 'my-secret-key'}
                   value={field.value ?? ''}
                 />
               </FormControl>
@@ -641,7 +668,7 @@ export const DuckLakeFields = ({
       {effectiveMode === DUCKLAKE_MODE_SUPABASE ? (
         <DuckLakeSupabaseFields form={form} />
       ) : (
-        <DuckLakeCustomFields form={form} />
+        <DuckLakeCustomFields form={form} editMode={editMode} />
       )}
     </div>
   )

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/Snowflake/Fields.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/Snowflake/Fields.tsx
@@ -5,9 +5,16 @@ import { Button, FormControl, FormField, Input, TextArea } from 'ui'
 import { Input as PasswordInput } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
+import { STORED_SECRET_PLACEHOLDER } from '../DestinationForm.constants'
 import type { DestinationPanelSchemaType } from '../DestinationForm.schema'
 
-export const SnowflakeFields = ({ form }: { form: UseFormReturn<DestinationPanelSchemaType> }) => {
+export const SnowflakeFields = ({
+  form,
+  editMode,
+}: {
+  form: UseFormReturn<DestinationPanelSchemaType>
+  editMode: boolean
+}) => {
   const [showPrivateKeyPassphrase, setShowPrivateKeyPassphrase] = useState(false)
 
   return (
@@ -118,14 +125,22 @@ export const SnowflakeFields = ({ form }: { form: UseFormReturn<DestinationPanel
             <FormItemLayout
               layout="horizontal"
               label="Private key"
-              description="RSA private key PEM contents in PKCS#8 or PKCS#1 format"
+              description={
+                editMode
+                  ? 'Stored private key is hidden. Enter a new private key to replace it.'
+                  : 'RSA private key PEM contents in PKCS#8 or PKCS#1 format'
+              }
             >
               <FormControl>
                 <TextArea
                   {...field}
                   rows={8}
                   maxLength={10000}
-                  placeholder={'-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----'}
+                  placeholder={
+                    editMode
+                      ? STORED_SECRET_PLACEHOLDER
+                      : '-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----'
+                  }
                   value={field.value ?? ''}
                   className="font-mono text-xs"
                 />
@@ -141,13 +156,17 @@ export const SnowflakeFields = ({ form }: { form: UseFormReturn<DestinationPanel
             <FormItemLayout
               layout="horizontal"
               label="Private key passphrase"
-              description="Optional passphrase for encrypted private keys"
+              description={
+                editMode
+                  ? 'Stored passphrase setting is hidden. Enter a new passphrase to replace it.'
+                  : 'Optional passphrase for encrypted private keys'
+              }
             >
               <FormControl>
                 <PasswordInput
                   value={field.value ?? ''}
                   type={showPrivateKeyPassphrase ? 'text' : 'password'}
-                  placeholder="Optional"
+                  placeholder={editMode ? STORED_SECRET_PLACEHOLDER : 'Optional'}
                   onChange={(event) => field.onChange(event.target.value)}
                   actions={
                     <div className="flex items-center justify-center">

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/Snowflake/Snowflake.utils.ts
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/Snowflake/Snowflake.utils.ts
@@ -31,6 +31,11 @@ const SNOWFLAKE_REQUIRED_FIELDS: { path: SnowflakeFieldPath; message: string }[]
 ]
 
 export const getSnowflakeValidationIssues = (
-  data: Pick<DestinationPanelSchemaType, SnowflakeFieldPath>
+  data: Pick<DestinationPanelSchemaType, SnowflakeFieldPath>,
+  options: { secretsOptional?: boolean } = {}
 ): SnowflakeValidationIssue[] =>
-  SNOWFLAKE_REQUIRED_FIELDS.filter(({ path }) => !data[path]?.trim().length)
+  SNOWFLAKE_REQUIRED_FIELDS.filter(({ path }) => {
+    if (options.secretsOptional && path === 'snowflakePrivateKey') return false
+
+    return !data[path]?.trim().length
+  })

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -163,11 +163,12 @@ export const DestinationForm = ({
             }
           )
         } else if (selectedType === 'Analytics Bucket') {
-          getAnalyticsBucketValidationIssues(data, { secretsOptional: editMode }).forEach(
-            ({ path, message }) => {
-              addRequiredFieldError(path, message)
-            }
-          )
+          getAnalyticsBucketValidationIssues(data, {
+            secretsOptional: editMode,
+            storedS3AccessKeyId: editMode ? defaultValues.s3AccessKeyId : undefined,
+          }).forEach(({ path, message }) => {
+            addRequiredFieldError(path, message)
+          })
         } else if (selectedType === 'DuckLake') {
           getDucklakeValidationIssues(data, { secretsOptional: editMode }).forEach(
             ({ path, message }) => {

--- a/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
+++ b/apps/studio/components/interfaces/Database/Replication/DestinationPanel/DestinationForm/index.tsx
@@ -157,21 +157,29 @@ export const DestinationForm = ({
         }
 
         if (selectedType === 'BigQuery') {
-          getBigQueryValidationIssues(data).forEach(({ path, message }) => {
-            addRequiredFieldError(path, message)
-          })
+          getBigQueryValidationIssues(data, { secretsOptional: editMode }).forEach(
+            ({ path, message }) => {
+              addRequiredFieldError(path, message)
+            }
+          )
         } else if (selectedType === 'Analytics Bucket') {
-          getAnalyticsBucketValidationIssues(data).forEach(({ path, message }) => {
-            addRequiredFieldError(path, message)
-          })
+          getAnalyticsBucketValidationIssues(data, { secretsOptional: editMode }).forEach(
+            ({ path, message }) => {
+              addRequiredFieldError(path, message)
+            }
+          )
         } else if (selectedType === 'DuckLake') {
-          getDucklakeValidationIssues(data).forEach(({ path, message }) => {
-            addRequiredFieldError(path, message)
-          })
+          getDucklakeValidationIssues(data, { secretsOptional: editMode }).forEach(
+            ({ path, message }) => {
+              addRequiredFieldError(path, message)
+            }
+          )
         } else if (selectedType === 'Snowflake') {
-          getSnowflakeValidationIssues(data).forEach(({ path, message }) => {
-            addRequiredFieldError(path, message)
-          })
+          getSnowflakeValidationIssues(data, { secretsOptional: editMode }).forEach(
+            ({ path, message }) => {
+              addRequiredFieldError(path, message)
+            }
+          )
         }
       })
     ),
@@ -319,17 +327,18 @@ export const DestinationForm = ({
               <DialogSectionSeparator />
 
               {selectedType === 'BigQuery' && etlEnableBigQuery ? (
-                <BigQueryFields form={form} />
+                <BigQueryFields form={form} editMode={editMode} />
               ) : selectedType === 'Analytics Bucket' && etlEnableIceberg ? (
                 <AnalyticsBucketFields
                   form={form}
+                  editMode={editMode}
                   setIsFormInteracting={setIsFormInteracting}
                   onSelectNewBucket={() => setNewBucketSheetVisible(true)}
                 />
               ) : selectedType === 'DuckLake' && etlEnableDucklake ? (
                 <DuckLakeFields form={form} editMode={editMode} />
               ) : selectedType === 'Snowflake' && etlEnableSnowflake ? (
-                <SnowflakeFields form={form} />
+                <SnowflakeFields form={form} editMode={editMode} />
               ) : null}
 
               <DialogSectionSeparator />

--- a/apps/studio/data/replication/create-destination-pipeline-mutation.test.ts
+++ b/apps/studio/data/replication/create-destination-pipeline-mutation.test.ts
@@ -78,4 +78,37 @@ describe('buildDucklakeApiConfig', () => {
       },
     })
   })
+
+  it('omits blank custom secret fields when requested', () => {
+    expect(
+      buildDucklakeApiConfig(
+        {
+          catalogUrl: '  ',
+          dataPath: 's3://bucket/path',
+          poolSize: 4,
+          s3AccessKeyId: '',
+          s3SecretAccessKey: '\n',
+          s3Region: 'eu-west-1',
+          s3Endpoint: 's3.example.com',
+          s3UrlStyle: 'path',
+          s3UseSsl: true,
+          metadataSchema: 'ducklake',
+        },
+        { omitBlankSecrets: true }
+      )
+    ).toEqual({
+      ducklake: {
+        catalog_url: undefined,
+        data_path: 's3://bucket/path',
+        pool_size: 4,
+        s3_access_key_id: undefined,
+        s3_secret_access_key: undefined,
+        s3_region: 'eu-west-1',
+        s3_endpoint: 's3.example.com',
+        s3_url_style: 'path',
+        s3_use_ssl: true,
+        metadata_schema: 'ducklake',
+      },
+    })
+  })
 })

--- a/apps/studio/data/replication/create-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/create-destination-pipeline-mutation.ts
@@ -2,6 +2,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { components } from 'api-types'
 import { toast } from 'sonner'
 
+import { optionalSecret } from './destination-secret-utils'
 import { replicationKeys } from './keys'
 import { handleError, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -66,9 +67,20 @@ function isDucklakeSupabaseConfig(
   return 'catalogProjectRef' in config
 }
 
+const maybeOmitBlankSecret = (value: string | undefined, omitBlankSecrets: boolean) => {
+  if (omitBlankSecrets) return optionalSecret(value)
+
+  return value
+}
+
 // Maps the studio-side DuckLake config to the snake_case `{ ducklake: ... }` payload accepted
 // by the platform API. Shared by the create / update / validate mutations.
-export function buildDucklakeApiConfig(config: DucklakeDestinationConfig) {
+export function buildDucklakeApiConfig(
+  config: DucklakeDestinationConfig,
+  options: { omitBlankSecrets?: boolean } = {}
+) {
+  const omitBlankSecrets = options.omitBlankSecrets ?? false
+
   if (isDucklakeSupabaseConfig(config)) {
     return {
       ducklake: {
@@ -92,11 +104,11 @@ export function buildDucklakeApiConfig(config: DucklakeDestinationConfig) {
 
   return {
     ducklake: {
-      catalog_url: config.catalogUrl,
+      catalog_url: maybeOmitBlankSecret(config.catalogUrl, omitBlankSecrets),
       data_path: config.dataPath,
       pool_size: config.poolSize,
-      s3_access_key_id: config.s3AccessKeyId,
-      s3_secret_access_key: config.s3SecretAccessKey,
+      s3_access_key_id: maybeOmitBlankSecret(config.s3AccessKeyId, omitBlankSecrets),
+      s3_secret_access_key: maybeOmitBlankSecret(config.s3SecretAccessKey, omitBlankSecrets),
       s3_region: config.s3Region,
       s3_endpoint: config.s3Endpoint,
       s3_url_style: config.s3UrlStyle,

--- a/apps/studio/data/replication/destination-secret-utils.test.ts
+++ b/apps/studio/data/replication/destination-secret-utils.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+
+import { optionalSecret } from './destination-secret-utils'
+
+describe('optionalSecret', () => {
+  it('omits blank secret values', () => {
+    expect(optionalSecret('')).toBeUndefined()
+    expect(optionalSecret('  ')).toBeUndefined()
+    expect(optionalSecret(undefined)).toBeUndefined()
+  })
+
+  it('omits masked placeholder values even when shortened', () => {
+    expect(optionalSecret('••••••••••••••••')).toBeUndefined()
+    expect(optionalSecret('••••••••')).toBeUndefined()
+    expect(optionalSecret('  ••••••  ')).toBeUndefined()
+  })
+
+  it('keeps provided replacement secrets', () => {
+    expect(optionalSecret('new-secret')).toBe('new-secret')
+  })
+})

--- a/apps/studio/data/replication/destination-secret-utils.ts
+++ b/apps/studio/data/replication/destination-secret-utils.ts
@@ -1,0 +1,11 @@
+const MASKED_SECRET_PLACEHOLDER_PATTERN = /^•+$/
+
+export const optionalSecret = (value: string | undefined) => {
+  const trimmed = value?.trim()
+
+  if (!trimmed || MASKED_SECRET_PLACEHOLDER_PATTERN.test(trimmed)) {
+    return undefined
+  }
+
+  return value
+}

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -28,6 +28,11 @@ export type UpdateDestinationPipelineParams = {
   }
 }
 
+type UpdateDestinationPipelineBody =
+  components['schemas']['UpdateReplicationDestinationPipelineBody']
+type UpdateDestinationConfig = UpdateDestinationPipelineBody['destination_config']
+type UpdatePipelineConfig = UpdateDestinationPipelineBody['pipeline_config']
+
 async function updateDestinationPipeline(
   {
     destinationId: destinationId,
@@ -49,7 +54,7 @@ async function updateDestinationPipeline(
   if (!projectRef) throw new Error('projectRef is required')
 
   // Build destination_config based on the type
-  let destination_config: components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
+  let destination_config: UpdateDestinationConfig
 
   if ('bigQuery' in destinationConfig) {
     const { projectId, datasetId, serviceAccountKey, connectionPoolSize, maxStalenessMins } =
@@ -62,7 +67,7 @@ async function updateDestinationPipeline(
         connection_pool_size: connectionPoolSize,
         max_staleness_mins: maxStalenessMins,
       },
-    } as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
+    } as UpdateDestinationConfig
   } else if ('iceberg' in destinationConfig) {
     const {
       projectRef: icebergProjectRef,
@@ -85,11 +90,11 @@ async function updateDestinationPipeline(
           s3_region: s3Region,
         },
       },
-    } as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
+    } as UpdateDestinationConfig
   } else if ('ducklake' in destinationConfig) {
     destination_config = buildDucklakeApiConfig(destinationConfig.ducklake, {
       omitBlankSecrets: true,
-    }) as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
+    }) as UpdateDestinationConfig
   } else if ('snowflake' in destinationConfig) {
     const { accountId, user, privateKey, privateKeyPassphrase, database, schema, role } =
       destinationConfig.snowflake
@@ -103,7 +108,7 @@ async function updateDestinationPipeline(
         schema,
         role,
       },
-    } as unknown as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
+    } as unknown as UpdateDestinationConfig
   } else {
     throw new Error(
       'Invalid destination config: must specify bigQuery, iceberg, ducklake, or snowflake'
@@ -126,8 +131,7 @@ async function updateDestinationPipeline(
         destination_config,
         source_id: sourceId,
         destination_name: destinationName,
-        pipeline_config:
-          pipeline_config as components['schemas']['UpdateReplicationDestinationPipelineBody']['pipeline_config'],
+        pipeline_config: pipeline_config as UpdatePipelineConfig,
       },
       signal,
     }

--- a/apps/studio/data/replication/update-destination-pipeline-mutation.ts
+++ b/apps/studio/data/replication/update-destination-pipeline-mutation.ts
@@ -7,6 +7,7 @@ import {
   buildDucklakeApiConfig,
   DestinationConfig,
 } from './create-destination-pipeline-mutation'
+import { optionalSecret } from './destination-secret-utils'
 import { replicationKeys } from './keys'
 import { handleError, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomMutationOptions } from '@/types'
@@ -57,7 +58,7 @@ async function updateDestinationPipeline(
       big_query: {
         project_id: projectId,
         dataset_id: datasetId,
-        service_account_key: serviceAccountKey,
+        service_account_key: optionalSecret(serviceAccountKey),
         connection_pool_size: connectionPoolSize,
         max_staleness_mins: maxStalenessMins,
       },
@@ -78,17 +79,17 @@ async function updateDestinationPipeline(
           project_ref: icebergProjectRef,
           warehouse_name: warehouseName,
           namespace: namespace,
-          catalog_token: catalogToken,
-          s3_access_key_id: s3AccessKeyId,
-          s3_secret_access_key: s3SecretAccessKey,
+          catalog_token: optionalSecret(catalogToken),
+          s3_access_key_id: optionalSecret(s3AccessKeyId),
+          s3_secret_access_key: optionalSecret(s3SecretAccessKey),
           s3_region: s3Region,
         },
       },
-    }
+    } as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
   } else if ('ducklake' in destinationConfig) {
-    destination_config = buildDucklakeApiConfig(
-      destinationConfig.ducklake
-    ) as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
+    destination_config = buildDucklakeApiConfig(destinationConfig.ducklake, {
+      omitBlankSecrets: true,
+    }) as components['schemas']['UpdateReplicationDestinationPipelineBody']['destination_config']
   } else if ('snowflake' in destinationConfig) {
     const { accountId, user, privateKey, privateKeyPassphrase, database, schema, role } =
       destinationConfig.snowflake
@@ -96,8 +97,8 @@ async function updateDestinationPipeline(
       snowflake: {
         account_id: accountId,
         user,
-        private_key: privateKey,
-        private_key_passphrase: privateKeyPassphrase,
+        private_key: optionalSecret(privateKey),
+        private_key_passphrase: optionalSecret(privateKeyPassphrase),
         database,
         schema,
         role,


### PR DESCRIPTION
On the pipeline details page, the API currently returns secret values in the response body (example endpoint: `/platform/replication/ddd/pipelines/555`) so the UI can prefill them during edits.

A safer UX is to never send secrets back to the UI and instead support partial updates when secret fields are already stored.

API PR: https://github.com/supabase/platform/pull/34880

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced edit-mode UI for destination credential fields, including consistent masked placeholders and clearer guidance when stored secrets are hidden.
  * Added optional-secret-aware validation behavior for edit flows, reducing unnecessary prompts when secrets are unchanged.

* **Bug Fixes**
  * Improved validation so users can update only part of S3/DuckLake/Snowflake/BigQuery credentials without triggering incorrect “required” errors.
  * Blank or masked secret inputs are now omitted from outgoing requests to avoid overwriting stored credentials.

* **Tests**
  * Expanded unit/integration coverage for edit-mode and optional-secret handling across destinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->