### PR TITLE
fix: studio observability sticky nav background is wrong

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportStickyNav.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportStickyNav.tsx
@@ -9,7 +9,7 @@ const ReportStickyNav = ({
   return (
     <section className={cn('relative flex flex-col gap-4 pt-16 -mt-2', className)}>
       <div className="absolute inset-0 z-40 pointer-events-none flex flex-col gap-4">
-        <div className="sticky top-0 py-4 mb-4 flex w-full items-center gap-2 pointer-events-auto dark:bg-background-200 bg-background">
+        <div className="sticky top-0 py-4 mb-4 flex w-full items-center gap-2 pointer-events-auto bg-background">
           {content}
         </div>
       </div>


### PR DESCRIPTION
## Problem
Only in dark mode

<img width="1003" height="324" alt="image" src="https://github.com/user-attachments/assets/e131fd07-1327-4a0b-bb27-eccf1f5d7f93" />

## Solution
<img width="943" height="230" alt="image" src="https://github.com/user-attachments/assets/bcbee6e6-d303-45c6-b612-eb0f0423d458" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the sticky report navigation background so it uses a consistent default appearance in all themes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->