### PR TITLE
fix(studio): make unified logs sidebar banner dismissible

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogsBanner.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogsBanner.tsx
@@ -27,6 +27,8 @@ export function UnifiedLogsBanner({ className = 'mx-4 mt-4' }: UnifiedLogsBanner
   )
 
   if (!IS_PLATFORM) return null
+
+  // Keep the "Go back" banner visible even after dismissal so manually opted-in users can switch back
   if (isDismissed && !(isEnabled && !isDefaultOptIn)) return null
 
   const cardClassName = cn(
@@ -71,7 +73,6 @@ export function UnifiedLogsBanner({ className = 'mx-4 mt-4' }: UnifiedLogsBanner
         <Button
           variant="text"
           size="tiny"
-          type="button"
           icon={<X size={14} strokeWidth={1.5} />}
           onClick={() => setIsDismissed(true)}
           className="opacity-75 hover:opacity-100 -mt-1 -mr-1 px-1"

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogsBanner.tsx
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogsBanner.tsx
@@ -1,5 +1,5 @@
-import { useParams } from 'common'
-import { CircleHelpIcon, Undo2 } from 'lucide-react'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
+import { CircleHelpIcon, Undo2, X } from 'lucide-react'
 import { useRouter } from 'next/router'
 import { Badge, Button, cn } from 'ui'
 
@@ -8,6 +8,7 @@ import {
   useUnifiedLogsPreview,
 } from '../App/FeaturePreview/FeaturePreviewContext'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { IS_PLATFORM } from '@/lib/constants'
 
 interface UnifiedLogsBannerProps {
@@ -20,8 +21,13 @@ export function UnifiedLogsBanner({ className = 'mx-4 mt-4' }: UnifiedLogsBanner
 
   const { selectFeaturePreview } = useFeaturePreviewModal()
   const { enable, disable, isDefaultOptIn, isEnabled } = useUnifiedLogsPreview()
+  const [isDismissed, setIsDismissed] = useLocalStorageQuery(
+    LOCAL_STORAGE_KEYS.UNIFIED_LOGS_SIDEBAR_BANNER_DISMISSED,
+    false
+  )
 
   if (!IS_PLATFORM) return null
+  if (isDismissed && !(isEnabled && !isDefaultOptIn)) return null
 
   const cardClassName = cn(
     'rounded-lg border p-4 space-y-3 text-left',
@@ -60,8 +66,17 @@ export function UnifiedLogsBanner({ className = 'mx-4 mt-4' }: UnifiedLogsBanner
 
   return (
     <div className={cardClassName}>
-      <div className="flex justify-start">
+      <div className="flex items-start justify-between">
         <Badge variant="success">New</Badge>
+        <Button
+          variant="text"
+          size="tiny"
+          type="button"
+          icon={<X size={14} strokeWidth={1.5} />}
+          onClick={() => setIsDismissed(true)}
+          className="opacity-75 hover:opacity-100 -mt-1 -mr-1 px-1"
+          aria-label="Dismiss banner"
+        />
       </div>
       <h3 className="font-medium text-sm text-foreground">Introducing unified logs</h3>
       <div className="flex justify-start items-start gap-x-2">

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -114,6 +114,7 @@ export const LOCAL_STORAGE_KEYS = {
   FREE_MICRO_UPGRADE_BANNER_DISMISSED: (ref: string) =>
     `free-micro-upgrade-banner-dismissed-${ref}`,
   UNIFIED_LOGS_BANNER_DISMISSED: 'unified-logs-banner-dismissed',
+  UNIFIED_LOGS_SIDEBAR_BANNER_DISMISSED: 'unified-logs-sidebar-banner-dismissed',
   STORAGE_PUBLIC_BUCKET_SELECT_POLICY_WARNING_DISMISSED: (ref: string, bucketId: string) =>
     `storage-public-bucket-select-policy-warning-dismissed-${ref}-${bucketId}`,
 


### PR DESCRIPTION
## Summary
- Adds a close button to the "Introducing unified logs" sidebar banner, storing the dismissal in localStorage so it stays hidden.

## Test plan
- [ ] Open Logs Explorer, confirm the X dismisses the banner and it stays gone after reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `X` close button to the unified logs preview banner.
  * Remember banner dismissal using local storage, so it stays hidden after closing.
  * Updated banner visibility rules to account for unified-logs preview enablement and default opt-in state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->