### PR TITLE
Joshen/fe 3972 add filter for application name

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -127,7 +127,8 @@ export const Activity = ({ live }: ActivityProps) => {
     quantity: data?.filter(
       (y) =>
         y.state === x.toLowerCase() &&
-        (rolesFilter.length === 0 || rolesFilter.includes(y.role_name))
+        (rolesFilter.length === 0 || rolesFilter.includes(y.role_name)) &&
+        (applicationsFilter.length === 0 || applicationsFilter.includes(y.application_name))
     ).length,
   }))
 
@@ -158,7 +159,8 @@ export const Activity = ({ live }: ActivityProps) => {
           y.role_name === x.name &&
           (!statesFilter ||
             statesFilter.length === 0 ||
-            (y.state !== null && statesFilter.includes(y.state)))
+            (y.state !== null && statesFilter.includes(y.state))) &&
+          (applicationsFilter.length === 0 || applicationsFilter.includes(y.application_name))
       ).length,
     }))
     .sort((a, b) => {
@@ -223,6 +225,7 @@ export const Activity = ({ live }: ActivityProps) => {
               onClick={() =>
                 setQueryStates({ states: [], roles: DEFAULT_ROLES_FILTER, applications: [] })
               }
+              aria-label="Reset filters"
               tooltip={{ content: { side: 'bottom', text: 'Reset filters' } }}
             />
           )}

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -107,7 +107,9 @@ export const Activity = ({ live }: ActivityProps) => {
       statesFilter.length === 0 ||
       (activity.state !== null && statesFilter.includes(activity.state))
     const matchesRole = rolesFilter.length === 0 || rolesFilter.includes(activity.role_name)
-    return matchesState && matchesRole
+    const matchesApplication =
+      applicationsFilter.length === 0 || applicationsFilter.includes(activity.application_name)
+    return matchesState && matchesRole && matchesApplication
   })
 
   const stateOptions = [
@@ -216,7 +218,9 @@ export const Activity = ({ live }: ActivityProps) => {
               variant="text"
               className="px-1"
               icon={<X />}
-              onClick={() => setQueryStates({ states: [], roles: DEFAULT_ROLES_FILTER })}
+              onClick={() =>
+                setQueryStates({ states: [], roles: DEFAULT_ROLES_FILTER, applications: [] })
+              }
               tooltip={{ content: { side: 'bottom', text: 'Reset filters' } }}
             />
           )}
@@ -274,7 +278,11 @@ export const Activity = ({ live }: ActivityProps) => {
                       variant="default"
                       className="mt-2"
                       onClick={() => {
-                        setQueryStates({ states: [], roles: DEFAULT_ROLES_FILTER })
+                        setQueryStates({
+                          states: [],
+                          roles: DEFAULT_ROLES_FILTER,
+                          applications: [],
+                        })
                       }}
                     >
                       Reset filters

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -86,7 +86,9 @@ export const Activity = ({ live }: ActivityProps) => {
   })
 
   const hasNoFiltersApplied =
-    statesFilter.length === 0 && isEqual(rolesFilter, DEFAULT_ROLES_FILTER)
+    statesFilter.length === 0 &&
+    applicationsFilter.length === 0 &&
+    isEqual(rolesFilter, DEFAULT_ROLES_FILTER)
 
   const { data, isPending, isSuccess } = useDatabaseActivityQuery(
     {

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs'
 import { isEqual } from 'lodash'
-import { Minus, MoreVertical, StopCircle } from 'lucide-react'
-import { parseAsArrayOf, parseAsInteger, parseAsJson, parseAsString, useQueryState } from 'nuqs'
+import { Minus, MoreVertical, StopCircle, X } from 'lucide-react'
+import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryState, useQueryStates } from 'nuqs'
 import { Fragment, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -36,8 +36,9 @@ import {
 import { CodeBlock } from 'ui-patterns/CodeBlock'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
-import { ReportsSelectFilter, selectFilterSchema } from '../../Reports/v2/ReportsSelectFilter'
+import { ReportsSelectFilter } from '../../Reports/v2/ReportsSelectFilter'
 import { formatDuration } from '@/components/interfaces/QueryPerformance/QueryPerformance.utils'
+import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { DropdownMenuItemTooltip } from '@/components/ui/DropdownMenuItemTooltip'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { useDatabaseRolesQuery } from '@/data/database-roles/database-roles-query'
@@ -74,16 +75,18 @@ export const Activity = ({ live }: ActivityProps) => {
 
   const [, setNow] = useState(() => dayjs())
   const [selectedPid] = useQueryState('pid', parseAsInteger)
-  const [stateFilter, setStateFilter] = useQueryState(
-    'state',
-    parseAsJson(selectFilterSchema.parse).withDefault([])
-  )
-  const [rolesFilter, setRolesFilter] = useQueryState(
-    'roles',
-    parseAsArrayOf(parseAsString, ',').withDefault(DEFAULT_ROLES_FILTER)
-  )
 
-  const hasNoFiltersApplied = stateFilter.length === 0 && isEqual(rolesFilter, DEFAULT_ROLES_FILTER)
+  const [
+    { states: statesFilter, applications: applicationsFilter, roles: rolesFilter },
+    setQueryStates,
+  ] = useQueryStates({
+    states: parseAsArrayOf(parseAsString, ',').withDefault([]),
+    applications: parseAsArrayOf(parseAsString, ',').withDefault([]),
+    roles: parseAsArrayOf(parseAsString, ',').withDefault(DEFAULT_ROLES_FILTER),
+  })
+
+  const hasNoFiltersApplied =
+    statesFilter.length === 0 && isEqual(rolesFilter, DEFAULT_ROLES_FILTER)
 
   const { data, isPending, isSuccess } = useDatabaseActivityQuery(
     {
@@ -100,9 +103,9 @@ export const Activity = ({ live }: ActivityProps) => {
 
   const activities = data?.filter((activity) => {
     const matchesState =
-      !stateFilter ||
-      stateFilter.length === 0 ||
-      (activity.state !== null && stateFilter.includes(activity.state))
+      !statesFilter ||
+      statesFilter.length === 0 ||
+      (activity.state !== null && statesFilter.includes(activity.state))
     const matchesRole = rolesFilter.length === 0 || rolesFilter.includes(activity.role_name)
     return matchesState && matchesRole
   })
@@ -124,6 +127,22 @@ export const Activity = ({ live }: ActivityProps) => {
     ).length,
   }))
 
+  const applicationOptions = Array.from(new Set(data?.map((x) => x.application_name) ?? []))
+    .sort()
+    .map((x) => ({
+      label: x,
+      value: x,
+      quantity: data?.filter(
+        (y) =>
+          y.application_name === x &&
+          (rolesFilter.length === 0 || rolesFilter.includes(y.role_name)) &&
+          (!statesFilter ||
+            statesFilter.length === 0 ||
+            (y.state !== null && statesFilter.includes(y.state)))
+      ).length,
+    }))
+    .filter((x) => !!x.value)
+
   const priorityRoles = ['anon', 'authenticated', 'postgres']
 
   const roleOptions = (roles ?? [])
@@ -133,9 +152,9 @@ export const Activity = ({ live }: ActivityProps) => {
       quantity: data?.filter(
         (y) =>
           y.role_name === x.name &&
-          (!stateFilter ||
-            stateFilter.length === 0 ||
-            (y.state !== null && stateFilter.includes(y.state)))
+          (!statesFilter ||
+            statesFilter.length === 0 ||
+            (y.state !== null && statesFilter.includes(y.state)))
       ).length,
     }))
     .sort((a, b) => {
@@ -167,22 +186,40 @@ export const Activity = ({ live }: ActivityProps) => {
         <h2>Sessions</h2>
         <div className="flex gap-x-2">
           <ReportsSelectFilter
+            label="State"
+            options={stateOptions}
+            value={statesFilter ?? []}
+            onChange={(states) => setQueryStates({ states })}
+            isLoading={isPending}
+            popoverClassName="w-60"
+          />
+          <ReportsSelectFilter
             showSearch
             label="Roles"
             options={roleOptions}
             value={rolesFilter ?? []}
-            onChange={setRolesFilter}
+            onChange={(roles) => setQueryStates({ roles })}
             isLoading={isPending}
             popoverClassName="w-72"
           />
           <ReportsSelectFilter
-            label="State"
-            options={stateOptions}
-            value={stateFilter ?? []}
-            onChange={setStateFilter}
+            showSearch
+            label="Application"
+            options={applicationOptions}
+            value={applicationsFilter ?? []}
+            onChange={(applications) => setQueryStates({ applications })}
             isLoading={isPending}
             popoverClassName="w-60"
           />
+          {!hasNoFiltersApplied && (
+            <ButtonTooltip
+              variant="text"
+              className="px-1"
+              icon={<X />}
+              onClick={() => setQueryStates({ states: [], roles: DEFAULT_ROLES_FILTER })}
+              tooltip={{ content: { side: 'bottom', text: 'Reset filters' } }}
+            />
+          )}
         </div>
       </div>
 
@@ -237,8 +274,7 @@ export const Activity = ({ live }: ActivityProps) => {
                       variant="default"
                       className="mt-2"
                       onClick={() => {
-                        setStateFilter([])
-                        setRolesFilter(DEFAULT_ROLES_FILTER)
+                        setQueryStates({ states: [], roles: DEFAULT_ROLES_FILTER })
                       }}
                     >
                       Reset filters


### PR DESCRIPTION
## Context

Adds supporting for filtering by application name for Database Connections
<img width="592" height="325" alt="image" src="https://github.com/user-attachments/assets/e09b8d61-4215-4da4-b2aa-980cdc475738" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Application** filter to database activity views.
  * Expanded activity filtering to include session **state** and **roles**, matching by the activity’s application name.
  * Updated filter option counts to reflect the currently selected criteria.

* **Bug Fixes**
  * Improved filter reset behavior to reliably clear application/state selections and restore role defaults.
  * Enhanced persistence of filter selections using URL query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->