### PR TITLE
fix(docs): before-user-created hook had invalid ipnet cmp

### DIFF
--- a/apps/docs/content/guides/auth/auth-hooks/before-user-created-hook.mdx
+++ b/apps/docs/content/guides/auth/auth-hooks/before-user-created-hook.mdx
@@ -404,7 +404,7 @@ begin
   -- Step 1: Check for explicit allow
   select count(*) into allow_count
   from public.signup_networks
-  where type = 'allow' and ip::inet << cidr;
+  where type = 'allow' and ip <<= cidr;
 
   if allow_count > 0 then
     -- If explicitly allowed, allow signup
@@ -414,7 +414,7 @@ begin
   -- Step 2: Check for explicit deny
   select count(*) into deny_count
   from public.signup_networks
-  where type = 'deny' and ip::inet << cidr;
+  where type = 'deny' and ip <<= cidr;
 
   if deny_count > 0 then
     return jsonb_build_object(


### PR DESCRIPTION
The comparison operator `<<` check if lhs is strictly contained by the rhs. Meaning a `/32` would return false for `/32` as the lhs is not contained, but equal to the rhs. The `<<=` is operator checks if a subnet is strictly contained or equal to which fixes the `/32` case.

[1] https://www.postgresql.org/docs/17/functions-net.html#FUNCTIONS-NET


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `before-user-created` hook SQL example to use the correct IP/CIDR containment syntax for both allow and deny network checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->