### PR TITLE
Allow users to continue with org if integration installed

### DIFF
--- a/apps/studio/pages/integrations/vercel/install.tsx
+++ b/apps/studio/pages/integrations/vercel/install.tsx
@@ -311,7 +311,7 @@ const VercelIntegration: NextPageWithLayout = () => {
                   loading={dataLoading}
                   onClick={onInstall}
                 >
-                  {alreadyInstalled ? 'Continue' : 'Install integration'}
+                  {selectedOrg && installed[selectedOrg.slug] ? 'Continue' : 'Install integration'}
                 </Button>
               </div>
             </div>

--- a/apps/studio/pages/integrations/vercel/install.tsx
+++ b/apps/studio/pages/integrations/vercel/install.tsx
@@ -215,12 +215,6 @@ const VercelIntegration: NextPageWithLayout = () => {
     return isOrganizationsDataSuccess && organizationsData?.length === 0 ? true : false
   }, [isOrganizationsDataSuccess, organizationsData])
 
-  const alreadyInstalled = useMemo(() => {
-    return selectedOrg && installed[selectedOrg.slug] && source === 'marketplace' && !dataLoading
-      ? true
-      : false
-  }, [dataLoading, installed, selectedOrg, source])
-
   const missingParams = [
     !code ? 'code' : undefined,
     !configurationId ? 'configurationId' : undefined,

--- a/apps/studio/pages/integrations/vercel/install.tsx
+++ b/apps/studio/pages/integrations/vercel/install.tsx
@@ -56,13 +56,14 @@ const PAGE_TITLE = buildStudioPageTitle({
 export type VercelIntegrationFlow = 'deploy-button' | 'marketing'
 
 const VercelIntegration: NextPageWithLayout = () => {
-  const router = useRouter()
-  const { code, configurationId, currentProjectId, externalId, next, teamId, source } = useParams()
-  const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null)
-  const { username, primaryEmail, avatarUrl } = useProfileNameAndPicture()
   const track = useTrack()
-
+  const router = useRouter()
   const snapshot = useIntegrationInstallationSnapshot()
+  const { code, configurationId, currentProjectId, externalId, next, teamId, source } = useParams()
+
+  const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null)
+
+  const { username, primaryEmail, avatarUrl } = useProfileNameAndPicture()
   const displayName = primaryEmail ?? username ?? ''
 
   /**
@@ -84,16 +85,6 @@ const VercelIntegration: NextPageWithLayout = () => {
     isError: isOrganizationsError,
     error: organizationsError,
   } = useOrganizationsQuery()
-
-  useEffect(() => {
-    if (organizationsData !== undefined && integrationData !== undefined) {
-      const firstOrg = organizationsData[0]
-
-      if (firstOrg && selectedOrg === null) {
-        setSelectedOrg(firstOrg)
-      }
-    }
-  }, [organizationsData, integrationData, selectedOrg])
 
   /**
    * Organizations with extra `installationInstalled` attribute
@@ -241,13 +232,18 @@ const VercelIntegration: NextPageWithLayout = () => {
   const showLoadingState = isLoadingOrganizationsQuery || isLoadingIntegrationsQuery
 
   const disableInstallationForm =
-    dataLoading ||
-    // disables installation button if integration is already installed and it is Marketplace flow
-    alreadyInstalled ||
-    noOrganizations ||
-    !selectedOrg ||
-    missingParams.length > 0 ||
-    isError
+    dataLoading || noOrganizations || !selectedOrg || missingParams.length > 0 || isError
+
+  useEffect(() => {
+    if (organizationsData !== undefined && integrationData !== undefined) {
+      const firstOrg = organizationsData[0]
+
+      if (firstOrg && selectedOrg === null) {
+        setSelectedOrg(firstOrg)
+      }
+    }
+  }, [organizationsData, integrationData, selectedOrg])
+
   return (
     <>
       <Head>
@@ -290,14 +286,6 @@ const VercelIntegration: NextPageWithLayout = () => {
                 />
               )}
 
-              {alreadyInstalled && (
-                <Admonition
-                  type="warning"
-                  title="Vercel integration is already installed"
-                  description="Choose another organization to install this marketplace integration."
-                />
-              )}
-
               {noOrganizations && (
                 <Admonition
                   type="warning"
@@ -323,7 +311,7 @@ const VercelIntegration: NextPageWithLayout = () => {
                   loading={dataLoading}
                   onClick={onInstall}
                 >
-                  Install integration
+                  {alreadyInstalled ? 'Continue' : 'Install integration'}
                 </Button>
               </div>
             </div>


### PR DESCRIPTION
## Context

For the Vercel integration, if the source is marketplace, currently selecting an organization that already has the integration installed prevents the user from proceeding.
<img width="267" height="172" alt="image" src="https://github.com/user-attachments/assets/ba3aafa0-f753-4797-89cd-a7f1e16bbdb2" />


Whereas users should just be able to proceed and select a project from within the organization
<img width="435" height="226" alt="image" src="https://github.com/user-attachments/assets/e659bc20-6980-4ef2-af5c-8612af99668b" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the Vercel integration installation flow with dynamic primary button text (“Continue” vs “Install integration”) based on installation status.
* **Bug Fixes**
  * Updated the install button so it no longer disables when the selected organization already has the Vercel marketplace integration installed.
  * Removed the “already installed” warning from the main render path.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->