### PR TITLE
fix(studio): show column format in sort/filter type labels

### DIFF
--- a/apps/studio/components/grid/components/header/filter/FilterRow.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterRow.tsx
@@ -4,7 +4,9 @@ import { Button, Input } from 'ui'
 
 import { FilterOperatorOptions } from './Filter.constants'
 import { DropdownControl } from '@/components/grid/components/common/DropdownControl'
+import { getColumnFormat } from '@/components/grid/components/grid/ColumnHeader.utils'
 import type { Filter, FilterOperator } from '@/components/grid/types'
+import { getColumnType } from '@/components/grid/utils/gridColumns'
 import { useTableEditorTableStateSnapshot } from '@/state/table-editor-table'
 
 export interface FilterRowProps {
@@ -18,11 +20,15 @@ export interface FilterRowProps {
 const FilterRow = ({ filter, filterIdx, onChange, onDelete, onKeyDown }: FilterRowProps) => {
   const snap = useTableEditorTableStateSnapshot()
   const column = snap.table.columns.find((x) => x.name === filter.column)
-  // Prefer `format` over `dataType` so extension types (e.g. geography) show
-  // their real name instead of the coarse "USER-DEFINED" label.
+  // Prefer display labels that match column headers (format, with arrays as int4[]).
+  // Avoid raw dataType, which is "USER-DEFINED" for extension types like geography.
   const columnOptions =
     snap.table.columns?.map((x) => {
-      return { value: x.name, label: x.name, postLabel: x.format }
+      return {
+        value: x.name,
+        label: x.name,
+        postLabel: getColumnFormat(getColumnType(x), x.format),
+      }
     }) || []
 
   const placeholder =

--- a/apps/studio/components/grid/components/header/filter/FilterRow.tsx
+++ b/apps/studio/components/grid/components/header/filter/FilterRow.tsx
@@ -18,9 +18,11 @@ export interface FilterRowProps {
 const FilterRow = ({ filter, filterIdx, onChange, onDelete, onKeyDown }: FilterRowProps) => {
   const snap = useTableEditorTableStateSnapshot()
   const column = snap.table.columns.find((x) => x.name === filter.column)
+  // Prefer `format` over `dataType` so extension types (e.g. geography) show
+  // their real name instead of the coarse "USER-DEFINED" label.
   const columnOptions =
     snap.table.columns?.map((x) => {
-      return { value: x.name, label: x.name, postLabel: x.dataType }
+      return { value: x.name, label: x.name, postLabel: x.format }
     }) || []
 
   const placeholder =

--- a/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
@@ -105,13 +105,15 @@ export const SortPopoverPrimitive = ({
     })
   }, [snap?.table?.columns, localSorts])
 
-  // Format the columns for the dropdown
+  // Format the columns for the dropdown.
+  // Prefer `format` (e.g. geography, citext) over `dataType`, which is the
+  // coarse information_schema-style label "USER-DEFINED" for extension types.
   const dropdownOptions = useMemo(() => {
     return (
       columns?.map((x) => ({
         value: x.name,
         label: x.name,
-        postLabel: x.dataType,
+        postLabel: x.format,
         disabled: x.dataType === 'json' || x.dataType === 'jsonb',
         tooltip:
           x.dataType === 'json' || x.dataType === 'jsonb'

--- a/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
+++ b/apps/studio/components/grid/components/header/sort/SortPopoverPrimitive.tsx
@@ -23,8 +23,10 @@ import ConfirmationModal from 'ui-patterns/Dialogs/ConfirmationModal'
 
 import { DropdownControl } from '../../common/DropdownControl'
 import SortRow from './SortRow'
+import { getColumnFormat } from '@/components/grid/components/grid/ColumnHeader.utils'
 import { useTableFilter } from '@/components/grid/hooks/useTableFilter'
 import type { Sort } from '@/components/grid/types'
+import { getColumnType } from '@/components/grid/utils/gridColumns'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { useTableRowsCountQuery } from '@/data/table-rows/table-rows-count-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -105,15 +107,14 @@ export const SortPopoverPrimitive = ({
     })
   }, [snap?.table?.columns, localSorts])
 
-  // Format the columns for the dropdown.
-  // Prefer `format` (e.g. geography, citext) over `dataType`, which is the
-  // coarse information_schema-style label "USER-DEFINED" for extension types.
+  // Prefer display labels that match column headers (format, with arrays as int4[]).
+  // Avoid raw dataType, which is "USER-DEFINED" for extension types like geography.
   const dropdownOptions = useMemo(() => {
     return (
       columns?.map((x) => ({
         value: x.name,
         label: x.name,
-        postLabel: x.format,
+        postLabel: getColumnFormat(getColumnType(x), x.format),
         disabled: x.dataType === 'json' || x.dataType === 'jsonb',
         tooltip:
           x.dataType === 'json' || x.dataType === 'jsonb'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Table editor sort (and filter) column pickers show `USER-DEFINED` for extension types such as PostGIS `geography`, because they use `dataType` from pg-meta.

| Before |
| --- |
| <img width="549" height="196" alt="CleanShot 2026-07-22 at 11 32 44" src="https://github.com/user-attachments/assets/9ba2dec8-f5a3-479f-81c8-2dd133f6d419" /> |

## What is the new behavior?

Those pickers use the same display helper as column headers (`getColumnFormat`), so labels match the header (e.g. `geography`, `int4[]`).

## Test plan

In SQL Editor:

```sql
create extension if not exists postgis with schema extensions;

create table public.geography_sort_repro (
  id bigint generated always as identity primary key,
  location extensions.geography(point, 4326),
  tags text[]
);
```

Then open `geography_sort_repro` in the Table Editor → Sort → pick `location` / `tags`. Confirm labels are `geography` and `text[]` (not `USER-DEFINED` / `_text`). Same check in the Filter column picker.

Cleanup: `drop table public.geography_sort_repro;`

## Additional context

`data_type` is intentionally coarse for non-`pg_catalog` types in pg-meta; `format` already carries the real type name. Arrays need `getColumnFormat` so `_int4` becomes `int4[]`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved column type labels in filter and sort menus by displaying the appropriate format instead of raw data types.
  * Preserved existing JSON-field restrictions and tooltips while improving the clarity of displayed column information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->