### PR TITLE
docs: clarify self-hosted S3-compatible provider configuration

### DIFF
--- a/apps/docs/content/guides/self-hosting/self-hosted-s3.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-s3.mdx
@@ -146,7 +146,7 @@ storage:
     STORAGE_BACKEND: s3
     GLOBAL_S3_BUCKET: your-bucket-name
     GLOBAL_S3_ENDPOINT: https://your-account-id.r2.cloudflarestorage.com
-    GLOBAL_S3_FORCE_PATH_STYLE: "true"
+    GLOBAL_S3_FORCE_PATH_STYLE: 'true'
     AWS_ACCESS_KEY_ID: your-access-key-id
     AWS_SECRET_ACCESS_KEY: your-secret-access-key
     REGION: your-region

--- a/apps/docs/content/guides/self-hosting/self-hosted-s3.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-s3.mdx
@@ -137,7 +137,7 @@ For AWS S3, you do not need `GLOBAL_S3_ENDPOINT` or `GLOBAL_S3_FORCE_PATH_STYLE`
 ### S3-compatible providers
 
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
-Use the same configuration as MinIO, but point to your provider's endpoint, e.g.:
+Use the same configuration as MinIO, replacing the endpoint, bucket name, region, and AWS credentials with the values provided by your S3-compatible provider, for example:
 
 ```yaml name=docker-compose.yml
 storage:
@@ -146,6 +146,10 @@ storage:
     STORAGE_BACKEND: s3
     GLOBAL_S3_BUCKET: your-bucket-name
     GLOBAL_S3_ENDPOINT: https://your-account-id.r2.cloudflarestorage.com
+    GLOBAL_S3_FORCE_PATH_STYLE: "true"
+    AWS_ACCESS_KEY_ID: your-access-key-id
+    AWS_SECRET_ACCESS_KEY: your-secret-access-key
+    REGION: your-region
 ```
 
 ## Verify


### PR DESCRIPTION
## Summary

This PR improves the self-hosted S3 documentation by clarifying how to configure S3-compatible storage providers.

The changes:
- clarify the distinction between the S3 protocol endpoint and the S3 backend
- improve the configuration examples for AWS S3 and other S3-compatible providers
- clarify that users should replace the endpoint, bucket name, region, and AWS credentials from the MinIO example with the values provided by their S3-compatible provider

This addresses part of the confusion described in #658 around configuring external S3 providers for self-hosted Storage.


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Documentation update.

## What is the current behavior?

The self-hosted S3 documentation can be confusing when configuring external S3-compatible providers. The MinIO example does not clearly explain which values should be replaced, making it unclear how to adapt the configuration for providers such as Cloudflare R2 or other S3-compatible services. This confusion is described in #658.

## What is the new behavior?

The documentation now:

- explains the difference between the S3 protocol endpoint and the S3 backend
- provides clearer AWS S3 and S3-compatible provider examples
- explicitly states which values from the MinIO example should be replaced when using an external S3-compatible provider

## Additional context

Documentation-only change. No functional code changes.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “S3-compatible providers” self-hosting guidance to align configuration with MinIO, while swapping in provider-specific endpoint, bucket name, region, and credentials.
  * Expanded the `docker-compose` storage environment example with additional S3 connection settings, including forcing path-style access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->