### PR TITLE
test(studio): cover branch-project guard on PauseProjectButton

### DIFF
--- a/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.test.tsx
+++ b/apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.test.tsx
@@ -1,0 +1,139 @@
+import { fireEvent, render, screen } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import PauseProjectButton from './PauseProjectButton'
+
+const {
+  mockUseAsyncCheckPermissions,
+  mockUseCheckEntitlements,
+  mockUseProjectPauseMutation,
+  mockUseSelectedOrganizationQuery,
+  mockUseSelectedProjectQuery,
+  mockUseSetProjectStatus,
+  mockPauseProject,
+} = vi.hoisted(() => ({
+  mockUseAsyncCheckPermissions: vi.fn(),
+  mockUseCheckEntitlements: vi.fn(),
+  mockUseProjectPauseMutation: vi.fn(),
+  mockUseSelectedOrganizationQuery: vi.fn(),
+  mockUseSelectedProjectQuery: vi.fn(),
+  mockUseSetProjectStatus: vi.fn(),
+  mockPauseProject: vi.fn(),
+}))
+
+vi.mock('next/router', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('ui', () => ({
+  AlertDialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogAction: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    disabled?: boolean
+  }) => (
+    <button disabled={disabled} onClick={onClick}>
+      {children}
+    </button>
+  ),
+  AlertDialogCancel: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  AlertDialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  AlertDialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>,
+}))
+
+vi.mock('@/components/ui/ButtonTooltip', () => ({
+  ButtonTooltip: ({
+    children,
+    onClick,
+    disabled,
+    tooltip,
+  }: {
+    children: ReactNode
+    onClick?: () => void
+    disabled?: boolean
+    tooltip: { content: { text?: string } }
+  }) => (
+    <button disabled={disabled} onClick={onClick} title={tooltip.content.text}>
+      {children}
+    </button>
+  ),
+}))
+
+vi.mock('@/data/projects/project-detail-query', () => ({
+  useSetProjectStatus: mockUseSetProjectStatus,
+}))
+
+vi.mock('@/data/projects/project-pause-mutation', () => ({
+  useProjectPauseMutation: mockUseProjectPauseMutation,
+}))
+
+vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
+  useCheckEntitlements: mockUseCheckEntitlements,
+}))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: mockUseAsyncCheckPermissions,
+}))
+
+vi.mock('@/hooks/misc/useSelectedOrganization', () => ({
+  useSelectedOrganizationQuery: mockUseSelectedOrganizationQuery,
+}))
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: mockUseSelectedProjectQuery,
+  useIsProjectActive: () => true,
+}))
+
+describe('PauseProjectButton', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    mockUseSetProjectStatus.mockReturnValue({ setProjectStatus: vi.fn() })
+    mockUseProjectPauseMutation.mockReturnValue({ mutate: mockPauseProject, isPending: false })
+    mockUseAsyncCheckPermissions.mockReturnValue({ can: true })
+    mockUseSelectedOrganizationQuery.mockReturnValue({ data: { plan: { id: 'pro' }, slug: 'org' } })
+    mockUseCheckEntitlements.mockReturnValue({ hasAccess: true })
+  })
+
+  it('disables pausing and explains why for branch projects', () => {
+    mockUseSelectedProjectQuery.mockReturnValue({
+      data: {
+        ref: 'branch-project',
+        parent_project_ref: 'main-project',
+        status: 'ACTIVE_HEALTHY',
+      },
+    })
+
+    render(<PauseProjectButton />)
+
+    const button = screen.getAllByRole('button', { name: 'Pause project' })[0]
+    expect(button).toBeDisabled()
+    expect(button).toHaveAttribute('title', 'Branch projects cannot be paused')
+
+    fireEvent.click(button)
+    expect(mockPauseProject).not.toHaveBeenCalled()
+  })
+
+  it('allows pausing a regular active project', () => {
+    mockUseSelectedProjectQuery.mockReturnValue({
+      data: {
+        ref: 'main-project',
+        parent_project_ref: undefined,
+        status: 'ACTIVE_HEALTHY',
+      },
+    })
+
+    render(<PauseProjectButton />)
+
+    const button = screen.getAllByRole('button', { name: 'Pause project' })[0]
+    expect(button).not.toBeDisabled()
+  })
+})


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Test coverage.

## What is the current behavior?

`PauseProjectButton` (`apps/studio/components/interfaces/Settings/General/Infrastructure/PauseProjectButton.tsx`) already disables pausing for branch/preview projects — `isBranch` is OR'd into `buttonDisabled` and the tooltip explains "Branch projects cannot be paused". However, there was no test asserting this, so a future refactor could silently reintroduce a path where branch projects can be paused.

I reviewed the surrounding code paths (permission resolution for branches via `useAsyncCheckPermissions`, the shared `Button` component's disabled-click guard, and the `Project.tsx`/`Project.test.tsx` container) and confirmed there's currently no way to trigger the pause mutation for a branch project through the UI.

## What is the new behavior?

Added `PauseProjectButton.test.tsx` with two cases:
- A branch project (`parent_project_ref` set): the button renders disabled with the "Branch projects cannot be paused" tooltip, and clicking it never calls the pause mutation.
- A regular active project: the button remains enabled.

This locks in the existing guard as a regression test.

## Additional context

No production code changes — this PR only adds test coverage.


---
_Generated by [Claude Code](https://claude.ai/code/session_017F2k3AJUuzCxeBPpmXgyWV)_