### PR TITLE
fix(ui): keep secondary Button label visible on hover and focus

### DIFF
--- a/packages/ui/src/components/Button/Button.tsx
+++ b/packages/ui/src/components/Button/Button.tsx
@@ -50,11 +50,11 @@ const buttonVariants = cva(
           data-[state=open]:border-button-hover
           `,
         secondary: `
-          bg-foreground
-          text-background hover:text-border-stronger
-          focus-visible:text-border-control
+          bg-foreground hover:bg-foreground/90
+          text-background
           border-foreground-light hover:border-foreground-lighter
           focus-visible:outline-border-strong
+          data-[state=open]:bg-foreground/90
           data-[state=open]:border-foreground-lighter
           data-[state=open]:outline-border-strong
         `,


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The shared `Button` component's `secondary` variant renders its label invisibly on hover and keyboard focus in both light and dark themes.

Reproduction:

1. Open https://supabase.com/pricing.
2. Hover the **Compare Plans** button under the plan cards.
3. The label disappears into the button fill until the cursor leaves.

The same happens anywhere else `<Button variant="secondary" />` is used.

## What is the new behavior?

The `secondary` variant keeps its label color stable across default, hover, focus, and open states. Interaction feedback now comes from a subtle background shift (`hover:bg-foreground/90`), which matches the shadcn primary button pattern already used elsewhere in the design system.

## Root cause

`packages/ui/src/components/Button/Button.tsx` had:

```
secondary: `
  bg-foreground
  text-background hover:text-border-stronger
  focus-visible:text-border-control
  ...
`
```

Under the current semantic color tokens, `--border-stronger` and `--border-control` both derive from `--foreground`:

```css
/* packages/ui/build/css/source/compat.css */
--border-stronger: oklch(
  from var(--foreground) l calc(c * 0.5) h / calc(5% + 45% * var(--contrast-border))
);
```

The button's fill is `bg-foreground`, so on hover/focus the label was repainted with a translucent version of the same base color as the fill and effectively vanished.

## Fix

Keep `text-background` as the label color across all states and move interaction feedback to the background:

```
secondary: `
  bg-foreground hover:bg-foreground/90
  text-background
  border-foreground-light hover:border-foreground-lighter
  focus-visible:outline-border-strong
  data-[state=open]:bg-foreground/90
  data-[state=open]:border-foreground-lighter
  data-[state=open]:outline-border-strong
`
```

Only the `secondary` variant is touched. Other variants (`primary`, `default`, `outline`, `dashed`, `link`, `text`, `danger`, `warning`) are unchanged.

## Additional context

- Affected page shown in the reproduction: `apps/www/app/pricing/PricingContent.tsx` (Compare Plans button uses `variant="secondary"`).
- The pattern mirrors the shadcn button (`packages/ui/src/components/shadcn/ui/button.tsx`): `bg-primary text-primary-foreground hover:bg-primary/90`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the secondary button’s hover and focus appearance for better visual consistency and accessibility.
  * Added a clearer open-state style so buttons reflect their active state more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->