### PR TITLE
Increase lightness of light theme surface

### DIFF
--- a/apps/design-system/styles/code-block-variables.css
+++ b/apps/design-system/styles/code-block-variables.css
@@ -20,11 +20,11 @@
   --code-token-keyword: #6b35dc;
   --code-foreground: oklch(from var(--foreground-light) l c h / 1);
   --code-token-constant: #15593b;
-  --code-token-string: #f1a10d;
+  --code-token-string: #c46a0a;
   --code-token-comment: #7e7e7e;
   --code-token-parameter: oklch(from var(--foreground-light) l c h / 1);
   --code-token-function: #15593b;
-  --code-token-string-expression: #f1a10d;
+  --code-token-string-expression: #c46a0a;
   --code-token-punctuation: oklch(from var(--foreground-light) l c h / 1);
   --code-token-link: oklch(from var(--foreground-light) l c h / 1);
   --code-token-number: oklch(from var(--foreground-light) l c h / 1);

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -439,11 +439,11 @@ th code {
   --code-token-keyword: #6b35dc;
   --code-foreground: oklch(from var(--foreground-light) l c h / 1);
   --code-token-constant: #15593b;
-  --code-token-string: #f1a10d;
+  --code-token-string: #c46a0a;
   --code-token-comment: #7e7e7e;
   --code-token-parameter: oklch(from var(--foreground-light) l c h / 1);
   --code-token-function: #15593b;
-  --code-token-string-expression: #f1a10d;
+  --code-token-string-expression: #c46a0a;
   --code-token-punctuation: oklch(from var(--foreground-light) l c h / 1);
   --code-token-link: oklch(from var(--foreground-light) l c h / 1);
   --code-token-number: oklch(from var(--foreground-light) l c h / 1);

--- a/apps/learn/styles/code-block-variables.css
+++ b/apps/learn/styles/code-block-variables.css
@@ -20,11 +20,11 @@
   --code-token-keyword: #6b35dc;
   --code-foreground: oklch(from var(--foreground-light) l c h / 1);
   --code-token-constant: #15593b;
-  --code-token-string: #f1a10d;
+  --code-token-string: #c46a0a;
   --code-token-comment: #7e7e7e;
   --code-token-parameter: oklch(from var(--foreground-light) l c h / 1);
   --code-token-function: #15593b;
-  --code-token-string-expression: #f1a10d;
+  --code-token-string-expression: #c46a0a;
   --code-token-punctuation: oklch(from var(--foreground-light) l c h / 1);
   --code-token-link: oklch(from var(--foreground-light) l c h / 1);
   --code-token-number: oklch(from var(--foreground-light) l c h / 1);

--- a/apps/ui-library/styles/code-block-variables.css
+++ b/apps/ui-library/styles/code-block-variables.css
@@ -20,11 +20,11 @@
   --code-token-keyword: #6b35dc;
   --code-foreground: oklch(from var(--foreground-light) l c h / 1);
   --code-token-constant: #15593b;
-  --code-token-string: #f1a10d;
+  --code-token-string: #c46a0a;
   --code-token-comment: #7e7e7e;
   --code-token-parameter: oklch(from var(--foreground-light) l c h / 1);
   --code-token-function: #15593b;
-  --code-token-string-expression: #f1a10d;
+  --code-token-string-expression: #c46a0a;
   --code-token-punctuation: oklch(from var(--foreground-light) l c h / 1);
   --code-token-link: oklch(from var(--foreground-light) l c h / 1);
   --code-token-number: oklch(from var(--foreground-light) l c h / 1);

--- a/packages/ui/build/css/themes/light.css
+++ b/packages/ui/build/css/themes/light.css
@@ -32,6 +32,9 @@
   --code-block-2: 33.1deg 80% 52.9%;
   --code-block-1: 170.6deg 43.2% 51%;
 
+  --code-token-string: #c46a0a;
+  --code-token-string-expression: #c46a0a;
+
   /* Stepped numeric scales (per-theme literals; mapped in theme.css) */
   --secondary-default: 247.8deg 100% 70%;
   --secondary-400: 248.3deg 54.5% 25.9%;

--- a/packages/ui/build/css/themes/light.css
+++ b/packages/ui/build/css/themes/light.css
@@ -4,14 +4,14 @@
   --hue: 159;
   /* Warm-gray surface ramp against the green brand (--primary stays on --hue). */
   --surface-hue: 34;
-  --chroma: 0.004;
+  --chroma: 0.001;
   /*
    * Soft-gray canvas (not pure white) so elevated surfaces have headroom to
    * brighten toward white. --elevation-step is positive here: higher surfaces
    * get lighter, matching dark mode's direction. Tuned literal (previously
    * derived from 1 - surface); retune alongside --surface.
    */
-  --surface: 0.98;
+  --surface: 0.995;
   --elevation-step: 0.024;
   --contrast: 0.53;
   --foreground-lightness: 0.16;


### PR DESCRIPTION
Adjusts surface value for light theme

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Refined the light theme’s color tuning (including a small adjustment to chroma) and retuned the canvas surface tone.
  * Updated code block light-theme styling so string literal token colors are now `#c46a0a` (applied consistently across the design system, docs, learning, and UI library).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->