### PR TITLE
fix: warning for resizes that touch < large

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.hooks.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.hooks.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 
 import { DiskStorageSchemaType } from '../DiskManagement.schema'
+import { ComputeInstanceAddonVariantId } from '../DiskManagement.types'
 import {
   calculateComputeSizePrice,
   calculateDiskSizePrice,
@@ -17,6 +18,13 @@ import {
   useIsAwsNimbusCloudProvider,
   useSelectedProjectQuery,
 } from '@/hooks/misc/useSelectedProject'
+
+const COMPUTE_SIZES_BELOW_LARGE: Array<ComputeInstanceAddonVariantId> = [
+  'ci_nano',
+  'ci_micro',
+  'ci_small',
+  'ci_medium',
+]
 
 export function useDiskManagementReviewChanges(
   form: UseFormReturn<DiskStorageSchemaType>,
@@ -131,6 +139,16 @@ export function useDiskManagementReviewChanges(
   // Show cooldown warning whenever any disk attribute that enforces the 4-hour lock changes
   const anyDiskAttributeChange = hasIOPSChanges || hasStorageTypeChanges || hasTotalSizeChanges
 
+  // Show extended downtime warning when resizing to/from a size below large
+  const hasExtendedDowntimeRisk =
+    hasComputeChanges &&
+    (COMPUTE_SIZES_BELOW_LARGE.includes(
+      (form.formState.defaultValues?.computeSize ?? 'ci_nano') as ComputeInstanceAddonVariantId
+    ) ||
+      COMPUTE_SIZES_BELOW_LARGE.includes(
+        form.getValues('computeSize') as ComputeInstanceAddonVariantId
+      ))
+
   // Throughput is only a user-configurable, separately-billed attribute for GP3. For IO2 it is
   // derived from provisioned IOPS (0.256 MiB/s per IOPS) and isn't surfaced as its own value, so
   // the form clears it to 0 — rendering a misleading "→ 0 MB/s". Only show the row when the
@@ -180,6 +198,7 @@ export function useDiskManagementReviewChanges(
     anyDiskAttributeChange,
     showThroughputRow,
     hasAnyBreakdownRows,
+    hasExtendedDowntimeRisk,
     // labels
     oldComputeLabel,
     newComputeLabel,

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.tsx
@@ -1,5 +1,5 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
-import { ArrowRight } from 'lucide-react'
+import { AlertTriangle, ArrowRight } from 'lucide-react'
 import { UseFormReturn } from 'react-hook-form'
 import {
   Alert,
@@ -84,6 +84,7 @@ export const DiskManagementReviewAndSubmitDialog = ({
     anyDiskAttributeChange,
     showThroughputRow,
     hasAnyBreakdownRows,
+    hasExtendedDowntimeRisk,
     oldComputeLabel,
     newComputeLabel,
   } = useDiskManagementReviewChanges(form, numReplicas)
@@ -265,6 +266,20 @@ export const DiskManagementReviewAndSubmitDialog = ({
               </div>
             )}
           </div>
+        )}
+
+        {hasExtendedDowntimeRisk && (
+          <>
+            <DialogSectionSeparator />
+            <DialogSection>
+              <Alert variant="warning">
+                <AlertTriangle />
+                <AlertTitle>
+                  Resizes may require more downtime than normal on this project.
+                </AlertTitle>
+              </Alert>
+            </DialogSection>
+          </>
         )}
 
         <DialogFooter className="px-5 py-4">


### PR DESCRIPTION
Add a warning that resizes may take additional time if they touch an instance size < large.

Resolves FE-3746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an additional warning in the disk management review dialog when a resize may require extra downtime.
  * The dialog now highlights higher-risk resize changes before submission, helping users make more informed decisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->