### PR TITLE
Update project pausing warning email timing

### DIFF
--- a/apps/docs/content/guides/platform/free-project-pausing.mdx
+++ b/apps/docs/content/guides/platform/free-project-pausing.mdx
@@ -18,7 +18,7 @@ A Free plan project is considered inactive if it does not receive sufficient use
 
 Supabase sends two emails to the project owner regarding project pausing:
 
-1. A warning email roughly one week before the pause takes effect.
+1. A warning email roughly one day before the pause takes effect.
 2. A confirmation email once the project has been paused.
 
 After receiving an initial email warning, the pause can be prevented by taking one of the following steps:


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

docs update

## What is the current behavior?

A warning email roughly **one week** before the pause takes effect.

## What is the new behavior?

A warning email roughly **one day** before the pause takes effect.

## Additional context

<img width="863" height="170" alt="Clipboard_Screenshot_1784184930" src="https://github.com/user-attachments/assets/04c539e0-b613-4ca7-a93e-fa597c36b1b8" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the automatic project pausing guide to clarify that warning emails are sent approximately one day before pausing, rather than one week before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->