### PR TITLE
feat: add admin studio link

### DIFF
--- a/apps/studio/components/layouts/Navigation/LayoutHeader/AdminStudioButton.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/AdminStudioButton.tsx
@@ -1,0 +1,37 @@
+import { useFlag, useParams } from 'common'
+import { Wrench } from 'lucide-react'
+import Link from 'next/link'
+
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { ADMIN_STUDIO_URL, IS_PLATFORM } from '@/lib/constants'
+
+export const AdminStudioButton = () => {
+  const params = useParams()
+  const adminStudioLinkEnabled = useFlag('adminStudioLink')
+
+  const isVisible = IS_PLATFORM ? adminStudioLinkEnabled : false
+
+  if (!isVisible || !ADMIN_STUDIO_URL || !params.ref) return null
+
+  return (
+    <ButtonTooltip
+      asChild
+      variant="default"
+      className="rounded-full w-[26px] h-[26px]"
+      icon={<Wrench size={16} strokeWidth={1.5} />}
+      tooltip={{
+        content: {
+          text: 'Open in Admin Studio',
+          side: 'bottom',
+          align: 'center',
+        },
+      }}
+    >
+      <Link
+        href={`${ADMIN_STUDIO_URL}?identifier=${params.ref}`}
+        target="_blank"
+        rel="noreferrer noopener"
+      />
+    </ButtonTooltip>
+  )
+}

--- a/apps/studio/components/layouts/Navigation/LayoutHeader/LayoutHeader.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/LayoutHeader.tsx
@@ -8,6 +8,7 @@ import { ReactNode, useMemo } from 'react'
 import { Badge, cn } from 'ui'
 import { CommandMenuTriggerInput } from 'ui-patterns/CommandMenu'
 
+import { AdminStudioButton } from './AdminStudioButton'
 import { BreadcrumbsView } from './BreadcrumbsView'
 import { FeedbackDropdown } from './FeedbackDropdown/FeedbackDropdown'
 import { HomeIcon } from './HomeIcon'
@@ -216,6 +217,7 @@ export const LayoutHeader = ({
                   }}
                 >
                   {IS_PLATFORM && <MergeRequestButton />}
+                  <AdminStudioButton />
                   <ConnectButton buttonVariant={connectButtonVariant} />
                 </motion.div>
               )}

--- a/apps/studio/lib/constants/index.ts
+++ b/apps/studio/lib/constants/index.ts
@@ -26,6 +26,12 @@ export const IS_STAGING_OR_LOCAL =
   process.env.NEXT_PUBLIC_ENVIRONMENT === 'staging' ||
   process.env.NEXT_PUBLIC_ENVIRONMENT === 'local'
 
+/**
+ * Base URL for the internal Admin Studio tool (kept out of source since this
+ * repo is public).
+ */
+export const ADMIN_STUDIO_URL = process.env.NEXT_PUBLIC_ADMIN_STUDIO_URL
+
 export const API_URL = (() => {
   if (process.env.NODE_ENV === 'test') return 'http://localhost:3000/api'
   //  If running in platform, use API_URL from the env var


### PR DESCRIPTION
Add link to Admin Studio in top bar for internal use only.

Resolves FE-3864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a conditional Admin Studio shortcut to the desktop project header.
  * The shortcut opens the relevant project in Admin Studio and is available only when configured and enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->