### PR TITLE
Fix/pricing compare plans button

### DIFF
--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -69,22 +69,32 @@ export default function IntegrationsContent({
 
   const [debouncedSearchTerm] = useDebounce(search, 300)
   const [isSearching, setIsSearching] = useState(false)
+  const [searchError, setSearchError] = useState(false)
   const searchIdRef = useRef(0)
 
   useEffect(() => {
     if (debouncedSearchTerm.trim() === '') {
       setIsSearching(false)
+      setSearchError(false)
       setPartners(initialPartners)
       return
     }
     setIsSearching(true)
+    setSearchError(false)
     const currentSearchId = ++searchIdRef.current
     searchCatalogPartners(debouncedSearchTerm)
       .then((results) => {
-        if (currentSearchId === searchIdRef.current) setPartners(results ?? [])
+        if (currentSearchId !== searchIdRef.current) return
+        // null is a soft failure from searchCatalogPartners — not an empty result set.
+        if (results === null) {
+          setSearchError(true)
+          return
+        }
+        setSearchError(false)
+        setPartners(results)
       })
       .catch(() => {
-        if (currentSearchId === searchIdRef.current) setPartners([])
+        if (currentSearchId === searchIdRef.current) setSearchError(true)
       })
       .finally(() => {
         if (currentSearchId === searchIdRef.current) setIsSearching(false)
@@ -340,7 +350,11 @@ export default function IntegrationsContent({
 
             {/* Grid view */}
             {viewMode === 'grid' &&
-              (listPartners.length ? (
+              (searchError ? (
+                <p className="text-foreground-lighter text-sm">
+                  Unable to search partners. Try again.
+                </p>
+              ) : listPartners.length ? (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
                   {visiblePartners.map((p) => (
                     <Link
@@ -388,7 +402,11 @@ export default function IntegrationsContent({
 
             {/* List view */}
             {viewMode === 'list' &&
-              (listPartners.length ? (
+              (searchError ? (
+                <p className="text-foreground-lighter text-sm">
+                  Unable to search partners. Try again.
+                </p>
+              ) : listPartners.length ? (
                 <div className="border bg-background rounded-xl overflow-hidden divide-y">
                   {visiblePartners.map((p) => (
                     <Link
@@ -431,7 +449,7 @@ export default function IntegrationsContent({
                 </p>
               ))}
 
-            {hasMorePartners && (
+            {!searchError && hasMorePartners && (
               <div
                 ref={partnersLoadMoreRef}
                 className="flex justify-center py-4"

--- a/apps/www/app/pricing/PricingContent.tsx
+++ b/apps/www/app/pricing/PricingContent.tsx
@@ -35,11 +35,14 @@ export default function PricingContent() {
 
       <div className="text-center mt-10 xl:mt-16 mx-auto max-w-lg flex flex-col gap-8">
         <div className="flex justify-center gap-2">
-          <a href="#compare-plans">
-            <Button size="tiny" variant="secondary" iconRight={<ArrowDownIcon className="w-3" />}>
-              Compare Plans
-            </Button>
-          </a>
+          <Button
+            size="tiny"
+            variant="secondary"
+            asChild
+            iconRight={<ArrowDownIcon className="w-3" />}
+          >
+            <a href="#compare-plans">Compare Plans</a>
+          </Button>
           <Button
             size="tiny"
             variant="default"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The "Compare Plans" CTA on the pricing page wraps a `Button` component inside an anchor element:

```tsx
<a href="#compare-plans">
  <Button>Compare Plans</Button>
</a>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved partner search error handling with a clear retry message.
  * Preserved existing partner results when a search fails.
  * Reset search results and errors when clearing the search field.
  * Prevented infinite-scroll loading indicators from appearing during search errors.

* **Style**
  * Updated the “Compare Plans” call-to-action to maintain consistent button and link behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->