### PR TITLE
chore: remove triplit link

### DIFF
--- a/apps/www/_blog/2025-10-08-triplit-joins-supabase.mdx
+++ b/apps/www/_blog/2025-10-08-triplit-joins-supabase.mdx
@@ -10,7 +10,7 @@ date: '2025-10-08T10:00:00'
 toc_depth: 2
 ---
 
-We're excited to welcome Matt Linkous, co-founder of [Triplit](https://www.triplit.dev/), to the Supabase team.
+We're excited to welcome Matt Linkous, co-founder of Triplit, to the Supabase team.
 
 With this acquisition, we're bringing Matt's deep expertise in the offline-first domain into our ecosystem. Our focus isn't to directly integrate Triplit into our platform. Instead, Matt will be working to expand third-party integrations at Supabase. Part of this effort will be making Supabase an excellent partner to other syncing systems such as [ElectricSQL](https://electric-sql.com/), [Zero](https://zero.rocicorp.dev/), and [PowerSync](https://www.powersync.com/).
 Creating a great self-serve integration system is a growing priority at Supabase, so we're excited for Matt to bring his experience as Y Combinator founder and open-source maintainer to build an integration experience that's seamless for both developers using Supabase and third-party providers.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Blog update

## What is the current behavior?

Triplit link goes to triplit.dev which is no longer registered/active

## What is the new behavior?

No more triplit.dev link


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the blog post’s opening paragraph by removing the hyperlink from the “Triplit” text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->