### PR TITLE
test(studio): cover Supabase API key formats in project client tests

### DIFF
--- a/apps/studio/lib/project-supabase-client.contract.test.ts
+++ b/apps/studio/lib/project-supabase-client.contract.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { createProjectSupabaseClient } from './project-supabase-client'
+import * as apiKeysUtils from '@/data/api-keys/temp-api-keys-utils'
+
+// Unlike project-supabase-client.test.ts, this file does not mock
+// @supabase/supabase-js: the real client constructor must run.
+vi.mock('@/data/api-keys/temp-api-keys-utils', () => ({
+  getOrRefreshTemporaryApiKey: vi.fn(),
+}))
+
+// Supabase API key formats this client must accept.
+const KEY_SHAPES = [
+  ['temporary key', 'sb_temp_nonce1234567890ab_payload'],
+  ['publishable key', 'sb_publishable_abc123'],
+  ['secret key', 'sb_secret_abc123'],
+  ['legacy JWT key', 'eyJhbGciOiJIUzI1NiJ9.payload.signature'],
+]
+
+describe('createProjectSupabaseClient key format contract', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it.each(KEY_SHAPES)('constructs a client with a %s', async (_label, apiKey) => {
+    vi.mocked(apiKeysUtils.getOrRefreshTemporaryApiKey).mockResolvedValue({
+      apiKey,
+      expiryTimeMs: Date.now() + 3600000,
+    })
+
+    const client = await createProjectSupabaseClient('test-ref', 'https://test.supabase.co')
+
+    expect(client).toBeDefined()
+    expect(client.auth).toBeDefined()
+  })
+})

--- a/apps/studio/lib/project-supabase-client.test.ts
+++ b/apps/studio/lib/project-supabase-client.test.ts
@@ -19,7 +19,7 @@ describe('project-supabase-client', () => {
 
   describe('createProjectSupabaseClient', () => {
     it('should create a Supabase client with temporary API key', async () => {
-      const mockApiKey = 'test-api-key-123'
+      const mockApiKey = 'sb_temp_nonce1234567890ab_payload1'
       const mockClient = { from: vi.fn() }
       const projectRef = 'test-project-ref'
       const clientEndpoint = 'https://test.supabase.co'
@@ -49,7 +49,7 @@ describe('project-supabase-client', () => {
     })
 
     it('should configure storage to not persist session', async () => {
-      const mockApiKey = 'test-api-key-456'
+      const mockApiKey = 'sb_temp_nonce1234567890ab_payload2'
       const mockClient = { from: vi.fn() }
 
       vi.mocked(apiKeysUtils.getOrRefreshTemporaryApiKey).mockResolvedValue({
@@ -82,7 +82,7 @@ describe('project-supabase-client', () => {
     })
 
     it('should pass through different project refs and endpoints', async () => {
-      const mockApiKey = 'api-key'
+      const mockApiKey = 'sb_temp_nonce1234567890ab_payload3'
       const mockClient = { from: vi.fn() }
 
       vi.mocked(apiKeysUtils.getOrRefreshTemporaryApiKey).mockResolvedValue({
@@ -102,7 +102,7 @@ describe('project-supabase-client', () => {
     })
 
     it('should disable session persistence options', async () => {
-      const mockApiKey = 'api-key'
+      const mockApiKey = 'sb_temp_nonce1234567890ab_payload4'
       const mockClient = { from: vi.fn() }
 
       vi.mocked(apiKeysUtils.getOrRefreshTemporaryApiKey).mockResolvedValue({


### PR DESCRIPTION
Adds a contract test that runs `createProjectSupabaseClient()` against the real `@supabase/supabase-js` for each Supabase API key format (temporary, publishable, secret, legacy JWT), asserting that client construction succeeds. Also replaces the placeholder key fixtures in the existing unit tests with realistically shaped ones. Previously the tests mocked the SDK entirely and used keys that don't resemble real formats, so an SDK version that rejects a valid key at construction (as `@supabase/supabase-js` 2.110.4 and 2.110.5 did, reverted in #47945 and fixed in supabase/supabase-js#2526) passed CI unnoticed; with this test, such a regression fails on the dependency bump PR itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming project clients work with temporary, publishable, secret, and legacy API key formats.
  * Updated test scenarios to use realistic temporary API key values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->