### PR TITLE
[FE-2271] fix: correct stale email confirmation dashboard paths

### DIFF
--- a/apps/studio/redirects.shared.ts
+++ b/apps/studio/redirects.shared.ts
@@ -105,7 +105,7 @@ export const SHARED_REDIRECTS: StudioRedirect[] = [
   },
   {
     source: '/project/:ref/auth/settings',
-    destination: '/project/:ref/auth/users',
+    destination: '/project/:ref/auth/providers',
     permanent: true,
   },
   {

--- a/apps/www/_blog/2022-06-30-flutter-tutorial-building-a-chat-app.mdx
+++ b/apps/www/_blog/2022-06-30-flutter-tutorial-building-a-chat-app.mdx
@@ -544,9 +544,7 @@ create trigger on_auth_user_created
 Also, Supabase has email confirmation turned on by default, meaning that every time someone signs up, they have to click the confirmation link they receive in their email.
 This is ideal for a production app, but for our sample app, we can turn it off since we want to get up and running with building a functioning chat app.
 We will cover secure authentications using Supabase in later articles.
-Go to authentication → settings and turn off the switch of `Enable email confirmations`.
-
-![turn off email confirmation](/images/blog/flutter-chat/turn-off-email-confirmation.png)
+Go to [Authentication → Sign In / Providers](https://supabase.com/dashboard/project/_/auth/providers) and turn off the **Confirm email** toggle under **User Signups**.
 
 ### Step 6: Create login page
 

--- a/apps/www/_blog/2022-08-24-building-a-realtime-trello-board-with-supabase-and-angular.mdx
+++ b/apps/www/_blog/2022-08-24-building-a-realtime-trello-board-with-supabase-and-angular.mdx
@@ -52,9 +52,7 @@ First of all we need a new Supabase project. If you don't have a Supabase accoun
 
 In your dashboard, click "New Project" and leave it to the default settings, but make sure you keep a copy o your Database password!
 
-The only thing we will change manually for now is disabling the email confirmation step. By doing this, users will be directly able to sign in when using the magic link, so go to the **Authentication** tab of your project, select **Settings** and scroll down to your **Auth Providers** where you can disable it.
-
-![Disable Email confirm](/images/blog/simon-grimm-angular-realtime/disable-email-confirm.png)
+The only thing we will change manually for now is disabling the email confirmation step. By doing this, users will be directly able to sign in when using the magic link, so go to [**Authentication → Sign In / Providers**](https://supabase.com/dashboard/project/_/auth/providers) in your project and turn off the **Confirm email** toggle under **User Signups**.
 
 Everything else regarding authentication[https://supabase.com/docs/guides/auth] is handled by Supabase and we don't need to worry about it at the moment!
 


### PR DESCRIPTION
Users were getting AI-generated troubleshooting steps pointing at **Authentication → Settings → Sign up → "Enable email confirmations"** — a dashboard path that no longer exists (FE-2271). The guidance comes from external LLMs trained on stale supabase.com content: two 2022 blog tutorials contain that exact phrasing. The real toggle is **Authentication → Sign In / Providers → User Signups → "Confirm email"**.

**Changed:**
- Updated the Flutter chat and Angular Trello blog tutorials to point at the current toggle location (and removed screenshots of the old UI)
- Repointed the legacy `/project/:ref/auth/settings` redirect from `/auth/users` to `/auth/providers`, so anyone following stale instructions lands on the page that actually has the auth config

## To test

- Visit `/project/<ref>/auth/settings` in Studio — it should redirect to `/project/<ref>/auth/providers` (verified locally on both the redirect and the existing `redirects.shared.test.ts` suite)
- Check the two blog posts render correctly and the dashboard deep link opens Sign In / Providers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated authentication settings redirects so project settings pages now open the correct sign-in and provider configuration page.

- **Documentation**
  - Updated Flutter and Angular tutorial instructions for disabling email confirmation.
  - Added current navigation guidance and clarified where to turn off the **Confirm email** option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->