### PR TITLE
fix: default scoped token resources to least privilege

### DIFF
--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.tsx
@@ -15,7 +15,7 @@ import {
 import { TokenFormValues } from '../../../AccessToken.schemas'
 import { PermissionResourceSelector } from './PermissionResourceSelector'
 import { PermissionsProps } from './Permissions.types'
-import { sortActions } from './Permissions.utils'
+import { getDefaultPermissionActions, sortActions } from './Permissions.utils'
 import { ACCESS_TOKEN_RESOURCES } from '@/components/interfaces/Account/AccessTokens/AccessToken.constants'
 import { formatAccessText } from '@/components/interfaces/Account/AccessTokens/AccessToken.utils'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
@@ -67,7 +67,10 @@ export const Permissions = ({
                 if (index > -1) {
                   return remove(index)
                 }
-                append(resource)
+                append({
+                  resource: resource.resource,
+                  actions: getDefaultPermissionActions(resource.actions),
+                })
               }}
               align="end"
             />

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.utils.test.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.utils.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
 import type { PermissionResource, PermissionRow } from './Permissions.types'
-import { sortActions, togglePermissionResource } from './Permissions.utils'
+import {
+  getDefaultPermissionActions,
+  sortActions,
+  togglePermissionResource,
+} from './Permissions.utils'
 
 // --- sortActions ---
 
@@ -50,6 +54,28 @@ describe('sortActions', () => {
   })
 })
 
+// --- getDefaultPermissionActions ---
+
+describe('getDefaultPermissionActions', () => {
+  it('should default to "read" when available', () => {
+    expect(getDefaultPermissionActions(['write', 'read', 'delete'])).toEqual(['read'])
+  })
+
+  it('should default to the first action when "read" is not available', () => {
+    expect(getDefaultPermissionActions(['write', 'create'])).toEqual(['write'])
+  })
+
+  it('should return an empty array when no actions are available', () => {
+    expect(getDefaultPermissionActions([])).toEqual([])
+  })
+
+  it('should not mutate the original array', () => {
+    const original = ['write', 'read']
+    getDefaultPermissionActions(original)
+    expect(original).toEqual(['write', 'read'])
+  })
+})
+
 // --- togglePermissionResource ---
 
 describe('togglePermissionResource', () => {
@@ -79,6 +105,16 @@ describe('togglePermissionResource', () => {
   it('should add a resource with the first action as default when "read" is not available', () => {
     const result = togglePermissionResource([], storageResource)
     expect(result).toEqual([{ resource: 'project:storage', actions: ['write'] }])
+  })
+
+  it('should add a resource with no selected actions when no actions are available', () => {
+    const result = togglePermissionResource([], {
+      resource: 'project:empty',
+      title: 'Empty',
+      actions: [],
+    })
+
+    expect(result).toEqual([{ resource: 'project:empty', actions: [] }])
   })
 
   it('should remove a resource if it is already in the list', () => {

--- a/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.utils.ts
+++ b/apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.utils.ts
@@ -17,6 +17,16 @@ export const sortActions = (actions: string[]): string[] => {
   return sorted
 }
 
+export const getDefaultPermissionActions = (actions: string[]): string[] => {
+  const firstAvailableAction = actions[0]
+
+  if (actions.includes('read')) {
+    return ['read']
+  }
+
+  return firstAvailableAction ? [firstAvailableAction] : []
+}
+
 export const togglePermissionResource = (
   permissionRows: PermissionRow[],
   resource: PermissionResource
@@ -27,6 +37,8 @@ export const togglePermissionResource = (
     return permissionRows.filter((row) => row.resource !== resource.resource)
   }
 
-  const defaultActions = resource.actions.includes('read') ? ['read'] : [resource.actions[0]]
-  return [...permissionRows, { resource: resource.resource, actions: defaultActions }]
+  return [
+    ...permissionRows,
+    { resource: resource.resource, actions: getDefaultPermissionActions(resource.actions) },
+  ]
 }


### PR DESCRIPTION
## What changed

- Default newly added scoped access token resources to a single least-privilege action.
- Prefer `read` when available, otherwise use the first available action.
- Share the default-action logic between the UI path and permission utilities.
- Add regression coverage for default action selection and empty action lists.

## Why

The scoped access token form appended the full permission resource when adding a resource, which pre-selected every available action. This could grant broader access than intended unless users manually deselected actions.

Fixes #48175.

## Validation

- `npx.cmd --yes vitest@latest --run apps/studio/components/interfaces/Account/AccessTokens/Scoped/Form/Permissions/Permissions.utils.test.ts`
- Focused Prettier check on touched files
- `git diff --check`

Full local CI was not run because workspace dependency installation timed out in this environment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default permission selection when adding access-token permissions.
  * Preserves empty action lists instead of selecting an unavailable action.
  * Prioritizes the “read” action when available, otherwise selecting the first available option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->