### PR TITLE
fix(studio): correct realtime settings UI limits to match backend

### DIFF
--- a/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
+++ b/apps/studio/components/interfaces/Realtime/RealtimeSettings.tsx
@@ -94,9 +94,9 @@ export const RealtimeSettings = () => {
         .max(maxConn?.maxConnections ?? 100)
         .optional(),
       max_concurrent_users: z.coerce.number().min(1).max(50000).optional(),
-      max_events_per_second: z.coerce.number().min(1).max(10000).optional(),
-      max_presence_events_per_second: z.coerce.number().min(1).max(10000).optional(),
-      max_payload_size_in_kb: z.coerce.number().min(1).max(3000).optional(),
+      max_events_per_second: z.coerce.number().min(1).max(50000).optional(),
+      max_presence_events_per_second: z.coerce.number().min(1).max(5000).optional(),
+      max_payload_size_in_kb: z.coerce.number().min(1).max(10000).optional(),
       // [Joshen] These fields are temporarily hidden from the UI
       // max_bytes_per_second: z.coerce.number().min(1).max(10000000).optional(),
       // max_channels_per_client: z.coerce.number().min(1).max(10000).optional(),
@@ -111,9 +111,9 @@ export const RealtimeSettings = () => {
         .min(1)
         .max(maxConn?.maxConnections ?? 100),
       max_concurrent_users: z.coerce.number().min(1).max(50000),
-      max_events_per_second: z.coerce.number().min(1).max(10000),
-      max_presence_events_per_second: z.coerce.number().min(1).max(10000),
-      max_payload_size_in_kb: z.coerce.number().min(1).max(3000),
+      max_events_per_second: z.coerce.number().min(1).max(50000),
+      max_presence_events_per_second: z.coerce.number().min(1).max(5000),
+      max_payload_size_in_kb: z.coerce.number().min(1).max(10000),
       // [Joshen] These fields are temporarily hidden from the UI
       // max_bytes_per_second: z.coerce.number().min(1).max(10000000),
       // max_channels_per_client: z.coerce.number().min(1).max(10000),


### PR DESCRIPTION
Realtime settings validation in Studio didn't match the backend's actual limits: 
- \`max_presence_events_per_second\` allowed up to 10000 (backend caps at 5000),
- \`max_payload_size_in_kb\` allowed up to 3000 (backend caps at 10000)
-  \`max_events_per_second\` allowed up to 10000 (backend caps at 50000).

Updated the Zod schema limits in both branches of the form's discriminated union to match.

Fixes FE-3991

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the allowed limits for realtime event throughput, presence events, and payload size settings.
  * Administrators can now configure higher-capacity realtime workloads, including payloads up to 10,000 KB.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->