### PR TITLE
fix(studio): increase max email OTP/invite expiry to 7 days

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -101,7 +101,7 @@ const PROVIDER_EMAIL = {
         z.coerce
           .number({ required_error: 'This is required', invalid_type_error: 'This is required' })
           .min(0, 'Must be greater or equal to 0')
-          .max(86400, 'Must be no more than 86400')
+          .max(604800, 'Must be no more than 604800')
       ),
       MAILER_OTP_LENGTH: z.preprocess(
         (val) => (val === '' || val == null ? undefined : val),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Raises Studio's client-side validation cap for the **Email OTP expiration** setting from 86400s (1 day) to 604800s (7 days). GoTrue and the Management API already allow higher values - this just aligns Studio with the backend.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the allowed maximum for email OTP expiration when external email is enabled, so longer expiration values are now accepted.
  * Updated the related validation message to match the new limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->