### PR TITLE
fix(www): stop on-demand mdx events from winning the events marquee

### DIFF
--- a/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
+++ b/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
@@ -20,8 +20,7 @@ company:
     /images/events/webinars/supabase-trae-high-quality-apps/trae-white.png
   logo_light: >-
     /images/events/webinars/supabase-trae-high-quality-apps/trae.png
-categories:
-  - webinar
+categories: []
 main_cta:
   url: '#recording'
   target: _self

--- a/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
+++ b/apps/www/_events/2026-07-22-supabase-trae-high-quality-apps.mdx
@@ -20,7 +20,8 @@ company:
     /images/events/webinars/supabase-trae-high-quality-apps/trae-white.png
   logo_light: >-
     /images/events/webinars/supabase-trae-high-quality-apps/trae.png
-categories: []
+categories:
+  - webinar
 main_cta:
   url: '#recording'
   target: _self

--- a/apps/www/lib/events.ts
+++ b/apps/www/lib/events.ts
@@ -269,10 +269,15 @@ function getAllParsedMdxEvents(): SupabaseEvent[] {
 /**
  * Read all events under `_events/` and return today-and-future events.
  * Past events are excluded (by end_date when present, otherwise start date).
+ * Events already flipped to `onDemand: true` are excluded too — they've
+ * already happened and belong in the on-demand bucket (getOnDemandMdxEvents),
+ * not the upcoming one, regardless of how their UTC-converted date compares to today.
  */
 export const getMdxEvents = (): SupabaseEvent[] => {
   const today = startOfTodayUtc()
-  return getAllParsedMdxEvents().filter((event) => new Date(event.end_date ?? event.date) >= today)
+  return getAllParsedMdxEvents().filter(
+    (event) => !event.onDemand && new Date(event.end_date ?? event.date) >= today
+  )
 }
 
 /** All MDX events with `onDemand: true`, including past recordings. */


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix — the [events index](https://supabase.com/events) was featuring the TRAE webinar in its marquee days after the event happened, instead of the next genuinely upcoming event (the Dublin meetup), and counting it toward the "Webinar" filter chip alongside actually-upcoming webinars.

## What is the current behavior?

`getMdxEvents()` in `lib/events.ts` only excludes past events by comparing dates against the start of today in UTC. It doesn't check `onDemand` at all. The TRAE event's timestamp (`2026-07-22T19:00:00.000-07:00`) converts to `2026-07-23T02:00:00Z`, which is still "today or later" by that UTC cutoff — so even though the event already happened and flipped to `onDemand: true`, it kept getting returned as an "upcoming" event. Since the events marquee (`featuredEvent`) just picks the earliest-dated event from that pool, TRAE kept winning over the actually-upcoming Dublin meetup, and it kept counting toward the "Webinar" filter chip.

## What is the new behavior?

`getMdxEvents()` now excludes any event with `onDemand: true` outright, regardless of how its date converts across timezones — on-demand events belong solely in the on-demand bucket (`getOnDemandMdxEvents`), not the upcoming/marquee pool. Verified locally: the "Webinar" filter chip count on `/events` drops to 0 with this in place (previously counted TRAE), while the TRAE event's card in the on-demand list still correctly shows its "Webinar" tag and "Supabase Live" line, matching the other on-demand webinars (Perplexity, Datadog) — only its bucket assignment changed, not its labeling.

## Additional context

Couldn't verify the marquee itself locally since the Luma events API returns a 500 in local dev (missing credentials, pre-existing/unrelated to this change). Confirmed independently via the production Luma API that the Dublin meetup (`2026-07-28T17:00:00Z`) is genuinely the next chronological event, so it will naturally take over the marquee once this ships — no hardcoding needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * On-demand events are no longer shown in the upcoming events list.
  * Upcoming events continue to be filtered by their relevant date, while on-demand event listings remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->