### PR TITLE
Docs/rls grant truncate fixes

### DIFF
--- a/apps/docs/content/guides/database/postgres/row-level-security.mdx
+++ b/apps/docs/content/guides/database/postgres/row-level-security.mdx
@@ -15,9 +15,10 @@ Supabase allows convenient and secure data access from the browser, as long as y
 
 RLS _must_ always be enabled on any tables stored in an exposed schema. By default, this is the `public` schema.
 
-RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create one in raw SQL or with the SQL editor, remember to enable RLS yourself and grant only the permissions each Postgres role needs.
+RLS is enabled by default on tables created with the Table Editor in the dashboard. If you create one in raw SQL or with the SQL editor, remember to enable RLS yourself and explicitly revoke default permissions before granting only the permissions each Postgres role needs.
 
 ```sql
+REVOKE ALL ON TABLE <schema_name>.<table_name> FROM anon, authenticated;
 GRANT SELECT ON <schema_name>.<table_name> TO anon;
 GRANT SELECT, INSERT, UPDATE, DELETE ON <schema_name>.<table_name> TO authenticated;
 GRANT SELECT, INSERT, UPDATE, DELETE ON <schema_name>.<table_name> TO service_role;
@@ -209,7 +210,7 @@ Say you have a table called `profiles` in the public schema and you only want us
 ```sql
 -- 1. Create table
 create table profiles (
-  id uuid primary key,
+  id uuid uuid primary key,
   user_id uuid references auth.users,
   avatar_url text
 );

--- a/apps/docs/content/guides/deployment/going-into-prod.mdx
+++ b/apps/docs/content/guides/deployment/going-into-prod.mdx
@@ -26,6 +26,7 @@ Check and review issues in your database using [Security Advisor](/dashboard/pro
   - Go to the [**Database > Publications**](/dashboard/project/_/database/publications) section of the Supabase Dashboard to manage replication tables.
 - Turn on [SSL Enforcement](/docs/guides/platform/ssl-enforcement) from the [**Database > Settings > SSL Configuration**](/dashboard/project/_/database/settings#ssl-configuration) section of the dashboard.
 - Enable [Network Restrictions](/docs/guides/platform/network-restrictions) for the database from the [**Database > Settings > Network Restrictions**](/dashboard/project/_/database/settings#network-restrictions) section of the dashboard.
+- Review `information_schema.role_table_grants` for `anon`/`authenticated` roles to understand default privileges, and note that RLS does not cover `TRUNCATE` operations.
 - Ensure that you protect your Supabase Account with multi-factor authentication (MFA).
   - If using a GitHub sign-in, [enable 2FA on GitHub](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication).
   - Since your GitHub account gives you administrative rights to your Supabase org, you should protect it with a strong password and 2FA using a U2F key or a TOTP app.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES/NO

## What kind of change does this PR introduce?

Bug fix, feature, docs update, ...

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that Row Level Security is enabled by default for tables created in the dashboard.
  - Added guidance to revoke default permissions before assigning role-specific access.
  - Updated SQL examples and security checklist guidance, including reviewing role grants and noting that RLS does not protect `TRUNCATE` operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->