### PR TITLE
fix(studio): batch of production Sentry crash fixes

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/Tables.utils.ts
+++ b/apps/studio/components/interfaces/Database/Tables/Tables.utils.ts
@@ -16,7 +16,7 @@ export const formatAllEntities = ({
   materializedViews?: PGMaterializedView[]
   foreignTables?: PGForeignTable[]
 }) => {
-  const formattedTables = tables.map((x) => {
+  const formattedTables = (Array.isArray(tables) ? tables : []).map((x) => {
     return {
       ...x,
       type: ENTITY_TYPE.TABLE as const,
@@ -25,7 +25,7 @@ export const formatAllEntities = ({
     }
   })
 
-  const formattedViews = views.map((x) => {
+  const formattedViews = (Array.isArray(views) ? views : []).map((x) => {
     return {
       type: ENTITY_TYPE.VIEW as const,
       id: x.id,
@@ -38,7 +38,9 @@ export const formatAllEntities = ({
     }
   })
 
-  const formattedMaterializedViews = materializedViews.map((x) => {
+  const formattedMaterializedViews = (
+    Array.isArray(materializedViews) ? materializedViews : []
+  ).map((x) => {
     return {
       type: ENTITY_TYPE.MATERIALIZED_VIEW as const,
       id: x.id,
@@ -51,7 +53,7 @@ export const formatAllEntities = ({
     }
   })
 
-  const formattedForeignTables = foreignTables.map((x) => {
+  const formattedForeignTables = (Array.isArray(foreignTables) ? foreignTables : []).map((x) => {
     return {
       type: ENTITY_TYPE.FOREIGN_TABLE as const,
       id: x.id,

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -18,6 +18,7 @@ import {
 
 import { LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD } from './Logs.constants'
 import type { DatetimeHelper } from './Logs.types'
+import { parseSelectedDate, resolveLogTimestamp } from './Logs.utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { TimeSplitInput } from '@/components/ui/DatePicker/TimeSplitInput'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
@@ -139,13 +140,13 @@ export const LogsDatePicker = ({
   useEffect(() => {
     if (!open) {
       setCustomValue('')
-      setStartDate(value.from ? new Date(value.from) : null)
-      const defaultEndDate = value.to ? new Date(value.to) : new Date()
+      setStartDate(parseSelectedDate(value.from))
+      const defaultEndDate = resolveLogTimestamp(value.to).toDate()
       setEndDate(defaultEndDate)
       setCurrentMonth(new Date(defaultEndDate))
 
-      const fromDate = value.from ? new Date(value.from) : null
-      const toDate = value.to ? new Date(value.to) : null
+      const fromDate = parseSelectedDate(value.from)
+      const toDate = parseSelectedDate(value.to)
 
       setStartTime({
         HH: fromDate?.getHours().toString().padStart(2, '0') || '00',
@@ -180,10 +181,10 @@ export const LogsDatePicker = ({
     setOpen(false)
   }
 
-  const [startDate, setStartDate] = useState<Date | null>(value.from ? new Date(value.from) : null)
-  const [endDate, setEndDate] = useState<Date | null>(value.to ? new Date(value.to) : new Date())
+  const [startDate, setStartDate] = useState<Date | null>(parseSelectedDate(value.from))
+  const [endDate, setEndDate] = useState<Date | null>(() => resolveLogTimestamp(value.to).toDate())
   const [currentMonth, setCurrentMonth] = useState<Date>(() =>
-    value.to ? new Date(value.to) : new Date()
+    resolveLogTimestamp(value.to).toDate()
   )
 
   const [startTime, setStartTime] = useState({

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.utils.ts
@@ -372,6 +372,13 @@ export const resolveLogTimestamp = (value?: string): Dayjs => {
   return value && parsed.isValid() ? parsed : dayjs()
 }
 
+// Like `resolveLogTimestamp` but keeps `null` for "no date selected" instead of defaulting to now.
+export const parseSelectedDate = (value?: string | null): Date | null => {
+  if (!value) return null
+  const parsed = dayjs(value)
+  return parsed.isValid() ? parsed.toDate() : null
+}
+
 /** calculates how much the chart start datetime should be offset given the current datetime filter params */
 const calcChartStart = (
   params: Partial<LogsEndpointParams>

--- a/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
+++ b/apps/studio/components/layouts/AppLayout/useStatusPageBannerVisibility.ts
@@ -51,7 +51,9 @@ export function useStatusPageBannerVisibility(): StatusPageBannerData | null {
     [allProjects]
   )
   const hasUnknownRegions = orgProjectsQueries.some(
-    (q) => q.isError || (q.data !== undefined && q.data.pagination.count > q.data.projects.length)
+    (q) =>
+      q.isError ||
+      (q.data !== undefined && (q.data.pagination?.count ?? 0) > q.data.projects.length)
   )
 
   const [dismissedIds, setDismissedIds, { isSuccess: isDismissedLoaded }] = useLocalStorageQuery<

--- a/apps/studio/data/branches/branches-query.ts
+++ b/apps/studio/data/branches/branches-query.ts
@@ -4,6 +4,7 @@ import { branchKeys } from './keys'
 import type { components } from '@/data/api'
 import { get, handleError } from '@/data/fetchers'
 import { IS_PLATFORM } from '@/lib/constants'
+import { EMPTY_ARR } from '@/lib/void'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 export type BranchesVariables = {
@@ -22,13 +23,13 @@ export async function getBranches({ projectRef }: BranchesVariables, signal?: Ab
 
   if (error) {
     if ((error as ResponseError).message === 'Preview branching is not enabled for this project.') {
-      return []
+      return EMPTY_ARR
     } else {
       handleError(error)
     }
   }
 
-  return data
+  return Array.isArray(data) ? data : EMPTY_ARR
 }
 
 export type BranchesData = Awaited<ReturnType<typeof getBranches>>

--- a/apps/studio/data/config/project-storage-config-query.ts
+++ b/apps/studio/data/config/project-storage-config-query.ts
@@ -55,7 +55,7 @@ export const useProjectStorageConfigQuery = <TData = ProjectStorageConfigData>(
 
 export const useIsAnalyticsBucketsEnabled = ({ projectRef }: { projectRef?: string }) => {
   const { data } = useProjectStorageConfigQuery({ projectRef })
-  const isIcebergCatalogEnabled = !!data?.features.icebergCatalog?.enabled
+  const isIcebergCatalogEnabled = !!data?.features?.icebergCatalog?.enabled
   return isIcebergCatalogEnabled
 }
 
@@ -63,6 +63,6 @@ export const useIsVectorBucketsEnabled = ({ projectRef }: { projectRef?: string 
   const { data } = useProjectStorageConfigQuery({ projectRef })
   const { isCli, isPlatform } = useDeploymentMode()
 
-  const isVectorBucketsEnabled = isCli || (isPlatform && !!data?.features.vectorBuckets?.enabled)
+  const isVectorBucketsEnabled = isCli || (isPlatform && !!data?.features?.vectorBuckets?.enabled)
   return isVectorBucketsEnabled
 }

--- a/apps/studio/data/projects/org-projects-infinite-query.ts
+++ b/apps/studio/data/projects/org-projects-infinite-query.ts
@@ -5,6 +5,7 @@ import { useCallback } from 'react'
 import { INFINITE_PROJECTS_KEY_PREFIX, projectKeys } from './keys'
 import { get, handleError } from '@/data/fetchers'
 import { useProfile } from '@/lib/profile'
+import { EMPTY_ARR } from '@/lib/void'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from '@/types'
 
 // [Joshen] Try to keep this value a multiple of 6 (common denominator of 2 and 3) to fit the cards view
@@ -49,7 +50,11 @@ export async function getOrganizationProjects(
   })
 
   if (error) handleError(error)
-  return data
+
+  return {
+    ...data,
+    projects: Array.isArray(data?.projects) ? data.projects : EMPTY_ARR,
+  }
 }
 
 export type OrgProjectsInfiniteData = Awaited<ReturnType<typeof getOrganizationProjects>>
@@ -85,9 +90,9 @@ export const useOrgProjectsInfiniteQuery = <TData = OrgProjectsInfiniteData>(
     getNextPageParam(lastPage, pages) {
       const page = pages.length
       const currentTotalCount = page * limit
-      const totalCount = lastPage.pagination.count
+      const totalCount = lastPage?.pagination?.count
 
-      if (currentTotalCount >= totalCount) return undefined
+      if (totalCount === undefined || currentTotalCount >= totalCount) return undefined
       return page
     },
     ...options,

--- a/apps/studio/data/projects/projects-infinite-query.ts
+++ b/apps/studio/data/projects/projects-infinite-query.ts
@@ -4,6 +4,7 @@ import { components } from 'api-types'
 import { projectKeys } from './keys'
 import { get, handleError } from '@/data/fetchers'
 import { useProfile } from '@/lib/profile'
+import { EMPTY_ARR } from '@/lib/void'
 import type { ResponseError, UseCustomInfiniteQueryOptions } from '@/types'
 
 const DEFAULT_LIMIT = 100
@@ -39,7 +40,12 @@ async function getProjects(
   })
 
   if (error) handleError(error)
-  return data as unknown as components['schemas']['ListProjectsPaginatedResponse']
+
+  const result = data as unknown as components['schemas']['ListProjectsPaginatedResponse']
+  return {
+    ...result,
+    projects: Array.isArray(result?.projects) ? result.projects : EMPTY_ARR,
+  }
 }
 
 export type ProjectsInfiniteData = Awaited<ReturnType<typeof getProjects>>

--- a/apps/studio/data/service-status/service-status-query.ts
+++ b/apps/studio/data/service-status/service-status-query.ts
@@ -3,6 +3,7 @@ import { components } from 'api-types'
 
 import { serviceStatusKeys } from './keys'
 import { get, handleError } from '@/data/fetchers'
+import { EMPTY_ARR } from '@/lib/void'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 export type ProjectServiceStatusVariables = {
@@ -34,7 +35,7 @@ export async function getProjectServiceStatus(
 
   if (error) handleError(error)
 
-  return data as ServiceHealthResponse[]
+  return Array.isArray(data) ? (data as ServiceHealthResponse[]) : EMPTY_ARR
 }
 
 export type ProjectServiceStatusData = Awaited<ReturnType<typeof getProjectServiceStatus>>

--- a/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
+++ b/apps/studio/pages/project/[ref]/logs/explorer/index.tsx
@@ -96,7 +96,9 @@ export const LogsExplorerPage: NextPageWithLayout = () => {
   const { profile } = useProfile()
   const { data: project } = useSelectedProjectQuery()
   const { data: organization } = useSelectedOrganizationQuery()
-  const { ref, q, queryId } = useParams()
+  const { ref, q: rawQ, queryId } = useParams()
+  // `useParams` types this as `string`, but router.query can be `string[]` for repeated keys.
+  const q = Array.isArray(rawQ) ? rawQ[0] : rawQ
   const track = useTrack()
   const projectRef = ref as string
   const { logsShowMetadataIpTemplate } = useIsFeatureEnabled(['logs:show_metadata_ip_template'])

--- a/packages/common/feature-flags.tsx
+++ b/packages/common/feature-flags.tsx
@@ -91,7 +91,15 @@ export const FeatureFlagProvider = ({
   ) => Promise<{ settingKey: string; settingValue: boolean | number | string | null | undefined }[]>
 }>) => {
   const { session, isLoading } = useAuth()
-  const userEmail = session?.user?.user_metadata.email ?? session?.user?.email
+  const sessionUser = session?.user
+  // auth-js swaps `session.user` for a proxy that throws on any property access when `userStorage`
+  // is configured but no user is persisted yet. `__isUserNotAvailableProxy` is the one property it allows.
+  const isSessionUserAvailable =
+    !!sessionUser &&
+    (sessionUser as { __isUserNotAvailableProxy?: boolean }).__isUserNotAvailableProxy !== true
+  const userEmail = isSessionUserAvailable
+    ? (sessionUser?.user_metadata?.email ?? sessionUser?.email)
+    : undefined
   const params = useParams()
   const resolvedOrganizationSlug = organizationSlug ?? params.slug
   const resolvedProjectRef = projectRef ?? params.ref


### PR DESCRIPTION
Follow-up to #47460 (FE-3748) — same non-array/malformed-API-response bug class, for issues that weren't caught in that pass, plus a few unrelated one-offs found while triaging.

Resolves FE-3862

## Issues fixed

| Sentry | Error | Fix |
| --- | --- | --- |
| [JTP](https://supabase.sentry.io/issues/SUPABASE-APP-JTP/) | `pagination.count`/`projects.length` on malformed org projects response | Guard in `useStatusPageBannerVisibility.ts` + normalize `org-projects-infinite-query.ts` |
| [B3M](https://supabase.sentry.io/issues/SUPABASE-APP-B3M/) | `pagination.count` on undefined | Guard pagination in org projects infinite query (org-variant of already-fixed B3K) |
| [K2D](https://supabase.sentry.io/issues/SUPABASE-APP-K2D/) | (destructured parameter) is undefined | Normalize `projects` array in `projects-infinite-query.ts` |
| [K2H](https://supabase.sentry.io/issues/SUPABASE-APP-K2H/) | Cannot read properties of undefined (reading 'projects') | Same fix as K2D |
| [JCD](https://supabase.sentry.io/issues/SUPABASE-APP-JCD/) | can't access property "vectorBuckets", features is undefined | Missing `?.` after `.features` in `project-storage-config-query.ts` |
| [JV9](https://supabase.sentry.io/issues/SUPABASE-APP-JV9/) | `t?.some` is not a function | Normalize `service-status-query.ts` to always return an array |
| [H6Y](https://supabase.sentry.io/issues/SUPABASE-APP-H6Y/) | `h?.find` is not a function | Same fix as JV9 |
| [K2F](https://supabase.sentry.io/issues/SUPABASE-APP-K2F/) | `t.map` is not a function | Guard all four entity arrays in `Tables.utils.ts` `formatAllEntities` |
| [JVQ](https://supabase.sentry.io/issues/SUPABASE-APP-JVQ/) | `m.find` is not a function | Normalize `branches-query.ts` to always return an array |
| [K2J](https://supabase.sentry.io/issues/SUPABASE-APP-K2J/) | Cannot read properties of undefined (reading 'email') | Missing `?.` after `user_metadata` in `feature-flags.tsx` |
| [K2E](https://supabase.sentry.io/issues/SUPABASE-APP-K2E/) | auth-js userStorage guard error | Detect auth-js's user-not-available proxy before reading `session.user` |
| [JE3](https://supabase.sentry.io/issues/SUPABASE-APP-JE3/) | `Q.toLowerCase` is not a function | Coerce `q` router param to a single string in Logs Explorer |
| [J89](https://supabase.sentry.io/issues/SUPABASE-APP-J89/) | Invalid time value | Validate URL-sourced dates before constructing `Date` in the Logs date picker |

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] Existing unit tests pass (`project-storage-config-query.test.tsx`, `Logs.Datepickers.test.tsx`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability across the Studio by handling missing or unexpected data more safely in tables, projects, branches, service status, and feature flag checks.
  * Fixed log date selection and log explorer query handling so filters and initial dates behave more consistently.
  * Prevented crashes in several views when optional data is unavailable, helping pages load reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->