### PR TITLE
fix: make status hovercard trigger on focus

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ServiceStatus.tsx
@@ -307,7 +307,7 @@ export const ServiceStatus = () => {
 
   return (
     <HoverCard openDelay={200} closeDelay={100}>
-      <HoverCardTrigger>
+      <HoverCardTrigger tabIndex={0}>
         <SingleStat
           icon={
             // Spinner only while the overall project is in COMING_UP; otherwise show 6-dot grid


### PR DESCRIPTION
## Problem

Status lists only appear on mouse hover and disappear when panning at 200%+ zoom.

## Solution

Make hover-triggered information available via click or focus in line with WCAG 1.4.13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard accessibility for the service status hover card by making the trigger focusable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->