### PR TITLE
Fix featured blog post layout breaking on mobile with many authors

### DIFF
--- a/apps/www/components/Blog/AuthorAvatars.tsx
+++ b/apps/www/components/Blog/AuthorAvatars.tsx
@@ -8,16 +8,25 @@ interface Props {
   size?: 'sm' | 'md'
 }
 
+const MAX_VISIBLE_AVATARS = 3
+
 export default function AuthorAvatars({ authors, showName = true, size = 'sm' }: Props) {
   const valid = authors.filter(Boolean) as Author[]
   if (!valid.length) return null
 
   const px = size === 'md' ? 'w-6 h-6' : 'w-5 h-5'
+  const visibleAvatars = valid.slice(0, MAX_VISIBLE_AVATARS)
+  const hiddenCount = valid.length - visibleAvatars.length
+
+  const nameLabel =
+    valid.length > 2
+      ? `${valid[0].author} +${valid.length - 1} other${valid.length - 1 > 1 ? 's' : ''}`
+      : valid.map((a) => a.author).join(', ')
 
   return (
-    <div className="flex items-center gap-2">
-      <div className="flex items-center -space-x-1.5">
-        {valid.map((author, i) => (
+    <div className="flex items-center gap-2 min-w-0">
+      <div className="flex items-center -space-x-1.5 shrink-0">
+        {visibleAvatars.map((author, i) => (
           <div
             key={i}
             className={`relative ${px} rounded-full ring-2 ring-background border border-foreground/20 overflow-hidden shrink-0`}
@@ -36,11 +45,19 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
             )}
           </div>
         ))}
+        {hiddenCount > 0 && (
+          <div
+            className={`relative ${px} rounded-full ring-2 ring-background border border-foreground/20 shrink-0 bg-surface-300 flex items-center justify-center`}
+            aria-hidden="true"
+          >
+            <span className="text-foreground-lighter text-[9px] leading-none">
+              +{hiddenCount}
+            </span>
+          </div>
+        )}
       </div>
       {showName && (
-        <p className="text-foreground-lighter text-xs truncate">
-          {valid.map((a) => a.author).join(', ')}
-        </p>
+        <p className="text-foreground-lighter text-xs truncate min-w-0">{nameLabel}</p>
       )}
     </div>
   )

--- a/apps/www/components/Blog/AuthorAvatars.tsx
+++ b/apps/www/components/Blog/AuthorAvatars.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image'
 
+import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 import type Author from '@/types/author'
 
 interface Props {
@@ -16,14 +17,14 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
 
   const px = size === 'md' ? 'w-6 h-6' : 'w-5 h-5'
   const visibleAvatars = valid.slice(0, MAX_VISIBLE_AVATARS)
-  const hiddenCount = valid.length - visibleAvatars.length
+  const allNames = valid.map((a) => a.author).join(', ')
 
   const nameLabel =
     valid.length > 2
       ? `${valid[0].author} +${valid.length - 1} other${valid.length - 1 > 1 ? 's' : ''}`
-      : valid.map((a) => a.author).join(', ')
+      : allNames
 
-  return (
+  const content = (
     <div className="flex items-center gap-2 min-w-0">
       <div className="flex items-center -space-x-1.5 shrink-0">
         {visibleAvatars.map((author, i) => (
@@ -44,22 +45,21 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
             </div>
           </div>
         ))}
-        {hiddenCount > 0 && (
-          <div
-            className={`relative ${px} rounded-full bg-background shrink-0 p-px`}
-            aria-hidden="true"
-          >
-            <div className="w-full h-full rounded-full border border-foreground/20 bg-surface-300 flex items-center justify-center">
-              <span className="text-foreground-lighter text-[9px] leading-none">
-                +{hiddenCount}
-              </span>
-            </div>
-          </div>
-        )}
       </div>
       {showName && (
         <p className="text-foreground-lighter text-xs truncate min-w-0">{nameLabel}</p>
       )}
     </div>
+  )
+
+  if (valid.length < 2) return content
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>{content}</TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-[300px]">
+        {allNames}
+      </TooltipContent>
+    </Tooltip>
   )
 }

--- a/apps/www/components/Blog/AuthorAvatars.tsx
+++ b/apps/www/components/Blog/AuthorAvatars.tsx
@@ -9,7 +9,7 @@ interface Props {
   size?: 'sm' | 'md'
 }
 
-const MAX_VISIBLE_AVATARS = 3
+const MAX_VISIBLE_AVATARS = 4
 
 export default function AuthorAvatars({ authors, showName = true, size = 'sm' }: Props) {
   const valid = authors.filter(Boolean) as Author[]
@@ -21,11 +21,11 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
 
   const nameLabel =
     valid.length > 2
-      ? `${valid[0].author} +${valid.length - 1} other${valid.length - 1 > 1 ? 's' : ''}`
+      ? `${valid[0].author}, +${valid.length - 1} other${valid.length - 1 > 1 ? 's' : ''}`
       : allNames
 
   const content = (
-    <div className="flex items-center gap-2 min-w-0" tabIndex={valid.length >= 2 ? 0 : undefined}>
+    <div className="flex items-center gap-2 min-w-0" tabIndex={0}>
       <div className="flex items-center -space-x-1.5 shrink-0">
         {visibleAvatars.map((author, i) => (
           <div key={i} className={`relative ${px} rounded-full bg-background shrink-0 p-px`}>
@@ -50,12 +50,10 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
     </div>
   )
 
-  if (valid.length < 2) return content
-
   return (
     <Tooltip>
       <TooltipTrigger asChild>{content}</TooltipTrigger>
-      <TooltipContent side="bottom" className="max-w-[300px]">
+      <TooltipContent side="bottom" className="max-w-[260px]">
         {allNames}
       </TooltipContent>
     </Tooltip>

--- a/apps/www/components/Blog/AuthorAvatars.tsx
+++ b/apps/www/components/Blog/AuthorAvatars.tsx
@@ -27,32 +27,33 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
     <div className="flex items-center gap-2 min-w-0">
       <div className="flex items-center -space-x-1.5 shrink-0">
         {visibleAvatars.map((author, i) => (
-          <div
-            key={i}
-            className={`relative ${px} rounded-full ring-2 ring-background border border-foreground/20 overflow-hidden shrink-0`}
-          >
-            {author.author_image_url && (
-              <Image
-                src={
-                  typeof author.author_image_url === 'string'
-                    ? author.author_image_url
-                    : (author.author_image_url as { url: string }).url
-                }
-                fill
-                className="object-cover"
-                alt={showName ? '' : author.author}
-              />
-            )}
+          <div key={i} className={`relative ${px} rounded-full bg-background shrink-0 p-px`}>
+            <div className="relative w-full h-full rounded-full border border-foreground/20 overflow-hidden">
+              {author.author_image_url && (
+                <Image
+                  src={
+                    typeof author.author_image_url === 'string'
+                      ? author.author_image_url
+                      : (author.author_image_url as { url: string }).url
+                  }
+                  fill
+                  className="object-cover"
+                  alt={showName ? '' : author.author}
+                />
+              )}
+            </div>
           </div>
         ))}
         {hiddenCount > 0 && (
           <div
-            className={`relative ${px} rounded-full ring-2 ring-background border border-foreground/20 shrink-0 bg-surface-300 flex items-center justify-center`}
+            className={`relative ${px} rounded-full bg-background shrink-0 p-px`}
             aria-hidden="true"
           >
-            <span className="text-foreground-lighter text-[9px] leading-none">
-              +{hiddenCount}
-            </span>
+            <div className="w-full h-full rounded-full border border-foreground/20 bg-surface-300 flex items-center justify-center">
+              <span className="text-foreground-lighter text-[9px] leading-none">
+                +{hiddenCount}
+              </span>
+            </div>
           </div>
         )}
       </div>

--- a/apps/www/components/Blog/AuthorAvatars.tsx
+++ b/apps/www/components/Blog/AuthorAvatars.tsx
@@ -1,6 +1,6 @@
 import Image from 'next/image'
-
 import { Tooltip, TooltipContent, TooltipTrigger } from 'ui'
+
 import type Author from '@/types/author'
 
 interface Props {
@@ -25,7 +25,7 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
       : allNames
 
   const content = (
-    <div className="flex items-center gap-2 min-w-0">
+    <div className="flex items-center gap-2 min-w-0" tabIndex={valid.length >= 2 ? 0 : undefined}>
       <div className="flex items-center -space-x-1.5 shrink-0">
         {visibleAvatars.map((author, i) => (
           <div key={i} className={`relative ${px} rounded-full bg-background shrink-0 p-px`}>
@@ -46,9 +46,7 @@ export default function AuthorAvatars({ authors, showName = true, size = 'sm' }:
           </div>
         ))}
       </div>
-      {showName && (
-        <p className="text-foreground-lighter text-xs truncate min-w-0">{nameLabel}</p>
-      )}
+      {showName && <p className="text-foreground-lighter text-xs truncate min-w-0">{nameLabel}</p>}
     </div>
   )
 

--- a/apps/www/components/Blog/FeaturedThumb.tsx
+++ b/apps/www/components/Blog/FeaturedThumb.tsx
@@ -59,12 +59,12 @@ function renderFeaturedThumb(blog: PostTypes, author: any[]) {
             <p className="p">{blog.description}</p>
           </div>
 
-          <div className="flex items-center justify-between mt-4">
-            <div>
+          <div className="flex items-center justify-between gap-4 mt-4">
+            <div className="min-w-0 flex-1">
               <span className="sr-only">Author: </span>
               <AuthorAvatars authors={author} size="md" />
             </div>
-            <div className="text-foreground-lighter flex space-x-2 text-sm">
+            <div className="text-foreground-lighter flex shrink-0 space-x-2 text-sm">
               <span>
                 <span className="sr-only">Published </span>
                 {blog.formattedDate}

--- a/apps/www/components/Blog/FeaturedThumb.tsx
+++ b/apps/www/components/Blog/FeaturedThumb.tsx
@@ -64,7 +64,7 @@ function renderFeaturedThumb(blog: PostTypes, author: any[]) {
               <span className="sr-only">Author: </span>
               <AuthorAvatars authors={author} size="md" />
             </div>
-            <div className="text-foreground-lighter flex shrink-0 space-x-2 text-sm">
+            <div className="text-foreground-lighter flex shrink-0 space-x-2 text-xs">
               <span>
                 <span className="sr-only">Published </span>
                 {blog.formattedDate}

--- a/apps/www/components/Blog/FeaturedThumb.tsx
+++ b/apps/www/components/Blog/FeaturedThumb.tsx
@@ -51,7 +51,7 @@ function renderFeaturedThumb(blog: PostTypes, author: any[]) {
         </div>
 
         {/* Text */}
-        <div className="flex flex-col lg:col-span-6 md:justify-center">
+        <div className="flex flex-col lg:col-span-6 md:justify-center lg:pr-8">
           <div>
             <h2 className="h2 lg:text-2xl! xl:text-3xl! mb-2! group-hover:underline">
               {blog.title}

--- a/apps/www/components/Blog/FeaturedThumb.tsx
+++ b/apps/www/components/Blog/FeaturedThumb.tsx
@@ -69,8 +69,10 @@ function renderFeaturedThumb(blog: PostTypes, author: any[]) {
                 <span className="sr-only">Published </span>
                 {blog.formattedDate}
               </span>
-              <span aria-hidden="true">·</span>
-              <span>{blog.readingTime}</span>
+              <span aria-hidden="true" className="hidden sm:inline">
+                ·
+              </span>
+              <span className="hidden sm:inline">{blog.readingTime}</span>
             </div>
           </div>
         </div>


### PR DESCRIPTION
AuthorAvatars now caps visible avatars at 4 (showing a "+N" badge for
the rest) and collapses author names to "First Author, +N others" once
there are more than two, instead of joining every name into one long
string. A tooltip shows the full list.

<img width="434" height="306" alt="Screenshot 2026-07-21 at 15 14 38" src="https://github.com/user-attachments/assets/507ce37e-b080-4dd6-bd49-ca694252cd72" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Enhancements**
  * Blog author displays now cap at three visible avatars and show a “+N” indicator for additional authors.
  * Author name labels are now summarized for multi-author posts (with full author names available via tooltip when applicable).
  * Featured post metadata (author, published date, reading time) has improved spacing, truncation behavior, and responsive visibility on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->