### PR TITLE
chore: simplify project copy buttons labels

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
@@ -205,9 +205,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
                 <Icon size={14} className="mt-0.5 shrink-0 text-foreground-light" />
                 <div className="min-w-0 flex-1">
                   <div className="text-sm text-foreground">
-                    {copiedItem !== item.label ? (
-                      <span className="sr-only">Press Enter to copy</span>
-                    ) : null}
+                    {copiedItem !== item.label ? <span className="sr-only">Copy</span> : null}
                     {item.label}
                     {copiedItem === item.label ? (
                       <span className="sr-only">copied to your clipboard</span>


### PR DESCRIPTION
## Problem

Screen reader users don't need to be told how to use a button: _Press Enter to copy project name_

## Solution

Simplify the button labels: _Copy project name_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Updated screen-reader text in the dropdown menu so uncopied items now announce “Copy” more clearly, improving clarity for assistive technology users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->