### PR TITLE
Add Paul Bauer to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -219,6 +219,7 @@ Oli R
 Pamela Chia
 Patricia Szasz
 Patrick Crane
+Paul Bauer
 Paul Caselton
 Paul Cioanca
 Paul Copplestone


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

humans.txt update

## What is the current behavior?

`humans.txt` is tragically missing _Paul Bauer_

## What is the new behavior?

`humans.txt` includes _Paul Bauer_

## Additional context

None. PR does what it says on the tin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the site’s public team information by adding a new team member name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->