### PR TITLE
fix(ui-patterns): keep the is-null value when changing to an options property

### DIFF
--- a/packages/ui-patterns/src/FilterBar/utils.test.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.test.ts
@@ -292,6 +292,18 @@ describe('FilterBar Utils', () => {
       expect(result).toEqual({ operator: '=', value: 'true', focusTarget: 'value' })
     })
 
+    it('preserves an is-null value even when the property has fixed options', () => {
+      const booleanWithIsProperty: FilterProperty = {
+        ...booleanProperty,
+        operators: [
+          { value: '=', label: 'Equals', group: 'comparison' },
+          { value: 'is', label: 'Is', group: 'setNull' },
+        ],
+      }
+      const result = resolvePropertyChange('is', 'null', booleanWithIsProperty)
+      expect(result).toEqual({ operator: 'is', value: 'null', focusTarget: 'value' })
+    })
+
     it('resets everything when current operator is empty', () => {
       const result = resolvePropertyChange('', 'hello', stringProperty)
       expect(result).toEqual({ operator: '', value: '', focusTarget: 'operator' })

--- a/packages/ui-patterns/src/FilterBar/utils.ts
+++ b/packages/ui-patterns/src/FilterBar/utils.ts
@@ -261,8 +261,10 @@ export function resolvePropertyChange(
     return { operator: currentOperator, value: '', focusTarget: 'value' }
   }
 
-  if (newProperty.options && Array.isArray(newProperty.options)) {
-    // New property has fixed options — only preserve value if it's in the list
+  if (currentOperator !== 'is' && newProperty.options && Array.isArray(newProperty.options)) {
+    // New property has fixed options — only preserve value if it's in the list.
+    // The `is` operator is excluded: its value is a null-check token
+    // (`null` / `not null`), which is independent of the property's options.
     const optionValues = newProperty.options.map((opt) =>
       typeof opt === 'string' ? opt : 'value' in opt ? opt.value : ''
     )


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

`resolvePropertyChange` in `packages/ui-patterns/src/FilterBar/utils.ts` runs when a condition's property is changed. When the new property has fixed `options`, it preserves the current value only if it's in the options list — but it applies this to every operator, including `is`.

The `is` operator's value is a null-check token (`null` / `not null`, produced by `getIsOperatorValueItems`), which is intentionally independent of a property's `options`. So switching from an `is null` filter to a property that has fixed options (and also supports `is`) fails the options-membership check and clears the value, leaving an incomplete `is` filter with no value.

## What is the new behavior?

The fixed-options check is skipped when the operator is `is`, so the `null` / `not null` value is preserved on the property change (matching how `is` is special-cased elsewhere, e.g. `menuItems.ts`). Other operators are unchanged. Added a regression test.

## Additional context

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed filter behavior for the “is” operator with null values.
  * Null checks now remain preserved and correctly focus the value field, including when fixed filter options are configured.

* **Tests**
  * Added coverage for null-value filtering with fixed options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->