### PR TITLE
docs: clarify apps/docs local env setup

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -97,7 +97,7 @@ You can run any of the sites individually by using the scope name. For example:
 pnpm dev:www
 ```
 
-Note: Particularly for `www` make sure you have copied `apps/www/.env.local.example` to `apps/www/.env.local`
+Note: Particularly for `www` make sure you have copied `apps/www/.env.local.example` to `apps/www/.env.local`. For `docs`, see [`apps/docs/DEVELOPERS.md`](./apps/docs/DEVELOPERS.md).
 
 #### Shared components
 

--- a/apps/docs/DEVELOPERS.md
+++ b/apps/docs/DEVELOPERS.md
@@ -17,7 +17,7 @@ For a complete run-down on how all of our tools work together, see the main DEVE
 [supabase.com/docs](https://supabase.com/docs) is a Next.js site. You can get setup by following the same steps for all of our other Next.js projects:
 
 1. Follow the steps outlined in the Local Development section of the main [DEVELOPERS.md](https://github.com/supabase/supabase/blob/master/DEVELOPERS.md)
-2. If you work at Supabase, run `dev:secrets:pull` to pull down the internal environment variables. If you're a community member, create a `.env` file and add this line to it: `NEXT_PUBLIC_IS_PLATFORM=false`
+2. If you work at Supabase, from `apps/docs` run `pnpm run dev:secrets:pull` to write internal env vars to `.env.local`. If you're a community member, create `apps/docs/.env.local` and add this line: `NEXT_PUBLIC_IS_PLATFORM=false`
 3. Start the local docs site by navigating to `/apps/docs` and running `pnpm run dev`
 4. Visit http://localhost:3001/docs in your browser - don't forget to append the `/docs` to the end
 5. Your local site should look exactly like [https://supabase.com/docs](https://supabase.com/docs)


### PR DESCRIPTION
## Summary
- Fix docs setup step 2: secrets go in `.env.local` (not `.env`), and staff should run `pnpm run dev:secrets:pull` from `apps/docs`
- Add a one-line pointer from the root `DEVELOPERS.md` to `apps/docs/DEVELOPERS.md`

## Test plan
- [ ] Skim the two touched lines and confirm they match how `dev:secrets:pull` / dotenv actually work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified environment setup instructions for running the website and documentation sites individually.
  * Added docs-specific guidance for retrieving secrets and configuring the local environment file.
  * Updated community setup instructions with the required local configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->