### PR TITLE
fix(studio): guard Auth Performance allocation strategy select against invalid values

### DIFF
--- a/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.test.tsx
+++ b/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.test.tsx
@@ -1,0 +1,70 @@
+import { screen } from '@testing-library/react'
+import { HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+
+import { PerformanceSettingsForm } from './PerformanceSettingsForm'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/constants')>()
+  return { ...actual, IS_PLATFORM: true }
+})
+
+vi.mock('@/hooks/misc/useSelectedProject', () => ({
+  useSelectedProjectQuery: () => ({ data: { ref: 'default', connectionString: null } }),
+}))
+
+vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
+  useCheckEntitlements: () => ({ hasAccess: true, isLoading: false }),
+}))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: () => ({ can: true, isLoading: false, isSuccess: true }),
+}))
+
+function mockAuthConfig(overrides: Record<string, unknown>) {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/auth/:ref/config',
+    response: () =>
+      HttpResponse.json<any>({
+        API_MAX_REQUEST_DURATION: 10,
+        DB_MAX_POOL_SIZE: 10,
+        DB_MAX_POOL_SIZE_UNIT: 'connections',
+        ...overrides,
+      }),
+  })
+}
+
+function mockMaxConnections(maxConnections: number) {
+  addAPIMock({
+    method: 'post',
+    path: '/platform/pg-meta/:ref/query',
+    response: () => HttpResponse.json<any>([{ max_connections: maxConnections }]),
+  })
+}
+
+describe('PerformanceSettingsForm', () => {
+  test('reflects a persisted percentage allocation strategy after loading', async () => {
+    mockAuthConfig({ DB_MAX_POOL_SIZE: 15, DB_MAX_POOL_SIZE_UNIT: 'percent' })
+    mockMaxConnections(60)
+
+    customRender(<PerformanceSettingsForm />)
+
+    expect(await screen.findByText('Percentage')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('15')).toBeInTheDocument()
+    expect(screen.getByText('%')).toBeInTheDocument()
+  })
+
+  test('reflects a persisted absolute allocation strategy after loading', async () => {
+    mockAuthConfig({ DB_MAX_POOL_SIZE: 12, DB_MAX_POOL_SIZE_UNIT: 'connections' })
+    mockMaxConnections(60)
+
+    customRender(<PerformanceSettingsForm />)
+
+    expect(await screen.findByText('Absolute')).toBeInTheDocument()
+    expect(screen.getByDisplayValue('12')).toBeInTheDocument()
+    expect(screen.getByText('connections')).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.tsx
@@ -25,6 +25,7 @@ import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 import { GenericSkeletonLoader, ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import * as z from 'zod'
 
+import { convertPoolSize, isAllocationUnit } from './PerformanceSettingsForm.utils'
 import { ScaffoldSection, ScaffoldSectionTitle } from '@/components/layouts/Scaffold'
 import { AlertError } from '@/components/ui/AlertError'
 import { NoPermission } from '@/components/ui/NoPermission'
@@ -103,7 +104,7 @@ export const PerformanceSettingsForm = () => {
     defaultValues: { API_MAX_REQUEST_DURATION: 10 },
   })
 
-  const databaseForm = useForm({
+  const databaseForm = useForm<z.infer<typeof DatabaseFormSchema>>({
     resolver: zodResolver(DatabaseFormSchema),
     defaultValues: {
       DB_MAX_POOL_SIZE: 10,
@@ -315,28 +316,22 @@ export const PerformanceSettingsForm = () => {
                         <Select
                           value={field.value}
                           onValueChange={(value) => {
+                            if (!isAllocationUnit(value)) return
+
                             const values = databaseForm.getValues()
+                            const currentUnit = values.DB_MAX_POOL_SIZE_UNIT
                             field.onChange(value)
 
-                            if (values.DB_MAX_POOL_SIZE_UNIT !== value) {
-                              const currentValue = values.DB_MAX_POOL_SIZE!
-
-                              let preservedPoolSize: number
-                              if (value === 'percent') {
-                                // convert from absolute number to roughly the same percentage
-                                preservedPoolSize = Math.ceil(
-                                  (Math.min(maxConnectionLimit, currentValue) /
-                                    maxConnectionLimit) *
-                                    100
-                                )
-                              } else {
-                                // convert from percentage to roughly the same connection number
-                                preservedPoolSize = Math.floor(
-                                  maxConnectionLimit * (Math.min(100, currentValue) / 100)
-                                )
-                              }
-
-                              databaseForm.setValue('DB_MAX_POOL_SIZE', preservedPoolSize)
+                            if (currentUnit !== value) {
+                              databaseForm.setValue(
+                                'DB_MAX_POOL_SIZE',
+                                convertPoolSize({
+                                  fromUnit: currentUnit,
+                                  toUnit: value,
+                                  currentValue: values.DB_MAX_POOL_SIZE!,
+                                  maxConnectionLimit,
+                                })
+                              )
                             }
                           }}
                         >

--- a/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.utils.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+
+import { convertPoolSize, isAllocationUnit } from './PerformanceSettingsForm.utils'
+
+describe('isAllocationUnit', () => {
+  it('accepts "percent"', () => {
+    expect(isAllocationUnit('percent')).toBe(true)
+  })
+
+  it('accepts "connections"', () => {
+    expect(isAllocationUnit('connections')).toBe(true)
+  })
+
+  it('rejects an empty string', () => {
+    expect(isAllocationUnit('')).toBe(false)
+  })
+
+  it('rejects undefined', () => {
+    expect(isAllocationUnit(undefined)).toBe(false)
+  })
+
+  it('rejects null', () => {
+    expect(isAllocationUnit(null)).toBe(false)
+  })
+
+  it('rejects an unrelated string', () => {
+    expect(isAllocationUnit('bytes')).toBe(false)
+  })
+
+  it('rejects a non-string value', () => {
+    expect(isAllocationUnit(15)).toBe(false)
+  })
+})
+
+describe('convertPoolSize', () => {
+  it('returns the value unchanged when the unit does not change', () => {
+    expect(
+      convertPoolSize({
+        fromUnit: 'percent',
+        toUnit: 'percent',
+        currentValue: 15,
+        maxConnectionLimit: 60,
+      })
+    ).toBe(15)
+  })
+
+  it('converts connections to percent, rounding up', () => {
+    // Matches the original customer report: 10 connections out of 60 -> 17%
+    expect(
+      convertPoolSize({
+        fromUnit: 'connections',
+        toUnit: 'percent',
+        currentValue: 10,
+        maxConnectionLimit: 60,
+      })
+    ).toBe(17)
+  })
+
+  it('converts percent to connections, rounding down', () => {
+    // Matches the reproduction: 15% of 60 -> 9 connections
+    expect(
+      convertPoolSize({
+        fromUnit: 'percent',
+        toUnit: 'connections',
+        currentValue: 15,
+        maxConnectionLimit: 60,
+      })
+    ).toBe(9)
+  })
+
+  it('clamps a connections value above the max when converting to percent', () => {
+    expect(
+      convertPoolSize({
+        fromUnit: 'connections',
+        toUnit: 'percent',
+        currentValue: 100,
+        maxConnectionLimit: 60,
+      })
+    ).toBe(100)
+  })
+
+  it('clamps a percent value above 100 when converting to connections', () => {
+    expect(
+      convertPoolSize({
+        fromUnit: 'percent',
+        toUnit: 'connections',
+        currentValue: 150,
+        maxConnectionLimit: 60,
+      })
+    ).toBe(60)
+  })
+
+  it('handles a zero value', () => {
+    expect(
+      convertPoolSize({
+        fromUnit: 'connections',
+        toUnit: 'percent',
+        currentValue: 0,
+        maxConnectionLimit: 60,
+      })
+    ).toBe(0)
+  })
+})

--- a/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.utils.ts
+++ b/apps/studio/components/interfaces/Auth/PerformanceSettingsForm.utils.ts
@@ -1,0 +1,27 @@
+export type AllocationUnit = 'percent' | 'connections'
+
+export function isAllocationUnit(value: unknown): value is AllocationUnit {
+  return value === 'percent' || value === 'connections'
+}
+
+// Converts a pool size between units when the allocation strategy changes,
+// preserving roughly the same effective connection budget.
+export function convertPoolSize({
+  fromUnit,
+  toUnit,
+  currentValue,
+  maxConnectionLimit,
+}: {
+  fromUnit: AllocationUnit
+  toUnit: AllocationUnit
+  currentValue: number
+  maxConnectionLimit: number
+}): number {
+  if (fromUnit === toUnit) return currentValue
+
+  if (toUnit === 'percent') {
+    return Math.ceil((Math.min(maxConnectionLimit, currentValue) / maxConnectionLimit) * 100)
+  }
+
+  return Math.floor(maxConnectionLimit * (Math.min(100, currentValue) / 100))
+}


### PR DESCRIPTION
## Summary
- The Connection management "Allocation strategy" select on the Auth > Performance page called its `onValueChange` handler's conversion logic with whatever value it was given, with no validation. If that handler ever fired with a value outside the `'percent' | 'connections'` enum, it would silently overwrite a correctly loaded config, converting it to the wrong absolute connection count and leaving the strategy dropdown in a blank/inconsistent state.
- Extracted the percent/connections conversion into a pure, unit-tested `convertPoolSize()` helper (`PerformanceSettingsForm.utils.ts`) and added a guard so `onValueChange` ignores any value that isn't a recognized allocation unit.

## How to test
1. Under **Connection management**, switch **Allocation strategy** back and forth between "Absolute number of connections" and "Percent of max connections" — the value should convert correctly each time and the dropdown should never render blank.
2. Save, then hard-reload the page — the saved strategy and value should persist as shown.

## Test plan
- [x] `PerformanceSettingsForm.utils.test.ts` — unit tests covering both conversion directions, clamping, and the invalid-value guard
- [x] `PerformanceSettingsForm.test.tsx` — MSW-backed component test verifying persisted percent/absolute configs render correctly on load
- [x] `pnpm test:studio`
- [x] `pnpm typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Switching database pool allocation strategies now automatically converts values between percentage and connection-based units.
  * Values are rounded and constrained appropriately to remain within supported limits.
  * Allocation settings now handle invalid or zero values more safely.
* **Tests**
  * Added coverage verifying persisted allocation strategies and pool-size conversion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->