### PR TITLE
fix(observability): use 6-hour buckets for 7-day service health view DEBUG-140

### DIFF
--- a/apps/studio/components/interfaces/Observability/useServiceHealthMetrics.ts
+++ b/apps/studio/components/interfaces/Observability/useServiceHealthMetrics.ts
@@ -46,7 +46,27 @@ export type ServiceHealthData = {
 const INTERVAL_TO_GRANULARITY: Record<'1hr' | '1day' | '7day', ServiceHealthGranularity> = {
   '1hr': 'minute',
   '1day': 'hour',
-  '7day': 'day',
+  '7day': '6h',
+}
+
+const GRANULARITY_SNAP_UNIT: Record<ServiceHealthGranularity, 'day' | 'hour' | 'minute'> = {
+  day: 'day',
+  '12h': 'hour',
+  '6h': 'hour',
+  hour: 'hour',
+  '30min': 'minute',
+  '15min': 'minute',
+  minute: 'minute',
+}
+
+const GRANULARITY_FILL_INTERVAL: Record<ServiceHealthGranularity, string> = {
+  day: '1d',
+  '12h': '12h',
+  '6h': '6h',
+  hour: '1h',
+  '30min': '30m',
+  '15min': '15m',
+  minute: '1m',
 }
 
 /** Maps our service keys to the field names returned by the service-health endpoint */
@@ -111,8 +131,9 @@ const useServiceHealthQuery = ({
 
   // Snap start/end to the granularity boundary so fillTimeseries iterates
   // in sync with the API's bucketed timestamps (e.g. midnight for 'day').
-  const fillStart = dayjs.utc(startDate).startOf(granularity).toISOString()
-  const fillEnd = dayjs.utc(endDate).startOf(granularity).toISOString()
+  const snapUnit = GRANULARITY_SNAP_UNIT[granularity]
+  const fillStart = dayjs.utc(startDate).startOf(snapUnit).toISOString()
+  const fillEnd = dayjs.utc(endDate).startOf(snapUnit).toISOString()
 
   // Fill gaps in timeseries
   const { data: filledData } = useFillTimeseriesSorted({
@@ -122,6 +143,7 @@ const useServiceHealthQuery = ({
     defaultValue: 0,
     startDate: fillStart,
     endDate: fillEnd,
+    interval: GRANULARITY_FILL_INTERVAL[granularity],
   })
 
   const eventChartData: LogsBarChartDatum[] = useMemo(

--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsage.metrics.test.ts
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsage.metrics.test.ts
@@ -98,10 +98,10 @@ describe('ProjectUsage.metrics', () => {
       })
     })
 
-    it('returns a one-day window for 7day', () => {
+    it('returns a six-hour window for 7day', () => {
       expect(getBucketLogRange(timestamp, '7day')).toEqual({
         start: timestamp,
-        end: '2024-01-16T12:00:00.000Z',
+        end: '2024-01-15T18:00:00.000Z',
       })
     })
 

--- a/apps/studio/components/interfaces/ProjectHome/ProjectUsage.metrics.ts
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectUsage.metrics.ts
@@ -80,9 +80,10 @@ export const getBucketLogRange = (
   timestamp: string,
   interval: ChartIntervalKey
 ): { start: string; end: string } => {
-  const unit = interval === '1hr' ? 'minute' : interval === '1day' ? 'hour' : 'day'
+  const [amount, unit]: [number, dayjs.OpUnitType] =
+    interval === '1hr' ? [1, 'minute'] : interval === '1day' ? [1, 'hour'] : [6, 'hour']
   return {
     start: timestamp,
-    end: dayjs.utc(timestamp).add(1, unit).toISOString(),
+    end: dayjs.utc(timestamp).add(amount, unit).toISOString(),
   }
 }

--- a/apps/studio/data/analytics/service-health-query.ts
+++ b/apps/studio/data/analytics/service-health-query.ts
@@ -1,6 +1,6 @@
 import { get, handleError } from '@/data/fetchers'
 
-export type ServiceHealthGranularity = 'day' | 'hour' | 'minute'
+export type ServiceHealthGranularity = 'day' | '12h' | '6h' | 'hour' | '30min' | '15min' | 'minute'
 
 export type ServiceHealthServiceData = {
   error: number


### PR DESCRIPTION
## Problem

The homepage service health charts request daily buckets for the 7-day view, producing only 7 data points. The chart looks sparse with overly wide bars compared to the 24-hour view.

## Fix

The service-health endpoint now accepts finer granularities (`6h`, `12h`, `30min`, `15min`, in addition to the existing `day`, `hour`, `minute`). The 7-day view now requests `6h` buckets (28 data points) instead of `day`, and the click-to-logs bucket window is updated to match.

## How to test

- Open a project's homepage
- Switch the service health interval to "Last 7 days"
- Expected result: the chart shows 28 bars (4 per day) instead of 7, no longer looking sparse
- Click a bar in the 7-day view and confirm the logs deep link opens a 6-hour window around that bucket
- Switch between "Last 60 minutes" and "Last 24 hours" and confirm those views are unchanged