### PR TITLE
feat(studio): share report snippets with the team when added to homepage report FE-3800

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/CustomReportSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/CustomReportSection.tsx
@@ -16,8 +16,9 @@ import type { CSSProperties, DragEvent, ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from 'ui'
-import { Row } from 'ui-patterns/Row'
+import { Row } from 'ui-patterns'
 
+import { MakeReportSnippetPublicModal } from '@/components/interfaces/ProjectHome/MakeReportSnippetPublicModal'
 import { SnippetDropdown } from '@/components/interfaces/ProjectHome/SnippetDropdown'
 import { ReportBlock } from '@/components/interfaces/Reports/ReportBlock/ReportBlock'
 import { createSqlSnippetSkeletonV2 } from '@/components/interfaces/SQLEditor/SQLEditor.utils'
@@ -52,6 +53,9 @@ export function CustomReportSection() {
   const { data: project } = useSelectedProjectQuery()
 
   const [isRefreshing, setIsRefreshing] = useState<boolean>(false)
+  const [snippetToMakePublic, setSnippetToMakePublic] = useState<
+    { id: string; name: string } | undefined
+  >(undefined)
 
   const { data: reportsData } = useContentInfiniteQuery(
     { projectRef: ref, type: 'report', name: 'Home', limit: 1 },
@@ -161,14 +165,17 @@ export function CustomReportSection() {
     []
   )
 
+  const isSnippetInReport = useCallback(
+    (id: string) =>
+      !!editableReport?.layout?.some(
+        (x) => String(x.id) === String(id) || String(x.attribute) === `snippet_${id}`
+      ),
+    [editableReport]
+  )
+
   const addSnippetToReport = useCallback(
     (snippet: { id: string; name: string }) => {
-      if (
-        editableReport?.layout?.some(
-          (x) =>
-            String(x.id) === String(snippet.id) || String(x.attribute) === `snippet_${snippet.id}`
-        )
-      ) {
+      if (isSnippetInReport(snippet.id)) {
         toast('This block is already in your report')
         return
       }
@@ -226,7 +233,23 @@ export function CustomReportSection() {
       findNextPlacement,
       createSnippetChartBlock,
       persistReport,
+      isSnippetInReport,
     ]
+  )
+
+  const handleSelectSnippet = useCallback(
+    (snippet: { id: string; name: string; visibility: Content['visibility'] }) => {
+      if (isSnippetInReport(snippet.id)) {
+        toast('This block is already in your report')
+        return
+      }
+      if (snippet.visibility === 'user') {
+        setSnippetToMakePublic({ id: snippet.id, name: snippet.name })
+        return
+      }
+      addSnippetToReport(snippet)
+    },
+    [isSnippetInReport, addSnippetToReport]
   )
 
   const handleRemoveChart = ({ metric }: { metric: { key: string } }) => {
@@ -280,12 +303,15 @@ export function CustomReportSection() {
 
       const toastId = toast.loading(`Creating new query: ${label}`)
 
-      const payload = createSqlSnippetSkeletonV2({
-        name: label,
-        sql,
-        owner_id: profile.id,
-        project_id: project.id,
-      }) as UpsertContentPayload
+      const payload = {
+        ...createSqlSnippetSkeletonV2({
+          name: label,
+          sql,
+          owner_id: profile.id,
+          project_id: project.id,
+        }),
+        visibility: 'project',
+      } as UpsertContentPayload
 
       upsertContent({ projectRef: ref, payload })
 
@@ -349,7 +375,7 @@ export function CustomReportSection() {
           {canUpdateReport || canCreateReport ? (
             <SnippetDropdown
               projectRef={ref}
-              onSelect={addSnippetToReport}
+              onSelect={handleSelectSnippet}
               trigger={
                 <Button variant="default" icon={<Plus />}>
                   Add block
@@ -380,7 +406,7 @@ export function CustomReportSection() {
             {canUpdateReport || canCreateReport ? (
               <SnippetDropdown
                 projectRef={ref}
-                onSelect={addSnippetToReport}
+                onSelect={handleSelectSnippet}
                 trigger={
                   <Button variant="default" iconRight={<Plus size={14} />}>
                     Add your first block
@@ -437,6 +463,16 @@ export function CustomReportSection() {
           </DndContext>
         )}
       </div>
+
+      <MakeReportSnippetPublicModal
+        projectRef={ref}
+        snippet={snippetToMakePublic}
+        onCancel={() => setSnippetToMakePublic(undefined)}
+        onConfirm={(snippet) => {
+          setSnippetToMakePublic(undefined)
+          addSnippetToReport(snippet)
+        }}
+      />
     </div>
   )
 }

--- a/apps/studio/components/interfaces/ProjectHome/CustomReportSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/CustomReportSection.tsx
@@ -16,7 +16,7 @@ import type { CSSProperties, DragEvent, ReactNode } from 'react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from 'ui'
-import { Row } from 'ui-patterns'
+import { Row } from 'ui-patterns/Row'
 
 import { MakeReportSnippetPublicModal } from '@/components/interfaces/ProjectHome/MakeReportSnippetPublicModal'
 import { SnippetDropdown } from '@/components/interfaces/ProjectHome/SnippetDropdown'

--- a/apps/studio/components/interfaces/ProjectHome/CustomReportSection.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/CustomReportSection.tsx
@@ -18,6 +18,7 @@ import { toast } from 'sonner'
 import { Button } from 'ui'
 import { Row } from 'ui-patterns/Row'
 
+import { resolveSnippetSelection } from '@/components/interfaces/ProjectHome/CustomReportSection.utils'
 import { MakeReportSnippetPublicModal } from '@/components/interfaces/ProjectHome/MakeReportSnippetPublicModal'
 import { SnippetDropdown } from '@/components/interfaces/ProjectHome/SnippetDropdown'
 import { ReportBlock } from '@/components/interfaces/Reports/ReportBlock/ReportBlock'
@@ -239,15 +240,17 @@ export function CustomReportSection() {
 
   const handleSelectSnippet = useCallback(
     (snippet: { id: string; name: string; visibility: Content['visibility'] }) => {
-      if (isSnippetInReport(snippet.id)) {
-        toast('This block is already in your report')
-        return
+      const action = resolveSnippetSelection(snippet, isSnippetInReport(snippet.id))
+      switch (action) {
+        case 'already-added':
+          toast('This block is already in your report')
+          return
+        case 'confirm-share':
+          setSnippetToMakePublic({ id: snippet.id, name: snippet.name })
+          return
+        case 'add':
+          addSnippetToReport(snippet)
       }
-      if (snippet.visibility === 'user') {
-        setSnippetToMakePublic({ id: snippet.id, name: snippet.name })
-        return
-      }
-      addSnippetToReport(snippet)
     },
     [isSnippetInReport, addSnippetToReport]
   )

--- a/apps/studio/components/interfaces/ProjectHome/CustomReportSection.utils.test.ts
+++ b/apps/studio/components/interfaces/ProjectHome/CustomReportSection.utils.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveSnippetSelection } from './CustomReportSection.utils'
+
+describe('resolveSnippetSelection', () => {
+  it('returns "already-added" when the snippet is already in the report', () => {
+    expect(resolveSnippetSelection({ visibility: 'user' }, true)).toBe('already-added')
+    expect(resolveSnippetSelection({ visibility: 'project' }, true)).toBe('already-added')
+  })
+
+  it('returns "confirm-share" for a private snippet not yet in the report', () => {
+    expect(resolveSnippetSelection({ visibility: 'user' }, false)).toBe('confirm-share')
+  })
+
+  it('returns "add" for an already-shared snippet not yet in the report', () => {
+    expect(resolveSnippetSelection({ visibility: 'project' }, false)).toBe('add')
+    expect(resolveSnippetSelection({ visibility: 'org' }, false)).toBe('add')
+    expect(resolveSnippetSelection({ visibility: 'public' }, false)).toBe('add')
+  })
+})

--- a/apps/studio/components/interfaces/ProjectHome/CustomReportSection.utils.ts
+++ b/apps/studio/components/interfaces/ProjectHome/CustomReportSection.utils.ts
@@ -1,0 +1,12 @@
+import type { Content } from '@/data/content/content-query'
+
+export type SnippetSelectionAction = 'already-added' | 'confirm-share' | 'add'
+
+export function resolveSnippetSelection(
+  snippet: { visibility: Content['visibility'] },
+  isAlreadyInReport: boolean
+): SnippetSelectionAction {
+  if (isAlreadyInReport) return 'already-added'
+  if (snippet.visibility === 'user') return 'confirm-share'
+  return 'add'
+}

--- a/apps/studio/components/interfaces/ProjectHome/MakeReportSnippetPublicModal.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/MakeReportSnippetPublicModal.tsx
@@ -1,0 +1,83 @@
+import { Eye, Unlock } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
+
+import { getContentById } from '@/data/content/content-id-query'
+import { useContentUpsertMutation } from '@/data/content/content-upsert-mutation'
+
+type ReportSnippet = { id: string; name: string }
+
+export const MakeReportSnippetPublicModal = ({
+  projectRef,
+  snippet,
+  onCancel,
+  onConfirm,
+}: {
+  projectRef?: string
+  snippet?: ReportSnippet
+  onCancel: () => void
+  onConfirm: (snippet: ReportSnippet) => void
+}) => {
+  const [isPreparing, setIsPreparing] = useState(false)
+
+  const { mutate: upsertContent, isPending: isUpserting } = useContentUpsertMutation({
+    onError: (error) => {
+      toast.error(`Failed to share snippet: ${error.message}`)
+    },
+  })
+
+  const onMakePublic = async () => {
+    if (!projectRef) return console.error('Project ref is required')
+    if (!snippet) return console.error('Snippet is required')
+
+    setIsPreparing(true)
+    try {
+      const item = await getContentById({ projectRef, id: snippet.id })
+      upsertContent(
+        {
+          projectRef,
+          payload: { ...item, visibility: 'project', folder_id: null },
+        },
+        {
+          onSuccess: () => {
+            toast.success('Snippet is now shared to the project')
+            onConfirm(snippet)
+          },
+        }
+      )
+    } catch (error: any) {
+      toast.error(`Failed to share snippet: ${error.message}`)
+    } finally {
+      setIsPreparing(false)
+    }
+  }
+
+  return (
+    <ConfirmationModal
+      size="medium"
+      loading={isPreparing || isUpserting}
+      title={`Share snippet with the team: ${snippet?.name}`}
+      confirmLabel="Share and add to report"
+      confirmLabelLoading="Sharing snippet"
+      visible={snippet !== undefined}
+      onCancel={onCancel}
+      onConfirm={onMakePublic}
+      alert={{
+        title: 'This snippet will become public to all team members',
+        description: 'Snippets added to the report must be shared so the team can view them',
+      }}
+    >
+      <ul className="text-sm text-foreground-light space-y-5">
+        <li className="flex gap-3 items-center">
+          <Eye size={16} />
+          <span>Project members will have read-only access to this snippet.</span>
+        </li>
+        <li className="flex gap-3 items-center">
+          <Unlock size={16} />
+          <span>Anyone will be able to duplicate it to their personal snippets.</span>
+        </li>
+      </ul>
+    </ConfirmationModal>
+  )
+}

--- a/apps/studio/components/interfaces/ProjectHome/MakeReportSnippetPublicModal.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/MakeReportSnippetPublicModal.tsx
@@ -64,7 +64,7 @@ export const MakeReportSnippetPublicModal = ({
       onCancel={onCancel}
       onConfirm={onMakePublic}
       alert={{
-        title: 'This snippet will become public to all team members',
+        title: 'This snippet will become visible to all project members',
         description: 'Snippets added to the report must be shared so the team can view them',
       }}
     >
@@ -75,7 +75,7 @@ export const MakeReportSnippetPublicModal = ({
         </li>
         <li className="flex gap-3 items-center">
           <Unlock size={16} />
-          <span>Anyone will be able to duplicate it to their personal snippets.</span>
+          <span>Project members can duplicate it to their personal snippets.</span>
         </li>
       </ul>
     </ConfirmationModal>

--- a/apps/studio/components/interfaces/ProjectHome/SnippetDropdown.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/SnippetDropdown.tsx
@@ -29,7 +29,7 @@ type SnippetDropdownProps = {
   align?: 'start' | 'center' | 'end'
   className?: string
   autoFocus?: boolean
-  onSelect: (snippet: { id: string; name: string }) => void
+  onSelect: (snippet: { id: string; name: string; visibility: Content['visibility'] }) => void
 }
 
 type SqlContentItem = Extract<Content, { type: 'sql' }>
@@ -112,7 +112,13 @@ export const SnippetDropdown = ({
                     <CommandItem
                       key={snippet.id}
                       value={snippet.id}
-                      onSelect={() => onSelect({ id: snippet.id, name: snippet.name })}
+                      onSelect={() =>
+                        onSelect({
+                          id: snippet.id,
+                          name: snippet.name,
+                          visibility: snippet.visibility,
+                        })
+                      }
                     >
                       {snippet.name}
                     </CommandItem>


### PR DESCRIPTION
## Problem

Adding a private SQL snippet ('user' visibility) as a Home / project overview report created a broken experience for other project members, who saw "SQL snippet not found" because they had no access to the snippet.

## Fix

Selecting a private snippet from the report block picker now shows a confirmation step that makes the snippet public to the project before it is added. Already-shared snippets are added directly, and snippets created via drag-and-drop onto the report are now shared on creation.

## How to test

- Open a project's homepage and go to the Reports section
- Create a private SQL snippet if you do not have one
- Click "Add block" and select the private snippet
- Confirm a dialog appears explaining the snippet will become visible to the team
- Confirm, and verify the block is added to the report
- Log in as another project member and confirm the report block renders instead of "SQL snippet not found"
- Selecting an already-shared snippet should add it without the confirmation dialog

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “make snippet public” confirmation flow for user-owned report blocks.
  * Updated snippet selection to support a private-snippet share prompt when appropriate.
* **Bug Fixes**
  * Improved duplicate-block handling to prevent adding the same snippet multiple times.
* **Refactor**
  * Refactored SQL snippet upsert payload construction for more consistent project visibility updates.
* **Tests**
  * Added unit tests covering snippet selection decision logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->