### PR TITLE
fix: guard against empty result arrays across database queries and replicas utils

### DIFF
--- a/apps/studio/components/ui/SparkBar.tsx
+++ b/apps/studio/components/ui/SparkBar.tsx
@@ -26,7 +26,8 @@ export const SparkBar = ({
   labelTopClass = '',
 }: SparkBarProps) => {
   if (type === 'horizontal') {
-    const width = Number((value / max) * 100)
+    const safeMax = max > 0 ? max : 100
+    const width = Number((value / safeMax) * 100)
     const widthCss = `${width}%`
     const hasLabels = labelBottom || labelTop
 
@@ -60,7 +61,8 @@ export const SparkBar = ({
     )
   } else {
     const totalHeight = 35
-    let height = Number((value / max) * totalHeight)
+    const safeMax = max > 0 ? max : 100
+    let height = Number((value / safeMax) * totalHeight)
     if (height < 2) height = 2
 
     return (

--- a/apps/studio/data/database-queues/database-queues-metrics-query.ts
+++ b/apps/studio/data/database-queues/database-queues-metrics-query.ts
@@ -59,6 +59,7 @@ export async function getDatabaseQueuesMetrics({
       connectionString,
       sql: preciseMetricsSqlQuery(queueName),
     })
+    if (!result.length) throw new Error('Queue table not found')
     return {
       queue_name: queueName,
       queue_length: result[0].row_count,
@@ -72,6 +73,7 @@ export async function getDatabaseQueuesMetrics({
         connectionString,
         sql: estimateMetricsSqlQuery(queueName),
       })
+      if (!result.length) throw new Error('Queue table not found for estimate')
       return {
         queue_name: queueName,
         queue_length: result[0].estimated_rows,

--- a/apps/studio/data/database/max-connections-query.ts
+++ b/apps/studio/data/database/max-connections-query.ts
@@ -23,6 +23,7 @@ export async function getMaxConnections(
     signal
   )
 
+  if (!result.length) throw new Error('max_connections query returned no results')
   const connections = parseInt(result[0].max_connections)
 
   return { maxConnections: connections }

--- a/apps/studio/data/database/table-definition-query.ts
+++ b/apps/studio/data/database/table-definition-query.ts
@@ -34,6 +34,7 @@ export async function getTableDefinition(
     signal
   )
 
+  if (!result.length) throw new Error('Table not found')
   return result[0].definition.trim() as string
 }
 

--- a/apps/studio/data/database/view-definition-query.ts
+++ b/apps/studio/data/database/view-definition-query.ts
@@ -32,6 +32,7 @@ export async function getViewDefinition(
     signal
   )
 
+  if (!result.length) throw new Error('View not found')
   return result[0].definition.trim()
 }
 

--- a/apps/studio/data/read-replicas/replicas.utils.ts
+++ b/apps/studio/data/read-replicas/replicas.utils.ts
@@ -5,4 +5,4 @@ import { AVAILABLE_REPLICA_REGIONS } from '@/components/interfaces/Settings/Infr
 export const formatDatabaseID = (id: string) => last(id.split('-') ?? [])
 
 export const formatDatabaseRegion = (region: string) =>
-  last(AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region)?.name.split('('))?.split(')')[0]
+  last(AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region)?.name.split('('))?.split(')')?.[0]

--- a/apps/studio/data/tables/table-retrieve-query.ts
+++ b/apps/studio/data/tables/table-retrieve-query.ts
@@ -29,7 +29,7 @@ export async function getTable(
     },
     signal
   )
-  // pg-meta sources `check` from pg_catalog; treat it as SafeSqlFragment for DDL composition.
+  if (!result.length) throw new Error('Table not found')
   return zod.parse(result[0]) as unknown as SafePostgresTable
 }
 

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -136,7 +136,7 @@ export const formatBytes = (
   const dm = decimals < 0 ? 0 : decimals
   const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
-  if (bytes === 0 || bytes === undefined) return size !== undefined ? `0 ${size}` : '0 bytes'
+  if (bytes === 0 || bytes === undefined || Number.isNaN(bytes)) return size !== undefined ? `0 ${size}` : '0 bytes'
 
   // Handle negative values
   const isNegative = bytes < 0

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -415,10 +415,9 @@ const DatabaseUsage = () => {
                       </Table.th>,
                     ]}
                     body={props.data?.map((object) => {
-                      const percentage = (
-                        ((object.table_size as number) / databaseSizeBytes) *
-                        100
-                      ).toFixed(2)
+                      const percentage = databaseSizeBytes > 0
+                        ? (((object.table_size as number) / databaseSizeBytes) * 100).toFixed(2)
+                        : '0.00'
 
                       return (
                         <Table.tr key={`${object.schema_name}.${object.relname}`}>

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1776,6 +1776,7 @@ function createStorageExplorerState({
 
     onUploadProgress: (toastId?: string | number) => {
       const totalFiles = state.uploadProgresses.length
+      if (totalFiles === 0) return
       const progress =
         (state.uploadProgresses.reduce((acc, { percentage }) => acc + percentage, 0) / totalFiles) *
         100


### PR DESCRIPTION
## Summary

Fixes 6 locations where `result[0]` was accessed without checking `result.length`, causing TypeError crashes on empty query results.

| # | File | Trigger |
|---|---|---|
| 1 | `table-retrieve-query.ts` | Table dropped between introspection and fetch |
| 2 | `database-queues-metrics-query.ts` (x2) | Missing pgmq extension / queue table deleted (both precise AND estimate paths) |
| 3 | `max-connections-query.ts` | Self-hosted without permission for `SHOW max_connections` |
| 4 | `view-definition-query.ts` | View dropped between introspection and definition fetch |
| 5 | `table-definition-query.ts` | Table dropped between introspection and DDL fetch |
| 6 | `replicas.utils.ts` | Unknown region string → missing `?.` before `[0]` |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of empty or missing database query results with clearer error messages.
  - Prevented invalid progress calculations when chart limits are zero or negative.
  - Fixed file upload progress notifications when no uploads are active.
  - Improved formatting for invalid byte values and database region names.
  - Maintained accurate large-object size percentages, including zero-size databases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->