### PR TITLE
fix(pg-meta): parameterize password in roles update to keep valid SQL

### DIFF
--- a/packages/pg-meta/src/pg-meta-roles.ts
+++ b/packages/pg-meta/src/pg-meta-roles.ts
@@ -197,9 +197,9 @@ begin
     ${isReplicationRole === undefined ? safeSql`` : isReplicationRole ? safeSql`replication` : safeSql`noreplication`}
     ${canBypassRls === undefined ? safeSql`` : canBypassRls ? safeSql`bypassrls` : safeSql`nobypassrls`}
     ${connectionLimit === undefined ? safeSql`` : safeSql`connection limit ${literal(connectionLimit)}`}
-    ${password === undefined ? safeSql`` : safeSql`password ${literal(password)}`}
+    ${password === undefined ? safeSql`` : safeSql`password %L`}
     ${validUntil === undefined ? safeSql`` : safeSql`valid until %L`}
-  ', old.name${validUntil === undefined ? safeSql`` : safeSql`, ${literal(validUntil)}`}));
+  ', old.name${password === undefined ? safeSql`` : safeSql`, ${literal(password)}`}${validUntil === undefined ? safeSql`` : safeSql`, ${literal(validUntil)}`}));
 
   ${
     newName === undefined

--- a/packages/pg-meta/test/roles.test.ts
+++ b/packages/pg-meta/test/roles.test.ts
@@ -24,6 +24,16 @@ const withTestDatabase = (
     }
   })
 }
+
+test('update with a password parameterizes it instead of breaking the format() string', () => {
+  const { sql } = pgMeta.roles.update({ id: 1 }, { password: 'secret' })
+  // The password must be a `%L` placeholder passed as a format() argument. A
+  // literal spliced straight into the format string terminates it early.
+  expect(sql).toContain('password %L')
+  expect(sql).not.toContain("password 'secret'")
+  expect(sql).toContain("'secret'")
+})
+
 withTestDatabase('list roles', async ({ executeQuery }) => {
   const { sql, zod } = await pgMeta.roles.list()
   const res = zod.parse(await executeQuery(sql))


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`update()` in `packages/pg-meta/src/pg-meta-roles.ts` builds the `alter role` statement as the format string of a `format(...)` call. Every value meant to go into that string is supposed to be passed as a `%L`/`%I` argument — which is how `valid until` is handled. A supplied `password`, however, was spliced directly into the format string as `password 'secret'`.

So the emitted text becomes `... password 'secret' ...` inside `format('alter role %I … ', old.name)`. The opening quote of `'secret'` terminates the format string literal early, and Postgres then parses `secret` as a bare identifier — `syntax error at or near "secret"`. Any `roles.update` call that includes a password fails. (`connection limit` uses the same direct-splice but is safe because a numeric literal emits no quotes.)

## What is the new behavior?

The password is emitted as a `password %L` placeholder and its value is passed as a `format()` argument, inserted before the `valid until` argument to match placeholder order. The generated SQL is now:

```
execute(format('alter role %I
    password %L
    valid until %L
  ', old.name, 'secret', '2030-01-01'));
```

Added a unit test asserting the password is parameterized rather than spliced.

## Additional context

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved role password updates to safely handle password values, including special characters.
  * Preserved correct SQL generation for password and expiration settings.

* **Tests**
  * Added coverage confirming password values are safely parameterized and correctly included in generated statements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->