### PR TITLE
fix(studio): let a custom Content-Type replace the tester default

### DIFF
--- a/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
+++ b/apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
@@ -223,6 +223,12 @@ const EdgeFunctionTesterSheetContent = ({ visible, onClose }: EdgeFunctionTester
       }
     })
 
+    // Header names are case-insensitive (RFC 9110 §5.1), so a header typed as
+    // "content-type" has to replace the default rather than be sent next to it.
+    const hasCustomContentType = Object.keys(customHeaders).some(
+      (key) => key.toLowerCase() === 'content-type'
+    )
+
     // Construct query parameters
     const queryString = values.queryParams
       .filter(({ key, value }) => key && value)
@@ -240,7 +246,7 @@ const EdgeFunctionTesterSheetContent = ({ visible, onClose }: EdgeFunctionTester
           Authorization: `Bearer ${accessToken}`,
         }),
         'x-test-authorization': testAuthorization ?? `Bearer ${serviceKey?.api_key}`,
-        'Content-Type': 'application/json',
+        ...(hasCustomContentType ? {} : { 'Content-Type': 'application/json' }),
         ...customHeaders,
       },
     })

--- a/apps/studio/pages/api/edge-functions/test.ts
+++ b/apps/studio/pages/api/edge-functions/test.ts
@@ -3,6 +3,15 @@ import { NextApiRequest, NextApiResponse } from 'next'
 
 import { isValidEdgeFunctionURL } from '@/lib/api/edgeFunctions'
 
+/**
+ * Look a header up by its case-insensitive name, since HTTP header names are
+ * case-insensitive (RFC 9110 §5.1) but a plain object lookup is not.
+ */
+function getHeader(headers: Record<string, string>, name: string) {
+  const match = Object.keys(headers).find((key) => key.toLowerCase() === name)
+  return match === undefined ? undefined : headers[match]
+}
+
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   const { method } = req
 
@@ -47,9 +56,15 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
       {} as Record<string, string>
     )
 
-    // Only use custom headers and ensure Content-Type is set
+    // Only use custom headers and ensure Content-Type is set. Header names are
+    // case-insensitive (RFC 9110 §5.1), so the default is only applied when the
+    // caller has not supplied a Content-Type under any casing - spreading it
+    // unconditionally would leave both keys in the object and send them as
+    // "Content-Type: application/json, text/plain".
     const requestHeaders: Record<string, string> = {
-      'Content-Type': 'application/json',
+      ...(getHeader(sanitizedCustomHeaders, 'content-type') === undefined
+        ? { 'Content-Type': 'application/json' }
+        : {}),
       ...sanitizedCustomHeaders,
     }
 
@@ -63,7 +78,7 @@ async function handlePost(req: NextApiRequest, res: NextApiResponse) {
     // Prepare the request body based on method and Content-Type
     let finalBody = undefined
     if (method !== 'GET' && method !== 'HEAD') {
-      if (requestHeaders['Content-Type'] === 'application/json') {
+      if (getHeader(requestHeaders, 'content-type') === 'application/json') {
         finalBody = typeof requestBody === 'string' ? requestBody : JSON.stringify(requestBody)
       } else {
         finalBody = requestBody

--- a/apps/studio/tests/pages/api/edge-functions/test.test.ts
+++ b/apps/studio/tests/pages/api/edge-functions/test.test.ts
@@ -138,4 +138,37 @@ describe('/api/edge-functions/test', () => {
       error: { message: 'Connection refused' },
     })
   })
+
+  it('lets a custom Content-Type replace the default whatever its casing', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { req, res } = createMocks({
+      method: 'POST',
+      body: {
+        url: 'https://abcdefghijklmnopqrst.supabase.co/functions/v1/test',
+        method: 'POST',
+        body: 'plain text payload',
+        headers: { 'content-type': 'text/plain' },
+      },
+    })
+
+    await handler(req, res)
+
+    const sentHeaders = fetchMock.mock.calls[0][1].headers
+    expect(new Headers(sentHeaders).get('content-type')).toBe('text/plain')
+    // The body is only JSON-encoded when the request is actually JSON.
+    expect(fetchMock.mock.calls[0][1].body).toBe('plain text payload')
+  })
+
+  it('still applies the default Content-Type when none is supplied', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+    const { req, res } = createRequest()
+
+    await handler(req, res)
+
+    expect(new Headers(fetchMock.mock.calls[0][1].headers).get('content-type')).toBe(
+      'application/json'
+    )
+  })
 })


### PR DESCRIPTION
## What

The edge function tester spreads the caller's headers over a default `Content-Type` in two places, and both merges are case-sensitive:

```ts
// apps/studio/pages/api/edge-functions/test.ts
const requestHeaders: Record<string, string> = {
  'Content-Type': 'application/json',
  ...sanitizedCustomHeaders,
}
```

```ts
// apps/studio/components/interfaces/Functions/EdgeFunctionDetails/EdgeFunctionTesterSheet.tsx
headers: {
  'x-test-authorization': ...,
  'Content-Type': 'application/json',
  ...customHeaders,
}
```

HTTP header names are case-insensitive (RFC 9110 §5.1), so a header typed as `content-type` in the tester's Headers rows does not replace the default — it sits beside it. Both keys survive into the object handed to `fetch`, so the edge function receives a malformed value:

```
SENT HEADERS: {"Content-Type":"application/json","content-type":"text/plain"}
EFFECTIVE:    application/json, text/plain
```

The override only worked when the user's capitalisation happened to match the default's. Typing the header in the conventional lowercase form is what breaks it.

Because the request-body branch also read `requestHeaders['Content-Type']` by exact key, it stayed truthy in the same situation, so a non-string body was still `JSON.stringify`-ed even though the caller had asked for a different type.

## Fix

Apply the default only when no `Content-Type` is present under any casing, and look the header up case-insensitively when deciding how to encode the body. Applied in both the API route and the client that feeds it, so the duplicate is never constructed in the first place.

`x-test-authorization` is set programmatically by the client and always lowercase, so its existing exact-key lookup is left alone.

## Tests

Two cases added to the existing `apps/studio/tests/pages/api/edge-functions/test.test.ts`:

- `lets a custom Content-Type replace the default whatever its casing` — **fails on master**:

```
× lets a custom Content-Type replace the default whatever its casing
```

- `still applies the default Content-Type when none is supplied` — passes both before and after, so it pins the default behaviour rather than restating the fix.

All 11 pre-existing tests in the file continue to pass unchanged (13 total). Prettier clean; ESLint reports 0 errors on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved custom `Content-Type` headers in Edge Function tests, regardless of capitalization.
  * Prevented duplicate or conflicting `Content-Type` headers.
  * Ensured request bodies are handled correctly based on the supplied content type.
  * Applied `application/json` only when no custom content type is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->