### PR TITLE
docs(tanstack): add a proper SSR quick start with cookie-based auth

### DIFF
--- a/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
+++ b/apps/docs/content/guides/auth/server-side/creating-a-client.mdx
@@ -160,6 +160,14 @@ SUPABASE_PUBLISHABLE_KEY=supabase_publishable_key
 ```
 
 </TabPanel>
+<TabPanel id="tanstack" label="TanStack Start">
+
+```bash .env.local
+VITE_SUPABASE_URL=supabase_project_url
+VITE_SUPABASE_PUBLISHABLE_KEY=supabase_publishable_key
+```
+
+</TabPanel>
 </Tabs>
 
 ## Create a client
@@ -822,6 +830,82 @@ language="typescript"
 
 </TabPanel>
 </Tabs>
+
+</TabPanel>
+<TabPanel id="tanstack" label="TanStack Start">
+
+### Write utility functions to create Supabase clients
+
+To access Supabase from a TanStack Start app, you need 2 types of Supabase clients:
+
+1. **Browser client** - To access Supabase from components that run in the browser.
+2. **Server client** - To access Supabase from loaders, server functions, and other code that runs only on the server.
+
+TanStack Start renders matched routes on the server by default, so `beforeLoad` and `loader` run server-side on the initial request. Unlike Next.js, this means you don't need a proxy or middleware layer to keep sessions fresh — the server client reads and writes the session cookie directly on each request.
+
+<$Partial path="auth_methods.mdx" />
+
+Create a `lib/supabase` folder at the root of your project, or inside the `./src` folder if you are using one, with a file for each type of client. Then copy the lib utility functions for each client type.
+
+<div className="mt-12">
+  <$CodeTabs>
+    <$CodeSample
+      path="/auth/tanstack/lib/supabase/client.ts"
+      meta="name=lib/supabase/client.ts"
+      language="typescript"
+    />
+    <$CodeSample
+      path="/auth/tanstack/lib/supabase/server.ts"
+      meta="name=lib/supabase/server.ts"
+      language="typescript"
+    />
+  </$CodeTabs>
+</div>
+
+### Protecting routes
+
+TanStack Start has no global middleware layer, so protect routes with a layout route's `beforeLoad` hook, backed by a server function that checks the session.
+
+<Admonition type="danger">
+
+`beforeLoad` only controls what gets rendered — it's a UX guard, not a security boundary. Because there's no proxy re-checking every request, the server function it calls is the **only** checkpoint before a redirect happens or private data is returned, so that function must authorize the request itself.
+
+Use `supabase.auth.getUser()` here, which revalidates the session against the Auth server on every call, rather than trusting local session data. This is a different tradeoff than the Next.js Proxy, which can rely on the cheaper `getClaims()` because it re-validates on every single request anyway — TanStack Start's per-route check needs the stronger guarantee, because it's the only check that runs.
+
+</Admonition>
+
+<div className="mt-12">
+  <$CodeTabs>
+    <$CodeSample
+      path="/auth/tanstack/lib/supabase/fetch-user-server-fn.ts"
+      meta="name=lib/supabase/fetch-user-server-fn.ts"
+      language="typescript"
+    />
+    <$CodeSample
+      path="/auth/tanstack/routes/_protected.tsx"
+      meta="name=routes/_protected.tsx"
+      language="typescript"
+    />
+  </$CodeTabs>
+</div>
+
+Any other server function that returns or mutates private data needs this same check — don't rely on a route being nested under `_protected` alone.
+
+<Admonition type="caution">
+
+TanStack Start is still in beta, so expect some breaking changes and rough edges. See the [TanStack Start quick start](https://tanstack.com/start/latest/docs/framework/react/quick-start) for the latest guidance.
+
+</Admonition>
+
+## Congratulations
+
+You're done! To recap, you've successfully:
+
+- Set up a Supabase client utility to call Supabase from a browser component. You can use this if you need to call Supabase from the browser, for example to set up a realtime subscription.
+- Set up a server client utility to call Supabase from loaders and server functions.
+- Protected a route with `beforeLoad`, backed by a server function that authorizes the request itself.
+
+You can now use any Supabase features from your client or server code!
 
 </TabPanel>
 </Tabs>

--- a/apps/docs/content/guides/getting-started/quickstarts/tanstack.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/tanstack.mdx
@@ -4,6 +4,12 @@ subtitle: 'Learn how to create a Supabase project, add some sample data to your 
 breadcrumb: 'Framework Quickstarts'
 ---
 
+<Admonition type="caution">
+
+TanStack Start is still in beta, so expect some breaking changes and rough edges. See the [TanStack Start quick start](https://tanstack.com/start/latest/docs/framework/react/quick-start) for the latest guidance.
+
+</Admonition>
+
 <$Partial path="quickstart_db_setup.mdx" />
 
 ## 3. Create a TanStack Start app
@@ -24,55 +30,51 @@ To install, run the following command in the root of your project:
 npx skills add supabase/agent-skills
 ```
 
-## 5. Install the Supabase client library
+## 5. Set up shadcn/ui
 
-The fastest way to get started is to use the `supabase-js` client library which provides a convenient interface for working with Supabase from a TanStack Start app.
-
-Navigate to the TanStack Start app and install `supabase-js`.
+Navigate to the TanStack Start app and set up [shadcn/ui](https://ui.shadcn.com/docs/installation/tanstack), which the Supabase auth flow you'll install in the next step is built on.
 
 ```bash
-cd my-app && npm install @supabase/supabase-js
+cd my-app && npx shadcn@latest init
 ```
 
-## 6. Declare Supabase environment variables
+## 6. Install the Supabase auth flow
 
-Create a `.env` file in the root of your project and populate with your Supabase connection variables that you can get from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true):
+Install a complete, cookie-based auth flow for TanStack Start — browser and server Supabase clients, plus login, sign-up, and password-reset pages — from the [Supabase UI Library](/ui) registry.
+
+```bash
+npx shadcn@latest add https://supabase.com/ui/r/password-based-auth-tanstack.json
+```
+
+## 7. Declare Supabase environment variables
+
+The previous step created a `.env.local` file in the root of your project with empty Supabase connection variables. Populate them with the values from the helper below, or [from the project **Connect** panel](/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=tanstack).
 
 <Button variant="primary" asChild>
-  <a href="/dashboard/project/_?showConnect=true">Open Connect panel</a>
+  <a href="/dashboard/project/_?showConnect=true&connectTab=frameworks&framework=tanstack">
+    Open Connect panel
+  </a>
 </Button>
 
-```text name=.env
+```text name=.env.local
 VITE_SUPABASE_URL=<SUBSTITUTE_SUPABASE_URL>
 VITE_SUPABASE_PUBLISHABLE_KEY=<SUBSTITUTE_SUPABASE_PUBLISHABLE_KEY>
 ```
 
-<$Partial path="api_settings.mdx" variables={{ "framework": "", "tab": "" }} />
+<$Partial path="api_settings.mdx" variables={{ "framework": "tanstack", "tab": "frameworks" }} />
 
-## 7. Create a Supabase client utility
+## 8. Query Supabase data from TanStack Start
 
-Create a new file at `src/utils/supabase.ts` to initialize the Supabase client.
-
-```ts name=src/utils/supabase.ts
-import { createClient } from '@supabase/supabase-js'
-
-export const supabase = createClient(
-  import.meta.env.VITE_SUPABASE_URL,
-  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY
-)
-```
-
-## 8. Query data from the app
-
-Replace the contents of `src/routes/index.tsx` with the following code to add a loader function that fetches the instruments data and displays it on the page.
+The auth flow you installed in the previous step already includes working login, sign-up, and `/protected` routes. Replace the contents of `src/routes/index.tsx` with the following to query the `instruments` table through the SSR-aware server client, inside a loader that runs on the server.
 
 ```tsx name=src/routes/index.tsx
 import { createFileRoute } from '@tanstack/react-router'
 
-import { supabase } from '../utils/supabase'
+import { createClient } from '@/lib/supabase/server'
 
 export const Route = createFileRoute('/')({
   loader: async () => {
+    const supabase = createClient()
     const { data: instruments } = await supabase.from('instruments').select()
     return { instruments }
   },
@@ -102,7 +104,8 @@ npm run dev
 
 ## Next steps
 
+- Learn more about [creating a Supabase client for TanStack Start SSR](/docs/guides/auth/server-side/creating-a-client?queryGroups=framework&framework=tanstack)
+- Customize the installed auth flow — email templates, redirect URLs, and social auth — in the [Supabase UI Library docs](/ui/docs/tanstack/password-based-auth)
 - Explore [drop-in UI components](/ui) for your Supabase app
-- Set up [Auth](/docs/guides/auth) for your app
 - [Insert more data](/docs/guides/database/import-data) into your database
 - Upload and serve static files using [Storage](/docs/guides/storage)

--- a/examples/auth/tanstack/lib/supabase/client.ts
+++ b/examples/auth/tanstack/lib/supabase/client.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/types/importMeta.d.ts" />
+import { createBrowserClient } from '@supabase/ssr'
+
+export function createClient() {
+  return createBrowserClient(
+    import.meta.env.VITE_SUPABASE_URL!,
+    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY!
+  )
+}

--- a/examples/auth/tanstack/lib/supabase/fetch-user-server-fn.ts
+++ b/examples/auth/tanstack/lib/supabase/fetch-user-server-fn.ts
@@ -1,0 +1,21 @@
+import type { Factor, User } from '@supabase/supabase-js'
+import { createServerFn } from '@tanstack/react-start'
+
+import { createClient } from '@/lib/supabase/server'
+
+type SSRSafeUser = User & {
+  factors: (Factor & { factor_type: 'phone' | 'totp' })[]
+}
+
+export const fetchUser: () => Promise<SSRSafeUser | null> = createServerFn({
+  method: 'GET',
+}).handler(async () => {
+  const supabase = createClient()
+  const { data, error } = await supabase.auth.getUser()
+
+  if (error) {
+    return null
+  }
+
+  return data.user as SSRSafeUser
+})

--- a/examples/auth/tanstack/lib/supabase/server.ts
+++ b/examples/auth/tanstack/lib/supabase/server.ts
@@ -1,0 +1,27 @@
+import { createServerClient } from '@supabase/ssr'
+import { getCookies, setCookie } from '@tanstack/react-start/server'
+
+export function createClient() {
+  return createServerClient(
+    process.env.VITE_SUPABASE_URL!,
+    process.env.VITE_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return Object.entries(getCookies()).map(
+            ([name, value]) =>
+              ({
+                name,
+                value,
+              }) as { name: string; value: string }
+          )
+        },
+        setAll(cookies) {
+          cookies.forEach((cookie) => {
+            setCookie(cookie.name, cookie.value)
+          })
+        },
+      },
+    }
+  )
+}

--- a/examples/auth/tanstack/routes/_protected.tsx
+++ b/examples/auth/tanstack/routes/_protected.tsx
@@ -1,0 +1,17 @@
+import { createFileRoute, redirect } from '@tanstack/react-router'
+
+import { fetchUser } from '@/lib/supabase/fetch-user-server-fn'
+
+export const Route = createFileRoute('/_protected')({
+  beforeLoad: async () => {
+    const user = await fetchUser()
+
+    if (!user) {
+      throw redirect({ to: '/login' })
+    }
+
+    return {
+      user,
+    }
+  },
+})


### PR DESCRIPTION
## Summary

TanStack Start's quickstart only ever wired up an anonymous `supabase-js` client — no cookies, no `@supabase/ssr`, no auth. This ports the real `@supabase/ssr` client/server split and password-based auth flow (already shipped in `apps/ui-library`) into the quickstart and adds a matching tab to the SSR guide.

## Where this changed

- `apps/docs/content/guides/getting-started/quickstarts/tanstack.mdx` — quickstart now installs the cookie-based auth flow via the Supabase UI Library registry and queries data through the SSR-aware server client.
- `apps/docs/content/guides/auth/server-side/creating-a-client.mdx` — new TanStack Start tab (client/server setup + protecting routes).
- `examples/auth/tanstack/` (new) — source files backing the `$CodeSample` snippets above, ported from `apps/ui-library`'s registry.

## Test plan

- [x] Scaffolded a real TanStack Start app and ran the quickstart commands end-to-end
- [x] Confirmed SSR loader + protected-route redirect work as documented
- [x] `pnpm lint:mdx` and `pnpm build:guides-markdown` pass