### PR TITLE
docs: clarify supabase_admin default privileges

### DIFF
--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -68,6 +68,12 @@ alter default privileges for role postgres in schema public
   revoke execute on functions from public;
 ```
 
+<Admonition type="tip">
+
+The default privileges shown in [pg_default_acl](https://www.postgresql.org/docs/current/catalog-pg-default-acl.html) that originate from [supabase_admin](/docs/guides/database/postgres/roles#supabaseadmin) (granting to anon, authenticated, and service_role) are intentional and part of Supabase's standard permission model. The supabase_admin role is an internal management role that cannot authenticate through the Data API, so it poses no direct security risk.
+
+</Admonition>
+
 ## Use a dedicated API schema
 
 If you want an extra boundary around your Data API, lock down the `public` schema and expose a dedicated schema, such as `api`, instead. You can control access with grants in any schema, but this can make the surface easier to reason about: objects in `api` represent your Data API, while internal tables and helper functions stay in schemas that are not exposed. See [Using Custom Schemas](/docs/guides/api/using-custom-schemas) for setup steps.

--- a/apps/docs/content/guides/api/securing-your-api.mdx
+++ b/apps/docs/content/guides/api/securing-your-api.mdx
@@ -70,7 +70,7 @@ alter default privileges for role postgres in schema public
 
 <Admonition type="tip">
 
-The default privileges shown in [pg_default_acl](https://www.postgresql.org/docs/current/catalog-pg-default-acl.html) that originate from [supabase_admin](/docs/guides/database/postgres/roles#supabaseadmin) (granting to anon, authenticated, and service_role) are intentional and part of Supabase's standard permission model. The supabase_admin role is an internal management role that cannot authenticate through the Data API, so it poses no direct security risk.
+These default privileges pose no direct security risk. They appear in [pg_default_acl](https://www.postgresql.org/docs/current/catalog-pg-default-acl.html), granted by [supabase_admin](/docs/guides/database/postgres/roles#supabaseadmin) to `anon`, `authenticated`, and `service_role`. The default privileges are intentional and part of Supabase's standard permission model. The `supabase_admin` role is an internal management role that can't authenticate through the Data API.
 
 </Admonition>
 


### PR DESCRIPTION
Adds a tip admonition explaining that the default privileges from supabase_admin are intentional and part of Supabase's standard permission model. This clarifies why these grants remain after revoking public access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a tip to the “Default privileges for new tables and functions” section clarifying that the default privileges tied to the internal administrative role are intentional.
  - Explained that this role cannot authenticate through the Data API, so it does not introduce a direct security risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->