### PR TITLE
fix: horizontal overflow on /solutions/no-code mobile view

### DIFF
--- a/apps/www/components/Solutions/TwoColumnsSection.tsx
+++ b/apps/www/components/Solutions/TwoColumnsSection.tsx
@@ -40,9 +40,9 @@ const CodeSnippet = ({ prompt }: { prompt: AIPrompt }) => {
   }
 
   return (
-    <div className="relative group bg-surface-75 border border-default rounded-lg">
+    <div className="relative group bg-surface-75 border border-default rounded-lg min-w-0">
       <div className="flex items-center justify-between px-4 py-3 border-b border-default bg-surface-100">
-        <h3 className="text-sm text-foreground truncate">{prompt.title}</h3>
+        <h3 className="text-sm text-foreground truncate min-w-0">{prompt.title}</h3>
         {prompt.docsUrl && (
           <Link href={prompt.docsUrl} className="relative">
             <ArrowUpRight className="w-4 h-4 not-sr-only stroke-1 opacity-80 transition-opacity group-hover:opacity-100" />


### PR DESCRIPTION
## Problem
Prompt cards on /solutions/no-code caused horizontal page scroll on mobile. Flex/grid children don't shrink below content size by default, so long card titles and content pushed cards past the viewport width.

## Fix
Added `min-w-0` to the card container and title in `TwoColumnsSection.tsx` so cards respect their grid/flex track width instead of growing with content.

## Screenshots
| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/069fa434-c202-4761-ab25-0eaf5f71b434" width="300" /> | <img src="https://github.com/user-attachments/assets/2478bd84-1361-46e9-a076-4148b0c38706" width="300" /> |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code snippet layout behavior to prevent content from overflowing or breaking in narrow columns.
  * Enhanced title truncation for long prompt names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->