### PR TITLE
fix(studio): guard against NaN/Infinity in parseNumericValue; fix stale "24h" copy in edge function errors panel

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.tsx
@@ -71,7 +71,7 @@ export const EdgeFunctionRecentErrors = ({
     [updatedAt]
   )
   const emptyStateFallback =
-    'Runtime errors since the last deploy will appear here when this function returns a 5xx response.'
+    'Runtime errors in the last 24h will appear here when this function returns a 5xx response.'
 
   const isQueryEnabled = Boolean(projectRef && functionId && isoTimestampStart)
   const recentErrorInvocationsSql = useMemo(
@@ -160,8 +160,8 @@ export const EdgeFunctionRecentErrors = ({
 
     return (
       <>
-        There {verb} been <span className="text-foreground">{invocationPhrase}</span> since last
-        deploy and no errors.
+        There {verb} been <span className="text-foreground">{invocationPhrase}</span> in the last
+        24h and no errors.
       </>
     )
   }, [

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.test.ts
@@ -137,13 +137,13 @@ limit 25`)
     expect(getSinceLastDeployInvocationPhrase(1200)).toBe('1,200 invocations')
 
     expect(getNoErrorsSinceLastDeployMessage(0)).toBe(
-      'There have been 0 invocations since last deploy and no errors.'
+      'There have been 0 invocations in the last 24h and no errors.'
     )
     expect(getNoErrorsSinceLastDeployMessage(1)).toBe(
-      'There has been 1 invocation since last deploy and no errors.'
+      'There has been 1 invocation in the last 24h and no errors.'
     )
     expect(getNoErrorsSinceLastDeployMessage(1200)).toBe(
-      'There have been 1,200 invocations since last deploy and no errors.'
+      'There have been 1,200 invocations in the last 24h and no errors.'
     )
   })
 

--- a/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionOverview/EdgeFunctionRecentErrors.utils.ts
@@ -240,7 +240,7 @@ export const getNoErrorsSinceLastDeployMessage = (invocationCount: number) => {
   const verb = invocationCount === 1 ? 'has' : 'have'
   const invocationPhrase = getSinceLastDeployInvocationPhrase(invocationCount)
 
-  return `There ${verb} been ${invocationPhrase} since last deploy and no errors.`
+  return `There ${verb} been ${invocationPhrase} in the last 24h and no errors.`
 }
 
 export const getFunctionRuntimeLogsSql = ({

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.test.ts
@@ -32,6 +32,14 @@ describe('parseNumericValue', () => {
   it('returns 0 for undefined', () => {
     expect(parseNumericValue(undefined)).toBe(0)
   })
+
+  it('returns 0 for non-finite numeric values (NaN, Infinity, -Infinity)', () => {
+    // NaN has typeof === 'number', so the naive `if (typeof val === 'number') return val`
+    // would silently propagate NaN into metric gauges (showing "NaN%" on the dashboard).
+    expect(parseNumericValue(NaN)).toBe(0)
+    expect(parseNumericValue(Infinity)).toBe(0)
+    expect(parseNumericValue(-Infinity)).toBe(0)
+  })
 })
 
 describe('parseInfrastructureMetrics', () => {

--- a/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseInfrastructureSection.utils.ts
@@ -4,10 +4,11 @@ type NumericValue = string | number | undefined
 
 /**
  * Parses a numeric value that can be a number, string, or undefined.
- * Returns 0 for invalid or missing values.
+ * Returns 0 for invalid or missing values, including non-finite numbers
+ * such as NaN or Infinity that can result from backend division-by-zero.
  */
 export function parseNumericValue(val: NumericValue): number {
-  if (typeof val === 'number') return val
+  if (typeof val === 'number') return Number.isFinite(val) ? val : 0
   if (typeof val === 'string') return parseFloat(val) || 0
   return 0
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.
Yes

## What kind of change does this PR introduce?
Bug fix + regression tests

## What is the current behavior?

**Bug 1 — `parseNumericValue` silently propagates numeric `NaN`**
`DatabaseInfrastructureSection.utils.ts` line 10:
```ts
if (typeof val === 'number') return val
typeof NaN === 'number' is true in JavaScript. If the backend returns NaN or Infinity for any infrastructure metric (e.g. from a division-by-zero when computing averages for a project with no traffic), the value propagates unchanged into the CPU / RAM / Disk / Disk-IO gauges in the Observability dashboard — rendering them as NaN% or Infinity%. The function's own docstring says "Returns 0 for invalid or missing values" but the numeric branch had no Number.isFinite guard. The existing tests only covered 42, 0, and 3.14 — no NaN, Infinity, or -Infinity cases existed.

Bug 2 — Empty-state still says "since last deploy" after #47911

PR #47911 renamed the section title to "Errors in the last 24h" but three companion strings were not updated and still say "since last deploy":

emptyStateFallback in EdgeFunctionRecentErrors.tsx
The inline JSX empty-state message in EdgeFunctionRecentErrors.tsx
getNoErrorsSinceLastDeployMessage() in EdgeFunctionRecentErrors.utils.ts
For functions deployed more than 24 hours ago, the UI told users the invocation count was "since last deploy" — but the actual query only covers 24 hours. Factually incorrect.

What is the new behavior?
Fix 1 — parseNumericValue now returns 0 for non-finite numbers

ts
// Before
if (typeof val === 'number') return val
// After  
if (typeof val === 'number') return Number.isFinite(val) ? val : 0
NaN, Infinity, and -Infinity all return 0, matching the documented contract. Three new regression tests added with comments explaining why the naive check fails.

Fix 2 — Copy consistently says "in the last 24h"

All three stale strings updated to match the section title from #47911. Test assertions updated to act as a regression guard.

Additional context
Follows up on #47911 — completes the copy update that was missed in that PR
5 files changed, 18 insertions, 9 deletions — no API changes, no new dependencies
Run tests: pnpm test:studio -- DatabaseInfrastructureSection.utils and pnpm test:studio -- EdgeFunctionRecentErrors.utils

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated Edge Function error empty-state messages to reference activity and errors from the last 24 hours, providing clearer and more timely context.
  - Improved infrastructure metric handling so invalid or non-finite numeric values are displayed as zero instead of producing unreliable results.

- **Tests**
  - Added coverage for invalid numeric values, including `NaN` and infinite values.
  - Updated validation for the revised 24-hour error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->