### PR TITLE
Fix feature preview dialog selected

### DIFF
--- a/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
+++ b/apps/studio/components/interfaces/App/FeaturePreview/FeaturePreviewModal.tsx
@@ -270,7 +270,7 @@ const FeaturePreviewItem = ({
       onClick={() => selectFeaturePreview(feature.key)}
       className={cn(
         'w-full! flex-1 flex items-center justify-between p-4 border-b cursor-pointer bg transition',
-        selectedFeature?.key === feature.key ? 'bg-surface-300' : 'bg-surface-100',
+        selectedFeature?.key === feature.key ? 'bg-accent' : 'bg-card',
         className
       )}
     >


### PR DESCRIPTION
Use bg-accent for selected state across elements. This fix is specific to the feature preview dialog. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated feature preview selection styling for clearer visual distinction between selected and unselected items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->