### PR TITLE
fix: Remove always-open Accordion behavior

### DIFF
--- a/apps/docs/app/contributing/content.mdx
+++ b/apps/docs/app/contributing/content.mdx
@@ -20,7 +20,6 @@ For content that requires progressive disclosure:
 ```mdx
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"
@@ -49,7 +48,6 @@ For content that requires progressive disclosure:
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"
@@ -501,7 +499,6 @@ We incorporate content reuse in the docs to avoid duplication. If you find yours
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/_partials/metrics_access.mdx
+++ b/apps/docs/content/_partials/metrics_access.mdx
@@ -1,6 +1,5 @@
 <Accordion
 type="default"
-openBehaviour="multiple"
 chevronAlign="right"
 justified
 size="medium"

--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -84,7 +84,6 @@ You can click this button to prefill all the SQL needed in [the SQL editor of yo
 
 <Accordion
   type="default"
-  openBehaviour="single"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -300,7 +300,6 @@ If your application uses the Supabase Database, Storage or Edge Functions, Row L
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/guides/cron/quickstart.mdx
+++ b/apps/docs/content/guides/cron/quickstart.mdx
@@ -40,7 +40,6 @@ select cron.schedule('permanent-cron-job-name', '30 seconds', 'CALL do_something
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/guides/platform/backups.mdx
+++ b/apps/docs/content/guides/platform/backups.mdx
@@ -91,7 +91,6 @@ Projects that want to use PITR must also use at least a Small compute add-on to 
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
@@ -198,7 +198,6 @@ create table private.user_metadata (
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/backup-restore.mdx
@@ -78,7 +78,6 @@ breadcrumb: 'Migrations'
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
+++ b/apps/docs/content/guides/platform/migrating-within-supabase/dashboard-restore.mdx
@@ -14,7 +14,6 @@ Dashboard backups are only available for older projects that still use logical b
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/guides/platform/read-replicas.mdx
+++ b/apps/docs/content/guides/platform/read-replicas.mdx
@@ -32,7 +32,6 @@ You can only read data from a Read Replica. This is in contrast to a Primary dat
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="large"

--- a/apps/docs/content/guides/telemetry/log-drains.mdx
+++ b/apps/docs/content/guides/telemetry/log-drains.mdx
@@ -38,7 +38,6 @@ Unsigned requests to HTTP endpoints are temporary and all requests will signed i
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
 >
     <AccordionItem
       header="Edge Function Walkthrough (Uncompressed)"
@@ -148,7 +147,6 @@ To setup Datadog log drain, generate a Datadog API key [here](https://app.datado
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
 >
     <AccordionItem
       header="Walkthrough"
@@ -280,7 +278,6 @@ Ensure your OTLP endpoint is configured to accept logs at the `/v1/logs` path wi
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
 >
     <AccordionItem
       header="OpenTelemetry Collector Example"

--- a/apps/docs/content/troubleshooting/cant-access-supabase-project-lovable-cloud.mdx
+++ b/apps/docs/content/troubleshooting/cant-access-supabase-project-lovable-cloud.mdx
@@ -54,7 +54,6 @@ For more information, read [the Lovable Cloud FAQ](https://docs.lovable.dev/feat
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/troubleshooting/edge-function-401-error-response.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-401-error-response.mdx
@@ -137,7 +137,6 @@ Your project uses the [new asymmetric keys](/blog/jwt-signing-keys) for authenti
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/troubleshooting/edge-function-546-error-response.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-546-error-response.mdx
@@ -135,7 +135,6 @@ There are a few other queries that may be useful for identifying patterns around
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/troubleshooting/identify-lovable-cloud-or-supabase-backend.mdx
+++ b/apps/docs/content/troubleshooting/identify-lovable-cloud-or-supabase-backend.mdx
@@ -54,7 +54,6 @@ If the page displays the Supabase icon, your Supabase project name, and some lin
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"
@@ -95,7 +94,6 @@ If the page displays the Supabase icon, your Supabase project name, and some lin
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/content/troubleshooting/restore-project-after-90-days-pause.mdx
+++ b/apps/docs/content/troubleshooting/restore-project-after-90-days-pause.mdx
@@ -75,7 +75,6 @@ chmod +x sync_supabase_config.sh
 
 <Accordion
   type="default"
-  openBehaviour="multiple"
   chevronAlign="right"
   justified
   size="medium"

--- a/apps/docs/features/ui/Accordion.tsx
+++ b/apps/docs/features/ui/Accordion.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { ComponentProps, useState } from 'react'
+import React, { useState } from 'react'
 import {
   AccordionContent,
   AccordionTrigger,
@@ -12,16 +12,13 @@ import {
 type Type = 'default' | 'bordered'
 type Align = 'left' | 'right'
 
-type BaseAccordionProps = ComponentProps<typeof Accordion>
-
 export interface AccordionProps {
   children?: React.ReactNode
   className?: string
   defaultActiveId?: (string | number)[]
   onChange?: (item: string | string[]) => void
-  openBehaviour: 'single' | 'multiple'
   type?: Type
-  defaultValue?: string | string[] | undefined
+  defaultValue?: string[] | undefined
   justified?: Boolean
   chevronAlign?: Align
 }
@@ -30,17 +27,15 @@ export function Accordion({
   children,
   className,
   onChange,
-  openBehaviour = 'multiple',
   defaultValue = undefined,
   // All props below are ignored but kept to avoid impacting all docs pages
-  type = 'default',
-  justified = false,
-  chevronAlign = 'right',
+  // type = 'default',
+  // justified = false,
+  // chevronAlign = 'right',
 }: AccordionProps) {
   return (
-    // @ts-expect-error: This is because the Radix component has 2 interfaces discriminated by its type prop. Safe to ignore
     <BaseAccordion
-      type={openBehaviour}
+      type="multiple"
       onValueChange={onChange}
       defaultValue={defaultValue}
       className={className}


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

`Accordion` components cannot have a single-open-like behavior. This is because the accordion remains open and cannot be closed while the elements are interactive, leaving the sensation of the component being broken.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated documentation accordions to use consistent default behavior across guides and troubleshooting pages.
  * Accordion sections now open and close more predictably, with fewer pages using custom multi-open settings.
* **Refactor**
  * Simplified the shared accordion component so docs pages rely on a single standardized behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->