### PR TITLE
fix(www): distinguish partner search failures from empty results

### DIFF
--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -69,22 +69,32 @@ export default function IntegrationsContent({
 
   const [debouncedSearchTerm] = useDebounce(search, 300)
   const [isSearching, setIsSearching] = useState(false)
+  const [searchError, setSearchError] = useState(false)
   const searchIdRef = useRef(0)
 
   useEffect(() => {
     if (debouncedSearchTerm.trim() === '') {
       setIsSearching(false)
+      setSearchError(false)
       setPartners(initialPartners)
       return
     }
     setIsSearching(true)
+    setSearchError(false)
     const currentSearchId = ++searchIdRef.current
     searchCatalogPartners(debouncedSearchTerm)
       .then((results) => {
-        if (currentSearchId === searchIdRef.current) setPartners(results ?? [])
+        if (currentSearchId !== searchIdRef.current) return
+        // null is a soft failure from searchCatalogPartners — not an empty result set.
+        if (results === null) {
+          setSearchError(true)
+          return
+        }
+        setSearchError(false)
+        setPartners(results)
       })
       .catch(() => {
-        if (currentSearchId === searchIdRef.current) setPartners([])
+        if (currentSearchId === searchIdRef.current) setSearchError(true)
       })
       .finally(() => {
         if (currentSearchId === searchIdRef.current) setIsSearching(false)
@@ -340,7 +350,11 @@ export default function IntegrationsContent({
 
             {/* Grid view */}
             {viewMode === 'grid' &&
-              (listPartners.length ? (
+              (searchError ? (
+                <p className="text-foreground-lighter text-sm">
+                  Unable to search partners. Try again.
+                </p>
+              ) : listPartners.length ? (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
                   {visiblePartners.map((p) => (
                     <Link
@@ -388,7 +402,11 @@ export default function IntegrationsContent({
 
             {/* List view */}
             {viewMode === 'list' &&
-              (listPartners.length ? (
+              (searchError ? (
+                <p className="text-foreground-lighter text-sm">
+                  Unable to search partners. Try again.
+                </p>
+              ) : listPartners.length ? (
                 <div className="border bg-background rounded-xl overflow-hidden divide-y">
                   {visiblePartners.map((p) => (
                     <Link
@@ -431,7 +449,7 @@ export default function IntegrationsContent({
                 </p>
               ))}
 
-            {hasMorePartners && (
+            {!searchError && hasMorePartners && (
               <div
                 ref={partnersLoadMoreRef}
                 className="flex justify-center py-4"


### PR DESCRIPTION
Partner catalog search failures were displayed using the same empty-state message as successful searches with zero results.

This change introduces a dedicated client-side error state so users can distinguish between a failed search request and a successful search with no matching partners.

## Changes

- Add `searchError` state
- Treat `null` responses as search failures
- Treat rejected search requests as failures
- Preserve existing partner data on failure
- Show an error message instead of the empty-results message
- Hide the infinite-scroll sentinel while an error is shown

## Non-goals

- Retry support
- Search caching
- API changes
- Filter behaviour changes

## Testing

- [x] Successful search returns results
- [x] Empty search results still show the existing empty-state message
- [x] Failed search shows a dedicated error message
- [x] Clearing the search restores the initial catalog
- [x] Verified in both Grid and List views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partner search error handling.
  * Displays a clear message when a search cannot be completed, instead of showing misleading empty results.
  * Prevents outdated search responses from replacing newer results.
  * Hides the loading indicator while a search error is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->