### PR TITLE
Use table for roles tooltip instead

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
@@ -135,12 +135,15 @@ export const Overview = ({ live }: OverviewProps) => {
               <MetricCardLabel
                 tooltip={
                   <div>
-                    <p className="text-foreground-light pr-2">Connections by roles:</p>
-                    {rolesWithActiveConnections.map((role) => (
-                      <div key={role.id} className="flex items-center">
-                        <p className="min-w-32">{role.name}:</p> {role.activeConnections}
-                      </div>
-                    ))}
+                    <p className="text-foreground-light">Connections by roles:</p>
+                    <table>
+                      {rolesWithActiveConnections.map((role) => (
+                        <tr key={role.id}>
+                          <td>{role.name}:</td>
+                          <td className="pl-2">{role.activeConnections}</td>
+                        </tr>
+                      ))}
+                    </table>
                   </div>
                 }
               >

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
@@ -137,12 +137,16 @@ export const Overview = ({ live }: OverviewProps) => {
                   <div>
                     <p className="text-foreground-light">Connections by roles:</p>
                     <table>
-                      {rolesWithActiveConnections.map((role) => (
-                        <tr key={role.id}>
-                          <td>{role.name}:</td>
-                          <td className="pl-2">{role.activeConnections}</td>
-                        </tr>
-                      ))}
+                      <tbody>
+                        {rolesWithActiveConnections.map((role) => (
+                          <tr key={role.id}>
+                            <th scope="row" className="text-left font-normal">
+                              {role.name}:
+                            </th>
+                            <td className="pl-2">{role.activeConnections}</td>
+                          </tr>
+                        ))}
+                      </tbody>
                     </table>
                   </div>
                 }


### PR DESCRIPTION
## Context

Opting to use native `table` element instead for the roles tooltip in `DatabaseConnections` to better handle varying role name lengths

### Before
<img width="314" height="226" alt="image" src="https://github.com/user-attachments/assets/f8a5f7a2-be2f-4ad6-a1f0-7a7812800819" />

### After
<img width="332" height="191" alt="image" src="https://github.com/user-attachments/assets/dcb30f5d-641c-4b42-b31d-bf6d76086791" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved the layout and readability of the “Connections by roles” tooltip in database observability metrics.
  * Role labels and connection counts are now presented in a clearer tabular format.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->