### PR TITLE
Fixed Grouped Checkbox Validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "test:docs": "turbo run test --filter=docs",
     "test:ui": "turbo run test --filter=ui",
     "test:ui-patterns": "turbo run test --filter=ui-patterns",
+    "test:marketing": "turbo run test --filter=marketing",
     "test:studio": "turbo run test --filter=studio",
     "test:studio:watch": "turbo run test --filter=studio -- watch",
     "e2e:setup:cli": "supabase stop --all --no-backup --workdir ./e2e/studio; supabase start --exclude studio,mailpit --workdir ./e2e/studio && supabase status --output json --workdir ./e2e/studio > keys.json && node scripts/generateLocalEnv.js",

--- a/packages/marketing/package.json
+++ b/packages/marketing/package.json
@@ -10,7 +10,9 @@
   },
   "scripts": {
     "preinstall": "npx only-allow pnpm",
-    "clean": "rimraf node_modules"
+    "clean": "rimraf node_modules",
+    "test": "vitest",
+    "test:ci": "vitest --run"
   },
   "dependencies": {
     "@types/react": "catalog:",
@@ -26,7 +28,8 @@
     "tailwindcss": "^4.2.4",
     "tsconfig": "workspace:",
     "@typescript/native": "catalog:",
-    "typescript": "catalog:"
+    "typescript": "catalog:",
+    "vitest": "catalog:"
   },
   "license": "MIT"
 }

--- a/packages/marketing/src/forms/MarketingForm.tsx
+++ b/packages/marketing/src/forms/MarketingForm.tsx
@@ -17,6 +17,7 @@ import type { z } from 'zod'
 
 import { submitFormAction } from '../go/actions/submitForm'
 import { formFieldSchema, type GoFormFieldShowWhen } from '../go/schemas'
+import { getCheckboxValidationErrors } from './checkboxValidation'
 
 /** Input-shape field type — fields with Zod defaults (`half`, `required`) are optional here. */
 export type MarketingFormField = z.input<typeof formFieldSchema>
@@ -213,39 +214,14 @@ export default function MarketingForm({
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
 
-    // Required checkboxes aren't covered by HTML5 validation; check them manually.
-    const uncheckedRequired = visibleFields.filter(
-      (f) => f.type === 'checkbox' && f.required && !f.group && values[f.name] !== 'true'
-    )
-    if (uncheckedRequired.length > 0) {
+    // Checkbox validation (required boxes and required groups) isn't covered by HTML5; do it here.
+    const validationErrors = getCheckboxValidationErrors(visibleFields, values)
+    if (validationErrors.length > 0) {
       setSubmitState('error')
-      setErrorMessages(
-        uncheckedRequired.map((f) => `Please confirm: ${f.label.replace(/\*$/, '').trim()}`)
-      )
+      setErrorMessages(validationErrors)
       return
     }
 
-    const requiredCheckboxGroups = new Map<string, MarketingFormField[]>()
-    visibleFields.forEach((field) => {
-      if (field.type !== 'checkbox' || !field.group || !field.groupRequired) return
-      const groupFields = requiredCheckboxGroups.get(field.group) ?? []
-      groupFields.push(field)
-      requiredCheckboxGroups.set(field.group, groupFields)
-    })
-
-    const missingRequiredGroups = Array.from(requiredCheckboxGroups.values()).filter((group) =>
-      group.every((field) => values[field.name] !== 'true')
-    )
-    if (missingRequiredGroups.length > 0) {
-      setSubmitState('error')
-      setErrorMessages(
-        missingRequiredGroups.map((group) => {
-          const labels = group.map((field) => field.label).join(', ')
-          return `Please select at least one option: ${labels}`
-        })
-      )
-      return
-    }
     // Strip values for fields that are currently hidden so stale data doesn't leak.
     const submittedValues = Object.fromEntries(
       Object.entries(values).filter(([name]) => visibleFieldNames.has(name))

--- a/packages/marketing/src/forms/checkboxValidation.test.ts
+++ b/packages/marketing/src/forms/checkboxValidation.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest'
+
+import { getCheckboxValidationErrors } from './checkboxValidation'
+
+type Field = Parameters<typeof getCheckboxValidationErrors>[0][number]
+
+function checkbox(name: string, label: string, extra: Partial<Field> = {}): Field {
+  return { type: 'checkbox', name, label, ...extra } as Field
+}
+
+describe('getCheckboxValidationErrors', () => {
+  describe('required checkbox group', () => {
+    const group = [
+      checkbox('a', 'A', { group: 'g', groupRequired: true }),
+      checkbox('b', 'B', { group: 'g', groupRequired: true }),
+      checkbox('c', 'C', { group: 'g', groupRequired: false }),
+    ]
+
+    it('is satisfied by any member, including one without groupRequired', () => {
+      // Regression: previously a group only counted its `groupRequired: true` members, so checking
+      // only C was wrongly rejected.
+      expect(getCheckboxValidationErrors(group, { c: 'true' })).toEqual([])
+      expect(getCheckboxValidationErrors(group, { a: 'true' })).toEqual([])
+    })
+
+    it('errors and lists every member when nothing in the group is checked', () => {
+      expect(getCheckboxValidationErrors(group, {})).toEqual([
+        'Please select at least one option: A, B, C',
+      ])
+    })
+
+    it('does not require a group where no member sets groupRequired', () => {
+      const optional = [checkbox('x', 'X', { group: 'opt' }), checkbox('y', 'Y', { group: 'opt' })]
+      expect(getCheckboxValidationErrors(optional, {})).toEqual([])
+    })
+  })
+
+  describe('individually required checkbox', () => {
+    it('is enforced even when the checkbox belongs to a group', () => {
+      // Regression: the `!f.group` guard used to skip grouped checkboxes entirely.
+      const field = checkbox('x', 'X', { required: true, group: 'g' })
+      expect(getCheckboxValidationErrors([field], {})).toEqual(['Please confirm: X'])
+      expect(getCheckboxValidationErrors([field], { x: 'true' })).toEqual([])
+    })
+
+    it('strips a trailing asterisk from the label', () => {
+      const field = checkbox('tos', 'I accept the terms *', { required: true })
+      expect(getCheckboxValidationErrors([field], {})).toEqual([
+        'Please confirm: I accept the terms',
+      ])
+    })
+
+    it('takes precedence over group errors', () => {
+      const fields = [
+        checkbox('r', 'R', { required: true }),
+        checkbox('p', 'P', { group: 'g', groupRequired: true }),
+      ]
+      expect(getCheckboxValidationErrors(fields, {})).toEqual(['Please confirm: R'])
+    })
+  })
+
+  it('matches the live pipelines form behaviour (all groupRequired, none required)', () => {
+    const destinations = [
+      checkbox('destination_clickhouse', 'ClickHouse', {
+        group: 'requested_destinations',
+        groupRequired: true,
+      }),
+      checkbox('destination_snowflake', 'Snowflake', {
+        group: 'requested_destinations',
+        groupRequired: true,
+      }),
+      checkbox('destination_ducklake', 'DuckLake', {
+        group: 'requested_destinations',
+        groupRequired: true,
+      }),
+    ]
+    expect(getCheckboxValidationErrors(destinations, {})).toEqual([
+      'Please select at least one option: ClickHouse, Snowflake, DuckLake',
+    ])
+    expect(getCheckboxValidationErrors(destinations, { destination_snowflake: 'true' })).toEqual([])
+  })
+
+  it('ignores non-checkbox fields', () => {
+    const fields = [
+      { type: 'email', name: 'email', label: 'Email', required: true },
+      { type: 'text', name: 'org', label: 'Org', required: true },
+    ] as Field[]
+    expect(getCheckboxValidationErrors(fields, {})).toEqual([])
+  })
+})

--- a/packages/marketing/src/forms/checkboxValidation.ts
+++ b/packages/marketing/src/forms/checkboxValidation.ts
@@ -1,0 +1,44 @@
+import type { z } from 'zod'
+
+import type { formFieldSchema } from '../go/schemas'
+
+// z.input (not z.infer) so fields with Zod defaults (`required`, `groupRequired`) stay optional —
+// the shape MarketingForm actually holds. Structurally identical to MarketingFormField.
+type FormField = z.input<typeof formFieldSchema>
+
+/**
+ * Client-side validation for checkbox fields, which HTML5 `required` doesn't cover:
+ *
+ * - A checkbox with `required: true` must be checked.
+ * - A checkbox group is required when any of its members sets `groupRequired: true`; a required
+ *   group is satisfied by checking any one of its members (see `checkboxFieldSchema`).
+ *
+ * Returns human-readable error messages, or an empty array when everything is satisfied.
+ * Individual-required errors take precedence over group errors.
+ */
+export function getCheckboxValidationErrors(
+  fields: FormField[],
+  values: Record<string, string>
+): string[] {
+  const uncheckedRequired = fields.filter(
+    (f) => f.type === 'checkbox' && f.required && values[f.name] !== 'true'
+  )
+  if (uncheckedRequired.length > 0) {
+    return uncheckedRequired.map((f) => `Please confirm: ${f.label.replace(/\*$/, '').trim()}`)
+  }
+
+  const groups = new Map<string, { fields: FormField[]; required: boolean }>()
+  fields.forEach((field) => {
+    if (field.type !== 'checkbox' || !field.group) return
+    const group = groups.get(field.group) ?? { fields: [], required: false }
+    group.fields.push(field)
+    group.required = group.required || Boolean(field.groupRequired)
+    groups.set(field.group, group)
+  })
+
+  return Array.from(groups.values())
+    .filter((group) => group.required && group.fields.every((f) => values[f.name] !== 'true'))
+    .map(
+      (group) => `Please select at least one option: ${group.fields.map((f) => f.label).join(', ')}`
+    )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2414,6 +2414,9 @@ importers:
       typescript:
         specifier: 'catalog:'
         version: 6.0.2
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.13.14)(@vitest/coverage-v8@4.1.4)(@vitest/ui@4.1.4)(jsdom@28.1.0(@noble/hashes@1.8.0)(supports-color@8.1.1))(msw@2.11.3(@types/node@22.13.14)(typescript@6.0.2))(vite@8.0.16(@types/node@22.13.14)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/pg-meta:
     dependencies:
@@ -24138,7 +24141,7 @@ snapshots:
       srvx: 0.11.16
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      vitefu: 1.1.1(vite@8.0.16(@types/node@22.13.14)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitefu: 1.1.1(vite@8.0.16(@types/node@22.13.14)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
@@ -24171,7 +24174,7 @@ snapshots:
       srvx: 0.11.16
       tinyglobby: 0.2.17
       ufo: 1.6.4
-      vitefu: 1.1.1(vite@8.0.16(@types/node@22.13.14)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitefu: 1.1.1(vite@8.0.16(@types/node@22.13.14)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0))
       xmlbuilder2: 4.0.3
       zod: 4.4.3
     optionalDependencies:
@@ -35118,7 +35121,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitefu@1.1.1(vite@8.0.16(@types/node@22.13.14)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitefu@1.1.1(vite@8.0.16(@types/node@22.13.14)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
       vite: 8.0.16(@types/node@22.13.14)(esbuild@0.28.1)(jiti@2.7.0)(sass@1.77.4)(terser@5.39.0)(tsx@4.22.4)(yaml@2.9.0)
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Fixes #48071.

`checkboxFieldSchema` in `packages/marketing/src/go/schemas.ts` documents that "when any visible checkbox in a group has `groupRequired: true`, at least one checkbox in that group must be selected." The validation in `MarketingForm.handleSubmit` doesn't match that contract in two ways:

- The group check only collects checkboxes that individually set `groupRequired: true`, then requires one of those to be checked. In a group that mixes the flag, selecting a member with `groupRequired: false` is rejected with "Please select at least one option", even though it belongs to the group.
- The individual required check is filtered with `!f.group`, so a checkbox declaring both `required: true` and a `group` loses its individual enforcement. If no member of that group is `groupRequired`, neither path validates it.

Nothing in the repo hits this today — the only grouped-checkbox form (`apps/www/_go/pre-release/supabase-pipelines-new-destinations.tsx`) sets `groupRequired: true` on every member and `required` on none — so it's a latent bug that would surface for the first schema that mixes the flags within a group.

## What is the new behavior?

The group is now built from every member and treated as required when any member sets `groupRequired: true`, so checking any option in the group satisfies it. The `!f.group` guard is removed so `required` is enforced independently of grouping, which is what the schema documents.

The validation is pulled into a small pure helper (`checkboxValidation.ts`) so it can be unit-tested without importing the client component (which reaches `server-only` transitively). `packages/marketing` had no test setup, so this also adds `vitest` and a first test covering the mixed-flag group and the grouped-`required` case.

Behavior is unchanged for the existing Pipelines destinations form (all members `groupRequired: true`), which the test verifies as well. No visual changes.

## Additional context

I kept `required` and `groupRequired` as independent flags rather than disallowing the combination in the Zod schema, since they're documented as orthogonal — happy to move that into a schema-level refinement instead if you'd prefer.

I didn't wire the new test into CI, since tests here run per-package and `marketing` didn't have a workflow yet; glad to add one (mirroring `ui-patterns-tests.yml`) if you'd like it enforced.

This is one of my earlier contributions to the repo, so if anything is out of scope or doesn't fit your conventions, I'd genuinely appreciate the feedback and will gladly revise.

A couple of notes:

- Fixes #48071 sits under "current behavior" so it both links the issue (as the template asks) and auto-closes it on merge.
- I called out the one design choice (independent flags vs. a Zod refinement) and the CI-wiring point up front, so a reviewer isn't left wondering — and both double as easy "revise if you'd like" hooks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved marketing form validation for required checkboxes and checkbox groups.
  - Added clear error messages for unchecked required options, including grouped selections.
  - Ensured individual checkbox requirements take precedence over group-level validation.

- **Tests**
  - Added coverage for required checkbox scenarios and non-checkbox fields.

- **Chores**
  - Added commands for running marketing package tests locally and in CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->