### PR TITLE
fix(studio): guard project password strength checks

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.test.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.test.tsx
@@ -1,0 +1,98 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { FormProvider, useForm, UseFormReturn } from 'react-hook-form'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { DatabasePasswordInput } from './DatabasePasswordInput'
+import { CreateProjectForm } from './ProjectCreation.schema'
+import { passwordStrength } from '@/lib/password-strength'
+
+vi.mock('@/lib/password-strength', () => ({
+  passwordStrength: vi.fn(),
+}))
+
+vi.mock('@/lib/project', () => ({
+  generateStrongPassword: vi.fn(() => 'GeneratedStrongPassword123!'),
+}))
+
+const defaultValues: CreateProjectForm = {
+  organization: 'default-org',
+  projectName: 'Default project',
+  highAvailability: false,
+  postgresVersion: '15',
+  dbRegion: 'us-east-1',
+  cloudProvider: 'AWS_K8S',
+  dbPass: '',
+  dbPassStrength: 0,
+  dbPassStrengthMessage: '',
+  dbPassStrengthWarning: '',
+  dataApi: true,
+  dataApiDefaultPrivileges: true,
+  enableRlsEventTrigger: true,
+  postgresVersionSelection: '15',
+  useOrioleDb: false,
+}
+
+function deferredPasswordStrength() {
+  let resolve!: (value: { warning: string; message: string; strength: 0 | 1 | 2 | 3 | 4 }) => void
+
+  const promise = new Promise<{
+    warning: string
+    message: string
+    strength: 0 | 1 | 2 | 3 | 4
+  }>((res) => {
+    resolve = res
+  })
+
+  return { promise, resolve }
+}
+
+describe('DatabasePasswordInput', () => {
+  const mockedPasswordStrength = vi.mocked(passwordStrength)
+
+  beforeEach(() => {
+    mockedPasswordStrength.mockReset()
+  })
+
+  it('ignores stale password strength results when checks resolve out of order', async () => {
+    const firstCheck = deferredPasswordStrength()
+    const secondCheck = deferredPasswordStrength()
+    let form!: UseFormReturn<CreateProjectForm>
+
+    mockedPasswordStrength
+      .mockReturnValueOnce(firstCheck.promise)
+      .mockReturnValueOnce(secondCheck.promise)
+
+    function TestComponent() {
+      form = useForm<CreateProjectForm>({ defaultValues })
+
+      return (
+        <FormProvider {...form}>
+          <DatabasePasswordInput form={form} />
+        </FormProvider>
+      )
+    }
+
+    render(<TestComponent />)
+
+    const input = screen.getByPlaceholderText('Type in a strong password')
+    fireEvent.change(input, { target: { value: 'first-password' } })
+    fireEvent.change(input, { target: { value: 'second-password' } })
+
+    await act(async () => {
+      secondCheck.resolve({ warning: '', message: 'Strong password', strength: 4 })
+      await secondCheck.promise
+    })
+
+    expect(form.getValues('dbPassStrength')).toBe(4)
+    expect(form.getValues('dbPassStrengthMessage')).toBe('Strong password')
+
+    await act(async () => {
+      firstCheck.resolve({ warning: 'Too weak', message: 'Weak password', strength: 1 })
+      await firstCheck.promise
+    })
+
+    expect(form.getValues('dbPassStrength')).toBe(4)
+    expect(form.getValues('dbPassStrengthMessage')).toBe('Strong password')
+    expect(form.getValues('dbPassStrengthWarning')).toBe('')
+  })
+})

--- a/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/DatabasePasswordInput.tsx
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import { FormControl, FormField } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
@@ -15,32 +16,42 @@ interface DatabasePasswordInputProps {
   form: UseFormReturn<CreateProjectForm>
 }
 
-const updatePasswordStrength = async (form: UseFormReturn<CreateProjectForm>, value: string) => {
-  try {
-    const { warning, message, strength } = await passwordStrength(value)
-    form.setValue('dbPassStrength', strength, { shouldValidate: false, shouldDirty: false })
-    form.setValue('dbPassStrengthMessage', message ?? '', {
-      shouldValidate: false,
-      shouldDirty: false,
-    })
-    form.setValue('dbPassStrengthWarning', warning ?? '', {
-      shouldValidate: false,
-      shouldDirty: false,
-    })
-
-    form.trigger('dbPass')
-  } catch (error) {
-    console.error(error)
-  }
-}
-
 export const DatabasePasswordInput = ({ form }: DatabasePasswordInputProps) => {
+  const passwordStrengthRequestIdRef = useRef(0)
+
   // [Refactor] DB Password could be a common component used in multiple pages with repeated logic
+  const updatePasswordStrength = async (value: string) => {
+    const requestId = passwordStrengthRequestIdRef.current + 1
+    passwordStrengthRequestIdRef.current = requestId
+
+    try {
+      const { warning, message, strength } = await passwordStrength(value)
+
+      if (requestId !== passwordStrengthRequestIdRef.current) return
+
+      form.setValue('dbPassStrength', strength, { shouldValidate: false, shouldDirty: false })
+      form.setValue('dbPassStrengthMessage', message ?? '', {
+        shouldValidate: false,
+        shouldDirty: false,
+      })
+      form.setValue('dbPassStrengthWarning', warning ?? '', {
+        shouldValidate: false,
+        shouldDirty: false,
+      })
+
+      form.trigger('dbPass')
+    } catch (error) {
+      if (requestId === passwordStrengthRequestIdRef.current) {
+        console.error(error)
+      }
+    }
+  }
+
   async function generatePassword() {
     const password = generateStrongPassword()
     form.setValue('dbPass', password)
 
-    updatePasswordStrength(form, password)
+    updatePasswordStrength(password)
   }
 
   return (
@@ -79,7 +90,7 @@ export const DatabasePasswordInput = ({ form }: DatabasePasswordInputProps) => {
                     const newValue = event.target.value
                     field.onChange(event)
 
-                    updatePasswordStrength(form, newValue)
+                    updatePasswordStrength(newValue)
                   }}
                 />
               </FormControl>


### PR DESCRIPTION
**Objective:** Project creation password strength checks could resolve out of order while users type, allowing an older async result to overwrite the latest password validation state.

**The Fix:** Added a request-id guard around the password strength update path so only the latest check can mutate the form state or trigger validation. Added a regression test covering out-of-order promise resolution.

---
*If you found this architectural insight helpful, let's connect�feel free to follow me on GitHub!*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database password strength checks so slower, outdated responses no longer overwrite newer results.
  * Ensured password warning text and strength indicators stay in sync with the latest input.
  * Reduced incorrect error logging by only reporting issues for the most recent check.

* **Tests**
  * Added coverage for out-of-order password strength responses to verify the UI keeps the latest result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->