### PR TITLE
adding joey to the humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -146,6 +146,7 @@ Joanna Michniewicz
 Joaquim Moreno
 Joel Low
 Joey Freeland
+Joey Lei
 John Fitzgerald
 Joel Martin
 Johan Bergström


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Updates Joey Lei to the list of Supabase team members

## What is the current behavior?

Missing joey!

## What is the new behavior?

Adds Joey

## Additional context

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Joey Lei to the team credits listed in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->