### PR TITLE
fix(studio): restore scrollbar visibility on hover in table grid on macOS

### DIFF
--- a/apps/studio/styles/grid.css
+++ b/apps/studio/styles/grid.css
@@ -95,6 +95,38 @@
   @apply border-t border-r-0 border-l-0;
   contain: strict;
   font-size: 14px;
+  scrollbar-width: thin;
+  scrollbar-color: transparent transparent;
+}
+
+.rdg:hover {
+  scrollbar-color: hsl(var(--border-strong)) transparent;
+}
+
+.rdg::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+
+.rdg::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.rdg::-webkit-scrollbar-thumb {
+  background: transparent;
+  border-radius: 4px;
+}
+
+.rdg:hover::-webkit-scrollbar-thumb {
+  background: hsl(var(--border-strong));
+}
+
+.rdg::-webkit-scrollbar-thumb:hover {
+  background: hsl(var(--foreground-muted));
+}
+
+.rdg::-webkit-scrollbar-corner {
+  background: transparent;
 }
 
 .rdg *,


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

On macOS with system scroll bar setting set to "When scrolling", the table editor grid scrollbars disappear after scrolling stops and do not reappear on hover. Users must use arrow keys or the mouse scroll wheel to make them visible again, with no way to grab the scrollbar handle with the cursor.

## What is the new behavior?

The `.rdg` element now has explicit `::-webkit-scrollbar` rules and the standard `scrollbar-width`/`scrollbar-color` properties. The scrollbar thumb is transparent by default and becomes visible when hovering over the grid, restoring the hover-to-show behaviour. Colour uses the `--border-strong` semantic token so it respects both light and dark themes.

## Does this PR introduce a breaking change?

No

Closes #44369

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table scrollbar styling for a cleaner appearance.
  * Scrollbars now become visible on hover and provide clearer visual feedback when interacting with them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->