### PR TITLE
Stop re-rendering UI if live mode is off

### DIFF
--- a/apps/studio/pages/project/[ref]/observability/connections.tsx
+++ b/apps/studio/pages/project/[ref]/observability/connections.tsx
@@ -25,7 +25,11 @@ export const DatabaseConnections: NextPageWithLayout = () => {
   const [live, setLive] = useState(true)
   const [now, setNow] = useState(() => dayjs.utc())
 
-  const { data, isPending: isLoadingActivity } = useDatabaseActivityQuery(
+  const {
+    data,
+    isPending: isLoadingActivity,
+    refetch: refetchActivity,
+  } = useDatabaseActivityQuery(
     {
       projectRef: project?.ref,
       connectionString: project?.connectionString,
@@ -51,9 +55,10 @@ export const DatabaseConnections: NextPageWithLayout = () => {
 
   // [Joshen] Just to trigger a UI re-render for the duration to be "live"
   useEffect(() => {
+    if (!live) return
     const interval = setInterval(() => setNow(dayjs.utc()), 1000)
     return () => clearInterval(interval)
-  }, [])
+  }, [live])
 
   return (
     <ReportPadding className="gap-y-12">
@@ -77,7 +82,11 @@ export const DatabaseConnections: NextPageWithLayout = () => {
         <div className="flex items-center gap-x-2">
           <Button
             variant={live ? 'default' : 'primary'}
-            onClick={() => setLive((prev) => !prev)}
+            onClick={() => {
+              const nextLive = !live
+              setLive(nextLive)
+              if (nextLive) refetchActivity()
+            }}
             icon={live ? <Pause /> : <Play />}
           >
             {live ? 'Pause' : 'Live'}

--- a/apps/studio/pages/project/[ref]/observability/connections.tsx
+++ b/apps/studio/pages/project/[ref]/observability/connections.tsx
@@ -85,7 +85,10 @@ export const DatabaseConnections: NextPageWithLayout = () => {
             onClick={() => {
               const nextLive = !live
               setLive(nextLive)
-              if (nextLive) refetchActivity()
+              if (nextLive) {
+                setNow(dayjs.utc())
+                refetchActivity()
+              }
             }}
             icon={live ? <Pause /> : <Play />}
           >


### PR DESCRIPTION
## Context

For the Database Connections page, we run a `useEffect` every second to re-render the UI so that the timestamps of each process' duration reflects real time. However, duration should stop counting if live mode is paused as otherwise it becomes inaccurate then.

Also forces an immediate refetch of the database activities when live mode is re-enabled

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved live activity updates on the Database Connections page.
  * Pausing live mode now stops activity timestamp updates and refreshes.
  * Resuming live mode immediately reloads the latest activity and updates the UI to reflect live state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->