### PR TITLE
fix: Correct pin length on OTP

### DIFF
--- a/apps/docs/content/guides/local-development/customizing-email-templates.mdx
+++ b/apps/docs/content/guides/local-development/customizing-email-templates.mdx
@@ -106,7 +106,7 @@ There are several authentication-related email templates which can be configured
 **Default subject**: "`{{ .Token }} is your verification code`"
 **When sent**: When a user needs to re-authenticate for sensitive operations
 **Purpose**: Ask users to verify their identity before a sensitive operation
-**Content**: Contains a 6-digit OTP code for verification
+**Content**: Contains a 8-digit OTP code for verification
 
 ## Available security notification email templates
 
@@ -181,7 +181,7 @@ https://project-ref.supabase.co/auth/v1/verify?token={{ .TokenHash }}&type=email
 
 ### `Token`
 
-Contains a 6-digit One-Time-Password (OTP) that can be used instead of the `ConfirmationURL`.
+Contains a 8-digit One-Time-Password (OTP) that can be used instead of the `ConfirmationURL`.
 
 **Usage**
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Correction on pin length for email authentication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the local email template customization guide to reflect that reauthentication verification codes are now 8-digit OTPs.
  * Clarified the `Token` template variable description so it matches the current 8-digit format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->