### PR TITLE
use card bg

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/ExtensionRow.tsx
@@ -152,7 +152,7 @@ export const ExtensionRow = ({ extension }: ExtensionRowProps) => {
           [Joshen] The div child here and all these classes is to properly add a left border
           to make the sticky column more distinct
         */}
-        <TableCell className="w-20 sticky bg-surface-100 right-0 relative">
+        <TableCell className="w-20 sticky bg-card right-0 relative">
           <div className="absolute top-0 right-0 left-0 bottom-0 flex items-center justify-center border-l">
             {isDisabling ? (
               <Loader2 className="animate-spin" size={16} />

--- a/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/Extensions.tsx
@@ -128,7 +128,7 @@ export const Extensions = () => {
                     in the dashboard with sticky columns
                   */}
                   <TableHead key="enabled" className="px-0">
-                    <div className="bg-200! px-4 w-full h-full flex items-center border-l">
+                    <div className="bg-card px-4 w-full h-full flex items-center border-l">
                       Enabled
                     </div>
                   </TableHead>

--- a/packages/ui/src/components/ShadowScrollArea/index.tsx
+++ b/packages/ui/src/components/ShadowScrollArea/index.tsx
@@ -57,10 +57,9 @@ const ShadowScrollArea = React.forwardRef<HTMLDivElement, ShadowScrollAreaProps>
             'w-full overflow-auto',
             stickyLastColumn && [
               '[&_tr>*:last-child]:sticky [&_tr>*:last-child]:z-38 [&_tr>*:last-child]:right-0',
-              '[&_tr:hover>*:last-child]:bg-transparent',
-              '[&_th>*:last-child]:bg-surface-100',
+              '[&_tr:hover>td:last-child]:bg-card',
+              '[&_th>*:last-child]:bg-card',
               stickyColumnShadow,
-              hasHorizontalScroll && '[&_tr:hover>td:last-child]:!bg-surface-200',
             ],
             canScrollRight &&
               '[&_td]:before:opacity-100 [&_tr>*:last-child]:before:opacity-100 [&_th:last-child]:before:opacity-100',


### PR DESCRIPTION
Updates to use bg card for extensions table and column

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated sticky table column backgrounds to use a consistent card-style surface.
  * Refined hover behavior for the last column in scrollable tables for a cleaner visual state.
  * Improved the appearance of the “Enabled” column header and switch column in database extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->