### PR TITLE
feat(www): update Grafana Cloud blog post authors

### DIFF
--- a/apps/www/_blog/2026-07-23-observability-for-every-supabase-project-with-grafana-cloud.mdx
+++ b/apps/www/_blog/2026-07-23-observability-for-every-supabase-project-with-grafana-cloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Observability for every Supabase project with Grafana Cloud'
 description: 'Connect your Supabase project to Grafana Cloud in one click. A pre-built dashboard, alerting, and metrics: available on every plan, including free.'
-author: raminder_singh
+author: alex_hall, matt_linkous, raminder_singh
 date: '2026-07-23'
 categories:
   - product

--- a/apps/www/lib/authors.json
+++ b/apps/www/lib/authors.json
@@ -1,5 +1,13 @@
 [
   {
+    "author_id": "alex_hall",
+    "author": "Alex Hall",
+    "username": "alexhall",
+    "position": "Engineering",
+    "author_url": "https://github.com/alexhall",
+    "author_image_url": "https://github.com/alexhall.png"
+  },
+  {
     "author_id": "angelico_de_los_reyes",
     "author": "Angelico de los Reyes",
     "position": "Engineering",


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Content update — updates the author byline on an existing blog post (`apps/www`).

## What is the current behavior?

The "Observability for every Supabase project with Grafana Cloud" post lists a single author (`raminder_singh`).

## What is the new behavior?

Updates the byline to the three authors credited in the source doc: Alex Hall, Matt Linkous, and Raminder Singh.

- Adds a new `authors.json` entry for `alex_hall` (GitHub `alexhall`, Engineering)
- `matt_linkous` and `raminder_singh` already existed
- Updates the post frontmatter: `author: alex_hall, matt_linkous, raminder_singh`

## Additional context

- Source doc: [Notion](https://app.notion.com/p/supabase/Blog-Post-Grafana-Cloud-Partner-drop-3455004b775f8108935feefecd87623f)
- Follow-up to #47716 (the original post, already merged)
- Pre-flight: Prettier passes; `authors.json` is valid JSON

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Grafana Cloud observability blog post to credit all contributing authors.
  * Added an author profile for Alex Hall, including their role and profile details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->