### PR TITLE
fix(pg-meta): raise a clear not-found error when updating/removing a role

### DIFF
--- a/packages/pg-meta/src/pg-meta-roles.ts
+++ b/packages/pg-meta/src/pg-meta-roles.ts
@@ -185,7 +185,7 @@ begin
   with roles as (${ROLES_SQL})
   select * into old from roles where ${getIdentifierWhereClause(identifier)};
   if old is null then
-    raise exception 'Cannot find role with id %', id;
+    raise exception 'Cannot find role matching the provided identifier';
   end if;
 
   execute(format('alter role %I
@@ -232,7 +232,7 @@ begin
   with roles as (${ROLES_SQL})
   select * into old from roles where ${getIdentifierWhereClause(identifier)};
   if old is null then
-    raise exception 'Cannot find role with id %', id;
+    raise exception 'Cannot find role matching the provided identifier';
   end if;
 
   execute(format('drop role ${ifExists ? safeSql`if exists` : safeSql``} %I;', old.name));

--- a/packages/pg-meta/test/roles.test.ts
+++ b/packages/pg-meta/test/roles.test.ts
@@ -237,3 +237,28 @@ withTestDatabase('retrieve, create, update, delete roles', async ({ executeQuery
   const finalRoles = finalListZod.parse(await executeQuery(finalListSql))
   expect(finalRoles.find((role) => role.name === 'config_role')).toBeUndefined()
 })
+
+withTestDatabase(
+  'update on a missing role raises a clear not-found error',
+  async ({ executeQuery }) => {
+    const { sql } = pgMeta.roles.update({ name: 'does_not_exist' }, { canLogin: true })
+
+    // The DO block previously referenced an undeclared `id` variable in this
+    // branch, so a missing role surfaced `column "id" does not exist` instead of
+    // the intended not-found message.
+    await expect(executeQuery(sql)).rejects.toThrow(
+      'Cannot find role matching the provided identifier'
+    )
+  }
+)
+
+withTestDatabase(
+  'remove on a missing role raises a clear not-found error',
+  async ({ executeQuery }) => {
+    const { sql } = pgMeta.roles.remove({ name: 'does_not_exist' })
+
+    await expect(executeQuery(sql)).rejects.toThrow(
+      'Cannot find role matching the provided identifier'
+    )
+  }
+)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The `update` and `remove` functions in `packages/pg-meta/src/pg-meta-roles.ts` build a `do $$ ... $$` block whose not-found branch references an `id` variable that is never declared (the block only declares `old record`):

```sql
select * into old from roles where <identifier>;
if old is null then
  raise exception 'Cannot find role with id %', id;
end if;
```

So updating or removing a role that doesn't exist fails with a confusing `column "id" does not exist` instead of a meaningful message. The identifier can also be a `name` rather than an `id`, in which case referencing `id` makes even less sense. (The retrieve-by-id path is unaffected, which is why existing tests didn't catch it.)

Reproduced against Postgres 16:

```
=# do $$ declare old record; begin old := null;
     if old is null then raise exception 'Cannot find role with id %', id; end if; end $$;
ERROR:  column "id" does not exist
```

## What is the new behavior?

Both branches raise a static, identifier-agnostic message:

```sql
raise exception 'Cannot find role matching the provided identifier';
```

Adds tests asserting that `update` and `remove` on a missing role surface this message. Verified against a local Postgres (`roles.test.ts`: 5/5 passing, including the existing create/update/delete happy path).

## Additional context

Only the not-found error message changes; the success path of `update`/`remove` is untouched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messages when updating or removing a role that does not exist.
  * Standardized the not-found message to: “Cannot find role matching the provided identifier.”


<!-- end of auto-generated comment: release notes by coderabbit.ai -->