### PR TITLE
feat(docs): serve troubleshooting guides list as markdown

### DIFF
--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -12,7 +12,7 @@ import { mdxjs } from 'micromark-extension-mdxjs'
 import { parse as parseToml } from 'smol-toml'
 import { mcpConfigPanelMarkdown as McpConfigPanel } from 'ui-patterns/McpUrlBuilder/McpConfigPanel.md'
 
-import { addBaseUrlPrefix } from './internal-links'
+import { addBaseUrlPrefix, getInternalLinkBaseUrl, withDocsBasePath } from './internal-links'
 import { AccordionItem } from './markdown-schema/Accordion'
 import { Admonition } from './markdown-schema/Admonition'
 import { AuthProviders } from './markdown-schema/AuthProviders'
@@ -207,25 +207,55 @@ async function transformBody(content: string, data: Record<string, unknown>): Pr
   return output
 }
 
-async function generateOne(sourceFile: string, frontmatter: FrontmatterFormat): Promise<string> {
+async function generateOne(
+  sourceFile: string,
+  frontmatter: FrontmatterFormat
+): Promise<{ output: string; data: Record<string, unknown> }> {
   const raw = await fs.readFile(sourceFile, 'utf8')
   const { content, data } = parseFrontmatter(raw, frontmatter)
-  return transformBody(content, data)
+  return { output: await transformBody(content, data), data }
 }
 
-function renderManifest(sources: MarkdownSource[]): string {
-  const slugs = [...new Set(sources.map((source) => source.slug))].sort()
+const TROUBLESHOOTING_INDEX_SLUG = 'troubleshooting'
+const TROUBLESHOOTING_INDEX_PATH = path.join(
+  process.cwd(),
+  'public',
+  'markdown',
+  'guides',
+  `${TROUBLESHOOTING_INDEX_SLUG}.md`
+)
+
+function buildTroubleshootingIndex(entries: { slug: string; title: string }[]): string {
+  const baseUrl = getInternalLinkBaseUrl()
+  const links = [...entries]
+    .sort((a, b) => a.title.localeCompare(b.title))
+    .map(({ slug, title }) => `- [${title}](${baseUrl}${withDocsBasePath(`/guides/${slug}.md`)})`)
+    .join('\n')
+
+  return `# Troubleshooting
+
+Search or browse our troubleshooting guides for solutions to common Supabase issues.
+
+${links}
+`
+}
+
+function renderManifest(sources: MarkdownSource[], extraSlugs: string[]): string {
+  const slugs = [...new Set([...sources.map((source) => source.slug), ...extraSlugs])].sort()
   return `${JSON.stringify(slugs, null, 2)}\n`
 }
 
 async function generate() {
   const sources = await collectMarkdownSources()
 
+  const troubleshootingEntries: { slug: string; title: string }[] = []
+
   await Promise.all(
-    sources.map(async ({ sourceFile, outPath, frontmatter }) => {
+    sources.map(async ({ sourceFile, slug, outPath, frontmatter }) => {
       let output: string
+      let data: Record<string, unknown>
       try {
-        output = await generateOne(sourceFile, frontmatter)
+        ;({ output, data } = await generateOne(sourceFile, frontmatter))
       } catch (err) {
         throw new Error(
           `Failed to process ${sourceFile}: ${err instanceof Error ? err.message : err}`,
@@ -233,16 +263,23 @@ async function generate() {
         )
       }
 
+      if (frontmatter === 'toml' && data.title) {
+        troubleshootingEntries.push({ slug, title: String(data.title) })
+      }
+
       await fs.mkdir(path.dirname(outPath), { recursive: true })
       await fs.writeFile(outPath, output)
     })
   )
 
+  await fs.mkdir(path.dirname(TROUBLESHOOTING_INDEX_PATH), { recursive: true })
+  await fs.writeFile(TROUBLESHOOTING_INDEX_PATH, buildTroubleshootingIndex(troubleshootingEntries))
+
   await fs.mkdir(path.dirname(MANIFEST_PATH), { recursive: true })
-  await fs.writeFile(MANIFEST_PATH, renderManifest(sources))
+  await fs.writeFile(MANIFEST_PATH, renderManifest(sources, [TROUBLESHOOTING_INDEX_SLUG]))
 
   console.log(
-    `Generated ${sources.length} markdown files under public/markdown/guides/ and updated public/markdown/manifest.json`
+    `Generated ${sources.length + 1} markdown files under public/markdown/guides/ and updated public/markdown/manifest.json`
   )
 }
 

--- a/apps/docs/internals/generate-guides-markdown.ts
+++ b/apps/docs/internals/generate-guides-markdown.ts
@@ -246,12 +246,12 @@ function renderManifest(sources: MarkdownSource[], extraSlugs: string[]): string
 }
 
 async function generate() {
-  const sources = await collectMarkdownSources()
+  const { all: sources, troubleshooting } = await collectMarkdownSources()
 
-  const troubleshootingEntries: { slug: string; title: string }[] = []
+  const titlesBySourceFile = new Map<string, string>()
 
   await Promise.all(
-    sources.map(async ({ sourceFile, slug, outPath, frontmatter }) => {
+    sources.map(async ({ sourceFile, outPath, frontmatter }) => {
       let output: string
       let data: Record<string, unknown>
       try {
@@ -263,14 +263,16 @@ async function generate() {
         )
       }
 
-      if (frontmatter === 'toml' && data.title) {
-        troubleshootingEntries.push({ slug, title: String(data.title) })
-      }
+      if (data.title) titlesBySourceFile.set(sourceFile, String(data.title))
 
       await fs.mkdir(path.dirname(outPath), { recursive: true })
       await fs.writeFile(outPath, output)
     })
   )
+
+  const troubleshootingEntries = troubleshooting
+    .map(({ slug, sourceFile }) => ({ slug, title: titlesBySourceFile.get(sourceFile) }))
+    .filter((entry): entry is { slug: string; title: string } => Boolean(entry.title))
 
   await fs.mkdir(path.dirname(TROUBLESHOOTING_INDEX_PATH), { recursive: true })
   await fs.writeFile(TROUBLESHOOTING_INDEX_PATH, buildTroubleshootingIndex(troubleshootingEntries))

--- a/apps/docs/internals/markdown-sources.ts
+++ b/apps/docs/internals/markdown-sources.ts
@@ -22,7 +22,12 @@ export function troubleshootingSlug(sourceFile: string): string {
   return `troubleshooting/${path.basename(sourceFile, '.mdx')}`
 }
 
-export async function collectMarkdownSources(): Promise<MarkdownSource[]> {
+export interface CollectedMarkdownSources {
+  all: MarkdownSource[]
+  troubleshooting: MarkdownSource[]
+}
+
+export async function collectMarkdownSources(): Promise<CollectedMarkdownSources> {
   const [guideFiles, troubleshootingFiles] = await Promise.all([
     globby([GUIDES_GLOB]),
     globby([TROUBLESHOOTING_GLOB]),
@@ -38,5 +43,5 @@ export async function collectMarkdownSources(): Promise<MarkdownSource[]> {
     return { sourceFile, slug, outPath: `${OUTPUT_ROOT}/${slug}.md`, frontmatter: 'toml' }
   })
 
-  return [...guides, ...troubleshooting]
+  return { all: [...guides, ...troubleshooting], troubleshooting }
 }


### PR DESCRIPTION
## What

Makes the troubleshooting guides list page ([/docs/guides/troubleshooting](https://supabase.com/docs/guides/troubleshooting)) serve optimized markdown instead of bloated HTML, the same way individual guides and `pricing.md` already do.

Requesting `/docs/guides/troubleshooting.md` (or `/docs/guides/troubleshooting` with `Accept: text/markdown` / an LLM user agent) now returns a clean markdown index of every troubleshooting guide, each linking to its own `.md` variant.

## How

Individual troubleshooting guides already generate `.md` files via `build:guides-markdown` and are wired through the docs middleware + `/api/guides-md/[...slug]` route. Only the list page was missing.

- `generate-guides-markdown.ts` now also writes `public/markdown/guides/troubleshooting.md` — a title, the same intro copy as the HTML page, and an alphabetized list of all guides linking to their `.md` variants.
- Registers the `troubleshooting` slug in the generated `manifest.json`, so the existing middleware content-negotiation and route handler serve it with no further changes.

No new routes or middleware logic needed; this reuses the existing markdown pipeline.

## Notes

- The generated markdown lives under the gitignored `public/markdown/` output and is rebuilt by `build:guides-markdown` (run by turbo ahead of build/typecheck/lint).
- Product-scoped troubleshooting list pages (e.g. `/guides/auth/troubleshooting`) are left as a possible follow-up.

Resolves DEBUG-169.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Troubleshooting index page that links to available troubleshooting guides.
  * Updated the documentation manifest to include the new Troubleshooting index.
  * Troubleshooting links are now generated with titles derived from each guide and sorted for easier browsing.
* **Bug Fixes**
  * Improved troubleshooting link generation to use correct base URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->