### PR TITLE
Fix import statements casing for Admonition

### DIFF
--- a/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/ConfirmationModal.tsx
@@ -16,7 +16,7 @@ import {
 } from 'ui'
 import { DialogDescription, DialogHeader } from 'ui/src/components/shadcn/ui/dialog'
 
-import { Admonition } from '../Admonition'
+import { Admonition } from '../admonition'
 
 export interface ConfirmationModalProps {
   loading?: boolean

--- a/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
+++ b/packages/ui-patterns/src/Dialogs/TextConfirmModal.tsx
@@ -29,7 +29,7 @@ import {
 import { DialogHeader } from 'ui/src/components/shadcn/ui/dialog'
 import { z } from 'zod'
 
-import { Admonition } from '../Admonition'
+import { Admonition } from '../admonition'
 
 export interface TextConfirmModalProps {
   loading: boolean

--- a/packages/ui-patterns/src/ErrorDisplay/ErrorDisplay.tsx
+++ b/packages/ui-patterns/src/ErrorDisplay/ErrorDisplay.tsx
@@ -4,7 +4,7 @@ import { HelpCircle } from 'lucide-react'
 import { forwardRef, useEffect, useRef } from 'react'
 import { Card, CardHeader, cn } from 'ui'
 
-import { WarningIcon } from '../Admonition'
+import { WarningIcon } from '../admonition'
 import type { ErrorDisplayProps, SupportFormParams } from './ErrorDisplay.types'
 
 export type { SupportFormParams } from './ErrorDisplay.types'

--- a/packages/ui-patterns/src/PrivacySettings/index.tsx
+++ b/packages/ui-patterns/src/PrivacySettings/index.tsx
@@ -17,7 +17,7 @@ import {
   Switch,
 } from 'ui'
 
-import { Admonition } from '../Admonition'
+import { Admonition } from '../admonition'
 
 interface PrivacySettingsProps {
   className?: string

--- a/packages/ui-patterns/src/SqlToRest/index.tsx
+++ b/packages/ui-patterns/src/SqlToRest/index.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic.js'
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
 
-import { Admonition } from '../Admonition'
+import { Admonition } from '../admonition'
 import { SqlToRestProps } from './sql-to-rest'
 
 function FallbackComponent({ error }: FallbackProps) {


### PR DESCRIPTION
## Context

Was running into typecheck errors when running the ts check locally - this should resolve it

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected component references across confirmation dialogs, error displays, privacy settings, and SQL-to-REST views.
  * Improved compatibility for environments with case-sensitive file handling.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->