### PR TITLE
blog: add UTM params to CipherStash post links

### DIFF
--- a/apps/www/_blog/2026-07-09-searchable-field-level-encryption-with-cipherstash.mdx
+++ b/apps/www/_blog/2026-07-09-searchable-field-level-encryption-with-cipherstash.mdx
@@ -15,9 +15,9 @@ date: '2026-07-09T10:00:00'
 toc_depth: 2
 ---
 
-The [CipherStash integration](https://supabase.com/partners/integrations/cipherstash) for Supabase is now available.
+The [CipherStash integration](https://supabase.com/partners/integrations/cipherstash?utm_source=supabase_announcement_post&utm_medium=blog&utm_campaign=launch) for Supabase is now available.
 
-[CipherStash](https://cipherstash.com) is a Data Level Access Control (DLAC) platform for applications built on Postgres. DLAC extends traditional access control, which typically operates at the row or table level, down to individual encrypted values, so policies are enforced at decryption rather than at the query layer.
+[CipherStash](https://cipherstash.com/?utm_source=supabase_announcement_post&utm_medium=blog&utm_campaign=launch) is a Data Level Access Control (DLAC) platform for applications built on Postgres. DLAC extends traditional access control, which typically operates at the row or table level, down to individual encrypted values, so policies are enforced at decryption rather than at the query layer.
 
 With CipherStash, teams can encrypt sensitive fields at the application layer with a unique key per value, run searches and joins against encrypted data without decrypting it, and keep keys under their own control through ZeroKMS, CipherStash's zero-knowledge key management service. Because keys never leave your control, neither CipherStash nor Supabase can access your plaintext data.
 
@@ -56,4 +56,4 @@ For cases where the SDK isn't a fit, such as analytics jobs, admin tooling, back
 
 ## Get started
 
-→ [Add CipherStash to your Supabase project](https://supabase.com/partners/integrations/cipherstash)
+→ [Add CipherStash to your Supabase project](https://supabase.com/partners/integrations/cipherstash?utm_source=supabase_announcement_post&utm_medium=blog&utm_campaign=launch)


### PR DESCRIPTION
## Add UTM params to CipherStash blog post links

Follow-up to #47751. The [Notion doc](https://app.notion.com/p/supabase/Blog-Post-CipherStash-partner-drop-3455004b775f81c68712f6a115ee43f8) now has UTM-tagged outbound links for launch tracking. This applies them to the three links in the published post.

All three use `?utm_source=supabase_announcement_post&utm_medium=blog&utm_campaign=launch`:
- Intro: CipherStash integration link
- Intro: cipherstash.com link
- Get started: Add CipherStash to your Supabase project

No content or copy changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CipherStash and Supabase links in the blog post with campaign tracking parameters.
  * Applied tracking to introductory links and the “Get started” call-to-action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->