### PR TITLE
docs: convert second-level hub pages to ContentListings (batch D)

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks.mdx
@@ -371,40 +371,4 @@ Outside of runtime errors, both HTTP Hooks and Postgres Hooks return timeout err
 
 Each Hook description contains an example JSON Schema which you can use in conjunction with [JSON Schema Faker](https://json-schema-faker.js.org/) in order to generate a mock payload. For HTTP Hooks, you can also use [the Standard Webhooks Testing Tool](https://www.standardwebhooks.com/simulate) to simulate a request.
 
-<div className="grid md:grid-cols-12 gap-4 not-prose">
-  <div className="col-span-4">
-    <Link href="/guides/auth/auth-hooks/custom-access-token-hook" passHref>
-      <GlassPanel title="Custom Access Token">
-        Customize the access token issued by Supabase Auth
-      </GlassPanel>
-    </Link>
-  </div>
-  <div className="col-span-4">
-    <Link href="/guides/auth/auth-hooks/send-sms-hook" passHref>
-      <GlassPanel title="Send SMS">
-        Use a custom SMS provider to send authentication messages
-      </GlassPanel>
-    </Link>
-  </div>
-  <div className="col-span-4">
-    <Link href="/guides/auth/auth-hooks/send-email-hook" passHref>
-      <GlassPanel title="Send Email">
-        Use a custom email provider to send authentication messages
-      </GlassPanel>
-    </Link>
-  </div>
-  <div className="col-span-4">
-    <Link href="/guides/auth/auth-hooks/mfa-verification-hook" passHref>
-      <GlassPanel title="MFA Verification">
-        Add additional checks to the MFA verification flow
-      </GlassPanel>
-    </Link>
-  </div>
-  <div className="col-span-4">
-    <Link href="/guides/auth/auth-hooks/password-verification-hook" passHref>
-      <GlassPanel title="Password verification">
-        Add additional checks to the password verification flow
-      </GlassPanel>
-    </Link>
-  </div>
-</div>
+<ContentListings id="auth-hooks-available" />

--- a/apps/docs/content/guides/auth/oauth-server.mdx
+++ b/apps/docs/content/guides/auth/oauth-server.mdx
@@ -49,40 +49,7 @@ OAuth 2.1 Server works seamlessly with your existing Supabase Auth configuration
 - Row Level Security policies control data access using the `client_id` claim in tokens
 - All standard Supabase features (email templates, hooks, rate limiting) continue to work
 
-## Set up OAuth 2.1 server
-
-To enable OAuth 2.1 Server in your project, follow these guides:
-
-<div className="grid md:grid-cols-12 gap-4 not-prose">
-  <div className="col-span-6">
-    <Link href="/guides/auth/oauth-server/getting-started" passHref>
-      <GlassPanel title="Getting Started">
-        Enable OAuth 2.1, configure your authorization endpoint, and register your first client.
-      </GlassPanel>
-    </Link>
-  </div>
-  <div className="col-span-6">
-    <Link href="/guides/auth/oauth-server/oauth-flows" passHref>
-      <GlassPanel title="OAuth Flows">
-        Detailed walkthrough of authorization code and refresh token flows.
-      </GlassPanel>
-    </Link>
-  </div>
-  <div className="col-span-6">
-    <Link href="/guides/auth/oauth-server/mcp-authentication" passHref>
-      <GlassPanel title="MCP Authentication">
-        Authenticate AI agents and LLM tools using Model Context Protocol.
-      </GlassPanel>
-    </Link>
-  </div>
-  <div className="col-span-6">
-    <Link href="/guides/auth/oauth-server/token-security" passHref>
-      <GlassPanel title="Token Security & RLS">
-        Control data access with Row Level Security policies for OAuth clients.
-      </GlassPanel>
-    </Link>
-  </div>
-</div>
+<ContentListings id="auth-oauth-server-setup" />
 
 ## Resources
 

--- a/apps/docs/content/guides/auth/server-side.mdx
+++ b/apps/docs/content/guides/auth/server-side.mdx
@@ -17,19 +17,4 @@ Make sure to use the PKCE flow instructions where those differ from the implicit
 
 We have developed an [`@supabase/ssr`](https://www.npmjs.com/package/@supabase/ssr) package for setting up the Supabase client. This package is currently in beta. Adoption is recommended but be aware that the API is still unstable and may have breaking changes in the future.
 
-## Framework quickstarts
-
-<div className="grid grid-cols-[repeat(auto-fit,minmax(300px,1fr))] gap-6 mb-6 not-prose">
-  <Link href="/guides/auth/server-side/nextjs" passHref>
-    <GlassPanel title="Next.js" background={false} icon="/docs/img/icons/nextjs-icon">
-      Automatically configure Supabase in Next.js to use cookies, making your user and their session
-      available on the client and server.
-    </GlassPanel>
-  </Link>
-  <Link href="/guides/auth/server-side/sveltekit" passHref>
-    <GlassPanel title="SvelteKit" background={false} icon="/docs/img/icons/svelte-icon">
-      Automatically configure Supabase in SvelteKit to use cookies, making your user and their
-      session available on the client and server.
-    </GlassPanel>
-  </Link>
-</div>
+<ContentListings id="auth-server-side-frameworks" />

--- a/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
+++ b/apps/docs/content/guides/database/connecting-to-postgres/serverless-drivers.mdx
@@ -15,31 +15,7 @@ Vercel's [Edge runtime](https://vercel.com/docs/functions/runtimes/edge-runtime)
 
 ### Quickstart
 
-Choose one of these Vercel Deploy Templates which use our [Vercel Deploy Integration](https://vercel.com/integrations/supabase) to automatically configure your connection strings as environment variables on your Vercel project!
-
-<div>
-  <div className="grid grid-cols-12 gap-6 not-prose">
-    <Link
-      href="https://supabase.link/nextjs-with-supabase-starter"
-      className="col-span-12 md:col-span-4"
-      passHref
-    >
-      <GlassPanel title="supabase-js" hasLightIcon={true} background={false} showIconBg={true}>
-        A Next.js App Router template configured with cookie-based auth using Supabase, TypeScript
-        and Tailwind CSS.
-      </GlassPanel>
-    </Link>
-    <Link
-      href="https://supabase.link/nextjs-supabase-kysely"
-      className="col-span-12 md:col-span-4"
-      passHref
-    >
-      <GlassPanel title="Kysely" hasLightIcon={true} background={false} showIconBg={true}>
-        Basic Next.js template that uses Supabase as the database and Kysely as the query builder.
-      </GlassPanel>
-    </Link>
-  </div>
-</div>
+<ContentListings id="database-serverless-drivers" />
 
 ### Manual configuration
 

--- a/apps/docs/data/content-listings/auth.data.ts
+++ b/apps/docs/data/content-listings/auth.data.ts
@@ -24,6 +24,90 @@ export const authGetStarted: ContentListingGroup = {
   ],
 }
 
+export const authServerSideFrameworks: ContentListingGroup = {
+  id: 'auth-server-side-frameworks',
+  heading: 'Framework quickstarts',
+  type: 'grid',
+  items: [
+    {
+      title: 'Next.js',
+      href: '/guides/auth/server-side/nextjs',
+      icon: '/docs/img/icons/nextjs-icon',
+      description:
+        'Automatically configure Supabase in Next.js to use cookies, making your user and their session available on the client and server.',
+    },
+    {
+      title: 'SvelteKit',
+      href: '/guides/auth/server-side/sveltekit',
+      description:
+        'Automatically configure Supabase in SvelteKit to use cookies, making your user and their session available on the client and server.',
+    },
+  ],
+}
+
+export const authHooksAvailable: ContentListingGroup = {
+  id: 'auth-hooks-available',
+  heading: 'Available Hooks',
+  type: 'grid',
+  items: [
+    {
+      title: 'Custom Access Token',
+      href: '/guides/auth/auth-hooks/custom-access-token-hook',
+      description: 'Customize the access token issued by Supabase Auth.',
+    },
+    {
+      title: 'Send SMS',
+      href: '/guides/auth/auth-hooks/send-sms-hook',
+      description: 'Use a custom SMS provider to send authentication messages.',
+    },
+    {
+      title: 'Send Email',
+      href: '/guides/auth/auth-hooks/send-email-hook',
+      description: 'Use a custom email provider to send authentication messages.',
+    },
+    {
+      title: 'MFA Verification',
+      href: '/guides/auth/auth-hooks/mfa-verification-hook',
+      description: 'Add additional checks to the MFA verification flow.',
+    },
+    {
+      title: 'Password Verification',
+      href: '/guides/auth/auth-hooks/password-verification-hook',
+      description: 'Add additional checks to the password verification flow.',
+    },
+  ],
+}
+
+export const authOauthServerSetup: ContentListingGroup = {
+  id: 'auth-oauth-server-setup',
+  heading: 'Set up OAuth 2.1 server',
+  type: 'grid',
+  columns: 2,
+  items: [
+    {
+      title: 'Getting Started',
+      href: '/guides/auth/oauth-server/getting-started',
+      description:
+        'Enable OAuth 2.1, configure your authorization endpoint, and register your first client.',
+    },
+    {
+      title: 'OAuth Flows',
+      href: '/guides/auth/oauth-server/oauth-flows',
+      description: 'Detailed walkthrough of authorization code and refresh token flows.',
+    },
+    {
+      title: 'MCP Authentication',
+      href: '/guides/auth/oauth-server/mcp-authentication',
+      description: 'Authenticate AI agents and LLM tools using Model Context Protocol.',
+    },
+    {
+      title: 'Token Security & RLS',
+      href: '/guides/auth/oauth-server/token-security',
+      description: 'Control data access with Row Level Security policies for OAuth clients.',
+    },
+  ],
+}
+
 export const authPricing: ContentListingGroup = {
   id: 'auth-pricing',
   heading: 'Pricing',

--- a/apps/docs/data/content-listings/database.data.ts
+++ b/apps/docs/data/content-listings/database.data.ts
@@ -43,6 +43,30 @@ export const databaseGetStarted: ContentListingGroup = {
   ],
 }
 
+export const databaseServerlessDrivers: ContentListingGroup = {
+  id: 'database-serverless-drivers',
+  heading: 'Quickstart',
+  headingLevel: 'h3',
+  description:
+    'Vercel Deploy Templates that use the Vercel Deploy Integration to automatically configure your connection strings as environment variables:',
+  type: 'grid',
+  columns: 2,
+  items: [
+    {
+      title: 'supabase-js',
+      href: 'https://supabase.link/nextjs-with-supabase-starter',
+      description:
+        'A Next.js App Router template configured with cookie-based auth using Supabase, TypeScript and Tailwind CSS.',
+    },
+    {
+      title: 'Kysely',
+      href: 'https://supabase.link/nextjs-supabase-kysely',
+      description:
+        'Basic Next.js template that uses Supabase as the database and Kysely as the query builder.',
+    },
+  ],
+}
+
 export const databaseNextSteps: ContentListingGroup = {
   id: 'database-next-steps',
   heading: 'Next steps',

--- a/apps/docs/data/content-listings/index.ts
+++ b/apps/docs/data/content-listings/index.ts
@@ -1,7 +1,14 @@
 import type { ContentListingGroup } from '~/lib/content-listings.schema'
 
-import { authGetStarted, authNextSteps, authPricing } from './auth.data'
-import { databaseGetStarted, databaseNextSteps } from './database.data'
+import {
+  authGetStarted,
+  authHooksAvailable,
+  authNextSteps,
+  authOauthServerSetup,
+  authPricing,
+  authServerSideFrameworks,
+} from './auth.data'
+import { databaseGetStarted, databaseNextSteps, databaseServerlessDrivers } from './database.data'
 import {
   functionsExamplesAiMedia,
   functionsExamplesMessaging,
@@ -18,8 +25,12 @@ const ALL_GROUPS: readonly ContentListingGroup[] = [
   authGetStarted,
   authPricing,
   authNextSteps,
+  authServerSideFrameworks,
+  authHooksAvailable,
+  authOauthServerSetup,
   databaseGetStarted,
   databaseNextSteps,
+  databaseServerlessDrivers,
   functionsGetStarted,
   functionsExamplesSupabase,
   functionsExamplesWebhooksPayments,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation improvement — converts four second-level hub pages from manual `GlassPanel` grids to the `ContentListings` data-driven component (DOCS-1137 batch D).

## Current behavior

Four sub-product hub pages still used hand-authored JSX `<GlassPanel>` grids; they were missed by the original DOCS-1137 audit which only covered top-level `content/guides/*.mdx`.

## New behavior

All four pages converted to `<ContentListings />`:

| Page | New export | id |
|------|-----------|-----|
| `auth/server-side.mdx` | `authServerSideFrameworks` | `auth-server-side-frameworks` |
| `auth/auth-hooks.mdx` | `authHooksAvailable` | `auth-hooks-available` |
| `auth/oauth-server.mdx` | `authOauthServerSetup` | `auth-oauth-server-setup` |
| `database/connecting-to-postgres/serverless-drivers.mdx` | `databaseServerlessDrivers` | `database-serverless-drivers` |

All new exports registered in `ALL_GROUPS` in `apps/docs/data/content-listings/index.ts`.

## Additional context

Part of DOCS-1137 ContentListings rollout — batch D (second-level hub pages). Companion PRs: #47467, #47468, #47469, #47472, #47534.

## Verification

| Gate | Result |
|------|--------|
| All 11 internal guide hrefs exist in content tree | ✅ verified |
| No `GlassPanel`/`IconPanel` remain in converted pages | ✅ verified |

### Proof: Framework quickstarts on auth/server-side page

| [Before (production)](https://supabase.com/docs/guides/auth/server-side) | [After (PR preview)](https://docs-git-nikrichers-docs-1137-batch-d-supabase.vercel.app/docs/guides/auth/server-side) |
|---|---|
| ![auth-server-side-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/auth-server-side-before-7c360e10.png) | ![auth-server-side-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/auth-server-side-after-e594e095.png) |

### Proof: Available Hooks grid on auth/auth-hooks page

| [Before (production)](https://supabase.com/docs/guides/auth/auth-hooks) | [After (PR preview)](https://docs-git-nikrichers-docs-1137-batch-d-supabase.vercel.app/docs/guides/auth/auth-hooks) |
|---|---|
| ![auth-hooks-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/auth-hooks-before-ec055a5a.png) | ![auth-hooks-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/auth-hooks-after-4d4f1c85.png) |

### Proof: OAuth 2.1 setup grid on auth/oauth-server page

| [Before (production)](https://supabase.com/docs/guides/auth/oauth-server) | [After (PR preview)](https://docs-git-nikrichers-docs-1137-batch-d-supabase.vercel.app/docs/guides/auth/oauth-server) |
|---|---|
| ![auth-oauth-server-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/auth-oauth-server-before-98acfc2d.png) | ![auth-oauth-server-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/auth-oauth-server-after-925fec49.png) |

### Proof: Quickstart grid on serverless-drivers page

| [Before (production)](https://supabase.com/docs/guides/database/connecting-to-postgres/serverless-drivers) | [After (PR preview)](https://docs-git-nikrichers-docs-1137-batch-d-supabase.vercel.app/docs/guides/database/connecting-to-postgres/serverless-drivers) |
|---|---|
| ![serverless-drivers-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/serverless-drivers-before-4398b3a4.png) | ![serverless-drivers-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr47549/serverless-drivers-after-19cb4f88.png) |