### PR TITLE
Joshen/fe 3967 support top for postgres in self hosted and local

### DIFF
--- a/apps/studio/components/interfaces/QueryPerformance/WithStatements/WithStatements.tsx
+++ b/apps/studio/components/interfaces/QueryPerformance/WithStatements/WithStatements.tsx
@@ -241,7 +241,11 @@ export const WithStatements = ({
           </>
         }
       />
-      <LoadingLine loading={isLoading || isRefetching || isFetchingNextPage} />
+
+      <div>
+        <LoadingLine loading={isLoading || isRefetching || isFetchingNextPage} />
+      </div>
+
       <QueryPerformanceGrid
         aggregatedData={processedData}
         isLoading={isLoading}

--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -29,7 +29,6 @@ import {
 
 import { Shortcut } from '../ui/Shortcut'
 import { Route } from '../ui/ui.types'
-import { useUnifiedLogsPreview } from './App/FeaturePreview/FeaturePreviewContext'
 import {
   generateProductRoutes,
   generateSettingsRoutes,

--- a/apps/studio/components/interfaces/Sidebar.tsx
+++ b/apps/studio/components/interfaces/Sidebar.tsx
@@ -31,10 +31,10 @@ import { Shortcut } from '../ui/Shortcut'
 import { Route } from '../ui/ui.types'
 import { useUnifiedLogsPreview } from './App/FeaturePreview/FeaturePreviewContext'
 import {
-  generateOtherRoutes,
   generateProductRoutes,
   generateSettingsRoutes,
   generateToolRoutes,
+  useGenerateOtherRoutes,
 } from '@/components/layouts/Navigation/NavigationBar/NavigationBar.utils'
 import { ProjectIndexPageLink } from '@/data/prefetchers/project.$ref'
 import { useHideSidebar } from '@/hooks/misc/useHideSidebar'
@@ -252,10 +252,6 @@ const ProjectLinks = () => {
   const { ref } = useParams()
   const { data: project, isPending: isProjectPending } = useSelectedProjectQuery()
   const { securityLints, errorLints } = useLints()
-  const showReports = useIsFeatureEnabled('reports:all')
-  const showLogs = useIsFeatureEnabled('logs:all')
-
-  const { isEnabled: isUnifiedLogsEnabled } = useUnifiedLogsPreview()
 
   const activeRoute = router.pathname.split('/')[3]
 
@@ -281,11 +277,7 @@ const ProjectLinks = () => {
     realtime: realtimeEnabled,
     authOverviewPage: authOverviewPageEnabled,
   })
-  const otherRoutes = generateOtherRoutes(ref, project, {
-    unifiedLogs: isUnifiedLogsEnabled,
-    showReports,
-    showLogs,
-  })
+  const otherRoutes = useGenerateOtherRoutes()
   const settingsRoutes = generateSettingsRoutes(ref)
 
   return (

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.test.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.test.tsx
@@ -102,75 +102,54 @@ describe('generateProductRoutes', () => {
 
 describe('generateOtherRoutes', () => {
   it('always includes advisors, logs, and integrations', () => {
-    const routes = generateOtherRoutes(REF, activeProject, { isPlatform: true })
+    const routes = generateOtherRoutes(REF, activeProject)
     expect(keys(routes)).toContain('advisors')
     expect(keys(routes)).toContain('logs')
     expect(keys(routes)).toContain('integrations')
   })
 
-  it('includes observability on platform when reports are enabled', () => {
-    const routes = generateOtherRoutes(REF, activeProject, {
-      isPlatform: true,
-      showReports: true,
-    })
+  it('includes observability when reports are enabled', () => {
+    const routes = generateOtherRoutes(REF, activeProject, { showReports: true })
     expect(keys(routes)).toContain('observability')
   })
 
-  it('excludes observability on platform when reports are disabled', () => {
-    const routes = generateOtherRoutes(REF, activeProject, {
-      isPlatform: true,
-      showReports: false,
-    })
+  it('excludes observability when reports are disabled', () => {
+    const routes = generateOtherRoutes(REF, activeProject, { showReports: false })
     expect(keys(routes)).not.toContain('observability')
   })
 
-  it('excludes observability in self-hosted mode even when reports are enabled', () => {
-    const routes = generateOtherRoutes(REF, activeProject, {
-      isPlatform: false,
-      showReports: true,
-    })
-    expect(keys(routes)).not.toContain('observability')
-  })
-
-  it('excludes observability in self-hosted mode when reports are disabled', () => {
-    const routes = generateOtherRoutes(REF, activeProject, {
-      isPlatform: false,
-      showReports: false,
-    })
-    expect(keys(routes)).not.toContain('observability')
+  it('links observability to the query performance page in self-hosted mode', () => {
+    // NEXT_PUBLIC_IS_PLATFORM is false in .env.test, so IS_PLATFORM is false here
+    const routes = generateOtherRoutes(REF, activeProject, { showReports: true })
+    const observabilityRoute = routes.find((r) => r.key === 'observability')
+    expect(observabilityRoute?.link).toBe(`/project/${REF}/query-performance`)
   })
 
   it('does not include API Docs nav item', () => {
-    const routes = generateOtherRoutes(REF, activeProject, { isPlatform: true })
+    const routes = generateOtherRoutes(REF, activeProject)
     expect(keys(routes)).not.toContain('api')
   })
 
   it('links logs to unified logs page when unifiedLogs is enabled', () => {
-    const routes = generateOtherRoutes(REF, activeProject, {
-      isPlatform: true,
-      unifiedLogs: true,
-    })
+    const routes = generateOtherRoutes(REF, activeProject, { unifiedLogs: true })
     const logsRoute = routes.find((r) => r.key === 'logs')
     expect(logsRoute?.link).toBe(`/project/${REF}/logs`)
   })
 
   it('links logs to explorer page by default', () => {
-    const routes = generateOtherRoutes(REF, activeProject, { isPlatform: true })
+    const routes = generateOtherRoutes(REF, activeProject)
     const logsRoute = routes.find((r) => r.key === 'logs')
     expect(logsRoute?.link).toBe(`/project/${REF}/logs/explorer`)
   })
 
   it('points links to building URL when project is building', () => {
-    const routes = generateOtherRoutes(REF, buildingProject, {
-      isPlatform: true,
-      showReports: true,
-    })
+    const routes = generateOtherRoutes(REF, buildingProject, { showReports: true })
     const observabilityRoute = routes.find((r) => r.key === 'observability')
     expect(observabilityRoute?.link).toBe(`/project/${REF}`)
   })
 
   it('marks routes as disabled when project is not active', () => {
-    const routes = generateOtherRoutes(REF, inactiveProject, { isPlatform: true })
+    const routes = generateOtherRoutes(REF, inactiveProject)
     const advisorsRoute = routes.find((r) => r.key === 'advisors')
     expect(advisorsRoute?.disabled).toBe(true)
   })

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -1,10 +1,14 @@
+import { useParams } from 'common'
 import { Auth, Database, EdgeFunctions, Realtime, SqlEditor, Storage, TableEditor } from 'icons'
 import { Blocks, Lightbulb, List, Settings, Telescope } from 'lucide-react'
 
+import { useUnifiedLogsPreview } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { ICON_SIZE, ICON_STROKE_WIDTH } from '@/components/interfaces/Sidebar'
 import type { Route } from '@/components/ui/ui.types'
 import { EditorIndexPageLink } from '@/data/prefetchers/project.$ref.editor'
 import type { Project } from '@/data/projects/project-detail-query'
+import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
+import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { IS_PLATFORM, PROJECT_STATUS } from '@/lib/constants'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 
@@ -159,6 +163,7 @@ export const generateOtherRoutes = (
   const unifiedLogsEnabled = features?.unifiedLogs ?? false
   const reportsEnabled = features?.showReports ?? true
   const logsEnabled = features?.showLogs ?? true
+
   return [
     {
       key: 'advisors',
@@ -204,6 +209,22 @@ export const generateOtherRoutes = (
       shortcutId: SHORTCUT_IDS.NAV_INTEGRATIONS,
     },
   ]
+}
+
+// [Joshen] Main hook to consume as it standardizes the generation of the menu items
+export const useGenerateOtherRoutes = (): Route[] => {
+  const { ref } = useParams()
+  const { data: project } = useSelectedProjectQuery()
+  const { isEnabled: unifiedLogsEnabled } = useUnifiedLogsPreview()
+  const reportsEnabled = useIsFeatureEnabled('reports:all')
+  const logsEnabled = useIsFeatureEnabled('logs:all')
+
+  return generateOtherRoutes(ref, project, {
+    isPlatform: IS_PLATFORM,
+    unifiedLogs: unifiedLogsEnabled,
+    showReports: reportsEnabled,
+    showLogs: logsEnabled,
+  })
 }
 
 export const generateSettingsRoutes = (ref?: string): Route[] => {

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -172,7 +172,6 @@ export const generateOtherRoutes = (
       link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/advisors/security`),
       shortcutId: SHORTCUT_IDS.NAV_ADVISORS,
     },
-    // Observability is only available on the platform, not for self-hosted/CLI
     ...(reportsEnabled
       ? [
           {

--- a/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
+++ b/apps/studio/components/layouts/Navigation/NavigationBar/NavigationBar.utils.tsx
@@ -159,7 +159,6 @@ export const generateOtherRoutes = (
 ): Route[] => {
   const { isProjectActive, isProjectBuilding, buildingUrl } = getRouteContext(ref, project)
 
-  const isPlatform = features?.isPlatform ?? IS_PLATFORM
   const unifiedLogsEnabled = features?.unifiedLogs ?? false
   const reportsEnabled = features?.showReports ?? true
   const logsEnabled = features?.showLogs ?? true
@@ -174,14 +173,20 @@ export const generateOtherRoutes = (
       shortcutId: SHORTCUT_IDS.NAV_ADVISORS,
     },
     // Observability is only available on the platform, not for self-hosted/CLI
-    ...(isPlatform && reportsEnabled
+    ...(reportsEnabled
       ? [
           {
             key: 'observability',
             label: 'Observability',
             disabled: !isProjectActive,
             icon: <Telescope size={ICON_SIZE} strokeWidth={ICON_STROKE_WIDTH} />,
-            link: ref && (isProjectBuilding ? buildingUrl : `/project/${ref}/observability`),
+            link:
+              ref &&
+              (isProjectBuilding
+                ? buildingUrl
+                : IS_PLATFORM
+                  ? `/project/${ref}/observability`
+                  : `/project/${ref}/query-performance`),
             shortcutId: SHORTCUT_IDS.NAV_OBSERVABILITY,
           },
         ]
@@ -220,7 +225,6 @@ export const useGenerateOtherRoutes = (): Route[] => {
   const logsEnabled = useIsFeatureEnabled('logs:all')
 
   return generateOtherRoutes(ref, project, {
-    isPlatform: IS_PLATFORM,
     unifiedLogs: unifiedLogsEnabled,
     showReports: reportsEnabled,
     showLogs: logsEnabled,

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/MobileMenuContent/MobileMenuContent.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/MobileMenuContent/MobileMenuContent.tsx
@@ -12,7 +12,6 @@ import { resolveSectionDisplay } from './MobileMenuContent.utils'
 import { getProductMenuComponent } from './mobileProductMenuRegistry'
 import { TopLevelRouteItem } from './TopLevelRouteItem'
 import { routeHasSubmenu, useMobileMenuNavigation } from './useMobileMenuNavigation'
-import { useUnifiedLogsPreview } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { ICON_SIZE, ICON_STROKE_WIDTH } from '@/components/interfaces/Sidebar'
 import {
   generateProductRoutes,

--- a/apps/studio/components/layouts/ProjectLayout/LayoutHeader/MobileMenuContent/MobileMenuContent.tsx
+++ b/apps/studio/components/layouts/ProjectLayout/LayoutHeader/MobileMenuContent/MobileMenuContent.tsx
@@ -15,10 +15,10 @@ import { routeHasSubmenu, useMobileMenuNavigation } from './useMobileMenuNavigat
 import { useUnifiedLogsPreview } from '@/components/interfaces/App/FeaturePreview/FeaturePreviewContext'
 import { ICON_SIZE, ICON_STROKE_WIDTH } from '@/components/interfaces/Sidebar'
 import {
-  generateOtherRoutes,
   generateProductRoutes,
   generateSettingsRoutes,
   generateToolRoutes,
+  useGenerateOtherRoutes,
 } from '@/components/layouts/Navigation/NavigationBar/NavigationBar.utils'
 import type { Route } from '@/components/ui/ui.types'
 import { useIsFeatureEnabled } from '@/hooks/misc/useIsFeatureEnabled'
@@ -63,8 +63,6 @@ export function MobileMenuContent({
     'realtime:all',
   ])
   const authOverviewPageEnabled = useFlag('authOverviewPage')
-  const showReports = useIsFeatureEnabled('reports:all')
-  const { isEnabled: isUnifiedLogsEnabled } = useUnifiedLogsPreview()
 
   const toolRoutes = useMemo(() => generateToolRoutes(ref, project), [ref, project])
   const productRoutes = useMemo(
@@ -86,14 +84,7 @@ export function MobileMenuContent({
       authOverviewPageEnabled,
     ]
   )
-  const otherRoutes = useMemo(
-    () =>
-      generateOtherRoutes(ref, project, {
-        unifiedLogs: isUnifiedLogsEnabled,
-        showReports,
-      }),
-    [ref, project, isUnifiedLogsEnabled, showReports]
-  )
+  const otherRoutes = useGenerateOtherRoutes()
   const settingsRoutes = useMemo(() => generateSettingsRoutes(ref), [ref])
 
   const homeRoute: Route = useMemo(

--- a/apps/studio/pages/project/[ref]/observability/query-performance.tsx
+++ b/apps/studio/pages/project/[ref]/observability/query-performance.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'common'
+import { IS_PLATFORM, useParams } from 'common'
 import { parseAsArrayOf, parseAsInteger, parseAsJson, parseAsString, useQueryStates } from 'nuqs'
 import { Admonition } from 'ui-patterns/admonition'
 
@@ -93,7 +93,7 @@ const QueryPerformanceReport: NextPageWithLayout = () => {
         <h3 className="text-foreground text-xl prose">{REPORT_TITLE}</h3>
         <div className="flex items-center gap-2 flex-wrap">
           <DocsButton href={OBSERVABILITY_DOCS_HREFS.queryPerformance} topic={REPORT_TITLE} />
-          <DatabaseSelector />
+          {IS_PLATFORM && <DatabaseSelector />}
         </div>
       </div>
       <QueryPerformance


### PR DESCRIPTION
## Context

Allow self-host / local dashboard to access the "Observability" pages
Currently only Query Performance will be accessible - eventually once Database Connections is publicly ready, it'll also be accessible here too

<img width="518" height="312" alt="image" src="https://github.com/user-attachments/assets/18e5f6c7-ca77-4e90-81ec-c303bd31dc33" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation, sidebar, and mobile menus now consistently display **Observability** and **Logs** based on enabled features, including the unified logs preview.
  * **Observability** destinations now adapt to platform and settings so users land on the correct Query Performance view.
* **Bug Fixes**
  * Improved Query Performance loading layout for a smoother loading experience.
  * Database selection is now shown only on supported platform environments.
* **Tests**
  * Updated navigation/menu tests to match the new routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->