### PR TITLE
fix(studio): don't let comments hide an UPDATE without a WHERE

### DIFF
--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.test.ts
@@ -681,6 +681,59 @@ describe('SQLEditor.utils:updateWithoutWhere', () => {
     expect(match).toBe(false)
   })
 
+  it('catches update without a where clause preceded by a line comment', () => {
+    const match = isUpdateWithoutWhere(stripIndent`
+      -- deactivate everyone
+      UPDATE messages SET id = 1;
+    `)
+
+    expect(match).toBe(true)
+  })
+
+  it('catches update without a where clause preceded by a block comment', () => {
+    const match = isUpdateWithoutWhere(`/* cleanup */ UPDATE messages SET id = 1;`)
+    expect(match).toBe(true)
+  })
+
+  it('catches update where the only "where" sits inside a trailing line comment', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET id = 1 -- where id = 2\n;`)
+    expect(match).toBe(true)
+  })
+
+  it('catches update where the only "where" sits inside a block comment', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET id = 1 /* where id = 2 */;`)
+    expect(match).toBe(true)
+  })
+
+  it('does not flag update with a real where clause and a comment mentioning where', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET id = 1 WHERE id = 2; -- where`)
+    expect(match).toBe(false)
+  })
+
+  it('does not flag update with a real where clause when a string literal contains a semicolon', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET name = 'a;b' WHERE id = 1;`)
+    expect(match).toBe(false)
+  })
+
+  it('catches update without a where clause when a string literal contains a semicolon', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET name = 'a;b';`)
+    expect(match).toBe(true)
+  })
+
+  it('does not treat a double dash inside a string literal as a comment', () => {
+    const match = isUpdateWithoutWhere(`UPDATE messages SET name = 'a--b' WHERE id = 1;`)
+    expect(match).toBe(false)
+  })
+
+  it('does not treat a quote inside a comment as opening a string literal', () => {
+    const match = isUpdateWithoutWhere(stripIndent`
+      -- don't touch this
+      UPDATE messages SET id = 1;
+    `)
+
+    expect(match).toBe(true)
+  })
+
   it('contains both an update query and a delete query, triggers destructive', () => {
     const match = checkDestructiveQuery(stripIndent`
       delete from countries; update countries set name = 'hello';

--- a/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
+++ b/apps/studio/components/interfaces/SQLEditor/SQLEditor.utils.ts
@@ -110,22 +110,39 @@ export function checkDestructiveQuery(sql: string) {
   return destructiveSqlRegex.some((regex) => regex.test(cleanedSql))
 }
 
-// Replace the contents of single-quoted string literals and double-quoted
-// identifiers with empty quotes, so a downstream `where` scan can't be fooled
-// by tokens like `UPDATE "where table" SET ...` or `SET name = 'where x'`.
-// Postgres uses doubled quotes to escape, so `''` and `""` are matched as
-// part of the same span rather than terminating it.
-const stripQuotedSpans = (sql: string) =>
-  sql.replace(/'(?:''|[^'])*'/g, "''").replace(/"(?:""|[^"])*"/g, '""')
+// Blank out the *contents* of string literals, quoted identifiers and comments
+// so that scanning for SQL structure can't be fooled by text that only looks
+// like syntax. Everything else — including the quote delimiters and every
+// character position — is left untouched, so `UPDATE "my table" SET ...` still
+// parses as an update on a quoted identifier.
+//
+// The alternation runs as a single left-to-right pass, which is what gives the
+// right precedence: a `--` inside a string literal is part of the literal, and
+// a quote inside a comment doesn't open a literal. Postgres escapes a quote by
+// doubling it, so `''` and `""` continue a span rather than ending it.
+//
+// Comments collapse to spaces (newlines kept, so statements stay on their own
+// lines) rather than being deleted, because deleting them would shift the rest
+// of the SQL and an unterminated literal would silently swallow real syntax.
+const maskLiteralsAndComments = (sql: string) =>
+  sql.replace(/'(?:''|[^'])*'|"(?:""|[^"])*"|--[^\r\n]*|\/\*[\s\S]*?\*\//g, (span) => {
+    if (span.startsWith('--') || span.startsWith('/*')) return span.replace(/[^\r\n]/g, ' ')
+    const quote = span[0]
+    return `${quote}${'x'.repeat(span.length - 2)}${quote}`
+  })
 
 // Function to check for UPDATE queries without WHERE clause
 export function isUpdateWithoutWhere(sql: string): boolean {
-  const updateStatements = sql
+  // Split and match on the masked SQL: a `;` inside a literal must not end a
+  // statement, and a `where` inside a literal or a comment must not count as a
+  // where clause. Masking preserves length and delimiters, so the statement
+  // shape the regex sees is the real one.
+  const masked = maskLiteralsAndComments(sql)
+  const updateStatements = masked
     .split(';')
     .filter((statement) => statement.trim().toLowerCase().startsWith('update'))
   return updateStatements.some(
-    (statement) =>
-      updateWithoutWhereRegex.test(statement) && !/where\s/i.test(stripQuotedSpans(statement))
+    (statement) => updateWithoutWhereRegex.test(statement) && !/where\s/i.test(statement)
   )
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`isUpdateWithoutWhere` backs the "UPDATE without a WHERE clause" confirmation modal — `analyzeQueryIssues` → `hasBlockingIssues` → the warning gate in `useSqlEditorExecution`. It currently splits the **raw** SQL on `;` and only masks quoted spans for the `where` scan:

```ts
const updateStatements = sql
  .split(';')
  .filter((statement) => statement.trim().toLowerCase().startsWith('update'))
return updateStatements.some(
  (statement) =>
    updateWithoutWhereRegex.test(statement) && !/where\s/i.test(stripQuotedSpans(statement))
)
```

Comments are never stripped — unlike its two siblings `checkDestructiveQuery` and `checkAlterDatabaseConnection`, which both call `removeCommentsFromSql` first — and the `;` split happens before literals are masked. Four consequences, **three of which silently skip the warning** and run a full-table UPDATE with no confirmation:

```sql
-- deactivate everyone
update users set is_active = false;
```
The statement now begins with `--`, so `startsWith('update')` is false and it is filtered out before any check runs. Not flagged.

```sql
/* cleanup */ update users set is_active = false;
```
Same, via a block comment. Not flagged.

```sql
update users set is_active = false -- where id = 1
;
```
The word `where` inside the comment satisfies the `where\s` scan. Not flagged.

```sql
update users set bio = 'a;b' where id = 1;
```
The `;` inside the string literal splits the statement, so the real `WHERE` ends up in a different chunk. **False positive** — a perfectly safe query gets the destructive-query modal.

The existing tests cover quoted identifiers and string literals containing `where` (`UPDATE "where table" ...`, `SET name = 'where x'`), but nothing about comments — which is what suggests this was an oversight rather than a deliberate trade-off.

## What is the new behavior?

Replaces `stripQuotedSpans` with `maskLiteralsAndComments`, which blanks the *contents* of string literals, quoted identifiers and comments in a single left-to-right pass while preserving length and delimiters, then runs the split, the regex match and the `where` scan all on the masked SQL.

The single pass is what gives the correct precedence: a `--` inside a string literal stays part of the literal, and a quote inside a comment doesn't open a literal. Comments collapse to spaces (newlines preserved) rather than being deleted, so nothing shifts and an unterminated literal can't swallow real syntax. Delimiters are kept so `UPDATE "my table" SET ...` still matches `updateWithoutWhereRegex` as a quoted identifier.

Note this deliberately does *not* reuse `removeCommentsFromSql` — that helper deletes `--.*$` unconditionally, so it would corrupt a literal like `'a--b'` and reintroduce a false positive in the other direction.

## Additional context

Added 9 regression tests covering both directions (missed warnings and false alarms); **6 of them fail on `master`**.

```
# before  (fix reverted, tests kept)
Tests  6 failed | 199 passed (205)

# after
✓ components/interfaces/SQLEditor/SQLEditor.utils.test.ts (205 tests)
Test Files  9 passed (9)
     Tests  356 passed (356)
```

The full `components/interfaces/SQLEditor` + `lib/helpers` suites pass, `tsgo --noEmit` is clean, and prettier reports no changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of SQL `UPDATE` statements missing a `WHERE` clause.
  * Prevented comments, quoted text, and string contents from being incorrectly interpreted as SQL clauses.
  * Reduced false warnings when valid `WHERE` clauses are present, including when comments contain similar text.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->