### PR TITLE
fix(advisor): exclude extension-owned tables from RLS disabled lint

### DIFF
--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -724,10 +724,15 @@ from
     pg_catalog.pg_class c
     join pg_catalog.pg_namespace n
         on c.relnamespace = n.oid
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
 where
     c.relkind = 'r' -- regular tables
     -- RLS is disabled
     and not c.relrowsecurity
+    -- exclude tables owned by extensions (e.g. PostGIS spatial_ref_sys)
+    and dep.objid is null
     and (
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')


### PR DESCRIPTION
Fixes #47206.

The `rls_disabled_in_public` advisor lint reports a Critical warning for `spatial_ref_sys` (and any other extension-owned table in a public-facing schema). Users cannot resolve it — `ALTER TABLE spatial_ref_sys ENABLE ROW LEVEL SECURITY` fails with `42501: must be owner of table spatial_ref_sys`.

Every other lint check in `lints.ts` that operates on `pg_catalog.pg_class` already excludes extension-owned objects with:
```sql
left join pg_catalog.pg_depend dep
    on c.oid = dep.objid
    and dep.deptype = 'e'
...
and dep.objid is null
```

The `rls_disabled_in_public` query was the only one missing this guard. Added the same join + filter so tables owned by an extension (PostGIS `spatial_ref_sys`, TimescaleDB system tables, etc.) are excluded from the results.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database security linting by excluding extension-owned tables from false-positive warnings about disabled row-level security.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->