### PR TITLE
fix(studio): properly clear storage policy expressions when emptied in editor

### DIFF
--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.utils.ts
@@ -54,7 +54,11 @@ export const createSQLPolicy = (
   }
 
   if (!isEmpty(fieldsToUpdate)) {
-    return createSQLStatementForUpdatePolicy(formattedPolicyFormFields, fieldsToUpdate)
+    return createSQLStatementForUpdatePolicy(
+      formattedPolicyFormFields,
+      fieldsToUpdate,
+      originalPolicyFormFields
+    )
   }
 
   return {}
@@ -77,9 +81,12 @@ const createSQLStatementForCreatePolicy = (policyFormFields: PolicyFormField): P
 
 const createSQLStatementForUpdatePolicy = (
   policyFormFields: PolicyFormField,
-  fieldsToUpdate: Partial<PolicyFormField>
+  fieldsToUpdate: Partial<PolicyFormField>,
+  originalPolicyFormFields: PGPolicy
 ): PolicyForReview => {
   const { name, schema, table } = policyFormFields
+  // Use the original name for the ALTER POLICY target when renaming
+  const targetName = originalPolicyFormFields?.name || name
 
   const definitionChanged = has(fieldsToUpdate, ['definition'])
   const checkChanged = has(fieldsToUpdate, ['check'])
@@ -97,11 +104,15 @@ const createSQLStatementForUpdatePolicy = (
   const roles =
     (fieldsToUpdate?.roles ?? []).length === 0 ? ['public'] : (fieldsToUpdate.roles as string[])
 
-  const alterStatement = `ALTER POLICY "${name}" ON "${schema}"."${table}"`
+  const alterStatement = `ALTER POLICY "${targetName}" ON "${schema}"."${table}"`
   const statement = [
     'BEGIN;',
-    ...(definitionChanged ? [`  ${alterStatement} USING (${fieldsToUpdate.definition});`] : []),
-    ...(checkChanged ? [`  ${alterStatement} WITH CHECK (${fieldsToUpdate.check});`] : []),
+    ...(definitionChanged ? [
+      `  ${alterStatement} USING (${fieldsToUpdate.definition || 'true'});`
+    ] : []),
+    ...(checkChanged ? [
+      `  ${alterStatement} WITH CHECK (${fieldsToUpdate.check || 'true'});`
+    ] : []),
     ...(rolesChanged ? [`  ${alterStatement} TO ${roles.join(', ')};`] : []),
     ...(nameChanged ? [`  ${alterStatement} RENAME TO "${fieldsToUpdate.name}";`] : []),
     'COMMIT;',
@@ -110,7 +121,7 @@ const createSQLStatementForUpdatePolicy = (
   return { description, statement }
 }
 
-// These constructors return DRAFT payloads — `definition`/`check` are still
+// These constructors return DRAFT payloads â€” `definition`/`check` are still
 // `DisplayableSqlFragment`. Promotion to `SafeSqlFragment` must happen at the user gesture
 // (the Save click in `PolicyEditorModal`), not here, since this module has no guarantee that
 // it was reached via a deliberate user action.
@@ -144,10 +155,10 @@ export const createPayloadForUpdatePolicy = (
     payload.name = policyFormFields.name
   }
   if (!isEqual(formattedDefinition, originalPolicyFormFields.definition)) {
-    payload.definition = !formattedDefinition ? undefined : untrustedSql(formattedDefinition)
+    payload.definition = !formattedDefinition ? null : untrustedSql(formattedDefinition)
   }
   if (!isEqual(formattedCheck, originalPolicyFormFields.check)) {
-    payload.check = !formattedCheck ? undefined : untrustedSql(formattedCheck)
+    payload.check = !formattedCheck ? null : untrustedSql(formattedCheck)
   }
   if (!isEqual(policyFormFields.roles, originalPolicyFormFields.roles)) {
     if (policyFormFields.roles.length === 0) payload.roles = ['public']


### PR DESCRIPTION
## Summary

Fixes #48015

### Problem
In the Storage policy editor, clearing an existing policy's `WITH CHECK` or `USING` expression and clicking Save shows a success toast but the old expression is silently kept. The root cause is in `createPayloadForUpdatePolicy`: when a field is emptied, the payload sets it to `undefined`, but `undefined` properties are dropped during JSON serialization — so the API never receives the change.

Additionally, the review step previews invalid SQL like `WITH CHECK ()` instead of showing meaningful SQL, and when renaming a policy the preview references the *new* name for the `ALTER POLICY` target instead of the original.

### Changes

1. **`createPayloadForUpdatePolicy`**: Changed `undefined` → `null` for cleared `definition` and `check` fields. Unlike `undefined`, `null` survives JSON serialization, so the backend correctly receives the instruction to clear the expression.

2. **Review step SQL preview**: When a field is being cleared and its value is empty (`null`/falsy), the previewed SQL now uses `USING (true)` / `WITH CHECK (true)` instead of generating invalid SQL like `USING ()` or `WITH CHECK ()`.

3. **Rename preview fix**: When a policy is renamed, the review step now correctly targets the *original* policy name for the `ALTER POLICY` statement (e.g., `ALTER POLICY "Old name" ... RENAME TO "New name"` instead of `ALTER POLICY "New name" ... RENAME TO "New name"`).

### How to test
1. Create a storage policy with both `USING` and `WITH CHECK` expressions
2. Edit the policy, clear one expression, click Review → preview should show `USING (true)` or `WITH CHECK (true)` instead of `USING ()`/`WITH CHECK ()`
3. Click Save → reopen the policy → the expression should actually be cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed storage policy updates when the policy name is changed.
  * Improved generated SQL when policy expressions are cleared or omitted.
  * Ensured cleared policy definitions and checks are saved correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->