### PR TITLE
fix: make high availability in project creation form public

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/HighAvailabilityInput.tsx
@@ -3,6 +3,7 @@ import { FormControl, FormField, Switch } from 'ui'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CreateProjectForm } from './ProjectCreation.schema'
+import Panel from '@/components/ui/Panel'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 
 interface HighAvailabilityInputProps {
@@ -15,20 +16,22 @@ export const HighAvailabilityInput = ({ form }: HighAvailabilityInputProps) => {
   if (!hasAccess) return null
 
   return (
-    <FormField
-      control={form.control}
-      name="highAvailability"
-      render={({ field }) => (
-        <FormItemLayout
-          label="High Availability"
-          description="Horizontally scalable Postgres for highly available, globally distributed deployments while staying true to standard Postgres."
-          layout="horizontal"
-        >
-          <FormControl>
-            <Switch checked={field.value} onCheckedChange={field.onChange} />
-          </FormControl>
-        </FormItemLayout>
-      )}
-    />
+    <Panel.Content>
+      <FormField
+        control={form.control}
+        name="highAvailability"
+        render={({ field }) => (
+          <FormItemLayout
+            label="High availability"
+            description="Horizontally scalable Postgres for highly available, globally distributed deployments while staying true to standard Postgres."
+            layout="horizontal"
+          >
+            <FormControl>
+              <Switch checked={field.value} onCheckedChange={field.onChange} />
+            </FormControl>
+          </FormItemLayout>
+        )}
+      />
+    </Panel.Content>
   )
 }

--- a/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/InternalOnlyConfiguration.tsx
@@ -6,7 +6,6 @@ import { CollapsibleCardSection } from 'ui-patterns/CollapsibleCardSection'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { CloudProviderSelector } from './CloudProviderSelector'
-import { HighAvailabilityInput } from './HighAvailabilityInput'
 import { PostgresVersionSelector } from './PostgresVersionSelector'
 import { CreateProjectForm } from './ProjectCreation.schema'
 import Panel from '@/components/ui/Panel'
@@ -40,8 +39,6 @@ export const InternalOnlyConfiguration = ({ form }: InternalOnlyConfigurationPro
                 />
               )}
             />
-
-            <HighAvailabilityInput form={form} />
           </div>
 
           {showNonProdFields && (

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -19,6 +19,7 @@ import { DatabasePasswordInput } from './DatabasePasswordInput'
 import { DataSeeding } from './DataSeeding'
 import { DisabledWarningDueToIncident } from './DisabledWarningDueToIncident'
 import { FreeProjectLimitWarning } from './FreeProjectLimitWarning'
+import { HighAvailabilityInput } from './HighAvailabilityInput'
 import { InternalOnlyConfiguration } from './InternalOnlyConfiguration'
 import { OrganizationSelector } from './OrganizationSelector'
 import { extractPostgresVersionDetails } from './PostgresVersionSelector'
@@ -657,6 +658,8 @@ export const ProjectCreationForm = ({
                     <ProjectNameInput form={form} />
 
                     {canChooseInstanceSize && <ComputeSizeSelector form={form} />}
+
+                    <HighAvailabilityInput form={form} />
 
                     <DatabasePasswordInput form={form} />
 

--- a/apps/studio/tests/pages/new/[slug].test.tsx
+++ b/apps/studio/tests/pages/new/[slug].test.tsx
@@ -525,12 +525,12 @@ describe('project creation wizard', () => {
       const onRequest = vi.fn()
       mockCreateProject(onRequest)
 
-      await renderWizard({ flags: { newProjectInternalOnlyConfiguration: true } })
+      await renderWizard()
 
       await fillProjectName('HA Oriole Project')
       await selectRegion(/Americas/)
 
-      fireEvent.click(await screen.findByRole('button', { name: 'Internal-only Configuration' }))
+      // The high availability toggle is now a top-level field, gated only by the entitlement.
       await user.click(await screen.findByRole('switch'))
 
       fireEvent.click(await screen.findByRole('button', { name: 'Advanced Configuration' }))
@@ -589,6 +589,58 @@ describe('project creation wizard', () => {
         )
       )
       expect(onRequest).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('high availability', () => {
+    test('shows the high availability toggle from the entitlement, without the internal-only flag', async () => {
+      mockWizardEndpoints()
+
+      await renderWizard()
+
+      expect(await screen.findByText('High availability')).toBeInTheDocument()
+      // The toggle must not depend on the internal-only configuration section.
+      expect(
+        screen.queryByRole('button', { name: 'Internal-only Configuration' })
+      ).not.toBeInTheDocument()
+    })
+
+    test('hides the high availability toggle when the org lacks the entitlement', async () => {
+      mockWizardEndpoints({
+        entitlements: [
+          {
+            feature: { key: 'instances.high_availability', type: 'boolean' },
+            hasAccess: false,
+            type: 'boolean',
+            config: { enabled: false },
+          } as Entitlement,
+        ],
+      })
+
+      await renderWizard()
+
+      await screen.findByPlaceholderText('Project name')
+      expect(screen.queryByText('High availability')).not.toBeInTheDocument()
+    })
+
+    test('enabling high availability submits the flag and forces the AWS_K8S cloud provider', async () => {
+      mockWizardEndpoints()
+      const onRequest = vi.fn()
+      mockCreateProject(onRequest)
+
+      await renderWizard()
+
+      await fillProjectName('HA Project')
+      await generateAndWaitForStrongPassword()
+      await user.click(await screen.findByRole('switch'))
+      await selectRegion(/Americas/)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Create new project' }))
+
+      await waitFor(() => expect(onRequest).toHaveBeenCalled())
+      const body = onRequest.mock.calls[0][0]
+      expect(body.high_availability).toBe(true)
+      expect(body.cloud_provider).toBe('AWS_K8S')
     })
   })
 


### PR DESCRIPTION
Move "High availability" from internal-only to public. Closes MUL-668.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

"High availability" is an internal-only config

<img width="724" height="1126" alt="Screenshot 2026-07-26 at 8 15 57 PM" src="https://github.com/user-attachments/assets/83e1856b-9020-4b65-a019-27e3cc29bae9" />

## What is the new behavior?

"High availability" is a public user-facing config

<img width="724" height="1036" alt="Screenshot 2026-07-26 at 8 15 31 PM" src="https://github.com/user-attachments/assets/4f369058-ce91-4bcf-bd3c-120277363b1a" />

Still hidden without the org entitlement, i.e. currently not available anywhere on prod

<img width="724" height="931" alt="Screenshot 2026-07-26 at 8 18 58 PM" src="https://github.com/user-attachments/assets/3e1deb76-210c-416b-b716-45ff6e3b0afd" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a High availability option directly to the project creation form.
  * The option is shown when available for the account and hidden when unavailable.
  * Enabling High availability automatically selects AWS as the cloud provider.

* **Bug Fixes**
  * Corrected validation for incompatible High availability and OrioleDB selections.

* **Tests**
  * Added coverage for High availability visibility, eligibility, and form submission behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->