### PR TITLE
Revert "fix(docs): guard federated-content schema reads when artifact is absent"

### DIFF
--- a/apps/docs/internals/markdown-schema/AiSkillsIndex.ts
+++ b/apps/docs/internals/markdown-schema/AiSkillsIndex.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 const SKILLS_PATH = path.join(process.cwd(), 'features/docs/generated/ai-skills.json')
@@ -10,12 +10,6 @@ interface SkillSummary {
 }
 
 export const AiSkillsIndex = (): string => {
-  // `build:guides-markdown` can run standalone (e.g. apps/www's prebuild) without
-  // `build:federated-content`, so this generated artifact may not exist yet.
-  if (!existsSync(SKILLS_PATH)) {
-    return ''
-  }
-
   const skills: SkillSummary[] = JSON.parse(readFileSync(SKILLS_PATH, 'utf-8'))
 
   return skills

--- a/apps/docs/internals/markdown-schema/TerraformProviderSchema.ts
+++ b/apps/docs/internals/markdown-schema/TerraformProviderSchema.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'node:fs'
+import { readFileSync } from 'node:fs'
 import path from 'node:path'
 
 const SCHEMA_PATH = path.join(process.cwd(), 'features/docs/generated/terraform.schema.json')
@@ -15,12 +15,6 @@ function attributesTable(attributes: Record<string, any>, extraColumns: string[]
 }
 
 export const TerraformProviderSchema = (): string => {
-  // `build:guides-markdown` can run standalone (e.g. apps/www's prebuild) without
-  // `build:federated-content`, so this generated artifact may not exist yet.
-  if (!existsSync(SCHEMA_PATH)) {
-    return ''
-  }
-
   const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf-8'))
   const provider = schema.provider_schemas['registry.terraform.io/supabase/supabase']
 


### PR DESCRIPTION
Reverts supabase/supabase#48144

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documentation generation now surfaces missing or unreadable AI skills and Terraform schema data instead of silently producing empty sections.
  * This improves visibility into incomplete documentation builds and helps ensure generated reference content is available and accurate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->