### PR TITLE
fix(e2e): avoid response-listener race in SQL editor flaky test

### DIFF
--- a/e2e/studio/features/sql-editor.spec.ts
+++ b/e2e/studio/features/sql-editor.spec.ts
@@ -145,10 +145,14 @@ test.describe('SQL Editor', () => {
     await page.locator('.view-lines').click()
     await page.keyboard.press('ControlOrMeta+KeyA')
     await page.keyboard.type(`select length('hello');`)
+
+    const secondSqlMutationPromise = waitForApiResponse(page, 'pg-meta', ref, 'query?key=', {
+      method: 'POST',
+    })
     await page.getByTestId('sql-run-button').click()
+    await secondSqlMutationPromise
 
     // verify the result is updated.
-    await waitForApiResponse(page, 'pg-meta', ref, 'query?key=', { method: 'POST' })
     await expect(page.getByRole('gridcell', { name: '5' })).toBeVisible()
 
     await expect(page.getByText('Loading...')).not.toBeVisible()


### PR DESCRIPTION
## Summary
- Fixes the flaky "should check if SQL editor is working as expected" self-hosted E2E test (FE-3863)
- The second query registered the pg-meta response waiter *after* clicking run, so a fast response could be missed, causing a 30s timeout. Moved the waiter registration before the click, matching the pattern already used for the first query.

Fixes FE-3863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved SQL editor end-to-end test synchronization to better wait for the correct API response during repeated query runs.
  * Increased test reliability for scenarios involving back-to-back SQL executions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->