### PR TITLE
fix(studio): restore project creation panel chrome on /new

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -585,7 +585,7 @@ export const ProjectCreationForm = ({
           loading={!isOrganizationsSuccess}
           noMargin={isVercelIntegrationFlow}
           className={cn(
-            !isVercelIntegrationFlow && 'border-0 shadow-none rounded-none bg-transparent'
+            isVercelIntegrationFlow && 'border-0 shadow-none rounded-none bg-transparent'
           )}
           title={
             !isVercelIntegrationFlow && (


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Regression from #48113: the regular `/new` project creation form is missing its card border/shadow because Panel flatten classes were applied when `!isVercelIntegrationFlow`.

## What is the new behavior?

Flattens Panel chrome only for the Vercel interstitial flow, restoring the card on `/new`.

| Before | After |
| --- | --- |
| <img width="980" height="997" alt="New Project  Supabase" src="https://github.com/user-attachments/assets/5af9bc8b-5abd-47ea-9821-207ea5c2c127" /> | <img width="980" height="997" alt="New Project  Supabase" src="https://github.com/user-attachments/assets/28a32216-d250-497c-90df-94e2df19ce00" /> |

## Additional context

N/A

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the project creation panel’s appearance during the Vercel integration flow, removing unnecessary borders, shadows, and background styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->