### PR TITLE
fix/json-editor-preserve-in-string-commas

### DIFF
--- a/apps/studio/lib/helpers.test.ts
+++ b/apps/studio/lib/helpers.test.ts
@@ -74,6 +74,43 @@ describe('removeJSONTrailingComma', () => {
 
     expect(result).toEqual('{"test":"test"}')
   })
+
+  it('should remove a trailing comma in an array', () => {
+    const result = removeJSONTrailingComma('[1, 2, 3,]')
+
+    expect(result).toEqual('[1, 2, 3]')
+  })
+
+  it('should remove trailing commas separated by whitespace/newlines', () => {
+    const result = removeJSONTrailingComma('{\n  "a": 1,\n}')
+
+    expect(JSON.parse(result)).toEqual({ a: 1 })
+  })
+
+  it('should preserve commas inside string values followed by a bracket', () => {
+    const result = removeJSONTrailingComma('{"pattern": "[a-z,]"}')
+
+    expect(result).toEqual('{"pattern": "[a-z,]"}')
+    expect(JSON.parse(result)).toEqual({ pattern: '[a-z,]' })
+  })
+
+  it('should preserve commas inside string values followed by a brace', () => {
+    const result = removeJSONTrailingComma('{"note": "done,}"}')
+
+    expect(JSON.parse(result)).toEqual({ note: 'done,}' })
+  })
+
+  it('should preserve in-string commas while still removing a real trailing comma', () => {
+    const result = removeJSONTrailingComma('{"a": "1,2,]", "b": 2,}')
+
+    expect(JSON.parse(result)).toEqual({ a: '1,2,]', b: 2 })
+  })
+
+  it('should not be fooled by escaped quotes inside strings', () => {
+    const result = removeJSONTrailingComma('{"a": "he said \\"hi,]\\""}')
+
+    expect(JSON.parse(result)).toEqual({ a: 'he said "hi,]"' })
+  })
 })
 
 describe('timeout', () => {

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -52,10 +52,53 @@ export const prettifyJSON = (minifiedJSON: string) => {
 
 export const removeJSONTrailingComma = (jsonString: string) => {
   /**
-   * Remove trailing commas: Delete any comma immediately preceding the closing brace '}' or
-   * bracket ']' using a regular expression.
+   * Remove *structural* trailing commas: a comma that directly precedes a closing brace '}' or
+   * bracket ']' (ignoring whitespace in between).
+   *
+   * We can't do this with a naive regex such as `/,\s*(?=[\}\]])/g` because it also matches commas
+   * that live inside string values. For example `{"pattern": "[a-z,]"}` would be silently rewritten
+   * to `{"pattern": "[a-z]"}` — still valid JSON, but corrupted data. Instead we scan the string and
+   * only strip commas that are not inside a string literal.
    */
-  return jsonString.replace(/,\s*(?=[\}\]])/g, '')
+  let result = ''
+  let isInsideString = false
+  let isEscaped = false
+
+  for (let i = 0; i < jsonString.length; i++) {
+    const char = jsonString[i]
+
+    if (isInsideString) {
+      result += char
+      if (isEscaped) {
+        isEscaped = false
+      } else if (char === '\\') {
+        isEscaped = true
+      } else if (char === '"') {
+        isInsideString = false
+      }
+      continue
+    }
+
+    if (char === '"') {
+      isInsideString = true
+      result += char
+      continue
+    }
+
+    if (char === ',') {
+      // Look ahead past any whitespace to find the next meaningful character
+      let next = i + 1
+      while (next < jsonString.length && /\s/.test(jsonString[next])) next++
+      if (jsonString[next] === '}' || jsonString[next] === ']') {
+        // Structural trailing comma — drop it
+        continue
+      }
+    }
+
+    result += char
+  }
+
+  return result
 }
 
 export const timeout = (ms: number) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

Fixes: #47474

## What kind of change does this PR introduce?

Bug fix — prevents silent data corruption when saving JSON/JSONB cells in the Table
Editor.

## What is the current behavior?

Related issue: see the linked bug report (JSON cell editor corrupts string values
containing `,]` or `,}`). This is distinct from #17794, which is the feature request that
introduced the helper being fixed here.

To support saving JSON with lenient trailing commas (#17794), Studio strips trailing
commas before validating a JSON value via `removeJSONTrailingComma` in
`apps/studio/lib/helpers.ts`:

```ts
return jsonString.replace(/,\s*(?=[\}\]])/g, '')
```

This regex has no concept of JSON string boundaries, so it also removes commas **inside
string values** when they are followed by `}` or `]`. The output is still valid JSON, so
the corrupted value passes validation and is written to the database with no error shown:

| Entered                 | Saved                  |
| ----------------------- | ---------------------- |
| `{"pattern": "[a-z,]"}` | `{"pattern": "[a-z]"}` |
| `{"note": "done,}"}`    | `{"note": "done}"}`    |
| `{"csv": "1,2,]"}`      | `{"csv": "1,2]"}`      |

The corruption reaches the database through both the inline grid JSON editor
(`components/grid/components/editor/JsonEditor.tsx`) and the side-panel JSON editor
(`components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx`).

## What is the new behavior?

`removeJSONTrailingComma` now does a single linear scan that tracks whether it is inside a
JSON string literal (honoring `\"` escapes) and removes a comma only when it is **not**
inside a string and is directly followed (ignoring whitespace) by `}` or `]`.

- Structural trailing commas are still removed — the original feature is preserved.
- Commas inside string values are left untouched — the corruption is fixed.

## Additional context

- Pure function change: no API, schema, migration, or infrastructure impact.
- Added regression tests in `apps/studio/lib/helpers.test.ts` covering structural removal,
  whitespace/newlines, in-string commas, mixed cases, and escaped quotes.

**Files changed**

- `apps/studio/lib/helpers.ts` — string-aware `removeJSONTrailingComma`.
- `apps/studio/lib/helpers.test.ts` — regression tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JSON cleanup so trailing commas are removed more reliably, including cases with whitespace/newlines and nested arrays or objects.
  * Preserved commas that appear inside string values, including strings with escaped quotes, to avoid corrupting valid JSON content.

* **Tests**
  * Expanded coverage for trailing-comma handling and string edge cases to verify the updated behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->