### PR TITLE
fix(docs): broken link

### DIFF
--- a/apps/docs/content/guides/integrations/partner-catalog.mdx
+++ b/apps/docs/content/guides/integrations/partner-catalog.mdx
@@ -6,7 +6,7 @@ description: 'Integrations and Partners'
 
 The [Partner Catalog](/partners/catalog) is Supabase's public directory of third-party integrations. It lists tools that extend your Supabase project. These tools cover Auth, Caching, Hosting, and Low-code categories.
 
-The Partner Catalog is different from [Dashboard Integrations](/guides/integrations#dashboard-integrations). You install Dashboard Integrations directly from a project in the Supabase Dashboard.
+The Partner Catalog is different from [Dashboard Integrations](/docs/guides/integrations#dashboard-integrations). You install Dashboard Integrations directly from a project in the Supabase Dashboard.
 
 ## Build an integration
 


### PR DESCRIPTION
Fix broken "Dashboard integrations" link with missing `/docs/` in the [Partner Catalog docs page](https://docs-git-fix-docs-dashboard-integrations-link-supabase.vercel.app/docs/guides/integrations/partner-catalog).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the difference between the Partner Catalog and Dashboard Integrations.
  * Explained that Dashboard Integrations are installed directly from a Supabase project in the dashboard.
  * Updated the Dashboard Integrations link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->