### PR TITLE
Fix MetricCard tooltip not tabbable

### DIFF
--- a/packages/ui-patterns/src/MetricCard/index.tsx
+++ b/packages/ui-patterns/src/MetricCard/index.tsx
@@ -158,7 +158,9 @@ const MetricCardLabel = React.forwardRef<HTMLDivElement, MetricCardLabelProps>(
         {tooltip && (
           <Tooltip>
             <TooltipTrigger asChild>
-              <HelpCircle size={14} strokeWidth={1.5} />
+              <button type="button" aria-label="More info">
+                <HelpCircle size={14} strokeWidth={1.5} />
+              </button>
             </TooltipTrigger>
             <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
           </Tooltip>

--- a/packages/ui-patterns/src/MetricCard/index.tsx
+++ b/packages/ui-patterns/src/MetricCard/index.tsx
@@ -157,10 +157,8 @@ const MetricCardLabel = React.forwardRef<HTMLDivElement, MetricCardLabelProps>(
         <span>{children}</span>
         {tooltip && (
           <Tooltip>
-            <TooltipTrigger asChild>
-              <button type="button" aria-label="More info">
-                <HelpCircle size={14} strokeWidth={1.5} />
-              </button>
+            <TooltipTrigger>
+              <HelpCircle size={14} strokeWidth={1.5} />
             </TooltipTrigger>
             <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>
           </Tooltip>


### PR DESCRIPTION
## Context

`MetricCard` component in ui-patterns has a tooltip that currently isn't tabbable as `asChild` is applied to `TooltipTrigger` which the child is just an SVG.

Removing `asChild` as the fix so that `TooltipTrigger` is rendered as a `button`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip behavior for metric card help icons.
  * Ensured the tooltip trigger renders consistently when users interact with it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->