### PR TITLE
ci: make Coveralls optional, add coverage-drop gate

### DIFF
--- a/.github/scripts/coverage-gate.sh
+++ b/.github/scripts/coverage-gate.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 lcov_file="$1"
 baseline_file="${2:-}"
 tolerance="${COVERAGE_TOLERANCE:-0.1}"
+enforce="${COVERAGE_ENFORCE:-true}"
 
 if [[ ! -f "$lcov_file" ]]; then
   echo "Coverage report not found at $lcov_file" >&2
@@ -44,7 +45,10 @@ dropped="$(awk -v baseline="$baseline" -v current="$current" -v tolerance="$tole
 if [[ "$dropped" == "yes" ]]; then
   echo "" >> "$summary"
   echo "Coverage dropped from ${baseline}% to ${current}% (allowed tolerance ${tolerance}%)." | tee -a "$summary" >&2
-  exit 1
+  if [[ "$enforce" == "true" ]]; then
+    exit 1
+  fi
+  exit 0
 fi
 
 echo "Coverage is at ${current}% (baseline ${baseline}%)." | tee -a "$summary"

--- a/.github/scripts/coverage-gate.sh
+++ b/.github/scripts/coverage-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+lcov_file="$1"
+baseline_file="${2:-}"
+tolerance="${COVERAGE_TOLERANCE:-0.1}"
+
+if [[ ! -f "$lcov_file" ]]; then
+  echo "Coverage report not found at $lcov_file" >&2
+  exit 1
+fi
+
+current="$(awk -F: '
+  /^LF:/ { lines_found += $2 }
+  /^LH:/ { lines_hit += $2 }
+  END { if (lines_found > 0) printf "%.2f", lines_hit / lines_found * 100; else print "0.00" }
+' "$lcov_file")"
+
+{
+  echo "current=$current"
+} >> "${GITHUB_OUTPUT:-/dev/null}"
+
+summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+if [[ -z "$baseline_file" || ! -f "$baseline_file" ]]; then
+  echo "No baseline coverage recorded yet — skipping comparison." | tee -a "$summary"
+  echo "Current coverage: ${current}%" | tee -a "$summary"
+  exit 0
+fi
+
+baseline="$(tr -d '[:space:]' < "$baseline_file")"
+
+dropped="$(awk -v baseline="$baseline" -v current="$current" -v tolerance="$tolerance" \
+  'BEGIN { print (current + tolerance < baseline) ? "yes" : "no" }')"
+
+{
+  echo "### Coverage check"
+  echo ""
+  echo "| Baseline | Current | Tolerance |"
+  echo "| --- | --- | --- |"
+  echo "| ${baseline}% | ${current}% | ${tolerance}% |"
+} >> "$summary"
+
+if [[ "$dropped" == "yes" ]]; then
+  echo "" >> "$summary"
+  echo "Coverage dropped from ${baseline}% to ${current}% (allowed tolerance ${tolerance}%)." | tee -a "$summary" >&2
+  exit 1
+fi
+
+echo "Coverage is at ${current}% (baseline ${baseline}%)." | tee -a "$summary"

--- a/.github/scripts/coverage-gate.test.sh
+++ b/.github/scripts/coverage-gate.test.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+gate="$script_dir/coverage-gate.sh"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+failures=0
+
+write_lcov() {
+  printf 'LF:%s\nLH:%s\n' "$1" "$2" > "$3"
+}
+
+assert_exit() {
+  local description="$1" expected="$2" actual="$3"
+  if [[ "$actual" == "$expected" ]]; then
+    echo "ok   - $description"
+  else
+    echo "FAIL - $description (expected exit $expected, got $actual)"
+    failures=$((failures + 1))
+  fi
+}
+
+cov_80="$work/cov_80.info"
+write_lcov 100 80 "$cov_80"
+cov_90="$work/cov_90.info"
+write_lcov 100 90 "$cov_90"
+
+baseline_80="$work/baseline_80.txt"
+echo "80.00" > "$baseline_80"
+baseline_90="$work/baseline_90.txt"
+echo "90.00" > "$baseline_90"
+baseline_within_tolerance="$work/baseline_within.txt"
+echo "80.05" > "$baseline_within_tolerance"
+
+GITHUB_OUTPUT=/dev/null bash "$gate" "$cov_80" "$work/absent.txt" >/dev/null 2>&1
+assert_exit "missing baseline passes" 0 $?
+
+GITHUB_OUTPUT=/dev/null bash "$gate" "$cov_90" "$baseline_80" >/dev/null 2>&1
+assert_exit "coverage increase passes" 0 $?
+
+GITHUB_OUTPUT=/dev/null bash "$gate" "$cov_80" "$baseline_80" >/dev/null 2>&1
+assert_exit "unchanged coverage passes" 0 $?
+
+GITHUB_OUTPUT=/dev/null bash "$gate" "$cov_80" "$baseline_within_tolerance" >/dev/null 2>&1
+assert_exit "drop within tolerance passes" 0 $?
+
+GITHUB_OUTPUT=/dev/null COVERAGE_ENFORCE=true bash "$gate" "$cov_80" "$baseline_90" >/dev/null 2>&1
+assert_exit "drop beyond tolerance fails when enforced" 1 $?
+
+GITHUB_OUTPUT=/dev/null COVERAGE_ENFORCE=false bash "$gate" "$cov_80" "$baseline_90" >/dev/null 2>&1
+assert_exit "drop beyond tolerance passes when not enforced" 0 $?
+
+GITHUB_OUTPUT=/dev/null COVERAGE_TOLERANCE=15 COVERAGE_ENFORCE=true bash "$gate" "$cov_80" "$baseline_90" >/dev/null 2>&1
+assert_exit "drop inside custom tolerance passes" 0 $?
+
+GITHUB_OUTPUT=/dev/null bash "$gate" "$work/does-not-exist.info" "$baseline_80" >/dev/null 2>&1
+assert_exit "missing lcov report fails" 1 $?
+
+output_file="$work/output.txt"
+GITHUB_OUTPUT="$output_file" bash "$gate" "$cov_80" "$work/absent.txt" >/dev/null 2>&1
+if grep -qx "current=80.00" "$output_file"; then
+  echo "ok   - reports current coverage on output"
+else
+  echo "FAIL - reports current coverage on output (got: $(cat "$output_file"))"
+  failures=$((failures + 1))
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+  echo "$failures test(s) failed"
+  exit 1
+fi
+
+echo "all coverage-gate tests passed"

--- a/.github/workflows/coverage-gate-test.yml
+++ b/.github/workflows/coverage-gate-test.yml
@@ -1,0 +1,34 @@
+name: Coverage Gate Script Test
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - '.github/scripts/coverage-gate.sh'
+      - '.github/scripts/coverage-gate.test.sh'
+      - '.github/workflows/coverage-gate-test.yml'
+  pull_request:
+    branches: [master]
+    paths:
+      - '.github/scripts/coverage-gate.sh'
+      - '.github/scripts/coverage-gate.test.sh'
+      - '.github/workflows/coverage-gate-test.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  self-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts
+      - name: Run coverage-gate self-test
+        run: bash .github/scripts/coverage-gate.test.sh

--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -98,6 +98,8 @@ jobs:
             studio-coverage-baseline-
       - name: Compare coverage against baseline
         id: compare
+        env:
+          COVERAGE_ENFORCE: ${{ github.event_name == 'pull_request' }}
         run: bash .github/scripts/coverage-gate.sh ./coverage/lcov.info coverage-baseline/value.txt
       - name: Record baseline coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -132,6 +132,7 @@ jobs:
           path: ./coverage
       - name: Upload coverage results to Coveralls
         continue-on-error: true
+        timeout-minutes: 5
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: studio-tests

--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -1,7 +1,4 @@
-# This workflow will do a clean install of node dependencies, cache/restore them, build the source code and run tests across different versions of node
-# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
-
-name: Studio Unit Tests & Build Check
+name: Studio Tests
 
 on:
   push:
@@ -61,7 +58,7 @@ jobs:
         if: steps.filter.outputs.relevant == 'true'
         run: pnpm install --frozen-lockfile
         working-directory: ./
-      - name: Run Tests
+      - name: Run tests
         if: steps.filter.outputs.relevant == 'true'
         env:
           # Default is 2 GB, increase to have less frequent OOM errors
@@ -75,6 +72,44 @@ jobs:
           name: studio-coverage
           path: ./apps/studio/coverage/lcov.info
           retention-days: 1
+
+  coverage:
+    name: Check coverage
+    needs: test
+    if: ${{ always() && needs.test.result == 'success' && needs.test.outputs.tests_ran == 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts
+      - name: Download coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: studio-coverage
+          path: ./coverage
+      - name: Restore baseline coverage
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: coverage-baseline
+          key: studio-coverage-baseline-${{ github.sha }}
+          restore-keys: |
+            studio-coverage-baseline-
+      - name: Compare coverage against baseline
+        id: compare
+        run: bash .github/scripts/coverage-gate.sh ./coverage/lcov.info coverage-baseline/value.txt
+      - name: Record baseline coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          mkdir -p coverage-baseline
+          echo "${{ steps.compare.outputs.current }}" > coverage-baseline/value.txt
+      - name: Save baseline coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: coverage-baseline
+          key: studio-coverage-baseline-${{ github.sha }}
 
   coveralls:
     needs: test
@@ -94,9 +129,11 @@ jobs:
           name: studio-coverage
           path: ./coverage
       - name: Upload coverage results to Coveralls
+        continue-on-error: true
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: studio-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage/lcov.info
           base-path: './apps/studio'
+          fail-on-error: false

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -1,6 +1,10 @@
 name: UI Tests
 
 on:
+  push:
+    branches: [master]
+    paths:
+      - 'packages/ui/**'
   pull_request:
     branches: [master]
 
@@ -22,19 +26,19 @@ jobs:
       tests_ran: ${{ steps.filter.outputs.relevant }}
 
     steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            packages
+            patches
+
       - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
         id: filter
         with:
           filters: |
             relevant:
               - 'packages/ui/**'
-      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
-        if: steps.filter.outputs.relevant == 'true'
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            packages
-            patches
 
       - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
         if: steps.filter.outputs.relevant == 'true'
@@ -65,6 +69,44 @@ jobs:
           path: ./packages/ui/coverage/lcov.info
           retention-days: 1
 
+  coverage:
+    name: Check coverage
+    needs: test
+    if: ${{ always() && needs.test.result == 'success' && needs.test.outputs.tests_ran == 'true' }}
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/scripts
+      - name: Download coverage artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ui-coverage
+          path: ./coverage
+      - name: Restore baseline coverage
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: coverage-baseline
+          key: ui-coverage-baseline-${{ github.sha }}
+          restore-keys: |
+            ui-coverage-baseline-
+      - name: Compare coverage against baseline
+        id: compare
+        run: bash .github/scripts/coverage-gate.sh ./coverage/lcov.info coverage-baseline/value.txt
+      - name: Record baseline coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        run: |
+          mkdir -p coverage-baseline
+          echo "${{ steps.compare.outputs.current }}" > coverage-baseline/value.txt
+      - name: Save baseline coverage
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: coverage-baseline
+          key: ui-coverage-baseline-${{ github.sha }}
+
   coveralls:
     needs: test
     if: ${{ always() && needs.test.result == 'success' && needs.test.outputs.tests_ran == 'true' }}
@@ -83,9 +125,11 @@ jobs:
           name: ui-coverage
           path: ./coverage
       - name: Upload coverage results to Coveralls
+        continue-on-error: true
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: ui-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage/lcov.info
           base-path: './packages/ui'
+          fail-on-error: false

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -94,6 +94,8 @@ jobs:
             ui-coverage-baseline-
       - name: Compare coverage against baseline
         id: compare
+        env:
+          COVERAGE_ENFORCE: ${{ github.event_name == 'pull_request' }}
         run: bash .github/scripts/coverage-gate.sh ./coverage/lcov.info coverage-baseline/value.txt
       - name: Record baseline coverage
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -128,6 +128,7 @@ jobs:
           path: ./coverage
       - name: Upload coverage results to Coveralls
         continue-on-error: true
+        timeout-minutes: 5
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
         with:
           flag-name: ui-tests


### PR DESCRIPTION
## Why

The Studio and UI test workflows each had two jobs: run tests, and upload results to Coveralls. Both `test (1)` and `coveralls` are required status checks, so Coveralls' frequent downtime blocks merges even when tests pass.

## What

Each workflow now has three jobs:

1. **`test`** – runs unit tests (unchanged, still required)
2. **`coverage`** (new, context `Check coverage`) – blocks the PR if line coverage drops vs the master baseline
3. **`coveralls`** – uploads to Coveralls, now **non-blocking** (`continue-on-error` + `fail-on-error: false`) and capped at a **5-minute step timeout**, so its downtime (including a hung endpoint) can't block or stall merges

The coverage gate is fully self-contained (`.github/scripts/coverage-gate.sh`): master pushes cache the total line-coverage %, PRs restore it and fail if coverage drops beyond a small tolerance (enforcement is PR-only; master pushes just re-record the baseline). No external service, so no new downtime dependency.

Also renamed the Studio workflow to `Studio Tests` and cleaned up step names. Job IDs `test`/`coveralls` are intentionally unchanged to preserve the existing required-check contexts (`test (1)`, `coveralls`).

## Tests

`.github/scripts/coverage-gate.test.sh` exercises the gate against fixture lcov reports + baselines and asserts exit codes for: missing baseline, coverage increase, unchanged, drop within tolerance, drop beyond tolerance (enforced and not), custom tolerance, missing report, and the reported `current` value. It runs in CI (`Coverage Gate Script Test`) whenever the script changes.

## Required follow-up (branch protection)

The check name is derived from the job, so `master` branch protection needs a matching update:

- **Add** `Check coverage` to required status checks (new gate).
- **Optionally remove** `coveralls` from required — with this PR its check always passes, so it no longer blocks either way, but removing it is cleaner.

Do this **after** merging: the `Check coverage` context doesn't exist on `master` until this lands, and marking it required beforehand would stall other open PRs on "waiting for status".

## Notes

- UI tests now also run on push to `master` so the UI coverage baseline gets recorded.
- The gate compares total line % only; per-file or new-code coverage can be layered on later if wanted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added a coverage gate script with automated validation via a dedicated self-test workflow.
  * Studio and UI test workflows now compare current coverage against saved baselines, with configurable tolerance.
  * When enforcement is enabled, coverage drops beyond the threshold can fail the workflow.
  * Coverage tables are included in workflow summaries.

* **Chores**
  * Baselines are recorded/updated on pushes to `master`.
  * Coveralls uploads are adjusted so reporting issues don’t block workflow completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->