### PR TITLE
fix(pg-meta): exclude extension-owned tables from rls_disabled_in_public lint

### DIFF
--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -724,10 +724,16 @@ from
     pg_catalog.pg_class c
     join pg_catalog.pg_namespace n
         on c.relnamespace = n.oid
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
 where
     c.relkind = 'r' -- regular tables
     -- RLS is disabled
     and not c.relrowsecurity
+    -- exclude tables owned by an extension (e.g. PostGIS spatial_ref_sys);
+    -- users cannot enable RLS on them as they do not own the table
+    and dep.objid is null
     and (
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')

--- a/packages/pg-meta/test/sql/studio/lints.test.ts
+++ b/packages/pg-meta/test/sql/studio/lints.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { enrichLintsQuery, safeSql } from '../../../src'
+import { getLintsSQL } from '../../../src/sql/studio/advisor/lints'
 
 describe('enrichLintsQuery', () => {
   const dummyQuery = safeSql`SELECT 1`
@@ -23,5 +24,28 @@ describe('enrichLintsQuery', () => {
   it('should always include the query', () => {
     const result = enrichLintsQuery(dummyQuery)
     expect(result).toContain(dummyQuery)
+  })
+})
+
+describe('getLintsSQL rls_disabled_in_public', () => {
+  const sql = getLintsSQL({ docsUrl: 'https://supabase.com/docs' })
+
+  // Isolate the rls_disabled_in_public lint block so the assertions below
+  // cannot be satisfied by pg_depend joins belonging to other lints.
+  const rlsLint = (() => {
+    const start = sql.indexOf("'rls_disabled_in_public' as name")
+    expect(start).toBeGreaterThan(-1)
+    const end = sql.indexOf('union all', start)
+    return sql.slice(start, end === -1 ? undefined : end)
+  })()
+
+  it('excludes extension-owned tables via a pg_depend join', () => {
+    expect(rlsLint).toContain('left join pg_catalog.pg_depend dep')
+    expect(rlsLint).toContain("and dep.deptype = 'e'")
+    expect(rlsLint).toContain('and dep.objid is null')
+  })
+
+  it('still flags user tables with RLS disabled', () => {
+    expect(rlsLint).toContain('and not c.relrowsecurity')
   })
 })


### PR DESCRIPTION
The `rls_disabled_in_public` (0013) advisor lint flags extension-managed tables such as PostGIS's `public.spatial_ref_sys` as "RLS Disabled in Public". Users cannot act on it — they do not own the table, so `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` fails with `must be owner of table`. The result is an unactionable critical warning in the dashboard.

This adds the same `pg_depend` `deptype = 'e'` left-join already used by the other lints in this file (e.g. `unused_index`, `function_search_path_mutable`) and filters `dep.objid is null`, so tables owned by an extension are excluded. No hardcoded PostGIS allowlist, so it stays correct as extensions change.

Verified against Postgres with an extension-owned table alongside a normal user table: before the change both are returned, after it only the user table is — extension tables are dropped while genuine unprotected tables are still flagged.

Fixes #47206


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the “RLS disabled in public” lint to ignore tables owned by extensions, reducing false-positive findings.
  * The lint output now more accurately targets user-managed regular tables where RLS is disabled.
* **Tests**
  * Added/updated coverage to verify the lint SQL excludes extension-owned tables while still flagging applicable user tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->