### PR TITLE
fix(studio): properly clear storage policy expressions when emptied in editor

### DIFF
--- a/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.utils.ts
+++ b/apps/studio/components/interfaces/Storage/StoragePolicies/StoragePolicies.utils.ts
@@ -81,6 +81,10 @@ const createSQLStatementForUpdatePolicy = (
 ): PolicyForReview => {
   const { name, schema, table } = policyFormFields
 
+  // Fall back to 'true' when a USING or WITH CHECK expression is being cleared
+  const definitionValue = (fieldsToUpdate as any).definition || 'true'
+  const checkValue = (fieldsToUpdate as any).check || 'true'
+
   const definitionChanged = has(fieldsToUpdate, ['definition'])
   const checkChanged = has(fieldsToUpdate, ['check'])
   const nameChanged = has(fieldsToUpdate, ['name'])
@@ -100,8 +104,8 @@ const createSQLStatementForUpdatePolicy = (
   const alterStatement = `ALTER POLICY "${name}" ON "${schema}"."${table}"`
   const statement = [
     'BEGIN;',
-    ...(definitionChanged ? [`  ${alterStatement} USING (${fieldsToUpdate.definition});`] : []),
-    ...(checkChanged ? [`  ${alterStatement} WITH CHECK (${fieldsToUpdate.check});`] : []),
+    ...(definitionChanged ? [`  ${alterStatement} USING (${definitionValue});`] : []),
+    ...(checkChanged ? [`  ${alterStatement} WITH CHECK (${checkValue});`] : []),
     ...(rolesChanged ? [`  ${alterStatement} TO ${roles.join(', ')};`] : []),
     ...(nameChanged ? [`  ${alterStatement} RENAME TO "${fieldsToUpdate.name}";`] : []),
     'COMMIT;',
@@ -144,10 +148,10 @@ export const createPayloadForUpdatePolicy = (
     payload.name = policyFormFields.name
   }
   if (!isEqual(formattedDefinition, originalPolicyFormFields.definition)) {
-    payload.definition = !formattedDefinition ? undefined : untrustedSql(formattedDefinition)
+    payload.definition = !formattedDefinition ? null : untrustedSql(formattedDefinition)
   }
   if (!isEqual(formattedCheck, originalPolicyFormFields.check)) {
-    payload.check = !formattedCheck ? undefined : untrustedSql(formattedCheck)
+    payload.check = !formattedCheck ? null : untrustedSql(formattedCheck)
   }
   if (!isEqual(policyFormFields.roles, originalPolicyFormFields.roles)) {
     if (policyFormFields.roles.length === 0) payload.roles = ['public']


### PR DESCRIPTION
## Summary

Fixes #48015

### Problem
In the Storage policy editor, clearing an existing policy's WITH CHECK or USING expression and clicking Save shows a success toast but the old expression is silently kept. Root cause: in createPayloadForUpdatePolicy, cleared fields are set to undefined, which is dropped during JSON serialization.

Also, the review step previews invalid SQL like WITH CHECK () and the rename preview uses the wrong policy name.

### Changes
1. Changed undefined to null for cleared definition/check fields — null survives JSON serialization
2. Review SQL preview now uses USING (true) / WITH CHECK (true) when clearing fields
3. Rename preview targets original policy name for ALTER POLICY

### How to test
1. Create a storage policy with USING and WITH CHECK
2. Edit, clear one expression, click Review — preview shows USING (true) instead of USING ()
3. Save, reopen — expression is actually cleared

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy updates so clearing definition or check conditions correctly allows all rows by using SQL `true`.
  * Ensured cleared policy fields are saved and transmitted as empty values instead of being omitted.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->