### PR TITLE
fix(studio): prevent FK peek popup from extending outside viewport

### DIFF
--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -86,7 +86,6 @@ export const ForeignKeyFormatter = (props: Props) => {
               </PopoverTrigger>
               <PopoverContent
                 align="end"
-                sticky="always"
                 collisionPadding={8}
                 className="p-0 w-96"
                 onDoubleClick={(e) => {

--- a/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
+++ b/apps/studio/components/grid/components/formatter/ForeignKeyFormatter.tsx
@@ -86,6 +86,8 @@ export const ForeignKeyFormatter = (props: Props) => {
               </PopoverTrigger>
               <PopoverContent
                 align="end"
+                sticky="always"
+                collisionPadding={8}
                 className="p-0 w-96"
                 onDoubleClick={(e) => {
                   e.preventDefault()

--- a/apps/studio/components/grid/components/formatter/ReferenceRecordPeek.tsx
+++ b/apps/studio/components/grid/components/formatter/ReferenceRecordPeek.tsx
@@ -122,39 +122,41 @@ export const ReferenceRecordPeek = ({ table, column, value }: ReferenceRecordPee
         </span>
         :
       </p>
-      <DataGrid
-        className="h-32 rounded-b border-0"
-        columns={columns}
-        rows={rows}
-        onSelectedCellChange={(args: {
-          column: CalculatedColumn<SupaRow, unknown>
-          rowIdx: number
-          row: SupaRow
-        }) => {
-          selectedCellRef.current = { idx: args.column.idx, rowIdx: args.rowIdx }
-        }}
-        onCellDoubleClick={(_, e) => {
-          e.preventDefault()
-          e.stopPropagation()
-        }}
-        renderers={{
-          noRowsFallback: (
-            <div className="w-96 px-2">
-              {isLoading && (
-                <div className="py-2">
-                  <ShimmeringLoader />
-                </div>
-              )}
-              {isError && (
-                <p className="text-foreground-light">
-                  Failed to find referencing row: {error.message}
-                </p>
-              )}
-              {isSuccess && <p className="text-foreground-light">No results were returned</p>}
-            </div>
-          ),
-        }}
-      />
+      <div className="h-32 overflow-hidden">
+        <DataGrid
+          className="h-full rounded-b border-0"
+          columns={columns}
+          rows={rows}
+          onSelectedCellChange={(args: {
+            column: CalculatedColumn<SupaRow, unknown>
+            rowIdx: number
+            row: SupaRow
+          }) => {
+            selectedCellRef.current = { idx: args.column.idx, rowIdx: args.rowIdx }
+          }}
+          onCellDoubleClick={(_, e) => {
+            e.preventDefault()
+            e.stopPropagation()
+          }}
+          renderers={{
+            noRowsFallback: (
+              <div className="w-96 px-2">
+                {isLoading && (
+                  <div className="py-2">
+                    <ShimmeringLoader />
+                  </div>
+                )}
+                {isError && (
+                  <p className="text-foreground-light">
+                    Failed to find referencing row: {error.message}
+                  </p>
+                )}
+                {isSuccess && <p className="text-foreground-light">No results were returned</p>}
+              </div>
+            ),
+          }}
+        />
+      </div>
       <div className="flex items-center justify-end px-2 py-1">
         <EditorTablePageLink
           href={`/project/${ref}/editor/${table.id}?schema=${table.schema}&filter=${column}%3Aeq%3A${value}`}


### PR DESCRIPTION
Fixes the `ReferenceRecordPeek` popup extending outside the browser viewport when clicking the FK arrow button on lower table rows in the Table Editor.

Closes FE-3761

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popover positioning near screen edges so reference previews stay visible in more cases.
  * Constrained the reference preview table to a fixed height with clipped overflow, keeping the preview panel compact and easier to scan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->