### PR TITLE
feat(studio): finesse logs date picker range colours

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -403,7 +403,7 @@ export const LogsDatePicker = ({
           </RadioGroup>
         </div>
 
-        <div>
+        <div className="w-fit max-w-full">
           <div className="flex p-2 gap-2 items-center">
             <div className="flex grow *:grow gap-2 font-mono">
               <TimeSplitInput
@@ -447,7 +447,7 @@ export const LogsDatePicker = ({
               ></ButtonTooltip>
             </div>
           </div>
-          <div className="p-2 border-t">
+          <div className="border-t">
             <Calendar
               mode="range"
               month={currentMonth}
@@ -459,9 +459,9 @@ export const LogsDatePicker = ({
             />
           </div>
           {isLargeRange && !hideWarnings && (
-            <div className="text-xs px-3 py-1.5 border-y bg-warning-300 border-warning-500 text-warning">
-              Large ranges may result in memory errors for <br /> big projects.
-            </div>
+            <p className="w-0 min-w-full px-3 pt-1 pb-4 text-xs text-warning">
+              Large ranges may result in memory errors for big projects.
+            </p>
           )}
           <div className="flex items-center justify-end gap-2 p-2 border-t">
             {startDate && endDate ? (
@@ -470,7 +470,7 @@ export const LogsDatePicker = ({
                 size="tiny"
                 onClick={handleCopy}
                 className={cn({
-                  'text-brand-600': copied || pasted,
+                  'text-brand-link': copied || pasted,
                 })}
               >
                 {copied ? 'Copied!' : pasted ? 'Pasted!' : 'Copy range'}

--- a/apps/studio/components/ui/DatePicker/TimeSplitInput.tsx
+++ b/apps/studio/components/ui/DatePicker/TimeSplitInput.tsx
@@ -235,10 +235,6 @@ export const TimeSplitInput = ({
         hover:border-stronger transition-colors
     `}
     >
-      <div className="mr-1 text-foreground-lighter">
-        <Clock size={14} strokeWidth={1.5} />
-      </div>
-
       <input
         type="text"
         onBlur={() => handleOnBlur()}

--- a/apps/studio/components/ui/DatePicker/TimeSplitInput.tsx
+++ b/apps/studio/components/ui/DatePicker/TimeSplitInput.tsx
@@ -1,5 +1,4 @@
 import { format } from 'date-fns'
-import { Clock } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { cn } from 'ui'
 

--- a/packages/ui/src/components/shadcn/ui/calendar.tsx
+++ b/packages/ui/src/components/shadcn/ui/calendar.tsx
@@ -69,32 +69,35 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         weekday: cn('text-foreground-muted rounded-md w-9 font-normal text-[0.8rem]', weekday),
         week: cn('flex w-full mt-2', week),
         day: cn(
-          'text-center text-sm p-0 relative [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md',
-          'last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20',
+          'text-center text-sm p-0 relative',
+          'first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md',
+          'focus-within:relative focus-within:z-20',
           'w-9 box-border',
           day
         ),
         day_button: cn(
           buttonVariants({ variant: 'ghost' }),
-          'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
+          'h-9 w-9 p-0 font-normal rounded-md aria-selected:opacity-100',
           // Keep selected days from picking up ghost hover bg/text
           'aria-selected:hover:bg-transparent aria-selected:hover:text-inherit',
           day_button
         ),
         selected: cn(
-          'bg-brand-400 dark:bg-brand-500 text-foreground',
-          !fullDateRangeSelected && 'rounded-md',
+          !fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-md',
           selected
         ),
-        today: cn('bg-accent text-accent-foreground', today),
-        outside: cn('text-foreground-muted opacity-50', outside),
+        today: cn('bg-accent text-accent-foreground has-[[aria-selected]]:bg-transparent', today),
+        outside: cn(
+          'text-foreground-muted opacity-50 has-[[aria-selected]]:opacity-100 has-[[aria-selected]]:text-foreground',
+          outside
+        ),
         disabled: cn('text-foreground-muted opacity-50', disabled),
         range_start: cn(
           fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-l-md',
           range_start
         ),
         range_middle: cn(
-          'aria-selected:bg-brand-200 dark:aria-selected:bg-brand-400 aria-selected:text-foreground rounded-none',
+          'bg-brand-200 dark:bg-brand-400 text-foreground rounded-none',
           range_middle
         ),
         range_end: cn(

--- a/packages/ui/src/components/shadcn/ui/calendar.tsx
+++ b/packages/ui/src/components/shadcn/ui/calendar.tsx
@@ -86,7 +86,10 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
           !fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-md',
           selected
         ),
-        today: cn('bg-accent text-accent-foreground has-[[aria-selected]]:bg-transparent', today),
+        today: cn(
+          '[&:not(:has([aria-selected]))]:bg-accent [&:not(:has([aria-selected]))]:text-accent-foreground',
+          today
+        ),
         outside: cn(
           'text-foreground-muted opacity-50 has-[[aria-selected]]:opacity-100 has-[[aria-selected]]:text-foreground',
           outside

--- a/packages/ui/src/components/shadcn/ui/calendar.tsx
+++ b/packages/ui/src/components/shadcn/ui/calendar.tsx
@@ -83,28 +83,26 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
           day_button
         ),
         selected: cn(
-          !fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-md',
+          !fullDateRangeSelected && 'bg-brand-400! dark:bg-brand-500! text-foreground rounded-md',
           selected
         ),
-        today: cn(
-          '[&:not(:has([aria-selected]))]:bg-accent [&:not(:has([aria-selected]))]:text-accent-foreground',
-          today
-        ),
+        // Plain accent — range/selected fills use ! so they still win when today is in the selection
+        today: cn('bg-accent text-accent-foreground', today),
         outside: cn(
           'text-foreground-muted opacity-50 has-[[aria-selected]]:opacity-100 has-[[aria-selected]]:text-foreground',
           outside
         ),
         disabled: cn('text-foreground-muted opacity-50', disabled),
         range_start: cn(
-          fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-l-md',
+          fullDateRangeSelected && 'bg-brand-400! dark:bg-brand-500! text-foreground rounded-l-md',
           range_start
         ),
         range_middle: cn(
-          'bg-brand-200 dark:bg-brand-400 text-foreground rounded-none',
+          'bg-brand-200! dark:bg-brand-400! text-foreground rounded-none',
           range_middle
         ),
         range_end: cn(
-          fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-r-md',
+          fullDateRangeSelected && 'bg-brand-400! dark:bg-brand-500! text-foreground rounded-r-md',
           range_end
         ),
         hidden: cn('invisible', hidden),

--- a/packages/ui/src/components/shadcn/ui/calendar.tsx
+++ b/packages/ui/src/components/shadcn/ui/calendar.tsx
@@ -77,15 +77,30 @@ function Calendar({ className, classNames, showOutsideDays = true, ...props }: C
         day_button: cn(
           buttonVariants({ variant: 'ghost' }),
           'h-9 w-9 p-0 font-normal aria-selected:opacity-100',
+          // Keep selected days from picking up ghost hover bg/text
+          'aria-selected:hover:bg-transparent aria-selected:hover:text-inherit',
           day_button
         ),
-        selected: cn('bg-brand-500 text-foreground text-foreground', selected),
+        selected: cn(
+          'bg-brand-400 dark:bg-brand-500 text-foreground',
+          !fullDateRangeSelected && 'rounded-md',
+          selected
+        ),
         today: cn('bg-accent text-accent-foreground', today),
         outside: cn('text-foreground-muted opacity-50', outside),
         disabled: cn('text-foreground-muted opacity-50', disabled),
-        range_start: cn(fullDateRangeSelected && 'bg-brand-500 rounded-r-none', range_start),
-        range_middle: cn('aria-selected:bg-brand-400 rounded-none', range_middle),
-        range_end: cn(fullDateRangeSelected && 'bg-brand-500 rounded-l-none', range_end),
+        range_start: cn(
+          fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-l-md',
+          range_start
+        ),
+        range_middle: cn(
+          'aria-selected:bg-brand-200 dark:aria-selected:bg-brand-400 aria-selected:text-foreground rounded-none',
+          range_middle
+        ),
+        range_end: cn(
+          fullDateRangeSelected && 'bg-brand-400 dark:bg-brand-500 text-foreground rounded-r-md',
+          range_end
+        ),
         hidden: cn('invisible', hidden),
         ...restClassNames,
       }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

UI polish / bug fix for the shared Calendar range selection and Logs date picker.

## What is the current behavior?

- Selected date ranges use opaque `brand-400` / `brand-500` fills that read too loud in light mode, with black text that is hard to read on darker endpoints.
- Start/end days are squared off on the connecting edge without intentional outer rounding.
- Outside days in a selected range are dimmed with `opacity-50`, which can tint the range wash incorrectly when a range starts in the prior month.
- The large-range warning in `LogsDatePicker` is a full-bleed yellow banner that feels too heavy for the popover.
- Time inputs show a clock icon that adds visual noise.

## What is the new behavior?

- Range middle uses a softer `brand-200` wash; start/end stay on stronger brand fills with readable foreground text.
- Start days round on the left (`rounded-l-md`), end days on the right (`rounded-r-md`); day hover keeps `rounded-md`.
- Selected outside days and “today” no longer fight the range wash colours.
- Large-range warning is quiet inline `text-warning` copy that wraps to the calendar column width.
- Clock icon removed from `TimeSplitInput`.

| Before | After |
| --- | --- |
| <img width="1096" height="1076" alt="CleanShot 2026-07-16 at 17 59 21@2x" src="https://github.com/user-attachments/assets/eac38022-ed92-4dbe-9932-55f7bf0af934" /> | <img width="988" height="1064" alt="CleanShot 2026-07-16 at 17 59 34@2x" src="https://github.com/user-attachments/assets/3dce30dd-9fd8-4da4-82b3-5663250a4ddc" /> |

## Additional context

Shared `Calendar` changes apply anywhere range mode is used, not only logs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Refined the date-picker popover layout for start/end controls with better fit and max-width handling.
  - Updated calendar day and range visuals (selection, outside states, rounding, and hover behavior) to reduce “ghost” styling and improve consistency.
  - Restyled the large-range warning to improve spacing and alignment.
  - Simplified the time-splitting input UI by removing the leading clock icon.
  - Adjusted the “Copy range” button feedback color for copied/pasted states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->