### PR TITLE
feat: add click Autocapture for posthog client on docs project

### DIFF
--- a/apps/docs/features/telemetry/telemetry.client.tsx
+++ b/apps/docs/features/telemetry/telemetry.client.tsx
@@ -12,6 +12,7 @@ const PageTelemetry = () => {
       API_URL={API_URL}
       hasAcceptedConsent={hasAcceptedConsent}
       enabled={IS_PLATFORM}
+      autocapture
     />
   )
 }

--- a/packages/common/posthog-client.ts
+++ b/packages/common/posthog-client.ts
@@ -50,7 +50,7 @@ class PostHogClient {
     }
   }
 
-  init(hasConsent: boolean = true) {
+  init(hasConsent: boolean = true, options?: { autocapture?: boolean }) {
     if (this.initStarted || typeof window === 'undefined' || !hasConsent) return
 
     if (!this.config.apiKey) {
@@ -61,7 +61,7 @@ class PostHogClient {
     const config: Partial<PostHogConfig> = {
       api_host: this.config.apiHost,
       ui_host: this.config.uiHost,
-      autocapture: false, // We'll manually track events
+      autocapture: options?.autocapture ?? false,
       capture_pageview: false, // We'll manually track pageviews
       capture_pageleave: false, // We'll manually track page leaves
       loaded: (posthog) => {

--- a/packages/common/telemetry.tsx
+++ b/packages/common/telemetry.tsx
@@ -253,12 +253,14 @@ export const PageTelemetry = ({
   API_URL,
   hasAcceptedConsent,
   enabled = true,
+  autocapture = false,
   organizationSlug,
   projectRef,
 }: {
   API_URL: string
   hasAcceptedConsent: boolean
   enabled?: boolean
+  autocapture?: boolean
   organizationSlug?: string
   projectRef?: string
 }) => {
@@ -315,9 +317,9 @@ export const PageTelemetry = ({
 
   useEffect(() => {
     if (hasAcceptedConsent && IS_PLATFORM) {
-      posthogClient.init(true)
+      posthogClient.init(true, { autocapture })
     }
-  }, [hasAcceptedConsent, IS_PLATFORM])
+  }, [hasAcceptedConsent, IS_PLATFORM, autocapture])
 
   // Waiting for router.isReady before sending to avoid dynamic route placeholders
   useEffect(() => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adding `autocapture` to our PostHog client to allow more complex click tracking across the project.

_Testing pending as we need to see in the network tab if post calls are correctly being sent..._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional telemetry autocapture support, allowing page analytics to be enabled with more control over event collection.
  * Telemetry initialization can now receive an autocapture setting from the app layer.

* **Bug Fixes**
  * Improved telemetry setup so the autocapture preference is consistently applied during initialization while preserving existing consent and enabled-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->