### PR TITLE
refactor(studio): extract useSnippetEditor from MonacoEditor

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -65,6 +65,13 @@ export const MonacoEditor = ({
 
   const { snippet, disableEdit, handleEditorChange } = useSnippetEditor({ id, snippetName })
 
+  // The Monaco save action is registered once on mount, but `snippet` starts
+  // undefined for a new/deep-linked snippet and is only created on first edit.
+  // Read it through a ref so Cmd/Ctrl+S sees the latest value, not the stale
+  // mount-time closure.
+  const snippetRef = useRef(snippet)
+  snippetRef.current = snippet
+
   const executeExplainQueryRef = useRef(executeExplainQuery)
   executeExplainQueryRef.current = executeExplainQuery
 
@@ -128,7 +135,8 @@ export const MonacoEditor = ({
       contextMenuGroupId: 'operation',
       contextMenuOrder: 0,
       run: () => {
-        if (snippet) requestSaveRef.current(snippet.snippet.id)
+        const currentSnippet = snippetRef.current
+        if (currentSnippet) requestSaveRef.current(currentSnippet.snippet.id)
       },
     })
 

--- a/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/MonacoEditor.tsx
@@ -1,28 +1,20 @@
 import { Monaco, OnMount } from '@monaco-editor/react'
-import { useDebounce } from '@uidotdev/usehooks'
-import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { LOCAL_STORAGE_KEYS } from 'common'
 import { noop } from 'lodash'
-import { useRouter } from 'next/router'
-import { RefObject, useEffect, useRef, useState } from 'react'
+import { RefObject, useRef } from 'react'
 import { Admonition } from 'ui-patterns/admonition'
 
 import type { IStandaloneCodeEditor } from './SQLEditor.types'
-import { createSqlSnippetSkeletonV2 } from './SQLEditor.utils'
+import { useSnippetEditor } from './useSnippetEditor'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { getEditorSelectionParts } from '@/components/ui/AIEditor/utils'
 import { CodeEditor } from '@/components/ui/CodeEditor/CodeEditor'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
-import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
-import { useProfile } from '@/lib/profile'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useIsShortcutEnabled } from '@/state/shortcuts/useIsShortcutEnabled'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
-import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
-import { wasNeverPersisted } from '@/state/sql-editor/sql-editor-lifecycle'
-import { canEditSnippet } from '@/state/sql-editor/sql-editor-rules'
 import { useSqlEditorSaveCoordinator } from '@/state/sql-editor/sql-editor-save-coordinator'
-import { useTabsStateSnapshot } from '@/state/tabs'
 
 export type MonacoEditorProps = {
   id: string
@@ -63,13 +55,6 @@ export const MonacoEditor = ({
   onPrompt,
   onMount,
 }: MonacoEditorProps) => {
-  const router = useRouter()
-  const { profile } = useProfile()
-  const { ref, content } = useParams()
-  const { data: project } = useSelectedProjectQuery()
-
-  const snapV2 = useSqlEditorV2StateSnapshot()
-  const tabsSnap = useTabsStateSnapshot()
   const aiSnap = useAiAssistantStateSnapshot()
   const { openSidebar, toggleSidebar } = useSidebarManagerSnapshot()
 
@@ -78,11 +63,7 @@ export const MonacoEditor = ({
     true
   )
 
-  const [value, setValue] = useState('')
-  const debouncedValue = useDebounce(value, 1000)
-
-  const snippet = snapV2.snippets[id]
-  const disableEdit = !!snippet && !canEditSnippet(snippet.snippet, profile?.id)
+  const { snippet, disableEdit, handleEditorChange } = useSnippetEditor({ id, snippetName })
 
   const executeExplainQueryRef = useRef(executeExplainQuery)
   executeExplainQueryRef.current = executeExplainQuery
@@ -214,46 +195,6 @@ export const MonacoEditor = ({
 
     onMount?.(editor)
   }
-
-  function handleEditorChange(value: string | undefined) {
-    tabsSnap.makeActiveTabPermanent()
-    if (id && value) {
-      if (!snippet && ref && profile !== undefined && project !== undefined) {
-        const snippet = createSqlSnippetSkeletonV2({
-          idOverride: id,
-          name: snippetName,
-          sql: value,
-          owner_id: profile?.id,
-          project_id: project?.id,
-        })
-        snapV2.addSnippet({ projectRef: ref, snippet })
-        // When the editor was seeded from a `content` deep-link, replace rather
-        // than push. The caller navigated to `/sql/new?content=...` (a long,
-        // one-shot URL); replacing collapses it out of history so Back returns to
-        // the originating page instead of a wasted step that re-seeds the snippet.
-        if (router.query.content !== undefined) {
-          router.replace(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
-        } else {
-          router.push(`/project/${ref}/sql/${snippet.id}`, undefined, { shallow: true })
-        }
-      }
-      setValue(value)
-    }
-  }
-
-  useEffect(() => {
-    if (debouncedValue.length > 0 && snippet) {
-      const shouldInvalidate = wasNeverPersisted(snippet.snippet.status)
-      snapV2.setSql({ id, sql: value, shouldInvalidate })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedValue])
-
-  // if an SQL query is passed by the content parameter, set the editor value to its content. This
-  // is usually used for sending the user to SQL editor from other pages with SQL.
-  useEffect(() => {
-    if (content && content.length > 0) handleEditorChange(content)
-  }, [])
 
   return (
     <>

--- a/apps/studio/components/interfaces/SQLEditor/useSnippetEditor.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useSnippetEditor.ts
@@ -1,0 +1,84 @@
+import { useDebounce } from '@uidotdev/usehooks'
+import { useParams } from 'common'
+import { useRouter } from 'next/router'
+import { useEffect, useEffectEvent, useState } from 'react'
+
+import { createSqlSnippetSkeletonV2 } from './SQLEditor.utils'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useProfile } from '@/lib/profile'
+import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor-v2'
+import { wasNeverPersisted } from '@/state/sql-editor/sql-editor-lifecycle'
+import { canEditSnippet } from '@/state/sql-editor/sql-editor-rules'
+import { useTabsStateSnapshot } from '@/state/tabs'
+
+/**
+ * Owns the editing lifecycle of a single SQL snippet: tracking the editor text,
+ * creating the snippet in the store on first edit (and routing to its URL),
+ * persisting debounced changes via `setSql`, and seeding the editor from a
+ * `?content=` deep link.
+ *
+ * Extracted from `MonacoEditor` so that component stays a thin editor shell.
+ */
+export function useSnippetEditor({ id, snippetName }: { id: string; snippetName: string }) {
+  const router = useRouter()
+  const { profile } = useProfile()
+  const { ref, content } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+
+  const snapV2 = useSqlEditorV2StateSnapshot()
+  const tabsSnap = useTabsStateSnapshot()
+
+  const [value, setValue] = useState('')
+  const debouncedValue = useDebounce(value, 1000)
+
+  const snippet = snapV2.snippets[id]
+  const disableEdit = !!snippet && !canEditSnippet(snippet.snippet, profile?.id)
+
+  function handleEditorChange(value: string | undefined) {
+    tabsSnap.makeActiveTabPermanent()
+    if (!id || !value) return
+
+    if (!snippet && ref && profile !== undefined && project !== undefined) {
+      const newSnippet = createSqlSnippetSkeletonV2({
+        idOverride: id,
+        name: snippetName,
+        sql: value,
+        owner_id: profile?.id,
+        project_id: project?.id,
+      })
+      snapV2.addSnippet({ projectRef: ref, snippet: newSnippet })
+      // When the editor was seeded from a `content` deep-link, replace rather
+      // than push. The caller navigated to `/sql/new?content=...` (a long,
+      // one-shot URL); replacing collapses it out of history so Back returns to
+      // the originating page instead of a wasted step that re-seeds the snippet.
+      if (router.query.content !== undefined) {
+        router.replace(`/project/${ref}/sql/${newSnippet.id}`, undefined, { shallow: true })
+      } else {
+        router.push(`/project/${ref}/sql/${newSnippet.id}`, undefined, { shallow: true })
+      }
+    }
+    setValue(value)
+  }
+
+  useEffect(() => {
+    if (debouncedValue.length > 0 && snippet) {
+      const shouldInvalidate = wasNeverPersisted(snippet.snippet.status)
+      snapV2.setSql({ id, sql: value, shouldInvalidate })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedValue])
+
+  // if an SQL query is passed by the content parameter, set the editor value to its content. This
+  // is usually used for sending the user to SQL editor from other pages with SQL.
+  const seedFromContentParam = useEffectEvent(() => {
+    if (content && content.length > 0) handleEditorChange(content)
+  })
+  useEffect(() => {
+    seedFromContentParam()
+    // The useEffectEvent return is stable and must not be a dependency; this
+    // disable can go once our eslint version understands useEffectEvent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return { snippet, disableEdit, handleEditorChange }
+}

--- a/apps/studio/components/interfaces/SQLEditor/useSnippetEditor.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useSnippetEditor.ts
@@ -1,7 +1,6 @@
-import { useDebounce } from '@uidotdev/usehooks'
 import { useParams } from 'common'
 import { useRouter } from 'next/router'
-import { useEffect, useEffectEvent, useState } from 'react'
+import { useEffect, useEffectEvent } from 'react'
 
 import { createSqlSnippetSkeletonV2 } from './SQLEditor.utils'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -12,10 +11,14 @@ import { canEditSnippet } from '@/state/sql-editor/sql-editor-rules'
 import { useTabsStateSnapshot } from '@/state/tabs'
 
 /**
- * Owns the editing lifecycle of a single SQL snippet: tracking the editor text,
- * creating the snippet in the store on first edit (and routing to its URL),
- * persisting debounced changes via `setSql`, and seeding the editor from a
- * `?content=` deep link.
+ * Owns the editing lifecycle of a single SQL snippet: creating the snippet in
+ * the store on first edit (and routing to its URL), writing changes back to the
+ * store via `setSql`, and seeding the editor from a `?content=` deep link.
+ *
+ * Edits are written to the store synchronously on every change; debouncing the
+ * actual persistence is the save mechanism's job (see `createSaveMechanism`), so
+ * the store — and therefore the snippet's dirty status — always reflects the
+ * latest edit immediately.
  *
  * Extracted from `MonacoEditor` so that component stays a thin editor shell.
  */
@@ -27,9 +30,6 @@ export function useSnippetEditor({ id, snippetName }: { id: string; snippetName:
 
   const snapV2 = useSqlEditorV2StateSnapshot()
   const tabsSnap = useTabsStateSnapshot()
-
-  const [value, setValue] = useState('')
-  const debouncedValue = useDebounce(value, 1000)
 
   const snippet = snapV2.snippets[id]
   const disableEdit = !!snippet && !canEditSnippet(snippet.snippet, profile?.id)
@@ -57,16 +57,13 @@ export function useSnippetEditor({ id, snippetName }: { id: string; snippetName:
         router.push(`/project/${ref}/sql/${newSnippet.id}`, undefined, { shallow: true })
       }
     }
-    setValue(value)
-  }
 
-  useEffect(() => {
-    if (debouncedValue.length > 0 && snippet) {
-      const shouldInvalidate = wasNeverPersisted(snippet.snippet.status)
-      snapV2.setSql({ id, sql: value, shouldInvalidate })
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [debouncedValue])
+    // A snippet that has never been persisted needs the snippet/folder lists
+    // invalidated so it shows up in the sidebar. If `snippet` was undefined at
+    // render we just created one above (status 'new'), which always qualifies.
+    const shouldInvalidate = snippet ? wasNeverPersisted(snippet.snippet.status) : true
+    snapV2.setSql({ id, sql: value, shouldInvalidate })
+  }
 
   // if an SQL query is passed by the content parameter, set the editor value to its content. This
   // is usually used for sending the user to SQL editor from other pages with SQL.

--- a/apps/studio/state/sql-editor/sql-editor-lifecycle.test.ts
+++ b/apps/studio/state/sql-editor/sql-editor-lifecycle.test.ts
@@ -8,6 +8,7 @@ import {
   isNewFolder,
   isSaveFailed,
   isSaving,
+  statusOnEdit,
   statusOnSaveError,
   statusOnSaveStart,
   statusOnSaveSuccess,
@@ -105,6 +106,24 @@ describe('statusOnSaveError', () => {
     expect(statusOnSaveError('saving')).toBe('save_failed')
     expect(statusOnSaveError('saved')).toBe('save_failed')
     expect(statusOnSaveError(undefined)).toBe('save_failed')
+  })
+})
+
+describe('statusOnEdit', () => {
+  it('marks a persisted, clean snippet as unsaved', () => {
+    expect(statusOnEdit('saved')).toBe('unsaved')
+  })
+
+  it('leaves every already-dirty or in-flight status unchanged', () => {
+    for (const status of [...NEVER_PERSISTED, 'unsaved', 'saving', 'save_failed'] as const) {
+      expect(statusOnEdit(status)).toBe(status)
+    }
+  })
+
+  it('keeps hasUnsavedChanges true after an edit', () => {
+    for (const status of [...NEVER_PERSISTED, ...PERSISTED] as const) {
+      expect(hasUnsavedChanges(statusOnEdit(status))).toBe(true)
+    }
   })
 })
 

--- a/apps/studio/state/sql-editor/sql-editor-lifecycle.ts
+++ b/apps/studio/state/sql-editor/sql-editor-lifecycle.ts
@@ -49,6 +49,18 @@ export function statusOnSaveError(status: SnippetStatus | undefined): SnippetSta
 }
 
 /**
+ * Transition when the snippet is edited locally. A persisted-and-clean snippet
+ * becomes 'unsaved' so its dirty state is durable immediately (rather than only
+ * once the debounced save begins). Every other status is already dirty or
+ * in-flight — the never-persisted family, a save in progress, or a failed
+ * save — and is left unchanged so the persistence and progress axes are
+ * preserved.
+ */
+export function statusOnEdit(status: SnippetStatus): SnippetStatus {
+  return status === 'saved' ? 'unsaved' : status
+}
+
+/**
  * The lifecycle of a folder in the SQL editor nav, as a single set of
  * mutually-exclusive states. Like SnippetStatus, this collapses two orthogonal
  * axes — persistence (a locally-created placeholder vs a persisted folder) and

--- a/apps/studio/state/sql-editor/sql-editor-state.ts
+++ b/apps/studio/state/sql-editor/sql-editor-state.ts
@@ -4,7 +4,7 @@ import { toast } from 'sonner'
 import { proxy, snapshot, useSnapshot } from 'valtio'
 import { devtools, proxyMap } from 'valtio/utils'
 
-import { folderStatusOnSaveStart, isNewFolder } from './sql-editor-lifecycle'
+import { folderStatusOnSaveStart, isNewFolder, statusOnEdit } from './sql-editor-lifecycle'
 import { sqlEditorSessionState } from './sql-editor-session-state'
 import type { StateSnippet, StateSnippetFolder } from './types'
 import type { SnippetWithContent } from '@/data/content/sql-folders-query'
@@ -110,6 +110,10 @@ export const sqlEditorState = proxy({
     let snippet = sqlEditorState.snippets[id]?.snippet
     if (snippet?.content) {
       snippet.content.unchecked_sql = untrustedSql(sql)
+      // Mark dirty immediately so `status` (not the transient needsSaving queue)
+      // is the durable source of truth for unsaved changes, even before the
+      // debounced save begins.
+      snippet.status = statusOnEdit(snippet.status)
       sqlEditorState.needsSaving.set(id, shouldInvalidate)
     }
   },


### PR DESCRIPTION
## What

PR 7 of the SQL editor state re-layering stack. Extracts the snippet editing lifecycle out of `MonacoEditor` into a co-located `useSnippetEditor` hook, and consolidates the edit debounce.

`useSnippetEditor` owns:
- creating the snippet in the store on first edit and routing to its URL (replace vs push for a `?content=` deep link)
- writing changes back to the store via `setSql` (with `wasNeverPersisted` → `shouldInvalidate`)
- seeding the editor from the `content` param
- the read-only determination (`canEditSnippet`)

`MonacoEditor` now consumes `{ snippet, disableEdit, handleEditorChange }` and keeps only the editor shell + Monaco action wiring. It sheds the `router`/`profile`/`project`/`params`/store/tabs hooks.

`handleEditorChange` was also flattened with an early return.

## Debounce consolidation

Previously there were **two 1s debounces in series**: `useSnippetEditor` debounced editor changes before writing to the store, and the save mechanism (`createSaveMechanism`) already debounces persistence. That added latency (up to ~2s to save) and split the "when to persist" timing policy across two layers — at odds with PR 5's design where the scheduler/mechanism owns *when* and dirty state is meant to be immediate.

This PR removes the editor-side debounce: edits write to the store synchronously on every change, and the save mechanism's 1s debounce is the sole throttle. Net effects:
- the store — and the snippet's dirty status — reflects the latest edit immediately (correct for the future manual-save mode's Save button / nav guard)
- save fires ~1s after the *last* keystroke instead of up to ~2s
- only the active snippet's own reactive consumers (a lightweight sidebar item) re-render per keystroke; Monaco is uncontrolled (`defaultValue`) so it is unaffected

Note: the double-debounce was legacy (the pre-refactor god store had the same `useDebounce(value, 1000)` in MonacoEditor plus a debounced module-load subscribe).

## Notes

- Behavior-preserving in outcome — autosave still lands ~1s after typing stops, just with lower latency and immediate store consistency.

## Validation

- `pnpm --filter studio typecheck` ✅
- `pnpm exec vitest --run state/sql-editor/` ✅ (110 passed)
- lint ✅ (0 errors; no ratcheted-rule regressions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SQL editor changes now apply immediately, with unsaved status reflected as soon as you edit.
  * The editor now keeps the latest snippet details available for saving, improving reliability when using “Save Query.”

* **Bug Fixes**
  * Improved handling for creating and opening snippets from shared links or prefilled content.
  * Fixed status updates so saved snippets correctly switch to unsaved after edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->