### PR TITLE
Support click to copy PID from activity row

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -17,6 +17,7 @@ import {
   Button,
   Card,
   cn,
+  copyToClipboard,
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
@@ -317,7 +318,7 @@ const ActivityRow = ({ activity }: { activity: DatabaseActivity }) => {
           <Badge variant={getBadgeVariant(activity.state)}>{activity.state}</Badge>
         </TableCell>
         <TableCell className="max-w-[300px]">
-          <HoverCard openDelay={100} closeDelay={100}>
+          <HoverCard openDelay={250} closeDelay={100}>
             <HoverCardTrigger>
               <p
                 className={cn(
@@ -343,8 +344,19 @@ const ActivityRow = ({ activity }: { activity: DatabaseActivity }) => {
               </HoverCardContent>
             )}
           </HoverCard>
-          <p className="text-xs text-foreground-lighter flex items-center gap-x-1 mt-0.5 truncate">
-            <span>PID: {activity.pid}</span>
+          <div className="text-xs text-foreground-lighter flex items-center gap-x-1 mt-0.5 truncate">
+            <Tooltip>
+              <TooltipTrigger
+                className="cursor-pointer"
+                onClick={() => {
+                  toast.success('Copied PID')
+                  copyToClipboard(activity.pid.toString())
+                }}
+              >
+                <span>PID: {activity.pid}</span>
+              </TooltipTrigger>
+              <TooltipContent side="bottom">Click to copy</TooltipContent>
+            </Tooltip>
             <span>·</span>
             <span>{activity.role_name}</span>
             {activity.application_name && (
@@ -353,7 +365,7 @@ const ActivityRow = ({ activity }: { activity: DatabaseActivity }) => {
                 <span>{activity.application_name}</span>
               </>
             )}
-          </p>
+          </div>
         </TableCell>
 
         <TableCell>


### PR DESCRIPTION
## Context

Very tiny one - just supports clicking to copy PID from the Activity Row in Database Connections
Will be useful for diving into details of the query with the Assistant if needed
<img width="323" height="120" alt="image" src="https://github.com/user-attachments/assets/b80a69eb-d1e8-49d3-93e3-08c111b3ea6e" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to click an activity process ID to copy it to the clipboard.
  * Added confirmation feedback after copying the process ID.

* **UI Improvements**
  * Improved query tooltip behavior by providing a slightly longer hover delay.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->