### PR TITLE
fix(studio): mirror Vercel interstitial layout change into TanStack routes

### DIFF
--- a/apps/studio/routes/integrations/vercel.tsx
+++ b/apps/studio/routes/integrations/vercel.tsx
@@ -1,19 +1,14 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router'
 
-import VercelIntegrationWindowLayout from '@/components/layouts/IntegrationsLayout/VercelIntegrationWindowLayout'
-
 export const Route = createFileRoute('/integrations/vercel')({
-  component: VercelIntegrationShell,
+  component: VercelIntegrationPassthrough,
 })
 
-// Placed at top-level rather than under _app — Next getLayout for all
-// three leaves only wraps in VercelIntegrationWindowLayout (no AppLayout
-// or DefaultLayout), so adding _app's chrome here would be a behaviour
-// change.
-function VercelIntegrationShell() {
-  return (
-    <VercelIntegrationWindowLayout>
-      <Outlet />
-    </VercelIntegrationWindowLayout>
-  )
+// No shared layout here. Since #47623, the install and
+// marketplace/choose-project pages render their own InterstitialLayout and
+// have no Next getLayout, so the Next runtime shows them without any window
+// chrome. Only deploy-button/new-project still uses
+// VercelIntegrationWindowLayout, and its route wraps it at the leaf.
+function VercelIntegrationPassthrough() {
+  return <Outlet />
 }

--- a/apps/studio/routes/integrations/vercel/$slug/deploy-button/new-project.tsx
+++ b/apps/studio/routes/integrations/vercel/$slug/deploy-button/new-project.tsx
@@ -1,11 +1,18 @@
 import { createFileRoute } from '@tanstack/react-router'
 
+import VercelIntegrationWindowLayout from '@/components/layouts/IntegrationsLayout/VercelIntegrationWindowLayout'
 import VercelIntegration from '@/pages/integrations/vercel/[slug]/deploy-button/new-project'
 
 export const Route = createFileRoute('/integrations/vercel/$slug/deploy-button/new-project')({
   component: VercelDeployButtonNewProjectRoute,
 })
 
+// Mirrors the page's Next getLayout, which wraps this leaf (and only this
+// leaf) in VercelIntegrationWindowLayout.
 function VercelDeployButtonNewProjectRoute() {
-  return <VercelIntegration dehydratedState={undefined} />
+  return (
+    <VercelIntegrationWindowLayout>
+      <VercelIntegration dehydratedState={undefined} />
+    </VercelIntegrationWindowLayout>
+  )
 }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #48023. On the TanStack runtime, `routes/integrations/vercel.tsx` still wraps all three `/integrations/vercel/*` leaves in `VercelIntegrationWindowLayout`. Since #47623, the install and marketplace/choose-project pages render their own `InterstitialLayout` and no longer define a Next `getLayout`, so TanStack shows the new interstitial card nested inside the old window chrome while the Next runtime shows the card on its own.

## What is the new behavior?

The `/integrations/vercel` route is a plain passthrough now, and `VercelIntegrationWindowLayout` moved down to the deploy-button/new-project leaf, the only page still using it via `getLayout`. Both runtimes render the same UI for all three routes.

## Additional context

This is the pages-to-routes mirror drift that `TANSTACK_MIGRATION.md` and the CodeRabbit guardrail describe: #47623 changed the page layouts, but the route shell (unchanged since #47117) kept the old wrapping.

Ran locally: prettier check, `typecheck --filter=studio`, `lint --filter=studio`, `test:studio` (the one failure, `lib/local-storage.test.ts`, fails identically on clean master, so it is unrelated to this change), `build:tanstack` including the smoke server, and `build --filter=studio`. No screenshots because the install flow needs a live Vercel session; the layout difference is visible directly in the two route files.

Note on the earlier description: I had two PRs in flight and accidentally pasted the write-up from a different project over this one right after opening it. This is the real description. Sorry for the confusion!

quick note: I'm a college freshman getting into OSS and I put this fix together with Claude Code's help, then went through the runtime behavior and the checks locally myself. apologies in advance if I missed something obvious, genuinely happy to learn and rework anything :)
