### PR TITLE
Fix: Update the auth user field in the Logs page

### DIFF
--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -282,14 +282,14 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
   })
 
   describe('user filter', () => {
-    it('restricts to auth_logs/postgres_logs and skips the default postgres+edge restriction', () => {
+    it('restricts to auth_logs/edge_logs and skips the default postgres+edge restriction', () => {
       const sql = getUnifiedLogsQuery(withUser('user-123'))
       const where = sql.split(/\bWHERE\b/)[1] ?? ''
       expect(where).toContain(`log_attributes['auth_event.actor_id'] = 'user-123'`)
-      expect(where).toContain(`source = 'postgres_logs'`)
-      // The unfiltered default (postgres_logs OR edge_logs) would incorrectly exclude
+      expect(where).toContain(`source = 'edge_logs'`)
+      // The unfiltered default (edge_logs OR postgres_logs) would incorrectly exclude
       // auth_logs, the primary attributable source, so it must not appear here.
-      expect(where).not.toContain(`(source = 'postgres_logs') OR (source = 'edge_logs')`)
+      expect(where).not.toContain(`(source = 'edge_logs') OR (source = 'postgres_logs')`)
     })
 
     it('does not restrict sources when the user filter is inactive', () => {
@@ -321,8 +321,8 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
       expect(isUserFilterUnreachable(withUser('user-123', 'log_type:eq:auth'))).toBe(false)
     })
 
-    it('is false when the explicit log_type filter includes an attributable source (postgres)', () => {
-      expect(isUserFilterUnreachable(withUser('user-123', 'log_type:eq:postgres'))).toBe(false)
+    it('is false when the explicit log_type filter includes an attributable source (edge)', () => {
+      expect(isUserFilterUnreachable(withUser('user-123', 'log_type:eq:edge'))).toBe(false)
     })
 
     it('is false when at least one of several selected log types is attributable', () => {
@@ -332,12 +332,12 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
     })
 
     it('is true when the explicit log_type filter restricts to a single non-attributable source', () => {
-      expect(isUserFilterUnreachable(withUser('user-123', 'log_type:eq:edge'))).toBe(true)
+      expect(isUserFilterUnreachable(withUser('user-123', 'log_type:eq:storage'))).toBe(true)
     })
 
     it('is true when every selected log type is non-attributable', () => {
       expect(
-        isUserFilterUnreachable(withUser('user-123', 'log_type:eq:edge', 'log_type:eq:storage'))
+        isUserFilterUnreachable(withUser('user-123', 'log_type:eq:realtime', 'log_type:eq:storage'))
       ).toBe(true)
     })
 
@@ -347,7 +347,7 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
 
     it('(neq) is true only when both attributable sources are excluded', () => {
       expect(
-        isUserFilterUnreachable(withUser('user-123', 'log_type:neq:auth', 'log_type:neq:postgres'))
+        isUserFilterUnreachable(withUser('user-123', 'log_type:neq:auth', 'log_type:neq:edge'))
       ).toBe(true)
     })
   })

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.test.ts
@@ -285,8 +285,12 @@ describe('UnifiedLogs.queries (OTEL flat)', () => {
     it('restricts to auth_logs/edge_logs and skips the default postgres+edge restriction', () => {
       const sql = getUnifiedLogsQuery(withUser('user-123'))
       const where = sql.split(/\bWHERE\b/)[1] ?? ''
-      expect(where).toContain(`log_attributes['auth_event.actor_id'] = 'user-123'`)
-      expect(where).toContain(`source = 'edge_logs'`)
+      expect(where).toContain(
+        `(source = 'auth_logs' AND log_attributes['auth_event.actor_id'] = 'user-123')`
+      )
+      expect(where).toContain(
+        `(source = 'edge_logs' AND log_attributes['request.sb.jwt.authorization.payload.subject'] = 'user-123')`
+      )
       // The unfiltered default (edge_logs OR postgres_logs) would incorrectly exclude
       // auth_logs, the primary attributable source, so it must not appear here.
       expect(where).not.toContain(`(source = 'edge_logs') OR (source = 'postgres_logs')`)

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -255,7 +255,7 @@ const truncationFunction = (level: 'MINUTE' | 'HOUR' | 'DAY'): SafeLogSqlFragmen
  * inlined so the result can be referenced (or filtered) at the same query
  * level — the OTEL endpoint rejects subqueries.
  */
-const rowProjection = (): SafeLogSqlFragment => safeSql`
+const ROW_PROJECTION: SafeLogSqlFragment = safeSql`
     id,
     null AS source_id,
     timestamp,
@@ -416,7 +416,7 @@ const applySearchParamsFilter = (search: QuerySearchParamsType): SafeLogSqlFragm
 export const getUnifiedLogsQuery = (search: QuerySearchParamsType): SafeLogSqlFragment => {
   const conditions = buildBaseWhere(search)
   return safeSql`-- unified logs: row list
-SELECT ${rowProjection()}
+SELECT ${ROW_PROJECTION}
 FROM logs
 ${whereClause(conditions)}
 `

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -343,13 +343,10 @@ const userAttributionCondition = (search: QuerySearchParamsType): SafeLogSqlFrag
   const value = userFilterValue(search)
   if (!value) return null
   const exact = lit(value)
-  const contains = lit('%' + value + '%')
   return safeSql`(
-    (source = 'auth_logs' AND (
-      log_attributes['auth_event.actor_id'] = ${exact}
-      OR event_message ILIKE ${contains}
-    ))
-    OR (source = 'postgres_logs' AND event_message ILIKE ${contains})
+    (source = 'auth_logs' AND log_attributes['auth_event.actor_id'] = ${exact})
+    OR 
+    (source = 'edge_logs' AND log_attributes['request.sb.jwt.authorization.payload.subject'] = ${exact})
   )`
 }
 

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -350,7 +350,7 @@ const userAttributionCondition = (search: QuerySearchParamsType): SafeLogSqlFrag
   )`
 }
 
-const USER_ATTRIBUTABLE_SOURCES = new Set([LOG_TYPE_TO_SOURCE.auth, LOG_TYPE_TO_SOURCE.postgres])
+const USER_ATTRIBUTABLE_SOURCES = new Set([LOG_TYPE_TO_SOURCE.auth, LOG_TYPE_TO_SOURCE.edge])
 
 /**
  * True when the user filter is active but an explicit log_type filter restricts the

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -105,11 +105,11 @@ const LEVEL_EXPR: SafeLogSqlFragment = safeSql`CASE
     END`
 
 // The `auth_user` column is derived from the source-specific fields that can be attributed to a user.
-const AUTH_USER_EXPR: SafeLogSqlFragment = safeSql`CASE
+const AUTH_USER_EXPR: SafeLogSqlFragment = safeSql`nullIf(CASE
       WHEN source = 'auth_logs' THEN log_attributes['auth_event.actor_id']
       WHEN source = 'edge_logs' THEN log_attributes['request.sb.jwt.authorization.payload.subject']
-      ELSE auth_user
-    END`
+      ELSE null
+    END, '')`
 
 const logTypeWhereCondition = (logTypes: string[]): SafeLogSqlFragment => {
   const effective = logTypes.filter((t) => t in LOG_TYPE_CONDITION)

--- a/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
+++ b/apps/studio/components/interfaces/UnifiedLogs/UnifiedLogs.queries.ts
@@ -104,6 +104,13 @@ const LEVEL_EXPR: SafeLogSqlFragment = safeSql`CASE
       ELSE 'success'
     END`
 
+// The `auth_user` column is derived from the source-specific fields that can be attributed to a user.
+const AUTH_USER_EXPR: SafeLogSqlFragment = safeSql`CASE
+      WHEN source = 'auth_logs' THEN log_attributes['auth_event.actor_id']
+      WHEN source = 'edge_logs' THEN log_attributes['request.sb.jwt.authorization.payload.subject']
+      ELSE auth_user
+    END`
+
 const logTypeWhereCondition = (logTypes: string[]): SafeLogSqlFragment => {
   const effective = logTypes.filter((t) => t in LOG_TYPE_CONDITION)
   const types = effective.length ? effective : [...DEFAULT_LOG_TYPES]
@@ -258,6 +265,7 @@ const rowProjection = (): SafeLogSqlFragment => safeSql`
     ${ATTR.path} AS pathname,
     event_message,
     ${ATTR.method} AS method,
+    ${AUTH_USER_EXPR} AS auth_user,
     null AS log_count,
     null AS logs
 `


### PR DESCRIPTION
- Fix the user filter to work with `edge_logs`. 
- Update the `auth_user` field to be derived from other log attributes.
- Removed filtering for `postgres_logs` since it didn't really filter by user actions, only by user id mentions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved unified logs user filtering to rely only on exact attribution identifiers from authentication and edge log sources, removing partial message-based matching.
  - Updated unified logs user identification by deriving `auth_user` from authentication actor IDs or edge JWT subject values.
  - Refined “user filter reachability” logic to consider only attributable log types (auth and edge).
- **Tests**
  - Adjusted unified logs query tests to match the updated attribution routing and reachability outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->