### PR TITLE
refactor(sql-editor): own shared editor refs in SQLEditorContext (decompose 3/N)

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.tsx
@@ -1,4 +1,3 @@
-import type { Monaco } from '@monaco-editor/react'
 import {
   acceptUntrustedSql,
   untrustedSql,
@@ -10,7 +9,7 @@ import { IS_PLATFORM, LOCAL_STORAGE_KEYS, useFlag, useParams } from 'common'
 import { Loader2 } from 'lucide-react'
 import dynamic from 'next/dynamic'
 import { useRouter } from 'next/router'
-import { useCallback, useEffect, useEffectEvent, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useEffectEvent, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { cn, ResizableHandle, ResizablePanel, ResizablePanelGroup } from 'ui'
 
@@ -21,12 +20,7 @@ import {
   sqlAiDisclaimerComment,
   untitledSnippetTitle,
 } from './SQLEditor.constants'
-import {
-  DiffType,
-  IStandaloneCodeEditor,
-  IStandaloneDiffEditor,
-  type PotentialIssues,
-} from './SQLEditor.types'
+import { DiffType, IStandaloneCodeEditor, type PotentialIssues } from './SQLEditor.types'
 import {
   appendEnableRLSStatements,
   assembleCompletionDiff,
@@ -35,7 +29,6 @@ import {
   checkAlterDatabaseConnection,
   checkDestructiveQuery,
   checkIfAppendLimitRequired,
-  computeErrorHighlightLine,
   createSqlSnippetSkeletonV2,
   filterTablesCoveredByEnsureRLSTrigger,
   getCreateTablesMissingRLS,
@@ -44,6 +37,7 @@ import {
   isUpdateWithoutWhere,
   suffixWithLimit,
 } from './SQLEditor.utils'
+import { SQLEditorProvider, useSQLEditorContext } from './SQLEditorContext'
 import { useAddDefinitions } from './useAddDefinitions'
 import { UtilityActions } from './UtilityPanel/UtilityActions'
 import { UtilityPanel } from './UtilityPanel/UtilityPanel'
@@ -97,7 +91,21 @@ const DiffEditor = dynamic(
   { ssr: false }
 )
 
-export const SQLEditor = () => {
+const SQLEditorContent = () => {
+  const {
+    editorRef,
+    monacoRef,
+    diffEditorRef,
+    scrollTopRef,
+    refocusEditor,
+    clearPendingRunRefocus,
+    markRefocusAfterRun,
+    refocusEditorAfterRunIfNeeded,
+    getEditorSql: getEditorSqlFromEditor,
+    clearHighlights,
+    applyErrorHighlight,
+  } = useSQLEditorContext()
+
   const os = detectOS()
   const router = useRouter()
   const { ref, id: urlId } = useParams()
@@ -133,14 +141,7 @@ export const SQLEditor = () => {
   const { promptState, setPromptState, promptInput, setPromptInput, resetPrompt } =
     useSqlEditorPrompt()
 
-  const editorRef = useRef<IStandaloneCodeEditor | null>(null)
-  const monacoRef = useRef<Monaco | null>(null)
-  const diffEditorRef = useRef<IStandaloneDiffEditor | null>(null)
-  const scrollTopRef = useRef<number>(0)
-  const shouldRefocusAfterRunRef = useRef(false)
-
   const [hasSelection, setHasSelection] = useState<boolean>(false)
-  const [lineHighlights, setLineHighlights] = useState<string[]>([])
   const [isDiffEditorMounted, setIsDiffEditorMounted] = useState(false)
   const [potentialIssues, setPotentialIssues] = useState<PotentialIssues>()
 
@@ -149,12 +150,6 @@ export const SQLEditor = () => {
   // so a diff request that arrived before the editor was ready gets re-processed.
   const [editorMountCount, setEditorMountCount] = useState(0)
   const [activeUtilityTab, setActiveUtilityTab] = useState<string>('results')
-
-  const refocusEditor = useCallback(() => {
-    requestAnimationFrame(() => {
-      setTimeout(() => editorRef.current?.focus(), 0)
-    })
-  }, [])
 
   useShortcut(SHORTCUT_IDS.SQL_EDITOR_FOCUS_EDITOR, refocusEditor, {
     registerInCommandMenu: true,
@@ -171,17 +166,6 @@ export const SQLEditor = () => {
   useShortcut(SHORTCUT_IDS.SQL_EDITOR_NEW_SNIPPET, openNewSnippet, {
     registerInCommandMenu: true,
   })
-
-  const clearPendingRunRefocus = useCallback(() => {
-    shouldRefocusAfterRunRef.current = false
-  }, [])
-
-  const refocusEditorAfterRunIfNeeded = useCallback(() => {
-    if (!shouldRefocusAfterRunRef.current) return
-
-    shouldRefocusAfterRunRef.current = false
-    refocusEditor()
-  }, [refocusEditor])
 
   // generate a new snippet title and an id to be used for new snippets. The dependency on urlId is to avoid a bug which
   // shows up when clicking on the SQL Editor while being in the SQL editor on a random snippet.
@@ -239,34 +223,7 @@ export const SQLEditor = () => {
     },
     onError(error: any, vars) {
       if (id) {
-        if (error.position && monacoRef.current) {
-          const editor = editorRef.current
-          const monaco = monacoRef.current
-
-          const startLineNumber = hasSelection ? (editor?.getSelection()?.startLineNumber ?? 0) : 0
-
-          const line = computeErrorHighlightLine(error, startLineNumber)
-
-          if (!isNaN(line)) {
-            const decorations = editor?.deltaDecorations(
-              [],
-              [
-                {
-                  range: new monaco.Range(line, 1, line, 20),
-                  options: {
-                    isWholeLine: true,
-                    inlineClassName: 'bg-warning-400',
-                  },
-                },
-              ]
-            )
-            if (decorations) {
-              editor?.revealLineInCenter(line)
-              setLineHighlights(decorations)
-            }
-          }
-        }
-
+        applyErrorHighlight(error, hasSelection)
         sessionSnap.addResultError(id, error, vars.autoLimit)
       }
 
@@ -327,7 +284,7 @@ export const SQLEditor = () => {
         snapV2.setSql({ id, sql: formattedSql })
       }
     }
-  }, [id, isDiffOpen, project, snapV2])
+  }, [editorRef, id, isDiffOpen, project, snapV2])
 
   useShortcut(SHORTCUT_IDS.SQL_EDITOR_FORMAT, prettifyQuery, {
     registerInCommandMenu: true,
@@ -338,11 +295,9 @@ export const SQLEditor = () => {
   // explain gesture handlers below — never inside the longer execute* helpers,
   // which by construction only accept already-reviewed SafeSqlFragments.
   const readEditorSql = useCallback((): UntrustedSqlFragment | undefined => {
-    const editor = editorRef.current
-    if (!editor) return undefined
     const snippet = getSqlEditorV2StateSnapshot().snippets[id]
-    return getEditorSql(editor, snippet?.snippet.content?.unchecked_sql)
-  }, [id])
+    return getEditorSqlFromEditor(snippet?.snippet.content?.unchecked_sql)
+  }, [getEditorSqlFromEditor, id])
 
   const executeQuery = useCallback(
     async (sql: SafeSqlFragment, force: boolean = false) => {
@@ -394,10 +349,7 @@ export const SQLEditor = () => {
         setAiTitle(id, sql)
       }
 
-      if (lineHighlights.length > 0) {
-        editorRef.current?.deltaDecorations(lineHighlights, [])
-        setLineHighlights([])
-      }
+      clearHighlights()
 
       const impersonatedRoleState = getImpersonatedRoleState()
       const connectionString = databases?.find(
@@ -447,12 +399,12 @@ export const SQLEditor = () => {
 
   // Run gesture from the toolbar button: promote here, then run.
   const executeQueryFromButton = useCallback(() => {
-    shouldRefocusAfterRunRef.current = true
+    markRefocusAfterRun()
     refocusEditor()
     const sql = readEditorSql()
     if (sql === undefined) return clearPendingRunRefocus()
     void executeQuery(acceptUntrustedSql(sql))
-  }, [clearPendingRunRefocus, executeQuery, readEditorSql, refocusEditor])
+  }, [clearPendingRunRefocus, executeQuery, markRefocusAfterRun, readEditorSql, refocusEditor])
 
   // Run gesture from the editor (Cmd/Ctrl+Enter): promote here, then run.
   const handleRunShortcut = useCallback(() => {
@@ -476,10 +428,7 @@ export const SQLEditor = () => {
           return
         }
 
-        if (lineHighlights.length > 0) {
-          editorRef.current?.deltaDecorations(lineHighlights, [])
-          setLineHighlights([])
-        }
+        clearHighlights()
 
         const impersonatedRoleState = getImpersonatedRoleState()
         const connectionString = databases?.find(
@@ -506,6 +455,7 @@ export const SQLEditor = () => {
       }
     },
     [
+      editorRef,
       isDiffOpen,
       id,
       isExplainExecuting,
@@ -514,7 +464,7 @@ export const SQLEditor = () => {
       getImpersonatedRoleState,
       databaseSelectorState.selectedDatabaseId,
       databases,
-      lineHighlights,
+      clearHighlights,
       sessionSnap,
     ]
   )
@@ -780,7 +730,15 @@ export const SQLEditor = () => {
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [os, isDiffOpen, promptState.isOpen, acceptAiHandler, discardAiHandler, resetPrompt])
+  }, [
+    editorRef,
+    os,
+    isDiffOpen,
+    promptState.isOpen,
+    acceptAiHandler,
+    discardAiHandler,
+    resetPrompt,
+  ])
 
   useEffect(() => {
     if (isDiffOpen) {
@@ -851,7 +809,7 @@ export const SQLEditor = () => {
       setShowWidget(true)
       return () => setShowWidget(false)
     }
-  }, [isDiffOpen, isDiffEditorMounted])
+  }, [diffEditorRef, isDiffOpen, isDiffEditorMounted])
 
   return (
     <>
@@ -864,7 +822,7 @@ export const SQLEditor = () => {
           refocusEditor()
         }}
         onConfirm={() => {
-          shouldRefocusAfterRunRef.current = true
+          markRefocusAfterRun()
           setPotentialIssues(undefined)
           refocusEditor()
           // The user has reviewed the warning and confirmed — promote here.
@@ -877,7 +835,7 @@ export const SQLEditor = () => {
           if (tables.length === 0) return
           const baseSql = readEditorSql() ?? untrustedSql('')
           const rewrittenSql = appendEnableRLSStatements(baseSql, tables)
-          shouldRefocusAfterRunRef.current = true
+          markRefocusAfterRun()
           setPotentialIssues(undefined)
           refocusEditor()
           // The user has reviewed the warning and confirmed — promote here.
@@ -1039,3 +997,9 @@ export const SQLEditor = () => {
     </>
   )
 }
+
+export const SQLEditor = () => (
+  <SQLEditorProvider>
+    <SQLEditorContent />
+  </SQLEditorProvider>
+)

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditorContext.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditorContext.tsx
@@ -1,0 +1,149 @@
+import type { Monaco } from '@monaco-editor/react'
+import type { UntrustedSqlFragment } from '@supabase/pg-meta'
+import {
+  createContext,
+  use,
+  useCallback,
+  useMemo,
+  useRef,
+  type PropsWithChildren,
+  type RefObject,
+} from 'react'
+
+import type { IStandaloneCodeEditor, IStandaloneDiffEditor } from './SQLEditor.types'
+import { computeErrorHighlightLine, getEditorSql } from './SQLEditor.utils'
+
+type SQLEditorContextValue = {
+  editorRef: RefObject<IStandaloneCodeEditor | null>
+  monacoRef: RefObject<Monaco | null>
+  diffEditorRef: RefObject<IStandaloneDiffEditor | null>
+  scrollTopRef: RefObject<number>
+  /** Focus the editor on the next frame (after layout settles). */
+  refocusEditor: () => void
+  /** Cancel a pending "refocus after the run finishes" request. */
+  clearPendingRunRefocus: () => void
+  /** Request that the editor be refocused once the current run finishes. */
+  markRefocusAfterRun: () => void
+  /** Refocus the editor iff a run-refocus was requested, then clear the flag. */
+  refocusEditorAfterRunIfNeeded: () => void
+  getEditorSql: (snippetContent?: UntrustedSqlFragment) => UntrustedSqlFragment | undefined
+  /** Clear any active error-highlight decorations. */
+  clearHighlights: () => void
+  /** Highlight and reveal the line referenced by an execute error's position. */
+  applyErrorHighlight: (
+    error: { position?: unknown; formattedError?: string },
+    hasSelection: boolean
+  ) => void
+}
+
+const SQLEditorContext = createContext<SQLEditorContextValue | null>(null)
+
+export const useSQLEditorContext = () => {
+  const context = use(SQLEditorContext)
+  if (!context) {
+    throw new Error('useSQLEditorContext must be used within a SQLEditorProvider')
+  }
+  return context
+}
+
+export const SQLEditorProvider = ({ children }: PropsWithChildren) => {
+  const editorRef = useRef<IStandaloneCodeEditor | null>(null)
+  const monacoRef = useRef<Monaco | null>(null)
+  const diffEditorRef = useRef<IStandaloneDiffEditor | null>(null)
+  const scrollTopRef = useRef<number>(0)
+  const shouldRefocusAfterRunRef = useRef(false)
+  // Decorations are only ever manipulated imperatively, so they live in a ref
+  // rather than React state (nothing renders off them).
+  const lineHighlightsRef = useRef<string[]>([])
+
+  const refocusEditor = useCallback(() => {
+    requestAnimationFrame(() => {
+      setTimeout(() => editorRef.current?.focus(), 0)
+    })
+  }, [])
+
+  const clearPendingRunRefocus = useCallback(() => {
+    shouldRefocusAfterRunRef.current = false
+  }, [])
+
+  const markRefocusAfterRun = useCallback(() => {
+    shouldRefocusAfterRunRef.current = true
+  }, [])
+
+  const refocusEditorAfterRunIfNeeded = useCallback(() => {
+    if (!shouldRefocusAfterRunRef.current) return
+
+    shouldRefocusAfterRunRef.current = false
+    refocusEditor()
+  }, [refocusEditor])
+
+  const getEditorSqlFromEditor = useCallback((snippetContent?: UntrustedSqlFragment) => {
+    const editor = editorRef.current
+    if (!editor) return undefined
+    return getEditorSql(editor, snippetContent)
+  }, [])
+
+  const clearHighlights = useCallback(() => {
+    if (lineHighlightsRef.current.length > 0) {
+      editorRef.current?.deltaDecorations(lineHighlightsRef.current, [])
+      lineHighlightsRef.current = []
+    }
+  }, [])
+
+  const applyErrorHighlight = useCallback(
+    (error: { position?: unknown; formattedError?: string }, hasSelection: boolean) => {
+      if (!error.position || !monacoRef.current) return
+
+      const editor = editorRef.current
+      const monaco = monacoRef.current
+      const startLineNumber = hasSelection ? (editor?.getSelection()?.startLineNumber ?? 0) : 0
+      const line = computeErrorHighlightLine(error, startLineNumber)
+      if (isNaN(line)) return
+
+      const decorations = editor?.deltaDecorations(
+        [],
+        [
+          {
+            range: new monaco.Range(line, 1, line, 20),
+            options: {
+              isWholeLine: true,
+              inlineClassName: 'bg-warning-400',
+            },
+          },
+        ]
+      )
+      if (decorations) {
+        editor?.revealLineInCenter(line)
+        lineHighlightsRef.current = decorations
+      }
+    },
+    []
+  )
+
+  const value = useMemo<SQLEditorContextValue>(
+    () => ({
+      editorRef,
+      monacoRef,
+      diffEditorRef,
+      scrollTopRef,
+      refocusEditor,
+      clearPendingRunRefocus,
+      markRefocusAfterRun,
+      refocusEditorAfterRunIfNeeded,
+      getEditorSql: getEditorSqlFromEditor,
+      clearHighlights,
+      applyErrorHighlight,
+    }),
+    [
+      refocusEditor,
+      clearPendingRunRefocus,
+      markRefocusAfterRun,
+      refocusEditorAfterRunIfNeeded,
+      getEditorSqlFromEditor,
+      clearHighlights,
+      applyErrorHighlight,
+    ]
+  )
+
+  return <SQLEditorContext.Provider value={value}>{children}</SQLEditorContext.Provider>
+}


### PR DESCRIPTION
## Summary

PR **3** in the SQLEditor decomposition stack. The keystone structural step: introduce a context provider that owns the shared, mutable Monaco state, so later PRs can extract logic hooks and presentational panes without threading the same three refs through every signature.

Behavior-preserving — the characterization suite (merged in PR 1) stays green with identical assertions.

## What changed

New `SQLEditorContext.tsx`:
- `SQLEditorProvider` owns the shared refs (`editorRef`, `monacoRef`, `diffEditorRef`, `scrollTopRef`), the run-refocus flag, and the error-highlight decorations.
- `useSQLEditorContext()` guard hook (React 19 `use()`), mirroring the canonical `PoliciesDataContext` pattern.
- Stable helpers: `refocusEditor`, `clearPendingRunRefocus`, `markRefocusAfterRun`, `refocusEditorAfterRunIfNeeded`, `getEditorSql`, `clearHighlights`, `applyErrorHighlight`.

`SQLEditor.tsx`:
- Split into `<SQLEditorProvider><SQLEditorContent/></SQLEditorProvider>`.
- `SQLEditorContent` reads refs/helpers from context instead of local `useRef`/`useCallback`.
- `lineHighlights` moves from React state to a ref inside the provider (decorations are purely imperative; nothing renders off them). This also removes the stale-closure hazard the old `executeQuery` dep-array omission worked around.

The context value holds only stable identities (refs + `useCallback`s, memoized once), so the provider never re-renders its consumers — it's a dependency-injection channel, not reactive state.

## Verification

- `vitest` — 156 pass (characterization + utils), assertions unchanged
- `pnpm --filter studio typecheck` — clean for all SQL editor files (the two `@sentry/tanstackstart-react` errors are a pre-existing local-install gap on master, unrelated)
- `eslint` — 0 errors
- Equivalence: single `useEffectEvent`, `drainDiffRequest` driving-effect deps `[diffRequest.pending, editorMountCount]` byte-identical, all 8 `eslint-disable` dep arrays preserved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SQL editor focus restoration after running or explaining queries.
  * Centralized run/explain highlighting so errors are highlighted consistently and old highlights are reliably cleared.
  * Ensured the SQL snippet used for run/explain is derived consistently from the current editor state.
* **Refactor**
  * Restructured the SQL editor to use a shared internal context for editor UI, refs, and imperative highlight/focus helpers, keeping the external editor interface unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->