### PR TITLE
fix: read FGA permissions from openapi spec x-fga-permissions extension

### DIFF
--- a/apps/docs/features/docs/Reference.api.utils.ts
+++ b/apps/docs/features/docs/Reference.api.utils.ts
@@ -26,6 +26,7 @@ export interface IApiEndPoint {
   security?: Array<ISecurityOption>
   'x-oauth-scope'?: string
   'x-allowed-plans'?: string[]
+  'x-fga-permissions'?: string[][]
 }
 
 export type ISchema =

--- a/apps/docs/features/docs/Reference.sections.tsx
+++ b/apps/docs/features/docs/Reference.sections.tsx
@@ -275,10 +275,7 @@ async function ApiEndpointSection({ link, section, servicePath }: ApiEndpointSec
     : await getApiEndpointById(section.id)
   if (!endpointDetails) return null
 
-  const endpointFgaPermissionGroups =
-    endpointDetails.security
-      ?.filter((sec) => 'fga_permissions' in sec)
-      .map((sec) => sec.fga_permissions) ?? []
+  const endpointFgaPermissionGroups = endpointDetails['x-fga-permissions'] ?? []
   const pathParameters = (endpointDetails.parameters ?? []).filter((param) => param.in === 'path')
   const queryParameters = (endpointDetails.parameters ?? []).filter((param) => param.in === 'query')
   const bodyParameters =


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Follow up to https://github.com/supabase/platform/pull/35940, which moved FGA permissions off security and onto the `x-fga-permissions` extension. 

This updates the docs reference component to read from the new field.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API documentation now supports displaying fine-grained access permissions for endpoints.
  * Endpoint security details are presented more consistently using the documented permissions configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->