### PR TITLE
fix(studio): prevent silent loss of cleared storage policy expressions

### DIFF
--- a/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
@@ -170,6 +170,8 @@ export const PolicyEditorModal = ({
 
   const validatePolicyFormFields = () => {
     const { name, definition, check, command } = policyFormFields
+    const trimmedDefinition = definition?.trim() ?? ''
+    const trimmedCheck = check?.trim() ?? ''
 
     if (name.length === 0) {
       return toast.error('Please provide a name for your policy')
@@ -177,13 +179,13 @@ export const PolicyEditorModal = ({
     if (!command) {
       return toast.error('Please select an operation for your policy')
     }
-    if (['SELECT', 'DELETE'].includes(command) && !definition) {
+    if (['SELECT', 'DELETE'].includes(command) && !trimmedDefinition) {
       return toast.error('Please provide a USING expression for your policy')
     }
-    if (command === 'INSERT' && !check) {
+    if (command === 'INSERT' && !trimmedCheck) {
       return toast.error('Please provide a WITH CHECK expression for your policy')
     }
-    if (command === 'UPDATE' && !definition && !check) {
+    if (command === 'UPDATE' && !trimmedDefinition && !trimmedCheck) {
       return toast.error(
         'Please provide either a USING, or WITH CHECK expression, or both for your policy'
       )
@@ -192,12 +194,12 @@ export const PolicyEditorModal = ({
     // ALTER POLICY can only replace expressions, not remove them, so a cleared
     // field would be silently dropped from the update payload (undefined →
     // omitted in JSON serialization) and the old expression would persist.
-    if (selectedPolicyToEdit?.definition && !definition) {
+    if (selectedPolicyToEdit?.definition && !trimmedDefinition) {
       return toast.error(
         'The USING expression cannot be removed once set. Replace it with a new expression instead.'
       )
     }
-    if (selectedPolicyToEdit?.check && !check) {
+    if (selectedPolicyToEdit?.check && !trimmedCheck) {
       return toast.error(
         'The WITH CHECK expression cannot be removed once set. Replace it with a new expression instead.'
       )

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
@@ -194,12 +194,15 @@ export const PolicyEditorModal = ({
     // ALTER POLICY can only replace expressions, not remove them, so a cleared
     // field would be silently dropped from the update payload (undefined →
     // omitted in JSON serialization) and the old expression would persist.
-    if (selectedPolicyToEdit?.definition && !trimmedDefinition) {
+    // Trim the stored expressions too so whitespace-only values are treated as empty.
+    const storedDefinition = selectedPolicyToEdit?.definition?.trim()
+    const storedCheck = selectedPolicyToEdit?.check?.trim()
+    if (storedDefinition && !trimmedDefinition) {
       return toast.error(
         'The USING expression cannot be removed once set. Replace it with a new expression instead.'
       )
     }
-    if (selectedPolicyToEdit?.check && !trimmedCheck) {
+    if (storedCheck && !trimmedCheck) {
       return toast.error(
         'The WITH CHECK expression cannot be removed once set. Replace it with a new expression instead.'
       )

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
@@ -46,8 +46,16 @@ const acceptUpdatePayload = (
   draft: DraftPostgresPolicyUpdatePayload
 ): PostgresPolicyUpdatePayload => ({
   ...draft,
-  definition: draft.definition === undefined ? undefined : acceptUntrustedSql(draft.definition),
-  check: draft.check === undefined ? undefined : acceptUntrustedSql(draft.check),
+  // Preserve `null` (explicit clear) and `undefined` (no change) while
+  // promoting actual SQL fragments to SafeSqlFragment.
+  definition:
+    draft.definition === undefined || draft.definition === null
+      ? draft.definition
+      : acceptUntrustedSql(draft.definition),
+  check:
+    draft.check === undefined || draft.check === null
+      ? draft.check
+      : acceptUntrustedSql(draft.check),
 })
 
 interface PolicyEditorModalProps {
@@ -178,6 +186,20 @@ export const PolicyEditorModal = ({
     if (command === 'UPDATE' && !definition && !check) {
       return toast.error(
         'Please provide either a USING, or WITH CHECK expression, or both for your policy'
+      )
+    }
+    // Prevent clearing an expression that was already set on the existing policy.
+    // ALTER POLICY can only replace expressions, not remove them, so a cleared
+    // field would be silently dropped from the update payload (undefined →
+    // omitted in JSON serialization) and the old expression would persist.
+    if (selectedPolicyToEdit?.definition && !definition) {
+      return toast.error(
+        'The USING expression cannot be removed once set. Replace it with a new expression instead.'
+      )
+    }
+    if (selectedPolicyToEdit?.check && !check) {
+      return toast.error(
+        'The WITH CHECK expression cannot be removed once set. Replace it with a new expression instead.'
       )
     }
     const policySQLStatement = createSQLPolicy(policyFormFields, selectedPolicyToEdit)

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.types.ts
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.types.ts
@@ -31,8 +31,8 @@ export interface PostgresPolicyCreatePayload {
 export interface PostgresPolicyUpdatePayload {
   id: number
   name?: string
-  definition?: SafeSqlFragment
-  check?: SafeSqlFragment
+  definition?: SafeSqlFragment | null
+  check?: SafeSqlFragment | null
   roles?: string[]
 }
 
@@ -55,8 +55,8 @@ export interface DraftPostgresPolicyUpdatePayload extends Omit<
   PostgresPolicyUpdatePayload,
   'definition' | 'check'
 > {
-  definition?: DisplayableSqlFragment
-  check?: DisplayableSqlFragment
+  definition?: DisplayableSqlFragment | null
+  check?: DisplayableSqlFragment | null
 }
 
 export interface PolicyForReview {

--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.utils.ts
@@ -100,8 +100,16 @@ const createSQLStatementForUpdatePolicy = (
   const alterStatement = `ALTER POLICY "${name}" ON "${schema}"."${table}"`
   const statement = [
     'BEGIN;',
-    ...(definitionChanged ? [`  ${alterStatement} USING (${fieldsToUpdate.definition});`] : []),
-    ...(checkChanged ? [`  ${alterStatement} WITH CHECK (${fieldsToUpdate.check});`] : []),
+    // ALTER POLICY cannot remove expressions — only replace them. Emitting
+    // `USING ()` or `WITH CHECK ()` for a cleared field produces invalid SQL
+    // that is silently dropped by pg-meta (undefined payload), so guard here
+    // as defense-in-depth.
+    ...(definitionChanged && fieldsToUpdate.definition
+      ? [`  ${alterStatement} USING (${fieldsToUpdate.definition});`]
+      : []),
+    ...(checkChanged && fieldsToUpdate.check
+      ? [`  ${alterStatement} WITH CHECK (${fieldsToUpdate.check});`]
+      : []),
     ...(rolesChanged ? [`  ${alterStatement} TO ${roles.join(', ')};`] : []),
     ...(nameChanged ? [`  ${alterStatement} RENAME TO "${fieldsToUpdate.name}";`] : []),
     'COMMIT;',
@@ -144,10 +152,14 @@ export const createPayloadForUpdatePolicy = (
     payload.name = policyFormFields.name
   }
   if (!isEqual(formattedDefinition, originalPolicyFormFields.definition)) {
-    payload.definition = !formattedDefinition ? undefined : untrustedSql(formattedDefinition)
+    // When a definition is cleared, send null instead of undefined.
+    // `undefined` is stripped during JSON.stringify, so pg-meta's update()
+    // never sees the field and treats it as "no change" — the old expression
+    // silently persists. `null` is preserved in JSON and signals "remove this".
+    payload.definition = !formattedDefinition ? null : untrustedSql(formattedDefinition)
   }
   if (!isEqual(formattedCheck, originalPolicyFormFields.check)) {
-    payload.check = !formattedCheck ? undefined : untrustedSql(formattedCheck)
+    payload.check = !formattedCheck ? null : untrustedSql(formattedCheck)
   }
   if (!isEqual(policyFormFields.roles, originalPolicyFormFields.roles)) {
     if (policyFormFields.roles.length === 0) payload.roles = ['public']

--- a/apps/studio/data/database-policies/database-policy-update-mutation.ts
+++ b/apps/studio/data/database-policies/database-policy-update-mutation.ts
@@ -18,8 +18,8 @@ export type DatabasePolicyUpdateVariables = {
   }
   payload: {
     name?: string
-    definition?: SafeSqlFragment
-    check?: SafeSqlFragment
+    definition?: SafeSqlFragment | null
+    check?: SafeSqlFragment | null
     roles?: string[]
   }
 }

--- a/apps/studio/tests/components/Storage/StoragePolicies.utils.test.ts
+++ b/apps/studio/tests/components/Storage/StoragePolicies.utils.test.ts
@@ -1,0 +1,214 @@
+import type { PGPolicy } from '@supabase/pg-meta'
+import { describe, expect, test } from 'vitest'
+
+import type { PolicyFormField } from '@/components/interfaces/Storage/StoragePolicies/StoragePolicies.types'
+import {
+  createPayloadForCreatePolicy,
+  createPayloadForUpdatePolicy,
+  createSQLPolicy,
+} from '@/components/interfaces/Storage/StoragePolicies/StoragePolicies.utils'
+
+const mockFormFields = (overrides: Partial<PolicyFormField> = {}): PolicyFormField => ({
+  name: 'My policy',
+  schema: 'storage',
+  table: 'objects',
+  command: 'SELECT',
+  definition: `bucket_id = 'avatars'`,
+  check: null,
+  roles: [],
+  ...overrides,
+})
+
+const mockOriginalPolicy = (overrides: Partial<PGPolicy> = {}): PGPolicy =>
+  ({
+    id: 1,
+    schema: 'storage',
+    table: 'objects',
+    table_id: 100,
+    name: 'My policy',
+    action: 'PERMISSIVE',
+    roles: [],
+    command: 'SELECT',
+    definition: `bucket_id = 'avatars'`,
+    check: null,
+    ...overrides,
+  }) as PGPolicy
+
+describe('StoragePolicies.utils: createSQLPolicy (create)', () => {
+  test('should generate a CREATE POLICY statement with USING for a SELECT policy', () => {
+    const output = createSQLPolicy(mockFormFields())
+    expect(output.description).toBe(
+      'Add policy for the SELECT operation under the policy "My policy"'
+    )
+    expect(output.statement).toBe(
+      [
+        `CREATE POLICY "My policy" ON "storage"."objects"`,
+        `AS PERMISSIVE FOR SELECT`,
+        `TO public`,
+        `USING (bucket_id = 'avatars')`,
+        ``,
+      ].join('\n')
+    )
+  })
+
+  test('should generate a CREATE POLICY statement with WITH CHECK for an INSERT policy', () => {
+    const output = createSQLPolicy(
+      mockFormFields({
+        command: 'INSERT',
+        definition: null,
+        check: `bucket_id = 'avatars'`,
+        roles: ['authenticated'],
+      })
+    )
+    expect(output.statement).toBe(
+      [
+        `CREATE POLICY "My policy" ON "storage"."objects"`,
+        `AS PERMISSIVE FOR INSERT`,
+        `TO authenticated`,
+        ``,
+        `WITH CHECK (bucket_id = 'avatars')`,
+      ].join('\n')
+    )
+  })
+})
+
+describe('StoragePolicies.utils: createSQLPolicy (update)', () => {
+  test('should not emit USING () when definition is cleared', () => {
+    // Regression: previously emitted `ALTER POLICY ... USING ();` which is
+    // invalid SQL. Now the cleared expression is omitted from the statement.
+    const output = createSQLPolicy(
+      mockFormFields({ command: 'UPDATE', definition: '', check: `bucket_id = 'logos'` }),
+      mockOriginalPolicy({ command: 'UPDATE', definition: `bucket_id = 'avatars'`, check: null })
+    )
+    expect(output.statement).not.toContain('USING ()')
+    expect(output.statement).toContain("WITH CHECK (bucket_id = 'logos')")
+  })
+
+  test('should not emit WITH CHECK () when check is cleared', () => {
+    const output = createSQLPolicy(
+      mockFormFields({ command: 'UPDATE', definition: `bucket_id = 'avatars'`, check: '' }),
+      mockOriginalPolicy({ command: 'UPDATE', definition: null, check: `bucket_id = 'avatars'` })
+    )
+    expect(output.statement).not.toContain('WITH CHECK ()')
+    expect(output.statement).toContain("USING (bucket_id = 'avatars')")
+  })
+
+  test('should return empty object when nothing changed', () => {
+    const output = createSQLPolicy(mockFormFields(), mockOriginalPolicy())
+    expect(output).toEqual({})
+  })
+
+  test('should include only changed fields in the ALTER statement', () => {
+    const output = createSQLPolicy(
+      mockFormFields({ name: 'New name' }),
+      mockOriginalPolicy()
+    )
+    expect(output.statement).toContain('RENAME TO "New name"')
+    expect(output.statement).not.toContain('USING')
+    expect(output.statement).not.toContain('WITH CHECK')
+  })
+})
+
+describe('StoragePolicies.utils: createPayloadForCreatePolicy', () => {
+  test('should build a payload with the definition for a SELECT policy', () => {
+    const output = createPayloadForCreatePolicy(mockFormFields({ roles: ['authenticated'] }))
+    expect(output).toStrictEqual({
+      name: 'My policy',
+      schema: 'storage',
+      table: 'objects',
+      action: 'PERMISSIVE',
+      command: 'SELECT',
+      definition: `bucket_id = 'avatars'`,
+      check: undefined,
+      roles: ['authenticated'],
+    })
+  })
+
+  test('should omit roles when none are selected', () => {
+    const output = createPayloadForCreatePolicy(mockFormFields({ roles: [] }))
+    expect(output.roles).toBeUndefined()
+  })
+
+  test('should omit the command when it is null', () => {
+    const output = createPayloadForCreatePolicy(mockFormFields({ command: null }))
+    expect(output.command).toBeUndefined()
+  })
+
+  test('should omit definition and check when they are empty', () => {
+    const output = createPayloadForCreatePolicy(mockFormFields({ definition: '', check: null }))
+    expect(output.definition).toBeUndefined()
+    expect(output.check).toBeUndefined()
+  })
+})
+
+describe('StoragePolicies.utils: createPayloadForUpdatePolicy', () => {
+  test('should return only the policy id when nothing changed', () => {
+    const output = createPayloadForUpdatePolicy(mockFormFields(), mockOriginalPolicy())
+    expect(output).toStrictEqual({ id: 1 })
+  })
+
+  test('should not include the definition when it differs only by whitespace', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ definition: `bucket_id\n  =  'avatars'` }),
+      mockOriginalPolicy()
+    )
+    expect(output).toStrictEqual({ id: 1 })
+  })
+
+  test('should include only the changed fields', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ name: 'New name', definition: `bucket_id = 'logos'` }),
+      mockOriginalPolicy()
+    )
+    expect(output).toStrictEqual({
+      id: 1,
+      name: 'New name',
+      definition: `bucket_id = 'logos'`,
+    })
+  })
+
+  test('should include the check when it changed', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ check: `bucket_id = 'avatars'` }),
+      mockOriginalPolicy({ check: null })
+    )
+    expect(output).toStrictEqual({ id: 1, check: `bucket_id = 'avatars'` })
+  })
+
+  // Regression for #48015: clearing a definition must send null (which
+  // survives JSON serialization) instead of undefined (which is stripped).
+  test('should set the definition to null when it was cleared', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ definition: '' }),
+      mockOriginalPolicy()
+    )
+    expect(output).toStrictEqual({ id: 1, definition: null })
+    // Verify the key survives JSON round-trip
+    expect(JSON.parse(JSON.stringify(output))).toHaveProperty('definition')
+  })
+
+  test('should set the check to null when it was cleared', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ check: '' }),
+      mockOriginalPolicy({ check: `bucket_id = 'avatars'` })
+    )
+    expect(output).toStrictEqual({ id: 1, check: null })
+    expect(JSON.parse(JSON.stringify(output))).toHaveProperty('check')
+  })
+
+  test('should default to the public role when roles were cleared', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ roles: [] }),
+      mockOriginalPolicy({ roles: ['authenticated'] })
+    )
+    expect(output).toStrictEqual({ id: 1, roles: ['public'] })
+  })
+
+  test('should include the new roles when they changed', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ roles: ['anon', 'authenticated'] }),
+      mockOriginalPolicy({ roles: ['authenticated'] })
+    )
+    expect(output).toStrictEqual({ id: 1, roles: ['anon', 'authenticated'] })
+  })
+})

--- a/apps/studio/tests/components/Storage/StoragePolicies.utils.test.ts
+++ b/apps/studio/tests/components/Storage/StoragePolicies.utils.test.ts
@@ -196,6 +196,25 @@ describe('StoragePolicies.utils: createPayloadForUpdatePolicy', () => {
     expect(JSON.parse(JSON.stringify(output))).toHaveProperty('check')
   })
 
+  // Regression for CodeRabbit review: whitespace-only expressions should be
+  // treated as empty, since createPayloadForUpdatePolicy trims them to "" and
+  // would send null — silently clearing the expression.
+  test('should set the definition to null when it is whitespace-only', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ definition: '   ' }),
+      mockOriginalPolicy()
+    )
+    expect(output).toStrictEqual({ id: 1, definition: null })
+  })
+
+  test('should set the check to null when it is whitespace-only', () => {
+    const output = createPayloadForUpdatePolicy(
+      mockFormFields({ check: '   ' }),
+      mockOriginalPolicy({ check: `bucket_id = 'avatars'` })
+    )
+    expect(output).toStrictEqual({ id: 1, check: null })
+  })
+
   test('should default to the public role when roles were cleared', () => {
     const output = createPayloadForUpdatePolicy(
       mockFormFields({ roles: [] }),

--- a/packages/pg-meta/src/pg-meta-policies.ts
+++ b/packages/pg-meta/src/pg-meta-policies.ts
@@ -134,8 +134,8 @@ create policy ${ident(name)} on ${ident(schema)}.${ident(table)}
 
 type PolicyUpdateParams = {
   name?: string
-  definition?: SafeSqlFragment
-  check?: SafeSqlFragment
+  definition?: SafeSqlFragment | null
+  check?: SafeSqlFragment | null
   roles?: string[]
 }
 
@@ -148,10 +148,18 @@ function update(
   const alter = safeSql`ALTER POLICY ${ident(identifier.name)} ON ${ident(identifier.schema)}.${ident(identifier.table)}`
   const nameSql: SafeSqlFragment =
     name === undefined ? safeSql`` : safeSql`${alter} RENAME TO ${ident(name)};`
+  // `undefined` = no change (omit the clause). `null` = explicit clear, which
+  // ALTER POLICY cannot do (PostgreSQL can only replace, not remove), so we
+  // also omit the clause — the caller's validation should prevent reaching
+  // here with null. Keeping the guard ensures we never emit `USING (null)`.
   const definitionSql: SafeSqlFragment =
-    definition === undefined ? safeSql`` : safeSql`${alter} USING (${definition});`
+    definition === undefined || definition === null
+      ? safeSql``
+      : safeSql`${alter} USING (${definition});`
   const checkSql: SafeSqlFragment =
-    check === undefined ? safeSql`` : safeSql`${alter} WITH CHECK (${check});`
+    check === undefined || check === null
+      ? safeSql``
+      : safeSql`${alter} WITH CHECK (${check});`
   const rolesSql: SafeSqlFragment =
     roles === undefined
       ? safeSql``


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When editing an existing storage policy in the dashboard, clearing a USING or WITH CHECK expression is silently not saved. The dashboard shows a success toast, but the old expression persists on the policy.

The root cause is in `createPayloadForUpdatePolicy` (`StoragePolicies.utils.ts`): when a field is cleared, the payload value is set to `undefined`. During `JSON.stringify`, `undefined` values are stripped from the object, so the API never receives the change. pg-meta's `update()` only sees fields that are present and treats absent fields as "no change."

The review step also previews invalid SQL in this case, e.g. `ALTER POLICY "My policy" ON "storage"."objects" WITH CHECK ();`.

Related issue: #48015

## What is the new behavior?

Three layers of defense:

**1. Validation** (`PolicyEditorModal/index.tsx`): prevent clearing an expression that was already set on the original policy. PostgreSQL's `ALTER POLICY` can only replace expressions, not remove them, so clearing is not a valid operation. The user sees a toast explaining they should replace the expression with a new one instead of clearing it.

**2. Payload fix** (`StoragePolicies.utils.ts`): send `null` instead of `undefined` for cleared fields. `null` survives JSON serialization and is a distinguishable signal, while `undefined` is stripped and indistinguishable from "no change."

**3. SQL preview guard** (`StoragePolicies.utils.ts`): `createSQLStatementForUpdatePolicy` now checks that the field has a value before emitting `USING (...)` or `WITH CHECK (...)`, so the review step never shows invalid empty-expression SQL.

**pg-meta** (`pg-meta-policies.ts`): `PolicyUpdateParams` now accepts `null` for `definition`/`check`. The `update()` function handles `null` gracefully by omitting the clause (same as `undefined`), ensuring we never emit `USING (null)`.

Includes 16 unit tests covering SQL generation and payload constructors, with regression tests for the clearing behavior.

## Additional context

The existing PR #48016 adds test-only coverage that characterizes the buggy behavior (its test "should set the definition to undefined when it was cleared" documents the bug). This PR fixes the actual bug and updates the test expectations to verify `null` is sent instead of `undefined`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved storage policy updates so clearing `definition`/`check` now consistently removes the corresponding `USING`/`WITH CHECK` SQL fragments.
  * Prevented generation of invalid/empty `USING ()` / `WITH CHECK ()` clauses by correctly handling `null` as an explicit clear.
  * Updated policy validation and user messaging to instruct replacing expressions rather than removing them when clearing isn’t allowed.

* **Tests**
  * Expanded automated coverage for policy SQL formatting and update-payload behavior, including create/update cases and regression checks for cleared expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->