### PR TITLE
fix(reports): chart click selects bucket range, fix logs datepicker crash

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -90,6 +90,12 @@ export type DatePickerValue = {
   text?: string
 }
 
+const toValidDate = (value?: string): Date | null => {
+  if (!value) return null
+  const date = new Date(value)
+  return isNaN(date.getTime()) ? null : date
+}
+
 interface LogsDatePickerProps {
   value: DatePickerValue
   helpers: DatetimeHelper[]
@@ -139,13 +145,13 @@ export const LogsDatePicker = ({
   useEffect(() => {
     if (!open) {
       setCustomValue('')
-      setStartDate(value.from ? new Date(value.from) : null)
-      const defaultEndDate = value.to ? new Date(value.to) : new Date()
+      setStartDate(toValidDate(value.from))
+      const defaultEndDate = toValidDate(value.to) ?? new Date()
       setEndDate(defaultEndDate)
       setCurrentMonth(new Date(defaultEndDate))
 
-      const fromDate = value.from ? new Date(value.from) : null
-      const toDate = value.to ? new Date(value.to) : null
+      const fromDate = toValidDate(value.from)
+      const toDate = toValidDate(value.to)
 
       setStartTime({
         HH: fromDate?.getHours().toString().padStart(2, '0') || '00',
@@ -180,11 +186,9 @@ export const LogsDatePicker = ({
     setOpen(false)
   }
 
-  const [startDate, setStartDate] = useState<Date | null>(value.from ? new Date(value.from) : null)
-  const [endDate, setEndDate] = useState<Date | null>(value.to ? new Date(value.to) : new Date())
-  const [currentMonth, setCurrentMonth] = useState<Date>(() =>
-    value.to ? new Date(value.to) : new Date()
-  )
+  const [startDate, setStartDate] = useState<Date | null>(toValidDate(value.from))
+  const [endDate, setEndDate] = useState<Date | null>(toValidDate(value.to) ?? new Date())
+  const [currentMonth, setCurrentMonth] = useState<Date>(() => toValidDate(value.to) ?? new Date())
 
   const [startTime, setStartTime] = useState({
     HH: startDate?.getHours().toString() || '00',

--- a/apps/studio/components/ui/Charts/ChartHighlightActions.tsx
+++ b/apps/studio/components/ui/Charts/ChartHighlightActions.tsx
@@ -14,6 +14,11 @@ import {
 import { ChartHighlight } from './useChartHighlight'
 import { useFormatDateTime } from '@/lib/datetime'
 
+const toFormattableDate = (value: string): string | number => {
+  const asNumber = Number(value)
+  return value !== '' && Number.isFinite(asNumber) ? asNumber : value
+}
+
 export type UpdateDateRange = (from: string, to: string) => void
 
 export type ChartHighlightActionContext = {
@@ -106,9 +111,9 @@ export const ChartHighlightActions = ({
         }}
       >
         <DropdownMenuLabel className="flex items-center justify-center text-foreground-light font-mono gap-x-2 text-xs">
-          <span>{formatChartDate(selectedRangeStart!, 'MMM D, H:mm')}</span>
+          <span>{formatChartDate(toFormattableDate(selectedRangeStart!), 'MMM D, H:mm')}</span>
           <ArrowRight size={10} />
-          <span>{formatChartDate(selectedRangeEnd!, 'MMM D, H:mm')}</span>
+          <span>{formatChartDate(toFormattableDate(selectedRangeEnd!), 'MMM D, H:mm')}</span>
         </DropdownMenuLabel>
         <DropdownMenuSeparator className="my-0" />
         {allActions.map((action) => {

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -493,11 +493,12 @@ export function ComposedChart({
 
             const next = data[activeTooltipIndex + 1]
             const prev = data[activeTooltipIndex - 1]
+            const prevTimestamp = prev?.[xAxisKey] ?? prev?.timestamp
             const nextTimestamp =
               next?.[xAxisKey] ??
               next?.timestamp ??
-              (prev && activeTimestamp != null
-                ? Number(activeTimestamp) + (Number(activeTimestamp) - Number(prev[xAxisKey]))
+              (prevTimestamp != null && activeTimestamp != null
+                ? Number(activeTimestamp) + (Number(activeTimestamp) - Number(prevTimestamp))
                 : undefined)
 
             chartHighlight?.handleMouseDown({

--- a/apps/studio/components/ui/Charts/ComposedChart.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChart.tsx
@@ -490,9 +490,21 @@ export function ComposedChart({
 
             const activeTimestamp =
               data[activeTooltipIndex]?.[xAxisKey] ?? data[activeTooltipIndex]?.timestamp
+
+            const next = data[activeTooltipIndex + 1]
+            const prev = data[activeTooltipIndex - 1]
+            const nextTimestamp =
+              next?.[xAxisKey] ??
+              next?.timestamp ??
+              (prev && activeTimestamp != null
+                ? Number(activeTimestamp) + (Number(activeTimestamp) - Number(prev[xAxisKey]))
+                : undefined)
+
             chartHighlight?.handleMouseDown({
               activeLabel: activeTimestamp?.toString(),
               coordinates: activeLabel,
+              nextLabel: nextTimestamp?.toString(),
+              nextCoordinate: nextTimestamp,
             })
           }}
           onMouseUp={chartHighlight?.handleMouseUp}

--- a/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
@@ -18,6 +18,11 @@ import { ProjectDailyStatsAttribute } from '@/data/analytics/project-daily-stats
 import type { UpdateDateRange } from '@/pages/project/[ref]/observability/database'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
 
+const parseChartTimestamp = (value: string) => {
+  const asNumber = Number(value)
+  return value !== '' && Number.isFinite(asNumber) ? dayjs(asNumber) : dayjs(value)
+}
+
 export interface ComposedChartHandlerProps {
   id?: string
   label: string
@@ -250,8 +255,8 @@ const ComposedChartHandler = ({
         onSelect: ({ start, end }) => {
           const projectRef = ref as string
           if (!projectRef) return
-          const its = dayjs(Number(start)).toISOString()
-          const ite = dayjs(Number(end)).toISOString()
+          const its = parseChartTimestamp(start).toISOString()
+          const ite = parseChartTimestamp(end).toISOString()
           const url = `/project/${projectRef}/logs/postgres-logs?its=${its}&ite=${ite}`
           router.push(url)
         },

--- a/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
+++ b/apps/studio/components/ui/Charts/ComposedChartHandler.tsx
@@ -250,7 +250,9 @@ const ComposedChartHandler = ({
         onSelect: ({ start, end }) => {
           const projectRef = ref as string
           if (!projectRef) return
-          const url = `/project/${projectRef}/logs/postgres-logs?its=${start}&ite=${end}`
+          const its = dayjs(Number(start)).toISOString()
+          const ite = dayjs(Number(end)).toISOString()
+          const url = `/project/${projectRef}/logs/postgres-logs?its=${its}&ite=${ite}`
           router.push(url)
         },
       },

--- a/apps/studio/components/ui/Charts/useChartHighlight.test.tsx
+++ b/apps/studio/components/ui/Charts/useChartHighlight.test.tsx
@@ -1,0 +1,52 @@
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { useChartHighlight } from './useChartHighlight'
+
+const BAR = '1784211420000'
+const NEXT_BAR = '1784211480000'
+const LATER_BAR = '1784211540000'
+
+describe('useChartHighlight', () => {
+  it('expands a single click to cover the clicked bucket', () => {
+    const { result } = renderHook(() => useChartHighlight())
+
+    act(() => {
+      result.current.handleMouseDown({
+        activeLabel: BAR,
+        coordinates: Number(BAR),
+        nextLabel: NEXT_BAR,
+        nextCoordinate: Number(NEXT_BAR),
+      })
+    })
+    act(() => {
+      result.current.handleMouseUp({ chartX: 10, chartY: 20 })
+    })
+
+    expect(result.current.left).toBe(BAR)
+    expect(result.current.right).toBe(NEXT_BAR)
+    expect(result.current.coordinates.left).not.toBe(result.current.coordinates.right)
+  })
+
+  it('keeps the dragged range without expanding it', () => {
+    const { result } = renderHook(() => useChartHighlight())
+
+    act(() => {
+      result.current.handleMouseDown({
+        activeLabel: BAR,
+        coordinates: Number(BAR),
+        nextLabel: NEXT_BAR,
+        nextCoordinate: Number(NEXT_BAR),
+      })
+    })
+    act(() => {
+      result.current.handleMouseMove({ activeLabel: LATER_BAR, coordinates: Number(LATER_BAR) })
+    })
+    act(() => {
+      result.current.handleMouseUp({ chartX: 10, chartY: 20 })
+    })
+
+    expect(result.current.left).toBe(BAR)
+    expect(result.current.right).toBe(LATER_BAR)
+  })
+})

--- a/apps/studio/components/ui/Charts/useChartHighlight.test.tsx
+++ b/apps/studio/components/ui/Charts/useChartHighlight.test.tsx
@@ -49,4 +49,22 @@ describe('useChartHighlight', () => {
     expect(result.current.left).toBe(BAR)
     expect(result.current.right).toBe(LATER_BAR)
   })
+
+  it('keeps left earlier than right when dragging leftward across epoch-ms labels', () => {
+    const { result } = renderHook(() => useChartHighlight())
+
+    act(() => {
+      result.current.handleMouseDown({ activeLabel: LATER_BAR, coordinates: Number(LATER_BAR) })
+    })
+    act(() => {
+      result.current.handleMouseMove({ activeLabel: BAR, coordinates: Number(BAR) })
+    })
+    act(() => {
+      result.current.handleMouseUp({ chartX: 10, chartY: 20 })
+    })
+
+    expect(Number(result.current.left)).toBeLessThan(Number(result.current.right))
+    expect(result.current.left).toBe(BAR)
+    expect(result.current.right).toBe(LATER_BAR)
+  })
 })

--- a/apps/studio/components/ui/Charts/useChartHighlight.tsx
+++ b/apps/studio/components/ui/Charts/useChartHighlight.tsx
@@ -1,11 +1,15 @@
 import dayjs from 'dayjs'
 import { useState } from 'react'
 
+type Coordinate = string | number
+
 type ChartHighlightMouseEvent = {
   activeLabel?: string
-  coordinates?: string
+  coordinates?: Coordinate
   chartX?: number
   chartY?: number
+  nextLabel?: string
+  nextCoordinate?: Coordinate
 }
 
 type Pixel = { x: number; y: number }
@@ -13,7 +17,7 @@ type Pixel = { x: number; y: number }
 export interface ChartHighlight {
   left: string | undefined
   right: string | undefined
-  coordinates: { left?: string; right?: string }
+  coordinates: { left?: Coordinate; right?: Coordinate }
   isSelecting: boolean
   popoverPosition: { x: number; y: number } | null
   handleMouseDown: (e: ChartHighlightMouseEvent) => void
@@ -25,7 +29,7 @@ export interface ChartHighlight {
 export function useChartHighlight(): ChartHighlight {
   const [left, setLeft] = useState<string | undefined>(undefined)
   const [right, setRight] = useState<string | undefined>(undefined)
-  const [coordinates, setCoordinates] = useState<{ left?: string; right?: string }>({
+  const [coordinates, setCoordinates] = useState<{ left?: Coordinate; right?: Coordinate }>({
     left: undefined,
     right: undefined,
   })
@@ -33,14 +37,18 @@ export function useChartHighlight(): ChartHighlight {
   const [popoverPosition, setPopoverPosition] = useState<{ x: number; y: number } | null>(null)
   const [initialPoint, setInitialPoint] = useState<string | undefined>(undefined)
   const [anchorPixel, setAnchorPixel] = useState<Pixel | undefined>(undefined)
+  const [hasDragged, setHasDragged] = useState(false)
+  const [nextPoint, setNextPoint] = useState<{ label?: string; coordinate?: Coordinate }>({})
 
   const handleMouseDown = (e: ChartHighlightMouseEvent) => {
     clearHighlight()
     if (!e || !e.activeLabel) return
     setIsSelecting(true)
+    setHasDragged(false)
     setLeft(e.activeLabel)
     setRight(e.activeLabel)
     setInitialPoint(e.activeLabel)
+    setNextPoint({ label: e.nextLabel, coordinate: e.nextCoordinate })
     setCoordinates({ left: e.coordinates, right: e.coordinates })
     if (typeof e.chartX === 'number' && typeof e.chartY === 'number') {
       setAnchorPixel({ x: e.chartX, y: e.chartY })
@@ -49,6 +57,8 @@ export function useChartHighlight(): ChartHighlight {
 
   const handleMouseMove = (e: ChartHighlightMouseEvent) => {
     if (!isSelecting || !e || !e.activeLabel) return
+
+    if (e.activeLabel !== initialPoint) setHasDragged(true)
 
     const currentTimestamp = dayjs(e.activeLabel)
     const initialTimestamp = dayjs(initialPoint)
@@ -77,6 +87,12 @@ export function useChartHighlight(): ChartHighlight {
     setIsSelecting(false)
     setInitialPoint(undefined)
 
+    const isClick = !hasDragged
+    if (isClick && nextPoint.label) {
+      setRight(nextPoint.label)
+      setCoordinates((prev) => ({ ...prev, right: nextPoint.coordinate }))
+    }
+
     // Anchor the popover to where the selection started rather than wherever
     // the mouse happened to be released.
     if (anchorPixel) {
@@ -100,6 +116,8 @@ export function useChartHighlight(): ChartHighlight {
     setPopoverPosition(null)
     setInitialPoint(undefined)
     setAnchorPixel(undefined)
+    setHasDragged(false)
+    setNextPoint({})
   }
 
   return {

--- a/apps/studio/components/ui/Charts/useChartHighlight.tsx
+++ b/apps/studio/components/ui/Charts/useChartHighlight.tsx
@@ -3,6 +3,13 @@ import { useState } from 'react'
 
 type Coordinate = string | number
 
+const toDayjs = (value?: string) => {
+  const asNumber = Number(value)
+  return value !== undefined && value !== '' && Number.isFinite(asNumber)
+    ? dayjs(asNumber)
+    : dayjs(value)
+}
+
 type ChartHighlightMouseEvent = {
   activeLabel?: string
   coordinates?: Coordinate
@@ -60,8 +67,8 @@ export function useChartHighlight(): ChartHighlight {
 
     if (e.activeLabel !== initialPoint) setHasDragged(true)
 
-    const currentTimestamp = dayjs(e.activeLabel)
-    const initialTimestamp = dayjs(initialPoint)
+    const currentTimestamp = toDayjs(e.activeLabel)
+    const initialTimestamp = toDayjs(initialPoint)
 
     if (currentTimestamp.isBefore(initialTimestamp)) {
       // If dragging left, update left and keep right as initial


### PR DESCRIPTION
## Problem

In a database report, dragging over a chart to open logs had two bugs. Clicking a bar instead of dragging produced a zero-width selection (its === ite), so the logs view showed no results. Separately, the logs datepicker crashed with "Invalid time value" because the chart put raw epoch-ms values into the its/ite URL params, which get parsed with new Date(string) and yield an Invalid Date that react-day-picker cannot format.

## Fix

The chart now emits ISO timestamps in the logs URL so its/ite match the format every other logs consumer already uses, and the datepicker guards against unparseable values from any source (such as old bookmarked links). A single click now expands the highlight to the clicked bucket, from the bar's start to the next bar's start, so the selection, popover, and logs range all cover the bar the user picked.

## How to test

1. Open a database report with a chart (for example Postgres, project logs).
2. Drag across the chart, choose "Open in Postgres Logs", then open the timepicker. Expected: it opens without crashing and shows the selected range.
3. Go back and single-click one bar instead of dragging. Expected: that bar's bucket is selected and "Open in Postgres Logs" loads logs for a real, non-empty range.
4. Run the chart tests, expected all pass: pnpm --filter studio exec vitest --run components/ui/Charts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid log date inputs from creating invalid date selections.
  * Improved chart “open logs” links by normalizing the selected time bounds (now consistently sent as ISO timestamps).
  * Refined chart highlight behavior for click-to-advance and more accurate left/right range selection, supporting both numeric and string coordinate values.
  * Updated the chart highlight dropdown display for clearer formatting of numeric vs non-numeric dates.
* **Tests**
  * Added Vitest coverage for chart highlight click, drag, and left/right ordering scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->