### PR TITLE
chore(studio): grafana-cloud slug

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
+++ b/apps/studio/components/interfaces/Integrations/Landing/Landing.utils.ts
@@ -169,7 +169,7 @@ export const isOAuthInstalled = ({
     )
   }
 
-  if (integration.id === 'grafana') {
+  if (integration.id === 'grafana' || integration.id === 'grafana-cloud') {
     // Grafana is not yet sending integration status, so just use presence of API key.
     return (
       isOAuthAppAuthorized(projectData, integration) ||

--- a/apps/studio/components/interfaces/Integrations/Landing/MarketplaceDetail.test.tsx
+++ b/apps/studio/components/interfaces/Integrations/Landing/MarketplaceDetail.test.tsx
@@ -48,6 +48,21 @@ const STABLE_INTEGRATIONS = [
     navigate: () => null,
     navigation: [{ route: 'overview', label: 'Overview' }],
   },
+  {
+    id: 'grafana-cloud',
+    name: 'Grafana',
+    type: 'oauth',
+    source: 'Partner',
+    description: 'Grafana',
+    content: 'Grafana overview content',
+    docsUrl: null,
+    siteUrl: null,
+    author: { name: 'Grafana Labs' },
+    oauthAppId: 'grafana-app',
+    icon: () => null,
+    navigate: () => null,
+    navigation: [{ route: 'overview', label: 'Overview' }],
+  },
 ]
 const STABLE_EMPTY_ARR = [] as unknown[]
 vi.mock('@/components/interfaces/Integrations/Landing/useAvailableIntegrations', () => ({

--- a/apps/studio/components/interfaces/Integrations/Marketplace/Marketplace.constants.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/Marketplace.constants.tsx
@@ -14,6 +14,7 @@ export type { MarketplaceSource } from '@/components/interfaces/Integrations/Lan
 // Defines featured integrations and their order in the featured hero
 export const FEATURED_INTEGRATION_IDS = [
   'grafana',
+  'grafana-cloud',
   'cron',
   'queues',
   'stripe_sync_engine',

--- a/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceFeaturedHeroGrid.tsx
+++ b/apps/studio/components/interfaces/Integrations/Marketplace/MarketplaceFeaturedHeroGrid.tsx
@@ -25,6 +25,10 @@ const FEATURED_INTEGRATION_IMAGES: Record<string, { dark: string; light?: string
     dark: `${BASE_PATH}/img/integrations/covers/grafana-cover.png`,
     light: `${BASE_PATH}/img/integrations/covers/grafana-cover-light.webp`,
   },
+  'grafana-cloud': {
+    dark: `${BASE_PATH}/img/integrations/covers/grafana-cover.png`,
+    light: `${BASE_PATH}/img/integrations/covers/grafana-cover-light.webp`,
+  },
 }
 
 interface ThemedImage {

--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -42,7 +42,14 @@ interface Props {
 
 type ViewMode = 'grid' | 'list'
 
-const OFFICIAL_PARTNER_SLUGS = new Set(['grafana', 'stripe', 'aikido', 'doppler', 'resend'])
+const OFFICIAL_PARTNER_SLUGS = new Set([
+  'grafana',
+  'grafana-cloud',
+  'stripe',
+  'aikido',
+  'doppler',
+  'resend',
+])
 const PARTNERS_PAGE_SIZE = 24
 
 export default function IntegrationsContent({

--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -42,14 +42,7 @@ interface Props {
 
 type ViewMode = 'grid' | 'list'
 
-const OFFICIAL_PARTNER_SLUGS = new Set([
-  'grafana',
-  'grafana-cloud',
-  'stripe',
-  'aikido',
-  'doppler',
-  'resend',
-])
+const OFFICIAL_PARTNER_SLUGS = new Set(['grafana', 'stripe', 'aikido', 'doppler', 'resend'])
 const PARTNERS_PAGE_SIZE = 24
 
 export default function IntegrationsContent({


### PR DESCRIPTION
Use `grafana-cloud` slug for the partner integration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Grafana Cloud to the featured integrations in the marketplace.
  * Added light and dark themed artwork for the Grafana Cloud featured integration.
* **Improvements**
  * Updated the OAuth “installed” detection to include Grafana Cloud alongside Grafana.
  * Included Grafana Cloud in the set of official partners for the partner-only filter.
* **Tests**
  * Expanded marketplace integration fixtures to cover Grafana Cloud scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->