### PR TITLE
Add create org CTA for authorize route if no org found

### DIFF
--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Error.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Error.tsx
@@ -18,13 +18,11 @@ export function ApiAuthorizationErrorScreen({
       <div className="flex flex-col gap-3 px-6 pb-6">
         <Admonition
           type="warning"
+          title="Retry the authorization request from the requesting app."
           description={
-            <>
-              Retry the authorization request from the requesting app.
-              {error && (
-                <span className="mt-1 block text-foreground-lighter">Error: {error.message}</span>
-              )}
-            </>
+            error && (
+              <span className="mt-1 block text-foreground-lighter">Error: {error.message}</span>
+            )
           }
         />
         <Button variant="default" block asChild>

--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Form.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Form.tsx
@@ -1,4 +1,5 @@
 import dayjs from 'dayjs'
+import Link from 'next/link'
 import { type ReactNode } from 'react'
 import type { UseFormReturn } from 'react-hook-form'
 import {
@@ -194,6 +195,12 @@ function OrganizationsEmptyState(): ReactNode {
       type="warning"
       title="No organizations found"
       description="Create an organization before authorizing this request."
+      actions={[
+        // [Joshen] JFYI this is a short term solution to guide users with creating an org from here
+        <Button asChild key="new-org" variant="default">
+          <Link href="/new">Create an organization</Link>
+        </Button>,
+      ]}
     />
   )
 }

--- a/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Invalid.tsx
+++ b/apps/studio/components/interfaces/ApiAuthorization/ApiAuthorization.Invalid.tsx
@@ -23,7 +23,8 @@ export function ApiAuthorizationInvalidScreen({
       <div className="flex flex-col gap-3 px-6 pb-6">
         <Admonition
           type="warning"
-          description={`Retry the authorization request from the requesting app. The URL is missing parameter${
+          title="Retry the authorization request from the requesting app. "
+          description={`The URL is missing parameter${
             isPlural ? 's' : ''
           }: ${missingParameters.join(', ')}.`}
         />


### PR DESCRIPTION
## Context

As per PR title - also left a comment that this is a short term solution for now, so we know where to clean up after the long term solution is implemented

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clear action in the empty organizations state so users can create an organization directly from the authorization flow.

- **Bug Fixes**
  - Improved authorization error messaging for clearer, more consistent display.
  - Refined invalid authorization guidance so the retry prompt and missing-parameter details are shown more cleanly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->