### PR TITLE
fix: homepage accessibility fixes

### DIFF
--- a/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
+++ b/apps/studio/components/interfaces/Home/ProjectList/ProjectCard.tsx
@@ -70,6 +70,7 @@ export const ProjectCard = ({
     <>
       <li className="list-none h-min">
         <CardButton
+          tabIndex={0}
           linkHref={rewriteHref ? rewriteHref : `/project/${projectRef}`}
           className="h-44 px-0! group pt-5 pb-0 overflow-hidden relative"
           hideChevron

--- a/apps/studio/components/layouts/Navigation/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
@@ -44,7 +44,6 @@ export const FeedbackDropdown = ({ className }: { className?: string }) => {
     >
       <PopoverTrigger asChild>
         <Button
-          asChild
           onClick={() => {
             setIsOpen((isOpen) => !isOpen)
             setStage('select')

--- a/apps/studio/components/layouts/Navigation/LayoutHeader/HomeIcon.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/HomeIcon.tsx
@@ -35,6 +35,7 @@ export const HomeIcon = ({ className }: { className?: string }) => {
           href={href}
           onClick={() => track('header_home_logo_clicked')}
           className={cn('items-center justify-center shrink-0 flex', className)}
+          tabIndex={0}
         >
           <img
             alt="Supabase"

--- a/apps/studio/components/ui/FilterPopover.tsx
+++ b/apps/studio/components/ui/FilterPopover.tsx
@@ -180,7 +180,6 @@ export const FilterPopover = <T extends Record<string, any>>({
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
-          asChild
           disabled={disabled}
           variant={buttonType ?? (activeOptions.length > 0 ? 'default' : 'dashed')}
           onClick={() => setOpen(false)}


### PR DESCRIPTION
## Problem

On the organization home page:
- you can't tab to a project card and navigate to the project
- the status filter popover cannot be open with keyboard
- the feedback popover cannot be open with keyboard

## Solution

- make the project card (which is a link) accessible with Tab
- fix the popover trigger buttons

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard accessibility so project cards can be focused with Tab navigation.
  * Updated dropdown and filter popover trigger wiring for more consistent click behavior.
  * Reset the feedback flow to its starting step whenever the trigger is clicked.
* **Bug Fixes**
  * Made the home icon link explicitly focusable via keyboard navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->