### PR TITLE
fix(studio): give unified logs filter 'Only' button a solid background

### DIFF
--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
@@ -144,12 +144,14 @@ export function DataTableFilterCheckbox<TData>({
                         '0'
                       ) : null}
                     </span>
+
                     <button
                       type="button"
                       onClick={() => column?.setFilterValue([option.value])}
                       className={cn(
-                        'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground hover:text-foreground group-hover:flex items-center',
-                        'rounded-md ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+                        'text-xs text-muted-foreground hover:text-foreground',
+                        'absolute inset-y-0 right-0 hidden bg-surface-100 group-hover:flex items-center cursor-pointer',
+                        'ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                       )}
                     >
                       <span className="pl-1 pr-2">Only</span>

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
@@ -148,11 +148,11 @@ export function DataTableFilterCheckbox<TData>({
                       type="button"
                       onClick={() => column?.setFilterValue([option.value])}
                       className={cn(
-                        'absolute inset-y-0 right-0 hidden font-normal text-muted-foreground backdrop-blur-xs hover:text-foreground group-hover:block',
+                        'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground bg-background hover:text-foreground group-hover:flex items-center',
                         'rounded-md ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                       )}
                     >
-                      <span className="pl-1 pr-2">only</span>
+                      <span className="pl-1 pr-2">Only</span>
                     </button>
                   </Label>
                 </div>

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckbox.tsx
@@ -135,7 +135,7 @@ export function DataTableFilterCheckbox<TData>({
                         {isExpanded ? <Minus size={12} /> : <Plus size={12} />}
                       </button>
                     )}
-                    <span className="shrink-0 flex items-center justify-center font-mono text-xs pr-2">
+                    <span className="shrink-0 flex items-center justify-center font-mono text-xs pr-2 group-hover:opacity-0">
                       {isLoadingCounts ? (
                         <Skeleton className="h-4 w-4" />
                       ) : facetedValue?.has(option.value) ? (
@@ -148,7 +148,7 @@ export function DataTableFilterCheckbox<TData>({
                       type="button"
                       onClick={() => column?.setFilterValue([option.value])}
                       className={cn(
-                        'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground bg-background hover:text-foreground group-hover:flex items-center',
+                        'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground hover:text-foreground group-hover:flex items-center',
                         'rounded-md ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                       )}
                     >

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
@@ -120,8 +120,9 @@ export function DataTableFilterCheckboxAsync<TData>({
                     type="button"
                     onClick={() => column?.setFilterValue([option.value])}
                     className={cn(
-                      'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground hover:text-foreground group-hover:flex items-center',
-                      'rounded-md ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
+                      'text-xs text-muted-foreground hover:text-foreground',
+                      'absolute inset-y-0 right-0 hidden bg-surface-100 group-hover:flex items-center cursor-pointer',
+                      'ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                     )}
                   >
                     <span className="px-2">Only</span>

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
@@ -107,7 +107,7 @@ export function DataTableFilterCheckboxAsync<TData>({
                       <span className="truncate font-normal block">{option.label}</span>
                     )}
                   </div>
-                  <span className="shrink-0 flex items-center justify-center font-mono text-xs">
+                  <span className="shrink-0 flex items-center justify-center font-mono text-xs group-hover:opacity-0">
                     {isLoadingCounts ? (
                       <Skeleton className="h-4 w-4" />
                     ) : facetedValue?.has(option.value) ? (
@@ -120,7 +120,7 @@ export function DataTableFilterCheckboxAsync<TData>({
                     type="button"
                     onClick={() => column?.setFilterValue([option.value])}
                     className={cn(
-                      'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground bg-background hover:text-foreground group-hover:flex items-center',
+                      'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground hover:text-foreground group-hover:flex items-center',
                       'rounded-md ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                     )}
                   >

--- a/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
+++ b/apps/studio/components/ui/DataTable/DataTableFilters/DataTableFilterCheckboxAsync.tsx
@@ -120,11 +120,11 @@ export function DataTableFilterCheckboxAsync<TData>({
                     type="button"
                     onClick={() => column?.setFilterValue([option.value])}
                     className={cn(
-                      'absolute inset-y-0 right-0 hidden font-normal text-muted-foreground backdrop-blur-xs hover:text-foreground group-hover:block',
+                      'absolute inset-y-0 right-0 hidden font-normal text-[10px] text-muted-foreground bg-background hover:text-foreground group-hover:flex items-center',
                       'rounded-md ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2'
                     )}
                   >
-                    <span className="px-2">only</span>
+                    <span className="px-2">Only</span>
                   </button>
                 </Label>
               </div>


### PR DESCRIPTION
The "Only" button in the Unified Logs filter facets had no background, so it overlapped the label/count behind it on hover. Added a solid `bg-background`, set the label to 10px, and capitalized it to "Only". Applied to both the sync and async filter checkbox components.

## Before / After
Button now sits on an opaque background and no longer bleeds into the row below.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved checkbox filter hover interactions by hiding count markers when hovering over an option.
  * Updated the “Only” control styling for clearer visibility, alignment, and hover behavior.
  * Capitalized the control label to “Only” for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->