### PR TITLE
docs(skills): add copywriting skill

### DIFF
--- a/.claude/skills/copywriting/SKILL.md
+++ b/.claude/skills/copywriting/SKILL.md
@@ -1,0 +1,8 @@
+---
+name: copywriting
+description: Write or audit UI copy (buttons, labels, empty states, error messages, tooltips, form text) anywhere in the monorepo. Always check this before shipping or reviewing user-facing text.
+---
+
+# Copywriting
+
+Source of truth: `apps/design-system/content/docs/copywriting.mdx`. Read it before writing or auditing any UI copy — it covers voice and tone, buttons, error messages, empty states, and confirmation dialogs with good/bad examples.


### PR DESCRIPTION
## Problem

Agents writing or auditing UI copy have no pointer to the existing copywriting guide in the design system, so copy conventions (voice, buttons, error messages, empty states) aren't consistently applied.

## Fix

Add a `copywriting` skill file that points agents to `apps/design-system/content/docs/copywriting.mdx` before writing or reviewing any user-facing text.

## How to test

- Ask an agent to write or review UI copy (e.g. a button label or error message)
- Confirm it reads `apps/design-system/content/docs/copywriting.mdx` before responding

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for writing and reviewing user-facing interface copy.
  * Included a requirement to consult the designated copywriting documentation before publishing or reviewing text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->