### PR TITLE
Joshen/fe 3983 no way to create a new project in vercel integration when

### DIFF
--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
@@ -1,80 +1,18 @@
-import { Check, ChevronDown, Plus, PlusIcon } from 'lucide-react'
-import Link from 'next/link'
-import { useRouter } from 'next/router'
-import { HTMLAttributes, ReactNode, useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { toast } from 'sonner'
-import {
-  Badge,
-  Button,
-  cn,
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-  CommandSeparator,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from 'ui'
 
-import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
-import ShimmerLine from '@/components/ui/ShimmerLine'
 import {
-  IntegrationConnectionsCreateVariables,
-  IntegrationProjectConnection,
-} from '@/data/integrations/integrations.types'
+  ActionButtons,
+  ForeignProjectSelector,
+  Panel,
+  SupabaseProjectSelector,
+} from './ProjectLinkerComponents'
+import { Project, ProjectLinkerProps } from './VercelGithub.types'
+import ShimmerLine from '@/components/ui/ShimmerLine'
 import { useOrgProjectsInfiniteQuery } from '@/data/projects/org-projects-infinite-query'
-import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { BASE_PATH } from '@/lib/constants'
-import { openInstallGitHubIntegrationWindow } from '@/lib/github'
 import { EMPTY_ARR } from '@/lib/void'
-
-interface Project {
-  name: string
-  ref: string
-}
-
-export interface ForeignProject {
-  id: string
-  name: string
-  installation_id?: number
-}
-
-const Panel = ({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) => {
-  return (
-    <div
-      className={cn(
-        'flex-1 min-w-0 flex flex-col grow gap-6 px-5 mx-auto w-full justify-center items-center',
-        className
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  )
-}
-
-interface ProjectLinkerProps {
-  slug?: string
-  organizationIntegrationId?: string
-  foreignProjects: ForeignProject[]
-  onCreateConnections: (variables: IntegrationConnectionsCreateVariables) => void
-  installedConnections?: IntegrationProjectConnection[]
-  isLoading?: boolean
-  integrationIcon: ReactNode
-  getForeignProjectIcon?: (project: ForeignProject) => ReactNode
-  choosePrompt?: string
-  onSkip?: () => void
-  loadingForeignProjects?: boolean
-  showNoEntitiesState?: boolean
-  defaultSupabaseProject?: Project
-  defaultForeignProjectId?: string
-  mode: 'Vercel' | 'GitHub'
-  variant?: 'default' | 'interstitial'
-}
 
 export const ProjectLinker = ({
   slug,
@@ -94,9 +32,6 @@ export const ProjectLinker = ({
   mode,
   variant = 'default',
 }: ProjectLinkerProps) => {
-  const router = useRouter()
-  const projectCreationEnabled = useIsFeatureEnabled('projects:create')
-
   const [openProjectsDropdown, setOpenProjectsDropdown] = useState(false)
   const [openForeignProjectsComboBox, setOpenForeignProjectsComboBox] = useState(false)
   const [foreignProjectId, setForeignProjectId] = useState<string | undefined>(
@@ -171,200 +106,6 @@ export const ProjectLinker = ({
     !selectedSupabaseProject ||
     !selectedForeignProject
 
-  const supabaseProjectSelector = (
-    <OrganizationProjectSelector
-      sameWidthAsTrigger
-      open={openProjectsDropdown}
-      setOpen={setOpenProjectsDropdown}
-      slug={slug}
-      selectedRef={selectedSupabaseProject?.ref}
-      onSelect={(project) => {
-        setSelectedSupabaseProject(project)
-        setOpenProjectsDropdown(false)
-      }}
-      renderRow={(project) => {
-        return (
-          <div className={cn('w-full flex items-center justify-between')}>
-            <div className="flex items-center gap-x-2">
-              {variant === 'default' && (
-                <div className="bg-white shadow-sm border rounded-sm p-1 w-6 h-6 flex justify-center items-center">
-                  <img src={`${BASE_PATH}/img/supabase-logo.svg`} alt="Supabase" className="w-4" />
-                </div>
-              )}
-              <p>{project.name}</p>
-              {project.status === 'INACTIVE' && <Badge>Paused</Badge>}
-              {project.status === 'GOING_DOWN' && <Badge>Pausing</Badge>}
-            </div>
-            {project.ref === selectedSupabaseProject?.ref && <Check size={16} />}
-          </div>
-        )
-      }}
-      renderTrigger={() => {
-        return (
-          <Button
-            variant="default"
-            block
-            disabled={defaultSupabaseProject !== undefined || loadingSupabaseProjects}
-            loading={loadingSupabaseProjects}
-            className="justify-between h-[34px]"
-            iconRight={
-              defaultSupabaseProject === undefined ? (
-                <span className="grow flex justify-end">
-                  <ChevronDown />
-                </span>
-              ) : null
-            }
-          >
-            <div className="flex items-center gap-x-2">
-              {variant === 'default' && (
-                <div className="bg-white shadow-sm border rounded-sm p-1 w-6 h-6 flex justify-center items-center">
-                  <img src={`${BASE_PATH}/img/supabase-logo.svg`} alt="Supabase" className="w-4" />
-                </div>
-              )}
-              <span className="truncate">
-                {selectedSupabaseProject ? selectedSupabaseProject.name : 'Choose Supabase project'}
-              </span>
-            </div>
-          </Button>
-        )
-      }}
-      renderActions={() => {
-        return (
-          projectCreationEnabled && (
-            <CommandGroup>
-              <CommandItem
-                className="cursor-pointer w-full"
-                onSelect={() => {
-                  setOpenProjectsDropdown(false)
-                  router.push(`/new/${selectedOrganization?.slug}`)
-                }}
-                onClick={() => setOpenProjectsDropdown(false)}
-              >
-                <Link
-                  href={`/new/${selectedOrganization?.slug}`}
-                  onClick={() => {
-                    setOpenProjectsDropdown(false)
-                  }}
-                  className="w-full flex items-center gap-2"
-                >
-                  <Plus size={14} strokeWidth={1.5} />
-                  <p>Create a new project</p>
-                </Link>
-              </CommandItem>
-            </CommandGroup>
-          )
-        )
-      }}
-    />
-  )
-
-  const foreignProjectSelector = (
-    <Popover open={openForeignProjectsComboBox} onOpenChange={setOpenForeignProjectsComboBox}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="default"
-          block
-          disabled={loadingForeignProjects}
-          loading={loadingForeignProjects}
-          className={cn(
-            variant === 'interstitial' ? 'h-[34px] justify-between' : 'justify-start h-[34px]'
-          )}
-          icon={
-            variant === 'default' ? (
-              <div>
-                {selectedForeignProject
-                  ? (getForeignProjectIcon?.(selectedForeignProject) ?? integrationIcon)
-                  : integrationIcon}
-              </div>
-            ) : undefined
-          }
-          iconRight={
-            <span className="grow flex justify-end">
-              <ChevronDown />
-            </span>
-          }
-        >
-          <span className="truncate">
-            {(selectedForeignProject && selectedForeignProject.name) ?? choosePrompt}
-          </span>
-        </Button>
-      </PopoverTrigger>
-      <PopoverContent className="p-0" side="bottom" align="center" sameWidthAsTrigger>
-        <Command>
-          <CommandInput placeholder="Search for a project" />
-          <CommandList className="max-h-[170px]!">
-            <CommandEmpty>No results found.</CommandEmpty>
-            <CommandGroup>
-              {foreignProjects.map((project, i) => {
-                return (
-                  <CommandItem
-                    key={project.id}
-                    value={`${project.name.replaceAll('"', '')}-${i}`}
-                    className="flex gap-2 items-center"
-                    onSelect={() => {
-                      if (project.id) setForeignProjectId(project.id)
-                      setOpenForeignProjectsComboBox(false)
-                    }}
-                  >
-                    <div>{getForeignProjectIcon?.(project) ?? integrationIcon}</div>
-                    <span className="truncate" title={project.name}>
-                      {project.name}
-                    </span>
-                  </CommandItem>
-                )
-              })}
-              {foreignProjects.length === 0 && <CommandEmpty>No results found.</CommandEmpty>}
-            </CommandGroup>
-            {mode === 'GitHub' && (
-              <>
-                <CommandSeparator />
-                <CommandGroup>
-                  <CommandItem
-                    className="flex gap-2 items-center cursor-pointer"
-                    onSelect={() => openInstallGitHubIntegrationWindow('install')}
-                  >
-                    <PlusIcon size={16} />
-                    Add GitHub Repositories
-                  </CommandItem>
-                </CommandGroup>
-              </>
-            )}
-          </CommandList>
-        </Command>
-      </PopoverContent>
-    </Popover>
-  )
-
-  const actionButtons = (
-    <div
-      className={cn('flex w-full gap-2', variant === 'interstitial' ? 'flex-col' : 'justify-end')}
-    >
-      <Button
-        size={variant === 'interstitial' ? undefined : 'medium'}
-        variant={variant === 'interstitial' ? 'primary' : 'default'}
-        block={variant === 'interstitial'}
-        className={variant === 'default' ? 'self-end' : undefined}
-        onClick={onCreateConnections}
-        loading={isLoading}
-        disabled={connectDisabled}
-      >
-        Connect project
-      </Button>
-      {onSkip !== undefined && (
-        <Button
-          size={variant === 'interstitial' ? undefined : 'medium'}
-          variant={variant === 'interstitial' ? 'text' : 'default'}
-          block={variant === 'interstitial'}
-          onClick={() => {
-            onSkip()
-          }}
-        >
-          Skip
-        </Button>
-      )}
-    </div>
-  )
-
   if (variant === 'interstitial') {
     return (
       <div className="flex flex-col gap-5">
@@ -384,19 +125,46 @@ export const ProjectLinker = ({
               <p className="text-xs font-medium uppercase tracking-wider text-foreground-light">
                 Supabase project
               </p>
-              {supabaseProjectSelector}
+              <SupabaseProjectSelector
+                open={openProjectsDropdown}
+                variant={variant}
+                slug={slug}
+                defaultSupabaseProject={defaultSupabaseProject}
+                selectedSupabaseProject={selectedSupabaseProject}
+                loadingSupabaseProjects={loadingSupabaseProjects}
+                setOpen={setOpenProjectsDropdown}
+                setSelectedSupabaseProject={setSelectedSupabaseProject}
+              />
             </section>
 
             <section className="space-y-2" aria-label="Vercel project">
               <p className="text-xs font-medium uppercase tracking-wider text-foreground-light">
                 Vercel project
               </p>
-              {foreignProjectSelector}
+              <ForeignProjectSelector
+                open={openForeignProjectsComboBox}
+                mode={mode}
+                variant={variant}
+                choosePrompt={choosePrompt}
+                selectedForeignProject={selectedForeignProject}
+                loadingForeignProjects={loadingForeignProjects}
+                foreignProjects={foreignProjects}
+                integrationIcon={integrationIcon}
+                setForeignProjectId={setForeignProjectId}
+                onOpenChange={setOpenForeignProjectsComboBox}
+                getForeignProjectIcon={getForeignProjectIcon}
+              />
             </section>
           </>
         )}
 
-        {actionButtons}
+        <ActionButtons
+          variant={variant}
+          connectDisabled={connectDisabled}
+          isLoading={isLoading}
+          onCreateConnections={onCreateConnections}
+          onSkip={onSkip}
+        />
       </div>
     )
   }
@@ -431,7 +199,16 @@ export const ProjectLinker = ({
                 <img src={`${BASE_PATH}/img/supabase-logo.svg`} alt="Supabase" className="w-6" />
               </div>
 
-              {supabaseProjectSelector}
+              <SupabaseProjectSelector
+                open={openProjectsDropdown}
+                variant={variant}
+                slug={slug}
+                defaultSupabaseProject={defaultSupabaseProject}
+                selectedSupabaseProject={selectedSupabaseProject}
+                loadingSupabaseProjects={loadingSupabaseProjects}
+                setOpen={setOpenProjectsDropdown}
+                setSelectedSupabaseProject={setSelectedSupabaseProject}
+              />
             </Panel>
 
             <div className="border border-foreground-lighter h-px w-8 border-dashed self-end mb-4" />
@@ -441,13 +218,33 @@ export const ProjectLinker = ({
                 {integrationIcon}
               </div>
 
-              {foreignProjectSelector}
+              <ForeignProjectSelector
+                open={openForeignProjectsComboBox}
+                mode={mode}
+                variant={variant}
+                choosePrompt={choosePrompt}
+                selectedForeignProject={selectedForeignProject}
+                loadingForeignProjects={loadingForeignProjects}
+                foreignProjects={foreignProjects}
+                integrationIcon={integrationIcon}
+                setForeignProjectId={setForeignProjectId}
+                onOpenChange={setOpenForeignProjectsComboBox}
+                getForeignProjectIcon={getForeignProjectIcon}
+              />
             </Panel>
           </div>
         )}
       </div>
 
-      <div className="flex w-full justify-end gap-2 p-4 bg-surface-75">{actionButtons}</div>
+      <div className="flex w-full justify-end gap-2 p-4 bg-surface-75">
+        <ActionButtons
+          variant={variant}
+          connectDisabled={connectDisabled}
+          isLoading={isLoading}
+          onCreateConnections={onCreateConnections}
+          onSkip={onSkip}
+        />
+      </div>
     </div>
   )
 }

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
@@ -159,6 +159,7 @@ export const ProjectLinker = ({
         )}
 
         <ActionButtons
+          slug={slug}
           mode={mode}
           variant={variant}
           showCreateProject={showNoEntitiesState && noSupabaseProjects}
@@ -241,6 +242,7 @@ export const ProjectLinker = ({
 
       <div className="flex w-full justify-end gap-2 p-4 bg-surface-75">
         <ActionButtons
+          slug={slug}
           mode={mode}
           variant={variant}
           showCreateProject={showNoEntitiesState && noSupabaseProjects}

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
@@ -45,16 +45,6 @@ export const ProjectLinker = ({
   })
   const numProjects = orgProjects?.pages[0].pagination.count ?? 0
 
-  useEffect(() => {
-    if (defaultSupabaseProject !== undefined && selectedSupabaseProject === undefined)
-      setSelectedSupabaseProject(defaultSupabaseProject)
-  }, [defaultSupabaseProject, selectedSupabaseProject])
-
-  useEffect(() => {
-    if (defaultForeignProjectId !== undefined && foreignProjectId === undefined)
-      setForeignProjectId(defaultForeignProjectId)
-  }, [defaultForeignProjectId, foreignProjectId])
-
   // create a flat array of foreign project ids. ie, ["prj_MlkO6AiLG5ofS9ojKrkS3PhhlY3f", ..]
   const flatInstalledConnectionsIds = new Set(installedConnections.map((x) => x.foreign_project_id))
 
@@ -105,6 +95,16 @@ export const ProjectLinker = ({
     isLoading ||
     !selectedSupabaseProject ||
     !selectedForeignProject
+
+  useEffect(() => {
+    if (defaultSupabaseProject !== undefined && selectedSupabaseProject === undefined)
+      setSelectedSupabaseProject(defaultSupabaseProject)
+  }, [defaultSupabaseProject, selectedSupabaseProject])
+
+  useEffect(() => {
+    if (defaultForeignProjectId !== undefined && foreignProjectId === undefined)
+      setForeignProjectId(defaultForeignProjectId)
+  }, [defaultForeignProjectId, foreignProjectId])
 
   if (variant === 'interstitial') {
     return (
@@ -159,8 +159,11 @@ export const ProjectLinker = ({
         )}
 
         <ActionButtons
+          mode={mode}
           variant={variant}
+          showCreateProject={showNoEntitiesState && noSupabaseProjects}
           connectDisabled={connectDisabled}
+          foreignProjectId={foreignProjectId}
           isLoading={isLoading}
           onCreateConnections={onCreateConnections}
           onSkip={onSkip}
@@ -238,8 +241,11 @@ export const ProjectLinker = ({
 
       <div className="flex w-full justify-end gap-2 p-4 bg-surface-75">
         <ActionButtons
+          mode={mode}
           variant={variant}
+          showCreateProject={showNoEntitiesState && noSupabaseProjects}
           connectDisabled={connectDisabled}
+          foreignProjectId={foreignProjectId}
           isLoading={isLoading}
           onCreateConnections={onCreateConnections}
           onSkip={onSkip}

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
@@ -1,0 +1,288 @@
+import { Check, ChevronDown, Plus, PlusIcon } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { HTMLAttributes } from 'react'
+import {
+  Badge,
+  Button,
+  cn,
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from 'ui'
+
+import { Project, type ForeignProject, type ProjectLinkerProps } from './VercelGithub.types'
+import { OrganizationProjectSelector } from '@/components/ui/OrganizationProjectSelector'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
+import { BASE_PATH } from '@/lib/constants'
+import { openInstallGitHubIntegrationWindow } from '@/lib/github'
+
+export const Panel = ({ children, className, ...props }: HTMLAttributes<HTMLDivElement>) => {
+  return (
+    <div
+      className={cn(
+        'flex-1 min-w-0 flex flex-col grow gap-6 px-5 mx-auto w-full justify-center items-center',
+        className
+      )}
+      {...props}
+    >
+      {children}
+    </div>
+  )
+}
+
+export const ForeignProjectSelector = ({
+  open,
+  mode,
+  variant,
+  choosePrompt,
+  selectedForeignProject,
+  loadingForeignProjects,
+  foreignProjects,
+  integrationIcon,
+  onOpenChange,
+  setForeignProjectId,
+  getForeignProjectIcon,
+}: {
+  open: boolean
+  selectedForeignProject?: ForeignProject
+  setForeignProjectId: (id: string) => void
+  onOpenChange: (val: boolean) => void
+} & Pick<
+  ProjectLinkerProps,
+  | 'mode'
+  | 'variant'
+  | 'choosePrompt'
+  | 'loadingForeignProjects'
+  | 'foreignProjects'
+  | 'getForeignProjectIcon'
+  | 'integrationIcon'
+>) => {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <Button
+          variant="default"
+          block
+          disabled={loadingForeignProjects}
+          loading={loadingForeignProjects}
+          className={cn(
+            variant === 'interstitial' ? 'h-[34px] justify-between' : 'justify-start h-[34px]'
+          )}
+          icon={
+            variant === 'default' ? (
+              <div>
+                {selectedForeignProject
+                  ? (getForeignProjectIcon?.(selectedForeignProject) ?? integrationIcon)
+                  : integrationIcon}
+              </div>
+            ) : undefined
+          }
+          iconRight={
+            <span className="grow flex justify-end">
+              <ChevronDown />
+            </span>
+          }
+        >
+          <span className="truncate">
+            {(selectedForeignProject && selectedForeignProject.name) ?? choosePrompt}
+          </span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="p-0" side="bottom" align="center" sameWidthAsTrigger>
+        <Command>
+          <CommandInput placeholder="Search for a project" />
+          <CommandList className="max-h-[170px]!">
+            <CommandEmpty>No results found.</CommandEmpty>
+            <CommandGroup>
+              {foreignProjects.map((project, i) => {
+                return (
+                  <CommandItem
+                    key={project.id}
+                    value={`${project.name.replaceAll('"', '')}-${i}`}
+                    className="flex gap-2 items-center"
+                    onSelect={() => {
+                      if (project.id) setForeignProjectId(project.id)
+                      onOpenChange(false)
+                    }}
+                  >
+                    <div>{getForeignProjectIcon?.(project) ?? integrationIcon}</div>
+                    <span className="truncate" title={project.name}>
+                      {project.name}
+                    </span>
+                  </CommandItem>
+                )
+              })}
+              {foreignProjects.length === 0 && <CommandEmpty>No results found.</CommandEmpty>}
+            </CommandGroup>
+            {mode === 'GitHub' && (
+              <>
+                <CommandSeparator />
+                <CommandGroup>
+                  <CommandItem
+                    className="flex gap-2 items-center cursor-pointer"
+                    onSelect={() => openInstallGitHubIntegrationWindow('install')}
+                  >
+                    <PlusIcon size={16} />
+                    Add GitHub Repositories
+                  </CommandItem>
+                </CommandGroup>
+              </>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+export const SupabaseProjectSelector = ({
+  open,
+  variant,
+  slug,
+  defaultSupabaseProject,
+  selectedSupabaseProject,
+  loadingSupabaseProjects,
+  setOpen,
+  setSelectedSupabaseProject,
+}: {
+  open: boolean
+  selectedSupabaseProject?: Project
+  loadingSupabaseProjects: boolean
+  setOpen: (val: boolean) => void
+  setSelectedSupabaseProject: (project: Project) => void
+} & Pick<ProjectLinkerProps, 'slug' | 'variant' | 'defaultSupabaseProject'>) => {
+  const router = useRouter()
+  const { data: selectedOrganization } = useSelectedOrganizationQuery()
+  const projectCreationEnabled = useIsFeatureEnabled('projects:create')
+
+  return (
+    <OrganizationProjectSelector
+      sameWidthAsTrigger
+      open={open}
+      setOpen={setOpen}
+      slug={slug}
+      selectedRef={selectedSupabaseProject?.ref}
+      onSelect={(project) => {
+        setSelectedSupabaseProject(project)
+        setOpen(false)
+      }}
+      renderRow={(project) => {
+        return (
+          <div className={cn('w-full flex items-center justify-between')}>
+            <div className="flex items-center gap-x-2">
+              {variant === 'default' && (
+                <div className="bg-white shadow-sm border rounded-sm p-1 w-6 h-6 flex justify-center items-center">
+                  <img src={`${BASE_PATH}/img/supabase-logo.svg`} alt="Supabase" className="w-4" />
+                </div>
+              )}
+              <p>{project.name}</p>
+              {project.status === 'INACTIVE' && <Badge>Paused</Badge>}
+              {project.status === 'GOING_DOWN' && <Badge>Pausing</Badge>}
+            </div>
+            {project.ref === selectedSupabaseProject?.ref && <Check size={16} />}
+          </div>
+        )
+      }}
+      renderTrigger={() => {
+        return (
+          <Button
+            variant="default"
+            block
+            disabled={defaultSupabaseProject !== undefined || loadingSupabaseProjects}
+            loading={loadingSupabaseProjects}
+            className="justify-between h-[34px]"
+            iconRight={
+              defaultSupabaseProject === undefined ? (
+                <span className="grow flex justify-end">
+                  <ChevronDown />
+                </span>
+              ) : null
+            }
+          >
+            <div className="flex items-center gap-x-2">
+              {variant === 'default' && (
+                <div className="bg-white shadow-sm border rounded-sm p-1 w-6 h-6 flex justify-center items-center">
+                  <img src={`${BASE_PATH}/img/supabase-logo.svg`} alt="Supabase" className="w-4" />
+                </div>
+              )}
+              <span className="truncate">
+                {selectedSupabaseProject ? selectedSupabaseProject.name : 'Choose Supabase project'}
+              </span>
+            </div>
+          </Button>
+        )
+      }}
+      renderActions={() => {
+        return (
+          projectCreationEnabled && (
+            <CommandGroup>
+              <CommandItem
+                className="cursor-pointer w-full"
+                onSelect={() => {
+                  setOpen(false)
+                  router.push(`/new/${selectedOrganization?.slug}`)
+                }}
+                onClick={() => setOpen(false)}
+              >
+                <Link
+                  href={`/new/${selectedOrganization?.slug}`}
+                  className="w-full flex items-center gap-2"
+                  onClick={() => setOpen(false)}
+                >
+                  <Plus size={14} strokeWidth={1.5} />
+                  <p>Create a new project</p>
+                </Link>
+              </CommandItem>
+            </CommandGroup>
+          )
+        )
+      }}
+    />
+  )
+}
+
+export const ActionButtons = ({
+  variant,
+  connectDisabled,
+  isLoading,
+  onCreateConnections,
+  onSkip,
+}: { connectDisabled: boolean; onCreateConnections: () => void } & Pick<
+  ProjectLinkerProps,
+  'variant' | 'onSkip' | 'isLoading'
+>) => (
+  <div className={cn('flex w-full gap-2', variant === 'interstitial' ? 'flex-col' : 'justify-end')}>
+    <Button
+      size={variant === 'interstitial' ? undefined : 'medium'}
+      variant={variant === 'interstitial' ? 'primary' : 'default'}
+      block={variant === 'interstitial'}
+      className={variant === 'default' ? 'self-end' : undefined}
+      onClick={onCreateConnections}
+      loading={isLoading}
+      disabled={connectDisabled}
+    >
+      Connect project
+    </Button>
+    {onSkip !== undefined && (
+      <Button
+        size={variant === 'interstitial' ? undefined : 'medium'}
+        variant={variant === 'interstitial' ? 'text' : 'default'}
+        block={variant === 'interstitial'}
+        onClick={() => {
+          onSkip()
+        }}
+      >
+        Skip
+      </Button>
+    )}
+  </div>
+)

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
@@ -1,3 +1,4 @@
+import { useParams } from 'common'
 import { Check, ChevronDown, Plus, PlusIcon } from 'lucide-react'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
@@ -251,38 +252,69 @@ export const SupabaseProjectSelector = ({
 }
 
 export const ActionButtons = ({
+  mode,
   variant,
+  showCreateProject,
   connectDisabled,
   isLoading,
+  foreignProjectId,
   onCreateConnections,
   onSkip,
-}: { connectDisabled: boolean; onCreateConnections: () => void } & Pick<
-  ProjectLinkerProps,
-  'variant' | 'onSkip' | 'isLoading'
->) => (
-  <div className={cn('flex w-full gap-2', variant === 'interstitial' ? 'flex-col' : 'justify-end')}>
-    <Button
-      size={variant === 'interstitial' ? undefined : 'medium'}
-      variant={variant === 'interstitial' ? 'primary' : 'default'}
-      block={variant === 'interstitial'}
-      className={variant === 'default' ? 'self-end' : undefined}
-      onClick={onCreateConnections}
-      loading={isLoading}
-      disabled={connectDisabled}
+}: {
+  showCreateProject: boolean
+  connectDisabled: boolean
+  foreignProjectId: string | undefined
+  onCreateConnections: () => void
+} & Pick<ProjectLinkerProps, 'variant' | 'mode' | 'onSkip' | 'isLoading'>) => {
+  const { slug, next } = useParams()
+  const newProjectURL =
+    mode === 'Vercel'
+      ? `/integrations/vercel/${slug}/deploy-button/new-project?${new URLSearchParams({
+          ...(next ? { next } : {}),
+          ...(foreignProjectId ? { currentProjectId: foreignProjectId } : {}),
+        })}`
+      : `/new/${slug}`
+
+  return (
+    <div
+      className={cn('flex w-full gap-2', variant === 'interstitial' ? 'flex-col' : 'justify-end')}
     >
-      Connect project
-    </Button>
-    {onSkip !== undefined && (
-      <Button
-        size={variant === 'interstitial' ? undefined : 'medium'}
-        variant={variant === 'interstitial' ? 'text' : 'default'}
-        block={variant === 'interstitial'}
-        onClick={() => {
-          onSkip()
-        }}
-      >
-        Skip
-      </Button>
-    )}
-  </div>
-)
+      {showCreateProject ? (
+        <Button
+          asChild
+          size={variant === 'interstitial' ? undefined : 'medium'}
+          variant={variant === 'interstitial' ? 'primary' : 'default'}
+          block={variant === 'interstitial'}
+          className={variant === 'default' ? 'self-end' : undefined}
+          loading={isLoading}
+        >
+          <Link href={newProjectURL}>Create project</Link>
+        </Button>
+      ) : (
+        <Button
+          size={variant === 'interstitial' ? undefined : 'medium'}
+          variant={variant === 'interstitial' ? 'primary' : 'default'}
+          block={variant === 'interstitial'}
+          className={variant === 'default' ? 'self-end' : undefined}
+          onClick={onCreateConnections}
+          loading={isLoading}
+          disabled={connectDisabled}
+        >
+          Connect project
+        </Button>
+      )}
+      {onSkip !== undefined && (
+        <Button
+          size={variant === 'interstitial' ? undefined : 'medium'}
+          variant={variant === 'interstitial' ? 'text' : 'default'}
+          block={variant === 'interstitial'}
+          onClick={() => {
+            onSkip()
+          }}
+        >
+          Skip
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
@@ -266,12 +266,14 @@ export const ActionButtons = ({
   foreignProjectId: string | undefined
   onCreateConnections: () => void
 } & Pick<ProjectLinkerProps, 'variant' | 'mode' | 'onSkip' | 'isLoading'>) => {
-  const { slug, next } = useParams()
+  const { slug, next, externalId, currentProjectId } = useParams()
+  const vercelProjectId = foreignProjectId ?? currentProjectId
   const newProjectURL =
     mode === 'Vercel'
       ? `/integrations/vercel/${slug}/deploy-button/new-project?${new URLSearchParams({
           ...(next ? { next } : {}),
-          ...(foreignProjectId ? { currentProjectId: foreignProjectId } : {}),
+          ...(vercelProjectId ? { currentProjectId: vercelProjectId } : {}),
+          ...(externalId ? { externalId } : {}),
         })}`
       : `/new/${slug}`
 

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinkerComponents.tsx
@@ -252,6 +252,7 @@ export const SupabaseProjectSelector = ({
 }
 
 export const ActionButtons = ({
+  slug,
   mode,
   variant,
   showCreateProject,
@@ -265,17 +266,19 @@ export const ActionButtons = ({
   connectDisabled: boolean
   foreignProjectId: string | undefined
   onCreateConnections: () => void
-} & Pick<ProjectLinkerProps, 'variant' | 'mode' | 'onSkip' | 'isLoading'>) => {
-  const { slug, next, externalId, currentProjectId } = useParams()
+} & Pick<ProjectLinkerProps, 'slug' | 'variant' | 'mode' | 'onSkip' | 'isLoading'>) => {
+  const { next, externalId, currentProjectId } = useParams()
+  const organizationSlug = slug
   const vercelProjectId = foreignProjectId ?? currentProjectId
+  // Deploy-button create is only for the install interstitial; settings side panels use /new.
   const newProjectURL =
-    mode === 'Vercel'
-      ? `/integrations/vercel/${slug}/deploy-button/new-project?${new URLSearchParams({
+    mode === 'Vercel' && variant === 'interstitial' && organizationSlug
+      ? `/integrations/vercel/${organizationSlug}/deploy-button/new-project?${new URLSearchParams({
           ...(next ? { next } : {}),
           ...(vercelProjectId ? { currentProjectId: vercelProjectId } : {}),
           ...(externalId ? { externalId } : {}),
         })}`
-      : `/new/${slug}`
+      : `/new/${organizationSlug}`
 
   return (
     <div

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/VercelGithub.types.ts
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/VercelGithub.types.ts
@@ -1,0 +1,36 @@
+import { ReactNode } from 'react'
+
+import {
+  type IntegrationConnectionsCreateVariables,
+  type IntegrationProjectConnection,
+} from '@/data/integrations/integrations.types'
+
+export interface Project {
+  name: string
+  ref: string
+}
+
+export interface ForeignProject {
+  id: string
+  name: string
+  installation_id?: number
+}
+
+export interface ProjectLinkerProps {
+  slug?: string
+  organizationIntegrationId?: string
+  foreignProjects: ForeignProject[]
+  onCreateConnections: (variables: IntegrationConnectionsCreateVariables) => void
+  installedConnections?: IntegrationProjectConnection[]
+  isLoading?: boolean
+  integrationIcon: ReactNode
+  getForeignProjectIcon?: (project: ForeignProject) => ReactNode
+  choosePrompt?: string
+  onSkip?: () => void
+  loadingForeignProjects?: boolean
+  showNoEntitiesState?: boolean
+  defaultSupabaseProject?: Project
+  defaultForeignProjectId?: string
+  mode: 'Vercel' | 'GitHub'
+  variant?: 'default' | 'interstitial'
+}

--- a/apps/studio/components/interfaces/Organization/IntegrationSettings/SidePanelVercelProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Organization/IntegrationSettings/SidePanelVercelProjectLinker.tsx
@@ -3,11 +3,9 @@ import { useCallback, useMemo } from 'react'
 import { toast } from 'sonner'
 import { SidePanel } from 'ui'
 
+import { type ForeignProject } from '../../Integrations/VercelGithub/VercelGithub.types'
 import { ENV_VAR_RAW_KEYS } from '@/components/interfaces/Integrations/Vercel/Integrations-Vercel.constants'
-import {
-  ForeignProject,
-  ProjectLinker,
-} from '@/components/interfaces/Integrations/VercelGithub/ProjectLinker'
+import { ProjectLinker } from '@/components/interfaces/Integrations/VercelGithub/ProjectLinker'
 import { Markdown } from '@/components/interfaces/Markdown'
 import { vercelIcon } from '@/components/to-be-cleaned/ListIcons'
 import { useOrgIntegrationsQuery } from '@/data/integrations/integrations-query-org-only'

--- a/apps/studio/lib/integrations/vercel-install.utils.ts
+++ b/apps/studio/lib/integrations/vercel-install.utils.ts
@@ -59,9 +59,12 @@ export function buildVercelInstallRouteQuery({
       })
     case 'marketplace':
     case 'external':
+      // Keep Deploy Button ids when present so choose-project → create can seed + link.
       return removeUndefinedValues({
         organizationSlug,
         configurationId,
+        currentProjectId,
+        externalId,
         next,
       })
     default:

--- a/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
@@ -174,8 +174,7 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
               title="Unable to load project connection"
               errorMessage="Organization not found. Retry the installation from Vercel."
             />
-          ) : // [JOSHEN TODO BEFORE MERGING] Please flip this back to integrationNotFound
-          false ? (
+          ) : integrationNotFound ? (
             <VercelIntegrationInterstitialErrorState
               title="Unable to load project connection"
               errorMessage="Vercel integration not found for this organization. Retry the installation from Vercel."
@@ -204,8 +203,7 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
                     window.location.href = next
                   }
                 }}
-                // // [JOSHEN TODO BEFORE MERGING] Please uncomment this out
-                // loadingForeignProjects={isLoadingVercelProjectsData}
+                loadingForeignProjects={isLoadingVercelProjectsData}
                 mode="Vercel"
               />
             </div>

--- a/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
@@ -40,7 +40,7 @@ const PAGE_TITLE = buildStudioPageTitle({
 })
 
 const VercelChooseProjectPage: NextPageWithLayout = () => {
-  const { slug, configurationId, next } = useParams()
+  const { slug, configurationId, next, currentProjectId } = useParams()
   const { username, primaryEmail, avatarUrl } = useProfileNameAndPicture()
   const displayName = primaryEmail ?? username ?? ''
 
@@ -198,6 +198,7 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
                 integrationIcon={VERCEL_INTEGRATION_ICON}
                 getForeignProjectIcon={getForeignProjectIcon}
                 choosePrompt="Choose Vercel project"
+                defaultForeignProjectId={currentProjectId}
                 onSkip={() => {
                   if (next && isVercelUrl(next)) {
                     window.location.href = next

--- a/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
@@ -17,10 +17,8 @@ import {
   VercelIntegrationInterstitialErrorState,
   VercelIntegrationLogo,
 } from '@/components/interfaces/Integrations/Vercel/VercelIntegrationInterstitial'
-import {
-  ProjectLinker,
-  type ForeignProject,
-} from '@/components/interfaces/Integrations/VercelGithub/ProjectLinker'
+import { ProjectLinker } from '@/components/interfaces/Integrations/VercelGithub/ProjectLinker'
+import type { ForeignProject } from '@/components/interfaces/Integrations/VercelGithub/VercelGithub.types'
 import { InterstitialAccountRow, InterstitialLayout } from '@/components/layouts/InterstitialLayout'
 import { vercelIcon } from '@/components/to-be-cleaned/ListIcons'
 import { useOrgIntegrationsQuery } from '@/data/integrations/integrations-query-org-only'
@@ -176,7 +174,8 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
               title="Unable to load project connection"
               errorMessage="Organization not found. Retry the installation from Vercel."
             />
-          ) : integrationNotFound ? (
+          ) : // [JOSHEN TODO BEFORE MERGING] Please flip this back to integrationNotFound
+          false ? (
             <VercelIntegrationInterstitialErrorState
               title="Unable to load project connection"
               errorMessage="Vercel integration not found for this organization. Retry the installation from Vercel."
@@ -205,7 +204,8 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
                     window.location.href = next
                   }
                 }}
-                loadingForeignProjects={isLoadingVercelProjectsData}
+                // // [JOSHEN TODO BEFORE MERGING] Please uncomment this out
+                // loadingForeignProjects={isLoadingVercelProjectsData}
                 mode="Vercel"
               />
             </div>

--- a/apps/studio/tests/pages/integrations/vercel/install.utils.test.ts
+++ b/apps/studio/tests/pages/integrations/vercel/install.utils.test.ts
@@ -45,7 +45,7 @@ describe('buildVercelInstallRouteQuery', () => {
     })
   })
 
-  test('only keeps marketplace destination params', () => {
+  test('keeps marketplace params and passes through deploy-button ids when present', () => {
     expect(
       buildVercelInstallRouteQuery({
         source: 'marketplace',
@@ -58,6 +58,8 @@ describe('buildVercelInstallRouteQuery', () => {
     ).toStrictEqual({
       organizationSlug: 'acme',
       configurationId: 'configuration-id',
+      currentProjectId: 'vercel-project',
+      externalId: 'github-repo',
       next: 'https://vercel.com/callback',
     })
   })


### PR DESCRIPTION
## Context

For the Vercel integration flow (e.g "Deploy with Vercel" button on GH)
If an organization has no projects, there currently isn't a way to create a project and connect it in the same session - users can only hit "Skip".

This addresses that by directing users to the /deploy-button/new-project route in this scenario

<img width="505" height="539" alt="image" src="https://github.com/user-attachments/assets/6cc85030-42c7-4e58-b4b3-cb8ac0f5da9e" />

## Other changes involved
- Also separates `ProjectLinker` into smaller components - preference for avoiding declaration of components within a component

## To test

I'm not sure if this can be tested on staging to be honest, but otherwise we can give it a go on production after the changes are through, as this doesn't change any existing logic to the usual "Connect project" flow

I did try clicking the "Deploy with Vercel" button on a repo, and just changing the URL to the staging URL at the Supabase step - seems to work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **UI Improvements**
  * Streamlined the Vercel/GitHub project-linking step while keeping the same create/connect/skip flow, including the searchable project picker, branding/status indicators, and the feature-flagged “create new project” option.
  * On the Vercel choose-project step, the default selection now reflects the current project context.

* **Bug Fixes / Tests**
  * Improved Vercel install routing query handling to preserve deploy-button configuration when present, with updated automated test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->