### PR TITLE
chore: Add docs team as CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,8 @@
 
 /apps/studio/ @supabase/Dashboard
 
+/apps/docs/ @supabase/docs
+
 /apps/www/ @supabase/marketing
 /apps/www/public/images/blog @supabase/marketing
 /apps/www/lib/redirects.js


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Introduces CODEOWNERS configuration so that Docs team gets tagged when changes within our domain happen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership rules to include the docs area, so changes in that section are now routed to the appropriate reviewers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->