### PR TITLE
fix(docs) Fix local broken links

### DIFF
--- a/apps/docs/content/guides/ai/integrations/amazon-bedrock.mdx
+++ b/apps/docs/content/guides/ai/integrations/amazon-bedrock.mdx
@@ -23,7 +23,7 @@ pip install vecs boto3
 You'll also need:
 
 - [Credentials to your AWS account](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html)
-- [A Postgres Database with the pgvector extension](hosting.md)
+- [A Postgres database with the pgvector extension](/docs/guides/database/extensions/pgvector)
 
 ## Create embeddings
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -849,7 +849,7 @@ It's a good practice to provide a settings page where users can view all authori
 
 </Admonition>
 
-For complete API reference, see the [OAuth methods in supabase-js](/docs/reference/javascript/auth-oauth).
+For complete API reference, see the [OAuth methods in supabase-js](/docs/reference/javascript/auth-admin-oauth-server).
 
 ## Next steps
 

--- a/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
@@ -88,7 +88,7 @@ ELEVENLABS_API_KEY=your_api_key
 The project uses a couple of dependencies:
 
 - The [@supabase/supabase-js](/docs/reference/javascript) library to interact with the Supabase database.
-- The ElevenLabs [JavaScript SDK](/docs/quickstart) to interact with the text-to-speech API.
+- The ElevenLabs [JavaScript SDK](https://github.com/elevenlabs/elevenlabs-js) to interact with the text-to-speech API.
 - The open-source [object-hash](https://www.npmjs.com/package/object-hash) to generate a hash from the request parameters.
 
 Since Supabase Edge Function uses the [Deno runtime](https://deno.land/), you don't need to install the dependencies, rather you can [import](https://docs.deno.com/examples/npm/) them via the `npm:` prefix.

--- a/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
@@ -98,7 +98,7 @@ The project uses a couple of dependencies:
 
 - The open-source [grammY Framework](https://grammy.dev/) to handle the Telegram webhook requests.
 - The [@supabase/supabase-js](/docs/reference/javascript) library to interact with the Supabase database.
-- The ElevenLabs [JavaScript SDK](/docs/quickstart) to interact with the speech-to-text API.
+- The ElevenLabs [JavaScript SDK](https://github.com/elevenlabs/elevenlabs-js) to interact with the speech-to-text API.
 
 Since Supabase Edge Function uses the [Deno runtime](https://deno.land/), you don't need to install the dependencies, rather you can [import](https://docs.deno.com/examples/npm/) them via the `npm:` prefix.
 

--- a/apps/docs/content/guides/getting-started.mdx
+++ b/apps/docs/content/guides/getting-started.mdx
@@ -363,7 +363,7 @@ hideToc: true
     </GlassPanel>
   </Link>
   <Link
-    href="/guides/getting-started/tutorials/with-expo-react-native-social-auth"
+    href="/guides/auth/quickstarts/with-expo-react-native-social-auth"
     passHref
     className="col-span-4"
   >

--- a/apps/docs/content/guides/security/product-security.mdx
+++ b/apps/docs/content/guides/security/product-security.mdx
@@ -24,7 +24,7 @@ Various products at Supabase have their own hardening and configuration guides, 
 - [Managing Postgres roles](/docs/guides/database/postgres/roles)
 - [Managing secrets with Vault](/docs/guides/database/vault)
 - [Postgres connection logging](/docs/guides/platform/postgres-connection-logging)
-- [Superuser access and unsupported operations](docs/guides/database/postgres/roles-superuser)
+- [Superuser access and unsupported operations](/docs/guides/database/postgres/roles-superuser)
 
 ## Storage
 

--- a/apps/docs/data/errorCodes/realtimeErrorCodes.json
+++ b/apps/docs/data/errorCodes/realtimeErrorCodes.json
@@ -51,7 +51,7 @@
     "resolution": "Your project may have been suspended for exceeding usage quotas. Contact support with your project reference ID and a description of your Realtime use case.",
     "references": [
       {
-        "href": "https://supabase.com/docs/troubleshooting/realtime-project-suspended-for-exceeding-quotas",
+        "href": "https://supabase.com/docs/guides/troubleshooting/realtime-project-suspended-for-exceeding-quotas",
         "description": "Troubleshooting guide for suspended projects"
       }
     ]

--- a/apps/www/lib/redirects.js
+++ b/apps/www/lib/redirects.js
@@ -1926,7 +1926,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/with-expo-social-auth',
-    destination: '/docs/guides/getting-started/tutorials/with-expo-react-native-social-auth',
+    destination: '/docs/guides/auth/quickstarts/with-expo-react-native-social-auth',
   },
   {
     permanent: true,
@@ -1936,7 +1936,7 @@ module.exports = [
   {
     permanent: true,
     source: '/docs/guides/getting-started/tutorials/with-expo-social-auth',
-    destination: '/docs/guides/getting-started/tutorials/with-expo-react-native-social-auth',
+    destination: '/docs/guides/auth/quickstarts/with-expo-react-native-social-auth',
   },
   {
     permanent: true,

--- a/packages/shared-data/error-codes.ts
+++ b/packages/shared-data/error-codes.ts
@@ -433,7 +433,7 @@ export const ERROR_CODES: Record<ErrorCodeService, Record<string, ErrorCodeDefin
         'Your project may have been suspended for exceeding usage quotas. Contact support with your project reference ID and a description of your Realtime use case.',
       references: [
         {
-          href: 'https://supabase.com/docs/troubleshooting/realtime-project-suspended-for-exceeding-quotas',
+          href: 'https://supabase.com/docs/guides/troubleshooting/realtime-project-suspended-for-exceeding-quotas',
           description: 'Troubleshooting guide for suspended projects',
         },
       ],


### PR DESCRIPTION
Closes DOCS-1202

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Problem

We have broken local links in docs.

I ran locally tests that crawl through all of our docs and flags broken local links.

## Solution

This PR fixes local links where they were errored. The report I generated had false-positives, so there are fewer fixes than initially thought.

## Preview checklist

Docs preview: https://docs-git-docs-fix-broken-local-links-supabase.vercel.app  
WWW preview (redirects): https://zone-www-dot-com-git-docs-fix-broken-local-links-supabase.vercel.app

| Page | Live (broken) | Preview (fixed) | Where to look |
| --- | --- | --- | --- |
| Amazon Bedrock | [Live](https://supabase.com/docs/guides/ai/integrations/amazon-bedrock) | [Preview](https://docs-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/ai/integrations/amazon-bedrock) | **You'll also need** → `A Postgres database with the pgvector extension` |
| Getting started | [Live](https://supabase.com/docs/guides/getting-started) | [Preview](https://docs-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/getting-started) | Tutorial cards → **Expo React Native Social Auth** |
| Product security | [Live](https://supabase.com/docs/guides/security/product-security) | [Preview](https://docs-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/security/product-security) | **Database** list → `Superuser access and unsupported operations` |
| OAuth flows | [Live](https://supabase.com/docs/guides/auth/oauth-server/oauth-flows) | [Preview](https://docs-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/auth/oauth-server/oauth-flows) | End of page, before **Next steps** → `OAuth methods in supabase-js` |
| ElevenLabs TTS | [Live](https://supabase.com/docs/guides/functions/examples/elevenlabs-generate-speech-stream) | [Preview](https://docs-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/functions/examples/elevenlabs-generate-speech-stream) | **Dependencies** → ElevenLabs `JavaScript SDK` |
| ElevenLabs STT | [Live](https://supabase.com/docs/guides/functions/examples/elevenlabs-transcribe-speech) | [Preview](https://docs-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/functions/examples/elevenlabs-transcribe-speech) | **Dependencies** → ElevenLabs `JavaScript SDK` |
| Realtime error codes | [Live](https://supabase.com/docs/guides/realtime/error_codes) | [Preview](https://docs-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/realtime/error_codes) | `RealtimeDisabledForTenant` → reference link |
| Expo social auth redirect (legacy) | [Live](https://supabase.com/docs/guides/with-expo-social-auth) | [Preview](https://zone-www-dot-com-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/with-expo-social-auth) | Should land on the Expo social auth quickstart |
| Expo social auth redirect (old tutorials path) | [Live](https://supabase.com/docs/guides/getting-started/tutorials/with-expo-social-auth) | [Preview](https://zone-www-dot-com-git-docs-fix-broken-local-links-supabase.vercel.app/docs/guides/getting-started/tutorials/with-expo-social-auth) | Should land on the Expo social auth quickstart |

### Manual testing

1. For each row, open the **Live** link and find the linked text in **Where to look**.
2. Click the link and confirm it 404s or lands on the wrong page.
3. Open the matching **Preview** link, find the same linked text, and click it.
4. Confirm the preview link resolves to the correct destination:
   - Amazon Bedrock → `/docs/guides/database/extensions/pgvector`
   - Getting started → `/docs/guides/auth/quickstarts/with-expo-react-native-social-auth`
   - Product security → `/docs/guides/database/postgres/roles-superuser`
   - OAuth flows → `/docs/reference/javascript/auth-admin-oauth-server`
   - ElevenLabs TTS / STT → `https://github.com/elevenlabs/elevenlabs-js`
   - Realtime error codes → `/docs/guides/troubleshooting/realtime-project-suspended-for-exceeding-quotas`
   - Redirect rows → `/docs/guides/auth/quickstarts/with-expo-react-native-social-auth`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated links for pgvector, OAuth, ElevenLabs SDK, and database security guidance.
  * Corrected the Expo React Native social authentication tutorial link.
  * Updated Realtime troubleshooting references to the current documentation path.

* **Bug Fixes**
  * Fixed redirects for Expo social authentication guides so legacy URLs reach the correct quickstart.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->