### PR TITLE
fix(studio): soften unified logs success grey

### DIFF
--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -147,7 +147,7 @@
   --chart-warning: hsl(var(--warning-500));
   --chart-warning-muted: hsl(var(--warning-400));
   --chart-destructive: hsl(var(--destructive-default));
-  --chart-success: color-mix(in oklch, var(--foreground-muted) 65%, white);
+  --chart-success: color-mix(in oklch, var(--foreground-muted) 50%, white);
   --sidebar-background: var(--background-dash-sidebar);
   --sidebar-foreground: var(--foreground-default);
   --sidebar-primary: var(--foreground-default);
@@ -170,7 +170,7 @@
   --chart-warning: hsl(var(--warning-default));
   --chart-warning-muted: hsl(var(--warning-500));
   --chart-destructive: hsl(var(--destructive-default));
-  --chart-success: color-mix(in oklch, var(--foreground-muted) 65%, white);
+  --chart-success: color-mix(in oklch, var(--foreground-muted) 55%, var(--background));
   --sidebar-background: var(--background-dash-sidebar);
   --sidebar-foreground: var(--foreground-default);
   --sidebar-primary: var(--foreground-default);


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

UI polish

## What is the current behavior?

`--chart-success` mixes `foreground-muted` with white in both themes. That softens light mode, but brightens dark mode so OK/success segments (and the Level key/dots) read too stark.

## What is the new behavior?

- Light: a bit softer (`50%` muted + white)
- Dark: mixes toward `--background` instead of white so the fill is clearly softer

| Before | After |
| --- | --- |
| <img width="1728" height="997" alt="Unified Logs  Agua  Basket  Supabase" src="https://github.com/user-attachments/assets/c9927079-34f7-41c3-99ff-7ad7b701ac20" /> | <img width="1728" height="997" alt="Unified Logs  Agua  Basket  Supabase" src="https://github.com/user-attachments/assets/e35e6c62-63bd-4974-aa36-4686e7b9f9e2" /> |
| <img width="1728" height="997" alt="Unified Logs  Agua  Basket  Supabase" src="https://github.com/user-attachments/assets/7c4bd3c4-739d-4fd4-bf65-b954d1df3270" /> | <img width="1728" height="997" alt="Unified Logs  Agua  Basket  Supabase" src="https://github.com/user-attachments/assets/6b59d4f0-32f8-4cb7-b0be-6036589a364a" /> |

Covers the unified logs chart, Level sidebar key, and row dots via the shared token.

## Additional context

Follow-up to #47829.