### PR TITLE
feat(auth): expose access token expiry under auth settings

### DIFF
--- a/apps/docs/content/guides/auth/sessions.mdx
+++ b/apps/docs/content/guides/auth/sessions.mdx
@@ -69,7 +69,7 @@ Otherwise sessions are progressively deleted from the database 24 hours after th
 
 ### What are recommended values for access token (JWT) expiration?
 
-Most applications should use the default expiration time of 1 hour. This can be customized under the **Access Tokens** section in the [Auth settings](/dashboard/project/_/auth/sessions).
+Most applications should use the default expiration time of 1 hour. You can customize this value in the [Auth settings > Sessions](/dashboard/project/_/auth/sessions).
 
 Setting a value over 1 hour is generally discouraged for security reasons, but it may make sense in certain situations.
 

--- a/apps/docs/content/guides/auth/sessions.mdx
+++ b/apps/docs/content/guides/auth/sessions.mdx
@@ -69,7 +69,7 @@ Otherwise sessions are progressively deleted from the database 24 hours after th
 
 ### What are recommended values for access token (JWT) expiration?
 
-Most applications should use the default expiration time of 1 hour. This can be customized in your [project's settings](/dashboard/project/_/settings/jwt/legacy) in the JWT Keys > Legacy JWT Secret section.
+Most applications should use the default expiration time of 1 hour. This can be customized under the **Access Tokens** section in the [Auth settings](/dashboard/project/_/auth/sessions).
 
 Setting a value over 1 hour is generally discouraged for security reasons, but it may make sense in certain situations.
 

--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.test.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.test.tsx
@@ -1,0 +1,106 @@
+import { fireEvent, screen, waitFor, within } from '@testing-library/react'
+import { mockAnimationsApi } from 'jsdom-testing-mocks'
+import { HttpResponse } from 'msw'
+import { describe, expect, test, vi } from 'vitest'
+
+import { SessionsAuthSettingsForm } from './SessionsAuthSettingsForm'
+import { customRender } from '@/tests/lib/custom-render'
+import { addAPIMock } from '@/tests/lib/msw'
+
+// FormMessage animates via framer-motion, which relies on the Web Animations API.
+mockAnimationsApi()
+
+vi.mock('@/lib/constants', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/constants')>()
+  return { ...actual, IS_PLATFORM: true }
+})
+
+vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
+  useCheckEntitlements: () => ({ hasAccess: true, isLoading: false }),
+}))
+
+vi.mock('@/hooks/misc/useCheckPermissions', () => ({
+  useAsyncCheckPermissions: () => ({ can: true, isLoading: false, isSuccess: true }),
+}))
+
+function mockAuthConfig(overrides: Record<string, unknown> = {}) {
+  addAPIMock({
+    method: 'get',
+    path: '/platform/auth/:ref/config',
+    response: () =>
+      HttpResponse.json<any>({
+        JWT_EXP: 3600,
+        REFRESH_TOKEN_ROTATION_ENABLED: true,
+        SECURITY_REFRESH_TOKEN_REUSE_INTERVAL: 10,
+        SESSIONS_TIMEBOX: 0,
+        SESSIONS_INACTIVITY_TIMEOUT: 0,
+        SESSIONS_SINGLE_PER_USER: false,
+        ...overrides,
+      }),
+  })
+}
+
+function mockUpdateAuthConfig(onPatch?: (body: unknown) => void) {
+  addAPIMock({
+    method: 'patch',
+    path: '/platform/auth/:ref/config',
+    response: async ({ request }) => {
+      const body = await request.json()
+      onPatch?.(body)
+      return HttpResponse.json<any>({ ...(body as object) })
+    },
+  })
+}
+
+describe('SessionsAuthSettingsForm — Access Tokens', () => {
+  test('renders the access token expiry from the auth config', async () => {
+    mockAuthConfig({ JWT_EXP: 3600 })
+
+    customRender(<SessionsAuthSettingsForm />)
+
+    expect(await screen.findByText('Access Tokens')).toBeInTheDocument()
+    expect(await screen.findByDisplayValue('3600')).toBeInTheDocument()
+    expect(screen.getByText('Access token expiry time')).toBeInTheDocument()
+  })
+
+  test('saving a new expiry issues a PATCH with the JWT_EXP payload', async () => {
+    mockAuthConfig({ JWT_EXP: 3600 })
+    let patchBody: unknown
+    mockUpdateAuthConfig((body) => {
+      patchBody = body
+    })
+
+    customRender(<SessionsAuthSettingsForm />)
+
+    const input = await screen.findByDisplayValue('3600')
+    fireEvent.change(input, { target: { value: '7200' } })
+
+    const form = input.closest('form') as HTMLFormElement
+    const saveButton = within(form).getByRole('button', { name: 'Save changes' })
+    await waitFor(() => expect(saveButton).toBeEnabled())
+    fireEvent.click(saveButton)
+
+    await waitFor(() => expect(patchBody).toEqual({ JWT_EXP: 7200 }))
+  })
+
+  test('blocks submit when the expiry exceeds the maximum', async () => {
+    mockAuthConfig({ JWT_EXP: 3600 })
+    let patchCalled = false
+    mockUpdateAuthConfig(() => {
+      patchCalled = true
+    })
+
+    customRender(<SessionsAuthSettingsForm />)
+
+    const input = await screen.findByDisplayValue('3600')
+    fireEvent.change(input, { target: { value: '999999' } })
+
+    const form = input.closest('form') as HTMLFormElement
+    const saveButton = within(form).getByRole('button', { name: 'Save changes' })
+    await waitFor(() => expect(saveButton).toBeEnabled())
+    fireEvent.click(saveButton)
+
+    expect(await screen.findByText('Must be less than 604800')).toBeInTheDocument()
+    expect(patchCalled).toBe(false)
+  })
+})

--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
@@ -242,6 +242,136 @@ export const SessionsAuthSettingsForm = () => {
       <PageSection>
         <PageSectionMeta>
           <PageSectionSummary>
+            <PageSectionTitle>User Sessions</PageSectionTitle>
+          </PageSectionSummary>
+        </PageSectionMeta>
+        <PageSectionContent>
+          <Form {...userSessionsForm}>
+            <form
+              onSubmit={userSessionsForm.handleSubmit(onSubmitUserSessions)}
+              className="space-y-4"
+            >
+              <Card>
+                <CardContent>
+                  <FormField
+                    control={userSessionsForm.control}
+                    name="SESSIONS_SINGLE_PER_USER"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        layout="flex-row-reverse"
+                        label="Enforce single session per user"
+                        description="If enabled, all but a user's most recently active session will be terminated."
+                      >
+                        <FormControl>
+                          <Switch
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                            disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
+                          />
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                </CardContent>
+
+                <CardContent>
+                  <FormField
+                    control={userSessionsForm.control}
+                    name="SESSIONS_TIMEBOX"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        layout="flex-row-reverse"
+                        label="Time-box user sessions"
+                        description="The amount of time before a user is forced to sign in again. Use 0 for never."
+                      >
+                        <FormControl className="w-full">
+                          <InputGroup>
+                            <FormInputGroupInput
+                              type="number"
+                              min={0}
+                              {...field}
+                              disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupText>
+                                <HoursOrNeverText value={field.value || 0} />
+                              </InputGroupText>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                </CardContent>
+
+                <CardContent>
+                  <FormField
+                    control={userSessionsForm.control}
+                    name="SESSIONS_INACTIVITY_TIMEOUT"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        layout="flex-row-reverse"
+                        label="Inactivity timeout"
+                        description="The amount of time a user needs to be inactive to be forced to sign in again. Use 0 for never."
+                      >
+                        <FormControl className="w-full">
+                          <InputGroup>
+                            <FormInputGroupInput
+                              type="number"
+                              {...field}
+                              className="flex-1"
+                              disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupText>
+                                <HoursOrNeverText value={field.value || 0} />
+                              </InputGroupText>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                </CardContent>
+
+                {promptProPlanUpgrade && (
+                  <UpgradeToPro
+                    fullWidth
+                    source="authSessions"
+                    featureProposition="configure user sessions"
+                    primaryText="Configuring user sessions is only available on the Pro Plan and above"
+                    secondaryText="Upgrade to Pro Plan to configure settings for user sessions."
+                  />
+                )}
+
+                <CardFooter className="justify-end space-x-2">
+                  {userSessionsForm.formState.isDirty && (
+                    <Button variant="default" onClick={() => userSessionsForm.reset()}>
+                      Cancel
+                    </Button>
+                  )}
+                  <Button
+                    variant={promptProPlanUpgrade ? 'default' : 'primary'}
+                    type="submit"
+                    disabled={
+                      !canUpdateConfig ||
+                      isUpdatingUserSessions ||
+                      !userSessionsForm.formState.isDirty
+                    }
+                    loading={isUpdatingUserSessions}
+                  >
+                    Save changes
+                  </Button>
+                </CardFooter>
+              </Card>
+            </form>
+          </Form>
+        </PageSectionContent>
+      </PageSection>
+
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
             <PageSectionTitle>Access Tokens</PageSectionTitle>
           </PageSectionSummary>
         </PageSectionMeta>
@@ -260,7 +390,7 @@ export const SessionsAuthSettingsForm = () => {
                       <FormItemLayout
                         layout="flex-row-reverse"
                         label="Access token expiry time"
-                        description="How long access tokens are valid for before it must be refreshed. Recommendation: 3600 seconds."
+                        description="How long access tokens are valid for before they must be refreshed. Recommendation: 3600 seconds."
                       >
                         <FormControl className="w-full">
                           <InputGroup>
@@ -380,136 +510,6 @@ export const SessionsAuthSettingsForm = () => {
                       !refreshTokenForm.formState.isDirty
                     }
                     loading={isUpdatingRefreshTokens}
-                  >
-                    Save changes
-                  </Button>
-                </CardFooter>
-              </Card>
-            </form>
-          </Form>
-        </PageSectionContent>
-      </PageSection>
-
-      <PageSection>
-        <PageSectionMeta>
-          <PageSectionSummary>
-            <PageSectionTitle>User Sessions</PageSectionTitle>
-          </PageSectionSummary>
-        </PageSectionMeta>
-        <PageSectionContent>
-          <Form {...userSessionsForm}>
-            <form
-              onSubmit={userSessionsForm.handleSubmit(onSubmitUserSessions)}
-              className="space-y-4"
-            >
-              <Card>
-                <CardContent>
-                  <FormField
-                    control={userSessionsForm.control}
-                    name="SESSIONS_SINGLE_PER_USER"
-                    render={({ field }) => (
-                      <FormItemLayout
-                        layout="flex-row-reverse"
-                        label="Enforce single session per user"
-                        description="If enabled, all but a user's most recently active session will be terminated."
-                      >
-                        <FormControl>
-                          <Switch
-                            checked={field.value}
-                            onCheckedChange={field.onChange}
-                            disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
-                          />
-                        </FormControl>
-                      </FormItemLayout>
-                    )}
-                  />
-                </CardContent>
-
-                <CardContent>
-                  <FormField
-                    control={userSessionsForm.control}
-                    name="SESSIONS_TIMEBOX"
-                    render={({ field }) => (
-                      <FormItemLayout
-                        layout="flex-row-reverse"
-                        label="Time-box user sessions"
-                        description="The amount of time before a user is forced to sign in again. Use 0 for never."
-                      >
-                        <FormControl className="w-full">
-                          <InputGroup>
-                            <FormInputGroupInput
-                              type="number"
-                              min={0}
-                              {...field}
-                              disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
-                            />
-                            <InputGroupAddon align="inline-end">
-                              <InputGroupText>
-                                <HoursOrNeverText value={field.value || 0} />
-                              </InputGroupText>
-                            </InputGroupAddon>
-                          </InputGroup>
-                        </FormControl>
-                      </FormItemLayout>
-                    )}
-                  />
-                </CardContent>
-
-                <CardContent>
-                  <FormField
-                    control={userSessionsForm.control}
-                    name="SESSIONS_INACTIVITY_TIMEOUT"
-                    render={({ field }) => (
-                      <FormItemLayout
-                        layout="flex-row-reverse"
-                        label="Inactivity timeout"
-                        description="The amount of time a user needs to be inactive to be forced to sign in again. Use 0 for never."
-                      >
-                        <FormControl className="w-full">
-                          <InputGroup>
-                            <FormInputGroupInput
-                              type="number"
-                              {...field}
-                              className="flex-1"
-                              disabled={!canUpdateConfig || !hasUserSessionsEntitlement}
-                            />
-                            <InputGroupAddon align="inline-end">
-                              <InputGroupText>
-                                <HoursOrNeverText value={field.value || 0} />
-                              </InputGroupText>
-                            </InputGroupAddon>
-                          </InputGroup>
-                        </FormControl>
-                      </FormItemLayout>
-                    )}
-                  />
-                </CardContent>
-
-                {promptProPlanUpgrade && (
-                  <UpgradeToPro
-                    fullWidth
-                    source="authSessions"
-                    featureProposition="configure user sessions"
-                    primaryText="Configuring user sessions is only available on the Pro Plan and above"
-                    secondaryText="Upgrade to Pro Plan to configure settings for user sessions."
-                  />
-                )}
-
-                <CardFooter className="justify-end space-x-2">
-                  {userSessionsForm.formState.isDirty && (
-                    <Button variant="default" onClick={() => userSessionsForm.reset()}>
-                      Cancel
-                    </Button>
-                  )}
-                  <Button
-                    variant={promptProPlanUpgrade ? 'default' : 'primary'}
-                    type="submit"
-                    disabled={
-                      !canUpdateConfig ||
-                      isUpdatingUserSessions ||
-                      !userSessionsForm.formState.isDirty
-                    }
-                    loading={isUpdatingUserSessions}
                   >
                     Save changes
                   </Button>

--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
@@ -48,6 +48,15 @@ function HoursOrNeverText({ value }: { value: number }) {
   }
 }
 
+const MAX_JWT_EXP = 604800
+
+const AccessTokenSchema = z.object({
+  JWT_EXP: z.coerce
+    .number()
+    .positive('Must be greater than 0')
+    .max(MAX_JWT_EXP, `Must be less than ${MAX_JWT_EXP}`),
+})
+
 const RefreshTokenSchema = z.object({
   REFRESH_TOKEN_ROTATION_ENABLED: z.boolean(),
   SECURITY_REFRESH_TOKEN_REUSE_INTERVAL: z.coerce.number().min(0, 'Must be a value more than 0'),
@@ -73,6 +82,7 @@ export const SessionsAuthSettingsForm = () => {
   const { mutate: updateAuthConfig } = useAuthConfigUpdateMutation()
 
   // Separate loading states for each form
+  const [isUpdatingAccessToken, setIsUpdatingAccessToken] = useState(false)
   const [isUpdatingRefreshTokens, setIsUpdatingRefreshTokens] = useState(false)
   const [isUpdatingUserSessions, setIsUpdatingUserSessions] = useState(false)
 
@@ -88,6 +98,13 @@ export const SessionsAuthSettingsForm = () => {
   const { hasAccess: hasUserSessionsEntitlement, isLoading: isLoadingEntitlements } =
     useCheckEntitlements('auth.user_sessions')
   const promptProPlanUpgrade = IS_PLATFORM && !hasUserSessionsEntitlement
+
+  const accessTokenForm = useForm<z.infer<typeof AccessTokenSchema>>({
+    resolver: zodResolver(AccessTokenSchema),
+    defaultValues: {
+      JWT_EXP: 3600,
+    },
+  })
 
   const refreshTokenForm = useForm<z.infer<typeof RefreshTokenSchema>>({
     resolver: zodResolver(RefreshTokenSchema),
@@ -109,6 +126,12 @@ export const SessionsAuthSettingsForm = () => {
   useEffect(() => {
     if (authConfig) {
       // Only reset forms if they're not currently being updated
+      if (!isUpdatingAccessToken) {
+        accessTokenForm.reset({
+          JWT_EXP: authConfig.JWT_EXP ?? 3600,
+        })
+      }
+
       if (!isUpdatingRefreshTokens) {
         refreshTokenForm.reset({
           REFRESH_TOKEN_ROTATION_ENABLED: authConfig.REFRESH_TOKEN_ROTATION_ENABLED || false,
@@ -124,7 +147,26 @@ export const SessionsAuthSettingsForm = () => {
         })
       }
     }
-  }, [authConfig, isUpdatingRefreshTokens, isUpdatingUserSessions])
+  }, [authConfig, isUpdatingAccessToken, isUpdatingRefreshTokens, isUpdatingUserSessions])
+
+  const onSubmitAccessToken = (values: z.infer<typeof AccessTokenSchema>) => {
+    const payload = { ...values }
+    setIsUpdatingAccessToken(true)
+
+    updateAuthConfig(
+      { projectRef: projectRef!, config: payload },
+      {
+        onError: (error) => {
+          toast.error(`Failed to update access token settings: ${error?.message}`)
+          setIsUpdatingAccessToken(false)
+        },
+        onSuccess: () => {
+          toast.success('Successfully updated access token settings')
+          setIsUpdatingAccessToken(false)
+        },
+      }
+    )
+  }
 
   const onSubmitRefreshTokens = (values: any) => {
     const payload = { ...values }
@@ -196,6 +238,71 @@ export const SessionsAuthSettingsForm = () => {
 
   return (
     <>
+      <PageSection>
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Access Tokens</PageSectionTitle>
+          </PageSectionSummary>
+        </PageSectionMeta>
+        <PageSectionContent>
+          <Form {...accessTokenForm}>
+            <form
+              onSubmit={accessTokenForm.handleSubmit(onSubmitAccessToken)}
+              className="space-y-4"
+            >
+              <Card>
+                <CardContent>
+                  <FormField
+                    control={accessTokenForm.control}
+                    name="JWT_EXP"
+                    render={({ field }) => (
+                      <FormItemLayout
+                        layout="flex-row-reverse"
+                        label="Access token expiry time"
+                        description="How long access tokens are valid for before it must be refreshed. Recommendation: 3600 seconds."
+                      >
+                        <FormControl className="w-full">
+                          <InputGroup>
+                            <FormInputGroupInput
+                              type="number"
+                              min={0}
+                              {...field}
+                              disabled={!canUpdateConfig}
+                            />
+                            <InputGroupAddon align="inline-end">
+                              <InputGroupText>seconds</InputGroupText>
+                            </InputGroupAddon>
+                          </InputGroup>
+                        </FormControl>
+                      </FormItemLayout>
+                    )}
+                  />
+                </CardContent>
+                <CardFooter className="justify-end space-x-2">
+                  {accessTokenForm.formState.isDirty && (
+                    <Button variant="default" onClick={() => accessTokenForm.reset()}>
+                      Cancel
+                    </Button>
+                  )}
+                  <Button
+                    variant="primary"
+                    type="submit"
+                    disabled={
+                      !canUpdateConfig ||
+                      isUpdatingAccessToken ||
+                      !accessTokenForm.formState.isDirty
+                    }
+                    loading={isUpdatingAccessToken}
+                  >
+                    Save changes
+                  </Button>
+                </CardFooter>
+              </Card>
+            </form>
+          </Form>
+        </PageSectionContent>
+      </PageSection>
+
       <PageSection>
         <PageSectionMeta>
           <PageSectionSummary>

--- a/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/SessionsAuthSettingsForm/SessionsAuthSettingsForm.tsx
@@ -53,6 +53,7 @@ const MAX_JWT_EXP = 604800
 const AccessTokenSchema = z.object({
   JWT_EXP: z.coerce
     .number()
+    .int('Must be a whole number')
     .positive('Must be greater than 0')
     .max(MAX_JWT_EXP, `Must be less than ${MAX_JWT_EXP}`),
 })
@@ -265,7 +266,7 @@ export const SessionsAuthSettingsForm = () => {
                           <InputGroup>
                             <FormInputGroupInput
                               type="number"
-                              min={0}
+                              min={1}
                               {...field}
                               disabled={!canUpdateConfig}
                             />

--- a/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
+++ b/apps/studio/components/interfaces/JwtSecrets/jwt-settings.tsx
@@ -21,8 +21,8 @@ import {
   TriangleAlert,
 } from 'lucide-react'
 import Link from 'next/link'
-import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react'
-import { useForm, type SubmitHandler } from 'react-hook-form'
+import { useState, type Dispatch, type SetStateAction } from 'react'
+import { useForm } from 'react-hook-form'
 import { toast } from 'sonner'
 import {
   Button,
@@ -45,14 +45,11 @@ import {
   Form,
   FormControl,
   FormField,
-  FormInputGroupInput,
-  InputGroup,
-  InputGroupAddon,
-  InputGroupText,
 } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
+import { FormLayout } from 'ui-patterns/form/Layout/FormLayout'
 import * as z from 'zod'
 
 import {
@@ -60,13 +57,10 @@ import {
   JWT_SECRET_UPDATE_PROGRESS_MESSAGES,
 } from './jwt.constants'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
-import { FormActions } from '@/components/ui/Forms/FormActions'
 import { InlineLink } from '@/components/ui/InlineLink'
 import Panel from '@/components/ui/Panel'
 import { TextConfirmModal } from '@/components/ui/TextConfirmModalWrapper'
 import { useLegacyAPIKeysStatusQuery } from '@/data/api-keys/legacy-api-keys-status-query'
-import { useAuthConfigQuery } from '@/data/auth/auth-config-query'
-import { useAuthConfigUpdateMutation } from '@/data/auth/auth-config-update-mutation'
 import { useJwtSecretUpdateMutation } from '@/data/config/jwt-secret-update-mutation'
 import { useJwtSecretUpdatingStatusQuery } from '@/data/config/jwt-secret-updating-status-query'
 import { useProjectPostgrestConfigQuery } from '@/data/config/project-postgrest-config-query'
@@ -74,21 +68,6 @@ import { useLegacyJWTSigningKeyQuery } from '@/data/jwt-signing-keys/legacy-jwt-
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
 import { DOCS_URL } from '@/lib/constants'
 import { uuidv4 } from '@/lib/helpers'
-
-const MAX_JWT_EXP = 604800
-const formSchema = z.object({
-  JWT_EXP: z.preprocess(
-    (val) => (val === '' || val === null || val === undefined ? undefined : val),
-    z.coerce
-      .number({
-        required_error: 'Must have a JWT expiry value',
-        invalid_type_error: 'Must have a JWT expiry value',
-      })
-      .positive('Must be greater than 0')
-      .max(MAX_JWT_EXP, `Must be less than ${MAX_JWT_EXP}`)
-  ),
-})
-const formId = 'jwt-exp-form'
 
 const customJwtSecretFormSchema = z.object({
   customToken: z
@@ -115,10 +94,6 @@ export const JWTSettings = () => {
     PermissionAction.INFRA_EXECUTE,
     'queue_job.projects.update_jwt'
   )
-  const { can: canUpdateConfig } = useAsyncCheckPermissions(
-    PermissionAction.UPDATE,
-    'custom_config_gotrue'
-  )
 
   const { data } = useJwtSecretUpdatingStatusQuery({ projectRef }, { enabled: IS_PLATFORM })
   const { data: config, isError } = useProjectPostgrestConfigQuery({ projectRef })
@@ -135,13 +110,6 @@ export const JWTSettings = () => {
     { enabled: IS_PLATFORM && canReadAPIKeys }
   )
 
-  const { data: authConfig, isPending: isLoadingAuthConfig } = useAuthConfigQuery(
-    { projectRef },
-    { enabled: IS_PLATFORM }
-  )
-  const { mutate: updateAuthConfig, isPending: isUpdatingAuthConfig } =
-    useAuthConfigUpdateMutation()
-
   const { Failed, Updated, Updating } = JwtSecretUpdateStatus
 
   const isJwtSecretUpdateFailed = data?.jwtSecretUpdateStatus === Failed
@@ -153,46 +121,10 @@ export const JWTSettings = () => {
   const jwtSecretUpdateProgressMessage =
     JWT_SECRET_UPDATE_PROGRESS_MESSAGES[data?.jwtSecretUpdateProgress as JwtSecretUpdateProgress]
 
-  const INITIAL_VALUES = useMemo(
-    () => ({
-      JWT_EXP: authConfig?.JWT_EXP ?? 3600,
-    }),
-    [authConfig]
-  )
-
-  const form = useForm<z.infer<typeof formSchema>>({
-    defaultValues: INITIAL_VALUES,
-    resolver: zodResolver(formSchema),
-  })
-
   const customJwtSecretForm = useForm<z.infer<typeof customJwtSecretFormSchema>>({
     defaultValues: { customToken: '' },
     resolver: zodResolver(customJwtSecretFormSchema),
   })
-
-  const { reset, formState } = form
-  const { isDirty } = formState
-
-  useEffect(() => {
-    reset(INITIAL_VALUES)
-  }, [INITIAL_VALUES, reset])
-
-  const onUpdateJwtExp: SubmitHandler<z.infer<typeof formSchema>> = async (values) => {
-    if (!projectRef) return console.error('Project ref is required')
-
-    updateAuthConfig(
-      { projectRef, config: values },
-      {
-        onError: (error) => {
-          toast.error(`Failed to update JWT expiry: ${error?.message}`)
-        },
-        onSuccess: (newValues) => {
-          toast.success('Successfully updated JWT expiry')
-          reset({ JWT_EXP: newValues.JWT_EXP ?? values.JWT_EXP })
-        },
-      }
-    )
-  }
 
   async function handleJwtSecretUpdate(
     jwt_secret: string,
@@ -215,16 +147,14 @@ export const JWTSettings = () => {
     return (
       <Panel>
         <Panel.Content className="border-t border-panel-border-interior-light in-data-[theme*=dark]:border-panel-border-interior-dark">
-          <Form {...form}>
-            <FormItemLayout
-              layout="flex-row-reverse"
-              id="JWT_SECRET"
-              label="JWT secret"
-              description="Used to verify legacy user session JWTs issued by Supabase Auth."
-            >
-              <Input id="JWT_SECRET" copy reveal readOnly value={config?.jwt_secret || ''} />
-            </FormItemLayout>
-          </Form>
+          <FormLayout
+            layout="flex-row-reverse"
+            id="JWT_SECRET"
+            label="JWT secret"
+            description="Used to verify legacy user session JWTs issued by Supabase Auth."
+          >
+            <Input id="JWT_SECRET" copy reveal readOnly value={config?.jwt_secret || ''} />
+          </FormLayout>
         </Panel.Content>
       </Panel>
     )
@@ -232,158 +162,89 @@ export const JWTSettings = () => {
 
   return (
     <>
-      <Panel
-        footer={
-          <div className="flex py-4 w-full">
-            <FormActions
-              form={formId}
-              isSubmitting={isUpdatingAuthConfig}
-              hasChanges={isDirty}
-              handleReset={reset}
-              disabled={!canUpdateConfig}
-              helper={
-                !canUpdateConfig
-                  ? 'You need additional permissions to update JWT settings'
-                  : undefined
-              }
-            />
-          </div>
-        }
-      >
+      <Panel>
         <Panel.Content className="border-t border-panel-border-interior-light in-data-[theme*=dark]:border-panel-border-interior-dark">
-          <Form {...form}>
-            <form
-              id={formId}
-              onSubmit={form.handleSubmit(onUpdateJwtExp)}
-              className="space-y-6"
-              noValidate
-            >
-              {isError ? (
-                <div className="flex items-center justify-center py-8 space-x-2">
-                  <AlertCircle size={16} strokeWidth={1.5} />
-                  <p className="text-sm text-foreground-light">Failed to retrieve JWT settings</p>
-                </div>
-              ) : (
-                <>
-                  {legacyKey && legacyKey.status !== 'revoked' && (
-                    <Admonition
-                      type="warning"
-                      title="Legacy JWT secret has been migrated to new JWT Signing Keys"
-                    >
-                      <p className="leading-normal!">
-                        Legacy JWT secret can only be changed by rotating to a standby key and then
-                        revoking it. It is used to{' '}
-                        <em className="text-foreground not-italic">
-                          {legacyKey.status === 'in_use' ? 'sign and verify' : 'only verify'}
-                        </em>{' '}
-                        JSON Web Tokens by Supabase products.
-                      </p>
-
-                      {legacyAPIKeysStatus && legacyAPIKeysStatus.enabled && (
-                        <p className="leading-normal!">
-                          <em className="text-warning not-italic">
-                            This includes the <code className="text-code-inline">anon</code> and{' '}
-                            <code className="text-code-inline">service_role</code> JWT based API
-                            keys.
-                          </em>{' '}
-                          Consider switching to publishable and secret API keys to disable them.
-                        </p>
-                      )}
-
-                      <Button asChild variant="default" icon={<ExternalLink />} className="mt-2">
-                        <Link href={`/project/${projectRef}/settings/api-keys`}>
-                          Go to API keys
-                        </Link>
-                      </Button>
-                    </Admonition>
-                  )}
-                  {legacyKey && legacyKey.status === 'revoked' && (
-                    <Admonition
-                      type="note"
-                      title="Your project has revoked the legacy JWT secret"
-                      description="No new JSON Web Tokens are issued nor verified with it by Supabase products."
-                    />
-                  )}
-                  <FormItemLayout
-                    layout="flex-row-reverse"
-                    id="JWT_SECRET"
-                    label={
-                      legacyKey?.status === 'revoked'
-                        ? 'Revoked legacy JWT secret'
-                        : legacyKey
-                          ? 'Legacy JWT secret (still used)'
-                          : 'Legacy JWT secret'
-                    }
-                    description={
-                      legacyKey?.status === 'revoked'
-                        ? 'No longer used to sign JWTs by Supabase Auth.'
-                        : !legacyKey || legacyKey.status === 'in_use'
-                          ? 'Used to sign and verify JWTs issued by Supabase Auth.'
-                          : 'Used only to verify JWTs.'
-                    }
+          <div className="space-y-6">
+            {isError ? (
+              <div className="flex items-center justify-center py-8 space-x-2">
+                <AlertCircle size={16} strokeWidth={1.5} />
+                <p className="text-sm text-foreground-light">Failed to retrieve JWT settings</p>
+              </div>
+            ) : (
+              <>
+                {legacyKey && legacyKey.status !== 'revoked' && (
+                  <Admonition
+                    type="warning"
+                    title="Legacy JWT secret has been migrated to new JWT Signing Keys"
                   >
-                    <Input
-                      id="JWT_SECRET"
-                      copy={canReadJWTSecret && isNotUpdatingJwtSecret}
-                      reveal={canReadJWTSecret && isNotUpdatingJwtSecret}
-                      readOnly
-                      value={
-                        !canReadJWTSecret
-                          ? 'You need additional permissions to view the JWT secret'
-                          : isJwtSecretUpdateFailed
-                            ? 'JWT secret update failed'
-                            : isUpdatingJwtSecret
-                              ? 'Updating JWT secret...'
-                              : config?.jwt_secret || ''
-                      }
-                    />
-                  </FormItemLayout>
+                    <p className="leading-normal!">
+                      Legacy JWT secret can only be changed by rotating to a standby key and then
+                      revoking it. It is used to{' '}
+                      <em className="text-foreground not-italic">
+                        {legacyKey.status === 'in_use' ? 'sign and verify' : 'only verify'}
+                      </em>{' '}
+                      JSON Web Tokens by Supabase products.
+                    </p>
 
-                  <FormField
-                    control={form.control}
-                    name="JWT_EXP"
-                    disabled={!canUpdateConfig || isLoadingAuthConfig}
-                    render={({ field }) => (
-                      <FormItemLayout
-                        name="JWT_EXP"
-                        layout="flex-row-reverse"
-                        label="Access token expiry time"
-                        description={
-                          <>
-                            <p>
-                              How long access tokens are valid for before a refresh token has to be
-                              used.
-                            </p>
-                            <p>Recommendation: 3600 (1 hour).</p>
-                          </>
-                        }
-                      >
-                        <FormControl>
-                          <InputGroup>
-                            <FormInputGroupInput
-                              {...field}
-                              id="JWT_EXP"
-                              type="number"
-                              min={0}
-                              max={MAX_JWT_EXP}
-                              onChange={(e) =>
-                                field.onChange(
-                                  isNaN(e.target.valueAsNumber) ? '' : e.target.valueAsNumber
-                                )
-                              }
-                            />
-                            <InputGroupAddon align="inline-end">
-                              <InputGroupText>seconds</InputGroupText>
-                            </InputGroupAddon>
-                          </InputGroup>
-                        </FormControl>
-                      </FormItemLayout>
+                    {legacyAPIKeysStatus && legacyAPIKeysStatus.enabled && (
+                      <p className="leading-normal!">
+                        <em className="text-warning not-italic">
+                          This includes the <code className="text-code-inline">anon</code> and{' '}
+                          <code className="text-code-inline">service_role</code> JWT based API keys.
+                        </em>{' '}
+                        Consider switching to publishable and secret API keys to disable them.
+                      </p>
                     )}
+
+                    <Button asChild variant="default" icon={<ExternalLink />} className="mt-2">
+                      <Link href={`/project/${projectRef}/settings/api-keys`}>Go to API keys</Link>
+                    </Button>
+                  </Admonition>
+                )}
+                {legacyKey && legacyKey.status === 'revoked' && (
+                  <Admonition
+                    type="note"
+                    title="Your project has revoked the legacy JWT secret"
+                    description="No new JSON Web Tokens are issued nor verified with it by Supabase products."
                   />
-                </>
-              )}
-            </form>
-          </Form>
+                )}
+                <FormLayout
+                  layout="flex-row-reverse"
+                  id="JWT_SECRET"
+                  label={
+                    legacyKey?.status === 'revoked'
+                      ? 'Revoked legacy JWT secret'
+                      : legacyKey
+                        ? 'Legacy JWT secret (still used)'
+                        : 'Legacy JWT secret'
+                  }
+                  description={
+                    legacyKey?.status === 'revoked'
+                      ? 'No longer used to sign JWTs by Supabase Auth.'
+                      : !legacyKey || legacyKey.status === 'in_use'
+                        ? 'Used to sign and verify JWTs issued by Supabase Auth.'
+                        : 'Used only to verify JWTs.'
+                  }
+                >
+                  <Input
+                    id="JWT_SECRET"
+                    copy={canReadJWTSecret && isNotUpdatingJwtSecret}
+                    reveal={canReadJWTSecret && isNotUpdatingJwtSecret}
+                    readOnly
+                    value={
+                      !canReadJWTSecret
+                        ? 'You need additional permissions to view the JWT secret'
+                        : isJwtSecretUpdateFailed
+                          ? 'JWT secret update failed'
+                          : isUpdatingJwtSecret
+                            ? 'Updating JWT secret...'
+                            : config?.jwt_secret || ''
+                    }
+                  />
+                </FormLayout>
+              </>
+            )}
+          </div>
 
           {!isPending && !legacyKey && (
             <>

--- a/apps/studio/pages/project/[ref]/auth/sessions.tsx
+++ b/apps/studio/pages/project/[ref]/auth/sessions.tsx
@@ -34,7 +34,7 @@ const SessionsPage: NextPageWithLayout = () => {
           <PageHeaderSummary>
             <PageHeaderTitle>User Sessions</PageHeaderTitle>
             <PageHeaderDescription>
-              Configure settings for user sessions and refresh tokens
+              Configure settings for access tokens, refresh tokens, and user sessions
             </PageHeaderDescription>
           </PageHeaderSummary>
         </PageHeaderMeta>


### PR DESCRIPTION
Exposes the access token expiry (`JWT_EXP`) under `Auth -> Sessions` settings as opposed to the Legacy JWT settings previously used.

<img width="1632" height="1199" alt="Screenshot 2026-07-23 at 10 06 33" src="https://github.com/user-attachments/assets/85356e57-da95-404c-852a-21cf9cab2b74" />
<img width="1198" height="1119" alt="Screenshot 2026-07-23 at 10 06 19" src="https://github.com/user-attachments/assets/bfa64b3b-1902-45eb-83ed-ca8bc12673af" />
<img width="1237" height="513" alt="Screenshot 2026-07-23 at 10 03 44" src="https://github.com/user-attachments/assets/85779e9b-30f2-48c5-9faa-4c650d450227" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an **Access Tokens** section to configure JWT expiration with dedicated Save/Cancel controls and success/error toasts.
  * Enforced a maximum JWT expiration value (must be **less than 604800 seconds**).
* **Bug Fixes**
  * Updated the Sessions auth page text to better clarify configuration for access tokens, refresh tokens, and user sessions.
* **Documentation**
  * Updated JWT expiration guidance to point to **Auth settings → Access Tokens** (replacing legacy JWT secret references).
* **Chores**
  * Expanded automated tests covering Access Tokens saving and validation.
* **Refactor**
  * Removed JWT expiration editing from the legacy JWT Secrets area, consolidating it under Access Tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->