### PR TITLE
fix(studio): report date range gating ignores unlimited retention entitlement

### DIFF
--- a/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
+++ b/apps/studio/components/interfaces/Settings/Logs/Logs.DatePickers.tsx
@@ -327,8 +327,8 @@ export const LogsDatePicker = ({
     Math.abs(dayjs(startDate).diff(dayjs(endDate), 'days')) >
     LOGS_LARGE_DATE_RANGE_DAYS_THRESHOLD - 1
 
-  const { getEntitlementNumericValue } = useCheckEntitlements('log.retention_days')
-  const entitledToAuditLogDays = getEntitlementNumericValue()
+  const { getEntitlementMax } = useCheckEntitlements('log.retention_days')
+  const entitledToAuditLogDays = getEntitlementMax()
 
   const showHelperBadge = (helper?: DatetimeHelper) => {
     if (!helper) return false

--- a/apps/studio/hooks/misc/useReportDateRange.test.tsx
+++ b/apps/studio/hooks/misc/useReportDateRange.test.tsx
@@ -1,0 +1,82 @@
+import { act } from '@testing-library/react'
+import dayjs from 'dayjs'
+import { beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { useReportDateRange } from './useReportDateRange'
+import { REPORT_DATERANGE_HELPER_LABELS } from '@/components/interfaces/Reports/Reports.constants'
+import { customRenderHook } from '@/tests/lib/custom-render'
+
+const { mockGetEntitlementMax, mockGetEntitlementNumericValue } = vi.hoisted(() => ({
+  mockGetEntitlementMax: vi.fn(),
+  mockGetEntitlementNumericValue: vi.fn(),
+}))
+
+vi.mock('@/hooks/misc/useCheckEntitlements', () => ({
+  useCheckEntitlements: () => ({
+    getEntitlementMax: mockGetEntitlementMax,
+    getEntitlementNumericValue: mockGetEntitlementNumericValue,
+  }),
+}))
+
+vi.mock('@/hooks/misc/useCurrentOrgPlan', () => ({
+  useCurrentOrgPlan: () => ({ plan: { id: 'team' }, isLoading: false }),
+}))
+
+describe('useReportDateRange', () => {
+  beforeEach(() => {
+    mockGetEntitlementMax.mockReset()
+    mockGetEntitlementNumericValue.mockReset()
+  })
+
+  test('selecting Last 7 days applies the range when the org is entitled per getEntitlementMax', () => {
+    // Org's `log.retention_days` entitlement is unlimited, so `getEntitlementMax` correctly
+    // reports no cap, even though the raw numeric value (`getEntitlementNumericValue`) still
+    // carries a low placeholder that would wrongly gate a 7-day range if it were used instead.
+    mockGetEntitlementMax.mockReturnValue(Number.MAX_SAFE_INTEGER)
+    mockGetEntitlementNumericValue.mockReturnValue(1)
+
+    const { result } = customRenderHook(() =>
+      useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
+    )
+
+    const from = dayjs().subtract(7, 'day').toISOString()
+    const to = dayjs().toISOString()
+
+    act(() => {
+      result.current.handleDatePickerChange({
+        from,
+        to,
+        isHelper: true,
+        text: REPORT_DATERANGE_HELPER_LABELS.LAST_7_DAYS,
+      })
+    })
+
+    expect(result.current.showUpgradePrompt).toBe(false)
+    expect(result.current.selectedDateRange.period_start.date).toBe(from)
+    expect(result.current.selectedDateRange.period_end.date).toBe(to)
+  })
+
+  test('selecting a range beyond the entitled cap shows the upgrade prompt instead of applying it', () => {
+    mockGetEntitlementMax.mockReturnValue(1)
+    mockGetEntitlementNumericValue.mockReturnValue(1)
+
+    const { result } = customRenderHook(() =>
+      useReportDateRange(REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES)
+    )
+
+    const from = dayjs().subtract(7, 'day').toISOString()
+    const to = dayjs().toISOString()
+
+    act(() => {
+      result.current.handleDatePickerChange({
+        from,
+        to,
+        isHelper: true,
+        text: REPORT_DATERANGE_HELPER_LABELS.LAST_7_DAYS,
+      })
+    })
+
+    expect(result.current.showUpgradePrompt).toBe(true)
+    expect(result.current.selectedDateRange.period_start.date).not.toBe(from)
+  })
+})

--- a/apps/studio/hooks/misc/useReportDateRange.ts
+++ b/apps/studio/hooks/misc/useReportDateRange.ts
@@ -62,8 +62,8 @@ export const useReportDateRange = (
     | ReportsDatetimeHelper = REPORT_DATERANGE_HELPER_LABELS.LAST_60_MINUTES
 ) => {
   const { plan: orgPlan, isLoading: isOrgPlanLoading } = useCurrentOrgPlan()
-  const { getEntitlementNumericValue } = useCheckEntitlements('log.retention_days')
-  const entitledToAuditLogDays = getEntitlementNumericValue()
+  const { getEntitlementMax } = useCheckEntitlements('log.retention_days')
+  const entitledToAuditLogDays = getEntitlementMax()
   const [showUpgradePrompt, setShowUpgradePrompt] = useState(false)
 
   // Get filtered date picker helpers based on organization plan


### PR DESCRIPTION
## Summary
Report dashboards (Edge Functions, Auth, Realtime) gated date-range selection using the raw `log.retention_days` entitlement value instead of `getEntitlementMax()`, so orgs entitled to unlimited retention were still capped by whatever placeholder value ships with `unlimited: true`. Selecting a longer preset like "Last 7 days" would silently revert to the default range with no visible feedback.

Fixes FE-4023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected audit log retention entitlement handling when selecting report date ranges.
  * Users with sufficient retention access can now select supported ranges, even when a placeholder value is present.
  * Users exceeding their allowed retention period continue to receive an upgrade prompt, and unsupported ranges are not applied.
  * Updated audit log helper badges and lock indicators to reflect the correct retention limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->