### PR TITLE
chore(lint): ignore dist build output in shared ESLint config

### DIFF
--- a/packages/eslint-config-supabase/next.js
+++ b/packages/eslint-config-supabase/next.js
@@ -48,8 +48,8 @@ const typescriptConfig = {
 }
 
 module.exports = defineConfig([
-  // Global ignore for the .next folder
-  { ignores: ['.next', 'public', '.contentlayer'] },
+  // Global ignore for build output and static assets
+  { ignores: ['.next', 'dist', 'public', '.contentlayer'] },
   turboConfig,
   prettierConfig,
   tanstackQuery.configs['flat/recommended'],


### PR DESCRIPTION
Follow-up to #48202. The shared ESLint flat config only globally ignored `.next`, `public`, and `.contentlayer`, so with the TanStack Start migration, Studio's Vite build output in `dist/` was getting linted too — making `pnpm --filter studio run lint:ratchet` (and regular lint) far slower than it should be. ESLint flat config doesn't respect `.gitignore`, so being gitignored didn't help.

**Changed:**

- Added `dist` to the global `ignores` in `eslint-config-supabase/next` (applies to all apps extending the shared config)

## To test

- In `apps/studio` (with a `dist/` folder present from a TanStack build), run `npx eslint dist/server/server.js` — it should report "File ignored because of a matching ignore pattern"
- `pnpm --filter studio run lint:ratchet` no longer spends time linting `dist/**`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting exclusions to ignore generated build output and static asset directories.
  * Generalized related configuration documentation for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->