### PR TITLE
Add CTA to update tax ID if run into tax ID issues when upgrading plan

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
@@ -4,7 +4,6 @@ import { loadStripe, PaymentMethod, StripeElementsOptions } from '@stripe/stripe
 import { useParams } from 'common'
 import { Loader, Plus } from 'lucide-react'
 import { useTheme } from 'next-themes'
-import Link from 'next/link'
 import {
   forwardRef,
   useCallback,
@@ -46,7 +45,7 @@ export interface PaymentMethodSelectionProps {
   onTaxIdChange?: (taxId: CustomerTaxId | null) => void
   useAsDefaultBillingAddress: boolean
   onUseAsDefaultBillingAddressChange: (useAsDefault: boolean) => void
-  onClose: () => void
+  onClose?: () => void
 }
 
 const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
@@ -238,10 +237,12 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
               variant="default"
               className="mt-2"
               onClick={() => {
-                snap.setPanelKey(undefined)
-                onClose()
-                const el = document.getElementById('address')
-                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                if (onClose) {
+                  onClose()
+                  snap.setPanelKey(undefined)
+                  const el = document.getElementById('address')
+                  if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+                }
               }}
             >
               Update tax ID

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/PaymentMethodSelection.tsx
@@ -4,6 +4,7 @@ import { loadStripe, PaymentMethod, StripeElementsOptions } from '@stripe/stripe
 import { useParams } from 'common'
 import { Loader, Plus } from 'lucide-react'
 import { useTheme } from 'next-themes'
+import Link from 'next/link'
 import {
   forwardRef,
   useCallback,
@@ -14,7 +15,7 @@ import {
   useState,
 } from 'react'
 import { toast } from 'sonner'
-import { Checkbox, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'ui'
+import { Button, Checkbox, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -32,6 +33,7 @@ import type { CustomerAddress, CustomerTaxId } from '@/data/organizations/types'
 import { SetupIntentResponse } from '@/data/stripe/setup-intent-mutation'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { BASE_PATH, STRIPE_PUBLIC_KEY } from '@/lib/constants'
+import { useOrgSettingsPageStateSnapshot } from '@/state/organization-settings'
 
 const stripePromise = loadStripe(STRIPE_PUBLIC_KEY)
 
@@ -44,6 +46,7 @@ export interface PaymentMethodSelectionProps {
   onTaxIdChange?: (taxId: CustomerTaxId | null) => void
   useAsDefaultBillingAddress: boolean
   onUseAsDefaultBillingAddressChange: (useAsDefault: boolean) => void
+  onClose: () => void
 }
 
 const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
@@ -56,10 +59,12 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
     onTaxIdChange,
     useAsDefaultBillingAddress,
     onUseAsDefaultBillingAddressChange,
+    onClose,
   }: PaymentMethodSelectionProps,
   ref
 ) {
   const { slug } = useParams()
+  const snap = useOrgSettingsPageStateSnapshot()
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const [captchaToken, setCaptchaToken] = useState<string | null>(null)
   const [captchaRef, setCaptchaRef] = useState<HCaptcha | null>(null)
@@ -223,7 +228,29 @@ const PaymentMethodSelection = forwardRef(function PaymentMethodSelection(
         dry_run: true,
       })
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to validate billing profile')
+      const errorMessage =
+        error instanceof Error ? error.message : 'Failed to validate billing profile'
+      if (errorMessage.includes('The tax ID type does not match the billing address country')) {
+        toast.error(
+          <div>
+            <p>{errorMessage} Update your billing address or tax ID before upgrading your plan.</p>
+            <Button
+              variant="default"
+              className="mt-2"
+              onClick={() => {
+                snap.setPanelKey(undefined)
+                onClose()
+                const el = document.getElementById('address')
+                if (el) el.scrollIntoView({ behavior: 'smooth', block: 'center' })
+              }}
+            >
+              Update tax ID
+            </Button>
+          </div>
+        )
+      } else {
+        toast.error(errorMessage)
+      }
       return false
     }
 

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/SubscriptionPlanUpdateDialog.tsx
@@ -361,6 +361,7 @@ export const SubscriptionPlanUpdateDialog = ({
                         onTaxIdChange={onTaxIdChange}
                         useAsDefaultBillingAddress={useAsDefaultBillingAddress}
                         onUseAsDefaultBillingAddressChange={onUseAsDefaultBillingAddressChange}
+                        onClose={onClose}
                       />
                     </div>
                   )}


### PR DESCRIPTION
## Context

There's a chance users may run into tax ID issues when upgrading a plan as such:
<img width="412" height="120" alt="image" src="https://github.com/user-attachments/assets/4c559ae0-d942-4c10-b83a-c5944a2a49ee" />

Adding a CTA here to guide users and mitigate confusion on how to proceed to remediate

<img width="399" height="147" alt="image" src="https://github.com/user-attachments/assets/3bcaca14-bd77-4168-b9ab-cd6b75f79e24" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing-profile validation feedback by standardizing error messaging for tax ID vs. billing address country mismatches.
  * Added an in-toast “Update tax ID” action to guide users directly to the fix.
  * Updated the billing dialog’s close behavior so it returns users to the relevant address section (including scrolling to it automatically).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->