### PR TITLE
chore: make local e2e testing similar to CI

### DIFF
--- a/.github/workflows/studio-e2e-test.yml
+++ b/.github/workflows/studio-e2e-test.yml
@@ -80,10 +80,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-nextjs-${{ hashFiles('pnpm-lock.yaml') }}-
 
-      - name: Reset supabase
-        if: steps.filter.outputs.studio == 'true'
-        run: rm -rf supabase && pnpm exec supabase init && mkdir supabase/functions
-
       # Authenticate with AWS ECR to avoid rate limiting
       - name: configure aws credentials
         if: steps.filter.outputs.studio == 'true' && !github.event.pull_request.head.repo.fork

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:ui-patterns": "turbo run test --filter=ui-patterns",
     "test:studio": "turbo run test --filter=studio",
     "test:studio:watch": "turbo run test --filter=studio -- watch",
-    "e2e:setup:cli": "supabase stop --all --no-backup ; supabase start --exclude studio,mailpit && if [ -z \"${CI}\" ]; then supabase db reset; fi && supabase status --output json > keys.json && node scripts/generateLocalEnv.js",
+    "e2e:setup:cli": "supabase stop --all --no-backup --workdir ./e2e/studio; supabase start --exclude studio,mailpit --workdir ./e2e/studio && supabase status --output json --workdir ./e2e/studio > keys.json && node scripts/generateLocalEnv.js",
     "e2e:setup:selfhosted": "SKIP_ASSET_UPLOAD=1 pnpm e2e:setup:cli && NODE_ENV=test MODE=test NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm run build:studio && NODE_ENV=test MODE=test pnpm --prefix ./apps/studio start",
     "e2e:setup:selfhosted:start-studio": "SKIP_ASSET_UPLOAD=1 NODE_ENV=test MODE=test pnpm --prefix ./apps/studio start",
     "e2e:setup:platform": "SKIP_ASSET_UPLOAD=1 NODE_OPTIONS=\"--max-old-space-size=4096\" pnpm run build:studio && pnpm --prefix ./apps/studio start",
@@ -67,6 +67,13 @@
     "pnpm": "10.24",
     "node": ">=22"
   },
-  "keywords": ["postgres", "firebase", "storage", "functions", "database", "auth"],
+  "keywords": [
+    "postgres",
+    "firebase",
+    "storage",
+    "functions",
+    "database",
+    "auth"
+  ],
   "packageManager": "pnpm@10.24.0"
 }


### PR DESCRIPTION
## Problem

Because some tests were taking too much time before with the studio supabase default instance, we used to do a reset of its config on CI. This makes local testing more cumbersome as you have to manually reset it without forgetting to create a `functions` directory.

## Solution

- prepare the existing e2e supabase config in `e2e/studio` to ensure functions work (create the directory)
- use the `workdir` option of the supabase CLI so that it uses the `e2e/studio` specific config
- remove the now unnecessary reset done on CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of the end-to-end setup flow by simplifying cleanup steps and avoiding an extra reset during shutdown.
* **Chores**
  * Updated workflow and script behavior to better support automated test runs without changing the user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->