### PR TITLE
chore(docs): add Chris Opland to humans.txt

### DIFF
--- a/apps/docs/public/humans.txt
+++ b/apps/docs/public/humans.txt
@@ -59,6 +59,7 @@ Chris Chapman (Chappie)
 Chris Copplestone
 Chris Gwilliams
 Chris Martin
+Chris Opland
 Chris Stockton
 Chris Ward
 Christian Funkhouser


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Add "Chris Opland" to humans.txt

## What is the current behavior?

My name is not in the humans.txt

## What is the new behavior?

My name IS in humans.txt

## Additional context

Add any other context or screenshots.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Chris Opland to the project contributors list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->