### PR TITLE
Flip show tooltip to true for supavisor connections chart

### DIFF
--- a/apps/studio/components/ui/Charts/ChartHeader.tsx
+++ b/apps/studio/components/ui/Charts/ChartHeader.tsx
@@ -195,7 +195,7 @@ export const ChartHeader = ({
             <TooltipTrigger asChild>
               <InfoIcon className="w-4 h-4 text-foreground-lighter" />
             </TooltipTrigger>
-            <TooltipContent side="top" className="max-w-xs">
+            <TooltipContent side="bottom" className="max-w-xs">
               {titleTooltip}
               {docsUrl && (
                 <>

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -424,6 +424,7 @@ export function ComposedChart({
         className={className}
         attribute={title}
         format={format}
+        docsUrl={docsUrl}
         titleTooltip={titleTooltip}
       />
     )

--- a/apps/studio/components/ui/Charts/NoDataPlaceholder.tsx
+++ b/apps/studio/components/ui/Charts/NoDataPlaceholder.tsx
@@ -15,6 +15,7 @@ interface NoDataPlaceholderProps {
   isFullHeight?: boolean
   titleTooltip?: string
   hideTotalPlaceholder?: boolean
+  docsUrl?: string
 }
 const NoDataPlaceholder = ({
   attribute,
@@ -26,6 +27,7 @@ const NoDataPlaceholder = ({
   isFullHeight = false,
   titleTooltip,
   hideTotalPlaceholder = false,
+  docsUrl,
 }: NoDataPlaceholderProps) => {
   const { minHeight } = useChartSize(size)
 
@@ -37,6 +39,7 @@ const NoDataPlaceholder = ({
           format={format}
           highlightedValue={hideTotalPlaceholder ? undefined : 0}
           titleTooltip={titleTooltip}
+          docsUrl={docsUrl}
         />
       )}
       <div

--- a/apps/studio/data/reports/database-charts.ts
+++ b/apps/studio/data/reports/database-charts.ts
@@ -529,7 +529,7 @@ export const getReportAttributesV2: (
       entitlement: 'database',
       requiredPlan: 'Pro',
       hide: !entitledFeatures.includes('database'),
-      showTooltip: false,
+      showTooltip: true,
       showLegend: false,
       showMaxValue: false,
       showGrid: true,


### PR DESCRIPTION
## Context

Realised that tooltips were not showing up for supavisor charts in database reports - just needed to flip a boolean
Although - i don't have any projects with supavisor connections data (even on prod) so I can't visually verify this atm

Also fixes a small issue in which docs url for the chart wasn't showing if the chart had no data, e.g:
<img width="996" height="311" alt="image" src="https://github.com/user-attachments/assets/926febe4-9e3d-4975-9278-e7582d6ae12d" />

Should have docs button like this
<img width="949" height="351" alt="image" src="https://github.com/user-attachments/assets/7561c1c5-94ae-405b-bd54-6bc94be0dd0a" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled tooltips for the “Shared Pooler (Supavisor) client connections” chart so the metric can be inspected directly.
* **UI Improvements**
  * Adjusted the tooltip positioning in the chart header for clearer readability.
  * When charts have no data, the “Learn more”/documentation link now follows the provided docs URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->