### PR TITLE
docs(wrappers): add doc link for MongoDB wrapper

### DIFF
--- a/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
+++ b/apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx
@@ -224,6 +224,14 @@ const pageMap = [
     remoteFile: 'logflare.md',
   },
   {
+    slug: 'mongodb',
+    meta: {
+      title: 'MongoDB',
+      dashboardIntegrationPath: undefined,
+    },
+    remoteFile: 'mongodb.md',
+  },
+  {
     slug: 'mssql',
     meta: {
       title: 'MSSQL',

--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -1421,6 +1421,10 @@ export const database: NavMenuConstant = {
               url: '/guides/database/extensions/wrappers/logflare' as `/${string}`,
             },
             {
+              name: 'MongoDB',
+              url: '/guides/database/extensions/wrappers/mongodb' as `/${string}`,
+            },
+            {
               name: 'MSSQL',
               url: '/guides/database/extensions/wrappers/mssql' as `/${string}`,
             },


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This PR is to add doc links for the new [MongoDB FDW](https://fdw.dev/catalog/mongodb/), which was released in [Wrappers v0.6.2](https://github.com/supabase/wrappers/releases/tag/v0.6.2).

## What is the current behavior?

There is no docs for MongoDB FDW.

## What is the new behavior?

MongoDB FDW doc links are added.

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MongoDB to the Foreign Data Wrappers documentation, including a dedicated page and navigation entry.
  * The documentation menu now includes a direct link to the MongoDB wrapper guide under Sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->