### PR TITLE
[FE-3423] chore(studio): flag pages/** edits to mirror into TanStack routes

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -48,6 +48,27 @@ reviews:
         tracking for: passive views, page loads, UI-only state changes (e.g. expanding
         a panel, switching tabs in a settings page), developer/internal tooling
         interactions, or interactions clearly unrelated to product adoption.
+    - path: 'apps/studio/pages/**'
+      instructions: |
+        Studio is mid-migration from the Next.js pages router (apps/studio/pages/**)
+        to TanStack Start (apps/studio/routes/**). Both runtimes ship side-by-side, so
+        every URL served from pages/** has a mirror in routes/**. See
+        apps/studio/TANSTACK_MIGRATION.md for the full route map and strategy.
+        Leave a comment reminding the author to check whether this change needs to be
+        mirrored into the corresponding apps/studio/routes/** file so the two builds
+        don't silently drift:
+        - Most route files re-export the page's default export (Path A), so pure
+          page-body edits propagate automatically — no mirror needed.
+        - A mirror IS needed when the change touches something the route file
+          duplicates rather than imports: getLayout / layout wrapping, page title or
+          other props the route encodes as staticData, withAuth / auth gating, or the
+          route/redirect path itself.
+        - A brand-new page under pages/** needs a matching new route under routes/**
+          (and a checklist entry in apps/studio/TANSTACK_MIGRATION.md).
+        - Do NOT suggest deleting the pages/** file — the Next file stays load-bearing
+          for both runtimes until the final cleanup pass (tracked in FE-3106).
+        Keep this a reminder to verify, not a hard blocker: if no mirror is required,
+        say so briefly rather than forcing a change.
 
 # Applies our internal engineering skills (.claude/skills/) as CodeRabbit review
 # guidelines. The skills are the single source of truth — they are consumed

--- a/apps/studio/TANSTACK_MIGRATION.md
+++ b/apps/studio/TANSTACK_MIGRATION.md
@@ -524,5 +524,5 @@ the allowlist when the underlying cycle is gone.
 - Lift `manualChunks` pins (`class-variance-authority`, `lucide-react`, `react-vendor`) once the structural fix in `packages/ui` lands — see CIRCULAR_IMPORTS.md. Keep `assertNoChunkCycles`; just clear `KNOWN_CHUNK_CYCLES`.
 - Delete `pages/_app.tsx`, `pages/_document.tsx`, `pages/_error.jsx`, `pages/500.tsx`, `pages/404.tsx` (Next-only catch-alls; TanStack equivalents on `__root.tsx`).
 - Drop the `dev:next` / `build:next` / `start:next` scripts from `apps/studio/package.json` once we're committed to TanStack.
-- Remove the `apps/studio/pages/**` `path_instructions` guardrail entry from `.coderabbit.yaml` (added for FE-3423) — it's only useful while both runtimes coexist.
+- Remove the `apps/studio/pages/**` `path_instructions` guardrail entry from `.coderabbit.yaml` (added in FE-3423; remove it as part of this FE-3106 cleanup) — it's only useful while both runtimes coexist.
 - Delete this file.

--- a/apps/studio/TANSTACK_MIGRATION.md
+++ b/apps/studio/TANSTACK_MIGRATION.md
@@ -23,6 +23,19 @@ Throughout this migration both runtimes coexist in the same workspace:
   they stay until the cleanup pass, regardless of how many routes have
   moved.
 
+**PR guardrail — mirror page edits into their route**
+
+Because both runtimes ship at once, any change to a `pages/...` file can
+leave its `routes/...` mirror stale. A CodeRabbit `path_instructions`
+rule (`.coderabbit.yaml`, scoped to `apps/studio/pages/**`) posts a
+review reminder on every PR that touches a page, prompting the author to
+check whether the corresponding route needs the same change. It's a
+verify-not-block reminder: pure body edits on re-export (Path A) pages
+propagate automatically, but layout/`getLayout`, `staticData` props,
+`withAuth`, redirect-path, or brand-new-page changes must be mirrored by
+hand. This guardrail is temporary scaffolding — remove it in the cleanup
+pass when `pages/**` is deleted (tracked by FE-3106).
+
 **Strategy — minimum-diff re-export**
 
 The goal is to flip URL ownership to TanStack without rewriting page internals yet. For each page we pick one of two paths:
@@ -511,4 +524,5 @@ the allowlist when the underlying cycle is gone.
 - Lift `manualChunks` pins (`class-variance-authority`, `lucide-react`, `react-vendor`) once the structural fix in `packages/ui` lands — see CIRCULAR_IMPORTS.md. Keep `assertNoChunkCycles`; just clear `KNOWN_CHUNK_CYCLES`.
 - Delete `pages/_app.tsx`, `pages/_document.tsx`, `pages/_error.jsx`, `pages/500.tsx`, `pages/404.tsx` (Next-only catch-alls; TanStack equivalents on `__root.tsx`).
 - Drop the `dev:next` / `build:next` / `start:next` scripts from `apps/studio/package.json` once we're committed to TanStack.
+- Remove the `apps/studio/pages/**` `path_instructions` guardrail entry from `.coderabbit.yaml` (added for FE-3423) — it's only useful while both runtimes coexist.
 - Delete this file.


### PR DESCRIPTION
Adds a PR-time reminder to mirror any edit to `apps/studio/pages/**` into the corresponding `apps/studio/routes/**` file, since the Next.js pages router and the TanStack Start route tree ship side-by-side during the migration and can silently drift.

**Added:**
- A CodeRabbit `path_instructions` rule (`.coderabbit.yaml`) scoped to `apps/studio/pages/**` that prompts authors to check whether a page change needs mirroring into `routes/**`. It encodes the migration's nuance so it isn't noise — pure body edits on re-export (Path A) pages propagate automatically, but layout/`getLayout`, `staticData` props, `withAuth`, redirect-path, or new-page changes must be mirrored by hand. Framed as verify-not-block, and explicitly tells authors *not* to delete the `pages/**` file.

**Changed:**
- `apps/studio/TANSTACK_MIGRATION.md` — documents the guardrail under the Runtime model section, and adds a cleanup-checklist line to remove it once `pages/**` is deleted (FE-3106).

This is temporary scaffolding — it comes out with the final `pages/**` cleanup pass.

## To test

- This needs to land on `master` first, then open a throwaway PR that touches a file under `apps/studio/pages/**` and confirm CodeRabbit leaves the reminder comment.
- `path_instructions` can be flaky — if CodeRabbit doesn't fire reliably, the fallback is a GitHub Action + sticky PR comment scoped to `paths: ['apps/studio/pages/**']`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added migration guidance for Studio page changes to help keep mirrored route files in sync during the transition.
  * Clarified when edits to `pages/**` must be mirrored into `routes/**` (e.g., layout/auth gating, page titles, static data, route paths, or new pages), and that verification isn’t a hard blocker.
  * Added a cleanup reminder to remove the temporary review guidance once coexistence ends.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->