### PR TITLE
Add sentry capture exception to apiWrapper

### DIFF
--- a/apps/studio/lib/api/apiWrapper.ts
+++ b/apps/studio/lib/api/apiWrapper.ts
@@ -1,5 +1,6 @@
 import type { JwtPayload } from '@supabase/supabase-js'
 import type { NextApiRequest, NextApiResponse } from 'next'
+import * as Sentry from '@sentry/nextjs'
 
 import { IS_PLATFORM } from '../constants'
 import { apiAuthenticate } from './apiAuthenticate'
@@ -24,7 +25,7 @@ export function isResponseOk<T>(response: T | ResponseFailure | undefined): resp
 // Purpose of this apiWrapper is to function like a global catchall for ANY errors
 // It's a safety net as the API service should never drop, nor fail
 
-async function apiWrapper(
+export async function apiWrapper(
   req: NextApiRequest,
   res: NextApiResponse,
   handler: (
@@ -50,11 +51,9 @@ async function apiWrapper(
       claims = response
     }
 
-    return handler(req, res, claims)
+    return await handler(req, res, claims)
   } catch (error) {
+    Sentry.captureException(error)
     return res.status(500).json({ error })
   }
 }
-
-export { apiWrapper }
-export default apiWrapper

--- a/apps/studio/lib/api/apiWrapper.ts
+++ b/apps/studio/lib/api/apiWrapper.ts
@@ -1,6 +1,6 @@
+import * as Sentry from '@sentry/nextjs'
 import type { JwtPayload } from '@supabase/supabase-js'
 import type { NextApiRequest, NextApiResponse } from 'next'
-import * as Sentry from '@sentry/nextjs'
 
 import { IS_PLATFORM } from '../constants'
 import { apiAuthenticate } from './apiAuthenticate'

--- a/apps/studio/lib/api/apiWrappers.test.ts
+++ b/apps/studio/lib/api/apiWrappers.test.ts
@@ -1,6 +1,6 @@
+import * as Sentry from '@sentry/nextjs'
 import type { JwtPayload } from '@supabase/supabase-js'
 import type { NextApiRequest, NextApiResponse } from 'next'
-import * as Sentry from '@sentry/nextjs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { apiAuthenticate } from './apiAuthenticate'

--- a/apps/studio/lib/api/apiWrappers.test.ts
+++ b/apps/studio/lib/api/apiWrappers.test.ts
@@ -1,9 +1,10 @@
 import type { JwtPayload } from '@supabase/supabase-js'
 import type { NextApiRequest, NextApiResponse } from 'next'
+import * as Sentry from '@sentry/nextjs'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { apiAuthenticate } from './apiAuthenticate'
-import apiWrapper from './apiWrapper'
+import { apiWrapper } from './apiWrapper'
 import { ResponseError } from '@/types'
 
 vi.mock('@/lib/constants', () => ({
@@ -13,6 +14,10 @@ vi.mock('@/lib/constants', () => ({
 
 vi.mock('./apiAuthenticate', () => ({
   apiAuthenticate: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => ({
+  captureException: vi.fn(),
 }))
 
 describe('apiWrapper', () => {
@@ -58,5 +63,15 @@ describe('apiWrapper', () => {
     await apiWrapper(mockReq, mockRes, mockHandler, { withAuth: true })
     expect(mockRes.status).toHaveBeenCalledWith(401)
     expect(mockHandler).not.toHaveBeenCalled()
+  })
+
+  it('should report to Sentry and return 500 when the handler throws', async () => {
+    const mockError = new Error('boom')
+    mockHandler.mockRejectedValue(mockError)
+
+    await apiWrapper(mockReq, mockRes, mockHandler, { withAuth: false })
+    expect(Sentry.captureException).toHaveBeenCalledWith(mockError)
+    expect(mockRes.status).toHaveBeenCalledWith(500)
+    expect(mockRes.json).toHaveBeenCalledWith({ error: mockError })
   })
 })

--- a/apps/studio/pages/api/ai/code/complete.ts
+++ b/apps/studio/pages/api/ai/code/complete.ts
@@ -18,7 +18,7 @@ import {
   SECURITY_PROMPT,
   SQL_COMPLETION_INSTRUCTIONS,
 } from '@/lib/ai/prompts'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { executeQuery } from '@/lib/api/self-hosted/query'
 
 export const maxDuration = 60

--- a/apps/studio/pages/api/ai/feedback/classify.ts
+++ b/apps/studio/pages/api/ai/feedback/classify.ts
@@ -4,7 +4,7 @@ import { z } from 'zod'
 
 import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { method } = req

--- a/apps/studio/pages/api/ai/feedback/rate.ts
+++ b/apps/studio/pages/api/ai/feedback/rate.ts
@@ -11,7 +11,7 @@ import { IS_TRACING_ENABLED, isTracingAllowed } from '@/lib/ai/braintrust-logger
 import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
 import { sanitizeMessagePart } from '@/lib/ai/tools/tool-sanitizer'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export const maxDuration = 30
 

--- a/apps/studio/pages/api/ai/onboarding/design.ts
+++ b/apps/studio/pages/api/ai/onboarding/design.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export const maxDuration = 60
 

--- a/apps/studio/pages/api/ai/sql/check-api-key.ts
+++ b/apps/studio/pages/api/ai/sql/check-api-key.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 const wrapper = (req: NextApiRequest, res: NextApiResponse) =>
   apiWrapper(req, res, handler, { withAuth: true })

--- a/apps/studio/pages/api/ai/sql/cron-v2.ts
+++ b/apps/studio/pages/api/ai/sql/cron-v2.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 const cronSchema = z.object({
   cron_expression: z.string().describe('The generated cron expression.'),

--- a/apps/studio/pages/api/ai/sql/filter-v1.ts
+++ b/apps/studio/pages/api/ai/sql/filter-v1.ts
@@ -4,7 +4,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import {
   filterGroupSchemaForAI,
   requestSchema,

--- a/apps/studio/pages/api/ai/sql/generate-v4.ts
+++ b/apps/studio/pages/api/ai/sql/generate-v4.ts
@@ -20,7 +20,7 @@ import {
   type AssistantModelId,
 } from '@/lib/ai/model.utils'
 import { getTools } from '@/lib/ai/tools'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { executeQuery } from '@/lib/api/self-hosted/query'
 import { getURL } from '@/lib/helpers'
 

--- a/apps/studio/pages/api/ai/sql/parse-client-code.ts
+++ b/apps/studio/pages/api/ai/sql/parse-client-code.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 const codeSchema = z.object({
   sql: z

--- a/apps/studio/pages/api/ai/sql/policy.ts
+++ b/apps/studio/pages/api/ai/sql/policy.ts
@@ -10,7 +10,7 @@ import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
 import { RLS_PROMPT } from '@/lib/ai/prompts'
 import { getTools } from '@/lib/ai/tools'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 const policySchema = z.object({
   sql: z.string().describe('The generated Postgres CREATE POLICY statement.'),

--- a/apps/studio/pages/api/ai/sql/title-v2.ts
+++ b/apps/studio/pages/api/ai/sql/title-v2.ts
@@ -5,7 +5,7 @@ import { z } from 'zod'
 
 import { getModel } from '@/lib/ai/model'
 import { DEFAULT_COMPLETION_MODEL } from '@/lib/ai/model.utils'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 const titleSchema = z.object({
   title: z

--- a/apps/studio/pages/api/generate-attachment-url.ts
+++ b/apps/studio/pages/api/generate-attachment-url.ts
@@ -3,7 +3,7 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import z from 'zod'
 
 import { DASHBOARD_LOG_BUCKET } from '@/components/interfaces/Support/dashboard-logs'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getUserClaims } from '@/lib/gotrue'
 
 export const maxDuration = 120

--- a/apps/studio/pages/api/platform/auth/[ref]/invite.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/invite.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchPost } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/auth/[ref]/magiclink.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/magiclink.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchPost } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/auth/[ref]/otp.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/otp.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchPost } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/auth/[ref]/recover.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/recover.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchPost } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/auth/[ref]/users/[id]/factors.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/users/[id]/factors.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/auth/[ref]/users/[id]/index.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/users/[id]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/auth/[ref]/users/index.ts
+++ b/apps/studio/pages/api/platform/auth/[ref]/users/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/database/[ref]/pooling.ts
+++ b/apps/studio/pages/api/platform/database/[ref]/pooling.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/deployment-mode.ts
+++ b/apps/studio/pages/api/platform/deployment-mode.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import type { DeploymentModeResponse } from '@/data/config/deployment-mode-query'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { IS_CLI } from '@/lib/constants'
 
 export default function deploymentMode(req: NextApiRequest, res: NextApiResponse) {

--- a/apps/studio/pages/api/platform/integrations/[slug].ts
+++ b/apps/studio/pages/api/platform/integrations/[slug].ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/integrations/github/authorization.ts
+++ b/apps/studio/pages/api/platform/integrations/github/authorization.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/integrations/github/connections.ts
+++ b/apps/studio/pages/api/platform/integrations/github/connections.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/integrations/github/repositories.ts
+++ b/apps/studio/pages/api/platform/integrations/github/repositories.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/organizations/[slug]/billing/subscription.ts
+++ b/apps/studio/pages/api/platform/organizations/[slug]/billing/subscription.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/organizations/index.ts
+++ b/apps/studio/pages/api/platform/organizations/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/column-privileges.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/column-privileges.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getPgMetaRedirectUrl } from './tables'
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>
   apiWrapper(req, res, handler, { withAuth: true })

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/extensions.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/extensions.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PG_META_URL } from '@/lib/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/foreign-tables.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/foreign-tables.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getPgMetaRedirectUrl } from './tables'
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>
   apiWrapper(req, res, handler, { withAuth: true })

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/materialized-views.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/materialized-views.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getPgMetaRedirectUrl } from './tables'
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>
   apiWrapper(req, res, handler, { withAuth: true })

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/policies.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/policies.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PG_META_URL } from '@/lib/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/publications.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/publications.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PG_META_URL } from '@/lib/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/query/index.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/query/index.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { executeQuery } from '@/lib/api/self-hosted/query'
 import { PgMetaDatabaseError } from '@/lib/api/self-hosted/types'
 

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/tables.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/tables.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PG_META_URL } from '@/lib/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/triggers.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/triggers.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PG_META_URL } from '@/lib/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/types.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/types.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PG_META_URL } from '@/lib/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>

--- a/apps/studio/pages/api/platform/pg-meta/[ref]/views.ts
+++ b/apps/studio/pages/api/platform/pg-meta/[ref]/views.ts
@@ -3,7 +3,7 @@ import { NextApiRequest, NextApiResponse } from 'next'
 import { getPgMetaRedirectUrl } from './tables'
 import { fetchGet } from '@/data/fetchers'
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) =>
   apiWrapper(req, res, handler, { withAuth: true })

--- a/apps/studio/pages/api/platform/profile/index.ts
+++ b/apps/studio/pages/api/platform/profile/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { DEFAULT_PROJECT } from '@/lib/constants/api'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { retrieveAnalyticsData } from '@/lib/api/self-hosted/logs'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/log-drains.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/log-drains.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PROJECT_ANALYTICS_URL } from '@/lib/constants/api'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/analytics/log-drains/[uuid].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/analytics/log-drains/[uuid].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { PROJECT_ANALYTICS_URL } from '@/lib/constants/api'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/api-keys/temporary.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/api-keys/temporary.ts
@@ -1,7 +1,7 @@
 import { components } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 type ProjectAppConfig = components['schemas']['ProjectSettingsResponse']['app_config'] & {
   protocol?: string

--- a/apps/studio/pages/api/platform/projects/[ref]/api/graphql.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/api/graphql.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/projects/[ref]/api/rest.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/api/rest.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/projects/[ref]/billing/addons.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/billing/addons.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/projects/[ref]/config/index.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/postgrest.ts
@@ -1,7 +1,7 @@
 import { components } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { DEFAULT_EXPOSED_SCHEMAS } from '@/lib/api/self-hosted/constants'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/config/secrets/update-status.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/config/secrets/update-status.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default function updateStatus(req: NextApiRequest, res: NextApiResponse) {
   return apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/content/count.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/content/count.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getSnippets } from '@/lib/api/snippets.utils'
 
 const wrappedHandler = (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/content/folders/[id].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/content/folders/[id].ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getFolders, getSnippets } from '@/lib/api/snippets.utils'
 
 const wrappedHandler = (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/content/folders/index.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/content/folders/index.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { createFolder, deleteFolder, getFolders, getSnippets } from '@/lib/api/snippets.utils'
 
 const wrappedHandler = (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/content/index.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/content/index.ts
@@ -3,7 +3,7 @@ import { compact } from 'lodash'
 import { NextApiRequest, NextApiResponse } from 'next'
 import { z } from 'zod'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import {
   deleteSnippet,
   getSnippets,

--- a/apps/studio/pages/api/platform/projects/[ref]/content/item/[id].ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/content/item/[id].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getSnippet } from '@/lib/api/snippets.utils'
 
 const wrappedHandler = (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/databases.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/databases.ts
@@ -1,7 +1,7 @@
 import { paths } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { POSTGRES_PORT } from '@/lib/api/self-hosted/constants'
 import { PROJECT_DB_HOST, PROJECT_REST_URL } from '@/lib/constants/api'
 

--- a/apps/studio/pages/api/platform/projects/[ref]/index.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { DEFAULT_PROJECT, PROJECT_REST_URL } from '@/lib/constants/api'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/projects/[ref]/infra-monitoring.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/infra-monitoring.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/projects/[ref]/run-lints.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/run-lints.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { DEFAULT_EXPOSED_SCHEMAS } from '@/lib/api/self-hosted/constants'
 import { getLints } from '@/lib/api/self-hosted/lints'
 

--- a/apps/studio/pages/api/platform/projects/[ref]/settings.ts
+++ b/apps/studio/pages/api/platform/projects/[ref]/settings.ts
@@ -1,7 +1,7 @@
 import { components } from 'api-types'
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getProjectSettings } from '@/lib/api/self-hosted/settings'
 
 type ProjectAppConfig = components['schemas']['ProjectSettingsResponse']['app_config'] & {

--- a/apps/studio/pages/api/platform/projects/index.ts
+++ b/apps/studio/pages/api/platform/projects/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { DEFAULT_PROJECT } from '@/lib/constants/api'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/props/org/[slug].tsx
+++ b/apps/studio/pages/api/platform/props/org/[slug].tsx
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/platform/props/project/[ref]/api.ts
+++ b/apps/studio/pages/api/platform/props/project/[ref]/api.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { POSTGRES_PORT } from '@/lib/api/self-hosted/constants'
 import {
   DEFAULT_PROJECT,

--- a/apps/studio/pages/api/platform/props/project/[ref]/index.ts
+++ b/apps/studio/pages/api/platform/props/project/[ref]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { DEFAULT_PROJECT } from '@/lib/constants/api'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/empty.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/empty.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/index.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/download.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/download.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/index.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/list.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/list.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/move.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/move.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/public-url.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/public-url.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/sign-multi.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/sign-multi.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 const wrappedHandler = (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/sign.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/[id]/objects/sign.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/buckets/index.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/buckets/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/[id]/index.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/[id]/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 // eslint-disable-next-line import/no-anonymous-default-export

--- a/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/[id]/indexes/[indexName].ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/[id]/indexes/[indexName].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 // eslint-disable-next-line import/no-anonymous-default-export

--- a/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/[id]/indexes/index.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/[id]/indexes/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 // eslint-disable-next-line import/no-anonymous-default-export

--- a/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/index.ts
+++ b/apps/studio/pages/api/platform/storage/[ref]/vector-buckets/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { selfHostedSupabaseAdmin as supabase } from '@/lib/api/self-hosted-admin'
 
 // eslint-disable-next-line import/no-anonymous-default-export

--- a/apps/studio/pages/api/platform/telemetry/event.ts
+++ b/apps/studio/pages/api/platform/telemetry/event.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 
 export default (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)
 

--- a/apps/studio/pages/api/v1/projects/[ref]/api-keys.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/api-keys.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import {
   applyRevealToApiKey,
   getNonPlatformApiKeys,

--- a/apps/studio/pages/api/v1/projects/[ref]/api-keys/[id].ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/api-keys/[id].ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getNonPlatformApiKeyById, parseRevealQuery } from '@/lib/api/self-hosted/api-keys'
 
 const apiKeyByIdRoute = (req: NextApiRequest, res: NextApiResponse) => apiWrapper(req, res, handler)

--- a/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/index.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/index.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getLegacySigningKey } from '@/lib/api/self-hosted/signing-keys'
 
 export default function signingKeys(req: NextApiRequest, res: NextApiResponse) {

--- a/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/legacy.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/config/auth/signing-keys/legacy.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getLegacySigningKey } from '@/lib/api/self-hosted/signing-keys'
 
 export default function legacySigningKey(req: NextApiRequest, res: NextApiResponse) {

--- a/apps/studio/pages/api/v1/projects/[ref]/database/migrations.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/database/migrations.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { applyAndTrackMigrations, listMigrationVersions } from '@/lib/api/self-hosted/migrations'
 import { PgMetaDatabaseError } from '@/lib/api/self-hosted/types'
 

--- a/apps/studio/pages/api/v1/projects/[ref]/functions/[slug]/body.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/functions/[slug]/body.ts
@@ -2,7 +2,7 @@ import { createReadStream } from 'node:fs'
 import { pipeline } from 'node:stream/promises'
 import { type NextApiRequest, type NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getFunctionsArtifactStore } from '@/lib/api/self-hosted/functions'
 import { uuidv4 } from '@/lib/helpers'
 

--- a/apps/studio/pages/api/v1/projects/[ref]/functions/[slug]/index.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/functions/[slug]/index.ts
@@ -1,7 +1,7 @@
 import type { components } from 'api-types'
 import { type NextApiRequest, type NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getFunctionsArtifactStore } from '@/lib/api/self-hosted/functions'
 import { uuidv4 } from '@/lib/helpers'
 

--- a/apps/studio/pages/api/v1/projects/[ref]/functions/index.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/functions/index.ts
@@ -1,7 +1,7 @@
 import type { components } from 'api-types'
 import { type NextApiRequest, type NextApiResponse } from 'next'
 
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { getFunctionsArtifactStore } from '@/lib/api/self-hosted/functions'
 import { uuidv4 } from '@/lib/helpers'
 

--- a/apps/studio/pages/api/v1/projects/[ref]/types/typescript.ts
+++ b/apps/studio/pages/api/v1/projects/[ref]/types/typescript.ts
@@ -1,7 +1,7 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 
 import { constructHeaders } from '@/lib/api/apiHelpers'
-import apiWrapper from '@/lib/api/apiWrapper'
+import { apiWrapper } from '@/lib/api/apiWrapper'
 import { generateTypescriptTypes } from '@/lib/api/self-hosted/generate-types'
 import { ResponseError } from '@/types'
 


### PR DESCRIPTION
## Context

As per PR title - also adjusts the imports for files consuming `apiWrapper` to remove the default export for `apiWrapper`

Have tested locally by throwing an error in one of the API routes - verified that the event shows up on Sentry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * API errors are now captured in Sentry before returning server error responses, improving production visibility while keeping endpoint behavior the same.
* **Tests**
  * Added coverage to confirm rejected handler executions are reported to Sentry and return the expected HTTP 500 JSON payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->