### PR TITLE
feat(studio): make unified logs available on self-hosted [experiment]

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
+++ b/apps/studio/components/interfaces/App/FeaturePreview/useFeaturePreviews.ts
@@ -46,7 +46,7 @@ export const useFeaturePreviews = (): FeaturePreview[] => {
           discussionsUrl: 'https://github.com/orgs/supabase/discussions/37234',
           enabled: true,
           isNew: true,
-          isPlatformOnly: true,
+          isPlatformOnly: false,
           isDefaultOptIn: unifiedLogsDefaultOptIn,
           getRoute: (ref?: string) => `/project/${ref}/logs`,
         },


### PR DESCRIPTION
## What

**Experimental** — the inverse of #47727. Instead of disabling unified logs on self-hosted, this makes it **available** there.

Explores FE-3747 from the other direction: rather than hiding unified logs on self-hosted, let self-hosted users opt into it.

## Change

Flip the "Updated Logs interface" feature preview from `isPlatformOnly: true` to `isPlatformOnly: false` (single line in `useFeaturePreviews.ts`).

That is sufficient because:
- The `FeaturePreviewModal` no longer filters it out on self-hosted, so the toggle appears.
- `FeaturePreviewContextProvider.initializeFlags` no longer zeroes the flag on reload, so the opt-in **persists**.
- The sidebar `UnifiedLogsBanner` ("Enable preview") and the logs nav/page already react to the hook, so once enabled everything routes to `/logs`.

## Why this can work on self-hosted

Unified logs POSTs to `/platform/projects/{ref}/analytics/endpoints/logs.all` — the same analytics endpoint the legacy Logs Explorer uses. On self-hosted that route is handled by `pages/api/platform/projects/[ref]/analytics/endpoints/[name].ts`, which already accepts POST and forwards the SQL body to Logflare (the FE-1696 backend work, now Done). `useOtel` defaults off, so it uses the BigQuery `logs.all` variant, not the ClickHouse `.otel` one.

## Open question (needs live testing)

The endpoint plumbing works, but the unified-logs SQL (multi-source unnests/unions, facet counts) is more complex than the explorer's. This experiment is to verify those queries actually run against a self-hosted Logflare backend.

Do **not** merge without deciding the product direction (disable vs enable) and adding/adjusting tests.