### PR TITLE
fix(www): correct Supabase Pipelines public alpha post date to July 21

### DIFF
--- a/apps/www/_blog/2026-07-21-supabase-pipelines-public-alpha.mdx
+++ b/apps/www/_blog/2026-07-21-supabase-pipelines-public-alpha.mdx
@@ -10,7 +10,7 @@ tags:
   - pipelines
   - bigquery
   - postgres
-date: '2026-07-15'
+date: '2026-07-21'
 toc_depth: 2
 ---
 

--- a/apps/www/_blog/2026-07-21-supabase-pipelines-public-alpha.mdx
+++ b/apps/www/_blog/2026-07-21-supabase-pipelines-public-alpha.mdx
@@ -135,4 +135,4 @@ Supabase Pipelines is available in public alpha on all paid plans, from the Supa
 
 Create a pipeline, choose BigQuery as your destination, select the tables you want to replicate, and start moving your Postgres data into your warehouse.
 
-To explore the underlying technology, visit the open-source [[Supabase ETL repository](https://github.com/supabase/etl)](https://github.com/supabase/etl). If you want to understand when to use Supabase Pipelines instead of Realtime, read [Realtime or Pipelines? How to choose the right tool](https://supabase.com/blog/realtime-or-etl-how-to-choose-the-right-tool).
+To explore the underlying technology, visit the open-source [Supabase ETL repository](https://github.com/supabase/etl). If you want to understand when to use Supabase Pipelines instead of Realtime, read [Realtime or Pipelines? How to choose the right tool](https://supabase.com/blog/realtime-or-etl-how-to-choose-the-right-tool).


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

- Updates the publish date of the "Supabase Pipelines is now in Public Alpha" blog post from July 15 to July 21
- Renames the post file to match the new date
- Updates the `date` frontmatter field

## What is the current behavior?

The post is dated 2026-07-15.

## What is the new behavior?

- The post is dated 2026-07-21 to match the public launch date
- File renamed to `apps/www/_blog/2026-07-21-supabase-pipelines-public-alpha.mdx`
- Frontmatter `date` set to `'2026-07-21'`

## Additional context

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the publication date for the Supabase Pipelines public alpha blog post to July 21, 2026.
  * Fixed a formatting issue so the “Supabase ETL repository” link in the “Get started” section renders correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->