### PR TITLE
feat(www): add Customer Legal Resources to legal hub and declutter footer

### DIFF
--- a/apps/www/data/Footer.ts
+++ b/apps/www/data/Footer.ts
@@ -184,10 +184,6 @@ const footerData = [
         url: '/legal',
       },
       {
-        text: 'Terms of Service',
-        url: '/terms',
-      },
-      {
         text: 'Privacy Policy',
         url: '/privacy',
       },
@@ -198,14 +194,6 @@ const footerData = [
       {
         text: 'Acceptable Use Policy',
         url: '/aup',
-      },
-      {
-        text: 'Support Policy',
-        url: '/support-policy',
-      },
-      {
-        text: 'Service Level Agreement',
-        url: '/sla',
       },
       {
         text: 'Humans.txt',

--- a/apps/www/data/Footer.ts
+++ b/apps/www/data/Footer.ts
@@ -180,7 +180,7 @@ const footerData = [
         url: '/ga',
       },
       {
-        text: 'Legal',
+        text: 'Legal Hub',
         url: '/legal',
       },
       {

--- a/apps/www/pages/legal/index.tsx
+++ b/apps/www/pages/legal/index.tsx
@@ -53,9 +53,9 @@ const linkIcons = {
 export default function LegalHubPage() {
   return (
     <DefaultLayout>
-      <NextSeo title="Legal" description="Supabase legal documents and resources." />
+      <NextSeo title="Legal Hub" description="Supabase legal documents and resources." />
       <PageHeader
-        h1="Legal"
+        h1="Legal Hub"
         subheader="Legal documents and resources for Supabase customers and partners."
       />
       <SectionContainer className="prose">

--- a/apps/www/pages/legal/index.tsx
+++ b/apps/www/pages/legal/index.tsx
@@ -7,6 +7,27 @@ import Link from 'next/link'
 
 const sections = [
   {
+    id: 'customer-legal-resources',
+    title: 'Customer Legal Resources',
+    links: [
+      {
+        label: 'Terms of Service',
+        href: '/terms',
+        type: 'document' as const,
+      },
+      {
+        label: 'Support Policy',
+        href: '/support-policy',
+        type: 'document' as const,
+      },
+      {
+        label: 'Service Level Agreement',
+        href: '/sla',
+        type: 'document' as const,
+      },
+    ],
+  },
+  {
     id: 'partner-legal-resources',
     title: 'Partner Legal Resources',
     links: [

--- a/apps/www/pages/legal/index.tsx
+++ b/apps/www/pages/legal/index.tsx
@@ -59,11 +59,11 @@ export default function LegalHubPage() {
         subheader="Legal documents and resources for Supabase customers and partners."
       />
       <SectionContainer className="prose">
-        <div className="divide-y divide-border">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-16">
           {sections.map((section) => (
             <section key={section.title} id={section.id} className="scroll-mt-24">
               <h2 className="mt-0">{section.title}</h2>
-              <div className="divide-y divide-border lg:max-w-1/2">
+              <div className="divide-y divide-border">
                 {section.links.map((link) => {
                   const Icon = linkIcons[link.type]
                   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature / content update to the Legal Hub (`apps/www`).

## What is the current behavior?

The `/legal` hub page (`apps/www/pages/legal/index.tsx`) has a single section, "Partner Legal Resources." The customer-facing legal documents (Terms of Service, Support Policy, Service Level Agreement) are only reachable from the footer "Company" column, which is cluttered.

## What is the new behavior?

- Adds a new **"Customer Legal Resources"** section to the `/legal` hub, placed **above** "Partner Legal Resources," with links to:
  - Terms of Service → `/terms`
  - Support Policy → `/support-policy`
  - Service Level Agreement → `/sla`
  
  These use the same formatting (document icon + link) as the existing "Master Partner Program Agreement" entry.
- Removes those same three links (Terms of Service, Support Policy, Service Level Agreement) from the footer **"Company"** column (`apps/www/data/Footer.ts`) to declutter it. The "Legal" hub link, Privacy Policy, Privacy Settings, and Acceptable Use Policy all remain.

The `/terms`, `/support-policy`, and `/sla` URLs are unchanged and continue to operate exactly as they do today — this only changes where they're surfaced in navigation.

Note: per discussion, the hidden `/enterprise-terms` page was intentionally **not** linked from the public hub; it remains `noindex/nofollow` and reachable only by direct URL.

## Additional context

Visual result (Customer section above Partner section, three matching links) and footer cleanup match the requested design. No routing, redirect, or page-content changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015kQyGkM9s9XEbA3HSLpeku)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **“Customer Legal Resources”** section to the legal resources page with links to **Terms of Service**, **Support Policy**, and **Service Level Agreement**.
* **UI Updates**
  * Updated the legal page branding from **“Legal”** to **“Legal Hub”** and adjusted the layout to a more spacious two-column presentation.
  * Updated the footer **Company** links by replacing **“Legal”** with **“Legal Hub”** and removing the Terms/Support/Service Level links from that set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->