### PR TITLE
fix(studio): light mode floating toolbar rendering on small screens

### DIFF
--- a/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.tsx
+++ b/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.tsx
@@ -106,7 +106,7 @@ export const FloatingMobileToolbar = ({ hideMobileMenu }: { hideMobileMenu?: boo
                 'flex lg:hidden mr-1 rounded-md min-w-[30px] w-[30px] h-[30px] data-open:bg-overlay-hover/30',
                 !sheet.isMenuOpen && 'bg-surface-300!'
               )}
-              icon={<Menu />}
+              icon={<Menu className={cn(sheet.isMenuOpen && 'text-background')} />}
               onClick={sheet.handleMenuClick}
             />
           )}

--- a/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.utils.test.ts
+++ b/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.utils.test.ts
@@ -93,6 +93,7 @@ describe('getToolbarStyle', () => {
       viewport,
       isDragging: false,
     })
-    expect(style.zIndex).toBe(101)
+    // Above the sheet + overlay (z-40) but below the tooltip/portal layer (z-50).
+    expect(style.zIndex).toBe(45)
   })
 })

--- a/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.utils.ts
+++ b/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.utils.ts
@@ -72,7 +72,10 @@ export function getToolbarStyle(params: {
     ? 'transform 0ms, z-index 0s'
     : 'transform 300ms cubic-bezier(0.4, 0, 0.2, 1), z-index 0s'
   const base: CSSProperties = {
-    zIndex: isSheetOpen ? 101 : 41,
+    // When the sheet is open the toolbar must sit above the sheet + overlay (z-40) so its
+    // buttons stay clickable, but below the tooltip/portal layer (z-50) so tooltips for those
+    // buttons aren't rendered behind them.
+    zIndex: isSheetOpen ? 45 : 41,
     transition,
     touchAction: 'none',
   }

--- a/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
@@ -54,6 +54,10 @@ const StudioMobileSheetNav = () => {
       open={content !== null}
       onOpenChange={handleOpenChange}
       shouldCloseOnViewportResize={!activeSidebar}
+      // Sit below the tooltip/portal layer (z-50) so the floating toolbar's tooltips
+      // aren't occluded by the toolbar while the sheet is open (see FloatingMobileToolbar).
+      className="z-40"
+      overlayClassName="z-40"
     >
       {sheetChildren}
     </MobileSheetNav>

--- a/packages/ui-patterns/src/MobileSheetNav/MobileSheetNav.tsx
+++ b/packages/ui-patterns/src/MobileSheetNav/MobileSheetNav.tsx
@@ -12,6 +12,7 @@ const MobileSheetNav: React.FC<{
   open?: boolean
   onOpenChange(open: boolean): void
   className?: string
+  overlayClassName?: string
   shouldCloseOnRouteChange?: boolean
   shouldCloseOnViewportResize?: boolean
 }> = ({
@@ -19,6 +20,7 @@ const MobileSheetNav: React.FC<{
   open = false,
   onOpenChange,
   className,
+  overlayClassName,
   shouldCloseOnRouteChange = true,
   shouldCloseOnViewportResize = true,
 }) => {
@@ -48,6 +50,7 @@ const MobileSheetNav: React.FC<{
         showClose={false}
         size="full"
         side="bottom"
+        overlayClassName={overlayClassName}
         className={cn(
           'rounded-t-lg bg-background overflow-hidden overflow-y-scroll h-[85dvh] md:max-h-[500px]',
           className

--- a/packages/ui/src/components/shadcn/ui/sheet.tsx
+++ b/packages/ui/src/components/shadcn/ui/sheet.tsx
@@ -1,8 +1,8 @@
 'use client'
 
-import { Dialog as SheetPrimitive } from 'radix-ui'
 import { cva, type VariantProps } from 'class-variance-authority'
 import { X } from 'lucide-react'
+import { Dialog as SheetPrimitive } from 'radix-ui'
 import * as React from 'react'
 
 import { cn } from '../../../lib/utils/cn'
@@ -152,34 +152,49 @@ export interface DialogContentProps
     VariantProps<typeof sheetVariants> {
   showClose?: boolean
   hasOverlay?: boolean
+  overlayClassName?: string
 }
 
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   DialogContentProps
->(({ side, size, className, children, showClose = true, hasOverlay = true, ...props }, ref) => (
-  <SheetPortal side={side}>
-    {hasOverlay && <SheetOverlay />}
-    <SheetPrimitive.Content
-      ref={ref}
-      className={cn(sheetVariants({ side, size }), className)}
-      {...props}
-    >
-      {children}
-      {showClose ? (
-        <SheetPrimitive.Close
-          className={cn(
-            'absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary',
-            'hit-area-6'
-          )}
-        >
-          <X className="h-4 w-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
-      ) : null}
-    </SheetPrimitive.Content>
-  </SheetPortal>
-))
+>(
+  (
+    {
+      side,
+      size,
+      className,
+      children,
+      showClose = true,
+      hasOverlay = true,
+      overlayClassName,
+      ...props
+    },
+    ref
+  ) => (
+    <SheetPortal side={side}>
+      {hasOverlay && <SheetOverlay className={overlayClassName} />}
+      <SheetPrimitive.Content
+        ref={ref}
+        className={cn(sheetVariants({ side, size }), className)}
+        {...props}
+      >
+        {children}
+        {showClose ? (
+          <SheetPrimitive.Close
+            className={cn(
+              'absolute right-4 top-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary',
+              'hit-area-6'
+            )}
+          >
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        ) : null}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+)
 SheetContent.displayName = SheetPrimitive.Content.displayName
 
 const SheetHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On small screens in light mode, opening a sheet from the floating mobile toolbar caused two rendering issues:

- Tooltips for the toolbar buttons rendered **behind** the buttons.
- The active menu button showed as a **featureless black box**.

## What is the new behavior?

Two root causes, both in the floating mobile toolbar:

1. **Z-index inversion.** While a sheet was open the toolbar jumped to `z-101` — above the shared `z-50` portal layer used by tooltips/dropdowns — so its buttons' tooltips (dark `bg-alternative` in light mode) painted behind them. The toolbar's sheet + overlay are now lowered to `z-40` and the open-state toolbar to `z-45`, giving a clean order: tooltip (`z-50`) > toolbar (`z-45`) > sheet (`z-40`). The toolbar still sits above its sheet so its buttons stay clickable.

2. **Black menu button.** The active menu button uses the `secondary` variant (`bg-foreground`, i.e. black in light mode) but its icon inherited the near-invisible `text-border-muted` color, so it read as an empty black box. The icon now gets a contrasting color when active, matching the existing Help/Advisor buttons.

A small optional `overlayClassName` prop was added to the shared `Sheet`/`MobileSheetNav` so the mobile sheet's overlay z-index can be lowered (additive, default behavior unchanged).

## Additional context

Updated the `getToolbarStyle` unit test for the new z-index; existing `MobileSheetNav` tests still pass.
