### PR TITLE
fix(studio): derive postgres log level from severity, not SQL state code

### DIFF
--- a/apps/studio/data/logs/otel-inspection.utils.test.ts
+++ b/apps/studio/data/logs/otel-inspection.utils.test.ts
@@ -108,6 +108,20 @@ describe('flattenOtelInspectionRow', () => {
     expect(e.level).toBe('success')
   })
 
+  it('derives level from severity for a postgres warning, not the SQL state code', () => {
+    const row: OtelLogRow = {
+      ...pgRow,
+      event_message: 'warning: there is already a transaction in progress',
+      log_attributes: {
+        ...pgRow.log_attributes,
+        'parsed.error_severity': 'WARNING',
+        'parsed.sql_state_code': '25001',
+      },
+    }
+    const e = flattenOtelInspectionRow(row) as unknown as Record<string, unknown>
+    expect(e.level).toBe('warning')
+  })
+
   it('derives level=error for 5xx responses', () => {
     const row: OtelLogRow = {
       ...edgeRow,

--- a/apps/studio/data/logs/otel-inspection.utils.ts
+++ b/apps/studio/data/logs/otel-inspection.utils.ts
@@ -60,12 +60,18 @@ export function flattenOtelInspectionRow(
     row.source === 'postgres_logs' ? attrs['parsed.sql_state_code'] : attrs['response.status_code']
   const statusNum = Number(status)
 
-  // Derive level from HTTP status first, then postgres severity, then severity_text.
+  // Derive level from postgres severity for postgres rows (their `status` is a
+  // SQL state code, not an HTTP status), otherwise from HTTP status, then
+  // severity_text.
   let level = ''
-  if (Number.isFinite(statusNum) && statusNum > 0) {
+  if (row.source === 'postgres_logs') {
+    if (attrs['parsed.error_severity']) {
+      level = pgSeverityToLevel(String(attrs['parsed.error_severity']))
+    } else if (row.severity_text) {
+      level = String(row.severity_text).toLowerCase()
+    }
+  } else if (Number.isFinite(statusNum) && statusNum > 0) {
     level = httpStatusToLevel(statusNum)
-  } else if (attrs['parsed.error_severity']) {
-    level = pgSeverityToLevel(String(attrs['parsed.error_severity']))
   } else if (row.severity_text) {
     level = String(row.severity_text).toLowerCase()
   }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In the log inspection panel, `flattenOtelInspectionRow` (`apps/studio/data/logs/otel-inspection.utils.ts`) coerces a row's status to a number and runs it through `httpStatusToLevel`. For `postgres_logs` rows that status is the Postgres SQL state code, not an HTTP status.

As a result, a Postgres warning such as SQLSTATE `25001` ("there is already a transaction in progress") is read as `25001`, which is `>= 500`, and is labelled `error`. Because any numeric non-zero SQL state takes this branch, the Postgres severity branch is never reached, so warnings and notices are consistently mislabelled as errors.

## What is the new behavior?

For `postgres_logs` rows the level is derived from `parsed.error_severity` (falling back to `severity_text`), while HTTP status mapping is kept for gateway rows. A regression test covers a Postgres `WARNING` row, which now resolves to `warning` instead of `error`.

## Additional context

The existing postgres test only passed because it used SQL state `00000` (`Number('00000') === 0`, which falls through to the severity branch); its description already states the level should come from severity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved log severity display for PostgreSQL entries by prioritizing the database-reported severity.
  * Improved severity classification for non-PostgreSQL entries using HTTP response status codes.
  * Added coverage to ensure warning-level PostgreSQL logs are displayed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->