### PR TITLE
docs: add workaround to avoid noisy logs when PostgREST is disabled

### DIFF
--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -4,7 +4,7 @@ Supabase Reference Docs
 
 ## Maintainers
 
-eIf you are a maintainer of any tools in the Supabase ecosystem, you can use this site to provide documentation for the tools & libraries that you maintain.
+If you are a maintainer of any tools in the Supabase ecosystem, you can use this site to provide documentation for the tools & libraries that you maintain.
 
 ## DocSpec
 

--- a/apps/docs/README.md
+++ b/apps/docs/README.md
@@ -4,7 +4,7 @@ Supabase Reference Docs
 
 ## Maintainers
 
-If you are a maintainer of any tools in the Supabase ecosystem, you can use this site to provide documentation for the tools & libraries that you maintain.
+eIf you are a maintainer of any tools in the Supabase ecosystem, you can use this site to provide documentation for the tools & libraries that you maintain.
 
 ## DocSpec
 

--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist.mdx
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist.mdx
@@ -22,15 +22,35 @@ PostgREST logs showing the error:
 
 ## Workaround
 
-In the meantime, you can create a dummy schema to avoid the noisy logs:
+To stop the missing-schema log entries:
 
-```sql
--- Create a schema with nothing inside
-create schema pgrst_no_exposed_schemas;
+1. Open the SQL Editor.
+2. Run the following statements:
 
--- Set the db-schemas configuration
-alter role authenticator set pgrst.db_schemas = 'pgrst_no_exposed_schemas';
+   ```sql
+   -- Create a schema with nothing inside
+   create schema pgrst_no_exposed_schemas;
 
--- Reload PostgREST's schema cache
-notify pgrst;
-```
+   -- Set the db-schemas configuration
+   alter role authenticator set pgrst.db_schemas = 'pgrst_no_exposed_schemas';
+
+   -- Reload PostgREST's schema cache and configuration
+   notify pgrst;
+   ```
+
+PostgREST now exposes an empty schema, which stops the missing-schema errors.
+
+## Re-enable the Data API
+
+Before you re-enable the data API:
+
+1. Open the SQL Editor.
+2. Run the following statements:
+
+   ```sql
+   -- Reset the db-schemas configuration
+   alter role authenticator reset pgrst.db_schemas;
+
+   -- Reload PostgREST's schema cache and configuration
+   notify pgrst;
+   ```

--- a/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist.mdx
+++ b/apps/docs/content/troubleshooting/schema-pg_pgrst_no_exposed_schemas-does-not-exist.mdx
@@ -19,3 +19,18 @@ PostgREST logs showing the error:
 - Currently, we don't really shutdown PostgREST when the Data API is disabled. You will see a schema called `pg_pgrst_no_exposed_schemas` added in the exposed schemas.
 - This should not adversely affect the project, although it may result in additional entries in your logs.
 - We're aware of this issue and are working on it.
+
+## Workaround
+
+In the meantime, you can create a dummy schema to avoid the noisy logs:
+
+```sql
+-- Create a schema with nothing inside
+create schema pgrst_no_exposed_schemas;
+
+-- Set the db-schemas configuration
+alter role authenticator set pgrst.db_schemas = 'pgrst_no_exposed_schemas';
+
+-- Reload PostgREST's schema cache
+notify pgrst;
+```


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Adds a workaround to stop noisy logs when PostgREST is disabled to the troubleshooting guide.

## What is the current behavior?

It mentions that we're currently working on solving the noisy logs issues but no extra solution is provided.

## What is the new behavior?

It adds the workaround to avoid this issue in the meantime.

## Additional context

See this issue for reference: https://github.com/supabase/supabase/issues/40617


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the troubleshooting guide with a new **Workaround** section for recurring missing-schema errors in PostgREST.
  - Added SQL that creates a placeholder schema, adjusts the exposed-schema configuration for the authenticator, and reloads the schema cache to stop the related log entries.
  - Added a **Re-enable the Data API** follow-up to restore the setting and reload again if the Data API is enabled later.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->