### PR TITLE
Fix(docs): guides subheadings

### DIFF
--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -102,7 +102,7 @@ const GuideTemplate = ({
                 <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
               </h1>
               {meta?.subtitle && (
-                <div className="mt-1 [&_p]:text-xl [&_p]:leading-7 text-foreground-light [&>p]:m-0">
+                <div className="mt-6 [&_p]:text-xl [&_p]:leading-7 text-foreground-light [&>p]:m-0">
                   <ReactMarkdown>{meta.subtitle}</ReactMarkdown>
                 </div>
               )}

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -102,9 +102,9 @@ const GuideTemplate = ({
                 <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
               </h1>
               {meta?.subtitle && (
-                <h2 className="mt-1 text-xl text-foreground-light [&>p]:m-0">
+                <div className="mt-1 [&_p]:text-xl [&_p]:leading-7 text-foreground-light [&>p]:m-0">
                   <ReactMarkdown>{meta.subtitle}</ReactMarkdown>
-                </h2>
+                </div>
               )}
             </header>
 

--- a/apps/docs/features/docs/GuidesMdx.template.tsx
+++ b/apps/docs/features/docs/GuidesMdx.template.tsx
@@ -102,7 +102,7 @@ const GuideTemplate = ({
                 <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
               </h1>
               {meta?.subtitle && (
-                <div className="mt-6 [&_p]:text-xl [&_p]:leading-7 text-foreground-light [&>p]:m-0">
+                <div className="mt-3 not-prose [&_p]:text-xl [&_p]:leading-7 text-foreground-light [&>p]:m-0">
                   <ReactMarkdown>{meta.subtitle}</ReactMarkdown>
                 </div>
               )}

--- a/apps/docs/features/ui/guide/GuideHeader.tsx
+++ b/apps/docs/features/ui/guide/GuideHeader.tsx
@@ -18,7 +18,7 @@ export function GuideHeader({ className }: GuideHeaderProps) {
         <ReactMarkdown>{meta?.title || 'Supabase Docs'}</ReactMarkdown>
       </h1>
       {meta?.subtitle && (
-        <div className="mt-6 not-prose [&_p]:text-xl [&_p]:leading-7 text-foreground-light [&>p]:m-0">
+        <div className="mt-3 not-prose [&_p]:text-xl [&_p]:leading-7 text-foreground-light [&>p]:m-0">
           <ReactMarkdown>{meta.subtitle}</ReactMarkdown>
         </div>
       )}


### PR DESCRIPTION
Fix docs subheading by removing the h2 html tag and adjusting styling.
Likely a result of a merge conflict resolution between #47441 and #47288 

## What is the current behavior?

<img width="1168" height="641" alt="Screenshot 2026-07-09 at 10 19 00" src="https://github.com/user-attachments/assets/c23b2e88-650c-4835-ae10-5a13c7b2e180" />


## What is the new behavior?

<img width="1167" height="605" alt="Screenshot 2026-07-09 at 10 32 56" src="https://github.com/user-attachments/assets/852f208c-2b22-4bf6-ad8c-edcf5bee5991" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined how guide subtitles are displayed for a cleaner, more consistent layout.
  * Adjusted subtitle spacing and presentation while keeping subtitle content rendering with formatted text support intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->