### PR TITLE
Migrate remaining requests to pg-meta API to use query endpoint

### DIFF
--- a/apps/studio/components/interfaces/Database/Tables/TableList.tsx
+++ b/apps/studio/components/interfaces/Database/Tables/TableList.tsx
@@ -137,7 +137,7 @@ export const TableList = ({
     {
       projectRef: project?.ref,
       connectionString: project?.connectionString,
-      schema: selectedSchema,
+      schemas: [selectedSchema],
     },
     {
       select(views) {
@@ -158,7 +158,7 @@ export const TableList = ({
     {
       projectRef: project?.ref,
       connectionString: project?.connectionString,
-      schema: selectedSchema,
+      schemas: [selectedSchema],
     },
     {
       select(materializedViews) {
@@ -181,7 +181,7 @@ export const TableList = ({
     {
       projectRef: project?.ref,
       connectionString: project?.connectionString,
-      schema: selectedSchema,
+      schemas: [selectedSchema],
     },
     {
       select(foreignTables) {

--- a/apps/studio/components/interfaces/Integrations/Queues/QueueTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueueTab.tsx
@@ -51,7 +51,7 @@ export const QueueTab = () => {
   const { data: policies } = useDatabasePoliciesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
-    schema: 'pgmq',
+    schemas: ['pgmq'],
   })
   const queuePolicies = (policies ?? []).filter((policy) => policy.table === queueRelname)
 

--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -63,7 +63,7 @@ export const RealtimeSettings = () => {
   const { data: policies, isSuccess: isSuccessPolicies } = useDatabasePoliciesQuery({
     projectRef,
     connectionString: project?.connectionString,
-    schema: 'realtime',
+    schemas: ['realtime'],
   })
 
   const isFreePlan = organization?.plan.id === 'free'

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -24,7 +24,7 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
   const { data: policies } = useDatabasePoliciesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
-    schema: 'storage',
+    schemas: ['storage'],
   })
 
   const { mutateAsync: deletePolicy } = useDatabasePolicyDeleteMutation()

--- a/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
+++ b/apps/studio/components/interfaces/Storage/PublicBucketWarning.tsx
@@ -74,7 +74,7 @@ export function PublicBucketWarning({ projectRef, bucketId }: PublicBucketWarnin
           queryKey: storageKeys.publicBucketsWithSelectPolicies(projectRef, bucketId),
         }),
         queryClient.invalidateQueries({
-          queryKey: databasePoliciesKeys.list(projectRef, 'storage'),
+          queryKey: databasePoliciesKeys.list(projectRef, ['storage']),
         }),
       ])
       track('storage_public_bucket_select_policy_removed', { bucketId })

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.tsx
@@ -68,7 +68,7 @@ export const StoragePolicies = () => {
   } = useDatabasePoliciesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
-    schema: 'storage',
+    schemas: ['storage'],
   })
 
   const isLoading = isLoadingBuckets || isLoadingPolicies

--- a/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
+++ b/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
@@ -9,7 +9,7 @@ export function useBucketPolicyCount() {
   const { data: policiesData = [], isPending: isPoliciesPending } = useDatabasePoliciesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
-    schema: 'storage',
+    schemas: ['storage'],
   })
 
   const policyCountByBucket = useMemo(() => {

--- a/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/GridHeaderActions.tsx
@@ -105,7 +105,7 @@ export const GridHeaderActions = ({ table, isRefetching }: GridHeaderActionsProp
     {
       projectRef: project?.ref,
       connectionString: project?.connectionString,
-      schema: table.schema,
+      schemas: [table.schema],
     },
     { enabled: !!table }
   )

--- a/apps/studio/data/database-columns/database-column-delete-mutation.ts
+++ b/apps/studio/data/database-columns/database-column-delete-mutation.ts
@@ -66,7 +66,7 @@ export const useDatabaseColumnDeleteMutation = ({
         // invalidate all views from this schema, not sure if this is needed since you can't actually delete a column
         // which has a view dependent on it
         queryClient.invalidateQueries({
-          queryKey: viewKeys.listBySchema(projectRef, column.schema),
+          queryKey: viewKeys.listBySchema(projectRef, [column.schema]),
         }),
       ])
 

--- a/apps/studio/data/database-policies/database-policies-query.ts
+++ b/apps/studio/data/database-policies/database-policies-query.ts
@@ -1,9 +1,9 @@
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
+import pgMeta, { type PGPolicy } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 
+import { executeSql } from '../sql/execute-sql-mutation'
 import { databasePoliciesKeys } from './keys'
 import type { Policy } from '@/components/interfaces/Database/Policies/PolicyTableRow/PolicyTableRow.utils'
-import { get, handleError } from '@/data/fetchers'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from '@/lib/constants'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
@@ -16,32 +16,22 @@ type DatabasePoliciesVariables = {
 
 export async function getDatabasePolicies(
   { projectRef, connectionString, schema }: DatabasePoliciesVariables,
-  signal?: AbortSignal,
-  headersInit?: HeadersInit
+  signal?: AbortSignal
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  let headers = new Headers(headersInit)
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
-
-  const { data, error } = await get('/platform/pg-meta/{ref}/policies', {
-    params: {
-      header: {
-        'x-connection-encrypted': connectionString!,
-        'x-pg-application-name': DEFAULT_PLATFORM_APPLICATION_NAME,
-      },
-      path: { ref: projectRef },
-      query: {
-        included_schemas: schema || '',
-        excluded_schemas: '',
-      },
+  const { sql } = pgMeta.policies.list({ includedSchemas: schema ? [schema] : undefined })
+  const { result } = await executeSql(
+    {
+      projectRef,
+      connectionString,
+      sql,
+      queryKey: ['policies', schema].filter(Boolean),
     },
-    headers,
-    signal,
-  })
+    signal
+  )
 
-  if (error) handleError(error)
-  return data
+  return result as PGPolicy[]
 }
 
 export type DatabasePoliciesData = Awaited<ReturnType<typeof getDatabasePolicies>>

--- a/apps/studio/data/database-policies/database-policies-query.ts
+++ b/apps/studio/data/database-policies/database-policies-query.ts
@@ -11,22 +11,22 @@ import type { ResponseError, UseCustomQueryOptions } from '@/types'
 type DatabasePoliciesVariables = {
   projectRef?: string
   connectionString?: string | null
-  schema?: string
+  schemas?: string[]
 }
 
 export async function getDatabasePolicies(
-  { projectRef, connectionString, schema }: DatabasePoliciesVariables,
+  { projectRef, connectionString, schemas }: DatabasePoliciesVariables,
   signal?: AbortSignal
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const { sql } = pgMeta.policies.list({ includedSchemas: schema ? [schema] : undefined })
+  const { sql } = pgMeta.policies.list({ includedSchemas: schemas })
   const { result } = await executeSql(
     {
       projectRef,
       connectionString,
       sql,
-      queryKey: ['policies', schema].filter(Boolean),
+      queryKey: ['policies', schemas],
     },
     signal
   )
@@ -42,16 +42,16 @@ function markSavedPolicySafe(policy: DatabasePoliciesData[number]): Policy {
 }
 
 export const useDatabasePoliciesQuery = <TData = Policy[]>(
-  { projectRef, connectionString, schema }: DatabasePoliciesVariables,
+  { projectRef, connectionString, schemas }: DatabasePoliciesVariables,
   { enabled = true, ...options }: UseCustomQueryOptions<Policy[], DatabasePoliciesError, TData> = {}
 ) => {
   const { data: project } = useSelectedProjectQuery()
   const isActive = project?.status === PROJECT_STATUS.ACTIVE_HEALTHY
 
   return useQuery<Policy[], DatabasePoliciesError, TData>({
-    queryKey: databasePoliciesKeys.list(projectRef, schema),
+    queryKey: databasePoliciesKeys.list(projectRef, schemas),
     queryFn: ({ signal }) =>
-      getDatabasePolicies({ projectRef, connectionString, schema }, signal).then((data) =>
+      getDatabasePolicies({ projectRef, connectionString, schemas }, signal).then((data) =>
         data.map(markSavedPolicySafe)
       ),
     enabled: enabled && typeof projectRef !== 'undefined' && isActive,

--- a/apps/studio/data/database-policies/keys.ts
+++ b/apps/studio/data/database-policies/keys.ts
@@ -1,4 +1,4 @@
 export const databasePoliciesKeys = {
-  list: (projectRef: string | undefined, schema?: string) =>
-    ['projects', projectRef, 'database-policies', schema].filter(Boolean),
+  list: (projectRef: string | undefined, schemas?: string[]) =>
+    ['projects', projectRef, 'database-policies', schemas].filter(Boolean),
 }

--- a/apps/studio/data/database-publications/database-publications-query.ts
+++ b/apps/studio/data/database-publications/database-publications-query.ts
@@ -1,8 +1,8 @@
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
+import pgMeta, { type PGPublication } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 
+import { executeSql } from '../sql/execute-sql-mutation'
 import { databasePublicationsKeys } from './keys'
-import { get, handleError } from '@/data/fetchers'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
@@ -17,25 +17,18 @@ export async function getDatabasePublications(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
-
-  const { data, error } = await get('/platform/pg-meta/{ref}/publications', {
-    params: {
-      header: {
-        'x-connection-encrypted': connectionString!,
-        'x-pg-application-name': DEFAULT_PLATFORM_APPLICATION_NAME,
-      },
-      path: {
-        ref: projectRef,
-      },
+  const { sql } = pgMeta.publications.list()
+  const { result } = await executeSql(
+    {
+      projectRef,
+      connectionString,
+      sql,
+      queryKey: ['publications'].filter(Boolean),
     },
-    headers,
-    signal,
-  })
+    signal
+  )
 
-  if (error) handleError(error)
-  return data
+  return result as PGPublication[]
 }
 
 export type DatabasePublicationsData = Awaited<ReturnType<typeof getDatabasePublications>>

--- a/apps/studio/data/database-triggers/database-triggers-query.ts
+++ b/apps/studio/data/database-triggers/database-triggers-query.ts
@@ -1,9 +1,9 @@
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
+import pgMeta, { type PGTrigger } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 
+import { executeSql } from '../sql/execute-sql-mutation'
 import { databaseTriggerKeys } from './keys'
 import type { PostgresTrigger } from '@/components/interfaces/Database/Triggers/TriggersList/TriggerList.utils'
-import { get, handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 function markSavedTriggerSafe(trigger: DatabaseTriggersData[number]): PostgresTrigger {
@@ -21,24 +21,18 @@ export async function getDatabaseTriggers(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
-
-  const { data, error } = await get('/platform/pg-meta/{ref}/triggers', {
-    params: {
-      header: {
-        'x-connection-encrypted': connectionString!,
-        'x-pg-application-name': DEFAULT_PLATFORM_APPLICATION_NAME,
-      },
-      path: { ref: projectRef },
-      query: undefined as any,
+  const { sql } = pgMeta.triggers.list()
+  const { result } = await executeSql(
+    {
+      projectRef,
+      connectionString,
+      sql,
+      queryKey: ['triggers'],
     },
-    headers,
-    signal,
-  })
+    signal
+  )
 
-  if (error) handleError(error)
-  return data
+  return result as PGTrigger[]
 }
 
 export type DatabaseTriggersData = Awaited<ReturnType<typeof getDatabaseTriggers>>

--- a/apps/studio/data/database-triggers/database-triggers-query.ts
+++ b/apps/studio/data/database-triggers/database-triggers-query.ts
@@ -13,15 +13,16 @@ function markSavedTriggerSafe(trigger: DatabaseTriggersData[number]): PostgresTr
 export type DatabaseTriggersVariables = {
   projectRef?: string
   connectionString?: string | null
+  schemas?: string[]
 }
 
 export async function getDatabaseTriggers(
-  { projectRef, connectionString }: DatabaseTriggersVariables,
+  { projectRef, connectionString, schemas }: DatabaseTriggersVariables,
   signal?: AbortSignal
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const { sql } = pgMeta.triggers.list()
+  const { sql } = pgMeta.triggers.list({ includedSchemas: schemas })
   const { result } = await executeSql(
     {
       projectRef,
@@ -39,14 +40,14 @@ export type DatabaseTriggersData = Awaited<ReturnType<typeof getDatabaseTriggers
 export type DatabaseTriggersError = ResponseError
 
 export const useDatabaseHooksQuery = <TData = DatabaseTriggersData>(
-  { projectRef, connectionString }: DatabaseTriggersVariables,
+  { projectRef, connectionString, schemas }: DatabaseTriggersVariables,
   {
     enabled = true,
     ...options
   }: UseCustomQueryOptions<DatabaseTriggersData, DatabaseTriggersError, TData> = {}
 ) =>
   useQuery<DatabaseTriggersData, DatabaseTriggersError, TData>({
-    queryKey: databaseTriggerKeys.list(projectRef),
+    queryKey: databaseTriggerKeys.list(projectRef, schemas),
     queryFn: ({ signal }) => getDatabaseTriggers({ projectRef, connectionString }, signal),
     select: (data) => {
       return data.filter((trigger) => {

--- a/apps/studio/data/database-triggers/keys.ts
+++ b/apps/studio/data/database-triggers/keys.ts
@@ -1,5 +1,6 @@
 export const databaseTriggerKeys = {
-  list: (projectRef: string | undefined) => ['projects', projectRef, 'database-triggers'] as const,
+  list: (projectRef: string | undefined, schemas?: string[]) =>
+    ['projects', projectRef, 'database-triggers', schemas].filter(Boolean),
   resource: (projectRef: string | undefined, id: string | undefined) =>
     ['projects', projectRef, 'resources', id] as const,
 }

--- a/apps/studio/data/enumerated-types/enumerated-types-query.ts
+++ b/apps/studio/data/enumerated-types/enumerated-types-query.ts
@@ -9,17 +9,18 @@ import type { ResponseError, UseCustomQueryOptions } from '@/types'
 export type EnumeratedTypesVariables = {
   projectRef?: string
   connectionString?: string | null
+  schemas?: string[]
 }
 
 export type EnumeratedType = components['schemas']['PostgresType']
 
 export async function getEnumeratedTypes(
-  { projectRef, connectionString }: EnumeratedTypesVariables,
+  { projectRef, connectionString, schemas }: EnumeratedTypesVariables,
   signal?: AbortSignal
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const { sql } = pgMeta.types.list()
+  const { sql } = pgMeta.types.list({ includedSchemas: schemas })
   const { result } = await executeSql(
     {
       projectRef,
@@ -37,14 +38,14 @@ export type EnumeratedTypesData = Awaited<ReturnType<typeof getEnumeratedTypes>>
 export type EnumeratedTypesError = ResponseError
 
 export const useEnumeratedTypesQuery = <TData = EnumeratedTypesData>(
-  { projectRef, connectionString }: EnumeratedTypesVariables,
+  { projectRef, connectionString, schemas }: EnumeratedTypesVariables,
   {
     enabled = true,
     ...options
   }: UseCustomQueryOptions<EnumeratedTypesData, EnumeratedTypesError, TData> = {}
 ) =>
   useQuery<EnumeratedTypesData, EnumeratedTypesError, TData>({
-    queryKey: enumeratedTypesKeys.list(projectRef),
+    queryKey: enumeratedTypesKeys.list(projectRef, schemas),
     queryFn: ({ signal }) => getEnumeratedTypes({ projectRef, connectionString }, signal),
     enabled: enabled && typeof projectRef !== 'undefined',
     ...options,

--- a/apps/studio/data/enumerated-types/enumerated-types-query.ts
+++ b/apps/studio/data/enumerated-types/enumerated-types-query.ts
@@ -46,7 +46,7 @@ export const useEnumeratedTypesQuery = <TData = EnumeratedTypesData>(
 ) =>
   useQuery<EnumeratedTypesData, EnumeratedTypesError, TData>({
     queryKey: enumeratedTypesKeys.list(projectRef, schemas),
-    queryFn: ({ signal }) => getEnumeratedTypes({ projectRef, connectionString }, signal),
+    queryFn: ({ signal }) => getEnumeratedTypes({ projectRef, connectionString, schemas }, signal),
     enabled: enabled && typeof projectRef !== 'undefined',
     ...options,
   })

--- a/apps/studio/data/enumerated-types/enumerated-types-query.ts
+++ b/apps/studio/data/enumerated-types/enumerated-types-query.ts
@@ -1,9 +1,9 @@
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
+import pgMeta, { type PGType } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 
+import { executeSql } from '../sql/execute-sql-mutation'
 import { enumeratedTypesKeys } from './keys'
 import type { components } from '@/data/api'
-import { get, handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 export type EnumeratedTypesVariables = {
@@ -19,23 +19,18 @@ export async function getEnumeratedTypes(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
-
-  const { data, error } = await get('/platform/pg-meta/{ref}/types', {
-    params: {
-      header: {
-        'x-connection-encrypted': connectionString!,
-        'x-pg-application-name': DEFAULT_PLATFORM_APPLICATION_NAME,
-      },
-      path: { ref: projectRef },
+  const { sql } = pgMeta.types.list()
+  const { result } = await executeSql(
+    {
+      projectRef,
+      connectionString,
+      sql,
+      queryKey: ['types'],
     },
-    headers: Object.fromEntries(headers),
-    signal,
-  })
+    signal
+  )
 
-  if (error) handleError(error)
-  return data
+  return result as PGType[]
 }
 
 export type EnumeratedTypesData = Awaited<ReturnType<typeof getEnumeratedTypes>>

--- a/apps/studio/data/enumerated-types/keys.ts
+++ b/apps/studio/data/enumerated-types/keys.ts
@@ -1,3 +1,4 @@
 export const enumeratedTypesKeys = {
-  list: (projectRef: string | undefined) => ['projects', projectRef, 'enumerated-types'] as const,
+  list: (projectRef: string | undefined, schemas?: string[]) =>
+    ['projects', projectRef, 'enumerated-types', schemas].filter(Boolean),
 }

--- a/apps/studio/data/foreign-tables/foreign-tables-query.ts
+++ b/apps/studio/data/foreign-tables/foreign-tables-query.ts
@@ -9,19 +9,19 @@ import type { ResponseError, UseCustomQueryOptions } from '@/types'
 export type ForeignTablesVariables = {
   projectRef?: string
   connectionString?: string | null
-  schema?: string
+  schemas?: string[]
 }
 
 export async function getForeignTables(
-  { projectRef, connectionString, schema }: ForeignTablesVariables,
+  { projectRef, connectionString, schemas }: ForeignTablesVariables,
   signal?: AbortSignal
 ) {
   const { result } = await executeSql(
     {
       projectRef,
       connectionString,
-      sql: pgMeta.foreignTables.list(schema ? { includedSchemas: [schema] } : undefined).sql,
-      queryKey: ['foreign-tables', schema],
+      sql: pgMeta.foreignTables.list({ includedSchemas: schemas }).sql,
+      queryKey: ['foreign-tables', schemas].filter(Boolean),
     },
     signal
   )
@@ -33,17 +33,17 @@ export type ForeignTablesData = Awaited<ReturnType<typeof getForeignTables>>
 export type ForeignTablesError = ResponseError
 
 export const useForeignTablesQuery = <TData = ForeignTablesData>(
-  { projectRef, connectionString, schema }: ForeignTablesVariables,
+  { projectRef, connectionString, schemas }: ForeignTablesVariables,
   {
     enabled = true,
     ...options
   }: UseCustomQueryOptions<ForeignTablesData, ForeignTablesError, TData> = {}
 ) =>
   useQuery<ForeignTablesData, ForeignTablesError, TData>({
-    queryKey: schema
-      ? foreignTableKeys.listBySchema(projectRef, schema)
+    queryKey: schemas
+      ? foreignTableKeys.listBySchema(projectRef, schemas)
       : foreignTableKeys.list(projectRef),
-    queryFn: ({ signal }) => getForeignTables({ projectRef, connectionString, schema }, signal),
+    queryFn: ({ signal }) => getForeignTables({ projectRef, connectionString, schemas }, signal),
     enabled: enabled && typeof projectRef !== 'undefined',
     ...options,
   })

--- a/apps/studio/data/foreign-tables/keys.ts
+++ b/apps/studio/data/foreign-tables/keys.ts
@@ -1,5 +1,5 @@
 export const foreignTableKeys = {
   list: (projectRef: string | undefined) => ['projects', projectRef, 'foreignTables'] as const,
-  listBySchema: (projectRef: string | undefined, schema: string) =>
-    [...foreignTableKeys.list(projectRef), schema] as const,
+  listBySchema: (projectRef: string | undefined, schemas?: string[]) =>
+    [...foreignTableKeys.list(projectRef), schemas].filter(Boolean),
 }

--- a/apps/studio/data/materialized-views/keys.ts
+++ b/apps/studio/data/materialized-views/keys.ts
@@ -1,5 +1,5 @@
 export const materializedViewKeys = {
   list: (projectRef: string | undefined) => ['projects', projectRef, 'materializedViews'] as const,
-  listBySchema: (projectRef: string | undefined, schema: string) =>
-    [...materializedViewKeys.list(projectRef), schema] as const,
+  listBySchema: (projectRef: string | undefined, schemas?: string[]) =>
+    [...materializedViewKeys.list(projectRef), schemas].filter(Boolean),
 }

--- a/apps/studio/data/materialized-views/materialized-view-delete-mutation.ts
+++ b/apps/studio/data/materialized-views/materialized-view-delete-mutation.ts
@@ -60,7 +60,7 @@ export const useMaterializedViewDeleteMutation = ({
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: tableEditorKeys.tableEditor(projectRef, id) }),
         queryClient.invalidateQueries({
-          queryKey: materializedViewKeys.listBySchema(projectRef, schema),
+          queryKey: materializedViewKeys.listBySchema(projectRef, [schema]),
         }),
         queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
       ])

--- a/apps/studio/data/materialized-views/materialized-views-query.ts
+++ b/apps/studio/data/materialized-views/materialized-views-query.ts
@@ -1,9 +1,8 @@
-import type { PGMaterializedView } from '@supabase/pg-meta'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
+import pgMeta, { type PGMaterializedView } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 
+import { executeSql } from '../sql/execute-sql-mutation'
 import { materializedViewKeys } from './keys'
-import { get, handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 export type MaterializedViewsVariables = {
@@ -18,27 +17,19 @@ export async function getMaterializedViews(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
+  const { sql } = pgMeta.materializedViews.list({ includedSchemas: schema ? [schema] : undefined })
 
-  const { data, error } = await get('/platform/pg-meta/{ref}/materialized-views', {
-    params: {
-      header: {
-        'x-connection-encrypted': connectionString!,
-        'x-pg-application-name': DEFAULT_PLATFORM_APPLICATION_NAME,
-      },
-      path: { ref: projectRef },
-      query: {
-        included_schemas: schema || '',
-        include_columns: true,
-      } as any,
+  const { result } = await executeSql(
+    {
+      projectRef,
+      connectionString,
+      sql,
+      queryKey: ['materialized-views', schema].filter(Boolean),
     },
-    headers,
-    signal,
-  })
+    signal
+  )
 
-  if (error) handleError(error)
-  return data as PGMaterializedView[]
+  return result as PGMaterializedView[]
 }
 
 export type MaterializedViewsData = Awaited<ReturnType<typeof getMaterializedViews>>

--- a/apps/studio/data/materialized-views/materialized-views-query.ts
+++ b/apps/studio/data/materialized-views/materialized-views-query.ts
@@ -8,23 +8,23 @@ import type { ResponseError, UseCustomQueryOptions } from '@/types'
 export type MaterializedViewsVariables = {
   projectRef?: string
   connectionString?: string | null
-  schema?: string
+  schemas?: string[]
 }
 
 export async function getMaterializedViews(
-  { projectRef, connectionString, schema }: MaterializedViewsVariables,
+  { projectRef, connectionString, schemas }: MaterializedViewsVariables,
   signal?: AbortSignal
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const { sql } = pgMeta.materializedViews.list({ includedSchemas: schema ? [schema] : undefined })
+  const { sql } = pgMeta.materializedViews.list({ includedSchemas: schemas })
 
   const { result } = await executeSql(
     {
       projectRef,
       connectionString,
       sql,
-      queryKey: ['materialized-views', schema].filter(Boolean),
+      queryKey: ['materialized-views', schemas].filter(Boolean),
     },
     signal
   )
@@ -36,17 +36,18 @@ export type MaterializedViewsData = Awaited<ReturnType<typeof getMaterializedVie
 export type MaterializedViewsError = ResponseError
 
 export const useMaterializedViewsQuery = <TData = MaterializedViewsData>(
-  { projectRef, connectionString, schema }: MaterializedViewsVariables,
+  { projectRef, connectionString, schemas }: MaterializedViewsVariables,
   {
     enabled = true,
     ...options
   }: UseCustomQueryOptions<MaterializedViewsData, MaterializedViewsError, TData> = {}
 ) =>
   useQuery<MaterializedViewsData, MaterializedViewsError, TData>({
-    queryKey: schema
-      ? materializedViewKeys.listBySchema(projectRef, schema)
+    queryKey: schemas
+      ? materializedViewKeys.listBySchema(projectRef, schemas)
       : materializedViewKeys.list(projectRef),
-    queryFn: ({ signal }) => getMaterializedViews({ projectRef, connectionString, schema }, signal),
+    queryFn: ({ signal }) =>
+      getMaterializedViews({ projectRef, connectionString, schemas }, signal),
     enabled: enabled && typeof projectRef !== 'undefined',
     staleTime: 0,
     ...options,

--- a/apps/studio/data/tables/table-delete-mutation.ts
+++ b/apps/studio/data/tables/table-delete-mutation.ts
@@ -62,7 +62,7 @@ export const useTableDeleteMutation = ({
         }),
         queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
         // invalidate all views from this schema
-        queryClient.invalidateQueries({ queryKey: viewKeys.listBySchema(projectRef, schema) }),
+        queryClient.invalidateQueries({ queryKey: viewKeys.listBySchema(projectRef, [schema]) }),
       ])
 
       await onSuccess?.(data, variables, context)

--- a/apps/studio/data/views/keys.ts
+++ b/apps/studio/data/views/keys.ts
@@ -1,5 +1,5 @@
 export const viewKeys = {
   list: (projectRef: string | undefined) => ['projects', projectRef, 'views'] as const,
-  listBySchema: (projectRef: string | undefined, schema: string) =>
-    [...viewKeys.list(projectRef), schema] as const,
+  listBySchema: (projectRef: string | undefined, schemas?: string[]) =>
+    [...viewKeys.list(projectRef), schemas].filter(Boolean),
 }

--- a/apps/studio/data/views/view-delete-mutation.ts
+++ b/apps/studio/data/views/view-delete-mutation.ts
@@ -55,7 +55,7 @@ export const useViewDeleteMutation = ({
       const { id, projectRef, schema } = variables
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: tableEditorKeys.tableEditor(projectRef, id) }),
-        queryClient.invalidateQueries({ queryKey: viewKeys.listBySchema(projectRef, schema) }),
+        queryClient.invalidateQueries({ queryKey: viewKeys.listBySchema(projectRef, [schema]) }),
         queryClient.invalidateQueries({ queryKey: entityTypeKeys.list(projectRef) }),
       ])
 

--- a/apps/studio/data/views/views-query.ts
+++ b/apps/studio/data/views/views-query.ts
@@ -8,22 +8,22 @@ import type { ResponseError, UseCustomQueryOptions } from '@/types'
 export type ViewsVariables = {
   projectRef?: string
   connectionString?: string | null
-  schema?: string
+  schemas?: string[]
 }
 
 export async function getViews(
-  { projectRef, connectionString, schema }: ViewsVariables,
+  { projectRef, connectionString, schemas }: ViewsVariables,
   signal?: AbortSignal
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  const { sql } = pgMeta.views.list({ includedSchemas: schema ? [schema] : undefined })
+  const { sql } = pgMeta.views.list({ includedSchemas: schemas })
   const { result } = await executeSql(
     {
       projectRef,
       connectionString,
       sql,
-      queryKey: ['views', schema].filter(Boolean),
+      queryKey: ['views', schemas].filter(Boolean),
     },
     signal
   )
@@ -35,12 +35,12 @@ export type ViewsData = Awaited<ReturnType<typeof getViews>>
 export type ViewsError = ResponseError
 
 export const useViewsQuery = <TData = ViewsData>(
-  { projectRef, connectionString, schema }: ViewsVariables,
+  { projectRef, connectionString, schemas }: ViewsVariables,
   { enabled = true, ...options }: UseCustomQueryOptions<ViewsData, ViewsError, TData> = {}
 ) =>
   useQuery<ViewsData, ViewsError, TData>({
-    queryKey: schema ? viewKeys.listBySchema(projectRef, schema) : viewKeys.list(projectRef),
-    queryFn: ({ signal }) => getViews({ projectRef, connectionString, schema }, signal),
+    queryKey: schemas ? viewKeys.listBySchema(projectRef, schemas) : viewKeys.list(projectRef),
+    queryFn: ({ signal }) => getViews({ projectRef, connectionString, schemas }, signal),
     enabled: enabled && typeof projectRef !== 'undefined',
     staleTime: 0,
     ...options,

--- a/apps/studio/data/views/views-query.ts
+++ b/apps/studio/data/views/views-query.ts
@@ -1,9 +1,8 @@
-import type { PGView } from '@supabase/pg-meta'
-import { DEFAULT_PLATFORM_APPLICATION_NAME } from '@supabase/pg-meta/src/constants'
+import pgMeta, { type PGView } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 
+import { executeSql } from '../sql/execute-sql-mutation'
 import { viewKeys } from './keys'
-import { get, handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
 export type ViewsVariables = {
@@ -18,26 +17,18 @@ export async function getViews(
 ) {
   if (!projectRef) throw new Error('projectRef is required')
 
-  let headers = new Headers()
-  if (connectionString) headers.set('x-connection-encrypted', connectionString)
-
-  const { data, error } = await get('/platform/pg-meta/{ref}/views', {
-    params: {
-      header: {
-        'x-connection-encrypted': connectionString!,
-        'x-pg-application-name': DEFAULT_PLATFORM_APPLICATION_NAME,
-      },
-      path: { ref: projectRef },
-      query: {
-        included_schemas: schema || '',
-      } as any,
+  const { sql } = pgMeta.views.list({ includedSchemas: schema ? [schema] : undefined })
+  const { result } = await executeSql(
+    {
+      projectRef,
+      connectionString,
+      sql,
+      queryKey: ['views', schema].filter(Boolean),
     },
-    headers,
-    signal,
-  })
+    signal
+  )
 
-  if (error) handleError(error)
-  return data as PGView[]
+  return result as PGView[]
 }
 
 export type ViewsData = Awaited<ReturnType<typeof getViews>>

--- a/apps/studio/lib/ai/tools/fallback-tools.ts
+++ b/apps/studio/lib/ai/tools/fallback-tools.ts
@@ -92,8 +92,7 @@ export const getFallbackTools = ({
                 connectionString,
                 schema: schemas?.join(','),
               },
-              undefined,
-              headers
+              undefined
             )
           : []
 

--- a/apps/studio/lib/ai/tools/fallback-tools.ts
+++ b/apps/studio/lib/ai/tools/fallback-tools.ts
@@ -90,7 +90,7 @@ export const getFallbackTools = ({
               {
                 projectRef,
                 connectionString,
-                schema: schemas?.join(','),
+                schemas,
               },
               undefined
             )

--- a/apps/studio/lib/ai/tools/index.ts
+++ b/apps/studio/lib/ai/tools/index.ts
@@ -69,7 +69,6 @@ export const getTools = async ({
       ...getSchemaTools({
         projectRef,
         connectionString,
-        authorization,
       }),
       ...(baseUrl ? getIncidentTools({ baseUrl }) : {}),
     }

--- a/apps/studio/lib/ai/tools/schema-tools.ts
+++ b/apps/studio/lib/ai/tools/schema-tools.ts
@@ -20,7 +20,7 @@ export const getSchemaTools = ({
         {
           projectRef,
           connectionString,
-          schema: schemas?.join(','),
+          schemas,
         },
         undefined
       )

--- a/apps/studio/lib/ai/tools/schema-tools.ts
+++ b/apps/studio/lib/ai/tools/schema-tools.ts
@@ -6,11 +6,9 @@ import { getDatabasePolicies } from '@/data/database-policies/database-policies-
 export const getSchemaTools = ({
   projectRef,
   connectionString,
-  authorization,
 }: {
   projectRef: string
   connectionString: string
-  authorization?: string
 }) => ({
   list_policies: tool({
     description: 'Get existing RLS policies for a given schema',
@@ -24,11 +22,7 @@ export const getSchemaTools = ({
           connectionString,
           schema: schemas?.join(','),
         },
-        undefined,
-        {
-          'Content-Type': 'application/json',
-          ...(authorization && { Authorization: authorization }),
-        }
+        undefined
       )
 
       const formattedPolicies = data

--- a/apps/studio/pages/project/[ref]/database/policies.tsx
+++ b/apps/studio/pages/project/[ref]/database/policies.tsx
@@ -171,7 +171,7 @@ const DatabasePoliciesPage: NextPageWithLayout = () => {
   } = useDatabasePoliciesQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
-    schema,
+    schemas: [schema],
   })
   const selectedPolicyToEdit = policies.find((policy) => policy.id.toString() === selectedIdToEdit)
 

--- a/e2e/studio/features/database.spec.ts
+++ b/e2e/studio/features/database.spec.ts
@@ -540,7 +540,7 @@ test.describe('Database', () => {
 
   test.describe('Triggers', () => {
     test('actions works as expected', async ({ page, ref }) => {
-      const triggersLoadWait = createApiResponseWaiter(page, 'pg-meta', ref, 'triggers')
+      const triggersLoadWait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=triggers')
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/triggers?schema=public`))
 
       // Wait for database triggers to be populated
@@ -582,7 +582,12 @@ test.describe('Database', () => {
         }
       )
 
-      const triggersCrudLoadWait = createApiResponseWaiter(page, 'pg-meta', ref, 'triggers')
+      const triggersCrudLoadWait = createApiResponseWaiter(
+        page,
+        'pg-meta',
+        ref,
+        'query?key=triggers'
+      )
       await page.goto(toUrl(`/project/${env.PROJECT_REF}/database/triggers?schema=public`))
 
       // Wait for database triggers to be populated
@@ -1190,7 +1195,7 @@ test.describe('Database Enumerated Types', () => {
     await page.locator('input[name="values.0.value"]').fill(databaseEnumValue1Name)
     await page.getByRole('button', { name: 'Add value' }).click()
     await page.locator('input[name="values.1.value"]').fill(databaseEnumValue2Name)
-    const enumCreateWait = createApiResponseWaiter(page, 'pg-meta', ref, 'types')
+    const enumCreateWait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=types')
     await page.getByRole('button', { name: 'Create type' }).click()
 
     // Wait for enum response to be completed and validate it
@@ -1224,7 +1229,7 @@ test.describe('Database Enumerated Types', () => {
     await page.locator('input[name="values.0.value"]').fill(quotedEnumValue1Name)
     await page.getByRole('button', { name: 'Add value' }).click()
     await page.locator('input[name="values.1.value"]').fill(quotedEnumValue2Name)
-    const quotedEnumCreateWait = createApiResponseWaiter(page, 'pg-meta', ref, 'types')
+    const quotedEnumCreateWait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=types')
     await page.getByRole('button', { name: 'Create type' }).click()
 
     await quotedEnumCreateWait

--- a/e2e/studio/features/rls-policies.spec.ts
+++ b/e2e/studio/features/rls-policies.spec.ts
@@ -9,7 +9,7 @@ import { createApiResponseWaiter } from '../utils/wait-for-response.js'
  * Helper function to navigate to policies page and wait for it to load
  */
 const navigateToPoliciesPage = async (page: Page, ref: string) => {
-  const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'policies')
+  const wait = createApiResponseWaiter(page, 'pg-meta', ref, 'query?key=policies')
   await page.goto(toUrl(`/project/${ref}/database/policies`))
   await wait
   await page.waitForTimeout(500)

--- a/e2e/studio/features/table-editor.spec.ts
+++ b/e2e/studio/features/table-editor.spec.ts
@@ -33,7 +33,7 @@ const deleteTable = async (page: Page, ref: string, tableName: string) => {
 }
 
 const deleteEnumIfExist = async (page: Page, ref: string, enumName: string) => {
-  const loadTypesPromise = waitForApiResponse(page, 'pg-meta', ref, `types`)
+  const loadTypesPromise = waitForApiResponse(page, 'pg-meta', ref, `query?key=types`)
   await page.goto(toUrl(`/project/${ref}/database/types?schema=public`))
   await loadTypesPromise
   expect(page.getByText('public').first()).toBeVisible()

--- a/packages/pg-meta/src/index.ts
+++ b/packages/pg-meta/src/index.ts
@@ -13,7 +13,7 @@ import schemas from './pg-meta-schemas'
 import tablePrivileges from './pg-meta-table-privileges'
 import * as tables from './pg-meta-tables'
 import triggers from './pg-meta-triggers'
-import types from './pg-meta-types'
+import * as types from './pg-meta-types'
 import version from './pg-meta-version'
 import views from './pg-meta-views'
 import * as query from './query/index'
@@ -54,6 +54,7 @@ export type { PGMaterializedView } from './pg-meta-materialized-views'
 export type { PGForeignTable } from './pg-meta-foreign-tables'
 export type { PGSchema } from './pg-meta-schemas'
 export type { PGPublication } from './pg-meta-publications'
+export type { PGType } from './pg-meta-types'
 
 export default {
   roles,

--- a/packages/pg-meta/src/pg-meta-types.ts
+++ b/packages/pg-meta/src/pg-meta-types.ts
@@ -21,6 +21,7 @@ const pgTypeZod = z.object({
 })
 
 const pgTypeArrayZod = z.array(pgTypeZod)
+export type PGType = z.infer<typeof pgTypeZod>
 
 function list({
   includeArrayTypes = false,
@@ -68,7 +69,4 @@ function list({
   }
 }
 
-export default {
-  list,
-  zod: pgTypeZod,
-}
+export { list }


### PR DESCRIPTION
## Context

Migrates the remaining API requests to the pg-meta endpoint to use the query endpoint directly with the SQL from the pg-meta package. This touches the following:
- policies
- publications
- triggers
- views
- materialized views
- types

## To test
Just need to verify that we're still fetching the data correctly on these pages
- Database policies
- Database publications
- Database triggers
- Database tables (views + materialized views)
- Database types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved and stabilized loading of database metadata (views, triggers, RLS policies, publications, materialized views, and enum types), including more reliable schema-scoped filtering.
  * Updated policy loading behavior and related UI queries to consistently use schema arrays, improving cache correctness and consistency.
* **Tests**
  * Updated end-to-end test synchronization to wait for the correct metadata responses using more specific request identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->