### PR TITLE
chore: `docs` tabs migration

### DIFF
--- a/apps/docs/features/ui/Tabs.tsx
+++ b/apps/docs/features/ui/Tabs.tsx
@@ -1,15 +1,15 @@
 'use client'
 
-import { useCallback, type ComponentPropsWithoutRef, type PropsWithChildren } from 'react'
-import { Tabs as TabsPrimitive, type TabsProps } from 'ui'
-import { withQueryParams, withSticky, type QueryParamsProps } from 'ui-patterns/ComplexTabs'
 import { useTocRerenderTrigger } from '~/features/docs/GuidesMdx.state'
+import { useCallback, type ComponentPropsWithoutRef, type PropsWithChildren } from 'react'
+import { DocsTabs } from 'ui'
+import { withQueryParams, withSticky, type QueryParamsProps } from 'ui-patterns/ComplexTabs'
 
-const TabsWithStickyAndQueryParams = withSticky<PropsWithChildren<TabsProps & QueryParamsProps>>(
-  withQueryParams(TabsPrimitive)
-)
+const TabsWithStickyAndQueryParams = withSticky<
+  PropsWithChildren<DocsTabs.TabsProps & QueryParamsProps>
+>(withQueryParams(DocsTabs.Tabs))
 
-const TabPanel = TabsPrimitive.Panel
+const TabPanel = DocsTabs.Tabs.Panel
 const Tabs = ({
   onChange,
   stickyTabList,

--- a/packages/ui-patterns/src/ComplexTabs/withQueryParams.tsx
+++ b/packages/ui-patterns/src/ComplexTabs/withQueryParams.tsx
@@ -3,7 +3,7 @@
 import { useSearchParamsShallow } from 'common'
 import { xor } from 'lodash'
 import { Children, isValidElement, useEffect, useRef, type FC, type PropsWithChildren } from 'react'
-import { type TabsProps } from 'ui'
+import { type DocsTabs } from 'ui'
 
 const isString = (maybeStr: unknown): maybeStr is string => typeof maybeStr === 'string'
 
@@ -18,7 +18,7 @@ interface QueryParamsProps {
  * selection state in query params.
  */
 const withQueryParams =
-  <Props extends PropsWithChildren<TabsProps>>(
+  <Props extends PropsWithChildren<DocsTabs.TabsProps>>(
     Component: FC<Omit<Props, 'children' | 'queryGroup' | 'onClick'>>
   ) =>
   ({

--- a/packages/ui-patterns/src/SqlToRest/sql-to-rest.tsx
+++ b/packages/ui-patterns/src/SqlToRest/sql-to-rest.tsx
@@ -28,19 +28,7 @@ import {
 } from 'react'
 import Markdown from 'react-markdown'
 import { format } from 'sql-formatter'
-import {
-  Alert,
-  Button,
-  ButtonProps,
-  cn,
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-  Tabs_Shadcn_ as Tabs,
-  TabsContent_Shadcn_ as TabsContent,
-  TabsList_Shadcn_ as TabsList,
-  TabsTrigger_Shadcn_ as TabsTrigger,
-} from 'ui'
+import { Alert, cn, Collapsible, CollapsibleContent, CollapsibleTrigger, DocsTabs } from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import { assumptions } from './assumptions'
@@ -367,23 +355,8 @@ export default function SqlToRest({
         )}
       >
         <div className="font-medium">Choose language to translate to</div>
-        <Tabs
-          value={currentLanguage}
-          onValueChange={(id: string) => setCurrentLanguage(id)}
-          className="mb-4"
-        >
-          <TabsList className="w-full gap-1 border-0">
-            <TabsTrigger value="curl" asChild>
-              <TabsButton active={currentLanguage === 'curl'}>cURL</TabsButton>
-            </TabsTrigger>
-            <TabsTrigger value="http" asChild>
-              <TabsButton active={currentLanguage === 'http'}>HTTP</TabsButton>
-            </TabsTrigger>
-            <TabsTrigger value="js" asChild>
-              <TabsButton active={currentLanguage === 'js'}>JavaScript</TabsButton>
-            </TabsTrigger>
-          </TabsList>
-          <TabsContent value="curl" className="flex flex-col gap-4">
+        <DocsTabs.Tabs activeId={currentLanguage} onChange={(id: string) => setCurrentLanguage(id)}>
+          <DocsTabs.Tabs.Panel id="curl" label="cURL" className="flex flex-col gap-4">
             {httpRenderError && <Alert className="text-red-900">{httpRenderError.message}</Alert>}
             <CodeBlock
               language="curl"
@@ -396,8 +369,8 @@ export default function SqlToRest({
             >
               {curlCommand}
             </CodeBlock>
-          </TabsContent>
-          <TabsContent value="http" className="flex flex-col gap-4">
+          </DocsTabs.Tabs.Panel>
+          <DocsTabs.Tabs.Panel id="http" label="HTTP" className="flex flex-col gap-4">
             {httpRenderError && <Alert className="text-red-900">{httpRenderError.message}</Alert>}
             <CodeBlock
               language="http"
@@ -410,8 +383,8 @@ export default function SqlToRest({
             >
               {rawHttp}
             </CodeBlock>
-          </TabsContent>
-          <TabsContent value="js" className="flex flex-col gap-4">
+          </DocsTabs.Tabs.Panel>
+          <DocsTabs.Tabs.Panel id="js" label="JavaScript" className="flex flex-col gap-4">
             {supabaseJsRenderError && (
               <Alert className="text-red-900">{supabaseJsRenderError.message}</Alert>
             )}
@@ -426,8 +399,8 @@ export default function SqlToRest({
             >
               {jsCommand}
             </CodeBlock>
-          </TabsContent>
-        </Tabs>
+          </DocsTabs.Tabs.Panel>
+        </DocsTabs.Tabs>
         <div
           className={cn(
             'flex flex-col gap-4',
@@ -512,14 +485,3 @@ function getTheme(isDarkMode: boolean): editor.IStandaloneThemeData {
     colors: { 'editor.background': isDarkMode ? '#1f1f1f' : '#f0f0f0' },
   }
 }
-
-const TabsButton = ({ active, className, ...props }: { active: boolean } & ButtonProps) => (
-  <Button
-    size="tiny"
-    variant={active ? 'default' : 'outline'}
-    className={cn({
-      'text-muted hover:text-foreground': !active,
-    })}
-    {...props}
-  />
-)

--- a/packages/ui-patterns/src/SqlToRest/sql-to-rest.tsx
+++ b/packages/ui-patterns/src/SqlToRest/sql-to-rest.tsx
@@ -28,7 +28,19 @@ import {
 } from 'react'
 import Markdown from 'react-markdown'
 import { format } from 'sql-formatter'
-import { Alert, cn, Collapsible, CollapsibleContent, CollapsibleTrigger, Tabs } from 'ui'
+import {
+  Alert,
+  Button,
+  ButtonProps,
+  cn,
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  Tabs_Shadcn_ as Tabs,
+  TabsContent_Shadcn_ as TabsContent,
+  TabsList_Shadcn_ as TabsList,
+  TabsTrigger_Shadcn_ as TabsTrigger,
+} from 'ui'
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 
 import { assumptions } from './assumptions'
@@ -355,8 +367,23 @@ export default function SqlToRest({
         )}
       >
         <div className="font-medium">Choose language to translate to</div>
-        <Tabs activeId={currentLanguage} onChange={(id: string) => setCurrentLanguage(id)}>
-          <Tabs.Panel id="curl" label="cURL" className="flex flex-col gap-4">
+        <Tabs
+          value={currentLanguage}
+          onValueChange={(id: string) => setCurrentLanguage(id)}
+          className="mb-4"
+        >
+          <TabsList className="w-full gap-1 border-0">
+            <TabsTrigger value="curl" asChild>
+              <TabsButton active={currentLanguage === 'curl'}>cURL</TabsButton>
+            </TabsTrigger>
+            <TabsTrigger value="http" asChild>
+              <TabsButton active={currentLanguage === 'http'}>HTTP</TabsButton>
+            </TabsTrigger>
+            <TabsTrigger value="js" asChild>
+              <TabsButton active={currentLanguage === 'js'}>JavaScript</TabsButton>
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="curl" className="flex flex-col gap-4">
             {httpRenderError && <Alert className="text-red-900">{httpRenderError.message}</Alert>}
             <CodeBlock
               language="curl"
@@ -369,8 +396,8 @@ export default function SqlToRest({
             >
               {curlCommand}
             </CodeBlock>
-          </Tabs.Panel>
-          <Tabs.Panel id="http" label="HTTP" className="flex flex-col gap-4">
+          </TabsContent>
+          <TabsContent value="http" className="flex flex-col gap-4">
             {httpRenderError && <Alert className="text-red-900">{httpRenderError.message}</Alert>}
             <CodeBlock
               language="http"
@@ -383,8 +410,8 @@ export default function SqlToRest({
             >
               {rawHttp}
             </CodeBlock>
-          </Tabs.Panel>
-          <Tabs.Panel id="js" label="JavaScript" className="flex flex-col gap-4">
+          </TabsContent>
+          <TabsContent value="js" className="flex flex-col gap-4">
             {supabaseJsRenderError && (
               <Alert className="text-red-900">{supabaseJsRenderError.message}</Alert>
             )}
@@ -399,7 +426,7 @@ export default function SqlToRest({
             >
               {jsCommand}
             </CodeBlock>
-          </Tabs.Panel>
+          </TabsContent>
         </Tabs>
         <div
           className={cn(
@@ -485,3 +512,14 @@ function getTheme(isDarkMode: boolean): editor.IStandaloneThemeData {
     colors: { 'editor.background': isDarkMode ? '#1f1f1f' : '#f0f0f0' },
   }
 }
+
+const TabsButton = ({ active, className, ...props }: { active: boolean } & ButtonProps) => (
+  <Button
+    size="tiny"
+    variant={active ? 'default' : 'outline'}
+    className={cn({
+      'text-muted hover:text-foreground': !active,
+    })}
+    {...props}
+  />
+)

--- a/packages/ui/index.tsx
+++ b/packages/ui/index.tsx
@@ -5,7 +5,7 @@ export * from './src/components/Icon/IconBackground'
 
 // DISPLAYS
 
-export * from './src/components/Tabs'
+export * as DocsTabs from './src/components/Tabs'
 
 // NAV
 


### PR DESCRIPTION
## Problem

The `Tabs` component is deprecated but is still used in `docs`. Migrating to the new one is hard and risky because it supported many features that are not in the new Shadcn tabs:

1. Many variants but only `pills` (tab switchers look like buttons) and `underlined` (match the shadcn look) are still used. The shadcn Tabs doesn't have variants, only underlined.
2. Additional logic to link the active tab to search params.
3. Additional logic to make the tab headers sticky
4. A scrollable prop which is not supported in shadcn either. I don't think it has any effect though as I've not found any page with more than 4 tabs.
5. Even more props that don't seem to be used

It's risky to create a new component as it's hard to really ensure we didn't break anything.

## Solution

Until we figure out a good solution, rename the deprecated `Tabs` to `DocsTabs`. This will allow us to remove the `_Shadcn_` suffix from everywhere else.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized tab components across the docs and UI patterns.
  * Updated the SQL-to-REST language selector and sticky/query-parameter tabs to use the same tab system.
  * Preserved existing tab behavior while keeping the interface consistent for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->