### PR TITLE
fix: visual tweaks and telemetry added to projectConfigVariables

### DIFF
--- a/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.tsx
+++ b/apps/docs/components/ProjectConfigVariables/ProjectConfigVariables.tsx
@@ -29,6 +29,7 @@ import {
   useProjectsInfiniteQuery,
 } from '~/lib/fetch/projects-infinite'
 import { retrieve, storeOrRemoveNull } from '~/lib/storage'
+import { useSendTelemetryEvent } from '~/lib/telemetry'
 import { useOnLogout } from '~/lib/userAuth'
 import { LOCAL_STORAGE_KEYS, useIsLoggedIn, useIsUserLoading } from 'common'
 import { Check, Copy } from 'lucide-react'
@@ -389,12 +390,13 @@ function VariableView({ variable, className }: { variable: Variable; className?:
   }
 
   const { copied, handleCopy } = useCopy()
+  const sendTelemetryEvent = useSendTelemetryEvent()
 
   return (
     <>
       <div className={cn('flex items-center gap-2', className)}>
         <Input
-          disabled
+          readOnly
           type="text"
           className="font-mono"
           value={
@@ -413,10 +415,16 @@ function VariableView({ variable, className }: { variable: Variable; className?:
             disabled={!variableValue}
             variant="ghost"
             className="px-0"
-            onClick={handleCopy}
+            onClick={() => {
+              handleCopy()
+              sendTelemetryEvent({
+                action: 'docs_project_config_variables_copy_button_clicked',
+                properties: { variable },
+              })
+            }}
             aria-label="Copy"
           >
-            {copied ? <Check /> : <Copy />}
+            {copied ? <Check size="18" /> : <Copy size="18" />}
           </Button>
         </CopyToClipboard>
       </div>
@@ -445,7 +453,7 @@ function LoginHint({ variable }: { variable: Variable }) {
   if (isUserLoading || isLoggedIn) return null
 
   return (
-    <p className="text-foreground-muted text-sm mt-2 mb-0 ml-1">
+    <p className="not-prose text-foreground-muted text-sm mt-2 mb-0 ml-1">
       To get your {prettyFormatVariable[variable]},{' '}
       <Link
         className="text-foreground-muted"

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -935,6 +935,19 @@ export interface Docs404RecommendationClickedEvent {
 }
 
 /**
+ * User clicked the copy button on a project config variable in the docs.
+ *
+ * @group Events
+ * @source docs
+ */
+export interface DocsProjectConfigVariablesCopyButtonClickedEvent {
+  action: 'docs_project_config_variables_copy_button_clicked'
+  properties: {
+    variable: 'url' | 'publishable' | 'anon' | 'sessionPooler'
+  }
+}
+
+/**
  * User clicked the framework quickstart card on the homepage, leading to the specific framework documentation.
  *
  * @group Events
@@ -3585,6 +3598,7 @@ export type TelemetryEvent =
   | AskAiClickedEvent
   | DocsContentListingClickedEvent
   | Docs404RecommendationClickedEvent
+  | DocsProjectConfigVariablesCopyButtonClickedEvent
   | HomepageFrameworkQuickstartClickedEvent
   | HomepageProductCardClickedEvent
   | WwwPricingPlanCtaClickedEvent


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

### 1. Visual tweaks to `ProjectConfigVariable` component.

Some classes were not taking effect since they were missing `not-prose` class name. Adjusting sizes and changing disabled for `readOnly` as that's the real usage the inputs have in the use case.

<img width="881" height="344" alt="Screenshot 2026-07-02 at 14 39 57" src="https://github.com/user-attachments/assets/2f8f0f4b-ea6c-412a-ad21-03d8337f2afe" />

### 2. Add telemetry to copy action to `ProjectConfigVariable` component.

To know if people are actually taking advantage of the aid the component gives to user experience, we add an event to track usage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tracking for copy actions on project configuration variables in the docs.
  * Variable values are now shown as read-only, making them easier to select and copy.

* **Style**
  * Improved the layout of the login hint text for better formatting in the docs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->