### PR TITLE
fix(studio): show an error when storage file deletion removes nothing

### DIFF
--- a/apps/studio/state/storage-explorer.test.ts
+++ b/apps/studio/state/storage-explorer.test.ts
@@ -1,0 +1,121 @@
+import { toast } from 'sonner'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createStorageExplorerState } from './storage-explorer'
+import {
+  STORAGE_ROW_STATUS,
+  STORAGE_ROW_TYPES,
+} from '@/components/interfaces/Storage/Storage.constants'
+import type { StorageItemWithColumn } from '@/components/interfaces/Storage/Storage.types'
+import { deleteBucketObject } from '@/data/storage/bucket-object-delete-mutation'
+import type { Bucket } from '@/data/storage/buckets-query'
+
+vi.mock('@/data/storage/bucket-object-delete-mutation', () => ({
+  deleteBucketObject: vi.fn(),
+}))
+
+vi.mock('@/data/storage/bucket-objects-list-mutation', () => ({
+  // Non-empty listing so validateParentFolderEmpty never uploads a placeholder
+  listBucketObjects: vi.fn(async () => [
+    {
+      id: 'object-1',
+      name: 'existing.txt',
+      updated_at: '2024-01-01T00:00:00.000Z',
+      created_at: '2024-01-01T00:00:00.000Z',
+      last_accessed_at: '2024-01-01T00:00:00.000Z',
+      metadata: { size: 1, mimetype: 'text/plain' },
+    },
+  ]),
+}))
+
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), {
+    loading: vi.fn(() => 'toast-id'),
+    success: vi.fn(),
+    error: vi.fn(),
+    dismiss: vi.fn(),
+  }),
+}))
+
+const mockedDeleteBucketObject = vi.mocked(deleteBucketObject)
+
+function setup() {
+  return createStorageExplorerState({
+    projectRef: 'default',
+    connectionString: '',
+    bucket: { id: 'bucket-1', name: 'bucket-1' } as Bucket,
+    resumableUploadUrl: '',
+    clientEndpoint: '',
+  })
+}
+
+function makeFile(name: string) {
+  return {
+    name,
+    prefix: 'docs',
+    columnIndex: 1,
+    type: STORAGE_ROW_TYPES.FILE,
+    status: STORAGE_ROW_STATUS.READY,
+  } as StorageItemWithColumn & { prefix: string }
+}
+
+describe('deleteFiles', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows an error toast when the API reports fewer deletions than requested', async () => {
+    mockedDeleteBucketObject.mockResolvedValueOnce([{ name: 'docs/a.txt' }] as never)
+
+    const state = setup()
+    await state.deleteFiles({ files: [makeFile('a.txt'), makeFile('b.txt')] })
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to delete 1 of 2 file(s)',
+      expect.objectContaining({ id: 'toast-id' })
+    )
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('shows an error toast when the API reports no deletions at all', async () => {
+    mockedDeleteBucketObject.mockResolvedValueOnce([] as never)
+
+    const state = setup()
+    await state.deleteFiles({ files: [makeFile('a.txt')] })
+
+    expect(toast.error).toHaveBeenCalledWith(
+      'Failed to delete 1 file(s)',
+      expect.objectContaining({ id: 'toast-id' })
+    )
+    expect(toast.success).not.toHaveBeenCalled()
+  })
+
+  it('shows the success toast when every requested path was removed', async () => {
+    mockedDeleteBucketObject.mockResolvedValueOnce([
+      { name: 'docs/a.txt' },
+      { name: 'docs/b.txt' },
+    ] as never)
+
+    const state = setup()
+    await state.deleteFiles({ files: [makeFile('a.txt'), makeFile('b.txt')] })
+
+    expect(toast.success).toHaveBeenCalledWith(
+      'Successfully deleted 2 file(s)',
+      expect.objectContaining({ id: 'toast-id' })
+    )
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+
+  it('keeps the success toast when the response has no body (hosted platform)', async () => {
+    mockedDeleteBucketObject.mockResolvedValueOnce(undefined as never)
+
+    const state = setup()
+    await state.deleteFiles({ files: [makeFile('a.txt')] })
+
+    expect(toast.success).toHaveBeenCalledWith(
+      'Successfully deleted 1 file(s)',
+      expect.objectContaining({ id: 'toast-id' })
+    )
+    expect(toast.error).not.toHaveBeenCalled()
+  })
+})

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -70,7 +70,7 @@ if (typeof window !== 'undefined') {
   abortController = new AbortController()
 }
 
-function createStorageExplorerState({
+export function createStorageExplorerState({
   projectRef,
   connectionString,
   bucket,
@@ -1462,7 +1462,7 @@ function createStorageExplorerState({
       const toastId = toast.loading(`Deleting ${prefixes.length} file(s)...`)
 
       try {
-        await deleteBucketObject({
+        const data = await deleteBucketObject({
           projectRef: state.projectRef,
           bucketId: state.selectedBucket.id,
           paths: prefixes,
@@ -1480,12 +1480,36 @@ function createStorageExplorerState({
             parentFolderPrefixes.map((prefix) => state.validateParentFolderEmpty(prefix))
           )
 
-          toast.success(`Successfully deleted ${prefixes.length} file(s)`, {
-            id: toastId,
-            closeButton: true,
-            duration: SONNER_DEFAULT_DURATION,
-            description: undefined,
-          })
+          // Self-hosted responds with the objects that were actually removed,
+          // while the platform API returns an empty body (its generated type
+          // has no content, hence the widening to unknown). The storage API
+          // silently skips paths that match nothing, so fewer removed objects
+          // than requested paths means some files were not deleted.
+          const deletedObjects: unknown = data
+          const failedCount = Array.isArray(deletedObjects)
+            ? prefixes.length - deletedObjects.length
+            : 0
+
+          if (failedCount > 0) {
+            toast.error(
+              failedCount === prefixes.length
+                ? `Failed to delete ${prefixes.length} file(s)`
+                : `Failed to delete ${failedCount} of ${prefixes.length} file(s)`,
+              {
+                id: toastId,
+                closeButton: true,
+                duration: SONNER_DEFAULT_DURATION,
+                description: 'They may have been renamed, moved, or already deleted elsewhere',
+              }
+            )
+          } else {
+            toast.success(`Successfully deleted ${prefixes.length} file(s)`, {
+              id: toastId,
+              closeButton: true,
+              duration: SONNER_DEFAULT_DURATION,
+              description: undefined,
+            })
+          }
           await state.refetchAllOpenedFolders()
           state.setSelectedItemsToDelete([])
         } else {


### PR DESCRIPTION
I have read the CONTRIBUTING.md file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #42415.

Deleting files in the Storage explorer always shows "Successfully deleted N file(s)" as long as the API call returns 2xx — the response body is never inspected (`deleteFiles` in `apps/studio/state/storage-explorer.tsx`). The storage API silently skips paths that match nothing and reports what it actually removed, so a delete that removed zero objects still produces a success toast.

Reproduced on current master (self-hosted stack + dev server): list a file, rename or remove it through any other client (SQL, supabase-js, a second tab), then delete the stale row in Studio → success toast, `DELETE .../objects` returns 200 with `[]`, and the object is untouched in `storage.objects`. The original report hit the same silent success via storage policy permissions on an older self-hosted Studio; on current master the admin route uses the service-role key, so the reachable variant is the no-match case — the root cause (ignoring the deletion result) is the same.

## What is the new behavior?

`deleteFiles` compares the requested paths against the objects the API reports as removed. On a mismatch the loading toast resolves to an error ("Failed to delete N of M file(s)", with a hint that the files may have been renamed, moved, or already deleted elsewhere) instead of a success, and the listing still refetches to the true state. Full deletions behave exactly as before.

Scope note: the hosted platform endpoint returns an empty body (`content?: never` in `packages/api-types`), so hosted behavior is unchanged by design — the check only engages when a deletion result is present (self-hosted today; hosted too if the platform API ever returns one). No shared packages are touched.

## Additional context

Adds unit tests for `deleteFiles` (`apps/studio/state/storage-explorer.test.ts`) covering partial mismatch, zero deletions, full success, and the bodyless hosted response; `createStorageExplorerState` is now exported for the tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file deletion feedback in Storage Explorer.
  - Displays an error notification when some or all selected files fail to delete.
  - Displays a success notification when all selected files are deleted successfully.
  - Preserved progress and completion handling for folder deletions.

- **Tests**
  - Added coverage for successful, partial, failed, and response-free deletion scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->