### PR TITLE
Joshen/fe 3775 create a larger assistant workspace for observability

### DIFF
--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -1,7 +1,7 @@
 import { useBreakpoint, useParams } from 'common'
 import { useRouter } from 'next/router'
 import { PropsWithChildren, useEffect, useState } from 'react'
-import { ResizablePanel, ResizablePanelGroup, SidebarProvider } from 'ui'
+import { ResizablePanel, ResizablePanelGroup, SidebarProvider, usePanelRef } from 'ui'
 
 import { BannerStack } from '../ui/BannerStack/BannerStack'
 import { LayoutHeader } from './Navigation/LayoutHeader/LayoutHeader'
@@ -17,6 +17,7 @@ import { useLastVisitedOrganization } from '@/hooks/misc/useLastVisitedOrganizat
 import { useCheckLatestDeploy } from '@/hooks/use-check-latest-deploy'
 import { IS_PLATFORM } from '@/lib/constants'
 import { useAppStateSnapshot } from '@/state/app-state'
+import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 export interface DefaultLayoutProps {
   headerTitle?: string
@@ -38,11 +39,17 @@ export const DefaultLayout = ({
   headerTitle,
   hideMobileMenu,
 }: PropsWithChildren<DefaultLayoutProps>) => {
+  useCheckLatestDeploy()
+
   const { ref } = useParams()
   const router = useRouter()
+  const panelRef = usePanelRef()
+  const isMobile = useBreakpoint('md')
   const appSnap = useAppStateSnapshot()
-
+  const { isMaximised } = useSidebarManagerSnapshot()
   const { lastVisitedOrganization } = useLastVisitedOrganization()
+
+  const [isMounted, setIsMounted] = useState(false)
 
   const backToDashboardURL = router.pathname.startsWith('/account')
     ? appSnap.lastRouteBeforeVisitingAccountPage.length > 0
@@ -54,18 +61,21 @@ export const DefaultLayout = ({
           : '/project/default'
     : undefined
 
-  useCheckLatestDeploy()
-
-  const isMobile = useBreakpoint('md')
-
   const contentMinSizePercentage = 50
   const contentMaxSizePercentage = 70
-
-  const [isMounted, setIsMounted] = useState(false)
 
   useEffect(() => {
     setIsMounted(true)
   }, [])
+
+  useEffect(() => {
+    if (!isMounted) return
+    if (isMaximised) {
+      panelRef.current?.collapse()
+    } else {
+      panelRef.current?.resize(`${contentMaxSizePercentage}%`)
+    }
+  }, [isMounted, isMaximised, contentMaxSizePercentage, panelRef])
 
   // This is required to prevent layout shift when rendering resizable panels (they initially render at 50%, then shift
   // to whatever is specified).
@@ -106,6 +116,8 @@ export const DefaultLayout = ({
                   <ResizablePanel
                     id="panel-content"
                     className="w-full"
+                    panelRef={panelRef}
+                    collapsible
                     minSize={`${contentMinSizePercentage}`}
                     maxSize={`${contentMaxSizePercentage}`}
                     defaultSize={`${contentMaxSizePercentage}`}
@@ -116,7 +128,7 @@ export const DefaultLayout = ({
                   </ResizablePanel>
                   <LayoutSidebar
                     minSize={`${100 - contentMaxSizePercentage}`}
-                    maxSize={`${100 - contentMinSizePercentage}`}
+                    maxSize="100"
                     defaultSize={`${100 - contentMaxSizePercentage}`}
                   />
                 </ResizablePanelGroup>

--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -9,7 +9,10 @@ import MobileNavigationBar from './Navigation/NavigationBar/MobileNavigationBar'
 import { MobileSheetProvider } from './Navigation/NavigationBar/MobileSheetContext'
 import { StudioMobileSheetNav } from './Navigation/NavigationBar/StudioMobileSheetNav'
 import { LayoutSidebar } from './ProjectLayout/LayoutSidebar'
-import { LayoutSidebarProvider } from './ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
+import {
+  LayoutSidebarProvider,
+  SIDEBAR_KEYS,
+} from './ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { ProjectContextProvider } from './ProjectLayout/ProjectContext'
 import { AppBannerWrapper } from '@/components/interfaces/App/AppBannerWrapper'
 import { Sidebar } from '@/components/interfaces/Sidebar'
@@ -46,7 +49,7 @@ export const DefaultLayout = ({
   const panelRef = usePanelRef()
   const isMobile = useBreakpoint('md')
   const appSnap = useAppStateSnapshot()
-  const { isMaximised } = useSidebarManagerSnapshot()
+  const { isMaximised, activeSidebar } = useSidebarManagerSnapshot()
   const { lastVisitedOrganization } = useLastVisitedOrganization()
 
   const [isMounted, setIsMounted] = useState(false)
@@ -69,13 +72,13 @@ export const DefaultLayout = ({
   }, [])
 
   useEffect(() => {
-    if (!isMounted) return
+    if (!isMounted || !panelRef.current || !activeSidebar) return
     if (isMaximised) {
-      panelRef.current?.collapse()
+      panelRef.current.collapse()
     } else {
-      panelRef.current?.resize(`${contentMaxSizePercentage}%`)
+      panelRef.current.resize(`${contentMaxSizePercentage}%`)
     }
-  }, [isMounted, isMaximised, contentMaxSizePercentage, panelRef])
+  }, [isMounted, isMaximised, panelRef])
 
   // This is required to prevent layout shift when rendering resizable panels (they initially render at 50%, then shift
   // to whatever is specified).
@@ -117,7 +120,7 @@ export const DefaultLayout = ({
                     id="panel-content"
                     className="w-full"
                     panelRef={panelRef}
-                    collapsible
+                    collapsible={activeSidebar?.id === SIDEBAR_KEYS.AI_ASSISTANT}
                     minSize={`${contentMinSizePercentage}`}
                     maxSize={`${contentMaxSizePercentage}`}
                     defaultSize={`${contentMaxSizePercentage}`}

--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -78,7 +78,7 @@ export const DefaultLayout = ({
     } else {
       panelRef.current.resize(`${contentMaxSizePercentage}%`)
     }
-  }, [isMounted, isMaximised, panelRef])
+  }, [isMounted, isMaximised, panelRef, activeSidebar])
 
   // This is required to prevent layout shift when rendering resizable panels (they initially render at 50%, then shift
   // to whatever is specified).

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
@@ -1,7 +1,6 @@
-import { usePrevious } from '@uidotdev/usehooks'
 import { useBreakpoint } from 'common'
 import { useEffect } from 'react'
-import { cn, ResizableHandle, ResizablePanel, usePanelRef } from 'ui'
+import { cn, ResizableHandle, ResizablePanel } from 'ui'
 
 import { SIDEBAR_KEYS, type TYPEOF_SIDEBAR_KEYS } from './LayoutSidebarProvider'
 import { useMobileSheet } from '@/components/layouts/Navigation/NavigationBar/MobileSheetContext'

--- a/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutSidebar/index.tsx
@@ -1,6 +1,7 @@
+import { usePrevious } from '@uidotdev/usehooks'
 import { useBreakpoint } from 'common'
 import { useEffect } from 'react'
-import { cn, ResizableHandle, ResizablePanel } from 'ui'
+import { cn, ResizableHandle, ResizablePanel, usePanelRef } from 'ui'
 
 import { SIDEBAR_KEYS, type TYPEOF_SIDEBAR_KEYS } from './LayoutSidebarProvider'
 import { useMobileSheet } from '@/components/layouts/Navigation/NavigationBar/MobileSheetContext'
@@ -24,8 +25,8 @@ export const LayoutSidebar = ({
   maxSize = '50',
   defaultSize = '30',
 }: LayoutSidebarProps) => {
-  const { activeSidebar } = useSidebarManagerSnapshot()
   const isMobile = useBreakpoint('md')
+  const { activeSidebar } = useSidebarManagerSnapshot()
   const { content: sheetContent, setContent: setMobileSheetContent } = useMobileSheet()
 
   useEffect(() => {

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistantHeader.tsx
@@ -1,4 +1,13 @@
-import { Clipboard, Edit, MessageCirclePlus, MoreVertical, Settings, X } from 'lucide-react'
+import {
+  Clipboard,
+  Edit,
+  Maximize,
+  MessageCirclePlus,
+  Minimize,
+  MoreVertical,
+  Settings,
+  X,
+} from 'lucide-react'
 import { KeyboardEvent, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -20,6 +29,7 @@ import { AIOptInModal } from './AIOptInModal'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { SHORTCUT_DEFINITIONS, SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
+import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 interface AIAssistantHeaderProps {
   isChatLoading: boolean
@@ -41,6 +51,7 @@ export const AIAssistantHeader = ({
   aiOptInLevel,
 }: AIAssistantHeaderProps) => {
   const snap = useAiAssistantStateSnapshot()
+  const { isMaximised, toggleMaximise } = useSidebarManagerSnapshot()
   const [value, setValue] = useState(snap.activeChat?.name)
   const [isEditingName, setIsEditingName] = useState(false)
   const [isOptInModalOpen, setIsOptInModalOpen] = useState(false)
@@ -80,6 +91,10 @@ export const AIAssistantHeader = ({
   })
 
   useShortcut(SHORTCUT_IDS.AI_ASSISTANT_OPEN_PERMISSIONS, () => setIsOptInModalOpen(true), {
+    enabled: !isChatLoading,
+  })
+
+  useShortcut(SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE, toggleMaximise, {
     enabled: !isChatLoading,
   })
 
@@ -126,6 +141,21 @@ export const AIAssistantHeader = ({
                 size="tiny"
                 icon={<MessageCirclePlus />}
                 onClick={onNewChat}
+                className="h-7 w-7 p-0"
+              />
+            </ShortcutTooltip>
+
+            <ShortcutTooltip
+              side="bottom"
+              label={isMaximised ? 'Minimize' : 'Maximize'}
+              shortcutId={SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE}
+            >
+              <Button
+                variant="text"
+                aria-label={isMaximised ? 'Minimize' : 'Maximize'}
+                size="tiny"
+                icon={isMaximised ? <Minimize /> : <Maximize />}
+                onClick={toggleMaximise}
                 className="h-7 w-7 p-0"
               />
             </ShortcutTooltip>

--- a/apps/studio/state/shortcuts/registry.ts
+++ b/apps/studio/state/shortcuts/registry.ts
@@ -71,6 +71,7 @@ export const SHORTCUT_IDS = {
   COMMAND_MENU_OPEN: 'command-menu.open',
   AI_ASSISTANT_TOGGLE: 'ai-assistant.toggle',
   AI_ASSISTANT_NEW_CHAT: 'ai-assistant.new-chat',
+  AI_ASSISTANT_MAXIMIZE: 'ai-assistant.maximize',
   AI_ASSISTANT_COPY_CHAT_ID: 'ai-assistant.copy-chat-id',
   AI_ASSISTANT_TOGGLE_HISTORY: 'ai-assistant.toggle-history',
   AI_ASSISTANT_OPEN_PERMISSIONS: 'ai-assistant.open-permissions',
@@ -261,6 +262,12 @@ export const SHORTCUT_DEFINITIONS: Record<ShortcutId, ShortcutDefinition> = {
     id: SHORTCUT_IDS.AI_ASSISTANT_NEW_CHAT,
     label: 'Start new chat',
     sequence: ['A', 'N'],
+    showInSettings: false,
+  },
+  [SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE]: {
+    id: SHORTCUT_IDS.AI_ASSISTANT_MAXIMIZE,
+    label: 'Maximize assistant',
+    sequence: ['A', '='],
     showInSettings: false,
   },
   [SHORTCUT_IDS.AI_ASSISTANT_COPY_CHAT_ID]: {

--- a/apps/studio/state/sidebar-manager-state.tsx
+++ b/apps/studio/state/sidebar-manager-state.tsx
@@ -119,10 +119,11 @@ const createSidebarManagerState = () => {
         return
       }
 
+      if (id !== 'ai-assistant' && state.isMaximised) {
+        state.toggleMaximise()
+      }
+
       if (state.activeSidebar && state.activeSidebar.id !== id) {
-        if (id !== 'ai-assistant' && state.isMaximised) {
-          state.toggleMaximise()
-        }
         const previousPanel = state.activeSidebar
         previousPanel?.onClose?.()
       }

--- a/apps/studio/state/sidebar-manager-state.tsx
+++ b/apps/studio/state/sidebar-manager-state.tsx
@@ -120,6 +120,9 @@ const createSidebarManagerState = () => {
       }
 
       if (state.activeSidebar && state.activeSidebar.id !== id) {
+        if (id !== 'ai-assistant' && state.isMaximised) {
+          state.toggleMaximise()
+        }
         const previousPanel = state.activeSidebar
         previousPanel?.onClose?.()
       }

--- a/apps/studio/state/sidebar-manager-state.tsx
+++ b/apps/studio/state/sidebar-manager-state.tsx
@@ -17,6 +17,7 @@ type SidebarManagerData = {
   sidebars: Partial<Record<string, ManagedSidebar>>
   activeSidebar: ManagedSidebar | undefined
   pendingSidebarOpen: string | undefined
+  isMaximised: boolean
 }
 
 type SidebarManagerState = SidebarManagerData & {
@@ -32,12 +33,14 @@ type SidebarManagerState = SidebarManagerData & {
   isSidebarOpen: (id: string) => boolean
   closeActive: () => void
   clearActiveSidebar: () => void
+  toggleMaximise: () => void
 }
 
 const INITIAL_SIDEBAR_MANAGER_DATA: SidebarManagerData = {
   sidebars: {},
   activeSidebar: undefined,
   pendingSidebarOpen: undefined,
+  isMaximised: false,
 }
 
 const createSidebarManagerState = () => {
@@ -148,6 +151,10 @@ const createSidebarManagerState = () => {
 
     clearActiveSidebar() {
       state.activeSidebar = undefined
+    },
+
+    toggleMaximise() {
+      state.isMaximised = !state.isMaximised
     },
   })
 


### PR DESCRIPTION
## Context

Supports maximising the AI assistant to fit the content width which will provide a larger workspace for observability work for example

<img width="424" height="179" alt="image" src="https://github.com/user-attachments/assets/f2b84571-0188-4d94-9798-a289496ab543" />

<img width="1388" height="960" alt="image" src="https://github.com/user-attachments/assets/07f52b1f-7b95-4d67-9a5c-151ef036fc7c" />


## To test
- [ ] Can maximize/minimize AI Assistant
- [ ] Swapping to another sidebar should bring the panel size back to previous
  - Only the AI Assistant can be maximized (for now at least)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added maximize/minimize controls for the AI assistant panel.
  * Added a keyboard shortcut to quickly maximize the assistant (hidden from settings).

* **Improvements**
  * The main content panel now collapses/resizes automatically based on assistant maximization.
  * Switching away from the AI assistant now automatically exits maximized mode; returning restores the maximized experience.
  * Updated the assistant header UI with dynamic label/icon/accessibility and a maximize shortcut when chat isn’t loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->