### PR TITLE
fix(products): edge functions page duplicated border

### DIFF
--- a/apps/www/app/(products)/edge-functions/_components/EdgeFunctionsContent.tsx
+++ b/apps/www/app/(products)/edge-functions/_components/EdgeFunctionsContent.tsx
@@ -11,7 +11,7 @@ import { ObservabilitySection } from './ObservabilitySection'
 export function EdgeFunctionsContent() {
   return (
     <div className="overflow-x-clip">
-      <section className="border-t border-border" aria-label="Hero">
+      <section aria-label="Hero">
         <Hero />
         <Highlights />
       </section>


### PR DESCRIPTION
## What kind of change does this PR introduce?

this pr fixes the duplicated border from the edge functions page hero.

## What is the current behavior?

there is currrently a duplicated border used that is not consistent with other sibling pages.

## What is the new behavior?

this pr removes the border applied to the hero to maintain consistency with sibling pages.

## Additional context

| state | preview |
| -------|------|
| before | <img width="697" height="169" alt="image" src="https://github.com/user-attachments/assets/af7d8258-cfd7-4b21-a004-0da4e0ad28dd" /> |
| after | <img width="697" height="169" alt="image" src="https://github.com/user-attachments/assets/09bb615d-c46a-4fc5-988d-da7dcd259478" /> | 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Edge Functions hero section styling for a cleaner page presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->