### PR TITLE
docs(billing): clarify top-ups do not apply to outstanding invoices

### DIFF
--- a/apps/docs/content/guides/platform/billing-faq.mdx
+++ b/apps/docs/content/guides/platform/billing-faq.mdx
@@ -208,6 +208,10 @@ Note that any changes made to your billing details will only be reflected in you
 
 When an invoice becomes overdue, we will pause your projects and downgrade your organization to the Free Plan. You will be able to restore your projects once you have paid all outstanding invoices.
 
+#### Can I use a credit top-up to pay an outstanding invoice?
+
+Credit top-ups apply only to future invoices. They cannot be used to pay or adjust outstanding invoices.
+
 #### Why am I overdue?
 
 We were unable to charge your payment method. This likely means that the payment was not successfully processed with the credit card on your account profile.

--- a/apps/docs/content/guides/platform/credits.mdx
+++ b/apps/docs/content/guides/platform/credits.mdx
@@ -67,6 +67,10 @@ height={758}
 
 Yes, once the payment is confirmed, you will get a matching invoice that can be accessed through your [organization's invoices page](/dashboard/org/_/billing#invoices).
 
+### Can I use a credit top-up to pay an outstanding invoice?
+
+Credit top-ups apply only to future invoices. They cannot be used to pay or adjust outstanding invoices.
+
 ### Can I transfer credits to another organization?
 
 Yes, you can transfer credits to another organization. Submit a [support ticket](https://supabase.help).

--- a/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
+++ b/apps/studio/components/interfaces/Organization/BillingSettings/CreditTopUp.tsx
@@ -301,8 +301,9 @@ export const CreditTopUp = ({ slug }: { slug: string | undefined }) => {
           <DialogDescription className="space-y-2">
             <p className="prose text-sm">
               On successful payment, an invoice will be issued and you'll be granted credits equal
-              to the pre-tax amount. Credits will be applied to future invoices only and are not
-              refundable. The topped up credits do not expire.
+              to the pre-tax amount. Credits will be applied to future invoices only. They cannot be
+              used to pay or adjust outstanding invoices. Credits are non-refundable and do not
+              expire.
             </p>
             <p className="prose text-sm">
               For larger discounted credit packages, please reach out to us via{' '}


### PR DESCRIPTION
### Summary

This PR clarifies that credit top-ups apply only to future invoices and cannot be used to pay or adjust outstanding invoices.

It updates the Credits FAQ, Billing FAQ, and credit top-up modal with consistent wording.

### Testing

#### Credits FAQ

https://docs-git-kanishk-billing-2726-update-billing-fa-bd77f2-supabase.vercel.app/docs/guides/platform/credits#credit-faq

#### Billing FAQ

https://docs-git-kanishk-billing-2726-update-billing-fa-bd77f2-supabase.vercel.app/docs/guides/platform/billing-faq#payments-and-billing-cycle

#### Credit Top Up Modal

<img width="544" height="473" alt="Screenshot 2026-07-23 at 1 17 30 AM" src="https://github.com/user-attachments/assets/5d016398-7b46-455d-8bf1-a5767d10bc48" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added FAQ guidance explaining that credit top-ups apply only to future invoices and cannot pay or adjust outstanding invoices.
* **Billing Updates**
  * Clarified that credits are granted based on the pre-tax payment amount.
  * Confirmed that credits are non-refundable and do not expire.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->