### PR TITLE
Update copy for grace period

### DIFF
--- a/apps/studio/components/interfaces/Organization/restriction.constants.tsx
+++ b/apps/studio/components/interfaces/Organization/restriction.constants.tsx
@@ -11,12 +11,11 @@ export const RESTRICTION_MESSAGES = {
       const label = dayjs(date).format('DD MMM, YYYY')
       return (
         <>
-          You have a grace period until{' '}
-          <TimestampInfo className="text-sm" utcTimestamp={date} label={label} />. After that, your
-          projects will be restricted while your organization is over quota.{' '}
+          Projects will be restricted from{' '}
+          <TimestampInfo className="text-sm" utcTimestamp={date} label={label} /> if your
+          organization remains over quota.{' '}
           <InlineLink href={`/org/${slug}/usage`}>Review usage</InlineLink> or{' '}
-          <InlineLink href={`/org/${slug}/billing`}>manage your plan</InlineLink> to avoid
-          restrictions.
+          <InlineLink href={`/org/${slug}/billing`}>billing</InlineLink>.
         </>
       )
     },


### PR DESCRIPTION
## Context

If an organization is exceeded usage and has the grace period banner - the current copy is really long which causes the text to truncate.
<img width="1126" height="67" alt="image" src="https://github.com/user-attachments/assets/f8095dc6-540c-47e5-941a-31a4264a6017" />

Banners are meant to be short and to the point, so opting to revise the copy a little.
<img width="1392" height="51" alt="image" src="https://github.com/user-attachments/assets/55596369-ee65-48cd-8616-66747e4d2590" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Copy Updates**
  - Clarified the grace-period message to explain that projects may be restricted from the displayed date if usage remains over quota.
  - Updated the available actions to include a billing link alongside “Review usage.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->