### PR TITLE
docs: add plugins package quick install for AI coding agent plugin

### DIFF
--- a/apps/docs/content/guides/ai-tools/plugins.mdx
+++ b/apps/docs/content/guides/ai-tools/plugins.mdx
@@ -30,6 +30,8 @@ The [`plugins`](https://www.npmjs.com/package/plugins) package installs the Supa
 npx plugins add supabase-community/supabase-plugin
 ```
 
+Add the `--yes` flag to install the Supabase plugin without the confirmation prompt/UI.
+
 ### Manual install
 
 Alternatively, choose your AI coding agent and follow the installation steps:

--- a/apps/docs/content/guides/ai-tools/plugins.mdx
+++ b/apps/docs/content/guides/ai-tools/plugins.mdx
@@ -22,7 +22,17 @@ Bundling the [MCP server](/docs/guides/getting-started/mcp) and [agent skills](/
 
 ## Installation
 
-Choose your AI coding agent and follow the installation steps:
+### Quick install
+
+The [`plugins`](https://www.npmjs.com/package/plugins) package installs the Supabase plugin into any supported AI coding agent with a single command. It auto-detects which agent tools you have installed and installs the plugin to all of them.
+
+```bash
+npx plugins add supabase-community/supabase-plugin
+```
+
+### Manual install
+
+Alternatively, choose your AI coding agent and follow the installation steps:
 
 <AgentPluginsPanel />
 


### PR DESCRIPTION
## Summary
- Adds the Vercel [`plugins`](https://www.npmjs.com/package/plugins) npm package as the default, single-command install option (`npx plugins add supabase-community/supabase-plugin`) on the Supabase AI coding agent plugin docs page.
- Keeps the existing per-agent manual installation instructions available below, as an alternative.

Closes AI-929.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a quick-install option for the plugin using a single command.
  * Documented the `--yes` flag for skipping the confirmation prompt.
  * Updated the manual installation guidance to follow the new quick-install instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->