### PR TITLE
fix(makefile): correct `.PHONY` typo `github.rcontributorsepos` → `github.contributors`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ github.contributors.%:
 	| sort_by(.username)' \
 	> $(REPO_DIR)/web/src/data/contributors/$*.json
 
-.PHONY: github.rcontributorsepos
+.PHONY: github.contributors
 github.contributors: \
 	github.contributors.supabase \
 	github.contributors.supabase-js \


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix — one-line typo correction in the root `Makefile`.

## What is the current behavior?

`Makefile:17` declares:

```make
.PHONY: github.rcontributorsepos
```

The string `github.rcontributorsepos` is a mangled concatenation of `contributors` and `repos`, does not match the `github.contributors` target defined immediately below (lines 18–23), and appears **nowhere else** in the repo (`rg rcontributorsepos` returns exactly one hit — this line). It's almost certainly a botched find-and-replace of `github.contributors`.

Refs #47586, which tracks a broader discussion of whether the root `Makefile` should be kept, rewritten against the current `apps/www/` layout, or deleted — several of its targets write to a `web/src/data/` directory that no longer exists.

## What is the new behavior?

`.PHONY` now correctly names the `github.contributors` target:

```make
.PHONY: github.contributors
```

No functional runtime change (the recipe still runs the same commands), but the `.PHONY` declaration now actually applies to the target it's meant for, which matters if a file named `github.contributors` ever lands next to the Makefile.

## Additional context

- Diff is one line; no code or configuration outside the `Makefile` changes.
- Root `Makefile` is not in the Prettier glob (`{apps,packages,blocks,examples,i18n}/**/*.{js,jsx,ts,tsx,css,md,mdx,json}`), so `pnpm test:prettier` is a no-op for this diff.
- Not touched by `turbo run build`, so `npm run build` is not affected.
- If the maintainers decide (via #47586) to delete the `Makefile` outright, feel free to close this PR — the discussion in the issue is more valuable than this cosmetic fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a build/workflow target so the contributors-related task is recognized properly.
  * Improved reliability of the associated automation by marking the intended target as phony.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->