### PR TITLE
fix(studio): add error toasts for uninitialized models in AI SQL diff

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -634,13 +634,18 @@ export const SQLEditor = () => {
     try {
       setIsAcceptDiffLoading(true)
 
-      // TODO: show error if undefined
-      if (!sourceSqlDiff || !editorRef.current || !diffEditorRef.current) return
+      if (!sourceSqlDiff || !editorRef.current || !diffEditorRef.current) {
+        toast.error('Failed to accept changes: Editor is not fully initialized.')
+        return
+      }
 
       const editorModel = editorRef.current.getModel()
       const diffModel = diffEditorRef.current.getModel()
 
-      if (!editorModel || !diffModel) return
+      if (!editorModel || !diffModel) {
+        toast.error('Failed to accept changes: Editor models are missing.')
+        return
+      }
 
       const sql = diffModel.modified.getValue()
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / UX improvement

## What is the current behavior?

Inside `acceptAiHandler` in `SQLEditor.tsx`, when `sourceSqlDiff` or the editor references/models are uninitialized or missing, the function silently returns early. From the user's perspective, clicking the "Accept" button does nothing, providing no visual feedback or error handling for an uninitialized state.

## What is the new behavior?

Replaced the silent early returns with clear user-facing error notifications using the project's existing toast system (`import { toast } from 'sonner'`). Now, if the editor or its models fail to initialize when accepting a diff, the user receives an explicit toast message explaining the failure, keeping the UI intuitive and responsive.

## Additional context

Addresses the active `// TODO: show error if undefined` comments inside `SQLEditor.tsx`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear error notification when accepting AI-generated SQL changes is unavailable because the editor is not fully initialized.
  * Improved handling of incomplete editor states to prevent silent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->