### PR TITLE
fix: password docs

### DIFF
--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -1036,7 +1036,7 @@ final UserResponse res = await supabase.auth.updateUser(
 
 #### Verifying the current password
 
-If your app requires users to confirm their current password before setting a new one, you can pass `currentPassword` (available in `supabase-js` v2.102.0+ and `supabase-kt` 3.5.0+):
+If your app requires users to confirm their current password before setting a new one, you can pass `current_password` (available in `supabase-js` v2.102.0+ and `supabase-kt` 3.5.0+):
 
 <Tabs
   scrollable
@@ -1050,7 +1050,7 @@ If your app requires users to confirm their current password before setting a ne
 ```js
 await supabase.auth.updateUser({
   password: 'new_password',
-  currentPassword: 'old_password',
+  current_password: 'old_password',
 })
 ```
 


### PR DESCRIPTION
- closes https://github.com/supabase/supabase/issues/47555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the password verification guide to use the `current_password` parameter name consistently.
  * Aligned the example code with the current parameter format for user password updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->