### PR TITLE
Revert override

### DIFF
--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -158,11 +158,6 @@
   --header-height: 3rem;
 }
 
-[data-theme='light'],
-.light {
-  --surface: 0.99;
-}
-
 [data-theme='dark'],
 .dark {
   --chart-1: hsl(var(--brand-default));


### PR DESCRIPTION
Reverts a color override which seems to be causing issues in some edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the light theme so its surface color now uses the default value instead of being overridden.
  * Preserved the dark theme appearance while keeping theme styling consistent across modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->