### PR TITLE
fix: allow newlines in SMS OTP template for WebOTP API compliance

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -181,7 +181,12 @@ const getSmsOtpPhoneProviderSchema = (optional = false) =>
         .number({ required_error: 'This is required', invalid_type_error: 'This is required' })
         .min(6, 'Must be 6 or larger')
     ),
-    SMS_TEMPLATE: optional ? z.string() : z.string().min(1, 'SMS Template is required'),
+    SMS_TEMPLATE: optional
+      ? z.string().transform((val) => val.replace(/\\n/g, '\n'))
+      : z
+          .string()
+          .min(1, 'SMS Template is required')
+          .transform((val) => val.replace(/\\n/g, '\n')),
   })
 
 const getTwilioPhoneProviderSchema = (optional = false) =>
@@ -563,7 +568,8 @@ export const PROVIDER_PHONE = {
     SMS_TEMPLATE: {
       title: 'SMS Message',
       type: 'multiline-string',
-      description: 'To format the OTP code use `{{ .Code }}`',
+      description:
+        'To format the OTP code use `{{ .Code }}`. Use `\\n` for newlines (required for WebOTP API compliance).',
       show: {
         key: 'SMS_PROVIDER',
         matches: ['twilio', 'messagebird', 'textlocal', 'vonage'],

--- a/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/schemas/auth.ts
+++ b/apps/ui-library/registry/default/platform/platform-kit-nextjs/lib/schemas/auth.ts
@@ -205,7 +205,13 @@ export const authPhoneProviderSchema = z
       .optional()
       .describe('Duration before an SMS OTP expires in seconds.'),
     sms_otp_length: z.number().int().optional().describe('Number of digits in OTP.'),
-    sms_template: z.string().optional().describe('To format the OTP code use `{{ .Code }}`'),
+    sms_template: z
+      .string()
+      .optional()
+      .transform((val) => (val ? val.replace(/\\n/g, '\n') : val))
+      .describe(
+        'To format the OTP code use `{{ .Code }}`. Use `\\n` for newlines (required for WebOTP API compliance).'
+      ),
     sms_test_otp: z
       .string()
       .optional()


### PR DESCRIPTION
- Add transform to convert \n to actual newlines in SMS_TEMPLATE validation
- Update SMS_TEMPLATE description to mention WebOTP API compliance
- Fixes #6435

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES
## What kind of change does this PR introduce?
Bug fix / Feature enhancement

## What is the current behavior?
The SMS OTP template does not allow newlines, which prevents developers
from using the WebOTP API for automatic SMS OTP handling on mobile devices.

## What is the new behavior?
This PR adds a transform that converts literal `\n` characters in the SMS
template to actual newlines. This allows developers to create SMS templates
that conform to the WebOTP API format requirement.

**Example:**
- Before: `Your code is {{ .Code }}` (no newlines possible)
- After: `Your code is\n{{ .Code }}\nhttps://example.com` (renders with actual newlines)

## Additional context
- Fixes #6435
- The WebOTP API requires at least one newline in the SMS for automatic code detection
- Updated the SMS_TEMPLATE description to document the `\n` escape sequence for newlines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SMS authentication templates now correctly handle escaped newline characters for improved WebOTP API compatibility.
  * Updated template guidance to document newline formatting and the `{{ .Code }}` placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->