### PR TITLE
Update FormField.tsx : preserve and encode newlines in multiline SMS templates (#6435)

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/FormField.tsx
@@ -209,14 +209,16 @@ const FormField = ({
                   }
                 >
                   <FormControl className="col-span-6">
-                    <Textarea
-                      {...field}
-                      id={name}
-                      rows={4}
-                      placeholder="Enter multi-line text"
-                      className="resize-none"
-                      readOnly={readOnly}
-                    />
+                   <Textarea
+                    {...field}
+                    id={name}
+                    rows={4}
+                    placeholder="Enter multi-line text"
+                    className="resize-none font-mono text-sm"
+                    readOnly={readOnly}
+                    value={field.value ? field.value.replace(/\\n/g, '\n') : ''}
+                    onChange={(e) => field.onChange(e.target.value.replace(/\n/g, '\\n'))}
+                  />
                   </FormControl>
                 </FormItemLayout>
               )}


### PR DESCRIPTION
Fixes #6435 by adding round-trip newline encoding and decoding logic to 'FormField.tsx'. 

1. Decodes stored '\\n' sequences into actual line breaks ('\n') when displaying in the '<Textarea>' component.
2.  Encodes user-entered line breaks ('\n') back into '\\n' when saving configuration updates.
3.Allows WebOTP-compliant SMS templates to preserve required origin-line line breaks.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Currently, the SMS template field in Studio strips or escapes newline characters (\n), preventing users from entering multi-line templates needed for WebOTP support.

Closes #6435

## What is the new behavior?

1. Decodes stored \\n strings into actual line breaks (\n) for display in the <Textarea> component.
2. Encodes user-entered line breaks (\n) back into \\n when saving configuration updates.
3. Preserves origin-line formatting required by the WebOTP API specification.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiline text field editing by displaying line breaks correctly.
  * Preserved entered line breaks when saving multiline values.
  * Updated the field styling for clearer editing of structured text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->