### PR TITLE
fix: MFA list Added on value uses last_challenged_at instead of created_at

### DIFF
--- a/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
+++ b/apps/studio/components/interfaces/Account/TOTPFactors/index.tsx
@@ -37,7 +37,7 @@ export const TOTPFactors = () => {
                       </p>
                       <div className="flex items-center gap-4">
                         <p className="text-sm text-foreground-light">
-                          Added on {dayjs(factor.updated_at).format(DATETIME_FORMAT)}
+                          Added on {dayjs(factor.created_at).format(DATETIME_FORMAT)}
                         </p>
                         <Button
                           size="tiny"


### PR DESCRIPTION
Fixes FE-3985. `TOTPFactors` was displaying `updated_at` (which mirrors `last_challenged_at`) for "Added on" instead of `created_at`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the TOTP factor list to display the date each factor was added, rather than its last update date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->