### PR TITLE
fix: limit command menu height in auth observability filter

### DIFF
--- a/apps/studio/components/interfaces/Reports/v2/ReportsSelectFilter.tsx
+++ b/apps/studio/components/interfaces/Reports/v2/ReportsSelectFilter.tsx
@@ -83,7 +83,7 @@ export const ReportsSelectFilter = ({
       <PopoverContent align="start" className="p-0 w-72">
         <Command>
           {showSearch && <CommandInput placeholder="Search..." />}
-          <CommandList>
+          <CommandList className="max-h-72">
             <CommandEmpty>No options found.</CommandEmpty>
             <CommandGroup>
               {options.map((option) => (


### PR DESCRIPTION
## Problem

We don't limit command menu height by default because we usually don't have that many options. It's an issue here as shown in the screenshot because it hides the _Apply_ button

## Solution

Add a max height to the list of options

Before:
<img width="1331" height="1019" alt="image" src="https://github.com/user-attachments/assets/512b26ca-c08b-44c5-8bed-c89d5ab87da3" />

After:
<img width="1217" height="828" alt="image" src="https://github.com/user-attachments/assets/43a4066d-7b20-4615-81ec-cebdb8539ec1" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the reports filter dropdown to limit its height, making long lists easier to browse and preventing the menu from growing too large on screen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->