### PR TITLE
feat(studio): log date range domain + session logRange state

### DIFF
--- a/apps/studio/CLAUDE.md
+++ b/apps/studio/CLAUDE.md
@@ -69,6 +69,7 @@ Older Studio code predates some of these conventions. For new or modified code, 
 - **Memoization is not the default**: `useMemo`/`useCallback` only for measured expense or referential stability a memoized child depends on.
 - **TypeScript**: avoid `as` casts — where external data enters, parse it with zod (`schema.parse`/`safeParse`) instead. Model multi-state values as discriminated unions (`{ status: 'success'; data: T } | { status: 'error'; error: Error }`) rather than independent boolean flags.
 - **Naming**: prop callbacks are `onX`, internal handlers are `handleX`. Custom hooks return objects, not tuples.
+- **Refactoring**: when you move or extract code into a new module, update every importer to point at the new location directly — do **not** leave a re-export shim in the old file "for backward compatibility." It's a one-line import change per consumer, and keeping shims around makes the codebase messy and the true source of a symbol ambiguous.
 
 ## Defaults that differ here
 

--- a/apps/studio/components/interfaces/SQLEditor/querySource.test.ts
+++ b/apps/studio/components/interfaces/SQLEditor/querySource.test.ts
@@ -1,6 +1,39 @@
-import { describe, expect, it } from 'vitest'
+import dayjs from 'dayjs'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { getSnippetSource } from './querySource'
+import {
+  datePickerValueToLogDateRange,
+  DEFAULT_LOG_DATE_RANGE,
+  getSnippetSource,
+  isoDateTimeString,
+  logDateRangeToDatePickerValue,
+  resolveLogRunRange,
+  type LogDateRange,
+} from './querySource'
+import {
+  EXPLORER_DATEPICKER_HELPERS,
+  getDefaultHelper,
+} from '@/components/interfaces/Settings/Logs/Logs.constants'
+import { generateHelpersFromInput } from '@/components/interfaces/Settings/Logs/Logs.datePickerHelpers'
+import type { DatePickerValue } from '@/components/interfaces/Settings/Logs/Logs.DatePickers'
+import type { DatetimeHelper } from '@/components/interfaces/Settings/Logs/Logs.types'
+
+/** Build the `DatePickerValue` the Logs picker submits when a helper is selected. */
+const valueFromHelper = (helper: DatetimeHelper): DatePickerValue => ({
+  from: helper.calcFrom(),
+  to: helper.calcTo(),
+  isHelper: true,
+  text: helper.text,
+})
+
+/** The single dynamic helper produced from typed input like "2h" / "30m". */
+const dynamicHelper = (input: string): DatetimeHelper => {
+  const generated = generateHelpersFromInput(input)
+  if (!generated || generated.length !== 1) {
+    throw new Error(`Expected a single dynamic helper for "${input}"`)
+  }
+  return generated[0]
+}
 
 describe('querySource.ts:getSnippetSource', () => {
   it('maps log_sql to the logs source', () => {
@@ -13,5 +46,185 @@ describe('querySource.ts:getSnippetSource', () => {
 
   it('maps report to the database source', () => {
     expect(getSnippetSource({ type: 'report' })).toBe('database')
+  })
+})
+
+describe('querySource.ts:isoDateTimeString', () => {
+  it('accepts a valid ISO datetime', () => {
+    const raw = '2025-01-01T12:00:00.000Z'
+    expect(isoDateTimeString(raw)).toBe(raw)
+  })
+
+  it('rejects an empty string', () => {
+    expect(isoDateTimeString('')).toBeNull()
+  })
+
+  it('rejects junk', () => {
+    expect(isoDateTimeString('not-a-date')).toBeNull()
+    expect(isoDateTimeString('2025-13-45T99:99:99Z')).toBeNull()
+  })
+})
+
+describe('querySource.ts:datePickerValueToLogDateRange', () => {
+  it('parses every static preset into a relative range', () => {
+    const cases: Array<[string, { amount: number; unit: 'minute' | 'hour' | 'day' }]> = [
+      ['Last hour', { amount: 1, unit: 'hour' }],
+      ['Last 3 hours', { amount: 3, unit: 'hour' }],
+      ['Last 24 hours', { amount: 24, unit: 'hour' }],
+      ['Last 3 days', { amount: 3, unit: 'day' }],
+      ['Last 7 days', { amount: 7, unit: 'day' }],
+    ]
+
+    for (const [text, last] of cases) {
+      const helper = EXPLORER_DATEPICKER_HELPERS.find((h) => h.text === text)
+      expect(helper, `preset "${text}" exists`).toBeDefined()
+      expect(datePickerValueToLogDateRange(valueFromHelper(helper!))).toEqual({
+        kind: 'relative',
+        last,
+      })
+    }
+  })
+
+  it('parses dynamic helpers ("2h", "30m", "7d") into relative ranges', () => {
+    expect(datePickerValueToLogDateRange(valueFromHelper(dynamicHelper('2h')))).toEqual({
+      kind: 'relative',
+      last: { amount: 2, unit: 'hour' },
+    })
+    expect(datePickerValueToLogDateRange(valueFromHelper(dynamicHelper('30m')))).toEqual({
+      kind: 'relative',
+      last: { amount: 30, unit: 'minute' },
+    })
+    expect(datePickerValueToLogDateRange(valueFromHelper(dynamicHelper('7d')))).toEqual({
+      kind: 'relative',
+      last: { amount: 7, unit: 'day' },
+    })
+  })
+
+  it('treats a preset (calcTo() === "") as relative — the empty end means "now"', () => {
+    const lastHour = getDefaultHelper(EXPLORER_DATEPICKER_HELPERS)
+    const value = valueFromHelper(lastHour)
+    expect(value.to).toBe('')
+    expect(datePickerValueToLogDateRange(value)).toEqual({
+      kind: 'relative',
+      last: { amount: 1, unit: 'hour' },
+    })
+  })
+
+  it('degrades an unparseable helper to an absolute range using from/now (never empty)', () => {
+    vi.useFakeTimers()
+    const now = new Date('2025-01-01T12:00:00.000Z')
+    vi.setSystemTime(now)
+
+    const from = '2024-12-31T00:00:00.000Z'
+    const result = datePickerValueToLogDateRange({
+      from,
+      to: '',
+      isHelper: true,
+      text: 'Some custom label',
+    })
+
+    expect(result).toEqual({
+      kind: 'absolute',
+      from,
+      to: dayjs(now).toISOString(),
+    })
+  })
+
+  it('maps a custom (non-helper) pick to an absolute range with both endpoints', () => {
+    const from = '2025-01-01T00:00:00.000Z'
+    const to = '2025-01-02T00:00:00.000Z'
+    expect(datePickerValueToLogDateRange({ from, to, isHelper: false })).toEqual({
+      kind: 'absolute',
+      from,
+      to,
+    })
+  })
+
+  it('falls back to the default range when the value has no usable from', () => {
+    expect(datePickerValueToLogDateRange({ from: '', to: '', isHelper: false })).toEqual(
+      DEFAULT_LOG_DATE_RANGE
+    )
+  })
+})
+
+describe('querySource.ts:logDateRangeToDatePickerValue', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T12:00:00.000Z'))
+  })
+
+  it('renders a relative range exactly as the picker would emit the helper', () => {
+    const value = logDateRangeToDatePickerValue({
+      kind: 'relative',
+      last: { amount: 1, unit: 'hour' },
+    })
+    expect(value).toEqual({
+      from: dayjs().subtract(1, 'hour').toISOString(),
+      to: dayjs().toISOString(),
+      isHelper: true,
+      text: 'Last 1 hour',
+    })
+  })
+
+  it('pluralizes the label for amounts greater than one', () => {
+    expect(
+      logDateRangeToDatePickerValue({ kind: 'relative', last: { amount: 3, unit: 'day' } }).text
+    ).toBe('Last 3 days')
+  })
+
+  it('round-trips through datePickerValueToLogDateRange', () => {
+    const range: LogDateRange = { kind: 'relative', last: { amount: 30, unit: 'minute' } }
+    expect(datePickerValueToLogDateRange(logDateRangeToDatePickerValue(range))).toEqual(range)
+  })
+
+  it('passes an absolute range through as a non-helper value', () => {
+    const range: LogDateRange = {
+      kind: 'absolute',
+      from: isoDateTimeString('2025-01-01T00:00:00.000Z')!,
+      to: isoDateTimeString('2025-01-02T00:00:00.000Z')!,
+    }
+    expect(logDateRangeToDatePickerValue(range)).toEqual({
+      from: '2025-01-01T00:00:00.000Z',
+      to: '2025-01-02T00:00:00.000Z',
+      isHelper: false,
+    })
+  })
+})
+
+describe('querySource.ts:resolveLogRunRange', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('re-resolves a relative range against the current time', () => {
+    vi.useFakeTimers()
+    const now = new Date('2025-06-15T08:30:00.000Z')
+    vi.setSystemTime(now)
+
+    expect(resolveLogRunRange({ kind: 'relative', last: { amount: 2, unit: 'hour' } })).toEqual({
+      from: dayjs(now).subtract(2, 'hour').toISOString(),
+      to: dayjs(now).toISOString(),
+    })
+  })
+
+  it('re-resolves the same relative range differently as time advances', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-06-15T08:00:00.000Z'))
+    const first = resolveLogRunRange({ kind: 'relative', last: { amount: 1, unit: 'hour' } })
+
+    vi.setSystemTime(new Date('2025-06-15T10:00:00.000Z'))
+    const second = resolveLogRunRange({ kind: 'relative', last: { amount: 1, unit: 'hour' } })
+
+    expect(first).not.toEqual(second)
+    expect(second.to).toBe(dayjs('2025-06-15T10:00:00.000Z').toISOString())
+  })
+
+  it('passes an absolute range through unchanged', () => {
+    const from = isoDateTimeString('2025-01-01T00:00:00.000Z')!
+    const to = isoDateTimeString('2025-01-02T00:00:00.000Z')!
+    expect(resolveLogRunRange({ kind: 'absolute', from, to })).toEqual({
+      from: '2025-01-01T00:00:00.000Z',
+      to: '2025-01-02T00:00:00.000Z',
+    })
   })
 })

--- a/apps/studio/components/interfaces/SQLEditor/querySource.ts
+++ b/apps/studio/components/interfaces/SQLEditor/querySource.ts
@@ -1,3 +1,9 @@
+import dayjs from 'dayjs'
+
+import { generateDynamicHelper } from '@/components/interfaces/Settings/Logs/Logs.datePickerHelpers'
+import type { Unit } from '@/components/interfaces/Settings/Logs/Logs.datePickerHelpers'
+import type { DatePickerValue } from '@/components/interfaces/Settings/Logs/Logs.DatePickers'
+import type { ResolvedLogDateRange } from '@/components/interfaces/Settings/Logs/logsDateRange'
 import type { Snippet } from '@/data/content/sql-folders-query'
 
 /**
@@ -17,4 +23,122 @@ export type SqlSnippetSource = 'database' | 'logs'
  */
 export function getSnippetSource(snippet: Pick<Snippet, 'type'>): SqlSnippetSource {
   return snippet.type === 'log_sql' ? 'logs' : 'database'
+}
+
+/**
+ * An ISO-8601 datetime proven valid at construction via a dayjs parse. Absolute
+ * log ranges carry these instead of raw strings so an unvalidated datetime can
+ * never reach execution.
+ */
+export type IsoDateTimeString = string & { readonly __isoDateTimeBrand: unique symbol }
+
+/**
+ * Validate a raw string as an ISO datetime, returning the branded value or null.
+ * The sole construction site for `IsoDateTimeString` outside `now`.
+ */
+export function isoDateTimeString(raw: string): IsoDateTimeString | null {
+  if (!raw) return null
+  return dayjs(raw).isValid() ? (raw as IsoDateTimeString) : null
+}
+
+/** `now` as a branded ISO datetime — `toISOString()` is always valid ISO-8601. */
+function nowIsoDateTime(): IsoDateTimeString {
+  return dayjs().toISOString() as IsoDateTimeString
+}
+
+/**
+ * The units a relative log range is expressed in. Aliases the Logs date picker's
+ * `Unit` so the two stay in lockstep rather than drifting as parallel unions.
+ */
+export type RelativeTimeUnit = Unit
+
+/**
+ * A log query's time range. Relative ranges are structural (amount + unit) and
+ * re-resolve against `now` at every run — so a saved "last hour" always means the
+ * hour before the run, not the hour before the snippet was opened. Absolute ranges
+ * carry validated ISO datetimes and pass through unchanged.
+ */
+export type LogDateRange =
+  | { kind: 'relative'; last: { amount: number; unit: RelativeTimeUnit } }
+  | { kind: 'absolute'; from: IsoDateTimeString; to: IsoDateTimeString }
+
+/** The range a freshly opened logs snippet starts with: the last hour. */
+export const DEFAULT_LOG_DATE_RANGE: LogDateRange = {
+  kind: 'relative',
+  last: { amount: 1, unit: 'hour' },
+}
+
+/**
+ * Parse a date-picker helper's label (e.g. "Last hour", "Last 3 hours", "Last 30
+ * minutes") into a relative amount/unit. Covers both the static presets in
+ * `EXPLORER_DATEPICKER_HELPERS` and the dynamic helpers `generateHelpersFromInput`
+ * produces from typed input like "2h"/"30m". A label with no number means one unit
+ * ("Last hour"). Returns null for any other label.
+ */
+function parseRelativeHelperLabel(
+  text: string | undefined
+): { amount: number; unit: RelativeTimeUnit } | null {
+  if (!text) return null
+  const match = text
+    .trim()
+    .toLowerCase()
+    .match(/^last\s+(?:(\d+)\s+)?(minute|hour|day)s?$/)
+  if (!match) return null
+  const amount = match[1] ? parseInt(match[1], 10) : 1
+  if (!Number.isFinite(amount) || amount <= 0) return null
+  const unit = match[2]
+  if (unit !== 'minute' && unit !== 'hour' && unit !== 'day') return null
+  return { amount, unit }
+}
+
+/**
+ * Convert a Logs date-picker value into a `LogDateRange`. Helper picks (presets and
+ * dynamic "2h"/"30m" helpers) become relative ranges by parsing the helper label;
+ * a preset's `calcTo()` resolves to `''` (meaning "now"), which the relative variant
+ * models implicitly. Everything else — custom calendar picks, or a helper whose label
+ * we can't parse — becomes an absolute range with validated ISO datetimes, degrading
+ * via `from`/now rather than rejecting an empty string. A value with no usable `from`
+ * falls back to the default range.
+ */
+export function datePickerValueToLogDateRange(value: DatePickerValue): LogDateRange {
+  if (value.isHelper) {
+    const relative = parseRelativeHelperLabel(value.text)
+    if (relative) return { kind: 'relative', last: relative }
+  }
+
+  const from = isoDateTimeString(value.from)
+  if (from === null) return DEFAULT_LOG_DATE_RANGE
+  const to = isoDateTimeString(value.to) ?? nowIsoDateTime()
+  return { kind: 'absolute', from, to }
+}
+
+/**
+ * Render a `LogDateRange` back into a Logs date-picker value for display. Relative
+ * ranges reuse the picker's own `generateDynamicHelper` to derive the resolved
+ * `from`/`to` and matching "Last N unit(s)" label, so the value is byte-for-byte
+ * what the picker itself would emit for that helper. Absolute ranges pass their
+ * datetimes through.
+ */
+export function logDateRangeToDatePickerValue(range: LogDateRange): DatePickerValue {
+  if (range.kind === 'relative') {
+    const helper = generateDynamicHelper(range.last.amount, range.last.unit)
+    return { from: helper.calcFrom(), to: helper.calcTo(), isHelper: true, text: helper.text }
+  }
+  return { from: range.from, to: range.to, isHelper: false }
+}
+
+/**
+ * Resolve a `LogDateRange` to concrete ISO endpoints for a run. Relative ranges
+ * re-resolve against `now` (so "last hour" is always the hour before the run);
+ * absolute ranges pass through. Reuses the Logs `ResolvedLogDateRange` shape.
+ */
+export function resolveLogRunRange(range: LogDateRange): ResolvedLogDateRange {
+  if (range.kind === 'relative') {
+    const now = dayjs()
+    return {
+      from: now.subtract(range.last.amount, range.last.unit).toISOString(),
+      to: now.toISOString(),
+    }
+  }
+  return { from: range.from, to: range.to }
 }

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -17,71 +17,13 @@ import {
 } from 'ui'
 
 import { LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD } from './Logs.constants'
+import { generateHelpersFromInput } from './Logs.datePickerHelpers'
 import type { DatetimeHelper } from './Logs.types'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { TimeSplitInput } from '@/components/ui/DatePicker/TimeSplitInput'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import type { ShortcutId } from '@/state/shortcuts/registry'
-
-type Unit = 'minute' | 'hour' | 'day'
-
-export type ParsedCustomInput =
-  | { type: 'number'; value: number }
-  | { type: 'unit'; value: number; unit: Unit }
-  | { type: 'invalid' }
-
-export const parseCustomInput = (input: string): ParsedCustomInput => {
-  const trimmed = input.trim().toLowerCase()
-  if (!trimmed) return { type: 'invalid' }
-
-  // Try to match "number + optional space + unit prefix"
-  const match = trimmed.match(/^(\d+)\s*([a-z]*)$/)
-  if (!match) return { type: 'invalid' }
-
-  const [, numStr, unitStr] = match
-  const value = parseInt(numStr, 10)
-
-  if (isNaN(value) || value <= 0) return { type: 'invalid' }
-
-  if (!unitStr) {
-    return { type: 'number', value }
-  }
-
-  // Match if unitStr is a prefix of any unit name or its first letter
-  const units: Unit[] = ['minute', 'hour', 'day']
-  const matchedUnit = units.find((u) => u.startsWith(unitStr) || u[0] === unitStr)
-
-  if (!matchedUnit) return { type: 'invalid' }
-
-  return { type: 'unit', value, unit: matchedUnit }
-}
-
-export const generateDynamicHelper = (value: number, unit: Unit): DatetimeHelper => {
-  return {
-    text: `Last ${value} ${unit}${value === 1 ? '' : 's'}`,
-    calcFrom: () => dayjs().subtract(value, unit).toISOString(),
-    calcTo: () => dayjs().toISOString(),
-  }
-}
-
-export const generateDynamicHelpers = (value: number): DatetimeHelper[] => {
-  const units: Unit[] = ['minute', 'hour', 'day']
-  return units.map((unit) => generateDynamicHelper(value, unit))
-}
-
-export const generateHelpersFromInput = (input: string): DatetimeHelper[] | null => {
-  const parsed = parseCustomInput(input)
-
-  switch (parsed.type) {
-    case 'number':
-      return generateDynamicHelpers(parsed.value)
-    case 'unit':
-      return [generateDynamicHelper(parsed.value, parsed.unit)]
-    case 'invalid':
-      return null
-  }
-}
 
 export type DatePickerValue = {
   to: string

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.datePickerHelpers.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.datePickerHelpers.ts
@@ -27,9 +27,11 @@ export const parseCustomInput = (input: string): ParsedCustomInput => {
   if (!match) return { type: 'invalid' }
 
   const [, numStr, unitStr] = match
-  const value = parseInt(numStr, 10)
+  const value = Number.parseInt(numStr, 10)
 
-  if (isNaN(value) || value <= 0) return { type: 'invalid' }
+  // Only finite positive values may reach generateDynamicHelper(): Number.isFinite
+  // rejects NaN and Infinity outright, and the <= 0 guard keeps out non-positive.
+  if (!Number.isFinite(value) || value <= 0) return { type: 'invalid' }
 
   if (!unitStr) {
     return { type: 'number', value }

--- a/apps/studio/components/interfaces/Settings/Logs/Logs.datePickerHelpers.ts
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.datePickerHelpers.ts
@@ -1,0 +1,71 @@
+import dayjs from 'dayjs'
+
+import type { DatetimeHelper } from './Logs.types'
+
+/**
+ * Framework-free date-range helpers shared by the Logs date picker
+ * (`Logs.DatePickers.tsx`) and the SQL editor's logs query-source domain
+ * (`SQLEditor/querySource.ts`). Kept in a pure `.ts` module — depending only on
+ * dayjs — so both a React component and a valtio-free domain module can import it
+ * without pulling in the picker's UI.
+ */
+
+/** The relative-range units the picker and the logs domain both speak. */
+export type Unit = 'minute' | 'hour' | 'day'
+
+export type ParsedCustomInput =
+  | { type: 'number'; value: number }
+  | { type: 'unit'; value: number; unit: Unit }
+  | { type: 'invalid' }
+
+export const parseCustomInput = (input: string): ParsedCustomInput => {
+  const trimmed = input.trim().toLowerCase()
+  if (!trimmed) return { type: 'invalid' }
+
+  // Try to match "number + optional space + unit prefix"
+  const match = trimmed.match(/^(\d+)\s*([a-z]*)$/)
+  if (!match) return { type: 'invalid' }
+
+  const [, numStr, unitStr] = match
+  const value = parseInt(numStr, 10)
+
+  if (isNaN(value) || value <= 0) return { type: 'invalid' }
+
+  if (!unitStr) {
+    return { type: 'number', value }
+  }
+
+  // Match if unitStr is a prefix of any unit name or its first letter
+  const units: Unit[] = ['minute', 'hour', 'day']
+  const matchedUnit = units.find((u) => u.startsWith(unitStr) || u[0] === unitStr)
+
+  if (!matchedUnit) return { type: 'invalid' }
+
+  return { type: 'unit', value, unit: matchedUnit }
+}
+
+export const generateDynamicHelper = (value: number, unit: Unit): DatetimeHelper => {
+  return {
+    text: `Last ${value} ${unit}${value === 1 ? '' : 's'}`,
+    calcFrom: () => dayjs().subtract(value, unit).toISOString(),
+    calcTo: () => dayjs().toISOString(),
+  }
+}
+
+export const generateDynamicHelpers = (value: number): DatetimeHelper[] => {
+  const units: Unit[] = ['minute', 'hour', 'day']
+  return units.map((unit) => generateDynamicHelper(value, unit))
+}
+
+export const generateHelpersFromInput = (input: string): DatetimeHelper[] | null => {
+  const parsed = parseCustomInput(input)
+
+  switch (parsed.type) {
+    case 'number':
+      return generateDynamicHelpers(parsed.value)
+    case 'unit':
+      return [generateDynamicHelper(parsed.value, parsed.unit)]
+    case 'invalid':
+      return null
+  }
+}

--- a/apps/studio/state/sql-editor/sql-editor-session-state.ts
+++ b/apps/studio/state/sql-editor/sql-editor-session-state.ts
@@ -1,10 +1,12 @@
 import { proxy, ref, snapshot, useSnapshot } from 'valtio'
 
+import type { LogDateRange } from '@/components/interfaces/SQLEditor/querySource'
+
 /**
- * Ephemeral, per-session SQL editor state that is NOT persisted: query results
- * and the row limit. Kept separate from the snippet/folder store (which deals
- * with persistence) because none of this is saved — it lives only for the
- * current editing session.
+ * Ephemeral, per-session SQL editor state that is NOT persisted: query results,
+ * the row limit, and the per-snippet logs time range. Kept separate from the
+ * snippet/folder store (which deals with persistence) because none of this is
+ * saved — it lives only for the current editing session.
  */
 export const sqlEditorSessionState = proxy({
   /**
@@ -29,6 +31,18 @@ export const sqlEditorSessionState = proxy({
 
   setLimit: (value: number) => (sqlEditorSessionState.limit = value),
 
+  /**
+   * The logs time range for a logs snippet, keyed by snippet id. Session state —
+   * never written to snippet content — so it works on read-only shared snippets
+   * and resets on reload. An unset snippet has no entry; read sites fall back to
+   * `DEFAULT_LOG_DATE_RANGE`.
+   */
+  logRange: {} as { [snippetId: string]: LogDateRange },
+
+  setLogRange: (id: string, range: LogDateRange) => {
+    sqlEditorSessionState.logRange[id] = range
+  },
+
   addResult: (id: string, results: any[], autoLimit?: number) => {
     // Use ref() to prevent Valtio from creating proxies for each row object.
     // This is critical for large result sets - without ref(), Valtio wraps every
@@ -49,6 +63,7 @@ export const sqlEditorSessionState = proxy({
   /** Drop all session state for a snippet (called when the snippet is removed). */
   clearForSnippet: (id: string) => {
     delete sqlEditorSessionState.results[id]
+    delete sqlEditorSessionState.logRange[id]
   },
 })
 

--- a/apps/studio/tests/features/logs/Logs.Datepickers.test.tsx
+++ b/apps/studio/tests/features/logs/Logs.Datepickers.test.tsx
@@ -11,9 +11,9 @@ import {
   generateDynamicHelper,
   generateDynamicHelpers,
   generateHelpersFromInput,
-  LogsDatePicker,
   parseCustomInput,
-} from '@/components/interfaces/Settings/Logs/Logs.DatePickers'
+} from '@/components/interfaces/Settings/Logs/Logs.datePickerHelpers'
+import { LogsDatePicker } from '@/components/interfaces/Settings/Logs/Logs.DatePickers'
 import { DatetimeHelper } from '@/components/interfaces/Settings/Logs/Logs.types'
 
 dayjs.extend(timezone)


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Feature (+ a small refactor and a docs/convention note). PR 4 of the stacked SQL-editor query-source series (Database vs Logs).

## What is the current behavior?

The SQL editor has no representation of a logs query's time range: `querySource.ts` only knows how to map a snippet type to a source (`getSnippetSource`), and session state (`sql-editor-session-state.ts`) tracks results and the row limit but not a per-snippet time range. The Logs date picker's pure range helpers (`parseCustomInput`, `generateDynamicHelper`, the `Unit` type) are trapped inside the `Logs.DatePickers.tsx` React component.

## What is the new behavior?

- **Logs time-range domain** in `querySource.ts`: branded `IsoDateTimeString` + `isoDateTimeString()`, `RelativeTimeUnit`, a `LogDateRange` discriminated union (relative/absolute), `DEFAULT_LOG_DATE_RANGE`, a single date-picker parser (`datePickerValueToLogDateRange` / `logDateRangeToDatePickerValue` — handles the five presets *and* dynamic `2h`/`30m` helpers; `calcTo === ''` means "now"; unparseable helpers degrade to absolute), and `resolveLogRunRange` which re-resolves relative ranges against `now` at run time (reusing the existing `ResolvedLogDateRange` shape).
- **Session state**: per-snippet `logRange` + `setLogRange` — session-only, never written to snippet content, so it works on read-only shared snippets and is cleaned up in `clearForSnippet`.
- **Refactor**: extracted the picker's framework-free helpers into a new pure `Logs.datePickerHelpers.ts`; the logs domain now shares the `Unit` type and reuses `generateDynamicHelper` instead of duplicating them. Importers point at the new module directly (no re-export shim). Hardened the amount parse against `NaN`.
- **Full unit coverage** in `querySource.test.ts`. Recorded the no-shim refactoring convention in the `studio-best-practices` skill.

Verification: `pnpm typecheck` clean, lint ratchet improved, 43 tests pass (querySource + Logs.Datepickers), Prettier clean.

## Additional context

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added robust Logs date-range modeling with support for relative (e.g., last N units) and absolute time periods.
  - SQL Editor sessions now remember log date ranges per snippet.
- **Bug Fixes**
  - Safer handling of invalid or missing date inputs, with sensible fallback to default/current time.
- **Tests**
  - Added/expanded automated coverage for date-range conversion, helper parsing, and resolution behavior.
- **Refactor**
  - Centralized date-picker helper utilities for reuse across the Logs and SQL query experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->