### PR TITLE
fix(studio): don't report shared references as [Circular] when sanitizing

### DIFF
--- a/apps/studio/lib/sanitize.test.ts
+++ b/apps/studio/lib/sanitize.test.ts
@@ -85,6 +85,24 @@ describe('sanitizeArrayOfObjects', () => {
     expect(result.name).toBe('loop')
   })
 
+  it('does not report a shared (non-circular) reference as circular', () => {
+    const shared = { name: 'world' }
+
+    const [result] = sanitizeArrayOfObjects([{ a: shared, b: shared }]) as Array<any>
+
+    expect(result.a).toEqual({ name: 'world' })
+    expect(result.b).toEqual({ name: 'world' })
+  })
+
+  it('sanitizes a reference reused across sibling items independently', () => {
+    const shared = { name: 'world' }
+
+    const result = sanitizeArrayOfObjects([{ ref: shared }, { ref: shared }]) as Array<any>
+
+    expect(result[0].ref).toEqual({ name: 'world' })
+    expect(result[1].ref).toEqual({ name: 'world' })
+  })
+
   it('sanitizes complex types consistently', () => {
     const date = new Date('2024-01-01T00:00:00.000Z')
     const regex = /abc/gi

--- a/apps/studio/lib/sanitize.ts
+++ b/apps/studio/lib/sanitize.ts
@@ -147,6 +147,10 @@ export function sanitizeArrayOfObjects(
     }
 
     if (typeof value === 'object') {
+      // `seen` tracks the current ancestor chain so `[Circular]` means the value
+      // references one of its own ancestors. Entries are removed once a subtree is
+      // fully processed, otherwise a value reachable by two paths (a shared, but
+      // non-circular, reference) would be misreported as circular.
       if (seen.has(value)) {
         return '[Circular]'
       }
@@ -157,6 +161,7 @@ export function sanitizeArrayOfObjects(
         for (let i = 0; i < value.length; i++) {
           outArr[i] = sanitizeValue(value[i], depth + 1)
         }
+        seen.delete(value)
         return outArr
       }
 
@@ -170,6 +175,7 @@ export function sanitizeArrayOfObjects(
             outObj[k] = sanitizeValue(v, depth + 1)
           }
         }
+        seen.delete(value)
         return outObj
       }
 
@@ -181,6 +187,7 @@ export function sanitizeArrayOfObjects(
           const redactedVal = shouldRedactByKey(k) ? redaction : sanitizeValue(v, depth + 1)
           out.push([redactedKey, redactedVal])
         }
+        seen.delete(value)
         return out
       }
 
@@ -190,6 +197,7 @@ export function sanitizeArrayOfObjects(
         for (const v of value.values()) {
           out.push(sanitizeValue(v, depth + 1))
         }
+        seen.delete(value)
         return out
       }
 
@@ -200,7 +208,6 @@ export function sanitizeArrayOfObjects(
           message: redactString(value.message),
           stack: truncationNotice,
         }
-        seen.set(value, o)
         return o
       }
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

In `apps/studio/lib/sanitize.ts`, `sanitizeValue` records every visited object in a `seen` map to guard against circular references, but never removes an entry once its subtree has finished. Since `seen` is shared across the whole walk, any object reachable by more than one path is misclassified as a cycle on its second visit:

- A diamond within one item, e.g. `{ a: shared, b: shared }`, sanitizes `b` to `"[Circular]"`.
- The same object reused across sibling items, e.g. `[{ ref: shared }, { ref: shared }]`, sanitizes the second `ref` to `"[Circular]"`.

`sanitizeArrayOfObjects` is used by `lib/sentry-client-options.ts` and `components/interfaces/Support/dashboard-logs.ts` to sanitize Sentry breadcrumbs / support logs before upload. Breadcrumbs commonly reuse object references, so repeated diagnostic data was being silently dropped as `[Circular]`.

## What is the new behavior?

Each container is removed from `seen` after its children are processed, so the map holds only the current ancestor chain — which is what a circular reference actually is. True cycles (a value referencing one of its own ancestors) are still reported as `[Circular]`; shared, non-circular references are sanitized normally. The Error branch no longer seeds `seen` because it does not recurse. Added regression tests for both shared-reference cases.

## Additional context

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sanitization of shared object references.
  * Prevented non-circular references from being incorrectly treated as circular.
  * Ensured repeated references across array entries are processed consistently.
  * Improved handling of sanitized error values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->