### PR TITLE
fix: allow literal newlines in SMS OTP template

### DIFF
--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -130,6 +130,10 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       if (payload[x] === '') payload[x] = null
     })
 
+    if (typeof payload.SMS_TEMPLATE === 'string') {
+      payload.SMS_TEMPLATE = payload.SMS_TEMPLATE.replace(/\\n/g, '\n')
+    }
+
     // The backend uses empty string to represent no required characters in the password
     if (payload.PASSWORD_REQUIRED_CHARACTERS === NO_REQUIRED_CHARACTERS) {
       payload.PASSWORD_REQUIRED_CHARACTERS = ''

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.tsx
@@ -23,6 +23,7 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import { FormItemLayout } from 'ui-patterns/form/FormItemLayout/FormItemLayout'
 
 import { NO_REQUIRED_CHARACTERS } from '../Auth.constants'
+import { sanitizeProviderFormPayload } from './ProviderForm.utils'
 import { AuthAlert } from './AuthAlert'
 import type { Provider } from './AuthProvidersForm.types'
 import FormField from './FormField'
@@ -130,9 +131,7 @@ export const ProviderForm = ({ config, provider, isActive }: ProviderFormProps) 
       if (payload[x] === '') payload[x] = null
     })
 
-    if (typeof payload.SMS_TEMPLATE === 'string') {
-      payload.SMS_TEMPLATE = payload.SMS_TEMPLATE.replace(/\\n/g, '\n')
-    }
+    sanitizeProviderFormPayload(payload)
 
     // The backend uses empty string to represent no required characters in the password
     if (payload.PASSWORD_REQUIRED_CHARACTERS === NO_REQUIRED_CHARACTERS) {

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.utils.test.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.utils.test.ts
@@ -1,0 +1,44 @@
+import { expect, test, describe } from 'vitest'
+import { sanitizeProviderFormPayload } from './ProviderForm.utils'
+
+describe('sanitizeProviderFormPayload', () => {
+  test('should replace literal \\n with actual newline in SMS_TEMPLATE', () => {
+    const payload = {
+      SMS_TEMPLATE: 'Your code is 1234.\\nHave a nice day!'
+    }
+    const result = sanitizeProviderFormPayload(payload)
+    expect(result.SMS_TEMPLATE).toBe('Your code is 1234.\nHave a nice day!')
+  })
+
+  test('should leave actual newlines intact', () => {
+    const payload = {
+      SMS_TEMPLATE: 'Your code is 1234.\nHave a nice day!'
+    }
+    const result = sanitizeProviderFormPayload(payload)
+    expect(result.SMS_TEMPLATE).toBe('Your code is 1234.\nHave a nice day!')
+  })
+
+  test('should not throw on non-string SMS_TEMPLATE', () => {
+    const payload = {
+      SMS_TEMPLATE: null
+    }
+    const result = sanitizeProviderFormPayload(payload)
+    expect(result.SMS_TEMPLATE).toBeNull()
+
+    const payload2 = {
+      SMS_TEMPLATE: 12345
+    }
+    const result2 = sanitizeProviderFormPayload(payload2)
+    expect(result2.SMS_TEMPLATE).toBe(12345)
+  })
+
+  test('should not modify other fields', () => {
+    const payload = {
+      SMS_TEMPLATE: 'Line 1\\nLine 2',
+      OTHER_FIELD: 'Literal \\n should stay'
+    }
+    const result = sanitizeProviderFormPayload(payload)
+    expect(result.SMS_TEMPLATE).toBe('Line 1\nLine 2')
+    expect(result.OTHER_FIELD).toBe('Literal \\n should stay')
+  })
+})

--- a/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.utils.ts
+++ b/apps/studio/components/interfaces/Auth/AuthProvidersForm/ProviderForm.utils.ts
@@ -1,0 +1,6 @@
+export const sanitizeProviderFormPayload = (payload: any) => {
+  if (typeof payload.SMS_TEMPLATE === 'string') {
+    payload.SMS_TEMPLATE = payload.SMS_TEMPLATE.replace(/\\n/g, '\n')
+  }
+  return payload
+}


### PR DESCRIPTION
Fixes #6435. This ensures that any literal `\n` strings in the SMS_TEMPLATE payload are replaced with actual newline bytes before saving, making it fully compliant with the WebOTP API and backward-compatible for users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SMS authentication template formatting by converting escaped “\n” sequences into real line breaks when saving provider settings.
  * Already-present line breaks remain unchanged, other form fields are preserved, and non-string template values no longer cause issues.
* **Tests**
  * Added automated test coverage for payload sanitization, including correct newline conversion and safe handling of non-string inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->