### PR TITLE
docs: fix typo 'Perfomance' -> 'Performance' in troubleshooting doc

### DIFF
--- a/apps/docs/content/troubleshooting/rls-performance-and-best-practices-Z5Jjwv.mdx
+++ b/apps/docs/content/troubleshooting/rls-performance-and-best-practices-Z5Jjwv.mdx
@@ -114,7 +114,7 @@ eliminate 'anon' users without taxing the database to process the rest of the RL
 
 ### Sample results
 
-The code used for the below tests can be found here: [LINK](https://github.com/GaryAustin1/RLS-Perfomance):
+The code used for the below tests can be found here: [LINK](https://github.com/GaryAustin1/RLS-Performance):
 The tests are doing selects on a 100K row table. Some have an additional join table.
 
 Show RLS and before after for above examples.


### PR DESCRIPTION
## Description
Fix typo in URL: `RLS-Perfomance` → `RLS-Performance` in troubleshooting documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a broken link in the troubleshooting documentation so the “Sample results” section now points to the proper page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->