### PR TITLE
[FE-2417] fix(studio): update disk EBS UI copy to match new limits

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -201,7 +201,7 @@ export function DiskManagementForm() {
     DISK_LIMITS[DiskType.GP3].minIops
   )
   // Suggested target when prompting a resize, sits above the floor so users
-  // aren't pinned at the minimum during the 4-hour disk-config cooldown.
+  // aren't pinned at the minimum between disk-config modifications.
   const suggestedDiskSizeForCustomIops = PLAN_DETAILS.pro.includedDiskGB.gp3
   const isDiskTooSmallForCustomIops =
     watchedStorageType === 'gp3' && watchedTotalSize < minDiskSizeForCustomIops
@@ -551,7 +551,7 @@ export function DiskManagementForm() {
                             <Admonition
                               type="default"
                               title="Increase disk size to adjust IOPS or throughput"
-                              description={`This disk is too small to update IOPS or throughput, since gp3 volumes are capped at 500 IOPS per GB with a 3,000 IOPS minimum. Resizing to ${suggestedDiskSizeForCustomIops} GB unlocks custom IOPS and throughput, and leaves headroom for further adjustments (disk config changes are locked for 4 hours after each resize).`}
+                              description={`This disk is too small to update IOPS or throughput, since gp3 volumes are capped at 500 IOPS per GB with a 3,000 IOPS minimum. Resizing to ${suggestedDiskSizeForCustomIops} GB unlocks custom IOPS and throughput, and leaves headroom for further adjustments (disk config changes are limited to 4 within a rolling 24-hour window).`}
                               actions={
                                 !disableDiskSizeInput ? (
                                   <Button

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.hooks.ts
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.hooks.ts
@@ -136,7 +136,7 @@ export function useDiskManagementReviewChanges(
     Number(iopsPrice.newPrice) !== Number(iopsPrice.oldPrice) ||
     Number(throughputPrice.newPrice) !== Number(throughputPrice.oldPrice)
 
-  // Show cooldown warning whenever any disk attribute that enforces the 4-hour lock changes
+  // Show cooldown warning whenever any disk attribute that counts toward the 24-hour modification limit changes
   const anyDiskAttributeChange = hasIOPSChanges || hasStorageTypeChanges || hasTotalSizeChanges
 
   // Show extended downtime warning when resizing to/from a size below large

--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementReviewAndSubmitDialog/DiskManagementReviewAndSubmitDialog.tsx
@@ -188,7 +188,7 @@ export const DiskManagementReviewAndSubmitDialog = ({
                 label="IOPS"
                 description={
                   anyDiskAttributeChange && !hasTotalSizeChanges && !hasStorageTypeChanges
-                    ? 'Disk attributes, including IOPS and disk size, may only be modified 4 times in any 24-hour window, starting from the first modification.'
+                    ? 'Disk attributes, including IOPS and disk size, may only be modified 4 times within a rolling 24-hour window. A new modification can be started as soon as the previous one completes.'
                     : undefined
                 }
               >
@@ -217,7 +217,7 @@ export const DiskManagementReviewAndSubmitDialog = ({
             {(hasTotalSizeChanges || hasStorageTypeChanges) && (
               <BreakdownRow
                 label="Disk size"
-                description="For 4 hours after changes you will not be able to modify disk attributes."
+                description="You can modify disk attributes up to 4 times within a rolling 24-hour window."
               >
                 <div className="flex flex-col items-end gap-0.5">
                   <ValueChange

--- a/apps/studio/components/interfaces/DiskManagement/ui/DiskCountdownRadial.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/ui/DiskCountdownRadial.tsx
@@ -51,12 +51,10 @@ export function DiskCountdownRadial() {
               <CountdownTimerRadial progress={progressPercentage} />
               <div className="flex flex-col gap-2">
                 <div>
-                  <p className="text-foreground text-sm p-0">
-                    4-hour cooldown period is in progress
-                  </p>
+                  <p className="text-foreground text-sm p-0">Disk modification limit reached</p>
                   <p className="text-foreground-lighter text-sm p-0">
-                    You can't modify your disk configuration again until the 4-hour cool down period
-                    ends.
+                    You can modify disk attributes up to 4 times within a rolling 24-hour window.
+                    You'll be able to make changes again once the window allows it.
                   </p>
                 </div>
                 <CountdownTimerSpan seconds={remainingTime} />

--- a/apps/studio/components/interfaces/DiskManagement/ui/DiskSpaceBar.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/ui/DiskSpaceBar.tsx
@@ -189,12 +189,13 @@ export const DiskSpaceBar = ({ form }: DiskSpaceBarProps) => {
                   </TooltipTrigger>
                   <TooltipContent side="bottom" className="w-[310px] flex flex-col gap-y-1">
                     <p>
-                      Supabase expands your disk storage automatically when the database reached 90%
-                      of the disk size. However, any disk modifications, including auto-scaling, can
-                      only take place once every 4 hours.
+                      Supabase expands your disk storage automatically when the database reaches 90%
+                      of the disk size. However, disk modifications, including auto-scaling, are
+                      limited to 4 within a rolling 24-hour window.
                     </p>
                     <p>
-                      If within those 4 hours you reach 95% of the disk space, your project{' '}
+                      If you exhaust these modifications and reach 95% of the disk space, your
+                      project{' '}
                       <span className="text-destructive-600">will enter read-only mode.</span>
                     </p>
                   </TooltipContent>

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfiguration.tsx
@@ -164,7 +164,7 @@ export const DiskSizeConfiguration = ({ disabled = false }: DiskSizeConfiguratio
                               <Markdown
                                 className="max-w-full"
                                 content={`
-We auto-scale your disk as you need more storage, but can only do this once every 4 hours.
+We auto-scale your disk as you need more storage, up to 4 modifications within a rolling 24-hour window.
 If you upload more than 1.5x the current size of your storage, your database will go
 into read-only mode. If you know how big your database is going to be, you can
 manually increase the size here.

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -34,6 +34,7 @@ import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import * as z from 'zod'
 
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
+import { COOLDOWN_DURATION } from '@/data/config/disk-attributes-update-mutation'
 import { useProjectDiskResizeMutation } from '@/data/config/project-disk-resize-mutation'
 import { useOrgSubscriptionQuery } from '@/data/subscriptions/org-subscription-query'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
@@ -68,8 +69,12 @@ const DiskSizeConfigurationModal = ({
 
   const isLoading = isLoadingProject || isLoadingSubscription || isLoadingDiskEntitlement
 
+  // COOLDOWN_DURATION is in seconds; convert to minutes to match the diff unit below.
+  const cooldownMinutes = COOLDOWN_DURATION / 60
   const timeTillNextAvailableDatabaseResize =
-    lastDatabaseResizeAt === null ? 0 : 6 * 60 - dayjs().diff(lastDatabaseResizeAt, 'minutes')
+    lastDatabaseResizeAt === null
+      ? 0
+      : cooldownMinutes - dayjs().diff(lastDatabaseResizeAt, 'minutes')
   const isAbleToResizeDatabase = timeTillNextAvailableDatabaseResize <= 0
   const formattedTimeTillNextAvailableResize =
     timeTillNextAvailableDatabaseResize < 60
@@ -175,16 +180,16 @@ const DiskSizeConfigurationModal = ({
                 <DialogSection className="w-full space-y-4">
                   <Alert variant={isAbleToResizeDatabase ? 'default' : 'warning'}>
                     <Info size={16} />
-                    <AlertTitle>This operation is only possible every 4 hours</AlertTitle>
+                    <AlertTitle>
+                      Disk modifications are limited to 4 per rolling 24-hour window
+                    </AlertTitle>
                     <AlertDescription>
                       <div className="mb-4">
                         {isAbleToResizeDatabase
-                          ? `Upon updating your disk size, the next disk size update will only be available from ${dayjs().format(
-                              'DD MMM YYYY, HH:mm (ZZ)'
-                            )}`
+                          ? `You can modify disk attributes up to 4 times within a rolling 24-hour window. A new modification can be started as soon as the previous one completes.`
                           : `Your database was last resized at ${dayjs(lastDatabaseResizeAt).format(
                               'DD MMM YYYY, HH:mm (ZZ)'
-                            )}. You can resize your database again in approximately ${formattedTimeTillNextAvailableResize}`}
+                            )}. You've reached the disk modification limit for now — you can resize again in approximately ${formattedTimeTillNextAvailableResize}.`}
                       </div>
                       <Button asChild variant="default" iconRight={<ExternalLink size={14} />}>
                         <Link href={`${DOCS_URL}/guides/platform/database-size#disk-management`}>

--- a/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/DiskSizeConfigurationModal.tsx
@@ -72,9 +72,9 @@ const DiskSizeConfigurationModal = ({
   // COOLDOWN_DURATION is in seconds; convert to minutes to match the diff unit below.
   const cooldownMinutes = COOLDOWN_DURATION / 60
   const timeTillNextAvailableDatabaseResize =
-    lastDatabaseResizeAt === null
+    lastDatabaseResizeAt == null
       ? 0
-      : cooldownMinutes - dayjs().diff(lastDatabaseResizeAt, 'minutes')
+      : Math.max(0, cooldownMinutes - dayjs().diff(lastDatabaseResizeAt, 'minutes'))
   const isAbleToResizeDatabase = timeTillNextAvailableDatabaseResize <= 0
   const formattedTimeTillNextAvailableResize =
     timeTillNextAvailableDatabaseResize < 60


### PR DESCRIPTION
Updates the dashboard disk-management copy to match the new AWS EBS modification limits (already reflected in the docs): from the old fixed "4-hour cooldown / once every 4 hours" framing to "up to 4 modifications within a rolling 24-hour window".

This is a copy-only change plus one small logic-constant alignment. Timer/countdown behavior is unchanged — this only updates wording to bring the dashboard in line with the docs.

**Changed:**
- `DiskSpaceBar` autoscaling tooltip, `DiskCountdownRadial` card, `DiskSizeConfiguration` "Importing a lot of data?" alert, `DiskSizeConfigurationModal` alert title + both countdown branches, `DiskManagementReviewAndSubmitDialog` IOPS + disk-size row descriptions, and two code comments — all reworded to the new "4 per rolling 24-hour window" framing
- `DiskSizeConfigurationModal` countdown now derives from the shared `COOLDOWN_DURATION` constant (4h) instead of a stale hardcoded `6 * 60` (6h), so the legacy resize path matches the newer disk-attributes path

## To test

- Open a Pro AWS project → **Settings → Compute and Disk** → hover the **Autoscaling** pill on the disk bar: tooltip should read "…limited to 4 within a rolling 24-hour window" (no "once every 4 hours")
- Change IOPS only → **Review changes** → IOPS row description shows the new "rolling 24-hour window… as soon as the previous one completes" copy
- Change disk size → **Review changes** → Disk size row shows "You can modify disk attributes up to 4 times within a rolling 24-hour window" (not "For 4 hours after changes…")
- On a non-AWS Pro project → **Database → Settings → Increase disk size**: modal title reads "Disk modifications are limited to 4 per rolling 24-hour window"; any "resize again in ~X" countdown is bounded by 4 hours, not 6
- Sanity: none of the old "4-hour cooldown" / "once every 4 hours" strings appear anywhere in the disk UI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated disk resizing messages across the app to reflect a rolling 24-hour limit instead of a fixed 4-hour cooldown.
  * Clarified when disk size, IOPS, and throughput changes are available again, including more accurate next-available timing.
  * Improved warning copy in disk configuration and review dialogs so limit messages are consistent and easier to understand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->