### PR TITLE
Fix some colors

### DIFF
--- a/apps/studio/styles/grid.css
+++ b/apps/studio/styles/grid.css
@@ -150,7 +150,7 @@
   @apply text-typography-body-light [[data-theme*=dark]_&]:text-typography-body-dark;
 }
 .rdg-header-row .rdg-checkbox {
-  @apply bg-surface-200 border-default rounded-xs border;
+  @apply bg-200 border-default rounded-xs border;
 }
 .rdg-header-row .rdg-checkbox-input:checked + .rdg-checkbox {
   @apply border-default border-4 bg-green-900;
@@ -171,7 +171,7 @@
 
 .rdg-row {
   @apply bg-dash-sidebar transition-colors;
-  @apply hover:bg-surface-200;
+  @apply hover:bg-200;
 }
 
 /* edit button */
@@ -188,7 +188,7 @@
 
 /* select row */
 .rdg-row[aria-selected='true'] {
-  @apply bg-surface-200;
+  @apply bg-200;
 }
 
 .tab-cursor {

--- a/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
+++ b/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
@@ -268,7 +268,7 @@ export const CodeBlock = ({
             >
               <Button
                 variant="default"
-                className="px-1.5 dark:bg-200! dark:hover:bg-button!"
+                className="px-1.5 dark:bg-200! dark:hover:bg-button! hover:bg-alternative!"
                 icon={copied ? <Check /> : <Copy />}
                 onClick={() => onSelectCopy(value || children)}
               >

--- a/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
+++ b/packages/ui-patterns/src/CodeBlock/CodeBlock.tsx
@@ -268,7 +268,7 @@ export const CodeBlock = ({
             >
               <Button
                 variant="default"
-                className="px-1.5"
+                className="px-1.5 dark:bg-200! dark:hover:bg-button!"
                 icon={copied ? <Check /> : <Copy />}
                 onClick={() => onSelectCopy(value || children)}
               >


### PR DESCRIPTION
## Context

In the table editor when hovering over a row that has fixed columns, the wordings could appear like they're overlapping
<img width="339" height="95" alt="image" src="https://github.com/user-attachments/assets/9de8252c-08fc-4dec-a2f2-21461e47691e" />

This is due to the `bg-surface-200` class that gets applied to rows on hover which use alpha values, hence why it's happening. Opting to use `bg-200` instead which doesn't have alpha values.

Also small fix for the copy button in `CodeBlock` as well which is running into the same issue - opting to use a set of colors that doesn't have alpha values instead.
<img width="127" height="115" alt="image" src="https://github.com/user-attachments/assets/4d773474-49e0-4c3b-bea1-042ff3102f9c" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated table header, row hover, and selected-row background colors for a more consistent appearance.
  * Enhanced the code block copy button’s dark-mode and hover background styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->