### PR TITLE
fix(studio): hide support access toggle when no project is selected

### DIFF
--- a/apps/studio/components/interfaces/Support/LinkSupportTicketForm.tsx
+++ b/apps/studio/components/interfaces/Support/LinkSupportTicketForm.tsx
@@ -14,8 +14,13 @@ import {
 } from './LinkSupportTicketForm.schema'
 import { OrganizationSelector } from './OrganizationSelector'
 import { ProjectAndPlanInfo } from './ProjectAndPlanInfo'
-import { DISABLE_SUPPORT_ACCESS_CATEGORIES, SupportAccessToggle } from './SupportAccessToggle'
-import { getOrgSubscriptionPlan, NO_ORG_MARKER, NO_PROJECT_MARKER } from './SupportForm.utils'
+import { SupportAccessToggle } from './SupportAccessToggle'
+import {
+  canAllowSupportAccess,
+  getOrgSubscriptionPlan,
+  NO_ORG_MARKER,
+  NO_PROJECT_MARKER,
+} from './SupportForm.utils'
 import { useLinkSupportTicketMutation } from '@/data/feedback/link-support-ticket-mutation'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 
@@ -81,10 +86,9 @@ export const LinkSupportTicketForm = ({
           ? values.projectRef
           : undefined,
       category: values.category,
-      allow_support_access:
-        values.category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(values.category)
-          ? values.allowSupportAccess
-          : false,
+      allow_support_access: canAllowSupportAccess(values.category, values.projectRef)
+        ? values.allowSupportAccess
+        : false,
     })
   }
 
@@ -146,7 +150,7 @@ export const LinkSupportTicketForm = ({
 
         <DialogSectionSeparator />
 
-        {!!category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(category) && (
+        {canAllowSupportAccess(category, projectRef) && (
           <>
             <div className="py-4">
               <SupportAccessToggle form={form as any} />

--- a/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
+++ b/apps/studio/components/interfaces/Support/SupportAccessToggle.tsx
@@ -1,20 +1,12 @@
 // End of third-party imports
 
-import { SupportCategories } from '@supabase/shared-types/out/constants'
 import { ChevronRight } from 'lucide-react'
 import Link from 'next/link'
 import type { UseFormReturn } from 'react-hook-form'
 import { Badge, Collapsible, CollapsibleContent, CollapsibleTrigger, FormField, Switch } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
-import type { ExtendedSupportCategories } from './Support.constants'
 import type { SupportFormValues } from './SupportForm.schema'
-
-export const DISABLE_SUPPORT_ACCESS_CATEGORIES: ExtendedSupportCategories[] = [
-  SupportCategories.ACCOUNT_DELETION,
-  SupportCategories.SALES_ENQUIRY,
-  SupportCategories.REFUND,
-]
 
 interface SupportAccessToggleProps {
   form: UseFormReturn<SupportFormValues>

--- a/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
+++ b/apps/studio/components/interfaces/Support/SupportForm.utils.tsx
@@ -1,5 +1,6 @@
 // End of third-party imports
 
+import { SupportCategories } from '@supabase/shared-types/out/constants'
 import {
   DocsSearchResultType as PageType,
   type DocsSearchResult as Page,
@@ -17,13 +18,30 @@ import {
   type UseQueryStatesKeysMap,
 } from 'nuqs'
 
-import { CATEGORY_OPTIONS } from './Support.constants'
+import { CATEGORY_OPTIONS, type ExtendedSupportCategories } from './Support.constants'
 import { getProjectDetail } from '@/data/projects/project-detail-query'
 import { DOCS_URL } from '@/lib/constants'
 import type { Organization } from '@/types'
 
 export const NO_PROJECT_MARKER = 'no-project'
 export const NO_ORG_MARKER = 'no-org'
+
+export const DISABLE_SUPPORT_ACCESS_CATEGORIES: ExtendedSupportCategories[] = [
+  SupportCategories.ACCOUNT_DELETION,
+  SupportCategories.SALES_ENQUIRY,
+  SupportCategories.REFUND,
+]
+
+export function canAllowSupportAccess(
+  category: ExtendedSupportCategories | undefined,
+  projectRef: string
+): boolean {
+  return (
+    !!category &&
+    !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(category) &&
+    projectRef !== NO_PROJECT_MARKER
+  )
+}
 
 export const formatMessage = ({
   message,

--- a/apps/studio/components/interfaces/Support/SupportFormV2.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV2.tsx
@@ -24,10 +24,11 @@ import { OrganizationSelector } from './OrganizationSelector'
 import { ProjectAndPlanInfo } from './ProjectAndPlanInfo'
 import { SubjectAndSuggestionsInfo } from './SubjectAndSuggestionsInfo'
 import { SubmitButton } from './SubmitButton'
-import { DISABLE_SUPPORT_ACCESS_CATEGORIES, SupportAccessToggle } from './SupportAccessToggle'
+import { SupportAccessToggle } from './SupportAccessToggle'
 import type { SupportFormValues } from './SupportForm.schema'
 import type { SupportFormActions, SupportFormState } from './SupportForm.state'
 import {
+  canAllowSupportAccess,
   formatMessage,
   formatStudioVersion,
   getOrgSubscriptionPlan,
@@ -160,10 +161,9 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
       ...values,
       organizationSlug: values.organizationSlug ?? NO_ORG_MARKER,
       projectRef: values.projectRef ?? NO_PROJECT_MARKER,
-      allowSupportAccess:
-        values.category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(values.category)
-          ? values.allowSupportAccess
-          : false,
+      allowSupportAccess: canAllowSupportAccess(values.category, values.projectRef)
+        ? values.allowSupportAccess
+        : false,
       library:
         values.category === SupportCategories.PROBLEM && selectedLibrary !== undefined
           ? selectedLibrary.key
@@ -254,7 +254,7 @@ export const SupportFormV2 = ({ form, initialError, state, dispatch }: SupportFo
           </>
         )}
 
-        {!!category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(category) && (
+        {canAllowSupportAccess(category, projectRef) && (
           <>
             <SupportAccessToggle form={form} className="px-6" />
             <DialogSectionSeparator />

--- a/apps/studio/components/interfaces/Support/SupportFormV3.tsx
+++ b/apps/studio/components/interfaces/Support/SupportFormV3.tsx
@@ -25,10 +25,11 @@ import { OrganizationSelector } from './OrganizationSelector'
 import { PlanExpectationInfoContent, ProjectAndPlanInfo } from './ProjectAndPlanInfo'
 import { SubjectAndSuggestionsInfo } from './SubjectAndSuggestionsInfo'
 import { SubmitButton } from './SubmitButton'
-import { DISABLE_SUPPORT_ACCESS_CATEGORIES, SupportAccessToggle } from './SupportAccessToggle'
+import { SupportAccessToggle } from './SupportAccessToggle'
 import type { SupportFormValues } from './SupportForm.schema'
 import type { SupportFormActions, SupportFormState } from './SupportForm.state'
 import {
+  canAllowSupportAccess,
   formatMessage,
   formatStudioVersion,
   getOrgSubscriptionPlan,
@@ -171,10 +172,9 @@ export const SupportFormV3 = ({
       ...values,
       organizationSlug: values.organizationSlug ?? NO_ORG_MARKER,
       projectRef: values.projectRef ?? NO_PROJECT_MARKER,
-      allowSupportAccess:
-        values.category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(values.category)
-          ? values.allowSupportAccess
-          : false,
+      allowSupportAccess: canAllowSupportAccess(values.category, values.projectRef)
+        ? values.allowSupportAccess
+        : false,
       library:
         values.category === SupportCategories.PROBLEM && selectedLibrary !== undefined
           ? selectedLibrary.key
@@ -265,7 +265,7 @@ export const SupportFormV3 = ({
         </div>
 
         {(DASHBOARD_LOG_CATEGORIES.includes(category) ||
-          (!!category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(category)) ||
+          canAllowSupportAccess(category, projectRef) ||
           showPlanExpectationInfo ||
           showDirectEmailInfo) && (
           <div className="flex flex-col gap-y-6">
@@ -275,7 +275,7 @@ export const SupportFormV3 = ({
               <DashboardLogsToggle form={form} sanitizedLog={sanitizedLogSnapshot} align="right" />
             )}
 
-            {!!category && !DISABLE_SUPPORT_ACCESS_CATEGORIES.includes(category) && (
+            {canAllowSupportAccess(category, projectRef) && (
               <SupportAccessToggle form={form} align="right" />
             )}
 

--- a/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
+++ b/apps/studio/components/interfaces/Support/__tests__/SupportFormPage.test.tsx
@@ -2,6 +2,7 @@ import { screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { platformComponents as components } from 'api-types'
 import dayjs from 'dayjs'
+import { mockIntersectionObserver } from 'jsdom-testing-mocks'
 import { http, HttpResponse } from 'msw'
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 
@@ -14,6 +15,9 @@ import { createMockOrganizationResponse, createMockProject } from '@/tests/helpe
 import { customRender } from '@/tests/lib/custom-render'
 import { addAPIMock, mswServer, type APIErrorBody } from '@/tests/lib/msw'
 import { createMockProfileContext } from '@/tests/lib/profile-helpers'
+
+// The project selector's infinite-scroll sentinel uses IntersectionObserver, which jsdom lacks
+mockIntersectionObserver()
 
 type ProjectDetailResponse = components['schemas']['ProjectDetailResponse']
 type OrganizationProjectsResponse = components['schemas']['OrganizationProjectsResponse']
@@ -314,6 +318,19 @@ const getDashboardLogsToggle = (screen: Screen, type: 'find' | 'query' = 'find')
   return type === 'find'
     ? screen.findByRole('switch', { name: labelMatcher })
     : screen.queryByRole('switch', { name: labelMatcher })
+}
+
+const getSupportAccessToggle = (screen: Screen, type: 'find' | 'query' = 'find') => {
+  const labelMatcher = /allow support access to your project/i
+  return type === 'find'
+    ? screen.findByRole('switch', { name: labelMatcher })
+    : screen.queryByRole('switch', { name: labelMatcher })
+}
+
+const selectNoSpecificProject = async (screen: Screen) => {
+  await userEvent.click(getProjectSelector(screen))
+  const option = await screen.findByRole('option', { name: /no specific project/i })
+  await userEvent.click(option)
 }
 
 const getSupportForm = () => {
@@ -633,6 +650,64 @@ describe('SupportFormPage', () => {
       { timeout: 5_000 }
     )
   })
+
+  test('hides support access toggle and submits allowSupportAccess: false when no project is selected', async () => {
+    const submitSpy = vi.fn()
+
+    addAPIMock({
+      method: 'post',
+      path: '/platform/feedback/send',
+      response: async ({ request }) => {
+        submitSpy(await request.json())
+        return HttpResponse.json<SendFeedbackResponse>({ result: 'ok' })
+      },
+    })
+
+    renderSupportFormPage()
+
+    await waitFor(
+      () => {
+        expect(getOrganizationSelector(screen)).toHaveTextContent('Organization 1')
+        expect(getProjectSelector(screen)).toHaveTextContent('Project 1')
+      },
+      { timeout: 5_000 }
+    )
+
+    await selectCategoryOption(screen, 'Dashboard bug')
+    await waitFor(() => {
+      expect(getCategorySelector(screen)).toHaveTextContent('Dashboard bug')
+    })
+
+    // A project is selected, so the toggle to grant support access is available
+    await expect(getSupportAccessToggle(screen)).resolves.toBeInTheDocument()
+
+    await selectNoSpecificProject(screen)
+    await waitFor(() => {
+      expect(getProjectSelector(screen)).toHaveTextContent('No specific project')
+    })
+
+    // Support access is granted on a per-project basis, so the toggle should disappear
+    // once no project is selected, rather than allowing it to be enabled with nothing to grant access to
+    await waitFor(() => {
+      expect(getSupportAccessToggle(screen, 'query')).not.toBeInTheDocument()
+    })
+
+    await fillField(getSummaryField(screen), 'Cannot access my account')
+    await fillField(getMessageField(screen), 'I need help accessing my Supabase account')
+
+    await userEvent.click(getSubmitButton(screen))
+
+    await waitFor(() => {
+      expect(submitSpy).toHaveBeenCalledTimes(1)
+    })
+
+    const payload = submitSpy.mock.calls[0]?.[0]
+    expect(payload).toMatchObject({
+      projectRef: NO_PROJECT_MARKER,
+      organizationSlug: 'org-1',
+      allowSupportAccess: false,
+    })
+  }, 10_000)
 
   test('loading a URL with an invalid project slug falls back to first organization and project', async () => {
     mswServer.use(
@@ -1805,6 +1880,9 @@ describe('SupportFormPage', () => {
     await userEvent.click(dashboardLogToggle!)
     expect(dashboardLogToggle).not.toBeChecked()
 
+    // Support access is per-project, so with no project selected the toggle shouldn't be offered
+    expect(getSupportAccessToggle(screen, 'query')).not.toBeInTheDocument()
+
     await fillField(getSummaryField(screen), 'Cannot access my account')
     await fillField(getMessageField(screen), 'I need help accessing my Supabase account')
 
@@ -1822,7 +1900,7 @@ describe('SupportFormPage', () => {
       organizationSlug: NO_ORG_MARKER,
       library: '',
       affectedServices: '',
-      allowSupportAccess: true,
+      allowSupportAccess: false,
       verified: true,
       tags: ['dashboard-support-form'],
       browserInformation: 'Chrome',


### PR DESCRIPTION
## Summary
Support access is granted per-project, but the "Allow support access" toggle stayed visible and submittable even when "No specific project" was selected. This hides the toggle and forces `allowSupportAccess`/`allow_support_access` to `false` in that case, across the standalone support form, sidebar form, and link-ticket form.

Addresses [FE-3979](https://linear.app/supabase/issue/FE-3979/support-form-allows-support-access-without-a-project-selected).

## Test plan
- [x] Added/updated unit tests in `SupportFormPage.test.tsx` covering toggle visibility and submitted payload when no project is selected
- [x] `pnpm vitest run components/interfaces/Support` passes (48 tests)
- [x] Typecheck and lint pass on changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Support access is now offered only when a valid project and eligible support category are selected.
  * Support access is automatically disabled when no specific project is selected.
  * Form submissions now prevent unsupported support-access requests from being enabled.
* **Tests**
  * Added coverage for project clearing and scenarios without available projects or organizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->