### PR TITLE
fixed support link under the Need help? section

### DIFF
--- a/apps/docs/content/guides/platform/delete-project.mdx
+++ b/apps/docs/content/guides/platform/delete-project.mdx
@@ -132,5 +132,5 @@ See [Access Controls](/docs/guides/platform/access-control)
 If you're unsure about deletion or need assistance:
 
 - Review this guide and the protection measures above
-- Contact [Supabase support](/supabase.com/support) for guidance
+- Contact [Supabase support](/support) for guidance
 - Consider reaching out to your team before deleting shared projects


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fix link to support help from [Need help? section in Delete Project docs](https://supabase.com/docs/guides/platform/delete-project#need-help)

## What is the current behavior?

Link returns 404 as it points to https://supabase.com/supabase.com/support instead of https://supabase.com/support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Need help?” link in the project deletion guide to point to the correct support page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->