### PR TITLE
fix(ui): don't garble negative percentages in AnimatedCounter padding

### DIFF
--- a/packages/ui/src/components/AnimatedCounter/AnimatedCounter.test.tsx
+++ b/packages/ui/src/components/AnimatedCounter/AnimatedCounter.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { getPaddedCounterValue } from './AnimatedCounter'
+
+describe('getPaddedCounterValue', () => {
+  describe('percentages', () => {
+    it('zero-pads a positive value to the width of the target', () => {
+      expect(getPaddedCounterValue(2, 13.4, true)).toBe('02.0%')
+    })
+
+    it('keeps the padding zeros after the minus sign for negative values (regression)', () => {
+      // Previously the whole signed string was padded, so the zero landed
+      // before the minus sign and produced "0-2.0%".
+      expect(getPaddedCounterValue(-2, -13.4, true)).toBe('-02.0%')
+      expect(getPaddedCounterValue(-2, -13.4, true)).not.toContain('0-2.0')
+    })
+
+    it('does not pad once the value reaches the target width', () => {
+      expect(getPaddedCounterValue(-13.4, -13.4, true)).toBe('-13.4%')
+      expect(getPaddedCounterValue(-2, -2, true)).toBe('-2.0%')
+    })
+
+    it('shows a plus prefix for positive values when prefix is set', () => {
+      expect(getPaddedCounterValue(5, 13.4, true, '+')).toBe('+05.0%')
+    })
+  })
+
+  describe('plain numbers', () => {
+    it('returns the comma-formatted value when no padding is needed', () => {
+      expect(getPaddedCounterValue(230550, 230550, false)).toBe('230,550')
+    })
+
+    it('zero-pads to the target digit count and preserves commas', () => {
+      expect(getPaddedCounterValue(550, 230550, false)).toBe('000,550')
+    })
+  })
+})

--- a/packages/ui/src/components/AnimatedCounter/AnimatedCounter.tsx
+++ b/packages/ui/src/components/AnimatedCounter/AnimatedCounter.tsx
@@ -43,6 +43,49 @@ export interface AnimatedCounterProps {
 }
 
 /**
+ * Formats the in-flight counter value, zero-padding it to the width of the
+ * target so the element keeps a stable width during the animation.
+ *
+ * For percentages the padding is applied to the numeric magnitude and the sign
+ * is re-attached afterwards. Padding the signed string directly inserts the
+ * zeros before the minus sign (e.g. `"-2.0"` padded to `"-13.4"`'s width yields
+ * `"0-2.0"`), producing a garbled value for negative percentages.
+ */
+export const getPaddedCounterValue = (
+  currentValue: number,
+  targetValue: number,
+  isPercentage: boolean,
+  prefix: string = ''
+) => {
+  if (isPercentage) {
+    const prefixed = prefix && currentValue > 0 ? '+' : prefix ? prefix : ''
+    const sign = currentValue < 0 ? '-' : ''
+    const targetString = Math.abs(targetValue).toFixed(1)
+    const currentString = Math.abs(currentValue).toFixed(1)
+    const paddedCurrent = sign + currentString.padStart(targetString.length, '0')
+    return `${prefixed}${paddedCurrent}%`
+  } else {
+    const targetString = targetValue.toLocaleString()
+    const currentString = currentValue.toLocaleString()
+    // Count digits in target (excluding commas)
+    const targetDigits = targetString.replace(/,/g, '').length
+    const currentDigits = currentString.replace(/,/g, '').length
+
+    if (currentDigits < targetDigits) {
+      const paddingNeeded = targetDigits - currentDigits
+      const currentWithoutCommas = currentValue.toString()
+      const paddedNumber = currentWithoutCommas.padStart(
+        currentWithoutCommas.length + paddingNeeded,
+        '0'
+      )
+      // Manually add commas to preserve leading zeros
+      return paddedNumber.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    }
+    return currentString
+  }
+}
+
+/**
  * AnimatedCounter - A component that animates numbers from 0 to a target value
  *
  * Features:
@@ -82,37 +125,8 @@ export const AnimatedCounter: FC<AnimatedCounterProps> = ({
     isPercentage ? Math.round(latest * 10) / 10 : Math.round(latest)
   )
 
-  // Calculate padding based on final value
-  const getPaddedValue = (currentValue: number, targetValue: number, isPercentage: boolean) => {
-    if (isPercentage) {
-      const prefixed = prefix && currentValue > 0 ? '+' : prefix ? prefix : ''
-      const targetString = targetValue.toFixed(1)
-      const currentString = currentValue.toFixed(1)
-      const paddedCurrent = currentString.padStart(targetString.length, '0')
-      return `${prefixed}${paddedCurrent}%`
-    } else {
-      const targetString = targetValue.toLocaleString()
-      const currentString = currentValue.toLocaleString()
-      // Count digits in target (excluding commas)
-      const targetDigits = targetString.replace(/,/g, '').length
-      const currentDigits = currentString.replace(/,/g, '').length
-
-      if (currentDigits < targetDigits) {
-        const paddingNeeded = targetDigits - currentDigits
-        const currentWithoutCommas = currentValue.toString()
-        const paddedNumber = currentWithoutCommas.padStart(
-          currentWithoutCommas.length + paddingNeeded,
-          '0'
-        )
-        // Manually add commas to preserve leading zeros
-        return paddedNumber.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
-      }
-      return currentString
-    }
-  }
-
   const displayValue = useTransform(rounded, (latest) =>
-    getPaddedValue(latest, value, isPercentage)
+    getPaddedCounterValue(latest, value, isPercentage, prefix)
   )
 
   const ref = useRef(null)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`AnimatedCounter` (`packages/ui/src/components/AnimatedCounter/AnimatedCounter.tsx`) zero-pads the in-flight value to the width of the target so the element keeps a stable width during the animation. For percentages it padded the **signed** string:

```ts
const targetString = targetValue.toFixed(1)   // e.g. "-13.4"
const currentString = currentValue.toFixed(1) // e.g. "-2.0"
const paddedCurrent = currentString.padStart(targetString.length, '0')
```

For a negative percentage the `-` sign is counted in the width, so the padding zero is inserted **before** the minus sign: a value of `-2.0` animating toward `-13.4` renders as `0-2.0%`. Negative values are a documented use case for this component (see the `prefix` prop docs).

## What is the new behavior?

The padding is applied to the numeric magnitude and the sign is re-attached afterwards, so `-2.0` toward `-13.4` renders as `-02.0%`. The formatting logic is extracted into a pure, exported `getPaddedCounterValue` helper.

Adds unit tests (`AnimatedCounter.test.tsx`) covering positive, negative (regression), full-width, prefixed, and plain-number cases.

## Additional context

Plain-number formatting is unchanged; only the percentage padding path is affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved animated counter formatting for percentages, including correct zero-padding for negative values and optional plus signs.
  * Preserved comma formatting while padding large numeric values.
  * Prevented unnecessary padding when values already reach the target width.

* **Tests**
  * Added coverage for percentage and plain-number formatting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->