### PR TITLE
fix(studio): preserve API report filter value casing so method filters match

### DIFF
--- a/apps/studio/components/interfaces/Reports/Reports.constants.test.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.test.ts
@@ -116,6 +116,18 @@ describe('generateRegexpWhereSafe', () => {
       },
     ]
     const result = generateRegexpWhereSafe(filters, true)
-    expect(result).toBe("WHERE `request`.`method` = 'get'")
+    expect(result).toBe("WHERE `request`.`method` = 'GET'")
+  })
+
+  it('should preserve value casing so uppercase HTTP methods match', () => {
+    const filters: ReportFilterItem[] = [
+      {
+        key: 'request.method',
+        value: 'DELETE',
+        compare: 'is',
+      },
+    ]
+    const result = generateRegexpWhereSafe(filters, true)
+    expect(result).toBe("WHERE `request`.`method` = 'DELETE'")
   })
 })

--- a/apps/studio/components/interfaces/Reports/Reports.constants.ts
+++ b/apps/studio/components/interfaces/Reports/Reports.constants.ts
@@ -114,7 +114,7 @@ export function generateRegexpWhereSafe(
       const valueIsNumber = !isNaN(Number(filter.value))
       const lit = valueIsNumber
         ? analyticsLiteral(Number(filter.value))
-        : analyticsLiteral(String(filter.value).toLowerCase())
+        : analyticsLiteral(String(filter.value))
 
       switch (filter.compare) {
         case 'matches':


### PR DESCRIPTION
## Problem

Filtering the API report (SharedAPIReport / Observability API pages) by `request.method = DELETE` returned no results, making DELETE requests look absent.

## Cause

`generateRegexpWhereSafe` in `Reports.constants.ts` lowercased every non-numeric filter value before building the WHERE clause. `edge_logs` stores `request.method` uppercase (`DELETE`, `GET`, `POST`), so the comparison never matched.

## Fix

Drop the `.toLowerCase()` so values compare as typed. Lives in the shared helper, so it fixes both the `SharedAPIReport` path and the legacy `PRESET_CONFIG` API report. Path filters (`matches`) are now case-sensitive too, which is correct for URLs; all built-in base filters are already lowercase.

Note: DELETEs also appear absent in the Top Routes table when unfiltered simply because that table is `limit 10` and low-volume methods rank out. That is expected behavior, not addressed here.

## Test

Updated the test that encoded the old lowercasing behavior and added a DELETE case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the original casing of text-based report filter values when generating query conditions.
  * HTTP methods such as `DELETE` are now retained in uppercase instead of being automatically lowercased.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->