### PR TITLE
Add focus states for spans in overview cards

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
@@ -232,7 +232,11 @@ export const Overview = ({ live }: OverviewProps) => {
                     <span
                       role="button"
                       tabIndex={0}
-                      className="text-foreground-light text-xs cursor-pointer hover:text-foreground transition normal-nums"
+                      className={cn(
+                        'text-foreground-light text-xs cursor-pointer transition-all normal-nums',
+                        'hover:text-foreground hover:underline',
+                        'focus:text-foreground focus:underline'
+                      )}
                       onClick={() => setSelectedPid(longestBlockedQuery.activity.pid)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
@@ -282,7 +286,7 @@ export const Overview = ({ live }: OverviewProps) => {
                     <span
                       role="button"
                       tabIndex={0}
-                      className="normal-nums cursor-pointer hover:underline"
+                      className="normal-nums cursor-pointer hover:underline focus:underline"
                       onClick={() => setSelectedPid(queryBlockingTheMostQueries.activity.pid)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
@@ -339,7 +343,7 @@ export const Overview = ({ live }: OverviewProps) => {
                     <span
                       role="button"
                       tabIndex={0}
-                      className="normal-nums hover:underline cursor-pointer"
+                      className="normal-nums hover:underline focus:underline cursor-pointer"
                       onClick={() => setSelectedPid(longestRunningQuery.activity.pid)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {


### PR DESCRIPTION
## Context

Tiny one to address for a11y stuff for the spans in the metric cards for database connections overview section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved hover and keyboard-focus styling for process ID details in database observability metrics.
  * Added a pointer cursor and smoother visual transitions to make interactive details easier to identify.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->