### PR TITLE
fix(pg-meta): widen `IQueryFilter.filter` to match the class impl and `Filter` type

### DIFF
--- a/packages/pg-meta/src/query/QueryFilter.ts
+++ b/packages/pg-meta/src/query/QueryFilter.ts
@@ -2,7 +2,7 @@ import { IQueryModifier, QueryModifier } from './QueryModifier'
 import type { ActionConfig, Dictionary, Filter, FilterOperator, QueryTable, Sort } from './types'
 
 export interface IQueryFilter {
-  filter: (column: string, operator: FilterOperator, value: string) => IQueryFilter
+  filter: (column: string | string[], operator: FilterOperator, value: any) => IQueryFilter
   match: (criteria: Dictionary<any>) => IQueryFilter
   order: (table: string, column: string, ascending?: boolean, nullsFirst?: boolean) => IQueryFilter
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix — one-line type-only change in `packages/pg-meta`. No runtime behavior change.

## What is the current behavior?

`packages/pg-meta/src/query/QueryFilter.ts:5` declares the interface:

```ts
export interface IQueryFilter {
  filter: (column: string, operator: FilterOperator, value: string) => IQueryFilter
  ...
}
```

The implementing class (same file, line 20) widens both parameters:

```ts
filter(column: string | string[], operator: FilterOperator, value: any) { ... }
```

And the underlying `Filter` type at `packages/pg-meta/src/query/types.ts:30-34` matches the class, not the interface:

```ts
export interface Filter {
  column: string | Array<string>
  operator: FilterOperator
  value: any
}
```

The existing tests exercise the wider shape and would fail against the interface:

- `packages/pg-meta/test/query/advanced-query.test.ts:547` — `.filter('id', 'in', [1, 2, 3])` passes an array value.
- `packages/pg-meta/test/query/query.test.ts:418` — `Filter[] = [{ column: 'id', operator: 'in', value: [1, 2, 3] }]`.

These type-check today only because callers receive the *class* type through inference from `new QueryFilter(...)`. Any consumer that types the receiver as `IQueryFilter` — e.g. `const q: IQueryFilter = queryAction.select()` — is blocked from passing an array column or a non-string value, even though the class accepts them fine.

## What is the new behavior?

The interface signature is widened to match the class and the underlying `Filter` type:

```ts
filter: (column: string | string[], operator: FilterOperator, value: any) => IQueryFilter
```

No runtime change. Widening parameter types is contravariantly safe — every existing call that satisfied the old signature still satisfies the new one, so this is non-breaking for external consumers of the package's `query` export.

## Additional context

- Diff is exactly one line; no other file touched.
- All three shapes (interface `IQueryFilter`, class `QueryFilter`, type `Filter`) are now consistent.
- `match` and `order` on `IQueryFilter` already match the class exactly — left untouched.
- Deliberately kept `value: any` rather than `value: unknown` to stay consistent with `Filter.value: any` in `types.ts`. Tightening both together would be a nice follow-up but is out of scope here.
- Line width is 91 characters, under the repo's Prettier `printWidth: 100`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded filter input support so queries can now use either a single column or multiple columns.
  * Relaxed value handling in filters to accept a wider range of input types, improving compatibility with more query scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->