### PR TITLE
refactor(sql-editor): extract title-gen/execute-params + merge auto-limit functions

### DIFF
--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -1,11 +1,11 @@
-import { acceptUntrustedSql } from '@supabase/pg-meta'
+import { acceptUntrustedSql, safeSql } from '@supabase/pg-meta'
 import { useQuery } from '@tanstack/react-query'
 import { useParams } from 'common'
 import { X } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
 
-import { checkIfAppendLimitRequired, suffixWithLimit } from '../../SQLEditor/SQLEditor.utils'
+import { applyAutoLimit } from '../../SQLEditor/SQLEditor.utils'
 import { BURSTABLE_IO_METRIC_KEYS, DEPRECATED_REPORTS } from '../Reports.constants'
 import { ChartBlock } from './ChartBlock'
 import { DeprecatedChartBlock } from './DeprecatedChartBlock'
@@ -81,7 +81,11 @@ export const ReportBlock = ({
 
   const autoLimit = 100
   const sql = isSnippet ? (data?.content as SqlSnippets.Content)?.unchecked_sql : undefined
-  const { appendAutoLimit } = checkIfAppendLimitRequired(sql ?? '', autoLimit)
+  // acceptUntrustedSql is usually not allowed outside a user-action event
+  // handler, but it's explicitly fine here: adding this block to a report is
+  // itself the user action that approves running its SQL.
+  const acceptedSql = sql !== undefined ? acceptUntrustedSql(sql) : safeSql``
+  const { sql: formattedSql, appendAutoLimit } = applyAutoLimit(acceptedSql, autoLimit)
 
   const chartConfig = { ...DEFAULT_CHART_CONFIG, ...(item.chartConfig ?? {}) }
   const isDeprecatedChart = DEPRECATED_REPORTS.includes(item.attribute)
@@ -114,14 +118,9 @@ export const ReportBlock = ({
         return null
       }
 
-      const formattedSql = suffixWithLimit(acceptUntrustedSql(sql), autoLimit)
-
       return executeSql({
         projectRef,
         connectionString,
-        // acceptUntrustedSql is usually not allowed in an auto-run position,
-        // but in this case we are explicitly allowing it because adding a block
-        // to a report is an explicit user action.
         sql: formattedSql,
       })
     },

--- a/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
+++ b/apps/studio/components/interfaces/Reports/ReportBlock/ReportBlock.tsx
@@ -101,6 +101,7 @@ export const ReportBlock = ({
     isPending: executeSqlLoading,
     refetch,
   } = useQuery({
+    // eslint-disable-next-line @tanstack/query/exhaustive-deps -- formattedSql/appendAutoLimit are fully derived from sql/autoLimit, both already in the key
     queryKey: sqlKeys.query(projectRef, [
       item.id,
       sql,

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
@@ -2,15 +2,17 @@ import { safeSql, untrustedSql } from '@supabase/pg-meta'
 import { stripIndent } from 'common-tags'
 import { describe, expect, it, test } from 'vitest'
 
+import { untitledSnippetTitle } from './SQLEditor.constants'
 import type { IStandaloneCodeEditor } from './SQLEditor.types'
 import {
   analyzeQueryIssues,
   appendEnableRLSStatements,
+  applyAutoLimit,
   assembleCompletionDiff,
   buildDebugPromptText,
+  buildExecuteParams,
   checkAlterDatabaseConnection,
   checkDestructiveQuery,
-  checkIfAppendLimitRequired,
   computeErrorHighlightLine,
   filterTablesCoveredByEnsureRLSTrigger,
   getCreateTablesMissingRLS,
@@ -19,10 +21,12 @@ import {
   hasBlockingIssues,
   isUpdateWithoutWhere,
   resolveConnectionString,
-  suffixWithLimit,
+  shouldAutoGenerateTitle,
+  trimTrailingSemicolons,
 } from './SQLEditor.utils'
 import type { DatabaseEventTrigger } from '@/data/database-event-triggers/database-event-triggers-query'
 import type { Database } from '@/data/read-replicas/replicas-query'
+import { createRoleImpersonationState } from '@/state/role-impersonation-state'
 
 const buildTrigger = (overrides: Partial<DatabaseEventTrigger> = {}): DatabaseEventTrigger => ({
   oid: 1,
@@ -37,149 +41,252 @@ const buildTrigger = (overrides: Partial<DatabaseEventTrigger> = {}): DatabaseEv
   ...overrides,
 })
 
-describe('SQLEditor.utils.ts:checkIfAppendLimitRequired', () => {
+describe('SQLEditor.utils.ts:trimTrailingSemicolons', () => {
+  test('removes a single trailing semicolon', () => {
+    const sql = safeSql`select * from countries;`
+    expect(trimTrailingSemicolons(sql)).toBe('select * from countries')
+  })
+  test('removes multiple trailing semicolons', () => {
+    const sql = safeSql`select * from countries;;;;;;;`
+    expect(trimTrailingSemicolons(sql)).toBe('select * from countries')
+  })
+  test('leaves a fragment with no trailing semicolon unchanged', () => {
+    const sql = safeSql`select * from countries`
+    expect(trimTrailingSemicolons(sql)).toBe('select * from countries')
+  })
+  test('does not touch semicolons that are not trailing', () => {
+    const sql = safeSql`select 1; select 2`
+    expect(trimTrailingSemicolons(sql)).toBe('select 1; select 2')
+  })
+})
+
+describe('SQLEditor.utils.ts:applyAutoLimit', () => {
   test('Should return false if limit passed is <= 0', () => {
-    const sql = 'select * from countries;'
+    const sql = safeSql`select * from countries;`
     const limit = -1
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return true if limit passed is > 0', () => {
-    const sql = 'select * from countries;'
+    const sql = safeSql`select * from countries;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(true)
   })
   test('Should return false if query already has a limit', () => {
-    const sql = 'select * from countries limit 10;'
+    const sql = safeSql`select * from countries limit 10;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query already has a limit (check for case-insensitiveness)', () => {
-    const sql = 'SELECT * FROM countries LIMIT 10;'
+    const sql = safeSql`SELECT * FROM countries LIMIT 10;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query already has a limit with whitespace before the semi colon', () => {
-    const sql = 'select * from countries limit 10 ;'
+    const sql = safeSql`select * from countries limit 10 ;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query already has a limit and offset', () => {
-    const sql = 'select * from countries limit 10 offset 0;'
+    const sql = safeSql`select * from countries limit 10 offset 0;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query already has a limit and offset with whitespace before the semi colon', () => {
-    const sql = 'select * from countries limit 10 offset 0 ;'
+    const sql = safeSql`select * from countries limit 10 offset 0 ;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query already has a limit and offset (flip order of limit and offset)', () => {
-    const sql = 'select * from countries offset 0 limit 1;'
+    const sql = safeSql`select * from countries offset 0 limit 1;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query already has a limit, even if no value provided for limit', () => {
-    const sql = 'select * from countries limit'
+    const sql = safeSql`select * from countries limit`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query uses `FETCH FIRST` instead of limit ', () => {
-    const sql = 'select * from countries FETCH FIRST 5 rows only'
+    const sql = safeSql`select * from countries FETCH FIRST 5 rows only`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query uses `fetch first` instead of limit ', () => {
-    const sql = 'select * from countries fetch first 5 rows only'
+    const sql = safeSql`select * from countries fetch first 5 rows only`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query uses `fetch   first` (with random spaces) instead of limit ', () => {
-    const sql = 'select * from countries FETCH FIRST 5 rows only'
+    const sql = safeSql`select * from countries FETCH FIRST 5 rows only`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query is not a select statement', () => {
-    const sql = 'create table test (id int8 primary key, name varchar);'
+    const sql = safeSql`create table test (id int8 primary key, name varchar);`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if there are multiple queries I', () => {
-    const sql1 = `
-select * from countries;
-select * from cities;
-`.trim()
+    const sql1 = safeSql`select * from countries;
+select * from cities;`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql1, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql1, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if there are multiple queries II', () => {
-    const sql1 = `
-select * from countries;
-select * from cities
-`.trim()
+    const sql1 = safeSql`select * from countries;
+select * from cities`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql1, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql1, limit)
     expect(appendAutoLimit).toBe(false)
   })
   // [Joshen] Opting to just avoid appending in this case to prevent making the logic overly complex atm
   test('Should return false if query has with a comment I', () => {
-    const sql = `
--- This is a comment
-select * from cities
-`.trim()
+    const sql = safeSql`-- This is a comment
+select * from cities`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
   test('Should return false if query has with a comment II', () => {
-    const sql = `
-select * from cities
--- This is a comment
-`.trim()
+    const sql = safeSql`select * from cities
+-- This is a comment`
     const limit = 100
-    const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
+    const { appendAutoLimit } = applyAutoLimit(sql, limit)
     expect(appendAutoLimit).toBe(false)
   })
-})
 
-// [Joshen] These will just need to test the cases when appendAutoLimit returns true then
-describe('SQLEditor.utils.ts:suffixWithLimit', () => {
+  // [Joshen] These will just need to test the cases when appendAutoLimit returns true then
   test('Should add the limit param properly if query ends without a semi colon', () => {
     const sql = safeSql`select * from countries`
     const limit = 100
-    const formattedSql = suffixWithLimit(sql, limit)
+    const { sql: formattedSql } = applyAutoLimit(sql, limit)
     expect(formattedSql).toBe('select * from countries limit 100;')
   })
   test('Should add the limit param properly if query ends with a semi colon', () => {
     const sql = safeSql`select * from countries;`
     const limit = 100
-    const formattedSql = suffixWithLimit(sql, limit)
+    const { sql: formattedSql } = applyAutoLimit(sql, limit)
     expect(formattedSql).toBe('select * from countries limit 100;')
   })
   test('Should add the limit param properly if query ends with multiple semi colon', () => {
     const sql = safeSql`select * from countries;;;;;;;`
     const limit = 100
-    const formattedSql = suffixWithLimit(sql, limit)
+    const { sql: formattedSql } = applyAutoLimit(sql, limit)
     expect(formattedSql).toBe('select * from countries limit 100;')
   })
   test('Should not append a limit if query already has one with whitespace before the semi colon', () => {
     const sql = safeSql`select * from countries limit 10 ;`
     const limit = 100
-    const formattedSql = suffixWithLimit(sql, limit)
+    const { sql: formattedSql } = applyAutoLimit(sql, limit)
     expect(formattedSql).toBe('select * from countries limit 10 ;')
+  })
+  test('returns the SafeSqlFragment result unchanged when no limit is appended', () => {
+    const sql = safeSql`select * from countries limit 10;`
+    const { sql: formattedSql } = applyAutoLimit(sql, 100)
+    expect(formattedSql).toBe(sql)
+  })
+})
+
+describe('SQLEditor.utils.ts:shouldAutoGenerateTitle', () => {
+  test('returns true when AI is enabled, the name is still the placeholder, and on platform', () => {
+    expect(
+      shouldAutoGenerateTitle({
+        aiOptInLevel: 'default',
+        snippetName: `${untitledSnippetTitle} 1`,
+        isPlatform: true,
+      })
+    ).toBe(true)
+  })
+  test('returns false when AI opt-in is disabled', () => {
+    expect(
+      shouldAutoGenerateTitle({
+        aiOptInLevel: 'disabled',
+        snippetName: `${untitledSnippetTitle} 1`,
+        isPlatform: true,
+      })
+    ).toBe(false)
+  })
+  test('returns false when the snippet already has a custom name', () => {
+    expect(
+      shouldAutoGenerateTitle({
+        aiOptInLevel: 'default',
+        snippetName: 'My saved query',
+        isPlatform: true,
+      })
+    ).toBe(false)
+  })
+  test('returns false when not running on the hosted platform', () => {
+    expect(
+      shouldAutoGenerateTitle({
+        aiOptInLevel: 'default',
+        snippetName: `${untitledSnippetTitle} 1`,
+        isPlatform: false,
+      })
+    ).toBe(false)
+  })
+  test('returns false when the snippet name is undefined', () => {
+    expect(
+      shouldAutoGenerateTitle({
+        aiOptInLevel: 'default',
+        snippetName: undefined,
+        isPlatform: true,
+      })
+    ).toBe(false)
+  })
+})
+
+describe('SQLEditor.utils.ts:buildExecuteParams', () => {
+  const impersonatedRoleState = createRoleImpersonationState('default', {
+    current: async () => ({}),
+  })
+
+  test('applies the auto-limit suffix when appropriate', () => {
+    const params = buildExecuteParams({
+      sql: safeSql`select * from countries`,
+      limit: 100,
+      connectionString: 'postgresql://example',
+      projectRef: 'default',
+      impersonatedRoleState,
+    })
+    expect(params.sql).toBe('select * from countries limit 100;')
+    expect(params.autoLimit).toBe(100)
+  })
+  test('leaves autoLimit undefined when a limit is already present', () => {
+    const params = buildExecuteParams({
+      sql: safeSql`select * from countries limit 10;`,
+      limit: 100,
+      connectionString: 'postgresql://example',
+      projectRef: 'default',
+      impersonatedRoleState,
+    })
+    expect(params.sql).toBe('select * from countries limit 10;')
+    expect(params.autoLimit).toBeUndefined()
+  })
+  test('reflects isRoleImpersonationEnabled from the impersonation state', () => {
+    const params = buildExecuteParams({
+      sql: safeSql`select * from countries`,
+      limit: 0,
+      connectionString: 'postgresql://example',
+      projectRef: 'default',
+      impersonatedRoleState,
+    })
+    expect(params.isRoleImpersonationEnabled).toBe(false)
+    expect(params.isStatementTimeoutDisabled).toBe(true)
+    expect(params.contextualInvalidation).toBe(true)
   })
 })
 

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -1,4 +1,10 @@
-import { untrustedSql, type SafeSqlFragment, type UntrustedSqlFragment } from '@supabase/pg-meta'
+import {
+  literal,
+  safeSql,
+  untrustedSql,
+  type SafeSqlFragment,
+  type UntrustedSqlFragment,
+} from '@supabase/pg-meta'
 import { TABLE_EVENT_ACTIONS } from 'common/telemetry-constants'
 
 import {
@@ -6,6 +12,7 @@ import {
   destructiveSqlRegex,
   NEW_SQL_SNIPPET_SKELETON,
   sqlAiDisclaimerComment,
+  untitledSnippetTitle,
   updateWithoutWhereRegex,
 } from './SQLEditor.constants'
 import { ContentDiff, type IStandaloneCodeEditor, type PotentialIssues } from './SQLEditor.types'
@@ -14,7 +21,12 @@ import type { DatabaseEventTrigger } from '@/data/database-event-triggers/databa
 import type { Database } from '@/data/read-replicas/replicas-query'
 import { generateUuid } from '@/lib/api/snippets.browser'
 import { removeCommentsFromSql } from '@/lib/helpers'
+import { wrapWithRoleImpersonation } from '@/lib/role-impersonation'
 import { sqlEventParser } from '@/lib/sql-event-parser'
+import {
+  isRoleImpersonationEnabled,
+  type RoleImpersonationState,
+} from '@/state/role-impersonation-state'
 
 export type CreateTableWithoutRLS = {
   schema?: string
@@ -225,6 +237,59 @@ export function resolveConnectionString(
   )
 }
 
+/**
+ * Whether a query run should lazily kick off AI title generation for the
+ * snippet: only when the org has AI enabled (not disabled/HIPAA — which would
+ * silently forward the query to the AI provider without consent), the
+ * snippet still has its placeholder name, and we're running on the hosted
+ * platform.
+ */
+export function shouldAutoGenerateTitle({
+  aiOptInLevel,
+  snippetName,
+  isPlatform,
+}: {
+  aiOptInLevel: string
+  snippetName: string | undefined
+  isPlatform: boolean
+}): boolean {
+  return (
+    aiOptInLevel !== 'disabled' && !!snippetName?.startsWith(untitledSnippetTitle) && isPlatform
+  )
+}
+
+/**
+ * Builds the params passed to `useExecuteSqlMutation`'s `execute`: applies the
+ * auto-limit suffix and role impersonation to the SQL, and derives the
+ * `autoLimit`/`isRoleImpersonationEnabled` flags. Callers still attach their
+ * own `handleError`.
+ */
+export function buildExecuteParams({
+  sql,
+  limit,
+  connectionString,
+  projectRef,
+  impersonatedRoleState,
+}: {
+  sql: SafeSqlFragment
+  limit: number
+  connectionString: string | undefined
+  projectRef: string
+  impersonatedRoleState: RoleImpersonationState
+}) {
+  const { sql: formattedSql, appendAutoLimit } = applyAutoLimit(sql, limit)
+
+  return {
+    projectRef,
+    connectionString,
+    sql: wrapWithRoleImpersonation(formattedSql, impersonatedRoleState),
+    autoLimit: appendAutoLimit ? limit : undefined,
+    isRoleImpersonationEnabled: isRoleImpersonationEnabled(impersonatedRoleState.role),
+    isStatementTimeoutDisabled: true as const,
+    contextualInvalidation: true as const,
+  }
+}
+
 export const generateMigrationCliCommand = (id: string, name: string, isNpx = false) =>
   `
 ${isNpx ? 'npx ' : ''}supabase snippets download ${id} |
@@ -270,13 +335,35 @@ export const compareAsNewSnippet = (sqlDiff: ContentDiff) => {
   }
 }
 
+/**
+ * Removes trailing `;` characters from a safe SQL fragment. Only ever removes
+ * existing terminators — never adds text — so the result is exactly as safe
+ * as the input; the brand carries over intentionally. This is the one place
+ * in the file allowed to reassert `SafeSqlFragment` on a derived string —
+ * every other function composes new fragments through `safeSql`/`literal`.
+ */
+export function trimTrailingSemicolons(sql: SafeSqlFragment): SafeSqlFragment {
+  return sql.replace(/;+\s*$/, '') as SafeSqlFragment
+}
+
 // [Joshen] Just FYI as well the checks here on whether to append limit is quite restricted
 // This is to prevent dashboard from accidentally appending limit to the end of a query
 // thats not supposed to have any, since there's too many cases to cover.
 // We can however look into making this logic better in the future
 // i.e It's harder to append the limit param, than just leaving the query as it is
 // Otherwise we'd need a full on parser to do this properly
-export const checkIfAppendLimitRequired = (sql: string, limit: number = 0) => {
+//
+// Only accepts `SafeSqlFragment`: this decides whether to build (and builds)
+// a new SQL fragment that gets executed, so every caller — including ones
+// that only want the `appendAutoLimit` flag for a display hint — must already
+// hold safe SQL. Composes the ` limit N;` suffix through `safeSql`/`literal`
+// rather than gluing raw template-literal text onto the fragment and casting
+// the result, so the only new content this function ever stamps safe is an
+// internally-generated integer literal, never arbitrary concatenated text.
+export function applyAutoLimit(
+  sql: SafeSqlFragment,
+  limit: number = 0
+): { sql: SafeSqlFragment; appendAutoLimit: boolean } {
   // Remove lines and whitespaces to use for checking
   const cleanedSql = sql.trim().replaceAll('\n', ' ').replaceAll(/\s+/g, ' ')
 
@@ -299,15 +386,13 @@ export const checkIfAppendLimitRequired = (sql: string, limit: number = 0) => {
     !cleanedSql.match(/limit;$/i) &&
     !cleanedSql.match(/limit [0-9]* offset [0-9]*\s*[;]?$/i) &&
     !cleanedSql.match(/limit [0-9]*\s*[;]?$/i)
-  return { cleanedSql, appendAutoLimit }
-}
 
-export const suffixWithLimit = (sql: SafeSqlFragment, limit: number = 0): SafeSqlFragment => {
-  const { cleanedSql, appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
-  if (!appendAutoLimit) return sql
-  return (
-    cleanedSql.endsWith(';') ? sql.replace(/[;]+$/, ` limit ${limit};`) : `${sql} limit ${limit};`
-  ) as SafeSqlFragment
+  if (!appendAutoLimit) return { sql, appendAutoLimit: false }
+
+  const core = cleanedSql.endsWith(';') ? trimTrailingSemicolons(sql) : sql
+  const suffixed = safeSql`${core} limit ${literal(limit)};`
+
+  return { sql: suffixed, appendAutoLimit: true }
 }
 
 /**

--- a/apps/studio/components/interfaces/SQLEditor/useSqlEditorExecution.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useSqlEditorExecution.ts
@@ -4,14 +4,13 @@ import { IS_PLATFORM, useParams } from 'common'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 
-import { untitledSnippetTitle } from './SQLEditor.constants'
 import type { PotentialIssues } from './SQLEditor.types'
 import {
   analyzeQueryIssues,
-  checkIfAppendLimitRequired,
+  buildExecuteParams,
   hasBlockingIssues,
   resolveConnectionString,
-  suffixWithLimit,
+  shouldAutoGenerateTitle,
 } from './SQLEditor.utils'
 import { useSQLEditorContext } from './SQLEditorContext'
 import { useDatabaseEventTriggersQuery } from '@/data/database-event-triggers/database-event-triggers-query'
@@ -21,13 +20,9 @@ import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { useExecuteSqlMutation } from '@/data/sql/execute-sql-mutation'
 import { useOrgAiOptInLevel } from '@/hooks/misc/useOrgOptedIntoAi'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
-import { wrapWithRoleImpersonation } from '@/lib/role-impersonation'
 import { useTrack } from '@/lib/telemetry/track'
 import { useDatabaseSelectorStateSnapshot } from '@/state/database-selector'
-import {
-  isRoleImpersonationEnabled,
-  useGetImpersonatedRoleState,
-} from '@/state/role-impersonation-state'
+import { useGetImpersonatedRoleState } from '@/state/role-impersonation-state'
 import { useSqlEditorSessionSnapshot } from '@/state/sql-editor/sql-editor-session-state'
 import { getSqlEditorV2StateSnapshot } from '@/state/sql-editor/sql-editor-state'
 
@@ -115,11 +110,11 @@ export function useSqlEditorExecution({
       // use the latest state for the title-generation check
       const snippet = getSqlEditorV2StateSnapshot().snippets[id]
       if (
-        // Don't auto-generate a title when the org has disabled AI or is a HIPAA project,
-        // as that would silently forward the query to the AI provider without consent
-        aiOptInLevel !== 'disabled' &&
-        snippet?.snippet.name.startsWith(untitledSnippetTitle) &&
-        IS_PLATFORM
+        shouldAutoGenerateTitle({
+          aiOptInLevel,
+          snippetName: snippet?.snippet.name,
+          isPlatform: IS_PLATFORM,
+        })
       ) {
         // Intentionally don't await title gen (lazy)
         setAiTitle(id, sql)
@@ -137,17 +132,14 @@ export function useSqlEditorExecution({
         return toast.error('Unable to run query: Connection string is missing')
       }
 
-      const { appendAutoLimit } = checkIfAppendLimitRequired(sql, limit)
-      const formattedSql = suffixWithLimit(sql, limit)
-
       execute({
-        projectRef: project.ref,
-        connectionString: connectionString,
-        sql: wrapWithRoleImpersonation(formattedSql, impersonatedRoleState),
-        autoLimit: appendAutoLimit ? limit : undefined,
-        isRoleImpersonationEnabled: isRoleImpersonationEnabled(impersonatedRoleState.role),
-        isStatementTimeoutDisabled: true,
-        contextualInvalidation: true,
+        ...buildExecuteParams({
+          sql,
+          limit,
+          connectionString,
+          projectRef: project.ref,
+          impersonatedRoleState,
+        }),
         handleError: (error) => {
           throw error
         },

--- a/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
+++ b/apps/studio/components/ui/EditorPanel/EditorPanel.tsx
@@ -46,8 +46,8 @@ import { SaveSnippetDialog } from './SaveSnippetDialog'
 import { isExplainQuery } from '@/components/interfaces/ExplainVisualizer/ExplainVisualizer.utils'
 import { generateSnippetTitle } from '@/components/interfaces/SQLEditor/SQLEditor.constants'
 import {
+  applyAutoLimit,
   createSqlSnippetSkeletonV2,
-  suffixWithLimit,
 } from '@/components/interfaces/SQLEditor/SQLEditor.utils'
 import { useAddDefinitions } from '@/components/interfaces/SQLEditor/useAddDefinitions'
 import { Results } from '@/components/interfaces/SQLEditor/UtilityPanel/Results'
@@ -231,7 +231,7 @@ export const EditorPanel = () => {
     }
 
     executeSql({
-      sql: suffixWithLimit(acceptUntrustedSql(currentValue), 100),
+      sql: applyAutoLimit(acceptUntrustedSql(currentValue), 100).sql,
       projectRef: project?.ref,
       connectionString: project?.connectionString,
       isStatementTimeoutDisabled: true,

--- a/apps/studio/state/sql-editor/sql-editor-session-state.ts
+++ b/apps/studio/state/sql-editor/sql-editor-session-state.ts
@@ -23,7 +23,7 @@ export const sqlEditorSessionState = proxy({
   /**
    * UI-imposed limit for the number of rows a query can return (a safeguard
    * against accidentally taking down the database with a huge SELECT). Related
-   * to `autoLimit` in `results`; see `checkIfAppendLimitRequired`/`suffixWithLimit`.
+   * to `autoLimit` in `results`; see `applyAutoLimit`.
    */
   limit: 100,
 


### PR DESCRIPTION
## Summary
Part 2/6 of the SQL Editor testability follow-up, stacked on #47980 (the analyzeQueryIssues/resolveConnectionString PR).

- Extracts `shouldAutoGenerateTitle` and `buildExecuteParams` out of `useSqlEditorExecution`'s inline logic into `SQLEditor.utils.ts`.
- Merges `checkIfAppendLimitRequired` and `suffixWithLimit` into a single `applyAutoLimit` function — the two were only ever called together and re-parsed the same query twice at every call site. `applyAutoLimit` only accepts `SafeSqlFragment` (never a plain string) and composes the `LIMIT` suffix through `safeSql`/`literal` rather than raw template concatenation, so the only place in the file that reasserts the `SafeSqlFragment` brand on a derived string is the small, dedicated `trimTrailingSemicolons` helper — removing existing terminators can't introduce unsafe content, unlike gluing new text onto the fragment.
- Updates the two other `checkIfAppendLimitRequired`/`suffixWithLimit` call sites (`EditorPanel.tsx`, `ReportBlock.tsx`) accordingly; `ReportBlock` now promotes its report SQL once and reuses the result for both its display-only auto-limit hint and its execution, instead of promoting twice.

## Test plan
- [x] `pnpm --filter studio typecheck`
- [x] `pnpm test:studio -- SQLEditor ReportBlock EditorPanel` (239 tests passing)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Automatic row limits are applied more consistently to SQL execution across reports and the SQL editor.
  * Improved handling of trailing semicolons, whitespace/comments, and multiple statements when applying limits.
  * Execution now more reliably preserves role impersonation and related execution settings.
  * AI-generated snippet titles are created only when eligible (based on opt-in and context).
* **Bug Fixes**
  * Safer, more consistent SQL preparation for execution when limits are enabled.
* **Tests**
  * Updated and expanded SQL editor utility tests to cover the new limit/title/execute behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->