### PR TITLE
Add Francisco Ulate to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -105,6 +105,7 @@ Felipe Stival
 Ferhat Elmas
 Firas El Rachidi
 Francesco Sansalvadore
+Francisco Ulate
 Gabriel Claudino
 Garrett Crowell
 Gerardo Estaba


### PR DESCRIPTION
Adding myself as part of the Supabase humans!!!

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes
## What kind of change does this PR introduce?

Docs

## What is the current behavior?

I'm not in the humans.txt

## What is the new behavior?

I'm now in the humans.txt

## Additional context

This is a task in my onboarding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the team credits page to include Francisco Ulate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->