### PR TITLE
fix(studio): show friendly error on infra-monitoring failure in db observability (DEBUG-155)

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -100,10 +100,8 @@ export const DatabaseInfrastructureSection = ({
     [infraData, maxConnectionsData]
   )
 
-  const errorMessage =
-    infraError && typeof infraError === 'object' && 'message' in infraError
-      ? String(infraError.message)
-      : 'Error loading data'
+  // Show a friendly, static message instead of leaking the raw API error to the user
+  const metricErrorState = <span className="text-xs text-foreground-lighter">Unable to load</span>
 
   // Generate database report URL with time range parameters
   const getDatabaseReportUrl = () => {
@@ -175,7 +173,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : connections.max > 0 ? (
                 <MetricCardValue>
                   {connections.peak}/{connections.max}
@@ -196,7 +194,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.disk.current.toFixed(0)}%</MetricCardValue>
               ) : (
@@ -215,7 +213,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.diskIo.current.toFixed(0)}%</MetricCardValue>
               ) : (
@@ -234,7 +232,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.ram.current.toFixed(0)}%</MetricCardValue>
               ) : (
@@ -253,7 +251,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.cpu.current.toFixed(0)}%</MetricCardValue>
               ) : (


### PR DESCRIPTION
## Problem

The Database section of the observability overview page (`/project/[ref]/observability`) rendered the raw infra-monitoring API error message (for example, "duplicate time series") directly inside each metric card. This surfaced internal error text to users when the `/platform/projects/{ref}/infra-monitoring` endpoint returned an error.

## Fix

`DatabaseInfrastructureSection` no longer reads and displays `error.message`. On an infra-monitoring error, each affected metric card now shows a static "Unable to load" message instead of the raw error string.

## How to test

- Open a project's observability overview page (`/project/[ref]/observability`).
- Force the `/platform/projects/{ref}/infra-monitoring` request to fail (for example, block it in devtools or point at a project that returns the duplicate time series error).
- Expected result: the Peak Connections, Disk Usage, Disk IO, Memory, and CPU cards show "Unable to load" rather than the raw API error message.