### PR TITLE
fix(studio): guard panel collapse/resize on narrow viewports

### DIFF
--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -72,9 +72,6 @@ export const DefaultLayout = ({
   }, [])
 
   useEffect(() => {
-    // On mobile, LayoutSidebar doesn't render its ResizablePanel (the sidebar is shown in a
-    // sheet instead), leaving panel-content as the group's only panel. Calling collapse()/resize()
-    // on it then throws in react-resizable-panels since there's no sibling panel to resize against.
     if (!isMounted || !panelRef.current || !activeSidebar || isMobile) return
     if (isMaximised) {
       panelRef.current.collapse()

--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -72,13 +72,16 @@ export const DefaultLayout = ({
   }, [])
 
   useEffect(() => {
-    if (!isMounted || !panelRef.current || !activeSidebar) return
+    // On mobile, LayoutSidebar doesn't render its ResizablePanel (the sidebar is shown in a
+    // sheet instead), leaving panel-content as the group's only panel. Calling collapse()/resize()
+    // on it then throws in react-resizable-panels since there's no sibling panel to resize against.
+    if (!isMounted || !panelRef.current || !activeSidebar || isMobile) return
     if (isMaximised) {
       panelRef.current.collapse()
     } else {
       panelRef.current.resize(`${contentMaxSizePercentage}%`)
     }
-  }, [isMounted, isMaximised, panelRef, activeSidebar])
+  }, [isMounted, isMaximised, panelRef, activeSidebar, isMobile])
 
   // This is required to prevent layout shift when rendering resizable panels (they initially render at 50%, then shift
   // to whatever is specified).


### PR DESCRIPTION
## Summary

Fixes FE-3955 / [SUPABASE-APP-K41](https://supabase.sentry.io/issues/7613475596/) — a crash affecting 101 users (502 occurrences, escalating) since the "maximise AI assistant" feature (#47954) shipped on 2026-07-15.

`DefaultLayout` calls `panelRef.current.collapse()` / `.resize()` on the `panel-content` resizable panel whenever the AI assistant sidebar is maximised. Below the `md` breakpoint, `LayoutSidebar` renders no panel at all (the sidebar shows as a mobile sheet instead), leaving `panel-content` as the *only* panel in the `ResizablePanelGroup`. `react-resizable-panels`' resize algorithm assumes a neighboring panel exists to pivot against, so with a single panel it computes an invalid pivot index of `-1` and throws `Panel constraints not found for index -1`.

This guards the effect with the same `isMobile` breakpoint check `LayoutSidebar` already uses, so we never call `collapse()`/`resize()` when there's no sibling panel to resize against.

## Test plan

- [ ] On a narrow viewport (or actual mobile device), open the AI assistant and toggle maximise — should no longer throw
- [ ] On desktop, confirm maximise/minimise still resizes the content panel as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a mobile layout issue where the sidebar could collapse or resize incorrectly, leading to runtime errors.
  * Improved the sidebar’s resize/collapse behavior on mobile devices to keep the layout stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->