### PR TITLE
fix(studio): show friendly error on infra-monitoring failure in db observability (DEBUG-155)

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -19,7 +19,6 @@ import { useInfraMonitoringAttributesQuery } from '@/data/analytics/infra-monito
 import { useMaxConnectionsQuery } from '@/data/database/max-connections-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
-// A single metric tile: a linked card with a labelled header and a value slot
 const MetricLinkCard = ({
   href,
   linkTooltip,

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -100,10 +100,8 @@ export const DatabaseInfrastructureSection = ({
     [infraData, maxConnectionsData]
   )
 
-  const errorMessage =
-    infraError && typeof infraError === 'object' && 'message' in infraError
-      ? String(infraError.message)
-      : 'Error loading data'
+  // Show a friendly, static message instead of leaking the raw API error to the user
+  const metricErrorState = <span className="text-xs text-foreground-lighter">Unable to load</span>
 
   // Generate database report URL with time range parameters
   const getDatabaseReportUrl = () => {
@@ -175,7 +173,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : connections.max > 0 ? (
                 <MetricCardValue>
                   {connections.peak}/{connections.max}
@@ -196,7 +194,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.disk.current.toFixed(0)}%</MetricCardValue>
               ) : (
@@ -215,7 +213,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.diskIo.current.toFixed(0)}%</MetricCardValue>
               ) : (
@@ -234,7 +232,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.ram.current.toFixed(0)}%</MetricCardValue>
               ) : (
@@ -253,7 +251,7 @@ export const DatabaseInfrastructureSection = ({
             </MetricCardHeader>
             <MetricCardContent>
               {infraError ? (
-                <div className="text-xs text-destructive wrap-break-word">{errorMessage}</div>
+                metricErrorState
               ) : metrics ? (
                 <MetricCardValue>{metrics.cpu.current.toFixed(0)}%</MetricCardValue>
               ) : (

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -14,6 +14,7 @@ import {
   parseConnectionsData,
   parseInfrastructureMetrics,
 } from './DatabaseInfrastructureSection.utils'
+import { InlineLink } from '@/components/ui/InlineLink'
 import { useInfraMonitoringAttributesQuery } from '@/data/analytics/infra-monitoring-query'
 import { useMaxConnectionsQuery } from '@/data/database/max-connections-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -100,9 +101,6 @@ export const DatabaseInfrastructureSection = ({
     [infraData, maxConnectionsData]
   )
 
-  // Show a friendly, static message instead of leaking the raw API error to the user
-  const metricErrorState = <span className="text-xs text-foreground-lighter">Unable to load</span>
-
   // Generate database report URL with time range parameters
   const getDatabaseReportUrl = () => {
     const now = dayjs()
@@ -164,102 +162,103 @@ export const DatabaseInfrastructureSection = ({
           </MetricCard>
         </Link>
 
-        <Link href={databaseReportUrl} className="block group">
-          <MetricCard isLoading={infraLoading}>
-            <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-              <MetricCardLabel tooltip="Highest concurrent database connections observed in the selected window, against the connection limit. Monitor to avoid connection exhaustion.">
-                Peak Connections
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              {infraError ? (
-                metricErrorState
-              ) : connections.max > 0 ? (
-                <MetricCardValue>
-                  {connections.peak}/{connections.max}
-                </MetricCardValue>
-              ) : (
-                <MetricCardValue>--</MetricCardValue>
-              )}
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+        {infraError ? (
+          <div className="col-span-2 flex items-center rounded-md border border-dashed px-4 py-3">
+            <p className="text-sm text-foreground-light">
+              Unable to load. Please try again in a few minutes. If the problem persists please check
+              our <InlineLink href="https://status.supabase.com">status page</InlineLink>.
+            </p>
+          </div>
+        ) : (
+          <>
+            <Link href={databaseReportUrl} className="block group">
+              <MetricCard isLoading={infraLoading}>
+                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
+                  <MetricCardLabel tooltip="Highest concurrent database connections observed in the selected window, against the connection limit. Monitor to avoid connection exhaustion.">
+                    Peak Connections
+                  </MetricCardLabel>
+                </MetricCardHeader>
+                <MetricCardContent>
+                  {connections.max > 0 ? (
+                    <MetricCardValue>
+                      {connections.peak}/{connections.max}
+                    </MetricCardValue>
+                  ) : (
+                    <MetricCardValue>--</MetricCardValue>
+                  )}
+                </MetricCardContent>
+              </MetricCard>
+            </Link>
 
-        <Link href={databaseReportUrl} className="block group">
-          <MetricCard isLoading={infraLoading}>
-            <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-              <MetricCardLabel tooltip="Disk usage percentage of total disk space used">
-                Disk Usage
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              {infraError ? (
-                metricErrorState
-              ) : metrics ? (
-                <MetricCardValue>{metrics.disk.current.toFixed(0)}%</MetricCardValue>
-              ) : (
-                <MetricCardValue>--</MetricCardValue>
-              )}
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+            <Link href={databaseReportUrl} className="block group">
+              <MetricCard isLoading={infraLoading}>
+                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
+                  <MetricCardLabel tooltip="Disk usage percentage of total disk space used">
+                    Disk Usage
+                  </MetricCardLabel>
+                </MetricCardHeader>
+                <MetricCardContent>
+                  {metrics ? (
+                    <MetricCardValue>{metrics.disk.current.toFixed(0)}%</MetricCardValue>
+                  ) : (
+                    <MetricCardValue>--</MetricCardValue>
+                  )}
+                </MetricCardContent>
+              </MetricCard>
+            </Link>
 
-        <Link href={databaseReportUrl} className="block group">
-          <MetricCard isLoading={infraLoading}>
-            <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-              <MetricCardLabel tooltip="Disk I/O consumption percentage. High values may indicate disk bottlenecks">
-                Disk IO
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              {infraError ? (
-                metricErrorState
-              ) : metrics ? (
-                <MetricCardValue>{metrics.diskIo.current.toFixed(0)}%</MetricCardValue>
-              ) : (
-                <MetricCardValue>--</MetricCardValue>
-              )}
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+            <Link href={databaseReportUrl} className="block group">
+              <MetricCard isLoading={infraLoading}>
+                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
+                  <MetricCardLabel tooltip="Disk I/O consumption percentage. High values may indicate disk bottlenecks">
+                    Disk IO
+                  </MetricCardLabel>
+                </MetricCardHeader>
+                <MetricCardContent>
+                  {metrics ? (
+                    <MetricCardValue>{metrics.diskIo.current.toFixed(0)}%</MetricCardValue>
+                  ) : (
+                    <MetricCardValue>--</MetricCardValue>
+                  )}
+                </MetricCardContent>
+              </MetricCard>
+            </Link>
 
-        <Link href={databaseReportUrl} className="block group">
-          <MetricCard isLoading={infraLoading}>
-            <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-              <MetricCardLabel tooltip="RAM usage percentage. Sustained high usage may indicate memory pressure">
-                Memory
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              {infraError ? (
-                metricErrorState
-              ) : metrics ? (
-                <MetricCardValue>{metrics.ram.current.toFixed(0)}%</MetricCardValue>
-              ) : (
-                <MetricCardValue>--</MetricCardValue>
-              )}
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+            <Link href={databaseReportUrl} className="block group">
+              <MetricCard isLoading={infraLoading}>
+                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
+                  <MetricCardLabel tooltip="RAM usage percentage. Sustained high usage may indicate memory pressure">
+                    Memory
+                  </MetricCardLabel>
+                </MetricCardHeader>
+                <MetricCardContent>
+                  {metrics ? (
+                    <MetricCardValue>{metrics.ram.current.toFixed(0)}%</MetricCardValue>
+                  ) : (
+                    <MetricCardValue>--</MetricCardValue>
+                  )}
+                </MetricCardContent>
+              </MetricCard>
+            </Link>
 
-        <Link href={databaseReportUrl} className="block group">
-          <MetricCard isLoading={infraLoading}>
-            <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-              <MetricCardLabel tooltip="CPU usage percentage. High values may suggest CPU-intensive queries or workloads">
-                CPU
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              {infraError ? (
-                metricErrorState
-              ) : metrics ? (
-                <MetricCardValue>{metrics.cpu.current.toFixed(0)}%</MetricCardValue>
-              ) : (
-                <MetricCardValue>--</MetricCardValue>
-              )}
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+            <Link href={databaseReportUrl} className="block group">
+              <MetricCard isLoading={infraLoading}>
+                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
+                  <MetricCardLabel tooltip="CPU usage percentage. High values may suggest CPU-intensive queries or workloads">
+                    CPU
+                  </MetricCardLabel>
+                </MetricCardHeader>
+                <MetricCardContent>
+                  {metrics ? (
+                    <MetricCardValue>{metrics.cpu.current.toFixed(0)}%</MetricCardValue>
+                  ) : (
+                    <MetricCardValue>--</MetricCardValue>
+                  )}
+                </MetricCardContent>
+              </MetricCard>
+            </Link>
+          </>
+        )}
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -1,7 +1,7 @@
 import { useParams } from 'common'
 import dayjs from 'dayjs'
 import Link from 'next/link'
-import { useMemo } from 'react'
+import { useMemo, type ReactNode } from 'react'
 import {
   MetricCard,
   MetricCardContent,
@@ -18,6 +18,32 @@ import { InlineLink } from '@/components/ui/InlineLink'
 import { useInfraMonitoringAttributesQuery } from '@/data/analytics/infra-monitoring-query'
 import { useMaxConnectionsQuery } from '@/data/database/max-connections-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+
+// A single metric tile: a linked card with a labelled header and a value slot
+const MetricLinkCard = ({
+  href,
+  linkTooltip,
+  label,
+  labelTooltip,
+  isLoading,
+  children,
+}: {
+  href: string
+  linkTooltip: string
+  label: string
+  labelTooltip: string
+  isLoading?: boolean
+  children: ReactNode
+}) => (
+  <Link href={href} className="block group">
+    <MetricCard isLoading={isLoading}>
+      <MetricCardHeader href={href} linkTooltip={linkTooltip}>
+        <MetricCardLabel tooltip={labelTooltip}>{label}</MetricCardLabel>
+      </MetricCardHeader>
+      <MetricCardContent>{children}</MetricCardContent>
+    </MetricCard>
+  </Link>
+)
 
 type DatabaseInfrastructureSectionProps = {
   interval: '1hr' | '1day' | '7day'
@@ -138,29 +164,47 @@ export const DatabaseInfrastructureSection = ({
 
   const databaseReportUrl = getDatabaseReportUrl()
 
+  const slowQueriesUrl = `/project/${projectRef}/observability/query-performance?totalTimeFilter=${encodeURIComponent(
+    JSON.stringify({ operator: '>', value: 1000 })
+  )}`
+
+  const infraMetrics = [
+    {
+      label: 'Disk Usage',
+      tooltip: 'Disk usage percentage of total disk space used',
+      value: metrics?.disk.current,
+    },
+    {
+      label: 'Disk IO',
+      tooltip: 'Disk I/O consumption percentage. High values may indicate disk bottlenecks',
+      value: metrics?.diskIo.current,
+    },
+    {
+      label: 'Memory',
+      tooltip: 'RAM usage percentage. Sustained high usage may indicate memory pressure',
+      value: metrics?.ram.current,
+    },
+    {
+      label: 'CPU',
+      tooltip: 'CPU usage percentage. High values may suggest CPU-intensive queries or workloads',
+      value: metrics?.cpu.current,
+    },
+  ]
+
   return (
     <div>
       <h2 className="mb-4">Database</h2>
       {/* First row: Metrics */}
       <div className="grid grid-cols-3 gap-2">
-        <Link
-          href={`/project/${projectRef}/observability/query-performance?totalTimeFilter=${encodeURIComponent(JSON.stringify({ operator: '>', value: 1000 }))}`}
-          className="block group"
+        <MetricLinkCard
+          href={slowQueriesUrl}
+          linkTooltip="Go to query performance"
+          label="Slow Queries"
+          labelTooltip="Queries with total execution time (execution time + planning time) greater than 1000ms. High values may indicate query optimization opportunities"
+          isLoading={slowQueriesLoading}
         >
-          <MetricCard isLoading={slowQueriesLoading}>
-            <MetricCardHeader
-              href={`/project/${projectRef}/observability/query-performance?totalTimeFilter=${encodeURIComponent(JSON.stringify({ operator: '>', value: 1000 }))}`}
-              linkTooltip="Go to query performance"
-            >
-              <MetricCardLabel tooltip="Queries with total execution time (execution time + planning time) greater than 1000ms. High values may indicate query optimization opportunities">
-                Slow Queries
-              </MetricCardLabel>
-            </MetricCardHeader>
-            <MetricCardContent>
-              <MetricCardValue>{slowQueriesCount}</MetricCardValue>
-            </MetricCardContent>
-          </MetricCard>
-        </Link>
+          <MetricCardValue>{slowQueriesCount}</MetricCardValue>
+        </MetricLinkCard>
 
         {infraError ? (
           <div className="col-span-2 flex items-center rounded-md border border-dashed px-4 py-3">
@@ -171,92 +215,32 @@ export const DatabaseInfrastructureSection = ({
           </div>
         ) : (
           <>
-            <Link href={databaseReportUrl} className="block group">
-              <MetricCard isLoading={infraLoading}>
-                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-                  <MetricCardLabel tooltip="Highest concurrent database connections observed in the selected window, against the connection limit. Monitor to avoid connection exhaustion.">
-                    Peak Connections
-                  </MetricCardLabel>
-                </MetricCardHeader>
-                <MetricCardContent>
-                  {connections.max > 0 ? (
-                    <MetricCardValue>
-                      {connections.peak}/{connections.max}
-                    </MetricCardValue>
-                  ) : (
-                    <MetricCardValue>--</MetricCardValue>
-                  )}
-                </MetricCardContent>
-              </MetricCard>
-            </Link>
+            <MetricLinkCard
+              href={databaseReportUrl}
+              linkTooltip="Go to database report"
+              label="Peak Connections"
+              labelTooltip="Highest concurrent database connections observed in the selected window, against the connection limit. Monitor to avoid connection exhaustion."
+              isLoading={infraLoading}
+            >
+              <MetricCardValue>
+                {connections.max > 0 ? `${connections.peak}/${connections.max}` : '--'}
+              </MetricCardValue>
+            </MetricLinkCard>
 
-            <Link href={databaseReportUrl} className="block group">
-              <MetricCard isLoading={infraLoading}>
-                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-                  <MetricCardLabel tooltip="Disk usage percentage of total disk space used">
-                    Disk Usage
-                  </MetricCardLabel>
-                </MetricCardHeader>
-                <MetricCardContent>
-                  {metrics ? (
-                    <MetricCardValue>{metrics.disk.current.toFixed(0)}%</MetricCardValue>
-                  ) : (
-                    <MetricCardValue>--</MetricCardValue>
-                  )}
-                </MetricCardContent>
-              </MetricCard>
-            </Link>
-
-            <Link href={databaseReportUrl} className="block group">
-              <MetricCard isLoading={infraLoading}>
-                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-                  <MetricCardLabel tooltip="Disk I/O consumption percentage. High values may indicate disk bottlenecks">
-                    Disk IO
-                  </MetricCardLabel>
-                </MetricCardHeader>
-                <MetricCardContent>
-                  {metrics ? (
-                    <MetricCardValue>{metrics.diskIo.current.toFixed(0)}%</MetricCardValue>
-                  ) : (
-                    <MetricCardValue>--</MetricCardValue>
-                  )}
-                </MetricCardContent>
-              </MetricCard>
-            </Link>
-
-            <Link href={databaseReportUrl} className="block group">
-              <MetricCard isLoading={infraLoading}>
-                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-                  <MetricCardLabel tooltip="RAM usage percentage. Sustained high usage may indicate memory pressure">
-                    Memory
-                  </MetricCardLabel>
-                </MetricCardHeader>
-                <MetricCardContent>
-                  {metrics ? (
-                    <MetricCardValue>{metrics.ram.current.toFixed(0)}%</MetricCardValue>
-                  ) : (
-                    <MetricCardValue>--</MetricCardValue>
-                  )}
-                </MetricCardContent>
-              </MetricCard>
-            </Link>
-
-            <Link href={databaseReportUrl} className="block group">
-              <MetricCard isLoading={infraLoading}>
-                <MetricCardHeader href={databaseReportUrl} linkTooltip="Go to database report">
-                  <MetricCardLabel tooltip="CPU usage percentage. High values may suggest CPU-intensive queries or workloads">
-                    CPU
-                  </MetricCardLabel>
-                </MetricCardHeader>
-                <MetricCardContent>
-                  {metrics ? (
-                    <MetricCardValue>{metrics.cpu.current.toFixed(0)}%</MetricCardValue>
-                  ) : (
-                    <MetricCardValue>--</MetricCardValue>
-                  )}
-                </MetricCardContent>
-              </MetricCard>
-            </Link>
+            {infraMetrics.map((metric) => (
+              <MetricLinkCard
+                key={metric.label}
+                href={databaseReportUrl}
+                linkTooltip="Go to database report"
+                label={metric.label}
+                labelTooltip={metric.tooltip}
+                isLoading={infraLoading}
+              >
+                <MetricCardValue>
+                  {metric.value !== undefined ? `${metric.value.toFixed(0)}%` : '--'}
+                </MetricCardValue>
+              </MetricLinkCard>
+            ))}
           </>
         )}
       </div>

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.tsx
@@ -209,8 +209,8 @@ export const DatabaseInfrastructureSection = ({
         {infraError ? (
           <div className="col-span-2 flex items-center rounded-md border border-dashed px-4 py-3">
             <p className="text-sm text-foreground-light">
-              Unable to load. Please try again in a few minutes. If the problem persists please check
-              our <InlineLink href="https://status.supabase.com">status page</InlineLink>.
+              Unable to load. Please try again in a few minutes. If the problem persists please
+              check our <InlineLink href="https://status.supabase.com">status page</InlineLink>.
             </p>
           </div>
         ) : (


### PR DESCRIPTION
## Problem

The Database section of the observability overview page (`/project/[ref]/observability`) rendered the raw infra-monitoring API error message (for example, "duplicate time series") directly inside each metric card. This surfaced internal error text to users when the `/platform/projects/{ref}/infra-monitoring` endpoint returned an error.

## Fix
<img width="2132" height="1122" alt="CleanShot 2026-07-06 at 11 14 53@2x" src="https://github.com/user-attachments/assets/cdfd0755-dce4-45df-9c1d-45a078cd35bb" />

`DatabaseInfrastructureSection` no longer reads and displays `error.message`. On an infra-monitoring error, each affected metric card now shows a static "Unable to load" message instead of the raw error string.

## How to test

- Open a project's observability overview page (`/project/[ref]/observability`).
- Force the `/platform/projects/{ref}/infra-monitoring` request to fail (for example, block it in devtools or point at a project that returns the duplicate time series error).
- Expected result: the Peak Connections, Disk Usage, Disk IO, Memory, and CPU cards show "Unable to load" rather than the raw API error message.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized database infrastructure error messaging across all infrastructure metric tiles.
  * If infrastructure data fails to load, the UI now displays a single consistent “Unable to load…” message with a status page link (instead of per-tile destructive errors).
  * Kept “Slow Queries” loading/count behavior separate from infrastructure errors.
* **Refactor**
  * Streamlined infrastructure metric tiles using shared, linkable card rendering.
  * Improved metric value formatting (percent-style for infrastructure metrics; “--” when unavailable).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->