### PR TITLE
test(logs): regression coverage for datepicker Invalid time value crash

### DIFF
--- a/apps/studio/tests/features/logs/Logs.Datepickers.test.tsx
+++ b/apps/studio/tests/features/logs/Logs.Datepickers.test.tsx
@@ -296,6 +296,19 @@ test('passing a value prop shows the correct dates in the label', async () => {
   )
 })
 
+test('opening with an unparseable date value (legacy epoch-ms its/ite) does not crash', async () => {
+  render(
+    <LogsDatePicker
+      helpers={[]}
+      value={{ from: '1784211420000', to: '1784211540000' }}
+      onSubmit={mockFn}
+    />
+  )
+
+  await userEvent.click(await screen.findByRole('button'))
+  expect(await screen.findByText('Apply')).toBeInTheDocument()
+})
+
 test('passing a helper as a value prop shows the helper text in the label', async () => {
   const helper = {
     text: 'Last 7 days',

--- a/apps/studio/tests/features/logs/LogsPreviewer.test.tsx
+++ b/apps/studio/tests/features/logs/LogsPreviewer.test.tsx
@@ -140,6 +140,20 @@ test('can click load older', async () => {
   expect(handleClick).toHaveBeenCalled()
 })
 
+test('loads its/ite from the URL into the date picker and opens without crashing', async () => {
+  const its = dayjs('2024-01-15T12:00:00.000Z')
+  const ite = dayjs('2024-01-15T12:02:00.000Z')
+
+  customRender(
+    <LogsPreviewer queryType="api" projectRef="default" tableName={LogsTableName.EDGE} />,
+    { nuqs: { searchParams: { its: its.toISOString(), ite: ite.toISOString() } } }
+  )
+
+  const label = `${its.format('DD MMM, HH:mm')} - ${ite.format('DD MMM, HH:mm')}`
+  await userEvent.click(await screen.findByText(label))
+  expect(await screen.findByText('Apply')).toBeInTheDocument()
+})
+
 describe('calculateBarClickTimeRange', () => {
   const clickedTime = '2024-01-15T12:30:00.000Z'
 


### PR DESCRIPTION
## Problem

The database-report chart to logs flow could crash the logs date picker with "RangeError: Invalid time value" (react-day-picker formatting an Invalid Date), and there was no regression coverage for it.

## Fix

Adds two Vitest tests that reproduce the crash path:

- Logs.Datepickers.test.tsx: opening LogsDatePicker with an unparseable value (the legacy epoch-ms its/ite) must render the calendar instead of throwing.
- LogsPreviewer.test.tsx (MSW): its/ite from the URL load into the picker and it opens without crashing, covering the chart-to-logs navigation end to end.

Note: these tests depend on the fix in #48009. On master the crash-guard test fails with the exact "Invalid time value" error (that is the regression it catches), so CI here will be red until #48009 merges.

## How to test

- Run: pnpm --filter studio exec vitest --run tests/features/logs/Logs.Datepickers.test.tsx tests/features/logs/LogsPreviewer.test.tsx
- On master: the "unparseable date value" test fails with RangeError: Invalid time value.
- With #48009 merged in: both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to ensure the logs date picker handles legacy or unparseable date values without crashing.
  * Added coverage verifying log preview date ranges are populated from URL parameters and can be opened successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->