### PR TITLE
fix: JSON.parse in logs, null query in sql filter, SSR guard in gotrue

### DIFF
--- a/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.tsx
+++ b/apps/studio/components/interfaces/Storage/StorageExplorer/StorageExplorer.utils.tsx
@@ -99,7 +99,8 @@ export function sanitizeNameForDuplicateInColumn(
       const fileName = fileNameSegments.slice(0, fileNameSegments.length - 1).join('.')
       const fileExt = fileNameSegments[fileNameSegments.length - 1]
 
-      const dupeNameRegex = new RegExp(`${fileName} \\([-0-9]+\\)${fileExt ? '.' + fileExt : ''}$`)
+      const escapedFileName = fileName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      const dupeNameRegex = new RegExp(`${escapedFileName} \\([-0-9]+\\)${fileExt ? '.' + fileExt : ''}$`)
       const itemsWithSameNameInColumn = currentColumnItems.filter((item) =>
         item.name.match(dupeNameRegex)
       )

--- a/apps/studio/components/ui/SparkBar.tsx
+++ b/apps/studio/components/ui/SparkBar.tsx
@@ -26,7 +26,8 @@ export const SparkBar = ({
   labelTopClass = '',
 }: SparkBarProps) => {
   if (type === 'horizontal') {
-    const width = Number((value / max) * 100)
+    const safeMax = max > 0 ? max : 100
+    const width = Number((value / safeMax) * 100)
     const widthCss = `${width}%`
     const hasLabels = labelBottom || labelTop
 
@@ -60,7 +61,8 @@ export const SparkBar = ({
     )
   } else {
     const totalHeight = 35
-    let height = Number((value / max) * totalHeight)
+    const safeMax = max > 0 ? max : 100
+    let height = Number((value / safeMax) * totalHeight)
     if (height < 2) height = 2
 
     return (

--- a/apps/studio/data/database-queues/database-queues-metrics-query.ts
+++ b/apps/studio/data/database-queues/database-queues-metrics-query.ts
@@ -59,6 +59,7 @@ export async function getDatabaseQueuesMetrics({
       connectionString,
       sql: preciseMetricsSqlQuery(queueName),
     })
+    if (!result.length) throw new Error('Queue table not found')
     return {
       queue_name: queueName,
       queue_length: result[0].row_count,
@@ -72,6 +73,7 @@ export async function getDatabaseQueuesMetrics({
         connectionString,
         sql: estimateMetricsSqlQuery(queueName),
       })
+      if (!result.length) throw new Error('Queue table not found for estimate')
       return {
         queue_name: queueName,
         queue_length: result[0].estimated_rows,

--- a/apps/studio/data/database/max-connections-query.ts
+++ b/apps/studio/data/database/max-connections-query.ts
@@ -23,6 +23,7 @@ export async function getMaxConnections(
     signal
   )
 
+  if (!result.length) throw new Error('max_connections query returned no results')
   const connections = parseInt(result[0].max_connections)
 
   return { maxConnections: connections }

--- a/apps/studio/data/database/table-definition-query.ts
+++ b/apps/studio/data/database/table-definition-query.ts
@@ -34,6 +34,7 @@ export async function getTableDefinition(
     signal
   )
 
+  if (!result.length) throw new Error('Table not found')
   return result[0].definition.trim() as string
 }
 

--- a/apps/studio/data/database/view-definition-query.ts
+++ b/apps/studio/data/database/view-definition-query.ts
@@ -32,6 +32,7 @@ export async function getViewDefinition(
     signal
   )
 
+  if (!result.length) throw new Error('View not found')
   return result[0].definition.trim()
 }
 

--- a/apps/studio/data/edge-functions/edge-function-test-mutation.ts
+++ b/apps/studio/data/edge-functions/edge-function-test-mutation.ts
@@ -27,7 +27,7 @@ export async function testEdgeFunction({ url, method, body, headers }: EdgeFunct
     body: JSON.stringify({ url, method, body, headers }),
   })
 
-  let data: any
+  let data: any = {}
 
   try {
     data = await response.json()

--- a/apps/studio/data/logs/get-unified-logs.ts
+++ b/apps/studio/data/logs/get-unified-logs.ts
@@ -60,7 +60,7 @@ export async function retrieveUnifiedLogs({
       pathname: (row.url || '').replace(/^https?:\/\/[^\/]+/, '') || row.pathname || '',
       event_message: row.event_message || row.body || '',
       headers:
-        typeof row.headers === 'string' ? JSON.parse(row.headers || '{}') : row.headers || {},
+        typeof row.headers === 'string' ? tryParseJson(row.headers || '{}') : row.headers || {},
       regions: row.region ? [row.region] : [],
       log_type: row.log_type || '',
       latency: row.latency || 0,

--- a/apps/studio/data/logs/unified-logs-infinite-query.ts
+++ b/apps/studio/data/logs/unified-logs-infinite-query.ts
@@ -140,7 +140,7 @@ export async function getUnifiedLogs(
       host: row.host,
       event_message: row.event_message || row.body || '',
       headers:
-        typeof row.headers === 'string' ? JSON.parse(row.headers || '{}') : row.headers || {},
+        typeof row.headers === 'string' ? tryParseJson(row.headers || '{}') : row.headers || {},
       regions: row.region ? [row.region] : [],
       log_type: row.log_type || '',
       latency: row.latency || 0,

--- a/apps/studio/data/organizations/organization-members-query.ts
+++ b/apps/studio/data/organizations/organization-members-query.ts
@@ -35,8 +35,7 @@ export async function getOrganizationMembers(
   if (orgMembersError) handleError(orgMembersError)
   if (orgInvitesError) handleError(orgInvitesError)
 
-  // Remap invite data to look like existing members data
-  const invitedMembers = orgInvites.invitations.map((invite) => {
+  const invitedMembers = orgInvites?.invitations?.map((invite) => {
     const member = {
       invited_at: invite.invited_at,
       invited_id: invite.id,
@@ -47,7 +46,7 @@ export async function getOrganizationMembers(
     return { ...member, role_ids: [invite.role_id] }
   })
 
-  return [...orgMembers, ...invitedMembers] as OrganizationMember[]
+  return [...(orgMembers ?? []), ...(invitedMembers ?? [])] as OrganizationMember[]
 }
 
 export type OrganizationMembersData = Awaited<ReturnType<typeof getOrganizationMembers>>

--- a/apps/studio/data/organizations/organization-query.ts
+++ b/apps/studio/data/organizations/organization-query.ts
@@ -15,7 +15,7 @@ export function castOrganizationSlugResponseToOrganization(org: OrganizationDeta
     ...org,
     billing_email: org.billing_email ?? 'Unknown',
     managed_by: getManagedByFromOrganizationPartner(org.billing_partner, org.integration_source),
-    partner_id: org.slug.startsWith('vercel_') ? org.slug.replace('vercel_', '') : undefined,
+    partner_id: org.slug?.startsWith('vercel_') ? org.slug.replace('vercel_', '') : undefined,
   }
 }
 

--- a/apps/studio/data/organizations/organizations-query.ts
+++ b/apps/studio/data/organizations/organizations-query.ts
@@ -14,7 +14,7 @@ export function castOrganizationResponseToOrganization(org: OrganizationBase): O
     ...org,
     billing_email: org.billing_email ?? 'Unknown',
     managed_by: getManagedByFromOrganizationPartner(org.billing_partner, org.integration_source),
-    partner_id: org.slug.startsWith('vercel_') ? org.slug.replace('vercel_', '') : undefined,
+    partner_id: org.slug?.startsWith('vercel_') ? org.slug.replace('vercel_', '') : undefined,
   }
 }
 
@@ -32,7 +32,7 @@ export async function getOrganizations({
 
   return data
     .map(castOrganizationResponseToOrganization)
-    .sort((a, b) => a.name.localeCompare(b.name))
+    .sort((a, b) => (a.name ?? '').localeCompare(b.name ?? ''))
 }
 
 export type OrganizationsData = Awaited<ReturnType<typeof getOrganizations>>

--- a/apps/studio/data/read-replicas/replicas.utils.ts
+++ b/apps/studio/data/read-replicas/replicas.utils.ts
@@ -5,4 +5,4 @@ import { AVAILABLE_REPLICA_REGIONS } from '@/components/interfaces/Settings/Infr
 export const formatDatabaseID = (id: string) => last(id.split('-') ?? [])
 
 export const formatDatabaseRegion = (region: string) =>
-  last(AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region)?.name.split('('))?.split(')')[0]
+  last(AVAILABLE_REPLICA_REGIONS.find((r) => r.region === region)?.name.split('('))?.split(')')?.[0]

--- a/apps/studio/data/sql/ongoing-queries-query.ts
+++ b/apps/studio/data/sql/ongoing-queries-query.ts
@@ -27,7 +27,7 @@ export async function getOngoingQueries(
     signal
   )
 
-  return (result ?? []).filter((x: OngoingQuery) => !x.query.startsWith(sql)) as OngoingQuery[]
+  return (result ?? []).filter((x: OngoingQuery) => x.query?.startsWith(sql)) as OngoingQuery[]
 }
 
 export type OngoingQueriesData = Awaited<ReturnType<typeof getOngoingQueries>>

--- a/apps/studio/data/table-rows/table-row-delete-mutation.tsx
+++ b/apps/studio/data/table-rows/table-row-delete-mutation.tsx
@@ -90,11 +90,13 @@ export const useTableRowDeleteMutation = ({
 
         if (isFkError) {
           const sourceTable = table.name
-          const referencingTable = data.message.split('on table ')[2].replaceAll('"', '')
-          const fkName = data.message
+          const parts = data.message.split('on table ')
+          const referencingTable = parts.length > 2 ? parts[2].replaceAll('"', '') : 'unknown'
+          const fkParts = data.message
+
             .split('foreign key constraint')[1]
-            .split('on table')[0]
-            .replaceAll('"', '')
+            ?.split('on table')[0]
+            ?.replaceAll('"', '') ?? 'unknown'
           const initialMessage = isMultipleRows
             ? `Unable to delete rows as one of them is currently referenced by a foreign key constraint from the table \`${referencingTable}\`.`
             : `Unable to delete row as it is currently referenced by a foreign key constraint from the table \`${referencingTable}\`.`

--- a/apps/studio/data/tables/table-retrieve-query.ts
+++ b/apps/studio/data/tables/table-retrieve-query.ts
@@ -29,7 +29,7 @@ export async function getTable(
     },
     signal
   )
-  // pg-meta sources `check` from pg_catalog; treat it as SafeSqlFragment for DDL composition.
+  if (!result.length) throw new Error('Table not found')
   return zod.parse(result[0]) as unknown as SafePostgresTable
 }
 

--- a/apps/studio/lib/gotrue.ts
+++ b/apps/studio/lib/gotrue.ts
@@ -62,7 +62,7 @@ export const buildPathWithParams = (pathname: string) => {
 
   // Merge the parameters, with pathname parameters taking precedence
   // over the current location's search parameters
-  const mergedParams = new URLSearchParams(location.search)
+  const mergedParams = new URLSearchParams(typeof location !== 'undefined' ? location.search : '')
   for (const [key, value] of pathnameSearchParams.entries()) {
     mergedParams.set(key, value)
   }

--- a/apps/studio/lib/helpers.ts
+++ b/apps/studio/lib/helpers.ts
@@ -136,7 +136,7 @@ export const formatBytes = (
   const dm = decimals < 0 ? 0 : decimals
   const sizes = ['bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
 
-  if (bytes === 0 || bytes === undefined) return size !== undefined ? `0 ${size}` : '0 bytes'
+  if (bytes === 0 || bytes === undefined || Number.isNaN(bytes)) return size !== undefined ? `0 ${size}` : '0 bytes'
 
   // Handle negative values
   const isNegative = bytes < 0

--- a/apps/studio/pages/project/[ref]/observability/database.tsx
+++ b/apps/studio/pages/project/[ref]/observability/database.tsx
@@ -415,10 +415,9 @@ const DatabaseUsage = () => {
                       </Table.th>,
                     ]}
                     body={props.data?.map((object) => {
-                      const percentage = (
-                        ((object.table_size as number) / databaseSizeBytes) *
-                        100
-                      ).toFixed(2)
+                      const percentage = databaseSizeBytes > 0
+                        ? (((object.table_size as number) / databaseSizeBytes) * 100).toFixed(2)
+                        : '0.00'
 
                       return (
                         <Table.tr key={`${object.schema_name}.${object.relname}`}>

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -1776,6 +1776,7 @@ function createStorageExplorerState({
 
     onUploadProgress: (toastId?: string | number) => {
       const totalFiles = state.uploadProgresses.length
+      if (totalFiles === 0) return
       const progress =
         (state.uploadProgresses.reduce((acc, { percentage }) => acc + percentage, 0) / totalFiles) *
         100

--- a/apps/studio/state/storage-explorer.tsx
+++ b/apps/studio/state/storage-explorer.tsx
@@ -515,7 +515,9 @@ function createStorageExplorerState({
             .from(state.selectedBucket.name)
             .upload(prefixToPlaceholder, new File([], EMPTY_FOLDER_PLACEHOLDER_FILE_NAME))
         }
-      } catch (error) {}
+      } catch (error) {
+        toast.error(`Failed to create folder: ${(error as Error)?.message ?? 'Unknown error'}`)
+      }
     },
 
     deleteFolder: async (folder: StorageItemWithColumn) => {


### PR DESCRIPTION
Malformed log headers crash, NULL query in pg_stat_activity, and location undefined during SSR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing database tables, views, queue data, and connection details with clearer errors.
  - Prevented crashes from invalid log headers, organization data, database regions, and server-side navigation.
  - Fixed ongoing query filtering and foreign-key deletion error parsing.
  - Improved storage upload progress and folder validation error reporting.
  - Prevented invalid filenames from affecting duplicate detection.
  - Stabilized progress bars, byte formatting, database size percentages, and edge function testing for invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->