### PR TITLE
fix: guard against NaN and division by zero in formatBytes, storage upload, observability, and SparkBar

### DIFF
--- a/apps/studio/components/ui/SparkBar.tsx
+++ b/apps/studio/components/ui/SparkBar.tsx
@@ -26,7 +26,8 @@ export const SparkBar = ({
   labelTopClass = '',
 }: SparkBarProps) => {
   if (type === 'horizontal') {
-    const width = Number((value / max) * 100)
+    const safeMax = max > 0 ? max : 100
+    const width = Number((value / safeMax) * 100)
     const widthCss = `${width}%`
     const hasLabels = labelBottom || labelTop
 
@@ -60,7 +61,8 @@ export const SparkBar = ({
     )
   } else {
     const totalHeight = 35
-    let height = Number((value / max) * totalHeight)
+    const safeMax = max > 0 ? max : 100
+    let height = Number((value / safeMax) * totalHeight)
     if (height < 2) height = 2
 
     return (

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -136,7 +136,7 @@ export const formatBytes = (
   const dm = decimals < 0 ? 0 : decimals
   const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
-  if (bytes === 0 || bytes === undefined) return size !== undefined ? `0 ${size}` : '0 bytes'
+  if (bytes === 0 || bytes === undefined || Number.isNaN(bytes)) return size !== undefined ? `0 ${size}` : '0 bytes'
 
   // Handle negative values
   const isNegative = bytes < 0

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -415,10 +415,9 @@ const DatabaseUsage = () => {
                       </Table.th>,
                     ]}
                     body={props.data?.map((object) => {
-                      const percentage = (
-                        ((object.table_size as number) / databaseSizeBytes) *
-                        100
-                      ).toFixed(2)
+                      const percentage = databaseSizeBytes > 0
+                        ? (((object.table_size as number) / databaseSizeBytes) * 100).toFixed(2)
+                        : '0.00'
 
                       return (
                         <Table.tr key={`${object.schema_name}.${object.relname}`}>

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1776,6 +1776,7 @@ function createStorageExplorerState({
 
     onUploadProgress: (toastId?: string | number) => {
       const totalFiles = state.uploadProgresses.length
+      if (totalFiles === 0) return
       const progress =
         (state.uploadProgresses.reduce((acc, { percentage }) => acc + percentage, 0) / totalFiles) *
         100


### PR DESCRIPTION
## Summary

Four fixes for NaN propagation and division by zero across the Supabase Studio.

| # | File | Bug | Impact |
|---|---|---|---|
| 1 | `lib/helpers.ts` | `formatBytes(NaN)` → `"NaN undefined"` in UI | Called 42 times — file sizes, DB sizes, charts |
| 2 | `state/storage-explorer.tsx` | Division by zero when upload progress fires with empty array | Broken progress bar on upload race condition |
| 3 | `observability/database.tsx` | Division by zero → `"Infinity%"` in Large Objects table | New projects with zero DB size |
| 4 | `components/ui/SparkBar.tsx` | Division by zero → `Infinity%` CSS width/height | SparkBar used for inline data visualization across dashboard |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chart rendering when maximum values are missing, zero, or negative.
  - Corrected byte formatting for invalid numeric values.
  - Prevented incorrect percentage calculations when database size is unavailable.
  - Avoided displaying upload progress notifications when no files are being uploaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->