### PR TITLE
fix(pg-meta): quote the reserved "table" identifier in policies retrieve

### DIFF
--- a/packages/pg-meta/src/pg-meta-policies.ts
+++ b/packages/pg-meta/src/pg-meta-policies.ts
@@ -41,7 +41,7 @@ function getIdentifierWhereClause(identifier: PolicyIdentifier): SafeSqlFragment
   if ('id' in identifier && identifier.id) {
     return safeSql`id = ${literal(identifier.id)}`
   } else if ('name' in identifier && identifier.name && identifier.schema && identifier.table) {
-    return safeSql`name = ${literal(identifier.name)} AND schema = ${literal(identifier.schema)} AND table = ${literal(identifier.table)}`
+    return safeSql`name = ${literal(identifier.name)} AND schema = ${literal(identifier.schema)} AND ${ident('table')} = ${literal(identifier.table)}`
   }
   throw new Error('Must provide either id or name, schema and table')
 }

--- a/packages/pg-meta/test/policies.test.ts
+++ b/packages/pg-meta/test/policies.test.ts
@@ -21,6 +21,13 @@ const withTestDatabase = (
   })
 }
 
+test('retrieve by name/schema/table quotes the reserved "table" identifier', () => {
+  const { sql } = pgMeta.policies.retrieve({ name: 'my policy', schema: 'public', table: 'memes' })
+  // `table` is a reserved keyword, so it must be quoted or the query is a syntax error.
+  expect(sql).toContain('"table" = \'memes\'')
+  expect(sql).not.toMatch(/\btable = /)
+})
+
 withTestDatabase('list policies', async ({ executeQuery }) => {
   const { sql, zod } = pgMeta.policies.list()
   const res = zod.parse(await executeQuery(sql))


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`getIdentifierWhereClause` in `packages/pg-meta/src/pg-meta-policies.ts` builds the `retrieve({ name, schema, table })` WHERE clause with a bare `table` column reference:

```
name = 'my policy' AND schema = 'public' AND table = 'memes'
```

`table` is a reserved keyword in Postgres, so referencing it unquoted is a syntax error and the retrieve-by-name query never runs. The sibling builders that expose the same `{ name, schema, table }` identifier — `pg-meta-triggers.ts` and `pg-meta-columns.ts` — already quote it with `ident('table')`; policies is the only one that does not.

## What is the new behavior?

The `table` identifier is quoted via `ident('table')` (matching the sibling builders), so the generated SQL is valid. Added a unit test asserting the retrieve-by-name SQL quotes `table`.

## Additional context

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed policy retrieval when filtering by a table name, ensuring reserved SQL identifiers are handled correctly.
  * Improved compatibility and reliability for policy queries involving table-based filters.

* **Tests**
  * Added coverage to verify generated policy queries use safe table identifier quoting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->