### PR TITLE
fix(studio): clamp edge function errors-since-last-deploy query to 24h

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs'
 import { BookOpen, Check, ExternalLink, Eye } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { Fragment, useMemo } from 'react'
@@ -24,6 +25,7 @@ import {
   PageSectionTitle,
 } from 'ui-patterns/PageSection'
 import { GenericSkeletonLoader } from 'ui-patterns/ShimmeringLoader'
+import { TimestampInfo } from 'ui-patterns/TimestampInfo'
 
 import {
   buildGroupAssistantPrompt,
@@ -208,10 +210,11 @@ export const EdgeFunctionRecentErrors = ({
             <PageSectionMeta>
               <PageSectionSummary>
                 <PageSectionTitle>Errors since last deploy</PageSectionTitle>
-                {isTruncatedToLookback && (
+                {isTruncatedToLookback && updatedAt !== undefined && (
                   <PageSectionDescription>
-                    Showing errors from the last 24 hours only, as this function's last deploy was
-                    longer ago than that.
+                    Last deploy was{' '}
+                    <TimestampInfo utcTimestamp={updatedAt} label={dayjs(updatedAt).fromNow()} />,
+                    showing errors from the last 24 hours
                   </PageSectionDescription>
                 )}
               </PageSectionSummary>

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -18,6 +18,7 @@ import {
   PageSection,
   PageSectionAside,
   PageSectionContent,
+  PageSectionDescription,
   PageSectionMeta,
   PageSectionSummary,
   PageSectionTitle,
@@ -66,12 +67,13 @@ export const EdgeFunctionRecentErrors = ({
   const router = useRouter()
   const { openSidebar } = useSidebarManagerSnapshot()
   const aiAssistant = useAiAssistantStateSnapshot()
-  const { isoTimestampStart, isoTimestampEnd } = useMemo(
+  const { isoTimestampStart, isoTimestampEnd, isTruncatedToLookback } = useMemo(
     () => getSinceLastDeployLogRange(updatedAt),
     [updatedAt]
   )
   const emptyStateFallback =
     'Runtime errors since the last deploy will appear here when this function returns a 5xx response.'
+  const sinceLastDeployPhrase = isTruncatedToLookback ? 'in the last 24 hours' : 'since last deploy'
 
   const isQueryEnabled = Boolean(projectRef && functionId && isoTimestampStart)
   const recentErrorInvocationsSql = useMemo(
@@ -160,8 +162,8 @@ export const EdgeFunctionRecentErrors = ({
 
     return (
       <>
-        There {verb} been <span className="text-foreground">{invocationPhrase}</span> since last
-        deploy and no errors.
+        There {verb} been <span className="text-foreground">{invocationPhrase}</span>{' '}
+        {sinceLastDeployPhrase} and no errors.
       </>
     )
   }, [
@@ -169,6 +171,7 @@ export const EdgeFunctionRecentErrors = ({
     isoTimestampStart,
     sinceLastDeployInvocationCount,
     sinceLastDeployInvocationCountError,
+    sinceLastDeployPhrase,
   ])
   const emptyStateIcon =
     isoTimestampStart && !sinceLastDeployInvocationCountError ? (
@@ -205,6 +208,12 @@ export const EdgeFunctionRecentErrors = ({
             <PageSectionMeta>
               <PageSectionSummary>
                 <PageSectionTitle>Errors since last deploy</PageSectionTitle>
+                {isTruncatedToLookback && (
+                  <PageSectionDescription>
+                    Showing errors from the last 24 hours only, as this function's last deploy was
+                    longer ago than that.
+                  </PageSectionDescription>
+                )}
               </PageSectionSummary>
               <PageSectionAside>
                 <Button

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -73,9 +73,8 @@ export const EdgeFunctionRecentErrors = ({
     () => getSinceLastDeployLogRange(updatedAt),
     [updatedAt]
   )
-  const emptyStateFallback =
-    'Runtime errors since the last deploy will appear here when this function returns a 5xx response.'
   const sinceLastDeployPhrase = isTruncatedToLookback ? 'in the last 24 hours' : 'since last deploy'
+  const emptyStateFallback = `Runtime errors ${sinceLastDeployPhrase} will appear here when this function returns a 5xx response.`
 
   const isQueryEnabled = Boolean(projectRef && functionId && isoTimestampStart)
   const recentErrorInvocationsSql = useMemo(

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
@@ -99,14 +99,33 @@ limit 25`)
     expect(getSinceLastDeployLogRange(deployedAt)).toEqual({
       isoTimestampStart: deployedAt,
       isoTimestampEnd: '2026-03-20T12:00:00.000Z',
+      isTruncatedToLookback: false,
     })
 
     expect(getSinceLastDeployLogRange('2026-03-20T13:00:00.000Z')).toEqual({
       isoTimestampStart: '2026-03-20T13:00:00.000Z',
       isoTimestampEnd: '2026-03-20T13:00:00.000Z',
+      isTruncatedToLookback: false,
     })
 
     expect(getSinceLastDeployLogRange()).toEqual({})
+  })
+
+  it('clamps the logs query range to the last 24 hours when the last deploy is older than that', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-03-20T12:00:00.000Z'))
+
+    expect(getSinceLastDeployLogRange('2026-01-01T00:00:00.000Z')).toEqual({
+      isoTimestampStart: '2026-03-19T12:00:00.000Z',
+      isoTimestampEnd: '2026-03-20T12:00:00.000Z',
+      isTruncatedToLookback: true,
+    })
+
+    expect(getSinceLastDeployLogRange('2026-03-19T13:00:00.000Z')).toEqual({
+      isoTimestampStart: '2026-03-19T13:00:00.000Z',
+      isoTimestampEnd: '2026-03-20T12:00:00.000Z',
+      isTruncatedToLookback: false,
+    })
   })
 
   it('builds the since-deploy invocation count query and empty-state message', () => {

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
@@ -14,6 +14,7 @@ dayjs.extend(relativeTime)
 export const MAX_RECENT_ERROR_GROUPS = 5
 export const RECENT_ERROR_INVOCATIONS_LIMIT = 50
 export const RELATED_RUNTIME_LOGS_LIMIT = 100
+export const SINCE_LAST_DEPLOY_MAX_LOOKBACK_HOURS = 24
 const NUMERIC_TIMESTAMP_PATTERN = /^\d+(?:\.\d+)?$/
 
 export type GroupedRuntimeLog = {
@@ -134,10 +135,18 @@ export const getSinceLastDeployLogRange = (updatedAt?: string | number, now: Dat
   const startDate = new Date(isoTimestampStart)
   const normalizedNow = new Date(now)
   const endDate = Number.isNaN(normalizedNow.valueOf()) ? new Date() : normalizedNow
+  const isoTimestampEndDate = new Date(Math.max(startDate.valueOf(), endDate.valueOf()))
+
+  const maxLookbackStartDate = new Date(
+    isoTimestampEndDate.valueOf() - SINCE_LAST_DEPLOY_MAX_LOOKBACK_HOURS * 60 * 60 * 1000
+  )
+  const isTruncatedToLookback = startDate.valueOf() < maxLookbackStartDate.valueOf()
+  const isoTimestampStartDate = isTruncatedToLookback ? maxLookbackStartDate : startDate
 
   return {
-    isoTimestampStart,
-    isoTimestampEnd: new Date(Math.max(startDate.valueOf(), endDate.valueOf())).toISOString(),
+    isoTimestampStart: isoTimestampStartDate.toISOString(),
+    isoTimestampEnd: isoTimestampEndDate.toISOString(),
+    isTruncatedToLookback,
   }
 }
 


### PR DESCRIPTION
## Summary
- The "Errors since last deploy" section on the Edge Function overview page queries ClickHouse from the function's last deploy timestamp to now. If a function hasn't been redeployed in a while, this became an unbounded/very large time range, which can be expensive/slow to query.
- Clamp the lookback window to at most 24 hours, regardless of how old the last deploy is.
- When the window is clamped, update the section description and empty-state copy so it doesn't imply full since-deploy coverage.

## Test plan
- [x] `pnpm --filter studio exec vitest run components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts` — 12/12 passing (2 new tests covering the clamp)
- [x] `pnpm --filter studio exec tsc --noEmit -p tsconfig.json` — no new errors introduced (pre-existing unrelated errors on master confirmed via diff)
- [ ] Manual check in Studio: deploy a function, wait, then check the section renders correctly both within and beyond the 24h window - will have to confirm on prod I guess

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Limited “since last deploy” error logs to the most recent 24 hours if the deployment occurred earlier.
  * Improved error overview wording to distinguish between “in the last 24 hours” and “since last deploy” based on the available range.
  * Added a relative “last deploy” timestamp and clarified that only the 24-hour window is shown when results are truncated.
* **Tests**
  * Updated and added utility tests for the new 24-hour lookback clamping behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->