### PR TITLE
Add some keyboard shortcuts for the Assistant

### DIFF
--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -71,6 +71,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     useSelectedOrganizationQuery()
 
   useShortcut(SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT, () => cancelEdit())
+  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_NEW_CHAT, () => snap.newChat())
 
   const disablePrompts = useFlag('disableAssistantPrompts')
   const { snippets } = useSqlEditorV2StateSnapshot()
@@ -498,6 +499,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           </Conversation>
         ) : (
           <AIOnboarding
+            key={snap.activeChatId}
             sqlSnippets={snap.sqlSnippets as SqlSnippet[] | undefined}
             suggestions={
               snap.suggestions as

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantChatSelector.tsx
@@ -39,24 +39,18 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
   }
 
   const handleDeleteChat = (id: string, e?: React.MouseEvent) => {
-    if (e) {
-      e.stopPropagation()
-    }
+    if (e) e.stopPropagation()
     snap.deleteChat(id)
   }
 
   const handleStartEditChat = (id: string, name: string, e?: React.MouseEvent) => {
-    if (e) {
-      e.stopPropagation()
-    }
+    if (e) e.stopPropagation()
     setEditingChatId(id)
     setEditingChatName(name)
   }
 
   const handleSaveEditChat = (e?: React.MouseEvent) => {
-    if (e) {
-      e.stopPropagation()
-    }
+    if (e) e.stopPropagation()
     if (editingChatId && editingChatName.trim()) {
       snap.renameChat(editingChatId, editingChatName.trim())
       setEditingChatId(null)
@@ -65,9 +59,7 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
   }
 
   const handleCancelEditChat = (e?: React.MouseEvent | React.FocusEvent) => {
-    if (e) {
-      e.stopPropagation()
-    }
+    if (e) e.stopPropagation()
     setEditingChatId(null)
     setEditingChatName('')
   }
@@ -96,7 +88,7 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
           {currentChat}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-[250px] p-0" align="start">
+      <PopoverContent className="w-[250px] p-0" align="center">
         <Command>
           <CommandInput className="text-xs" placeholder="Search chats..." />
           <CommandList>
@@ -138,6 +130,7 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
                           />
                           <div className="flex items-center gap-0">
                             <Button
+                              aria-label="Save chat name"
                               variant="text"
                               size="tiny"
                               icon={<Check size={14} />}
@@ -145,6 +138,7 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
                               className="h-7 w-7"
                             />
                             <Button
+                              aria-label="Cancel edit chat"
                               variant="text"
                               size="tiny"
                               icon={<X size={14} />}
@@ -168,6 +162,7 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
                     {editingChatId !== id && (
                       <div className="flex items-center gap-x-0 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
                         <Button
+                          aria-label="Edit chat name"
                           variant="text"
                           size="tiny"
                           icon={<Edit size={14} />}
@@ -176,6 +171,7 @@ export const AIAssistantChatSelector = ({ disabled = false }: AIAssistantChatSel
                         />
                         {chats.length > 1 && (
                           <Button
+                            aria-label="Delete chat"
                             variant="text"
                             size="tiny"
                             icon={<Trash size={14} />}

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -12,9 +12,12 @@ import {
 import { Admonition } from 'ui-patterns/admonition'
 
 import { ButtonTooltip } from '../ButtonTooltip'
+import { ShortcutTooltip } from '../ShortcutTooltip'
 import { AIAssistantChatSelector } from './AIAssistantChatSelector'
 import { AIOptInModal } from './AIOptInModal'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 
 interface AIAssistantHeaderProps {
   isChatLoading: boolean
@@ -37,12 +40,17 @@ export const AIAssistantHeader = ({
 }: AIAssistantHeaderProps) => {
   const snap = useAiAssistantStateSnapshot()
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
+
+  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS, () => setIsOptInModalOpen(true), {
+    enabled: !isChatLoading,
+  })
+
   return (
     <div className="z-30 sticky top-0">
       <div className="border-b border-b-muted flex items-center bg-card gap-x-4 pl-4 pr-3 min-h-(--header-height)">
         <div className="text-sm flex-1 flex items-center">
-          <AiIconAnimation size={20} allowHoverEffect={false} />
-          <span className="text-border-stronger dark:text-border-strong ml-3">
+          <AiIconAnimation size={18} allowHoverEffect={false} />
+          <span className="text-border-stronger dark:text-border-strong ml-2">
             <svg
               viewBox="0 0 24 24"
               width="16"
@@ -61,25 +69,33 @@ export const AIAssistantHeader = ({
         </div>
         <div className="flex items-center gap-x-4">
           <div className="flex items-center">
-            <ButtonTooltip
-              variant="text"
-              size="tiny"
-              icon={<Plus strokeWidth={1.5} />}
-              onClick={onNewChat}
-              className="h-7 w-7 p-0"
-              tooltip={{ content: { side: 'bottom', text: 'New chat' } }}
-            />
-            <ButtonTooltip
-              variant="text"
-              size="tiny"
-              icon={<Settings strokeWidth={1.5} />}
-              onClick={() => setIsOptInModalOpen(true)}
-              className="h-7 w-7 p-0"
-              disabled={isChatLoading}
-              tooltip={{
-                content: { side: 'bottom', text: 'Permission settings' },
-              }}
-            />
+            <ShortcutTooltip
+              side="bottom"
+              label="New chat"
+              shortcutId={SHORTCUT_IDS.AI_ASSISTANT_NEW_CHAT}
+            >
+              <Button
+                variant="text"
+                aria-label="New chat"
+                size="tiny"
+                icon={<Plus strokeWidth={1.5} />}
+                onClick={onNewChat}
+                className="h-7 w-7 p-0"
+              />
+            </ShortcutTooltip>
+
+            <ShortcutTooltip side="bottom" shortcutId={SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS}>
+              <Button
+                variant="text"
+                aria-label="Permission settings"
+                size="tiny"
+                icon={<Settings strokeWidth={1.5} />}
+                onClick={() => setIsOptInModalOpen(true)}
+                className="h-7 w-7 p-0"
+                disabled={isChatLoading}
+              />
+            </ShortcutTooltip>
+
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <ButtonTooltip
@@ -90,7 +106,7 @@ export const AIAssistantHeader = ({
                   tooltip={{ content: { side: 'bottom', text: 'More options' } }}
                 />
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
+              <DropdownMenuContent align="end" className="w-40">
                 <DropdownMenuItem
                   className="gap-x-2"
                   onClick={() => copyToClipboard(snap.activeChatId ?? '')}
@@ -100,13 +116,20 @@ export const AIAssistantHeader = ({
                 </DropdownMenuItem>
               </DropdownMenuContent>
             </DropdownMenu>
-            <ButtonTooltip
-              variant="text"
-              className="w-7 h-7"
-              onClick={onCloseAssistant}
-              icon={<X strokeWidth={1.5} />}
-              tooltip={{ content: { side: 'bottom', text: 'Close assistant' } }}
-            />
+
+            <ShortcutTooltip
+              side="bottom"
+              label="Close assistant"
+              shortcutId={SHORTCUT_IDS.AI_ASSISTANT_TOGGLE}
+            >
+              <Button
+                aria-label="Close Assistant"
+                variant="text"
+                className="w-7 h-7"
+                onClick={onCloseAssistant}
+                icon={<X strokeWidth={1.5} />}
+              />
+            </ShortcutTooltip>
           </div>
         </div>
       </div>

--- a/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
@@ -47,7 +47,14 @@ export const AIOnboarding = ({
     <div className="flex-1 overflow-y-auto">
       <div className="w-full flex-1 max-h-full min-h-full px-4 flex flex-col gap-0">
         <div className="mt-auto w-full space-y-6 py-8 ">
-          <h2 className="heading-section text-foreground mx-4">How can I assist you?</h2>
+          <motion.h2
+            className="heading-section text-foreground mx-4"
+            initial={{ y: 5, opacity: 0 }}
+            animate={{ y: 0, opacity: 1 }}
+            transition={{ duration: 0.3 }}
+          >
+            How can I assist you?
+          </motion.h2>
           {suggestions?.prompts?.length ? (
             <div>
               <h3 className="heading-meta text-foreground-light mb-3 mx-4">Suggestions</h3>
@@ -79,8 +86,9 @@ export const AIOnboarding = ({
             <>
               {isPendingLints ? (
                 <div className="px-4 flex flex-col gap-2">
+                  <Skeleton className="h-5 w-20" />
                   {Array.from({ length: 6 }).map((_, index) => (
-                    <Skeleton key={`loader-${index}`} className="h-4 w-full" />
+                    <Skeleton key={`loader-${index}`} className="h-7 w-full" />
                   ))}
                 </div>
               ) : (

--- a/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
@@ -36,12 +36,7 @@ export const AIOnboarding = ({
       : defaultPrompts
 
   const { ref: projectRef } = useParams()
-  const {
-    data: lints,
-    isPending: isLoadingLints,
-    isFetching: isFetchingLints,
-  } = useProjectLintsQuery({ projectRef })
-  const isLintsLoading = isLoadingLints || isFetchingLints
+  const { data: lints, isPending: isPendingLints } = useProjectLintsQuery({ projectRef })
 
   const errorLints: Lint[] = (lints?.filter((lint) => lint.level === LINTER_LEVELS.ERROR) ??
     []) as Lint[]
@@ -82,7 +77,7 @@ export const AIOnboarding = ({
             </div>
           ) : (
             <>
-              {isLintsLoading ? (
+              {isPendingLints ? (
                 <div className="px-4 flex flex-col gap-2">
                   {Array.from({ length: 6 }).map((_, index) => (
                     <Skeleton key={`loader-${index}`} className="h-4 w-full" />

--- a/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
@@ -36,7 +36,7 @@ export const AIOnboarding = ({
       : defaultPrompts
 
   const { ref: projectRef } = useParams()
-  const { data: lints, isPending: isPendingLints } = useProjectLintsQuery({ projectRef })
+  const { data: lints, isLoading: isLoadingLints } = useProjectLintsQuery({ projectRef })
 
   const errorLints: Lint[] = (lints?.filter((lint) => lint.level === LINTER_LEVELS.ERROR) ??
     []) as Lint[]
@@ -84,7 +84,7 @@ export const AIOnboarding = ({
             </div>
           ) : (
             <>
-              {isPendingLints ? (
+              {isLoadingLints ? (
                 <div className="px-4 flex flex-col gap-2">
                   <Skeleton className="h-5 w-20" />
                   {Array.from({ length: 6 }).map((_, index) => (

--- a/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AssistantChatForm.tsx
@@ -96,6 +96,8 @@ const AssistantChatFormComponent = forwardRef<HTMLFormElement, FormProps>(
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault()
         handleSubmit()
+      } else if (event.key === 'Escape') {
+        event.currentTarget.blur()
       }
     }
 

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -70,6 +70,8 @@ import { ShortcutDefinition } from './types'
 export const SHORTCUT_IDS = {
   COMMAND_MENU_OPEN: 'command-menu.open',
   AI_ASSISTANT_TOGGLE: 'ai-assistant.toggle',
+  AI_ASSISTANT_NEW_CHAT: 'ai-assistant.new-chat',
+  AI_ASSISTANT_OPEN_PERMISSIONS: 'ai-assistant.open-permissions',
   AI_ASSISTANT_CANCEL_EDIT: 'ai-assistant.cancel-edit',
   INLINE_EDITOR_TOGGLE: 'inline-editor.toggle',
   RESULTS_COPY_MARKDOWN: 'results.copy-markdown',
@@ -252,6 +254,18 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     id: SHORTCUT_IDS.RESULTS_DOWNLOAD_CSV,
     label: 'Download results as CSV',
     sequence: ['Mod+Shift+D'],
+  },
+  [SHORTCUT_IDS.AI_ASSISTANT_NEW_CHAT]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_NEW_CHAT,
+    label: 'Start new chat',
+    sequence: ['A', 'N'],
+    showInSettings: false,
+  },
+  [SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS,
+    label: 'Permission settings',
+    sequence: ['A', 'P'],
+    showInSettings: false,
   },
   [SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT]: {
     id: SHORTCUT_IDS.AI_ASSISTANT_CANCEL_EDIT,

--- a/packages/ui/src/components/ExpandingTextArea/index.tsx
+++ b/packages/ui/src/components/ExpandingTextArea/index.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { forwardRef, useImperativeHandle, useLayoutEffect, useRef } from 'react'
+import React, { forwardRef, useEffect, useImperativeHandle, useLayoutEffect, useRef } from 'react'
 
 import { cn } from '../../lib/utils'
 import { Textarea } from '../shadcn/ui/textarea'
@@ -19,7 +19,8 @@ const ExpandingTextArea = forwardRef<HTMLTextAreaElement | null, ExpandingTextAr
 
     useImperativeHandle(ref, () => internalRef.current as HTMLTextAreaElement, [])
 
-    const updateTextAreaHeight = (element: HTMLTextAreaElement | null) => {
+    const updateTextAreaHeight = () => {
+      const element = internalRef.current
       if (!element) return
 
       // Match single-line input height (h-10 = 40px) so we don't shrink when typing; grow only when content wraps
@@ -30,16 +31,26 @@ const ExpandingTextArea = forwardRef<HTMLTextAreaElement | null, ExpandingTextAr
     }
 
     useLayoutEffect(() => {
-      updateTextAreaHeight(internalRef.current)
+      updateTextAreaHeight()
     }, [value])
+
+    useEffect(() => {
+      const element = internalRef.current
+      if (!element) return
+
+      // A measurement taken right on mount can catch the element mid-layout (e.g. while
+      // an ancestor panel is still settling its width), baking in a wrong height that
+      // never gets corrected since the effect above only reruns on `value` changes.
+      // Re-measure whenever the element's own box actually changes size.
+      const observer = new ResizeObserver(() => updateTextAreaHeight())
+      observer.observe(element)
+      return () => observer.disconnect()
+    }, [])
 
     return (
       <Textarea
         ref={(element) => {
-          if (element) {
-            internalRef.current = element
-            updateTextAreaHeight(element)
-          }
+          internalRef.current = element
         }}
         rows={1}
         aria-expanded={false}


### PR DESCRIPTION
## Context

Part of some minor improvements to the AI Assistant - this one's about adding some keyboard shortcuts

## Changes involved
- Added keyboard shortcut for "New chat"
  <img width="212" height="96" alt="image" src="https://github.com/user-attachments/assets/e9c3bd63-adbc-4b05-8c52-1baed67e365a" />
  - Also added a small animation for the "How can I assist you?" text for visual indication when moving between chats that might not have a conversation yet
- Added keyboard shortcut for "Permission settings"
  <img width="236" height="86" alt="image" src="https://github.com/user-attachments/assets/337da009-5979-4910-9292-73cc4d7f7cce" />
- Show keyboard shortcut for "Close Assistant"  
  <img width="165" height="88" alt="image" src="https://github.com/user-attachments/assets/b45a4f5a-8e12-45f1-8fdb-a18c0deedb02" />
- Fix `ExpandingTextArea` height calculation logic issue
  - If you open and close the Assistant panel a number of times, the height of the input field isn't consistent, so this fixes that


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Added keyboard shortcuts for starting a new AI Assistant chat and opening permission settings.
  - Header actions now display shortcut hints and support keyboard access.

- **Improvements**
  - Enhanced accessibility with labels for chat edit controls (save, cancel, edit, delete).
  - Chat onboarding now remounts when switching active chats.
  - Improved chat popover alignment.
  - Escape now blurs the message input; textarea resizing is more reliable during content/layout changes.

- **Bug Fixes**
  - Updated onboarding loading behavior based on the lints loading state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->