### PR TITLE
Add edge log type with service filters

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
@@ -17,6 +17,7 @@ import {
 export const REGIONS = ['ams', 'fra', 'gru', 'hkg', 'iad', 'syd'] as const
 export const METHODS = ['GET', 'POST', 'PUT', 'DELETE', 'OPTIONS'] as const
 export const LOG_TYPES_LABELS = {
+  edge: 'API Gateway',
   postgres: 'Postgres',
   postgrest: 'PostgREST',
   auth: 'Auth',
@@ -29,7 +30,7 @@ export const LOG_TYPES_LABELS = {
 
 type LogType = keyof typeof LOG_TYPES_LABELS
 export const LOG_TYPES = Object.keys(LOG_TYPES_LABELS) as [LogType, ...LogType[]]
-export const DEFAULT_LOG_TYPES = ['postgres', 'postgrest'] as const
+export const DEFAULT_LOG_TYPES = ['postgres', 'edge'] as const
 
 const parseAsSort = createParser({
   parse(queryValue: string) {
@@ -72,6 +73,9 @@ export const SEARCH_PARAMS_PARSER = {
 
   // View options
   show_connection_logs: parseAsBoolean.withDefault(true),
+  edge_auth: parseAsBoolean.withDefault(true),
+  edge_storage: parseAsBoolean.withDefault(true),
+  edge_postgrest: parseAsBoolean.withDefault(true),
 }
 
 const POSTGRES_STATUS_CODE_LABELS = {

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.fields.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.fields.tsx
@@ -28,7 +28,15 @@ export const filterFields = [
       options:
         // [Joshen] Nested options are treated as just boolean toggles atm for simplicity
         // Refer to DataTableFilterCheckbox for their logic
-        value === 'postgres' ? [{ label: 'Connection logs', value: 'show_connection_logs' }] : [],
+        value === 'edge'
+          ? [
+              { label: 'Auth', value: 'edge_auth' },
+              { label: 'Storage', value: 'edge_storage' },
+              { label: 'Postgrest', value: 'edge_postgrest' },
+            ]
+          : value === 'postgres'
+            ? [{ label: 'Connection logs', value: 'show_connection_logs' }]
+            : [],
     })),
     component: (props: Option) => {
       return (

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -17,31 +17,28 @@ const withFilters = (...entries: string[]) => ({ ...baseSearch, filter: entries 
 
 describe('UnifiedLogs.queries (OTEL flat)', () => {
   describe('getUnifiedLogsQuery', () => {
-    it('defaults to postgres + postgrest log types when none specified', () => {
+    it('defaults to postgres + edge log types when none specified', () => {
       const sql = getUnifiedLogsQuery(baseSearch)
       const where = sql.split(/\bWHERE\b/)[1] ?? ''
       expect(where).toContain(`source = 'postgres_logs'`)
-      // postgrest = postgrest_logs OR edge_logs with /rest/ path
-      expect(where).toContain(`source = 'postgrest_logs'`)
-      expect(where).toContain(`log_attributes['request.path'] LIKE '%/rest/%'`)
+      expect(where).toContain(`source = 'edge_logs'`)
+      expect(where).not.toContain(`source = 'postgrest_logs'`)
     })
 
-    it('routes the `postgrest` log type to postgrest_logs or edge_logs /rest/', () => {
+    it('routes the `postgrest` log type solely to postgrest_logs (mutually exclusive from edge_logs)', () => {
       const sql = getUnifiedLogsQuery(withFilters('log_type:eq:postgrest'))
       const where = sql.split(/\bWHERE\b/)[1] ?? ''
       expect(where).toContain(`source = 'postgrest_logs'`)
-      expect(where).toContain(
-        `source = 'edge_logs' AND log_attributes['request.path'] LIKE '%/rest/%'`
-      )
+      expect(where).not.toContain(`source = 'edge_logs'`)
+      expect(where).not.toContain(`log_attributes['request.path'] LIKE '%/rest/%'`)
     })
 
-    it('routes the `storage` log type to storage_logs or edge_logs /storage/', () => {
+    it('routes the `storage` log type solely to storage_logs (mutually exclusive from edge_logs)', () => {
       const sql = getUnifiedLogsQuery(withFilters('log_type:eq:storage'))
       const where = sql.split(/\bWHERE\b/)[1] ?? ''
       expect(where).toContain(`source = 'storage_logs'`)
-      expect(where).toContain(
-        `source = 'edge_logs' AND log_attributes['request.path'] LIKE '%/storage/%'`
-      )
+      expect(where).not.toContain(`source = 'edge_logs'`)
+      expect(where).not.toContain(`log_attributes['request.path'] LIKE '%/storage/%'`)
     })
 
     it('escapes single quotes in filter values to prevent SQL injection', () => {
@@ -127,6 +124,44 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(sql).not.toContain("event_message NOT LIKE 'connection received%'")
     })
 
+    it.each([
+      ['edge_auth', '%/auth/%'],
+      ['edge_storage', '%/storage/%'],
+      ['edge_postgrest', '%/rest/%'],
+    ] as const)(
+      'excludes %s-pathed requests from edge_logs when %s=false',
+      (key, pathFilter) => {
+        const sql = getUnifiedLogsQuery({ ...baseSearch, [key]: false } as any)
+        expect(sql).toContain("source != 'edge_logs'")
+        expect(sql).toContain(
+          `log_attributes['request.path'] NOT LIKE '${pathFilter}'`
+        )
+      }
+    )
+
+    it('does not filter edge_logs by service path by default (all edge_* toggles true)', () => {
+      const sql = getUnifiedLogsQuery(baseSearch)
+      expect(sql).not.toContain("log_attributes['request.path'] NOT LIKE '%/auth/%'")
+      expect(sql).not.toContain("log_attributes['request.path'] NOT LIKE '%/storage/%'")
+      expect(sql).not.toContain("log_attributes['request.path'] NOT LIKE '%/rest/%'")
+    })
+
+    it('leaves dedicated auth_logs/storage_logs/postgrest_logs rows untouched by the edge_* toggles', () => {
+      // These toggles only hide traffic nested inside the `edge_logs` (API
+      // Gateway) source — the dedicated sources are separate log types now
+      // that log types are mutually exclusive, so they shouldn't be scoped by
+      // a `source != 'edge_logs' OR ...` guard meant for gateway rows.
+      const sql = getUnifiedLogsQuery({
+        ...baseSearch,
+        edge_auth: false,
+        edge_storage: false,
+        edge_postgrest: false,
+      } as any)
+      expect(sql).toContain("(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/auth/%')")
+      expect(sql).toContain("(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/storage/%')")
+      expect(sql).toContain("(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/rest/%')")
+    })
+
     it('does not emit subqueries or CTEs (rejected by the OTEL endpoint)', () => {
       const sql = getUnifiedLogsQuery(baseSearch)
       expect(sql).not.toMatch(/WITH\s+\w+\s+AS\s*\(/i)
@@ -163,7 +198,8 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       const sql = getLogsCountQuery(withFilters('log_type:eq:storage'))
       // Assert on the WHERE only: value expressions mention other sources inline.
       const totalWhere = whereOfBranchContaining(sql, `'all'`)
-      expect(totalWhere).toContain(`source = 'edge_logs'`)
+      expect(totalWhere).toContain(`source = 'storage_logs'`)
+      expect(totalWhere).not.toContain(`source = 'edge_logs'`)
       expect(totalWhere).not.toContain(`source = 'postgres_logs'`)
     })
 
@@ -179,6 +215,15 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(scans.length).toBeGreaterThan(1)
       for (const scan of scans) {
         expect(scan).toContain("event_message NOT LIKE 'connection received%'")
+      }
+    })
+
+    it('applies the edge_* service filters to every count scan so badges match the list', () => {
+      const sql = getLogsCountQuery({ ...baseSearch, edge_postgrest: false } as any)
+      const scans = sql.split(/\bUNION ALL\b/)
+      expect(scans.length).toBeGreaterThan(1)
+      for (const scan of scans) {
+        expect(scan).toContain("log_attributes['request.path'] NOT LIKE '%/rest/%'")
       }
     })
   })

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -128,16 +128,11 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       ['edge_auth', '%/auth/%'],
       ['edge_storage', '%/storage/%'],
       ['edge_postgrest', '%/rest/%'],
-    ] as const)(
-      'excludes %s-pathed requests from edge_logs when %s=false',
-      (key, pathFilter) => {
-        const sql = getUnifiedLogsQuery({ ...baseSearch, [key]: false } as any)
-        expect(sql).toContain("source != 'edge_logs'")
-        expect(sql).toContain(
-          `log_attributes['request.path'] NOT LIKE '${pathFilter}'`
-        )
-      }
-    )
+    ] as const)('excludes %s-pathed requests from edge_logs when %s=false', (key, pathFilter) => {
+      const sql = getUnifiedLogsQuery({ ...baseSearch, [key]: false } as any)
+      expect(sql).toContain("source != 'edge_logs'")
+      expect(sql).toContain(`log_attributes['request.path'] NOT LIKE '${pathFilter}'`)
+    })
 
     it('does not filter edge_logs by service path by default (all edge_* toggles true)', () => {
       const sql = getUnifiedLogsQuery(baseSearch)
@@ -157,9 +152,15 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
         edge_storage: false,
         edge_postgrest: false,
       } as any)
-      expect(sql).toContain("(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/auth/%')")
-      expect(sql).toContain("(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/storage/%')")
-      expect(sql).toContain("(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/rest/%')")
+      expect(sql).toContain(
+        "(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/auth/%')"
+      )
+      expect(sql).toContain(
+        "(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/storage/%')"
+      )
+      expect(sql).toContain(
+        "(source != 'edge_logs' OR log_attributes['request.path'] NOT LIKE '%/rest/%')"
+      )
     })
 
     it('does not emit subqueries or CTEs (rejected by the OTEL endpoint)', () => {

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -304,12 +304,11 @@ const buildBaseWhere = (
 // (API Gateway) row was routed to. Mirrors the convention already used by
 // the sibling Logs Explorer (Logs.constants.ts / Logs.utils.otel.ts) and by
 // ServiceFlow.sql.ts within this same feature.
-const EDGE_SERVICE_PATH_FILTER: Record<'edge_auth' | 'edge_storage' | 'edge_postgrest', string> =
-  {
-    edge_auth: '%/auth/%',
-    edge_storage: '%/storage/%',
-    edge_postgrest: '%/rest/%',
-  }
+const EDGE_SERVICE_PATH_FILTER: Record<'edge_auth' | 'edge_storage' | 'edge_postgrest', string> = {
+  edge_auth: '%/auth/%',
+  edge_storage: '%/storage/%',
+  edge_postgrest: '%/rest/%',
+}
 
 /**
  * Returns view-option WHERE conditions — toggles from the filter sidebar that

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -55,9 +55,9 @@ const HTTP_STATUS_EXPR: SafeLogSqlFragment = safeSql`if(source = 'auth_logs', lo
  * logs; the UI surfaces gateway HTTP traffic for those buckets.
  */
 const LOG_TYPE_CONDITION: Record<string, SafeLogSqlFragment> = {
-  edge: safeSql`source = 'edge_logs' AND ${ATTR.path} NOT LIKE '%/rest/%' AND ${ATTR.path} NOT LIKE '%/storage/%'`,
-  postgrest: safeSql`source = 'postgrest_logs' OR (source = 'edge_logs' AND ${ATTR.path} LIKE '%/rest/%')`,
-  storage: safeSql`source = 'storage_logs' OR (source = 'edge_logs' AND ${ATTR.path} LIKE '%/storage/%')`,
+  edge: safeSql`source = 'edge_logs'`,
+  postgrest: safeSql`source = 'postgrest_logs'`,
+  storage: safeSql`source = 'storage_logs'`,
   postgres: safeSql`source = 'postgres_logs'`,
   'edge function': safeSql`source = 'function_edge_logs'`,
   auth: safeSql`source = 'auth_logs'`,
@@ -67,11 +67,11 @@ const LOG_TYPE_CONDITION: Record<string, SafeLogSqlFragment> = {
 }
 
 // Derived `log_type` column for SELECT / GROUP BY / countIf use.
+// WHEN source = 'edge_logs' AND ${ATTR.path} LIKE '%/rest/%' THEN 'postgrest'
+// WHEN source = 'edge_logs' AND ${ATTR.path} LIKE '%/storage/%' THEN 'storage'
 const LOG_TYPE_EXPR: SafeLogSqlFragment = safeSql`CASE
       WHEN source = 'postgrest_logs' THEN 'postgrest'
-      WHEN source = 'edge_logs' AND ${ATTR.path} LIKE '%/rest/%' THEN 'postgrest'
       WHEN source = 'storage_logs' THEN 'storage'
-      WHEN source = 'edge_logs' AND ${ATTR.path} LIKE '%/storage/%' THEN 'storage'
       WHEN source = 'edge_logs' THEN 'edge'
       WHEN source = 'postgres_logs' THEN 'postgres'
       WHEN source = 'function_edge_logs' THEN 'edge function'
@@ -294,26 +294,55 @@ const buildBaseWhere = (
     }
   }
 
-  const connFilter = connectionLogsFilter(search)
-  if (connFilter) parts.push(connFilter)
+  const searchParamsFilter = applySearchParamsFilter(search)
+  if (searchParamsFilter) parts.push(searchParamsFilter)
 
   return parts
 }
 
+// Path substrings that identify which downstream service an `edge_logs`
+// (API Gateway) row was routed to. Mirrors the convention already used by
+// the sibling Logs Explorer (Logs.constants.ts / Logs.utils.otel.ts) and by
+// ServiceFlow.sql.ts within this same feature.
+const EDGE_SERVICE_PATH_FILTER: Record<'edge_auth' | 'edge_storage' | 'edge_postgrest', string> =
+  {
+    edge_auth: '%/auth/%',
+    edge_storage: '%/storage/%',
+    edge_postgrest: '%/rest/%',
+  }
+
 /**
- * Returns a WHERE condition that excludes Postgres connection lifecycle messages.
- * Shared by every query via `buildBaseWhere`, so the row list, chart and sidebar
- * facet counts all hide connection logs together (otherwise the badges over-count
- * by the connection rows the list hides).
+ * Returns view-option WHERE conditions — toggles from the filter sidebar that
+ * hide a subset of rows without being a `filter` URL param (Postgres
+ * connection lifecycle messages, and per-service traffic nested inside the
+ * API Gateway `edge_logs` source). Shared by every query via `buildBaseWhere`,
+ * so the row list, chart and sidebar facet counts stay in sync (otherwise the
+ * badges over-count by the rows the list hides).
  */
-const connectionLogsFilter = (search: QuerySearchParamsType): SafeLogSqlFragment | null => {
+const applySearchParamsFilter = (search: QuerySearchParamsType): SafeLogSqlFragment | null => {
+  const conditions: SafeLogSqlFragment[] = []
+
   // Visible by default — only an explicit `false` hides connection logs.
-  if (search.show_connection_logs !== false) return null
-  return safeSql`(source != 'postgres_logs' OR (
-    event_message NOT LIKE 'connection received%' AND
-    event_message NOT LIKE 'connection authenticated%' AND
-    event_message NOT LIKE 'connection authorized%'
-  ))`
+  if (search.show_connection_logs === false) {
+    conditions.push(safeSql`(source != 'postgres_logs' OR (
+      event_message NOT LIKE 'connection received%' AND
+      event_message NOT LIKE 'connection authenticated%' AND
+      event_message NOT LIKE 'connection authorized%'
+    ))`)
+  }
+
+  // Visible by default — only an explicit `false` hides that service's
+  // requests within the API Gateway log type.
+  for (const key of ['edge_auth', 'edge_storage', 'edge_postgrest'] as const) {
+    if (search[key] === false) {
+      conditions.push(
+        safeSql`(source != 'edge_logs' OR ${ATTR.path} NOT LIKE ${lit(EDGE_SERVICE_PATH_FILTER[key])})`
+      )
+    }
+  }
+
+  if (conditions.length === 0) return null
+  return safeSql`(${joinSqlFragments(conditions, ' AND ')})`
 }
 
 /**

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
@@ -111,7 +111,7 @@ export function DataTableFilterCheckbox<TData>({
                   />
                   <Label
                     htmlFor={`${value}-${option.value}`}
-                    className="flex w-full items-center justify-between gap-2 text-foreground/70 group-hover:text-accent-foreground text-[0.8rem] min-w-0"
+                    className="relative flex w-full items-center justify-between gap-2 text-foreground/70 group-hover:text-accent-foreground text-[0.8rem] min-w-0"
                   >
                     <div className="flex-1 min-w-0 overflow-hidden">
                       {Component ? (
@@ -126,7 +126,11 @@ export function DataTableFilterCheckbox<TData>({
                         aria-label={isExpanded ? 'Collapse' : 'Expand'}
                         aria-expanded={isExpanded}
                         onClick={() => toggleExpanded(optionKey)}
-                        className="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-foreground-lighter hover:bg-selection hover:text-foreground mr-2.5"
+                        className={cn(
+                          'flex h-4 w-4 shrink-0 items-center justify-center rounded-sm text-foreground-lighter',
+                          'hover:bg-selection hover:text-foreground',
+                          'absolute top-0 right-10'
+                        )}
                       >
                         {isExpanded ? <Minus size={12} /> : <Plus size={12} />}
                       </button>
@@ -148,15 +152,17 @@ export function DataTableFilterCheckbox<TData>({
                         'rounded-md ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                       )}
                     >
-                      <span className="px-2">only</span>
+                      <span className="pr-2">only</span>
                     </button>
                   </Label>
                 </div>
+
                 {hasNested &&
                   isExpanded &&
                   option.options?.map((optionNested, nestedIndex) => {
                     const nestedChecked = getBooleanParam(optionNested.value)
                     const isLastNested = nestedIndex === (option.options?.length ?? 0) - 1
+
                     return (
                       <div
                         key={optionNested.value}

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3335,6 +3335,7 @@ export interface UnifiedLogsRowClickedEvent {
      * reaching the table; anything else is rejected upstream so the union here is exhaustive.
      */
     logType:
+      | 'edge'
       | 'postgres'
       | 'postgrest'
       | 'auth'


### PR DESCRIPTION
## Context

Couple of changes to the Unified Logs logic, mainly to align unified logs filters with legacy logs behaviour

## Changes involved
- Postgrest + Storage logs will no longer overlap with edge logs source
  - They will specifically just pull logs from their own sources only
  - This will match legacy logs behaviour + also the observability overview behaviour as well
- Re-introduce "API Gateway" as a log type (was there in the old UI)
  - Added service filters for convenience
  <img width="271" height="233" alt="image" src="https://github.com/user-attachments/assets/6264b7c5-e3e8-4db8-a378-4d8c46af3d62" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **API Gateway** (“Edge”) logs to Unified Logs, including new sub-filters for auth, storage, and postgrest activity.
  * Updated the default log selection to include API Gateway logs.
* **Bug Fixes**
  * Improved how log types are bucketed and filtered, ensuring edge, postgrest, and storage sources display under the correct views and toggles.
  * Refined “connection logs” filtering so results and counts remain consistent with the selected options.
* **Style**
  * Refined the Unified Logs filter checkbox layout and nested expand/collapse controls.
* **Tests**
  * Updated and expanded query tests to cover the new edge filter behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->