### PR TITLE
[FE-3790] fix(studio): hide Multigres from user-facing surfaces

### DIFF
--- a/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useMemo } from 'react'
 import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
@@ -32,6 +33,10 @@ import { DocsButton } from '@/components/ui/DocsButton'
 import { useDatabaseExtensionEnableMutation } from '@/data/database-extensions/database-extension-enable-mutation'
 import { type DatabaseExtension } from '@/data/database-extensions/database-extensions-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useIsOrioleDb, useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from '@/hooks/useProtectedSchemas'
 import { DOCS_URL } from '@/lib/constants'
@@ -72,10 +77,15 @@ export const EnableExtensionModal = ({
     },
     { enabled: visible }
   )
-  const availableSchemas = schemas.filter(
-    (schema) =>
-      schema.name === recommendedSchema ||
-      !protectedSchemas.some((protectedSchema) => protectedSchema.name === schema.name)
+  const { isHighAvailability } = useHighAvailability()
+  const availableSchemas = useMemo(
+    () =>
+      filterSchemasForHighAvailability(schemas, isHighAvailability).filter(
+        (schema) =>
+          schema.name === recommendedSchema ||
+          !protectedSchemas.some((protectedSchema) => protectedSchema.name === schema.name)
+      ),
+    [schemas, isHighAvailability, recommendedSchema, protectedSchemas]
   )
 
   // [Joshen] Hard-coding pg_cron here as this is enforced on our end (Not via pg_available_extension_versions)

--- a/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
+++ b/apps/studio/components/interfaces/Database/Extensions/EnableExtensionModal.tsx
@@ -33,10 +33,7 @@ import { DocsButton } from '@/components/ui/DocsButton'
 import { useDatabaseExtensionEnableMutation } from '@/data/database-extensions/database-extension-enable-mutation'
 import { type DatabaseExtension } from '@/data/database-extensions/database-extensions-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
-import {
-  filterSchemasForHighAvailability,
-  useHighAvailability,
-} from '@/hooks/misc/useHighAvailability'
+import { useSchemasFilteredForHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useIsOrioleDb, useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from '@/hooks/useProtectedSchemas'
 import { DOCS_URL } from '@/lib/constants'
@@ -77,15 +74,15 @@ export const EnableExtensionModal = ({
     },
     { enabled: visible }
   )
-  const { isHighAvailability } = useHighAvailability()
+  const visibleSchemas = useSchemasFilteredForHighAvailability(schemas)
   const availableSchemas = useMemo(
     () =>
-      filterSchemasForHighAvailability(schemas, isHighAvailability).filter(
+      visibleSchemas.filter(
         (schema) =>
           schema.name === recommendedSchema ||
           !protectedSchemas.some((protectedSchema) => protectedSchema.name === schema.name)
       ),
-    [schemas, isHighAvailability, recommendedSchema, protectedSchemas]
+    [visibleSchemas, recommendedSchema, protectedSchemas]
   )
 
   // [Joshen] Hard-coding pg_cron here as this is enforced on our end (Not via pg_available_extension_versions)

--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -52,6 +52,10 @@ import { useDatabaseIndexCreateMutation } from '@/data/database-indexes/index-cr
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useTableColumnsQuery } from '@/data/database/table-columns-query'
 import { useEntityTypesQuery } from '@/data/entity-types/entity-types-infinite-query'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useIsOrioleDb, useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 
@@ -98,10 +102,15 @@ export const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelP
   const [schemaSearchTerm, setSchemaSearchTerm] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
 
-  const { data: schemas } = useSchemasQuery({
+  const { isHighAvailability } = useHighAvailability()
+  const { data: allSchemas } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+  const schemas = useMemo(
+    () => filterSchemasForHighAvailability(allSchemas ?? [], isHighAvailability),
+    [allSchemas, isHighAvailability]
+  )
   const { data: entities, isPending: isLoadingEntities } = useEntityTypesQuery({
     schemas: [selectedSchema],
     sort: 'alphabetical',

--- a/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
+++ b/apps/studio/components/interfaces/Database/Indexes/CreateIndexSidePanel.tsx
@@ -52,10 +52,7 @@ import { useDatabaseIndexCreateMutation } from '@/data/database-indexes/index-cr
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useTableColumnsQuery } from '@/data/database/table-columns-query'
 import { useEntityTypesQuery } from '@/data/entity-types/entity-types-infinite-query'
-import {
-  filterSchemasForHighAvailability,
-  useHighAvailability,
-} from '@/hooks/misc/useHighAvailability'
+import { useSchemasFilteredForHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useIsOrioleDb, useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 
@@ -102,15 +99,11 @@ export const CreateIndexSidePanel = ({ visible, onClose }: CreateIndexSidePanelP
   const [schemaSearchTerm, setSchemaSearchTerm] = useState('')
   const [searchTerm, setSearchTerm] = useState('')
 
-  const { isHighAvailability } = useHighAvailability()
   const { data: allSchemas } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const schemas = useMemo(
-    () => filterSchemasForHighAvailability(allSchemas ?? [], isHighAvailability),
-    [allSchemas, isHighAvailability]
-  )
+  const schemas = useSchemasFilteredForHighAvailability(allSchemas)
   const { data: entities, isPending: isLoadingEntities } = useEntityTypesQuery({
     schemas: [selectedSchema],
     sort: 'alphabetical',

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
@@ -1,4 +1,4 @@
-import { type Dispatch, type SetStateAction } from 'react'
+import { useMemo, type Dispatch, type SetStateAction } from 'react'
 import {
   Accordion,
   AccordionContent,
@@ -21,6 +21,10 @@ import { type ExtensionsSchema, type InstallIntegrationSheetProps } from './Inst
 import { extensionsWithRecommendedSchemas } from '@/components/interfaces/Database/Extensions/Extensions.constants'
 import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from '@/hooks/useProtectedSchemas'
 
@@ -48,8 +52,14 @@ export const AdvancedSettings = ({
     { projectRef: project?.ref, connectionString: project?.connectionString },
     { enabled: involvesExtensions }
   )
-  const availableSchemas = schemas.filter(
-    (schema) => !protectedSchemas.some((protectedSchema) => protectedSchema.name === schema.name)
+  const { isHighAvailability } = useHighAvailability()
+  const availableSchemas = useMemo(
+    () =>
+      filterSchemasForHighAvailability(schemas, isHighAvailability).filter(
+        (schema) =>
+          !protectedSchemas.some((protectedSchema) => protectedSchema.name === schema.name)
+      ),
+    [schemas, isHighAvailability, protectedSchemas]
   )
 
   return (

--- a/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
+++ b/apps/studio/components/interfaces/Integrations/Integration/IntegrationOverviewTabV2/InstallIntegrationSheet/AdvancedSettings.tsx
@@ -21,10 +21,7 @@ import { type ExtensionsSchema, type InstallIntegrationSheetProps } from './Inst
 import { extensionsWithRecommendedSchemas } from '@/components/interfaces/Database/Extensions/Extensions.constants'
 import { useDatabaseExtensionsQuery } from '@/data/database-extensions/database-extensions-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
-import {
-  filterSchemasForHighAvailability,
-  useHighAvailability,
-} from '@/hooks/misc/useHighAvailability'
+import { useSchemasFilteredForHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useProtectedSchemas } from '@/hooks/useProtectedSchemas'
 
@@ -52,14 +49,14 @@ export const AdvancedSettings = ({
     { projectRef: project?.ref, connectionString: project?.connectionString },
     { enabled: involvesExtensions }
   )
-  const { isHighAvailability } = useHighAvailability()
+  const visibleSchemas = useSchemasFilteredForHighAvailability(schemas)
   const availableSchemas = useMemo(
     () =>
-      filterSchemasForHighAvailability(schemas, isHighAvailability).filter(
+      visibleSchemas.filter(
         (schema) =>
           !protectedSchemas.some((protectedSchema) => protectedSchema.name === schema.name)
       ),
-    [schemas, isHighAvailability, protectedSchemas]
+    [visibleSchemas, protectedSchemas]
   )
 
   return (

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
@@ -51,6 +51,10 @@ import type { AvailableColumn, Table, TableOption } from './Wrappers.types'
 import { getTableFormSchema } from './Wrappers.utils'
 import { ActionBar } from '@/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar'
 import { useSchemasQuery } from '@/data/database/schemas-query'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 export type WrapperTableEditorProps = {
@@ -239,10 +243,15 @@ const TableForm = ({
   initialData: any
 }) => {
   const { data: project } = useSelectedProjectQuery()
-  const { data: schemas, isPending: isLoading } = useSchemasQuery({
+  const { isHighAvailability } = useHighAvailability()
+  const { data: allSchemas, isPending: isLoading } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+  const schemas = useMemo(
+    () => filterSchemasForHighAvailability(allSchemas ?? [], isHighAvailability),
+    [allSchemas, isHighAvailability]
+  )
 
   const requiredOptions: TableOption[] = []
   const optionalOptions: TableOption[] = []

--- a/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
+++ b/apps/studio/components/interfaces/Integrations/Wrappers/WrapperTableEditor.tsx
@@ -51,10 +51,7 @@ import type { AvailableColumn, Table, TableOption } from './Wrappers.types'
 import { getTableFormSchema } from './Wrappers.utils'
 import { ActionBar } from '@/components/interfaces/TableGridEditor/SidePanelEditor/ActionBar'
 import { useSchemasQuery } from '@/data/database/schemas-query'
-import {
-  filterSchemasForHighAvailability,
-  useHighAvailability,
-} from '@/hooks/misc/useHighAvailability'
+import { useSchemasFilteredForHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 export type WrapperTableEditorProps = {
@@ -243,15 +240,11 @@ const TableForm = ({
   initialData: any
 }) => {
   const { data: project } = useSelectedProjectQuery()
-  const { isHighAvailability } = useHighAvailability()
   const { data: allSchemas, isPending: isLoading } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const schemas = useMemo(
-    () => filterSchemasForHighAvailability(allSchemas ?? [], isHighAvailability),
-    [allSchemas, isHighAvailability]
-  )
+  const schemas = useSchemasFilteredForHighAvailability(allSchemas)
 
   const requiredOptions: TableOption[] = []
   const optionalOptions: TableOption[] = []

--- a/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
@@ -1,4 +1,3 @@
-import Link from 'next/link'
 import { UseFormReturn } from 'react-hook-form'
 import { FormControl, FormField, Switch } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
@@ -22,16 +21,7 @@ export const HighAvailabilityInput = ({ form }: HighAvailabilityInputProps) => {
       render={({ field }) => (
         <FormItemLayout
           label="High Availability"
-          description={
-            <>
-              Powered by{' '}
-              <Link href="https://multigres.com/" target="_blank" className="text-link">
-                Multigres
-              </Link>
-              : horizontally scalable Postgres for multi-tenant, highly available, globally
-              distributed deployments while staying true to standard Postgres.
-            </>
-          }
+          description="Horizontally scalable Postgres for highly available, globally distributed deployments while staying true to standard Postgres."
           layout="horizontal"
         >
           <FormControl>

--- a/apps/studio/components/interfaces/ProjectHome/HighAvailabilityBadge.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/HighAvailabilityBadge.tsx
@@ -33,9 +33,8 @@ export function HighAvailabilityBadge({ size = 'default' }: HighAvailabilityBadg
         <Separator />
         <div className="flex flex-col gap-1 p-3 px-5">
           <p className="text-sm text-foreground-light">
-            Driven by <span className="text-foreground">Multigres</span>, a horizontally scalable
-            Postgres architecture that supports highly-available and globally distributed
-            deployments.
+            A horizontally scalable Postgres architecture that supports highly-available and
+            globally distributed deployments.
           </p>
           <Link
             href={`${DOCS_URL}/guides/deployment/high-availability`}

--- a/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
@@ -1,7 +1,7 @@
 import { Monaco } from '@monaco-editor/react'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import type { IDisposable } from 'monaco-editor'
-import { useEffect, useRef } from 'react'
+import { useEffect, useMemo, useRef } from 'react'
 
 import getPgsqlCompletionProvider from '@/components/ui/CodeEditor/Providers/PgSQLCompletionProvider'
 import getPgsqlSignatureHelpProvider from '@/components/ui/CodeEditor/Providers/PgSQLSignatureHelpProvider'
@@ -9,6 +9,10 @@ import { useDatabaseFunctionsQuery } from '@/data/database-functions/database-fu
 import { useKeywordsQuery } from '@/data/database/keywords-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useTableColumnsQuery } from '@/data/database/table-columns-query'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { formatSql } from '@/lib/formatSql'
@@ -16,6 +20,7 @@ import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor/sql-editor-state
 
 export const useAddDefinitions = (id: string, monaco: Monaco | null) => {
   const { data: project } = useSelectedProjectQuery()
+  const { isHighAvailability } = useHighAvailability()
   const snapV2 = useSqlEditorV2StateSnapshot()
 
   const [intellisenseEnabled] = useLocalStorageQuery(
@@ -54,6 +59,11 @@ export const useAddDefinitions = (id: string, monaco: Monaco | null) => {
 
   const pgInfoRef = useRef<any>(null)
 
+  const filteredSchemas = useMemo(
+    () => filterSchemasForHighAvailability(schemas ?? [], isHighAvailability),
+    [schemas, isHighAvailability]
+  )
+
   const isPgInfoReady =
     intellisenseEnabled &&
     isTableColumnsSuccess &&
@@ -66,7 +76,7 @@ export const useAddDefinitions = (id: string, monaco: Monaco | null) => {
       pgInfoRef.current = {}
     }
     pgInfoRef.current.tableColumns = tableColumns
-    pgInfoRef.current.schemas = schemas
+    pgInfoRef.current.schemas = filteredSchemas
     pgInfoRef.current.keywords = keywords
     pgInfoRef.current.functions = functions
   }

--- a/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
+++ b/apps/studio/components/interfaces/SQLEditor/useAddDefinitions.ts
@@ -1,7 +1,7 @@
 import { Monaco } from '@monaco-editor/react'
 import { LOCAL_STORAGE_KEYS } from 'common'
 import type { IDisposable } from 'monaco-editor'
-import { useEffect, useMemo, useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 import getPgsqlCompletionProvider from '@/components/ui/CodeEditor/Providers/PgSQLCompletionProvider'
 import getPgsqlSignatureHelpProvider from '@/components/ui/CodeEditor/Providers/PgSQLSignatureHelpProvider'
@@ -9,10 +9,7 @@ import { useDatabaseFunctionsQuery } from '@/data/database-functions/database-fu
 import { useKeywordsQuery } from '@/data/database/keywords-query'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useTableColumnsQuery } from '@/data/database/table-columns-query'
-import {
-  filterSchemasForHighAvailability,
-  useHighAvailability,
-} from '@/hooks/misc/useHighAvailability'
+import { useSchemasFilteredForHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { formatSql } from '@/lib/formatSql'
@@ -20,7 +17,6 @@ import { useSqlEditorV2StateSnapshot } from '@/state/sql-editor/sql-editor-state
 
 export const useAddDefinitions = (id: string, monaco: Monaco | null) => {
   const { data: project } = useSelectedProjectQuery()
-  const { isHighAvailability } = useHighAvailability()
   const snapV2 = useSqlEditorV2StateSnapshot()
 
   const [intellisenseEnabled] = useLocalStorageQuery(
@@ -59,10 +55,7 @@ export const useAddDefinitions = (id: string, monaco: Monaco | null) => {
 
   const pgInfoRef = useRef<any>(null)
 
-  const filteredSchemas = useMemo(
-    () => filterSchemasForHighAvailability(schemas ?? [], isHighAvailability),
-    [schemas, isHighAvailability]
-  )
+  const filteredSchemas = useSchemasFilteredForHighAvailability(schemas)
 
   const isPgInfoReady =
     intellisenseEnabled &&

--- a/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
@@ -18,6 +18,10 @@ import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { getExposedSchemaCounts } from './ExposedSchemaSelector.utils'
 import { useSchemasQuery } from '@/data/database/schemas-query'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
 import { pluralize } from '@/lib/helpers'
@@ -48,6 +52,7 @@ export const ExposedSchemaSelector = ({
   const [open, setOpen] = useState(false)
 
   const { data: project } = useSelectedProjectQuery()
+  const { isHighAvailability } = useHighAvailability()
 
   const {
     data: allSchemas,
@@ -61,10 +66,10 @@ export const ExposedSchemaSelector = ({
 
   const schemas = useMemo(
     () =>
-      (allSchemas ?? [])
+      filterSchemasForHighAvailability(allSchemas ?? [], isHighAvailability)
         .filter((s) => !internalSchemasCannotExpose.has(s.name))
         .sort((a, b) => a.name.localeCompare(b.name)),
-    [allSchemas]
+    [allSchemas, isHighAvailability]
   )
 
   const missingExposedSchema = useMemo(

--- a/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
@@ -20,6 +20,7 @@ import { getExposedSchemaCounts } from './ExposedSchemaSelector.utils'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import {
   filterSchemasForHighAvailability,
+  MULTIGRES_SCHEMA_NAME,
   useHighAvailability,
 } from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -72,15 +73,25 @@ export const ExposedSchemaSelector = ({
     [allSchemas, isHighAvailability]
   )
 
-  const missingExposedSchema = useMemo(
-    () => selectedSchemas.filter((schema) => !schemas.some((s) => s.name === schema)),
-    [schemas, selectedSchemas]
+  // Persisted selections go through the same HA filtering as the schema list, so a
+  // multigres schema exposed in the config doesn't render as a "missing" schema row.
+  const visibleSelectedSchemas = useMemo(
+    () =>
+      isHighAvailability
+        ? selectedSchemas.filter((schema) => schema !== MULTIGRES_SCHEMA_NAME)
+        : selectedSchemas,
+    [selectedSchemas, isHighAvailability]
   )
 
-  const selectedSet = useMemo(() => new Set(selectedSchemas), [selectedSchemas])
+  const missingExposedSchema = useMemo(
+    () => visibleSelectedSchemas.filter((schema) => !schemas.some((s) => s.name === schema)),
+    [schemas, visibleSelectedSchemas]
+  )
+
+  const selectedSet = useMemo(() => new Set(visibleSelectedSchemas), [visibleSelectedSchemas])
   const { selectedCount, totalCount } = getExposedSchemaCounts({
     visibleSchemas: schemas.map((s) => s.name),
-    selectedSchemas,
+    selectedSchemas: visibleSelectedSchemas,
     protectedSchemas: internalSchemasCannotExpose,
   })
 

--- a/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
+++ b/apps/studio/components/interfaces/Settings/API/ExposedSchemaSelector.tsx
@@ -19,9 +19,9 @@ import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 import { getExposedSchemaCounts } from './ExposedSchemaSelector.utils'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import {
-  filterSchemasForHighAvailability,
   MULTIGRES_SCHEMA_NAME,
   useHighAvailability,
+  useSchemasFilteredForHighAvailability,
 } from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { INTERNAL_SCHEMAS } from '@/hooks/useProtectedSchemas'
@@ -65,12 +65,13 @@ export const ExposedSchemaSelector = ({
     connectionString: project?.connectionString,
   })
 
+  const visibleSchemas = useSchemasFilteredForHighAvailability(allSchemas)
   const schemas = useMemo(
     () =>
-      filterSchemasForHighAvailability(allSchemas ?? [], isHighAvailability)
+      visibleSchemas
         .filter((s) => !internalSchemasCannotExpose.has(s.name))
         .sort((a, b) => a.name.localeCompare(b.name)),
-    [allSchemas, isHighAvailability]
+    [visibleSchemas]
   )
 
   // Persisted selections go through the same HA filtering as the schema list, so a

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -2,7 +2,7 @@ import { FOREIGN_KEY_CASCADE_ACTION } from '@supabase/pg-meta'
 import type { PGTable } from '@supabase/pg-meta'
 import { sortBy } from 'lodash'
 import { ArrowRight, HelpCircle, Loader2, X } from 'lucide-react'
-import { Fragment, useEffect, useState } from 'react'
+import { Fragment, useEffect, useMemo, useState } from 'react'
 import {
   Alert,
   AlertDescription,
@@ -34,6 +34,10 @@ import InformationBox from '@/components/ui/InformationBox'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useTableQuery } from '@/data/tables/table-retrieve-query'
 import { useTablesQuery } from '@/data/tables/tables-query'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useQuerySchemaState } from '@/hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
@@ -85,11 +89,18 @@ export const ForeignKeySelector = ({
   const hasTypeErrors = (errors.types ?? []).length > 0
   const hasTypeNotices = (errors.typeNotice ?? []).length > 0
 
+  const { isHighAvailability } = useHighAvailability()
   const { data: schemas = [] } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
-  const sortedSchemas = [...schemas].sort((a, b) => a.name.localeCompare(b.name))
+  const sortedSchemas = useMemo(
+    () =>
+      [...filterSchemasForHighAvailability(schemas, isHighAvailability)].sort((a, b) =>
+        a.name.localeCompare(b.name)
+      ),
+    [schemas, isHighAvailability]
+  )
 
   const { data: tables } = useTablesQuery({
     projectRef: project?.ref,

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/ForeignKeySelector/ForeignKeySelector.tsx
@@ -34,10 +34,7 @@ import InformationBox from '@/components/ui/InformationBox'
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useTableQuery } from '@/data/tables/table-retrieve-query'
 import { useTablesQuery } from '@/data/tables/tables-query'
-import {
-  filterSchemasForHighAvailability,
-  useHighAvailability,
-} from '@/hooks/misc/useHighAvailability'
+import { useSchemasFilteredForHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useQuerySchemaState } from '@/hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useConfirmOnClose } from '@/hooks/ui/useConfirmOnClose'
@@ -89,17 +86,14 @@ export const ForeignKeySelector = ({
   const hasTypeErrors = (errors.types ?? []).length > 0
   const hasTypeNotices = (errors.typeNotice ?? []).length > 0
 
-  const { isHighAvailability } = useHighAvailability()
   const { data: schemas = [] } = useSchemasQuery({
     projectRef: project?.ref,
     connectionString: project?.connectionString,
   })
+  const visibleSchemas = useSchemasFilteredForHighAvailability(schemas)
   const sortedSchemas = useMemo(
-    () =>
-      [...filterSchemasForHighAvailability(schemas, isHighAvailability)].sort((a, b) =>
-        a.name.localeCompare(b.name)
-      ),
-    [schemas, isHighAvailability]
+    () => [...visibleSchemas].sort((a, b) => a.name.localeCompare(b.name)),
+    [visibleSchemas]
   )
 
   const { data: tables } = useTablesQuery({

--- a/apps/studio/components/ui/SchemaSelector.test.tsx
+++ b/apps/studio/components/ui/SchemaSelector.test.tsx
@@ -1,0 +1,69 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { HttpResponse } from 'msw'
+import { describe, expect, it, vi } from 'vitest'
+
+import { SchemaSelector } from './SchemaSelector'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+mockAnimationsApi()
+
+const mockProjectAndSchemas = ({ highAvailability }: { highAvailability: boolean }) => {
+  // useSelectedProjectQuery
+  addAPIMock({
+    method: 'get',
+    path: '/platform/projects/:ref',
+    // @ts-expect-error partial project response
+    response: {
+      cloud_provider: 'localhost',
+      id: 1,
+      inserted_at: '2021-08-02T06:40:40.646Z',
+      name: 'Default Project',
+      organization_id: 1,
+      ref: 'default',
+      region: 'local',
+      status: 'ACTIVE_HEALTHY',
+      high_availability: highAvailability,
+    },
+  })
+  // useSchemasQuery (schemas list SQL via pg-meta)
+  addAPIMock({
+    method: 'post',
+    path: '/platform/pg-meta/:ref/query',
+    response: () =>
+      HttpResponse.json([
+        { id: 1, name: 'public' },
+        { id: 2, name: 'multigres' },
+        { id: 3, name: 'other' },
+      ]),
+  })
+}
+
+const renderAndOpenSelector = async () => {
+  customRender(<SchemaSelector selectedSchemaName="public" onSelectSchema={vi.fn()} />)
+
+  await userEvent.click(await screen.findByTestId('schema-selector'))
+  // Wait for the list to be populated before asserting absence
+  await screen.findByRole('option', { name: 'public' })
+}
+
+describe('SchemaSelector', () => {
+  it('hides the multigres schema on high availability projects', async () => {
+    mockProjectAndSchemas({ highAvailability: true })
+
+    await renderAndOpenSelector()
+
+    expect(screen.getByRole('option', { name: 'other' })).toBeInTheDocument()
+    expect(screen.queryByRole('option', { name: 'multigres' })).not.toBeInTheDocument()
+  })
+
+  it('shows the multigres schema on non high availability projects', async () => {
+    mockProjectAndSchemas({ highAvailability: false })
+
+    await renderAndOpenSelector()
+
+    expect(screen.getByRole('option', { name: 'multigres' })).toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -1,6 +1,6 @@
 import { PermissionAction } from '@supabase/shared-types/out/constants'
 import { Check, ChevronsUpDown, Plus } from 'lucide-react'
-import { ComponentPropsWithoutRef, forwardRef, useState } from 'react'
+import { ComponentPropsWithoutRef, forwardRef, useMemo, useState } from 'react'
 import {
   Alert,
   AlertDescription,
@@ -22,6 +22,10 @@ import {
 
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import {
+  filterSchemasForHighAvailability,
+  useHighAvailability,
+} from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 type SchemaSelectorProps = Omit<ComponentPropsWithoutRef<'div'>, 'onSelect'> & {
@@ -40,6 +44,8 @@ type SchemaSelectorProps = Omit<ComponentPropsWithoutRef<'div'>, 'onSelect'> & {
   onOpenChange?: (open: boolean) => void
 }
 
+const DEFAULT_EXCLUDED_SCHEMAS: string[] = []
+
 export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
   (
     {
@@ -50,7 +56,7 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
       selectedSchemaName,
       placeholderLabel = 'Choose a schema...',
       supportSelectAll = false,
-      excludedSchemas = [],
+      excludedSchemas = DEFAULT_EXCLUDED_SCHEMAS,
       stopScrollPropagation = false,
       onSelectSchema,
       onSelectCreateSchema,
@@ -86,9 +92,15 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
       connectionString: project?.connectionString,
     })
 
-    const schemas = (data || [])
-      .filter((schema) => !excludedSchemas.includes(schema.name))
-      .sort((a, b) => a.name.localeCompare(b.name))
+    const { isHighAvailability } = useHighAvailability()
+
+    const schemas = useMemo(
+      () =>
+        filterSchemasForHighAvailability(data || [], isHighAvailability)
+          .filter((schema) => !excludedSchemas.includes(schema.name))
+          .sort((a, b) => a.name.localeCompare(b.name)),
+      [data, isHighAvailability, excludedSchemas]
+    )
 
     return (
       <div ref={ref} className={className} {...rest}>

--- a/apps/studio/components/ui/SchemaSelector.tsx
+++ b/apps/studio/components/ui/SchemaSelector.tsx
@@ -22,10 +22,7 @@ import {
 
 import { useSchemasQuery } from '@/data/database/schemas-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
-import {
-  filterSchemasForHighAvailability,
-  useHighAvailability,
-} from '@/hooks/misc/useHighAvailability'
+import { useSchemasFilteredForHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 type SchemaSelectorProps = Omit<ComponentPropsWithoutRef<'div'>, 'onSelect'> & {
@@ -92,14 +89,14 @@ export const SchemaSelector = forwardRef<HTMLDivElement, SchemaSelectorProps>(
       connectionString: project?.connectionString,
     })
 
-    const { isHighAvailability } = useHighAvailability()
+    const visibleSchemas = useSchemasFilteredForHighAvailability(data)
 
     const schemas = useMemo(
       () =>
-        filterSchemasForHighAvailability(data || [], isHighAvailability)
+        visibleSchemas
           .filter((schema) => !excludedSchemas.includes(schema.name))
           .sort((a, b) => a.name.localeCompare(b.name)),
-      [data, isHighAvailability, excludedSchemas]
+      [visibleSchemas, excludedSchemas]
     )
 
     return (

--- a/apps/studio/hooks/misc/__tests__/useHighAvailability.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useHighAvailability.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+
+import { filterSchemasForHighAvailability } from '../useHighAvailability'
+import { MULTIGRES_SCHEMA_NAME, resolveHighAvailability } from '../useHighAvailability.constants'
+
+describe('filterSchemasForHighAvailability', () => {
+  const schemas = [{ name: 'public' }, { name: MULTIGRES_SCHEMA_NAME }, { name: 'other' }]
+
+  it('removes the multigres schema on high availability projects', () => {
+    expect(filterSchemasForHighAvailability(schemas, true)).toEqual([
+      { name: 'public' },
+      { name: 'other' },
+    ])
+  })
+
+  it('keeps all schemas on non high availability projects', () => {
+    expect(filterSchemasForHighAvailability(schemas, false)).toEqual(schemas)
+  })
+})
+
+describe('resolveHighAvailability', () => {
+  it('returns the project flag when set', () => {
+    expect(resolveHighAvailability({ high_availability: true })).toBe(true)
+    expect(resolveHighAvailability({ high_availability: false })).toBe(false)
+  })
+
+  it('defaults to false when the project or flag is missing', () => {
+    expect(resolveHighAvailability(undefined)).toBe(false)
+    expect(resolveHighAvailability({ high_availability: null })).toBe(false)
+    expect(resolveHighAvailability({})).toBe(false)
+  })
+})

--- a/apps/studio/hooks/misc/useHighAvailability.ts
+++ b/apps/studio/hooks/misc/useHighAvailability.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { MULTIGRES_SCHEMA_NAME, resolveHighAvailability } from './useHighAvailability.constants'
 import { useSelectedProjectQuery } from './useSelectedProject'
 
@@ -22,4 +24,19 @@ export function filterSchemasForHighAvailability<T extends { name: string }>(
   if (!isHighAvailability) return schemas
 
   return schemas.filter((schema) => schema.name !== MULTIGRES_SCHEMA_NAME)
+}
+
+/**
+ * Memoized `filterSchemasForHighAvailability` bound to the selected project's
+ * high availability state.
+ */
+export function useSchemasFilteredForHighAvailability<T extends { name: string }>(
+  schemas: T[] | undefined
+): T[] {
+  const { isHighAvailability } = useHighAvailability()
+
+  return useMemo(
+    () => filterSchemasForHighAvailability(schemas ?? [], isHighAvailability),
+    [schemas, isHighAvailability]
+  )
 }


### PR DESCRIPTION
Hides the "Multigres" term from user-facing surfaces — it's the tech powering High Availability projects, but "High Availability" is the only term users should see for now (per Slack discussion with Saxon/Ivan).

**Changed:**
- High Availability badge hover card (project overview) no longer says "Driven by Multigres"
- Project creation HA toggle description drops the Multigres name + multigres.com link, keeps the informational copy
- All schema dropdowns now hide the `multigres` schema on HA projects, by wiring in the previously-unused `filterSchemasForHighAvailability` helper:
  - `SchemaSelector` (shared — Table Editor, Functions, Indexes, Triggers, Schema Visualizer, etc.)
  - `ExposedSchemaSelector` (API settings → exposed schemas)
  - `EnableExtensionModal`, `CreateIndexSidePanel`, `ForeignKeySelector`, `WrapperTableEditor`, Integrations install sheet `AdvancedSettings`
  - SQL editor schema autocomplete (`useAddDefinitions`)
- Schema list computations in the touched components are now memoized (incl. stabilizing `SchemaSelector`'s `excludedSchemas` default so the memo actually holds)

**Added:**
- Unit tests for `filterSchemasForHighAvailability` / `resolveHighAvailability`
- MSW component test for `SchemaSelector` asserting `multigres` is hidden on HA projects and still shown on non-HA projects

The filter is HA-gated on purpose: a self-hosted/non-HA user with their own schema named `multigres` still sees it. The flag-gated Multigres option in Logs is intentionally untouched — that exposure is kept for the Multigres team's debugging (separate track).

## To test

- On an HA project (`high_availability: true`): hover the High Availability badge on project overview — no "Multigres" mention; open schema dropdowns in Table Editor / Database pages / SQL editor autocomplete — no `multigres` schema
- Project creation with HA entitlement: toggle description has no Multigres wording/link
- On a non-HA project: schema dropdowns behave as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Made schema dropdowns and related selectors high-availability aware across extensions, indexes, integrations, SQL editing, API exposed schemas, and relationship editors.
  * Updated project high-availability UI text and badge hover description to remove outdated branding and clarify horizontally scalable Postgres architecture.
* **Tests**
  * Added coverage to ensure the schema “multigres” option is hidden/shown correctly based on high availability, and validated high-availability value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->