### PR TITLE
fix(studio): guard router.replace against unmounted component in SignInPartner

### DIFF
--- a/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
+++ b/apps/studio/components/interfaces/SignIn/SignInPartner.tsx
@@ -9,6 +9,8 @@ export const SignInPartner = () => {
   const router = useRouter()
 
   useEffect(() => {
+    let isMounted = true
+
     ;(async () => {
       const params = new URLSearchParams(window.location.hash.substring(1))
 
@@ -21,12 +23,16 @@ export const SignInPartner = () => {
         try {
           await auth.signInWithIdToken({ provider: partner, token })
         } finally {
-          router.replace({ pathname: '/sign-in-mfa' })
+          if (isMounted) router.replace({ pathname: '/sign-in-mfa' })
         }
       } else {
-        router.replace({ pathname: '/sign-in' })
+        if (isMounted) router.replace({ pathname: '/sign-in' })
       }
     })()
+
+    return () => {
+      isMounted = false
+    }
   }, [])
 
   return (


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When a user navigates away from the partner sign-in page before `auth.getSession()` or `auth.signInWithIdToken()` resolve, the `router.replace()` calls in the `finally`/`else` blocks still execute and forcefully redirect the user away from whichever page they already navigated to.

Reproducing: throttle network to Slow 3G, visit `/sign-in-partner?partner=foo&id_token=bar`, click away while the spinner is visible — you get ghost-redirected to `/sign-in-mfa` or `/sign-in`.

## What is the new behavior?

An `isMounted` flag is set at the top of the effect and cleared in the cleanup function. All `router.replace()` calls are wrapped in `if (isMounted)` so they are no-ops if the component has already unmounted.

## Does this PR introduce a breaking change?

No

Closes #46593

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sign-in navigation reliability by preventing redirects after the sign-in component has been closed or unmounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->