### PR TITLE
chore: dependabot autobump gha major versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
       interval: 'weekly'
     cooldown:
       default-days: 7
-    ignore:
-      - dependency-name: '*'
-        update-types:
-          - 'version-update:semver-major'


### PR DESCRIPTION
We were ignoring major version updates for Dependabot updates of GitHub Actions, so we are now several major versions behind on several actions. Turning major version updates back on so we can update everything.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Dependency update configuration now includes major version updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->