### PR TITLE
fix: update realtime-warn-sending-broadcast-message

### DIFF
--- a/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
+++ b/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
@@ -26,7 +26,7 @@ This is why the log line is a warning and not an error.
 
 The most common cause is a missing daily partition on `realtime.messages`. The table is partitioned by day, and `realtime.send` or `realtime.send_binary` does not create partitions itself. If no partition exists for the current day, the insert fails with a message like `no partition of relation "messages" found for row`, and you get the `WarnSendingBroadcastMessage` warning.
 
-Partitions are created on two occasions:
+Partitions are created on these occasions:
 
 | Where                            | When it runs                                                                                                                                                                                                                    |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -35,13 +35,13 @@ Partitions are created on two occasions:
 
 Each of these creates a rolling window of partitions: yesterday, today, and the next three days.
 
-Both depend on a client connecting: the connection creates the partitions, and it also makes the project visible to the janitor on its next run. Janitor coverage is not permanent, so a project that stops connecting successfully drops out of it.
+These occasions depend on a client connecting: the connection creates the partitions, and it also makes the project visible to the janitor on its next run. Janitor coverage is not permanent, so a project that stops connecting successfully drops out of it.
 
 <Admonition type="note" title="What's not included">
 
-Calling `realtime.send` / `realtime.send_binary`, the broadcast REST endpoint, and subscribe or replication operations do not create partitions. The tenant health check endpoint does not create them either, so opening the Realtime section of your project dashboard has no effect on them.
+A project that has never had a WebSocket client connect has no partition to insert into, so broadcasting from the database before that point produces the warning.
 
-So a project that has never had a WebSocket client connect has no partition to insert into. Broadcasting from the database before that point produces the warning.
+Calling `realtime.send` or `realtime.send_binary`, the broadcast REST endpoint, and subscribe or replication operations do not create partitions. The tenant health check endpoint does not create them either, so opening the Realtime section in the Supabase Dashboard has no effect on them.
 
 </Admonition>
 
@@ -56,11 +56,13 @@ Because both mechanisms require a client to connect, a project whose clients can
 
 The usual cause is authentication. When every connection attempt is rejected, no partition is created, and old ones are never cleaned up. The newest partition stays at the last day a client connected.
 
-Check whether your clients are connecting before treating this as a partition problem:
+### Check whether your clients are connecting
 
-- Look for connection errors in your project's Realtime logs, such as failures to validate a JWT signature.
-- Try connecting with the [Realtime Inspector](https://realtime.supabase.com/inspector/new) using your project's current publishable or anon key. If the Inspector connects but your app does not, your app is sending a different key or a stale user session.
-- If you rotated your JWT secret or migrated to asymmetric JWT signing keys, sessions issued before the change no longer validate. Existing clients need to sign out and re-authenticate to get a token signed with the current key.
+Work through these checks before treating the warning as a partition problem:
+
+1. Look for connection errors in your project's Realtime logs, such as failures to validate a JWT signature.
+2. Join a channel with the [Realtime Inspector](/dashboard/project/_/realtime/inspector), which connects using your project's own keys. If the Inspector connects and your app does not, your app is sending a different key or a stale user session.
+3. If you rotated your JWT secret or migrated to asymmetric JWT signing keys, sessions issued before the change no longer validate. Existing clients need to sign out and re-authenticate to get a token signed with the current key.
 
 Once a client connects, the partitions are created and maintained again.
 

--- a/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
+++ b/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
@@ -56,7 +56,7 @@ Because both mechanisms require a client to connect, a project whose clients can
 
 The usual cause is authentication. When every connection attempt is rejected, no partition is created, and old ones are never cleaned up. The newest partition stays at the last day a client connected.
 
-Check whether your clients are actually connecting before treating this as a partition problem:
+Check whether your clients are connecting before treating this as a partition problem:
 
 - Look for connection errors in your project's Realtime logs, such as failures to validate a JWT signature.
 - Try connecting with the [Realtime Inspector](https://realtime.supabase.com/inspector/new) using your project's current publishable or anon key. If the Inspector connects but your app does not, your app is sending a different key or a stale user session.

--- a/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
+++ b/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
@@ -26,19 +26,22 @@ This is why the log line is a warning and not an error.
 
 The most common cause is a missing daily partition on `realtime.messages`. The table is partitioned by day, and `realtime.send` or `realtime.send_binary` does not create partitions itself. If no partition exists for the current day, the insert fails with a message like `no partition of relation "messages" found for row`, and you get the `WarnSendingBroadcastMessage` warning.
 
-Partitions are created in three occasions:
+Partitions are created on two occasions:
 
-| Where                            | When it runs                                                                                                                                                                                     |
-| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| A client connects over WebSocket | The first time a client joins a channel for the project, after database migrations run                                                                                                           |
-| The tenant health check endpoint | When the health endpoint is called and the project either has an active database connection or has connected clients. Opening the Realtime section of your project dashboard calls this endpoint |
-| The scheduled janitor            | Periodically (roughly every 4 hours), when it deletes old messages and recreates the partition window. It only runs for projects that have had a connection established at least once            |
+| Where                            | When it runs                                                                                                                                                                  |
+| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A client connects over WebSocket | The first time a client joins a channel for the project, after database migrations run                                                                                        |
+| The scheduled janitor            | Periodically (roughly every 3 hours), when it deletes old messages and recreates the partition window. It only runs for projects that have had a client connect at least once |
 
 Each of these creates a rolling window of partitions: yesterday, today, and the next three days.
 
+Both depend on a client connecting: the connection creates the partitions, and it also makes the project visible to the janitor.
+
 <Admonition type="note" title="What's not included">
 
-Calling `realtime.send` / `realtime.send_binary`, the broadcast REST endpoint, and subscribe or replication operations do not create partitions. So a project that has never had a WebSocket client connect, and whose health check and janitor have not yet run for the day, has no partition to insert into. Broadcasting from the database before that point produces the warning.
+Calling `realtime.send` / `realtime.send_binary`, the broadcast REST endpoint, and subscribe or replication operations do not create partitions. The tenant health check endpoint does not create them either, so opening the Realtime section of your project dashboard has no effect on them.
+
+So a project that has never had a WebSocket client connect has no partition to insert into. Broadcasting from the database before that point produces the warning.
 
 </Admonition>
 
@@ -46,6 +49,20 @@ Calling `realtime.send` / `realtime.send_binary`, the broadcast REST endpoint, a
 
 - Connect a client before broadcasting from the database. A live WebSocket connection both creates the partitions and starts the consumer that receives the message.
 - If you broadcast from the database on a schedule, make sure at least one subscriber is connected when you send. Otherwise the messages have no destination.
+
+## If no client can connect
+
+Because both mechanisms require a client to connect, a project whose clients cannot connect never gets new partitions. The warning keeps firing, and it looks like partition maintenance stopped on its own.
+
+The usual cause is authentication. When every connection attempt is rejected, no partition is created, and old ones are never cleaned up. The newest partition stays at the last day a client connected.
+
+Check whether your clients are actually connecting before treating this as a partition problem:
+
+- Look for connection errors in your project's Realtime logs, such as failures to validate a JWT signature.
+- Try connecting with the [Realtime Inspector](https://realtime.supabase.com/inspector/new) using your project's current publishable or anon key. If the Inspector connects but your app does not, your app is sending a different key or a stale user session.
+- If you rotated your JWT secret or migrated to asymmetric JWT signing keys, sessions issued before the change no longer validate. Existing clients need to sign out and re-authenticate to get a token signed with the current key.
+
+Once a client connects, the partitions are created and maintained again.
 
 ## When it is a real problem
 

--- a/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
+++ b/apps/docs/content/troubleshooting/realtime-warn-sending-broadcast-message.mdx
@@ -28,14 +28,14 @@ The most common cause is a missing daily partition on `realtime.messages`. The t
 
 Partitions are created on two occasions:
 
-| Where                            | When it runs                                                                                                                                                                  |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| A client connects over WebSocket | The first time a client joins a channel for the project, after database migrations run                                                                                        |
-| The scheduled janitor            | Periodically (roughly every 3 hours), when it deletes old messages and recreates the partition window. It only runs for projects that have had a client connect at least once |
+| Where                            | When it runs                                                                                                                                                                                                                    |
+| -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| A client connects over WebSocket | The first time a client joins a channel for the project, after database migrations run                                                                                                                                          |
+| The scheduled janitor            | Periodically (roughly every 3~4 hours depending on env config), when it deletes old messages and recreates the partition window. It only covers projects that are currently connected, or that connected since its previous run |
 
 Each of these creates a rolling window of partitions: yesterday, today, and the next three days.
 
-Both depend on a client connecting: the connection creates the partitions, and it also makes the project visible to the janitor.
+Both depend on a client connecting: the connection creates the partitions, and it also makes the project visible to the janitor on its next run. Janitor coverage is not permanent, so a project that stops connecting successfully drops out of it.
 
 <Admonition type="note" title="What's not included">
 


### PR DESCRIPTION
Update to reflect actual funcionality and give more tips to fix the issue.

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Update troubleshoot guides.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified when missing daily partitions trigger the `WarnSendingBroadcastMessage` warning.
  - Updated guidance to explain that partitions are created only after a client connects via WebSocket.
  - Removed the tenant health check endpoint as a described partition-creation trigger.
  - Added troubleshooting steps for connection/authentication failures, including checking realtime logs, using the Realtime Inspector, and verifying JWT settings/remediation.
  - Revised janitor timing and partition maintenance behavior, including scenarios where clients cannot connect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->