### PR TITLE
Fix R2NP disk size multiplier in FE copy

### DIFF
--- a/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/AdditionalMonthlySpend.tsx
+++ b/apps/studio/components/interfaces/Database/Backups/RestoreToNewProject/AdditionalMonthlySpend.tsx
@@ -9,7 +9,7 @@ export const AdditionalMonthlySpend = ({
     <div className="text-sm text-foreground-lighter border-t p-5">
       <p>
         The new project will start with the same compute size as your current project, but the disk
-        size will be slightly larger (1.25×) to ensure the restore completes successfully. You will
+        size will be slightly larger (1.5×) to ensure the restore completes successfully. You will
         be able to update the compute size and increase the disk size after the new project is
         created in{' '}
         <span className="font-mono text-xs tracking-tighter text-foreground-light">


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixes the copy here to accurately reflect the [constant defined on the backend](https://github.com/supabase/platform/blob/7653f016838fc1bba15bbce201a1c58566f1751a/packages/api-core/src/shared/disk.ts#L32). No behavior change. 

https://linear.app/supabase/issue/INDATA-906/ensure-fe-r2np-disk-size-multiplier-is-accurate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated restore guidance to accurately indicate that the restored disk size may be approximately 1.5× larger.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->