### PR TITLE
fix: pin pnpm to v9 in mgmt-api docs update workflow

### DIFF
--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -27,7 +27,6 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
-          version: 9
           run_install: false
 
       - name: Use Node.js
@@ -38,6 +37,12 @@ jobs:
 
       - name: Install deps
         run: pnpm install --frozen-lockfile
+
+      - name: Debug pnpm env
+        run: |
+          echo "NODE_ENV=$NODE_ENV"
+          pnpm config list
+          ls apps/docs/node_modules/.bin/ | grep redocly || echo "redocly bin missing"
 
       - name: Change to apps/docs/spec directory and run make command
         working-directory: apps/docs/spec

--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -38,12 +38,6 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
-      - name: Debug pnpm env
-        run: |
-          echo "NODE_ENV=$NODE_ENV"
-          pnpm config list
-          ls apps/docs/node_modules/.bin/ | grep redocly || echo "redocly bin missing"
-
       - name: Change to apps/docs/spec directory and run make command
         working-directory: apps/docs/spec
         run: make download.api.v1 dereference.api.v1 generate.sections.api.v1 format

--- a/.github/workflows/docs-mgmt-api-update.yml
+++ b/.github/workflows/docs-mgmt-api-update.yml
@@ -27,6 +27,7 @@ jobs:
       - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         name: Install pnpm
         with:
+          version: 9
           run_install: false
 
       - name: Use Node.js

--- a/apps/docs/spec/Makefile
+++ b/apps/docs/spec/Makefile
@@ -62,17 +62,17 @@ download.analytics.v0:
 transform: dereference.api.v1 dereference.auth.v1 dereference.storage.v0
 
 dereference.api.v1:
-	pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/api_v1_openapi_deparsed.json $(REPO_DIR)/api_v1_openapi.json
-	pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/api_v2_openapi_deparsed.json $(REPO_DIR)/api_v2_openapi.json
+	npx redocly bundle --dereferenced -o $(REPO_DIR)/transforms/api_v1_openapi_deparsed.json $(REPO_DIR)/api_v1_openapi.json
+	npx redocly bundle --dereferenced -o $(REPO_DIR)/transforms/api_v2_openapi_deparsed.json $(REPO_DIR)/api_v2_openapi.json
 
 dereference.auth.v1:
-	pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/auth_v1_openapi_deparsed.json $(REPO_DIR)/auth_v1_openapi.json
+	npx redocly bundle --dereferenced -o $(REPO_DIR)/transforms/auth_v1_openapi_deparsed.json $(REPO_DIR)/auth_v1_openapi.json
 
 dereference.storage.v0:
-	pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/storage_v0_openapi_deparsed.json $(REPO_DIR)/storage_v0_openapi.json
+	npx redocly bundle --dereferenced -o $(REPO_DIR)/transforms/storage_v0_openapi_deparsed.json $(REPO_DIR)/storage_v0_openapi.json
 
 dereference.analytics.v0:
-	pnpm exec redocly bundle --dereferenced -o $(REPO_DIR)/transforms/analytics_v0_openapi_deparsed.json $(REPO_DIR)/analytics_v0_openapi.json
+	npx redocly bundle --dereferenced -o $(REPO_DIR)/transforms/analytics_v0_openapi_deparsed.json $(REPO_DIR)/analytics_v0_openapi.json
 
 ###############################################################################
 # Generate sections from OpenAPI 3.0
@@ -90,7 +90,7 @@ generate.sections.api.v1:
 ###############################################################################
 
 validate.analytics.v0:
-	pnpm exec redocly lint --extends=minimal $(REPO_DIR)/analytics_v0_openapi.json
+	npx redocly lint --extends=minimal $(REPO_DIR)/analytics_v0_openapi.json
 
 ###############################################################################
 # Format everything - easier for git to track changes.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Pin `pnpm/action-setup` to pnpm v9 in the mgmt-api docs update workflow.

## What is the current behavior?

`pnpm/action-setup` was bumped 4.2.0 → 6.0.9 via Dependabot, which changed the default resolved pnpm version since no version was pinned. 

Our lockfile is `pnpm 9.x`, and the mismatch caused `pnpm install --frozen-lockfile` to silently skip resolving some devDependencies (e.g. `@redocly/cli`), breaking `dereference.api.v1` with `redocly not found`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated OpenAPI documentation generation and validation commands while preserving existing outputs and behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->