### PR TITLE
fix: allow newline separated SMS_TEST_OTP entries

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -148,14 +148,15 @@ const PROVIDER_EMAIL = {
 
 const smsProviderBaseSchema = z.object({
   SMS_TEST_OTP: z
-    .string()
-    .trim()
-    .transform((value: string) => value.replace(/\s+/g, ''))
-    .refine((value) => {
-      // This ensure users can empty the SMS_TEST_OTP field
-      if (!value) return true
-      return /^\s*([0-9]{1,15}=[0-9]+)(\s*,\s*[0-9]{1,15}=[0-9]+)*\s*$/g.test(value)
-    }, 'Must be a comma-separated list of <phone number>=<OTP> pairs. Phone numbers should be in international format, without spaces, dashes or the + prefix. Example: 123456789=987654'),
+  .string()
+  .trim()
+  .transform((value: string) => value.replace(/[ \t]+/g, ''))
+  .refine((value) => {
+    if (!value) return true
+
+    return /^([0-9]{1,15}=[0-9]+\s*([,\n]\s*[0-9]{1,15}=[0-9]+)*)?$/.test(value)
+  },
+  'Must be a comma-separated or newline-separated list of <phone number>=<OTP> pairs.'),
   SMS_TEST_OTP_VALID_UNTIL: z
     .string()
     .optional()


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`SMS_TEST_OTP` validation only accepts comma-separated OTP pairs.

Inputs containing newline-separated entries fail validation even though they are useful for multiline text input.

## What is the new behavior?

Validation now supports both:
- comma-separated OTP entries
- newline-separated OTP entries

Examples:

Comma-separated:
123456789=111111,987654321=222222

Newline-separated:
123456789=111111
987654321=222222

## Additional context

Updated the regex validation pattern in `AuthProvidersFormValidation.tsx` to support multiline input while preserving existing validation behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for SMS test OTP entries so phone number and code pairs can be entered using either commas or line breaks.
  * Updated input handling to preserve supported separators while still trimming spaces and tabs.
  * Refreshed the validation message to reflect the accepted formats more clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->