### PR TITLE
Joshen/fe 4000 activity table to show queries which are blockers

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -7,7 +7,7 @@ import { Input } from 'ui-patterns/DataInputs/Input'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { ReportsSelectFilter } from '../../Reports/v2/ReportsSelectFilter'
-import { ActivityRow } from './ActivityRow'
+import { GroupedActivityRow } from './ActivityRow'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useDatabaseRolesQuery } from '@/data/database-roles/database-roles-query'
 import { useDatabaseActivityQuery } from '@/data/database/activity-query'
@@ -64,6 +64,9 @@ export const Activity = ({ live }: ActivityProps) => {
   const matchesSearch = (activity: { query: string | null }) =>
     !searchFilter || (activity.query?.toLowerCase().includes(searchFilter.toLowerCase()) ?? false)
 
+  // Pids referenced in some other activity's blocked_by - i.e. they are blocking something
+  const blockingPids = new Set((data ?? []).flatMap((x) => x.blocked_by))
+
   const activities = data?.filter((activity) => {
     const matchesState =
       !statesFilter ||
@@ -72,10 +75,18 @@ export const Activity = ({ live }: ActivityProps) => {
     const matchesRole = rolesFilter.length === 0 || rolesFilter.includes(activity.role_name)
     const matchesApplication =
       applicationsFilter.length === 0 || applicationsFilter.includes(activity.application_name)
-    const matchesView = viewFilter !== 'blocked' || activity.blocked_by.length > 0
-    return matchesState && matchesRole && matchesApplication && matchesView && matchesSearch(activity)
+    // In the blocked view, only show root blockers - activities blocking others while not
+    // themselves blocked. Everything they block is shown nested under them instead.
+    const matchesView =
+      viewFilter !== 'blockers' ||
+      (activity.blocked_by.length === 0 && blockingPids.has(activity.pid))
+    return (
+      matchesState && matchesRole && matchesApplication && matchesView && matchesSearch(activity)
+    )
   })
-  const blockedQueries = (data ?? []).filter((x) => x.blocked_by.length > 0)
+  const rootBlockers = (data ?? []).filter(
+    (x) => x.blocked_by.length === 0 && blockingPids.has(x.pid)
+  )
 
   const stateOptions = [
     'Idle',
@@ -92,7 +103,7 @@ export const Activity = ({ live }: ActivityProps) => {
         y.state === x.toLowerCase() &&
         (rolesFilter.length === 0 || rolesFilter.includes(y.role_name)) &&
         (applicationsFilter.length === 0 || applicationsFilter.includes(y.application_name)) &&
-        (viewFilter !== 'blocked' || y.blocked_by.length > 0) &&
+        (viewFilter !== 'blockers' || y.blocked_by.length > 0) &&
         matchesSearch(y)
     ).length,
   }))
@@ -109,7 +120,7 @@ export const Activity = ({ live }: ActivityProps) => {
           (!statesFilter ||
             statesFilter.length === 0 ||
             (y.state !== null && statesFilter.includes(y.state))) &&
-          (viewFilter !== 'blocked' || y.blocked_by.length > 0) &&
+          (viewFilter !== 'blockers' || y.blocked_by.length > 0) &&
           matchesSearch(y)
       ).length,
     }))
@@ -128,7 +139,7 @@ export const Activity = ({ live }: ActivityProps) => {
             statesFilter.length === 0 ||
             (y.state !== null && statesFilter.includes(y.state))) &&
           (applicationsFilter.length === 0 || applicationsFilter.includes(y.application_name)) &&
-          (viewFilter !== 'blocked' || y.blocked_by.length > 0) &&
+          (viewFilter !== 'blockers' || y.blocked_by.length > 0) &&
           matchesSearch(y)
       ).length,
     }))
@@ -150,14 +161,6 @@ export const Activity = ({ live }: ActivityProps) => {
       view: '',
     })
   }
-
-  useEffect(() => {
-    if (selectedPid && isSuccess) {
-      document
-        .getElementById(selectedPid.toString())
-        ?.scrollIntoView({ behavior: 'smooth', block: 'center' })
-    }
-  }, [selectedPid, isSuccess])
 
   return (
     <div className="flex flex-col gap-y-4">
@@ -198,11 +201,11 @@ export const Activity = ({ live }: ActivityProps) => {
           popoverClassName="w-60"
         />
         <Button
-          variant={viewFilter === 'blocked' ? 'default' : 'dashed'}
-          iconRight={<span>{blockedQueries.length}</span>}
-          onClick={() => setQueryStates({ view: viewFilter === 'blocked' ? '' : 'blocked' })}
+          variant={viewFilter === 'blockers' ? 'default' : 'dashed'}
+          iconRight={<span>{rootBlockers.length}</span>}
+          onClick={() => setQueryStates({ view: viewFilter === 'blockers' ? '' : 'blockers' })}
         >
-          Blocked queries
+          Root blockers
         </Button>
         {!hasNoFiltersApplied && (
           <ButtonTooltip
@@ -272,7 +275,7 @@ export const Activity = ({ live }: ActivityProps) => {
             ) : null}
 
             {activities?.map((activity) => (
-              <ActivityRow key={activity.pid} activity={activity} />
+              <GroupedActivityRow key={activity.pid} activity={activity} />
             ))}
           </TableBody>
         </Table>

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -197,13 +197,19 @@ export const Activity = ({ live }: ActivityProps) => {
           isLoading={isPending}
           popoverClassName="w-60"
         />
-        <Button
+        <ButtonTooltip
           variant={viewFilter === 'blockers' ? 'default' : 'dashed'}
-          iconRight={<span>{rootBlockers.length}</span>}
+          iconRight={rootBlockers.length > 0 ? <span>{rootBlockers.length}</span> : null}
           onClick={() => setQueryStates({ view: viewFilter === 'blockers' ? '' : 'blockers' })}
+          tooltip={{
+            content: {
+              side: 'bottom',
+              text: 'Shows queries currently blocking others',
+            },
+          }}
         >
           Root blockers
-        </Button>
+        </ButtonTooltip>
         {!hasNoFiltersApplied && (
           <ButtonTooltip
             variant="text"

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -1,7 +1,6 @@
 import { isEqual } from 'lodash'
 import { Search, X } from 'lucide-react'
-import { parseAsArrayOf, parseAsInteger, parseAsString, useQueryState, useQueryStates } from 'nuqs'
-import { useEffect } from 'react'
+import { parseAsArrayOf, parseAsString, useQueryStates } from 'nuqs'
 import { Button, Card, Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from 'ui'
 import { Input } from 'ui-patterns/DataInputs/Input'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
@@ -21,8 +20,6 @@ interface ActivityProps {
 
 export const Activity = ({ live }: ActivityProps) => {
   const { data: project } = useSelectedProjectQuery()
-
-  const [selectedPid] = useQueryState('pid', parseAsInteger)
 
   const [
     {
@@ -48,7 +45,7 @@ export const Activity = ({ live }: ActivityProps) => {
     isEqual(rolesFilter, DEFAULT_ROLES_FILTER) &&
     viewFilter === ''
 
-  const { data, isPending, isSuccess } = useDatabaseActivityQuery(
+  const { data, isPending } = useDatabaseActivityQuery(
     {
       projectRef: project?.ref,
       connectionString: project?.connectionString,
@@ -165,7 +162,7 @@ export const Activity = ({ live }: ActivityProps) => {
   return (
     <div className="flex flex-col gap-y-4">
       <h2>Sessions</h2>
-      <div className="flex gap-x-2">
+      <div className="flex gap-2 flex-wrap">
         <Input
           size="tiny"
           icon={<Search />}

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -30,6 +30,7 @@ export const Activity = ({ live }: ActivityProps) => {
       states: statesFilter,
       applications: applicationsFilter,
       roles: rolesFilter,
+      view: viewFilter,
     },
     setQueryStates,
   ] = useQueryStates({
@@ -37,13 +38,15 @@ export const Activity = ({ live }: ActivityProps) => {
     states: parseAsArrayOf(parseAsString, ',').withDefault([]),
     applications: parseAsArrayOf(parseAsString, ',').withDefault([]),
     roles: parseAsArrayOf(parseAsString, ',').withDefault(DEFAULT_ROLES_FILTER),
+    view: parseAsString.withDefault(''),
   })
 
   const hasNoFiltersApplied =
     searchFilter.length === 0 &&
     statesFilter.length === 0 &&
     applicationsFilter.length === 0 &&
-    isEqual(rolesFilter, DEFAULT_ROLES_FILTER)
+    isEqual(rolesFilter, DEFAULT_ROLES_FILTER) &&
+    viewFilter === ''
 
   const { data, isPending, isSuccess } = useDatabaseActivityQuery(
     {
@@ -69,8 +72,10 @@ export const Activity = ({ live }: ActivityProps) => {
     const matchesRole = rolesFilter.length === 0 || rolesFilter.includes(activity.role_name)
     const matchesApplication =
       applicationsFilter.length === 0 || applicationsFilter.includes(activity.application_name)
-    return matchesState && matchesRole && matchesApplication && matchesSearch(activity)
+    const matchesView = viewFilter !== 'blocked' || activity.blocked_by.length > 0
+    return matchesState && matchesRole && matchesApplication && matchesView && matchesSearch(activity)
   })
+  const blockedQueries = (data ?? []).filter((x) => x.blocked_by.length > 0)
 
   const stateOptions = [
     'Idle',
@@ -87,6 +92,7 @@ export const Activity = ({ live }: ActivityProps) => {
         y.state === x.toLowerCase() &&
         (rolesFilter.length === 0 || rolesFilter.includes(y.role_name)) &&
         (applicationsFilter.length === 0 || applicationsFilter.includes(y.application_name)) &&
+        (viewFilter !== 'blocked' || y.blocked_by.length > 0) &&
         matchesSearch(y)
     ).length,
   }))
@@ -103,6 +109,7 @@ export const Activity = ({ live }: ActivityProps) => {
           (!statesFilter ||
             statesFilter.length === 0 ||
             (y.state !== null && statesFilter.includes(y.state))) &&
+          (viewFilter !== 'blocked' || y.blocked_by.length > 0) &&
           matchesSearch(y)
       ).length,
     }))
@@ -121,6 +128,7 @@ export const Activity = ({ live }: ActivityProps) => {
             statesFilter.length === 0 ||
             (y.state !== null && statesFilter.includes(y.state))) &&
           (applicationsFilter.length === 0 || applicationsFilter.includes(y.application_name)) &&
+          (viewFilter !== 'blocked' || y.blocked_by.length > 0) &&
           matchesSearch(y)
       ).length,
     }))
@@ -139,6 +147,7 @@ export const Activity = ({ live }: ActivityProps) => {
       states: [],
       roles: DEFAULT_ROLES_FILTER,
       applications: [],
+      view: '',
     })
   }
 
@@ -158,7 +167,7 @@ export const Activity = ({ live }: ActivityProps) => {
           size="tiny"
           icon={<Search />}
           placeholder="Search query"
-          className="w-64"
+          className="w-56"
           value={searchFilter}
           onChange={(e) => setQueryStates({ search: e.target.value })}
         />
@@ -188,6 +197,13 @@ export const Activity = ({ live }: ActivityProps) => {
           isLoading={isPending}
           popoverClassName="w-60"
         />
+        <Button
+          variant={viewFilter === 'blocked' ? 'default' : 'dashed'}
+          iconRight={<span>{blockedQueries.length}</span>}
+          onClick={() => setQueryStates({ view: viewFilter === 'blocked' ? '' : 'blocked' })}
+        >
+          Blocked queries
+        </Button>
         {!hasNoFiltersApplied && (
           <ButtonTooltip
             variant="text"

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
@@ -150,7 +150,11 @@ export const ActivityRow = ({
 
   return (
     <>
-      <TableRow id={activity.pid.toString()} key={activity.pid} className={cn('[&>td]:py-3')}>
+      <TableRow
+        id={activity.pid.toString()}
+        key={activity.pid}
+        className={cn('[&>td]:py-3', nested && 'bg-alternative')}
+      >
         <TableCell className="relative w-[70px]">
           {selectedPid === activity.pid && (
             <div className="absolute h-full bg-brand top-0 left-0 w-1 bg-foreground-lighter" />

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
@@ -1,5 +1,5 @@
-import { Minus, MoreVertical, StopCircle } from 'lucide-react'
-import { parseAsInteger, useQueryState } from 'nuqs'
+import { ChevronRight, Minus, MoreVertical, StopCircle } from 'lucide-react'
+import { parseAsInteger, parseAsString, useQueryState } from 'nuqs'
 import { Fragment, useState } from 'react'
 import { toast } from 'sonner'
 import {
@@ -34,7 +34,12 @@ import {
   WARN_DURATION_ACTIVE_QUERY,
   WARN_DURATION_IDLE_TXN,
 } from './DatabaseConnections.constants'
-import { getBadgeVariant, getDuration } from './DatabaseConnections.utils'
+import {
+  getBadgeVariant,
+  getBlockChain,
+  getBlockingChain,
+  getDuration,
+} from './DatabaseConnections.utils'
 import { formatDuration } from '@/components/interfaces/QueryPerformance/QueryPerformance.utils'
 import { DropdownMenuItemTooltip } from '@/components/ui/DropdownMenuItemTooltip'
 import { InlineLinkClassName } from '@/components/ui/InlineLink'
@@ -44,23 +49,60 @@ import { useQueryAbortMutation } from '@/data/sql/abort-query-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { formatSql } from '@/lib/formatSql'
 
-const getBlockChain = (pid: number, activities: DatabaseActivity[]) => {
-  const chain = [pid]
-  const visited = new Set([pid])
-  let current = activities.find((x) => x.pid === pid)
+export const GroupedActivityRow = ({ activity }: { activity: DatabaseActivity }) => {
+  const { data: project } = useSelectedProjectQuery()
+  const [view] = useQueryState('view', parseAsString.withDefault(''))
 
-  while (current && current.blocked_by.length > 0) {
-    const nextPid = current.blocked_by[0]
-    if (visited.has(nextPid)) break
-    chain.push(nextPid)
-    visited.add(nextPid)
-    current = activities.find((x) => x.pid === nextPid)
-  }
+  const [expanded, setExpanded] = useState<boolean>(false)
 
-  return chain
+  const { data } = useDatabaseActivityQuery({
+    projectRef: project?.ref,
+    connectionString: project?.connectionString,
+  })
+
+  const queriesBlockedBy = getBlockingChain(activity.pid, data ?? [])
+    .map((pid) => data?.find((x) => x.pid === pid))
+    .filter((x) => x !== undefined)
+
+  return (
+    <>
+      <ActivityRow
+        activity={activity}
+        expanded={expanded}
+        onExpand={
+          queriesBlockedBy.length > 0 && view === 'blockers'
+            ? () => setExpanded((prev) => !prev)
+            : undefined
+        }
+      />
+
+      {expanded &&
+        view === 'blockers' &&
+        queriesBlockedBy.map((x, index) => (
+          <ActivityRow
+            nested
+            activity={x}
+            isLast={index === queriesBlockedBy.length - 1}
+            key={`${activity.pid}-${x.pid}`}
+          />
+        ))}
+    </>
+  )
 }
 
-export const ActivityRow = ({ activity }: { activity: DatabaseActivity }) => {
+export const ActivityRow = ({
+  activity,
+  expanded,
+  nested,
+  isLast,
+  onExpand,
+}: {
+  activity: DatabaseActivity
+  expanded?: boolean
+  nested?: boolean
+  isLast?: boolean
+  onExpand?: () => void
+}) => {
   const { data: project } = useSelectedProjectQuery()
   const [showTerminateConfirmDialog, setShowTerminateConfirmDialog] = useState(false)
   const [selectedPid, setSelectedPid] = useQueryState('pid', parseAsInteger)
@@ -108,20 +150,65 @@ export const ActivityRow = ({ activity }: { activity: DatabaseActivity }) => {
 
   return (
     <>
-      <TableRow id={activity.pid.toString()} key={activity.pid}>
+      <TableRow id={activity.pid.toString()} key={activity.pid} className={cn('[&>td]:py-3')}>
         <TableCell className="relative w-[70px]">
           {selectedPid === activity.pid && (
-            <div className="absolute h-full bg-brand top-0 left-0 w-1 bg-foreground-lighter"></div>
+            <div className="absolute h-full bg-brand top-0 left-0 w-1 bg-foreground-lighter" />
           )}
-          <Tooltip>
-            <TooltipTrigger>
-              <Badge variant={badgeVariant}>{activity.state}</Badge>
-            </TooltipTrigger>
-            {activity.state && (
-              <TooltipContent side="bottom">{QUERY_STATE_TOOLTIP[activity.state]}</TooltipContent>
+
+          {/* Absolute (not inline in the flex row) so top-0/bottom-0 ignore the cell's padding and touch the adjacent row */}
+          {nested &&
+            (isLast ? (
+              <div className="absolute left-[27px] top-0 h-1/2 w-14 border-l border-b border-stronger rounded-bl-md" />
+            ) : (
+              <>
+                <div className="absolute left-[27px] top-0 h-full border-l border-stronger" />
+                <div className="absolute left-[27px] top-1/2 w-14 border-b border-stronger" />
+              </>
+            ))}
+
+          {/* Starts right below the expand button (row's own py-3 top padding + button height), reaches bottom-0 to touch the first nested row's border */}
+          {!!onExpand && expanded && (
+            <div className="absolute left-[27px] top-[43px] bottom-0 border-l border-stronger" />
+          )}
+
+          <div className="flex items-center">
+            {nested && <div className="w-12 mr-1" />}
+
+            {!!onExpand && (
+              <Button
+                aria-label="Expand row"
+                variant="outline"
+                className="px-1 mr-3"
+                onClick={onExpand}
+                icon={<ChevronRight className={cn('transition', expanded && 'rotate-90')} />}
+              />
             )}
-          </Tooltip>
+
+            {!nested ? (
+              <Tooltip>
+                <TooltipTrigger>
+                  <Badge variant={badgeVariant}>{activity.state}</Badge>
+                </TooltipTrigger>
+                {activity.state && (
+                  <TooltipContent side="bottom">
+                    {QUERY_STATE_TOOLTIP[activity.state]}
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            ) : (
+              <Tooltip>
+                <TooltipTrigger className="translate-x-4">
+                  <Badge variant="default">Waiting</Badge>
+                </TooltipTrigger>
+                <TooltipContent side="bottom">
+                  Waiting for previous query to complete
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
         </TableCell>
+
         <TableCell className="max-w-[300px]">
           <HoverCard openDelay={250} closeDelay={100}>
             <HoverCardTrigger>

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.test.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.test.ts
@@ -210,6 +210,20 @@ describe('getConnectionMetrics', () => {
       expect(queryBlockingTheMostQueries?.count).toBe(2)
     })
 
+    it('counts a diamond-shaped block pattern once, not per incoming path', () => {
+      // root blocks both p1 and p2 directly, and both p1 and p2 block w - w must only count once
+      const activities = [
+        activity({ pid: 0, blocked_by: [] }),
+        activity({ pid: 1, blocked_by: [0] }),
+        activity({ pid: 2, blocked_by: [0] }),
+        activity({ pid: 3, blocked_by: [1, 2] }),
+      ]
+
+      const { queryBlockingTheMostQueries } = getConnectionMetrics(activities)
+      expect(queryBlockingTheMostQueries?.activity.pid).toBe(0)
+      expect(queryBlockingTheMostQueries?.count).toBe(3)
+    })
+
     it('does not warn when the top blocker is under the threshold (3)', () => {
       const activities = [
         activity({ pid: 1, blocked_by: [] }),

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.test.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getConnectionMetrics } from './DatabaseConnections.utils'
+import { getBlockChain, getBlockingChain, getConnectionMetrics } from './DatabaseConnections.utils'
 import { type DatabaseActivity } from '@/data/database/activity-query'
 
 const NOW = '2024-01-15T12:00:00Z'
@@ -193,7 +193,21 @@ describe('getConnectionMetrics', () => {
 
       const { queryBlockingTheMostQueries } = getConnectionMetrics(activities)
       expect(queryBlockingTheMostQueries?.activity.pid).toBe(1)
-      expect(queryBlockingTheMostQueries?.count).toBe(3)
+      expect(queryBlockingTheMostQueries?.count).toBe(4)
+    })
+
+    it('counts transitively - a longer block chain outweighs several short ones', () => {
+      const activities = [
+        activity({ pid: 1, blocked_by: [2] }),
+        activity({ pid: 2, blocked_by: [3] }),
+        activity({ pid: 3, blocked_by: [] }),
+        activity({ pid: 4, blocked_by: [5] }),
+        activity({ pid: 5, blocked_by: [] }),
+      ]
+
+      const { queryBlockingTheMostQueries } = getConnectionMetrics(activities)
+      expect(queryBlockingTheMostQueries?.activity.pid).toBe(3)
+      expect(queryBlockingTheMostQueries?.count).toBe(2)
     })
 
     it('does not warn when the top blocker is under the threshold (3)', () => {
@@ -215,5 +229,91 @@ describe('getConnectionMetrics', () => {
 
       expect(getConnectionMetrics(activities).warnTopBlocker).toBe(true)
     })
+  })
+})
+
+describe('getBlockChain', () => {
+  it('returns just the pid when it is not blocked', () => {
+    const activities = [activity({ pid: 1, blocked_by: [] })]
+
+    expect(getBlockChain(1, activities)).toEqual([1])
+  })
+
+  it('walks blocked_by up to the root, nearest first', () => {
+    const activities = [
+      activity({ pid: 1, blocked_by: [2] }),
+      activity({ pid: 2, blocked_by: [3] }),
+      activity({ pid: 3, blocked_by: [] }),
+    ]
+
+    expect(getBlockChain(1, activities)).toEqual([1, 2, 3])
+  })
+
+  it('only follows the first blocker when blocked by multiple pids', () => {
+    const activities = [
+      activity({ pid: 1, blocked_by: [2, 3] }),
+      activity({ pid: 2, blocked_by: [] }),
+      activity({ pid: 3, blocked_by: [] }),
+    ]
+
+    expect(getBlockChain(1, activities)).toEqual([1, 2])
+  })
+
+  it('stops rather than looping on a cycle', () => {
+    const activities = [
+      activity({ pid: 1, blocked_by: [2] }),
+      activity({ pid: 2, blocked_by: [1] }),
+    ]
+
+    expect(getBlockChain(1, activities)).toEqual([1, 2])
+  })
+
+  it('includes a blocker pid even if its own activity record is missing', () => {
+    const activities = [activity({ pid: 1, blocked_by: [99] })]
+
+    expect(getBlockChain(1, activities)).toEqual([1, 99])
+  })
+})
+
+describe('getBlockingChain', () => {
+  it('returns an empty chain when nothing is blocked by the root', () => {
+    const activities = [activity({ pid: 1, blocked_by: [] })]
+
+    expect(getBlockingChain(1, activities)).toEqual([])
+  })
+
+  it('walks forward from the root, nearest waiter first', () => {
+    const activities = [
+      activity({ pid: 1, blocked_by: [2] }),
+      activity({ pid: 2, blocked_by: [3] }),
+      activity({ pid: 3, blocked_by: [] }),
+    ]
+
+    expect(getBlockingChain(3, activities)).toEqual([2, 1])
+  })
+
+  it('does not require the root pid to have its own activity record', () => {
+    const activities = [activity({ pid: 2, blocked_by: [1] })]
+
+    expect(getBlockingChain(1, activities)).toEqual([2])
+  })
+
+  it('stops rather than looping on a cycle', () => {
+    const activities = [
+      activity({ pid: 2, blocked_by: [1] }),
+      activity({ pid: 3, blocked_by: [2] }),
+      activity({ pid: 1, blocked_by: [3] }), // would cycle back to the root
+    ]
+
+    expect(getBlockingChain(1, activities)).toEqual([2, 3])
+  })
+
+  it('only follows one branch when the root has multiple direct waiters', () => {
+    const activities = [
+      activity({ pid: 2, blocked_by: [1] }),
+      activity({ pid: 3, blocked_by: [1] }),
+    ]
+
+    expect(getBlockingChain(1, activities)).toEqual([2])
   })
 })

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.ts
@@ -79,20 +79,25 @@ const findLongestRunning = (
   }, null)
 
 // Counts every activity transitively blocked by pid - not just direct waiters, but their waiters
-// in turn - so a long chain outweighs several short ones.
-const countTransitivelyBlocked = (
-  pid: number,
-  activities: DatabaseActivity[],
-  visited: Set<number> = new Set()
-): number => {
-  if (visited.has(pid)) return 0
-  visited.add(pid)
+// in turn - so a long chain outweighs several short ones. Traverses breadth-first over a single
+// counted set so a waiter reachable through more than one blocker (a "diamond") is still only
+// counted once.
+const countTransitivelyBlocked = (pid: number, activities: DatabaseActivity[]): number => {
+  const counted = new Set<number>()
+  const queue = [pid]
 
-  const directWaiters = activities.filter((x) => x.blocked_by.includes(pid))
-  return directWaiters.reduce(
-    (count, waiter) => count + 1 + countTransitivelyBlocked(waiter.pid, activities, visited),
-    0
-  )
+  while (queue.length > 0) {
+    const currentPid = queue.shift()!
+    const directWaiters = activities.filter((x) => x.blocked_by.includes(currentPid))
+
+    for (const waiter of directWaiters) {
+      if (counted.has(waiter.pid)) continue
+      counted.add(waiter.pid)
+      queue.push(waiter.pid)
+    }
+  }
+
+  return counted.size
 }
 
 // Derives the Overview page's connection/activity metrics (and their warning thresholds) from the

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.ts
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/DatabaseConnections.utils.ts
@@ -78,6 +78,23 @@ const findLongestRunning = (
     return longest === null || duration > longest.duration ? { activity, duration } : longest
   }, null)
 
+// Counts every activity transitively blocked by pid - not just direct waiters, but their waiters
+// in turn - so a long chain outweighs several short ones.
+const countTransitivelyBlocked = (
+  pid: number,
+  activities: DatabaseActivity[],
+  visited: Set<number> = new Set()
+): number => {
+  if (visited.has(pid)) return 0
+  visited.add(pid)
+
+  const directWaiters = activities.filter((x) => x.blocked_by.includes(pid))
+  return directWaiters.reduce(
+    (count, waiter) => count + 1 + countTransitivelyBlocked(waiter.pid, activities, visited),
+    0
+  )
+}
+
 // Derives the Overview page's connection/activity metrics (and their warning thresholds) from the
 // raw pg_stat_activity rows, so the logic can be unit tested independently of the component.
 export const getConnectionMetrics = (activities: DatabaseActivity[]): ConnectionMetrics => {
@@ -113,18 +130,14 @@ export const getConnectionMetrics = (activities: DatabaseActivity[]): Connection
       longestRunningQuery?.activity.state === 'idle in transaction (aborted)') &&
       longestRunningQuery.duration >= WARN_DURATION_IDLE_TXN)
 
-  const blockingCounts = activities.reduce<Map<number, number>>((counts, activity) => {
-    activity.blocked_by.forEach((pid) => counts.set(pid, (counts.get(pid) ?? 0) + 1))
-    return counts
-  }, new Map())
-
-  const queryBlockingTheMostQueries = [...blockingCounts].reduce<{
+  const queryBlockingTheMostQueries = activities.reduce<{
     activity: DatabaseActivity
     count: number
-  } | null>((mostBlocking, [pid, count]) => {
+  } | null>((mostBlocking, activity) => {
+    const count = countTransitivelyBlocked(activity.pid, activities)
+    if (count === 0) return mostBlocking
     if (mostBlocking && count <= mostBlocking.count) return mostBlocking
-    const activity = activities.find((x) => x.pid === pid)
-    return activity ? { activity, count } : mostBlocking
+    return { activity, count }
   }, null)
 
   const warnTopBlocker = (queryBlockingTheMostQueries?.count ?? 0) >= WARN_TOP_BLOCKER
@@ -140,4 +153,38 @@ export const getConnectionMetrics = (activities: DatabaseActivity[]): Connection
     queryBlockingTheMostQueries,
     warnTopBlocker,
   }
+}
+
+export const getBlockChain = (pid: number, activities: DatabaseActivity[]) => {
+  const chain = [pid]
+  const visited = new Set([pid])
+  let current = activities.find((x) => x.pid === pid)
+
+  while (current && current.blocked_by.length > 0) {
+    const nextPid = current.blocked_by[0]
+    if (visited.has(nextPid)) break
+    chain.push(nextPid)
+    visited.add(nextPid)
+    current = activities.find((x) => x.pid === nextPid)
+  }
+
+  return chain
+}
+
+// Walks the opposite direction of getBlockChain: starting from a root blocker
+// (blocked_by.length === 0), finds the chain of pids waiting on it, nearest first
+export const getBlockingChain = (rootPid: number, activities: DatabaseActivity[]) => {
+  const chain: number[] = []
+  const visited = new Set([rootPid])
+  let currentPid = rootPid
+
+  while (true) {
+    const next = activities.find((x) => !visited.has(x.pid) && x.blocked_by.includes(currentPid))
+    if (!next) break
+    chain.push(next.pid)
+    visited.add(next.pid)
+    currentPid = next.pid
+  }
+
+  return chain
 }

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
@@ -66,6 +66,11 @@ export const Overview = ({ live }: OverviewProps) => {
     }
   )
 
+  const onSelectPid = (pid: number) => {
+    setSelectedPid(pid)
+    document.getElementById(pid.toString())?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+
   return (
     <div className="flex flex-col gap-y-4">
       <div className="flex gap-x-4">
@@ -188,11 +193,11 @@ export const Overview = ({ live }: OverviewProps) => {
                         'hover:text-foreground hover:underline',
                         'focus:text-foreground focus:underline'
                       )}
-                      onClick={() => setSelectedPid(longestBlockedQuery.activity.pid)}
+                      onClick={() => onSelectPid(longestBlockedQuery.activity.pid)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
-                          setSelectedPid(longestBlockedQuery.activity.pid)
+                          onSelectPid(longestBlockedQuery.activity.pid)
                         }
                       }}
                     >
@@ -238,11 +243,11 @@ export const Overview = ({ live }: OverviewProps) => {
                       role="button"
                       tabIndex={0}
                       className="normal-nums cursor-pointer hover:underline focus:underline"
-                      onClick={() => setSelectedPid(queryBlockingTheMostQueries.activity.pid)}
+                      onClick={() => onSelectPid(queryBlockingTheMostQueries.activity.pid)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
-                          setSelectedPid(queryBlockingTheMostQueries.activity.pid)
+                          onSelectPid(queryBlockingTheMostQueries.activity.pid)
                         }
                       }}
                     >
@@ -295,11 +300,11 @@ export const Overview = ({ live }: OverviewProps) => {
                       role="button"
                       tabIndex={0}
                       className="normal-nums hover:underline focus:underline cursor-pointer"
-                      onClick={() => setSelectedPid(longestRunningQuery.activity.pid)}
+                      onClick={() => onSelectPid(longestRunningQuery.activity.pid)}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
-                          setSelectedPid(longestRunningQuery.activity.pid)
+                          onSelectPid(longestRunningQuery.activity.pid)
                         }
                       }}
                     >

--- a/apps/studio/pages/project/[ref]/observability/connections.tsx
+++ b/apps/studio/pages/project/[ref]/observability/connections.tsx
@@ -80,7 +80,7 @@ export const DatabaseConnections: NextPageWithLayout = () => {
     <ReportPadding className="gap-y-12">
       <div className="flex items-center justify-between gap-x-4">
         <div className="flex items-center gap-x-2">
-          <h1 className="w-min">Database Connections</h1>
+          <h1 className="w-max">Database Connections</h1>
           {live && (
             <Tooltip>
               <TooltipTrigger>

--- a/apps/studio/pages/project/[ref]/observability/connections.tsx
+++ b/apps/studio/pages/project/[ref]/observability/connections.tsx
@@ -78,9 +78,9 @@ export const DatabaseConnections: NextPageWithLayout = () => {
 
   return (
     <ReportPadding className="gap-y-12">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-x-4">
         <div className="flex items-center gap-x-2">
-          <h1>Database Connections</h1>
+          <h1 className="w-min">Database Connections</h1>
           {live && (
             <Tooltip>
               <TooltipTrigger>


### PR DESCRIPTION
## Context

One for Database Connections - allow a user to view the root blocking queries

Adds an additional filter button here that toggles the view
<img width="738" height="142" alt="image" src="https://github.com/user-attachments/assets/9fea17ba-c6f6-419d-8847-47dba67fc00a" />

When toggled, will render a list of the _root_ blocking queries - these are queries that are at the end of the blocking chain (or otherwise the problematic ones causing other queries to be blocked)
<img width="964" height="420" alt="image" src="https://github.com/user-attachments/assets/5300f523-6abe-49b6-92d0-7e16bbddd291" />

Within this view - you can expand the row to view the blocking chain
<img width="950" height="335" alt="image" src="https://github.com/user-attachments/assets/bb07095a-3841-4db6-8959-ac2bb264ebf6" />

## Other changes involved
- Realised that "Top blocker" overview metric card logic is incorrect
  - Was previously naively checking the length of the `blocked_by` array, but it should be consider the nested chain length instead, so this PR fixes that
  <img width="364" height="108" alt="image" src="https://github.com/user-attachments/assets/89beccef-f6f0-43d1-9dcf-fc35958b09e5" />
- Clicking the PID if highlighted on a metric card will not scroll to the PID if it's already selected. This PR fixes that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Root blockers** view to highlight sessions that block others, with expandable blocking chains revealing related waiting activity.
* **Bug Fixes**
  * Updated blocking metrics to use **transitive** blocker counts and improved cycle protection and behavior when activity records are missing.
  * The blockers view now consistently affects state/application/role quantities, and **reset filters** clears the view.
* **Refactor / UI**
  * Improved the sessions table with grouped/nested rows, clearer waiting indicators, and more consistent expand/collapse behavior.
* **Tests**
  * Expanded coverage for blocking/waiting chain traversal and branching scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->