### PR TITLE
fix(www): postgres card art overlaps text column

### DIFF
--- a/apps/www/components/Products/DatabaseVisual.tsx
+++ b/apps/www/components/Products/DatabaseVisual.tsx
@@ -60,7 +60,7 @@ const DatabaseVisual: React.FC<Props> = ({ className, hasGlow = true }) => {
       role="img"
       aria-label="Supabase Postgres database visual composition"
     >
-      <span className="absolute group w-full md:w-auto h-full md:aspect-square flex items-end md:items-center justify-center md:justify-end right-0 left-0 md:left-auto xl:-right-12 2xl:right-0 top-12 md:top-0 md:bottom-0 my-auto">
+      <span className="absolute group w-full md:w-auto h-full md:aspect-square md:max-w-[calc(100%-280px)] flex items-end md:items-center justify-center md:justify-end right-0 left-0 md:left-auto xl:-right-12 2xl:right-0 top-12 md:top-0 md:bottom-0 my-auto">
         <Image
           src="/images/index/products/database-dark.png"
           alt="Supabase Postgres database"

--- a/apps/www/components/Products/DatabaseVisual.tsx
+++ b/apps/www/components/Products/DatabaseVisual.tsx
@@ -60,7 +60,7 @@ const DatabaseVisual: React.FC<Props> = ({ className, hasGlow = true }) => {
       role="img"
       aria-label="Supabase Postgres database visual composition"
     >
-      <span className="absolute group w-full md:w-auto h-full md:aspect-square md:max-w-[calc(100%-280px)] flex items-end md:items-center justify-center md:justify-end right-0 left-0 md:left-auto xl:-right-12 2xl:right-0 top-12 md:top-0 md:bottom-0 my-auto">
+      <span className="absolute group w-full md:w-auto h-full md:aspect-square md:max-w-[calc(100%-280px)] flex items-end md:items-center justify-center md:justify-end right-0 left-0 md:left-auto top-12 md:top-0 md:bottom-0 my-auto">
         <Image
           src="/images/index/products/database-dark.png"
           alt="Supabase Postgres database"


### PR DESCRIPTION
Before 
<img width="588" height="439" alt="Screenshot 2026-07-08 at 7 29 07 PM" src="https://github.com/user-attachments/assets/8a3380d3-571f-49cd-8f32-7b38650dd0e5" />

After 
<img width="578" height="436" alt="Screenshot 2026-07-08 at 7 29 55 PM" src="https://github.com/user-attachments/assets/09e74c31-e131-41d5-87da-b4518514cfb5" />


## Summary

On the homepage, the Postgres Database product card's elephant artwork renders over the card's description text at every viewport ≥1280px. I traced it to #47226 (merged June 24): standardizing the marketing container to `section-container` (`max-w-7xl` + `xl:px-24`) capped products-grid content at 1088px, shrinking the card to ~538px while its fixed geometry (250px text column + 398px right-anchored square artwork box) needs ~625px. Large monitors regressed hardest: before June 24 they got ~676px cards and no overlap. The app-router homepage move (#47228), the color system PR (#47288), and the artwork PNGs are all unrelated (verified against production DOM and full diffs).

Two changes to the artwork span in `DatabaseVisual.tsx`:

1. Cap the box width at `calc(100% - 280px)` from `md` up, where 280 covers the text column's `md:max-w-[250px]` cap (in `ProductCard.tsx`'s `isDatabase` branch) plus card padding and breathing room. The art scales down through its existing `object-contain`. At md/lg the card is full-width (`md:col-span-12`), so the clamp never binds and rendering is unchanged there.
2. Remove the `xl:-right-12` bleed (base `right-0` stands, matching how 2xl already rendered). The bleed used to clip only the art's transparent canvas margin; with the clamped box the art fills its full width, so the 48px offset was cropping the elephant itself at 1280-1535px.

The hover line-art SVG scales with the box and stays aligned with the PNG (identical aspect ratios: viewBox 390:430, PNG 585x645).

## Changes
- Add `md:max-w-[calc(100%-280px)]` to the artwork span in `DatabaseVisual.tsx` so the Postgres card art can never cross its text column
- Drop `xl:-right-12 2xl:right-0` from the same span so the smaller art isn't clipped at the card's right edge

## Testing

Round 1 on the Vercel preview (commit e1ca671, measured via getBoundingClientRect + computed styles):
- [x] Art clear of the text column at 1280/1440/1600/1920 (gap 54px at 1280/1440, 6px at 1600/1920); computed `max-width: calc(100% - 280px)` applies
- [x] Hover at 1440 — SVG and PNG rects identical (pixel-exact alignment)
- [x] 768/1024 — full-width card unchanged, span still a 398px square (clamp resolves but doesn't bind)
- [x] Light theme at 1440 — same geometry, no overlap

Round 1 also surfaced that the `xl:-right-12` bleed now cropped the elephant at 1280-1535px widths → second commit removes it. Round 2 (commit e28b408):
- [x] 1280/1440/1512/1600/1920 — art fully visible (span right edge flush at the card's inner edge, e.g. 713 vs 714 at 1440), still clear of the text column (span left 457 vs text right 451)
- [x] 768/1024 — unchanged (span still a right-anchored 398px square)
- [x] Hover alignment still exact (PNG and SVG rects identical: 457,452,256,398)

## Linear
- fixes GROWTH-971
