### PR TITLE
ci: add zizmor lint and harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Check if organization member
         id: is-org-member
-        uses: JamesSingleton/is-organization-member@39c59b3b17cca4eb75c81772b95e724e2a24c025 # v1.0.0
+        uses: JamesSingleton/is-organization-member@39c59b3b17cca4eb75c81772b95e724e2a24c025 # 1.0.0
         with:
           organization: ${{ github.repository_owner }}
           username: ${{ github.event.issue.user.login }}

--- a/.github/workflows/braintrust-evals.yml
+++ b/.github/workflows/braintrust-evals.yml
@@ -11,7 +11,6 @@ concurrency:
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
   contents: read
 
 jobs:
@@ -51,6 +50,8 @@ jobs:
   eval:
     name: Run evals
     needs: preflight
+    permissions:
+      pull-requests: write
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'run-evals') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/docs-lint-v2.yml
+++ b/.github/workflows/docs-lint-v2.yml
@@ -47,7 +47,7 @@ jobs:
       - name: cache cargo
         id: cache-cargo
         if: steps.filter.outputs.docs == 'true'
-        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/fix-typos.yml
+++ b/.github/workflows/fix-typos.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           persist-credentials: false
           ref: master
-      - uses: sobolevn/misspell-fixer-action@06ff0b508d4f4c0ba70d15f9a628232c0aade536 # v0.1.0
+      - uses: sobolevn/misspell-fixer-action@06ff0b508d4f4c0ba70d15f9a628232c0aade536 # 0.1.0
 
       - name: Generate token
         id: app-token

--- a/.github/workflows/publish_image.yml
+++ b/.github/workflows/publish_image.yml
@@ -8,8 +8,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
-  id-token: write
 
 jobs:
   settings:
@@ -145,6 +143,10 @@ jobs:
     needs:
       - settings
       - merge_manifest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     # Call workflow explicitly because events from actions cannot trigger more actions
     uses: ./.github/workflows/mirror.yml
     with:

--- a/.github/workflows/self-host-tests-smoke.yml
+++ b/.github/workflows/self-host-tests-smoke.yml
@@ -23,13 +23,13 @@ jobs:
         config: [default, logs, envoy, rustfs, envoy-rustfs]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           persist-credentials: false
           sparse-checkout: |
             docker/
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,58 @@
+name: zizmor
+
+on:
+  pull_request:
+    branches:
+      - 'master'
+    paths:
+      - '.github/workflows/**'
+      - 'zizmor.yml'
+
+# Cancel old builds on new commit for same workflow + branch/PR
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  ZIZMOR_VERSION: 1.26.1
+
+jobs:
+  zizmor:
+    name: zizmor
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            .github/workflows
+            zizmor.yml
+
+      - name: Cache zizmor binary
+        id: cache-zizmor
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7 # v5.0.2
+        with:
+          path: ~/.local/bin/zizmor
+          key: zizmor-${{ runner.os }}-${{ runner.arch }}-${{ env.ZIZMOR_VERSION }}
+
+      - name: Download zizmor
+        if: steps.cache-zizmor.outputs.cache-hit != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          archive="zizmor-x86_64-unknown-linux-gnu.tar.gz"
+          curl -sSLO "https://github.com/zizmorcore/zizmor/releases/download/v${ZIZMOR_VERSION}/${archive}"
+          gh attestation verify "${archive}" --repo zizmorcore/zizmor
+          mkdir -p ~/.local/bin
+          tar -xzf "${archive}" -C ~/.local/bin zizmor
+          chmod +x ~/.local/bin/zizmor
+
+      - name: Run zizmor
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: ~/.local/bin/zizmor --config zizmor.yml .github/workflows

--- a/zizmor.yml
+++ b/zizmor.yml
@@ -1,0 +1,8 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      - "authorize-vercel-deploys.yml"
+      - "docs-lint-v2-comment.yml"
+      - "external-pr-comment.yml"
+      - "label_prs.yml"
+      - "studio-master-alert.yml"


### PR DESCRIPTION
## Summary
- Add a zizmor config and CI job that lints `.github/workflows` on every PR touching it, downloading and attestation-verifying the pinned v1.26.1 release binary (cached across runs)
- Fix the mutable-tag and excess-permission findings zizmor surfaces in `braintrust-evals.yml`, `publish_image.yml`, and `self-host-tests-smoke.yml`: pin `actions/checkout`/`actions/setup-node` to commit SHAs, and scope `pull-requests`/`packages`/`id-token` permissions down to the specific jobs that need them

## Test plan
- [x] Confirm the `zizmor` job runs and passes on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated security scanning for workflow changes on pull requests.
  * Added configuration to allow specific workflow trigger exceptions.

* **Security**
  * Tightened GitHub Actions permissions at the workflow level and re-granted only where required per job.
  * Pinned common build action versions to specific commits for more consistent execution.

* **Maintenance**
  * Updated workflow caching and action step annotations without changing linting or fixing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->