### PR TITLE
Use Link component instead of native a element in marketplace settings

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Integration/ConnectedResourceGroupSection.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/ConnectedResourceGroupSection.tsx
@@ -1,4 +1,5 @@
 import { Settings, Trash2, TriangleAlert } from 'lucide-react'
+import Link from 'next/link'
 import { Badge, Button } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
@@ -46,7 +47,7 @@ export const ResourceGroupSection = ({
         group.manageAction && (
           <div className="max-w-2xl">
             <Button asChild variant="default" icon={<Settings />}>
-              <a href={group.manageAction.href}>{group.manageAction.label}</a>
+              <Link href={group.manageAction.href}>{group.manageAction.label}</Link>
             </Button>
           </div>
         )
@@ -69,7 +70,7 @@ export const ResourceGroupSection = ({
               <div className="flex shrink-0 items-center gap-x-2">
                 {group.manageAction && (
                   <Button asChild variant="default" icon={<Settings />}>
-                    <a href={group.manageAction.href}>{group.manageAction.label}</a>
+                    <Link href={group.manageAction.href}>{group.manageAction.label}</Link>
                   </Button>
                 )}
                 <Button


### PR DESCRIPTION
## Context

Just a tiny one to use `Link` instead of `a` tags to render links in Marketplace settings

The `a` tags would otherwise drop the `/dashboard` URL prefix on staging and prod

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation in the integrations resource group section by using app-native links for management actions, making links behave more consistently across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->