### PR TITLE
fix(studio): group storage policies under every bucket they reference

### DIFF
--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { useRouter } from 'next/router'
 import { toast } from 'sonner'
 
-import { extractBucketNameFromDefinition } from './Storage.utils'
+import { extractBucketNamesFromDefinition } from './Storage.utils'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useDatabasePolicyDeleteMutation } from '@/data/database-policies/database-policy-delete-mutation'
@@ -44,8 +44,8 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
       const bucketPolicies = (policies ?? []).filter((policy) => {
         if (policy.table !== 'objects') return false
 
-        const policyBucket = extractBucketNameFromDefinition(policy.definition ?? policy.check)
-        return policyBucket === bucket.name
+        const policyBuckets = extractBucketNamesFromDefinition(policy.definition ?? policy.check)
+        return policyBuckets.includes(bucket.name)
       })
 
       if (bucketPolicies.length === 0) return

--- a/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
+++ b/apps/studio/components/interfaces/Storage/DeleteBucketModal.tsx
@@ -2,7 +2,7 @@ import { useParams } from 'common'
 import { useRouter } from 'next/router'
 import { toast } from 'sonner'
 
-import { extractBucketNamesFromDefinition } from './Storage.utils'
+import { getPolicyBucketNames } from './Storage.utils'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useDatabasePolicyDeleteMutation } from '@/data/database-policies/database-policy-delete-mutation'
@@ -44,8 +44,10 @@ export const DeleteBucketModal = ({ visible, bucket, onClose }: DeleteBucketModa
       const bucketPolicies = (policies ?? []).filter((policy) => {
         if (policy.table !== 'objects') return false
 
-        const policyBuckets = extractBucketNamesFromDefinition(policy.definition ?? policy.check)
-        return policyBuckets.includes(bucket.name)
+        // Only auto-delete policies exclusively tied to this bucket; a policy shared
+        // with other buckets must keep protecting them.
+        const policyBuckets = getPolicyBucketNames(policy)
+        return policyBuckets.length === 1 && policyBuckets[0] === bucket.name
       })
 
       if (bucketPolicies.length === 0) return

--- a/apps/studio/components/interfaces/Storage/Storage.utils.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.utils.ts
@@ -63,43 +63,62 @@ const formatStoragePolicies = (buckets: Bucket[], policies: Policy[]) => {
   const formattedPolicies = policies.map((policy) => {
     const { definition: policyDefinition, check: policyCheck } = policy
 
-    const bucketName =
+    const bucketNames =
       policyDefinition !== null
-        ? extractBucketNameFromDefinition(policyDefinition)
-        : extractBucketNameFromDefinition(policyCheck)
+        ? extractBucketNamesFromDefinition(policyDefinition)
+        : extractBucketNamesFromDefinition(policyCheck)
 
-    if (bucketName) {
-      const isBucketLoaded = availableBuckets.includes(bucketName)
-
-      return {
-        ...policy,
-        bucket: isBucketLoaded ? bucketName : UNKNOWN_BUCKET_SYMBOL,
-      }
+    if (bucketNames.length === 0) {
+      return { ...policy, buckets: [UNGROUPED_POLICY_SYMBOL] }
     }
 
-    return { ...policy, bucket: UNGROUPED_POLICY_SYMBOL }
+    const groups = Array.from(
+      new Set(
+        bucketNames.map((name) => (availableBuckets.includes(name) ? name : UNKNOWN_BUCKET_SYMBOL))
+      )
+    )
+
+    return { ...policy, buckets: groups }
   })
 
   return formattedPolicies
 }
 
-export const extractBucketNameFromDefinition = (definition: string | null) => {
-  if (!definition) return null
+/**
+ * Extracts every bucket name a policy applies to from its pg_policies definition.
+ * Handles single-bucket equality (`bucket_id = 'name'`) and multi-bucket membership,
+ * which Postgres renders as `bucket_id = ANY (ARRAY['a'::text, 'b'::text])`.
+ * Negated conditions (`bucket_id <> 'name'`) contribute no buckets since the policy
+ * applies to every bucket except the named one — callers treat an empty result as
+ * "not attributable to specific buckets".
+ */
+export const extractBucketNamesFromDefinition = (definition: string | null): string[] => {
+  if (!definition) return []
 
-  const definitionSegments = definition?.split(' AND ') ?? []
-  const [bucketDefinition] = definitionSegments.filter((segment: string) =>
-    segment.includes('bucket_id')
-  )
-  return bucketDefinition ? bucketDefinition.split("'")[1] : null
+  const names = new Set<string>()
+
+  for (const match of definition.matchAll(/bucket_id\s*=\s*'([^']*)'/g)) {
+    names.add(match[1])
+  }
+
+  for (const match of definition.matchAll(/bucket_id\s*=\s*ANY\s*\(\s*ARRAY\[([^\]]*)\]/gi)) {
+    for (const quoted of match[1].matchAll(/'([^']*)'/g)) {
+      names.add(quoted[1])
+    }
+  }
+
+  return Array.from(names)
 }
 
-const groupPoliciesByBucket = (policies: (Policy & { bucket: string | Symbol })[]) => {
+const groupPoliciesByBucket = (policies: (Policy & { buckets: (string | Symbol)[] })[]) => {
   const policiesByBucket = new Map<string | Symbol, Policy[]>()
   policies.forEach((policy) => {
-    if (!policiesByBucket.has(policy.bucket)) {
-      policiesByBucket.set(policy.bucket, [])
-    }
-    policiesByBucket.get(policy.bucket)?.push(policy)
+    policy.buckets.forEach((bucket) => {
+      if (!policiesByBucket.has(bucket)) {
+        policiesByBucket.set(bucket, [])
+      }
+      policiesByBucket.get(bucket)?.push(policy)
+    })
   })
   return Array.from(policiesByBucket).map(([bucketName, policies]) => ({
     name: bucketName,

--- a/apps/studio/components/interfaces/Storage/Storage.utils.ts
+++ b/apps/studio/components/interfaces/Storage/Storage.utils.ts
@@ -61,12 +61,7 @@ export const UNGROUPED_POLICY_SYMBOL = createWrappedSymbol('ungrouped-policy', '
 const formatStoragePolicies = (buckets: Bucket[], policies: Policy[]) => {
   const availableBuckets = buckets.map((bucket) => bucket.name)
   const formattedPolicies = policies.map((policy) => {
-    const { definition: policyDefinition, check: policyCheck } = policy
-
-    const bucketNames =
-      policyDefinition !== null
-        ? extractBucketNamesFromDefinition(policyDefinition)
-        : extractBucketNamesFromDefinition(policyCheck)
+    const bucketNames = getPolicyBucketNames(policy)
 
     if (bucketNames.length === 0) {
       return { ...policy, buckets: [UNGROUPED_POLICY_SYMBOL] }
@@ -108,6 +103,22 @@ export const extractBucketNamesFromDefinition = (definition: string | null): str
   }
 
   return Array.from(names)
+}
+
+/**
+ * Collects every bucket name a policy references across both its USING (definition)
+ * and WITH CHECK (check) clauses.
+ */
+export const getPolicyBucketNames = (policy: {
+  definition: string | null
+  check: string | null
+}): string[] => {
+  return Array.from(
+    new Set([
+      ...extractBucketNamesFromDefinition(policy.definition),
+      ...extractBucketNamesFromDefinition(policy.check),
+    ])
+  )
 }
 
 const groupPoliciesByBucket = (policies: (Policy & { buckets: (string | Symbol)[] })[]) => {

--- a/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
+++ b/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import { extractBucketNameFromDefinition } from '@/components/interfaces/Storage/Storage.utils'
+import { extractBucketNamesFromDefinition } from '@/components/interfaces/Storage/Storage.utils'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
@@ -16,10 +16,12 @@ export function useBucketPolicyCount() {
     const countMap = new Map<string, number>()
     for (const policy of policiesData) {
       if (policy.table !== 'objects') continue
-      const bucketName =
-        extractBucketNameFromDefinition(policy.definition) ??
-        extractBucketNameFromDefinition(policy.check)
-      if (bucketName) {
+      const definitionBuckets = extractBucketNamesFromDefinition(policy.definition)
+      const bucketNames =
+        definitionBuckets.length > 0
+          ? definitionBuckets
+          : extractBucketNamesFromDefinition(policy.check)
+      for (const bucketName of bucketNames) {
         countMap.set(bucketName, (countMap.get(bucketName) ?? 0) + 1)
       }
     }

--- a/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
+++ b/apps/studio/components/interfaces/Storage/useBucketPolicyCount.ts
@@ -1,6 +1,6 @@
 import { useCallback, useMemo } from 'react'
 
-import { extractBucketNamesFromDefinition } from '@/components/interfaces/Storage/Storage.utils'
+import { getPolicyBucketNames } from '@/components/interfaces/Storage/Storage.utils'
 import { useDatabasePoliciesQuery } from '@/data/database-policies/database-policies-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
@@ -16,11 +16,7 @@ export function useBucketPolicyCount() {
     const countMap = new Map<string, number>()
     for (const policy of policiesData) {
       if (policy.table !== 'objects') continue
-      const definitionBuckets = extractBucketNamesFromDefinition(policy.definition)
-      const bucketNames =
-        definitionBuckets.length > 0
-          ? definitionBuckets
-          : extractBucketNamesFromDefinition(policy.check)
+      const bucketNames = getPolicyBucketNames(policy)
       for (const bucketName of bucketNames) {
         countMap.set(bucketName, (countMap.get(bucketName) ?? 0) + 1)
       }

--- a/apps/studio/tests/components/Storage/Storage.utils.test.ts
+++ b/apps/studio/tests/components/Storage/Storage.utils.test.ts
@@ -1,0 +1,168 @@
+import { rawSql } from '@supabase/pg-meta'
+import { describe, expect, test } from 'vitest'
+
+import type { Policy } from '@/components/interfaces/Database/Policies/PolicyTableRow/PolicyTableRow.utils'
+import {
+  extractBucketNamesFromDefinition,
+  formatPoliciesForStorage,
+  UNGROUPED_POLICY_SYMBOL,
+  UNKNOWN_BUCKET_SYMBOL,
+} from '@/components/interfaces/Storage/Storage.utils'
+import type { Bucket } from '@/data/storage/buckets-query'
+
+const mockBucket = (name: string) => ({ name }) as unknown as Bucket
+
+const mockPolicy = (overrides: Partial<Policy> = {}): Policy =>
+  ({
+    id: 1,
+    schema: 'storage',
+    table: 'objects',
+    table_id: 100,
+    name: 'My policy',
+    action: 'PERMISSIVE',
+    roles: ['public'],
+    command: 'SELECT',
+    definition: rawSql(`(bucket_id = 'avatars'::text)`),
+    check: null,
+    ...overrides,
+  }) as Policy
+
+describe('Storage.utils: extractBucketNamesFromDefinition', () => {
+  test('should extract the bucket name from a simple definition', () => {
+    expect(extractBucketNamesFromDefinition(`(bucket_id = 'avatars'::text)`)).toStrictEqual([
+      'avatars',
+    ])
+  })
+
+  test('should extract the bucket name from a definition with multiple conditions', () => {
+    expect(
+      extractBucketNamesFromDefinition(
+        `((bucket_id = 'avatars'::text) AND (auth.role() = 'authenticated'::text))`
+      )
+    ).toStrictEqual(['avatars'])
+  })
+
+  test('should extract every bucket name from an ANY (ARRAY[...]) membership condition', () => {
+    expect(
+      extractBucketNamesFromDefinition(`(bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text]))`)
+    ).toStrictEqual(['avatars', 'logos'])
+  })
+
+  test('should extract bucket names from OR conditions across separate equalities', () => {
+    expect(
+      extractBucketNamesFromDefinition(
+        `((bucket_id = 'avatars'::text) OR (bucket_id = 'logos'::text))`
+      )
+    ).toStrictEqual(['avatars', 'logos'])
+  })
+
+  test('should not pick up quoted values from non-bucket conditions', () => {
+    expect(
+      extractBucketNamesFromDefinition(
+        `((auth.role() = 'authenticated'::text) AND (bucket_id = 'logos'::text))`
+      )
+    ).toStrictEqual(['logos'])
+  })
+
+  test('should return no buckets for a negated condition', () => {
+    expect(extractBucketNamesFromDefinition(`(bucket_id <> 'avatars'::text)`)).toStrictEqual([])
+  })
+
+  test('should return no buckets when there is no bucket_id condition', () => {
+    expect(extractBucketNamesFromDefinition('(auth.uid() IS NOT NULL)')).toStrictEqual([])
+  })
+
+  test('should return no buckets for a null definition', () => {
+    expect(extractBucketNamesFromDefinition(null)).toStrictEqual([])
+  })
+
+  test('should return no buckets for an empty definition', () => {
+    expect(extractBucketNamesFromDefinition('')).toStrictEqual([])
+  })
+
+  test('should deduplicate repeated bucket names', () => {
+    expect(
+      extractBucketNamesFromDefinition(
+        `((bucket_id = 'avatars'::text) OR (bucket_id = 'avatars'::text))`
+      )
+    ).toStrictEqual(['avatars'])
+  })
+})
+
+describe('Storage.utils: formatPoliciesForStorage', () => {
+  test('should return an empty array when there are no policies', () => {
+    expect(formatPoliciesForStorage([mockBucket('avatars')], [])).toStrictEqual([])
+  })
+
+  test('should group a single-bucket policy under its bucket', () => {
+    const output = formatPoliciesForStorage([mockBucket('avatars')], [mockPolicy()])
+
+    expect(output).toHaveLength(1)
+    expect(output[0].name).toBe('avatars')
+    expect(output[0].policies).toHaveLength(1)
+  })
+
+  test('should list a multi-bucket policy under every bucket it applies to', () => {
+    const policies = [
+      mockPolicy({
+        definition: rawSql(`(bucket_id = ANY (ARRAY['avatars'::text, 'logos'::text]))`),
+      }),
+    ]
+    const output = formatPoliciesForStorage([mockBucket('avatars'), mockBucket('logos')], policies)
+
+    expect(output.map((group) => group.name)).toStrictEqual(['avatars', 'logos'])
+    expect(output[0].policies).toHaveLength(1)
+    expect(output[1].policies).toHaveLength(1)
+  })
+
+  test('should group a negated policy under the ungrouped section instead of the excluded bucket', () => {
+    const policies = [mockPolicy({ definition: rawSql(`(bucket_id <> 'avatars'::text)`) })]
+    const output = formatPoliciesForStorage([mockBucket('avatars')], policies)
+
+    expect(output).toHaveLength(1)
+    expect(output[0].name).toBe(UNGROUPED_POLICY_SYMBOL)
+  })
+
+  test('should fall back to the check clause when the definition is null', () => {
+    const policies = [
+      mockPolicy({
+        command: 'INSERT',
+        definition: null,
+        check: rawSql(`(bucket_id = 'avatars'::text)`),
+      }),
+    ]
+    const output = formatPoliciesForStorage([mockBucket('avatars')], policies)
+
+    expect(output).toHaveLength(1)
+    expect(output[0].name).toBe('avatars')
+  })
+
+  test('should group policies of buckets that are not loaded under the unknown bucket symbol', () => {
+    const policies = [mockPolicy({ definition: rawSql(`(bucket_id = 'not-loaded'::text)`) })]
+    const output = formatPoliciesForStorage([mockBucket('avatars')], policies)
+
+    expect(output).toHaveLength(1)
+    expect(output[0].name).toBe(UNKNOWN_BUCKET_SYMBOL)
+  })
+
+  test('should list a multi-bucket policy once under the unknown symbol when several buckets are not loaded', () => {
+    const policies = [
+      mockPolicy({
+        definition: rawSql(`(bucket_id = ANY (ARRAY['missing-a'::text, 'missing-b'::text]))`),
+      }),
+    ]
+    const output = formatPoliciesForStorage([mockBucket('avatars')], policies)
+
+    expect(output).toHaveLength(1)
+    expect(output[0].name).toBe(UNKNOWN_BUCKET_SYMBOL)
+    expect(output[0].policies).toHaveLength(1)
+  })
+
+  test('should group policies without a bucket_id condition under the ungrouped symbol', () => {
+    const policies = [mockPolicy({ definition: rawSql('(auth.uid() IS NOT NULL)') })]
+    const output = formatPoliciesForStorage([mockBucket('avatars')], policies)
+
+    expect(output).toHaveLength(1)
+    expect(output[0].name).toBe(UNGROUPED_POLICY_SYMBOL)
+  })
+})

--- a/apps/studio/tests/components/Storage/Storage.utils.test.ts
+++ b/apps/studio/tests/components/Storage/Storage.utils.test.ts
@@ -2,7 +2,12 @@ import { rawSql } from '@supabase/pg-meta'
 import { describe, expect, test } from 'vitest'
 
 import type { Policy } from '@/components/interfaces/Database/Policies/PolicyTableRow/PolicyTableRow.utils'
+import type { StoragePolicyFormField } from '@/components/interfaces/Storage/Storage.types'
 import {
+  applyBucketIdToTemplateDefinition,
+  createPayloadsForAddPolicy,
+  createSQLPolicies,
+  deriveAllowedClientLibraryMethods,
   extractBucketNamesFromDefinition,
   formatPoliciesForStorage,
   getPolicyBucketNames,
@@ -27,6 +32,17 @@ const mockPolicy = (overrides: Partial<Policy> = {}): Policy =>
     check: null,
     ...overrides,
   }) as Policy
+
+const mockPolicyFormFields = (
+  overrides: Partial<StoragePolicyFormField> = {}
+): StoragePolicyFormField =>
+  ({
+    name: 'My policy',
+    definition: `bucket_id = 'avatars'`,
+    allowedOperations: ['SELECT'],
+    roles: [],
+    ...overrides,
+  }) as StoragePolicyFormField
 
 describe('Storage.utils: extractBucketNamesFromDefinition', () => {
   test('should extract the bucket name from a simple definition', () => {
@@ -216,5 +232,187 @@ describe('Storage.utils: formatPoliciesForStorage', () => {
 
     expect(output).toHaveLength(1)
     expect(output[0].name).toBe(UNGROUPED_POLICY_SYMBOL)
+  })
+})
+describe('Storage.utils: createPayloadsForAddPolicy', () => {
+  test('should create one payload per allowed operation', () => {
+    const output = createPayloadsForAddPolicy(
+      'avatars',
+      mockPolicyFormFields({ allowedOperations: ['SELECT', 'INSERT'] })
+    )
+    expect(output).toHaveLength(2)
+    expect(output.map((payload) => payload.command)).toStrictEqual(['SELECT', 'INSERT'])
+  })
+
+  test('should use the check clause for INSERT and the definition for other operations', () => {
+    const [select, insert] = createPayloadsForAddPolicy(
+      'avatars',
+      mockPolicyFormFields({ allowedOperations: ['SELECT', 'INSERT'] })
+    )
+
+    expect(select.definition).toBe(`(bucket_id = 'avatars')`)
+    expect(select.check).toBeUndefined()
+    expect(insert.definition).toBeUndefined()
+    expect(insert.check).toBe(`(bucket_id = 'avatars')`)
+  })
+
+  test('should target the storage.objects table with a permissive action', () => {
+    const [output] = createPayloadsForAddPolicy('avatars', mockPolicyFormFields())
+    expect(output.schema).toBe('storage')
+    expect(output.table).toBe('objects')
+    expect(output.action).toBe('PERMISSIVE')
+  })
+
+  test('should omit roles when none are selected', () => {
+    const [output] = createPayloadsForAddPolicy('avatars', mockPolicyFormFields({ roles: [] }))
+    expect(output.roles).toBeUndefined()
+  })
+
+  test('should include the selected roles', () => {
+    const [output] = createPayloadsForAddPolicy(
+      'avatars',
+      mockPolicyFormFields({ roles: ['authenticated'] })
+    )
+    expect(output.roles).toStrictEqual(['authenticated'])
+  })
+
+  test('should collapse consecutive whitespace in the definition', () => {
+    const [output] = createPayloadsForAddPolicy(
+      'avatars',
+      mockPolicyFormFields({ definition: `bucket_id =\n   'avatars'` })
+    )
+    expect(output.definition).toBe(`(bucket_id = 'avatars')`)
+  })
+
+  test('should add a deterministic per-operation suffix to the policy name', () => {
+    const [first] = createPayloadsForAddPolicy('avatars', mockPolicyFormFields())
+    const [second] = createPayloadsForAddPolicy('avatars', mockPolicyFormFields())
+    const [otherBucket] = createPayloadsForAddPolicy('logos', mockPolicyFormFields())
+
+    expect(first.name).toMatch(/^My policy [a-z0-9]+_0$/)
+    expect(first.name).toBe(second.name)
+    expect(otherBucket.name).not.toBe(first.name)
+  })
+
+  test('should keep the policy name as is when the suffix is disabled', () => {
+    const [output] = createPayloadsForAddPolicy('avatars', mockPolicyFormFields(), false)
+    expect(output.name).toBe('My policy')
+  })
+})
+
+describe('Storage.utils: createSQLPolicies', () => {
+  test('should create one statement per allowed operation', () => {
+    const output = createSQLPolicies(
+      'avatars',
+      mockPolicyFormFields({ allowedOperations: ['SELECT', 'DELETE'] }),
+      false
+    )
+    expect(output).toHaveLength(2)
+    expect(output[0].description).toBe(
+      'Add policy for the SELECT operation under the policy "My policy"'
+    )
+    expect(output[0].statement).toBe(
+      `CREATE POLICY "My policy" ON storage.objects FOR SELECT TO public USING (bucket_id = 'avatars');`
+    )
+    expect(output[1].statement).toBe(
+      `CREATE POLICY "My policy" ON storage.objects FOR DELETE TO public USING (bucket_id = 'avatars');`
+    )
+  })
+
+  test('should use WITH CHECK for INSERT statements', () => {
+    const [output] = createSQLPolicies(
+      'avatars',
+      mockPolicyFormFields({ allowedOperations: ['INSERT'] }),
+      false
+    )
+    expect(output.statement).toBe(
+      `CREATE POLICY "My policy" ON storage.objects FOR INSERT TO public WITH CHECK (bucket_id = 'avatars');`
+    )
+  })
+
+  test('should list the selected roles in the statement', () => {
+    const [output] = createSQLPolicies(
+      'avatars',
+      mockPolicyFormFields({ roles: ['authenticated', 'anon'] }),
+      false
+    )
+    expect(output.statement).toContain('TO authenticated, anon')
+  })
+
+  test('should fall back to an empty definition when none is provided', () => {
+    const [output] = createSQLPolicies(
+      'avatars',
+      mockPolicyFormFields({ definition: undefined }),
+      false
+    )
+    expect(output.statement).toContain('USING ();')
+  })
+
+  test('should append the same deterministic suffix as the policy payloads', () => {
+    const [sql] = createSQLPolicies('avatars', mockPolicyFormFields())
+    const [payload] = createPayloadsForAddPolicy('avatars', mockPolicyFormFields())
+    expect(sql.statement).toContain(`CREATE POLICY "${payload.name}"`)
+  })
+})
+
+describe('Storage.utils: applyBucketIdToTemplateDefinition', () => {
+  test('should replace the bucket_id placeholder with a quoted bucket id', () => {
+    expect(applyBucketIdToTemplateDefinition(`bucket_id = {bucket_id}`, 'avatars')).toBe(
+      `bucket_id = 'avatars'`
+    )
+  })
+
+  test('should leave a definition without a placeholder untouched', () => {
+    expect(applyBucketIdToTemplateDefinition(`bucket_id = 'avatars'`, 'logos')).toBe(
+      `bucket_id = 'avatars'`
+    )
+  })
+})
+
+describe('Storage.utils: deriveAllowedClientLibraryMethods', () => {
+  test('should only allow getPublicUrl when no operations are selected', () => {
+    expect(deriveAllowedClientLibraryMethods([])).toStrictEqual(['getPublicUrl'])
+  })
+
+  test('should allow read methods for SELECT', () => {
+    expect(deriveAllowedClientLibraryMethods(['SELECT'] as never[])).toStrictEqual([
+      'download',
+      'list',
+      'createSignedUrl',
+      'createSignedUrls',
+      'getPublicUrl',
+    ])
+  })
+
+  test('should allow upload for INSERT', () => {
+    expect(deriveAllowedClientLibraryMethods(['INSERT'] as never[])).toStrictEqual([
+      'upload',
+      'getPublicUrl',
+    ])
+  })
+
+  test('should allow methods requiring multiple operations only when all are selected', () => {
+    const output = deriveAllowedClientLibraryMethods(['SELECT', 'UPDATE'] as never[])
+    expect(output).toContain('update')
+    expect(output).toContain('move')
+    expect(output).not.toContain('copy')
+    expect(output).not.toContain('remove')
+  })
+
+  test('should allow every method when all operations are selected', () => {
+    expect(
+      deriveAllowedClientLibraryMethods(['SELECT', 'INSERT', 'UPDATE', 'DELETE'] as never[])
+    ).toStrictEqual([
+      'upload',
+      'download',
+      'list',
+      'update',
+      'move',
+      'copy',
+      'remove',
+      'createSignedUrl',
+      'createSignedUrls',
+      'getPublicUrl',
+    ])
   })
 })

--- a/apps/studio/tests/components/Storage/Storage.utils.test.ts
+++ b/apps/studio/tests/components/Storage/Storage.utils.test.ts
@@ -129,6 +129,7 @@ describe('Storage.utils: formatPoliciesForStorage', () => {
   test('should group a policy under a bucket referenced only in its check clause', () => {
     const policies = [
       mockPolicy({
+        id: 42,
         definition: rawSql(`((select auth.uid()::text) = owner)`),
         check: rawSql(`(bucket_id = 'avatars'::text)`),
       }),
@@ -137,6 +138,8 @@ describe('Storage.utils: formatPoliciesForStorage', () => {
 
     expect(output).toHaveLength(1)
     expect(output[0].name).toBe('avatars')
+    expect(output[0].policies).toHaveLength(1)
+    expect(output[0].policies[0].id).toBe(42)
   })
 
   test('should return an empty array when there are no policies', () => {

--- a/apps/studio/tests/components/Storage/Storage.utils.test.ts
+++ b/apps/studio/tests/components/Storage/Storage.utils.test.ts
@@ -5,6 +5,7 @@ import type { Policy } from '@/components/interfaces/Database/Policies/PolicyTab
 import {
   extractBucketNamesFromDefinition,
   formatPoliciesForStorage,
+  getPolicyBucketNames,
   UNGROUPED_POLICY_SYMBOL,
   UNKNOWN_BUCKET_SYMBOL,
 } from '@/components/interfaces/Storage/Storage.utils'
@@ -89,7 +90,55 @@ describe('Storage.utils: extractBucketNamesFromDefinition', () => {
   })
 })
 
+describe('Storage.utils: getPolicyBucketNames', () => {
+  test('should union bucket names from the definition and check clauses', () => {
+    expect(
+      getPolicyBucketNames({
+        definition: `(bucket_id = 'avatars'::text)`,
+        check: `(bucket_id = 'logos'::text)`,
+      })
+    ).toStrictEqual(['avatars', 'logos'])
+  })
+
+  test('should find a bucket in the check clause when the definition has no bucket condition', () => {
+    expect(
+      getPolicyBucketNames({
+        definition: `((select auth.uid()::text) = owner)`,
+        check: `(bucket_id = 'avatars'::text)`,
+      })
+    ).toStrictEqual(['avatars'])
+  })
+
+  test('should deduplicate buckets referenced in both clauses', () => {
+    expect(
+      getPolicyBucketNames({
+        definition: `(bucket_id = 'avatars'::text)`,
+        check: `(bucket_id = 'avatars'::text)`,
+      })
+    ).toStrictEqual(['avatars'])
+  })
+
+  test('should return no buckets when neither clause references bucket_id', () => {
+    expect(
+      getPolicyBucketNames({ definition: '(auth.uid() IS NOT NULL)', check: null })
+    ).toStrictEqual([])
+  })
+})
+
 describe('Storage.utils: formatPoliciesForStorage', () => {
+  test('should group a policy under a bucket referenced only in its check clause', () => {
+    const policies = [
+      mockPolicy({
+        definition: rawSql(`((select auth.uid()::text) = owner)`),
+        check: rawSql(`(bucket_id = 'avatars'::text)`),
+      }),
+    ]
+    const output = formatPoliciesForStorage([mockBucket('avatars')], policies)
+
+    expect(output).toHaveLength(1)
+    expect(output[0].name).toBe('avatars')
+  })
+
   test('should return an empty array when there are no policies', () => {
     expect(formatPoliciesForStorage([mockBucket('avatars')], [])).toStrictEqual([])
   })


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix plus tests.

## What is the current behavior?

Fixes #48164. The bucket name parser in `Storage.utils.ts` returns only the first quoted string near `bucket_id` and treats negated conditions as positive matches. As a result, multi bucket policies (`bucket_id = ANY (ARRAY[...])`) are listed and counted under only the first bucket, negated policies (`bucket_id <> 'x'`) are attributed to the excluded bucket, and `DeleteBucketModal` can delete a negated policy that still governs every other bucket.

## What is the new behavior?

- New `extractBucketNamesFromDefinition` returns every bucket a policy references. It handles `bucket_id = 'x'`, the `ANY (ARRAY[...])` rendering of `IN`, and OR conditions, and returns no buckets for negated conditions so those policies fall back to the Ungrouped section.
- New `getPolicyBucketNames` unifies extraction across a policy's `definition` and `check` clauses, so the policies page, the per bucket counts, and bucket deletion all agree on which buckets a policy targets.
- The Policies page groups a policy under each bucket it references. Bucket deletion only removes policies that target that bucket alone, so shared and negated policies survive.
- 43 unit tests cover the parser shapes, the grouping behavior including unknown bucket and ungrouped paths, and the remaining `Storage.utils` helpers.

## Additional context

Rebased on latest master. Addresses the earlier review feedback on unifying bucket extraction and preserving shared policies on delete.

`pnpm test:studio`, `tsc --noEmit`, and Prettier are clean.
