### PR TITLE
fix(studio): make failed Postgres upgrade banner dismissible

### DIFF
--- a/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
+++ b/apps/studio/components/ui/ProjectUpgradeFailedBanner.tsx
@@ -1,13 +1,16 @@
 import { SupportCategories } from '@supabase/shared-types/out/constants'
 import { DatabaseUpgradeStatus } from '@supabase/shared-types/out/events'
-import { useParams } from 'common'
+import { LOCAL_STORAGE_KEYS, useParams } from 'common'
 import dayjs from 'dayjs'
+import { X } from 'lucide-react'
 import { Button } from 'ui'
 import { Admonition } from 'ui-patterns/admonition'
 
+import { ButtonTooltip } from './ButtonTooltip'
 import { InlineLink } from './InlineLink'
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
 import { useProjectUpgradingStatusQuery } from '@/data/config/project-upgrade-status-query'
+import { useLocalStorageQuery } from '@/hooks/misc/useLocalStorage'
 import { useShowPostgresUpgradeLogs } from '@/hooks/misc/useShowPostgresUpgradeLogs'
 import { IS_PLATFORM } from '@/lib/constants'
 import { guessLocalTimezone } from '@/lib/dayjs'
@@ -20,7 +23,12 @@ export const ProjectUpgradeFailedBanner = () => {
   const { status, initiated_at, latest_status_at, error } = data?.databaseUpgradeStatus ?? {}
   const showPostgresUpgradeLogs = useShowPostgresUpgradeLogs()
 
-  const isFailed = status === DatabaseUpgradeStatus.Failed
+  const [dismissedAt, setDismissedAt] = useLocalStorageQuery<string | null>(
+    LOCAL_STORAGE_KEYS.PROJECT_UPGRADE_FAILED_BANNER_DISMISSED_AT(ref ?? 'unknown'),
+    null
+  )
+
+  const isFailed = status === DatabaseUpgradeStatus.Failed && initiated_at !== dismissedAt
   const initiatedAt = dayjs
     .utc(initiated_at ?? 0)
     .tz(guessLocalTimezone())
@@ -48,18 +56,28 @@ export const ProjectUpgradeFailedBanner = () => {
         type="warning"
         title={`Postgres version upgrade was not successful (Initiated at ${initiatedAt})`}
         actions={
-          <Button asChild variant="default">
-            <SupportLink
-              queryParams={{
-                category: SupportCategories.DATABASE_UNRESPONSIVE,
-                projectRef: ref,
-                subject,
-                message,
-              }}
-            >
-              Contact support
-            </SupportLink>
-          </Button>
+          <>
+            <Button asChild variant="default">
+              <SupportLink
+                queryParams={{
+                  category: SupportCategories.DATABASE_UNRESPONSIVE,
+                  projectRef: ref,
+                  subject,
+                  message,
+                }}
+              >
+                Contact support
+              </SupportLink>
+            </Button>
+            <ButtonTooltip
+              icon={<X />}
+              variant="text"
+              className="w-6"
+              tooltip={{ content: { side: 'bottom', text: 'Dismiss' } }}
+              aria-label="Dismiss upgrade failed banner"
+              onClick={() => setDismissedAt(initiated_at ?? null)}
+            />
+          </>
         }
       >
         <div>

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -113,6 +113,10 @@ export const LOCAL_STORAGE_KEYS = {
     `table-editor-queue-operations-banner-dismissed-${ref}`,
   FREE_MICRO_UPGRADE_BANNER_DISMISSED: (ref: string) =>
     `free-micro-upgrade-banner-dismissed-${ref}`,
+  // Stores the `initiated_at` of the failed upgrade attempt that was dismissed, so a later
+  // failed attempt (different `initiated_at`) still shows the banner
+  PROJECT_UPGRADE_FAILED_BANNER_DISMISSED_AT: (ref: string) =>
+    `project-upgrade-failed-banner-dismissed-at-${ref}`,
   UNIFIED_LOGS_BANNER_DISMISSED: 'unified-logs-banner-dismissed',
   UNIFIED_LOGS_SIDEBAR_BANNER_DISMISSED: 'unified-logs-sidebar-banner-dismissed',
   STORAGE_PUBLIC_BUCKET_SELECT_POLICY_WARNING_DISMISSED: (ref: string, bucketId: string) =>

--- a/packages/common/constants/local-storage.ts
+++ b/packages/common/constants/local-storage.ts
@@ -113,8 +113,6 @@ export const LOCAL_STORAGE_KEYS = {
     `table-editor-queue-operations-banner-dismissed-${ref}`,
   FREE_MICRO_UPGRADE_BANNER_DISMISSED: (ref: string) =>
     `free-micro-upgrade-banner-dismissed-${ref}`,
-  // Stores the `initiated_at` of the failed upgrade attempt that was dismissed, so a later
-  // failed attempt (different `initiated_at`) still shows the banner
   PROJECT_UPGRADE_FAILED_BANNER_DISMISSED_AT: (ref: string) =>
     `project-upgrade-failed-banner-dismissed-at-${ref}`,
   UNIFIED_LOGS_BANNER_DISMISSED: 'unified-logs-banner-dismissed',


### PR DESCRIPTION
- The failed-upgrade banner reflects the API's last-known upgrade status, which stays "Failed" indefinitely even after a project is restored, so it never went away
- A hard refresh didn't help, since this isn't client-cached state
- Adds a dismiss action, scoped to the attempt's `initiated_at` so a future failed upgrade still shows the banner

Fixes FE-3964

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dismiss control to project upgrade failure notifications.
  * Dismissed notifications remain hidden for the current project until a new upgrade failure occurs.
  * Contact support remains available alongside the dismiss option.

* **Bug Fixes**
  * Improved upgrade failure banner behavior by persisting dismissal state across page visits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->