### PR TITLE
fix: remove dead Makefile targets referencing missing web/ dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,48 +1,9 @@
-REPO_DIR=$(shell pwd)
-
+# NOTE: The `github.*` and `dev` targets that previously lived here were
+# removed because they were dead code: they referenced a top-level `web/`
+# directory that no longer exists (the marketing site now lives at
+# `apps/www`), an `npm run traction` script that doesn't exist anywhere in
+# the repo, and a `vercel-local.json` file that isn't present either.
+# See: https://github.com/supabase/supabase/issues/47586
 help:
-	@echo "\SCRIPTS\n"
-	@echo "make github.contributors  	# pull a list of all contributors"
-	@echo "make github.issues			# pull a list of all issue creators"
-	@echo "make github.repos			# pull a list of our repos"
-	@echo "make github.traction			# get a history of stargazers for our individual repos"
-
-github.contributors.%:
-	curl -sS https://api.github.com/repos/supabase/$*/contributors \
-	| jq -r 'map_values({ username: .login }) \
-	| unique \
-	| sort_by(.username)' \
-	> $(REPO_DIR)/web/src/data/contributors/$*.json
-
-.PHONY: github.rcontributorsepos
-github.contributors: \
-	github.contributors.supabase \
-	github.contributors.supabase-js \
-	github.contributors.supabase-py \
-	github.contributors.supabase-flutter \
-	github.contributors.supabase-dart
-
-github.issues:
-	curl -sS https://api.github.com/repos/supabase/supabase/issues \
-	| jq -r 'map_values({username: .user.login, avatar_url: .user.avatar_url}) \
-	| unique \
-	| sort_by(.username)' \
-	> $(REPO_DIR)/web/src/data/contributors/issues.json
-
-.PHONY: github.repos
-github.repos: \
-	github.repos.supabase \
-	github.repos.realtime  \
-	github.repos.postgres \
-	github.repos.postgres-meta
-
-github.repos.%:
-	curl -sS https://api.github.com/repos/supabase/$* \
-	> $(REPO_DIR)/web/src/data/repos/$*.json
-
-github.traction:
-	cd "$(REPO_DIR)"/web && \
-	npm run traction
-
-dev:
-	vercel dev --listen 8080 --local-config vercel-local.json
+	@echo "This Makefile currently has no active targets."
+	@echo "See apps/www for the marketing site scripts, and the root README/DEVELOPERS.md for local dev setup."


### PR DESCRIPTION
## What
Removes the `github.contributors`, `github.issues`, `github.repos`, and `dev` targets from the root `Makefile`, and the stray/garbled `.PHONY: github.rcontributorsepos` line.

## Why
All of these targets were dead code:
- `github.contributors*` and `github.repos*` write to `$(REPO_DIR)/web/src/data/...`, but there is no `web/` directory anywhere in the repo (the marketing site now lives at `apps/www`).
- `github.traction` runs `npm run traction`, but no `package.json` in the repo defines a `traction` script.
- `dev` references `vercel-local.json`, which doesn't exist in the repo either.
- `.PHONY: github.rcontributorsepos` appears to be a corrupted/mangled line (looks like `github.contributors` and `github.repos` got merged together).

I verified all of the above directly against the current `master` branch before making this change.

Fixes #47586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified the root Makefile by removing obsolete GitHub data-fetching and local development commands.
  * Updated the help output to indicate that no active root-level targets are available.
  * Added guidance directing developers to `apps/www` and the root documentation for local development setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->