### PR TITLE
fix(studio): use wildcard route for support assistant

### DIFF
--- a/apps/studio/components/interfaces/Support/AIAssistantOption.test.tsx
+++ b/apps/studio/components/interfaces/Support/AIAssistantOption.test.tsx
@@ -1,0 +1,73 @@
+import { act, render, screen } from '@testing-library/react'
+import type { ComponentProps, PropsWithChildren, ReactNode } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { AIAssistantOption } from './AIAssistantOption'
+import { NO_PROJECT_MARKER } from './SupportForm.utils'
+
+vi.mock('framer-motion', () => ({
+  AnimatePresence: ({ children }: PropsWithChildren) => <>{children}</>,
+  motion: {
+    aside: ({
+      children,
+      initial: _initial,
+      animate: _animate,
+      exit: _exit,
+      ...props
+    }: PropsWithChildren<
+      ComponentProps<'aside'> & { initial?: unknown; animate?: unknown; exit?: unknown }
+    >) => <aside {...props}>{children}</aside>,
+  },
+}))
+
+vi.mock('next/link', () => ({
+  default: ({ children, ...props }: PropsWithChildren<ComponentProps<'a'>>) => (
+    <a {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('ui', () => ({
+  AiIconAnimation: () => null,
+  Button: ({
+    children,
+    icon: _icon,
+    ...props
+  }: PropsWithChildren<ComponentProps<'button'> & { icon?: ReactNode }>) => (
+    <button {...props}>{children}</button>
+  ),
+}))
+
+vi.mock('@/lib/telemetry/track', () => ({
+  useTrack: () => vi.fn(),
+}))
+
+describe('AIAssistantOption', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it.each([
+    { projectRef: null, expectedProjectRef: '_' },
+    { projectRef: undefined, expectedProjectRef: '_' },
+    { projectRef: NO_PROJECT_MARKER, expectedProjectRef: '_' },
+    { projectRef: 'project-123', expectedProjectRef: 'project-123' },
+  ])(
+    'links to the correct assistant project route for $projectRef',
+    ({ projectRef, expectedProjectRef }) => {
+      render(<AIAssistantOption projectRef={projectRef} organizationSlug="org-123" />)
+
+      act(() => {
+        vi.advanceTimersByTime(800)
+      })
+
+      expect(screen.getByRole('link', { name: 'Ask the Assistant' })).toHaveAttribute(
+        'href',
+        `/project/${expectedProjectRef}?sidebar=ai-assistant&slug=org-123`
+      )
+    }
+  )
+})

--- a/apps/studio/components/interfaces/Support/AIAssistantOption.tsx
+++ b/apps/studio/components/interfaces/Support/AIAssistantOption.tsx
@@ -39,7 +39,8 @@ export const AIAssistantOption = ({
   }, [onClick, projectRef, organizationSlug, track])
 
   // If no specific project selected, use the wildcard route
-  const aiLink = `/project/${projectRef !== NO_PROJECT_MARKER ? projectRef : '_'}?sidebar=ai-assistant&slug=${organizationSlug}`
+  const projectPathRef = projectRef && projectRef !== NO_PROJECT_MARKER ? projectRef : '_'
+  const aiLink = `/project/${projectPathRef}?sidebar=ai-assistant&slug=${organizationSlug}`
 
   if (!organizationSlug || organizationSlug === NO_ORG_MARKER) return null
 


### PR DESCRIPTION
﻿## Summary

- Direct the Support form Assistant CTA to the existing wildcard project route when no project is selected.
- Preserve routes for selected projects.
- Add route coverage for null, undefined, sentinel, and selected refs.

## Root cause

The Support form returns null when no project is selected, but the CTA only recognized the sentinel value. That produced a project/null route.

## Testing

- Targeted Vitest coverage for the CTA route
- Studio TypeScript check
- Targeted Prettier and ESLint checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI Assistant link routing for projects without a project reference.
  * Ensured links use the correct path for missing, undefined, marked, and valid project references.

* **Tests**
  * Added coverage for AI Assistant link generation across supported project reference scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->