### PR TITLE
Joshen/fe 3384 prevent ai assistant chat panel from closing after query

### DIFF
--- a/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.tsx
+++ b/apps/studio/components/layouts/Navigation/FloatingMobileToolbar/FloatingMobileToolbar.tsx
@@ -50,6 +50,7 @@ export const FloatingMobileToolbar = ({ hideMobileMenu }: { hideMobileMenu?: boo
       onPointerMove={drag.handlePointerMove}
     >
       <div
+        id="mobile-nav-actions"
         className={cn(
           'flex pointer-events-auto cursor-grab active:cursor-grabbing flex-row items-center justify-between w-auto rounded-full',
           'bg-overlay/80 backdrop-blur-md px-2.5 py-2 gap-2',

--- a/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
@@ -47,9 +47,11 @@ const StudioMobileSheetNav = () => {
   const handleOpenChange = (open: boolean) => {
     if (!open) {
       setContent(null)
-      if (isMobile) sidebarManagerState.closeActive()
+      sidebarManagerState.closeActive()
     }
   }
+
+  if (!isMobile) return null
 
   return (
     <MobileSheetNav

--- a/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
@@ -38,7 +38,7 @@ function getSheetChildren(
   return null
 }
 
-const StudioMobileSheetNav = () => {
+export const StudioMobileSheetNav = () => {
   const isMobile = useBreakpoint('md')
   const { content, setContent } = useMobileSheet()
   const { activeSidebar } = useSidebarManagerSnapshot()
@@ -63,5 +63,3 @@ const StudioMobileSheetNav = () => {
     </MobileSheetNav>
   )
 }
-
-export { StudioMobileSheetNav }

--- a/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
@@ -58,6 +58,15 @@ export const StudioMobileSheetNav = () => {
       open={content !== null}
       onOpenChange={handleOpenChange}
       shouldCloseOnViewportResize={!activeSidebar}
+      onPointerDownOutside={(event) => {
+        // Buttons in the floating toolbar (#mobile-nav-actions) render outside this sheet, so
+        // Radix treats taps on them as an outside click and closes the sheet before the button's
+        // own onClick runs. Those buttons already manage the sheet themselves, so don't let
+        // Radix's outside-dismiss pre-empt them.
+        if ((event.target as HTMLElement | null)?.closest('#mobile-nav-actions')) {
+          event.preventDefault()
+        }
+      }}
     >
       {sheetChildren}
     </MobileSheetNav>

--- a/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/StudioMobileSheetNav.tsx
@@ -1,3 +1,4 @@
+import { useBreakpoint } from 'common'
 import type { ReactNode } from 'react'
 import { CommandWrapper } from 'ui-patterns/CommandMenu'
 import { MobileSheetNav } from 'ui-patterns/MobileSheetNav'
@@ -38,6 +39,7 @@ function getSheetChildren(
 }
 
 const StudioMobileSheetNav = () => {
+  const isMobile = useBreakpoint('md')
   const { content, setContent } = useMobileSheet()
   const { activeSidebar } = useSidebarManagerSnapshot()
   const sheetChildren = getSheetChildren(content, activeSidebar ?? null)
@@ -45,7 +47,7 @@ const StudioMobileSheetNav = () => {
   const handleOpenChange = (open: boolean) => {
     if (!open) {
       setContent(null)
-      sidebarManagerState.closeActive()
+      if (isMobile) sidebarManagerState.closeActive()
     }
   }
 

--- a/packages/ui-patterns/src/MobileSheetNav/MobileSheetNav.tsx
+++ b/packages/ui-patterns/src/MobileSheetNav/MobileSheetNav.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useRouter } from 'next/router'
-import { useEffect } from 'react'
+import { ComponentProps, useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { useWindowSize } from 'react-use'
 import { CommandEmpty, Sheet, SheetContent } from 'ui'
@@ -14,6 +14,7 @@ const MobileSheetNav: React.FC<{
   className?: string
   shouldCloseOnRouteChange?: boolean
   shouldCloseOnViewportResize?: boolean
+  onPointerDownOutside?: ComponentProps<typeof SheetContent>['onPointerDownOutside']
 }> = ({
   children,
   open = false,
@@ -21,6 +22,7 @@ const MobileSheetNav: React.FC<{
   className,
   shouldCloseOnRouteChange = true,
   shouldCloseOnViewportResize = true,
+  onPointerDownOutside,
 }) => {
   const router = useRouter()
   const { width } = useWindowSize()
@@ -48,15 +50,7 @@ const MobileSheetNav: React.FC<{
         showClose={false}
         size="full"
         side="bottom"
-        onPointerDownOutside={(event) => {
-          // Buttons in the floating toolbar (#mobile-nav-actions) render outside this sheet, so
-          // Radix treats taps on them as an outside click and closes the sheet before the button's
-          // own onClick runs. Those buttons already manage the sheet themselves, so don't let
-          // Radix's outside-dismiss pre-empt them.
-          if ((event.target as HTMLElement | null)?.closest('#mobile-nav-actions')) {
-            event.preventDefault()
-          }
-        }}
+        onPointerDownOutside={onPointerDownOutside}
         className={cn(
           'rounded-t-lg bg-background overflow-hidden overflow-y-scroll h-[85dvh] md:max-h-[500px]',
           className

--- a/packages/ui-patterns/src/MobileSheetNav/MobileSheetNav.tsx
+++ b/packages/ui-patterns/src/MobileSheetNav/MobileSheetNav.tsx
@@ -48,6 +48,15 @@ const MobileSheetNav: React.FC<{
         showClose={false}
         size="full"
         side="bottom"
+        onPointerDownOutside={(event) => {
+          // Buttons in the floating toolbar (#mobile-nav-actions) render outside this sheet, so
+          // Radix treats taps on them as an outside click and closes the sheet before the button's
+          // own onClick runs. Those buttons already manage the sheet themselves, so don't let
+          // Radix's outside-dismiss pre-empt them.
+          if ((event.target as HTMLElement | null)?.closest('#mobile-nav-actions')) {
+            event.preventDefault()
+          }
+        }}
         className={cn(
           'rounded-t-lg bg-background overflow-hidden overflow-y-scroll h-[85dvh] md:max-h-[500px]',
           className


### PR DESCRIPTION
## Context

2 problems that this PR addresses - but these are in general due to the mobile UI behaviour 
- Sidebars (e.g Help Panel, Advisor Panel, etc) closes whenever there's a route change
  - This is happening because of `StudioMobileSheetNav`'s `handleOpenChange` interfering with the sidebar visible state
  - Am opting to not render `StudioMobileSheetNav` at all unless on mobile
- On mobile, if you're on the Advisor Panel, clicking the "Menu" button closes the mobile sheet
  - Clicking on the Menu button seems to be triggering `MobileSheetNav`'s `onOpenChange`
  - My suspicion is because of state asymmetry between two independent stores (MobileSheetContext and SidebarManagerState - these 2 are a bit too complex imo)
  - Am opting to skip calling `onOpenChange` in `StudioMobileSheetNav` if the click target is within the Floating toolbar

## To test
- [x] Desktop: Have the assistant panel open and change routes, panel should stay open
- [x] Mobile: Open the assistant panel, then switch to the menu, panel should stay open

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile navigation interactions so the navigation sheet remains open while toolbar actions are being selected.
  * Mobile navigation now displays only on smaller screens, preventing it from appearing at medium and larger breakpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->