### PR TITLE
fix(pg-meta): widen IQueryModifier.toSql signature to match class impl

### DIFF
--- a/packages/pg-meta/src/query/QueryModifier.ts
+++ b/packages/pg-meta/src/query/QueryModifier.ts
@@ -11,7 +11,7 @@ import type { ActionConfig, Filter, QueryPagination, QueryTable, Sort } from './
 
 export interface IQueryModifier {
   range: (from: number, to: number) => QueryModifier
-  toSql: () => SafeSqlFragment
+  toSql: (options?: { isCTE: boolean; isFinal: boolean }) => SafeSqlFragment
 }
 
 export class QueryModifier implements IQueryModifier {


### PR DESCRIPTION
## Summary

Fixes #48052

The IQueryModifier interface in packages/pg-meta/src/query/QueryModifier.ts declared toSql: () => SafeSqlFragment (no parameters), but the implementing class QueryModifier accepts an optional options argument that is actually used by all internal call sites (QueryFilter.ts, table-row-query.ts).

This PR widens the interface signature to match the class implementation:

// Before
toSql: () => SafeSqlFragment

// After
toSql: (options?: { isCTE: boolean; isFinal: boolean }) => SafeSqlFragment

Adding an optional parameter is non-breaking for existing consumers.

This is the same class of bug as #47589 (IQueryFilter.filter narrower than its class/type), in a sibling file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved SQL query generation to support optional handling for common table expressions and final queries.
  * Updated the query interface to accommodate these options while preserving existing usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->