### PR TITLE
[FE-3544] fix(studio): role impersonation for truncated cell loads

### DIFF
--- a/apps/studio/components/grid/components/editor/JsonEditor.tsx
+++ b/apps/studio/components/grid/components/editor/JsonEditor.tsx
@@ -23,6 +23,8 @@ import { isTableLike } from '@/data/table-editor/table-editor-types'
 import { useGetCellValueMutation } from '@/data/table-rows/get-cell-value-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { prettifyJSON, removeJSONTrailingComma, tryParseJson } from '@/lib/helpers'
+import { RoleImpersonationState } from '@/lib/role-impersonation'
+import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
 
 const verifyJSON = (value: string) => {
   try {
@@ -86,6 +88,7 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
   const applyChangesLabel = isQueueOperationsEnabled ? 'Queue changes' : 'Save changes'
 
   const { mutate: getCellValue, isPending, isSuccess } = useGetCellValueMutation()
+  const roleImpersonationState = useRoleImpersonationStateSnapshot()
 
   const loadFullValue = () => {
     if (selectedTable === undefined || project === undefined || !isTableLike(selectedTable)) return
@@ -104,6 +107,7 @@ export const JsonEditor = <TRow, TSummaryRow = unknown>({
         pkMatch,
         projectRef: project?.ref,
         connectionString: project?.connectionString,
+        roleImpersonationState: roleImpersonationState as RoleImpersonationState,
       },
       {
         onSuccess: (data) => {

--- a/apps/studio/components/grid/components/editor/TextEditor.tsx
+++ b/apps/studio/components/grid/components/editor/TextEditor.tsx
@@ -26,6 +26,8 @@ import { useTableEditorQuery } from '@/data/table-editor/table-editor-query'
 import { isTableLike } from '@/data/table-editor/table-editor-types'
 import { useGetCellValueMutation } from '@/data/table-rows/get-cell-value-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { RoleImpersonationState } from '@/lib/role-impersonation'
+import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
 
 export const TextEditor = <TRow, TSummaryRow = unknown>({
   row,
@@ -58,6 +60,7 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
   const applyChangesLabel = isQueueEnabled ? 'Queue changes' : 'Save changes'
 
   const { mutate: getCellValue, isPending, isSuccess } = useGetCellValueMutation()
+  const roleImpersonationState = useRoleImpersonationStateSnapshot()
 
   const isTruncated = isValueTruncated(initialValue)
 
@@ -78,6 +81,7 @@ export const TextEditor = <TRow, TSummaryRow = unknown>({
         pkMatch,
         projectRef: project?.ref,
         connectionString: project?.connectionString,
+        roleImpersonationState: roleImpersonationState as RoleImpersonationState,
       },
       { onSuccess: (data) => setValue(data) }
     )

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/JsonEditor/index.tsx
@@ -17,6 +17,8 @@ import { isTableLike } from '@/data/table-editor/table-editor-types'
 import { useGetCellValueMutation } from '@/data/table-rows/get-cell-value-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { minifyJSON, prettifyJSON, removeJSONTrailingComma, tryParseJson } from '@/lib/helpers'
+import { RoleImpersonationState } from '@/lib/role-impersonation'
+import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
 
 interface JsonEditProps {
   row?: { [key: string]: any }
@@ -60,6 +62,7 @@ export const JsonEditor = ({
   const isTruncated = isValueTruncated(jsonString, columnFormat)
 
   const { mutate: getCellValue, isPending, isSuccess, reset } = useGetCellValueMutation()
+  const roleImpersonationState = useRoleImpersonationStateSnapshot()
 
   const validateJSON = useCallback(
     async (nextValue: string, resolve: () => void) => {
@@ -117,6 +120,7 @@ export const JsonEditor = ({
         pkMatch,
         projectRef: project?.ref,
         connectionString: project?.connectionString,
+        roleImpersonationState: roleImpersonationState as RoleImpersonationState,
       },
       {
         onSuccess: (data: unknown | undefined) => {

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.test.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.test.tsx
@@ -1,0 +1,147 @@
+import { MAX_CHARACTERS } from '@supabase/pg-meta/src/query/table-row-query'
+import { fireEvent, screen, waitFor } from '@testing-library/react'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { HttpResponse } from 'msw'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { TextEditor } from './TextEditor'
+import { ENTITY_TYPE } from '@/data/entity-types/entity-type-constants'
+import {
+  createRoleImpersonationState,
+  RoleImpersonationStateContext,
+} from '@/state/role-impersonation-state'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+// The table editor reads the table id off the URL params
+vi.mock('common', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('common')>()
+  return {
+    ...actual,
+    useParams: () => ({ ref: 'default', id: '1' }),
+    useFlag: () => false,
+  }
+})
+
+// CodeEditor wraps Monaco, which can't mount in jsdom
+vi.mock('@/components/ui/CodeEditor/CodeEditor', () => ({
+  CodeEditor: () => <div data-testid="code-editor" />,
+}))
+
+mockAnimationsApi()
+
+// A value that isValueTruncated() recognizes as truncated (ends with "..." and
+// is longer than MAX_CHARACTERS), so the "Load full text data" button renders.
+const TRUNCATED_VALUE = 'a'.repeat(MAX_CHARACTERS + 1) + '...'
+const FULL_VALUE = 'the full untruncated value'
+
+const tableEntity = {
+  entity_type: ENTITY_TYPE.TABLE,
+  id: 1,
+  schema: 'public',
+  name: 'profiles',
+  primary_keys: [{ name: 'id' }],
+  columns: [{ name: 'description', format: 'text' }],
+}
+
+describe('RowEditor TextEditor - load full truncated value', () => {
+  let cellValueQueries: string[] = []
+
+  beforeEach(() => {
+    cellValueQueries = []
+
+    addAPIMock({
+      method: 'get',
+      path: '/platform/projects/:ref',
+      // @ts-expect-error partial project is enough for useSelectedProjectQuery
+      response: {
+        cloud_provider: 'localhost',
+        id: 1,
+        inserted_at: '2021-08-02T06:40:40.646Z',
+        name: 'Default Project',
+        organization_id: 1,
+        ref: 'default',
+        region: 'local',
+        status: 'ACTIVE_HEALTHY',
+      },
+    })
+
+    // Both the table-editor introspection and getCellValue hit this endpoint.
+    // The cell-value query is the one that selects from the user table
+    // ("public"."profiles"); the introspection query filters pg_catalog by id.
+    addAPIMock({
+      method: 'post',
+      path: '/platform/pg-meta/:ref/query',
+      response: async ({ request }) => {
+        const body = (await request.json()) as { query: string }
+        const query = body.query
+
+        if (query.includes('profiles')) {
+          cellValueQueries.push(query)
+          return HttpResponse.json([{ description: FULL_VALUE }])
+        }
+        // table-editor introspection
+        return HttpResponse.json([{ entity: tableEntity }])
+      },
+    })
+  })
+
+  it('wraps the getCellValue SQL with the impersonated role when View as role is active', async () => {
+    const roleImpersonationState = createRoleImpersonationState('default', {
+      current: async () => {},
+    })
+    roleImpersonationState.role = { type: 'custom', role: 'test_role' }
+
+    customRender(
+      <RoleImpersonationStateContext.Provider value={roleImpersonationState}>
+        <TextEditor
+          visible
+          row={{ id: 1, description: TRUNCATED_VALUE }}
+          column="description"
+          closePanel={() => {}}
+          onSaveField={() => {}}
+        />
+      </RoleImpersonationStateContext.Provider>
+    )
+
+    const loadButton = await screen.findByRole('button', { name: 'Load full text data' })
+
+    // Retry the click: it no-ops until the table-editor introspection resolves
+    // and populates selectedTable. Every captured query is role-impersonated,
+    // so extra clicks (if any) don't affect the assertion.
+    await waitFor(() => {
+      fireEvent.click(loadButton)
+      expect(cellValueQueries.length).toBeGreaterThan(0)
+    })
+
+    expect(cellValueQueries[0]).toContain("set local role 'test_role'")
+  })
+
+  it('does not impersonate a role when View as role is inactive', async () => {
+    const roleImpersonationState = createRoleImpersonationState('default', {
+      current: async () => {},
+    })
+    // role stays undefined -> runs as the default (postgres) role
+
+    customRender(
+      <RoleImpersonationStateContext.Provider value={roleImpersonationState}>
+        <TextEditor
+          visible
+          row={{ id: 1, description: TRUNCATED_VALUE }}
+          column="description"
+          closePanel={() => {}}
+          onSaveField={() => {}}
+        />
+      </RoleImpersonationStateContext.Provider>
+    )
+
+    const loadButton = await screen.findByRole('button', { name: 'Load full text data' })
+
+    await waitFor(() => {
+      fireEvent.click(loadButton)
+      expect(cellValueQueries.length).toBeGreaterThan(0)
+    })
+
+    expect(cellValueQueries[0]).not.toContain('set local role')
+  })
+})

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/RowEditor/TextEditor.tsx
@@ -15,6 +15,8 @@ import { useTableEditorQuery } from '@/data/table-editor/table-editor-query'
 import { isTableLike } from '@/data/table-editor/table-editor-types'
 import { useGetCellValueMutation } from '@/data/table-rows/get-cell-value-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { RoleImpersonationState } from '@/lib/role-impersonation'
+import { useRoleImpersonationStateSnapshot } from '@/state/role-impersonation-state'
 
 interface TextEditorProps {
   visible: boolean
@@ -49,6 +51,7 @@ export const TextEditor = ({
   const isTruncated = isValueTruncated(value)
 
   const { mutate: getCellValue, isPending, isSuccess, reset } = useGetCellValueMutation()
+  const roleImpersonationState = useRoleImpersonationStateSnapshot()
 
   const loadFullValue = () => {
     if (
@@ -73,6 +76,7 @@ export const TextEditor = ({
         pkMatch,
         projectRef: project?.ref,
         connectionString: project?.connectionString,
+        roleImpersonationState: roleImpersonationState as RoleImpersonationState,
       },
       { onSuccess: (data) => setStrValue(data) }
     )


### PR DESCRIPTION
Loading a truncated cell's full value from the inline grid editors or the row side-panel editors called `getCellValue` without `roleImpersonationState`, so the fetch ran with full DB privileges instead of the role selected in **View as role** — leaking values RLS would deny. Same class of bug #46442 fixed for row copy/export; the mutation already accepted the state, these call sites just weren't passing it.

**Changed:**

- Pass `roleImpersonationState` into `getCellValue` in all 4 truncated-cell loaders (inline grid Text/Json editors + row side-panel Text/Json editors), mirroring the existing `Header.tsx` pattern

**Added:**

- MSW component test on the row side-panel `TextEditor` asserting the cell-value SQL is wrapped with `set local role` when impersonation is active, and not wrapped when it isn't

## To test

Note: if the impersonated role can't select the row at all (e.g. force RLS with no policy), the main grid correctly shows 0 rows under **View as role**, so the "Load full value" button is never reachable — you can't exercise this path that way. Use a row the role *can* see and verify the request is role-wrapped:

- Create a table with a text value long enough to be truncated in the grid (>16KB), with RLS enabled and an anon-visible row:
  ```sql
  create table public.secrets (id int primary key, secret text);
  alter table public.secrets enable row level security;
  alter table public.secrets force row level security;
  create policy "anon can read" on public.secrets for select to anon using (true);
  insert into public.secrets values (1, repeat('a', 20000));
  ```
- In the Table Editor, set **View as role → anon** — the row should be visible with the `secret` cell truncated
- With the network tab open, load the full value via each path: double-click the cell (inline editor) and the row side panel's expand editor → "Load full text data" (a `jsonb` column exercises the two JSON editor paths the same way)
- The `pg-meta` query request body should start with `set_config('role', 'anon', true)` + anon JWT claims before the `select secret …`. Before this fix it was a bare unwrapped `select secret from public.secrets where id = 1;`
- Drop the policy and confirm the grid shows 0 records under anon (denial still applies at the grid level); switch back to the default role and confirm the full value still loads normally with no wrapper