### PR TITLE
fix(studio): extend downgrade error toast duration

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
@@ -38,7 +38,10 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
   const { mutate: updateOrgSubscription, isPending: isUpdating } = useOrgSubscriptionUpdateMutation(
     {
       onError: (error) => {
-        toast.error(`Failed to downgrade project: ${error.message}`)
+        toast.error(`Failed to downgrade project: ${error.message}`, {
+          duration: 10_000,
+          dismissible: true,
+        })
       },
     }
   )


### PR DESCRIPTION
## Summary
- Downgrading to Free tier is blocked server-side when an org has an active branch, but the resulting error toast in `ExitSurveyModal.tsx` used the default 4s toast duration, making it easy to miss.
- Adds `duration: 10_000, dismissible: true`, matching the pattern already used for other important billing error toasts (`org-subscription-update-mutation.ts`, `NewOrgForm.tsx`).

Fixes FE-3882

## Test plan
- [ ] Attempt to downgrade an org with an active branch to Free tier and confirm the error toast stays visible for 10s and can be dismissed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the downgrade error message to stay visible longer and be easier to dismiss, making failures clearer for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->