### PR TITLE
fix(studio): honor openai base url

### DIFF
--- a/apps/studio/lib/ai/model.test.ts
+++ b/apps/studio/lib/ai/model.test.ts
@@ -1,12 +1,16 @@
-import { openai } from '@ai-sdk/openai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as bedrockModule from './bedrock'
 import { getModel } from './model'
 import { DEFAULT_COMPLETION_MODEL, openaiModelEntry } from './model.utils'
 
+const { openaiProvider } = vi.hoisted(() => ({
+  openaiProvider: vi.fn(),
+}))
+
 vi.mock('@ai-sdk/openai', () => ({
-  openai: vi.fn(() => 'openai-model'),
+  createOpenAI: vi.fn(),
 }))
 
 vi.mock('./bedrock', async () => ({
@@ -20,6 +24,10 @@ describe('getModel', () => {
 
   beforeEach(() => {
     vi.resetAllMocks()
+    vi.mocked(createOpenAI).mockReturnValue(
+      openaiProvider as unknown as ReturnType<typeof createOpenAI>
+    )
+    openaiProvider.mockReturnValue('openai-model')
   })
 
   afterEach(() => {
@@ -56,8 +64,47 @@ describe('getModel', () => {
     })
 
     expect(modelParams?.model).toEqual('openai-model')
-    expect(openai).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      baseURL: 'https://api.openai.com/v1',
+    })
+    expect(openaiProvider).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(systemProviderOptions).toBeUndefined()
+  })
+
+  it('passes OPENAI_BASE_URL to the openai provider', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test-key')
+    vi.stubEnv('OPENAI_BASE_URL', 'https://integrate.api.nvidia.com/v1/')
+
+    const { modelParams, systemProviderOptions } = await getModel({
+      provider: 'openai',
+      modelEntry: openaiModelEntry({ id: 'gpt-5.4-nano' }),
+    })
+
+    expect(modelParams?.model).toEqual('openai-model')
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      baseURL: 'https://integrate.api.nvidia.com/v1',
+    })
+    expect(openaiProvider).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(systemProviderOptions).toBeUndefined()
+  })
+
+  it('ignores blank OPENAI_BASE_URL values', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test-key')
+    vi.stubEnv('OPENAI_BASE_URL', '   ')
+
+    const { modelParams } = await getModel({
+      provider: 'openai',
+      modelEntry: openaiModelEntry({ id: 'gpt-5.4-nano' }),
+    })
+
+    expect(modelParams?.model).toEqual('openai-model')
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      baseURL: 'https://api.openai.com/v1',
+    })
+    expect(openaiProvider).toHaveBeenCalledWith('gpt-5.4-nano')
   })
 
   it('returns error when OPENAI_API_KEY is not available', async () => {
@@ -81,7 +128,7 @@ describe('getModel', () => {
 
     expect(error).toBeUndefined()
     expect(modelParams?.model).toEqual('openai-model')
-    expect(openai).toHaveBeenCalledWith('gpt-5.3-codex')
+    expect(openaiProvider).toHaveBeenCalledWith('gpt-5.3-codex')
     expect(modelParams?.providerOptions?.openai?.reasoningEffort).toBe('low')
   })
 
@@ -94,7 +141,7 @@ describe('getModel', () => {
     })
 
     expect(error).toBeUndefined()
-    expect(openai).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(openaiProvider).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(modelParams?.providerOptions?.openai?.reasoningEffort).toBe('none')
   })
 })

--- a/apps/studio/lib/ai/model.ts
+++ b/apps/studio/lib/ai/model.ts
@@ -1,4 +1,4 @@
-import { openai } from '@ai-sdk/openai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { LanguageModel } from 'ai'
 
 import { checkAwsCredentials, createRoutedBedrock } from './bedrock'
@@ -14,6 +14,8 @@ import {
 
 type ProviderOptions = Record<string, any>
 type SystemProviderOptions = Record<string, any>
+
+const DEFAULT_OPENAI_BASE_URL = 'https://api.openai.com/v1'
 
 type ModelSuccess = {
   /** Spread directly into AI SDK calls: `streamText({ ...modelParams, ... })` */
@@ -84,9 +86,15 @@ export async function getModel(params: GetModelParams): Promise<ModelResponse> {
   }
 
   if (provider === 'openai') {
-    if (!process.env.OPENAI_API_KEY) {
+    const openAIApiKey = process.env.OPENAI_API_KEY
+    if (!openAIApiKey) {
       return { error: new Error('OPENAI_API_KEY not available') }
     }
+    const openAIBaseURL = process.env.OPENAI_BASE_URL?.trim().replace(/\/+$/, '')
+    const openai = createOpenAI({
+      apiKey: openAIApiKey,
+      baseURL: openAIBaseURL || DEFAULT_OPENAI_BASE_URL,
+    })
     const baseProviderOptions = providerRegistry.providerOptions?.openai ?? {}
     const openaiProviderOptions = modelEntry?.reasoningEffort
       ? { ...baseProviderOptions, reasoningEffort: modelEntry.reasoningEffort }

--- a/apps/studio/turbo.jsonc
+++ b/apps/studio/turbo.jsonc
@@ -69,6 +69,7 @@
         "DEFAULT_PROJECT_NAME",
         "DEFAULT_ORGANIZATION_NAME",
         "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
         "BRAINTRUST_API_KEY",
         "BRAINTRUST_PROJECT_ID",
         // Gates the dashboard assistant between the remote MCP server and the
@@ -129,12 +130,7 @@
         "S3_PROTOCOL_ACCESS_KEY_ID",
         "S3_PROTOCOL_ACCESS_KEY_SECRET",
       ],
-      "outputs": [
-        ".next/**",
-        "!.next/cache/**",
-        "!.next/dev/**/*",
-        "dist/**",
-      ],
+      "outputs": [".next/**", "!.next/cache/**", "!.next/dev/**/*", "dist/**"],
     },
   },
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Studio's OpenAI model path reads `OPENAI_API_KEY`, but it always constructs the provider with the default OpenAI endpoint. As a result, `OPENAI_BASE_URL` is ignored for self-hosted or proxy deployments.

Fixes #45269.

## What is the new behavior?

Studio now creates the OpenAI provider with both the configured API key and a normalized base URL. `OPENAI_BASE_URL` has trailing slashes trimmed, and missing or blank values fall back to `https://api.openai.com/v1`. The Studio turbo env allowlist includes `OPENAI_BASE_URL`, and the behavior is covered by focused tests.

## Additional context

Tested with:

- `npx --yes pnpm@10.24.0 install --filter studio --frozen-lockfile --ignore-scripts`
- `npx --yes pnpm@10.24.0 install --filter studio... --frozen-lockfile --ignore-scripts`
- `npx --yes pnpm@10.24.0 --dir apps/studio exec vitest --run lib/ai/model.test.ts`
- `npx --yes pnpm@10.24.0 --dir apps/studio exec prettier --check lib/ai/model.ts lib/ai/model.test.ts turbo.jsonc`
- `npx --yes pnpm@10.24.0 --dir apps/studio exec eslint lib/ai/model.ts lib/ai/model.test.ts`
- `git diff --check`

I also tried the full Studio typecheck; it currently stops on an unrelated existing `StaticImageData` mismatch in `packages/ui-patterns/src/McpUrlBuilder/components/InstructionBlocks.tsx`.