### PR TITLE
fix(studio): block clearing an existing storage policy's USING/WITH CHECK

### DIFF
--- a/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/PolicyEditorModal/index.tsx
@@ -169,6 +169,15 @@ export const PolicyEditorModal = ({
     if (!command) {
       return toast.error('Please select an operation for your policy')
     }
+    if (
+      selectedPolicyToEdit &&
+      ((selectedPolicyToEdit.definition && !definition) ||
+        (selectedPolicyToEdit.check && !check))
+    ) {
+      return toast.error(
+        'Clearing an existing USING or WITH CHECK expression is not supported yet. Delete and recreate the policy instead, or leave the expression unchanged.'
+      )
+    }
     if (['SELECT', 'DELETE'].includes(command) && !definition) {
       return toast.error('Please provide a USING expression for your policy')
     }


### PR DESCRIPTION
## Summary
- `createPayloadForUpdatePolicy` (`StoragePolicies.utils.ts`) sets `payload.definition`/`payload.check` to `undefined` when a field is cleared in the policy edit form.
- That key is dropped during JSON serialization, so `pg-meta`'s `ALTER POLICY` builder (`packages/pg-meta/src/pg-meta-policies.ts`, `update()`) never emits a clause for it — the save silently no-ops. A success toast appears, but reopening the policy shows the old expression is still there.
- The review step also previews invalid SQL for this exact case, e.g. `ALTER POLICY "My policy" ON "storage"."objects" WITH CHECK ();`.
- Rather than changing `pg-meta`'s SQL generation, or defaulting a cleared RLS expression to some implicit value (a security-relevant decision on a Row Level Security field that shouldn't be made silently in this PR), this blocks the save with a clear error when editing an existing policy would clear a previously-set `USING` or `WITH CHECK` expression — matching the alternative the issue reporter suggested. New-policy creation and normal value edits are unaffected.

Fixes #48015.

## Test plan
- Traced the full path: `PolicyEditorModal.validatePolicyFormFields()` → `createPayloadForUpdatePolicy()` → `pg-meta-policies.ts update()` to confirm the root cause (undefined key dropped from JSON → no ALTER clause emitted).
- Verified `PGPolicy.definition`/`.check` are typed `string | null` (`pg-meta-policies.ts` zod schema), so the new truthy checks against `selectedPolicyToEdit.definition`/`.check` are type-safe.
- No existing test file for this component (`StoragePolicies/PolicyEditorModal`) to extend; didn't want to introduce a new test scaffold as a side effect of a small bug fix. Happy to add one if maintainers point me at the preferred pattern.
- Could not run the studio app's full type-check/test suite in this environment (`pnpm`/`node_modules` not set up here) — would appreciate CI confirming.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented accidental removal of existing policy expressions when editing storage policies.
  * Displays a clear error message when an expression is cleared, instructing users to leave it unchanged or delete and recreate the policy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->