### PR TITLE
fix(docs) Prevent dashboard links from breaking

### DIFF
--- a/apps/docs/lib/content-listings.test.ts
+++ b/apps/docs/lib/content-listings.test.ts
@@ -1,3 +1,4 @@
+import { CONTENT_LISTINGS } from '~/data/content-listings'
 import { storageGetStarted } from '~/data/content-listings/storage.data'
 import {
   ContentListings as ContentListingsMarkdownHandler,
@@ -5,6 +6,21 @@ import {
 } from '~/internals/markdown-schema/ContentListings'
 import { isExternalContentListingHref } from '~/lib/content-listings.utils'
 import { describe, expect, it } from 'vitest'
+
+const SUPABASE_DASHBOARD_ORIGIN = 'https://supabase.com/dashboard'
+
+function isDashboardHref(href: string): boolean {
+  try {
+    const url = new URL(href, 'https://supabase.com')
+    return url.pathname === '/dashboard' || url.pathname.startsWith('/dashboard/')
+  } catch {
+    return href === '/dashboard' || href.startsWith('/dashboard/')
+  }
+}
+
+function isAbsoluteSupabaseDashboardHref(href: string): boolean {
+  return href === SUPABASE_DASHBOARD_ORIGIN || href.startsWith(`${SUPABASE_DASHBOARD_ORIGIN}/`)
+}
 
 describe('isExternalContentListingHref', () => {
   it('treats protocol-relative URLs as external', () => {
@@ -147,6 +163,25 @@ describe('ContentListings markdown handler', () => {
     const handler = ContentListingsMarkdownHandler({ props: { id: 'storage-get-started' } })
     const direct = serializeContentListingGroupToMarkdown(storageGetStarted, '')
     expect(handler).toBe(direct)
+  })
+})
+
+describe('dashboard content listing hrefs', () => {
+  // Root-relative /dashboard hrefs get the docs basePath and 404; use absolute URLs.
+  it('uses absolute https://supabase.com dashboard URLs', () => {
+    const dashboardLinks = Object.values(CONTENT_LISTINGS).flatMap((group) =>
+      group.items
+        .filter((item) => isDashboardHref(item.href))
+        .map((item) => ({ listingId: group.id, title: item.title, href: item.href }))
+    )
+
+    expect(dashboardLinks.length).toBeGreaterThan(0)
+
+    const relativeOrNonCanonical = dashboardLinks.filter(
+      (link) => !isAbsoluteSupabaseDashboardHref(link.href)
+    )
+
+    expect(relativeOrNonCanonical).toEqual([])
   })
 })
 


### PR DESCRIPTION
Closes DOCS-1174

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Problem

Links from docs to studio can break. There's no way to programmatically check.

## Solution

Add a unit test to check that `/dashboard` relative links from docs is absolute.

## Testing

1. Pull this branch to your local machine.
1. Break the link in `apps/docs/data/content-listings/database.data.ts` — change: `href: 'https://supabase.com/dashboard/project/_/sql',` to: `href: '/dashboard/project/_/sql',`
1. Run: cd `apps/docs && pnpm exec vitest run lib/content-listings.test.ts`. You should see dashboard content listing hrefs fail. Restore the absolute URL when you’re done.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added validation to ensure dashboard links in documentation content listings use complete, canonical URLs.
  * Added coverage for identifying dashboard links across all content listing groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->