### PR TITLE
fix(docs): don't drop a legitimate row in last-page error pagination

### DIFF
--- a/apps/docs/resources/error/errorModel.test.ts
+++ b/apps/docs/resources/error/errorModel.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { trimPageSentinel } from './errorModel'
+
+describe('trimPageSentinel', () => {
+  describe('first (last = false)', () => {
+    it('drops the over-fetched sentinel row when present', () => {
+      // limit 2, over-fetched 3 rows -> keep the first 2
+      expect(trimPageSentinel(['a', 'b', 'c'], 2, false)).toEqual(['a', 'b'])
+    })
+
+    it('keeps every row when the window is not full', () => {
+      expect(trimPageSentinel(['a', 'b'], 5, false)).toEqual(['a', 'b'])
+    })
+
+    it('returns an empty array for no rows', () => {
+      expect(trimPageSentinel([], 5, false)).toEqual([])
+    })
+  })
+
+  describe('last (last = true)', () => {
+    it('drops the leading sentinel row when present', () => {
+      // a `last` query is fetched in reverse then re-reversed to ascending, so
+      // the over-fetched sentinel is the first (lowest-id) row.
+      expect(trimPageSentinel(['a', 'b', 'c'], 2, true)).toEqual(['b', 'c'])
+    })
+
+    it('keeps every row when the window has <= limit rows (regression)', () => {
+      // Previously this branch unconditionally sliced off the first row, so a
+      // `last` query whose result window was not full silently lost its
+      // lowest-id row (returned ['b','c','d'] instead of ['a','b','c','d']).
+      expect(trimPageSentinel(['a', 'b', 'c', 'd'], 10, true)).toEqual(['a', 'b', 'c', 'd'])
+    })
+
+    it('keeps a single row rather than dropping it', () => {
+      expect(trimPageSentinel(['a'], 10, true)).toEqual(['a'])
+    })
+
+    it('returns an empty array for no rows', () => {
+      expect(trimPageSentinel([], 10, true)).toEqual([])
+    })
+  })
+})

--- a/apps/docs/resources/error/errorModel.ts
+++ b/apps/docs/resources/error/errorModel.ts
@@ -27,6 +27,28 @@ type ErrorCollectionFetch = CollectionFetch<
   { service?: Service; code?: string }
 >['fetch']
 
+/**
+ * Trims the sentinel row from an over-fetched page.
+ *
+ * Both pagination directions request `limit + 1` rows to detect whether a
+ * further page exists. The extra ("sentinel") row is fetched at the far end of
+ * the window: it is the last row for a `first` query and — because a `last`
+ * query is fetched in reverse and then re-reversed to ascending order — the
+ * first row for a `last` query.
+ *
+ * The sentinel must only be dropped when it was actually fetched. When the
+ * window holds `<= limit` rows there is no sentinel, so a `last` query must
+ * return every row; unconditionally slicing off the first row would silently
+ * drop a legitimate result.
+ */
+export function trimPageSentinel<T>(rows: T[], limit: number, last: boolean): T[] {
+  const hasSentinel = rows.length > limit
+  if (last) {
+    return hasSentinel ? rows.slice(1) : rows
+  }
+  return rows.slice(0, limit)
+}
+
 export class ErrorModel {
   public id: string
   public code: string
@@ -117,7 +139,7 @@ export class ErrorModel {
       .join(errorCodesResult)
       .map(([count, errorCodes]) => {
         const hasMoreItems = errorCodes.length > limit
-        const items = args?.last ? errorCodes.slice(1) : errorCodes.slice(0, limit)
+        const items = trimPageSentinel(errorCodes, limit, !!args?.last)
 
         return {
           items: items.map((errorCode) => new ErrorModel(errorCode)),


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`ErrorModel.loadErrors` (`apps/docs/resources/error/errorModel.ts`) over-fetches `limit + 1` rows in both pagination directions to detect whether a further page exists. The `first` branch trims that extra "sentinel" row only when it is present (`slice(0, limit)`), but the `last` branch always sliced off the first row:

```ts
const items = args?.last ? errorCodes.slice(1) : errorCodes.slice(0, limit)
```

A `last` query is fetched in reverse and then re-reversed to ascending order, so the sentinel is the first (lowest-id) row. When the result window holds `<= limit` rows there is no sentinel — but `slice(1)` still dropped the lowest-id row. So any `last:` query whose window isn't full silently loses a legitimate result (e.g. 4 matching error codes returned 3).

## What is the new behavior?

The sentinel-trimming is extracted into a pure, exported `trimPageSentinel` helper that only drops the extra row when it was actually fetched, mirroring the `first` branch:

```ts
export function trimPageSentinel<T>(rows: T[], limit: number, last: boolean): T[] {
  const hasSentinel = rows.length > limit
  if (last) return hasSentinel ? rows.slice(1) : rows
  return rows.slice(0, limit)
}
```

Adds unit tests (`errorModel.test.ts`) covering both directions, including the regression where a `last` query with `<= limit` rows must return every row.

## Additional context

Pure refactor of the trimming logic; the DB queries and page-flag computation are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pagination so legitimate first or last results are not incorrectly removed when a page contains fewer items than the requested limit.
  * Improved handling of empty, single-item, and over-fetched result pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->