### PR TITLE
fix(studio): trim leading whitespace in site URL form

### DIFF
--- a/apps/studio/components/interfaces/Auth/SiteUrl/SiteUrl.test.tsx
+++ b/apps/studio/components/interfaces/Auth/SiteUrl/SiteUrl.test.tsx
@@ -1,0 +1,105 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { HttpResponse } from 'msw'
+import { toast } from 'sonner'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import SiteUrl from './SiteUrl'
+import type { AuthConfigResponse } from '@/data/auth/auth-config-query'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: () => ({ can: true, isSuccess: true }),
+}))
+
+vi.mock('@/lib/constants', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('@/lib/constants')
+  return {
+    ...actual,
+    get IS_PLATFORM() {
+      return true
+    },
+  }
+})
+
+const CURRENT_SITE_URL = 'https://old.example.com'
+
+const renderSiteUrl = () => customRender(<SiteUrl />)
+
+describe('SiteUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/auth/:ref/config',
+      response: { SITE_URL: CURRENT_SITE_URL } as unknown as AuthConfigResponse,
+    })
+  })
+
+  it('trims leading and trailing whitespace from the site URL before submitting', async () => {
+    const user = userEvent.setup()
+
+    const requests: Array<{ body: unknown }> = []
+    addAPIMock({
+      method: 'patch',
+      path: '/platform/auth/:ref/config',
+      response: async ({ request }) => {
+        requests.push({ body: await request.json() })
+        return HttpResponse.json<AuthConfigResponse>({
+          SITE_URL: 'https://new.example.com',
+        } as unknown as AuthConfigResponse)
+      },
+    })
+
+    renderSiteUrl()
+
+    const input = await screen.findByDisplayValue(CURRENT_SITE_URL)
+
+    await user.clear(input)
+    await user.type(input, '   https://new.example.com   ')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() => expect(requests).toHaveLength(1))
+    expect(requests[0].body).toEqual({ SITE_URL: 'https://new.example.com' })
+    expect(toast.success).toHaveBeenCalledWith('Successfully updated site URL')
+  })
+
+  it('shows a validation error and does not submit when the value is only whitespace', async () => {
+    const user = userEvent.setup()
+
+    const requests: Array<{ body: unknown }> = []
+    addAPIMock({
+      method: 'patch',
+      path: '/platform/auth/:ref/config',
+      response: async ({ request }) => {
+        requests.push({ body: await request.json() })
+        return HttpResponse.json<AuthConfigResponse>({
+          SITE_URL: '',
+        } as unknown as AuthConfigResponse)
+      },
+    })
+
+    renderSiteUrl()
+
+    const input = await screen.findByDisplayValue(CURRENT_SITE_URL)
+
+    await user.clear(input)
+    await user.type(input, '     ')
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Save changes' }))
+
+    expect(await screen.findByText('Must have a Site URL')).toBeInTheDocument()
+    await waitFor(() => expect(requests).toHaveLength(0))
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/components/interfaces/Auth/SiteUrl/SiteUrl.tsx
+++ b/apps/studio/components/interfaces/Auth/SiteUrl/SiteUrl.tsx
@@ -22,7 +22,7 @@ import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-muta
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 
 const schema = z.object({
-  SITE_URL: z.string().min(1, 'Must have a Site URL'),
+  SITE_URL: z.string().trim().min(1, 'Must have a Site URL'),
 })
 
 const SiteUrl = () => {


### PR DESCRIPTION
## Changes

- **SiteUrl.tsx**: Added `.trim()` to the Zod schema so whitespace is stripped before validation and before the value reaches the mutation. All-whitespace input now correctly fails with "Must have a Site URL" instead of being silently accepted. This matches the existing pattern in the sibling Redirect URLs form (AddNewURLModal.tsx).
- **SiteUrl.test.tsx** (new): MSW component test with two cases:
  - Trims leading/trailing whitespace before submitting to PATCH /platform/auth/:ref/config
  - Shows a validation error and does not submit when the value is only whitespace

## Test plan

- [x] `npx vitest --run components/interfaces/Auth/SiteUrl/SiteUrl.test.tsx` — 2/2 pass
- [x] `npm run typecheck` — clean
- [x] `npx eslint` on both files — no new warnings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved site URL validation so leading and trailing whitespace is ignored before saving.
  * Prevents whitespace-only values from being submitted and shows a validation error instead.

* **Tests**
  * Added coverage for site URL saving, including trimmed input, validation failures, request payloads, and success feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->