### PR TITLE
fix(copy-button): show checkmark only after clipboard write succeeds

### DIFF
--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -49,11 +49,9 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     return (
       <Button
         ref={ref}
-        onClick={async (e) => {
-          if (!window.document.hasFocus()) return
+        onClick={(e) => {
           const textToCopy = asyncText ? asyncText() : text
-          await copyToClipboard(textToCopy)
-          setShowCopied(true)
+          copyToClipboard(textToCopy, () => setShowCopied(true))
           onClick?.(e)
         }}
         {...props}

--- a/apps/studio/components/ui/CopyButton.tsx
+++ b/apps/studio/components/ui/CopyButton.tsx
@@ -49,10 +49,11 @@ const CopyButton = forwardRef<HTMLButtonElement, CopyButtonProps>(
     return (
       <Button
         ref={ref}
-        onClick={(e) => {
+        onClick={async (e) => {
+          if (!window.document.hasFocus()) return
           const textToCopy = asyncText ? asyncText() : text
+          await copyToClipboard(textToCopy)
           setShowCopied(true)
-          copyToClipboard(textToCopy)
           onClick?.(e)
         }}
         {...props}

--- a/packages/pg-meta/src/sql/studio/advisor/lints.ts
+++ b/packages/pg-meta/src/sql/studio/advisor/lints.ts
@@ -724,10 +724,15 @@ from
     pg_catalog.pg_class c
     join pg_catalog.pg_namespace n
         on c.relnamespace = n.oid
+    left join pg_catalog.pg_depend dep
+        on c.oid = dep.objid
+        and dep.deptype = 'e'
 where
     c.relkind = 'r' -- regular tables
     -- RLS is disabled
     and not c.relrowsecurity
+    -- exclude tables owned by extensions (e.g. PostGIS spatial_ref_sys)
+    and dep.objid is null
     and (
         pg_catalog.has_table_privilege('anon', c.oid, 'SELECT')
         or pg_catalog.has_table_privilege('authenticated', c.oid, 'SELECT')


### PR DESCRIPTION
`setShowCopied(true)` fired before `copyToClipboard` was awaited, so the "Copied!" checkmark appeared even when the copy failed (e.g. document not focused, clipboard permission denied).

- Make handler `async` and `await copyToClipboard`
- Move `setShowCopied(true)` to after the await
- Add early return when `document.hasFocus()` is false (mirrors the existing guard inside `copyToClipboard`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copy confirmation now appears after content has been copied successfully.
  * Reduced false-positive warnings for tables owned by installed extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->