### PR TITLE
build: do not run federated content and markdown pipeline on dev

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -37,7 +37,7 @@
     "lint:mdx": "supa-mdx-lint content --config ../../supa-mdx-lint.config.toml",
     "postbuild": "pnpm run build:sitemap && ./../../scripts/upload-static-assets.sh",
     "prebuild": "pnpm run codegen:graphql && pnpm run codegen:references && pnpm run codegen:examples && pnpm build:federated-content && pnpm run build:markdown && pnpm run build:gz-archive",
-    "predev": "pnpm run codegen:graphql && pnpm run codegen:references && pnpm run codegen:examples && pnpm build:federated-content && pnpm run build:markdown",
+    "predev": "pnpm run codegen:graphql && pnpm run codegen:references && pnpm run codegen:examples",
     "preembeddings": "pnpm run codegen:references",
     "preinstall": "npx only-allow pnpm",
     "presync": "pnpm run codegen:graphql",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Do not run federated content and markdown scripts on `predev` to prevent external contributors from being blocked because of missing GitHub API keys needed for federated content.

_Note: I tried to do some smarter things like detecting missing env variables and checking on development environment on the fly but it has some quirks which can cause errors. This is the simplest path to unblocking for now._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Reduced documentation development startup steps for a faster local development experience.
  * Documentation development now performs only essential code generation before launching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->