### PR TITLE
fix(studio): honor OPENAI_BASE_URL in the AI Assistant model client

### DIFF
--- a/apps/studio/lib/ai/model.test.ts
+++ b/apps/studio/lib/ai/model.test.ts
@@ -1,12 +1,14 @@
-import { openai } from '@ai-sdk/openai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import * as bedrockModule from './bedrock'
 import { getModel } from './model'
 import { DEFAULT_COMPLETION_MODEL, openaiModelEntry } from './model.utils'
 
+const mockOpenAIModel = vi.fn(() => 'openai-model')
+
 vi.mock('@ai-sdk/openai', () => ({
-  openai: vi.fn(() => 'openai-model'),
+  createOpenAI: vi.fn(() => mockOpenAIModel),
 }))
 
 vi.mock('./bedrock', async () => ({
@@ -56,8 +58,23 @@ describe('getModel', () => {
     })
 
     expect(modelParams?.model).toEqual('openai-model')
-    expect(openai).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(mockOpenAIModel).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(systemProviderOptions).toBeUndefined()
+  })
+
+  it('passes OPENAI_BASE_URL through to createOpenAI for self-hosted OpenAI-compatible endpoints', async () => {
+    vi.stubEnv('OPENAI_API_KEY', 'test-key')
+    vi.stubEnv('OPENAI_BASE_URL', 'https://integrate.api.nvidia.com/v1')
+
+    await getModel({
+      provider: 'openai',
+      modelEntry: openaiModelEntry({ id: 'gpt-5.4-nano' }),
+    })
+
+    expect(createOpenAI).toHaveBeenCalledWith({
+      apiKey: 'test-key',
+      baseURL: 'https://integrate.api.nvidia.com/v1',
+    })
   })
 
   it('returns error when OPENAI_API_KEY is not available', async () => {
@@ -81,7 +98,7 @@ describe('getModel', () => {
 
     expect(error).toBeUndefined()
     expect(modelParams?.model).toEqual('openai-model')
-    expect(openai).toHaveBeenCalledWith('gpt-5.3-codex')
+    expect(mockOpenAIModel).toHaveBeenCalledWith('gpt-5.3-codex')
     expect(modelParams?.providerOptions?.openai?.reasoningEffort).toBe('low')
   })
 
@@ -94,7 +111,7 @@ describe('getModel', () => {
     })
 
     expect(error).toBeUndefined()
-    expect(openai).toHaveBeenCalledWith('gpt-5.4-nano')
+    expect(mockOpenAIModel).toHaveBeenCalledWith('gpt-5.4-nano')
     expect(modelParams?.providerOptions?.openai?.reasoningEffort).toBe('none')
   })
 })

--- a/apps/studio/lib/ai/model.ts
+++ b/apps/studio/lib/ai/model.ts
@@ -1,4 +1,4 @@
-import { openai } from '@ai-sdk/openai'
+import { createOpenAI } from '@ai-sdk/openai'
 import { LanguageModel } from 'ai'
 
 import { checkAwsCredentials, createRoutedBedrock } from './bedrock'
@@ -87,6 +87,10 @@ export async function getModel(params: GetModelParams): Promise<ModelResponse> {
     if (!process.env.OPENAI_API_KEY) {
       return { error: new Error('OPENAI_API_KEY not available') }
     }
+    const openai = createOpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+      baseURL: process.env.OPENAI_BASE_URL,
+    })
     const baseProviderOptions = providerRegistry.providerOptions?.openai ?? {}
     const openaiProviderOptions = modelEntry?.reasoningEffort
       ? { ...baseProviderOptions, reasoningEffort: modelEntry.reasoningEffort }

--- a/apps/studio/turbo.jsonc
+++ b/apps/studio/turbo.jsonc
@@ -69,6 +69,7 @@
         "DEFAULT_PROJECT_NAME",
         "DEFAULT_ORGANIZATION_NAME",
         "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
         "BRAINTRUST_API_KEY",
         "BRAINTRUST_PROJECT_ID",
         // Gates the dashboard assistant between the remote MCP server and the


### PR DESCRIPTION
## Summary
- `getModel()`'s `openai` branch imported `@ai-sdk/openai`'s pre-built `openai` provider instance, which always targets `https://api.openai.com/v1` and never reads `OPENAI_BASE_URL`.
- Self-hosted deployments configuring an OpenAI-compatible endpoint (NVIDIA's API, or any other OpenAI-compatible gateway) had every Studio AI Assistant request silently routed to the real OpenAI API instead, regardless of the configured base URL — reported and root-caused in #45269.
- Switched to `createOpenAI({ apiKey, baseURL })` to build the provider instance per-call, passing `OPENAI_BASE_URL` through. When unset, the AI SDK falls back to its own default (real OpenAI) endpoint, so existing `OPENAI_BASE_URL`-less setups are unaffected.
- Declared `OPENAI_BASE_URL` in `apps/studio/turbo.jsonc`'s env list alongside `OPENAI_API_KEY` — required by the `turbo/no-undeclared-env-vars` eslint rule (caught by running the linter, not just by inspection).

## Test plan
- Updated `model.test.ts`'s `@ai-sdk/openai` mock from a static `openai` export to `createOpenAI: vi.fn(() => mockOpenAIModel)`, since the mocked module needs to export what the code actually imports now (the old mock would have made every existing OpenAI-path test throw `No "createOpenAI" export is defined on the "@ai-sdk/openai" mock` — caught this by actually running the suite, not just editing blind).
- Added a test asserting `OPENAI_BASE_URL` reaches `createOpenAI`'s `baseURL` option; confirmed it fails without the `model.ts` fix and passes with it.
- `pnpm --filter studio exec vitest run lib/ai/model.test.ts` — 7/7 pass
- `pnpm --filter studio exec tsc --noEmit` — clean for the changed files
- `pnpm --filter studio exec eslint lib/ai/model.ts lib/ai/model.test.ts` — clean (2 pre-existing, unrelated `no-explicit-any` warnings only)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring custom OpenAI-compatible API endpoints through `OPENAI_BASE_URL`.
  * OpenAI model requests now use the configured API key and endpoint.

* **Bug Fixes**
  * Studio builds now correctly detect changes to the OpenAI base URL configuration.
  * Expanded automated coverage for OpenAI model configuration and selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->