### PR TITLE
fix(studio): preserve falsy values when copying table editor cells

### DIFF
--- a/apps/studio/components/grid/utils/common.test.ts
+++ b/apps/studio/components/grid/utils/common.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest'
+
+import { formatClipboardValue } from './common'
+
+describe('formatClipboardValue', () => {
+  test('returns empty string for null and undefined', () => {
+    expect(formatClipboardValue(null)).toBe('')
+    expect(formatClipboardValue(undefined)).toBe('')
+  })
+
+  test('preserves falsy primitives', () => {
+    expect(formatClipboardValue(false)).toBe('false')
+    expect(formatClipboardValue(0)).toBe('0')
+    expect(formatClipboardValue('')).toBe('')
+  })
+
+  test('converts truthy primitives to string', () => {
+    expect(formatClipboardValue(true)).toBe('true')
+    expect(formatClipboardValue(42)).toBe('42')
+    expect(formatClipboardValue('hello')).toBe('hello')
+  })
+
+  test('stringifies objects and arrays', () => {
+    expect(formatClipboardValue({ a: 1 })).toBe('{"a":1}')
+    expect(formatClipboardValue([1, 2])).toBe('[1,2]')
+  })
+})

--- a/apps/studio/components/grid/utils/common.ts
+++ b/apps/studio/components/grid/utils/common.ts
@@ -1,5 +1,5 @@
 export function formatClipboardValue(value: unknown) {
-  if (!value) return ''
+  if (value === null || value === undefined) return ''
   if (typeof value === 'object') {
     return JSON.stringify(value)
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

<img width="1448" height="1086" alt="Copying a FALSE or 0 cell pastes nothing, while TRUE pastes true" src="https://github.com/user-attachments/assets/e2ab6632-2a70-4e6f-8d58-1788bc4fe284" />

Copying a Table Editor cell that holds a falsy value copies an empty string instead of the value. A boolean cell showing `FALSE` and an integer cell showing `0` both copy as nothing, while `TRUE` copies as `true`. The "Copied cell value to clipboard" toast still appears, so nothing signals that the copy was empty.

The copy helper `formatClipboardValue` (`apps/studio/components/grid/utils/common.ts`) guards with `if (!value) return ''`. That's meant to catch `null`/`undefined`, but it also catches `false`, `0`, and empty string:

```ts
export function formatClipboardValue(value: unknown) {
  if (!value) return ''
  ...
}
```

Boolean and numeric columns arrive in the grid as real JS `boolean`/`number` values, and the copy paths pass them straight to this helper, so the falsy ones get dropped.

## What is the new behavior?

Only `null`/`undefined` map to an empty string now. `false`, `0`, and empty string are preserved, so copying a `FALSE` cell gives `false` and `0` gives `0`.

The SQL editor results grid already has a `formatClipboardValue` that does this and is covered by tests, so this brings the Table Editor grid in line with it. I added a unit test covering the falsy cases along with the existing behavior.
