### PR TITLE
fix(studio): improve unified logs checkbox hit area and align icons

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/DetailSection.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/ServiceFlow/components/shared/DetailSection.tsx
@@ -2,7 +2,9 @@ import { LucideIcon } from 'lucide-react'
 import { ReactNode } from 'react'
 import { cn } from 'ui'
 
-type IconComponent = LucideIcon | React.ComponentType<{ size?: number; className?: string }>
+type IconComponent =
+  | LucideIcon
+  | React.ComponentType<{ size?: number; strokeWidth?: number; className?: string }>
 
 interface DetailSectionHeaderProps {
   title: string
@@ -25,7 +27,7 @@ export const DetailSectionHeader = ({
     )}
     <div className="flex min-w-0 items-center gap-2">
       {Icon ? (
-        <Icon size={14} className="shrink-0 text-foreground-lighter" />
+        <Icon size={14} strokeWidth={1.5} className="shrink-0 text-foreground-lighter" />
       ) : (
         <span className="w-3.5 shrink-0" aria-hidden />
       )}

--- a/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/Columns.tsx
@@ -45,6 +45,7 @@ export function generateDynamicColumns({ data }: { data: ColumnSchema[] }): {
       cell: ({ row }) => {
         return (
           <Checkbox
+            className="hit-area-2 hover:border-foreground-muted"
             checked={row.getIsSelected()}
             onCheckedChange={(value) => row.toggleSelected(!!value)}
             onClick={(e) => e.stopPropagation()}
@@ -112,7 +113,7 @@ export function generateDynamicColumns({ data }: { data: ColumnSchema[] }): {
         const logType = row.getValue<ColumnSchema['log_type']>('log_type')
         return (
           <div className="flex items-center justify-end gap-1">
-            <LogTypeIcon type={logType} size={16} className="text-foreground-muted" />
+            <LogTypeIcon type={logType} size={14} className="text-foreground-lighter" />
           </div>
         )
       },

--- a/apps/studio/components/interfaces/UnifiedLogs/components/LogTypeIcon.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/components/LogTypeIcon.tsx
@@ -33,7 +33,7 @@ const ICON_MAP: Partial<Record<(typeof LOG_TYPES)[number], IconComponent>> = {
 
 export const LogTypeIcon = ({
   type,
-  size = 16,
+  size = 14,
   strokeWidth = 1.5,
   className,
 }: LogTypeIconProps) => {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix / polish

## What is the current behavior?

Unified logs row selection checkboxes only respond to clicks on the checkbox itself, so it's easy to miss. Log type icons in the table also don't match the ServiceFlow panel (16px / muted vs 14px / lighter / strokeWidth 1.5).

## What is the new behavior?

- Expand the select checkbox tap target with `hit-area-2`, and add a visible `hover:border-foreground-muted` affordance (matching the older logs explorer intent; the base Checkbox hover is a no-op after the colour-system token collapse).
- Align log type icons with ServiceFlow: 14px, `text-foreground-lighter`, `strokeWidth={1.5}` on both the table column and ServiceFlow section headers.

## Additional context

Older logs used an `absolute inset-0` wrapper for the same hit-area problem; unified logs uses the design-system `hit-area` utility instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined unified log visuals with more consistent icon sizing, stroke weight, and muted coloring.
  * Improved checkbox hover styling and expanded its clickable area for easier selection.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->