### PR TITLE
design demo: security page content additions (content-only)

### DIFF
--- a/apps/www/pages/security.mdx
+++ b/apps/www/pages/security.mdx
@@ -75,7 +75,7 @@ Enterprise and Team customers can access our SOC 2 Type 2 report [on the dashboa
 
 ### HIPAA
 
-Supabase is HIPAA compliant. You can store Protected Health Information (PHI) on our hosted platform once you enter into a Business Associate Agreement (BAA) with us and fulfill your HIPAA obligations under our [shared responsibility model](/docs/guides/platform/shared-responsibility-model#managing-healthcare-data).
+Supabase is HIPAA compliant. You can store Protected Health Information (PHI) on our hosted platform once you enter into a Business Associate Agreement (BAA) with us and fulfill your HIPAA obligations under our [shared responsibility model](https://supabase.com/docs/guides/deployment/shared-responsibility-model#managing-healthcare-data).
 
 Enterprise and Team customers can request to sign our BAA [on the dashboard](/dashboard/org/_/documents).
 
@@ -159,7 +159,7 @@ In addition to protection at the CDN level via Cloudflare, we employ [fail2ban](
 
 Supabase supports GDPR-compliant deployments. Projects hosted in EU regions keep your primary database data in-region, and a Data Processing Agreement (DPA) is available for customers who need a formal data processing contract under GDPR.
 
-Read more about [GDPR compliance at Supabase](/docs/guides/security/gdpr) or view our [sub-processor list](/legal/privacy).
+See how [Markprompt uses Supabase for GDPR-compliant deployments](/customers/markprompt).
 
 </Section>
 
@@ -169,7 +169,7 @@ Read more about [GDPR compliance at Supabase](/docs/guides/security/gdpr) or vie
 
 When you create a project in an AWS region, your Postgres database, Auth service, and Storage objects are hosted in that region. Supabase offers regions across the US, EU, and Asia Pacific.
 
-See the full list of [available regions](/docs/guides/platform/regions).
+See the full list of [available regions](https://supabase.com/docs/guides/platform/regions).
 
 </Section>
 
@@ -187,7 +187,7 @@ A Data Processing Agreement (DPA) is available for customers who require a forma
 
 Supabase secures the underlying infrastructure — physical data centers, operating systems, database engines, encryption, and network perimeter protection. Customers are responsible for Row Level Security policies, API key management, application-layer access controls, and the security of their own code.
 
-Read our full [shared responsibility model](/docs/guides/platform/shared-responsibility-model).
+Read our full [shared responsibility model](https://supabase.com/docs/guides/deployment/shared-responsibility-model).
 
 </Section>
 

--- a/apps/www/pages/security.mdx
+++ b/apps/www/pages/security.mdx
@@ -44,20 +44,19 @@ export const Section = ({ children, icon, img }) => (
   </div>
 </div>
 
-<div className="section-container mb-16">
+<div className="section-container mb-16 flex flex-col gap-12">
+
+{/* Compliance */}
+
+<div className="flex flex-col gap-4">
+
+<h3 className="not-prose text-sm font-medium text-foreground-muted uppercase tracking-widest">
+  Compliance
+</h3>
 
 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-16">
 
-<Section icon={<Lock strokeWidth={1}/>}>
-
-### Multi-factor Authentication
-
-Supabase allows users to enable Multi-factor authentication (MFA) on their account.
-MFA adds an additional layer of security to your user account, by requiring a second factor to verify your user identity.
-
-</Section>
-
-<Section icon={<ShieldCheckIcon strokeWidth={1}/>}>
+<Section icon={<Lock strokeWidth={1} />}>
 
 ### SOC 2
 
@@ -71,7 +70,7 @@ Enterprise and Team customers can access our SOC 2 Type 2 report [on the dashboa
 
 </Section>
 
-<Section icon={<Activity strokeWidth={1}/>}>
+<Section icon={<Activity strokeWidth={1} />}>
 
 ### HIPAA
 
@@ -84,7 +83,8 @@ Enterprise and Team customers can request to sign our BAA [on the dashboard](/da
 </div>
 
 </Section>
-<Section icon={<ShieldCheckIcon strokeWidth={1}/>}>
+
+<Section icon={<ShieldCheckIcon strokeWidth={1} />}>
 
 ### ISO 27001
 
@@ -93,67 +93,8 @@ Supabase is ISO 27001 certified. ISO 27001 is an internationally recognized stan
 Enterprise and Team customers can access our ISO 27001 certificate [on the dashboard](/dashboard/org/_/documents).
 
 </Section>
-<Section icon={<KeyIcon strokeWidth={1}/>}>
 
-### Data Encryption
-
-All customer data is encrypted at rest with AES-256 and in transit via TLS.
-
-Sensitive information like access tokens and keys are encrypted at the application level before they are stored in the database.
-
-</Section>
-
-<Section icon={<UserGroupIcon strokeWidth={1}/>}>
-
-### Role-based access control
-
-Members of organizations in Supabase can be granted access to specific resources.
-
-Read more about [fine grained access controls](/docs/guides/platform/access-control) including Read-Only and Billing-Only access.
-
-</Section>
-
-<Section icon={<RewindIcon strokeWidth={1}/>}>
-
-### Backups
-
-All paid customer databases are backed up every day.
-
-Point in Time Recovery allows restoring the database to any point in time. Customers from the Pro Plan have access to this feature as an add-on.
-
-</Section>
-
-<Section icon={<CreditCardIcon strokeWidth={1}/>}>
-
-### Payment processing
-
-Supabase uses [Stripe](https://stripe.com) to process payments and does not store personal credit card information for any of our customers.
-
-Stripe is a certified PCI Service Provider Level 1, which is the highest level of certification in the payments industry.
-
-</Section>
-
-<Section icon={<ClipboardCheckIcon strokeWidth={1}/>}>
-
-### Vulnerability Management
-
-Supabase works with industry experts to conduct regular penetration tests.
-
-In addition to internal security reviews, we use various tools to scan our code for vulnerabilities including [GitHub](https://github.com), [Vanta](https://www.vanta.com/), and [Snyk](https://snyk.io/).
-
-</Section>
-
-<Section icon={<ShieldCheckIcon strokeWidth={1}/>}>
-
-### DDoS Protection
-
-Supabase combats Distributed Denial of Service attacks in several ways to mitigate resource abuse and prevent runaway bills.
-
-In addition to protection at the CDN level via Cloudflare, we employ [fail2ban](https://github.com/fail2ban/fail2ban) to prevent brute force logins. Users can [customize rate limits](/docs/guides/platform/going-into-prod#rate-limiting-resource-allocation--abuse-prevention) for critical API routes and set [spend caps](/docs/guides/platform/cost-control#spend-cap) to prevent surprise bills.
-
-</Section>
-
-<Section icon={<Globe strokeWidth={1}/>}>
+<Section icon={<Globe strokeWidth={1} />}>
 
 ### GDPR & European Compliance
 
@@ -163,7 +104,31 @@ See how [Markprompt uses Supabase for GDPR-compliant deployments](/customers/mar
 
 </Section>
 
-<Section icon={<Globe strokeWidth={1}/>}>
+</div>
+
+</div>
+
+{/* Data */}
+
+<div className="flex flex-col gap-4">
+
+<h3 className="not-prose text-sm font-medium text-foreground-muted uppercase tracking-widest">
+  Data
+</h3>
+
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-16">
+
+<Section icon={<KeyIcon strokeWidth={1} />}>
+
+### Data Encryption
+
+All customer data is encrypted at rest with AES-256 and in transit via TLS.
+
+Sensitive information like access tokens and keys are encrypted at the application level before they are stored in the database.
+
+</Section>
+
+<Section icon={<Globe strokeWidth={1} />}>
 
 ### Data Residency
 
@@ -173,7 +138,17 @@ See the full list of [available regions](/docs/guides/platform/regions).
 
 </Section>
 
-<Section icon={<FileText strokeWidth={1}/>}>
+<Section icon={<RewindIcon strokeWidth={1} />}>
+
+### Backups
+
+All paid customer databases are backed up every day.
+
+Point in Time Recovery allows restoring the database to any point in time. Customers from the Pro Plan have access to this feature as an add-on.
+
+</Section>
+
+<Section icon={<FileText strokeWidth={1} />}>
 
 ### Data Processing Agreement
 
@@ -181,7 +156,73 @@ A Data Processing Agreement (DPA) is available for customers who need a formal G
 
 </Section>
 
-<Section icon={<Scale strokeWidth={1}/>}>
+</div>
+
+</div>
+
+{/* Configuration */}
+
+<div className="flex flex-col gap-4">
+
+<h3 className="not-prose text-sm font-medium text-foreground-muted uppercase tracking-widest">
+  Configuration
+</h3>
+
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-16">
+
+<Section icon={<Lock strokeWidth={1} />}>
+
+### Multi-factor Authentication
+
+Supabase allows users to enable Multi-factor authentication (MFA) on their account. MFA adds an additional layer of security to your user account, by requiring a second factor to verify your user identity.
+
+</Section>
+
+<Section icon={<UserGroupIcon strokeWidth={1} />}>
+
+### Role-based access control
+
+Members of organizations in Supabase can be granted access to specific resources.
+
+Read more about [fine grained access controls](/docs/guides/platform/access-control) including Read-Only and Billing-Only access.
+
+</Section>
+
+<Section icon={<ClipboardCheckIcon strokeWidth={1} />}>
+
+### Vulnerability Management
+
+Supabase works with industry experts to conduct regular penetration tests.
+
+In addition to internal security reviews, we use various tools to scan our code for vulnerabilities including [GitHub](https://github.com), [Vanta](https://www.vanta.com/), and [Snyk](https://snyk.io/).
+
+</Section>
+
+<Section icon={<ShieldCheckIcon strokeWidth={1} />}>
+
+### DDoS Protection
+
+Supabase combats Distributed Denial of Service attacks in several ways to mitigate resource abuse and prevent runaway bills.
+
+In addition to protection at the CDN level via Cloudflare, we employ [fail2ban](https://github.com/fail2ban/fail2ban) to prevent brute force logins. Users can [customize rate limits](/docs/guides/platform/going-into-prod#rate-limiting-resource-allocation--abuse-prevention) for critical API routes and set [spend caps](/docs/guides/platform/cost-control#spend-cap) to prevent surprise bills.
+
+</Section>
+
+</div>
+
+</div>
+
+{/* Misc */}
+
+<div className="flex flex-col gap-4">
+
+<h3 className="not-prose text-sm font-medium text-foreground-muted uppercase tracking-widest">
+  Misc
+</h3>
+
+<div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8 lg:gap-16">
+
+<Section icon={<Scale strokeWidth={1} />}>
 
 ### Shared Responsibility
 
@@ -190,6 +231,18 @@ Supabase secures the infrastructure. You secure your application — RLS policie
 Read the [shared responsibility model](/docs/guides/deployment/shared-responsibility-model).
 
 </Section>
+
+<Section icon={<CreditCardIcon strokeWidth={1} />}>
+
+### Payment processing
+
+Supabase uses [Stripe](https://stripe.com) to process payments and does not store personal credit card information for any of our customers.
+
+Stripe is a certified PCI Service Provider Level 1, which is the highest level of certification in the payments industry.
+
+</Section>
+
+</div>
 
 </div>
 

--- a/apps/www/pages/security.mdx
+++ b/apps/www/pages/security.mdx
@@ -184,7 +184,7 @@ Supabase allows users to enable Multi-factor authentication (MFA) on their accou
 
 Members of organizations in Supabase can be granted access to specific resources.
 
-Read more about [fine grained access controls](/docs/guides/platform/access-control) including Read-Only and Billing-Only access.
+Read more about [fine-grained access controls](/docs/guides/platform/access-control) including Read-Only and Billing-Only access.
 
 </Section>
 

--- a/apps/www/pages/security.mdx
+++ b/apps/www/pages/security.mdx
@@ -7,7 +7,7 @@ import {
   UserGroupIcon,
 } from '@heroicons/react/outline'
 import SecurityNewsletterForm from '~/components/SecurityNewsletterForm'
-import { Activity, Lock } from 'lucide-react'
+import { Activity, FileText, Globe, Lock, Scale } from 'lucide-react'
 
 import Layout from '../layouts/Layout'
 
@@ -150,6 +150,44 @@ In addition to internal security reviews, we use various tools to scan our code 
 Supabase combats Distributed Denial of Service attacks in several ways to mitigate resource abuse and prevent runaway bills.
 
 In addition to protection at the CDN level via Cloudflare, we employ [fail2ban](https://github.com/fail2ban/fail2ban) to prevent brute force logins. Users can [customize rate limits](/docs/guides/platform/going-into-prod#rate-limiting-resource-allocation--abuse-prevention) for critical API routes and set [spend caps](/docs/guides/platform/cost-control#spend-cap) to prevent surprise bills.
+
+</Section>
+
+<Section icon={<Globe strokeWidth={1}/>}>
+
+### GDPR & European Compliance
+
+Supabase supports GDPR-compliant deployments. Projects hosted in EU regions keep your primary database data in-region, and a Data Processing Agreement (DPA) is available for customers who need a formal data processing contract under GDPR.
+
+Read more about [GDPR compliance at Supabase](/docs/guides/security/gdpr) or view our [sub-processor list](/legal/privacy).
+
+</Section>
+
+<Section icon={<Globe strokeWidth={1}/>}>
+
+### Data Residency
+
+When you create a project in an AWS region, your Postgres database, Auth service, and Storage objects are hosted in that region. Supabase offers regions across the US, EU, and Asia Pacific.
+
+See the full list of [available regions](/docs/guides/platform/regions).
+
+</Section>
+
+<Section icon={<FileText strokeWidth={1}/>}>
+
+### Data Processing Agreement
+
+A Data Processing Agreement (DPA) is available for customers who require a formal GDPR data processing contract. Team and Enterprise customers can access and sign the DPA directly from the [organization dashboard](/dashboard/org/_/documents). Other customers can request one via [/legal/dpa](/legal/dpa).
+
+</Section>
+
+<Section icon={<Scale strokeWidth={1}/>}>
+
+### Shared Responsibility
+
+Supabase secures the underlying infrastructure — physical data centers, operating systems, database engines, encryption, and network perimeter protection. Customers are responsible for Row Level Security policies, API key management, application-layer access controls, and the security of their own code.
+
+Read our full [shared responsibility model](/docs/guides/platform/shared-responsibility-model).
 
 </Section>
 

--- a/apps/www/pages/security.mdx
+++ b/apps/www/pages/security.mdx
@@ -169,7 +169,7 @@ See how [Markprompt uses Supabase for GDPR-compliant deployments](/customers/mar
 
 When you create a project in an AWS region, your Postgres database, Auth service, and Storage objects are hosted in that region. Supabase offers regions across the US, EU, and Asia Pacific.
 
-See the full list of [available regions](https://supabase.com/docs/guides/platform/regions).
+See the full list of [available regions](/docs/guides/platform/regions).
 
 </Section>
 
@@ -177,7 +177,7 @@ See the full list of [available regions](https://supabase.com/docs/guides/platfo
 
 ### Data Processing Agreement
 
-A Data Processing Agreement (DPA) is available for customers who require a formal GDPR data processing contract. Team and Enterprise customers can access and sign the DPA directly from the [organization dashboard](/dashboard/org/_/documents). Other customers can request one via [/legal/dpa](/legal/dpa).
+A Data Processing Agreement (DPA) is available for customers who need a formal GDPR data processing contract. [Request or view the DPA](/legal/dpa).
 
 </Section>
 
@@ -185,9 +185,9 @@ A Data Processing Agreement (DPA) is available for customers who require a forma
 
 ### Shared Responsibility
 
-Supabase secures the underlying infrastructure — physical data centers, operating systems, database engines, encryption, and network perimeter protection. Customers are responsible for Row Level Security policies, API key management, application-layer access controls, and the security of their own code.
+Supabase secures the infrastructure. You secure your application — RLS policies, API keys, and access controls.
 
-Read our full [shared responsibility model](https://supabase.com/docs/guides/deployment/shared-responsibility-model).
+Read the [shared responsibility model](/docs/guides/deployment/shared-responsibility-model).
 
 </Section>
 

--- a/apps/www/pages/security.mdx
+++ b/apps/www/pages/security.mdx
@@ -74,7 +74,7 @@ Enterprise and Team customers can access our SOC 2 Type 2 report [on the dashboa
 
 ### HIPAA
 
-Supabase is HIPAA compliant. You can store Protected Health Information (PHI) on our hosted platform once you enter into a Business Associate Agreement (BAA) with us and fulfill your HIPAA obligations under our [shared responsibility model](https://supabase.com/docs/guides/deployment/shared-responsibility-model#managing-healthcare-data).
+Supabase is HIPAA compliant. You can store Protected Health Information (PHI) on our hosted platform once you enter into a Business Associate Agreement (BAA) with us and fulfill your HIPAA obligations under our [shared responsibility model](/docs/guides/deployment/shared-responsibility-model#managing-healthcare-data).
 
 Enterprise and Team customers can request to sign our BAA [on the dashboard](/dashboard/org/_/documents).
 


### PR DESCRIPTION
## Summary

- Adds four missing content cards to the existing `security.mdx` using the same `Section` component and grid already on the page — no new UI components or features
- Cards added: **GDPR & European Compliance**, **Data Residency**, **Data Processing Agreement**, **Shared Responsibility**
- Also fixes the HIPAA shared responsibility link path (`/deployment/` not `/platform/`)

Worth validating still.

## What this is

A content-only drop-in that addresses some gaps

## What's out of scope here

- No sticky nav, tables, plan comparison grids, or new components
- No DPA request automation — just a plain link to `/legal/dpa`
- No plan-gating claims (removed — accuracy unconfirmed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reorganized the security page into clearer Compliance, Data, Configuration, and Misc sections.
  * Added GDPR and European compliance, data residency, and Data Processing Agreement information.
  * Updated HIPAA information and shared responsibility details.
  * Reorganized security controls, including MFA and role-based access control, and refreshed page visuals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->