### PR TITLE
fix: limit regex 

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
@@ -53,8 +53,20 @@ describe('SQLEditor.utils.ts:checkIfAppendLimitRequired', () => {
     const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
+  test('Should return false if query already has a limit with whitespace before the semi colon', () => {
+    const sql = 'select * from countries limit 10 ;'
+    const limit = 100
+    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    expect(appendAutoLimit).toBe(false)
+  })
   test('Should return false if query already has a limit and offset', () => {
     const sql = 'select * from countries limit 10 offset 0;'
+    const limit = 100
+    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    expect(appendAutoLimit).toBe(false)
+  })
+  test('Should return false if query already has a limit and offset with whitespace before the semi colon', () => {
+    const sql = 'select * from countries limit 10 offset 0 ;'
     const limit = 100
     const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
     expect(appendAutoLimit).toBe(false)
@@ -153,6 +165,12 @@ describe('SQLEditor.utils.ts:suffixWithLimit', () => {
     const limit = 100
     const formattedSql = suffixWithLimit(sql, limit)
     expect(formattedSql).toBe('select * from countries limit 100;')
+  })
+  test('Should not append a limit if query already has one with whitespace before the semi colon', () => {
+    const sql = safeSql`select * from countries limit 10 ;`
+    const limit = 100
+    const formattedSql = suffixWithLimit(sql, limit)
+    expect(formattedSql).toBe('select * from countries limit 10 ;')
   })
 })
 

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -249,8 +249,8 @@ export const checkIfAppendLimitRequired = (sql: string, limit: number = 0) => {
     !cleanedSql.toLowerCase().match(/fetch\s+first/i) &&
     !cleanedSql.match(/limit$/i) &&
     !cleanedSql.match(/limit;$/i) &&
-    !cleanedSql.match(/limit [0-9]* offset [0-9]*[;]?$/i) &&
-    !cleanedSql.match(/limit [0-9]*[;]?$/i)
+    !cleanedSql.match(/limit [0-9]* offset [0-9]*\s*[;]?$/i) &&
+    !cleanedSql.match(/limit [0-9]*\s*[;]?$/i)
   return { cleanedSql, appendAutoLimit }
 }
 


### PR DESCRIPTION
- closes https://github.com/supabase/supabase/issues/47712 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL query handling so automatic row limits are no longer added when a query already ends with `LIMIT`, even if there’s whitespace before the semicolon.
  * Preserved correct behavior for queries using `LIMIT ... OFFSET ...`.
* **Tests**
  * Expanded coverage for SQL limit detection and limit-suffix behavior around whitespace and semicolon placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->