### PR TITLE
docs(skills): scope studio-ui-patterns description to apps/studio

### DIFF
--- a/.claude/skills/studio-ui-patterns/SKILL.md
+++ b/.claude/skills/studio-ui-patterns/SKILL.md
@@ -1,8 +1,11 @@
 ---
 name: studio-ui-patterns
-description: Design system UI patterns for Supabase Studio. Use when building or updating
-  pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels
-  (sheets). Covers layout selection, component choice, and placement conventions.
+description: Design system UI patterns for Supabase Studio (`apps/studio`). Use when
+  building or updating Studio pages, forms, tables, charts, empty states, navigation,
+  cards, alerts, or side panels (sheets). Covers layout selection, component choice, and
+  placement conventions, all bound to the Supabase design system in `apps/design-system`.
+  Do not use for UI work outside this monorepo, or for apps that do not consume the
+  Supabase design system.
 ---
 
 # Studio UI Patterns


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update — one `description` field in a skill's frontmatter. No code changes.

## What is the current behavior?

Closes #45347.

The `description` in `.claude/skills/studio-ui-patterns/SKILL.md` lists generic UI surfaces (pages, forms, tables, charts, empty states, navigation, cards, alerts, sheets) without naming a codebase, and gives no signal for when the skill should *not* apply:

> Design system UI patterns for Supabase Studio. Use when building or updating pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels (sheets). Covers layout selection, component choice, and placement conventions.

As a result the skill triggers on unrelated frontend work in other projects that share an agent session, and Studio-specific design system conventions get applied to codebases that do not consume the Supabase design system.

This makes it an outlier among its siblings: `studio-queries` names `apps/studio/data/`, `studio-e2e-tests` names `e2e/studio`, `dev-toolbar-review` names `packages/dev-tools/`, and `docs-content` names `apps/docs`.

## What is the new behavior?

The description now carries an explicit path signal, names the design system constraint, and closes with a negative clause:

> Design system UI patterns for Supabase Studio (`apps/studio`). Use when building or updating Studio pages, forms, tables, charts, empty states, navigation, cards, alerts, or side panels (sheets). Covers layout selection, component choice, and placement conventions, all bound to the Supabase design system in `apps/design-system`. Do not use for UI work outside this monorepo, or for apps that do not consume the Supabase design system.

The body of the skill is unchanged, as the issue specifies.

## Additional context

- Diff is 1 file, frontmatter only.
- Verified with Prettier (repo settings, LF, print width 100) — passes.
- `npm run build` was skipped: the change is Markdown frontmatter that no build step consumes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the scope and intended use of the Studio UI patterns guidance.
  * Added coverage details for supported interface areas and usage boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->