### PR TITLE
chore: remove `mise.toml`

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,0 @@
-[settings]
-idiomatic_version_file_enable_tools = ["node", "pnpm"]


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Removes the `mise.toml` file (partial revert of a change in https://github.com/supabase/supabase/pull/47719)

## What is the current behavior?

Folks with `mise` installed are seeing a confusing "error parsing config file" error

## What is the new behavior?

Folks with `mise` installed should no longer see that error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the configuration that enabled automatic version-file handling for Node.js and pnpm.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->