### PR TITLE
feat(studio): identify unified logs analytics queries

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -351,7 +351,7 @@ const applySearchParamsFilter = (search: QuerySearchParamsType): SafeLogSqlFragm
  */
 export const getUnifiedLogsQuery = (search: QuerySearchParamsType): SafeLogSqlFragment => {
   const conditions = buildBaseWhere(search)
-  return safeSql`
+  return safeSql`-- unified logs: row list
 SELECT ${rowProjection()}
 FROM logs
 ${whereClause(conditions)}
@@ -397,7 +397,7 @@ export const getFacetCountQuery = ({
     conditions.push(safeSql`(${facetExpr}) LIKE ${lit('%' + facetSearch + '%')}`)
   }
 
-  return safeSql`
+  return safeSql`-- unified logs: single-facet counts (${lit(facet)})
 SELECT ${lit(facet)} AS facet, (${facetExpr}) AS value, count() AS count
 FROM logs
 ${whereClause(conditions)}
@@ -466,7 +466,8 @@ HAVING value != ''
   // rejects LIMIT BY inside the shared arrayJoin).
   blocks.push(safeSql`(${getFacetCountQuery({ search, facet: 'pathname' })})`)
 
-  return joinSqlFragments(blocks, ' UNION ALL ')
+  return safeSql`-- unified logs: sidebar facet counts
+${joinSqlFragments(blocks, ' UNION ALL ')}`
 }
 
 /**
@@ -477,7 +478,7 @@ export const getLogsChartQuery = (search: QuerySearchParamsType): SafeLogSqlFrag
   const truncFn = truncationFunction(truncationLevel)
   const conditions = buildBaseWhere(search)
 
-  return safeSql`
+  return safeSql`-- unified logs: severity chart (${truncFn} buckets)
 SELECT
   ${truncFn}(timestamp) AS time_bucket,
   countIf((${LEVEL_EXPR}) = 'success') AS success,

--- a/apps/studio/data/logs/unified-log-inspection-query.ts
+++ b/apps/studio/data/logs/unified-log-inspection-query.ts
@@ -186,7 +186,7 @@ export async function getUnifiedLogInspection(
   if (!/^[0-9a-fA-F-]{1,64}$/.test(logId)) {
     throw new Error('Invalid logId')
   }
-  const sql = safeSql`
+  const sql = safeSql`-- unified logs: inspect single log by id
 SELECT id, timestamp, source, event_message, severity_text, log_attributes
 FROM logs
 WHERE id = ${lit(logId)}
@@ -216,7 +216,7 @@ LIMIT 1
   if (row.source === 'function_edge_logs') {
     const executionId = row.log_attributes?.['execution_id'] ?? row.log_attributes?.['request_id']
     if (typeof executionId === 'string' && /^[0-9a-fA-F-]{1,64}$/.test(executionId)) {
-      const fnSql = safeSql`
+      const fnSql = safeSql`-- unified logs: edge function console logs for execution
 SELECT id, timestamp, source, event_message, severity_text, log_attributes
 FROM logs
 WHERE source = 'function_logs' AND log_attributes['execution_id'] = ${lit(executionId)}


### PR DESCRIPTION
## What

Unified Logs fires several `logs.all.otel` requests on load (row list, chart, sidebar facet counts, single-facet counts) plus inspection queries, all with no identifier — indistinguishable in the network tab.

Adds a leading `-- unified logs: <what>` SQL comment to each query builder so each request is identifiable at a glance:

- row list
- severity chart (with bucket function)
- sidebar facet counts
- single-facet counts (with facet name)
- inspect single log by id
- edge function console logs for execution

## Notes

`--` comments run to end of line; queries are sent multi-line, so the comment doesn't swallow the SQL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Diagnostics**
  * Added descriptive labels to generated log queries, making SQL statements easier to identify in logs and diagnostics.
  * Added labels for unified log listings, facet counts, sidebar counts, severity charts, individual log inspections, and related console logs.
* **Bug Fixes**
  * No changes to filtering, grouping, query results, or log retrieval behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->