### PR TITLE
Add default aria label for MetricCard tooltip

### DIFF
--- a/packages/ui-patterns/src/MetricCard/index.tsx
+++ b/packages/ui-patterns/src/MetricCard/index.tsx
@@ -157,7 +157,7 @@ const MetricCardLabel = React.forwardRef<HTMLDivElement, MetricCardLabelProps>(
         <span>{children}</span>
         {tooltip && (
           <Tooltip>
-            <TooltipTrigger>
+            <TooltipTrigger aria-label="More information">
               <HelpCircle size={14} strokeWidth={1.5} />
             </TooltipTrigger>
             <TooltipContent className="max-w-xs">{tooltip}</TooltipContent>


### PR DESCRIPTION
## Context

As per PR title

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility Improvements**
  * Added an accessible “More information” label to metric card tooltip triggers, improving support for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->