### PR TITLE
chore(studio): add bullet-point to integration uninstall modal

### DIFF
--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -77,7 +77,7 @@ export const RevokeAppModal = ({
                         There may also be a Secret Key remaining with access, go to the Project this
                         was installed, and navigate to Integrations. Check and remove any{' '}
                         <strong>Secret API key</strong> that is noted to ensure all access is
-                        removed for Grafana
+                        removed for Grafana.
                       </li>
                     </ul>
                   </div>

--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -73,6 +73,12 @@ export const RevokeAppModal = ({
                         Restoring access will require an organization administrator to re-authorize
                         the application.
                       </li>
+                      <li className="list-disc ml-4">
+                        There may also be a Secret Key remaining with access, go to the Project this
+                        was installed, and navigate to Integrations. Check and remove any{' '}
+                        <strong>Secret API key</strong> that is noted to ensure all access is
+                        removed for Grafana
+                      </li>
                     </ul>
                   </div>
                 </li>

--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -80,7 +80,7 @@ export const RevokeAppModal = ({
                         <InlineLink
                           href={`/dashboard/project/_/integrations/${selectedApp?.id}/settings`}
                         >
-                          Integration's page
+                          Integration's Settings
                         </InlineLink>
                         , and remove any listed Secret API key to fully revoke its access.
                       </li>

--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -13,6 +13,7 @@ import {
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
+import { InlineLink } from '@/components/ui/InlineLink'
 import { useAuthorizedAppRevokeMutation } from '@/data/oauth/authorized-app-revoke-mutation'
 import type { AuthorizedApp } from '@/data/oauth/authorized-apps-query'
 
@@ -75,8 +76,13 @@ export const RevokeAppModal = ({
                       </li>
                       <li className="list-disc ml-4">
                         The application may also have a <strong>Secret API key</strong> with access.
-                        Go to the project where it was installed, open Integrations, and remove any
-                        listed Secret API key to fully revoke its access.
+                        Go to the{' '}
+                        <InlineLink
+                          href={`/dashboard/project/_/integrations/${selectedApp?.id}/settings`}
+                        >
+                          Integration's page
+                        </InlineLink>
+                        , and remove any listed Secret API key to fully revoke its access.
                       </li>
                     </ul>
                   </div>

--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -74,10 +74,9 @@ export const RevokeAppModal = ({
                         the application.
                       </li>
                       <li className="list-disc ml-4">
-                        There may also be a Secret Key remaining with access, go to the Project this
-                        was installed, and navigate to Integrations. Check and remove any{' '}
-                        <strong>Secret API key</strong> that is noted to ensure all access is
-                        removed for Grafana.
+                        The application may also have a <strong>Secret API key</strong> with access.
+                        Go to the project where it was installed, open Integrations, and remove any
+                        listed Secret API key to fully revoke its access.
                       </li>
                     </ul>
                   </div>

--- a/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
+++ b/apps/studio/components/interfaces/Organization/OAuthApps/RevokeAppModal.tsx
@@ -49,15 +49,15 @@ export const RevokeAppModal = ({
         <AlertDialogHeader>
           <AlertDialogTitle>{`Revoke access for ${selectedApp?.name}?`}</AlertDialogTitle>
           <AlertDialogDescription>
-            <div className="flex flex-col space-y-2">
+            <div className="flex flex-col space-y-4">
               <Admonition
                 type="warning"
                 title="This action cannot be undone"
                 description={`${selectedApp?.name} will no longer have access to your organization's settings
           and projects.`}
               />
-              <ul className="space-y-5">
-                <li className="flex gap-3 text-sm">
+              <div className="space-y-5">
+                <div className="flex gap-2 text-sm">
                   <Lock size={14} className="shrink-0" />
                   <div>
                     <strong>Before you remove this app, consider:</strong>
@@ -80,8 +80,8 @@ export const RevokeAppModal = ({
                       </li>
                     </ul>
                   </div>
-                </li>
-              </ul>
+                </div>
+              </div>
             </div>
           </AlertDialogDescription>
         </AlertDialogHeader>

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -478,5 +478,5 @@ div[data-radix-portal]:not(.portal--toast) {
 .prose :where(strong, b):not(:where([class~='not-prose'], [class~='not-prose'] *)),
 strong[class~='not-prose'],
 strong {
-  font-weight: 700;
+  @apply font-semibold;
 }

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -476,7 +476,7 @@ div[data-radix-portal]:not(.portal--toast) {
 }
 
 .prose :where(strong, b):not(:where([class~='not-prose'], [class~='not-prose'] *)),
-strong[class~='not-prose'],
-strong {
+strong,
+b {
   @apply font-bold;
 }

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -478,5 +478,5 @@ div[data-radix-portal]:not(.portal--toast) {
 .prose :where(strong, b):not(:where([class~='not-prose'], [class~='not-prose'] *)),
 strong[class~='not-prose'],
 strong {
-  @apply font-semibold;
+  @apply font-bold;
 }

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -474,3 +474,9 @@ div[data-radix-portal]:not(.portal--toast) {
 .prose.text-sm ul > li::before {
   top: 0.65rem;
 }
+
+.prose :where(strong, b):not(:where([class~='not-prose'], [class~='not-prose'] *)),
+strong[class~='not-prose'],
+strong {
+  font-weight: 700;
+}


### PR DESCRIPTION
## What is the current behavior?

<img width="533" height="394" alt="Screenshot 2026-07-21 at 11 55 05" src="https://github.com/user-attachments/assets/4e5e8fde-5823-4ad2-849e-abad90bfa72a" />

## What is the new behavior?

<img width="501" height="430" alt="Screenshot 2026-07-21 at 12 43 17" src="https://github.com/user-attachments/assets/2888d815-8c2c-47db-a058-dc60b208d6b1" />

## Additional context

Also fixed font-weight for strong text in studio to be `font-bold`.