### PR TITLE
fix(logs): color regressions from design system update

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -455,7 +455,7 @@ export const LogsDatePicker = ({
             />
           </div>
           {isLargeRange && !hideWarnings && (
-            <div className="text-xs px-3 py-1.5 border-y bg-warning-300 text-warning-foreground border-warning-500 text-warning">
+            <div className="text-xs px-3 py-1.5 border-y bg-warning-300 border-warning-500 text-warning">
               Large ranges may result in memory errors for <br /> big projects.
             </div>
           )}

--- a/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
+++ b/apps/studio/components/layouts/LogsLayout/LogsSidebarMenuV2.tsx
@@ -214,7 +214,7 @@ export function LogsSidebarMenuV2() {
 
       <div
         className={cn(
-          'flex gap-x-2 items-center sticky top-0 bg-background-200 z-1 px-4',
+          'flex gap-x-2 items-center sticky top-0 bg-dash-sidebar z-1 px-4',
           !templatesEnabled ? 'pt-4' : 'py-4'
         )}
       >

--- a/apps/studio/components/ui/DataTable/LiveButton.tsx
+++ b/apps/studio/components/ui/DataTable/LiveButton.tsx
@@ -2,7 +2,7 @@ import type { FetchPreviousPageOptions } from '@tanstack/react-query'
 import { CirclePause, CirclePlay } from 'lucide-react'
 import { useQueryStates } from 'nuqs'
 import { useEffect } from 'react'
-import { Button, cn } from 'ui'
+import { Button } from 'ui'
 
 import { useDataTable } from './providers/DataTableProvider'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
@@ -66,7 +66,6 @@ export function LiveButton({ fetchPreviousPage, searchParamsParser }: LiveButton
       side="bottom"
     >
       <Button
-        className={cn(live && 'border-info text-info hover:text-info')}
         onClick={handleClick}
         variant={live ? 'primary' : 'default'}
         size="tiny"


### PR DESCRIPTION
## Summary
- Fix unreadable "Large ranges may result in memory errors" warning text in the Logs date picker — a stray `text-warning-foreground` class (dark ink) was winning over `text-warning` on the dark `bg-warning-300` fill.
- Fix "Search collections..." sidebar wrapper background mismatch — `bg-background-200` now resolves to the elevated `--card` surface instead of `--background`, so it no longer matches the sidebar's `bg-dash-sidebar`.
- Fix the Unified Logs "Live" toggle button rendering blue text instead of white when active — a leftover `border-info text-info` override was fighting the `primary` variant's own text color, now that `--info` resolves to a more distinct blue.

All three are contrast/color regressions surfaced by the recent design-system color token changes.

## Test plan
- [ ] Open a project's Logs Explorer, pick a large date range, confirm the warning text is readable
- [ ] Check the Logs sidebar "Search collections..." box background matches the rest of the sidebar in both light and dark mode
- [ ] Toggle "Live" mode in Unified Logs and confirm the button text is white/legible on the green background

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the large-range warning banner appearance in Logs settings.
  * Refined the Logs sidebar header background styling for a more consistent look.
  * Simplified the DataTable live button styling behavior by removing conditional class composition while preserving the existing live-mode visuals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->