### PR TITLE
feat(www): serve evals frontend at `/evals`

### DIFF
--- a/apps/www/lib/rewrites.js
+++ b/apps/www/lib/rewrites.js
@@ -37,6 +37,14 @@ const rewrites = [
     source: '/design-system/:path*',
     destination: `${process.env.NEXT_PUBLIC_DESIGN_SYSTEM_URL}/:path*`,
   },
+  {
+    source: '/evals',
+    destination: 'https://supabase-evals.vercel.app',
+  },
+  {
+    source: '/evals/:path*',
+    destination: 'https://supabase-evals.vercel.app/:path*',
+  },
 
   {
     source: '/new-docs',


### PR DESCRIPTION
## Changes

Proxies `supabase.com/evals` to the [evals](https://github.com/supabase/evals) frontend, following a similar rewrite pattern as `/ui` and `/design-system`. The evals app already serves under an `/evals` base path per supabase/evals#125.

The destination is hardcoded rather than an env var because the evals app lives in a separate repo, and there’s not much benefit to a fully local dev flow here, so the target URL is kept the same in every environment.

## Before merge

- Disable deployment protection on the evals Vercel project, otherwise `supabase.com/evals` will show a Vercel login page
- Wait until closer to Evals announcement target (July 30th)

Closes AI-826


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added routing for the `/evals` section and its subpages.
  * Evals pages now load from the designated hosted destination while preserving URL paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->