### PR TITLE
fix(studio): activate the adjacent tab when closing the active first tab

### DIFF
--- a/apps/studio/state/tabs.test.ts
+++ b/apps/studio/state/tabs.test.ts
@@ -103,6 +103,33 @@ describe('tabs removal', () => {
     expect(store.activeTab).toBe('sql-a')
   })
 
+  it('activates the adjacent tab when the active first tab is removed', () => {
+    const store = createTabsState('default')
+
+    addSqlTab(store, 'a')
+    addSqlTab(store, 'b')
+    addSqlTab(store, 'c')
+    store.activeTab = 'sql-a'
+
+    store.removeTab('sql-a')
+
+    expect(store.openTabs).toEqual(['sql-b', 'sql-c'])
+    expect(store.activeTab).toBe('sql-b')
+  })
+
+  it('activates the remaining tab when the active first of two tabs is removed', () => {
+    const store = createTabsState('default')
+
+    addSqlTab(store, 'a')
+    addSqlTab(store, 'b')
+    store.activeTab = 'sql-a'
+
+    store.removeTab('sql-a')
+
+    expect(store.openTabs).toEqual(['sql-b'])
+    expect(store.activeTab).toBe('sql-b')
+  })
+
   it('clears the active tab when the last tab is removed', () => {
     const store = createTabsState('default')
 

--- a/apps/studio/state/tabs.tsx
+++ b/apps/studio/state/tabs.tsx
@@ -302,9 +302,10 @@ export function createTabsState(projectRef: string) {
         store.previewTabId = undefined
       }
 
-      // Update active tab if the removed tab was active
+      // Update active tab if the removed tab was active. `idx` is the position in
+      // the pre-filter array, so after removal the next tab has shifted into `idx`.
       if (id === store.activeTab) {
-        store.activeTab = store.openTabs[idx - 1] || store.openTabs[idx + 1] || null
+        store.activeTab = store.openTabs[idx - 1] || store.openTabs[idx] || null
       }
     },
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In `apps/studio/state/tabs.tsx`, `removeTab` computes the removed tab's index (`idx`) on the pre-filter `openTabs` array, then reads the already-filtered (shorter) array with `idx + 1` when picking the next active tab. Because everything after `idx` has shifted left by one, `idx + 1` points past the immediate neighbour.

Closing the active **first** tab therefore reassigns the wrong tab:
- `[a, b, c]` with `a` active → activates `c` instead of `b`.
- `[a, b]` with `a` active → leaves no tab active (`null`), even though `b` is still open.

This is reached from the low-level `removeTab`/`removeTabs` paths used when snippets are deleted or re-keyed (e.g. `DeleteSnippetsModal`, `RenameQueryModal`, `MoveQueryModal`).

## What is the new behavior?

The next tab lands at `idx` after filtering, so the reassignment uses `openTabs[idx - 1] || openTabs[idx]`. Closing the active first tab now activates its adjacent tab. Removing a middle or last tab is unchanged. Added regression tests for both cases above.

## Additional context

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tab navigation when removing the active tab at the beginning of the tab list.
  * The next adjacent tab is now correctly selected, including when only two tabs remain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->