### PR TITLE
fix(e2e/studio): remove dead `|| IS_CI` from playwright headless config

### DIFF
--- a/e2e/studio/playwright.config.ts
+++ b/e2e/studio/playwright.config.ts
@@ -60,7 +60,7 @@ export default defineConfig({
     baseURL: env.STUDIO_URL,
     screenshot: 'off',
     video: 'retain-on-failure',
-    headless: true || IS_CI,
+    headless: true,
     trace: 'retain-on-failure',
     permissions: ['clipboard-read', 'clipboard-write'],
     extraHTTPHeaders: {


### PR DESCRIPTION
`true || IS_CI` always evaluates to `true`, making the right-hand side unreachable. The Chromium launch args already pass `--headless=new`, confirming always-headless is the intended behavior. Behavior-preserving cleanup.

Closes #47590

---

- [x] I have read the CONTRIBUTING.md file.

**What kind of change does this PR introduce?**
Cleanup / dead code removal.

**What is the current behavior?**
`headless: true || IS_CI` in `e2e/studio/playwright.config.ts:63`. The `|| IS_CI` is unreachable because `true || anything === true`.

**What is the new behavior?**
`headless: true`. No runtime change. `IS_CI` remains used elsewhere in the file (retries, workers).