### PR TITLE
fix(docs) Fix broken link on Dashboard overview

### DIFF
--- a/apps/docs/data/content-listings/database.data.ts
+++ b/apps/docs/data/content-listings/database.data.ts
@@ -37,7 +37,7 @@ export const databaseGetStarted: ContentListingGroup = {
     },
     {
       title: 'Run SQL commands',
-      href: '/dashboard/project/_/sql',
+      href: 'https://supabase.com/dashboard/project/_/sql',
       description: "Use the Dashboard's SQL Editor for ad-hoc queries and saved snippets.",
     },
   ],


### PR DESCRIPTION
Closes [DOCS-1172](https://linear.app/supabase/issue/DOCS-1172/fix-broken-run-sql-commands-link-in-database-overview-docs)

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Fixes broken link.

## What is the current behavior?

Link is broken on dashboard overview.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Run SQL commands” link to direct users to the fully qualified SQL editor URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->