### PR TITLE
chore(studio): remove unused ExternalLinkIcon from DatabaseMenu.utils

### DIFF
--- a/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
+++ b/apps/studio/components/layouts/DatabaseLayout/DatabaseMenu.utils.tsx
@@ -1,5 +1,4 @@
 import { useParams } from 'common'
-import { ArrowUpRight } from 'lucide-react'
 
 import { useIsColumnLevelPrivilegesEnabled } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useIsETLPrivateAlpha } from '@/components/interfaces/Database/Replication/useIsETLPrivateAlpha'
@@ -12,8 +11,6 @@ import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { IS_PLATFORM } from '@/lib/constants'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
-
-const ExternalLinkIcon = <ArrowUpRight strokeWidth={1} className="h-4 w-4" />
 
 export const useGenerateDatabaseMenu = (): ProductMenuGroup[] => {
   const { ref } = useParams()


### PR DESCRIPTION
Removes a dead `ExternalLinkIcon` constant and its now-orphaned `ArrowUpRight` import that were breaking the build with a TS6133 (declared but never read) error.

**Removed:**
- `ExternalLinkIcon` constant and the `ArrowUpRight` lucide import (unused)

## To test

- `pnpm typecheck --filter=studio` passes
- Database menu still renders normally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused icon import and a redundant internal constant.
  * No user-facing behavior or menu options changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->