### PR TITLE
fix(sql-editor): guard removeFavorite against missing snippet like addFavorite

### DIFF
--- a/apps/studio/state/sql-editor/sql-editor-state.test.ts
+++ b/apps/studio/state/sql-editor/sql-editor-state.test.ts
@@ -1,0 +1,72 @@
+import { untrustedSql } from '@supabase/pg-meta'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { sqlEditorState } from './sql-editor-state'
+import type { SnippetWithContent } from '@/data/content/sql-folders-query'
+
+function makeSnippet(
+  id: string,
+  overrides: Omit<Partial<SnippetWithContent>, 'content'> = {}
+): SnippetWithContent {
+  return {
+    id,
+    type: 'sql',
+    name: 'My Query',
+    description: 'A description',
+    visibility: 'user',
+    project_id: 42,
+    owner_id: 7,
+    folder_id: null,
+    favorite: false,
+    status: 'saved',
+    inserted_at: '2024-01-01T00:00:00.000Z',
+    updated_at: '2024-01-01T00:00:00.000Z',
+    ...overrides,
+    content: {
+      content_id: id,
+      schema_version: '1',
+      unchecked_sql: untrustedSql('SELECT * FROM users;'),
+    },
+  }
+}
+
+describe('addFavorite / removeFavorite', () => {
+  beforeEach(() => {
+    // sqlEditorState is a module-level singleton, so reset the state these tests touch
+    for (const id of Object.keys(sqlEditorState.snippets)) {
+      delete sqlEditorState.snippets[id]
+    }
+    sqlEditorState.needsSaving.clear()
+  })
+
+  it('marks a loaded snippet as favorite and queues it for saving', () => {
+    sqlEditorState.addSnippet({ projectRef: 'ref', snippet: makeSnippet('snippet-1') })
+
+    sqlEditorState.addFavorite('snippet-1')
+
+    expect(sqlEditorState.snippets['snippet-1'].snippet.favorite).toBe(true)
+    expect(sqlEditorState.needsSaving.get('snippet-1')).toBe(true)
+  })
+
+  it('unmarks a favorited snippet and queues it for saving', () => {
+    sqlEditorState.addSnippet({
+      projectRef: 'ref',
+      snippet: makeSnippet('snippet-1', { favorite: true }),
+    })
+
+    sqlEditorState.removeFavorite('snippet-1')
+
+    expect(sqlEditorState.snippets['snippet-1'].snippet.favorite).toBe(false)
+    expect(sqlEditorState.needsSaving.get('snippet-1')).toBe(true)
+  })
+
+  it('ignores addFavorite for a snippet that is not in the store', () => {
+    expect(() => sqlEditorState.addFavorite('missing')).not.toThrow()
+    expect(sqlEditorState.needsSaving.has('missing')).toBe(false)
+  })
+
+  it('ignores removeFavorite for a snippet that is not in the store', () => {
+    expect(() => sqlEditorState.removeFavorite('missing')).not.toThrow()
+    expect(sqlEditorState.needsSaving.has('missing')).toBe(false)
+  })
+})

--- a/apps/studio/state/sql-editor/sql-editor-state.ts
+++ b/apps/studio/state/sql-editor/sql-editor-state.ts
@@ -257,7 +257,7 @@ export const sqlEditorState = proxy({
 
   removeFavorite: (id: string) => {
     const storeSnippet = sqlEditorState.snippets[id]
-    if (storeSnippet.snippet) {
+    if (storeSnippet) {
       storeSnippet.snippet.favorite = false
       sqlEditorState.needsSaving.set(id, true)
     }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Fixes #48110

In the SQL editor Valtio store, `removeFavorite` guards against a missing snippet with `if (storeSnippet.snippet)`, which reads `.snippet` off `undefined` and throws `TypeError: Cannot read properties of undefined (reading 'snippet')` whenever the id is not loaded in `sqlEditorState.snippets`. Its counterpart `addFavorite` guards correctly with `if (storeSnippet)` and no-ops on the same input.

## What is the new behavior?

`removeFavorite` now uses the same `if (storeSnippet)` guard as `addFavorite`, so un-favoriting an id that is not in the store is a safe no-op instead of a crash. Behavior for loaded snippets is unchanged.

Since `StateSnippet.snippet` is a required field, the old check was always true whenever `storeSnippet` existed, so the only real world difference between the two guards was the crash on the missing case.

I also added a small vitest file covering both methods (favorite set plus needsSaving queued for loaded snippets, no-op for missing ids). The missing-id test for `removeFavorite` fails with the exact TypeError above when run against the old guard, and passes with this fix.

## Additional context

Root cause: `apps/studio/state/sql-editor/sql-editor-state.ts` line 260 (compare `removeFavorite` at lines 258 to 264 with `addFavorite` at lines 250 to 256).

Gates run locally on top of current master (45ba40eff9): `pnpm test:prettier`, `pnpm typecheck` (8/8 packages), `pnpm lint --filter=studio` (0 errors), `pnpm test:studio` (only failure is `lib/local-storage.test.ts`, which fails identically on clean master), and `pnpm build --filter=studio`.

quick disclosure: I traced this one down and built the fix and test with help from Claude Code, then verified everything locally myself. still a college freshman finding my way around this codebase, so if the minimal guard fix is not the direction you want (for example collapsing both methods into one setFavorite), happy to rework it :)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed favorite removal so it works correctly for saved SQL snippets.
  * Prevented favorite and unfavorite actions from causing errors when the specified snippet cannot be found.

* **Tests**
  * Added coverage for favoriting, unfavoriting, saving state updates, and missing snippets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->