### PR TITLE
fix(ci): don't fail CI when Coveralls upload fails

### DIFF
--- a/.github/workflows/studio-unit-tests.yml
+++ b/.github/workflows/studio-unit-tests.yml
@@ -95,8 +95,10 @@ jobs:
           path: ./coverage
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        continue-on-error: true
         with:
           flag-name: studio-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage/lcov.info
           base-path: './apps/studio'
+          fail-on-error: false

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -84,8 +84,10 @@ jobs:
           path: ./coverage
       - name: Upload coverage results to Coveralls
         uses: coverallsapp/github-action@648a8eb78e6d50909eff900e4ec85cab4524a45b # v2.3.6
+        continue-on-error: true
         with:
           flag-name: ui-tests
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./coverage/lcov.info
           base-path: './packages/ui'
+          fail-on-error: false


### PR DESCRIPTION
## Summary
- Coveralls outages were putting a red X on PRs even when tests passed
- Add `fail-on-error: false` and `continue-on-error: true` to the "Upload coverage results to Coveralls" step in `studio-unit-tests.yml` and `ui-tests.yml`, matching `supabase-js` behavior

## Test plan
- [ ] Confirm both workflows run successfully on this PR
- [ ] Confirm a simulated Coveralls upload failure no longer marks the step/job as failed

Fixes FE-3908

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the reliability of automated test workflows by allowing coverage-report uploads to fail without interrupting the overall workflow.
  * Existing coverage reporting continues when the upload service is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->