### PR TITLE
fix(docs): CLI command flag ordering in documentation

### DIFF
--- a/apps/docs/content/guides/database/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/database/custom-postgres-config.mdx
@@ -119,7 +119,7 @@ Parameters marked with **Restart: Yes** cause the CLI to automatically restart y
 
 </Admonition>
 
-Use the examples below with `supabase --experimental --project-ref <project-ref> postgres-config update`:
+Use the examples below with `supabase postgres-config update --project-ref <project-ref> --experimental`:
 
 | Parameter                                                                                                                                                                                                                      | Type      | Restart | Example                                       |
 | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- | ------- | --------------------------------------------- |

--- a/apps/docs/content/guides/database/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/database/custom-postgres-config.mdx
@@ -165,26 +165,26 @@ To start:
 To update Postgres configurations, use the [`postgres config`](/docs/reference/cli/supabase-postgres-config) command:
 
 ```bash
-supabase --experimental \
-postgres-config update --config shared_buffers=250MB \
---project-ref <project-ref>
+supabase postgres-config update --config shared_buffers=250MB \
+--project-ref <project-ref> \
+--experimental
 ```
 
 By default, the CLI will merge any provided config overrides with any existing ones. The `--replace-existing-overrides` flag can be used to instead force all existing overrides to be replaced with the ones being provided:
 
 ```bash
-supabase --experimental \
-postgres-config update --config max_parallel_workers=3 \
+supabase postgres-config update --config max_parallel_workers=3 \
 --replace-existing-overrides \
---project-ref <project-ref>
+--project-ref <project-ref> \
+--experimental
 ```
 
 To delete specific configuration overrides, use the `postgres-config delete` command:
 
 ```bash
-supabase --experimental \
-postgres-config delete --config shared_buffers,work_mem \
---project-ref <project-ref>
+supabase postgres-config delete --config shared_buffers,work_mem \
+--project-ref <project-ref> \
+--experimental
 ```
 
 By default, CLI v2 (≥ 2.0.0) checks the parameter’s context and requests the correct action (reload or restart):
@@ -223,9 +223,9 @@ By default, Supabase ensures that this propagation is executed correctly. Howeve
 </Admonition>
 
 ```bash
-supabase --experimental \
+supabase postgres-config delete --config shared_buffers --no-restart \
 --project-ref <project-ref> \
-postgres-config delete --config shared_buffers --no-restart
+--experimental
 ```
 
 ### Resetting to default config

--- a/apps/docs/content/guides/database/inspect.mdx
+++ b/apps/docs/content/guides/database/inspect.mdx
@@ -47,7 +47,7 @@ Most inspection commands are Postgres agnostic. You can run inspection routines 
 For example you can connect to your local Postgres instance:
 
 ```
-supabase --db-url postgresql://postgres:postgres@localhost:5432/postgres inspect db bloat
+supabase inspect db bloat --db-url postgresql://postgres:postgres@localhost:5432/postgres
 ```
 
 ### Connect to a Supabase instance

--- a/apps/docs/content/guides/functions/examples/slack-bot-mention.mdx
+++ b/apps/docs/content/guides/functions/examples/slack-bot-mention.mdx
@@ -20,8 +20,9 @@ For your bot to seamlessly interact with Slack, you'll need to configure Slack A
 Deploy the following code as an Edge function using the CLI:
 
 ```bash
-supabase --project-ref nacho_slacker secrets \
-set SLACK_TOKEN=<xoxb-0000000000-0000000000-01010101010nacho101010>
+supabase secrets set \
+  SLACK_TOKEN=<xoxb-0000000000-0000000000-01010101010nacho101010> \
+  --project-ref nacho_slacker
 ```
 
 Here's the code of the Edge Function, you can change the response to handle the text received:

--- a/apps/docs/content/guides/platform/custom-domains.mdx
+++ b/apps/docs/content/guides/platform/custom-domains.mdx
@@ -168,7 +168,7 @@ Assume your Supabase project's domain is `abcdefghijklmnopqrst.supabase.co` and 
 Use the [`vanity-subdomains check-availability`](/docs/reference/cli/supabase-vanity-subdomains-check-availability) command of the CLI to check if your desired subdomain is available for use:
 
 ```bash
-supabase vanity-subdomains --project-ref abcdefghijklmnopqrst check-availability --desired-subdomain my-example-brand --experimental
+supabase vanity-subdomains check-availability --project-ref abcdefghijklmnopqrst --desired-subdomain my-example-brand --experimental
 ```
 
 ### Prepare to activate the subdomain

--- a/apps/docs/content/guides/platform/custom-domains.mdx
+++ b/apps/docs/content/guides/platform/custom-domains.mdx
@@ -200,7 +200,7 @@ Once you've chosen an available subdomain and have done all the necessary prepar
 Use the [`vanity-subdomains activate`](/docs/reference/cli/supabase-vanity-subdomains-activate) command to activate and claim your subdomain:
 
 ```bash
-supabase vanity-subdomains --project-ref abcdefghijklmnopqrst activate --desired-subdomain my-example-brand --experimental
+supabase vanity-subdomains activate --project-ref abcdefghijklmnopqrst --desired-subdomain my-example-brand --experimental
 ```
 
 If you wish to use the new domain in client code, you can set it up like so:

--- a/apps/docs/content/guides/platform/ssl-enforcement.mdx
+++ b/apps/docs/content/guides/platform/ssl-enforcement.mdx
@@ -70,7 +70,7 @@ To get started:
 You can use the `get` subcommand of the CLI to check whether SSL is currently being enforced:
 
 ```bash
-supabase ssl-enforcement --project-ref {ref} get --experimental
+supabase ssl-enforcement get --project-ref {ref} --experimental
 ```
 
 Response if SSL is being enforced:
@@ -90,13 +90,13 @@ SSL is *NOT* being enforced.
 The `update` subcommand is used to change the SSL enforcement status for your project:
 
 ```bash
-supabase ssl-enforcement --project-ref {ref} update --enable-db-ssl-enforcement --experimental
+supabase ssl-enforcement update --project-ref {ref} --enable-db-ssl-enforcement --experimental
 ```
 
 Similarly, to disable SSL enforcement:
 
 ```bash
-supabase ssl-enforcement --project-ref {ref} update --disable-db-ssl-enforcement --experimental
+supabase ssl-enforcement update --project-ref {ref} --disable-db-ssl-enforcement --experimental
 ```
 
 ### A note about Postgres SSL modes


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Documentation examples show CLI commands with inconsistent flag ordering, where `--project-ref` and other flags appear before subcommands, which doesn't match the actual CLI syntax.

## What is the new behavior?

Updated all CLI command examples to use the correct flag ordering where:
- The main command comes first
- Subcommands follow
- Flags come after subcommands

Examples updated:
- `supabase ssl-enforcement get --project-ref {ref} --experimental`
- `supabase secrets set SLACK_TOKEN=... --project-ref nacho_slacker`
- `supabase postgres-config update --project-ref <project-ref> --experimental`
- `supabase inspect db bloat --db-url postgresql://...`
- `supabase vanity-subdomains activate --project-ref abcdefghijklmnopqrst --desired-subdomain my-example-brand --experimental`

## Additional context

These changes ensure that documentation examples accurately reflect the actual CLI syntax and will help users avoid command errors when following the guides.

https://claude.ai/code/session_01WMx8BBuCJwZfrN1RJhY2Fq

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated multiple CLI examples across database, functions, and platform guides to use consistent, current argument ordering.
  * Refreshed guidance and examples for Postgres configuration management, database bloat inspection, setting Edge Function secrets, vanity subdomain availability/activation, and SSL enforcement.
  * No product behavior changed—these updates improve the accuracy and reliability of the documented commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->