### PR TITLE
fix: improve project URL and keys copy button accessibility

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
@@ -37,7 +37,6 @@ interface ProjectConnectionPopoverProps {
 export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopoverProps) => {
   const [open, setOpen] = useState(false)
   const [copiedItem, setCopiedItem] = useState<string | null>(null)
-  const copiedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const [, setShowConnect] = useQueryState('showConnect', parseAsBoolean.withDefault(false))
 
   const { isLoading: isLoadingPermissions, can: canReadAPIKeys } = useAsyncCheckPermissions(
@@ -159,10 +158,10 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
   )
 
   useEffect(() => {
-    return () => {
-      if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current)
+    if (!open) {
+      setCopiedItem(null)
     }
-  }, [])
+  }, [open])
 
   return (
     <div className="mt-3 inline-flex max-w-full items-center gap-3 min-w-0">
@@ -183,7 +182,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
               <ChevronDown size={14} className={cn('transition-transform', open && 'rotate-180')} />
             }
           >
-            Copy
+            Copy <span className="sr-only">project's URL and API keys</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="end" className="w-80 p-1">
@@ -201,14 +200,19 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
 
                   copyToClipboard(item.value)
                   setCopiedItem(item.label)
-
-                  if (copiedTimeoutRef.current) clearTimeout(copiedTimeoutRef.current)
-                  copiedTimeoutRef.current = setTimeout(() => setCopiedItem(null), 1500)
                 }}
               >
                 <Icon size={14} className="mt-0.5 shrink-0 text-foreground-light" />
                 <div className="min-w-0 flex-1">
-                  <div className="text-sm text-foreground">{item.label}</div>
+                  <div className="text-sm text-foreground">
+                    {copiedItem !== item.label ? (
+                      <span className="sr-only">Press Enter to copy</span>
+                    ) : null}
+                    {item.label}
+                    {copiedItem === item.label ? (
+                      <span className="sr-only">copied to your clipboard</span>
+                    ) : null}
+                  </div>
                   <div className="truncate text-sm text-foreground-lighter">
                     {item.displayValue}
                   </div>

--- a/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
@@ -182,7 +182,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
               <ChevronDown size={14} className={cn('transition-transform', open && 'rotate-180')} />
             }
           >
-            Copy <span className="sr-only">project's URL and API keys</span>
+            Copy <span className="sr-only">project URL and API keys</span>
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent side="bottom" align="end" className="w-80 p-1">

--- a/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
@@ -1,7 +1,7 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Check, ChevronDown, Copy, Database, KeyRound, Link2, Terminal } from 'lucide-react'
 import { parseAsBoolean, useQueryState } from 'nuqs'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import {
   Button,
   cn,


### PR DESCRIPTION
## Problem

The _Copy_ button is difficult to understand for screen reader users:
- They don't know what it copies
- They have no clear indication about what each dropdown item does
- They have no confirmation a value has been copied to their clipboard

## Solution

- Make sure the button that triggers the popover has a clear label for screen readers
- Make sure each item has a clear label: _Press Enter to copy ..._
- Make sure each item label changes to confirm the value has been copied

## How to test

- Activate the OS VoiceOver
- Navigate to a project home page
- Tab to the _Copy_ button. It should announce _Copy project URL and API keys_
- Press Enter then use Arrow keys to move through the items. It should announce _Press Enter to copy_ the item label
- Press Enter to copy an item. It should announce item label _Press Enter to copy_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved clipboard copy feedback so the “copied” state now resets when the popover closes, making copy confirmations more consistent.
  * Enhanced accessibility for copy actions by refining screen-reader text to indicate whether an item is ready to copy (“Press Enter to copy”) or has already been copied.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->