### PR TITLE
chore: migrate repo to pnpm v11

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
-engine-strict=true
-update-notifier=false
 @jsr:registry=https://npm.jsr.io

--- a/apps/design-system/package.json
+++ b/apps/design-system/package.json
@@ -13,7 +13,7 @@
     "start": "next start",
     "lint": "eslint .",
     "content:build": "contentlayer2 build",
-    "clean": "rimraf node_modules .next .turbo",
+    "clean": "rimraf .next .turbo tsconfig.tsbuildinfo",
     "typecheck": "contentlayer2 build && tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -13,7 +13,7 @@
     "build:markdown": "pnpm build:guides-markdown && pnpm build:reference-markdown",
     "build:gz-archive": "tsx ./internals/generate-gz-archive.ts",
     "build:sitemap": "tsx ./internals/generate-sitemap.ts",
-    "clean": "rimraf .next .turbo node_modules features/docs/generated examples __generated__",
+    "clean": "rimraf .next .turbo features/docs/generated examples __generated__ tsconfig.tsbuildinfo",
     "codegen:examples": "shx cp -r ../../examples ./examples",
     "codegen:graphql": "tsx --conditions=react-server ./scripts/graphqlSchema.ts && graphql-codegen --config codegen.ts",
     "codegen:references:new:ensure": "(test -f spec/reference/javascript/v2/supabase.json || (cd spec && make download.tsdoc.v2)) && (test -f spec/reference/server/v1/server.json || (cd spec && make download.server.v1))",

--- a/apps/learn/package.json
+++ b/apps/learn/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint .",
     "lint:mdx": "supa-mdx-lint content --config ../../supa-mdx-lint.config.toml",
     "content:build": "contentlayer2 build",
-    "clean": "rimraf node_modules .next .turbo tsconfig.tsbuildinfo",
+    "clean": "rimraf .next .turbo tsconfig.tsbuildinfo",
     "typecheck": "contentlayer2 build && tsc --noEmit"
   },
   "dependencies": {

--- a/apps/lite-studio/package.json
+++ b/apps/lite-studio/package.json
@@ -7,7 +7,7 @@
     "dev": "react-router dev",
     "start": "react-router-serve ./build/server/index.js",
     "typecheck": "react-router typegen && tsc",
-    "clean": "rimraf node_modules tsconfig.tsbuildinfo build .react-router .turbo"
+    "clean": "rimraf build .react-router .turbo tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@react-router/fs-routes": "^7.17.0",

--- a/apps/studio/Dockerfile
+++ b/apps/studio/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update -qq && \
   rm -rf /var/lib/apt/lists/* && \
   update-ca-certificates
 
-RUN npm install -g pnpm@10.24.0
+RUN npm install -g pnpm@11.13.1
 
 WORKDIR /app
 

--- a/apps/studio/package.json
+++ b/apps/studio/package.json
@@ -19,7 +19,7 @@
     "start:tanstack": "node scripts/serve.js",
     "lint": "eslint .",
     "lint:ratchet": "tsx scripts/ratchet-eslint-rules.ts --rules-file scripts/ratchet-rules.json",
-    "clean": "rimraf node_modules tsconfig.tsbuildinfo .next .turbo",
+    "clean": "rimraf .next .turbo tsconfig.tsbuildinfo",
     "test": "vitest --run --coverage",
     "test:watch": "vitest watch",
     "test:ui": "vitest --ui",

--- a/apps/ui-library/package.json
+++ b/apps/ui-library/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "lint:mdx": "supa-mdx-lint content --config ../../supa-mdx-lint.config.toml",
     "content:build": "contentlayer2 build",
-    "clean": "rimraf node_modules .next .turbo",
+    "clean": "rimraf .next .turbo tsconfig.tsbuildinfo",
     "typecheck": "contentlayer2 build && tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {

--- a/apps/www/package.json
+++ b/apps/www/package.json
@@ -11,7 +11,7 @@
     "export": "next export",
     "start": "next start",
     "lint": "eslint .",
-    "clean": "rimraf node_modules",
+    "clean": "rimraf .next .turbo tsconfig.tsbuildinfo",
     "pretypecheck": "next typegen",
     "typecheck": "pnpm run content:build:core && tsc --noEmit",
     "content:build:core": "node scripts/generateStaticContent.mjs && node scripts/generateMdContent.mjs",

--- a/blocks/vue/package.json
+++ b/blocks/vue/package.json
@@ -6,7 +6,7 @@
   "exports": "./index.ts",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules .next .turbo tsconfig.tsbuildinfo",
+    "clean": "rimraf .next .turbo tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -65,8 +65,8 @@
     "url": "git+https://github.com/supabase/supabase.git"
   },
   "engines": {
-    "pnpm": "10.24",
-    "node": ">=22"
+    "pnpm": "11.13",
+    "node": ">=22.13"
   },
   "keywords": [
     "postgres",
@@ -76,5 +76,5 @@
     "database",
     "auth"
   ],
-  "packageManager": "pnpm@10.24.0"
+  "packageManager": "pnpm@11.13.1"
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:studio:docker": "docker build . -f apps/studio/Dockerfile --target production -t supabase-studio:local --build-arg NEXT_PUBLIC_STUDIO_AUTH_MODE=supabase --no-cache",
     "build:design-system": "turbo run build --filter=design-system",
     "build:docs": "turbo run build --filter=docs",
-    "clean": "turbo run clean --parallel && rimraf -G node_modules/{*,.bin,.modules.yaml} .turbo/cache",
+    "clean": "turbo run clean --parallel && rimraf -G .turbo/cache && pnpm purge",
     "dev": "turbo run dev --parallel",
     "dev:studio": "turbo run dev --filter=studio --parallel",
     "dev:studio-local": "pnpm setup:cli && NODE_ENV=test MODE=test pnpm --prefix ./apps/studio dev",

--- a/packages/ai-commands/package.json
+++ b/packages/ai-commands/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "test": "vitest"
   },

--- a/packages/api-types/package.json
+++ b/packages/api-types/package.json
@@ -6,7 +6,7 @@
   "types": "./index.ts",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "codegen": "openapi-typescript --redocly ./redocly.yaml --alphabetize --default-non-nullable=false && prettier --cache --write types/*.d.ts"
   },
   "author": "",

--- a/packages/build-icons/package.json
+++ b/packages/build-icons/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules"
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo"
   },
   "engines": {
     "node": ">= 16"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules .turbo tsconfig.tsbuildinfo",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "gen:types": "supabase gen types typescript --local >| ./database-types.ts",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules"
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.5.11",

--- a/packages/dev-tools/package.json
+++ b/packages/dev-tools/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules .turbo tsconfig.tsbuildinfo dist",
+    "clean": "rimraf .turbo dist tsconfig.tsbuildinfo",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"

--- a/packages/eslint-config-supabase/package.json
+++ b/packages/eslint-config-supabase/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules"
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.0.0",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "tsdoc:dereference:functions:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/functions.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/functions_dereferenced.json",
     "tsdoc:dereference:gotrue:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/gotrue.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/gotrue_dereferenced.json",
     "tsdoc:dereference:postgrest:v1": "tsx ./tsdoc.ts --input ../../apps/docs/spec/enrichments/tsdoc_v1/postgrest.json --output ../../apps/docs/spec/enrichments/tsdoc_v1/postgrest_dereferenced.json",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "build:icons": "build-icons --templateSrc=./scripts/exportTemplate.mjs --renderUniqueKey --iconFileExtension=.ts --exportFileName=index.ts",
-    "clean": "rimraf node_modules .turbo"
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@typescript/native": "catalog:",

--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -10,7 +10,7 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules"
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo"
   },
   "dependencies": {
     "@types/react": "catalog:",

--- a/packages/pg-meta/package.json
+++ b/packages/pg-meta/package.json
@@ -7,7 +7,7 @@
   "repository": "supabase/supabase",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules .turbo tsconfig.tsbuildinfo",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "test": "test/run-tests.sh vitest run --coverage",
     "test:update": "test/run-tests.sh vitest run --update",
     "lint": "tsc --noEmit",

--- a/packages/shared-data/package.json
+++ b/packages/shared-data/package.json
@@ -6,7 +6,7 @@
   "types": "./index.ts",
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules .turbo tsconfig.tsbuildinfo",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {

--- a/packages/ui-patterns/package.json
+++ b/packages/ui-patterns/package.json
@@ -8,7 +8,7 @@
     "preinstall": "npx only-allow pnpm",
     "test": "vitest",
     "test:coverage": "vitest --run --coverage",
-    "clean": "rimraf node_modules .turbo tsconfig.tsbuildinfo",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "typecheck": "tsc --noEmit",
     "gen:exports": "tsx ./scripts/update-exports.ts"
   },

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,7 +9,7 @@
     "preinstall": "npx only-allow pnpm",
     "typecheck": "tsc --noEmit",
     "generate-tailwind-classes": "tsx ./scripts/generate-tailwind-classes.ts",
-    "clean": "rimraf node_modules .turbo tsconfig.tsbuildinfo",
+    "clean": "rimraf .turbo tsconfig.tsbuildinfo",
     "test": "vitest",
     "test:ci": "vitest --run --coverage",
     "test:report": "open coverage/lcov-report/index.html"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,9 +129,7 @@ overrides:
   webpack: ^5.104.1
 
 patchedDependencies:
-  react-data-grid:
-    hash: 803f02d6cede565990ab9675326b93195b98bcc6477a4811715405892c257488
-    path: patches/react-data-grid.patch
+  react-data-grid: 803f02d6cede565990ab9675326b93195b98bcc6477a4811715405892c257488
 
 importers:
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,8 @@ packages:
   - e2e/*
 
 blockExoticSubdeps: true
+engineStrict: true
+updateNotifier: false
 
 catalog:
   '@monaco-editor/react': ^4.7.0
@@ -49,17 +51,19 @@ catalog:
   vitest: ^4.1.4
   zod: 3.25.76
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - '@sentry/cli'
-  - contentlayer2
-  - core-js
-  - es5-ext
-  - esbuild
-  - libpg-query
-  - msw
-  - protobufjs
-  - sharp
+allowBuilds:
+  '@parcel/watcher': false
+  '@sentry/cli': false
+  contentlayer2: false
+  core-js: false
+  es5-ext: false
+  esbuild: false
+  libpg-query: false
+  msw: false
+  node-pty: true
+  protobufjs: false
+  sharp: false
+  supabase: true
 
 minimumReleaseAge: 4320
 
@@ -73,10 +77,6 @@ minimumReleaseAgeExclude:
   - mdast-jsx
   # The following are excluded to fix vulnerablities.
   - react-use
-
-onlyBuiltDependencies:
-  - node-pty
-  - supabase
 
 overrides:
   '@ardatan/relay-compiler>immutable': ^3.8.3

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,7 @@ packages:
 blockExoticSubdeps: true
 engineStrict: true
 updateNotifier: false
+enableGlobalVirtualStore: true
 
 catalog:
   '@monaco-editor/react': ^4.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,6 @@ packages:
 blockExoticSubdeps: true
 engineStrict: true
 updateNotifier: false
-enableGlobalVirtualStore: true
 
 catalog:
   '@monaco-editor/react': ^4.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
 blockExoticSubdeps: true
 engineStrict: true
 updateNotifier: false
+# Doesn't work because of Typescript issues with peer dependencies, see https://github.com/pnpm/pnpm/issues/9739
+enableGlobalVirtualStore: false 
 
 catalog:
   '@monaco-editor/react': ^4.7.0

--- a/turbo.jsonc
+++ b/turbo.jsonc
@@ -13,6 +13,7 @@
     "clean": {
       "outputs": [],
       "cache": false,
+      "outputLogs": "errors-only",
     },
     "dev": {
       "cache": false,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Chore / dependency tooling update.

## What is the current behavior?

The repo is pinned to pnpm 10.24.0. Closes https://linear.app/supabase/issue/FE-3673/migrate-the-repo-to-use-pnpm-v11.

## What is the new behavior?

The repo is pinned to pnpm 11.13.1, pnpm v11 workspace settings are migrated to `allowBuilds`, and the Studio Dockerfile installs pnpm 11.13.1.

## Additional context

Validated with `CI=true mise exec node@22 -- pnpm install --frozen-lockfile`, `mise exec node@22 -- pnpm run typecheck`, and `mise exec node@22 -- pnpm run lint`; full Prettier check still fails on existing generated docs/router files outside this migration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated tooling requirements (pnpm **11.13.1**, Node **>=22.13**) and aligned container build tooling accordingly.
  * Adjusted package manager behavior (scoped registry override, update notifications disabled) and workspace build/engine validation settings.

* **Maintenance**
  * Updated `clean` scripts across apps/packages to remove only build/cache artifacts (no longer delete installed dependencies).
  * Reduced Turbo `clean` task output to **errors-only** for cleaner logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->