### PR TITLE
fix(auth): allow newlines in SMS OTP template for WebOTP compliance

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -130,6 +130,13 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       if (payload[x] === '') payload[x] = null
     })
 
+    // Convert literal \n sequences to actual newlines in multiline string fields
+    // so that users who type \n in the SMS template get proper line breaks
+    // (needed for WebOTP API compliance)
+    if (typeof payload.SMS_TEMPLATE === 'string') {
+      payload.SMS_TEMPLATE = payload.SMS_TEMPLATE.replace(/\\n/g, '\n')
+    }
+
     // The backend uses empty string to represent no required characters in the password
     if (payload.PASSWORD_REQUIRED_CHARACTERS === NO_REQUIRED_CHARACTERS) {
       payload.PASSWORD_REQUIRED_CHARACTERS = ''

--- a/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersFormValidation.tsx
@@ -563,7 +563,8 @@ export const PROVIDER_PHONE = {
     SMS_TEMPLATE: {
       title: 'SMS Message',
       type: 'multiline-string',
-      description: 'To format the OTP code use `{{ .Code }}`',
+      description:
+        'To format the OTP code use `{{ .Code }}`. Newlines are supported — press Enter in the field below, or type `\\n` to insert a line break. Required for [WebOTP](https://web.dev/web-otp/) compliance.',
       show: {
         key: 'SMS_PROVIDER',
         matches: ['twilio', 'messagebird', 'textlocal', 'vonage'],


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix for issue #6435.

## What is the current behavior?

The SMS OTP template field () renders as a multiline textarea, but:

1. Users who type literal `\n` characters expect line breaks — the form saves them as the two literal characters `\n` instead of actual newlines
2. The field description gives no indication that newlines are supported, making it unclear how to add line breaks

This prevents using the [WebOTP API](https://web.dev/web-otp/) which requires at least one newline in the SMS message for automated OTP handling on mobile PWAs.

## What is the new behavior?

- Literal `\n` sequences are converted to actual newline characters before saving (so users who type `\n` get proper line breaks)
- Users can also press Enter in the textarea for newlines (this already worked)
- The field description now documents newline support and links to the WebOTP specification

## Steps to reproduce

1. Enable Phone provider with Twilio/Messagebird/etc in Supabase Dashboard
2. In the SMS Message field, type: `Your code is {{ .Code }}\nDo not share`
3. Save — the template is saved with literal `\n` instead of an actual line break
4. The SMS is sent as a single line without the expected line break

## How to test

1. Open Supabase Dashboard → Authentication → Providers → Phone
2. Set the SMS Message template to include `\n` (literal backslash-n)
3. Save — verify the newline is properly applied
4. Also test pressing Enter in the textarea to verify that still works

## Does this PR introduce a breaking change?

No.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * SMS authentication templates now support converting `\n` sequences into line breaks when saved.
  * Added guidance for formatting OTP messages with `{{ .Code }}`, including newline and WebOTP compliance instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->