### PR TITLE
docs: add Next Steps to storage, functions, and realtime as ContentListings

### DIFF
--- a/apps/docs/content/guides/functions.mdx
+++ b/apps/docs/content/guides/functions.mdx
@@ -56,3 +56,5 @@ Check out [Supabase Edge Function Examples](https://github.com/supabase/supabase
 <ContentListings id="functions-examples-messaging" />
 
 <ContentListings id="functions-examples-operations" />
+
+<ContentListings id="functions-next-steps" />

--- a/apps/docs/content/guides/realtime.mdx
+++ b/apps/docs/content/guides/realtime.mdx
@@ -25,3 +25,5 @@ Supabase provides a globally distributed [Realtime](https://github.com/supabase/
 <ContentListings id="realtime-examples" />
 
 <ContentListings id="realtime-resources" />
+
+<ContentListings id="realtime-next-steps" />

--- a/apps/docs/content/guides/storage.mdx
+++ b/apps/docs/content/guides/storage.mdx
@@ -22,3 +22,5 @@ Supabase Storage is a robust, scalable solution for managing files of any size w
 <ContentListings id="storage-examples" />
 
 <ContentListings id="storage-resources" />
+
+<ContentListings id="storage-next-steps" />

--- a/apps/docs/data/content-listings/functions.data.ts
+++ b/apps/docs/data/content-listings/functions.data.ts
@@ -176,6 +176,29 @@ export const functionsExamplesMessaging: ContentListingGroup = {
   ],
 }
 
+export const functionsNextSteps: ContentListingGroup = {
+  id: 'functions-next-steps',
+  heading: 'Next steps',
+  type: 'grid',
+  items: [
+    {
+      title: 'Deploy',
+      href: '/guides/functions/deploy',
+      description: 'Deploy Edge Functions to production with the Supabase CLI or dashboard.',
+    },
+    {
+      title: 'Secrets',
+      href: '/guides/functions/secrets',
+      description: 'Store and access credentials and environment variables securely.',
+    },
+    {
+      title: 'Local development',
+      href: '/guides/functions/development-environment',
+      description: 'Set up a local runtime for testing and debugging Edge Functions.',
+    },
+  ],
+}
+
 export const functionsExamplesOperations: ContentListingGroup = {
   id: 'functions-examples-operations',
   heading: 'Operations & security',

--- a/apps/docs/data/content-listings/index.ts
+++ b/apps/docs/data/content-listings/index.ts
@@ -9,10 +9,21 @@ import {
   functionsExamplesSupabase,
   functionsExamplesWebhooksPayments,
   functionsGetStarted,
+  functionsNextSteps,
 } from './functions.data'
 import { gettingStartedGetStarted } from './getting-started.data'
-import { realtimeExamples, realtimeGetStarted, realtimeResources } from './realtime.data'
-import { storageExamples, storageGetStarted, storageResources } from './storage.data'
+import {
+  realtimeExamples,
+  realtimeGetStarted,
+  realtimeNextSteps,
+  realtimeResources,
+} from './realtime.data'
+import {
+  storageExamples,
+  storageGetStarted,
+  storageNextSteps,
+  storageResources,
+} from './storage.data'
 
 const ALL_GROUPS: readonly ContentListingGroup[] = [
   authGetStarted,
@@ -32,7 +43,10 @@ const ALL_GROUPS: readonly ContentListingGroup[] = [
   realtimeResources,
   storageGetStarted,
   storageExamples,
+  storageNextSteps,
   storageResources,
+  functionsNextSteps,
+  realtimeNextSteps,
 ]
 
 export const CONTENT_LISTINGS: Readonly<Record<string, ContentListingGroup>> = Object.fromEntries(

--- a/apps/docs/data/content-listings/realtime.data.ts
+++ b/apps/docs/data/content-listings/realtime.data.ts
@@ -45,6 +45,29 @@ export const realtimeExamples: ContentListingGroup = {
   ],
 }
 
+export const realtimeNextSteps: ContentListingGroup = {
+  id: 'realtime-next-steps',
+  heading: 'Next steps',
+  type: 'grid',
+  items: [
+    {
+      title: 'Broadcast',
+      href: '/guides/realtime/broadcast',
+      description: 'Send low-latency messages between connected clients.',
+    },
+    {
+      title: 'Presence',
+      href: '/guides/realtime/presence',
+      description: 'Track who is online and synchronize shared state across clients.',
+    },
+    {
+      title: 'Postgres Changes',
+      href: '/guides/realtime/postgres-changes',
+      description: 'Listen to database inserts, updates, and deletes in real time.',
+    },
+  ],
+}
+
 export const realtimeResources: ContentListingGroup = {
   id: 'realtime-resources',
   heading: 'Resources',

--- a/apps/docs/data/content-listings/storage.data.ts
+++ b/apps/docs/data/content-listings/storage.data.ts
@@ -50,6 +50,29 @@ export const storageExamples: ContentListingGroup = {
   ],
 }
 
+export const storageNextSteps: ContentListingGroup = {
+  id: 'storage-next-steps',
+  heading: 'Next steps',
+  type: 'grid',
+  items: [
+    {
+      title: 'Access control',
+      href: '/guides/storage/security/access-control',
+      description: 'Secure buckets and objects with row-level security policies.',
+    },
+    {
+      title: 'Image transformations',
+      href: '/guides/storage/serving/image-transformations',
+      description: 'Resize, compress, and convert images on the fly at the CDN edge.',
+    },
+    {
+      title: 'CDN',
+      href: '/guides/storage/cdn/fundamentals',
+      description: 'Understand how the global CDN caches and delivers your assets.',
+    },
+  ],
+}
+
 export const storageResources: ContentListingGroup = {
   id: 'storage-resources',
   heading: 'Resources',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement — adds "Next steps" sections to the Storage, Edge Functions, and Realtime overview pages (DOCS-1137 pilot pages batch).

## Current behavior

The three pilot overview pages (`storage.mdx`, `functions.mdx`, `realtime.mdx`) have "Get started" and "Examples/Resources" sections but no "Next steps" section to guide readers toward depth topics after the basics.

## New behavior

Each page ends with a "Next steps" `<ContentListings />` section linking to relevant depth guides:

- **Storage**: Access control, Image transformations, CDN
- **Edge Functions**: Deploy, Secrets, Local development
- **Realtime**: Broadcast, Presence, Postgres Changes

New exports: `storageNextSteps`, `functionsNextSteps`, `realtimeNextSteps` — all registered in `ALL_GROUPS`.

## Additional context

Part of DOCS-1137 ContentListings rollout — pilot pages batch. Companion PRs: #47467, #47468, #47469, #47472, #47549.

## Verification

| Gate | Result |
|------|--------|
| All linked guide pages exist in content tree | ✅ 9/9 verified |

### Proof: Next steps section on Storage page

| [Before (production)](https://supabase.com/docs/guides/storage) | [After (PR preview)](https://docs-git-nikrichers-docs-1137-pilot-next-steps-supabase.vercel.app/docs/guides/storage) |
|---|---|
| ![storage-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47534/storage-before-dc942894.png) | ![storage-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47534/storage-after-aab5bb62.png) |

### Proof: Next steps section on Edge Functions page

| [Before (production)](https://supabase.com/docs/guides/functions) | [After (PR preview)](https://docs-git-nikrichers-docs-1137-pilot-next-steps-supabase.vercel.app/docs/guides/functions) |
|---|---|
| ![functions-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47534/functions-before-33d8a72a.png) | ![functions-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47534/functions-after-813fc064.png) |

### Proof: Next steps section on Realtime page

| [Before (production)](https://supabase.com/docs/guides/realtime) | [After (PR preview)](https://docs-git-nikrichers-docs-1137-pilot-next-steps-supabase.vercel.app/docs/guides/realtime) |
|---|---|
| ![realtime-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47534/realtime-before-66a1b5a7.png) | ![realtime-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47534/realtime-after-cc5eba94.png) |