### PR TITLE
fix: add a skip to main content link in default layout

### DIFF
--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -79,6 +79,9 @@ export const DefaultLayout = ({
         <ProjectContextProvider projectRef={ref}>
           <MobileSheetProvider>
             <div className="flex flex-col h-screen w-screen">
+              <a class="sr-only" href="#main" tabIndex={0}>
+                Skip to content
+              </a>
               {/* Top Banner */}
               <AppBannerWrapper />
               <div className="shrink-0">
@@ -107,7 +110,9 @@ export const DefaultLayout = ({
                     maxSize={`${contentMaxSizePercentage}`}
                     defaultSize={`${contentMaxSizePercentage}`}
                   >
-                    <div className="h-full overflow-y-auto">{children}</div>
+                    <main id="main" className="h-full overflow-y-auto">
+                      {children}
+                    </main>
                   </ResizablePanel>
                   <LayoutSidebar
                     minSize={`${100 - contentMaxSizePercentage}`}

--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -79,7 +79,7 @@ export const DefaultLayout = ({
         <ProjectContextProvider projectRef={ref}>
           <MobileSheetProvider>
             <div className="flex flex-col h-screen w-screen">
-              <a class="sr-only" href="#main" tabIndex={0}>
+              <a className="sr-only" href="#main" tabIndex={0}>
                 Skip to content
               </a>
               {/* Top Banner */}


### PR DESCRIPTION
## Problem

Screen reader and keyboard users have no way to skip the header and sidepanel navbar so they have to manually tab through every items before accessing the actual main page items.

## Solution

Add a _Skip to content_ link for them

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Skip to content” link to help users jump directly to the main page area.
  * Updated the main content wrapper to a semantic `main` landmark with an anchor target.

* **Accessibility**
  * Improved keyboard and screen reader navigation by supporting better in-page navigation and landmarks, without changing the page’s visible content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->