### PR TITLE
feat(docs): generate server.txt reference and wire into www llms

### DIFF
--- a/apps/docs/internals/generate-reference-markdown.ts
+++ b/apps/docs/internals/generate-reference-markdown.ts
@@ -33,8 +33,11 @@ type LegacyFn = {
   examples?: Example[]
 }
 
+type TypeComment = { shortText?: string; text?: string; examples?: Example[] }
+
 type TypeSpec = {
-  methods: Record<string, { comment?: { shortText?: string; examples?: Example[] } }>
+  methods: Record<string, { comment?: TypeComment }>
+  variables: Record<string, { comment?: TypeComment }>
 }
 
 type RefBase = {
@@ -108,7 +111,7 @@ const REFERENCES: Ref[] = [
   },
   {
     kind: 'sdk-new',
-    title: 'Supabase Server Library Reference',
+    title: 'Supabase Server SDK Reference',
     outFile: 'server.md',
     mdxDir: path.join(MDX_ROOT, 'server'),
     contentDir: path.join(process.cwd(), 'content/reference/server/v1'),
@@ -288,6 +291,7 @@ async function renderSdkNew(ref: SdkNewRef): Promise<string> {
   ])
   const fnsById = new Map(functions.map((fn) => [fn.id, fn]))
   const methods = typeSpec.methods ?? {}
+  const variables = typeSpec.variables ?? {}
 
   const parts: string[] = [`# ${ref.title}`]
   for (const section of flatten(sections)) {
@@ -303,11 +307,18 @@ async function renderSdkNew(ref: SdkNewRef): Promise<string> {
     if (section.type !== 'function' || !section.id) continue
     const fn = fnsById.get(section.id)
     if (!fn) continue
-    const tsm = fn.$ref ? methods[fn.$ref] : undefined
+    // Mirror the site's getTypeSpec fallback: TypeDoc consts and type aliases
+    // (e.g. server's error/type exports) live under `variables`, not `methods`.
+    const tsm = fn.$ref ? (methods[fn.$ref] ?? variables[fn.$ref]) : undefined
+    // The site joins shortText + text for the full description; some entries
+    // (e.g. deprecated type aliases) carry content only in `text`.
+    const commentBody = [tsm?.comment?.shortText, tsm?.comment?.text]
+      .filter((s): s is string => !!s?.trim())
+      .join('\n\n')
     parts.push(
       renderFunctionSection({
         title: fn.title || section.title || fn.id,
-        description: fn.description ?? tsm?.comment?.shortText,
+        description: fn.description ?? (commentBody || undefined),
         notes: fn.notes,
         examples: fn.examples ?? tsm?.comment?.examples,
       })

--- a/apps/docs/internals/generate-reference-markdown.ts
+++ b/apps/docs/internals/generate-reference-markdown.ts
@@ -107,6 +107,13 @@ const REFERENCES: Ref[] = [
     feature: 'sdk:dart',
   },
   {
+    kind: 'sdk-new',
+    title: 'Supabase Server Library Reference',
+    outFile: 'server.md',
+    mdxDir: path.join(MDX_ROOT, 'server'),
+    contentDir: path.join(process.cwd(), 'content/reference/server/v1'),
+  },
+  {
     kind: 'sdk-legacy',
     title: 'Kotlin Client Library Reference',
     outFile: 'kotlin.md',

--- a/apps/www/app/llms-full.txt/route.ts
+++ b/apps/www/app/llms-full.txt/route.ts
@@ -31,6 +31,7 @@ function getSources(): Source[] {
 
   return [
     { title: 'Supabase Reference (JavaScript)', slug: 'js', enabled: true },
+    { title: 'Supabase Server Library Reference', slug: 'server', enabled: true },
     { title: 'Supabase Reference (Dart)', slug: 'dart', enabled: sdkDart },
     { title: 'Supabase Reference (Swift)', slug: 'swift', enabled: sdkSwift },
     { title: 'Supabase Reference (Kotlin)', slug: 'kotlin', enabled: sdkKotlin },

--- a/apps/www/app/llms-full.txt/route.ts
+++ b/apps/www/app/llms-full.txt/route.ts
@@ -31,12 +31,12 @@ function getSources(): Source[] {
 
   return [
     { title: 'Supabase Reference (JavaScript)', slug: 'js', enabled: true },
-    { title: 'Supabase Server Library Reference', slug: 'server', enabled: true },
     { title: 'Supabase Reference (Dart)', slug: 'dart', enabled: sdkDart },
     { title: 'Supabase Reference (Swift)', slug: 'swift', enabled: sdkSwift },
     { title: 'Supabase Reference (Kotlin)', slug: 'kotlin', enabled: sdkKotlin },
     { title: 'Supabase Reference (Python)', slug: 'python', enabled: sdkPython },
     { title: 'Supabase Reference (C#)', slug: 'csharp', enabled: sdkCsharp },
+    { title: 'Supabase Server SDK Reference', slug: 'server', enabled: true },
     { title: 'Supabase CLI Reference', slug: 'cli', enabled: true },
     { title: 'Supabase Management API Reference', slug: 'api', enabled: true },
   ]

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -62,6 +62,7 @@ async function getSources(): Promise<Source[]> {
   return [
     ...guideSources,
     { title: 'Supabase Reference (JavaScript)', relPath: 'llms/js.txt', enabled: true },
+    { title: 'Supabase Server Library Reference', relPath: 'llms/server.txt', enabled: true },
     { title: 'Supabase Reference (Dart)', relPath: 'llms/dart.txt', enabled: sdkDart },
     { title: 'Supabase Reference (Swift)', relPath: 'llms/swift.txt', enabled: sdkSwift },
     { title: 'Supabase Reference (Kotlin)', relPath: 'llms/kotlin.txt', enabled: sdkKotlin },

--- a/apps/www/app/llms.txt/route.ts
+++ b/apps/www/app/llms.txt/route.ts
@@ -62,12 +62,12 @@ async function getSources(): Promise<Source[]> {
   return [
     ...guideSources,
     { title: 'Supabase Reference (JavaScript)', relPath: 'llms/js.txt', enabled: true },
-    { title: 'Supabase Server Library Reference', relPath: 'llms/server.txt', enabled: true },
     { title: 'Supabase Reference (Dart)', relPath: 'llms/dart.txt', enabled: sdkDart },
     { title: 'Supabase Reference (Swift)', relPath: 'llms/swift.txt', enabled: sdkSwift },
     { title: 'Supabase Reference (Kotlin)', relPath: 'llms/kotlin.txt', enabled: sdkKotlin },
     { title: 'Supabase Reference (Python)', relPath: 'llms/python.txt', enabled: sdkPython },
     { title: 'Supabase Reference (C#)', relPath: 'llms/csharp.txt', enabled: sdkCsharp },
+    { title: 'Supabase Server SDK Reference', relPath: 'llms/server.txt', enabled: true },
     { title: 'Supabase CLI Reference', relPath: 'llms/cli.txt', enabled: true },
     { title: 'Supabase Management API Reference', relPath: 'llms/api.txt', enabled: true },
   ]


### PR DESCRIPTION
Add a `server` entry to the reference-markdown pipeline so it emits `public/markdown/reference/server.md`, and register the Supabase Server Library Reference as a source in the www `llms.txt` and `llms-full.txt` routes.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the **Supabase Server SDK Reference** to the documentation set, including server-side API details.
  * Updated generated documentation outputs so the server reference appears in both the standard and plaintext documentation indexes/feeds.
  * Improved reference content rendering by enhancing how API descriptions are extracted and composed for more complete, readable SDK documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->