### PR TITLE
fix(studio): bucket multi-hour report ranges hourly instead of by minute

### DIFF
--- a/apps/studio/hooks/misc/__tests__/useReportDateRange.test.ts
+++ b/apps/studio/hooks/misc/__tests__/useReportDateRange.test.ts
@@ -1,0 +1,35 @@
+import dayjs from 'dayjs'
+import { describe, expect, test } from 'vitest'
+
+import { analyticsIntervalToGranularity } from '@/data/reports/report.utils'
+import { getIntervalGranularity } from '@/hooks/misc/useReportDateRange'
+
+const rangeOf = (value: number, unit: dayjs.ManipulateType) => {
+  const to = dayjs()
+  return { from: to.subtract(value, unit).toISOString(), to: to.toISOString() }
+}
+
+describe('getIntervalGranularity', () => {
+  test.each([
+    [24, 'hour' as dayjs.ManipulateType, 24],
+    [7, 'day' as dayjs.ManipulateType, 168],
+  ])('a %s-%s range buckets hourly (FE-4023)', (value, unit, expectedBuckets) => {
+    const { from, to } = rangeOf(value, unit)
+    const interval = getIntervalGranularity(from, to)
+
+    expect(interval).toBe('1h')
+    expect(analyticsIntervalToGranularity(interval)).toBe('hour')
+    expect(dayjs(to).diff(from, 'hour')).toBe(expectedBuckets)
+  })
+
+  test.each([
+    [10, 'minute' as dayjs.ManipulateType, '1m'],
+    [1, 'hour' as dayjs.ManipulateType, '1m'],
+    [3, 'hour' as dayjs.ManipulateType, '2m'],
+    [14, 'day' as dayjs.ManipulateType, '1d'],
+    [28, 'day' as dayjs.ManipulateType, '1d'],
+  ])('leaves a %s-%s range on the %s interval', (value, unit, expected) => {
+    const { from, to } = rangeOf(value, unit)
+    expect(getIntervalGranularity(from, to)).toBe(expected)
+  })
+})

--- a/apps/studio/hooks/misc/useReportDateRange.ts
+++ b/apps/studio/hooks/misc/useReportDateRange.ts
@@ -19,8 +19,7 @@ export const getIntervalGranularity = (from: string, to: string): AnalyticsInter
 
   if (diffInHours <= 1) return '1m'
   if (diffInHours <= 12) return '2m'
-  if (diffInHours <= 24) return '10m'
-  if (diffInDays <= 7) return '30m'
+  if (diffInDays <= 7) return '1h'
   return '1d'
 }
 


### PR DESCRIPTION
Selecting "Last 7 days" on an Observability report rendered only the most recent ~10 hours, while the header still showed the full range.

`timestamp_trunc` only does minute/hour/day, so `analyticsIntervalToGranularity` floors any sub-hour interval to `minute`. The `'30m'` and `'10m'` intervals used for 7-day and 24-hour ranges therefore asked for 10,080 and 1,440 per-minute buckets. The analytics endpoint caps each query at 1,000 data points, and report queries are ordered newest-first with no `LIMIT`, so the oldest buckets got dropped. Confirmed against a production HAR: 168h requested, exactly 1,000 rows returned, 10.6h of data.

Both tiers now use `'1h'` — 168 and 24 buckets respectively, well inside the cap. Applies to Edge Functions, Auth and Realtime reports, which share this helper.

Remaining sites that can exceed 1,000 points, not touched here:

- Logs event chart (`calcChartStart`) — minute buckets over a range extended 6h earlier (~1,080), and hourly over a range extended 5 days earlier (90d → 2,280)
- API and Storage reports (`PRESET_CONFIG`) and `SharedAPIReport` — hardcoded `hour`, so a 90-day custom range is 2,160 points
- Query Insights — hardcoded `MINUTE` grouped per query, so unbounded

UnifiedLogs is fine; its ladder already caps at 720.

Fixes FE-4023

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated report date-range interval selection for ranges up to seven days to use hourly granularity instead of 30-minute intervals for clearer, more consistent reporting.

* **Tests**
  * Added automated coverage for interval granularity across minute-, hour-, and multi-week ranges.
  * Included assertions validating expected hourly bucket counts for a seven-day window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->