### PR TITLE
fix(www): use unique id for Full SQL access feature

### DIFF
--- a/apps/www/data/solutions/postgres-developers.tsx
+++ b/apps/www/data/solutions/postgres-developers.tsx
@@ -391,7 +391,7 @@ const data: () => {
           ),
         },
         {
-          id: 'row-level-security',
+          id: 'full-sql-access',
           title: 'Full SQL access',
           icon: '',
           subheading: (


### PR DESCRIPTION
## Summary

This fixes a duplicate `id` in `apps/www/data/solutions/postgres-developers.tsx`.

The "Full SQL access" feature was using the same `id` (`row-level-security`) as the "Row Level Security" feature, which caused the React warning:

> Encountered two children with the same key, row-level-security.

I've renamed the second `id` to `full-sql-access` so each feature has a unique identifier.

Fixes #48324


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the identifier for the “Full SQL access” feature to ensure it is referenced and displayed consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->