### PR TITLE
chore(studio): hide wal2json from extensions list

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.constants.ts
@@ -15,6 +15,7 @@ export const HIDDEN_EXTENSIONS = [
   'xml2',
   'pg_tle',
   'pg_stat_monitor',
+  'wal2json',
 ]
 
 export const SEARCH_TERMS: Record<string, string[]> = {


### PR DESCRIPTION
## What kind of change does this PR introduce?


Adds `'wal2json'` to `HIDDEN_EXTENSIONS` so it's filtered out of the extensions list in the Dashboard, matching how other non-user-facing extensions (e.g. `pg_stat_monitor`, `supautils`) are already hidden.

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the list of hidden database extensions so `wal2json` no longer appears in places where hidden extensions are excluded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->