### PR TITLE
fix(studio): make paused project messaging easier to scan DEPR-581

### DIFF
--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -105,7 +105,24 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                   </ul>
                 ) : (
                   <ul className="text-sm list-disc pl-4 space-y-2">
-                    <li>Your project data is safe but inaccessible while paused.</li>
+                    <li>
+                      Your project data is safe and available for{' '}
+                      <span className="text-foreground">
+                        {finalDaysRemainingBeforeRestoreDisabled} day
+                        {finalDaysRemainingBeforeRestoreDisabled > 1 ? 's' : ''}
+                      </span>{' '}
+                      (until{' '}
+                      <TimestampInfo
+                        displayAs="local"
+                        utcTimestamp={dayjs()
+                          .utc()
+                          .add(pauseStatus.remaining_days_till_restore_disabled ?? 0, 'day')
+                          .toISOString()}
+                        className="text-sm text-foreground"
+                        labelFormat="DD MMM YYYY"
+                      />
+                      ), but inaccessible while paused.
+                    </li>
                     <li>Once resumed, usage will be billed by compute size and hours active.</li>
                   </ul>
                 )

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -59,7 +59,7 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
         <PauseCircle size={48} strokeWidth={1} className="text-foreground-lighter shrink-0 mb-4" />
         <div className="flex-1">
           <div>
-            <h2 className="mb-4">The project "{project?.name}" is currently paused</h2>
+            <h2 className="mb-4">Project "{project?.name}" is paused</h2>
             <div className="text-foreground-light max-w-4xl">
               {isLoading && <GenericSkeletonLoader className="mt-3" />}
 
@@ -104,10 +104,10 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                     </li>
                   </ul>
                 ) : (
-                  <p className="text-sm">
-                    Your project data is safe but inaccessible while paused. Once resumed, usage
-                    will be billed by compute size and hours active.
-                  </p>
+                  <ul className="text-sm list-disc pl-4 space-y-2">
+                    <li>Your project data is safe but inaccessible while paused.</li>
+                    <li>Once resumed, usage will be billed by compute size and hours active.</li>
+                  </ul>
                 )
               ) : !isLoading ? (
                 <p className="text-sm">

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -65,10 +65,10 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
 
               {isPauseStatusSuccess && !isRestoreDisabled ? (
                 isFreePlan ? (
-                  <>
-                    <p className="text-sm">
-                      All data, including backups and storage objects, remains safe. You can resume
-                      this project from the dashboard within{' '}
+                  <ul className="text-sm list-disc pl-4 space-y-2">
+                    <li>All data, including backups and storage objects, remains safe.</li>
+                    <li>
+                      You can resume this project from the dashboard within{' '}
                       <Tooltip>
                         <TooltipTrigger>
                           <span className={cn(InlineLinkClassName, 'text-foreground')}>
@@ -91,15 +91,18 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                         className="text-sm text-foreground"
                         labelFormat="DD MMM YYYY"
                       />
-                      ). After that, this project will not be resumable, but data will still be
+                      ).
+                    </li>
+                    <li>
+                      After that, this project will not be resumable, but data will still be
                       available for download.
-                    </p>
-                    <p className="text-sm mt-4">
+                    </li>
+                    <li>
                       {enableProBenefitWording === 'variant-a'
                         ? 'Upgrade to Pro to prevent pauses and unlock features like branching, compute upgrades, and daily backups.'
                         : 'To prevent future pauses, consider upgrading to Pro.'}
-                    </p>
-                  </>
+                    </li>
+                  </ul>
                 ) : (
                   <p className="text-sm">
                     Your project data is safe but inaccessible while paused. Once resumed, usage

--- a/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/PausedState/ProjectPausedState.tsx
@@ -104,8 +104,8 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                     </li>
                   </ul>
                 ) : (
-                  <ul className="text-sm list-disc pl-4 space-y-2">
-                    <li>
+                  <>
+                    <p className="text-sm">
                       Your project data is safe and available for{' '}
                       <span className="text-foreground">
                         {finalDaysRemainingBeforeRestoreDisabled} day
@@ -122,9 +122,11 @@ export const ProjectPausedState = ({ product }: ProjectPausedStateProps) => {
                         labelFormat="DD MMM YYYY"
                       />
                       ), but inaccessible while paused.
-                    </li>
-                    <li>Once resumed, usage will be billed by compute size and hours active.</li>
-                  </ul>
+                    </p>
+                    <p className="text-sm mt-2">
+                      Once resumed, usage will be billed by compute size and hours active.
+                    </p>
+                  </>
                 )
               ) : !isLoading ? (
                 <p className="text-sm">

--- a/apps/studio/components/ui/DevToolbar/ProjectStatusTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ProjectStatusTab.tsx
@@ -8,6 +8,12 @@ import { cn, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } fro
 import { projectKeys } from '@/data/projects/keys'
 import { useSetProjectStatus, type Project } from '@/data/projects/project-detail-query'
 import {
+  clearPauseStatusOverride,
+  getPauseStatusOverride,
+  setPauseStatusOverride,
+  type PauseStateOverride,
+} from '@/data/projects/project-pause-status-override'
+import {
   clearProjectStatusOverride,
   getProjectStatusOverride,
   setProjectStatusOverride,
@@ -38,6 +44,17 @@ const STATUS_LABELS: Record<ProjectStatus, string> = {
 
 const STATUS_OPTIONS = Object.values(PROJECT_STATUS)
 
+const PAUSE_STATE_VALUE_REAL = 'real'
+
+const PAUSE_STATE_OPTIONS: {
+  value: PauseStateOverride | typeof PAUSE_STATE_VALUE_REAL
+  label: string
+}[] = [
+  { value: PAUSE_STATE_VALUE_REAL, label: 'Real data' },
+  { value: 'restorable', label: 'Restorable (can resume)' },
+  { value: 'restore-disabled', label: 'Restore disabled (90+ days)' },
+]
+
 export const ProjectStatusTab = () => {
   const { ref } = useParams()
   const queryClient = useQueryClient()
@@ -46,14 +63,18 @@ export const ProjectStatusTab = () => {
   const { data: selectedOrg } = useSelectedOrganizationQuery()
   const orgSlug = selectedOrg?.slug
 
-  const [override, setOverride] = useState<ProjectStatus | undefined>(undefined)
+  const [statusOverride, setStatusOverride] = useState<ProjectStatus | undefined>(undefined)
+  const [pauseOverride, setPauseOverride] = useState<PauseStateOverride | undefined>(undefined)
   useEffect(() => {
-    setOverride(getProjectStatusOverride(ref))
+    setStatusOverride(getProjectStatusOverride(ref))
+    setPauseOverride(getPauseStatusOverride(ref))
   }, [ref])
 
-  const currentValue = override ?? project?.status
+  const currentStatus = statusOverride ?? project?.status
+  const isPaused = currentStatus === PROJECT_STATUS.INACTIVE
+  const hasOverride = statusOverride !== undefined || pauseOverride !== undefined
 
-  const refetchRealStatus = () => {
+  const refetchProjectStatus = () => {
     queryClient.invalidateQueries({ queryKey: projectKeys.detail(ref) })
     queryClient.invalidateQueries({ queryKey: projectKeys.infiniteList() })
     if (orgSlug) {
@@ -64,14 +85,31 @@ export const ProjectStatusTab = () => {
   const handleStatusChange = (status: ProjectStatus) => {
     if (!ref) return
     setProjectStatusOverride(ref, status)
-    setOverride(status)
+    setStatusOverride(status)
     setProjectStatus({ ref, slug: orgSlug, status })
   }
 
+  const handlePauseStateChange = (value: PauseStateOverride | typeof PAUSE_STATE_VALUE_REAL) => {
+    if (!ref) return
+    if (value === PAUSE_STATE_VALUE_REAL) {
+      clearPauseStatusOverride(ref)
+      setPauseOverride(undefined)
+    } else {
+      setPauseStatusOverride(ref, value)
+      setPauseOverride(value)
+    }
+    queryClient.invalidateQueries({ queryKey: projectKeys.pauseStatus(ref) })
+  }
+
   const handleReset = () => {
-    if (ref) clearProjectStatusOverride(ref)
-    setOverride(undefined)
-    refetchRealStatus()
+    if (ref) {
+      clearProjectStatusOverride(ref)
+      clearPauseStatusOverride(ref)
+    }
+    setStatusOverride(undefined)
+    setPauseOverride(undefined)
+    refetchProjectStatus()
+    queryClient.invalidateQueries({ queryKey: projectKeys.pauseStatus(ref) })
   }
 
   const isDisabled = !ref
@@ -80,12 +118,12 @@ export const ProjectStatusTab = () => {
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
         <p className="text-sm text-foreground-light">
-          Override the status of the current project. The override persists across refetches until
+          Override the status of the current project. Overrides persist across refetches until
           reset.
         </p>
         <button
           onClick={handleReset}
-          disabled={isDisabled || override === undefined}
+          disabled={isDisabled || !hasOverride}
           className="text-xs text-foreground-lighter hover:text-foreground transition underline disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Reset to real data
@@ -96,29 +134,50 @@ export const ProjectStatusTab = () => {
         <p className="text-xs text-foreground-muted">Navigate to a project page to use this tab.</p>
       )}
 
-      <div
-        className={cn(
-          'flex items-center justify-between',
-          isDisabled && 'opacity-50 pointer-events-none'
-        )}
-      >
-        <span className="text-sm text-foreground-light">Status</span>
-        <Select
-          value={currentValue}
-          onValueChange={(value) => handleStatusChange(value as ProjectStatus)}
-        >
-          <SelectTrigger className="w-56 text-xs">
-            <SelectValue placeholder="Select a status" />
-          </SelectTrigger>
-          <SelectContent>
-            {STATUS_OPTIONS.map((status) => (
-              <SelectItem key={status} value={status} className="text-xs">
-                {STATUS_LABELS[status]}
-                <span className="ml-1.5 font-mono text-foreground-lighter">{status}</span>
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
+      <div className={cn('space-y-3', isDisabled && 'opacity-50 pointer-events-none')}>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-foreground-light">Status</span>
+          <Select
+            value={currentStatus}
+            onValueChange={(value) => handleStatusChange(value as ProjectStatus)}
+          >
+            <SelectTrigger className="w-64 text-xs">
+              <SelectValue placeholder="Select a status" />
+            </SelectTrigger>
+            <SelectContent>
+              {STATUS_OPTIONS.map((status) => (
+                <SelectItem key={status} value={status} className="text-xs">
+                  {STATUS_LABELS[status]}
+                  <span className="ml-1.5 font-mono text-foreground-lighter">{status}</span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className={cn('flex items-center justify-between', !isPaused && 'opacity-50')}>
+          <div className="flex flex-col">
+            <span className="text-sm text-foreground-light">Pause state</span>
+            <span className="text-xs text-foreground-muted">Applies when status is Paused</span>
+          </div>
+          <Select
+            value={pauseOverride ?? PAUSE_STATE_VALUE_REAL}
+            onValueChange={(value) =>
+              handlePauseStateChange(value as PauseStateOverride | typeof PAUSE_STATE_VALUE_REAL)
+            }
+          >
+            <SelectTrigger className="w-64 text-xs">
+              <SelectValue placeholder="Select a pause state" />
+            </SelectTrigger>
+            <SelectContent>
+              {PAUSE_STATE_OPTIONS.map((option) => (
+                <SelectItem key={option.value} value={option.value} className="text-xs">
+                  {option.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
       </div>
     </div>
   )

--- a/apps/studio/components/ui/DevToolbar/ProjectStatusTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ProjectStatusTab.tsx
@@ -2,14 +2,39 @@
 
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
-import { useEffect, useRef } from 'react'
+import { useEffect, useState } from 'react'
 import { cn, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'ui'
 
 import { projectKeys } from '@/data/projects/keys'
 import { useSetProjectStatus, type Project } from '@/data/projects/project-detail-query'
+import {
+  clearProjectStatusOverride,
+  getProjectStatusOverride,
+  setProjectStatusOverride,
+} from '@/data/projects/project-status-override'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from '@/lib/constants'
+
+type ProjectStatus = Project['status']
+
+const STATUS_LABELS: Record<ProjectStatus, string> = {
+  INACTIVE: 'Paused',
+  ACTIVE_HEALTHY: 'Active (healthy)',
+  ACTIVE_UNHEALTHY: 'Active (unhealthy)',
+  COMING_UP: 'Coming up',
+  UNKNOWN: 'Unknown',
+  GOING_DOWN: 'Going down',
+  INIT_FAILED: 'Init failed',
+  REMOVED: 'Removed',
+  RESTARTING: 'Restarting',
+  RESTORING: 'Restoring',
+  RESTORE_FAILED: 'Restore failed',
+  UPGRADING: 'Upgrading',
+  PAUSING: 'Pausing',
+  PAUSE_FAILED: 'Pause failed',
+  RESIZING: 'Resizing',
+}
 
 const STATUS_OPTIONS = Object.values(PROJECT_STATUS)
 
@@ -21,47 +46,32 @@ export const ProjectStatusTab = () => {
   const { data: selectedOrg } = useSelectedOrganizationQuery()
   const orgSlug = selectedOrg?.slug
 
-  const hasOverrideRef = useRef(false)
-  const latestValues = useRef({ ref, orgSlug })
+  const [override, setOverride] = useState<ProjectStatus | undefined>(undefined)
   useEffect(() => {
-    latestValues.current = { ref, orgSlug }
-  })
+    setOverride(getProjectStatusOverride(ref))
+  }, [ref])
 
-  const revertToRealStatus = (targetRef?: string, targetSlug?: string) => {
-    queryClient.invalidateQueries({ queryKey: projectKeys.detail(targetRef) })
+  const currentValue = override ?? project?.status
+
+  const refetchRealStatus = () => {
+    queryClient.invalidateQueries({ queryKey: projectKeys.detail(ref) })
     queryClient.invalidateQueries({ queryKey: projectKeys.infiniteList() })
-    if (targetSlug) {
-      queryClient.invalidateQueries({ queryKey: projectKeys.infiniteListByOrg(targetSlug) })
+    if (orgSlug) {
+      queryClient.invalidateQueries({ queryKey: projectKeys.infiniteListByOrg(orgSlug) })
     }
   }
 
-  useEffect(() => {
-    return () => {
-      if (!hasOverrideRef.current) return
-      const { ref: latestRef, orgSlug: latestOrgSlug } = latestValues.current
-      revertToRealStatus(latestRef, latestOrgSlug)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
-
-  useEffect(() => {
-    return () => {
-      if (!hasOverrideRef.current) return
-      revertToRealStatus(ref, latestValues.current.orgSlug)
-      hasOverrideRef.current = false
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [ref])
-
-  const handleStatusChange = (status: Project['status']) => {
+  const handleStatusChange = (status: ProjectStatus) => {
     if (!ref) return
+    setProjectStatusOverride(ref, status)
+    setOverride(status)
     setProjectStatus({ ref, slug: orgSlug, status })
-    hasOverrideRef.current = true
   }
 
   const handleReset = () => {
-    hasOverrideRef.current = false
-    revertToRealStatus(ref, orgSlug)
+    if (ref) clearProjectStatusOverride(ref)
+    setOverride(undefined)
+    refetchRealStatus()
   }
 
   const isDisabled = !ref
@@ -69,10 +79,13 @@ export const ProjectStatusTab = () => {
   return (
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
-        <p className="text-sm text-foreground-light">Override the status of the current project.</p>
+        <p className="text-sm text-foreground-light">
+          Override the status of the current project. The override persists across refetches until
+          reset.
+        </p>
         <button
           onClick={handleReset}
-          disabled={isDisabled}
+          disabled={isDisabled || override === undefined}
           className="text-xs text-foreground-lighter hover:text-foreground transition underline disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Reset to real data
@@ -91,16 +104,17 @@ export const ProjectStatusTab = () => {
       >
         <span className="text-sm text-foreground-light">Status</span>
         <Select
-          value={project?.status}
-          onValueChange={(value) => handleStatusChange(value as Project['status'])}
+          value={currentValue}
+          onValueChange={(value) => handleStatusChange(value as ProjectStatus)}
         >
-          <SelectTrigger className="w-56 font-mono text-xs">
+          <SelectTrigger className="w-56 text-xs">
             <SelectValue placeholder="Select a status" />
           </SelectTrigger>
           <SelectContent>
             {STATUS_OPTIONS.map((status) => (
-              <SelectItem key={status} value={status} className="font-mono text-xs">
-                {status}
+              <SelectItem key={status} value={status} className="text-xs">
+                {STATUS_LABELS[status]}
+                <span className="ml-1.5 font-mono text-foreground-lighter">{status}</span>
               </SelectItem>
             ))}
           </SelectContent>

--- a/apps/studio/components/ui/DevToolbar/ProjectStatusTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ProjectStatusTab.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { useParams } from 'common'
+import { useEffect, useRef } from 'react'
+import { cn, Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from 'ui'
+
+import { projectKeys } from '@/data/projects/keys'
+import { useSetProjectStatus, type Project } from '@/data/projects/project-detail-query'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { PROJECT_STATUS } from '@/lib/constants'
+
+const STATUS_OPTIONS = Object.values(PROJECT_STATUS)
+
+export const ProjectStatusTab = () => {
+  const { ref } = useParams()
+  const queryClient = useQueryClient()
+  const { setProjectStatus } = useSetProjectStatus()
+  const { data: project } = useSelectedProjectQuery()
+  const { data: selectedOrg } = useSelectedOrganizationQuery()
+  const orgSlug = selectedOrg?.slug
+
+  const hasOverrideRef = useRef(false)
+  const latestValues = useRef({ ref, orgSlug })
+  useEffect(() => {
+    latestValues.current = { ref, orgSlug }
+  })
+
+  const revertToRealStatus = (targetRef?: string, targetSlug?: string) => {
+    queryClient.invalidateQueries({ queryKey: projectKeys.detail(targetRef) })
+    queryClient.invalidateQueries({ queryKey: projectKeys.infiniteList() })
+    if (targetSlug) {
+      queryClient.invalidateQueries({ queryKey: projectKeys.infiniteListByOrg(targetSlug) })
+    }
+  }
+
+  useEffect(() => {
+    return () => {
+      if (!hasOverrideRef.current) return
+      const { ref: latestRef, orgSlug: latestOrgSlug } = latestValues.current
+      revertToRealStatus(latestRef, latestOrgSlug)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    return () => {
+      if (!hasOverrideRef.current) return
+      revertToRealStatus(ref, latestValues.current.orgSlug)
+      hasOverrideRef.current = false
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ref])
+
+  const handleStatusChange = (status: Project['status']) => {
+    if (!ref) return
+    setProjectStatus({ ref, slug: orgSlug, status })
+    hasOverrideRef.current = true
+  }
+
+  const handleReset = () => {
+    hasOverrideRef.current = false
+    revertToRealStatus(ref, orgSlug)
+  }
+
+  const isDisabled = !ref
+
+  return (
+    <div className="p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-foreground-light">Override the status of the current project.</p>
+        <button
+          onClick={handleReset}
+          disabled={isDisabled}
+          className="text-xs text-foreground-lighter hover:text-foreground transition underline disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          Reset to real data
+        </button>
+      </div>
+
+      {isDisabled && (
+        <p className="text-xs text-foreground-muted">Navigate to a project page to use this tab.</p>
+      )}
+
+      <div
+        className={cn(
+          'flex items-center justify-between',
+          isDisabled && 'opacity-50 pointer-events-none'
+        )}
+      >
+        <span className="text-sm text-foreground-light">Status</span>
+        <Select
+          value={project?.status}
+          onValueChange={(value) => handleStatusChange(value as Project['status'])}
+        >
+          <SelectTrigger className="w-56 font-mono text-xs">
+            <SelectValue placeholder="Select a status" />
+          </SelectTrigger>
+          <SelectContent>
+            {STATUS_OPTIONS.map((status) => (
+              <SelectItem key={status} value={status} className="font-mono text-xs">
+                {status}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+    </div>
+  )
+}

--- a/apps/studio/data/projects/project-detail-query.ts
+++ b/apps/studio/data/projects/project-detail-query.ts
@@ -5,6 +5,7 @@ import { replicaKeys } from '../read-replicas/keys'
 import { ReadReplicasData } from '../read-replicas/replicas-query'
 import { projectKeys } from './keys'
 import { OrgProjectsResponse } from './org-projects-infinite-query'
+import { getProjectStatusOverride } from './project-status-override'
 import type { components } from '@/data/api'
 import { get, handleError, isValidConnString, post } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
@@ -78,7 +79,13 @@ export async function getProjectDetail(
   }
 
   if (error) handleError(error)
-  return { ...data, connectionString: connectionString } as Project
+
+  const project = { ...data, connectionString: connectionString } as Project
+
+  const statusOverride = getProjectStatusOverride(ref)
+  if (statusOverride) project.status = statusOverride
+
+  return project
 }
 
 export type ProjectDetailData = Awaited<ReturnType<typeof getProjectDetail>>

--- a/apps/studio/data/projects/project-pause-status-override.ts
+++ b/apps/studio/data/projects/project-pause-status-override.ts
@@ -1,4 +1,6 @@
-import type { ProjectPauseStatusData } from './project-pause-status-query'
+import type { components } from '@/data/api'
+
+type PauseStatusResponse = components['schemas']['PauseStatusResponse']
 
 export type PauseStateOverride = 'restorable' | 'restore-disabled'
 
@@ -44,7 +46,7 @@ export function clearPauseStatusOverride(ref: string) {
   writeOverrides(overrides)
 }
 
-export function buildPauseStatus(override: PauseStateOverride): ProjectPauseStatusData {
+export function buildPauseStatus(override: PauseStateOverride): PauseStatusResponse {
   const isRestorable = override === 'restorable'
   return {
     can_restore: isRestorable,

--- a/apps/studio/data/projects/project-pause-status-override.ts
+++ b/apps/studio/data/projects/project-pause-status-override.ts
@@ -1,0 +1,56 @@
+import type { ProjectPauseStatusData } from './project-pause-status-query'
+
+export type PauseStateOverride = 'restorable' | 'restore-disabled'
+
+const STORAGE_KEY = 'devToolbar:pauseStatusOverrides'
+
+const IS_ENABLED =
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'local' ||
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
+
+function readOverrides(): Record<string, PauseStateOverride> {
+  if (!IS_ENABLED || typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as Record<string, PauseStateOverride>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeOverrides(overrides: Record<string, PauseStateOverride>) {
+  if (typeof window === 'undefined') return
+  if (Object.keys(overrides).length > 0) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides))
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY)
+  }
+}
+
+export function getPauseStatusOverride(ref: string | undefined): PauseStateOverride | undefined {
+  if (!IS_ENABLED || !ref) return undefined
+  return readOverrides()[ref]
+}
+
+export function setPauseStatusOverride(ref: string, override: PauseStateOverride) {
+  if (!IS_ENABLED) return
+  writeOverrides({ ...readOverrides(), [ref]: override })
+}
+
+export function clearPauseStatusOverride(ref: string) {
+  if (!IS_ENABLED) return
+  const overrides = readOverrides()
+  delete overrides[ref]
+  writeOverrides(overrides)
+}
+
+export function buildPauseStatus(override: PauseStateOverride): ProjectPauseStatusData {
+  const isRestorable = override === 'restorable'
+  return {
+    can_restore: isRestorable,
+    last_paused_on: null,
+    latest_downloadable_backup_id: null,
+    max_days_till_restore_disabled: 90,
+    remaining_days_till_restore_disabled: isRestorable ? 78 : 0,
+  }
+}

--- a/apps/studio/data/projects/project-pause-status-query.ts
+++ b/apps/studio/data/projects/project-pause-status-query.ts
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query'
 
 import { projectKeys } from './keys'
+import { buildPauseStatus, getPauseStatusOverride } from './project-pause-status-override'
 import { get, handleError } from '@/data/fetchers'
 import type { ResponseError, UseCustomQueryOptions } from '@/types'
 
@@ -11,6 +12,9 @@ export async function getProjectPausedStatus(
   signal?: AbortSignal
 ) {
   if (!ref) throw new Error('Project ref is required')
+
+  const override = getPauseStatusOverride(ref)
+  if (override) return buildPauseStatus(override)
 
   const { data, error } = await get('/platform/projects/{ref}/pause/status', {
     params: { path: { ref } },

--- a/apps/studio/data/projects/project-status-override.ts
+++ b/apps/studio/data/projects/project-status-override.ts
@@ -1,0 +1,45 @@
+import type { components } from '@/data/api'
+
+type ProjectStatus = components['schemas']['ProjectDetailResponse']['status']
+
+const STORAGE_KEY = 'devToolbar:projectStatusOverrides'
+
+const IS_ENABLED =
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'local' ||
+  process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging'
+
+function readOverrides(): Record<string, ProjectStatus> {
+  if (!IS_ENABLED || typeof window === 'undefined') return {}
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY)
+    return raw ? (JSON.parse(raw) as Record<string, ProjectStatus>) : {}
+  } catch {
+    return {}
+  }
+}
+
+function writeOverrides(overrides: Record<string, ProjectStatus>) {
+  if (typeof window === 'undefined') return
+  if (Object.keys(overrides).length > 0) {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(overrides))
+  } else {
+    window.localStorage.removeItem(STORAGE_KEY)
+  }
+}
+
+export function getProjectStatusOverride(ref: string | undefined): ProjectStatus | undefined {
+  if (!IS_ENABLED || !ref) return undefined
+  return readOverrides()[ref]
+}
+
+export function setProjectStatusOverride(ref: string, status: ProjectStatus) {
+  if (!IS_ENABLED) return
+  writeOverrides({ ...readOverrides(), [ref]: status })
+}
+
+export function clearProjectStatusOverride(ref: string) {
+  if (!IS_ENABLED) return
+  const overrides = readOverrides()
+  delete overrides[ref]
+  writeOverrides(overrides)
+}

--- a/apps/studio/pages/_app.tsx
+++ b/apps/studio/pages/_app.tsx
@@ -81,8 +81,17 @@ const ResourceWarningsTab = IS_DEV_TOOLBAR_ENABLED
     )
   : () => null
 
+const ProjectStatusTab = IS_DEV_TOOLBAR_ENABLED
+  ? dynamic(() =>
+      import('@/components/ui/DevToolbar/ProjectStatusTab').then((m) => m.ProjectStatusTab)
+    )
+  : () => null
+
 const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
-  ? [{ id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> }]
+  ? [
+      { id: 'warnings', label: 'Warnings', content: <ResourceWarningsTab /> },
+      { id: 'project-status', label: 'Project Status', content: <ProjectStatusTab /> },
+    ]
   : []
 
 const FeatureFlagProviderWithOrgContext = ({

--- a/apps/studio/routes/__root.tsx
+++ b/apps/studio/routes/__root.tsx
@@ -121,6 +121,14 @@ const ResourceWarningsTab = IS_DEV_TOOLBAR_ENABLED
     )
   : () => null
 
+const ProjectStatusTab = IS_DEV_TOOLBAR_ENABLED
+  ? lazy(() =>
+      import('@/components/ui/DevToolbar/ProjectStatusTab').then((m) => ({
+        default: m.ProjectStatusTab,
+      }))
+    )
+  : () => null
+
 const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
   ? [
       {
@@ -129,6 +137,15 @@ const devToolbarExtraTabs: ExtraTab[] = IS_DEV_TOOLBAR_ENABLED
         content: (
           <Suspense fallback={null}>
             <ResourceWarningsTab />
+          </Suspense>
+        ),
+      },
+      {
+        id: 'project-status',
+        label: 'Project Status',
+        content: (
+          <Suspense fallback={null}>
+            <ProjectStatusTab />
           </Suspense>
         ),
       },


### PR DESCRIPTION
## Problem

The free-plan paused project notice was a dense paragraph, so the key points (data is safe, resume window, download-after-expiry, upgrade) were easy to skip.

## Fix

Present those points as a scannable bullet list, keeping the dynamic day-count tooltip, restore-deadline timestamp, and the existing Pro-wording variant.

Also adds a "Project Status" tab to the dev toolbar (local and staging only) with a select for forcing the current project's status, so the paused state and other statuses are easy to preview without touching the backend. It overrides the status in the React Query cache and reverts on close, project navigation, or reset.

## How to test

- Run Studio locally against the platform API
- Open the dev toolbar, go to the Project Status tab, and select INACTIVE
- Navigate to a project page and confirm the paused screen renders
- On a free-plan org, confirm the notice now shows the details as bullet points with the day-count tooltip and restore-deadline date intact
- Click "Reset to real data" (or close the toolbar) and confirm the status reverts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a development toolbar “Project Status” tab to simulate project status and pause states in non-production environments.
  * Status and pause-state overrides persist locally, can be reset, and are reflected across project detail and paused-state views.
* **Style**
  * Refined paused-project messaging: updated the heading and reworked the free-plan explanation into bullet points, while keeping paid-plan messaging paragraph-based for readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->