### PR TITLE
docs(realtime): schema restriction

### DIFF
--- a/apps/docs/content/guides/realtime/authorization.mdx
+++ b/apps/docs/content/guides/realtime/authorization.mdx
@@ -25,7 +25,7 @@ By creating RLS policies on the `realtime.messages` table you can control the ac
 
 <Admonition type="caution">
 
-Realtime locks dows the `realtime` schema to protect it against unexpected changes to guarantee the healthy operation of the Realtime service and avoid conflicts that could be caused by future migrations. Creating a table or function in `realtime` is expected to fail with `permission denied for schema realtime`, whether you run the SQL yourself or through the dashboard. Managing RLS policies on `realtime.messages` is alllowed.
+Realtime locks down the `realtime` schema to protect it against unexpected changes to guarantee the healthy operation of the Realtime service and avoid conflicts that could be caused by future migrations. Creating a table or function in `realtime` is expected to fail with `permission denied for schema realtime`, whether you run the SQL yourself or through the dashboard. Managing RLS policies on `realtime.messages` is allowed.
 
 Row level security (RLS) is enabled by default on table `realtime.messages`, you don't need to execute `ALTER TABLE realtime.messages ENABLE ROW LEVEL SECURITY`.
 

--- a/apps/docs/content/guides/realtime/authorization.mdx
+++ b/apps/docs/content/guides/realtime/authorization.mdx
@@ -23,6 +23,14 @@ Realtime uses the `messages` table in your database's `realtime` schema to gener
 
 By creating RLS policies on the `realtime.messages` table you can control the access users have to a Channel topic, and features within a Channel topic.
 
+<Admonition type="caution">
+
+Realtime locks dows the `realtime` schema to protect it against unexpected changes to guarantee the healthy operation of the Realtime service and avoid conflicts that could be caused by future migrations. Creating a table or function in `realtime` is expected to fail with `permission denied for schema realtime`, whether you run the SQL yourself or through the dashboard. Managing RLS policies on `realtime.messages` is alllowed.
+
+Row level security (RLS) is enabled by default on table `realtime.messages`, you don't need to execute `ALTER TABLE realtime.messages ENABLE ROW LEVEL SECURITY`.
+
+</Admonition>
+
 The validation is done when the user connects. When their WebSocket connection is established and a Channel topic is joined, their permissions are calculated based on:
 
 - The RLS policies on the `realtime.messages` table

--- a/apps/docs/content/guides/realtime/concepts.mdx
+++ b/apps/docs/content/guides/realtime/concepts.mdx
@@ -106,7 +106,8 @@ Realtime has a cleanup process that will delete tables older than 3 days.
 
 ### Functions
 
-Realtime creates two functions on your database:
+Realtime creates some functions on your database:
 
 - `realtime.send` - Inserts an entry into `realtime.messages` table that will trigger the replication slot to broadcast the changes to the clients. It also captures errors to prevent the trigger from breaking.
+- `realtime.send_binary` - Similar to `realtime.send` but allows you to broadcast binaries.
 - `realtime.broadcast_changes` - uses `realtime.send` to broadcast the changes with a format that is compatible with Postgres Changes


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Make it clear what users can and can't do on `realtime` schema.

## What is the current behavior?

After https://github.com/supabase/realtime/pull/1993 creating or altering the realtime schema is no longer allowed, but some users are still trying to execute `ALTER TABLE realtime.messages ENABLE ROW LEVEL SECURITY` or trying to create objects on that schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified Realtime schema protections, including a caution about how the `realtime` schema is restricted and what permission errors to expect when creating objects there.
  * Confirmed that row level security is enabled by default on `realtime.messages`, and that managing its RLS policies is supported.
  * Documented the additional binary-capable function, `realtime.send_binary`, alongside the existing `realtime.send` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->