### PR TITLE
Update dev toolbar to support mocking org restrictions

### DIFF
--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -7,8 +7,8 @@ import { useEffect, useRef, useState } from 'react'
 import { cn, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Separator } from 'ui'
 import { InfoTooltip } from 'ui-patterns/info-tooltip'
 
-import { invoicesKeys } from '@/data/invoices/keys'
 import type { OverdueInvoicesResponse } from '@/data/invoices/invoices-overdue-query'
+import { invoicesKeys } from '@/data/invoices/keys'
 import { organizationKeys } from '@/data/organizations/keys'
 import { usageKeys } from '@/data/usage/keys'
 import type { ResourceWarning } from '@/data/usage/resource-warnings-query'
@@ -89,9 +89,12 @@ export const ResourceWarningsTab = () => {
         queryClient.invalidateQueries({
           queryKey: usageKeys.resourceWarnings(currentOrgSlug, undefined),
         })
+        queryClient.invalidateQueries({ queryKey: organizationKeys.list() })
+        queryClient.invalidateQueries({ queryKey: invoicesKeys.overdueInvoices() })
       }
       setSeverities(INITIAL_STATE)
       setIsReadOnly(false)
+      setOrgWarning('none')
       hasOverridesRef.current = false
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
+++ b/apps/studio/components/ui/DevToolbar/ResourceWarningsTab.tsx
@@ -2,12 +2,18 @@
 
 import { useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'common'
+import dayjs from 'dayjs'
 import { useEffect, useRef, useState } from 'react'
-import { cn } from 'ui'
+import { cn, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Separator } from 'ui'
+import { InfoTooltip } from 'ui-patterns/info-tooltip'
 
+import { invoicesKeys } from '@/data/invoices/keys'
+import type { OverdueInvoicesResponse } from '@/data/invoices/invoices-overdue-query'
+import { organizationKeys } from '@/data/organizations/keys'
 import { usageKeys } from '@/data/usage/keys'
 import type { ResourceWarning } from '@/data/usage/resource-warnings-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import type { Organization } from '@/types'
 
 type Severity = 'warning' | 'critical' | null
 
@@ -35,7 +41,9 @@ export const ResourceWarningsTab = () => {
   const queryClient = useQueryClient()
   const { data: selectedOrg, isLoading: isOrgLoading } = useSelectedOrganizationQuery()
   const orgSlug = selectedOrg?.slug
+
   const [isReadOnly, setIsReadOnly] = useState(false)
+  const [orgWarning, setOrgWarning] = useState<string>('none')
   const [severities, setSeverities] = useState<WarningState>(INITIAL_STATE)
 
   // Track latest ref/orgSlug so the unmount cleanup always invalidates the
@@ -62,6 +70,8 @@ export const ResourceWarningsTab = () => {
           queryKey: usageKeys.resourceWarnings(latestOrgSlug, undefined),
         })
       }
+      queryClient.invalidateQueries({ queryKey: organizationKeys.list() })
+      queryClient.invalidateQueries({ queryKey: invoicesKeys.overdueInvoices() })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
@@ -87,7 +97,15 @@ export const ResourceWarningsTab = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ref])
 
-  const applyOverrides = (nextSeverities: WarningState, nextIsReadOnly: boolean) => {
+  const applyOverrides = ({
+    nextSeverities,
+    nextIsReadOnly,
+    nextOrgWarnings,
+  }: {
+    nextSeverities: WarningState
+    nextIsReadOnly: boolean
+    nextOrgWarnings?: string
+  }) => {
     if (!orgSlug || !ref) return
     const mockWarning: ResourceWarning = {
       project: ref,
@@ -101,27 +119,78 @@ export const ResourceWarningsTab = () => {
     // slug-based (ProjectLayout, TopSection, ProjectList) consumers.
     queryClient.setQueryData(usageKeys.resourceWarnings(undefined, ref), [mockWarning])
     queryClient.setQueryData(usageKeys.resourceWarnings(orgSlug, undefined), [mockWarning])
+
+    const effectiveOrgWarning = nextOrgWarnings ?? orgWarning
+    const restrictionStatus: Organization['restriction_status'] =
+      effectiveOrgWarning === 'grace_period' ||
+      effectiveOrgWarning === 'grace_period_over' ||
+      effectiveOrgWarning === 'restricted'
+        ? effectiveOrgWarning
+        : null
+
+    queryClient.setQueryData<Organization[]>(organizationKeys.list(), (prev) =>
+      prev?.map((org) =>
+        org.slug === orgSlug
+          ? {
+              ...org,
+              restriction_status: restrictionStatus,
+              restriction_data:
+                restrictionStatus === 'grace_period'
+                  ? { grace_period_end: dayjs().add(7, 'day').toISOString() }
+                  : null,
+            }
+          : org
+      )
+    )
+
+    // Overdue invoices come from a separate, org-independent cache and are
+    // distinguished by organization_id rather than a status enum, so they can't
+    // be folded into the restriction_status patch above.
+    const selectedOrgId = selectedOrg?.id
+    const overdueInvoices: OverdueInvoicesResponse[] =
+      selectedOrgId === undefined
+        ? []
+        : effectiveOrgWarning === 'overdue_invoices'
+          ? [{ organization_id: selectedOrgId, overdue_invoice_count: 1 }]
+          : effectiveOrgWarning === 'overdue_invoices_from_other_org'
+            ? [{ organization_id: selectedOrgId + 1, overdue_invoice_count: 1 }]
+            : []
+    queryClient.setQueryData(invoicesKeys.overdueInvoices(), overdueInvoices)
+
     hasOverridesRef.current = true
   }
 
   const handleSeverityChange = (key: WarningKey, value: Severity) => {
     const next = { ...severities, [key]: value }
     setSeverities(next)
-    applyOverrides(next, isReadOnly)
+    applyOverrides({ nextSeverities: next, nextIsReadOnly: isReadOnly })
   }
 
   const handleReadOnlyChange = (value: boolean) => {
     setIsReadOnly(value)
-    applyOverrides(severities, value)
+    applyOverrides({ nextSeverities: severities, nextIsReadOnly: value })
+  }
+
+  const handleOrgWarningChange = (value: string) => {
+    setOrgWarning(value)
+    applyOverrides({
+      nextSeverities: severities,
+      nextIsReadOnly: isReadOnly,
+      nextOrgWarnings: value,
+    })
   }
 
   const handleReset = () => {
     setSeverities(INITIAL_STATE)
     setIsReadOnly(false)
+    setOrgWarning('none')
+
     hasOverridesRef.current = false
     queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(undefined, ref) })
     if (orgSlug) {
       queryClient.invalidateQueries({ queryKey: usageKeys.resourceWarnings(orgSlug, undefined) })
+      queryClient.invalidateQueries({ queryKey: organizationKeys.list() })
+      queryClient.invalidateQueries({ queryKey: invoicesKeys.overdueInvoices() })
     }
   }
 
@@ -133,7 +202,7 @@ export const ResourceWarningsTab = () => {
     <div className="p-6 space-y-4">
       <div className="flex items-center justify-between">
         <p className="text-sm text-foreground-light">
-          Override resource warning banners for the current project.
+          Override resource warning banners for the current organization or project.
         </p>
         <button
           onClick={handleReset}
@@ -145,15 +214,48 @@ export const ResourceWarningsTab = () => {
         </button>
       </div>
 
-      {isDisabled && (
-        <p className="text-xs text-foreground-muted">
-          {!ref ? 'Navigate to a project page to use this tab.' : 'Loading org context...'}
-        </p>
-      )}
+      <div className="flex flex-col gap-y-1">
+        <h4>Organization warnings</h4>
+      </div>
 
       <div className={cn('space-y-3', isDisabled && 'opacity-50 pointer-events-none')}>
-        <div className="flex items-center justify-between py-2 border-b border-overlay">
-          <span className="text-sm font-medium">Read-only mode</span>
+        <div className="flex items-center justify-between">
+          <span className="text-sm text-foreground-light">Restriction status</span>
+          <Select value={orgWarning} onValueChange={handleOrgWarningChange}>
+            <SelectTrigger className="w-64">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="none">None</SelectItem>
+              <SelectItem value="grace_period">Grace period</SelectItem>
+              <SelectItem value="grace_period_over">Grace period over</SelectItem>
+              <SelectItem value="restricted">Restricted</SelectItem>
+              <SelectItem value="overdue_invoices">Overdue invoices</SelectItem>
+              <SelectItem value="overdue_invoices_from_other_org">
+                Overdue invoices from other org
+              </SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="flex flex-col gap-y-1">
+        <h4>Project warnings</h4>
+        {isDisabled && (
+          <p className="text-xs text-foreground-muted">
+            {!ref ? 'Navigate to a project page to use this tab.' : 'Loading org context...'}
+          </p>
+        )}
+      </div>
+
+      <div className={cn('space-y-3', isDisabled && 'opacity-50 pointer-events-none')}>
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-foreground-light flex items-center gap-x-2">
+            <span>Read-only mode</span>
+            <InfoTooltip side="right">Takes precedence above all other warnings</InfoTooltip>
+          </p>
           <div className="flex gap-1">
             <SeverityButton
               active={!isReadOnly}


### PR DESCRIPTION
## Context

Only applies for local development - adds a way to mock org restrictions with the dev toolbar
<img width="1392" height="484" alt="image" src="https://github.com/user-attachments/assets/64b8b0c6-c59a-453a-88fa-ffbc2565cd87" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organization-level warning controls to the development toolbar, including a new “Organization warnings” section to simulate restriction status variants (none, grace periods, restricted, and overdue-invoice scenarios, including an “other org” option).
  * Updated the existing project-warning controls’ guidance to reference the current organization or project.
* **Bug Fixes**
  * Improved cleanup so resetting or closing warning overrides reliably restores the real organization and invoice warning data, including after navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->