### PR TITLE
feat(functions): set up @supabase/server middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,16 @@
     "pnpm": "10.24",
     "node": ">=22"
   },
-  "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
-  "packageManager": "pnpm@10.24.0"
+  "keywords": [
+    "postgres",
+    "firebase",
+    "storage",
+    "functions",
+    "database",
+    "auth"
+  ],
+  "packageManager": "pnpm@10.24.0",
+  "dependencies": {
+    "@supabase/server": "^1.2.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -130,6 +130,10 @@ patchedDependencies:
 importers:
 
   .:
+    dependencies:
+      '@supabase/server':
+        specifier: ^1.2.0
+        version: 1.2.0(@supabase/supabase-js@2.108.2)(hono@4.12.25)
     devDependencies:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.1041.0
@@ -7571,6 +7575,25 @@ packages:
     resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
     engines: {node: '>=20.0.0'}
 
+  '@supabase/server@1.2.0':
+    resolution: {integrity: sha512-6ts8/aC5FEf03A9+WnEsrb79YYqlE1lf8KKtWKVHZIyaDq+RM5tzP4tHRzc8Bwg88pmoDImAkaj9D3lunnanvg==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@nestjs/common': ^10.0.0 || ^11.0.0
+      '@supabase/supabase-js': ^2.0.0
+      elysia: ^1.4.0
+      h3: ^2.0.0
+      hono: ^4.0.0
+    peerDependenciesMeta:
+      '@nestjs/common':
+        optional: true
+      elysia:
+        optional: true
+      h3:
+        optional: true
+      hono:
+        optional: true
+
   '@supabase/shared-types@0.1.88':
     resolution: {integrity: sha512-9LYy+pD6cD2o8ZSxeUeJ1nrHPigeoP1kzhd2+k6MmzrwBHwxwUhWjywQJVjpU6fLNQxdkoNqxPfI7UQgOjG7Lg==}
 
@@ -12455,6 +12478,9 @@ packages:
 
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
 
   jotai@2.8.1:
     resolution: {integrity: sha512-Gmk5Y3yJL/vN5S0rQ6AaWpXH5Q+HBGHThMHXfylVzXGVuO8YxPRtZf8Y9XYvl+h7ZMQXoHNdFi37vNsJFsiszQ==}
@@ -23289,6 +23315,13 @@ snapshots:
       '@supabase/phoenix': 0.4.2
       tslib: 2.8.1
 
+  '@supabase/server@1.2.0(@supabase/supabase-js@2.108.2)(hono@4.12.25)':
+    dependencies:
+      '@supabase/supabase-js': 2.108.2
+      jose: 6.2.3
+    optionalDependencies:
+      hono: 4.12.25
+
   '@supabase/shared-types@0.1.88': {}
 
   '@supabase/sql-to-rest@0.1.6(encoding@0.1.13)(supports-color@8.1.1)':
@@ -28951,6 +28984,8 @@ snapshots:
   jose@5.9.6: {}
 
   jose@6.1.3: {}
+
+  jose@6.2.3: {}
 
   jotai@2.8.1(@types/react@19.2.14)(react@19.2.6):
     optionalDependencies:

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -104,3 +104,6 @@ url = ""
 
 [functions.search-embeddings]
 verify_jwt = false
+
+[functions.og-images]
+verify_jwt = false

--- a/supabase/functions/og-images/index.ts
+++ b/supabase/functions/og-images/index.ts
@@ -1,6 +1,8 @@
-import { serve } from 'https://deno.land/std@0.170.0/http/server.ts'
+import { withSupabase } from 'npm:@supabase/server@^1'
 import { handler } from './handler.tsx'
 
-serve(handler)
+export default {
+  fetch: withSupabase({ auth: 'none' }, handler),
+}
 
 console.log('Serving og-images function')

--- a/supabase/functions/search-embeddings/index.ts
+++ b/supabase/functions/search-embeddings/index.ts
@@ -1,129 +1,118 @@
 import 'https://deno.land/x/xhr@0.2.1/mod.ts'
-import { createClient } from 'jsr:@supabase/supabase-js@2'
+import { withSupabase } from 'npm:@supabase/server@^1'
 import { Configuration, OpenAIApi } from 'https://esm.sh/openai@3.1.0'
-import { Database } from '../../../packages/common/database-types.ts'
 import { ApplicationError, UserError } from '../common/errors.ts'
 
 const openAiKey = Deno.env.get('OPENAI_API_KEY')
-const supabaseUrl = Deno.env.get('SUPABASE_URL')
-const supabaseServiceKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
 
 export const corsHeaders = {
   'Access-Control-Allow-Origin': '*',
   'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
 }
 
-Deno.serve(async (req) => {
-  try {
-    // Handle CORS
-    if (req.method === 'OPTIONS') {
-      return new Response('ok', { headers: corsHeaders })
-    }
+export default {
+  fetch: withSupabase({ auth: ['publishable', 'secret'] }, async (req, ctx) => {
+    try {
+      // Handle CORS
+      if (req.method === 'OPTIONS') {
+        return new Response('ok', { headers: corsHeaders })
+      }
 
-    if (!openAiKey) {
-      throw new ApplicationError('Missing environment variable OPENAI_API_KEY')
-    }
+      if (!openAiKey) {
+        throw new ApplicationError('Missing environment variable OPENAI_API_KEY')
+      }
 
-    if (!supabaseUrl) {
-      throw new ApplicationError('Missing environment variable SUPABASE_URL')
-    }
+      const requestData = await req.json()
 
-    if (!supabaseServiceKey) {
-      throw new ApplicationError('Missing environment variable SUPABASE_SERVICE_ROLE_KEY')
-    }
+      if (!requestData) {
+        throw new UserError('Missing request data')
+      }
 
-    const requestData = await req.json()
+      const { query, useAlternateSearchIndex } = requestData
 
-    if (!requestData) {
-      throw new UserError('Missing request data')
-    }
+      if (!query) {
+        throw new UserError('Missing query in request data')
+      }
 
-    const { query, useAlternateSearchIndex } = requestData
+      // Intentionally log the query
+      console.log({ query })
 
-    if (!query) {
-      throw new UserError('Missing query in request data')
-    }
+      const sanitizedQuery = query.trim()
 
-    // Intentionally log the query
-    console.log({ query })
+      const configuration = new Configuration({ apiKey: openAiKey })
+      const openai = new OpenAIApi(configuration)
 
-    const sanitizedQuery = query.trim()
+      // Moderate the content to comply with OpenAI T&C
+      const moderationResponse = await openai.createModeration({ input: sanitizedQuery })
 
-    const supabaseClient = createClient<Database>(supabaseUrl, supabaseServiceKey)
+      const [results] = moderationResponse.data.results
 
-    const configuration = new Configuration({ apiKey: openAiKey })
-    const openai = new OpenAIApi(configuration)
+      if (results.flagged) {
+        throw new UserError('Flagged content', {
+          flagged: true,
+          categories: results.categories,
+        })
+      }
 
-    // Moderate the content to comply with OpenAI T&C
-    const moderationResponse = await openai.createModeration({ input: sanitizedQuery })
-
-    const [results] = moderationResponse.data.results
-
-    if (results.flagged) {
-      throw new UserError('Flagged content', {
-        flagged: true,
-        categories: results.categories,
+      const embeddingResponse = await openai.createEmbedding({
+        model: 'text-embedding-ada-002',
+        input: sanitizedQuery.replaceAll('\n', ' '),
       })
-    }
 
-    const embeddingResponse = await openai.createEmbedding({
-      model: 'text-embedding-ada-002',
-      input: sanitizedQuery.replaceAll('\n', ' '),
-    })
+      if (embeddingResponse.status !== 200) {
+        throw new ApplicationError('Failed to create embedding for question', embeddingResponse)
+      }
 
-    if (embeddingResponse.status !== 200) {
-      throw new ApplicationError('Failed to create embedding for question', embeddingResponse)
-    }
+      const [{ embedding }] = embeddingResponse.data.data
 
-    const [{ embedding }] = embeddingResponse.data.data
+      const searchFunction = useAlternateSearchIndex
+        ? 'docs_search_embeddings_nimbus'
+        : 'docs_search_embeddings'
+      const { error: matchError, data: pages } = await ctx.supabaseAdmin.rpc(searchFunction, {
+        embedding,
+        match_threshold: 0.78,
+      })
 
-    const searchFunction = useAlternateSearchIndex
-      ? 'docs_search_embeddings_nimbus'
-      : 'docs_search_embeddings'
-    const { error: matchError, data: pages } = await supabaseClient.rpc(searchFunction, {
-      embedding,
-      match_threshold: 0.78,
-    })
+      if (matchError) {
+        throw new ApplicationError('Failed to match page sections', matchError)
+      }
 
-    if (matchError) {
-      throw new ApplicationError('Failed to match page sections', matchError)
-    }
+      return new Response(JSON.stringify(pages), {
+        headers: {
+          ...corsHeaders,
+          'Content-Type': 'application/json',
+        },
+      })
+    } catch (err: unknown) {
+      if (err instanceof UserError) {
+        return new Response(
+          JSON.stringify({
+            error: err.message,
+            data: err.data,
+          }),
+          {
+            status: 400,
+            headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+          }
+        )
+      } else if (err instanceof ApplicationError) {
+        // Print out application errors with their additional data
+        console.error(`${err.message}: ${JSON.stringify(err.data)}`)
+      } else {
+        // Print out unexpected errors as is to help with debugging
+        console.error(err)
+      }
 
-    return new Response(JSON.stringify(pages), {
-      headers: {
-        ...corsHeaders,
-        'Content-Type': 'application/json',
-      },
-    })
-  } catch (err: unknown) {
-    if (err instanceof UserError) {
+      // TODO: include more response info in debug environments
       return new Response(
         JSON.stringify({
-          error: err.message,
-          data: err.data,
+          error: 'There was an error processing your request',
         }),
         {
-          status: 400,
+          status: 500,
           headers: { ...corsHeaders, 'Content-Type': 'application/json' },
         }
       )
-    } else if (err instanceof ApplicationError) {
-      // Print out application errors with their additional data
-      console.error(`${err.message}: ${JSON.stringify(err.data)}`)
-    } else {
-      // Print out unexpected errors as is to help with debugging
-      console.error(err)
     }
-
-    // TODO: include more response info in debug environments
-    return new Response(
-      JSON.stringify({
-        error: 'There was an error processing your request',
-      }),
-      {
-        status: 500,
-        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
-      }
-    )
-  }
-})
+  }),
+}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature/update to Edge Functions auth middleware and dependency setup.

## What is the current behavior?

The updated functions were using older patterns (`Deno.serve` and manual `createClient` with service role env vars) rather than `@supabase/server` request middleware. `og-images` did not explicitly use `withSupabase`, and only `search-embeddings` had an explicit `verify_jwt = false` entry.

## What is the new behavior?

This change wires `@supabase/server` into the repo and migrates the affected functions to `withSupabase` handlers.

- Adds `@supabase/server` to workspace dependencies.
- Updates `search-embeddings` to `withSupabase({ auth: ['publishable', 'secret'] }, ...)` and uses `ctx.supabaseAdmin` for the RPC call that should bypass RLS.
- Updates `og-images` to `withSupabase({ auth: 'none' }, handler)`.
- Adds `verify_jwt = false` for `[functions.og-images]` in `supabase/config.toml` (while preserving the existing `search-embeddings` setting).

## Additional context

`npm install @supabase/server` is not compatible in this monorepo because of pnpm workspace `catalog:` specifiers, so the package was added with `pnpm add -w @supabase/server`.