### PR TITLE
Add keyboard shortcut to live mode

### DIFF
--- a/apps/studio/components/ui/DataTable/LiveButton.tsx
+++ b/apps/studio/components/ui/DataTable/LiveButton.tsx
@@ -19,7 +19,7 @@ interface LiveButtonProps {
 export function LiveButton({ fetchPreviousPage, searchParamsParser }: LiveButtonProps) {
   const [{ live, date, sort }, setSearch] = useQueryStates(searchParamsParser)
   const { table } = useDataTable()
-  useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_LIVE, handleClick, { registerInCommandMenu: true })
+  useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_LIVE, handleClick, { registerInCommandMenu: false })
 
   useEffect(() => {
     let timeoutId: NodeJS.Timeout

--- a/apps/studio/pages/project/[ref]/observability/connections.tsx
+++ b/apps/studio/pages/project/[ref]/observability/connections.tsx
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { Pause, Play } from 'lucide-react'
+import { CirclePause, CirclePlay } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Badge, Button, Tooltip, TooltipContent, TooltipTrigger } from 'ui'
 
@@ -11,9 +11,12 @@ import { DefaultLayout } from '@/components/layouts/DefaultLayout'
 import ObservabilityLayout from '@/components/layouts/ObservabilityLayout/ObservabilityLayout'
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
+import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useDatabaseActivityQuery } from '@/data/database/activity-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
+import { useShortcut } from '@/state/shortcuts/useShortcut'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 import type { NextPageWithLayout } from '@/types'
 
@@ -24,6 +27,10 @@ export const DatabaseConnections: NextPageWithLayout = () => {
 
   const [live, setLive] = useState(true)
   const [now, setNow] = useState(() => dayjs.utc())
+
+  useShortcut(SHORTCUT_IDS.DATA_TABLE_TOGGLE_LIVE, handleToggleLive, {
+    registerInCommandMenu: false,
+  })
 
   const {
     data,
@@ -36,6 +43,15 @@ export const DatabaseConnections: NextPageWithLayout = () => {
     },
     { refetchOnWindowFocus: live, refetchInterval: live ? 3000 : false }
   )
+
+  function handleToggleLive() {
+    const nextLive = !live
+    setLive(nextLive)
+    if (nextLive) {
+      setNow(dayjs.utc())
+      refetchActivity()
+    }
+  }
 
   const buildPrompt = () => {
     return buildDatabaseConnectionsSummaryPrompt({
@@ -73,27 +89,24 @@ export const DatabaseConnections: NextPageWithLayout = () => {
                   <span>Live</span>
                 </Badge>
               </TooltipTrigger>
-              <TooltipContent side="bottom">
-                Data on this page is refreshed every 3 seconds
-              </TooltipContent>
+              <TooltipContent side="bottom">Refreshes data every 3 seconds</TooltipContent>
             </Tooltip>
           )}
         </div>
         <div className="flex items-center gap-x-2">
-          <Button
-            variant={live ? 'default' : 'primary'}
-            onClick={() => {
-              const nextLive = !live
-              setLive(nextLive)
-              if (nextLive) {
-                setNow(dayjs.utc())
-                refetchActivity()
-              }
-            }}
-            icon={live ? <Pause /> : <Play />}
+          <ShortcutTooltip
+            shortcutId={SHORTCUT_IDS.DATA_TABLE_TOGGLE_LIVE}
+            label={live ? 'Pause live mode' : 'Refresh data every 3 seconds'}
+            side="bottom"
           >
-            {live ? 'Pause' : 'Live'}
-          </Button>
+            <Button
+              variant={live ? 'default' : 'primary'}
+              onClick={handleToggleLive}
+              icon={live ? <CirclePause /> : <CirclePlay />}
+            >
+              {live ? 'Pause' : 'Live'}
+            </Button>
+          </ShortcutTooltip>
           <AiAssistantDropdown
             label="Summarize activity"
             buildPrompt={buildPrompt}


### PR DESCRIPTION
## Context

As per PR title - there's already a keyboard shortcut mapping for the live mode toggle that was originally present in `UnifiedLogs`, so this reuses that.

Opting for a more explicit tooltip copy as well as "Live" doesn't really explain what it does
<img width="257" height="82" alt="image" src="https://github.com/user-attachments/assets/2159eef3-6291-4fdc-93ca-da706c8688f0" />
<img width="195" height="101" alt="image" src="https://github.com/user-attachments/assets/0d5d211c-af66-406d-9cff-7de7b15f0892" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard shortcut support for toggling live updates in database connections.
  * Added shortcut guidance to the Live/Pause control.
  * Resuming live updates now refreshes activity immediately and updates the displayed timestamp.

* **Bug Fixes**
  * Improved live-refresh controls and messaging to clearly reflect the refresh cadence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->