### PR TITLE
feat(studio): surface critical notifications layout-wide

### DIFF
--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -226,10 +226,21 @@ export function SideBarNavLink({
 }
 
 const ActiveDot = ({ hasErrors, hasWarnings }: { hasErrors: boolean; hasWarnings: boolean }) => {
+  const [sidebarBehaviour] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.SIDEBAR_BEHAVIOR,
+    DEFAULT_SIDEBAR_BEHAVIOR
+  )
+
+  // The nav icon only shifts right (pl-1.5 -> pl-2) when the sidebar is
+  // persistently open — not on hover-expand. Tie the dot to the same
+  // condition so it stays put while skimming the nav.
+  const isPersistentlyOpen = sidebarBehaviour === 'open'
+
   return (
     <div
       className={cn(
-        'absolute pointer-events-none flex h-2 w-2 left-[18px] group-data-[state=expanded]:left-[20px] top-2 z-10 rounded-full',
+        'absolute pointer-events-none flex h-2 w-2 top-2 z-10 rounded-full',
+        isPersistentlyOpen ? 'left-[20px]' : 'left-[18px]',
         hasErrors ? 'bg-destructive-600' : hasWarnings ? 'bg-warning-600' : 'bg-transparent'
       )}
     />

--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -36,10 +36,10 @@ import {
   generateSettingsRoutes,
   generateToolRoutes,
 } from '@/components/layouts/Navigation/NavigationBar/NavigationBar.utils'
+import { useAdvisorAttention } from '@/components/ui/AdvisorPanel/useAdvisorAttention'
 import { ProjectIndexPageLink } from '@/data/prefetchers/project.$ref'
 import { useHideSidebar } from '@/hooks/misc/useHideSidebar'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
-import { useLints } from '@/hooks/misc/useLints'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -240,7 +240,7 @@ const ProjectLinks = () => {
   const router = useRouter()
   const { ref } = useParams()
   const { data: project, isPending: isProjectPending } = useSelectedProjectQuery()
-  const { securityLints, errorLints } = useLints()
+  const { hasCriticalIssues, hasWarningIssues } = useAdvisorAttention({ projectRef: ref })
   const showReports = useIsFeatureEnabled('reports:all')
   const showLogs = useIsFeatureEnabled('logs:all')
 
@@ -319,10 +319,7 @@ const ProjectLinks = () => {
             return (
               <div className="relative" key={route.key}>
                 {!route.disabled && (
-                  <ActiveDot
-                    hasErrors={errorLints.length > 0}
-                    hasWarnings={securityLints.length > 0}
-                  />
+                  <ActiveDot hasErrors={hasCriticalIssues} hasWarnings={hasWarningIssues} />
                 )}
                 <SideBarNavLink
                   key={route.key}

--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.self-hosted.test.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.self-hosted.test.tsx
@@ -1,30 +1,16 @@
+import { screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { AdvisorButton } from '@/components/layouts/AppLayout/AdvisorButton'
 import { render } from '@/tests/helpers'
 
-const {
-  mockUseProjectLintsQuery,
-  mockUseNotificationsV2Query,
-  mockUseAdvisorSignals,
-  mockToggleSidebar,
-} = vi.hoisted(() => ({
-  mockUseProjectLintsQuery: vi.fn(),
-  mockUseNotificationsV2Query: vi.fn(),
-  mockUseAdvisorSignals: vi.fn(),
+const { mockUseAdvisorAttention, mockToggleSidebar } = vi.hoisted(() => ({
+  mockUseAdvisorAttention: vi.fn(),
   mockToggleSidebar: vi.fn(),
 }))
 
-vi.mock('@/data/lint/lint-query', () => ({
-  useProjectLintsQuery: mockUseProjectLintsQuery,
-}))
-
-vi.mock('@/data/notifications/notifications-v2-query', () => ({
-  useNotificationsV2Query: mockUseNotificationsV2Query,
-}))
-
-vi.mock('@/components/ui/AdvisorPanel/useAdvisorSignals', () => ({
-  useAdvisorSignals: mockUseAdvisorSignals,
+vi.mock('@/components/ui/AdvisorPanel/useAdvisorAttention', () => ({
+  useAdvisorAttention: mockUseAdvisorAttention,
 }))
 
 vi.mock('@/lib/constants', async (importOriginal) => ({
@@ -41,17 +27,11 @@ vi.mock('@/state/sidebar-manager-state', () => ({
 
 describe('AdvisorButton on self-hosted', () => {
   beforeEach(() => {
-    mockUseProjectLintsQuery.mockReturnValue({ data: [], isPending: false, isError: false })
-    mockUseNotificationsV2Query.mockReturnValue({
-      data: { pages: [[]] },
-      isPending: false,
-      isError: false,
-    })
-    mockUseAdvisorSignals.mockReturnValue({
-      data: [],
-      isPending: false,
-      isError: false,
-      dismissSignal: vi.fn(),
+    mockUseAdvisorAttention.mockReturnValue({
+      hasCriticalIssues: false,
+      hasWarningIssues: false,
+      hasUnreadNotifications: false,
+      criticalNotifications: [],
     })
   })
 
@@ -59,12 +39,10 @@ describe('AdvisorButton on self-hosted', () => {
     vi.clearAllMocks()
   })
 
-  it('disables the notifications query so no request is made to the platform endpoint', () => {
+  it('renders without platform notification state', () => {
     render(<AdvisorButton projectRef="project-ref" />)
 
-    expect(mockUseNotificationsV2Query).toHaveBeenCalledWith(
-      { filters: {}, limit: 20 },
-      { enabled: false }
-    )
+    expect(mockUseAdvisorAttention).toHaveBeenCalledWith({ projectRef: 'project-ref' })
+    expect(screen.getByRole('button')).toBeInTheDocument()
   })
 })

--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.test.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.test.tsx
@@ -4,33 +4,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { AdvisorButton } from '@/components/layouts/AppLayout/AdvisorButton'
 import { render } from '@/tests/helpers'
 
-const {
-  mockUseProjectLintsQuery,
-  mockUseNotificationsV2Query,
-  mockUseAdvisorSignals,
-  mockToggleSidebar,
-} = vi.hoisted(() => ({
-  mockUseProjectLintsQuery: vi.fn(),
-  mockUseNotificationsV2Query: vi.fn(),
-  mockUseAdvisorSignals: vi.fn(),
+const { mockUseAdvisorAttention, mockToggleSidebar } = vi.hoisted(() => ({
+  mockUseAdvisorAttention: vi.fn(),
   mockToggleSidebar: vi.fn(),
 }))
 
-vi.mock('@/data/lint/lint-query', () => ({
-  useProjectLintsQuery: mockUseProjectLintsQuery,
-}))
-
-vi.mock('@/data/notifications/notifications-v2-query', () => ({
-  useNotificationsV2Query: mockUseNotificationsV2Query,
-}))
-
-vi.mock('@/components/ui/AdvisorPanel/useAdvisorSignals', () => ({
-  useAdvisorSignals: mockUseAdvisorSignals,
-}))
-
-vi.mock('@/lib/constants', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('@/lib/constants')>()),
-  IS_PLATFORM: true,
+vi.mock('@/components/ui/AdvisorPanel/useAdvisorAttention', () => ({
+  useAdvisorAttention: mockUseAdvisorAttention,
 }))
 
 vi.mock('@/state/sidebar-manager-state', () => ({
@@ -42,17 +22,11 @@ vi.mock('@/state/sidebar-manager-state', () => ({
 
 describe('AdvisorButton', () => {
   beforeEach(() => {
-    mockUseProjectLintsQuery.mockReturnValue({ data: [], isPending: false, isError: false })
-    mockUseNotificationsV2Query.mockReturnValue({
-      data: { pages: [[]] },
-      isPending: false,
-      isError: false,
-    })
-    mockUseAdvisorSignals.mockReturnValue({
-      data: [],
-      isPending: false,
-      isError: false,
-      dismissSignal: vi.fn(),
+    mockUseAdvisorAttention.mockReturnValue({
+      hasCriticalIssues: false,
+      hasWarningIssues: false,
+      hasUnreadNotifications: false,
+      criticalNotifications: [],
     })
   })
 
@@ -61,27 +35,11 @@ describe('AdvisorButton', () => {
   })
 
   it('shows a warning dot when advisor signals are present', () => {
-    mockUseAdvisorSignals.mockReturnValue({
-      data: [
-        {
-          id: 'signal-1',
-          fingerprint: 'signal:banned-ip:203.0.113.10:v1',
-          source: 'signal',
-          signalType: 'banned-ip',
-          severity: 'warning',
-          tab: 'security',
-          title: 'Banned IP address',
-          description: 'Signal',
-          actions: [],
-          sourceData: {
-            type: 'banned-ip',
-            ip: '203.0.113.10',
-          },
-        },
-      ],
-      isPending: false,
-      isError: false,
-      dismissSignal: vi.fn(),
+    mockUseAdvisorAttention.mockReturnValue({
+      hasCriticalIssues: false,
+      hasWarningIssues: true,
+      hasUnreadNotifications: false,
+      criticalNotifications: [],
     })
 
     const { container } = render(<AdvisorButton projectRef="project-ref" />)
@@ -92,65 +50,26 @@ describe('AdvisorButton', () => {
   })
 
   it('keeps the destructive dot when a critical issue is present', () => {
-    mockUseProjectLintsQuery.mockReturnValue({
-      data: [
-        {
-          cache_key: 'lint-1',
-          name: 'unknown_lint',
-          detail: 'Critical lint detail',
-          description: 'Description',
-          level: 'ERROR',
-          categories: ['SECURITY'],
-          metadata: {},
-        },
-      ],
-      isPending: false,
-      isError: false,
-    })
-    mockUseAdvisorSignals.mockReturnValue({
-      data: [
-        {
-          id: 'signal-1',
-          fingerprint: 'signal:banned-ip:203.0.113.10:v1',
-          source: 'signal',
-          signalType: 'banned-ip',
-          severity: 'warning',
-          tab: 'security',
-          title: 'Banned IP address',
-          description: 'Signal',
-          actions: [],
-          sourceData: {
-            type: 'banned-ip',
-            ip: '203.0.113.10',
-          },
-        },
-      ],
-      isPending: false,
-      isError: false,
-      dismissSignal: vi.fn(),
+    mockUseAdvisorAttention.mockReturnValue({
+      hasCriticalIssues: true,
+      hasWarningIssues: false,
+      hasUnreadNotifications: false,
+      criticalNotifications: [],
     })
 
     const { container } = render(<AdvisorButton projectRef="project-ref" />)
 
     expect(container.querySelector('.bg-destructive')).toBeInTheDocument()
     expect(container.querySelector('.bg-warning')).not.toBeInTheDocument()
+    expect(container.querySelector('.text-destructive')).toBeInTheDocument()
   })
 
   it('falls back to the brand dot for unread notifications when there are no issues', () => {
-    mockUseNotificationsV2Query.mockReturnValue({
-      data: {
-        pages: [
-          [
-            {
-              id: 'notif-1',
-              status: 'new',
-              priority: 'Info',
-            },
-          ],
-        ],
-      },
-      isPending: false,
-      isError: false,
+    mockUseAdvisorAttention.mockReturnValue({
+      hasCriticalIssues: false,
+      hasWarningIssues: false,
+      hasUnreadNotifications: true,
+      criticalNotifications: [],
     })
 
     const { container } = render(<AdvisorButton projectRef="project-ref" />)

--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
@@ -22,15 +22,20 @@ export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
   }
 
   return (
-    <div className="relative">
+    <div className="relative inline-flex size-8 items-center justify-center">
       <ButtonTooltip
         variant="outline"
         size="tiny"
         id="advisor-center-trigger"
         className={cn(
           'rounded-full w-[32px] h-[32px] flex items-center justify-center p-0 group',
-          hasCriticalIssues && 'bg-destructive-200 border-destructive-500',
-          isOpen && 'bg-foreground text-background'
+          hasCriticalIssues &&
+            !isOpen &&
+            'bg-destructive-200 border-destructive-500 hover:border-destructive-600',
+          hasCriticalIssues &&
+            isOpen &&
+            'bg-destructive-300 border-destructive-500 hover:border-destructive-600',
+          !hasCriticalIssues && isOpen && 'bg-foreground text-background'
         )}
         onClick={handleClick}
         tooltip={{
@@ -43,19 +48,19 @@ export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
           size={16}
           strokeWidth={1.5}
           className={cn(
-            hasCriticalIssues && !isOpen && 'text-destructive group-hover:text-destructive',
-            !hasCriticalIssues && 'text-foreground-light group-hover:text-foreground',
-            isOpen && 'text-background group-hover:text-background'
+            hasCriticalIssues && 'text-destructive group-hover:text-destructive',
+            !hasCriticalIssues && !isOpen && 'text-foreground-light group-hover:text-foreground',
+            !hasCriticalIssues && isOpen && 'text-background group-hover:text-background'
           )}
         />
         <span className="sr-only">Advisor Center</span>
       </ButtonTooltip>
       {hasCriticalIssues ? (
-        <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-destructive" />
+        <span className="pointer-events-none absolute top-1 right-1 w-2 h-2 rounded-full bg-destructive" />
       ) : hasWarningIssues ? (
-        <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-warning" />
+        <span className="pointer-events-none absolute top-1 right-1 w-2 h-2 rounded-full bg-warning" />
       ) : hasUnreadNotifications ? (
-        <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-brand" />
+        <span className="pointer-events-none absolute top-1 right-1 w-2 h-2 rounded-full bg-brand" />
       ) : null}
     </div>
   )

--- a/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
+++ b/apps/studio/components/layouts/AppLayout/AdvisorButton.tsx
@@ -1,40 +1,18 @@
 import { Lightbulb } from 'lucide-react'
-import { useMemo } from 'react'
 import { cn } from 'ui'
 
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
-import { useAdvisorSignals } from '@/components/ui/AdvisorPanel/useAdvisorSignals'
+import { useAdvisorAttention } from '@/components/ui/AdvisorPanel/useAdvisorAttention'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
-import { useProjectLintsQuery } from '@/data/lint/lint-query'
-import { useNotificationsV2Query } from '@/data/notifications/notifications-v2-query'
-import { IS_PLATFORM } from '@/lib/constants'
 import { useTrack } from '@/lib/telemetry/track'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
   const { toggleSidebar, activeSidebar } = useSidebarManagerSnapshot()
   const track = useTrack()
-
-  const { data: lints } = useProjectLintsQuery({ projectRef })
-  const { data: signalItems } = useAdvisorSignals({ projectRef })
-
-  const { data: notificationsData } = useNotificationsV2Query(
-    { filters: {}, limit: 20 },
-    { enabled: IS_PLATFORM }
-  )
-  const notifications = useMemo(() => {
-    return notificationsData?.pages.flatMap((page) => page) ?? []
-  }, [notificationsData?.pages])
-  const hasUnreadNotifications = notifications.some((x) => x?.status === 'new')
-  const hasCriticalNotifications = notifications.some((x) => x?.priority === 'Critical')
-  const hasSignals = signalItems.length > 0
-  const hasCriticalSignals = signalItems.some((item) => item.severity === 'critical')
-
-  const hasCriticalIssues =
-    hasCriticalNotifications ||
-    hasCriticalSignals ||
-    (Array.isArray(lints) && lints.some((lint) => lint.level === 'ERROR'))
-  const hasWarningIssues = hasSignals && !hasCriticalIssues
+  const { hasCriticalIssues, hasWarningIssues, hasUnreadNotifications } = useAdvisorAttention({
+    projectRef,
+  })
 
   const isOpen = activeSidebar?.id === SIDEBAR_KEYS.ADVISOR_PANEL
 
@@ -65,18 +43,19 @@ export const AdvisorButton = ({ projectRef }: { projectRef?: string }) => {
           size={16}
           strokeWidth={1.5}
           className={cn(
-            'text-foreground-light group-hover:text-foreground',
+            hasCriticalIssues && !isOpen && 'text-destructive group-hover:text-destructive',
+            !hasCriticalIssues && 'text-foreground-light group-hover:text-foreground',
             isOpen && 'text-background group-hover:text-background'
           )}
         />
         <span className="sr-only">Advisor Center</span>
       </ButtonTooltip>
       {hasCriticalIssues ? (
-        <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-destructive" />
+        <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-destructive" />
       ) : hasWarningIssues ? (
-        <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-warning" />
+        <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-warning" />
       ) : hasUnreadNotifications ? (
-        <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-brand" />
+        <span className="absolute top-1 right-1 w-2 h-2 rounded-full bg-brand" />
       ) : null}
     </div>
   )

--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren, useEffect, useState } from 'react'
 import { ResizablePanel, ResizablePanelGroup, SidebarProvider } from 'ui'
 
 import { BannerStack } from '../ui/BannerStack/BannerStack'
+import { CriticalNotificationBannerManager } from '../ui/BannerStack/CriticalNotificationBannerManager'
 import { LayoutHeader } from './Navigation/LayoutHeader/LayoutHeader'
 import MobileNavigationBar from './Navigation/NavigationBar/MobileNavigationBar'
 import { MobileSheetProvider } from './Navigation/NavigationBar/MobileSheetContext'
@@ -124,6 +125,7 @@ export const DefaultLayout = ({
             </div>
 
             <BannerStack />
+            <CriticalNotificationBannerManager />
             <StudioMobileSheetNav />
           </MobileSheetProvider>
         </ProjectContextProvider>

--- a/apps/studio/components/ui/AdvisorPanel/useAdvisorAttention.ts
+++ b/apps/studio/components/ui/AdvisorPanel/useAdvisorAttention.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react'
+
+import { computeAdvisorAttention } from './useAdvisorAttention.utils'
+import { useAdvisorSignals } from './useAdvisorSignals'
+import { useProjectLintsQuery } from '@/data/lint/lint-query'
+import { useNotificationsV2Query } from '@/data/notifications/notifications-v2-query'
+import { IS_PLATFORM } from '@/lib/constants'
+
+interface UseAdvisorAttentionOptions {
+  projectRef?: string
+  enabled?: boolean
+}
+
+export const useAdvisorAttention = ({
+  projectRef,
+  enabled = true,
+}: UseAdvisorAttentionOptions = {}) => {
+  const { data: lints } = useProjectLintsQuery({ projectRef }, { enabled: enabled && !!projectRef })
+
+  const { data: signalItems } = useAdvisorSignals({
+    projectRef,
+    enabled: enabled && !!projectRef,
+  })
+
+  const { data: notificationsData } = useNotificationsV2Query(
+    { filters: {}, limit: 20 },
+    { enabled: enabled && IS_PLATFORM }
+  )
+
+  const notifications = useMemo(() => {
+    return notificationsData?.pages.flatMap((page) => page) ?? []
+  }, [notificationsData?.pages])
+
+  return useMemo(
+    () =>
+      computeAdvisorAttention({
+        lints,
+        signalItems,
+        notifications,
+      }),
+    [lints, signalItems, notifications]
+  )
+}

--- a/apps/studio/components/ui/AdvisorPanel/useAdvisorAttention.utils.ts
+++ b/apps/studio/components/ui/AdvisorPanel/useAdvisorAttention.utils.ts
@@ -1,0 +1,37 @@
+import type { AdvisorSignalItem } from './AdvisorPanel.types'
+import type { Lint } from '@/data/lint/lint-query'
+import type { Notification } from '@/data/notifications/notifications-v2-query'
+
+export function isCriticalUnreadNotification(notification: Notification) {
+  return notification.status === 'new' && notification.priority === 'Critical'
+}
+
+export function computeAdvisorAttention({
+  lints,
+  signalItems,
+  notifications,
+}: {
+  lints?: Lint[]
+  signalItems: AdvisorSignalItem[]
+  notifications: Notification[]
+}) {
+  const hasCriticalNotifications = notifications.some(
+    (notification) => notification.priority === 'Critical'
+  )
+  const hasUnreadNotifications = notifications.some((notification) => notification.status === 'new')
+  const hasSignals = signalItems.length > 0
+  const hasCriticalSignals = signalItems.some((item) => item.severity === 'critical')
+  const hasCriticalLint = Array.isArray(lints) && lints.some((lint) => lint.level === 'ERROR')
+
+  const hasCriticalIssues = hasCriticalNotifications || hasCriticalSignals || hasCriticalLint
+  const hasWarningIssues = hasSignals && !hasCriticalIssues
+
+  const criticalNotifications = notifications.filter(isCriticalUnreadNotification)
+
+  return {
+    hasCriticalIssues,
+    hasWarningIssues,
+    hasUnreadNotifications,
+    criticalNotifications,
+  }
+}

--- a/apps/studio/components/ui/BannerStack/BannerCard.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerCard.tsx
@@ -7,24 +7,40 @@ interface BannerCardProps {
   onDismiss?: () => void
   children: React.ReactNode
   className?: string
+  variant?: 'default' | 'critical'
 }
 
-export const BannerCard = ({ onDismiss, children, className }: BannerCardProps) => {
+export const BannerCard = ({
+  onDismiss,
+  children,
+  className,
+  variant = 'default',
+}: BannerCardProps) => {
+  const isCritical = variant === 'critical'
+
   return (
-    <Card className={cn('relative overflow-hidden shadow-lg rounded-2xl', className)}>
-      <div className="absolute -inset-16 z-0 opacity-100 pointer-events-none">
-        <img
-          src={`${BASE_PATH}/img/reports/bg-grafana-dark.svg`}
-          alt="Background pattern"
-          className="w-full h-full object-cover object-right hidden dark:block"
-        />
-        <img
-          src={`${BASE_PATH}/img/reports/bg-grafana-light.svg`}
-          alt="Background pattern"
-          className="w-full h-full object-cover object-right dark:hidden"
-        />
-        <div className="absolute inset-0 bg-linear-to-r from-background-alternative to-transparent" />
-      </div>
+    <Card
+      className={cn(
+        'relative overflow-hidden shadow-lg rounded-2xl',
+        isCritical && 'border-destructive-400',
+        className
+      )}
+    >
+      {!isCritical && (
+        <div className="absolute -inset-16 z-0 opacity-100 pointer-events-none">
+          <img
+            src={`${BASE_PATH}/img/reports/bg-grafana-dark.svg`}
+            alt="Background pattern"
+            className="w-full h-full object-cover object-right hidden dark:block"
+          />
+          <img
+            src={`${BASE_PATH}/img/reports/bg-grafana-light.svg`}
+            alt="Background pattern"
+            className="w-full h-full object-cover object-right dark:hidden"
+          />
+          <div className="absolute inset-0 bg-linear-to-r from-background-alternative to-transparent" />
+        </div>
+      )}
 
       <CardContent className="relative z-10 p-6">
         {onDismiss && (

--- a/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
+++ b/apps/studio/components/ui/BannerStack/BannerStackProvider.tsx
@@ -11,7 +11,11 @@ export const BANNER_ID = {
   UNIFIED_LOGS: 'unified-logs-banner',
 } as const
 
-export type BannerId = (typeof BANNER_ID)[keyof typeof BANNER_ID]
+export const CRITICAL_NOTIFICATION_BANNER_PRIORITY = 10
+
+export type BannerId =
+  | (typeof BANNER_ID)[keyof typeof BANNER_ID]
+  | `critical-notification:${string}`
 
 export interface Banner {
   id: BannerId
@@ -41,7 +45,7 @@ export const BannerStackProvider = ({ children }: { children: React.ReactNode })
     })
   }, [])
 
-  const dismissBanner = useCallback((id: string) => {
+  const dismissBanner = useCallback((id: BannerId) => {
     setBanners((prev) => prev.map((b) => (b.id === id ? { ...b, isDismissed: true } : b)))
     setTimeout(() => {
       setBanners((prev) => prev.filter((b) => b.id !== id))

--- a/apps/studio/components/ui/BannerStack/Banners/BannerCriticalNotification.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerCriticalNotification.tsx
@@ -20,7 +20,7 @@ export const BannerCriticalNotification = ({
   const message = data.message?.replace(/[#*_`[\]]/g, '').trim()
 
   return (
-    <BannerCard variant="critical">
+    <BannerCard variant="critical" onDismiss={onArchive}>
       <div className="flex flex-col gap-y-4">
         <div className="flex flex-col gap-y-2 items-start">
           <div className="p-2 rounded-lg bg-destructive-200 text-destructive">
@@ -31,7 +31,7 @@ export const BannerCriticalNotification = ({
           <Badge variant="destructive" className="w-min uppercase">
             Critical
           </Badge>
-          <p className="text-sm font-medium">{title}</p>
+          <p className="text-sm font-medium pr-6">{title}</p>
           {message ? (
             <p className="text-xs text-foreground-lighter text-balance line-clamp-3">{message}</p>
           ) : null}
@@ -39,9 +39,6 @@ export const BannerCriticalNotification = ({
         <div className="flex gap-2">
           <Button variant="default" size="tiny" onClick={onViewDetails}>
             View details
-          </Button>
-          <Button variant="outline" size="tiny" onClick={onArchive}>
-            Archive
           </Button>
         </div>
       </div>

--- a/apps/studio/components/ui/BannerStack/Banners/BannerCriticalNotification.tsx
+++ b/apps/studio/components/ui/BannerStack/Banners/BannerCriticalNotification.tsx
@@ -1,0 +1,50 @@
+import { AlertTriangle } from 'lucide-react'
+import { Badge, Button } from 'ui'
+
+import { BannerCard } from '../BannerCard'
+import type { Notification, NotificationData } from '@/data/notifications/notifications-v2-query'
+
+interface BannerCriticalNotificationProps {
+  notification: Notification
+  onArchive: () => void
+  onViewDetails: () => void
+}
+
+export const BannerCriticalNotification = ({
+  notification,
+  onArchive,
+  onViewDetails,
+}: BannerCriticalNotificationProps) => {
+  const data = notification.data as NotificationData
+  const title = data.title || 'Critical notification'
+  const message = data.message?.replace(/[#*_`[\]]/g, '').trim()
+
+  return (
+    <BannerCard variant="critical">
+      <div className="flex flex-col gap-y-4">
+        <div className="flex flex-col gap-y-2 items-start">
+          <div className="p-2 rounded-lg bg-destructive-200 text-destructive">
+            <AlertTriangle size={16} />
+          </div>
+        </div>
+        <div className="flex flex-col gap-y-1 mb-2">
+          <Badge variant="destructive" className="w-min uppercase">
+            Critical
+          </Badge>
+          <p className="text-sm font-medium">{title}</p>
+          {message ? (
+            <p className="text-xs text-foreground-lighter text-balance line-clamp-3">{message}</p>
+          ) : null}
+        </div>
+        <div className="flex gap-2">
+          <Button variant="default" size="tiny" onClick={onViewDetails}>
+            View details
+          </Button>
+          <Button variant="outline" size="tiny" onClick={onArchive}>
+            Archive
+          </Button>
+        </div>
+      </div>
+    </BannerCard>
+  )
+}

--- a/apps/studio/components/ui/BannerStack/CriticalNotificationBannerManager.tsx
+++ b/apps/studio/components/ui/BannerStack/CriticalNotificationBannerManager.tsx
@@ -23,7 +23,7 @@ export const CriticalNotificationBannerManager = () => {
   const router = useRouter()
   const track = useTrack()
   const { addBanner, dismissBanner } = useBannerStack()
-  const { toggleSidebar } = useSidebarManagerSnapshot()
+  const { openSidebar } = useSidebarManagerSnapshot()
   const { mutate: updateNotifications } = useNotificationsV2UpdateMutation()
   const activeBannerIdsRef = useRef(new Set<string>())
 
@@ -88,13 +88,17 @@ export const CriticalNotificationBannerManager = () => {
                 tab: 'messages',
                 source: 'notification',
               })
-              toggleSidebar(SIDEBAR_KEYS.ADVISOR_PANEL)
+              openSidebar(SIDEBAR_KEYS.ADVISOR_PANEL)
+              // Once the user is looking at the item in the panel, retire the loud
+              // banner for the session (without archiving — the inbox entry stays).
+              addSessionDismissedCriticalNotificationId(notification.id)
+              dismissBanner(bannerId)
             }}
           />
         ),
       })
     })
-  }, [surfacedNotifications, addBanner, dismissBanner, track, toggleSidebar, updateNotifications])
+  }, [surfacedNotifications, addBanner, dismissBanner, track, openSidebar, updateNotifications])
 
   return null
 }

--- a/apps/studio/components/ui/BannerStack/CriticalNotificationBannerManager.tsx
+++ b/apps/studio/components/ui/BannerStack/CriticalNotificationBannerManager.tsx
@@ -1,0 +1,100 @@
+import { useParams } from 'common'
+import { useRouter } from 'next/router'
+import { useEffect, useMemo, useRef } from 'react'
+
+import { BannerCriticalNotification } from './Banners/BannerCriticalNotification'
+import { CRITICAL_NOTIFICATION_BANNER_PRIORITY, useBannerStack } from './BannerStackProvider'
+import {
+  addSessionDismissedCriticalNotificationId,
+  getCriticalNotificationBannerId,
+  getSessionDismissedCriticalNotificationIds,
+  shouldSurfaceCriticalNotification,
+} from './CriticalNotificationBannerManager.utils'
+import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import { useAdvisorAttention } from '@/components/ui/AdvisorPanel/useAdvisorAttention'
+import { useNotificationsV2UpdateMutation } from '@/data/notifications/notifications-v2-update-mutation'
+import { IS_PLATFORM } from '@/lib/constants'
+import { useTrack } from '@/lib/telemetry/track'
+import { advisorState } from '@/state/advisor-state'
+import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
+
+export const CriticalNotificationBannerManager = () => {
+  const { ref: projectRef } = useParams()
+  const router = useRouter()
+  const track = useTrack()
+  const { addBanner, dismissBanner } = useBannerStack()
+  const { toggleSidebar } = useSidebarManagerSnapshot()
+  const { mutate: updateNotifications } = useNotificationsV2UpdateMutation()
+  const activeBannerIdsRef = useRef(new Set<string>())
+
+  const { criticalNotifications } = useAdvisorAttention({ projectRef, enabled: IS_PLATFORM })
+
+  const surfacedNotifications = useMemo(() => {
+    const sessionDismissedIds = new Set(getSessionDismissedCriticalNotificationIds())
+
+    return criticalNotifications
+      .filter((notification) =>
+        shouldSurfaceCriticalNotification(notification, {
+          projectRef,
+          pathname: router.pathname,
+        })
+      )
+      .filter((notification) => !sessionDismissedIds.has(notification.id))
+      .sort((a, b) => {
+        const aTime = a.inserted_at ? new Date(a.inserted_at).getTime() : 0
+        const bTime = b.inserted_at ? new Date(b.inserted_at).getTime() : 0
+        return bTime - aTime
+      })
+  }, [criticalNotifications, projectRef, router.pathname])
+
+  useEffect(() => {
+    if (!IS_PLATFORM) return
+
+    const activeBannerIds = new Set(
+      surfacedNotifications.map((notification) => getCriticalNotificationBannerId(notification.id))
+    )
+
+    activeBannerIdsRef.current.forEach((bannerId) => {
+      if (!activeBannerIds.has(bannerId)) {
+        dismissBanner(bannerId)
+      }
+    })
+    activeBannerIdsRef.current = activeBannerIds
+
+    surfacedNotifications.forEach((notification) => {
+      const bannerId = getCriticalNotificationBannerId(notification.id)
+
+      addBanner({
+        id: bannerId,
+        isDismissed: false,
+        priority: CRITICAL_NOTIFICATION_BANNER_PRIORITY,
+        content: (
+          <BannerCriticalNotification
+            notification={notification}
+            onArchive={() => {
+              track('critical_notification_banner_archive_clicked', {
+                notificationId: notification.id,
+              })
+              addSessionDismissedCriticalNotificationId(notification.id)
+              dismissBanner(bannerId)
+              updateNotifications({ ids: [notification.id], status: 'archived' })
+            }}
+            onViewDetails={() => {
+              track('critical_notification_banner_cta_clicked', {
+                notificationId: notification.id,
+              })
+              advisorState.focusItem({
+                id: notification.id,
+                tab: 'messages',
+                source: 'notification',
+              })
+              toggleSidebar(SIDEBAR_KEYS.ADVISOR_PANEL)
+            }}
+          />
+        ),
+      })
+    })
+  }, [surfacedNotifications, addBanner, dismissBanner, track, toggleSidebar, updateNotifications])
+
+  return null
+}

--- a/apps/studio/components/ui/BannerStack/CriticalNotificationBannerManager.utils.ts
+++ b/apps/studio/components/ui/BannerStack/CriticalNotificationBannerManager.utils.ts
@@ -1,0 +1,67 @@
+import { isCriticalUnreadNotification } from '@/components/ui/AdvisorPanel/useAdvisorAttention.utils'
+import type { Notification, NotificationData } from '@/data/notifications/notifications-v2-query'
+
+export const CRITICAL_NOTIFICATION_BANNER_ID_PREFIX = 'critical-notification:' as const
+
+export function getCriticalNotificationBannerId(notificationId: string) {
+  return `${CRITICAL_NOTIFICATION_BANNER_ID_PREFIX}${notificationId}` as const
+}
+
+export function shouldSurfaceCriticalNotification(
+  notification: Notification,
+  {
+    projectRef,
+    pathname,
+  }: {
+    projectRef?: string
+    pathname: string
+  }
+) {
+  if (!isCriticalUnreadNotification(notification)) return false
+
+  const data = notification.data as NotificationData
+  const notificationProjectRef = data.project_ref
+  const notificationOrgSlug = data.org_slug
+
+  if (pathname.startsWith('/project/') && projectRef) {
+    return !notificationProjectRef || notificationProjectRef === projectRef
+  }
+
+  if (pathname.startsWith('/org/')) {
+    const orgSlug = pathname.split('/')[2]
+    if (notificationProjectRef) return false
+    return !notificationOrgSlug || notificationOrgSlug === orgSlug
+  }
+
+  if (pathname.startsWith('/account')) {
+    return !notificationProjectRef
+  }
+
+  return !notificationProjectRef
+}
+
+export const CRITICAL_NOTIFICATION_BANNER_SESSION_KEY = 'critical-notification-banners-dismissed'
+
+export function getSessionDismissedCriticalNotificationIds(): string[] {
+  if (typeof window === 'undefined') return []
+
+  try {
+    const value = window.sessionStorage.getItem(CRITICAL_NOTIFICATION_BANNER_SESSION_KEY)
+    if (!value) return []
+    const parsed = JSON.parse(value)
+    return Array.isArray(parsed) ? parsed.filter((id) => typeof id === 'string') : []
+  } catch {
+    return []
+  }
+}
+
+export function addSessionDismissedCriticalNotificationId(notificationId: string) {
+  if (typeof window === 'undefined') return
+
+  const current = new Set(getSessionDismissedCriticalNotificationIds())
+  current.add(notificationId)
+  window.sessionStorage.setItem(
+    CRITICAL_NOTIFICATION_BANNER_SESSION_KEY,
+    JSON.stringify([...current])
+  )
+}

--- a/apps/studio/tests/components/ui/AdvisorPanel/useAdvisorAttention.test.ts
+++ b/apps/studio/tests/components/ui/AdvisorPanel/useAdvisorAttention.test.ts
@@ -1,0 +1,59 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useAdvisorAttention } from '@/components/ui/AdvisorPanel/useAdvisorAttention'
+
+const { mockUseProjectLintsQuery, mockUseNotificationsV2Query, mockUseAdvisorSignals } = vi.hoisted(
+  () => ({
+    mockUseProjectLintsQuery: vi.fn(),
+    mockUseNotificationsV2Query: vi.fn(),
+    mockUseAdvisorSignals: vi.fn(),
+  })
+)
+
+vi.mock('@/data/lint/lint-query', () => ({
+  useProjectLintsQuery: mockUseProjectLintsQuery,
+}))
+
+vi.mock('@/data/notifications/notifications-v2-query', () => ({
+  useNotificationsV2Query: mockUseNotificationsV2Query,
+}))
+
+vi.mock('@/components/ui/AdvisorPanel/useAdvisorSignals', () => ({
+  useAdvisorSignals: mockUseAdvisorSignals,
+}))
+
+vi.mock('@/lib/constants', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('@/lib/constants')>()),
+  IS_PLATFORM: false,
+}))
+
+describe('useAdvisorAttention on self-hosted', () => {
+  beforeEach(() => {
+    mockUseProjectLintsQuery.mockReturnValue({ data: [], isPending: false, isError: false })
+    mockUseNotificationsV2Query.mockReturnValue({
+      data: { pages: [[]] },
+      isPending: false,
+      isError: false,
+    })
+    mockUseAdvisorSignals.mockReturnValue({
+      data: [],
+      isPending: false,
+      isError: false,
+      dismissSignal: vi.fn(),
+    })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('disables the notifications query so no request is made to the platform endpoint', () => {
+    renderHook(() => useAdvisorAttention({ projectRef: 'project-ref' }))
+
+    expect(mockUseNotificationsV2Query).toHaveBeenCalledWith(
+      { filters: {}, limit: 20 },
+      { enabled: false }
+    )
+  })
+})

--- a/apps/studio/tests/components/ui/AdvisorPanel/useAdvisorAttention.utils.test.ts
+++ b/apps/studio/tests/components/ui/AdvisorPanel/useAdvisorAttention.utils.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  computeAdvisorAttention,
+  isCriticalUnreadNotification,
+} from '@/components/ui/AdvisorPanel/useAdvisorAttention.utils'
+import type { Notification } from '@/data/notifications/notifications-v2-query'
+
+const createNotification = (
+  overrides: Partial<Notification> & { data?: Record<string, unknown> }
+): Notification =>
+  ({
+    id: 'notification-1',
+    status: 'new',
+    priority: 'Critical',
+    inserted_at: '2026-06-10T10:00:00Z',
+    data: {
+      title: 'Capacity unavailable',
+      message: 'Unable to resize due to capacity.',
+      actions: [],
+    },
+    ...overrides,
+  }) as Notification
+
+describe('useAdvisorAttention.utils', () => {
+  describe('computeAdvisorAttention', () => {
+    it('marks critical notifications as critical issues', () => {
+      const result = computeAdvisorAttention({
+        lints: [],
+        signalItems: [],
+        notifications: [createNotification({})],
+      })
+
+      expect(result.hasCriticalIssues).toBe(true)
+      expect(result.hasWarningIssues).toBe(false)
+      expect(result.criticalNotifications).toHaveLength(1)
+    })
+
+    it('marks error lints as critical issues', () => {
+      const result = computeAdvisorAttention({
+        lints: [{ level: 'ERROR' } as any],
+        signalItems: [],
+        notifications: [],
+      })
+
+      expect(result.hasCriticalIssues).toBe(true)
+      expect(result.criticalNotifications).toHaveLength(0)
+    })
+
+    it('shows warning issues from signals when there are no critical issues', () => {
+      const result = computeAdvisorAttention({
+        lints: [],
+        signalItems: [
+          {
+            id: 'signal-1',
+            dismissalKey: 'signal-1',
+            source: 'signal',
+            type: 'banned-ip',
+            severity: 'warning',
+            tab: 'security',
+            title: 'Banned IP address',
+            summary: 'Summary',
+            description: 'Description',
+            actions: [],
+            sourceData: { type: 'banned-ip', ip: '203.0.113.10' },
+          },
+        ],
+        notifications: [],
+      })
+
+      expect(result.hasCriticalIssues).toBe(false)
+      expect(result.hasWarningIssues).toBe(true)
+    })
+
+    it('prioritises critical issues over warning signals', () => {
+      const result = computeAdvisorAttention({
+        lints: [],
+        signalItems: [
+          {
+            id: 'signal-1',
+            dismissalKey: 'signal-1',
+            source: 'signal',
+            type: 'banned-ip',
+            severity: 'warning',
+            tab: 'security',
+            title: 'Banned IP address',
+            summary: 'Summary',
+            description: 'Description',
+            actions: [],
+            sourceData: { type: 'banned-ip', ip: '203.0.113.10' },
+          },
+        ],
+        notifications: [createNotification({})],
+      })
+
+      expect(result.hasCriticalIssues).toBe(true)
+      expect(result.hasWarningIssues).toBe(false)
+    })
+
+    it('reports unread notifications without critical issues', () => {
+      const result = computeAdvisorAttention({
+        lints: [],
+        signalItems: [],
+        notifications: [createNotification({ priority: 'Info' })],
+      })
+
+      expect(result.hasUnreadNotifications).toBe(true)
+      expect(result.hasCriticalIssues).toBe(false)
+    })
+  })
+
+  describe('isCriticalUnreadNotification', () => {
+    it('ignores non-critical or read notifications', () => {
+      expect(isCriticalUnreadNotification(createNotification({ priority: 'Warning' }))).toBe(false)
+      expect(isCriticalUnreadNotification(createNotification({ status: 'seen' }))).toBe(false)
+      expect(isCriticalUnreadNotification(createNotification({}))).toBe(true)
+    })
+  })
+})

--- a/apps/studio/tests/components/ui/BannerStack/CriticalNotificationBannerManager.utils.test.ts
+++ b/apps/studio/tests/components/ui/BannerStack/CriticalNotificationBannerManager.utils.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  addSessionDismissedCriticalNotificationId,
+  CRITICAL_NOTIFICATION_BANNER_SESSION_KEY,
+  getCriticalNotificationBannerId,
+  getSessionDismissedCriticalNotificationIds,
+  shouldSurfaceCriticalNotification,
+} from '@/components/ui/BannerStack/CriticalNotificationBannerManager.utils'
+import type { Notification } from '@/data/notifications/notifications-v2-query'
+
+const createNotification = (
+  overrides: Partial<Notification> & { data?: Record<string, unknown> }
+): Notification =>
+  ({
+    id: 'notification-1',
+    status: 'new',
+    priority: 'Critical',
+    inserted_at: '2026-06-10T10:00:00Z',
+    data: {
+      title: 'Capacity unavailable',
+      message: 'Unable to resize due to capacity.',
+      actions: [],
+    },
+    ...overrides,
+  }) as Notification
+
+describe('CriticalNotificationBannerManager.utils', () => {
+  describe('shouldSurfaceCriticalNotification', () => {
+    it('surfaces project-scoped notifications on matching project pages', () => {
+      const notification = createNotification({
+        data: {
+          title: 'Capacity unavailable',
+          message: 'Unable to resize.',
+          project_ref: 'project-ref',
+          actions: [],
+        },
+      })
+
+      expect(
+        shouldSurfaceCriticalNotification(notification, {
+          projectRef: 'project-ref',
+          pathname: '/project/[ref]/settings/compute-and-disk',
+        })
+      ).toBe(true)
+    })
+
+    it('hides project-scoped notifications on other project pages', () => {
+      const notification = createNotification({
+        data: {
+          title: 'Capacity unavailable',
+          message: 'Unable to resize.',
+          project_ref: 'other-ref',
+          actions: [],
+        },
+      })
+
+      expect(
+        shouldSurfaceCriticalNotification(notification, {
+          projectRef: 'project-ref',
+          pathname: '/project/[ref]/settings/compute-and-disk',
+        })
+      ).toBe(false)
+    })
+
+    it('surfaces org-wide notifications on project pages', () => {
+      const notification = createNotification({
+        data: {
+          title: 'Org notice',
+          message: 'Message',
+          actions: [],
+        },
+      })
+
+      expect(
+        shouldSurfaceCriticalNotification(notification, {
+          projectRef: 'project-ref',
+          pathname: '/project/[ref]',
+        })
+      ).toBe(true)
+    })
+
+    it('does not surface non-critical notifications', () => {
+      const notification = createNotification({ priority: 'Warning' })
+
+      expect(
+        shouldSurfaceCriticalNotification(notification, {
+          projectRef: 'project-ref',
+          pathname: '/project/[ref]',
+        })
+      ).toBe(false)
+    })
+  })
+
+  describe('getCriticalNotificationBannerId', () => {
+    it('builds stable banner ids', () => {
+      expect(getCriticalNotificationBannerId('abc')).toBe('critical-notification:abc')
+    })
+  })
+
+  describe('session dismissal helpers', () => {
+    beforeEach(() => {
+      window.sessionStorage.clear()
+    })
+
+    afterEach(() => {
+      window.sessionStorage.clear()
+    })
+
+    it('tracks dismissed notification ids in session storage', () => {
+      expect(getSessionDismissedCriticalNotificationIds()).toEqual([])
+
+      addSessionDismissedCriticalNotificationId('notification-1')
+
+      expect(getSessionDismissedCriticalNotificationIds()).toEqual(['notification-1'])
+      expect(window.sessionStorage.getItem(CRITICAL_NOTIFICATION_BANNER_SESSION_KEY)).toContain(
+        'notification-1'
+      )
+    })
+  })
+})

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -3478,6 +3478,34 @@ export interface HeaderAdvisorButtonClickedEvent {
 }
 
 /**
+ * User clicked the view details CTA on a critical notification banner.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface CriticalNotificationBannerCtaClickedEvent {
+  action: 'critical_notification_banner_cta_clicked'
+  properties: {
+    notificationId: string
+  }
+  groups: Partial<TelemetryGroups>
+}
+
+/**
+ * User clicked archive on a critical notification banner.
+ *
+ * @group Events
+ * @source studio
+ */
+export interface CriticalNotificationBannerArchiveClickedEvent {
+  action: 'critical_notification_banner_archive_clicked'
+  properties: {
+    notificationId: string
+  }
+  groups: Partial<TelemetryGroups>
+}
+
+/**
  * User clicked the Inline SQL Editor toggle button in the page header.
  *
  * @group Events
@@ -3739,6 +3767,8 @@ export type TelemetryEvent =
   | HeaderConnectButtonClickedEvent
   | HeaderFeedbackDropdownOpenedEvent
   | HeaderAdvisorButtonClickedEvent
+  | CriticalNotificationBannerCtaClickedEvent
+  | CriticalNotificationBannerArchiveClickedEvent
   | HeaderInlineEditorButtonClickedEvent
   | HeaderAssistantButtonClickedEvent
   | HeaderUserDropdownOpenedEvent


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature.

## What is the current behavior?

Critical platform notifications are only visible in the notifications inbox / Advisor panel. There is no persistent, impossible-to-miss surface for them, and the one full-width banner we do have (`ResourceExhaustionWarningBanner`) is suppressed on some pages — which is exactly where an incident can be missed. This is the core of DEPR-595.

## What is the new behavior?

Adds a `CriticalNotificationBannerManager` that surfaces `Critical`, unread notifications through the existing `BannerStack`, so they persist layout-wide (including on pages where the full-width banner is suppressed).

- Banners are context-scoped: project-scoped notifications only show on the matching project, org-wide ones show more broadly, etc.
- Each banner uses the standard top-right dismiss (X) shared by the other banners; dismissing archives the notification optimistically.
- The single **View details** action opens (rather than toggles) the Advisor panel focused on the notification, and retires the banner for the session without archiving the underlying inbox entry.
- Adds a `critical` `BannerCard` variant (no decorative background, destructive border) and dynamic banner ids with a high priority so critical alerts sort to the top of the stack.
- Adds click telemetry for the CTA and archive actions to monitor the careful rollout.

## How to test

Real notifications require a `Critical`, unread platform notification scoped to your project/org, which comes from the platform notifications service (not the project database). To exercise the UI locally without one, apply this throwaway mock and visit any project page with `?demo-critical-notification=1`.

<details>
<summary>Local mock (do not commit)</summary>

1. Add `apps/studio/components/ui/BannerStack/CriticalNotificationBannerManager.demo.ts`:

```ts
/**
 * DEMO ONLY — do not commit.
 * Enables a fake Critical notification banner via `?demo-critical-notification=1`.
 */
import type { Notification } from '@/data/notifications/notifications-v2-query'

export const DEMO_CRITICAL_NOTIFICATION_ID = 'demo-critical-notification-depr-595'

export function isDemoCriticalNotificationEnabled(
  query: Record<string, string | string[] | undefined>
) {
  if (process.env.NODE_ENV === 'production') return false
  const value = query['demo-critical-notification']
  if (Array.isArray(value)) return value.includes('1') || value.includes('true')
  return value === '1' || value === 'true'
}

export function createDemoCriticalNotification(projectRef?: string): Notification {
  return {
    id: DEMO_CRITICAL_NOTIFICATION_ID,
    status: 'new',
    priority: 'Critical',
    inserted_at: new Date().toISOString(),
    data: {
      title: 'Capacity unavailable in target availability zone',
      message:
        'We were unable to resize your project due to capacity constraints in the selected availability zone.',
      project_ref: projectRef,
      actions: [],
    },
  } as Notification
}

export function isDemoCriticalNotification(notificationId: string) {
  return notificationId === DEMO_CRITICAL_NOTIFICATION_ID
}
```

2. In `CriticalNotificationBannerManager.tsx`, inject the demo notification before filtering, and skip the server archive for it:

```tsx
import {
  createDemoCriticalNotification,
  isDemoCriticalNotification,
  isDemoCriticalNotificationEnabled,
} from './CriticalNotificationBannerManager.demo'

// inside the component, before `surfacedNotifications`:
const notificationsToSurface = useMemo(() => {
  const notifications = [...criticalNotifications]
  if (isDemoCriticalNotificationEnabled(router.query)) {
    notifications.unshift(createDemoCriticalNotification(projectRef))
  }
  return notifications
}, [criticalNotifications, projectRef, router.query])
// ...then filter `notificationsToSurface` instead of `criticalNotifications`.

// in onArchive, guard the mutation:
if (!isDemoCriticalNotification(notification.id)) {
  updateNotifications({ ids: [notification.id], status: 'archived' })
}
```

3. (Optional, to make **View details** open the detail view for the mock) mirror the demo notification into `AdvisorPanel.tsx`'s notification list, gated by the same query flag.

Activate with e.g. `http://localhost:8082/project/<ref>?demo-critical-notification=1`. The mock id is stable, so once dismissed it's session-dismissed — clear the `critical-notification-banners-dismissed` sessionStorage key or use a fresh tab to re-test.

</details>

## Additional context

- Second of two stacked PRs for DEPR-595. **Based on `chore/depr-595-advisor-signalling` (#47714)** — please review/merge that one first. The diff against master will shrink once the base PR merges.
- Deliberately does **not** dedupe against `ResourceExhaustionWarningBanner`. These are currently separate systems and force-deduping would paper over that fragmentation; unifying the two alert patterns is tracked as follow-up tech debt.
- `_exposed` view telemetry was intentionally dropped to stay within our telemetry standards (no passive-view events outside A/B experiments); only the two click actions are tracked.
- Unit tests added for the banner surfacing/session-dismissal utilities.
