### PR TITLE
fix(www): changelog frontmatter

### DIFF
--- a/apps/www/components/Changelog/ChangelogEntryTitle.tsx
+++ b/apps/www/components/Changelog/ChangelogEntryTitle.tsx
@@ -1,0 +1,31 @@
+import ReactMarkdown, { type Components } from 'react-markdown'
+import remarkGfm from 'remark-gfm'
+
+/**
+ * Renders a changelog entry title as inline markdown so backticks become
+ * inline code and `**bold**` / `_italic_` / `~~strikethrough~~` render, e.g.
+ * "Migration of the `logs.all` endpoint to `logs`".
+ *
+ * Every block-level node is unwrapped to its children so the output stays
+ * inline and safe to drop inside a heading (`<h1>`/`<h3>`) — react-markdown
+ * otherwise wraps content in a `<p>`, which is invalid inside a heading. Links
+ * are unwrapped too: titles on the index and timeline are already inside a
+ * `<Link>`, and a nested `<a>` would be invalid HTML.
+ */
+const INLINE_TITLE_COMPONENTS: Components = {
+  p: ({ children }) => <>{children}</>,
+  a: ({ children }) => <>{children}</>,
+  code: ({ children }) => (
+    <code className="bg-muted text-foreground rounded px-1 py-0.5 font-mono text-[0.85em] font-normal">
+      {children}
+    </code>
+  ),
+}
+
+export function ChangelogEntryTitle({ title }: { title: string }) {
+  return (
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={INLINE_TITLE_COMPONENTS}>
+      {title}
+    </ReactMarkdown>
+  )
+}

--- a/apps/www/components/Changelog/ChangelogInlineMarkdown.tsx
+++ b/apps/www/components/Changelog/ChangelogInlineMarkdown.tsx
@@ -2,17 +2,17 @@ import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 /**
- * Renders a changelog entry title as inline markdown so backticks become
- * inline code and `**bold**` / `_italic_` / `~~strikethrough~~` render, e.g.
- * "Migration of the `logs.all` endpoint to `logs`".
+ * Renders a short changelog string (entry title or summary) as inline markdown,
+ * so backticks become inline code and `**bold**` / `_italic_` / `~~strike~~`
+ * render — e.g. "Migration of the `logs.all` endpoint to `logs`".
  *
- * Every block-level node is unwrapped to its children so the output stays
- * inline and safe to drop inside a heading (`<h1>`/`<h3>`) — react-markdown
+ * Every block-level node is unwrapped to its children so the output stays inline
+ * and safe to drop inside a heading (`<h1>`/`<h3>`) or a `<p>` — react-markdown
  * otherwise wraps content in a `<p>`, which is invalid inside a heading. Links
  * are unwrapped too: titles on the index and timeline are already inside a
  * `<Link>`, and a nested `<a>` would be invalid HTML.
  */
-const INLINE_TITLE_COMPONENTS: Components = {
+const INLINE_COMPONENTS: Components = {
   p: ({ children }) => <>{children}</>,
   a: ({ children }) => <>{children}</>,
   code: ({ children }) => (
@@ -22,10 +22,10 @@ const INLINE_TITLE_COMPONENTS: Components = {
   ),
 }
 
-export function ChangelogEntryTitle({ title }: { title: string }) {
+export function ChangelogInlineMarkdown({ children }: { children: string }) {
   return (
-    <ReactMarkdown remarkPlugins={[remarkGfm]} components={INLINE_TITLE_COMPONENTS}>
-      {title}
+    <ReactMarkdown remarkPlugins={[remarkGfm]} components={INLINE_COMPONENTS}>
+      {children}
     </ReactMarkdown>
   )
 }

--- a/apps/www/components/Changelog/ChangelogInlineMarkdown.tsx
+++ b/apps/www/components/Changelog/ChangelogInlineMarkdown.tsx
@@ -2,15 +2,9 @@ import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 
 /**
- * Renders a short changelog string (entry title or summary) as inline markdown,
- * so backticks become inline code and `**bold**` / `_italic_` / `~~strike~~`
- * render — e.g. "Migration of the `logs.all` endpoint to `logs`".
- *
- * Every block-level node is unwrapped to its children so the output stays inline
- * and safe to drop inside a heading (`<h1>`/`<h3>`) or a `<p>` — react-markdown
- * otherwise wraps content in a `<p>`, which is invalid inside a heading. Links
- * are unwrapped too: titles on the index and timeline are already inside a
- * `<Link>`, and a nested `<a>` would be invalid HTML.
+ * Renders a changelog title/summary as inline markdown (backticks → inline code).
+ * `p` and `a` are unwrapped so the output is valid inside a heading and never
+ * nests an anchor (titles are already wrapped in a `<Link>`).
  */
 const INLINE_COMPONENTS: Components = {
   p: ({ children }) => <>{children}</>,

--- a/apps/www/components/Changelog/ChangelogTimelineList.tsx
+++ b/apps/www/components/Changelog/ChangelogTimelineList.tsx
@@ -11,7 +11,7 @@ import Link from 'next/link'
 import { type MouseEvent } from 'react'
 import { Badge, cn } from 'ui'
 
-import { ChangelogEntryTitle } from '@/components/Changelog/ChangelogEntryTitle'
+import { ChangelogInlineMarkdown } from '@/components/Changelog/ChangelogInlineMarkdown'
 
 function groupChangelogIndexByYear(
   items: ChangelogTimelineIndexItem[]
@@ -102,11 +102,15 @@ function TimelineRow({ item, href }: { item: ChangelogTimelineIndexItem; href: s
         <div className="min-w-0">
           <Link href={href} prefetch={false} className="min-w-0 text-left">
             <h3 className="text-foreground text-lg leading-snug hover:underline [&_code]:align-middle">
-              <ChangelogEntryTitle title={item.title} />
+              <ChangelogInlineMarkdown>{item.title}</ChangelogInlineMarkdown>
             </h3>
           </Link>
         </div>
-        {item.summary && <p className="text-foreground-lighter text-sm">{item.summary}</p>}
+        {item.summary && (
+          <p className="text-foreground-lighter text-sm">
+            <ChangelogInlineMarkdown>{item.summary}</ChangelogInlineMarkdown>
+          </p>
+        )}
         <div className="flex min-w-0 gap-2 pt-0.5">
           <time
             dateTime={item.sortDate}

--- a/apps/www/components/Changelog/ChangelogTimelineList.tsx
+++ b/apps/www/components/Changelog/ChangelogTimelineList.tsx
@@ -11,6 +11,8 @@ import Link from 'next/link'
 import { type MouseEvent } from 'react'
 import { Badge, cn } from 'ui'
 
+import { ChangelogEntryTitle } from '@/components/Changelog/ChangelogEntryTitle'
+
 function groupChangelogIndexByYear(
   items: ChangelogTimelineIndexItem[]
 ): [number, ChangelogTimelineIndexItem[]][] {
@@ -99,7 +101,9 @@ function TimelineRow({ item, href }: { item: ChangelogTimelineIndexItem; href: s
       <div className="border-default timeline-row-content flex min-w-0 flex-1 flex-col gap-0.5 border-b py-3">
         <div className="min-w-0">
           <Link href={href} prefetch={false} className="min-w-0 text-left">
-            <h3 className="text-foreground text-lg leading-snug hover:underline">{item.title}</h3>
+            <h3 className="text-foreground text-lg leading-snug hover:underline [&_code]:align-middle">
+              <ChangelogEntryTitle title={item.title} />
+            </h3>
           </Link>
         </div>
         {item.summary && <p className="text-foreground-lighter text-sm">{item.summary}</p>}

--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -142,6 +142,22 @@ function resolveDateFromFilename(filename) {
 }
 
 /**
+ * Coerces a frontmatter date to a `YYYY-MM-DD` string.
+ *
+ * YAML parses an *unquoted* date (`publish_date: 2026-07-22`) into a JS `Date`
+ * object, while a quoted one (`publish_date: "2026-07-22"`) stays a string.
+ * A `Date` here is poison: it breaks the string sort comparator and, worse,
+ * Next.js cannot JSON-serialize it into page props, which throws and 500s the
+ * whole changelog. Normalizing to a string keeps `sortDate` uniformly typed
+ * regardless of how an entry happens to quote its date.
+ */
+function toDateString(value) {
+  if (value == null) return null
+  if (value instanceof Date) return value.toISOString().slice(0, 10)
+  return String(value)
+}
+
+/**
  * `legacy_gh_discussion-suffix` for backfilled entries
  * (preserves old supabase.com/changelog URLs)
  * or the filename without timestamp and extension.
@@ -166,7 +182,7 @@ export function parseChangelogEntryFile(filename, raw) {
     filename,
     // Allowlisted so private frontmatter (e.g. `internal:`) never reaches the client.
     frontmatter: toPublicFrontmatter(frontmatter),
-    sortDate: frontmatter.publish_date ?? resolveDateFromFilename(filename) ?? '',
+    sortDate: toDateString(frontmatter.publish_date) ?? resolveDateFromFilename(filename) ?? '',
     summary: extractSection(publicBody, 'Summary'),
     bodySection: extractSection(publicBody, 'Body', ['Migration steps']),
     migrationSteps: extractSection(publicBody, 'Migration steps'),

--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -71,6 +71,42 @@ export async function fetchChangelogEntryFilesFromTarball(
   return files
 }
 
+/**
+ * Public frontmatter keys — the only fields ever exposed to the browser.
+ *
+ * `matter()` parses EVERY YAML key in an entry, including private blocks like
+ * `internal:` (escalation teams, notes, etc.). Because the page passes
+ * `entry.frontmatter` straight into Next.js props, anything left on the object
+ * is serialized into the page's `__NEXT_DATA__` and visible in View Source —
+ * even when it's never rendered. We allowlist rather than denylist so a new
+ * private field added upstream doesn't silently start leaking.
+ *
+ * Keep in sync with `ChangelogEntryFrontmatter` in `changelog-repo.ts`.
+ */
+export const PUBLIC_FRONTMATTER_KEYS = [
+  'title',
+  'change_type',
+  'product_stage',
+  'affected_products',
+  'affects_self_hosted',
+  'version',
+  'public',
+  'publish_date',
+  'sunset_date',
+  'learn_more_url',
+  'rfc_url',
+  'legacy_gh_discussion',
+]
+
+/** Projects raw parsed frontmatter down to the public allowlist, dropping `internal:` and any other private keys. */
+export function toPublicFrontmatter(frontmatter) {
+  const publicFrontmatter = {}
+  for (const key of PUBLIC_FRONTMATTER_KEYS) {
+    if (frontmatter[key] !== undefined) publicFrontmatter[key] = frontmatter[key]
+  }
+  return publicFrontmatter
+}
+
 export function stripInternalBlock(body) {
   let sanitized = body.replace(/<!--\s*internal\s*-->[\s\S]*?<!--\s*\/internal\s*-->/gi, '')
   // MDX doesn't support raw HTML comments (only {/* */}) — strip any that are left
@@ -128,7 +164,8 @@ export function parseChangelogEntryFile(filename, raw) {
   return {
     slug: computeChangelogEntrySlug(filename, frontmatter),
     filename,
-    frontmatter,
+    // Allowlisted so private frontmatter (e.g. `internal:`) never reaches the client.
+    frontmatter: toPublicFrontmatter(frontmatter),
     sortDate: frontmatter.publish_date ?? resolveDateFromFilename(filename) ?? '',
     summary: extractSection(publicBody, 'Summary'),
     bodySection: extractSection(publicBody, 'Body', ['Migration steps']),

--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -97,11 +97,26 @@ export const PUBLIC_FRONTMATTER_KEYS = [
   'legacy_gh_discussion',
 ]
 
-/** Projects raw parsed frontmatter down to the public allowlist, dropping `internal:` and any other private keys. */
+/**
+ * Allowlisted fields that YAML may parse into a JS `Date` (when the value is
+ * left unquoted). They must be coerced to a string before reaching page props.
+ */
+const DATE_FRONTMATTER_KEYS = new Set(['publish_date', 'sunset_date'])
+
+/**
+ * Projects raw parsed frontmatter down to the public allowlist, dropping
+ * `internal:` and any other private keys. Date fields are normalized to a
+ * `YYYY-MM-DD` string so an unquoted YAML date (a JS `Date`) can't break
+ * Next.js prop serialization — `entry.frontmatter` is passed straight into the
+ * detail page's props — or render as `[object Date]` in the sidebar.
+ */
 export function toPublicFrontmatter(frontmatter) {
   const publicFrontmatter = {}
   for (const key of PUBLIC_FRONTMATTER_KEYS) {
-    if (frontmatter[key] !== undefined) publicFrontmatter[key] = frontmatter[key]
+    if (frontmatter[key] === undefined) continue
+    publicFrontmatter[key] = DATE_FRONTMATTER_KEYS.has(key)
+      ? toDateString(frontmatter[key])
+      : frontmatter[key]
   }
   return publicFrontmatter
 }

--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -72,16 +72,10 @@ export async function fetchChangelogEntryFilesFromTarball(
 }
 
 /**
- * Public frontmatter keys — the only fields ever exposed to the browser.
- *
- * `matter()` parses EVERY YAML key in an entry, including private blocks like
- * `internal:` (escalation teams, notes, etc.). Because the page passes
- * `entry.frontmatter` straight into Next.js props, anything left on the object
- * is serialized into the page's `__NEXT_DATA__` and visible in View Source —
- * even when it's never rendered. We allowlist rather than denylist so a new
- * private field added upstream doesn't silently start leaking.
- *
- * Keep in sync with `ChangelogEntryFrontmatter` in `changelog-repo.ts`.
+ * The only frontmatter fields exposed to the browser. `matter()` also parses
+ * private blocks like `internal:`, and the page ships `entry.frontmatter` into
+ * props — so we allowlist to keep them out of the page source. Keep in sync with
+ * `ChangelogEntryFrontmatter` in `changelog-repo.ts`.
  */
 export const PUBLIC_FRONTMATTER_KEYS = [
   'title',
@@ -97,19 +91,9 @@ export const PUBLIC_FRONTMATTER_KEYS = [
   'legacy_gh_discussion',
 ]
 
-/**
- * Allowlisted fields that YAML may parse into a JS `Date` (when the value is
- * left unquoted). They must be coerced to a string before reaching page props.
- */
 const DATE_FRONTMATTER_KEYS = new Set(['publish_date', 'sunset_date'])
 
-/**
- * Projects raw parsed frontmatter down to the public allowlist, dropping
- * `internal:` and any other private keys. Date fields are normalized to a
- * `YYYY-MM-DD` string so an unquoted YAML date (a JS `Date`) can't break
- * Next.js prop serialization — `entry.frontmatter` is passed straight into the
- * detail page's props — or render as `[object Date]` in the sidebar.
- */
+/** Projects raw frontmatter to the public allowlist; date fields are stringified. */
 export function toPublicFrontmatter(frontmatter) {
   const publicFrontmatter = {}
   for (const key of PUBLIC_FRONTMATTER_KEYS) {
@@ -156,14 +140,8 @@ function resolveDateFromFilename(filename) {
 }
 
 /**
- * Coerces a frontmatter date to a `YYYY-MM-DD` string.
- *
- * YAML parses an *unquoted* date (`publish_date: 2026-07-22`) into a JS `Date`
- * object, while a quoted one (`publish_date: "2026-07-22"`) stays a string.
- * A `Date` here is poison: it breaks the string sort comparator and, worse,
- * Next.js cannot JSON-serialize it into page props, which throws and 500s the
- * whole changelog. Normalizing to a string keeps `sortDate` uniformly typed
- * regardless of how an entry happens to quote its date.
+ * Coerces a frontmatter date to `YYYY-MM-DD`. An unquoted YAML date parses to a
+ * JS `Date`, which breaks the string sort and can't be serialized into props.
  */
 function toDateString(value) {
   if (value == null) return null
@@ -194,7 +172,6 @@ export function parseChangelogEntryFile(filename, raw) {
   return {
     slug: computeChangelogEntrySlug(filename, frontmatter),
     filename,
-    // Allowlisted so private frontmatter (e.g. `internal:`) never reaches the client.
     frontmatter: toPublicFrontmatter(frontmatter),
     sortDate: toDateString(frontmatter.publish_date) ?? resolveDateFromFilename(filename) ?? '',
     summary: extractSection(publicBody, 'Summary'),

--- a/apps/www/lib/changelog-entries-core.mjs
+++ b/apps/www/lib/changelog-entries-core.mjs
@@ -94,7 +94,6 @@ export const PUBLIC_FRONTMATTER_KEYS = [
   'publish_date',
   'sunset_date',
   'learn_more_url',
-  'rfc_url',
   'legacy_gh_discussion',
 ]
 

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -53,8 +53,6 @@ describe('toPublicFrontmatter', () => {
   })
 
   it('normalizes Date-valued date fields to YYYY-MM-DD strings', () => {
-    // gray-matter parses an unquoted YAML date into a JS Date; the projected
-    // public frontmatter must be a string so it survives Next.js prop serialization.
     const publicFrontmatter = toPublicFrontmatter({
       title: 'Hello',
       publish_date: new Date('2026-05-18T00:00:00.000Z'),
@@ -70,7 +68,7 @@ describe('toPublicFrontmatter', () => {
 describe('parseChangelogEntryFile', () => {
   it('never exposes the internal block on the parsed entry frontmatter', () => {
     const entry = parseChangelogEntryFile('20260101-pipelines.md', ENTRY_WITH_INTERNAL)
-    // The .mjs source has no type declarations, so `frontmatter` is inferred as {}.
+    // Untyped .mjs export, so `frontmatter` is inferred as {}.
     const frontmatter = entry.frontmatter as Record<string, unknown>
 
     expect(frontmatter.internal).toBeUndefined()
@@ -78,7 +76,6 @@ describe('parseChangelogEntryFile', () => {
     expect(JSON.stringify(frontmatter)).not.toContain('team-etl')
     expect(JSON.stringify(frontmatter)).not.toContain('escalation_teams')
 
-    // Public fields still flow through untouched.
     expect(frontmatter.title).toBe('Supabase Pipelines')
     expect(frontmatter.change_type).toBe('new-feature')
     expect(frontmatter.public).toBe(true)
@@ -86,8 +83,6 @@ describe('parseChangelogEntryFile', () => {
   })
 
   it('always yields a string sortDate, even for an unquoted (Date-parsed) publish_date', () => {
-    // Unquoted YAML dates are parsed into JS Date objects by gray-matter; a Date
-    // in sortDate breaks the string sort and Next.js prop serialization.
     const unquoted = parseChangelogEntryFile(
       '20260722-unquoted.md',
       `---\ntitle: Unquoted\nchange_type: improvement\npublic: true\npublish_date: 2026-05-18\n---\n\n# Body\n\nx\n`
@@ -110,8 +105,7 @@ describe('parseChangelogEntryFile', () => {
   })
 
   it('normalizes date frontmatter reaching detail-page props, even when unquoted', () => {
-    // `[slug].tsx` passes `entry.frontmatter` straight into getStaticProps props,
-    // so a Date here would throw during serialization. Verify it is a string.
+    // `[slug].tsx` ships `entry.frontmatter` into props; a Date would break serialization.
     const entry = parseChangelogEntryFile(
       '20260722-unquoted-dates.md',
       `---\ntitle: Unquoted dates\nchange_type: deprecation\npublic: true\npublish_date: 2026-05-18\nsunset_date: 2026-08-05\n---\n\n# Body\n\nx\n`

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -70,4 +70,28 @@ describe('parseChangelogEntryFile', () => {
     expect(frontmatter.public).toBe(true)
     expect(frontmatter.affected_products).toEqual(['pipelines'])
   })
+
+  it('always yields a string sortDate, even for an unquoted (Date-parsed) publish_date', () => {
+    // Unquoted YAML dates are parsed into JS Date objects by gray-matter; a Date
+    // in sortDate breaks the string sort and Next.js prop serialization.
+    const unquoted = parseChangelogEntryFile(
+      '20260722-unquoted.md',
+      `---\ntitle: Unquoted\nchange_type: improvement\npublic: true\npublish_date: 2026-05-18\n---\n\n# Body\n\nx\n`
+    )
+    expect(typeof unquoted.sortDate).toBe('string')
+    expect(unquoted.sortDate).toBe('2026-05-18')
+
+    const quoted = parseChangelogEntryFile(
+      '20260722-quoted.md',
+      `---\ntitle: Quoted\nchange_type: improvement\npublic: true\npublish_date: "2026-05-18"\n---\n\n# Body\n\nx\n`
+    )
+    expect(quoted.sortDate).toBe('2026-05-18')
+
+    // publish_date: null falls back to the filename date, also as a string.
+    const nullDate = parseChangelogEntryFile(
+      '20260722-null-date.md',
+      `---\ntitle: Null date\nchange_type: improvement\npublic: true\npublish_date: null\n---\n\n# Body\n\nx\n`
+    )
+    expect(nullDate.sortDate).toBe('2026-07-22')
+  })
 })

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  PUBLIC_FRONTMATTER_KEYS,
+  parseChangelogEntryFile,
+  toPublicFrontmatter,
+} from './changelog-entries-core.mjs'
+
+const ENTRY_WITH_INTERNAL = `---
+title: Supabase Pipelines
+change_type: new-feature
+public: true
+publish_date: 2026-01-01
+affected_products:
+  - pipelines
+internal:
+  escalation_teams:
+    - team-etl
+  notes: Do not ship this to the browser
+reviewers:
+  - alice
+---
+
+# Summary
+
+Pipelines are here.
+
+# Body
+
+Long form body.
+`
+
+describe('toPublicFrontmatter', () => {
+  it('keeps only allowlisted public keys', () => {
+    const publicFrontmatter = toPublicFrontmatter({
+      title: 'Hello',
+      change_type: 'new-feature',
+      internal: { escalation_teams: ['team-etl'] },
+      reviewers: ['alice'],
+      some_future_private_field: 'secret',
+    })
+
+    expect(publicFrontmatter).toEqual({ title: 'Hello', change_type: 'new-feature' })
+    for (const key of Object.keys(publicFrontmatter)) {
+      expect(PUBLIC_FRONTMATTER_KEYS).toContain(key)
+    }
+  })
+
+  it('omits keys whose value is undefined', () => {
+    expect(toPublicFrontmatter({ title: 'Hello', product_stage: undefined })).toEqual({
+      title: 'Hello',
+    })
+  })
+})
+
+describe('parseChangelogEntryFile', () => {
+  it('never exposes the internal block on the parsed entry frontmatter', () => {
+    const entry = parseChangelogEntryFile('20260101-pipelines.md', ENTRY_WITH_INTERNAL)
+
+    expect(entry.frontmatter.internal).toBeUndefined()
+    expect(entry.frontmatter.reviewers).toBeUndefined()
+    expect(JSON.stringify(entry.frontmatter)).not.toContain('team-etl')
+    expect(JSON.stringify(entry.frontmatter)).not.toContain('escalation_teams')
+
+    // Public fields still flow through untouched.
+    expect(entry.frontmatter.title).toBe('Supabase Pipelines')
+    expect(entry.frontmatter.change_type).toBe('new-feature')
+    expect(entry.frontmatter.public).toBe(true)
+    expect(entry.frontmatter.affected_products).toEqual(['pipelines'])
+  })
+})

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  PUBLIC_FRONTMATTER_KEYS,
   parseChangelogEntryFile,
+  PUBLIC_FRONTMATTER_KEYS,
   toPublicFrontmatter,
 } from './changelog-entries-core.mjs'
 
@@ -51,6 +51,20 @@ describe('toPublicFrontmatter', () => {
       title: 'Hello',
     })
   })
+
+  it('normalizes Date-valued date fields to YYYY-MM-DD strings', () => {
+    // gray-matter parses an unquoted YAML date into a JS Date; the projected
+    // public frontmatter must be a string so it survives Next.js prop serialization.
+    const publicFrontmatter = toPublicFrontmatter({
+      title: 'Hello',
+      publish_date: new Date('2026-05-18T00:00:00.000Z'),
+      sunset_date: new Date('2026-08-05T00:00:00.000Z'),
+    }) as Record<string, unknown>
+
+    expect(publicFrontmatter.publish_date).toBe('2026-05-18')
+    expect(publicFrontmatter.sunset_date).toBe('2026-08-05')
+    expect(typeof publicFrontmatter.publish_date).toBe('string')
+  })
 })
 
 describe('parseChangelogEntryFile', () => {
@@ -93,5 +107,19 @@ describe('parseChangelogEntryFile', () => {
       `---\ntitle: Null date\nchange_type: improvement\npublic: true\npublish_date: null\n---\n\n# Body\n\nx\n`
     )
     expect(nullDate.sortDate).toBe('2026-07-22')
+  })
+
+  it('normalizes date frontmatter reaching detail-page props, even when unquoted', () => {
+    // `[slug].tsx` passes `entry.frontmatter` straight into getStaticProps props,
+    // so a Date here would throw during serialization. Verify it is a string.
+    const entry = parseChangelogEntryFile(
+      '20260722-unquoted-dates.md',
+      `---\ntitle: Unquoted dates\nchange_type: deprecation\npublic: true\npublish_date: 2026-05-18\nsunset_date: 2026-08-05\n---\n\n# Body\n\nx\n`
+    )
+    const frontmatter = entry.frontmatter as Record<string, unknown>
+
+    expect(frontmatter.publish_date).toBe('2026-05-18')
+    expect(frontmatter.sunset_date).toBe('2026-08-05')
+    expect(() => JSON.stringify(entry.frontmatter)).not.toThrow()
   })
 })

--- a/apps/www/lib/changelog-entries-core.test.ts
+++ b/apps/www/lib/changelog-entries-core.test.ts
@@ -56,16 +56,18 @@ describe('toPublicFrontmatter', () => {
 describe('parseChangelogEntryFile', () => {
   it('never exposes the internal block on the parsed entry frontmatter', () => {
     const entry = parseChangelogEntryFile('20260101-pipelines.md', ENTRY_WITH_INTERNAL)
+    // The .mjs source has no type declarations, so `frontmatter` is inferred as {}.
+    const frontmatter = entry.frontmatter as Record<string, unknown>
 
-    expect(entry.frontmatter.internal).toBeUndefined()
-    expect(entry.frontmatter.reviewers).toBeUndefined()
-    expect(JSON.stringify(entry.frontmatter)).not.toContain('team-etl')
-    expect(JSON.stringify(entry.frontmatter)).not.toContain('escalation_teams')
+    expect(frontmatter.internal).toBeUndefined()
+    expect(frontmatter.reviewers).toBeUndefined()
+    expect(JSON.stringify(frontmatter)).not.toContain('team-etl')
+    expect(JSON.stringify(frontmatter)).not.toContain('escalation_teams')
 
     // Public fields still flow through untouched.
-    expect(entry.frontmatter.title).toBe('Supabase Pipelines')
-    expect(entry.frontmatter.change_type).toBe('new-feature')
-    expect(entry.frontmatter.public).toBe(true)
-    expect(entry.frontmatter.affected_products).toEqual(['pipelines'])
+    expect(frontmatter.title).toBe('Supabase Pipelines')
+    expect(frontmatter.change_type).toBe('new-feature')
+    expect(frontmatter.public).toBe(true)
+    expect(frontmatter.affected_products).toEqual(['pipelines'])
   })
 })

--- a/apps/www/lib/changelog.utils.ts
+++ b/apps/www/lib/changelog.utils.ts
@@ -27,6 +27,22 @@ export function toChangelogTimelineIndexItem(entry: ChangelogEntry): ChangelogTi
   }
 }
 
+/**
+ * Strips inline markdown from a title for plain-text contexts — the document
+ * `<title>`, meta description, and Open Graph title — which take text, not HTML.
+ * Keeps the visible word (drops the backticks, asterisks, and link URL) so
+ * "Migrate `logs.all`" reads as "Migrate logs.all".
+ */
+export function stripTitleMarkdown(title: string) {
+  return title
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1') // [text](url) / ![alt](src) → text/alt
+    .replace(/(\*\*|__)(.*?)\1/g, '$2') // bold
+    .replace(/(\*|_)(.*?)\1/g, '$2') // italic
+    .replace(/~~(.*?)~~/g, '$1') // strikethrough
+    .replace(/`+([^`]*)`+/g, '$1') // inline code
+    .trim()
+}
+
 const CHANGE_TYPE_BADGE_VARIANT: Record<
   ChangeType,
   'default' | 'warning' | 'success' | 'destructive'

--- a/apps/www/lib/changelog.utils.ts
+++ b/apps/www/lib/changelog.utils.ts
@@ -27,18 +27,13 @@ export function toChangelogTimelineIndexItem(entry: ChangelogEntry): ChangelogTi
   }
 }
 
-/**
- * Strips inline markdown from a title for plain-text contexts — the document
- * `<title>`, meta description, and Open Graph title — which take text, not HTML.
- * Keeps the visible word (drops the backticks, asterisks, and link URL) so
- * "Migrate `logs.all`" reads as "Migrate logs.all".
- */
+/** Strips inline markdown from a title for plain-text contexts (`<title>`, meta, Open Graph). */
 export function stripTitleMarkdown(title: string) {
   return title
-    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1') // [text](url) / ![alt](src) → text/alt
-    .replace(/(\*\*|__)(.*?)\1/g, '$2') // bold
-    .replace(/(\*|_)(.*?)\1/g, '$2') // italic
-    .replace(/~~(.*?)~~/g, '$1') // strikethrough
+    .replace(/!?\[([^\]]*)\]\([^)]*\)/g, '$1') // links / images
+    .replace(/(\*\*|__)(.*?)\1/g, '$2')
+    .replace(/(\*|_)(.*?)\1/g, '$2')
+    .replace(/~~(.*?)~~/g, '$1')
     .replace(/`+([^`]*)`+/g, '$1') // inline code
     .trim()
 }

--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -12,7 +12,7 @@ import { NuqsAdapter } from 'nuqs/adapters/next/pages'
 import { useEffect, useMemo, useState } from 'react'
 import { Badge, Button, cn, IconYCombinator, Input } from 'ui'
 
-import { ChangelogEntryTitle } from '@/components/Changelog/ChangelogEntryTitle'
+import { ChangelogInlineMarkdown } from '@/components/Changelog/ChangelogInlineMarkdown'
 import { ChangelogLlmMarkdownButton } from '@/components/Changelog/ChangelogLlmMarkdownButton'
 import {
   ChangelogTimelineList,
@@ -512,7 +512,7 @@ function ChangelogIndex({ featured, restIndex, allIndex }: PageProps) {
                           {entry.title && (
                             <Link href={`/changelog/${entry.slug}`}>
                               <h3 className="text-foreground text-lg hover:underline [&_code]:align-middle">
-                                <ChangelogEntryTitle title={entry.title} />
+                                <ChangelogInlineMarkdown>{entry.title}</ChangelogInlineMarkdown>
                               </h3>
                             </Link>
                           )}

--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -63,7 +63,6 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({ res })
   const entries = await getChangelogEntries()
   const allIndex = entries.map(toChangelogTimelineIndexItem)
   const firstEntries = entries.slice(0, FEATURED_COUNT)
-  const restIndex = allIndex.slice(FEATURED_COUNT)
 
   // Serialized independently so one entry's MDX failure doesn't drop the others.
   const featuredResults = await Promise.allSettled(
@@ -85,6 +84,12 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({ res })
     }
     return [result.value]
   })
+
+  // Everything not successfully featured falls back to the timeline list — including
+  // a featured entry whose MDX failed to serialize, which would otherwise vanish
+  // from the page entirely (it lives only in `featured`, never in the sliced rest).
+  const featuredSlugs = new Set(featured.map((entry) => entry.slug))
+  const restIndex = allIndex.filter((item) => !featuredSlugs.has(item.slug))
 
   res.setHeader('Cache-Control', 'public, max-age=900, stale-while-revalidate=900')
   return { props: { featured, restIndex, allIndex } }

--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -86,9 +86,8 @@ export const getServerSideProps: GetServerSideProps<PageProps> = async ({ res })
     return [result.value]
   })
 
-  // Everything not successfully featured falls back to the timeline list — including
-  // a featured entry whose MDX failed to serialize, which would otherwise vanish
-  // from the page entirely (it lives only in `featured`, never in the sliced rest).
+  // Anything not successfully featured falls back to the timeline, so a featured
+  // entry whose MDX failed to serialize doesn't vanish from the page.
   const featuredSlugs = new Set(featured.map((entry) => entry.slug))
   const restIndex = allIndex.filter((item) => !featuredSlugs.has(item.slug))
 

--- a/apps/www/pages/changelog.tsx
+++ b/apps/www/pages/changelog.tsx
@@ -12,6 +12,7 @@ import { NuqsAdapter } from 'nuqs/adapters/next/pages'
 import { useEffect, useMemo, useState } from 'react'
 import { Badge, Button, cn, IconYCombinator, Input } from 'ui'
 
+import { ChangelogEntryTitle } from '@/components/Changelog/ChangelogEntryTitle'
 import { ChangelogLlmMarkdownButton } from '@/components/Changelog/ChangelogLlmMarkdownButton'
 import {
   ChangelogTimelineList,
@@ -510,8 +511,8 @@ function ChangelogIndex({ featured, restIndex, allIndex }: PageProps) {
                         <div className="flex w-full flex-col gap-1">
                           {entry.title && (
                             <Link href={`/changelog/${entry.slug}`}>
-                              <h3 className="text-foreground text-lg hover:underline">
-                                {entry.title}
+                              <h3 className="text-foreground text-lg hover:underline [&_code]:align-middle">
+                                <ChangelogEntryTitle title={entry.title} />
                               </h3>
                             </Link>
                           )}

--- a/apps/www/pages/changelog/[slug].tsx
+++ b/apps/www/pages/changelog/[slug].tsx
@@ -93,9 +93,8 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
 
   const entries = await getChangelogEntries()
   const entry = entries.find((e) => e.slug === slug)
-  // `revalidate` is required on the notFound branch too: without it Next.js caches
-  // the 404 indefinitely, so an entry requested before it went live (or before the
-  // in-process cache refreshed) would keep 404ing even once it's published.
+  // `revalidate` on notFound too, else Next.js caches the 404 forever — an entry
+  // requested before it went live would keep 404ing after publish.
   if (!entry) return { notFound: true, revalidate: 900 }
 
   const source = await mdxSerialize(entry.bodySection)

--- a/apps/www/pages/changelog/[slug].tsx
+++ b/apps/www/pages/changelog/[slug].tsx
@@ -86,7 +86,10 @@ export const getStaticProps: GetStaticProps<PageProps> = async ({ params }) => {
 
   const entries = await getChangelogEntries()
   const entry = entries.find((e) => e.slug === slug)
-  if (!entry) return { notFound: true }
+  // `revalidate` is required on the notFound branch too: without it Next.js caches
+  // the 404 indefinitely, so an entry requested before it went live (or before the
+  // in-process cache refreshed) would keep 404ing even once it's published.
+  if (!entry) return { notFound: true, revalidate: 900 }
 
   const source = await mdxSerialize(entry.bodySection)
 

--- a/apps/www/pages/changelog/[slug].tsx
+++ b/apps/www/pages/changelog/[slug].tsx
@@ -6,7 +6,7 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import { ChangelogDetailSidebar } from '@/components/Changelog/ChangelogDetailSidebar'
-import { ChangelogEntryTitle } from '@/components/Changelog/ChangelogEntryTitle'
+import { ChangelogInlineMarkdown } from '@/components/Changelog/ChangelogInlineMarkdown'
 import CTABanner from '@/components/CTABanner'
 import DefaultLayout from '@/components/Layouts/Default'
 import { getChangelogEntries, type ChangelogEntryFrontmatter } from '@/lib/changelog-repo'
@@ -50,7 +50,7 @@ const ChangelogDetailPage = ({ title, created_at, slug, frontmatter, source }: P
           </nav>
           <header className="border-default mb-8 flex flex-col gap-2 border-b pb-6">
             <h1 className="h1 text-2xl sm:text-3xl [&_code]:align-middle">
-              <ChangelogEntryTitle title={title} />
+              <ChangelogInlineMarkdown>{title}</ChangelogInlineMarkdown>
             </h1>
             <div className="flex items-center gap-2">
               <p className="text-foreground-lighter font-mono text-xs">

--- a/apps/www/pages/changelog/[slug].tsx
+++ b/apps/www/pages/changelog/[slug].tsx
@@ -6,9 +6,11 @@ import Head from 'next/head'
 import Link from 'next/link'
 
 import { ChangelogDetailSidebar } from '@/components/Changelog/ChangelogDetailSidebar'
+import { ChangelogEntryTitle } from '@/components/Changelog/ChangelogEntryTitle'
 import CTABanner from '@/components/CTABanner'
 import DefaultLayout from '@/components/Layouts/Default'
 import { getChangelogEntries, type ChangelogEntryFrontmatter } from '@/lib/changelog-repo'
+import { stripTitleMarkdown } from '@/lib/changelog.utils'
 import mdxComponents from '@/lib/mdx/mdxComponents'
 import { mdxSerialize } from '@/lib/mdx/mdxSerialize'
 
@@ -20,61 +22,66 @@ type PageProps = {
   source: MDXRemoteSerializeResult
 }
 
-const ChangelogDetailPage = ({ title, created_at, slug, frontmatter, source }: PageProps) => (
-  <>
-    <Head>
-      <link rel="alternate" type="text/markdown" href={`/changelog/${slug}.md`} />
-    </Head>
-    <NextSeo
-      title={`${title} · Changelog`}
-      description={title}
-      openGraph={{
-        title,
-        url: `https://supabase.com/changelog/${slug}`,
-        type: 'article',
-      }}
-    />
-    <DefaultLayout>
-      <div className="container mx-auto max-w-5xl px-4 py-10 sm:px-16 xl:px-20">
-        <nav
-          aria-label="Breadcrumb"
-          className="text-foreground-lighter mb-6 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm"
-        >
-          <Link href="/changelog" className="text-foreground-lighter hover:underline">
-            Changelog
-          </Link>
-        </nav>
-        <header className="border-default mb-8 flex flex-col gap-2 border-b pb-6">
-          <h1 className="h1 text-2xl sm:text-3xl">{title}</h1>
-          <div className="flex items-center gap-2">
-            <p className="text-foreground-lighter font-mono text-xs">
-              {dayjs(created_at).format('MMM D, YYYY')}
-            </p>
-          </div>
-        </header>
-
-        <div className="grid grid-cols-1 gap-8 lg:grid-cols-12 lg:gap-10 mb-8 lg:mb-20">
-          <div className="min-w-0 lg:col-span-8">
-            <article className="prose prose-docs max-w-none wrap-break-word [&>*:first-child:not(style):not(script)]:mt-0 [&>style:first-child+*]:mt-0 [&>script:first-child+*]:mt-0 [&>*:last-child:not(style):not(script)]:mb-0">
-              {'error' in source ? (
-                <p>Error rendering changelog entry: {source.error.message}</p>
-              ) : (
-                <MDXClient {...source} components={mdxComponents('blog')} />
-              )}
-            </article>
-          </div>
-
-          <aside className="border-default border-t pt-6 lg:col-span-4 lg:border-t-0 lg:pl-4 lg:pt-0">
-            <div className="thin-scrollbar lg:sticky lg:top-24 lg:max-h-[calc(100vh-8rem)] lg:overflow-y-auto">
-              <ChangelogDetailSidebar slug={slug} frontmatter={frontmatter} />
+const ChangelogDetailPage = ({ title, created_at, slug, frontmatter, source }: PageProps) => {
+  const plainTitle = stripTitleMarkdown(title)
+  return (
+    <>
+      <Head>
+        <link rel="alternate" type="text/markdown" href={`/changelog/${slug}.md`} />
+      </Head>
+      <NextSeo
+        title={`${plainTitle} · Changelog`}
+        description={plainTitle}
+        openGraph={{
+          title: plainTitle,
+          url: `https://supabase.com/changelog/${slug}`,
+          type: 'article',
+        }}
+      />
+      <DefaultLayout>
+        <div className="container mx-auto max-w-5xl px-4 py-10 sm:px-16 xl:px-20">
+          <nav
+            aria-label="Breadcrumb"
+            className="text-foreground-lighter mb-6 flex flex-wrap items-center gap-x-2 gap-y-1 text-sm"
+          >
+            <Link href="/changelog" className="text-foreground-lighter hover:underline">
+              Changelog
+            </Link>
+          </nav>
+          <header className="border-default mb-8 flex flex-col gap-2 border-b pb-6">
+            <h1 className="h1 text-2xl sm:text-3xl [&_code]:align-middle">
+              <ChangelogEntryTitle title={title} />
+            </h1>
+            <div className="flex items-center gap-2">
+              <p className="text-foreground-lighter font-mono text-xs">
+                {dayjs(created_at).format('MMM D, YYYY')}
+              </p>
             </div>
-          </aside>
+          </header>
+
+          <div className="grid grid-cols-1 gap-8 lg:grid-cols-12 lg:gap-10 mb-8 lg:mb-20">
+            <div className="min-w-0 lg:col-span-8">
+              <article className="prose prose-docs max-w-none wrap-break-word [&>*:first-child:not(style):not(script)]:mt-0 [&>style:first-child+*]:mt-0 [&>script:first-child+*]:mt-0 [&>*:last-child:not(style):not(script)]:mb-0">
+                {'error' in source ? (
+                  <p>Error rendering changelog entry: {source.error.message}</p>
+                ) : (
+                  <MDXClient {...source} components={mdxComponents('blog')} />
+                )}
+              </article>
+            </div>
+
+            <aside className="border-default border-t pt-6 lg:col-span-4 lg:border-t-0 lg:pl-4 lg:pt-0">
+              <div className="thin-scrollbar lg:sticky lg:top-24 lg:max-h-[calc(100vh-8rem)] lg:overflow-y-auto">
+                <ChangelogDetailSidebar slug={slug} frontmatter={frontmatter} />
+              </div>
+            </aside>
+          </div>
         </div>
-      </div>
-      <CTABanner />
-    </DefaultLayout>
-  </>
-)
+        <CTABanner />
+      </DefaultLayout>
+    </>
+  )
+}
 
 export const getStaticPaths: GetStaticPaths = async () => {
   return { paths: [], fallback: 'blocking' }


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Security/bug fix

## What is the current behavior?

The changelog entry parser exposes all YAML frontmatter fields parsed by `matter()` directly to the client via Next.js props. This includes private fields like `internal:` (escalation teams, notes) and `reviewers:`, which get serialized into the page's `__NEXT_DATA__` and are visible in View Source even if never rendered.

## What is the new behavior?

- Added `PUBLIC_FRONTMATTER_KEYS` constant that explicitly allowlists only the fields safe to expose to the browser
- Added `toPublicFrontmatter()` function that filters frontmatter down to the allowlist, dropping `internal:`, `reviewers:`, and any other private keys
- Updated `parseChangelogEntryFile()` to apply the allowlist before returning frontmatter to callers
- Added comprehensive unit tests covering both the filtering logic and the integration with the parser

This uses an allowlist approach rather than a denylist, so new private fields added upstream won't silently leak to clients.

## Additional context

The allowlist is kept in sync with `ChangelogEntryFrontmatter` in `changelog-repo.ts` per the code comment. Tests verify that:
- Only allowlisted keys are present in the returned frontmatter
- Private fields like `internal` and `reviewers` are never exposed
- Public fields flow through untouched
- Undefined values are omitted from the result

https://claude.ai/code/session_017uSmnCLsskFYR7YH8DKGkr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a shared changelog title renderer that safely displays titles as inline Markdown.
  * Added plain-text title extraction for consistent headings and SEO metadata.
* **Bug Fixes**
  * Prevented private/internal changelog frontmatter (including reviewer metadata) from being exposed to browser-rendered pages.
  * Ensured featured and non-featured changelog timelines stay consistent even when some entries fail to serialize.
  * Improved the changelog detail not-found behavior to revalidate instead of caching 404s indefinitely.
* **Tests**
  * Added coverage for public frontmatter allowlisting, date normalization (`publish_date`/sorting), and `sortDate` consistency across YAML variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->