### PR TITLE
feat(studio): chart bar links open unified logs when enabled

### DIFF
--- a/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
+++ b/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
@@ -77,7 +77,9 @@ export const ObservabilityOverview = () => {
         key: 'data_api' as const,
         name: 'API Gateway',
         reportUrl: undefined,
-        logsUrl: `/project/${projectRef}/logs/edge-logs`,
+        logsUrl: isUnifiedLogsEnabled
+          ? `/project/${projectRef}/logs?filter=log_type:eq:edge`
+          : `/project/${projectRef}/logs/edge-logs`,
         enabled: isDataApiEnabled,
         hasReport: false,
       },
@@ -160,11 +162,13 @@ export const ObservabilityOverview = () => {
       const start = datum.timestamp
       const end = dayjs.utc(datum.timestamp).add(1, unit).toISOString()
 
-      const queryParams = new URLSearchParams({ its: start, ite: end })
+      const queryParams = isUnifiedLogsEnabled
+        ? new URLSearchParams({ date: `${new Date(start).valueOf()}-${new Date(end).valueOf()}` })
+        : new URLSearchParams({ its: start, ite: end })
       const separator = logsUrl.includes('?') ? '&' : '?'
       router.push(`${logsUrl}${separator}${queryParams.toString()}`)
     },
-    [router, interval]
+    [router, interval, isUnifiedLogsEnabled]
   )
 
   return (

--- a/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
+++ b/apps/studio/components/interfaces/Observability/ObservabilityOverview.tsx
@@ -15,6 +15,10 @@ import { ServiceHealthTable } from './ServiceHealthTable'
 import { useSlowQueriesCount } from './useSlowQueriesCount'
 import ReportHeader from '@/components/interfaces/Reports/ReportHeader'
 import ReportPadding from '@/components/interfaces/Reports/ReportPadding'
+import {
+  buildUnifiedLogsUrl,
+  type UnifiedLogType,
+} from '@/components/interfaces/UnifiedLogs/UnifiedLogs.utils'
 import { DocsButton } from '@/components/ui/DocsButton'
 import { ChartIntervalDropdown } from '@/components/ui/Logs/ChartIntervalDropdown'
 import { CHART_INTERVALS } from '@/components/ui/Logs/logs.utils'
@@ -71,15 +75,22 @@ export const ObservabilityOverview = () => {
     setShowIntervalDropdown((open) => !open)
   })
 
+  const getLogsUrl = useCallback(
+    (logType: UnifiedLogType, legacyLogsUrl: string) =>
+      isUnifiedLogsEnabled
+        ? buildUnifiedLogsUrl({ projectRef: projectRef!, logType })
+        : `/project/${projectRef}${legacyLogsUrl}`,
+    [projectRef, isUnifiedLogsEnabled]
+  )
+
   const serviceBase = useMemo(
     () => [
       {
         key: 'data_api' as const,
         name: 'API Gateway',
         reportUrl: undefined,
-        logsUrl: isUnifiedLogsEnabled
-          ? `/project/${projectRef}/logs?filter=log_type:eq:edge`
-          : `/project/${projectRef}/logs/edge-logs`,
+        logType: 'edge' as const,
+        logsUrl: getLogsUrl('edge', '/logs/edge-logs'),
         enabled: isDataApiEnabled,
         hasReport: false,
       },
@@ -87,9 +98,8 @@ export const ObservabilityOverview = () => {
         key: 'db' as const,
         name: 'Database',
         reportUrl: `/project/${projectRef}/observability/database`,
-        logsUrl: isUnifiedLogsEnabled
-          ? `/project/${projectRef}/logs?filter=log_type:eq:postgres`
-          : `/project/${projectRef}/logs/postgres-logs`,
+        logType: 'postgres' as const,
+        logsUrl: getLogsUrl('postgres', '/logs/postgres-logs'),
         enabled: true,
         hasReport: true,
       },
@@ -97,9 +107,8 @@ export const ObservabilityOverview = () => {
         key: 'postgrest' as const,
         name: 'PostgREST',
         reportUrl: `/project/${projectRef}/observability/postgrest`,
-        logsUrl: isUnifiedLogsEnabled
-          ? `/project/${projectRef}/logs?filter=log_type:eq:postgrest`
-          : `/project/${projectRef}/logs/postgrest-logs`,
+        logType: 'postgrest' as const,
+        logsUrl: getLogsUrl('postgrest', '/logs/postgrest-logs'),
         enabled: true,
         hasReport: true,
       },
@@ -107,9 +116,8 @@ export const ObservabilityOverview = () => {
         key: 'auth' as const,
         name: 'Auth',
         reportUrl: `/project/${projectRef}/observability/auth`,
-        logsUrl: isUnifiedLogsEnabled
-          ? `/project/${projectRef}/logs?filter=log_type:eq:auth`
-          : `/project/${projectRef}/logs/auth-logs`,
+        logType: 'auth' as const,
+        logsUrl: getLogsUrl('auth', '/logs/auth-logs'),
         enabled: true,
         hasReport: true,
       },
@@ -117,9 +125,8 @@ export const ObservabilityOverview = () => {
         key: 'functions' as const,
         name: 'Edge Functions',
         reportUrl: `/project/${projectRef}/observability/edge-functions`,
-        logsUrl: isUnifiedLogsEnabled
-          ? `/project/${projectRef}/logs?filter=log_type:eq:edge+function`
-          : `/project/${projectRef}/logs/edge-functions-logs`,
+        logType: 'edge function' as const,
+        logsUrl: getLogsUrl('edge function', '/logs/edge-functions-logs'),
         enabled: true,
         hasReport: true,
       },
@@ -127,9 +134,8 @@ export const ObservabilityOverview = () => {
         key: 'storage' as const,
         name: 'Storage',
         reportUrl: `/project/${projectRef}/observability/storage`,
-        logsUrl: isUnifiedLogsEnabled
-          ? `/project/${projectRef}/logs?filter=log_type:eq:storage`
-          : `/project/${projectRef}/logs/storage-logs`,
+        logType: 'storage' as const,
+        logsUrl: getLogsUrl('storage', '/logs/storage-logs'),
         enabled: storageSupported,
         hasReport: true,
       },
@@ -137,14 +143,13 @@ export const ObservabilityOverview = () => {
         key: 'realtime' as const,
         name: 'Realtime',
         reportUrl: `/project/${projectRef}/observability/realtime`,
-        logsUrl: isUnifiedLogsEnabled
-          ? `/project/${projectRef}/logs?filter=log_type:eq:realtime`
-          : `/project/${projectRef}/logs/realtime-logs`,
+        logType: 'realtime' as const,
+        logsUrl: getLogsUrl('realtime', '/logs/realtime-logs'),
         enabled: true,
         hasReport: true,
       },
     ],
-    [projectRef, storageSupported, isDataApiEnabled, isUnifiedLogsEnabled]
+    [projectRef, storageSupported, isDataApiEnabled, getLogsUrl]
   )
 
   const enabledServices = serviceBase.filter((s) => s.enabled)
@@ -153,7 +158,7 @@ export const ObservabilityOverview = () => {
 
   // Navigate to the log view scoped to the clicked bar's bucket window
   const handleBarClick = useCallback(
-    (logsUrl: string) => (datum: any) => {
+    (service: { logType: UnifiedLogType; logsUrl: string }) => (datum: any) => {
       if (!datum?.timestamp) return
 
       // datum.timestamp is already the UTC-truncated bucket boundary from timestamp_trunc(),
@@ -162,13 +167,17 @@ export const ObservabilityOverview = () => {
       const start = datum.timestamp
       const end = dayjs.utc(datum.timestamp).add(1, unit).toISOString()
 
-      const queryParams = isUnifiedLogsEnabled
-        ? new URLSearchParams({ date: `${new Date(start).valueOf()}-${new Date(end).valueOf()}` })
-        : new URLSearchParams({ its: start, ite: end })
-      const separator = logsUrl.includes('?') ? '&' : '?'
-      router.push(`${logsUrl}${separator}${queryParams.toString()}`)
+      if (isUnifiedLogsEnabled) {
+        router.push(
+          buildUnifiedLogsUrl({ projectRef: projectRef!, logType: service.logType, start, end })
+        )
+      } else {
+        const queryParams = new URLSearchParams({ its: start, ite: end })
+        const separator = service.logsUrl.includes('?') ? '&' : '?'
+        router.push(`${service.logsUrl}${separator}${queryParams.toString()}`)
+      }
     },
-    [router, interval, isUnifiedLogsEnabled]
+    [router, interval, isUnifiedLogsEnabled, projectRef]
   )
 
   return (
@@ -224,6 +233,7 @@ export const ObservabilityOverview = () => {
             name: service.name,
             description: '',
             reportUrl: service.hasReport ? service.reportUrl : undefined,
+            logType: service.logType,
             logsUrl: service.logsUrl,
           }))}
           serviceData={overviewData.services}

--- a/apps/studio/components/interfaces/Observability/ServiceHealthTable.tsx
+++ b/apps/studio/components/interfaces/Observability/ServiceHealthTable.tsx
@@ -15,6 +15,7 @@ import { ChartEmptyState, ChartLoadingState } from 'ui-patterns/Chart'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
 
 import type { LogsBarChartDatum } from '../ProjectHome/ProjectUsage.metrics'
+import type { UnifiedLogType } from '../UnifiedLogs/UnifiedLogs.utils'
 import { getHealthStatus, type ServiceKey } from './ObservabilityOverview.utils'
 
 type ServiceConfig = {
@@ -22,6 +23,7 @@ type ServiceConfig = {
   name: string
   description: string
   reportUrl?: string
+  logType: UnifiedLogType
   logsUrl: string
 }
 
@@ -37,7 +39,7 @@ type ServiceData = {
 export type ServiceHealthTableProps = {
   services: ServiceConfig[]
   serviceData: Record<string, ServiceData>
-  onBarClick: (logsUrl: string) => (datum: LogsBarChartDatum) => void
+  onBarClick: (service: ServiceConfig) => (datum: LogsBarChartDatum) => void
   datetimeFormat: string
 }
 
@@ -216,7 +218,7 @@ export const ServiceHealthTable = ({
                   key={service.key}
                   service={service}
                   data={data}
-                  onBarClick={onBarClick(service.logsUrl)}
+                  onBarClick={onBarClick(service)}
                   datetimeFormat={datetimeFormat}
                   className={cn(
                     'border-default border-b',

--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsageSection.tsx
@@ -8,6 +8,11 @@ import { ChartEmptyState } from 'ui-patterns/Chart'
 import { LogsBarChart } from 'ui-patterns/LogsBarChart'
 import { Row } from 'ui-patterns/Row'
 
+import { useUnifiedLogsPreview } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
+import {
+  buildUnifiedLogsUrl,
+  type UnifiedLogType,
+} from '@/components/interfaces/UnifiedLogs/UnifiedLogs.utils'
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import { ChartIntervalDropdown } from '@/components/ui/Logs/ChartIntervalDropdown'
 import { CHART_INTERVALS } from '@/components/ui/Logs/logs.utils'
@@ -34,6 +39,7 @@ type ServiceEntry = {
   title: string
   href?: string
   route: string
+  logType: UnifiedLogType
   enabled: boolean
 }
 
@@ -55,6 +61,7 @@ export const ProjectUsageSection = () => {
   ])
   const { getEntitlementMax } = useCheckEntitlements('log.retention_days')
   const retentionDays = getEntitlementMax()
+  const { isEnabled: isUnifiedLogsEnabled } = useUnifiedLogsPreview()
 
   const DEFAULT_INTERVAL: ChartIntervalKey =
     retentionDays !== undefined && retentionDays < 7 ? '1hr' : '1day'
@@ -116,6 +123,7 @@ export const ProjectUsageSection = () => {
         title: 'Database requests',
         href: `/project/${projectRef}/editor`,
         route: '/logs/postgres-logs',
+        logType: 'postgres',
         enabled: true,
       },
       {
@@ -123,6 +131,7 @@ export const ProjectUsageSection = () => {
         title: 'Auth requests',
         href: `/project/${projectRef}/auth/users`,
         route: '/logs/auth-logs',
+        logType: 'auth',
         enabled: authEnabled,
       },
       {
@@ -130,6 +139,7 @@ export const ProjectUsageSection = () => {
         title: 'Storage requests',
         href: `/project/${projectRef}/storage/buckets`,
         route: '/logs/storage-logs',
+        logType: 'storage',
         enabled: storageEnabled,
       },
       {
@@ -137,6 +147,7 @@ export const ProjectUsageSection = () => {
         title: 'Realtime requests',
         href: `/project/${projectRef}/realtime/inspector`,
         route: '/logs/realtime-logs',
+        logType: 'realtime',
         enabled: true,
       },
     ],
@@ -179,26 +190,30 @@ export const ProjectUsageSection = () => {
     [serviceBase, filledCharts, isLoading, error]
   )
 
-  const handleBarClick =
-    (logRoute: string, serviceKey: ServiceKey) => (datum: LogsBarChartDatum) => {
-      if (!datum?.timestamp) return
+  const handleBarClick = (service: ServiceEntry) => (datum: LogsBarChartDatum) => {
+    if (!datum?.timestamp) return
 
-      const datumTimestamp = dayjs(datum.timestamp).toISOString()
-      const start = dayjs(datumTimestamp).subtract(1, 'minute').toISOString()
-      const end = dayjs(datumTimestamp).add(1, 'minute').toISOString()
+    const datumTimestamp = dayjs(datum.timestamp).toISOString()
+    const start = dayjs(datumTimestamp).subtract(1, 'minute').toISOString()
+    const end = dayjs(datumTimestamp).add(1, 'minute').toISOString()
 
+    if (isUnifiedLogsEnabled) {
+      router.push(
+        buildUnifiedLogsUrl({ projectRef: projectRef!, logType: service.logType, start, end })
+      )
+    } else {
       const queryParams = new URLSearchParams({
         iso_timestamp_start: start,
         iso_timestamp_end: end,
       })
-
-      router.push(`/project/${projectRef}${logRoute}?${queryParams.toString()}`)
-
-      track('home_project_usage_chart_clicked', {
-        service_type: serviceKey,
-        bar_timestamp: datum.timestamp,
-      })
+      router.push(`/project/${projectRef}${service.route}?${queryParams.toString()}`)
     }
+
+    track('home_project_usage_chart_clicked', {
+      service_type: service.key,
+      bar_timestamp: datum.timestamp,
+    })
+  }
 
   const enabledServices = services.filter((s) => s.enabled)
   const totalRequests = enabledServices.reduce((sum, s) => sum + (s.total || 0), 0)
@@ -252,7 +267,7 @@ export const ProjectUsageSection = () => {
                   data={s.data}
                   error={s.error}
                   DateTimeFormat={datetimeFormat}
-                  onBarClick={handleBarClick(s.route, s.key)}
+                  onBarClick={handleBarClick(s)}
                   hideZeroValues={true}
                   chartConfig={{
                     error_count: {

--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsageSectionDeltas.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsageSectionDeltas.tsx
@@ -14,7 +14,12 @@ import {
   type ChartIntervalKey,
   type LogsBarChartDatum,
 } from './ProjectUsage.metrics'
+import { useUnifiedLogsPreview } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { useServiceHealthMetrics } from '@/components/interfaces/Observability/useServiceHealthMetrics'
+import {
+  buildUnifiedLogsUrl,
+  type UnifiedLogType,
+} from '@/components/interfaces/UnifiedLogs/UnifiedLogs.utils'
 import NoDataPlaceholder from '@/components/ui/Charts/NoDataPlaceholder'
 import { ChartIntervalDropdown } from '@/components/ui/Logs/ChartIntervalDropdown'
 import { CHART_INTERVALS } from '@/components/ui/Logs/logs.utils'
@@ -35,6 +40,7 @@ type ServiceEntry = {
   title: string
   href?: string
   route: string
+  logType: UnifiedLogType
   enabled: boolean
 }
 
@@ -48,6 +54,7 @@ export const ProjectUsageSectionDeltas = () => {
     'project_storage:all',
   ])
   const { isEnabled: dataApiEnabled } = useIsDataApiEnabled({ projectRef })
+  const { isEnabled: isUnifiedLogsEnabled } = useUnifiedLogsPreview()
   const { getEntitlementMax } = useCheckEntitlements('log.retention_days')
   const retentionDays = getEntitlementMax()
 
@@ -71,6 +78,7 @@ export const ProjectUsageSectionDeltas = () => {
         title: 'Postgres',
         href: `/project/${projectRef}/editor`,
         route: '/logs/postgres-logs',
+        logType: 'postgres',
         enabled: true,
       },
       {
@@ -78,6 +86,7 @@ export const ProjectUsageSectionDeltas = () => {
         title: 'Edge Functions',
         href: `/project/${projectRef}/functions`,
         route: '/logs/edge-functions-logs',
+        logType: 'edge function',
         enabled: true,
       },
       {
@@ -85,6 +94,7 @@ export const ProjectUsageSectionDeltas = () => {
         title: 'Auth',
         href: `/project/${projectRef}/auth/users`,
         route: '/logs/auth-logs',
+        logType: 'auth',
         enabled: authEnabled,
       },
       {
@@ -92,6 +102,7 @@ export const ProjectUsageSectionDeltas = () => {
         title: 'Storage',
         href: `/project/${projectRef}/storage/buckets`,
         route: '/logs/storage-logs',
+        logType: 'storage',
         enabled: storageEnabled,
       },
       {
@@ -99,6 +110,7 @@ export const ProjectUsageSectionDeltas = () => {
         title: 'Realtime',
         href: `/project/${projectRef}/realtime/inspector`,
         route: '/logs/realtime-logs',
+        logType: 'realtime',
         enabled: true,
       },
       {
@@ -106,6 +118,7 @@ export const ProjectUsageSectionDeltas = () => {
         title: 'API Gateway',
         href: `/project/${projectRef}/integrations/data_api/overview`,
         route: '/logs/edge-logs',
+        logType: 'edge',
         enabled: dataApiEnabled,
       },
     ],
@@ -127,26 +140,27 @@ export const ProjectUsageSectionDeltas = () => {
     totalErrors
   )
 
-  const handleBarClick =
-    (logRoute: string, serviceKey: HomeServiceKey) => (datum: LogsBarChartDatum) => {
-      if (!datum?.timestamp) return
+  const handleBarClick = (service: ServiceEntry) => (datum: LogsBarChartDatum) => {
+    if (!datum?.timestamp) return
 
+    const { start, end } = getBucketLogRange(datum.timestamp, interval)
+
+    if (isUnifiedLogsEnabled) {
+      router.push(
+        buildUnifiedLogsUrl({ projectRef: projectRef!, logType: service.logType, start, end })
+      )
+    } else {
       // Logs explorer reads the range from `its`/`ite` (iso_timestamp_start/end
       // only set the label).
-      const { start, end } = getBucketLogRange(datum.timestamp, interval)
-
-      const queryParams = new URLSearchParams({
-        its: start,
-        ite: end,
-      })
-
-      router.push(`/project/${projectRef}${logRoute}?${queryParams.toString()}`)
-
-      track('home_project_usage_chart_clicked', {
-        service_type: serviceKey,
-        bar_timestamp: datum.timestamp,
-      })
+      const queryParams = new URLSearchParams({ its: start, ite: end })
+      router.push(`/project/${projectRef}${service.route}?${queryParams.toString()}`)
     }
+
+    track('home_project_usage_chart_clicked', {
+      service_type: service.key,
+      bar_timestamp: datum.timestamp,
+    })
+  }
 
   return (
     <div className="space-y-6">
@@ -226,7 +240,7 @@ export const ProjectUsageSectionDeltas = () => {
                     isFullHeight
                     data={s.data}
                     DateTimeFormat={datetimeFormat}
-                    onBarClick={disabled ? undefined : handleBarClick(s.route, s.key)}
+                    onBarClick={disabled ? undefined : handleBarClick(s)}
                     hideZeroValues={true}
                     chartConfig={{
                       error_count: { label: 'Errors' },

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildUnifiedLogsUrl } from './UnifiedLogs.utils'
+
+describe('buildUnifiedLogsUrl', () => {
+  const parse = (url: string) => {
+    const [path, query] = url.split('?')
+    return { path, params: new URLSearchParams(query) }
+  }
+
+  it('targets the project logs route with a log_type filter', () => {
+    const { path, params } = parse(buildUnifiedLogsUrl({ projectRef: 'abc', logType: 'postgres' }))
+    expect(path).toBe('/project/abc/logs')
+    expect(params.get('filter')).toBe('log_type:eq:postgres')
+    expect(params.has('date')).toBe(false)
+  })
+
+  it('preserves multi-word log types once decoded', () => {
+    const { params } = parse(buildUnifiedLogsUrl({ projectRef: 'abc', logType: 'edge function' }))
+    expect(params.get('filter')).toBe('log_type:eq:edge function')
+  })
+
+  it('adds the date range as an epoch-ms pair when start and end are provided', () => {
+    const start = new Date('2026-05-08T00:00:00.000Z')
+    const end = new Date('2026-05-08T01:00:00.000Z')
+    const { params } = parse(
+      buildUnifiedLogsUrl({ projectRef: 'abc', logType: 'auth', start, end })
+    )
+    expect(params.get('date')).toBe(`${start.valueOf()}-${end.valueOf()}`)
+  })
+
+  it('accepts ISO strings for the date range', () => {
+    const start = '2026-05-08T00:00:00.000Z'
+    const end = '2026-05-08T01:00:00.000Z'
+    const { params } = parse(
+      buildUnifiedLogsUrl({ projectRef: 'abc', logType: 'auth', start, end })
+    )
+    expect(params.get('date')).toBe(`${new Date(start).valueOf()}-${new Date(end).valueOf()}`)
+  })
+
+  it('omits the date range when only one bound is provided', () => {
+    const { params } = parse(
+      buildUnifiedLogsUrl({ projectRef: 'abc', logType: 'storage', start: new Date() })
+    )
+    expect(params.has('date')).toBe(false)
+  })
+})

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
@@ -1,8 +1,30 @@
 import { type Table as TTable } from '@tanstack/react-table'
 import { cn } from 'ui'
 
+import { LOG_TYPES_LABELS } from './UnifiedLogs.constants'
 import { FacetMetadataSchema } from './UnifiedLogs.schema'
 import { LEVELS } from '@/components/ui/DataTable/DataTable.constants'
+
+export type UnifiedLogType = keyof typeof LOG_TYPES_LABELS
+
+export const buildUnifiedLogsUrl = ({
+  projectRef,
+  logType,
+  start,
+  end,
+}: {
+  projectRef: string
+  logType: UnifiedLogType
+  start?: string | Date
+  end?: string | Date
+}) => {
+  const params = new URLSearchParams()
+  params.append('filter', `log_type:eq:${logType}`)
+  if (start && end) {
+    params.set('date', `${new Date(start).valueOf()}-${new Date(end).valueOf()}`)
+  }
+  return `/project/${projectRef}/logs?${params.toString()}`
+}
 
 export const getFacetedUniqueValues = <TData>(facets?: Record<string, FacetMetadataSchema>) => {
   return (_table: TTable<TData>, columnId: string) => {


### PR DESCRIPTION
## What

When the unified logs preview is enabled, clicking a chart bar that links to a logs view now opens **unified logs** (scoped to the service and time bucket) instead of the legacy logs explorer.

Surfaces updated:
- Homepage project usage charts (`ProjectUsageSectionDeltas`, `ProjectUsageSection`)
- Observability overview service health table (`ObservabilityOverview`) — also fixes the API Gateway row and passes the time range via the `date` param unified logs actually reads

Adds a small `buildUnifiedLogsUrl` helper so the deep-link format (`filter=log_type:eq:<type>` + `date` epoch-ms range) lives in one place.

When the preview is off, behavior is unchanged (legacy logs explorer).

Resolves O11Y-2133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified logs navigation for project usage and observability charts.
  * Chart bar clicks now open the unified logs view with service-specific filtering and a computed time window.
* **Bug Fixes**
  * Updated observability and usage charts to generate the correct unified logs URLs (including `log_type` filtering and optional date ranges).
  * Preserved legacy log navigation behavior when unified logs are disabled.
* **Tests**
  * Added unit tests covering unified logs URL generation, query parameters, and date handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->