### PR TITLE
fix(studio): prevent duplicate success toast on disk upgrade

### DIFF
--- a/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
+++ b/apps/studio/components/interfaces/DiskManagement/DiskManagementForm.tsx
@@ -301,9 +301,10 @@ export function DiskManagementForm() {
 
       setIsDialogOpen(false)
       form.reset(data as DiskStorageSchemaType)
-      toast.success(
-        `Successfully updated disk settings!${willUpdateDiskConfiguration ? ' The requested changes will be applied to your disk shortly.' : ''}`
-      )
+      // Disk resizes get their own completion toast once polling confirms it's applied
+      if (!willUpdateDiskConfiguration) {
+        toast.success('Successfully updated disk settings!')
+      }
     } catch (error: unknown) {
       setMessageState({
         message: error instanceof Error ? error.message : 'An unknown error occurred',


### PR DESCRIPTION
## Summary
Fixes FE-3948: two success toasts were firing after a disk upgrade. Now the immediate toast is skipped when a disk resize is requested, since the polling effect already shows a completion toast once the resize is applied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved disk settings update notifications to prevent premature success messages while configuration changes are still being applied.
  * Success confirmation now appears after disk resizing is fully completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->