### PR TITLE
feat(studio): add Go to API Keys command menu action

### DIFF
--- a/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.tsx
+++ b/apps/studio/components/interfaces/App/CommandMenu/ApiKeys.tsx
@@ -160,4 +160,17 @@ export function useApiKeysCommands() {
       sectionMeta: { priority: 3 },
     }
   )
+
+  useRegisterCommands(
+    COMMAND_MENU_SECTIONS.NAVIGATE,
+    [
+      {
+        id: 'nav-api-keys',
+        name: 'Go to API Keys',
+        route: `/project/${ref}/settings/api-keys`,
+        icon: () => <Key />,
+      },
+    ],
+    { enabled: !!project }
+  )
 }


### PR DESCRIPTION
## Summary
- Add a "Go to API Keys" action under the command menu's Navigate section, linking to `/project/[ref]/settings/api-keys`

## Test plan
- [ ] Open command menu, search "api key", confirm "Go to API Keys" navigates to the settings page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-menu option to quickly navigate to the project’s API Keys settings page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->