### PR TITLE
fix site_title

### DIFF
--- a/apps/www/app/layout.tsx
+++ b/apps/www/app/layout.tsx
@@ -9,7 +9,7 @@ import type { Metadata, Viewport } from 'next'
 import Providers from './providers'
 import { APP_NAME, DEFAULT_META_DESCRIPTION } from '@/lib/constants'
 
-const site_title = `${APP_NAME} | The Open Source Firebase Alternative`
+const site_title = `${APP_NAME} | The Postgres Development Platform`
 
 export const metadata: Metadata = {
   title: site_title,


### PR DESCRIPTION
Update www `site_title`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the site title and browser metadata to describe the product as “The Postgres Development Platform.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->