### PR TITLE
docs: fix confusing loader snippets in Remix and React Router SSR client guide

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -468,19 +468,19 @@ You can now use any Supabase features from your client or server code!
 </TabPanel>
 <TabPanel id="remix" label="Remix">
 
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="remix-loader"
-  queryGroup="environment"
->
-<TabPanel id="remix-loader" label="Loader">
+In Remix, a route module (`_index.tsx`) can export a `loader` (runs on the server to load data), an `action` (runs on the server to handle form submissions), and a default component (runs in the browser). Create a server client inside the `loader` and `action`, and a browser client inside the component. Because the browser client needs your Supabase URL and key, return them from the `loader` and read them with `useLoaderData`.
 
 ```ts _index.tsx
-import { type LoaderFunctionArgs } from '@remix-run/node'
-import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
+import { json, type ActionFunctionArgs, type LoaderFunctionArgs } from '@remix-run/node'
+import { useLoaderData } from '@remix-run/react'
+import {
+  createBrowserClient,
+  createServerClient,
+  parseCookieHeader,
+  serializeCookieHeader,
+} from '@supabase/ssr'
 
+// Server: load data and manage the user's session.
 export async function loader({ request }: LoaderFunctionArgs) {
   const responseHeaders = new Headers()
 
@@ -502,20 +502,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   )
 
-  return new Response('...', {
-    headers: responseHeaders,
-  })
+  // Use `supabase` here for server-side work, e.g. await supabase.auth.getUser()
+
+  // Return the env vars so the browser can create its own client.
+  return json(
+    {
+      env: {
+        SUPABASE_URL: process.env.SUPABASE_URL!,
+        SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY!,
+      },
+    },
+    { headers: responseHeaders }
+  )
 }
-```
 
-</TabPanel>
-
-<TabPanel id="remix-action" label="Action">
-
-```ts _index.tsx
-import { type ActionFunctionArgs } from '@remix-run/node'
-import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
-
+// Server: handle form submissions and mutations.
 export async function action({ request }: ActionFunctionArgs) {
   const responseHeaders = new Headers()
 
@@ -537,41 +538,18 @@ export async function action({ request }: ActionFunctionArgs) {
     }
   )
 
-  return new Response('...', {
-    headers: responseHeaders,
-  })
-}
-```
-
-</TabPanel>
-
-<TabPanel id="remix-component" label="Component">
-
-```ts _index.tsx
-import { type LoaderFunctionArgs } from "@remix-run/node";
-import { useLoaderData } from "@remix-run/react";
-import { createBrowserClient } from "@supabase/ssr";
-
-export async function loader({}: LoaderFunctionArgs) {
-  return {
-    env: {
-      SUPABASE_URL: process.env.SUPABASE_URL!,
-      SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY!,
-    },
-  };
+  return json(null, { headers: responseHeaders })
 }
 
+// Browser: create a client using the env vars returned by the loader.
 export default function Index() {
-  const { env } = useLoaderData<typeof loader>();
+  const { env } = useLoaderData<typeof loader>()
 
-  const supabase = createBrowserClient(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY);
+  const supabase = createBrowserClient(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY)
 
-  return ...
+  return <div>...</div>
 }
 ```
-
-</TabPanel>
-</Tabs>
 
 ## Congratulations
 
@@ -654,19 +632,19 @@ You can now use any Supabase features from your client or server code!
 
 <TabPanel id="react-router" label="React Router">
 
-<Tabs
-  scrollable
-  size="small"
-  type="underlined"
-  defaultActiveId="react-router-loader"
-  queryGroup="environment"
->
-<TabPanel id="react-router-loader" label="Loader">
+In React Router, a route module (`_index.tsx`) can export a `loader`, an `action`, and a default component. Create a server client inside the `loader` and `action`, and a browser client inside the component, passing the env vars through the `loader`.
 
 ```ts _index.tsx
-import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
-import { LoaderFunctionArgs } from 'react-router'
+import { data, type ActionFunctionArgs, type LoaderFunctionArgs } from 'react-router'
+import { useLoaderData } from 'react-router'
+import {
+  createBrowserClient,
+  createServerClient,
+  parseCookieHeader,
+  serializeCookieHeader,
+} from '@supabase/ssr'
 
+// Server: load data and manage the user's session.
 export async function loader({ request }: LoaderFunctionArgs) {
   const responseHeaders = new Headers()
 
@@ -679,8 +657,8 @@ export async function loader({ request }: LoaderFunctionArgs) {
           return parseCookieHeader(request.headers.get('Cookie') ?? '')
         },
         setAll(cookiesToSet, cacheHeaders) {
-          cookiesToSet.forEach(({ name, value }) =>
-            responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value))
+          cookiesToSet.forEach(({ name, value, options }) =>
+            responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value, options))
           )
           Object.entries(cacheHeaders).forEach(([key, value]) => responseHeaders.set(key, value))
         },
@@ -688,20 +666,21 @@ export async function loader({ request }: LoaderFunctionArgs) {
     }
   )
 
-  return new Response('...', {
-    headers: responseHeaders,
-  })
+  // Use `supabase` here for server-side work, e.g. await supabase.auth.getUser()
+
+  // Return the env vars so the browser can create its own client.
+  return data(
+    {
+      env: {
+        SUPABASE_URL: process.env.SUPABASE_URL!,
+        SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY!,
+      },
+    },
+    { headers: responseHeaders }
+  )
 }
-```
 
-</TabPanel>
-
-<TabPanel id="react-router-action" label="Action">
-
-```ts _index.tsx
-import { type ActionFunctionArgs } from '@react-router'
-import { createServerClient, parseCookieHeader, serializeCookieHeader } from '@supabase/ssr'
-
+// Server: handle form submissions and mutations.
 export async function action({ request }: ActionFunctionArgs) {
   const responseHeaders = new Headers()
 
@@ -714,8 +693,8 @@ export async function action({ request }: ActionFunctionArgs) {
           return parseCookieHeader(request.headers.get('Cookie') ?? '')
         },
         setAll(cookiesToSet, cacheHeaders) {
-          cookiesToSet.forEach(({ name, value }) =>
-            responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value))
+          cookiesToSet.forEach(({ name, value, options }) =>
+            responseHeaders.append('Set-Cookie', serializeCookieHeader(name, value, options))
           )
           Object.entries(cacheHeaders).forEach(([key, value]) => responseHeaders.set(key, value))
         },
@@ -723,41 +702,18 @@ export async function action({ request }: ActionFunctionArgs) {
     }
   )
 
-  return new Response('...', {
-    headers: responseHeaders,
-  })
-}
-```
-
-</TabPanel>
-
-<TabPanel id="react-router-component" label="Component">
-
-```ts _index.tsx
-import { type LoaderFunctionArgs } from "react-router";
-import { useLoaderData } from "react-router";
-import { createBrowserClient } from "@supabase/ssr";
-
-export async function loader({}: LoaderFunctionArgs) {
-  return {
-    env: {
-      SUPABASE_URL: process.env.SUPABASE_URL!,
-      SUPABASE_PUBLISHABLE_KEY: process.env.SUPABASE_PUBLISHABLE_KEY!,
-    },
-  };
+  return data(null, { headers: responseHeaders })
 }
 
+// Browser: create a client using the env vars returned by the loader.
 export default function Index() {
-  const { env } = useLoaderData<typeof loader>();
+  const { env } = useLoaderData<typeof loader>()
 
-  const supabase = createBrowserClient(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY);
+  const supabase = createBrowserClient(env.SUPABASE_URL, env.SUPABASE_PUBLISHABLE_KEY)
 
-  return ...
+  return <div>...</div>
 }
 ```
-
-</TabPanel>
-</Tabs>
 
 ## Congratulations
 

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -504,7 +504,7 @@ export async function loader({ request }: LoaderFunctionArgs) {
 
   // Use `supabase` here for server-side work, e.g. await supabase.auth.getUser()
 
-  // Return the env vars so the browser can create its own client.
+  // Return the environment variables so the browser can create its own client.
   return json(
     {
       env: {

--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -468,7 +468,15 @@ You can now use any Supabase features from your client or server code!
 </TabPanel>
 <TabPanel id="remix" label="Remix">
 
-In Remix, a route module (`_index.tsx`) can export a `loader` (runs on the server to load data), an `action` (runs on the server to handle form submissions), and a default component (runs in the browser). Create a server client inside the `loader` and `action`, and a browser client inside the component. Because the browser client needs your Supabase URL and key, return them from the `loader` and read them with `useLoaderData`.
+With Remix, in a route module such as `_index.tsx`, you can export a `loader`, an `action`, and a default component.
+
+Configure Supabase clients as follows:
+
+1. **Create a server client in the `loader`.** Use it to load data and manage the user session on the server. Return your Supabase URL and publishable key so the browser can create a client.
+2. **Create a server client in the `action`.** Use it to handle form submissions and other mutations on the server.
+3. **Create a browser client in the default component.** Call `useLoaderData` to read the URL and key, then call `createBrowserClient`.
+
+The following example shows all three exports in one route module:
 
 ```ts _index.tsx
 import { json, type ActionFunctionArgs, type LoaderFunctionArgs } from '@remix-run/node'


### PR DESCRIPTION
## Summary

Fixes the Remix and React Router sections of the SSR "creating a client" guide, which showed three separate `_index.tsx` snippets (Loader, Action, Component) with two different `loader` exports that cannot coexist in one route, leaving readers unsure which to use.

Each framework now has a short intro plus a single coherent `_index.tsx`: one `loader` that creates the server client and returns the env vars, one `action`, and a browser-client component that reads those env vars via `useLoaderData`. Along the way this also fixes three React Router bugs: the invalid `'@react-router'` import, the dropped cookie `options` argument in `setAll`, and the incomplete `return ...` in the component.

One thing worth a reviewer check: a loader that both sets cookies and returns data must return through the `json` (Remix) / `data` (React Router v7) helper with `{ headers }` rather than a plain object, so the `Set-Cookie` headers are preserved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Updated the server-side “creating a client” guide for Remix and React Router SSR examples.
  * Refreshed the example structure to a single end-to-end route setup with `loader`, `action`, and one default page component.
  * Improved SSR cookie and header handling to better match practical server/client behavior.
  * Passes the required Supabase URL and publishable key from the server to the browser so the client can be initialized with `useLoaderData`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->