### PR TITLE
feat(www): convert TRAE webinar page to on-demand

### DIFF
--- a/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
+++ b/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
@@ -8,6 +8,7 @@ meta_description: >-
   and TRAE to see how TRAE SOLO uses your live Supabase context (schema, auth,
   RLS policies, and logs) to generate code that holds up in production.
 type: webinar
+type_label: 'Supabase Live'
 onDemand: true
 date: '2026-07-22T19:00:00.000-07:00'
 timezone: America/Los_Angeles
@@ -37,6 +38,7 @@ TRAE and Supabase are built for both. TRAE gives you the speed of a fully autono
 In this session, Gerardo Estaba from Supabase and Gary Qi from TRAE show you how to go from prompt to production without compromising on code quality.
 
 {/* TODO: swap in the YouTube embed URL once the recording is available, e.g. src="https://www.youtube-nocookie.com/embed/<video-id>" */}
+
 <div className="video-container mb-8" id="recording">
   <iframe
     className="w-full"

--- a/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
+++ b/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
@@ -8,7 +8,7 @@ meta_description: >-
   and TRAE to see how TRAE SOLO uses your live Supabase context (schema, auth,
   RLS policies, and logs) to generate code that holds up in production.
 type: webinar
-onDemand: false
+onDemand: true
 date: '2026-07-22T19:00:00.000-07:00'
 timezone: America/Los_Angeles
 duration: 45 mins
@@ -22,9 +22,9 @@ company:
 categories:
   - webinar
 main_cta:
-  url: 'https://attendee.gotowebinar.com/register/2865727980603383392'
-  target: _blank
-  label: Register now
+  url: '#recording'
+  target: _self
+  label: Watch the recording
 speakers: 'gerardo_estaba,gary_qi'
 ---
 
@@ -34,15 +34,27 @@ More people than ever are shipping real products with AI tools. The gap between 
 
 TRAE and Supabase are built for both. TRAE gives you the speed of a fully autonomous AI coding agent that takes you from prompt to working app. Supabase handles the backend: open-source managed Postgres with Auth, Storage, Edge Functions, and Realtime built in. When TRAE has live context of your Supabase projects, the code it generates is production-ready from the start.
 
-In this session, Gerardo Estaba from Supabase and Gary Qi from TRAE will show you how to go from prompt to production without compromising on code quality.
+In this session, Gerardo Estaba from Supabase and Gary Qi from TRAE show you how to go from prompt to production without compromising on code quality.
 
-### What we'll cover
+{/* TODO: swap in the YouTube embed URL once the recording is available, e.g. src="https://www.youtube-nocookie.com/embed/<video-id>" */}
+<div className="video-container mb-8" id="recording">
+  <iframe
+    className="w-full"
+    src=""
+    title="Building high quality Supabase apps using TRAE"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
+    allowFullScreen
+  />
+</div>
 
-- Where AI-generated apps break in production and how TRAE and Supabase catch those problems before they ship
-- How TRAE SOLO uses your live Supabase context (schema, auth config, RLS policies, and logs) to generate more accurate code
-- Managing your Supabase backend with natural language via the Supabase and TRAE SOLO integration: running migrations, modifying RLS policies, creating storage buckets, and managing secrets
-- Live build: a full-stack app from prompt to deployed, with Auth, Storage, and a secure database, built entirely inside TRAE
+## Key Takeaways
 
-You'll leave with a clear picture of what the TRAE and Supabase workflow looks like end to end, and what to set up first on your own project.
+- Where AI-generated apps break in production, and how TRAE and Supabase catch those problems before they ship
 
-Plus, bring your questions for the live Q&A. Can't make it? Register anyway and we'll send you the recording.
+- How TRAE SOLO uses your live Supabase context (schema, Auth config, RLS policies, and logs) to generate more accurate code
+
+- How to manage your Supabase backend in natural language through the Supabase and TRAE SOLO integration: running migrations, modifying RLS policies, creating Storage buckets, and managing secrets
+
+- A full live build of a full-stack app, from prompt to deployed, with Auth, Storage, and a secure database, built entirely inside TRAE
+
+We hope you enjoy the recording!

--- a/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
+++ b/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
@@ -37,12 +37,10 @@ TRAE and Supabase are built for both. TRAE gives you the speed of a fully autono
 
 In this session, Gerardo Estaba from Supabase and Gary Qi from TRAE show you how to go from prompt to production without compromising on code quality.
 
-{/* TODO: swap in the YouTube embed URL once the recording is available, e.g. src="https://www.youtube-nocookie.com/embed/<video-id>" */}
-
 <div className="video-container mb-8" id="recording">
   <iframe
     className="w-full"
-    src=""
+    src="https://www.youtube-nocookie.com/embed/SVxZ_aPq4U4"
     title="Building high quality Supabase apps using TRAE"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; fullscreen; gyroscope; picture-in-picture; web-share"
     allowFullScreen

--- a/apps/www/pages/events/[slug].tsx
+++ b/apps/www/pages/events/[slug].tsx
@@ -61,6 +61,7 @@ interface EventData {
   main_cta?: CTA
   description: string
   type: EventType
+  type_label?: string
   company?: CompanyType
   onDemand?: boolean
   disable_page_build?: boolean
@@ -283,7 +284,9 @@ const EventPage = ({ event }: InferGetStaticPropsType<typeof getStaticProps>) =>
                 <div className="flex flex-col gap-2 md:gap-3 items-start mb-8">
                   <div className="flex flex-row text-sm items-center flex-wrap">
                     <Icon className="hidden sm:inline-block w-4 h-4 text-brand mr-2" />
-                    <span className="uppercase text-brand font-mono">{event.type}</span>
+                    <span className="uppercase text-brand font-mono">
+                      {event.type_label ?? event.type}
+                    </span>
                     <span className="mx-3 px-3 border-x">
                       {dayjs(event.date).tz(event.timezone).format(`DD MMM YYYY [at] hA z`)}
                     </span>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature — converts the TRAE webinar event page to its on-demand version and adds a small template enhancement to support a custom type label.

## What is the current behavior?

The [TRAE webinar page](https://supabase.com/events/supabase-trae-high-quality-apps) is set up as a live, upcoming event: `onDemand: false`, a registration CTA linking out to GoToWebinar, and copy written in the future tense ("What we'll cover").

The shared event page template (`pages/events/[slug].tsx`) always renders the raw `type` frontmatter value (e.g. "WEBINAR") as the label at the top of the page, with no way to override it.

## What is the new behavior?

- Flips `onDemand` to `true` and swaps the `main_cta` from the GoToWebinar registration link to a `#recording` anchor labeled "Watch the recording", matching the pattern used for the Bolt and Perplexity webinars once they went on-demand.
- Adds a `video-container` iframe placeholder (`id="recording"`) below the intro copy. The `src` is intentionally left empty with a `TODO` comment — neither the Bolt nor Perplexity on-demand pages expose the recording URL in frontmatter, it's a hardcoded YouTube embed URL in the MDX body, so this needs the real embed URL dropped in before merging.
- Replaces the "What we'll cover" section with updated "Key Takeaways" copy and a closing line ("We hope you enjoy the recording!").
- Adds an optional `type_label` frontmatter field to the event page template. When set, it renders in place of the raw `type` value at the top of the page; when unset, behavior is unchanged for every other event page. Used here to show "Supabase Live" instead of "WEBINAR".

## Additional context

Verified locally in preview:
- TRAE event page renders correctly with the new CTA, video placeholder, updated copy, and "SUPABASE LIVE" label.
- Other event pages (e.g. `enterprise-innovation-with-bolt`) are unaffected and still show their original type label, confirming the `type_label` change is backward compatible.

Still needed before merging: the actual recording embed URL in the iframe `src`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for custom event type labels, with a fallback to the standard event type.
  - Updated the webinar page to display an on-demand recording with an embedded video.
  - Added a “Key Takeaways” section to highlight the webinar’s main points.

- **Improvements**
  - Updated the primary call-to-action to link directly to the recording.
  - Refreshed webinar metadata and end-of-page messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->