### PR TITLE
[DOCS-1148] Improve prose for LLM readability

### DIFF
--- a/apps/docs/content/_partials/metrics_access.mdx
+++ b/apps/docs/content/_partials/metrics_access.mdx
@@ -8,7 +8,7 @@ className="rounded-lg border border-foreground/10 bg-surface-100 text-foreground
 >
 
     <AccordionItem
-    header={<span className="text-foreground font-medium">What you can do with the Metrics API</span>}
+    header="What you can do with the Metrics API"
     id="how-do-i-check-when-a-user-went-through-mfa"
     className="border-0 px-2 py-4"
     >

--- a/apps/docs/content/guides/ai/concepts.mdx
+++ b/apps/docs/content/guides/ai/concepts.mdx
@@ -41,7 +41,7 @@ Embeddings compress discrete information (words & symbols) into distributed cont
 
 The chart below plots example phrases as points. Phrases with similar meanings sit close together, and unrelated phrases sit far apart.
 
-<img
+<Image
   src="/docs/img/ai/vector-similarity.png"
   alt="A two-dimensional chart plotting example phrases as points, where phrases with similar meanings sit close together and unrelated phrases sit far apart."
   width="640"

--- a/apps/docs/content/guides/ai/hugging-face.mdx
+++ b/apps/docs/content/guides/ai/hugging-face.mdx
@@ -149,7 +149,7 @@ curl --output result.jpg --location --request POST 'http://localhost:54321/funct
 
 In this example, your generated image will save to `result.jpg`:
 
-<img
+<Image
   src="/docs/img/ai/hugging-face/llama-sunglasses-example.png"
   alt="Llama wearing sunglasses example"
   width="400"

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -308,7 +308,7 @@ If your application uses the Supabase Database, Storage or Edge Functions, Row L
 >
 
 <AccordionItem
-header={<span className="text-foreground">How do I check when a user went through MFA?</span>}
+header="How do I check when a user went through MFA?"
 id="how-do-i-check-when-a-user-went-through-mfa"
 >
 

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -200,7 +200,7 @@ The Proxy is responsible for:
 <Accordion>
 
     <AccordionItem
-      header={<span className="text-foreground">What does the `cookies` object do?</span>}
+      header="What does the `cookies` object do?"
       id="utility-cookies"
     >
 
@@ -213,7 +213,7 @@ The Proxy is responsible for:
     </AccordionItem>
 
     <AccordionItem
-      header={<span className="text-foreground">Do I need to create a new client for every route?</span>}
+      header="Do I need to create a new client for every route?"
       id="client-deduplication"
     >
 

--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -58,7 +58,7 @@ and run one of the following:
 - `sudo rpm -i <...>.rpm`
 
 </TabPanel>
-<TabPanel id="npm" label="nodejs">
+<TabPanel id="npm" label="Node.js">
 
 Run the CLI by prefixing each command with `npx` or `bunx`:
 
@@ -122,7 +122,7 @@ brew link --overwrite supabase-beta
 Beta builds are attached to [GitHub pre-releases](https://github.com/supabase/cli/releases). Download the `.apk`, `.deb`, or `.rpm` for your platform and install with the same commands as [Linux packages](#linux-packages) above.
 
 </TabPanel>
-<TabPanel id="npm" label="nodejs">
+<TabPanel id="npm" label="Node.js">
 
 Install as a dev dependency:
 
@@ -199,7 +199,7 @@ brew upgrade supabase-beta
    - `sudo rpm -i <...>.rpm`
 
 </TabPanel>
-<TabPanel id="npm" label="nodejs">
+<TabPanel id="npm" label="Node.js">
 
 If you have installed the CLI as dev dependency via [npm](https://www.npmjs.com/package/supabase), you can update it with:
 

--- a/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/auth0.mdx
@@ -80,6 +80,7 @@ Migrate existing users to Supabase Auth. This requires two main steps: first, ch
 
     ```ts
     import { createClient } from '@supabase/supabase-js'
+
     const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
     // ---cut---
@@ -100,6 +101,7 @@ Migrate existing users to Supabase Auth. This requires two main steps: first, ch
 
     ```ts
     import { createClient } from '@supabase/supabase-js'
+
     const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
     // ---cut---
@@ -122,6 +124,7 @@ For passwordless signin via email or phone, check for users with verified email 
 
 ```ts
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
 // ---cut---
@@ -162,6 +165,7 @@ Both columns are accessible from the admin user methods. To create a user with c
 
 ```ts
 import { createClient } from '@supabase/supabase-js'
+
 const supabase = createClient('your_project_url', 'your_supabase_api_key')
 
 // ---cut---
@@ -206,7 +210,7 @@ create table private.user_metadata (
 >
 
 <AccordionItem
-header={<span className="text-foreground">I have IDs assigned to existing users in my database, how can I maintain these IDs?</span>}
+header="I have IDs assigned to existing users in my database, how can I maintain these IDs?"
 id="custom-user-id"
 >
 
@@ -229,7 +233,7 @@ const { data, error } = await supabase.auth.admin.createUser({
 </AccordionItem>
 
 <AccordionItem
-header={<span className="text-foreground">How can I allow my users to retain their existing password?</span>}
+header="How can I allow my users to retain their existing password?"
 id="existing-password"
 >
 
@@ -238,7 +242,7 @@ Supabase Auth never stores passwords as plaintext. Since Supabase Auth supports 
 </AccordionItem>
 
 <AccordionItem
-header={<span className="text-foreground">My users have multi-factor authentication (MFA) enabled, how do I make sure they don't have to set up MFA again?</span>}
+header="My users have multi-factor authentication (MFA) enabled, how do I make sure they don't have to set up MFA again?"
 id="mfa"
 >
 
@@ -247,7 +251,7 @@ You can obtain an export of your users' MFA secrets by opening a support ticket 
 </AccordionItem>
 
 <AccordionItem
-header={<span className="text-foreground">How do I migrate existing SAML Single Sign-On (SSO) connections?</span>}
+header="How do I migrate existing SAML Single Sign-On (SSO) connections?"
 id="saml"
 >
 
@@ -256,7 +260,7 @@ Customers may need to link their identity provider with Supabase Auth separately
 </AccordionItem>
 
 <AccordionItem
-header={<span className="text-foreground">How do I migrate my Auth0 organizations to Supabase?</span>}
+header="How do I migrate my Auth0 organizations to Supabase?"
 id="migrate-org"
 >
 

--- a/apps/docs/content/guides/storage/analytics/creating-analytics-buckets.mdx
+++ b/apps/docs/content/guides/storage/analytics/creating-analytics-buckets.mdx
@@ -72,7 +72,12 @@ print('Analytics bucket created:', response)
 4. Select **Analytics Bucket** as the bucket type.
 5. Click **Create**.
 
-<img alt="Create Analytics Bucket in Dashboard" src="/docs/img/storage/iceberg-bucket.png" />
+<Image
+  alt="Create Analytics Bucket in Dashboard"
+  width="644"
+  height="402"
+  src="/docs/img/storage/iceberg-bucket.png"
+/>
 
 ## Next steps
 

--- a/apps/docs/content/guides/storage/s3/authentication.mdx
+++ b/apps/docs/content/guides/storage/s3/authentication.mdx
@@ -23,7 +23,12 @@ To authenticate with S3, generate a pair of credentials (Access Key ID and Secre
 
 This is all the information you need to connect to Supabase Storage using any S3-compatible service.
 
-<img alt="Storage S3 Access keys" src="/docs/img/storage/s3-credentials.png" width="100%" />
+<Image
+  alt="Storage S3 Access keys"
+  src="/docs/img/storage/s3-credentials.png"
+  width="749"
+  height="490"
+/>
 
 <Admonition type="note">
 

--- a/apps/docs/content/guides/telemetry/metrics.mdx
+++ b/apps/docs/content/guides/telemetry/metrics.mdx
@@ -27,10 +27,11 @@ Pick the workflow that best matches your tooling. Cards link to Supabase-authore
 
 <MetricsStackCards />
 
-<img
+<Image
   src="/docs/img/guides/platform/supabase-grafana-prometheus.png"
   alt="Supabase Grafana dashboard showcasing database metrics"
-  className="mt-8 rounded-lg border border-foreground/10 shadow-xs"
+  width="3000"
+  height="1509"
 />
 
 ## Additional resources

--- a/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-cloud.mdx
@@ -44,10 +44,11 @@ If you prefer to reuse an existing Grafana Agent deployment, configure an [integ
 
 This dashboard includes 200+ charts grouped by CPU, IO, connections, replication, WAL, and bloat indicators.
 
-<img
+<Image
   src="/docs/img/guides/platform/supabase-grafana-prometheus.png"
   alt="Supabase Grafana dashboard showcasing database metrics"
-  className="mt-6 rounded-lg border border-foreground/10 shadow-xs"
+  width="3000"
+  height="1509"
 />
 
 ## 4. Configure alerts (optional)

--- a/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
@@ -63,10 +63,11 @@ Install Grafana (Docker image, Helm chart, or packages) and connect it to Promet
 
 You now have over 200 production-ready panels covering CPU, IO, WAL, replication, index bloat, and query throughput.
 
-<img
+<Image
   src="/docs/img/guides/platform/supabase-grafana-prometheus.png"
   alt="Supabase Grafana dashboard showcasing database metrics"
-  className="mt-6 rounded-lg border border-foreground/10 shadow-xs"
+  width="3000"
+  height="1509"
 />
 
 ## 4. Configure alerting

--- a/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/vendor-agnostic.mdx
@@ -51,10 +51,11 @@ No matter which collector you use, you need to hit the Metrics API once per minu
 - For other tools, group metrics by categories (CPU, IO, WAL, replication, connections) and recreate the visualizations that matter most to your team.
 - Tag or relabel series with `project`, `env`, or `team` labels to make multi-project views easier.
 
-<img
+<Image
   src="/docs/img/guides/platform/supabase-grafana-prometheus.png"
   alt="Supabase Grafana dashboard showcasing database metrics"
-  className="mt-6 rounded-lg border border-foreground/10 shadow-xs"
+  width="3000"
+  height="1509"
 />
 
 ## 4. Alerts and automation

--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -19,6 +19,7 @@ import { AuthProviders } from './markdown-schema/AuthProviders'
 import { ComputeDiskLimitsTable } from './markdown-schema/ComputeDiskLimitsTable'
 import { ErrorCodes } from './markdown-schema/ErrorCodes'
 import { IconCheck, IconX } from './markdown-schema/Icons'
+import { Image } from './markdown-schema/Image'
 import { Link } from './markdown-schema/Link'
 import { ContentListings } from './markdown-schema/ContentListings'
 import { MetricsStackCards } from './markdown-schema/MetricsStackCards'
@@ -155,6 +156,7 @@ const SCHEMA: ComponentSchema = {
   Admonition,
   IconCheck,
   IconX,
+  Image,
   AuthProviders,
   ComputeDiskLimitsTable,
   ErrorCodes,

--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -17,6 +17,7 @@ import { Admonition } from './markdown-schema/Admonition'
 import { AuthProviders } from './markdown-schema/AuthProviders'
 import { ComputeDiskLimitsTable } from './markdown-schema/ComputeDiskLimitsTable'
 import { ErrorCodes } from './markdown-schema/ErrorCodes'
+import { IconCheck, IconX } from './markdown-schema/Icons'
 import { Link } from './markdown-schema/Link'
 import { ContentListings } from './markdown-schema/ContentListings'
 import { MetricsStackCards } from './markdown-schema/MetricsStackCards'
@@ -150,6 +151,8 @@ function applySchema(parent: Parent, schema: ComponentSchema): void {
  */
 const SCHEMA: ComponentSchema = {
   Admonition,
+  IconCheck,
+  IconX,
   AuthProviders,
   ComputeDiskLimitsTable,
   ErrorCodes,

--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -13,6 +13,7 @@ import { parse as parseToml } from 'smol-toml'
 import { mcpConfigPanelMarkdown as McpConfigPanel } from 'ui-patterns/McpUrlBuilder/McpConfigPanel.md'
 
 import { addBaseUrlPrefix } from './internal-links'
+import { AccordionItem } from './markdown-schema/Accordion'
 import { Admonition } from './markdown-schema/Admonition'
 import { AuthProviders } from './markdown-schema/AuthProviders'
 import { ComputeDiskLimitsTable } from './markdown-schema/ComputeDiskLimitsTable'
@@ -150,6 +151,7 @@ function applySchema(parent: Parent, schema: ComponentSchema): void {
  * component not listed is unwrapped (children are kept, wrapper is dropped).
  */
 const SCHEMA: ComponentSchema = {
+  AccordionItem,
   Admonition,
   IconCheck,
   IconX,

--- a/apps/docs/internals/markdown-schema/Accordion.ts
+++ b/apps/docs/internals/markdown-schema/Accordion.ts
@@ -1,0 +1,10 @@
+export const AccordionItem = ({
+  props,
+  children,
+}: {
+  props: Record<string, unknown>
+  children: string
+}): string => {
+  const header = String(props.header ?? '').trim()
+  return header ? `**${header}**\n\n${children}` : children
+}

--- a/apps/docs/internals/markdown-schema/ContentListings.ts
+++ b/apps/docs/internals/markdown-schema/ContentListings.ts
@@ -30,7 +30,7 @@ export function serializeContentListingGroupToMarkdown(
     const href = isExternalContentListingHref(item.href)
       ? item.href
       : `${linkBaseUrl}${withDocsBasePath(item.href)}`
-    lines.push(`- **[${item.title}](${href}):** ${item.description}`)
+    lines.push(`- [${item.title}](${href}): ${item.description}`)
   }
 
   return lines.join('\n')

--- a/apps/docs/internals/markdown-schema/ContentListings.ts
+++ b/apps/docs/internals/markdown-schema/ContentListings.ts
@@ -30,7 +30,7 @@ export function serializeContentListingGroupToMarkdown(
     const href = isExternalContentListingHref(item.href)
       ? item.href
       : `${linkBaseUrl}${withDocsBasePath(item.href)}`
-    lines.push(`- [${item.title}](${href}): ${item.description}`)
+    lines.push(`- **[${item.title}](${href}):** ${item.description}`)
   }
 
   return lines.join('\n')

--- a/apps/docs/internals/markdown-schema/Icons.ts
+++ b/apps/docs/internals/markdown-schema/Icons.ts
@@ -1,0 +1,2 @@
+export const IconCheck = (): string => '✅'
+export const IconX = (): string => '❌'

--- a/apps/docs/internals/markdown-schema/Image.ts
+++ b/apps/docs/internals/markdown-schema/Image.ts
@@ -1,0 +1,21 @@
+import { getInternalLinkBaseUrl, withDocsBasePath } from '../internal-links'
+
+export const Image = ({ props }: { props: Record<string, unknown> }): string => {
+  const alt = String(props.alt ?? '')
+  const rawSrc = props.src as string
+
+  // propsFrom() always stores attribute values as strings: either the literal
+  // string value for `src="/..."`, or the raw JS expression for `src={{ dark, light }}`.
+  const srcStr = String(rawSrc ?? '')
+  let src = String(props.src)
+
+  if (!srcStr.startsWith('/')) {
+    // Object expression form: `src={{ dark: '/...', light: '/...' }}`
+    const match =
+      srcStr.match(/dark:\s*['"]([^'"]+)['"]/) ?? srcStr.match(/light:\s*['"]([^'"]+)['"]/)
+    src = match ? match[1] : ''
+  }
+
+  const baseUrl = getInternalLinkBaseUrl()
+  return `![${alt}](${baseUrl}${withDocsBasePath(src)})`
+}

--- a/apps/docs/internals/markdown-schema/Panel.ts
+++ b/apps/docs/internals/markdown-schema/Panel.ts
@@ -1,3 +1,14 @@
-export const Panel = ({ props }: { props: Record<string, unknown> }): string => {
-  return String(props.title)
+export const Panel = ({
+  props,
+  children,
+}: {
+  props: Record<string, unknown>
+  children: string
+}): string => {
+  const title = String(props.title ?? '')
+  const description = children.replace(/\s+/g, ' ').trim()
+
+  if (title && description) return `${title}: ${description}`
+
+  return title || description
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

After analyzing the most visited URLs data, we found these offenses in terms of content obscuring for markdown output:

Components affected and changes:
 - `IconCheck` and `IconX` are turned into ✅  and ❌ respectively.
 - Accordion item headers are now rendered.
 - GlassPanel children now are rendered.
 - Image components were before obscured, now they are rendered as normal images with an absolute URLs for LLMs to inspect, plus `alt` attribute to give more context.
 - Migrate `img` tags to `Image` components (images coming from `/troubleshooting` and `/reference` routes ignored).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved docs markdown conversion for accordions, icons, images, and panels, resulting in more consistent generated documentation formatting.

* **Documentation**
  * Updated multiple guides to use simplified FAQ accordion headings and refined Auth0 migration code snippets.
  * Replaced several raw `<img>` elements with the standardized `<Image>` component across AI, Storage, and Telemetry guides to improve rendering consistency.
  * Relabeled the CLI install tab to “Node.js” for clearer labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->