### PR TITLE
Apply max width for ai assistant panel when maximized

### DIFF
--- a/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.tsx
@@ -21,7 +21,7 @@ interface SupportAssistantSuccessCardProps {
 
 const SupportAssistantSuccessCardContent = dynamic<SupportAssistantSuccessCardProps>(
   () =>
-    import('@/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent').then(
+    import('@/components/ui/AIAssistantPanel/AIAssistant').then(
       (mod) => mod.SupportAssistantSuccessCardContent
     ),
   {

--- a/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAssistantSuccessCard.tsx
@@ -21,7 +21,7 @@ interface SupportAssistantSuccessCardProps {
 
 const SupportAssistantSuccessCardContent = dynamic<SupportAssistantSuccessCardProps>(
   () =>
-    import('@/components/ui/AIAssistantPanel/AIAssistant').then(
+    import('@/components/ui/AIAssistantPanel/SupportAssistantSuccessCardContent').then(
       (mod) => mod.SupportAssistantSuccessCardContent
     ),
   {

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -433,7 +433,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
         />
         {hasMessages ? (
           <Conversation className={cn('flex-1')}>
-            <ConversationContent className="w-full px-7 py-8 mb-10">
+            <ConversationContent className="w-full px-7 py-8 mb-10 max-w-3xl mx-auto">
               {renderedMessages}
               {error && (
                 <>
@@ -555,9 +555,9 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           )}
         </AnimatePresence>
 
-        <div className="px-3 pb-3 z-20 relative">
+        <div className="px-3 pb-3 z-20 relative w-full max-w-3xl mx-auto flex flex-col gap-y-3">
           {isSupportChat && !isSupportChatClosed && (
-            <div className="mb-3">
+            <div>
               <div className="mb-3 border-t" />
               <div className="flex items-center gap-2">
                 <Button
@@ -583,6 +583,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
               </div>
             </div>
           )}
+
           {disablePrompts && (
             <Admonition
               showIcon={false}
@@ -609,7 +610,10 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           <AssistantChatForm
             textAreaRef={inputRef}
             className={cn(
-              'z-20 [&>form>textarea]:text-base [&>form>textarea]:md:text-sm [&>form>textarea]:border [&>form>textarea]:rounded-md [&>form>textarea]:outline-hidden! [&>form>textarea]:ring-offset-0! [&>form>textarea]:ring-0!'
+              'z-20',
+              '[&>form>textarea]:text-base [&>form>textarea]:md:text-sm [&>form>textarea]:border',
+              '[&>form>textarea]:rounded-md [&>form>textarea]:outline-hidden!',
+              '[&>form>textarea]:ring-offset-0! [&>form>textarea]:ring-0!'
             )}
             loading={isChatLoading}
             isEditing={!!editingMessageId}

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -433,7 +433,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
         />
         {hasMessages ? (
           <Conversation className={cn('flex-1')}>
-            <ConversationContent className="w-full px-7 py-8 mb-10 max-w-3xl mx-auto">
+            <ConversationContent className="w-full px-7 py-8 mb-10">
               {renderedMessages}
               {error && (
                 <>
@@ -555,9 +555,9 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           )}
         </AnimatePresence>
 
-        <div className="px-3 pb-3 z-20 relative w-full max-w-3xl mx-auto flex flex-col gap-y-3">
+        <div className="px-3 pb-3 z-20 relative">
           {isSupportChat && !isSupportChatClosed && (
-            <div>
+            <div className="mb-3">
               <div className="mb-3 border-t" />
               <div className="flex items-center gap-2">
                 <Button
@@ -583,7 +583,6 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
               </div>
             </div>
           )}
-
           {disablePrompts && (
             <Admonition
               showIcon={false}
@@ -610,10 +609,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           <AssistantChatForm
             textAreaRef={inputRef}
             className={cn(
-              'z-20',
-              '[&>form>textarea]:text-base [&>form>textarea]:md:text-sm [&>form>textarea]:border',
-              '[&>form>textarea]:rounded-md [&>form>textarea]:outline-hidden!',
-              '[&>form>textarea]:ring-offset-0! [&>form>textarea]:ring-0!'
+              'z-20 [&>form>textarea]:text-base [&>form>textarea]:md:text-sm [&>form>textarea]:border [&>form>textarea]:rounded-md [&>form>textarea]:outline-hidden! [&>form>textarea]:ring-offset-0! [&>form>textarea]:ring-0!'
             )}
             loading={isChatLoading}
             isEditing={!!editingMessageId}
@@ -657,3 +653,5 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     </ErrorBoundary>
   )
 }
+
+export { SupportAssistantSuccessCardContent } from './SupportAssistantSuccessCardContent'

--- a/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIAssistant.tsx
@@ -433,7 +433,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
         />
         {hasMessages ? (
           <Conversation className={cn('flex-1')}>
-            <ConversationContent className="w-full px-7 py-8 mb-10">
+            <ConversationContent className="w-full px-7 py-8 mb-10 max-w-3xl mx-auto">
               {renderedMessages}
               {error && (
                 <>
@@ -555,9 +555,9 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           )}
         </AnimatePresence>
 
-        <div className="px-3 pb-3 z-20 relative">
+        <div className="px-3 pb-3 z-20 relative w-full max-w-3xl mx-auto flex flex-col gap-y-3">
           {isSupportChat && !isSupportChatClosed && (
-            <div className="mb-3">
+            <div>
               <div className="mb-3 border-t" />
               <div className="flex items-center gap-2">
                 <Button
@@ -583,6 +583,7 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
               </div>
             </div>
           )}
+
           {disablePrompts && (
             <Admonition
               showIcon={false}
@@ -609,7 +610,10 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
           <AssistantChatForm
             textAreaRef={inputRef}
             className={cn(
-              'z-20 [&>form>textarea]:text-base [&>form>textarea]:md:text-sm [&>form>textarea]:border [&>form>textarea]:rounded-md [&>form>textarea]:outline-hidden! [&>form>textarea]:ring-offset-0! [&>form>textarea]:ring-0!'
+              'z-20',
+              '[&>form>textarea]:text-base [&>form>textarea]:md:text-sm [&>form>textarea]:border',
+              '[&>form>textarea]:rounded-md [&>form>textarea]:outline-hidden!',
+              '[&>form>textarea]:ring-offset-0! [&>form>textarea]:ring-0!'
             )}
             loading={isChatLoading}
             isEditing={!!editingMessageId}
@@ -653,5 +657,3 @@ export const AIAssistant = ({ className }: AIAssistantProps) => {
     </ErrorBoundary>
   )
 }
-
-export { SupportAssistantSuccessCardContent } from './SupportAssistantSuccessCardContent'

--- a/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
+++ b/apps/studio/components/ui/AIAssistantPanel/AIOnboarding.tsx
@@ -44,7 +44,7 @@ export const AIOnboarding = ({
   const performanceErrorLints = errorLints.filter((lint) => lint.categories?.[0] !== 'SECURITY')
 
   return (
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1 overflow-y-auto max-w-3xl mx-auto w-full">
       <div className="w-full flex-1 max-h-full min-h-full px-4 flex flex-col gap-0">
         <div className="mt-auto w-full space-y-6 py-8 ">
           <motion.h2


### PR DESCRIPTION
## Context

Applies a max width for the AI Assistant content area while maximised to improve reading UX
<img width="1390" height="958" alt="image" src="https://github.com/user-attachments/assets/296c394d-6bcf-4b0f-b147-ca0253dfa724" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved AI Assistant conversation layout by centering content and limiting its maximum width for easier reading.
  * Updated support-chat spacing and alignment for a more consistent visual flow.
  * Refined onboarding content sizing and positioning to improve readability across screen sizes.
  * Preserved existing chat input behavior while simplifying its styling configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->