### PR TITLE
fix: Skip to main content link should be visible when focused

### DIFF
--- a/apps/studio/components/layouts/DefaultLayout.tsx
+++ b/apps/studio/components/layouts/DefaultLayout.tsx
@@ -1,7 +1,14 @@
 import { useBreakpoint, useParams } from 'common'
 import { useRouter } from 'next/router'
 import { PropsWithChildren, useEffect, useState } from 'react'
-import { ResizablePanel, ResizablePanelGroup, SidebarProvider, usePanelRef } from 'ui'
+import {
+  buttonVariants,
+  cn,
+  ResizablePanel,
+  ResizablePanelGroup,
+  SidebarProvider,
+  usePanelRef,
+} from 'ui'
 
 import { BannerStack } from '../ui/BannerStack/BannerStack'
 import { LayoutHeader } from './Navigation/LayoutHeader/LayoutHeader'
@@ -94,7 +101,17 @@ export const DefaultLayout = ({
         <ProjectContextProvider projectRef={ref}>
           <MobileSheetProvider>
             <div className="flex flex-col h-screen w-screen">
-              <a className="sr-only" href="#main" tabIndex={0}>
+              <a
+                className={cn(
+                  buttonVariants({
+                    size: 'xlarge',
+                    variant: 'primary',
+                  }),
+                  'absolute top-0 left-1/2 -translate-x-1/2 -translate-y-full focus:translate-y-4'
+                )}
+                href="#main"
+                tabIndex={0}
+              >
                 Skip to content
               </a>
               {/* Top Banner */}


### PR DESCRIPTION
## Problem

#47694 introduced a _Skip to main content_ link allowing keyboard users to jump to the main section without having to tab through all the navigation elements.

However, this link is completely invisible which means sighted users will not see what is actually focused.

## Solution

The best practice for such links is to make them visible on focus. For instance on https://tetralogical.com:
<img width="1556" height="305" alt="image" src="https://github.com/user-attachments/assets/e36f6d73-98b0-46ca-b464-72540a482b5f" />

Here's what it looks like on Studio:
<img width="1835" height="335" alt="image" src="https://github.com/user-attachments/assets/71623306-587a-48aa-b955-43d3368f6073" />

## How to test

- Make sure your browser allows to tab to links (https://www.articulatesupport.com/article/How-to-Enable-Tab-Key-Navigation-on-a-Mac)
- Open https://studio-staging-git-gildasgarcia-fe-3805-add-ski-cf6824-supabase.vercel.app and sign in
- Once the Studio is loaded, verify the button isn't be visible
- Press _Tab_: the button should be visible.
- Press _Enter_, then press _Tab: the organizations search input should be focused 