### PR TITLE
fix(studio): keep table editor scrollbars visible and draggable on macOS

### DIFF
--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -405,7 +405,7 @@ export const Grid = memo(
                   ref={ref}
                   className={cn(
                     gridClass,
-                    'grow border-t-default! border-b-0!',
+                    'grow border-t-default! border-b-0! persistent-scrollbar',
                     isContextMenuOpen && 'rdg-context-menu-open'
                   )}
                   rowClass={computedRowClass}

--- a/apps/studio/components/grid/components/grid/Grid.tsx
+++ b/apps/studio/components/grid/components/grid/Grid.tsx
@@ -405,7 +405,7 @@ export const Grid = memo(
                   ref={ref}
                   className={cn(
                     gridClass,
-                    'grow border-t-default! border-b-0! persistent-scrollbar',
+                    'grow border-t-default! border-b-0!',
                     isContextMenuOpen && 'rdg-context-menu-open'
                   )}
                   rowClass={computedRowClass}

--- a/apps/studio/components/layouts/Tabs/Tabs.tsx
+++ b/apps/studio/components/layouts/Tabs/Tabs.tsx
@@ -147,7 +147,7 @@ export const EditorTabs = () => {
           ref={tabsListRef}
           className={cn(
             'rounded-b-none gap-0 min-h-(--header-height) flex items-center w-full z-1',
-            'bg-surface-200 dark:bg-alternative border-none text-clip overflow-x-auto'
+            'bg-surface-200 dark:bg-alternative border-none text-clip overflow-x-auto persistent-scrollbar'
           )}
         >
           <SortableContext

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -350,6 +350,38 @@ input[type='number'] {
   display: none;
 }
 
+/*
+  Opts an overflow container out of macOS overlay scrollbars so the thumb is
+  always visible and draggable with a mouse, regardless of the system
+  "Show scroll bars" setting (https://github.com/supabase/supabase/issues/44369).
+*/
+.persistent-scrollbar::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+  background: transparent;
+}
+.persistent-scrollbar::-webkit-scrollbar-thumb {
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+  background-color: var(--foreground-muted);
+}
+.persistent-scrollbar::-webkit-scrollbar-thumb:hover {
+  background-color: var(--foreground-lighter);
+}
+.persistent-scrollbar::-webkit-scrollbar-corner {
+  background: transparent;
+}
+/* Firefox — Chromium/WebKit ignore ::-webkit-scrollbar styling when
+   scrollbar-width/scrollbar-color are set, so scope these to browsers
+   without ::-webkit-scrollbar support */
+@supports not selector(::-webkit-scrollbar) {
+  .persistent-scrollbar {
+    scrollbar-width: thin;
+    scrollbar-color: var(--foreground-muted) transparent;
+  }
+}
+
 div[data-radix-portal]:not(.portal--toast) {
   z-index: 2147483646 !important;
 }

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -355,34 +355,40 @@ input[type='number'] {
   always visible and draggable with a mouse, regardless of the system
   "Show scroll bars" setting (https://github.com/supabase/supabase/issues/44369).
   Consumers can override --persistent-scrollbar-size/-radius before applying
-  this class instead of duplicating the rules below (e.g. .rdg in grid.css).
+  this class instead of duplicating the rules below.
+
+  .rdg is included directly (rather than requiring every react-data-grid
+  call site across Studio to add the persistent-scrollbar class) so every
+  data grid in the app — table editor, SQL results, logs, auth users, cron
+  jobs, queues, etc. — keeps a grabbable scrollbar, not just the table
+  editor grid. .rdg overrides the two size variables in grid.css.
 */
-.persistent-scrollbar {
+:is(.persistent-scrollbar, .rdg) {
   --persistent-scrollbar-size: 8px;
   --persistent-scrollbar-radius: 4px;
 }
-.persistent-scrollbar::-webkit-scrollbar {
+:is(.persistent-scrollbar, .rdg)::-webkit-scrollbar {
   width: var(--persistent-scrollbar-size);
   height: var(--persistent-scrollbar-size);
   background: transparent;
 }
-.persistent-scrollbar::-webkit-scrollbar-thumb {
+:is(.persistent-scrollbar, .rdg)::-webkit-scrollbar-thumb {
   border-radius: var(--persistent-scrollbar-radius);
   border: 2px solid transparent;
   background-clip: content-box;
   background-color: var(--foreground-muted);
 }
-.persistent-scrollbar::-webkit-scrollbar-thumb:hover {
+:is(.persistent-scrollbar, .rdg)::-webkit-scrollbar-thumb:hover {
   background-color: var(--foreground-lighter);
 }
-.persistent-scrollbar::-webkit-scrollbar-corner {
+:is(.persistent-scrollbar, .rdg)::-webkit-scrollbar-corner {
   background: transparent;
 }
 /* Firefox — Chromium/WebKit ignore ::-webkit-scrollbar styling when
    scrollbar-width/scrollbar-color are set, so scope these to browsers
    without ::-webkit-scrollbar support */
 @supports not selector(::-webkit-scrollbar) {
-  .persistent-scrollbar {
+  :is(.persistent-scrollbar, .rdg) {
     scrollbar-width: thin;
     scrollbar-color: var(--foreground-muted) transparent;
   }

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -354,14 +354,20 @@ input[type='number'] {
   Opts an overflow container out of macOS overlay scrollbars so the thumb is
   always visible and draggable with a mouse, regardless of the system
   "Show scroll bars" setting (https://github.com/supabase/supabase/issues/44369).
+  Consumers can override --persistent-scrollbar-size/-radius before applying
+  this class instead of duplicating the rules below (e.g. .rdg in grid.css).
 */
+.persistent-scrollbar {
+  --persistent-scrollbar-size: 8px;
+  --persistent-scrollbar-radius: 4px;
+}
 .persistent-scrollbar::-webkit-scrollbar {
-  width: 8px;
-  height: 8px;
+  width: var(--persistent-scrollbar-size);
+  height: var(--persistent-scrollbar-size);
   background: transparent;
 }
 .persistent-scrollbar::-webkit-scrollbar-thumb {
-  border-radius: 4px;
+  border-radius: var(--persistent-scrollbar-radius);
   border: 2px solid transparent;
   background-clip: content-box;
   background-color: var(--foreground-muted);

--- a/apps/studio/styles/grid.css
+++ b/apps/studio/styles/grid.css
@@ -104,38 +104,14 @@
 }
 
 /*
-  Always-grabbable scrollbars for the grid.
-  On macOS with overlay scrollbars ("Show scroll bars" not set to Always),
-  native scrollbars are hidden until a scroll happens and cannot be reached
-  with the mouse (https://github.com/supabase/supabase/issues/44369).
-  Styling ::-webkit-scrollbar opts the grid out of overlay scrollbars in
-  Chromium/WebKit so the thumb is always visible and draggable.
+  Reuse the .persistent-scrollbar rules (globals.css) so the grid keeps a
+  grabbable scrollbar on macOS instead of a hidden overlay one
+  (https://github.com/supabase/supabase/issues/44369), just with a slightly
+  larger thumb sized for the grid's own scroll area.
 */
-.rdg::-webkit-scrollbar {
-  width: 10px;
-  height: 10px;
-  background: transparent;
-}
-.rdg::-webkit-scrollbar-thumb {
-  border-radius: 5px;
-  border: 2px solid transparent;
-  background-clip: content-box;
-  background-color: var(--foreground-muted);
-}
-.rdg::-webkit-scrollbar-thumb:hover {
-  background-color: var(--foreground-lighter);
-}
-.rdg::-webkit-scrollbar-corner {
-  background: transparent;
-}
-/* Firefox — Chromium/WebKit ignore ::-webkit-scrollbar styling when
-   scrollbar-width/scrollbar-color are set, so scope these to browsers
-   without ::-webkit-scrollbar support */
-@supports not selector(::-webkit-scrollbar) {
-  .rdg {
-    scrollbar-width: thin;
-    scrollbar-color: var(--foreground-muted) transparent;
-  }
+.rdg {
+  --persistent-scrollbar-size: 10px;
+  --persistent-scrollbar-radius: 5px;
 }
 
 @supports not (contain: strict) {

--- a/apps/studio/styles/grid.css
+++ b/apps/studio/styles/grid.css
@@ -104,10 +104,11 @@
 }
 
 /*
-  Reuse the .persistent-scrollbar rules (globals.css) so the grid keeps a
-  grabbable scrollbar on macOS instead of a hidden overlay one
-  (https://github.com/supabase/supabase/issues/44369), just with a slightly
-  larger thumb sized for the grid's own scroll area.
+  The persistent-scrollbar rules that keep .rdg's scrollbar grabbable on
+  macOS (https://github.com/supabase/supabase/issues/44369) live in
+  globals.css so every data grid in Studio shares one definition. Override
+  just the size here for a slightly larger thumb on the grid's own scroll
+  area.
 */
 .rdg {
   --persistent-scrollbar-size: 10px;

--- a/apps/studio/styles/grid.css
+++ b/apps/studio/styles/grid.css
@@ -103,6 +103,41 @@
   box-sizing: inherit;
 }
 
+/*
+  Always-grabbable scrollbars for the grid.
+  On macOS with overlay scrollbars ("Show scroll bars" not set to Always),
+  native scrollbars are hidden until a scroll happens and cannot be reached
+  with the mouse (https://github.com/supabase/supabase/issues/44369).
+  Styling ::-webkit-scrollbar opts the grid out of overlay scrollbars in
+  Chromium/WebKit so the thumb is always visible and draggable.
+*/
+.rdg::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+  background: transparent;
+}
+.rdg::-webkit-scrollbar-thumb {
+  border-radius: 5px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+  background-color: var(--foreground-muted);
+}
+.rdg::-webkit-scrollbar-thumb:hover {
+  background-color: var(--foreground-lighter);
+}
+.rdg::-webkit-scrollbar-corner {
+  background: transparent;
+}
+/* Firefox — Chromium/WebKit ignore ::-webkit-scrollbar styling when
+   scrollbar-width/scrollbar-color are set, so scope these to browsers
+   without ::-webkit-scrollbar support */
+@supports not selector(::-webkit-scrollbar) {
+  .rdg {
+    scrollbar-width: thin;
+    scrollbar-color: var(--foreground-muted) transparent;
+  }
+}
+
 @supports not (contain: strict) {
   .rdg {
     position: relative;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix — fixes #44369 (Scrolling not working on macOS: table editor scrollbars cannot be reached or dragged with the mouse).

## What is the current behavior?

On macOS with the default system setting **"Show scroll bars: Automatically based on mouse or trackpad"**, the browser renders *overlay* scrollbars. Overlay scrollbars are only painted while a scroll is in progress and fade out shortly afterwards.

Neither the table editor grid (`react-data-grid`, the `.rdg` container) nor the editor tabs strip applies any scrollbar styling of its own, so both rely entirely on this native overlay behavior. The practical consequence, as reported and demonstrated in the videos attached to #44369:

1. Hovering over the edge of the grid (or the tabs strip) shows no scrollbar at all.
2. The user must first scroll via the keyboard (or a scroll wheel) purely to make the scrollbar appear.
3. Only then can the thumb be grabbed with the mouse — and it disappears again moments later.

This makes navigating wide/long tables with a mouse slow and frustrating. Investigation notes:

- `git` history of `apps/studio/styles/` shows no scrollbar styling was ever present or removed for these containers, so this is not a Studio CSS regression.
- The `react-data-grid` `7.0.0-beta.41 → beta.47` bump was ruled out by diffing the published stylesheets of both versions: the root scroll properties (`overflow`, `contain`, `content-visibility`) are identical.
- The root cause is simply that native macOS overlay scrollbars are unreachable by mouse until a scroll has already happened.

## What is the new behavior?

The affected scroll containers are opted out of overlay scrollbars so a thin, theme-aware thumb is always visible and draggable. The implementation keeps a single source of truth for the scrollbar rules:

- **Shared rules (`apps/studio/styles/globals.css`)** — one block of `::-webkit-scrollbar` rules is defined under the selector `:is(.persistent-scrollbar, .rdg)`, sized via two custom properties (`--persistent-scrollbar-size`, `--persistent-scrollbar-radius`, defaulting to 8px/4px). Styling these pseudo-elements switches the container from overlay to classic scrollbars in Chromium/WebKit, which is what makes the thumb permanently grabbable. The thumb uses `--foreground-muted` with a `--foreground-lighter` hover state; the track and corner stay transparent.
- **Why `.rdg` is part of the shared selector** — `react-data-grid` is used in 50+ places across Studio (SQL editor results, logs, auth users, cron jobs, queues, query performance, realtime inspector, linter, and more), and every instance carries the library's built-in `.rdg` class. Including `.rdg` in the selector fixes all of these grids at once, without requiring each call site to opt in with a class — and without duplicating the rule block.
- **Grid sizing override (`apps/studio/styles/grid.css`)** — `.rdg` overrides the two custom properties to 10px/5px for a slightly larger thumb suited to the grid's scroll area. `grid.css` is imported after `globals.css` in `_app.tsx`, so the override wins the equal-specificity cascade.
- **Editor tabs strip (`apps/studio/components/layouts/Tabs/Tabs.tsx`)** — the `TabsList` adds the `persistent-scrollbar` class and picks up the default 8px sizing, fixing the horizontal scrolling of open tabs also mentioned in the issue.
- **Firefox** — an equivalent thin scrollbar is provided via `scrollbar-width: thin` / `scrollbar-color`. This is deliberately scoped inside `@supports not selector(::-webkit-scrollbar)`: when the standard properties are set alongside `::-webkit-scrollbar`, Chromium ignores the pseudo-element styling entirely (verified during testing — the scrollbar gutter measured 0px until the standard properties were scoped away from Chromium).

Behavior on other platforms is unaffected in practice: Windows/Linux already render classic scrollbars, which now simply pick up the theme colors instead of the default chrome.

## Verification

Reproduced and verified in an isolated harness rather than by eye:

1. Rendered `react-data-grid@7.0.0-beta.47` with the same overrides Studio applies to `.rdg` (`overflow-x: auto; overflow-y: scroll; contain: strict`) alongside an unstyled control container, in both headed and headless Chrome on macOS.
2. **Before:** no scrollbar is painted on any container until a scroll event occurs; hovering shows nothing, matching the issue videos.
3. **After (with the exact CSS blocks from this PR extracted into the harness):** measured `offsetWidth − clientWidth` on three independent `<DataGrid>` instances (beta.41, beta.47, and beta.47 with the Studio overrides) — all report a 12px gutter (10px thumb + 2px border) purely through the built-in `.rdg` class, confirming coverage does not depend on any class we pass in. A plain element carrying only `.persistent-scrollbar` reports 10px (8px thumb + 2px border), and the unstyled control reports 2px (no scrollbar rendered).
4. `pnpm build --filter=studio` completes successfully; the compiled CSS chunks in `.next/static/chunks` contain the `:is(.persistent-scrollbar, .rdg)` rules and the `.rdg` size override verbatim, and the emitted HTML loads the `globals.css` chunk before the `grid.css` chunk, preserving the intended cascade.
5. `pnpm run format` (scoped to the three changed files) reports no changes, `eslint` on the changed component reports no issues, and the grid-related unit tests pass (6 files, 109 tests).

## Additional context

The always-visible thumb was chosen over a hover-revealed one because the core problem is discoverability: with an overlay-style behavior the user still has to know where to hover. A thin themed thumb matches the existing `.thin-scrollbars` convention already present in `apps/studio/styles/ui.css` while remaining unobtrusive.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent scrollbar styling across the studio interface for a smoother, easier-to-use scrolling experience.
  * Updated tab and grid scrollbar behavior to use the persistent scrollbar utility for consistent sizing and appearance.
* **Style**
  * Improved scrollbar visuals with shared defaults, plus specific overrides for the grid view.
  * Added cross-browser support (including non-WebKit fallback) to keep scrollbar sizing and colors consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->