### PR TITLE
Fix observability custom reports menu item

### DIFF
--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityLayout.tsx
@@ -3,7 +3,7 @@ import { usePathname } from 'next/navigation'
 import { PropsWithChildren, useEffect, useRef } from 'react'
 
 import { ProjectLayout } from '../ProjectLayout'
-import ObservabilityMenu from './ObservabilityMenu'
+import { ObservabilityMenu } from './ObservabilityMenu'
 import { useIndexAdvisorStatus } from '@/components/interfaces/QueryPerformance/hooks/useIsIndexAdvisorStatus'
 import { BannerIndexAdvisor } from '@/components/ui/BannerStack/Banners/BannerIndexAdvisor'
 import { BannerMetricsAPI } from '@/components/ui/BannerStack/Banners/BannerMetricsAPI'

--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenu.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenu.tsx
@@ -28,7 +28,7 @@ import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
 import type { Dashboards } from '@/types'
 
-const ObservabilityMenu = () => {
+export const ObservabilityMenu = () => {
   const router = useRouter()
   const { profile } = useProfile()
   const { ref, id } = useParams()
@@ -292,5 +292,3 @@ const ObservabilityMenu = () => {
     </div>
   )
 }
-
-export default ObservabilityMenu

--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenuItem.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenuItem.tsx
@@ -73,7 +73,7 @@ export const ObservabilityMenuItem = ({
                 }}
               />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-42 *:gap-x-2">
+            <DropdownMenuContent align="start" className="w-44 *:gap-x-2">
               <DropdownMenuItem
                 onClick={(e) => {
                   e.preventDefault()

--- a/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenuItem.tsx
+++ b/apps/studio/components/layouts/ObservabilityLayout/ObservabilityMenuItem.tsx
@@ -55,16 +55,17 @@ export const ObservabilityMenuItem = ({
   )
 
   const menuItem = (
-    <Menu.Item active={item.key === pageKey}>
+    <Menu.Item active={item.key === pageKey} className="pr-2.5">
       <div className="flex w-full items-center justify-between gap-1">
-        <span className="truncate">{item.name}</span>
+        <p className="truncate w-full">{item.name}</p>
 
         {canUpdateCustomReport && (
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button
+                aria-label="More actions"
                 variant="text"
-                className="px-1 opacity-50 hover:opacity-100"
+                className="px-0.5 h-[20px] opacity-50 hover:opacity-100"
                 icon={<MoreVertical size={12} strokeWidth={2} />}
                 onClick={(e) => {
                   e.preventDefault()
@@ -72,7 +73,7 @@ export const ObservabilityMenuItem = ({
                 }}
               />
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-32 *:gap-x-2">
+            <DropdownMenuContent align="start" className="w-42 *:gap-x-2">
               <DropdownMenuItem
                 onClick={(e) => {
                   e.preventDefault()

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/MobileMenuContent/mobileProductMenuRegistry.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/MobileMenuContent/mobileProductMenuRegistry.tsx
@@ -49,7 +49,7 @@ export const MOBILE_PRODUCT_MENU_REGISTRY: Record<string, ComponentType | null> 
   ),
   observability: React.lazy(() =>
     import('@/components/layouts/ObservabilityLayout/ObservabilityMenu').then((m) => ({
-      default: m.default,
+      default: m.ObservabilityMenu,
     }))
   ),
   logs: React.lazy(() =>

--- a/packages/ui/src/components/Menu/Menu.tsx
+++ b/packages/ui/src/components/Menu/Menu.tsx
@@ -40,6 +40,7 @@ interface ItemProps {
   doNotCloseOverlay?: boolean
   showActiveBar?: boolean
   style?: React.CSSProperties
+  className?: string
 }
 
 export const menuItemVariants = cva(
@@ -91,13 +92,13 @@ export const menuItemVariants = cva(
   }
 )
 
-export function Item({ children, icon, active, onClick, style }: ItemProps) {
+export function Item({ children, icon, active, onClick, style, className }: ItemProps) {
   const { type } = useMenuContext()
 
   return (
     <li
       role="menuitem"
-      className={cn('outline-hidden', menuItemVariants({ type, active }))}
+      className={cn('outline-hidden', menuItemVariants({ type, active }), className)}
       style={style}
       onClick={onClick}
       aria-current={active ? 'page' : undefined}
@@ -112,14 +113,14 @@ export function Item({ children, icon, active, onClick, style }: ItemProps) {
           {icon}
         </div>
       )}
-      <span
-        className={cn('transition truncate text-sm', {
+      <div
+        className={cn('transition truncate text-sm w-full', {
           'text-foreground-light group-hover:text-foreground': !active,
           'text-foreground font-semibold': active,
         })}
       >
         {children}
-      </span>
+      </div>
     </li>
   )
 }


### PR DESCRIPTION
## Context

More action button should be flushed to the right here
<img width="294" height="156" alt="image" src="https://github.com/user-attachments/assets/65017960-3edb-4268-bb0e-1e2c26937d4b" />

## Changes involved
- Adjust `Menu.Item` in `packages/ui` to use a `div` instead of a `span`
  - Was otherwise causing HTML validation issues as we were trying to nest a `div` within a `span`
  - Having a `div` is a bit more flexible as well since `Menu.Item` expects `children` to be of any type (e.g a react node)

<img width="279" height="149" alt="image" src="https://github.com/user-attachments/assets/12730cef-b077-4ef4-93c9-c21def939888" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized the Observability menu component to use named exports, ensuring consistent usage across the app.
  * Updated the mobile observability menu registration to reference the correct exported component.
* **Style**
  * Refined Observability menu item layout, spacing, truncation, and dropdown sizing for a cleaner presentation.
  * Enhanced menu item rendering to allow custom `className` styling and full-width content layout.
* **Accessibility**
  * Added an aria-label to the “more actions” button for improved screen reader support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->