### PR TITLE
chore: update pg changes documentation

### DIFF
--- a/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.constants.ts
+++ b/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.constants.ts
@@ -14,7 +14,7 @@ export const COMPUTE_LABELS: Record<string, string> = Object.fromEntries(
 )
 
 // Input-parameter columns (only shown in the full/raw table).
-export const THROUGHPUT_PARAM_HEADINGS = ['Filters', 'RLS', 'Connected clients'] as const
+export const THROUGHPUT_PARAM_HEADINGS = ['RLS', 'Connected clients'] as const
 
 // Result columns (shown in both the current-selection table and the raw table).
 export const THROUGHPUT_METRIC_HEADINGS = [

--- a/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.tsx
+++ b/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.tsx
@@ -22,42 +22,37 @@ import {
 } from './RealtimeLimitsEstimator.constants'
 
 export default function RealtimeLimitsEstimater({}) {
-  const findTableValue = ({ computeAddOn, filters, rls, concurrency }) => {
+  const findTableValue = ({ computeAddOn, rls, concurrency }) => {
     return throughputTable.find(
-      (l) =>
-        l.computeAddOn === computeAddOn &&
-        l.filters === filters &&
-        l.rls === rls &&
-        l.concurrency === concurrency
+      (l) => l.computeAddOn === computeAddOn && l.rls === rls && l.concurrency === concurrency
     )
   }
 
   const [computeAddOn, setComputeAddOn] = useState('micro')
-  const filters = false
   const [rls, setRLS] = useState(false)
   const [concurrency, setConcurrency] = useState(500)
 
-  const [limits, setLimits] = useState(findTableValue({ computeAddOn, filters, rls, concurrency }))
+  const [limits, setLimits] = useState(findTableValue({ computeAddOn, rls, concurrency }))
 
   const [expandPreview, setExpandPreview] = useState(false)
 
   const handleComputeAddOnSelection = (val) => {
     setComputeAddOn(val)
     setConcurrency(500)
-    setLimits(findTableValue({ computeAddOn: val, filters, rls, concurrency: 500 }))
+    setLimits(findTableValue({ computeAddOn: val, rls, concurrency: 500 }))
   }
 
   const handleRLSSelection = (value) => {
     const val = value.toLowerCase() === 'true'
     setRLS(val)
     setConcurrency(500)
-    setLimits(findTableValue({ computeAddOn, filters, rls: val, concurrency: 500 }))
+    setLimits(findTableValue({ computeAddOn, rls: val, concurrency: 500 }))
   }
 
   const handleConcurrencySelection = (value) => {
     const val = parseInt(value)
     setConcurrency(val)
-    setLimits(findTableValue({ computeAddOn, filters, rls, concurrency: val }))
+    setLimits(findTableValue({ computeAddOn, rls, concurrency: val }))
   }
 
   return (
@@ -99,9 +94,7 @@ export default function RealtimeLimitsEstimater({}) {
             </SelectTrigger>
             <SelectContent>
               {throughputTable
-                .filter(
-                  (l) => l.computeAddOn === computeAddOn && l.filters === filters && l.rls === rls
-                )
+                .filter((l) => l.computeAddOn === computeAddOn && l.rls === rls)
                 .map((l) => (
                   <SelectItem key={l.concurrency} value={l.concurrency.toString()}>
                     {Intl.NumberFormat().format(l.concurrency)}
@@ -181,7 +174,6 @@ export default function RealtimeLimitsEstimater({}) {
                         .filter((l) => l.computeAddOn === computeAddOn)
                         .map((l) => (
                           <tr>
-                            <td className="border px-4 py-2">{l.filters ? '✅' : '🚫'}</td>
                             <td className="border px-4 py-2">{l.rls ? '✅' : '🚫'}</td>
                             <td className="border px-4 py-2">
                               {Intl.NumberFormat().format(l.concurrency)}

--- a/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.tsx
+++ b/apps/docs/components/RealtimeLimitsEstimator/RealtimeLimitsEstimator.tsx
@@ -33,7 +33,7 @@ export default function RealtimeLimitsEstimater({}) {
   }
 
   const [computeAddOn, setComputeAddOn] = useState('micro')
-  const [filters, setFilters] = useState(false)
+  const filters = false
   const [rls, setRLS] = useState(false)
   const [concurrency, setConcurrency] = useState(500)
 
@@ -45,13 +45,6 @@ export default function RealtimeLimitsEstimater({}) {
     setComputeAddOn(val)
     setConcurrency(500)
     setLimits(findTableValue({ computeAddOn: val, filters, rls, concurrency: 500 }))
-  }
-
-  const handleFiltersSelection = (value) => {
-    const val = value.toLowerCase() === 'true'
-    setFilters(val)
-    setConcurrency(500)
-    setLimits(findTableValue({ computeAddOn, filters: val, rls, concurrency: 500 }))
   }
 
   const handleRLSSelection = (value) => {
@@ -83,18 +76,6 @@ export default function RealtimeLimitsEstimater({}) {
                   {option.label}
                 </SelectItem>
               ))}
-            </SelectContent>
-          </Select>
-        </div>
-        <div>
-          <Label htmlFor="filters">Filters:</Label>
-          <Select onValueChange={handleFiltersSelection} value={filters.toString()} disabled>
-            <SelectTrigger id="filters">
-              <SelectValue className="font-mono" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="false">No</SelectItem>
-              <SelectItem value="true">Yes</SelectItem>
             </SelectContent>
           </Select>
         </div>

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -955,7 +955,40 @@ changes = supabase.channel('db-changes').on_postgres_changes(
 
 ## Available filters
 
-Realtime offers filters so you can specify the data your client receives at a more granular level.
+Realtime offers filters so you can specify the data your client receives at a more granular level. A filter is a `column=operator.value` expression (for example `id=eq.1` or `title=like.%foo%`) that Realtime evaluates on the server, so filtered-out events never leave the database.
+
+The following operators are available:
+
+| Operator           | Matches when the column…                             | Example                   |
+| ------------------ | ---------------------------------------------------- | ------------------------- |
+| `eq`               | equals the value                                     | `id=eq.1`                 |
+| `neq`              | does not equal the value                             | `status=neq.done`         |
+| `lt` / `lte`       | is less than / less than or equal to                 | `age=lt.65`               |
+| `gt` / `gte`       | is greater than / greater than or equal to           | `quantity=gte.10`         |
+| `in`               | is one of a list (max 100 values)                    | `name=in.(red,blue)`      |
+| `like` / `ilike`   | matches a pattern (case-sensitive / insensitive)     | `title=like.%foo%`        |
+| `match` / `imatch` | matches a POSIX regex (case-sensitive / insensitive) | `slug=match.^post-`       |
+| `is`               | `IS null` / `true` / `false` / `unknown`             | `deleted_at=is.null`      |
+| `isdistinct`       | is distinct from the value (NULL-safe `!=`)          | `state=isdistinct.active` |
+
+You can also [negate any operator](#negating-a-filter-not) with `not.` and [combine multiple conditions](#combining-filters-with-and) with commas (applied as an `AND`).
+
+<$Show if="sdk:js">
+
+<Admonition type="tip">
+
+In JavaScript you can pass a raw filter string, or build one with the type-safe `postgresChangesFilter()` helper, which handles operator names, negation, `AND` composition, and escaping for you:
+
+```js
+import { postgresChangesFilter } from '@supabase/supabase-js'
+
+// → 'quantity=gte.10,status=eq.open'
+const filter = postgresChangesFilter().gte('quantity', 10).eq('status', 'open')
+```
+
+</Admonition>
+
+</$Show>
 
 ### Equal to (`eq`)
 
@@ -969,6 +1002,34 @@ To listen to changes when a column's value in a table equals a client-specified 
   queryGroup="language"
 >
 <TabPanel id="js" label="JavaScript">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'UPDATE',
+      schema: 'public',
+      table: 'messages',
+      filter: postgresChangesFilter().eq('body', 'hey'),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
 
 ```js
 const channel = supabase
@@ -985,6 +1046,9 @@ const channel = supabase
   )
   .subscribe()
 ```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 <$Show if="sdk:dart">
@@ -1085,6 +1149,34 @@ To listen to changes when a column's value in a table does not equal a client-sp
 >
 <TabPanel id="js" label="JavaScript">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'messages',
+      filter: postgresChangesFilter().neq('body', 'bye'),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
 ```js
 const channel = supabase
   .channel('changes')
@@ -1100,6 +1192,9 @@ const channel = supabase
   )
   .subscribe()
 ```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 <$Show if="sdk:dart">
@@ -1201,6 +1296,34 @@ To listen to changes when a column's value in a table is less than a client-spec
 >
 <TabPanel id="js" label="JavaScript">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'profiles',
+      filter: postgresChangesFilter().lt('age', 65),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
 ```js
 const channel = supabase
   .channel('changes')
@@ -1216,6 +1339,9 @@ const channel = supabase
   )
   .subscribe()
 ```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 <$Show if="sdk:dart">
@@ -1316,6 +1442,34 @@ To listen to changes when a column's value in a table is less than or equal to a
 >
 <TabPanel id="js" label="JavaScript">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'UPDATE',
+      schema: 'public',
+      table: 'profiles',
+      filter: postgresChangesFilter().lte('age', 65),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
 ```js
 const channel = supabase
   .channel('changes')
@@ -1331,6 +1485,9 @@ const channel = supabase
   )
   .subscribe()
 ```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 <$Show if="sdk:dart">
@@ -1431,6 +1588,34 @@ To listen to changes when a column's value in a table is greater than a client-s
 >
 <TabPanel id="js" label="JavaScript">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'products',
+      filter: postgresChangesFilter().gt('quantity', 10),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
 ```js
 const channel = supabase
   .channel('changes')
@@ -1446,6 +1631,9 @@ const channel = supabase
   )
   .subscribe()
 ```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 <$Show if="sdk:dart">
@@ -1546,6 +1734,34 @@ To listen to changes when a column's value in a table is greater than or equal t
 >
 <TabPanel id="js" label="JavaScript">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'products',
+      filter: postgresChangesFilter().gte('quantity', 10),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
 ```js
 const channel = supabase
   .channel('changes')
@@ -1561,6 +1777,9 @@ const channel = supabase
   )
   .subscribe()
 ```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 <$Show if="sdk:dart">
@@ -1661,6 +1880,34 @@ To listen to changes when a column's value in a table equals any client-specifie
 >
 <TabPanel id="js" label="JavaScript">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'colors',
+      filter: postgresChangesFilter().in('name', ['red', 'blue', 'yellow']),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
 ```js
 const channel = supabase
   .channel('changes')
@@ -1676,6 +1923,9 @@ const channel = supabase
   )
   .subscribe()
 ```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 <$Show if="sdk:dart">
@@ -1762,6 +2012,970 @@ changes = supabase.channel('db-changes').on_postgres_changes(
 </Tabs>
 
 This filter uses Postgres's `= ANY`. Realtime allows a maximum of 100 values for this filter.
+
+### Pattern matching (`like`, `ilike`)
+
+To listen to changes when a text column matches a pattern, use `like` (case-sensitive) or `ilike` (case-insensitive). Use `%` to match any sequence of characters and `_` to match a single character.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'articles',
+      // matches "Breaking News", "BREAKING", ...
+      filter: postgresChangesFilter().ilike('title', '%breaking%'),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'articles',
+      filter: 'title=ilike.%breaking%', // matches "Breaking News", "BREAKING", ...
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
+<$Show if="sdk:dart">
+<TabPanel id="dart" label="Dart">
+
+```dart
+supabase
+    .channel('changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.insert,
+        schema: 'public',
+        table: 'articles',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.ilike,
+          column: 'title',
+          value: '%breaking%',
+        ),
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:swift">
+<TabPanel id="swift" label="Swift">
+
+```swift
+let myChannel = await supabase.channel("db-changes")
+
+let changes = await myChannel.postgresChange(
+  InsertAction.self,
+  schema: "public",
+  table: "articles",
+  filter: .ilike("title", value: "%breaking%")
+)
+
+await myChannel.subscribe()
+
+for await change in changes {
+  print(change.record)
+}
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:kotlin">
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction.Insert>(schema = "public") {
+    table = "articles"
+    filter = "title=ilike.%breaking%"
+}
+
+changes
+    .onEach {
+        println(it.record)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:python">
+<TabPanel id="python" label="Python">
+
+```python
+changes = supabase.channel('db-changes').on_postgres_changes(
+  "INSERT",
+  schema="public",
+  table="articles",
+  filter="title=ilike.%breaking%",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
+
+`like` uses Postgres's `LIKE` and `ilike` uses `ILIKE`. Both require a text-compatible column.
+
+### Regular expression matching (`match`, `imatch`)
+
+To listen to changes when a text column matches a POSIX regular expression, use `match` (case-sensitive) or `imatch` (case-insensitive).
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'posts',
+      // matches "post-1", "post-42", ...
+      filter: postgresChangesFilter().match('slug', '^post-\\d+$'),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'posts',
+      filter: 'slug=match.^post-\\d+$', // matches "post-1", "post-42", ...
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
+<$Show if="sdk:dart">
+<TabPanel id="dart" label="Dart">
+
+```dart
+supabase
+    .channel('changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.insert,
+        schema: 'public',
+        table: 'posts',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.match,
+          column: 'slug',
+          value: r'^post-\d+$',
+        ),
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:swift">
+<TabPanel id="swift" label="Swift">
+
+```swift
+let myChannel = await supabase.channel("db-changes")
+
+let changes = await myChannel.postgresChange(
+  InsertAction.self,
+  schema: "public",
+  table: "posts",
+  filter: .match("slug", value: "^post-\\d+$")
+)
+
+await myChannel.subscribe()
+
+for await change in changes {
+  print(change.record)
+}
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:kotlin">
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction.Insert>(schema = "public") {
+    table = "posts"
+    filter = "slug=match.^post-\\d+$"
+}
+
+changes
+    .onEach {
+        println(it.record)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:python">
+<TabPanel id="python" label="Python">
+
+```python
+changes = supabase.channel('db-changes').on_postgres_changes(
+  "INSERT",
+  schema="public",
+  table="posts",
+  filter="slug=match.^post-\\d+$",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
+
+`match` uses Postgres's `~` operator and `imatch` uses `~*`. Both require a text-compatible column, and the pattern is validated when you subscribe.
+
+### Null and boolean checks (`is`)
+
+To listen to changes when a column `IS` `null`, `true`, `false`, or `unknown`, use `is`. `is.null` works on any column type; `is.true`, `is.false`, and `is.unknown` require a boolean column.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'UPDATE',
+      schema: 'public',
+      table: 'todos',
+      // only rows that are not yet completed
+      filter: postgresChangesFilter().is('completed_at', null),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'UPDATE',
+      schema: 'public',
+      table: 'todos',
+      filter: 'completed_at=is.null', // only rows that are not yet completed
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
+<$Show if="sdk:dart">
+<TabPanel id="dart" label="Dart">
+
+```dart
+supabase
+    .channel('changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.update,
+        schema: 'public',
+        table: 'todos',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.isFilter,
+          column: 'completed_at',
+          value: null,
+        ),
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:swift">
+<TabPanel id="swift" label="Swift">
+
+```swift
+let myChannel = await supabase.channel("db-changes")
+
+let changes = await myChannel.postgresChange(
+  UpdateAction.self,
+  schema: "public",
+  table: "todos",
+  filter: .is("completed_at", value: .null)
+)
+
+await myChannel.subscribe()
+
+for await change in changes {
+  print(change.record)
+}
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:kotlin">
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction.Update>(schema = "public") {
+    table = "todos"
+    filter = "completed_at=is.null"
+}
+
+changes
+    .onEach {
+        println(it.record)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:python">
+<TabPanel id="python" label="Python">
+
+```python
+changes = supabase.channel('db-changes').on_postgres_changes(
+  "UPDATE",
+  schema="public",
+  table="todos",
+  filter="completed_at=is.null",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
+
+This filter uses Postgres's `IS` operator.
+
+### Distinct from (`isdistinct`)
+
+`isdistinct` is a NULL-safe inequality (`IS DISTINCT FROM`). Unlike `neq`, it treats `null` as a comparable value, so a `null` column is considered distinct from a non-null value.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'UPDATE',
+      schema: 'public',
+      table: 'orders',
+      // includes rows where status is null
+      filter: postgresChangesFilter().isDistinct('status', 'shipped'),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'UPDATE',
+      schema: 'public',
+      table: 'orders',
+      filter: 'status=isdistinct.shipped', // includes rows where status is null
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
+<$Show if="sdk:dart">
+<TabPanel id="dart" label="Dart">
+
+```dart
+supabase
+    .channel('changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.update,
+        schema: 'public',
+        table: 'orders',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.isDistinct,
+          column: 'status',
+          value: 'shipped',
+        ),
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:swift">
+<TabPanel id="swift" label="Swift">
+
+```swift
+let myChannel = await supabase.channel("db-changes")
+
+let changes = await myChannel.postgresChange(
+  UpdateAction.self,
+  schema: "public",
+  table: "orders",
+  filter: .isDistinct("status", value: "shipped")
+)
+
+await myChannel.subscribe()
+
+for await change in changes {
+  print(change.record)
+}
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:kotlin">
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction.Update>(schema = "public") {
+    table = "orders"
+    filter = "status=isdistinct.shipped"
+}
+
+changes
+    .onEach {
+        println(it.record)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:python">
+<TabPanel id="python" label="Python">
+
+```python
+changes = supabase.channel('db-changes').on_postgres_changes(
+  "UPDATE",
+  schema="public",
+  table="orders",
+  filter="status=isdistinct.shipped",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
+
+### Negating a filter (`not`)
+
+Prefix any operator with `not.` to invert it — for example `not.in`, `not.is`, or `not.like`.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: '*',
+      schema: 'public',
+      table: 'posts',
+      // anything except drafts and archived
+      filter: postgresChangesFilter().not('status', 'in', ['draft', 'archived']),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: '*',
+      schema: 'public',
+      table: 'posts',
+      filter: 'status=not.in.(draft,archived)', // anything except drafts and archived
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
+<$Show if="sdk:dart">
+<TabPanel id="dart" label="Dart">
+
+Set `negate: true` on a `PostgresChangeFilter` to apply the `not.` prefix.
+
+```dart
+supabase
+    .channel('changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'posts',
+        filter: PostgresChangeFilter(
+          type: PostgresChangeFilterType.inFilter,
+          column: 'status',
+          value: ['draft', 'archived'],
+          negate: true,
+        ),
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:swift">
+<TabPanel id="swift" label="Swift">
+
+Wrap any single-condition filter in `.not(...)`.
+
+```swift
+let myChannel = await supabase.channel("db-changes")
+
+let changes = await myChannel.postgresChange(
+  AnyAction.self,
+  schema: "public",
+  table: "posts",
+  filter: .not(.in("status", values: ["draft", "archived"]))
+)
+
+await myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:kotlin">
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction>(schema = "public") {
+    table = "posts"
+    filter = "status=not.in.(draft,archived)"
+}
+
+changes
+    .onEach {
+        println(it.record)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:python">
+<TabPanel id="python" label="Python">
+
+```python
+changes = supabase.channel('db-changes').on_postgres_changes(
+  "*",
+  schema="public",
+  table="posts",
+  filter="status=not.in.(draft,archived)",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
+
+### Combining filters with `AND`
+
+Combine multiple conditions by separating them with commas. All conditions must match (logical `AND`). You can only combine conditions with `AND` — `OR` is not supported.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="builder"
+  queryGroup="realtime-js-filter"
+>
+<TabPanel id="builder" label="Builder">
+
+The builder composes conditions and escapes reserved characters for you.
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'orders',
+      // amount > 100 AND status = "open"
+      filter: postgresChangesFilter().gt('amount', 100).eq('status', 'open'),
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="string" label="Filter string">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'INSERT',
+      schema: 'public',
+      table: 'orders',
+      filter: 'amount=gt.100,status=eq.open', // amount > 100 AND status = "open"
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
+<$Show if="sdk:dart">
+<TabPanel id="dart" label="Dart">
+
+Pass a list of filters to `filters` to combine them with `AND`.
+
+```dart
+supabase
+    .channel('changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.insert,
+        schema: 'public',
+        table: 'orders',
+        filters: [
+          PostgresChangeFilter(
+            type: PostgresChangeFilterType.gt,
+            column: 'amount',
+            value: 100,
+          ),
+          PostgresChangeFilter(
+            type: PostgresChangeFilterType.eq,
+            column: 'status',
+            value: 'open',
+          ),
+        ],
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:swift">
+<TabPanel id="swift" label="Swift">
+
+Use `.and([...])` to combine multiple conditions.
+
+```swift
+let myChannel = await supabase.channel("db-changes")
+
+let changes = await myChannel.postgresChange(
+  InsertAction.self,
+  schema: "public",
+  table: "orders",
+  filter: .and([
+    .gt("amount", value: 100),
+    .eq("status", value: "open"),
+  ])
+)
+
+await myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:kotlin">
+<TabPanel id="kotlin" label="Kotlin">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction.Insert>(schema = "public") {
+    table = "orders"
+    filter = "amount=gt.100,status=eq.open"
+}
+
+changes
+    .onEach {
+        println(it.record)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:python">
+<TabPanel id="python" label="Python">
+
+```python
+changes = supabase.channel('db-changes').on_postgres_changes(
+  "INSERT",
+  schema="public",
+  table="orders",
+  filter="amount=gt.100,status=eq.open",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
+
+<Admonition type="note">
+
+Values that contain reserved characters (`,`, `(`, `)`, `"`, or `\`) must be double-quoted PostgREST-style so the server doesn't read them as condition or list boundaries — for example `name=eq."Doe, Jane"`. The `postgresChangesFilter()` builder (JavaScript), `PostgresChangeFilter` (Dart), and `RealtimePostgresFilter` (Swift) apply this quoting for you.
+
+</Admonition>
+
+## Selecting specific columns
+
+By default each change event contains the full row. Use `select` to receive only a subset of columns instead. This reduces payload size and the data transferred per event, which is especially useful for tables with large `bytea`, `jsonb`, or `text` columns.
+
+The listed columns must be selectable by the subscribing role, and the table's primary key is always included so you can identify the row. `select` requires an explicit `schema` and `table` — it's not supported on wildcard subscriptions.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="js"
+  queryGroup="language"
+>
+<TabPanel id="js" label="JavaScript">
+
+```js
+const channel = supabase
+  .channel('changes')
+  .on(
+    'postgres_changes',
+    {
+      event: '*',
+      schema: 'public',
+      table: 'profiles',
+      select: ['id', 'username'], // payload.new only contains { id, username }
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<$Show if="sdk:dart">
+<TabPanel id="dart" label="Dart">
+
+```dart
+supabase
+    .channel('changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        table: 'profiles',
+        select: ['id', 'username'],
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</$Show>
+<$Show if="sdk:swift">
+<TabPanel id="swift" label="Swift">
+
+```swift
+let myChannel = await supabase.channel("db-changes")
+
+let changes = await myChannel.postgresChange(
+  AnyAction.self,
+  schema: "public",
+  table: "profiles",
+  select: ["id", "username"]
+)
+
+await myChannel.subscribe()
+```
+
+</TabPanel>
+</$Show>
+</Tabs>
 
 ## Receiving `old` records
 
@@ -2002,24 +3216,23 @@ supabase.realtime.set_auth('fresh-token')
 
 You can't filter Delete events when tracking Postgres Changes. This limitation is due to the way changes are pulled from Postgres.
 
-### Spaces in table names
+## Scaling Postgres Changes
 
-Realtime currently does not work when table names contain spaces.
+Postgres Changes authorizes every event against each subscriber. When you make a single change to a table with 100 subscribed users, Realtime performs 100 authorization checks — one per user — so throughput scales with the number of subscribers, not just the write rate. Changes are also processed on a single thread to preserve their order, which means larger compute add-ons don't meaningfully increase Postgres Changes throughput.
 
-### Database instance and realtime performance
+For most applications this is plenty. To get the best performance:
 
-Realtime systems usually require forethought because of their scaling dynamics. For the `Postgres Changes` feature, every change event must be checked to see if the subscribed user has access. For instance, if you have 100 users subscribed to a table where you make a single insert, it will then trigger 100 "reads": one for each user.
+- Use [filters](#available-filters) and [column selection](#selecting-specific-columns) to send each client only the events and columns it needs.
+- Keep authorization cheap by writing simple, indexed [RLS policies](/docs/guides/database/postgres/row-level-security).
 
-There can be a database bottleneck which limits message throughput. If your database cannot authorize the changes rapidly enough, the changes will be delayed until you receive a timeout.
-
-Database changes are processed on a single thread to maintain the change order. That means compute upgrades don't have a large effect on the performance of Postgres change subscriptions. You can estimate the expected maximum throughput for your database below.
-
-If you are using Postgres Changes at scale, you should consider using separate "public" table without RLS and filters. Alternatively, you can use Realtime server-side only and then re-stream the changes to your clients using a Realtime Broadcast.
-
-Enter your database settings to estimate the maximum throughput for your instance:
+Use the estimator below to gauge the maximum throughput for your instance, and run your own benchmarks to confirm it fits your use case:
 
 <RealtimeLimitsEstimator />
 
-Don't forget to run your own benchmarks to make sure that the performance is acceptable for your use case.
+<Admonition type="tip">
 
-We are making many improvements to Realtime's Postgres Changes. If you are uncertain about the performance of your use case, reach out using [Support Form](/dashboard/support/new) and we will be happy to help you. We have a team of engineers that can advise you on the best solution for your use-case.
+If you expect more than ~3,000 concurrent subscribers on the same changes, use [Broadcast to stream database changes](/docs/guides/realtime/subscribing-to-database-changes#using-broadcast) instead. Broadcast sends each change once and fans it out to all subscribers, so it scales to far higher connection counts than per-subscriber authorization allows.
+
+</Admonition>
+
+If you're unsure which approach fits your use case, reach out through the [Support Form](/dashboard/support/new) — our engineers are happy to help you find the best solution.

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -333,13 +333,22 @@ Use the `event` parameter to listen only to a specific database event. `event` c
 >
 <TabPanel id="js" label="JavaScript">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="insert"
+  queryGroup="pg-changes-event"
+>
+<TabPanel id="insert" label="Insert">
+
 ```js
 const changes = supabase
   .channel('schema-db-changes')
   .on(
     'postgres_changes',
     {
-      event: 'INSERT', // Listen only to INSERTs. Use 'UPDATE', 'DELETE', or '*' for other events.
+      event: 'INSERT',
       schema: 'public',
     },
     (payload) => console.log(payload)
@@ -348,14 +357,76 @@ const changes = supabase
 ```
 
 </TabPanel>
+<TabPanel id="update" label="Update">
+
+```js
+const changes = supabase
+  .channel('schema-db-changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'UPDATE',
+      schema: 'public',
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="delete" label="Delete">
+
+```js
+const changes = supabase
+  .channel('schema-db-changes')
+  .on(
+    'postgres_changes',
+    {
+      event: 'DELETE',
+      schema: 'public',
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+<TabPanel id="all" label="All events">
+
+```js
+const changes = supabase
+  .channel('schema-db-changes')
+  .on(
+    'postgres_changes',
+    {
+      event: '*',
+      schema: 'public',
+    },
+    (payload) => console.log(payload)
+  )
+  .subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
 <$Show if="sdk:dart">
 <TabPanel id="dart" label="Dart">
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="insert"
+  queryGroup="pg-changes-event"
+>
+<TabPanel id="insert" label="Insert">
 
 ```dart
 supabase
     .channel('schema-db-changes')
     .onPostgresChanges(
-        // Use .update, .delete, or .all for other events
         event: PostgresChangeEvent.insert,
         schema: 'public',
         callback: (payload) => print(payload))
@@ -363,11 +434,62 @@ supabase
 ```
 
 </TabPanel>
+<TabPanel id="update" label="Update">
+
+```dart
+supabase
+    .channel('schema-db-changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.update,
+        schema: 'public',
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+<TabPanel id="delete" label="Delete">
+
+```dart
+supabase
+    .channel('schema-db-changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.delete,
+        schema: 'public',
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+<TabPanel id="all" label="All events">
+
+```dart
+supabase
+    .channel('schema-db-changes')
+    .onPostgresChanges(
+        event: PostgresChangeEvent.all,
+        schema: 'public',
+        callback: (payload) => print(payload))
+    .subscribe();
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
 </$Show>
 <$Show if="sdk:swift">
 <TabPanel id="swift" label="Swift">
 
-Pass the action type to select the event. Use `InsertAction.self`, `UpdateAction.self`, `DeleteAction.self`, or `AnyAction.self` to listen to all changes.
+Pass the action type to select the event.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="insert"
+  queryGroup="pg-changes-event"
+>
+<TabPanel id="insert" label="Insert">
 
 ```swift
 let myChannel = await supabase.channel("schema-db-changes")
@@ -382,11 +504,73 @@ for await change in changes {
 ```
 
 </TabPanel>
+<TabPanel id="update" label="Update">
+
+```swift
+let myChannel = await supabase.channel("schema-db-changes")
+
+let changes = await myChannel.postgresChange(UpdateAction.self, schema: "public")
+
+await myChannel.subscribe()
+
+for await change in changes {
+  print(change.record)
+}
+```
+
+</TabPanel>
+<TabPanel id="delete" label="Delete">
+
+```swift
+let myChannel = await supabase.channel("schema-db-changes")
+
+let changes = await myChannel.postgresChange(DeleteAction.self, schema: "public")
+
+await myChannel.subscribe()
+
+for await change in changes {
+  print(change.oldRecord)
+}
+```
+
+</TabPanel>
+<TabPanel id="all" label="All events">
+
+```swift
+let myChannel = await supabase.channel("schema-db-changes")
+
+let changes = await myChannel.postgresChange(AnyAction.self, schema: "public")
+
+await myChannel.subscribe()
+
+for await change in changes {
+  switch change {
+  case .insert(let action): print(action.record)
+  case .update(let action): print(action.record)
+  case .delete(let action): print(action.oldRecord)
+  case .select(let action): print(action.record)
+  }
+}
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
 </$Show>
 <$Show if="sdk:kotlin">
 <TabPanel id="kotlin" label="Kotlin">
 
-Pass the action type to select the event. Use `PostgresAction.Insert`, `PostgresAction.Update`, `PostgresAction.Delete`, or `PostgresAction` to listen to all changes.
+Pass the action type to select the event.
+
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="insert"
+  queryGroup="pg-changes-event"
+>
+<TabPanel id="insert" label="Insert">
 
 ```kotlin
 val myChannel = supabase.channel("db-changes")
@@ -403,18 +587,124 @@ myChannel.subscribe()
 ```
 
 </TabPanel>
+<TabPanel id="update" label="Update">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction.Update>(schema = "public")
+
+changes
+    .onEach {
+        println(it.record)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+<TabPanel id="delete" label="Delete">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction.Delete>(schema = "public")
+
+changes
+    .onEach {
+        println(it.oldRecord)
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+<TabPanel id="all" label="All events">
+
+```kotlin
+val myChannel = supabase.channel("db-changes")
+
+val changes = myChannel.postgresChangeFlow<PostgresAction>(schema = "public")
+
+changes
+    .onEach {
+        when (it) { //You can also check for <is PostgresAction.Insert>, etc.. manually
+            is HasRecord -> println(it.record)
+            is HasOldRecord -> println(it.oldRecord)
+            else -> println(it)
+        }
+    }
+    .launchIn(yourCoroutineScope)
+
+myChannel.subscribe()
+```
+
+</TabPanel>
+</Tabs>
+
+</TabPanel>
 </$Show>
 <$Show if="sdk:python">
 <TabPanel id="python" label="Python">
 
+<Tabs
+  scrollable
+  size="small"
+  type="underlined"
+  defaultActiveId="insert"
+  queryGroup="pg-changes-event"
+>
+<TabPanel id="insert" label="Insert">
+
 ```python
 changes = supabase.channel('schema-db-changes').on_postgres_changes(
-  "INSERT", # Listen only to INSERTs. Use "UPDATE", "DELETE", or "*" for other events.
+  "INSERT",
   schema="public",
   callback=lambda payload: print(payload)
 )
 .subscribe()
 ```
+
+</TabPanel>
+<TabPanel id="update" label="Update">
+
+```python
+changes = supabase.channel('schema-db-changes').on_postgres_changes(
+  "UPDATE",
+  schema="public",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+<TabPanel id="delete" label="Delete">
+
+```python
+changes = supabase.channel('schema-db-changes').on_postgres_changes(
+  "DELETE",
+  schema="public",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+<TabPanel id="all" label="All events">
+
+```python
+changes = supabase.channel('schema-db-changes').on_postgres_changes(
+  "*",
+  schema="public",
+  callback=lambda payload: print(payload)
+)
+.subscribe()
+```
+
+</TabPanel>
+</Tabs>
 
 </TabPanel>
 </$Show>

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -3218,12 +3218,12 @@ You can't filter Delete events when tracking Postgres Changes. This limitation i
 
 ## Scaling Postgres Changes
 
-Postgres Changes authorizes every event against each subscriber. When you make a single change to a table with 100 subscribed users, Realtime performs 100 authorization checks — one per user — so throughput scales with the number of subscribers, not just the write rate. Changes are also processed on a single thread to preserve their order, which means larger compute add-ons don't meaningfully increase Postgres Changes throughput.
+Postgres Changes authorizes every event against each subscriber. When you make a single change to a table with 100 subscribed users, Realtime performs 100 authorization checks — one per user — so throughput scales with the number of subscribers, not the write rate. Changes are also processed on a single thread to preserve their order, which means larger compute add-ons don't meaningfully increase Postgres Changes throughput.
 
 For most applications this is plenty. To get the best performance:
 
 - Use [filters](#available-filters) and [column selection](#selecting-specific-columns) to send each client only the events and columns it needs.
-- Keep authorization cheap by writing simple, indexed [RLS policies](/docs/guides/database/postgres/row-level-security).
+- Keep authorization cheap by writing , indexed [RLS policies](/docs/guides/database/postgres/row-level-security).
 
 Use the estimator below to gauge the maximum throughput for your instance, and run your own benchmarks to confirm it fits your use case:
 

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -320,7 +320,9 @@ changes = supabase.channel('schema-db-changes').on_postgres_changes(
 
 The channel name can be any string except 'realtime'.
 
-### Listening to `INSERT` events
+### Listening to specific events
+
+Use the `event` parameter to listen only to a specific database event. `event` can be `INSERT`, `UPDATE`, `DELETE`, or `*` to listen to all changes.
 
 <Tabs
   scrollable
@@ -331,15 +333,13 @@ The channel name can be any string except 'realtime'.
 >
 <TabPanel id="js" label="JavaScript">
 
-Use the `event` parameter to listen only to database `INSERT`s:
-
 ```js
 const changes = supabase
   .channel('schema-db-changes')
   .on(
     'postgres_changes',
     {
-      event: 'INSERT', // Listen only to INSERTs
+      event: 'INSERT', // Listen only to INSERTs. Use 'UPDATE', 'DELETE', or '*' for other events.
       schema: 'public',
     },
     (payload) => console.log(payload)
@@ -352,9 +352,10 @@ const changes = supabase
 <TabPanel id="dart" label="Dart">
 
 ```dart
-final changes = supabase
+supabase
     .channel('schema-db-changes')
     .onPostgresChanges(
+        // Use .update, .delete, or .all for other events
         event: PostgresChangeEvent.insert,
         schema: 'public',
         callback: (payload) => print(payload))
@@ -366,7 +367,7 @@ final changes = supabase
 <$Show if="sdk:swift">
 <TabPanel id="swift" label="Swift">
 
-Use `InsertAction.self` as type to listen only to database `INSERT`s:
+Pass the action type to select the event. Use `InsertAction.self`, `UpdateAction.self`, `DeleteAction.self`, or `AnyAction.self` to listen to all changes.
 
 ```swift
 let myChannel = await supabase.channel("schema-db-changes")
@@ -385,7 +386,7 @@ for await change in changes {
 <$Show if="sdk:kotlin">
 <TabPanel id="kotlin" label="Kotlin">
 
-Use `PostgresAction.Insert` as type to listen only to database `INSERT`s:
+Pass the action type to select the event. Use `PostgresAction.Insert`, `PostgresAction.Update`, `PostgresAction.Delete`, or `PostgresAction` to listen to all changes.
 
 ```kotlin
 val myChannel = supabase.channel("db-changes")
@@ -408,209 +409,7 @@ myChannel.subscribe()
 
 ```python
 changes = supabase.channel('schema-db-changes').on_postgres_changes(
-  "INSERT", # Listen only to INSERTs
-  schema="public",
-  callback=lambda payload: print(payload)
-)
-.subscribe()
-```
-
-</TabPanel>
-</$Show>
-</Tabs>
-
-The channel name can be any string except 'realtime'.
-
-### Listening to `UPDATE` events
-
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="js"
-  queryGroup="language"
->
-<TabPanel id="js" label="JavaScript">
-
-Use the `event` parameter to listen only to database `UPDATE`s:
-
-```js
-const changes = supabase
-  .channel('schema-db-changes')
-  .on(
-    'postgres_changes',
-    {
-      event: 'UPDATE', // Listen only to UPDATEs
-      schema: 'public',
-    },
-    (payload) => console.log(payload)
-  )
-  .subscribe()
-```
-
-</TabPanel>
-<$Show if="sdk:dart">
-<TabPanel id="dart" label="Dart">
-
-```dart
-supabase
-    .channel('schema-db-changes')
-    .onPostgresChanges(
-        event: PostgresChangeEvent.update, // Listen only to UPDATEs
-        schema: 'public',
-        callback: (payload) => print(payload))
-    .subscribe();
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:swift">
-<TabPanel id="swift" label="Swift">
-
-Use `UpdateAction.self` as type to listen only to database `UPDATE`s:
-
-```swift
-let myChannel = await supabase.channel("schema-db-changes")
-
-let changes = await myChannel.postgresChange(UpdateAction.self, schema: "public")
-
-await myChannel.subscribe()
-
-for await change in changes {
-  print(change.oldRecord, change.record)
-}
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:kotlin">
-<TabPanel id="kotlin" label="Kotlin">
-
-Use `PostgresAction.Update` as type to listen only to database `UPDATE`s:
-
-```kotlin
-val myChannel = supabase.channel("db-changes")
-
-val changes = myChannel.postgresChangeFlow<PostgresAction.Update>(schema = "public")
-
-changes
-    .onEach {
-        println(it.record)
-    }
-    .launchIn(yourCoroutineScope)
-
-myChannel.subscribe()
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:python">
-<TabPanel id="python" label="Python">
-
-```python
-changes = supabase.channel('schema-db-changes').on_postgres_changes(
-  "UPDATE", # Listen only to UPDATEs
-  schema="public",
-  callback=lambda payload: print(payload)
-)
-.subscribe()
-```
-
-</TabPanel>
-</$Show>
-</Tabs>
-
-The channel name can be any string except 'realtime'.
-
-### Listening to `DELETE` events
-
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="js"
-  queryGroup="language"
->
-<TabPanel id="js" label="JavaScript">
-
-Use the `event` parameter to listen only to database `DELETE`s:
-
-```js
-const changes = supabase
-  .channel('schema-db-changes')
-  .on(
-    'postgres_changes',
-    {
-      event: 'DELETE', // Listen only to DELETEs
-      schema: 'public',
-    },
-    (payload) => console.log(payload)
-  )
-  .subscribe()
-```
-
-</TabPanel>
-<$Show if="sdk:dart">
-<TabPanel id="dart" label="Dart">
-
-```dart
-supabase
-    .channel('schema-db-changes')
-    .onPostgresChanges(
-        event: PostgresChangeEvent.delete, // Listen only to DELETEs
-        schema: 'public',
-        callback: (payload) => print(payload))
-    .subscribe();
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:swift">
-<TabPanel id="swift" label="Swift">
-
-Use `DeleteAction.self` as type to listen only to database `DELETE`s:
-
-```swift
-let myChannel = await supabase.channel("schema-db-changes")
-
-let changes = await myChannel.postgresChange(DeleteAction.self, schema: "public")
-
-await myChannel.subscribe()
-
-for await change in changes {
-  print(change.oldRecord)
-}
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:kotlin">
-<TabPanel id="kotlin" label="Kotlin">
-
-Use `PostgresAction.Delete` as type to listen only to database `DELETE`s:
-
-```kotlin
-val myChannel = supabase.channel("db-changes")
-
-val changes = myChannel.postgresChangeFlow<PostgresAction.Delete>(schema = "public")
-
-changes
-    .onEach {
-        println(it.oldRecord)
-    }
-    .launchIn(yourCoroutineScope)
-
-myChannel.subscribe()
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:python">
-<TabPanel id="python" label="Python">
-
-```python
-changes = supabase.channel('schema-db-changes').on_postgres_changes(
-  "DELETE", # Listen only to DELETEs
+  "INSERT", # Listen only to INSERTs. Use "UPDATE", "DELETE", or "*" for other events.
   schema="public",
   callback=lambda payload: print(payload)
 )
@@ -3142,68 +2941,6 @@ changes = supabase.channel('db-changes').on_postgres_changes(
   callback=lambda payload: print(payload)
 )
 .subscribe()
-```
-
-</TabPanel>
-</$Show>
-</Tabs>
-
-### Refreshed tokens
-
-You will need to refresh tokens on your own, but once generated, you can pass them to Realtime.
-
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="js"
-  queryGroup="language"
->
-<TabPanel id="js" label="JavaScript">
-
-For example, if you're using the `supabase-js` `v2` client then you can pass your token like this:
-
-```js
-// Client setup
-
-supabase.realtime.setAuth('fresh-token')
-```
-
-</TabPanel>
-<$Show if="sdk:dart">
-<TabPanel id="dart" label="Dart">
-
-```dart
-supabase.realtime.setAuth('fresh-token');
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:swift">
-<TabPanel id="swift" label="Swift">
-
-```swift
-await supabase.realtime.setAuth("fresh-token")
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:kotlin">
-<TabPanel id="kotlin" label="Kotlin">
-
-In Kotlin, you have to update the token manually per channel:
-
-```kotlin
-myChannel.updateAuth("fresh-token")
-```
-
-</TabPanel>
-</$Show>
-<$Show if="sdk:python">
-<TabPanel id="python" label="Python">
-
-```python
-supabase.realtime.set_auth('fresh-token')
 ```
 
 </TabPanel>

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -1716,7 +1716,7 @@ const channel = supabase
       event: 'INSERT',
       schema: 'public',
       table: 'colors',
-      filter: 'name=in.(red, blue, yellow)',
+      filter: 'name=in.(red,blue,yellow)',
     },
     (payload) => console.log(payload)
   )
@@ -1778,7 +1778,7 @@ val myChannel = supabase.channel("db-changes")
 
 val changes = myChannel.postgresChangeFlow<PostgresAction.Update>(schema = "public") {
     table = "products"
-    filter = "name=in.(red, blue, yellow)"
+    filter = "name=in.(red,blue,yellow)"
 }
 
 changes
@@ -1800,7 +1800,7 @@ changes = supabase.channel('db-changes').on_postgres_changes(
   "UPDATE",
   schema="public",
   table="products",
-  filter="name=in.(red, blue, yellow)",
+  filter="name=in.(red,blue,yellow)",
   callback=lambda payload: print(payload)
 )
 .subscribe()
@@ -1957,7 +1957,7 @@ changes = supabase.channel('db-changes').on_postgres_changes(
 </$Show>
 </Tabs>
 
-`like` uses Postgres's `LIKE` and `ilike` uses `ILIKE`. Both require a text-compatible column.
+`like` uses Postgres's `LIKE` and `ilike` uses `ILIKE`. Both require a text-compatible column. The examples above use `ilike`; swap in `like` for case-sensitive matching—usage is otherwise identical.
 
 ### Regular expression matching (`match`, `imatch`)
 
@@ -2104,7 +2104,7 @@ changes = supabase.channel('db-changes').on_postgres_changes(
 </$Show>
 </Tabs>
 
-`match` uses Postgres's `~` operator and `imatch` uses `~*`. Both require a text-compatible column, and the pattern is validated when you subscribe.
+`match` uses Postgres's `~` operator and `imatch` uses `~*`. Both require a text-compatible column, and the pattern is validated when you subscribe. The examples above use `match`; swap in `imatch` for case-insensitive matching—usage is otherwise identical.
 
 ### Null and boolean checks (`is`)
 
@@ -2888,7 +2888,7 @@ let changes = await myChannel.postgresChange(
   UpdateAction.self,
   schema: "public",
   table: "products",
-  filter: "name=in.(red, blue, yellow)"
+  filter: "name=in.(red,blue,yellow)"
 )
 
 await myChannel.subscribe()
@@ -2913,7 +2913,7 @@ val myChannel = supabase.channel("db-changes")
 
 val changes = myChannel.postgresChangeFlow<PostgresAction.Update>(schema = "public") {
     table = "products"
-    filter = "name=in.(red, blue, yellow)"
+    filter = "name=in.(red,blue,yellow)"
 }
 
 changes
@@ -2937,7 +2937,7 @@ changes = supabase.channel('db-changes').on_postgres_changes(
   "UPDATE",
   schema="public",
   table="products",
-  filter="name=in.(red, blue, yellow)",
+  filter="name=in.(red,blue,yellow)",
   callback=lambda payload: print(payload)
 )
 .subscribe()

--- a/apps/docs/internals/markdown-schema/RealtimeLimitsEstimator.ts
+++ b/apps/docs/internals/markdown-schema/RealtimeLimitsEstimator.ts
@@ -6,7 +6,6 @@ import throughputTable from '../../data/realtime/throughput.json'
 
 type Row = {
   computeAddOn: string
-  filters: boolean
   rls: boolean
   concurrency: number
   maxDBChanges: number
@@ -27,7 +26,7 @@ ${dividerRow}
 ${rows
   .map(
     (l) =>
-      `| ${l.filters ? 'Yes' : 'No'} | ${l.rls ? 'Yes' : 'No'} | ${l.concurrency.toLocaleString()} | ${l.maxDBChanges} | ${l.maxMessagesPerClient} | ${l.totalMessagesPerSecond.toLocaleString()} | ${l.p95Latency}ms |`
+      `| ${l.rls ? 'Yes' : 'No'} | ${l.concurrency.toLocaleString()} | ${l.maxDBChanges} | ${l.maxMessagesPerClient} | ${l.totalMessagesPerSecond.toLocaleString()} | ${l.p95Latency}ms |`
   )
   .join('\n')}`
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

update pg changes documentation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Realtime Postgres Changes guide with a new, generalized “Listening to specific events” section (including INSERT/UPDATE/DELETE/* examples) and standardized `event` usage.
  * Refreshed “Available filters” with a unified filter builder approach, expanded operator reference, consistent Filter-string/tab patterns, `not.` and `AND` guidance, and clearer limitations (including delete-event filtering).
  * Updated “Selecting specific columns” examples to match the latest payload/subscription guidance.
* **Refactor**
  * Simplified the Realtime limits estimator by removing filter-based throughput inputs and related UI/table columns; throughput is now based on compute add-on, RLS, and concurrency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->