### PR TITLE
fix(studio): default scoped PAT permissions to read

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.test.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { FormProvider, useForm } from 'react-hook-form'
+import { describe, expect, it } from 'vitest'
+
+import { TokenFormValues } from '../../../AccessToken.schemas'
+import { Permissions } from './Permissions'
+import { ACCESS_TOKEN_RESOURCES } from '@/components/interfaces/Account/AccessTokens/AccessToken.constants'
+import { render } from '@/tests/helpers'
+
+/**
+ * Renders the real Permissions form with the resource picker already open, and
+ * exposes the current `permissionRows` value so tests can assert on the seeded
+ * actions rather than on button label formatting.
+ */
+function Harness() {
+  const form = useForm<TokenFormValues>({
+    defaultValues: { permissionRows: [] },
+    mode: 'onChange',
+  })
+  const rows = form.watch('permissionRows') || []
+  return (
+    <FormProvider {...form}>
+      <div data-testid="permission-rows">{JSON.stringify(rows)}</div>
+      <Permissions control={form.control} resourceSearchOpen setResourceSearchOpen={() => {}} />
+    </FormProvider>
+  )
+}
+
+const readRows = () =>
+  JSON.parse(
+    screen.getByTestId('permission-rows').textContent || '[]'
+  ) as TokenFormValues['permissionRows']
+
+describe('Permissions — default actions when adding a resource', () => {
+  it('seeds a newly added resource with a single least-privilege action, not its full action set', async () => {
+    // Use a real resource that (a) exposes more than one action, so the
+    // all-vs-one difference is observable, and (b) has a unique title, so the
+    // picker row can be located unambiguously.
+    const titleCounts = ACCESS_TOKEN_RESOURCES.reduce<Record<string, number>>((acc, r) => {
+      acc[r.title] = (acc[r.title] ?? 0) + 1
+      return acc
+    }, {})
+    const resource = ACCESS_TOKEN_RESOURCES.find(
+      (r) => r.actions.length > 1 && titleCounts[r.title] === 1
+    )
+    expect(resource, 'expected a resource with >1 action and a unique title').toBeTruthy()
+
+    render(<Harness />)
+
+    // The picker is open; toggle the resource on via its row checkbox.
+    const row = screen.getByText(resource!.title).closest('[cmdk-item]') as HTMLElement
+    fireEvent.click(within(row).getByRole('checkbox'))
+
+    await waitFor(() => expect(readRows()).toHaveLength(1))
+
+    const added = readRows()![0]
+    expect(added.resource).toBe(resource!.resource)
+    // A newly added resource is least-privilege by default: exactly one action
+    // (read when available, otherwise the first action) — never its full set.
+    expect(added.actions).toHaveLength(1)
+    expect(added.actions).toEqual(
+      resource!.actions.includes('read') ? ['read'] : [resource!.actions[0]]
+    )
+  })
+})

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.tsx
@@ -15,7 +15,7 @@ import {
 import { TokenFormValues } from '../../../AccessToken.schemas'
 import { PermissionResourceSelector } from './PermissionResourceSelector'
 import { PermissionsProps } from './Permissions.types'
-import { sortActions } from './Permissions.utils'
+import { getDefaultActions, sortActions } from './Permissions.utils'
 import { ACCESS_TOKEN_RESOURCES } from '@/components/interfaces/Account/AccessTokens/AccessToken.constants'
 import { formatAccessText } from '@/components/interfaces/Account/AccessTokens/AccessToken.utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -67,7 +67,7 @@ export const Permissions = ({
                 if (index > -1) {
                   return remove(index)
                 }
-                append(resource)
+                append({ resource: resource.resource, actions: getDefaultActions(resource) })
               }}
               align="end"
             />

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.utils.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.utils.ts
@@ -17,6 +17,13 @@ export const sortActions = (actions: string[]): string[] => {
   return sorted
 }
 
+// The default action(s) selected when a resource is first added. Newly added
+// resources should be least-privilege by default: just `read` when available,
+// otherwise the first available action — never the resource's full action set.
+export const getDefaultActions = (resource: PermissionResource): string[] => {
+  return resource.actions.includes('read') ? ['read'] : [resource.actions[0]]
+}
+
 export const togglePermissionResource = (
   permissionRows: PermissionRow[],
   resource: PermissionResource
@@ -27,6 +34,5 @@ export const togglePermissionResource = (
     return permissionRows.filter((row) => row.resource !== resource.resource)
   }
 
-  const defaultActions = resource.actions.includes('read') ? ['read'] : [resource.actions[0]]
-  return [...permissionRows, { resource: resource.resource, actions: defaultActions }]
+  return [...permissionRows, { resource: resource.resource, actions: getDefaultActions(resource) }]
 }


### PR DESCRIPTION
When adding a resource in the scoped access token form, the new permission row was seeded with the resource's entire action set (read/write/create/delete). A newly added resource should be least-privilege by default, just `read`, or the first available action, so tokens meant to be narrowly scoped aren't granted more than intended.

Seed the row through a shared getDefaultActions() helper (used by both form and the toggle util) and add a component test asserting a single default action.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

Yes

## What kind of change does this PR introduce?

Bug fix. Fixes: #48175

## What is the current behavior?

In the "Generate scoped token" form (Account → Access Tokens → scoped), adding a
resource under **Configure permissions** pre-selects **all** of that resource's
actions (e.g. read, write, create, delete). The access dropdown shows
"N selected" with every checkbox ticked. If the user submits without manually
deselecting, the created token is granted every action for that resource rather
than a minimal default. the opposite of what a *scoped*, least-privilege token
is for.

No existing issue. found while reviewing the scoped access token form.

## What is the new behavior?

Adding a resource now selects a single least-privilege action by default:
`read` when the resource supports it, otherwise its first available action. The
user can still tick additional actions as needed. This matches the default the
`togglePermissionResource` util already applied before the form was reworked.

The default-action logic is extracted into a shared `getDefaultActions()` helper
so the form and the util can't drift apart again.

## Additional context

**Root cause:** 
- The add-resource handler appended the full resource object,
whose `actions` field lists every available action, instead of a row seeded with
a single default action.

**Fix:**
- `Permissions.tsx`: `append(resource)` → `append({ resource: resource.resource, actions: getDefaultActions(resource) })`
- `Permissions.utils.ts`: new `getDefaultActions()` helper; `togglePermissionResource` reuses it (no behavior change)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New access-token permission entries now start with least-privilege defaults, selecting `read` when available or the first supported action.

* **Bug Fixes**
  * Improved initialization of permissions when resources are added, ensuring each entry includes its resource and default actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->