### PR TITLE
fix(telemetry): dedupe funnel toast error events

### DIFF
--- a/apps/studio/components/interfaces/ErrorHandling/ErrorMatcher.tsx
+++ b/apps/studio/components/interfaces/ErrorHandling/ErrorMatcher.tsx
@@ -3,6 +3,7 @@
 import { ErrorDisplay, SupportFormParams } from 'ui-patterns/ErrorDisplay/ErrorDisplay'
 
 import { getMappingForError } from './ErrorMatcher.utils'
+import { isDashboardErrorSampled } from '@/lib/telemetry/error-sampling'
 import { useTrack } from '@/lib/telemetry/track'
 
 interface ErrorMatcherProps {
@@ -26,7 +27,7 @@ export function ErrorMatcher({ title, error, supportFormParams, className }: Err
       supportFormParams={supportFormParams}
       className={className}
       onRender={() => {
-        if (Math.random() < 0.1) {
+        if (isDashboardErrorSampled()) {
           track('dashboard_error_created', {
             source: 'error_display',
             errorType: mapping?.id,

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -65,6 +65,7 @@ import {
 } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
 import { useTrackFunnelError } from '@/lib/telemetry/use-track-funnel-error'
+import { markToastAsTracked } from '@/lib/toast-errors'
 
 interface NewOrgFormProps {
   onPaymentMethodReset: () => void
@@ -253,7 +254,7 @@ export const NewOrgForm = ({
       }
     },
     onError: (data) => {
-      toast.error(data.message, { duration: 10_000 })
+      markToastAsTracked(toast.error(data.message, { duration: 10_000 }))
       trackFunnelError('org_creation', classifyApiError('org_creation', data), 'toast')
       setNewOrgLoading(false)
     },
@@ -266,7 +267,7 @@ export const NewOrgForm = ({
       }
     },
     onError: (error) => {
-      toast.error(error.message, { dismissible: true, duration: 10_000 })
+      markToastAsTracked(toast.error(error.message, { dismissible: true, duration: 10_000 }))
       trackFunnelError('org_creation', classifyApiError('org_creation', error), 'toast')
     },
   })
@@ -289,9 +290,11 @@ export const NewOrgForm = ({
         'toast'
       )
       // If the payment intent is not successful, we reset the payment method and show an error
-      toast.error(`Could not confirm payment. Please try again or use a different card.`, {
-        duration: 10_000,
-      })
+      markToastAsTracked(
+        toast.error(`Could not confirm payment. Please try again or use a different card.`, {
+          duration: 10_000,
+        })
+      )
       resetPaymentMethod()
       setNewOrgLoading(false)
     }
@@ -591,7 +594,7 @@ export const NewOrgForm = ({
               }
               onLoadingChange={(loading) => setPaymentConfirmationLoading(loading)}
               onError={(err) => {
-                toast.error(err.message, { duration: 10_000 })
+                markToastAsTracked(toast.error(err.message, { duration: 10_000 }))
                 trackFunnelError(
                   'org_creation',
                   { errorCategory: 'payment', errorReason: 'payment_error' },

--- a/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
+++ b/apps/studio/components/interfaces/Organization/NewOrg/NewOrgForm.tsx
@@ -65,7 +65,6 @@ import {
 } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
 import { useTrackFunnelError } from '@/lib/telemetry/use-track-funnel-error'
-import { markToastAsTracked } from '@/lib/toast-errors'
 
 interface NewOrgFormProps {
   onPaymentMethodReset: () => void
@@ -254,8 +253,8 @@ export const NewOrgForm = ({
       }
     },
     onError: (data) => {
-      markToastAsTracked(toast.error(data.message, { duration: 10_000 }))
-      trackFunnelError('org_creation', classifyApiError('org_creation', data), 'toast')
+      const toastId = toast.error(data.message, { duration: 10_000 })
+      trackFunnelError('org_creation', classifyApiError('org_creation', data), 'toast', toastId)
       setNewOrgLoading(false)
     },
   })
@@ -267,8 +266,8 @@ export const NewOrgForm = ({
       }
     },
     onError: (error) => {
-      markToastAsTracked(toast.error(error.message, { dismissible: true, duration: 10_000 }))
-      trackFunnelError('org_creation', classifyApiError('org_creation', error), 'toast')
+      const toastId = toast.error(error.message, { dismissible: true, duration: 10_000 })
+      trackFunnelError('org_creation', classifyApiError('org_creation', error), 'toast', toastId)
     },
   })
 
@@ -284,16 +283,16 @@ export const NewOrgForm = ({
         size: form.getValues('size'),
       })
     } else {
+      // If the payment intent is not successful, we reset the payment method and show an error
+      const toastId = toast.error(
+        `Could not confirm payment. Please try again or use a different card.`,
+        { duration: 10_000 }
+      )
       trackFunnelError(
         'org_creation',
         classifyStripeError(paymentIntentConfirmation.error),
-        'toast'
-      )
-      // If the payment intent is not successful, we reset the payment method and show an error
-      markToastAsTracked(
-        toast.error(`Could not confirm payment. Please try again or use a different card.`, {
-          duration: 10_000,
-        })
+        'toast',
+        toastId
       )
       resetPaymentMethod()
       setNewOrgLoading(false)
@@ -594,11 +593,12 @@ export const NewOrgForm = ({
               }
               onLoadingChange={(loading) => setPaymentConfirmationLoading(loading)}
               onError={(err) => {
-                markToastAsTracked(toast.error(err.message, { duration: 10_000 }))
+                const toastId = toast.error(err.message, { duration: 10_000 })
                 trackFunnelError(
                   'org_creation',
                   { errorCategory: 'payment', errorReason: 'payment_error' },
-                  'toast'
+                  'toast',
+                  toastId
                 )
                 setNewOrgLoading(false)
                 resetPaymentMethod()

--- a/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -27,7 +27,6 @@ import { BASE_PATH } from '@/lib/constants'
 import { buildPathWithParams } from '@/lib/gotrue'
 import { classifyApiError, classifyValidationError } from '@/lib/telemetry/funnel-errors'
 import { useTrackFunnelError } from '@/lib/telemetry/use-track-funnel-error'
-import { markToastAsTracked } from '@/lib/toast-errors'
 
 const schema = z.object({
   email: z.string().min(1, 'Email is required').email('Must be a valid email'),
@@ -80,8 +79,8 @@ export const SignUpForm = () => {
     onError: (error) => {
       setCaptchaToken(null)
       captchaRef.current?.resetCaptcha()
-      markToastAsTracked(toast.error(`Failed to sign up: ${error.message}`))
-      trackFunnelError('signup', classifyApiError('signup', error), 'toast')
+      const toastId = toast.error(`Failed to sign up: ${error.message}`)
+      trackFunnelError('signup', classifyApiError('signup', error), 'toast', toastId)
     },
   })
 

--- a/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignUpForm.tsx
@@ -27,6 +27,7 @@ import { BASE_PATH } from '@/lib/constants'
 import { buildPathWithParams } from '@/lib/gotrue'
 import { classifyApiError, classifyValidationError } from '@/lib/telemetry/funnel-errors'
 import { useTrackFunnelError } from '@/lib/telemetry/use-track-funnel-error'
+import { markToastAsTracked } from '@/lib/toast-errors'
 
 const schema = z.object({
   email: z.string().min(1, 'Email is required').email('Must be a valid email'),
@@ -79,7 +80,7 @@ export const SignUpForm = () => {
     onError: (error) => {
       setCaptchaToken(null)
       captchaRef.current?.resetCaptcha()
-      toast.error(`Failed to sign up: ${error.message}`)
+      markToastAsTracked(toast.error(`Failed to sign up: ${error.message}`))
       trackFunnelError('signup', classifyApiError('signup', error), 'toast')
     },
   })

--- a/apps/studio/components/ui/AlertError.tsx
+++ b/apps/studio/components/ui/AlertError.tsx
@@ -4,6 +4,7 @@ import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
+import { isDashboardErrorSampled } from '@/lib/telemetry/error-sampling'
 import { useTrack } from '@/lib/telemetry/track'
 
 export interface AlertErrorProps {
@@ -70,7 +71,7 @@ export const AlertError = ({
   useEffect(() => {
     if (!hasTrackedRef.current) {
       hasTrackedRef.current = true
-      if (Math.random() < 0.1) {
+      if (isDashboardErrorSampled()) {
         track('dashboard_error_created', {
           source: 'admonition',
         })

--- a/apps/studio/lib/telemetry/error-sampling.ts
+++ b/apps/studio/lib/telemetry/error-sampling.ts
@@ -1,0 +1,8 @@
+// dashboard_error_created is emitted from several sources (toast, form, admonition,
+// error_display) that must share one capture rate — downstream analysis assumes a uniform
+// sampling multiplier when comparing volumes across sources.
+export const DASHBOARD_ERROR_SAMPLE_RATE = 0.1
+
+export function isDashboardErrorSampled() {
+  return Math.random() < DASHBOARD_ERROR_SAMPLE_RATE
+}

--- a/apps/studio/lib/telemetry/use-track-funnel-error.ts
+++ b/apps/studio/lib/telemetry/use-track-funnel-error.ts
@@ -1,13 +1,9 @@
 import { useCallback } from 'react'
 
+import { isDashboardErrorSampled } from '@/lib/telemetry/error-sampling'
 import type { FunnelErrorClassification, FunnelOrigin } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
 import { registerFunnelErrorToast } from '@/lib/toast-errors'
-
-// Matches the existing dashboard_error_created capture rate; keeps PostHog volume bounded.
-// Only form-sourced events are sampled here — toast-sourced events are sampled once by
-// ToastErrorTracker, which is the sole emitter for them.
-const SAMPLE_RATE = 0.1
 
 interface TrackFunnelError {
   /**
@@ -47,7 +43,9 @@ export function useTrackFunnelError() {
         if (toastId !== undefined) registerFunnelErrorToast(toastId, properties)
         return
       }
-      if (Math.random() >= SAMPLE_RATE) return
+      // Form-sourced events are sampled here — toast-sourced events are sampled once by
+      // ToastErrorTracker, which is the sole emitter for them.
+      if (!isDashboardErrorSampled()) return
       track('dashboard_error_created', { source, ...properties })
     },
     [track]

--- a/apps/studio/lib/telemetry/use-track-funnel-error.ts
+++ b/apps/studio/lib/telemetry/use-track-funnel-error.ts
@@ -2,26 +2,53 @@ import { useCallback } from 'react'
 
 import type { FunnelErrorClassification, FunnelOrigin } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
+import { registerFunnelErrorToast } from '@/lib/toast-errors'
 
 // Matches the existing dashboard_error_created capture rate; keeps PostHog volume bounded.
+// Only form-sourced events are sampled here — toast-sourced events are sampled once by
+// ToastErrorTracker, which is the sole emitter for them.
 const SAMPLE_RATE = 0.1
+
+interface TrackFunnelError {
+  /**
+   * Toast-sourced errors are emitted by ToastErrorTracker as a single enriched
+   * dashboard_error_created event. Pass the id returned by toast.error() so the tracker
+   * attaches the funnel properties instead of firing an untagged duplicate.
+   *
+   * Call this in the same synchronous block that created the toast — the tracker processes
+   * new toasts in an effect on the next render, so registering after an await could be too
+   * late and the event would go out untagged.
+   */
+  (
+    origin: FunnelOrigin,
+    classification: FunnelErrorClassification,
+    source: 'toast',
+    toastId: string | number
+  ): void
+  (origin: FunnelOrigin, classification: FunnelErrorClassification, source: 'form'): void
+}
 
 export function useTrackFunnelError() {
   const track = useTrack()
-  return useCallback(
+  return useCallback<TrackFunnelError>(
     (
       origin: FunnelOrigin,
       classification: FunnelErrorClassification,
-      source: 'toast' | 'form' = 'toast'
+      source: 'toast' | 'form',
+      toastId?: string | number
     ) => {
-      if (Math.random() >= SAMPLE_RATE) return
-      track('dashboard_error_created', {
-        source,
+      const properties = {
         origin,
         errorCategory: classification.errorCategory,
         errorReason: classification.errorReason,
         ...(classification.errorCode !== undefined && { errorCode: classification.errorCode }),
-      })
+      }
+      if (source === 'toast') {
+        if (toastId !== undefined) registerFunnelErrorToast(toastId, properties)
+        return
+      }
+      if (Math.random() >= SAMPLE_RATE) return
+      track('dashboard_error_created', { source, ...properties })
     },
     [track]
   )

--- a/apps/studio/lib/toast-errors.test.tsx
+++ b/apps/studio/lib/toast-errors.test.tsx
@@ -1,8 +1,9 @@
-import { act, render, waitFor } from '@testing-library/react'
+import { act, render, renderHook, waitFor } from '@testing-library/react'
 import { toast } from 'sonner'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { markToastAsTracked, ToastErrorTracker } from './toast-errors'
+import { registerFunnelErrorToast, ToastErrorTracker } from './toast-errors'
+import { useTrackFunnelError } from '@/lib/telemetry/use-track-funnel-error'
 
 const { mockTrack } = vi.hoisted(() => ({ mockTrack: vi.fn() }))
 
@@ -18,7 +19,7 @@ describe('ToastErrorTracker', () => {
     vi.restoreAllMocks()
   })
 
-  it('tracks an unmarked error toast', async () => {
+  it('tracks an unregistered error toast without funnel properties', async () => {
     render(<ToastErrorTracker />)
     act(() => {
       toast.error('request failed')
@@ -29,16 +30,50 @@ describe('ToastErrorTracker', () => {
     expect(mockTrack).toHaveBeenCalledTimes(1)
   })
 
-  it('skips a toast marked as tracked', async () => {
+  it('fires a single enriched event for a registered funnel toast', async () => {
     render(<ToastErrorTracker />)
     act(() => {
-      markToastAsTracked(toast.error('funnel error tracked at the call site'))
+      registerFunnelErrorToast(toast.error('funnel error'), {
+        origin: 'signup',
+        errorCategory: 'api',
+        errorReason: 'other',
+        errorCode: 500,
+      })
     })
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith('dashboard_error_created', {
+        source: 'toast',
+        origin: 'signup',
+        errorCategory: 'api',
+        errorReason: 'other',
+        errorCode: 500,
+      })
+    )
+    expect(mockTrack).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes toast-sourced funnel errors from useTrackFunnelError into one enriched event', async () => {
+    render(<ToastErrorTracker />)
+    const { result } = renderHook(() => useTrackFunnelError())
     act(() => {
-      toast.error('unmarked sentinel')
+      const toastId = toast.error('funnel failure')
+      result.current(
+        'project_creation',
+        { errorCategory: 'api', errorReason: 'rate_limited', errorCode: 429 },
+        'toast',
+        toastId
+      )
     })
-    await waitFor(() => expect(mockTrack).toHaveBeenCalledTimes(1))
-    expect(mockTrack).toHaveBeenCalledWith('dashboard_error_created', { source: 'toast' })
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith('dashboard_error_created', {
+        source: 'toast',
+        origin: 'project_creation',
+        errorCategory: 'api',
+        errorReason: 'rate_limited',
+        errorCode: 429,
+      })
+    )
+    expect(mockTrack).toHaveBeenCalledTimes(1)
   })
 
   it('ignores non-error toasts', async () => {

--- a/apps/studio/lib/toast-errors.test.tsx
+++ b/apps/studio/lib/toast-errors.test.tsx
@@ -1,0 +1,66 @@
+import { act, render, waitFor } from '@testing-library/react'
+import { toast } from 'sonner'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { markToastAsTracked, ToastErrorTracker } from './toast-errors'
+
+const { mockTrack } = vi.hoisted(() => ({ mockTrack: vi.fn() }))
+
+vi.mock('@/lib/telemetry/track', () => ({ useTrack: () => mockTrack }))
+
+describe('ToastErrorTracker', () => {
+  beforeEach(() => {
+    mockTrack.mockReset()
+    vi.spyOn(Math, 'random').mockReturnValue(0)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('tracks an unmarked error toast', async () => {
+    render(<ToastErrorTracker />)
+    act(() => {
+      toast.error('request failed')
+    })
+    await waitFor(() =>
+      expect(mockTrack).toHaveBeenCalledWith('dashboard_error_created', { source: 'toast' })
+    )
+    expect(mockTrack).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips a toast marked as tracked', async () => {
+    render(<ToastErrorTracker />)
+    act(() => {
+      markToastAsTracked(toast.error('funnel error tracked at the call site'))
+    })
+    act(() => {
+      toast.error('unmarked sentinel')
+    })
+    await waitFor(() => expect(mockTrack).toHaveBeenCalledTimes(1))
+    expect(mockTrack).toHaveBeenCalledWith('dashboard_error_created', { source: 'toast' })
+  })
+
+  it('ignores non-error toasts', async () => {
+    render(<ToastErrorTracker />)
+    act(() => {
+      toast.success('all good')
+    })
+    act(() => {
+      toast.error('unmarked sentinel')
+    })
+    await waitFor(() => expect(mockTrack).toHaveBeenCalledTimes(1))
+  })
+
+  it('skips error toasts that lose the sampling draw', async () => {
+    vi.spyOn(Math, 'random').mockReturnValueOnce(0.5)
+    render(<ToastErrorTracker />)
+    act(() => {
+      toast.error('sampled out')
+    })
+    act(() => {
+      toast.error('sampled in')
+    })
+    await waitFor(() => expect(mockTrack).toHaveBeenCalledTimes(1))
+  })
+})

--- a/apps/studio/lib/toast-errors.tsx
+++ b/apps/studio/lib/toast-errors.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react'
 import { useSonner } from 'sonner'
 
+import { isDashboardErrorSampled } from '@/lib/telemetry/error-sampling'
 import type { FunnelErrorClassification, FunnelOrigin } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
 
@@ -28,7 +29,7 @@ export const ToastErrorTracker = () => {
       seenToastIds.current.add(toast.id)
       const funnelProperties = funnelErrorToasts.get(toast.id)
       funnelErrorToasts.delete(toast.id)
-      if (Math.random() < 0.1) {
+      if (isDashboardErrorSampled()) {
         track('dashboard_error_created', {
           source: 'toast',
           ...funnelProperties,

--- a/apps/studio/lib/toast-errors.tsx
+++ b/apps/studio/lib/toast-errors.tsx
@@ -3,20 +3,27 @@ import { useSonner } from 'sonner'
 
 import { useTrack } from '@/lib/telemetry/track'
 
+const trackedToastIds = new Set<string | number>()
+
+export function markToastAsTracked(toastId: string | number) {
+  trackedToastIds.add(toastId)
+  return toastId
+}
+
 export const ToastErrorTracker = () => {
   const track = useTrack()
   const { toasts } = useSonner()
-  const trackRef = useRef(new Set<string | number>())
+  const seenToastIds = useRef(new Set<string | number>())
 
   useEffect(() => {
     toasts.forEach((toast) => {
-      if (toast.type === 'error' && !trackRef.current.has(toast.id)) {
-        trackRef.current.add(toast.id)
-        if (Math.random() < 0.1) {
-          track('dashboard_error_created', {
-            source: 'toast',
-          })
-        }
+      if (toast.type !== 'error' || seenToastIds.current.has(toast.id)) return
+      seenToastIds.current.add(toast.id)
+      if (trackedToastIds.has(toast.id)) return
+      if (Math.random() < 0.1) {
+        track('dashboard_error_created', {
+          source: 'toast',
+        })
       }
     })
   }, [toasts, track])

--- a/apps/studio/lib/toast-errors.tsx
+++ b/apps/studio/lib/toast-errors.tsx
@@ -1,13 +1,20 @@
 import { useEffect, useRef } from 'react'
 import { useSonner } from 'sonner'
 
+import type { FunnelErrorClassification, FunnelOrigin } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
 
-const trackedToastIds = new Set<string | number>()
+type FunnelErrorProperties = { origin: FunnelOrigin } & FunnelErrorClassification
 
-export function markToastAsTracked(toastId: string | number) {
-  trackedToastIds.add(toastId)
-  return toastId
+// Funnel call sites register their toast id (via useTrackFunnelError) so the tracker emits a
+// single enriched event for that toast instead of an untagged duplicate.
+const funnelErrorToasts = new Map<string | number, FunnelErrorProperties>()
+
+export function registerFunnelErrorToast(
+  toastId: string | number,
+  properties: FunnelErrorProperties
+) {
+  funnelErrorToasts.set(toastId, properties)
 }
 
 export const ToastErrorTracker = () => {
@@ -19,10 +26,12 @@ export const ToastErrorTracker = () => {
     toasts.forEach((toast) => {
       if (toast.type !== 'error' || seenToastIds.current.has(toast.id)) return
       seenToastIds.current.add(toast.id)
-      if (trackedToastIds.has(toast.id)) return
+      const funnelProperties = funnelErrorToasts.get(toast.id)
+      funnelErrorToasts.delete(toast.id)
       if (Math.random() < 0.1) {
         track('dashboard_error_created', {
           source: 'toast',
+          ...funnelProperties,
         })
       }
     })

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -74,6 +74,7 @@ import { useProfile } from '@/lib/profile'
 import { classifyApiError, classifyValidationError } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
 import { useTrackFunnelError } from '@/lib/telemetry/use-track-funnel-error'
+import { markToastAsTracked } from '@/lib/toast-errors'
 import type { NextPageWithLayout } from '@/types'
 
 const sizesWithNoCostConfirmationRequired: DesiredInstanceSize[] = ['micro', 'small']
@@ -322,7 +323,7 @@ const Wizard: NextPageWithLayout = () => {
       router.push(`/project/${res.ref}`)
     },
     onError: (error) => {
-      toast.error(`Failed to create new project: ${error.message}`)
+      markToastAsTracked(toast.error(`Failed to create new project: ${error.message}`))
       trackFunnelError('project_creation', classifyApiError('project_creation', error), 'toast')
     },
   })
@@ -369,7 +370,9 @@ const Wizard: NextPageWithLayout = () => {
         { errorCategory: 'validation', errorReason: 'oriole_unavailable' },
         'toast'
       )
-      return toast.error('No available OrioleDB image found, only Postgres is available')
+      return markToastAsTracked(
+        toast.error('No available OrioleDB image found, only Postgres is available')
+      )
     }
 
     const { postgresEngine, releaseChannel } =

--- a/apps/studio/pages/new/[slug].tsx
+++ b/apps/studio/pages/new/[slug].tsx
@@ -74,7 +74,6 @@ import { useProfile } from '@/lib/profile'
 import { classifyApiError, classifyValidationError } from '@/lib/telemetry/funnel-errors'
 import { useTrack } from '@/lib/telemetry/track'
 import { useTrackFunnelError } from '@/lib/telemetry/use-track-funnel-error'
-import { markToastAsTracked } from '@/lib/toast-errors'
 import type { NextPageWithLayout } from '@/types'
 
 const sizesWithNoCostConfirmationRequired: DesiredInstanceSize[] = ['micro', 'small']
@@ -323,8 +322,13 @@ const Wizard: NextPageWithLayout = () => {
       router.push(`/project/${res.ref}`)
     },
     onError: (error) => {
-      markToastAsTracked(toast.error(`Failed to create new project: ${error.message}`))
-      trackFunnelError('project_creation', classifyApiError('project_creation', error), 'toast')
+      const toastId = toast.error(`Failed to create new project: ${error.message}`)
+      trackFunnelError(
+        'project_creation',
+        classifyApiError('project_creation', error),
+        'toast',
+        toastId
+      )
     },
   })
 
@@ -365,14 +369,14 @@ const Wizard: NextPageWithLayout = () => {
     } = values
 
     if (useOrioleDb && !availableOrioleVersion) {
+      const toastId = toast.error('No available OrioleDB image found, only Postgres is available')
       trackFunnelError(
         'project_creation',
         { errorCategory: 'validation', errorReason: 'oriole_unavailable' },
-        'toast'
+        'toast',
+        toastId
       )
-      return markToastAsTracked(
-        toast.error('No available OrioleDB image found, only Postgres is available')
-      )
+      return
     }
 
     const { postgresEngine, releaseChannel } =

--- a/apps/studio/routes/__root.tsx
+++ b/apps/studio/routes/__root.tsx
@@ -77,6 +77,7 @@ import { API_URL, BASE_PATH, IS_PLATFORM, useDefaultProvider } from '@/lib/const
 import { NuqsAdapter } from '@/lib/nuqs-tanstack-adapter'
 import { ProfileProvider } from '@/lib/profile'
 import { Telemetry } from '@/lib/telemetry'
+import { ToastErrorTracker } from '@/lib/toast-errors'
 import { Toaster } from '@/lib/toaster'
 import Error404 from '@/pages/404'
 import Error500 from '@/pages/500'
@@ -340,6 +341,7 @@ function RootComponent() {
                             </FeaturePreviewContextProvider>
                           </BannerStackProvider>
                           <Toaster />
+                          <ToastErrorTracker />
                           <MonacoThemeProvider />
                         </CommandProvider>
                       </AiAssistantStateContextProvider>


### PR DESCRIPTION
## Summary
Since #47293, an API failure on a signup / org-creation / project-creation form emitted `dashboard_error_created` twice: `useTrackFunnelError` fired the origin-tagged event and the global `ToastErrorTracker` independently fired the legacy untagged `source:'toast'` event for the same toast, each behind its own 10% sampling draw. I verified the twin rate empirically at 8-11% of origin-tagged funnel toasts, exactly the floor for two independent 10% draws, meaning the twin co-fires for effectively every funnel error ([Hex thread](https://app.hex.tech/supabase/thread/019f3bc1-3a5c-7200-9122-8e3439bfbe8c)). Any consumer counting funnel errors without an `origin IS NOT NULL` filter saw ~2x inflation.

The fix makes `ToastErrorTracker` the sole emitter of `source:'toast'` events, so the duplicate is unrepresentable rather than suppressed. Funnel call sites pass the id returned by `toast.error()` into `trackFunnelError`, which registers the funnel properties against that toast id instead of firing its own event – the tracker then emits a single `dashboard_error_created` enriched with `origin` / `errorCategory` / `errorReason` / `errorCode` for registered toasts, and the plain untagged event otherwise. The `'toast'` overload of `trackFunnelError` requires the toast id, so a missed pairing is a compile error rather than a silent double count. Registration is unconditional and there's only one sampling draw, so suppression can't lose a sampling race. `'form'`-sourced funnel events are unchanged.

## Changes
- `lib/toast-errors.tsx`: toast-id → funnel-properties registry (`registerFunnelErrorToast`); `ToastErrorTracker` emits one (optionally enriched) event per error toast under a single 10% draw, deleting entries once consumed
- `lib/telemetry/use-track-funnel-error.ts`: overloaded signature – `'toast'` requires the id returned by `toast.error()` (type-enforced), `'form'` keeps direct emission with its own sampling
- Update the 7 funnel `toast.error` call sites in `NewOrgForm`, `SignUpForm`, and `pages/new/[slug]` to pass the toast id
- Component tests for the tracker (previously uncovered), including an end-to-end test through `useTrackFunnelError`
- Code hygiene (also flagged by CodeRabbit): all four `dashboard_error_created` emitters (toast, form, `AlertError`, `ErrorMatcher`) independently encoded the 10% draw – downstream analysis assumes a uniform sampling multiplier across sources, so one site drifting would silently skew comparisons. The rate and the draw now live in one place (`isDashboardErrorSampled()` in `lib/telemetry/error-sampling.ts`). No behavior change.
- Mount `ToastErrorTracker` in the TanStack root (`routes/__root.tsx`), mirroring `pages/_app.tsx`. The TanStack tree mounted `Toaster` but never the tracker, so untagged toast error telemetry has never fired in that flavour – and with the tracker now the sole emitter, the missing mount would have silently dropped funnel toast events there too. Side effect once the TanStack flavour ships: untagged `source:'toast'` volume from it goes from zero to normal.

## Testing
Component-tested (`apps/studio/lib/toast-errors.test.tsx`):
- [x] Unregistered error toast fires exactly one untagged `dashboard_error_created {source:'toast'}`
- [x] Registered funnel toast fires exactly one event, enriched with `origin`/`errorCategory`/`errorReason`/`errorCode`
- [x] `useTrackFunnelError` with a toast id routes through the tracker as a single enriched event
- [x] Non-error toasts ignored; the 10% sampling gate still applies

Full Studio unit suite passes (392 files / 4371 tests), plus typecheck and lint.

Also verified end-to-end in a local browser (TanStack flavour, sample rate temporarily forced to 1): a failed signup produced exactly one `dashboard_error_created` with `{source:'toast', origin:'signup', errorCategory:'api', errorReason:'email_already_registered', errorCode:403}` and no untagged twin (two independent trials); an unregistered error toast produced exactly one plain `{source:'toast'}`; a client-side validation failure produced exactly one `{source:'form', origin:'signup', errorCategory:'validation', errorReason:'email_invalid'}`; success toasts produced nothing.

Post-deploy I'll re-run the twin-rate query from the Hex thread; the untagged-twin rate on funnel pages should decay to ~0 as stale bundles reload over 2-3 days.

## Notes
- Origin-tagged funnel toast events now ride the tracker's single 10% draw instead of their own independent draw – statistically identical volume, but the event fires on the tracker's next effect rather than synchronously at the call site (irrelevant for PostHog)
- Registration must happen in the same synchronous block as `toast.error()` (documented on the `TrackFunnelError` type) – all current call sites comply
- The invalid Postgres version toast in `pages/new/[slug].tsx` (~line 416) needs no special-casing: unregistered toasts keep the plain untagged event, so its telemetry is preserved
- Heads-up for `dashboard_error_created` consumers: overall untagged `source:'toast'` volume will dip slightly after this deploys, since funnel-page twins disappear. A volume monitor seeing that drop is this fix landing, not a tracking regression (same class as the intended GROWTH-893 sampling-unification drop).

## Linear
- fixes GROWTH-965


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error telemetry for organization creation, sign-up, payment, and project-creation flows by associating failures with toast identifiers and enriched funnel context.
  * Standardized dashboard error sampling logic across error handling components for consistency.

* **Tests**
  * Added comprehensive test coverage for toast error tracking, including funnel registration, deduplication, filtering, and sampling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->