### PR TITLE
chore: remove old group references from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -21,4 +21,4 @@
 /apps/studio/components/interfaces/Organization/Documents/          @supabase/security
 /apps/studio/pages/new/index.tsx                                    @supabase/security
 
-/packages/shared-data/compute-disk-limits.ts @supabase/infra @supabase/platform
+/packages/shared-data/compute-disk-limits.ts @supabase/platform


### PR DESCRIPTION
This PR cleans up CODEOWNERS after the infrastructure teams have been renamed.

Removes old group references:
- @supabase/infra → (removed, now @supabase/platform)


The new group names are now in use and working correctly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership settings for one shared data area to reflect the current team responsible for it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->