### PR TITLE
fix(studio): replace hardcoded query linter warnings with dynamic cla…

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryDetail.tsx
@@ -14,6 +14,7 @@ import { formatSql } from '@/lib/formatSql'
 import { useTrack } from '@/lib/telemetry/track'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
+import { classifyQuery } from '../QueryInsights/hooks/useQueryInsightsIssues.utils'
 
 interface QueryDetailProps {
   selectedRow?: QueryPerformanceRow
@@ -30,8 +31,7 @@ const SqlMonacoBlock = dynamic(
 )
 
 export const QueryDetail = ({ selectedRow, onClickViewSuggestion, onClose }: QueryDetailProps) => {
-  // [Joshen] TODO implement this logic once the linter rules are in
-  const isLinterWarning = false
+  const isLinterWarning = selectedRow ? classifyQuery(selectedRow).issueType !== null : false
   const report = QUERY_PERFORMANCE_COLUMNS
   const [query, setQuery] = useState(selectedRow?.['query'])
 

--- a/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/QueryIndexes.tsx
@@ -61,8 +61,6 @@ export const QueryIndexes = ({
   prefetchedIndexAdvisorResult,
   onClose,
 }: QueryIndexesProps) => {
-  // [Joshen] TODO implement this logic once the linter rules are in
-  const isLinterWarning = false
   const { data: project } = useSelectedProjectQuery()
   const [showStartupCosts, setShowStartupCosts] = useState(false)
   const [isExecuting, setIsExecuting] = useState(false)
@@ -111,6 +109,10 @@ export const QueryIndexes = ({
     : fetchedIndexAdvisorResult
   const isSuccessIndexAdvisorResult = hasPrefetchedResult || isFetchSuccessIndexAdvisorResult
   const isLoadingIndexAdvisorResult = hasPrefetchedResult ? false : isFetchLoadingIndexAdvisorResult
+
+  const isLinterWarning = indexAdvisorResult
+    ? hasIndexRecommendations(indexAdvisorResult, true)
+    : false
 
   const {
     index_statements,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / Feature restoration

## What is the current behavior?

In `QueryDetail.tsx` and `QueryIndexes.tsx`, the indicator warning flag for query linter issues was hardcoded to `const isLinterWarning = false` under a temporary placeholder comment. Because of this, active or slow query warnings on the dashboard never correctly surface to the user.

## What is the new behavior?

Replaced the hardcoded boolean flags with active evaluation logic linked directly to Supabase's query insights engine:
- In `QueryDetail.tsx`, imported and utilized `classifyQuery` to dynamically analyze the `QueryPerformanceRow` data structure for slow metrics or structural issues.
- In `QueryIndexes.tsx`, dynamically set the indicator via the existing `hasIndexRecommendations` checker running over the file's scoped `indexAdvisorResult`.

## Additional context

Addresses the unresolved `// [Joshen] TODO implement this logic once the linter rules are in` flags across the Query Performance panel components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Query performance pages now show index optimization suggestions when a query qualifies for them.
  * Index recommendation messaging is now displayed more consistently based on available analysis results.

* **Bug Fixes**
  * Fixed cases where optimization alerts were not appearing because warning states were previously left off by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->