### PR TITLE
chore: add ssl_enforcement_required for jit

### DIFF
--- a/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
+++ b/apps/studio/components/interfaces/Settings/Database/JitDatabaseAccess/JitDbAccessConfiguration.tsx
@@ -302,13 +302,17 @@ export const JitDbAccessConfiguration = () => {
       ? 'Postgres upgrade required'
       : unavailableReason === 'manual_migration_required'
         ? 'Migration required'
-        : 'Temporary access unavailable'
+        : unavailableReason === 'ssl_enforcement_required'
+          ? 'SSL enforcement required'
+          : 'Temporary access unavailable'
   const unavailableDescription =
     unavailableReason === 'postgres_upgrade_required'
       ? 'must be upgraded to Postgres 17 or later before temporary access can be enabled.'
       : unavailableReason === 'manual_migration_required'
         ? 'must be migrated before temporary access can be enabled. Contact support to migrate this project.'
-        : 'This feature is currently unavailable for this project. Contact support if you need help enabling it.'
+        : unavailableReason === 'ssl_enforcement_required'
+          ? 'must have SSL enforcement enabled before temporary access can be enabled.'
+          : 'This feature is currently unavailable for this project. Contact support if you need help enabling it.'
 
   useEffect(() => {
     if (!isLoadingConfiguration && jitDbAccessConfiguration) {
@@ -376,6 +380,12 @@ export const JitDbAccessConfiguration = () => {
                 unavailableReason === 'postgres_upgrade_required' && ref ? (
                   <Button variant="default" asChild>
                     <Link href={`/project/${ref}/settings/infrastructure`}>Upgrade Postgres</Link>
+                  </Button>
+                ) : unavailableReason === 'ssl_enforcement_required' && ref ? (
+                  <Button variant="default" asChild>
+                    <Link href={`/project/${ref}/settings/database#ssl-configuration`}>
+                      Enable SSL enforcement
+                    </Link>
                   </Button>
                 ) : (
                   <Button variant="default" asChild>

--- a/packages/api-types/types/api.d.ts
+++ b/packages/api-types/types/api.d.ts
@@ -3223,6 +3223,7 @@ export interface components {
           unavailableReason:
             | 'manual_migration_required'
             | 'postgres_upgrade_required'
+            | 'ssl_enforcement_required'
             | 'temporarily_unavailable'
         }
     LegacyApiKeysResponse: {


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

chore / bug fix

## What is the current behavior?

The new `ssl_enforcement_required` state is not handled

## What is the new behavior?

Displays the correct message




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved temporary database access messaging when SSL enforcement is required.
  * Added a direct action to open database settings and enable SSL enforcement before activating temporary access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->