### PR TITLE
docs: Update documentation from Dart, and Swift SDK changes

### DIFF
--- a/apps/docs/spec/supabase_dart_v2.yml
+++ b/apps/docs/spec/supabase_dart_v2.yml
@@ -2589,11 +2589,16 @@ functions:
     notes: |
       Delete a user.
       - The `deleteUser()` method requires the user's ID, which maps to the `auth.users.id` column.
+      - When `shouldSoftDelete` is `true`, the user is soft-deleted: their record and associated data are retained but the user is marked as deleted. Defaults to `false`, which permanently removes the user.
     params:
       - name: id
         isOptional: false
         type: String
         description: ID of the user to be deleted.
+      - name: shouldSoftDelete
+        isOptional: true
+        type: bool
+        description: If true, soft-deletes the user (keeps the record but marks it deleted). Defaults to false (permanent delete).
     examples:
       - id: removes-a-user
         name: Removes a user
@@ -2602,6 +2607,16 @@ functions:
           ```dart
           await supabase.auth.admin
               .deleteUser('715ed5db-f090-4b8c-a067-640ecee36aa0');
+          ```
+      - id: soft-delete-a-user
+        name: Soft-delete a user
+        code: |
+          ```dart
+          await supabase.auth.admin
+              .deleteUser(
+                '715ed5db-f090-4b8c-a067-640ecee36aa0',
+                shouldSoftDelete: true,
+              );
           ```
   - id: invite-user-by-email
     title: 'inviteUserByEmail()'
@@ -4634,6 +4649,10 @@ functions:
         isOptional: false
         type: int
         description: The number of seconds until the signed URL expires. For example, 60 for a URL which is valid for one minute.
+      - name: download
+        isOptional: true
+        type: DownloadBehavior
+        description: Triggers the file to be downloaded rather than opened in the browser. Use `DownloadBehavior.withOriginalName` to keep the original file name or `DownloadBehavior.named('custom.png')` to override it.
       - name: transform
         isOptional: true
         type: TransformOptions
@@ -4690,6 +4709,61 @@ functions:
           ```json
           'https://example.supabase.co/storage/v1/object/sign/avatars/folder/avatar1.png?token=<TOKEN>''
           ```
+      - id: create-signed-url-with-download
+        name: With download
+        code: |
+          ```dart
+          final String signedUrl = await supabase
+            .storage
+            .from('avatars')
+            .createSignedUrl(
+              'avatar1.png',
+              60,
+              download: DownloadBehavior.withOriginalName,
+            );
+          ```
+
+  - id: from-create-signed-upload-url
+    description: |
+      Creates a signed upload URL. Signed upload URLs can be used to upload files to a bucket without further authentication. They are valid for 2 hours.
+    title: 'from.createSignedUploadUrl()'
+    notes: |
+      - Policy permissions required:
+        - `buckets` permissions: none
+        - `objects` permissions: `insert`
+      - Refer to the [Storage guide](https://supabase.com/docs/guides/storage/security/access-control) on how access control works
+    params:
+      - name: path
+        isOptional: false
+        type: String
+        description: The file path, including the current file name. For example folder/image.png.
+      - name: upsert
+        isOptional: true
+        type: bool
+        description: If true, the signed URL allows overwriting an existing file at the path. Defaults to false.
+    examples:
+      - id: create-signed-upload-url
+        name: Create signed upload URL
+        isSpotlight: true
+        code: |
+          ```dart
+          final response = await supabase
+            .storage
+            .from('avatars')
+            .createSignedUploadUrl('folder/avatar1.png');
+          ```
+      - id: create-signed-upload-url-with-upsert
+        name: With upsert
+        code: |
+          ```dart
+          final response = await supabase
+            .storage
+            .from('avatars')
+            .createSignedUploadUrl(
+              'folder/avatar1.png',
+              upsert: true,
+            );
+          ```
 
   - id: from-get-public-url
     description: |
@@ -4706,6 +4780,10 @@ functions:
         isOptional: false
         type: String
         description: The path and name of the file to generate the public URL for. For example folder/image.png.
+      - name: download
+        isOptional: true
+        type: DownloadBehavior
+        description: Triggers the file to be downloaded rather than opened in the browser. Use `DownloadBehavior.withOriginalName` to keep the original file name or `DownloadBehavior.named('custom.png')` to override it.
       - name: transform
         isOptional: true
         type: TransformOptions
@@ -4765,6 +4843,18 @@ functions:
         response: |
           ```json
           'https://example.supabase.co/storage/v1/object/public/public-bucket/folder/avatar1.png'
+          ```
+      - id: returns-the-url-for-an-asset-with-download
+        name: Trigger download
+        code: |
+          ```dart
+          final String publicUrl = supabase
+            .storage
+            .from('public-bucket')
+            .getPublicUrl(
+              'avatar1.png',
+              download: DownloadBehavior.withOriginalName,
+            );
           ```
 
   - id: from-download

--- a/apps/docs/spec/supabase_swift_v2.yml
+++ b/apps/docs/spec/supabase_swift_v2.yml
@@ -4384,6 +4384,8 @@ functions:
       It's best to only enable this for testing environments but if you wish to enable it for production you can provide additional protection by using a `pre-request` function.
 
       Follow the [Performance Debugging Guide](/docs/guides/database/debugging-performance) to enable the functionality on your project.
+    notes: |
+      The `format` parameter accepts an `ExplainFormat` value — either `.text` (default, human-readable) or `.json` (machine-readable JSON).
     examples:
       - id: get-execution-plan
         name: Get the execution plan
@@ -4462,6 +4464,21 @@ functions:
         description: |
           By default, the data is returned in TEXT format, but can also be returned as JSON by using the `format` parameter.
         hideCodeBlock: true
+        isSpotlight: false
+
+      - id: get-execution-plan-json-format
+        name: Get the execution plan as JSON
+        code: |
+          ```swift
+          try await supabase
+            .from("instruments")
+            .select()
+            .explain(format: .json)
+            .execute()
+            .value
+          ```
+        description: |
+          Use `format: .json` to get a machine-readable JSON execution plan. The `ExplainFormat` type accepts `.text` (default) or `.json`.
         isSpotlight: false
   - id: invoke
     title: invoke()
@@ -5176,7 +5193,7 @@ functions:
             .createBucket(
               "avatars",
               options: BucketOptions(
-                public: false,
+                isPublic: false,
                 allowedMimeTypes: ["image/png"],
                 fileSizeLimit: 1024
               )
@@ -5216,7 +5233,7 @@ functions:
             .updateBucket(
               "avatars",
               options: BucketOptions(
-                public: false,
+                isPublic: false,
                 fileSizeLimit: 1024,
                 allowedMimeTypes: ["image/png"]
               )
@@ -5375,12 +5392,13 @@ functions:
           let signedURL = try await supabase.storage
             .from("avatars")
             .createSignedURL(
-              path: "folder/avatar1.png", expiresIn: 60,
-              download: true
+              path: "folder/avatar1.png",
+              expiresIn: 60,
+              download: .withOriginalName
             )
           ```
         note: |
-          You can also sepcify a `String` in the `download` parameter to define the file name for the downloaded asset.
+          Use `.withOriginalName` to download with the original file name, or `.named("custom.png")` to specify a custom file name. The `download: Bool` overload still compiles but is disfavored.
 
   - id: from-create-signed-urls
     title: from.createSignedUrls()
@@ -5519,11 +5537,11 @@ functions:
             .from("public-bucket")
             .getPublicURL(
               path: "folder/avatar1.png",
-              download: true
+              download: .withOriginalName
             )
           ```
         note: |
-          You can also sepcify a `String` in the `download` parameter to define the file name for the downloaded asset.
+          Use `.withOriginalName` to download with the original file name, or `.named("custom.png")` to specify a custom file name. The `download: Bool` overload still compiles but is disfavored.
 
   - id: from-download
     title: from.download()


### PR DESCRIPTION
## Summary

Updates reference specs based on new stable releases in two SDK repos (JS spec is auto-generated and was excluded).

## Changes analyzed

| SDK | Repo | Stable tag range |
|-----|------|-----------------|
| dart | supabase/supabase-flutter | `supabase_flutter-v2.15.0...supabase_flutter-v2.15.4` |
| swift | supabase/supabase-swift | `v2.48.0...v2.49.0` |

## Documentation updates

### Dart (supabase_flutter-v2.15.0 → v2.15.4)
- **`supabase_dart_v2.yml`**: Updated `deleteUser()` — added `shouldSoftDelete: bool` parameter with example
- **`supabase_dart_v2.yml`**: Updated `from.createSignedUrl()` — added `download: DownloadBehavior?` parameter with example
- **`supabase_dart_v2.yml`**: Updated `from.getPublicUrl()` — added `download: DownloadBehavior?` parameter with example
- **`supabase_dart_v2.yml`**: Added new `from-create-signed-upload-url` entry with `upsert: bool` parameter (was missing from the Dart spec)

### Swift (v2.48.0 → v2.49.0)
- **`supabase_swift_v2.yml`**: Updated `explain()` — added note on `ExplainFormat` enum (`.text`/`.json`), added JSON format example
- **`supabase_swift_v2.yml`**: Updated `createBucket()` and `updateBucket()` examples — `BucketOptions(public:)` renamed to `BucketOptions(isPublic:)`
- **`supabase_swift_v2.yml`**: Updated `createSignedURL()` and `getPublicURL()` download examples — `download: Bool` replaced by `download: DownloadBehavior?` (`.withOriginalName` / `.named()`)

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for soft-deleting users, including a new example.
  * Documented download behavior for signed URLs and public URLs, including original or custom filenames.
  * Added documentation and examples for generating signed upload URLs, with optional overwrite support.
  * Expanded query plan documentation to show JSON output.
  * Updated storage examples to match the latest option names and recommended usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->