### PR TITLE
docs(rbac): enable RLS on the RBAC tables

### DIFF
--- a/apps/docs/content/guides/api/custom-claims-and-role-based-access-control-rbac.mdx
+++ b/apps/docs/content/guides/api/custom-claims-and-role-based-access-control-rbac.mdx
@@ -51,7 +51,19 @@ create table public.role_permissions (
   unique (role, permission)
 );
 comment on table public.role_permissions is 'Application permissions for each role.';
+
+-- Secure the tables
+alter table public.user_roles enable row level security;
+alter table public.role_permissions enable row level security;
 ```
+
+<Admonition type="caution">
+
+Both tables decide what every user is allowed to do, so they need Row Level Security. Tables created in the `public` schema carry default privileges for `anon` and `authenticated`, so without `enable row level security` any signed-in user can read and write them — including inserting a row that grants themselves the `admin` role.
+
+Neither table gets a policy for `anon` or `authenticated`, because nothing should read them directly. The `authorize` function below is `security definer`, so it queries `role_permissions` on the caller's behalf without exposing it.
+
+</Admonition>
 
 <Admonition type="note">
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Documentation fix (security footgun).

## What is the current behavior?

Closes #36816.

The RBAC guide's schema block creates `public.user_roles` and `public.role_permissions` but never enables Row Level Security on either.

Because both tables are created in the `public` schema, they inherit the default privileges granted to `anon` and `authenticated`. A reader who follows the guide as written ends up with the two tables that decide their entire authorization model readable *and writable* by any signed-in user — a user can insert `(their_uid, 'admin')` into `user_roles`, or add a permission to `role_permissions`, and the auth hook will happily mint them the claim on next token issue.

It also leaves the guide internally inconsistent: the auth hook section creates

```sql
create policy "Allow auth admin to read user roles" ON public.user_roles ...
```

which has no effect at all while RLS is disabled on that table.

The [Slack Clone migration](https://github.com/supabase/supabase/blob/master/examples/slack-clone/nextjs-slack-clone/supabase/migrations/20240214102356_init.sql#L74-L79) that this guide is explicitly based on does have both statements — they just didn't make it into the doc.

## What is the new behavior?

Adds the two missing statements to the schema block, matching the example app:

```sql
-- Secure the tables
alter table public.user_roles enable row level security;
alter table public.role_permissions enable row level security;
```

Plus a `caution` admonition explaining why this matters and why neither table gets an `anon`/`authenticated` policy — `authorize()` is `security definer`, so it reads `role_permissions` on the caller's behalf without the caller needing access.

## Additional context

Docs-only change. The `security definer` `authorize()` function and the `supabase_auth_admin` policy later in the guide continue to work; the latter in fact only starts working once RLS is enabled.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SQL guidance for enabling Row Level Security on role and permission tables.
  * Clarified the security risks of leaving these tables unprotected, including unauthorized role changes.
  * Explained why direct access policies are not provided and how the authorization function accesses permissions securely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->