### PR TITLE
fix(studio): close Vercel create popup on cancel

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/FreeProjectLimitWarning.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/FreeProjectLimitWarning.tsx
@@ -6,13 +6,9 @@ import type { MemberWithFreeProjectLimit } from '@/data/organizations/free-proje
 
 interface FreeProjectLimitWarningProps {
   membersExceededLimit: MemberWithFreeProjectLimit[]
-  showVercelReturnHint?: boolean
 }
 
-export const FreeProjectLimitWarning = ({
-  membersExceededLimit,
-  showVercelReturnHint = false,
-}: FreeProjectLimitWarningProps) => {
+export const FreeProjectLimitWarning = ({ membersExceededLimit }: FreeProjectLimitWarningProps) => {
   return (
     <Panel.Content>
       <Admonition
@@ -36,11 +32,6 @@ export const FreeProjectLimitWarning = ({
               These members will need to either delete, pause, or upgrade one or more of these
               projects before you're able to create a free project within this organization.
             </p>
-            {showVercelReturnHint && (
-              <p className="text-sm leading-normal">
-                Or return to Vercel and restart with a different organization.
-              </p>
-            )}
 
             <UpgradePlanButton
               source="freeProjectLimitWarning"

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
@@ -1,5 +1,6 @@
-import { useFlag, useParams } from 'common'
+import { useFlag } from 'common'
 import { useRouter } from 'next/router'
+import { useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import {
   Badge,
@@ -16,14 +17,14 @@ import { InfoTooltip } from 'ui-patterns/info-tooltip'
 
 import { CreateProjectForm } from './ProjectCreation.schema'
 import { instanceLabel, monthlyInstancePrice } from './ProjectCreation.utils'
-import { getValidVercelReturnUrl } from '@/components/interfaces/Integrations/Vercel/VercelIntegration.utils'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { OrgProject } from '@/data/projects/org-projects-infinite-query'
 import { useLastVisitedOrganization } from '@/hooks/misc/useLastVisitedOrganization'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { DOCS_URL } from '@/lib/constants'
 
-export type ProjectCreationCancelAction = 'studio' | 'vercel' | 'hidden'
+/** `close` = close the popup (Vercel interstitial); `studio` = navigate into Studio. */
+export type ProjectCreationCancelAction = 'studio' | 'close' | 'hidden'
 
 interface ProjectCreationFooterProps {
   form: UseFormReturn<CreateProjectForm>
@@ -45,10 +46,10 @@ export const ProjectCreationFooter = ({
   cancelAction = 'studio',
 }: ProjectCreationFooterProps) => {
   const router = useRouter()
-  const { next } = useParams()
   const { data: currentOrg } = useSelectedOrganizationQuery()
   const isFreePlan = currentOrg?.plan?.id === 'free'
   const { lastVisitedOrganization } = useLastVisitedOrganization()
+  const [showCloseWindowHint, setShowCloseWindowHint] = useState(false)
 
   const projectCreationDisabled = useFlag('disableProjectCreationAndUpdate')
 
@@ -57,8 +58,8 @@ export const ProjectCreationFooter = ({
     ? 0
     : monthlyInstancePrice(instanceSize) - availableComputeCredits
 
-  const vercelReturnUrl = getValidVercelReturnUrl(next)
-  const canReturnToVercel = cancelAction === 'vercel' && vercelReturnUrl !== undefined
+  const showAdditionalCosts =
+    !isFreePlan && !projectCreationDisabled && canCreateProject && additionalMonthlySpend > 0
 
   // [kevin] This will eventually all be provided by a new API endpoint to preview and validate project creation, this is just for kaizen now
   const monthlyComputeCosts =
@@ -74,135 +75,159 @@ export const ProjectCreationFooter = ({
     10
 
   const onCancel = () => {
-    if (canReturnToVercel && vercelReturnUrl) {
-      window.location.href = vercelReturnUrl
+    if (cancelAction === 'close') {
+      window.close()
+      // Browsers only allow closing script-opened windows. If we're still open, ask the user.
+      window.setTimeout(() => {
+        if (!window.closed) setShowCloseWindowHint(true)
+      }, 100)
       return
     }
 
-    // Fall back to Studio when cancelAction is studio, or when vercel next is missing/invalid
     if (!!lastVisitedOrganization) router.push(`/org/${lastVisitedOrganization}`)
     else router.push('/organizations')
+  }
+
+  const cancelButton =
+    cancelAction !== 'hidden' ? (
+      <div className="flex flex-col items-start gap-1">
+        <Button
+          variant="default"
+          disabled={isCreatingNewProject || isSuccessNewProject}
+          onClick={onCancel}
+        >
+          Cancel
+        </Button>
+        {showCloseWindowHint && (
+          <p className="text-sm text-foreground-light">Close this window to cancel.</p>
+        )}
+      </div>
+    ) : null
+
+  const createButton = (
+    <Button
+      type="submit"
+      loading={isCreatingNewProject || isSuccessNewProject}
+      disabled={!canCreateProject}
+    >
+      Create new project
+    </Button>
+  )
+
+  // When there are no additional costs and Cancel is visible, put Cancel on the left
+  // and Create on the right. When costs are shown, keep both actions together on the right.
+  if (!showAdditionalCosts) {
+    return (
+      <div
+        key="panel-footer"
+        className={
+          cancelButton
+            ? 'flex w-full items-center justify-between gap-4'
+            : 'flex w-full items-center justify-end gap-4'
+        }
+      >
+        {cancelButton}
+        {createButton}
+      </div>
+    )
   }
 
   return (
     <div key="panel-footer" className="grid grid-cols-12 w-full gap-4 items-center">
       <div className="col-span-4">
-        {!isFreePlan &&
-          !projectCreationDisabled &&
-          canCreateProject &&
-          additionalMonthlySpend > 0 && (
-            <div className="flex justify-between text-sm">
-              <span>Additional costs</span>
-              <div className="text-brand flex gap-1 items-center font-mono font-medium">
-                <span>${additionalMonthlySpend}/m</span>
-                <InfoTooltip side="top" className="max-w-[450px] p-0">
-                  <div className="p-4 text-sm text-foreground-light space-y-1">
-                    <p>
-                      Each project includes a dedicated Postgres instance running on its own server.
-                      You are charged for the{' '}
-                      <InlineLink href={`${DOCS_URL}/guides/platform/billing-on-supabase`}>
-                        Compute resource
-                      </InlineLink>{' '}
-                      of that server, independent of your database usage.
-                    </p>
-                    {monthlyComputeCosts > 0 && (
-                      <p>Compute costs are applied on top of your subscription plan costs.</p>
-                    )}
-                  </div>
-
-                  <Table className="mt-2">
-                    <TableHeader className="[&_th]:h-7">
-                      <TableRow className="py-2">
-                        <TableHead className="w-[170px]">Project</TableHead>
-                        <TableHead>Compute Size</TableHead>
-                        <TableHead className="text-right">Monthly Costs</TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody className="[&_td]:py-2">
-                      {organizationProjects.map((project) => {
-                        const primaryDb = project.databases.find(
-                          (db) => db.identifier === project.ref
-                        )
-                        return (
-                          <TableRow key={project.ref} className="text-foreground-light">
-                            <TableCell className="w-[170px] truncate">{project.name}</TableCell>
-                            <TableCell className="text-center">
-                              {instanceLabel(primaryDb?.infra_compute_size)}
-                            </TableCell>
-                            <TableCell className="text-right">
-                              ${monthlyInstancePrice(primaryDb?.infra_compute_size)}
-                            </TableCell>
-                          </TableRow>
-                        )
-                      })}
-
-                      <TableRow>
-                        <TableCell className="w-[170px] flex gap-2">
-                          <span className="truncate">
-                            {form.getValues('projectName') || 'New project'}
-                          </span>
-                          <Badge variant="success">New</Badge>
-                        </TableCell>
-                        <TableCell className="text-center">{instanceLabel(instanceSize)}</TableCell>
-                        <TableCell className="text-right">
-                          ${monthlyInstancePrice(instanceSize)}
-                        </TableCell>
-                      </TableRow>
-                    </TableBody>
-                  </Table>
-                  <PopoverSeparator />
-                  <Table>
-                    <TableHeader className="[&_th]:h-7">
-                      <TableRow>
-                        <TableHead colSpan={2}>Compute Credits</TableHead>
-                        <TableHead colSpan={1} className="text-right">
-                          -$10
-                        </TableHead>
-                      </TableRow>
-                    </TableHeader>
-                    <TableBody className="[&_td]:py-2">
-                      <TableRow className="text-foreground">
-                        <TableCell colSpan={2}>
-                          Total Monthly Compute Costs
-                          {/**
-                           * API currently doesnt output replica information on the projects list endpoint. Until then, we cannot correctly calculate the costs including RRs.
-                           * Will be adjusted in the future [kevin]
-                           */}
-                          {organizationProjects.length > 0 && (
-                            <p className="text-xs text-foreground-lighter">
-                              Excluding Read replicas
-                            </p>
-                          )}
-                        </TableCell>
-                        <TableCell colSpan={1} className="text-right">
-                          ${monthlyComputeCosts}
-                        </TableCell>
-                      </TableRow>
-                    </TableBody>
-                  </Table>
-                </InfoTooltip>
+        <div className="flex justify-between text-sm">
+          <span>Additional costs</span>
+          <div className="text-brand flex gap-1 items-center font-mono font-medium">
+            <span>${additionalMonthlySpend}/m</span>
+            <InfoTooltip side="top" className="max-w-[450px] p-0">
+              <div className="p-4 text-sm text-foreground-light space-y-1">
+                <p>
+                  Each project includes a dedicated Postgres instance running on its own server. You
+                  are charged for the{' '}
+                  <InlineLink href={`${DOCS_URL}/guides/platform/billing-on-supabase`}>
+                    Compute resource
+                  </InlineLink>{' '}
+                  of that server, independent of your database usage.
+                </p>
+                {monthlyComputeCosts > 0 && (
+                  <p>Compute costs are applied on top of your subscription plan costs.</p>
+                )}
               </div>
-            </div>
-          )}
+
+              <Table className="mt-2">
+                <TableHeader className="[&_th]:h-7">
+                  <TableRow className="py-2">
+                    <TableHead className="w-[170px]">Project</TableHead>
+                    <TableHead>Compute Size</TableHead>
+                    <TableHead className="text-right">Monthly Costs</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody className="[&_td]:py-2">
+                  {organizationProjects.map((project) => {
+                    const primaryDb = project.databases.find((db) => db.identifier === project.ref)
+                    return (
+                      <TableRow key={project.ref} className="text-foreground-light">
+                        <TableCell className="w-[170px] truncate">{project.name}</TableCell>
+                        <TableCell className="text-center">
+                          {instanceLabel(primaryDb?.infra_compute_size)}
+                        </TableCell>
+                        <TableCell className="text-right">
+                          ${monthlyInstancePrice(primaryDb?.infra_compute_size)}
+                        </TableCell>
+                      </TableRow>
+                    )
+                  })}
+
+                  <TableRow>
+                    <TableCell className="w-[170px] flex gap-2">
+                      <span className="truncate">
+                        {form.getValues('projectName') || 'New project'}
+                      </span>
+                      <Badge variant="success">New</Badge>
+                    </TableCell>
+                    <TableCell className="text-center">{instanceLabel(instanceSize)}</TableCell>
+                    <TableCell className="text-right">
+                      ${monthlyInstancePrice(instanceSize)}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+              <PopoverSeparator />
+              <Table>
+                <TableHeader className="[&_th]:h-7">
+                  <TableRow>
+                    <TableHead colSpan={2}>Compute Credits</TableHead>
+                    <TableHead colSpan={1} className="text-right">
+                      -$10
+                    </TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody className="[&_td]:py-2">
+                  <TableRow className="text-foreground">
+                    <TableCell colSpan={2}>
+                      Total Monthly Compute Costs
+                      {/**
+                       * API currently doesnt output replica information on the projects list endpoint. Until then, we cannot correctly calculate the costs including RRs.
+                       * Will be adjusted in the future [kevin]
+                       */}
+                      {organizationProjects.length > 0 && (
+                        <p className="text-xs text-foreground-lighter">Excluding Read replicas</p>
+                      )}
+                    </TableCell>
+                    <TableCell colSpan={1} className="text-right">
+                      ${monthlyComputeCosts}
+                    </TableCell>
+                  </TableRow>
+                </TableBody>
+              </Table>
+            </InfoTooltip>
+          </div>
+        </div>
       </div>
 
-      <div className="flex items-end col-span-8 space-x-2 ml-auto">
-        {cancelAction !== 'hidden' && (
-          <Button
-            variant="default"
-            disabled={isCreatingNewProject || isSuccessNewProject}
-            onClick={onCancel}
-          >
-            {canReturnToVercel ? 'Return to Vercel' : 'Cancel'}
-          </Button>
-        )}
-        <Button
-          type="submit"
-          loading={isCreatingNewProject || isSuccessNewProject}
-          disabled={!canCreateProject}
-        >
-          Create new project
-        </Button>
+      <div className="flex items-center col-span-8 space-x-2 ml-auto">
+        {cancelButton}
+        {createButton}
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
@@ -89,20 +89,19 @@ export const ProjectCreationFooter = ({
   }
 
   const cancelButton =
-    cancelAction !== 'hidden' ? (
-      <div className="flex flex-col items-start gap-1">
-        <Button
-          variant="default"
-          disabled={isCreatingNewProject || isSuccessNewProject}
-          onClick={onCancel}
-        >
-          Cancel
-        </Button>
-        {showCloseWindowHint && (
-          <p className="text-sm text-foreground-light">Close this window to cancel.</p>
-        )}
-      </div>
-    ) : null
+    cancelAction === 'hidden' ? null : showCloseWindowHint ? (
+      <p role="status" aria-live="polite" className="text-xs text-foreground-muted mr-3">
+        Close window to cancel
+      </p>
+    ) : (
+      <Button
+        variant="default"
+        disabled={isCreatingNewProject || isSuccessNewProject}
+        onClick={onCancel}
+      >
+        Cancel
+      </Button>
+    )
 
   const createButton = (
     <Button

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
@@ -1,10 +1,11 @@
 import { useFlag } from 'common'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { UseFormReturn } from 'react-hook-form'
 import {
   Badge,
   Button,
+  cn,
   PopoverSeparator,
   Table,
   TableBody,
@@ -77,10 +78,6 @@ export const ProjectCreationFooter = ({
   const onCancel = () => {
     if (cancelAction === 'close') {
       window.close()
-      // Browsers only allow closing script-opened windows. If we're still open, ask the user.
-      window.setTimeout(() => {
-        if (!window.closed) setShowCloseWindowHint(true)
-      }, 100)
       return
     }
 
@@ -88,146 +85,137 @@ export const ProjectCreationFooter = ({
     else router.push('/organizations')
   }
 
-  const cancelButton =
-    cancelAction === 'hidden' ? null : showCloseWindowHint ? (
-      <p role="status" aria-live="polite" className="text-xs text-foreground-muted mr-3">
-        Close window to cancel
-      </p>
-    ) : (
-      <Button
-        type="button"
-        variant="default"
-        disabled={isCreatingNewProject || isSuccessNewProject}
-        onClick={onCancel}
-      >
-        Cancel
-      </Button>
-    )
-
-  const createButton = (
-    <Button
-      type="submit"
-      loading={isCreatingNewProject || isSuccessNewProject}
-      disabled={!canCreateProject}
-    >
-      Create new project
-    </Button>
-  )
-
-  // When there are no additional costs and Cancel is visible, put Cancel on the left
-  // and Create on the right. When costs are shown, keep both actions together on the right.
-  if (!showAdditionalCosts) {
-    return (
-      <div
-        key="panel-footer"
-        className={
-          cancelButton
-            ? 'flex w-full items-center justify-between gap-4'
-            : 'flex w-full items-center justify-end gap-4'
-        }
-      >
-        {cancelButton}
-        {createButton}
-      </div>
-    )
-  }
+  useEffect(() => {
+    // Browsers only allow closing windows that were opened by script (i.e. have a live `opener`).
+    // Detect this upfront so we don't need to attempt-and-check after the user clicks cancel.
+    if (cancelAction === 'close' && !window.opener) setShowCloseWindowHint(true)
+  }, [cancelAction])
 
   return (
     <div key="panel-footer" className="grid grid-cols-12 w-full gap-4 items-center">
-      <div className="col-span-4">
-        <div className="flex justify-between text-sm">
-          <span>Additional costs</span>
-          <div className="text-brand flex gap-1 items-center font-mono font-medium">
-            <span>${additionalMonthlySpend}/m</span>
-            <InfoTooltip side="top" className="max-w-[450px] p-0">
-              <div className="p-4 text-sm text-foreground-light space-y-1">
-                <p>
-                  Each project includes a dedicated Postgres instance running on its own server. You
-                  are charged for the{' '}
-                  <InlineLink href={`${DOCS_URL}/guides/platform/billing-on-supabase`}>
-                    Compute resource
-                  </InlineLink>{' '}
-                  of that server, independent of your database usage.
-                </p>
-                {monthlyComputeCosts > 0 && (
-                  <p>Compute costs are applied on top of your subscription plan costs.</p>
-                )}
-              </div>
+      {showAdditionalCosts && (
+        <div className="col-span-4">
+          <div className="flex justify-between text-sm">
+            <span>Additional costs</span>
+            <div className="text-brand flex gap-1 items-center font-mono font-medium">
+              <span>${additionalMonthlySpend}/m</span>
+              <InfoTooltip side="top" className="max-w-[450px] p-0">
+                <div className="p-4 text-sm text-foreground-light space-y-1">
+                  <p>
+                    Each project includes a dedicated Postgres instance running on its own server.
+                    You are charged for the{' '}
+                    <InlineLink href={`${DOCS_URL}/guides/platform/billing-on-supabase`}>
+                      Compute resource
+                    </InlineLink>{' '}
+                    of that server, independent of your database usage.
+                  </p>
+                  {monthlyComputeCosts > 0 && (
+                    <p>Compute costs are applied on top of your subscription plan costs.</p>
+                  )}
+                </div>
 
-              <Table className="mt-2">
-                <TableHeader className="[&_th]:h-7">
-                  <TableRow className="py-2">
-                    <TableHead className="w-[170px]">Project</TableHead>
-                    <TableHead>Compute Size</TableHead>
-                    <TableHead className="text-right">Monthly Costs</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody className="[&_td]:py-2">
-                  {organizationProjects.map((project) => {
-                    const primaryDb = project.databases.find((db) => db.identifier === project.ref)
-                    return (
-                      <TableRow key={project.ref} className="text-foreground-light">
-                        <TableCell className="w-[170px] truncate">{project.name}</TableCell>
-                        <TableCell className="text-center">
-                          {instanceLabel(primaryDb?.infra_compute_size)}
-                        </TableCell>
-                        <TableCell className="text-right">
-                          ${monthlyInstancePrice(primaryDb?.infra_compute_size)}
-                        </TableCell>
-                      </TableRow>
-                    )
-                  })}
+                <Table className="mt-2">
+                  <TableHeader className="[&_th]:h-7">
+                    <TableRow className="py-2">
+                      <TableHead className="w-[170px]">Project</TableHead>
+                      <TableHead>Compute Size</TableHead>
+                      <TableHead className="text-right">Monthly Costs</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody className="[&_td]:py-2">
+                    {organizationProjects.map((project) => {
+                      const primaryDb = project.databases.find(
+                        (db) => db.identifier === project.ref
+                      )
+                      return (
+                        <TableRow key={project.ref} className="text-foreground-light">
+                          <TableCell className="w-[170px] truncate">{project.name}</TableCell>
+                          <TableCell className="text-center">
+                            {instanceLabel(primaryDb?.infra_compute_size)}
+                          </TableCell>
+                          <TableCell className="text-right">
+                            ${monthlyInstancePrice(primaryDb?.infra_compute_size)}
+                          </TableCell>
+                        </TableRow>
+                      )
+                    })}
 
-                  <TableRow>
-                    <TableCell className="w-[170px] flex gap-2">
-                      <span className="truncate">
-                        {form.getValues('projectName') || 'New project'}
-                      </span>
-                      <Badge variant="success">New</Badge>
-                    </TableCell>
-                    <TableCell className="text-center">{instanceLabel(instanceSize)}</TableCell>
-                    <TableCell className="text-right">
-                      ${monthlyInstancePrice(instanceSize)}
-                    </TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-              <PopoverSeparator />
-              <Table>
-                <TableHeader className="[&_th]:h-7">
-                  <TableRow>
-                    <TableHead colSpan={2}>Compute Credits</TableHead>
-                    <TableHead colSpan={1} className="text-right">
-                      -$10
-                    </TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody className="[&_td]:py-2">
-                  <TableRow className="text-foreground">
-                    <TableCell colSpan={2}>
-                      Total Monthly Compute Costs
-                      {/**
-                       * API currently doesnt output replica information on the projects list endpoint. Until then, we cannot correctly calculate the costs including RRs.
-                       * Will be adjusted in the future [kevin]
-                       */}
-                      {organizationProjects.length > 0 && (
-                        <p className="text-xs text-foreground-lighter">Excluding Read replicas</p>
-                      )}
-                    </TableCell>
-                    <TableCell colSpan={1} className="text-right">
-                      ${monthlyComputeCosts}
-                    </TableCell>
-                  </TableRow>
-                </TableBody>
-              </Table>
-            </InfoTooltip>
+                    <TableRow>
+                      <TableCell className="w-[170px] flex gap-2">
+                        <span className="truncate">
+                          {form.getValues('projectName') || 'New project'}
+                        </span>
+                        <Badge variant="success">New</Badge>
+                      </TableCell>
+                      <TableCell className="text-center">{instanceLabel(instanceSize)}</TableCell>
+                      <TableCell className="text-right">
+                        ${monthlyInstancePrice(instanceSize)}
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+                <PopoverSeparator />
+                <Table>
+                  <TableHeader className="[&_th]:h-7">
+                    <TableRow>
+                      <TableHead colSpan={2}>Compute Credits</TableHead>
+                      <TableHead colSpan={1} className="text-right">
+                        -$10
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody className="[&_td]:py-2">
+                    <TableRow className="text-foreground">
+                      <TableCell colSpan={2}>
+                        Total Monthly Compute Costs
+                        {/**
+                         * API currently doesnt output replica information on the projects list endpoint. Until then, we cannot correctly calculate the costs including RRs.
+                         * Will be adjusted in the future [kevin]
+                         */}
+                        {organizationProjects.length > 0 && (
+                          <p className="text-xs text-foreground-lighter">Excluding Read replicas</p>
+                        )}
+                      </TableCell>
+                      <TableCell colSpan={1} className="text-right">
+                        ${monthlyComputeCosts}
+                      </TableCell>
+                    </TableRow>
+                  </TableBody>
+                </Table>
+              </InfoTooltip>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
-      <div className="flex items-center col-span-8 space-x-2 ml-auto">
-        {cancelButton}
-        {createButton}
+      <div
+        className={cn(
+          showAdditionalCosts ? 'col-span-8' : 'col-span-12',
+          'flex items-center gap-x-2 ml-auto'
+        )}
+      >
+        {cancelAction === 'hidden' ? null : showCloseWindowHint ? (
+          <p role="status" aria-live="polite" className="text-xs text-foreground-muted mr-3">
+            Close window to cancel
+          </p>
+        ) : (
+          <Button
+            type="button"
+            variant="default"
+            disabled={isCreatingNewProject || isSuccessNewProject}
+            onClick={onCancel}
+          >
+            Cancel
+          </Button>
+        )}
+
+        <Button
+          type="submit"
+          loading={isCreatingNewProject || isSuccessNewProject}
+          disabled={!canCreateProject}
+        >
+          Create new project
+        </Button>
       </div>
     </div>
   )

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationFooter.tsx
@@ -95,6 +95,7 @@ export const ProjectCreationFooter = ({
       </p>
     ) : (
       <Button
+        type="button"
         variant="default"
         disabled={isCreatingNewProject || isSuccessNewProject}
         onClick={onCancel}

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -35,7 +35,6 @@ import { ProjectNameInput } from './ProjectNameInput'
 import { RegionSelector } from './RegionSelector'
 import { SecurityOptions } from './SecurityOptions'
 import { AUTO_ENABLE_RLS_EVENT_TRIGGER_SQL } from '@/components/interfaces/Database/Triggers/EventTriggersList/EventTriggers.constants'
-import { getValidVercelReturnUrl } from '@/components/interfaces/Integrations/Vercel/VercelIntegration.utils'
 import {
   GitHubRepositoryField,
   useGitHubRepositoryOptions,
@@ -91,7 +90,7 @@ interface ProjectCreationFormProps {
  *  - "Internal configuration" section
  *  - "GitHub repository" field
  *  - "Free project info" at the bottom
- * - Shows Cancel as "Return to Vercel" (via `next`) instead of navigating into Studio
+ * - Cancel closes the popup window instead of navigating into Studio
  * - Shows the following:
  *  - "Data seeding" section
  * - When embedded in the Vercel interstitial, flattens Panel chrome so the shared
@@ -106,8 +105,7 @@ export const ProjectCreationForm = ({
   const track = useTrack()
   const router = useRouter()
   const { profile } = useProfile()
-  const { slug, projectName, externalId, next } = useParams()
-  const canReturnToVercel = getValidVercelReturnUrl(next) !== undefined
+  const { slug, projectName, externalId } = useParams()
   const trackFunnelError = useTrackFunnelError()
   const defaultProvider = useDefaultProvider()
 
@@ -609,7 +607,7 @@ export const ProjectCreationForm = ({
               organizationProjects={organizationProjects}
               isCreatingNewProject={isCreatingNewProject}
               isSuccessNewProject={isSuccessNewProject}
-              cancelAction={isVercelIntegrationFlow ? 'vercel' : 'studio'}
+              cancelAction={isVercelIntegrationFlow ? 'close' : 'studio'}
             />
           }
         >
@@ -702,10 +700,7 @@ export const ProjectCreationForm = ({
                 {freePlanWithExceedingLimits ? (
                   isAdmin &&
                   slug && (
-                    <FreeProjectLimitWarning
-                      membersExceededLimit={membersExceededLimit || []}
-                      showVercelReturnHint={isVercelIntegrationFlow && canReturnToVercel}
-                    />
+                    <FreeProjectLimitWarning membersExceededLimit={membersExceededLimit || []} />
                   )
                 ) : hasOutstandingInvoices ? (
                   <Panel.Content>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix / UX polish.

## What is the current behavior?

Cancel on the Vercel create interstitial redirects to Vercel’s `next` URL. That finishes the install flow and shows “Completing installation…” / “Installation complete”, even though the user cancelled. The Deploy Button job still proceeds and fails. The button was also labelled “Return to Vercel”, which read like an alternate success path.

| Before |
| --- |
| <img width="719" height="118" alt="Create Vercel Project  Supabase" src="https://github.com/user-attachments/assets/c7ad261a-f132-4226-b460-21ec267595c0" />|
| <img width="800" height="599" alt="95801" src="https://github.com/user-attachments/assets/6d235c4b-be90-4d5e-89bc-a68933f9dc46" /> |

## What is the new behavior?

- _Return to Vercel_ button now labelled **Cancel**
- **Cancel** closes the popup via `window.close()` (same honest abort as manually closing the window)
- If the browser blocks programmatic close, Cancel is replaced by muted fallback copy: “Close window to cancel” (`role="status"` / `aria-live="polite"`)
- Cancel is left-aligned with `justify-between` when there’s no additional-costs block; with costs, both actions stay on the right
- Removes the free-limit hint line about returning to Vercel (Cancel makes that self-evident)
- Success path is unchanged: after create, we still redirect via `next`
- `/new` Cancel still navigates into Studio (`cancelAction: 'studio'`). This is unchanged behaviour

| After (Fallback) |
| --- |
| <img width="713" height="103" alt="img" src="https://github.com/user-attachments/assets/95aafc0d-1c3d-4093-9681-88ad0a40f9fe" /> |

## Additional context

Follow-up to #48311. Vercel’s `next` URL has no documented cancel/abort status, so closing the popup is the correct escape hatch.

### To test

Full Deploy Button popup cancel can’t be verified on prod until this merges. Locally:

1. Open Studio on this branch.
2. In `ProjectCreationFooter.tsx`, temporarily force the fallback:
   ```ts
   const [showCloseWindowHint, setShowCloseWindowHint] = useState(true)
   ```
3. Load create-project UI:
   - Free org / no costs: Confirm Cancel is left, Create is right (`justify-between`). With the forced hint, Cancel is replaced by “Close window to cancel”.
   - Paid org with additional costs: Confirm costs on the left; hint/Create on the right.
4. Revert `useState` to `false`.
5. Optional: open a Vercel create interstitial URL in a normal tab (not a popup), click Cancel. `window.close()` fails and the hint should replace Cancel after ~100ms.
6. On `/new/[slug]`, Confirm Cancel still returns to the Studio dashboard (not close-window).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Updated Project Creation Cancel to close the popup window directly when applicable, with a “close window to cancel” hint when closing isn’t available.
* **Bug Fixes**
  * Removed Vercel-specific “return and restart” messaging and related return-url handling.
  * Standardized Cancel navigation for non-popup flows to return to the last relevant location (or the organizations page).
* **Refactor**
  * Improved Project Creation footer layout/visibility for additional cost details. 
* **Chores**
  * Simplified the free-project limit warning configuration by removing an unused option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->