### PR TITLE
fix(account): stop sb marker leaking into email toast

### DIFF
--- a/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
+++ b/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.tsx
@@ -29,6 +29,7 @@ import {
 } from 'ui-patterns/PageSection'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
+import { parseRedirectMessage } from './AccountIdentities.utils'
 import {
   ChangeEmailAddressForm,
   GitHubChangeEmailAddress,
@@ -68,7 +69,7 @@ export const AccountIdentities = () => {
   const [selectedProviderUpdateEmail, setSelectedProviderUpdateEmail] = useState<string>()
   const [linkingProviderId, setLinkingProviderId] = useState<string>()
 
-  const [, message] = router.asPath.split('#message=')
+  const message = parseRedirectMessage(router.asPath)
   const unlinkedExternalProviders = connectableExternalProviders.filter((provider) => {
     return !identities.some(
       (identity) => identity.provider === provider.authProvider || identity.provider === provider.id
@@ -119,7 +120,7 @@ export const AccountIdentities = () => {
   }
 
   useEffect(() => {
-    if (message) toast.success(message.replaceAll('+', ' '))
+    if (message) toast.success(message)
   }, [message])
 
   return (

--- a/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.utils.test.ts
+++ b/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseRedirectMessage } from './AccountIdentities.utils'
+
+describe('parseRedirectMessage', () => {
+  it('drops the trailing sb marker and decodes + as spaces', () => {
+    expect(
+      parseRedirectMessage(
+        '/account/me#message=Confirmation+link+accepted.+Please+proceed+to+confirm+link+sent+to+the+other+email&sb='
+      )
+    ).toBe('Confirmation link accepted. Please proceed to confirm link sent to the other email')
+  })
+
+  it('returns undefined when there is no hash', () => {
+    expect(parseRedirectMessage('/account/me')).toBeUndefined()
+  })
+
+  it('returns undefined when the fragment has no message key', () => {
+    expect(parseRedirectMessage('/account/me#sb=')).toBeUndefined()
+  })
+
+  it('finds message even when it is not the first fragment param', () => {
+    expect(parseRedirectMessage('/account/me#sb=&message=Hi+there')).toBe('Hi there')
+  })
+
+  it('preserves a literal + via percent-encoding', () => {
+    expect(parseRedirectMessage('/account/me#message=a%2Bb&sb=')).toBe('a+b')
+  })
+})

--- a/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.utils.ts
+++ b/apps/studio/components/interfaces/Account/Preferences/AccountIdentities.utils.ts
@@ -1,0 +1,2 @@
+export const parseRedirectMessage = (asPath: string) =>
+  new URLSearchParams(asPath.split('#')[1] ?? '').get('message') ?? undefined


### PR DESCRIPTION
## Summary

The email-change confirmation toast rendered a trailing `&sb=` ("...sent to the other email&sb="). The dashboard parsed the auth-redirect URL fragment with a naive `split('#message=')` that grabbed everything after the key, including the empty `sb` origin marker the auth service appends to every redirect fragment (an intentional, server-side Supabase-Auth identifier so clients can tell a Supabase redirect from a third-party OAuth one). The marker is working as designed; the bug is that the dashboard wasn't parsing the fragment as URL params, so I fixed the parse rather than the marker.

## Changes

- Parse the redirect fragment with `URLSearchParams` via a new `parseRedirectMessage` helper, reading only the `message` key. Any other trailing fragment param (the `sb` marker, or future ones) is now ignored instead of being concatenated into the toast.
- Drop the manual `+`-to-space replacement. `URLSearchParams.get()` already decodes form-encoded values, and the old `.replaceAll('+', ' ')` would have clobbered a legitimately encoded `+`.
- Add unit tests for the helper: marker stripped, no hash, no `message` key, `message` not first, and percent-encoded `+` preserved.

## Testing (Vercel preview)

The toast only reads the URL fragment, so the redirect can be simulated directly. Do not use the real email round-trip on the preview: a real confirm-link click is redirected to prod (the backend sets `redirect_to`), not the preview build.

- [x] On the preview, log in and open the account preferences page with this fragment appended: `/account/me#message=Confirmation+link+accepted.+Please+proceed+to+confirm+link+sent+to+the+other+email&sb=` — toast shows the clean sentence with no `&sb=`.
- [x] Open the same page with no fragment — no toast fires.

## Linear

- fixes GROWTH-938


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how success messages are read after redirect in account identity preferences, so notifications now display the correct text more reliably.
  * Supported messages with spaces and special characters, including cases where the message appears later in the URL fragment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->