### PR TITLE
docs(auth): correct audit log format and actions reference

### DIFF
--- a/apps/docs/content/guides/auth/audit-logs.mdx
+++ b/apps/docs/content/guides/auth/audit-logs.mdx
@@ -40,20 +40,51 @@ Disabling Postgres storage reduces your database storage costs. Audit logs will 
 
 ## Log format
 
-Audit logs contain detailed information about each authentication event:
+The two storage options record slightly different information, so the shape of an event depends on where you read it from.
+
+### In Postgres
+
+Each event is one row in `auth.audit_log_entries`, with the event details in the `payload` JSON column:
+
+| Column       | Description                                              |
+| ------------ | -------------------------------------------------------- |
+| `id`         | Unique ID of the audit log entry                         |
+| `payload`    | Event details (see below)                                |
+| `ip_address` | IP address the request came from, or `''` if unavailable |
+| `created_at` | When the event was recorded                              |
 
 ```json
 {
-  "timestamp": "2025-08-01T10:30:00Z",
-  "user_id": "uuid",
+  "actor_id": "8a3f1a2e-1c4b-4f0e-9a3d-6b2c5d7e8f90",
+  "actor_username": "user@example.com",
+  "actor_via_sso": false,
   "action": "user_signedup",
-  "ip_address": "192.168.1.1",
-  "user_agent": "Mozilla/5.0...",
-  "metadata": {
+  "log_type": "team",
+  "traits": {
     "provider": "email"
   }
 }
 ```
+
+`actor_name` is included when the user has a `full_name` in their user metadata, and `traits` is included when the event carries extra context such as the provider used.
+
+<Admonition type="note">
+
+`ip_address` is a column on `auth.audit_log_entries`, not a field inside `payload`. The user agent is not stored in Postgres — if you need to associate a device with a user, `auth.sessions` has both `ip` and `user_agent`.
+
+</Admonition>
+
+### In dashboard logs
+
+Events sent to external log storage carry the same fields as `payload`, plus:
+
+| Field          | Description                                  |
+| -------------- | -------------------------------------------- |
+| `audit_log_id` | Matches `auth.audit_log_entries.id`          |
+| `created_at`   | When the event was recorded                  |
+| `ip_address`   | IP address the request came from             |
+| `user_agent`   | User agent of the request, when one was sent |
+| `request_id`   | ID of the request that produced the event    |
 
 ### Log actions reference
 
@@ -73,16 +104,16 @@ Audit logs contain detailed information about each authentication event:
 | `user_updated_password`         | Password change completed               |
 | `token_revoked`                 | Refresh token revoked                   |
 | `token_refreshed`               | Refresh token used to obtain new tokens |
-| `generate_recovery_codes`       | MFA recovery codes generated            |
 | `factor_in_progress`            | MFA factor enrollment started           |
 | `factor_unenrolled`             | MFA factor removed                      |
 | `challenge_created`             | MFA challenge initiated                 |
 | `verification_attempted`        | MFA verification attempt                |
 | `factor_deleted`                | MFA factor deleted                      |
-| `recovery_codes_deleted`        | MFA recovery codes deleted              |
 | `factor_updated`                | MFA factor settings updated             |
-| `mfa_code_login`                | Login with MFA code                     |
 | `identity_unlinked`             | An identity unlinked from account       |
+| `passkey_created`               | Passkey registered                      |
+| `passkey_updated`               | Passkey updated                         |
+| `passkey_deleted`               | Passkey removed                         |
 
 ## Limitations
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix.

## What is the current behavior?

Closes #42997.

The **Log format** section of `guides/auth/audit-logs` shows an example that doesn't match anything Auth writes:

```json
{
  "timestamp": "2025-08-01T10:30:00Z",
  "user_id": "uuid",
  "action": "user_signedup",
  "ip_address": "192.168.1.1",
  "user_agent": "Mozilla/5.0...",
  "metadata": { "provider": "email" }
}
```

Checking against [`internal/models/audit_log_entry.go`](https://github.com/supabase/auth/blob/master/internal/models/audit_log_entry.go):

- The Postgres row is `{ id, payload, ip_address, created_at }`. Event details live inside the `payload` JSON column — the example presents everything as one flat object.
- The payload keys are `actor_id`, `actor_username`, `actor_via_sso`, `action`, `log_type`, and optionally `actor_name` / `traits`. The doc shows `user_id`, `metadata`, and `timestamp`, none of which exist.
- `ip_address` **is** recorded, but as a column on `auth.audit_log_entries`, not a payload field — which is why the issue reporter couldn't find it. `user_agent` is genuinely not stored in Postgres; it only appears in the external log stream.

The actions reference is also out of sync with `AuditAction`: `generate_recovery_codes`, `recovery_codes_deleted` and `mfa_code_login` aren't defined anywhere in the Auth repo, while `passkey_created`, `passkey_updated` and `passkey_deleted` (added in `20260302000000_add_passkeys`) are missing.

## What is the new behavior?

- Split **Log format** into **In Postgres** and **In dashboard logs**, since the two storage options genuinely record different fields.
- Document the actual `auth.audit_log_entries` columns and the real `payload` shape.
- Add a note clarifying that `ip_address` is a column rather than a payload field, and pointing readers at `auth.sessions` (`ip`, `user_agent`) for device information.
- List the extra fields the dashboard log entries carry (`audit_log_id`, `created_at`, `ip_address`, `user_agent`, `request_id`).
- Correct the actions reference to match the `AuditAction` constants.

## Additional context

Docs-only change; no code paths touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified differences between audit log data retrieved from Postgres and external log storage.
  * Added examples of Postgres audit log fields and payload structure.
  * Documented additional fields available through dashboard logs.
  * Updated the action reference with passkey-related events and revised MFA entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->