### PR TITLE
color text refine

### DIFF
--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -121,7 +121,7 @@ const GuideTemplate = ({
                 className={cn(
                   'w-fit',
                   'flex items-center gap-1',
-                  'text-sm text-scale-1000 hover:text-scale-1200',
+                  'text-sm text-tertiary-foreground hover:text-foreground',
                   'transition-colors'
                 )}
                 target="_blank"

--- a/apps/docs/features/ui/guide/GuideFooter.tsx
+++ b/apps/docs/features/ui/guide/GuideFooter.tsx
@@ -17,8 +17,7 @@ export function GuideFooter({ className, editLink }: GuideFooterProps) {
         className={cn(
           'w-fit',
           'flex items-center gap-1',
-          'text-sm text-scale-1000 hover:text-scale-1200',
-          'transition-colors'
+          'text-sm text-tertiary-foreground hover:text-foreground'
         )}
         target="_blank"
         rel="noreferrer noopener edit"

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -424,7 +424,7 @@ th code {
   --code-foreground: #ffffff;
   --code-token-constant: #3ecf8e;
   --code-token-string: #ffcda1;
-  --code-token-comment: #7e7e7e;
+  --code-token-comment: #949494;
   --code-token-parameter: #ffffff;
   --code-token-function: #3ecf8e;
   --code-token-string-expression: #ffcda1;
@@ -436,14 +436,14 @@ th code {
 }
 [data-theme='light'],
 .light {
-  --code-token-keyword: #6b35dc;
+  --code-token-keyword: #5f2fc4;
   --code-foreground: oklch(from var(--foreground-light) l c h / 1);
   --code-token-constant: #15593b;
-  --code-token-string: #c46a0a;
-  --code-token-comment: #7e7e7e;
+  --code-token-string: #9a5200;
+  --code-token-comment: #6a6a6a;
   --code-token-parameter: oklch(from var(--foreground-light) l c h / 1);
   --code-token-function: #15593b;
-  --code-token-string-expression: #c46a0a;
+  --code-token-string-expression: #9a5200;
   --code-token-punctuation: oklch(from var(--foreground-light) l c h / 1);
   --code-token-link: oklch(from var(--foreground-light) l c h / 1);
   --code-token-number: oklch(from var(--foreground-light) l c h / 1);

--- a/packages/ui/build/css/themes/light.css
+++ b/packages/ui/build/css/themes/light.css
@@ -14,9 +14,9 @@
   --surface: 0.98;
   --elevation-step: 0.024;
   --contrast: 0.53;
-  --foreground-lightness: 0.16;
-  --muted-foreground-level: 0.68;
-  --tertiary-foreground-level: 0.48;
+  --foreground-lightness: 0.1;
+  --muted-foreground-level: 0.65;
+  --tertiary-foreground-level: 0.5;
   /*
    * Expressive fills run darker than the dark-theme anchors so they hold contrast
    * against the near-white surface (a light amber on white disappears). Lightness

--- a/packages/ui/build/css/themes/light.css
+++ b/packages/ui/build/css/themes/light.css
@@ -39,7 +39,7 @@
   --secondary-default: 247.8deg 100% 70%;
   --secondary-400: 248.3deg 54.5% 25.9%;
   --secondary-200: 248deg 53.6% 11%;
-  --brand-link: 153.4deg 100% 36.7%;
+  --brand-link: 153.4deg 86.5% 28.3%;
   --brand-default: 152.9deg 60% 52.9%;
   --brand-600: 156.5deg 86.5% 26.1%;
   --brand-500: 155.3deg 78.4% 40%;

--- a/packages/ui/build/css/themes/light.css
+++ b/packages/ui/build/css/themes/light.css
@@ -2,9 +2,8 @@
 .light {
   --helpers-os-appearance: Light;
   --hue: 159;
-  /* Warm-gray surface ramp against the green brand (--primary stays on --hue). */
   --surface-hue: 34;
-  --chroma: 0.001;
+  --chroma: 0;
   /*
    * Soft-gray canvas (not pure white) so elevated surfaces have headroom to
    * brighten toward white. --elevation-step is positive here: higher surfaces


### PR DESCRIPTION
Adjusts light theme for better contrast on foreground, muted-foreground and tertiary-foreground text

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Retuned the light theme’s surface chroma and updated light, muted, and tertiary foreground levels for improved readability.
  * Updated the brand link color saturation to better align with the revised theme.
  * Refreshed code block token colors for both light and dark themes.
* **Documentation**
  * Updated the “Edit this page on GitHub” link styling to use updated token-based text colors for default and hover states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->