### PR TITLE
Disable unsupported Studio features for HA projects

### DIFF
--- a/apps/studio/components/interfaces/ProjectHome/ActivityStats.test.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ActivityStats.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+
+import { BranchStatValue } from './ActivityStats'
+
+describe('BranchStatValue', () => {
+  it('shows branches as unavailable for HA projects without cached branch data', () => {
+    render(
+      <BranchStatValue
+        currentBranch={undefined}
+        isDefaultProject
+        isError={false}
+        isHighAvailability
+        isLoading
+        latestNonDefaultBranch={undefined}
+      />
+    )
+
+    expect(screen.getByText('Unavailable')).toBeInTheDocument()
+    expect(screen.queryByText('No branches')).not.toBeInTheDocument()
+  })
+})

--- a/apps/studio/components/interfaces/ProjectHome/ActivityStats.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ActivityStats.tsx
@@ -14,6 +14,7 @@ import { useBackupsQuery } from '@/data/database/backups-query'
 import { DatabaseMigration, useMigrationsQuery } from '@/data/database/migrations-query'
 import { useGitHubConnectionsQuery } from '@/data/integrations/github-connections-query'
 import { useResourceWarningsQuery } from '@/data/usage/resource-warnings-query'
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from '@/lib/constants'
@@ -22,14 +23,18 @@ import { EMPTY_ARR } from '@/lib/void'
 export const ActivityStats = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
+  const { isHighAvailability } = useHighAvailability()
   const { data: organization } = useSelectedOrganizationQuery()
   const { data: resourceWarnings } = useResourceWarningsQuery({ slug: organization?.slug })
   const projectResourceWarnings = resourceWarnings?.find((warning) => warning.project === ref)
   const parentProjectRef = project?.parent_project_ref ?? project?.ref
 
-  const { data: branchesData, isPending: isLoadingBranches } = useBranchesQuery({
-    projectRef: parentProjectRef,
-  })
+  const { data: branchesData, isPending: isLoadingBranches } = useBranchesQuery(
+    {
+      projectRef: parentProjectRef,
+    },
+    { enabled: !isHighAvailability }
+  )
   const isDefaultProject = project?.parent_project_ref === undefined
   const currentBranch = useMemo(
     () => (branchesData ?? []).find((b) => b.project_ref === ref),
@@ -132,38 +137,40 @@ export const ActivityStats = () => {
           }
         />
 
-        <SingleStat
-          href={`/project/${ref}/branches`}
-          icon={<GitBranch size={18} strokeWidth={1.5} className="text-foreground" />}
-          label={<span>{isDefaultProject ? 'Recent branch' : 'Branch Created'}</span>}
-          trackingProperties={{
-            stat_type: 'branches',
-            stat_value: branchesData?.length ?? 0,
-          }}
-          value={
-            isLoadingBranches ? (
-              <Skeleton className="h-6 w-24" />
-            ) : isDefaultProject ? (
-              <p
-                className={cn(
-                  'truncate min-w-0',
-                  !latestNonDefaultBranch && 'text-foreground-lighter'
-                )}
-                title={latestNonDefaultBranch?.name ?? 'No branches'}
-              >
-                {latestNonDefaultBranch?.name ?? 'No branches'}
-              </p>
-            ) : currentBranch?.created_at ? (
-              <TimestampInfo
-                className="text-base"
-                label={dayjs(currentBranch.created_at).fromNow()}
-                utcTimestamp={currentBranch.created_at}
-              />
-            ) : (
-              <p className="text-foreground-lighter">Unknown</p>
-            )
-          }
-        />
+        {!isHighAvailability && (
+          <SingleStat
+            href={`/project/${ref}/branches`}
+            icon={<GitBranch size={18} strokeWidth={1.5} className="text-foreground" />}
+            label={<span>{isDefaultProject ? 'Recent branch' : 'Branch Created'}</span>}
+            trackingProperties={{
+              stat_type: 'branches',
+              stat_value: branchesData?.length ?? 0,
+            }}
+            value={
+              isLoadingBranches ? (
+                <Skeleton className="h-6 w-24" />
+              ) : isDefaultProject ? (
+                <p
+                  className={cn(
+                    'truncate min-w-0',
+                    !latestNonDefaultBranch && 'text-foreground-lighter'
+                  )}
+                  title={latestNonDefaultBranch?.name ?? 'No branches'}
+                >
+                  {latestNonDefaultBranch?.name ?? 'No branches'}
+                </p>
+              ) : currentBranch?.created_at ? (
+                <TimestampInfo
+                  className="text-base"
+                  label={dayjs(currentBranch.created_at).fromNow()}
+                  utcTimestamp={currentBranch.created_at}
+                />
+              ) : (
+                <p className="text-foreground-lighter">Unknown</p>
+              )
+            }
+          />
+        )}
 
         <SingleStat
           href={`/project/${ref}/database/migrations`}

--- a/apps/studio/components/interfaces/ProjectHome/ActivityStats.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ActivityStats.tsx
@@ -8,6 +8,7 @@ import { TimestampInfo } from 'ui-patterns/TimestampInfo'
 import { HighAvailabilityBadge } from './HighAvailabilityBadge'
 import { ServiceStatus } from './ServiceStatus'
 import { ComputeBadgeWrapper } from '@/components/ui/ComputeBadgeWrapper'
+import { DisableInteraction } from '@/components/ui/DisableInteraction'
 import { SingleStat } from '@/components/ui/SingleStat'
 import { useBranchesQuery } from '@/data/branches/branches-query'
 import { useBackupsQuery } from '@/data/database/backups-query'
@@ -137,9 +138,9 @@ export const ActivityStats = () => {
           }
         />
 
-        {!isHighAvailability && (
+        <DisableInteraction disabled={isHighAvailability} aria-disabled={isHighAvailability}>
           <SingleStat
-            href={`/project/${ref}/branches`}
+            href={isHighAvailability ? undefined : `/project/${ref}/branches`}
             icon={<GitBranch size={18} strokeWidth={1.5} className="text-foreground" />}
             label={<span>{isDefaultProject ? 'Recent branch' : 'Branch Created'}</span>}
             trackingProperties={{
@@ -170,7 +171,7 @@ export const ActivityStats = () => {
               )
             }
           />
-        )}
+        </DisableInteraction>
 
         <SingleStat
           href={`/project/${ref}/database/migrations`}

--- a/apps/studio/components/interfaces/ProjectHome/ActivityStats.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ActivityStats.tsx
@@ -21,6 +21,59 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { PROJECT_STATUS } from '@/lib/constants'
 import { EMPTY_ARR } from '@/lib/void'
 
+interface BranchStatValueProps {
+  currentBranch?: { created_at?: string }
+  isDefaultProject: boolean
+  isError: boolean
+  isHighAvailability: boolean
+  isLoading: boolean
+  latestNonDefaultBranch?: { name?: string }
+}
+
+export const BranchStatValue = ({
+  currentBranch,
+  isDefaultProject,
+  isError,
+  isHighAvailability,
+  isLoading,
+  latestNonDefaultBranch,
+}: BranchStatValueProps) => {
+  if (isHighAvailability) {
+    return <p className="text-foreground-lighter">Unavailable</p>
+  }
+
+  if (isLoading) {
+    return <Skeleton className="h-6 w-24" />
+  }
+
+  if (isError) {
+    return <p className="text-foreground-lighter">Unable to load</p>
+  }
+
+  if (isDefaultProject) {
+    return (
+      <p
+        className={cn('truncate min-w-0', !latestNonDefaultBranch && 'text-foreground-lighter')}
+        title={latestNonDefaultBranch?.name ?? 'No branches'}
+      >
+        {latestNonDefaultBranch?.name ?? 'No branches'}
+      </p>
+    )
+  }
+
+  if (currentBranch?.created_at) {
+    return (
+      <TimestampInfo
+        className="text-base"
+        label={dayjs(currentBranch.created_at).fromNow()}
+        utcTimestamp={currentBranch.created_at}
+      />
+    )
+  }
+
+  return <p className="text-foreground-lighter">Unknown</p>
+}
+
 export const ActivityStats = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
@@ -30,7 +83,11 @@ export const ActivityStats = () => {
   const projectResourceWarnings = resourceWarnings?.find((warning) => warning.project === ref)
   const parentProjectRef = project?.parent_project_ref ?? project?.ref
 
-  const { data: branchesData, isPending: isLoadingBranches } = useBranchesQuery(
+  const {
+    data: branchesData,
+    isPending: isLoadingBranches,
+    isError: isBranchesError,
+  } = useBranchesQuery(
     {
       projectRef: parentProjectRef,
     },
@@ -148,27 +205,14 @@ export const ActivityStats = () => {
               stat_value: branchesData?.length ?? 0,
             }}
             value={
-              isLoadingBranches ? (
-                <Skeleton className="h-6 w-24" />
-              ) : isDefaultProject ? (
-                <p
-                  className={cn(
-                    'truncate min-w-0',
-                    !latestNonDefaultBranch && 'text-foreground-lighter'
-                  )}
-                  title={latestNonDefaultBranch?.name ?? 'No branches'}
-                >
-                  {latestNonDefaultBranch?.name ?? 'No branches'}
-                </p>
-              ) : currentBranch?.created_at ? (
-                <TimestampInfo
-                  className="text-base"
-                  label={dayjs(currentBranch.created_at).fromNow()}
-                  utcTimestamp={currentBranch.created_at}
-                />
-              ) : (
-                <p className="text-foreground-lighter">Unknown</p>
-              )
+              <BranchStatValue
+                currentBranch={currentBranch}
+                isDefaultProject={isDefaultProject}
+                isError={isBranchesError}
+                isHighAvailability={isHighAvailability}
+                isLoading={isLoadingBranches}
+                latestNonDefaultBranch={latestNonDefaultBranch}
+              />
             }
           />
         </DisableInteraction>

--- a/apps/studio/components/interfaces/ProjectHome/ServiceStatus.test.ts
+++ b/apps/studio/components/interfaces/ProjectHome/ServiceStatus.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest'
+
+import { resolveRealtimeServiceStatus } from './ServiceStatus.utils'
+
+describe('resolveRealtimeServiceStatus', () => {
+  it('marks Realtime as disabled on High Availability projects', () => {
+    expect(resolveRealtimeServiceStatus(true, 'UNHEALTHY')).toBe('DISABLED')
+  })
+
+  it('preserves Realtime health on standard projects', () => {
+    expect(resolveRealtimeServiceStatus(false, 'ACTIVE_HEALTHY')).toBe('ACTIVE_HEALTHY')
+    expect(resolveRealtimeServiceStatus(false, 'UNHEALTHY')).toBe('UNHEALTHY')
+  })
+})

--- a/apps/studio/components/interfaces/ProjectHome/ServiceStatus.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ServiceStatus.tsx
@@ -5,22 +5,21 @@ import Link from 'next/link'
 import { cn, HoverCard, HoverCardContent, HoverCardTrigger, InfoIcon } from 'ui'
 
 import { useUnifiedLogsPreview } from '../App/FeaturePreview/FeaturePreviewContext'
+import { resolveRealtimeServiceStatus, type ProjectServiceStatus } from './ServiceStatus.utils'
 import { InlineLink } from '@/components/ui/InlineLink'
 import { SingleStat } from '@/components/ui/SingleStat'
 import { useBranchesQuery } from '@/data/branches/branches-query'
 import { useEdgeFunctionServiceStatusQuery } from '@/data/service-status/edge-functions-status-query'
 import {
   useProjectServiceStatusQuery,
-  type ProjectServiceStatus as APIProjectServiceStatus,
   type ServiceHealthResponse,
 } from '@/data/service-status/service-status-query'
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 
 const SERVICE_STATUS_THRESHOLD = 5 // minutes
-
-type ProjectServiceStatus = APIProjectServiceStatus | 'DISABLED'
 
 const iconProps = {
   size: 18,
@@ -101,6 +100,7 @@ const extractDbSchema = (response: ServiceHealthResponse | undefined) => {
 export const ServiceStatus = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
+  const { isHighAvailability } = useHighAvailability()
   const { isEnabled: isUnifiedLogsEnabled } = useUnifiedLogsPreview()
 
   const {
@@ -136,6 +136,9 @@ export const ServiceStatus = () => {
       refetchInterval: (query) => {
         const data = query.state.data
         const isServiceUnhealthy = data?.some((service) => {
+          if (isHighAvailability && service.name === 'realtime') {
+            return false
+          }
           // if the postgrest service has an empty schema, postgrest has been disabled
           if (service.name === 'rest' && extractDbSchema(service) === '') {
             return false
@@ -213,7 +216,7 @@ export const ServiceStatus = () => {
             error: realtimeStatus?.error,
             docsUrl: undefined,
             isLoading,
-            status: realtimeStatus?.status ?? 'UNHEALTHY',
+            status: resolveRealtimeServiceStatus(isHighAvailability, realtimeStatus?.status),
             logsUrl: isUnifiedLogsEnabled
               ? '/logs?filter=log_type:eq:realtime'
               : '/logs/realtime-logs',

--- a/apps/studio/components/interfaces/ProjectHome/ServiceStatus.utils.ts
+++ b/apps/studio/components/interfaces/ProjectHome/ServiceStatus.utils.ts
@@ -1,0 +1,10 @@
+import type { ProjectServiceStatus as APIProjectServiceStatus } from '@/data/service-status/service-status-query'
+
+export type ProjectServiceStatus = APIProjectServiceStatus | 'DISABLED'
+
+export const resolveRealtimeServiceStatus = (
+  isHighAvailability: boolean,
+  status?: APIProjectServiceStatus
+): ProjectServiceStatus => {
+  return isHighAvailability ? 'DISABLED' : (status ?? 'UNHEALTHY')
+}

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -17,6 +17,7 @@ import { CustomDomainsConfigureHostname } from './CustomDomainsConfigureHostname
 import { CustomDomainsShimmerLoader } from './CustomDomainsShimmerLoader'
 import { CustomDomainVerify } from './CustomDomainVerify'
 import { SupportLink } from '@/components/interfaces/Support/SupportLink'
+import { HighAvailabilityDisabledEmptyState } from '@/components/ui/HighAvailability/HighAvailabilityDisabledEmptyState'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
 import { UpgradeToPro } from '@/components/ui/UpgradeToPro'
 import {
@@ -24,12 +25,14 @@ import {
   type CustomDomainsData,
 } from '@/data/custom-domains/custom-domains-query'
 import { useProjectAddonsQuery } from '@/data/subscriptions/project-addons-query'
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 
 export const CustomDomainConfig = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
+  const { isHighAvailability } = useHighAvailability()
   const { data: organization } = useSelectedOrganizationQuery()
   const isBranch = Boolean(project?.parent_project_ref)
   const entityLabel = isBranch ? 'branch' : 'project'
@@ -38,7 +41,10 @@ export const CustomDomainConfig = () => {
 
   const plan = organization?.plan?.id
 
-  const { data: addons, isPending: isLoadingAddons } = useProjectAddonsQuery({ projectRef: ref })
+  const { data: addons, isPending: isLoadingAddons } = useProjectAddonsQuery(
+    { projectRef: ref },
+    { enabled: !isHighAvailability }
+  )
   const hasCustomDomainAddon = !!addons?.selected_addons.find((x) => x.type === 'custom_domain')
 
   const {
@@ -50,6 +56,7 @@ export const CustomDomainConfig = () => {
   } = useCustomDomainsQuery(
     { projectRef: ref },
     {
+      enabled: !isHighAvailability,
       refetchInterval: (query) => {
         const data = query.state.data
         // while setting up the ssl certificate, we want to poll every 5 seconds
@@ -75,7 +82,13 @@ export const CustomDomainConfig = () => {
         </PageSectionSummary>
       </PageSectionMeta>
       <PageSectionContent>
-        {isLoadingAddons ? (
+        {isHighAvailability ? (
+          <HighAvailabilityDisabledEmptyState
+            title="Custom domains unavailable on High Availability projects"
+            description="We're working to bring custom domains to High Availability projects. Contact support if this is blocking your work."
+            className="max-w-none mx-0 py-6"
+          />
+        ) : isLoadingAddons ? (
           <Card>
             <CardContent className="space-y-6">
               <CustomDomainsShimmerLoader />

--- a/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
+++ b/apps/studio/components/interfaces/Settings/General/CustomDomainConfig/CustomDomainConfig.tsx
@@ -32,7 +32,7 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 export const CustomDomainConfig = () => {
   const { ref } = useParams()
   const { data: project } = useSelectedProjectQuery()
-  const { isHighAvailability } = useHighAvailability()
+  const { isHighAvailability, isPending: isHighAvailabilityPending } = useHighAvailability()
   const { data: organization } = useSelectedOrganizationQuery()
   const isBranch = Boolean(project?.parent_project_ref)
   const entityLabel = isBranch ? 'branch' : 'project'
@@ -40,10 +40,11 @@ export const CustomDomainConfig = () => {
   const customDomainsDisabledDueToQuota = useFlag('customDomainsDisabledDueToQuota')
 
   const plan = organization?.plan?.id
+  const canLoadCustomDomains = !isHighAvailability && !isHighAvailabilityPending
 
   const { data: addons, isPending: isLoadingAddons } = useProjectAddonsQuery(
     { projectRef: ref },
-    { enabled: !isHighAvailability }
+    { enabled: canLoadCustomDomains }
   )
   const hasCustomDomainAddon = !!addons?.selected_addons.find((x) => x.type === 'custom_domain')
 
@@ -56,7 +57,7 @@ export const CustomDomainConfig = () => {
   } = useCustomDomainsQuery(
     { projectRef: ref },
     {
-      enabled: !isHighAvailability,
+      enabled: canLoadCustomDomains,
       refetchInterval: (query) => {
         const data = query.state.data
         // while setting up the ssl certificate, we want to poll every 5 seconds
@@ -71,6 +72,28 @@ export const CustomDomainConfig = () => {
 
   const { status } = customDomainData || {}
 
+  if (isHighAvailability) {
+    return (
+      <PageSection id="custom-domains">
+        <PageSectionMeta>
+          <PageSectionSummary>
+            <PageSectionTitle>Custom domains</PageSectionTitle>
+            <PageSectionDescription>
+              Present a branded experience to your users
+            </PageSectionDescription>
+          </PageSectionSummary>
+        </PageSectionMeta>
+        <PageSectionContent>
+          <HighAvailabilityDisabledEmptyState
+            title="Custom domains unavailable on High Availability projects"
+            description="We're working to bring custom domains to High Availability projects. Contact support if this is blocking your work."
+            className="max-w-none mx-0 py-6"
+          />
+        </PageSectionContent>
+      </PageSection>
+    )
+  }
+
   return (
     <PageSection id="custom-domains">
       <PageSectionMeta>
@@ -82,13 +105,7 @@ export const CustomDomainConfig = () => {
         </PageSectionSummary>
       </PageSectionMeta>
       <PageSectionContent>
-        {isHighAvailability ? (
-          <HighAvailabilityDisabledEmptyState
-            title="Custom domains unavailable on High Availability projects"
-            description="We're working to bring custom domains to High Availability projects. Contact support if this is blocking your work."
-            className="max-w-none mx-0 py-6"
-          />
-        ) : isLoadingAddons ? (
+        {isHighAvailabilityPending || isLoadingAddons ? (
           <Card>
             <CardContent className="space-y-6">
               <CustomDomainsShimmerLoader />

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.test.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { describe, expect, it, vi } from 'vitest'
+
+import { TableRealtimeToggle } from './TableEditor'
+
+describe('TableRealtimeToggle', () => {
+  it('disables Realtime and shows the HA-specific description for HA projects', () => {
+    render(
+      <TableRealtimeToggle
+        checked={false}
+        isHighAvailability
+        isPending={false}
+        onCheckedChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('checkbox', { name: 'Enable Realtime' })).toBeDisabled()
+    expect(
+      screen.getByText('Realtime is unavailable on High Availability projects.')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Broadcast changes on this table to authorized subscribers.')
+    ).not.toBeInTheDocument()
+  })
+
+  it('keeps Realtime available with the standard description for non-HA projects', () => {
+    render(
+      <TableRealtimeToggle
+        checked={false}
+        isHighAvailability={false}
+        isPending={false}
+        onCheckedChange={vi.fn()}
+      />
+    )
+
+    expect(screen.getByRole('checkbox', { name: 'Enable Realtime' })).toBeEnabled()
+    expect(
+      screen.getByText('Broadcast changes on this table to authorized subscribers.')
+    ).toBeInTheDocument()
+    expect(
+      screen.queryByText('Realtime is unavailable on High Availability projects.')
+    ).not.toBeInTheDocument()
+  })
+
+  it('prevents toggling until HA detection completes', async () => {
+    const user = userEvent.setup()
+    const onCheckedChange = vi.fn()
+    const { rerender } = render(
+      <TableRealtimeToggle
+        checked={false}
+        isHighAvailability={false}
+        isPending
+        onCheckedChange={onCheckedChange}
+      />
+    )
+
+    const checkbox = screen.getByRole('checkbox', { name: 'Enable Realtime' })
+    expect(checkbox).toBeDisabled()
+    await user.click(checkbox)
+    expect(onCheckedChange).not.toHaveBeenCalled()
+
+    rerender(
+      <TableRealtimeToggle
+        checked={false}
+        isHighAvailability={false}
+        isPending={false}
+        onCheckedChange={onCheckedChange}
+      />
+    )
+
+    expect(checkbox).toBeEnabled()
+    await user.click(checkbox)
+    expect(onCheckedChange).toHaveBeenCalledOnce()
+  })
+})

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -64,6 +64,44 @@ export interface TableEditorProps {
   apiAccessToggleHandler: TableApiAccessHandlerWithHistoryReturn
 }
 
+interface TableRealtimeToggleProps {
+  checked: boolean
+  isHighAvailability: boolean
+  isPending: boolean
+  onCheckedChange: () => void
+}
+
+export const TableRealtimeToggle = ({
+  checked,
+  isHighAvailability,
+  isPending,
+  onCheckedChange,
+}: TableRealtimeToggleProps) => {
+  return (
+    <div className="items-top flex space-x-2">
+      <Checkbox
+        id="enable-realtime"
+        checked={checked}
+        disabled={isHighAvailability || isPending}
+        onCheckedChange={onCheckedChange}
+      />
+      <div className="grid gap-1.5 leading-none">
+        <label
+          htmlFor="enable-realtime"
+          className="text-sm text-foreground-light flex items-center space-x-2 leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+        >
+          Enable Realtime
+        </label>
+        <p className="text-sm text-foreground-muted">
+          {isHighAvailability
+            ? 'Realtime is unavailable on High Availability projects.'
+            : 'Broadcast changes on this table to authorized subscribers.'}
+        </p>
+      </div>
+    </div>
+  )
+}
+
 export const TableEditor = ({
   table,
   isDuplicating,
@@ -78,7 +116,7 @@ export const TableEditor = ({
   const snap = useTableEditorStateSnapshot()
   const tableEditorApi = useContext(TableEditorStateContext)
   const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
-  const { isHighAvailability } = useHighAvailability()
+  const { isHighAvailability, isPending: isHighAvailabilityPending } = useHighAvailability()
   const { docsRowLevelSecurityGuidePath } = useCustomContent(['docs:row_level_security_guide_path'])
 
   const [params, setParams] = useUrlState()
@@ -222,7 +260,7 @@ export const TableEditor = ({
           tableId: table?.id,
           importContent,
           isRLSEnabled: tableFields.isRLSEnabled,
-          isRealtimeEnabled: tableFields.isRealtimeEnabled,
+          isRealtimeEnabled: !isHighAvailability && tableFields.isRealtimeEnabled,
           isDuplicateRows: isDuplicateRows,
           existingForeignKeyRelations: foreignKeys,
           primaryKey,
@@ -502,35 +540,20 @@ export const TableEditor = ({
         )}
 
         {realtimeEnabled && (
-          <div className="items-top flex space-x-2">
-            <Checkbox
-              id="enable-realtime"
-              checked={tableFields.isRealtimeEnabled}
-              disabled={isHighAvailability}
-              onCheckedChange={() => {
-                track('realtime_toggle_table_clicked', {
-                  newState: tableFields.isRealtimeEnabled ? 'disabled' : 'enabled',
-                  origin: 'tableSidePanel',
-                })
-                onUpdateField({
-                  isRealtimeEnabled: !tableFields.isRealtimeEnabled,
-                })
-              }}
-            />
-            <div className="grid gap-1.5 leading-none">
-              <label
-                htmlFor="enable-realtime"
-                className="text-sm text-foreground-light flex items-center space-x-2 leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
-              >
-                Enable Realtime
-              </label>
-              <p className="text-sm text-foreground-muted">
-                {isHighAvailability
-                  ? 'Realtime is unavailable on High Availability projects.'
-                  : 'Broadcast changes on this table to authorized subscribers.'}
-              </p>
-            </div>
-          </div>
+          <TableRealtimeToggle
+            checked={tableFields.isRealtimeEnabled}
+            isHighAvailability={isHighAvailability}
+            isPending={isHighAvailabilityPending}
+            onCheckedChange={() => {
+              track('realtime_toggle_table_clicked', {
+                newState: tableFields.isRealtimeEnabled ? 'disabled' : 'enabled',
+                origin: 'tableSidePanel',
+              })
+              onUpdateField({
+                isRealtimeEnabled: !tableFields.isRealtimeEnabled,
+              })
+            }}
+          />
         )}
       </SidePanel.Content>
 

--- a/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
+++ b/apps/studio/components/interfaces/TableGridEditor/SidePanelEditor/TableEditor/TableEditor.tsx
@@ -32,6 +32,7 @@ import { useForeignKeyConstraintsQuery } from '@/data/database/foreign-key-const
 import { useEnumeratedTypesQuery } from '@/data/enumerated-types/enumerated-types-query'
 import { useCustomContent } from '@/hooks/custom-content/useCustomContent'
 import { useChanged } from '@/hooks/misc/useChanged'
+import { useHighAvailability } from '@/hooks/misc/useHighAvailability'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
 import { useQuerySchemaState } from '@/hooks/misc/useSchemaQueryState'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
@@ -77,6 +78,7 @@ export const TableEditor = ({
   const snap = useTableEditorStateSnapshot()
   const tableEditorApi = useContext(TableEditorStateContext)
   const { realtimeAll: realtimeEnabled } = useIsFeatureEnabled(['realtime:all'])
+  const { isHighAvailability } = useHighAvailability()
   const { docsRowLevelSecurityGuidePath } = useCustomContent(['docs:row_level_security_guide_path'])
 
   const [params, setParams] = useUrlState()
@@ -504,6 +506,7 @@ export const TableEditor = ({
             <Checkbox
               id="enable-realtime"
               checked={tableFields.isRealtimeEnabled}
+              disabled={isHighAvailability}
               onCheckedChange={() => {
                 track('realtime_toggle_table_clicked', {
                   newState: tableFields.isRealtimeEnabled ? 'disabled' : 'enabled',
@@ -522,7 +525,9 @@ export const TableEditor = ({
                 Enable Realtime
               </label>
               <p className="text-sm text-foreground-muted">
-                Broadcast changes on this table to authorized subscribers.
+                {isHighAvailability
+                  ? 'Realtime is unavailable on High Availability projects.'
+                  : 'Broadcast changes on this table to authorized subscribers.'}
               </p>
             </div>
           </div>

--- a/apps/studio/data/custom-domains/custom-domains-query.ts
+++ b/apps/studio/data/custom-domains/custom-domains-query.ts
@@ -110,7 +110,7 @@ export const useCustomDomainsQuery = <TData = CustomDomainsData>(
     ...options
   }: UseCustomQueryOptions<CustomDomainsData, CustomDomainsError, TData> = {}
 ) => {
-  const { data } = useProjectAddonsQuery({ projectRef })
+  const { data } = useProjectAddonsQuery({ projectRef }, { enabled: enabled !== false })
   const hasCustomDomainsAddon = !!data?.selected_addons.find((x) => x.type === 'custom_domain')
 
   return useQuery<CustomDomainsData, CustomDomainsError, TData>({


### PR DESCRIPTION
## Summary

More gating to support upcoming High Availability projects. 

- Keep the Recent Branch stat visible on the project home page for HA projects, but disable its interaction, reduce its opacity, and skip the branches query.
- Treat Realtime as disabled for HA projects in the service-status dropdown so it does not make the project appear unhealthy or trigger unhealthy polling.
- Show the shared unsupported-feature empty state for Custom Domains and skip its query on HA projects.
- Disable the Enable Realtime checkbox in the table creation sheet for HA projects.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added High Availability–aware behavior across activity stats, service status, custom domains, and table realtime controls.
  - Introduced reusable Branch value UI that shows an “Unavailable” state in High Availability mode.
  - Added a dedicated realtime toggle UI that disables interaction and updates helper text when unavailable.

- **Bug Fixes**
  - Ensured realtime is treated as disabled (not unhealthy) in High Availability and prevented realtime enabling/saving.
  - Reduced unnecessary data fetching by gating addon/custom-domain requests and disabling branch queries.

- **Tests**
  - Added coverage for realtime status resolution, BranchStatValue “Unavailable” rendering, and TableRealtimeToggle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->