### PR TITLE
docs(edge-functions): use error key in examples

### DIFF
--- a/examples/edge-functions/supabase/functions/_shared/jwt/clerk.ts
+++ b/examples/edge-functions/supabase/functions/_shared/jwt/clerk.ts
@@ -42,7 +42,7 @@ export async function AuthMiddleware(req: Request, next: (req: Request) => Promi
     if (isValidJWT) return await next(req)
 
     return Response.json(
-      { msg: 'Invalid JWT' },
+      { error: 'Invalid JWT' },
       {
         status: 401,
       }
@@ -50,7 +50,7 @@ export async function AuthMiddleware(req: Request, next: (req: Request) => Promi
   } catch (e) {
     console.error(e)
     return Response.json(
-      { msg: e?.toString() },
+      { error: e?.toString() },
       {
         status: 401,
       }

--- a/examples/edge-functions/supabase/functions/_shared/jwt/default.ts
+++ b/examples/edge-functions/supabase/functions/_shared/jwt/default.ts
@@ -39,14 +39,14 @@ export async function AuthMiddleware(req: Request, next: (req: Request) => Promi
     if (isValidJWT) return await next(req)
 
     return Response.json(
-      { msg: 'Invalid JWT' },
+      { error: 'Invalid JWT' },
       {
         status: 401,
       }
     )
   } catch (e) {
     return Response.json(
-      { msg: e?.toString() },
+      { error: e?.toString() },
       {
         status: 401,
       }

--- a/examples/edge-functions/supabase/functions/_shared/jwt/legacy-jwt.ts
+++ b/examples/edge-functions/supabase/functions/_shared/jwt/legacy-jwt.ts
@@ -40,7 +40,7 @@ export async function AuthMiddleware(req: Request, next: (req: Request) => Promi
     if (isValidJWT) return await next(req)
 
     return Response.json(
-      { msg: 'Invalid JWT' },
+      { error: 'Invalid JWT' },
       {
         status: 401,
       }
@@ -48,7 +48,7 @@ export async function AuthMiddleware(req: Request, next: (req: Request) => Promi
   } catch (e) {
     console.error(e)
     return Response.json(
-      { msg: e?.toString() },
+      { error: e?.toString() },
       {
         status: 401,
       }

--- a/examples/edge-functions/supabase/functions/sentry/index.ts
+++ b/examples/edge-functions/supabase/functions/sentry/index.ts
@@ -53,7 +53,7 @@ export default {
       if (error) console.log(e.twitter, error.message)
       return Response.json(
         {
-          msg: `Congrats, you are wrong https://itsjustpostgres.com/ 🎉 @${e.twitter} has been added to the draw!`,
+          error: `Congrats, you are wrong https://itsjustpostgres.com/ 🎉 @${e.twitter} has been added to the draw!`,
         },
         { status: 500 }
       )

--- a/examples/edge-functions/supabase/functions/sentryfied/index.ts
+++ b/examples/edge-functions/supabase/functions/sentryfied/index.ts
@@ -25,7 +25,7 @@ export default {
       return Response.json(data)
     } catch (e) {
       Sentry.captureException(e)
-      return Response.json({ msg: 'error' }, { status: 500 })
+      return Response.json({ error: 'error' }, { status: 500 })
     }
   }),
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

Several edge function examples (`examples/edge-functions/supabase/functions/sentryfied/index.ts`, and the shared JWT auth middlewares `_shared/jwt/default.ts`, `_shared/jwt/clerk.ts`, `_shared/jwt/legacy-jwt.ts`) return errors as `{ "msg": "..." }`. This doesn't match the shape Supabase's own tooling expects (platform gateway, self-hosted worker, Studio's test panel all use `{ "error": "..." }`) — see #47835 for the full writeup of this pattern across the codebase. A developer copying any of these would hit the same "generic unhelpful error" symptom that issue describes, just caused by their own function.

The three `_shared/jwt/*` files are auth middleware imported by multiple example functions, so fixing them there covers every example that uses `AuthMiddleware` from any of the three, not just the one function that imports it directly.

## What is the new behavior?

All four return `{ "error": "..." }` instead, matching platform's shape and the now-fixed self-hosted/CLI workers.

## Additional context

Related to #47835. Not a functional bug in any of these examples (JWT verification and Sentry capture still work either way), just aligning the taught pattern with what Supabase's own tooling actually expects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authentication and error payloads to use the `error` field instead of `msg`.
  * Ensured invalid or failed JWT validation continues to return HTTP 401.
  * Updated error responses for the affected edge-function examples to return consistent `{ error: ... }` JSON when failures occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->