### PR TITLE
Table editor filters FE #1: Table editor sidebar

### DIFF
--- a/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/EntityListItem.tsx
@@ -208,14 +208,14 @@ export const EntityListItem = ({
         </Tooltip>
         <div
           className={cn(
-            'truncate overflow-hidden text-ellipsis whitespace-nowrap flex items-center gap-2 relative w-full',
+            'overflow-hidden text-ellipsis whitespace-nowrap flex items-center gap-2 relative w-full min-w-0',
             isActive && 'text-foreground'
           )}
         >
           <span
             className={cn(
               isActive ? 'text-foreground' : 'text-foreground-light group-hover:text-foreground',
-              'text-sm transition truncate'
+              'text-sm transition truncate min-w-0'
             )}
           >
             {entity.name}
@@ -239,7 +239,8 @@ export const EntityListItem = ({
             >
               <Button
                 variant="text"
-                className="w-6 h-6"
+                size="tiny"
+                className="border-transparent text-xs px-2.5 py-1 w-6 h-6 shrink-0"
                 icon={<MoreVertical size={14} strokeWidth={2} />}
                 onClick={(e) => e.preventDefault()}
               />
@@ -606,7 +607,12 @@ const EntityTooltipTrigger = ({
     return (
       <Tooltip>
         <TooltipTrigger className="min-w-4">
-          <Badge variant="destructive">Unrestricted</Badge>
+          <Badge
+            variant="destructive"
+            className="inline-flex items-center gap-1 justify-center rounded-full whitespace-nowrap tracking-[0.07em] uppercase font-medium text-[9px] leading-none px-[5.5px] py-[3px] bg-destructive/10 text-destructive border border-border-destructive shrink-0"
+          >
+            Unrestricted
+          </Badge>
         </TooltipTrigger>
         <TooltipContent side="right" className="max-w-52">
           {tooltipContent}
@@ -623,7 +629,7 @@ const EntityTooltipTrigger = ({
     return (
       <Tooltip>
         <TooltipTrigger className="min-w-4" aria-label="Table exposed via Data API">
-          <Globe size={14} strokeWidth={1} className="text-foreground-lighter" />
+          <Globe size={14} strokeWidth={1} className="text-foreground-lighter shrink-0" />
         </TooltipTrigger>
         <TooltipContent side="right" className="max-w-52">
           This table can be accessed via the Data API but no RLS policies exist so no data will be
@@ -639,7 +645,7 @@ const EntityTooltipTrigger = ({
     return (
       <Tooltip>
         <TooltipTrigger className="min-w-4" aria-label="Table exposed via Data API">
-          <Globe size={14} strokeWidth={1} className="text-foreground-lighter" />
+          <Globe size={14} strokeWidth={1} className="text-foreground-lighter shrink-0" />
         </TooltipTrigger>
         <TooltipContent side="right">This table can be accessed via the Data API</TooltipContent>
       </Tooltip>

--- a/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
+++ b/apps/studio/components/layouts/TableEditorLayout/TableEditorMenu.tsx
@@ -170,6 +170,7 @@ export const TableEditorMenu = () => {
           >
             <SchemaSelector
               className="mx-4"
+              triggerClassName="text-xs px-2.5 py-1 h-[26px]"
               selectedSchemaName={selectedSchema}
               onSelectSchema={(name: string) => {
                 setSearchText('')
@@ -195,7 +196,7 @@ export const TableEditorMenu = () => {
                 size="tiny"
                 icon={<Plus size={14} strokeWidth={1.5} className="text-foreground-muted" />}
                 variant="default"
-                className="justify-start"
+                className="w-full text-xs px-2.5 py-1 h-[26px] justify-start"
                 onClick={() => snap.onAddTable()}
                 tooltip={{
                   content: {
@@ -245,9 +246,10 @@ export const TableEditorMenu = () => {
             <Popover>
               <PopoverTrigger asChild>
                 <ButtonTooltip
-                  className="h-[32px] md:h-[28px] px-1.5"
+                  size="tiny"
+                  className="text-xs py-1 h-[28px] px-1.5 shrink-0"
                   variant={hasFiltersApplied ? 'default' : 'dashed'}
-                  icon={<Filter />}
+                  icon={<Filter size={14} />}
                   aria-label="Filter"
                   tooltip={{ content: { side: 'bottom', text: 'Filter' } }}
                 />
@@ -321,7 +323,7 @@ export const TableEditorMenu = () => {
                 />
               )}
               {(entityTypes?.length ?? 0) > 0 && (
-                <div className="flex flex-1 min-h-0 w-full" data-testid="tables-list">
+                <div className="flex flex-1 min-h-0 w-full overflow-auto" data-testid="tables-list">
                   <InfiniteListDefault
                     className="h-full w-full"
                     items={entityTypes!}

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -6,6 +6,7 @@ import {
   AlertDescription,
   AlertTitle,
   Button,
+  cn,
   Command,
   CommandEmpty,
   CommandGroup,
@@ -38,6 +39,7 @@ type SchemaSelectorProps = Omit<ComponentPropsWithoutRef<'div'>, 'onSelect'> & {
   align?: 'start' | 'end'
   open?: boolean
   onOpenChange?: (open: boolean) => void
+  triggerClassName?: string
 }
 
 export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
@@ -57,6 +59,7 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
       align = 'start',
       open: openProp,
       onOpenChange,
+      triggerClassName,
       ...rest
     },
     ref
@@ -124,7 +127,7 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
                 disabled={disabled}
                 variant="default"
                 data-testid="schema-selector"
-                className={`w-full [&>span]:w-full pr-1! space-x-1`}
+                className={cn('w-full [&>span]:w-full pr-1! space-x-1', triggerClassName)}
                 iconRight={
                   <ChevronsUpDown className="text-foreground-muted" strokeWidth={2} size={14} />
                 }


### PR DESCRIPTION
## Summary
- Align `TableEditorMenu` sidebar controls with the table-editor-filters prototype: compact schema selector and New table CTA heights, search/filter row sizing, and scrollable entity list overflow.
- Update `EntityListItem` active-row affordances to match prototype fidelity — truncated name layout, compact row actions menu, prototype-style Unrestricted badge, and API-access globe icons.

## Scope
Part 1 of the Table editor filters FE split. Sidebar only — no grid toolbar, empty/error overlays, or add-column panel changes in this PR.

## Test plan
- [ ] Open Table Editor in Studio and confirm schema selector, New table button, search input, and filter button match prototype spacing/heights
- [ ] Select a table and verify active-row left bar, ellipsis menu, Unrestricted badge styling, and Globe API icons
- [ ] Scroll a long entity list and confirm overflow behavior in the sidebar
- [ ] Confirm schema switching, search, entity-type filter popover, and New table CTA still work


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved table editor layout, spacing, truncation, and scrolling behavior.
  * Refined schema selector, filter, and “New table” controls for a more compact, consistent appearance.
  * Updated menu buttons, tooltip badges, and icons for clearer sizing and alignment.
* **New Features**
  * Added support for customizing schema selector trigger styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->