### PR TITLE
fix(self-hosted): type generation should respect exposed schemas

### DIFF
--- a/apps/studio/lib/api/self-hosted/constants.ts
+++ b/apps/studio/lib/api/self-hosted/constants.ts
@@ -2,8 +2,7 @@
 
 // Schemas exposed via PostgREST Data API, read from the PGRST_DB_SCHEMAS env var
 // that is passed to the Studio container via docker-compose / CLI.
-export const DEFAULT_EXPOSED_SCHEMAS =
-  process.env.PGRST_DB_SCHEMAS ?? 'public,storage,graphql_public'
+export const DEFAULT_EXPOSED_SCHEMAS = process.env.PGRST_DB_SCHEMAS ?? 'public,graphql_public'
 
 export const ENCRYPTION_KEY = process.env.PG_META_CRYPTO_KEY || 'SAMPLE_KEY'
 export const POSTGRES_PORT = parseInt(process.env.POSTGRES_PORT || '5432', 10)

--- a/apps/studio/lib/api/self-hosted/generate-types.test.ts
+++ b/apps/studio/lib/api/self-hosted/generate-types.test.ts
@@ -14,6 +14,14 @@ vi.mock('./util', () => ({
   assertSelfHosted: vi.fn(),
 }))
 
+// A distinctive, non-default value so the assertions verify the URL reflects the
+// configured exposed schemas (PGRST_DB_SCHEMAS) — whatever they are — rather than
+// coupling the test to a specific default.
+const EXPOSED_SCHEMAS = 'public,custom_schema,graphql_public'
+vi.mock('./constants', () => ({
+  DEFAULT_EXPOSED_SCHEMAS: 'public,custom_schema,graphql_public',
+}))
+
 describe('api/self-hosted/generate-types', () => {
   let mockFetchGet: ReturnType<typeof vi.fn>
   let mockAssertSelfHosted: ReturnType<typeof vi.fn>
@@ -37,57 +45,17 @@ describe('api/self-hosted/generate-types', () => {
       expect(mockAssertSelfHosted).toHaveBeenCalled()
     })
 
-    it('should fetch from correct URL with schema params', async () => {
+    it('should request types for the configured exposed schemas', async () => {
       mockFetchGet.mockResolvedValue({ types: 'export type User = {}' })
 
       await generateTypescriptTypes({ headers: {} })
 
-      expect(mockFetchGet).toHaveBeenCalledWith(
-        expect.stringContaining('http://localhost:8080/generators/typescript'),
-        expect.any(Object)
-      )
-
       const callUrl = mockFetchGet.mock.calls[0][0]
-      expect(callUrl).toContain('included_schema=public,graphql_public,storage')
-      expect(callUrl).toContain('excluded_schemas=')
-    })
-
-    it('should include correct schemas in URL', async () => {
-      mockFetchGet.mockResolvedValue({ types: '' })
-
-      await generateTypescriptTypes({ headers: {} })
-
-      const callUrl = mockFetchGet.mock.calls[0][0]
-      expect(callUrl).toContain('public')
-      expect(callUrl).toContain('graphql_public')
-      expect(callUrl).toContain('storage')
-    })
-
-    it('should exclude system schemas', async () => {
-      mockFetchGet.mockResolvedValue({ types: '' })
-
-      await generateTypescriptTypes({ headers: {} })
-
-      const callUrl = mockFetchGet.mock.calls[0][0]
-      const excludedSchemas = [
-        'auth',
-        'cron',
-        'extensions',
-        'graphql',
-        'net',
-        'pgsodium',
-        'pgsodium_masks',
-        'realtime',
-        'supabase_functions',
-        'supabase_migrations',
-        'vault',
-        '_analytics',
-        '_realtime',
-      ]
-
-      excludedSchemas.forEach((schema) => {
-        expect(callUrl).toContain(schema)
-      })
+      expect(callUrl).toContain('http://localhost:8080/generators/typescript')
+      // Forwards the exposed-schemas config verbatim as the plural allowlist param.
+      expect(callUrl).toContain(`included_schemas=${EXPOSED_SCHEMAS}`)
+      // No hardcoded exclude list — the exposed-schemas config is the source of truth.
+      expect(callUrl).not.toContain('excluded_schemas=')
     })
 
     it('should pass headers to fetchGet', async () => {
@@ -127,16 +95,6 @@ describe('api/self-hosted/generate-types', () => {
       await generateTypescriptTypes({})
 
       expect(mockFetchGet).toHaveBeenCalledWith(expect.any(String), { headers: undefined })
-    })
-
-    it('should construct URL with both included and excluded schemas', async () => {
-      mockFetchGet.mockResolvedValue({ types: '' })
-
-      await generateTypescriptTypes({ headers: {} })
-
-      const callUrl = mockFetchGet.mock.calls[0][0]
-      expect(callUrl).toContain('included_schema=')
-      expect(callUrl).toContain('excluded_schemas=')
     })
   })
 })

--- a/apps/studio/lib/api/self-hosted/generate-types.ts
+++ b/apps/studio/lib/api/self-hosted/generate-types.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_EXPOSED_SCHEMAS } from './constants'
 import { assertSelfHosted } from './util'
 import { fetchGet } from '@/data/fetchers'
 import { PG_META_URL } from '@/lib/constants'
@@ -21,26 +22,12 @@ export async function generateTypescriptTypes({
 }: GenerateTypescriptTypesOptions): Promise<GenerateTypescriptTypesResult | ResponseError> {
   assertSelfHosted()
 
-  const includedSchema = ['public', 'graphql_public', 'storage'].join(',')
-
-  const excludedSchema = [
-    'auth',
-    'cron',
-    'extensions',
-    'graphql',
-    'net',
-    'pgsodium',
-    'pgsodium_masks',
-    'realtime',
-    'supabase_functions',
-    'supabase_migrations',
-    'vault',
-    '_analytics',
-    '_realtime',
-  ].join(',')
-
+  // Use the schemas actually exposed via PostgREST (PGRST_DB_SCHEMAS) so generated
+  // types match the Data API surface, instead of a hardcoded include/exclude list.
+  // Note the param is `included_schemas` (plural) — pg-meta treats a non-empty list
+  // as a strict allowlist; the singular spelling is silently ignored (includes all).
   const response = await fetchGet<GenerateTypescriptTypesResult>(
-    `${PG_META_URL}/generators/typescript?included_schema=${includedSchema}&excluded_schemas=${excludedSchema}`,
+    `${PG_META_URL}/generators/typescript?included_schemas=${DEFAULT_EXPOSED_SCHEMAS}`,
     { headers }
   )
 

--- a/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
@@ -2,6 +2,7 @@ import { components } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import apiWrapper from '@/lib/api/apiWrapper'
+import { DEFAULT_EXPOSED_SCHEMAS } from '@/lib/api/self-hosted/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 
@@ -21,7 +22,7 @@ const handleGet = async (_req: NextApiRequest, res: NextApiResponse) => {
   const responseObj: components['schemas']['GetPostgrestConfigResponse'] = {
     db_anon_role: 'anon',
     db_extra_search_path: process.env.PGRST_DB_EXTRA_SEARCH_PATH ?? 'public',
-    db_schema: process.env.PGRST_DB_SCHEMAS ?? 'public,storage,graphql_public',
+    db_schema: DEFAULT_EXPOSED_SCHEMAS,
     jwt_secret:
       process.env.AUTH_JWT_SECRET ?? 'super-secret-jwt-token-with-at-least-32-characters-long',
     max_rows: Number(process.env.PGRST_DB_MAX_ROWS) || 1000,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

In non-platform Studio, **Generate and download types** (Data API docs → Tables and Views → Introduction) ignored the operator's `PGRST_DB_SCHEMAS` config. It called pg-meta with a hardcoded include list (`public,graphql_public,storage`)
plus a hardcoded `excluded_schemas` blocklist of internal schemas.

Two problems:
1. The generated types didn't reflect the schemas actually exposed on the Data API - a custom `PGRST_DB_SCHEMAS` had no effect.
2. There was a latent param-name bug: pg-meta's typescript generator reads `included_schemas` (**plural**), but the request used `included_schema` (**singular**), which pg-meta silently ignores. So the include list never did anything - filtering was done entirely by the `excluded_schemas` blocklist.

Fixes:
- `generateTypescriptTypes` now requests `included_schemas` (plural) with `DEFAULT_EXPOSED_SCHEMAS` (derived from `PGRST_DB_SCHEMAS`). pg-meta treats a non-empty list as a strict allowlist, so generated types cover exactly the exposed schemas
- The hardcoded include/exclude lists are removed - with a correct allowlist they're redundant
- The self-hosted PostgREST config route (`/config/postgrest`) now reuses `DEFAULT_EXPOSED_SCHEMAS` instead of duplicating the fallback string, so the fallback default lives in one place and the config route and type generation stay in sync
- Dropped `storage` from the `DEFAULT_EXPOSED_SCHEMAS` fallback. This only affects the dev/test fallback when `PGRST_DB_SCHEMAS` is unset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default exposed database schemas to exclude `storage` when no custom schema list is set.
  * Type generation now uses the same default schema list as project configuration, keeping schema-related behavior consistent.
  * Project configuration responses now reflect the updated default schema list for PostgREST settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->