### PR TITLE
fix(docs): add required Expires field to security.txt (RFC 9116)

### DIFF
--- a/apps/docs/public/.well-known/security.txt
+++ b/apps/docs/public/.well-known/security.txt
@@ -1,4 +1,5 @@
 Contact: https://hackerone.com/supabase
+Expires: 2027-07-13T00:00:00.000Z
 Canonical: https://supabase.com/.well-known/security.txt
 
 


### PR DESCRIPTION
## Problem

`security.txt` is missing the `Expires` field. RFC 9116 defines exactly two mandatory fields for a `security.txt` file — `Contact` and `Expires` — and says of `Expires` (section 2.5.5): *"This field MUST always be present."* The current file has `Contact` and `Canonical`, but no `Expires`:

```
$ curl -s https://supabase.com/.well-known/security.txt | grep -E '^[A-Za-z-]+:'
Contact: https://hackerone.com/supabase
Canonical: https://supabase.com/.well-known/security.txt
```

Because the mandatory field is absent, RFC 9116 validators and automated VDP-discovery tooling read the file as non-conformant, and a reader can't tell whether the HackerOne contact is still current.

## Change

Adds one line — `Expires` — with a value one year out:

```
Contact: https://hackerone.com/supabase
Expires: 2027-07-13T00:00:00.000Z
Canonical: https://supabase.com/.well-known/security.txt
```

Please set the date and refresh cadence to whatever suits you — the point is just that the field is present and future-dated. One file, one line.

## Testing

The file is served statically from `apps/docs/public/`, so no build logic changes. I didn't run the full `apps/docs` build locally (large monorepo), since this is a static-file addition — happy to if you'd like.

<sub>I used an AI assistant to spot this and prepare the change; it's noted in the commit. I verified the RFC and the live file myself.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an expiration date to the security contact information file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->