### PR TITLE
docs: Update connect panel syntax

### DIFF
--- a/apps/docs/content/guides/getting-started/quickstarts/astrojs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/astrojs.mdx
@@ -51,7 +51,7 @@ export default defineConfig({
 
 ## 7. Declare Supabase environment variables
 
-Create a `.env.local` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=astro&tab=frameworks):
+Create a `.env.local` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=astro&connectTab=frameworks):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=astro">

--- a/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/flutter.mdx
@@ -36,7 +36,7 @@ supabase_flutter: ^2.0.0
 
 ## 6. Initialize the Supabase client
 
-Open `lib/main.dart` and edit the main function to initialize Supabase using your project URL and publishable key, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=flutter&tab=mobiles):
+Open `lib/main.dart` and edit the main function to initialize Supabase using your project URL and publishable key, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=flutter&connectTab=mobiles):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=mobiles&framework=flutter">

--- a/apps/docs/content/guides/getting-started/quickstarts/hono.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/hono.mdx
@@ -34,7 +34,7 @@ npm install
 
 ## 6. Set up the required environment variables
 
-Copy the `.env.example` file to `.env` and update the values with your Supabase project URL and publishable key, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&tab=frameworks).
+Copy the `.env.example` file to `.env` and update the values with your Supabase project URL and publishable key, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&connectTab=frameworks).
 
 Lastly, [enable anonymous sign-ins](/dashboard/project/_/auth/providers) in the Auth settings.
 

--- a/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/ios-swiftui.mdx
@@ -30,7 +30,7 @@ Make sure to add `Supabase` product package as a dependency to your application 
 
 ## 6. Initialize the Supabase client
 
-Create a new `Supabase.swift` file add a new Supabase instance using your project URL and publishable key, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=swift&tab=mobiles):
+Create a new `Supabase.swift` file add a new Supabase instance using your project URL and publishable key, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=swift&connectTab=mobiles):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=mobiles&framework=swift">

--- a/apps/docs/content/guides/getting-started/quickstarts/kotlin.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/kotlin.mdx
@@ -62,7 +62,7 @@ You can create a Supabase client whenever you need to perform an API call.
 
 For a quick example, create a client at the top of the `MainActivity.kt` file below the imports.
 
-Replace the `supabaseUrl` and `supabaseKey` with your own, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=androidkotlin&tab=mobiles):
+Replace the `supabaseUrl` and `supabaseKey` with your own, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=androidkotlin&connectTab=mobiles):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=mobiles&framework=androidkotlin">

--- a/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nextjs.mdx
@@ -26,7 +26,7 @@ npx skills add supabase/agent-skills
 
 ## 5. Declare Supabase environment variables
 
-Rename `.env.example` to `.env.local` and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=nextjs&tab=frameworks).
+Rename `.env.example` to `.env.local` and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=nextjs&connectTab=frameworks).
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=nextjs">

--- a/apps/docs/content/guides/getting-started/quickstarts/nuxtjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nuxtjs.mdx
@@ -36,7 +36,7 @@ cd my-app && npm install @supabase/supabase-js
 
 ## 6. Declare Supabase environment variables
 
-Create a `.env` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=nuxt&tab=frameworks):
+Create a `.env` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=nuxt&connectTab=frameworks):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=nuxt">

--- a/apps/docs/content/guides/getting-started/quickstarts/reactjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/reactjs.mdx
@@ -36,7 +36,7 @@ cd my-app && npm install @supabase/supabase-js
 
 ## 6. Declare Supabase environment variables
 
-Create a `.env.local` file and populate it with your Supabase URL and publishable key that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=react&tab=frameworks)
+Create a `.env.local` file and populate it with your Supabase URL and publishable key that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=react&connectTab=frameworks)
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=react">

--- a/apps/docs/content/guides/getting-started/quickstarts/refine.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/refine.mdx
@@ -30,7 +30,7 @@ npx skills add supabase/agent-skills
 
 ## 5. Update `supabaseClient` with environment variables
 
-Update the `supabaseClient` with the `SUPABASE_URL` and `SUPABASE_KEY` of your Supabase API, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=refine&tab=frameworks). The `supabaseClient` is used in auth provider and data provider methods that allow the Refine app to connect to your Supabase backend.
+Update the `supabaseClient` with the `SUPABASE_URL` and `SUPABASE_KEY` of your Supabase API, which you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=refine&connectTab=frameworks). The `supabaseClient` is used in auth provider and data provider methods that allow the Refine app to connect to your Supabase backend.
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=refine">

--- a/apps/docs/content/guides/getting-started/quickstarts/solidjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/solidjs.mdx
@@ -36,7 +36,7 @@ cd my-app && npm install @supabase/supabase-js
 
 ## 6. Declare Supabase environment variables
 
-Create a `.env.local` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=solidjs&tab=frameworks):
+Create a `.env.local` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=solidjs&connectTab=frameworks):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=solidjs">

--- a/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/sveltekit.mdx
@@ -36,7 +36,7 @@ cd my-app && npm install @supabase/supabase-js
 
 ## 6. Declare Supabase environment variables
 
-Create a `.env` file at the root of your project and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=sveltekit&tab=frameworks):
+Create a `.env` file at the root of your project and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=sveltekit&connectTab=frameworks):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=sveltekit">

--- a/apps/docs/content/guides/getting-started/quickstarts/vue.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/vue.mdx
@@ -36,7 +36,7 @@ cd my-app && npm install @supabase/supabase-js
 
 ## 6. Declare Supabase environment variables
 
-Create a `.env.local` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=vue&tab=frameworks):
+Create a `.env.local` file and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&framework=vue&connectTab=frameworks):
 
 <Button variant="primary" asChild>
   <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=vue">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

At some point, the incorrect URL arguments crept into the quickstarts. This PR fixes that.

## Steps to test

Click one of the links to the "Connect panel" and it should dep link to the appropriate selection in the panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multiple getting-started quickstarts to use the current project **Connect** panel links.
  * Corrected environment-variable setup instructions across web, mobile, and cross-platform guides.
  * Improved wording in a few guides for clearer setup steps, including `.env.local` guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->