### PR TITLE
feat(studio): add Database Upgrades filter to Unified Logs

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.constants.tsx
@@ -27,6 +27,7 @@ export const LOG_TYPES_LABELS = {
   supavisor: 'Supavisor',
   pgbouncer: 'PgBouncer',
   multigres: 'Multigres',
+  'database upgrades': 'Database Upgrades',
 }
 
 type LogType = keyof typeof LOG_TYPES_LABELS

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -65,6 +65,7 @@ const LOG_TYPE_CONDITION: Record<string, SafeLogSqlFragment> = {
   supavisor: safeSql`source = 'supavisor_logs'`,
   pgbouncer: safeSql`source = 'pgbouncer_logs'`,
   multigres: safeSql`source = 'multigres_logs'`,
+  'database upgrades': safeSql`source = 'pg_upgrade_logs'`,
 }
 
 // Derived `log_type` column for SELECT / GROUP BY / countIf use.
@@ -81,6 +82,7 @@ const LOG_TYPE_EXPR: SafeLogSqlFragment = safeSql`CASE
       WHEN source = 'supavisor_logs' THEN 'supavisor'
       WHEN source = 'pgbouncer_logs' THEN 'pgbouncer'
       WHEN source = 'multigres_logs' THEN 'multigres'
+      WHEN source = 'pg_upgrade_logs' THEN 'database upgrades'
       ELSE source
     END`
 

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.utils.ts
@@ -122,6 +122,7 @@ export function formatServiceTypeForDisplay(serviceType: string): string {
     supavisor: 'Supavisor',
     pgbouncer: 'PgBouncer',
     multigres: 'Multigres',
+    'database upgrades': 'Database Upgrades',
   }
 
   return specialCases[serviceType.toLowerCase()] || serviceType

--- a/apps/studio/components/interfaces/UnifiedLogs/components/LogTypeIcon.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/LogTypeIcon.tsx
@@ -1,5 +1,5 @@
 import { Auth, EdgeFunctions, Realtime, Storage } from 'icons'
-import { Box, Cable, Code2, Database, Network } from 'lucide-react'
+import { ArrowUpCircle, Box, Cable, Code2, Database, Network } from 'lucide-react'
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
 import { type LOG_TYPES } from '../UnifiedLogs.constants'
@@ -29,6 +29,7 @@ const ICON_MAP: Partial<Record<(typeof LOG_TYPES)[number], IconComponent>> = {
   supavisor: Cable,
   pgbouncer: Cable,
   multigres: Network,
+  'database upgrades': ArrowUpCircle,
 }
 
 export const LogTypeIcon = ({

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3370,6 +3370,7 @@ export interface UnifiedLogsRowClickedEvent {
       | 'supavisor'
       | 'pgbouncer'
       | 'multigres'
+      | 'database upgrades'
   }
   groups: TelemetryGroups
 }


### PR DESCRIPTION
## Problem

Unified Logs has no way to view Postgres version upgrade logs. The legacy Logs Explorer exposes these under Database Operations > Postgres Version Upgrade (source: pg_upgrade_logs), but that log type is entirely absent from Unified Logs, so users who rely on Unified Logs lose visibility into upgrade failures.

## Fix

Adds a "Database Upgrades" log type to Unified Logs that maps to the pg_upgrade_logs source, following the same pattern used for postgres, auth, supavisor, etc. Updates the log type filter, query condition/expression, display formatting, icon, and telemetry event union accordingly.

Availability depends on pg_upgrade_logs being exposed through the logs.all analytics/OTEL endpoint, still to be confirmed on the backend side.

## How to test

- Open Unified Logs for a project that has undergone a Postgres version upgrade
- Open the Log Type filter and confirm "Database Upgrades" appears as an option
- Select it and confirm the query runs without error
- Expected result: rows from pg_upgrade_logs render if the backend source exists; if not, the filter should return an empty result set rather than erroring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new **Database Upgrades** log type in Unified Logs.
  * Database upgrade entries now display with their own label and icon for easier recognition.
  * Filtering and viewing unified logs now includes database upgrade events alongside existing log types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->