### PR TITLE
fix(docs): restore Supabase env vars to stop crash on every page load

### DIFF
--- a/apps/docs/.env.development
+++ b/apps/docs/.env.development
@@ -22,5 +22,5 @@ NEXT_PUBLIC_MARKETPLACE_API_URL="https://fgxbxpvumhvzrhqngsyu.supabase.co"
 NEXT_PUBLIC_MARKETPLACE_PUBLISHABLE_KEY="sb_publishable_VuF5ZvGqj6ODhZgN1J_vMw_YbiEs1R6"
 
 # Supabase project containing docs content information
-NEXT_PUBLIC_MARKETPLACE_API_URL="https://otqhrpbxhxkrhrnjqbba.supabase.co/"
-NEXT_PUBLIC_MARKETPLACE_PUBLISHABLE_KEY="sb_publishable_ZVVKKu1s88KsSBWVYlou-g_phb2OJVQ"
+NEXT_PUBLIC_SUPABASE_URL="https://otqhrpbxhxkrhrnjqbba.supabase.co/"
+NEXT_PUBLIC_SUPABASE_ANON_KEY="sb_publishable_ZVVKKu1s88KsSBWVYlou-g_phb2OJVQ"

--- a/apps/docs/components/Feedback/Feedback.tsx
+++ b/apps/docs/components/Feedback/Feedback.tsx
@@ -77,12 +77,11 @@ function Feedback({ className }: { className?: string }) {
 
   const pathname = usePathname() ?? ''
   const sendTelemetryEvent = useSendTelemetryEvent()
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
   const supabase = useConstant(() =>
-    IS_PLATFORM
-      ? createClient<Database>(
-          process.env.NEXT_PUBLIC_SUPABASE_URL!,
-          process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
-        )
+    IS_PLATFORM && supabaseUrl && supabaseAnonKey
+      ? createClient<Database>(supabaseUrl, supabaseAnonKey)
       : undefined
   )
 


### PR DESCRIPTION


https://github.com/user-attachments/assets/0b9e4bd1-e2b6-4a58-b47e-803e2b34a32e


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Every page in `apps/docs` crashes at runtime with `Error: supabaseUrl is required.`

Regression from #46757, which flipped `NEXT_PUBLIC_IS_PLATFORM` to `"true"` in `apps/docs/.env.development` and, in the same diff, duplicated a `NEXT_PUBLIC_MARKETPLACE_API_URL`/`NEXT_PUBLIC_MARKETPLACE_PUBLISHABLE_KEY` block where `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY` should have been. With `IS_PLATFORM` now `true`, `Feedback.tsx` (rendered on every docs page) unconditionally calls `createClient()` with an undefined URL/key, throwing synchronously on every page load.

Closes DOCS-1208 / FE-3980.

## What is the new behavior?

- `apps/docs/.env.development`: renamed the mislabeled duplicate block back to `NEXT_PUBLIC_SUPABASE_URL`/`NEXT_PUBLIC_SUPABASE_ANON_KEY`.
- `apps/docs/components/Feedback/Feedback.tsx`: widened the guard to `IS_PLATFORM && supabaseUrl && supabaseAnonKey`, mirroring the existing pattern in `app/api/ai/docs/route.ts`, so a future env misconfiguration degrades gracefully (feedback votes silently skipped) instead of crashing every page.

Verified locally by running `pnpm dev:docs` with no GitHub credentials set:
- No more `"supabaseUrl is required."` anywhere; the Feedback widget renders and fires its vote request instead of throwing.
- A normal guide page renders fine.
- `/guides/database/database-advisors` still shows its existing graceful fallback admonition.
- `/guides/graphql` (federated content, absent on a clean checkout) returns a clean 404 rather than crashing — confirming the related goal of running docs dev locally without federated content already works (via #48205 + existing `notFound()` handling), no extra changes needed there.

## Additional context

A related but separate gap was found in `apps/docs/app/guides/database/extensions/wrappers/[[...slug]]/page.tsx`. A new Linear issue is created: https://linear.app/supabase/issue/DOCS-1209/wrappers-guide-page-crashes-on-unhandled-github-fetch-failure-without

## Manual testing


1. Checkout branch locally and run `pnpm run dev:docs` with no GitHub credentials set. Confirm it starts without errors.
2. Open any guide page on docs locally and confirm no `supabaseUrl is required` error, and the Feedback widget renders and responds to clicks.
3. Open `/docs/guides/database/database-advisors`. Confirm it renders and does not crash.
4. Open `/docs/guides/graphql`. Confirm a clean 404, not a server error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feedback functionality by safely handling missing configuration.
  * Feedback votes and comments are skipped when the required service configuration is unavailable, preventing errors.
* **Chores**
  * Updated documentation-site configuration to use the appropriate content service settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->