### PR TITLE
docs: note SELECT RLS needed for INSERT RETURNING via Data API

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -224,6 +224,21 @@ to authenticated                          -- the Postgres Role (recommended)
 with check ( (select auth.uid()) = user_id );      -- the actual Policy
 ```
 
+<Admonition type="caution">
+
+When the Data API returns the inserted row (PostgREST `Prefer: return=representation`, or supabase-js `.insert(...).select()`), Postgres runs `insert ... returning *`. That also requires a corresponding [`SELECT` policy](#select-policies). An `INSERT` policy alone is enough for a plain SQL `insert` without `returning`, which is why the same statement can succeed in the SQL Editor under `set role anon` and still fail over the API.
+
+To insert without reading the new row back, omit `.select()` or use `Prefer: return=minimal`. Otherwise add a `SELECT` policy that covers the inserted rows, for example:
+
+```sql
+create policy "Users can view their own profile."
+on profiles for select
+to authenticated
+using ( (select auth.uid()) = user_id );
+```
+
+</Admonition>
+
 ### UPDATE policies
 
 You can specify update policies by combining both the `using` and `with check` expressions.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update

## What is the current behavior?

The RLS guide warns that `UPDATE` needs a matching `SELECT` policy, but the INSERT section does not mention that Data API inserts which return the row (`Prefer: return=representation` / supabase-js `.insert(...).select()`) run `INSERT … RETURNING *` and also need `SELECT` RLS.

That leads to reports like #48302 (same pattern as #43528 / #47917): INSERT policy + GRANT look correct, `SET ROLE anon; INSERT` works in the SQL Editor, but REST still returns `42501`.

## What is the new behavior?

Under **INSERT policies**, the guide now cautions that:

- Returning the inserted row requires a corresponding SELECT policy
- An INSERT-only policy is enough for plain SQL without `RETURNING`
- Workarounds: omit `.select()`, use `Prefer: returninimal`, or add a SELECT policy (example included)

## Additional context

No product code changes. Aligns INSERT docs with the existing UPDATE SELECT warning and with Storage’s INSERT+RETURNING troubleshooting note.