### PR TITLE
fix(www): add missing partner slug redirects

### DIFF
--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -2455,8 +2455,28 @@ module.exports = [
   },
   {
     permanent: true,
+    source: '/partners/integrations/atomic_crm',
+    destination: '/partners/integrations/atomic-crm',
+  },
+  {
+    permanent: true,
     source: '/partners/integrations/refine_dev',
     destination: '/partners/integrations/refine',
+  },
+  {
+    permanent: true,
+    source: '/partners/integrations/sequin_io',
+    destination: '/partners/integrations/sequin',
+  },
+  {
+    permanent: true,
+    source: '/partners/integrations/supabase_wrapper_bigquery',
+    destination: '/partners/integrations/bigquery-wrapper',
+  },
+  {
+    permanent: true,
+    source: '/partners/integrations/supabase_wrapper_firebase',
+    destination: '/partners/integrations/firebase-wrapper',
   },
   {
     permanent: true,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Partner slugs were renamed from underscores to hyphens, but the redirect map only got partially updated. #46264 added entries for `refine_dev` and `supabase_wrapper_stripe`. Four others were missed and still hard 404, even though their replacement pages are live:

| 404s today | Replacement page (200) |
|---|---|
| `/partners/integrations/atomic_crm` | `/partners/integrations/atomic-crm` |
| `/partners/integrations/sequin_io` | `/partners/integrations/sequin` |
| `/partners/integrations/supabase_wrapper_bigquery` | `/partners/integrations/bigquery-wrapper` |
| `/partners/integrations/supabase_wrapper_firebase` | `/partners/integrations/firebase-wrapper` |

These are the URLs Google has indexed and that external sites link to, so that traffic lands on an error page instead of the partner. Roughly 1.3k pageviews/month.

Worth flagging for the reviewer: partner slugs come from the database, not the codebase, so renaming one doesn't force a matching redirect entry and nothing catches it at build time. This will happen again.

## What is the new behavior?

Four `permanent: true` redirects added to `apps/www/lib/redirects.js`, matching the two that already exist in the partners block.

## Additional context

Found while [digging into a decline in /partners traffic](https://supabase.slack.com/archives/C0161K73J1J/p1783931237132339). This accounts for ~7% of that decline — the rest is happening on healthy, indexed pages and is a separate question.

Not included here: a few partner URLs 404 with no replacement page (`getstream_io`, `fezto`, `trevor_io`, `zapp_run`) — those partners look genuinely gone. Pointing them at `/partners/integrations` would hold onto more link equity than a hard 404, but that's a product call rather than a bug fix. Happy to add if people want it.

Verified each old URL currently 404s and each destination returns 200. No duplicate `source` entries introduced. Prettier passes.
