### PR TITLE
fix(billing): exit survey does not fire after downgrade via cancellation button

### DIFF
--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
@@ -34,6 +34,9 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
   const [message, setMessage] = useState('')
   const [selectedReason, setSelectedReason] = useState<string[]>([])
 
+  const { mutateAsync: sendExitSurvey, isPending: isSubmittingFeedback } =
+    useSendDowngradeFeedbackMutation()
+
   const subscriptionUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
   const { mutate: updateOrgSubscription, isPending: isUpdating } = useOrgSubscriptionUpdateMutation(
     {
@@ -43,10 +46,30 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
           dismissible: true,
         })
       },
+      onSuccess: async () => {
+        toast.success(
+          hasProjectsWithComputeDowngrade
+            ? 'Successfully downgraded organization to the Free Plan. Your projects are currently restarting to update their compute instances.'
+            : 'Successfully downgraded organization to the Free Plan',
+          { duration: hasProjectsWithComputeDowngrade ? 8000 : 4000 }
+        )
+
+        if (slug) {
+          sendExitSurvey({
+            orgSlug: slug,
+            reasons: selectedReason.reduce((a, b) => `${a}- ${b}\n`, ''),
+            message,
+            exitAction: 'downgrade',
+          }).catch(() => {
+            // [Joshen] In this case we don't raise any errors if the exit survey fails to send since it shouldn't block the user
+          })
+        }
+
+        onClose(true)
+        window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
+      },
     }
   )
-  const { mutateAsync: sendExitSurvey, isPending: isSubmittingFeedback } =
-    useSendDowngradeFeedbackMutation()
   const isSubmitting = isUpdating || isSubmittingFeedback
 
   const projectsWithComputeDowngrade = projects.filter((project) => {
@@ -86,32 +109,7 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
     // If compute instance is present within the existing subscription, then a restart will be triggered
     if (!slug) return console.error('Slug is required')
 
-    updateOrgSubscription(
-      { slug, tier: 'tier_free' },
-      {
-        onSuccess: async () => {
-          try {
-            await sendExitSurvey({
-              orgSlug: slug,
-              reasons: selectedReason.reduce((a, b) => `${a}- ${b}\n`, ''),
-              message,
-              exitAction: 'downgrade',
-            })
-          } catch (error) {
-            // [Joshen] In this case we don't raise any errors if the exit survey fails to send since it shouldn't block the user
-          } finally {
-            toast.success(
-              hasProjectsWithComputeDowngrade
-                ? 'Successfully downgraded organization to the Free Plan. Your projects are currently restarting to update their compute instances.'
-                : 'Successfully downgraded organization to the Free Plan',
-              { duration: hasProjectsWithComputeDowngrade ? 8000 : 4000 }
-            )
-            onClose(true)
-            window.scrollTo({ top: 0, left: 0, behavior: 'smooth' })
-          }
-        },
-      }
-    )
+    await updateOrgSubscription({ slug, tier: 'tier_free' })
   }
 
   return (

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
@@ -36,9 +36,8 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
 
   const { mutateAsync: sendExitSurvey, isPending: isSubmittingFeedback } =
     useSendDowngradeFeedbackMutation({
-      onError: () => {
-        // the user should not get a toast saying "submitting survey failed"
-      },
+      // the user should not get a toast saying "submitting survey failed"
+      onError: () => {},
     })
 
   const subscriptionUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
@@ -64,9 +63,7 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
             reasons: selectedReason.reduce((a, b) => `${a}- ${b}\n`, ''),
             message,
             exitAction: 'downgrade',
-          }).catch(() => {
-            // [Joshen] In this case we don't raise any errors if the exit survey fails to send since it shouldn't block the user
-          })
+          }).catch(() => {})
         }
 
         onClose(true)
@@ -112,8 +109,7 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
     // Update the subscription first, followed by posting the exit survey if successful
     // If compute instance is present within the existing subscription, then a restart will be triggered
     if (!slug) return console.error('Slug is required')
-
-    await updateOrgSubscription({ slug, tier: 'tier_free' })
+    updateOrgSubscription({ slug, tier: 'tier_free' })
   }
 
   return (

--- a/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/Subscription/ExitSurveyModal.tsx
@@ -35,7 +35,11 @@ export const ExitSurveyModal = ({ visible, projects, onClose }: ExitSurveyModalP
   const [selectedReason, setSelectedReason] = useState<string[]>([])
 
   const { mutateAsync: sendExitSurvey, isPending: isSubmittingFeedback } =
-    useSendDowngradeFeedbackMutation()
+    useSendDowngradeFeedbackMutation({
+      onError: () => {
+        // the user should not get a toast saying "submitting survey failed"
+      },
+    })
 
   const subscriptionUpdateDisabled = useFlag('disableProjectCreationAndUpdate')
   const { mutate: updateOrgSubscription, isPending: isUpdating } = useOrgSubscriptionUpdateMutation(


### PR DESCRIPTION
When the `ExitSurveyModal` unmounts, the `onSuccess` callback in `updateOrgSubscription({..}, { onSuccess })` is dropped.

It unmounts not because of the `onClose()` in the callback, but because `updateOrgSubscription` invalidates query keys.

Moving the callback to `useOrgSubscriptionUpdateMutation(.., { onSuccess })` fixes that issue.

Two more small things: 

- we're no longer waiting for the survey request to complete before we close the modal
- the user no longer gets a toast when the survey fails (they don't care about that)

### Testing

Tested these locally e2e. To simulate errors, I updated the handlers in the `mgmt-api`.

- [x] Upgrades are possible
- [x] We send the survey on Downgrade via the old Panel Flow
- [x] We send the survey on Downgrade via the new Button flow
- [x] We do not send the survey if the downgrade fails (both flows)
- [x] The user is not affected when the survey fails

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the subscription downgrade experience by displaying a success message and closing the dialog immediately after completion.
  - Exit survey submission now runs in the background, so it won’t delay or interfere with the downgrade flow.
  - Downgrades continue to complete successfully even if exit survey submission fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->