### PR TITLE
fix(studio): cap errors-since-last-deploy log range to 24h DEBUG-173

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -204,7 +204,7 @@ export const EdgeFunctionRecentErrors = ({
           <div className="flex flex-col gap-6">
             <PageSectionMeta>
               <PageSectionSummary>
-                <PageSectionTitle>Errors since last deploy</PageSectionTitle>
+                <PageSectionTitle>Errors in the last 24h</PageSectionTitle>
               </PageSectionSummary>
               <PageSectionAside>
                 <Button

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
@@ -107,6 +107,13 @@ limit 25`)
     })
 
     expect(getSinceLastDeployLogRange()).toEqual({})
+
+    expect(getSinceLastDeployLogRange('2026-03-18T00:00:00.000Z')).toEqual({
+      isoTimestampStart: '2026-03-19T12:00:00.000Z',
+      isoTimestampEnd: '2026-03-20T12:00:00.000Z',
+    })
+
+    vi.useRealTimers()
   })
 
   it('builds the since-deploy invocation count query and empty-state message', () => {

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
@@ -140,9 +140,7 @@ export const getSinceLastDeployLogRange = (updatedAt?: string | number, now: Dat
   const earliestAllowedStart = endDate.valueOf() - SINCE_LAST_DEPLOY_MAX_RANGE_MS
 
   return {
-    isoTimestampStart: new Date(
-      Math.max(startDate.valueOf(), earliestAllowedStart)
-    ).toISOString(),
+    isoTimestampStart: new Date(Math.max(startDate.valueOf(), earliestAllowedStart)).toISOString(),
     isoTimestampEnd: endDate.toISOString(),
   }
 }

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
@@ -127,6 +127,8 @@ export const toIsoTimestamp = (value?: string | number) => {
   return Number.isNaN(date.valueOf()) ? undefined : date.toISOString()
 }
 
+export const SINCE_LAST_DEPLOY_MAX_RANGE_MS = 24 * 60 * 60 * 1000
+
 export const getSinceLastDeployLogRange = (updatedAt?: string | number, now: Date = new Date()) => {
   const isoTimestampStart = toIsoTimestamp(updatedAt)
   if (!isoTimestampStart) return {}
@@ -134,9 +136,12 @@ export const getSinceLastDeployLogRange = (updatedAt?: string | number, now: Dat
   const startDate = new Date(isoTimestampStart)
   const normalizedNow = new Date(now)
   const endDate = Number.isNaN(normalizedNow.valueOf()) ? new Date() : normalizedNow
+  const earliestAllowedStart = endDate.valueOf() - SINCE_LAST_DEPLOY_MAX_RANGE_MS
 
   return {
-    isoTimestampStart,
+    isoTimestampStart: new Date(
+      Math.min(Math.max(startDate.valueOf(), earliestAllowedStart), endDate.valueOf())
+    ).toISOString(),
     isoTimestampEnd: new Date(Math.max(startDate.valueOf(), endDate.valueOf())).toISOString(),
   }
 }

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
@@ -135,14 +135,15 @@ export const getSinceLastDeployLogRange = (updatedAt?: string | number, now: Dat
 
   const startDate = new Date(isoTimestampStart)
   const normalizedNow = new Date(now)
-  const endDate = Number.isNaN(normalizedNow.valueOf()) ? new Date() : normalizedNow
+  const nowDate = Number.isNaN(normalizedNow.valueOf()) ? new Date() : normalizedNow
+  const endDate = new Date(Math.max(startDate.valueOf(), nowDate.valueOf()))
   const earliestAllowedStart = endDate.valueOf() - SINCE_LAST_DEPLOY_MAX_RANGE_MS
 
   return {
     isoTimestampStart: new Date(
-      Math.min(Math.max(startDate.valueOf(), earliestAllowedStart), endDate.valueOf())
+      Math.max(startDate.valueOf(), earliestAllowedStart)
     ).toISOString(),
-    isoTimestampEnd: new Date(Math.max(startDate.valueOf(), endDate.valueOf())).toISOString(),
+    isoTimestampEnd: endDate.toISOString(),
   }
 }
 


### PR DESCRIPTION
## Problem

The edge function overview's "Errors since last deploy" panel queried ClickHouse from the deploy timestamp to now, with no upper bound. When a function had not been redeployed in a long time, this produced an unbounded query range, which is suspected to have caused a recent uptime incident.

## Fix

`getSinceLastDeployLogRange` now clamps the query start to at most 24 hours before now, shared by all three queries this panel issues (invocation list, invocation count, runtime logs). The section title was also updated from "Errors since last deploy" to "Errors in the last 24h" to reflect the new bound.

## How to test

- Open an edge function's overview page for a function that was deployed more than 24 hours ago
- Confirm the "Errors in the last 24h" panel loads without an excessively large query range
- Expected result: the panel only queries the last 24 hours of logs regardless of how old the last deploy was
- Run `pnpm test:studio -- EdgeFunctionRecentErrors.utils` and confirm the range-clamping tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated the Edge Function errors section to show errors from the last 24 hours.

- **Bug Fixes**
  - Limited error log searches to a maximum 24-hour window, preventing outdated results from appearing.
  - Improved handling of error time ranges when the last deployment occurred earlier than the available window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->