### PR TITLE
docs: prototype hero + feature grid for self-hosting overview

### DIFF
--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -5,29 +5,33 @@ subtitle: 'Install and run your own Supabase on your computer, server, or cloud 
 hideToc: true
 ---
 
-Self-hosting runs Supabase on your own infrastructure instead of the managed platform. Get full control over your data, meet compliance requirements, or run in a fully isolated environment.
-
-<div className="flex flex-wrap gap-3 not-prose">
-  <Button variant="primary" asChild>
-    <Link href="/guides/self-hosting/docker">Get started with Docker</Link>
-  </Button>
-  <Button variant="outline" asChild>
-    <Link href="#support-and-community">Join the community</Link>
-  </Button>
+<div className="grid grid-cols-12 gap-6 lg:gap-4 items-center not-prose">
+  <div className="col-span-12 lg:col-span-5">
+    <p className="text-foreground-light m-0">
+      Self-hosting runs Supabase on your own infrastructure instead of the managed platform. Get
+      full control over your data, meet compliance requirements, or run in a fully isolated
+      environment.
+    </p>
+  </div>
+  <div className="col-span-12 lg:col-span-7 xl:col-span-6 xl:col-start-7">
+    <Image
+      alt="Diagram of the Supabase stack running on your own infrastructure, with Database, Auth, Storage, and Realtime services."
+      src={{
+        dark: '/docs/img/self-hosting/self-hosting-hero-dark.svg',
+        light: '/docs/img/self-hosting/self-hosting-hero-light.svg',
+      }}
+      width={669}
+      height={360}
+      className="w-full h-auto"
+    />
+  </div>
 </div>
 
-<div className="w-full aspect-[16/6] rounded-lg border border-dashed border-strong flex items-center justify-center text-foreground-lighter text-sm not-prose">
-  Hero illustration — placeholder for Design
-</div>
-
-<div className="my-16 flex flex-col gap-2 max-w-xl">
+<div className="mt-8 mb-6 flex flex-col gap-1 max-w-xl">
   <span className="text-brand font-mono uppercase text-xs tracking-wider">Full platform</span>
-  <h2 className="text-foreground-lighter">
+  <h2 className="text-foreground-lighter !mt-0 !mb-0">
     Everything you get, <span className="text-foreground">self-hosted</span>
   </h2>
-  <p className="text-foreground-lighter">
-    Self-hosting isn't a stripped-down version — you get the full Supabase platform.
-  </p>
 </div>
 
 <ul className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12 not-prose">
@@ -62,7 +66,9 @@ Self-hosting runs Supabase on your own infrastructure instead of the managed pla
         <span className="h-7 bg-foreground-lighter" />
       </div>
       <h4 className="text-foreground text-lg mt-1">Storage</h4>
-      <p className="text-foreground-lighter text-sm">Store and serve files, from images to videos.</p>
+      <p className="text-foreground-lighter text-sm">
+        Store and serve files, from images to videos.
+      </p>
     </Link>
   </li>
   <li>

--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -5,9 +5,75 @@ subtitle: 'Install and run your own Supabase on your computer, server, or cloud 
 hideToc: true
 ---
 
-Self-hosting is a good fit if you need full control over your data, have compliance requirements that prevent you from using managed services, or want to run Supabase in an isolated environment.
+Self-hosting runs Supabase on your own infrastructure instead of the managed platform. Get full control over your data, meet compliance requirements, or run in a fully isolated environment.
 
-### How self-hosted Supabase differs
+<div className="flex flex-wrap gap-3 not-prose">
+  <Button variant="primary" asChild>
+    <Link href="/guides/self-hosting/docker">Get started with Docker</Link>
+  </Button>
+  <Button variant="outline" asChild>
+    <Link href="#support-and-community">Join the community</Link>
+  </Button>
+</div>
+
+## Everything you get, self-hosted
+
+<div className="grid grid-cols-12 gap-6 not-prose">
+  <Link href="/reference/self-hosting-auth/introduction" className="col-span-6 md:col-span-3" passHref>
+    <IconPanel
+      title="Auth"
+      icon="/docs/img/icons/menu/auth"
+      hasLightIcon={true}
+      background={true}
+      showIconBg={true}
+    >
+      Email/password, OAuth, and phone authentication.
+    </IconPanel>
+  </Link>
+  <Link href="/guides/database/overview" className="col-span-6 md:col-span-3" passHref>
+    <IconPanel
+      title="Database"
+      icon="/docs/img/icons/menu/database"
+      hasLightIcon={true}
+      background={true}
+      showIconBg={true}
+    >
+      A full Postgres database with realtime subscriptions.
+    </IconPanel>
+  </Link>
+  <Link href="/reference/self-hosting-storage/introduction" className="col-span-6 md:col-span-3" passHref>
+    <IconPanel
+      title="Storage"
+      icon="/docs/img/icons/menu/storage"
+      hasLightIcon={true}
+      background={true}
+      showIconBg={true}
+    >
+      Store and serve files, from images to videos.
+    </IconPanel>
+  </Link>
+  <Link href="/reference/self-hosting-realtime/introduction" className="col-span-6 md:col-span-3" passHref>
+    <IconPanel
+      title="Realtime"
+      icon="/docs/img/icons/menu/realtime"
+      hasLightIcon={true}
+      background={true}
+      showIconBg={true}
+    >
+      Listen to database changes and broadcast messages.
+    </IconPanel>
+  </Link>
+</div>
+
+<ContentListings id="self-hosting-get-started" />
+
+<ContentListings id="self-hosting-community" />
+
+## More about self-hosting
+
+<Accordion type="default" chevronAlign="right" justified>
+
+<AccordionItem header="How self-hosted Supabase differs" id="differs">
 
 Self-hosted Supabase is different from:
 
@@ -16,7 +82,9 @@ Self-hosted Supabase is different from:
 
 Self-hosted Supabase mimics a single project. Studio doesn't support multiple organizations or projects. Platform-only [features](/features) such as branching, advanced metrics beyond logs, managed backups and PITR, analytics and vector buckets, ETL, and the platform management API are **unavailable** in self-hosted configuration. Most settings are configured through [environment variables](https://github.com/supabase/supabase/blob/master/docker/.env.example).
 
-### Your responsibilities when self-hosting
+</AccordionItem>
+
+<AccordionItem header="Your responsibilities when self-hosting" id="responsibilities">
 
 When you self-host, **you are responsible for**:
 
@@ -28,15 +96,17 @@ When you self-host, **you are responsible for**:
 - Backups and disaster recovery
 - Monitoring and uptime
 
-### Telemetry
+</AccordionItem>
+
+<AccordionItem header="Telemetry" id="telemetry">
 
 Self-hosted Supabase (run via Docker Compose) **does not phone home or collect any telemetry**.
 
 The **Supabase CLI** is a [separate tool](/docs/guides/local-development/cli/getting-started) and collects usage telemetry to help improve the developer experience. See [CLI telemetry](/docs/guides/local-development/cli/getting-started#telemetry) for opt-out methods.
 
-<ContentListings id="self-hosting-get-started" />
+</AccordionItem>
 
-<ContentListings id="self-hosting-community" />
+</Accordion>
 
 ## Support and community
 

--- a/apps/docs/content/guides/self-hosting.mdx
+++ b/apps/docs/content/guides/self-hosting.mdx
@@ -16,53 +16,74 @@ Self-hosting runs Supabase on your own infrastructure instead of the managed pla
   </Button>
 </div>
 
-## Everything you get, self-hosted
+<div className="w-full aspect-[16/6] rounded-lg border border-dashed border-strong flex items-center justify-center text-foreground-lighter text-sm not-prose">
+  Hero illustration — placeholder for Design
+</div>
 
-<div className="grid grid-cols-12 gap-6 not-prose">
-  <Link href="/reference/self-hosting-auth/introduction" className="col-span-6 md:col-span-3" passHref>
-    <IconPanel
-      title="Auth"
-      icon="/docs/img/icons/menu/auth"
-      hasLightIcon={true}
-      background={true}
-      showIconBg={true}
-    >
-      Email/password, OAuth, and phone authentication.
-    </IconPanel>
-  </Link>
-  <Link href="/guides/database/overview" className="col-span-6 md:col-span-3" passHref>
-    <IconPanel
-      title="Database"
-      icon="/docs/img/icons/menu/database"
-      hasLightIcon={true}
-      background={true}
-      showIconBg={true}
-    >
-      A full Postgres database with realtime subscriptions.
-    </IconPanel>
-  </Link>
-  <Link href="/reference/self-hosting-storage/introduction" className="col-span-6 md:col-span-3" passHref>
-    <IconPanel
-      title="Storage"
-      icon="/docs/img/icons/menu/storage"
-      hasLightIcon={true}
-      background={true}
-      showIconBg={true}
-    >
-      Store and serve files, from images to videos.
-    </IconPanel>
-  </Link>
-  <Link href="/reference/self-hosting-realtime/introduction" className="col-span-6 md:col-span-3" passHref>
-    <IconPanel
-      title="Realtime"
-      icon="/docs/img/icons/menu/realtime"
-      hasLightIcon={true}
-      background={true}
-      showIconBg={true}
-    >
-      Listen to database changes and broadcast messages.
-    </IconPanel>
-  </Link>
+<div className="my-16 flex flex-col gap-2 max-w-xl">
+  <span className="text-brand font-mono uppercase text-xs tracking-wider">Full platform</span>
+  <h2 className="text-foreground-lighter">
+    Everything you get, <span className="text-foreground">self-hosted</span>
+  </h2>
+  <p className="text-foreground-lighter">
+    Self-hosting isn't a stripped-down version — you get the full Supabase platform.
+  </p>
+</div>
+
+<ul className="grid grid-cols-2 md:grid-cols-4 gap-8 md:gap-12 not-prose">
+  <li>
+    <Link href="/reference/self-hosting-auth/introduction">
+      <img src="/docs/img/icons/menu/auth.svg" alt="" className="w-7 h-7 mb-2" />
+      <div className="w-full h-px overflow-hidden flex items-start bg-border-muted">
+        <span className="h-7 bg-foreground-lighter" />
+      </div>
+      <h4 className="text-foreground text-lg mt-1">Auth</h4>
+      <p className="text-foreground-lighter text-sm">
+        Email/password, OAuth, and phone authentication.
+      </p>
+    </Link>
+  </li>
+  <li>
+    <Link href="/guides/database/overview">
+      <img src="/docs/img/icons/menu/database.svg" alt="" className="w-7 h-7 mb-2" />
+      <div className="w-full h-px overflow-hidden flex items-start bg-border-muted">
+        <span className="h-7 bg-foreground-lighter" />
+      </div>
+      <h4 className="text-foreground text-lg mt-1">Database</h4>
+      <p className="text-foreground-lighter text-sm">
+        A full Postgres database with realtime subscriptions.
+      </p>
+    </Link>
+  </li>
+  <li>
+    <Link href="/reference/self-hosting-storage/introduction">
+      <img src="/docs/img/icons/menu/storage.svg" alt="" className="w-7 h-7 mb-2" />
+      <div className="w-full h-px overflow-hidden flex items-start bg-border-muted">
+        <span className="h-7 bg-foreground-lighter" />
+      </div>
+      <h4 className="text-foreground text-lg mt-1">Storage</h4>
+      <p className="text-foreground-lighter text-sm">Store and serve files, from images to videos.</p>
+    </Link>
+  </li>
+  <li>
+    <Link href="/reference/self-hosting-realtime/introduction">
+      <img src="/docs/img/icons/menu/realtime.svg" alt="" className="w-7 h-7 mb-2" />
+      <div className="w-full h-px overflow-hidden flex items-start bg-border-muted">
+        <span className="h-7 bg-foreground-lighter" />
+      </div>
+      <h4 className="text-foreground text-lg mt-1">Realtime</h4>
+      <p className="text-foreground-lighter text-sm">
+        Listen to database changes and broadcast messages.
+      </p>
+    </Link>
+  </li>
+</ul>
+
+<div className="my-16 flex flex-col items-center text-center gap-4 not-prose">
+  <h2>Ready to self-host Supabase?</h2>
+  <Button variant="primary" asChild>
+    <Link href="/guides/self-hosting/docker">Get started with Docker</Link>
+  </Button>
 </div>
 
 <ContentListings id="self-hosting-get-started" />
@@ -112,11 +133,7 @@ The **Supabase CLI** is a [separate tool](/docs/guides/local-development/cli/get
 
 Self-hosted Supabase is community-supported.
 
-<ContentListings id="self-hosting-resolve-issues" />
-
-<ContentListings id="self-hosting-get-help" />
-
-<ContentListings id="self-hosting-share-experience" />
+<ContentListings id="self-hosting-support" />
 
 ### Enterprise self-hosting
 

--- a/apps/docs/data/content-listings/index.ts
+++ b/apps/docs/data/content-listings/index.ts
@@ -15,10 +15,8 @@ import { logDrainsDestinations } from './log-drains.data'
 import { realtimeExamples, realtimeGetStarted, realtimeResources } from './realtime.data'
 import {
   selfHostingCommunity,
-  selfHostingGetHelp,
   selfHostingGetStarted,
-  selfHostingResolveIssues,
-  selfHostingShareExperience,
+  selfHostingSupport,
 } from './self-hosting.data'
 import { storageExamples, storageGetStarted, storageResources } from './storage.data'
 
@@ -42,9 +40,7 @@ const ALL_GROUPS: readonly ContentListingGroup[] = [
   realtimeResources,
   selfHostingGetStarted,
   selfHostingCommunity,
-  selfHostingResolveIssues,
-  selfHostingGetHelp,
-  selfHostingShareExperience,
+  selfHostingSupport,
   storageGetStarted,
   storageExamples,
   storageResources,

--- a/apps/docs/data/content-listings/self-hosting.data.ts
+++ b/apps/docs/data/content-listings/self-hosting.data.ts
@@ -44,9 +44,8 @@ export const selfHostingCommunity: ContentListingGroup = {
   ],
 }
 
-export const selfHostingResolveIssues: ContentListingGroup = {
-  id: 'self-hosting-resolve-issues',
-  description: 'For resolving common issues:',
+export const selfHostingSupport: ContentListingGroup = {
+  id: 'self-hosting-support',
   type: 'grid',
   columns: 2,
   items: [
@@ -54,51 +53,33 @@ export const selfHostingResolveIssues: ContentListingGroup = {
       title: 'GitHub Discussions',
       href: 'https://github.com/orgs/supabase/discussions?discussions_q=is%3Aopen+label%3Aself-hosted',
       icon: '/docs/img/icons/github-icon',
-      description: 'Questions, feature requests, and workarounds',
+      description: 'Ask questions, resolve common issues, and make feature requests',
     },
     {
       title: 'GitHub Issues',
       href: 'https://github.com/supabase/supabase/issues?q=is%3Aissue%20state%3Aopen%20label%3Aself-hosted',
       icon: '/docs/img/icons/github-icon',
-      description: 'Known issues',
+      description: 'Find out about known issues and workarounds',
     },
-  ],
-}
-
-export const selfHostingGetHelp: ContentListingGroup = {
-  id: 'self-hosting-get-help',
-  description: 'Get help and connect with other users:',
-  type: 'grid',
-  columns: 2,
-  items: [
     {
       title: 'Discord',
       href: 'https://discord.supabase.com',
       icon: '/docs/img/icons/discord-icon',
       hasLightIcon: false,
-      description: 'Real-time chat and community support',
+      description: 'Connect with other users and get help',
     },
     {
       title: 'Reddit',
       href: 'https://www.reddit.com/r/Supabase/',
       icon: '/docs/img/icons/reddit-icon',
       hasLightIcon: false,
-      description: 'Official Supabase subreddit',
+      description: 'Join the official Supabase subreddit',
     },
-  ],
-}
-
-export const selfHostingShareExperience: ContentListingGroup = {
-  id: 'self-hosting-share-experience',
-  description: 'Share your self-hosting experience:',
-  type: 'grid',
-  columns: 2,
-  items: [
     {
-      title: 'GitHub Discussions',
+      title: 'Share your experience',
       href: 'https://github.com/orgs/supabase/discussions/39820',
       icon: '/docs/img/icons/github-icon',
-      description: "Self-hosting: What's working (and what's not)?",
+      description: 'Share your self-hosting experience',
     },
   ],
 }

--- a/apps/docs/public/img/self-hosting/self-hosting-hero-dark.svg
+++ b/apps/docs/public/img/self-hosting/self-hosting-hero-dark.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="669" height="360" fill="none" viewBox="0 0 669 360">
+  <defs>
+    <linearGradient id="gGreen" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3ECF8E"/>
+      <stop offset="100%" stop-color="#249361"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="#000" flood-opacity="0.35"/>
+    </filter>
+    <radialGradient id="glow" cx="72%" cy="42%" r="48%">
+      <stop offset="0%" stop-color="#3ECF8E" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#3ECF8E" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="669" height="360" fill="url(#glow)"/>
+
+  <g filter="url(#shadow)">
+    <rect x="72" y="88" width="160" height="184" rx="28" fill="#1C1C1C" stroke="#343434" stroke-width="1.1"/>
+  </g>
+  <line x1="92" y1="96" x2="92" y2="264" stroke="#282828" stroke-width="0.75"/><line x1="112" y1="96" x2="112" y2="264" stroke="#282828" stroke-width="0.75"/><line x1="132" y1="96" x2="132" y2="264" stroke="#282828" stroke-width="0.75"/><line x1="152" y1="96" x2="152" y2="264" stroke="#282828" stroke-width="0.75"/><line x1="172" y1="96" x2="172" y2="264" stroke="#282828" stroke-width="0.75"/><line x1="192" y1="96" x2="192" y2="264" stroke="#282828" stroke-width="0.75"/><line x1="212" y1="96" x2="212" y2="264" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="116" x2="226" y2="116" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="136" x2="226" y2="136" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="156" x2="226" y2="156" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="176" x2="226" y2="176" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="196" x2="226" y2="196" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="216" x2="226" y2="216" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="236" x2="226" y2="236" stroke="#282828" stroke-width="0.75"/><line x1="78" y1="256" x2="226" y2="256" stroke="#282828" stroke-width="0.75"/>
+  <rect x="108" y="140" width="88" height="88" rx="14" fill="none" stroke="#707070" stroke-width="1.2" stroke-dasharray="4 4"/>
+  <rect x="124" y="156" width="56" height="14" rx="3" fill="#454545" fill-opacity="0.35"/>
+  <rect x="124" y="178" width="56" height="14" rx="3" fill="#454545" fill-opacity="0.35"/>
+  <rect x="124" y="200" width="56" height="14" rx="3" fill="#3ECF8E" fill-opacity="0.55"/>
+  <text x="152" y="254" text-anchor="middle" fill="#707070" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10">YOUR INFRA</text>
+
+  <path d="M232 120 H256 V52 H424 V72" stroke="#454545" stroke-width="1.25" fill="none"/>
+  <circle cx="232" cy="120" r="3" fill="#454545"/>
+  <circle cx="424" cy="72" r="4.5" fill="#EDEDED"/>
+
+  <g filter="url(#shadow)">
+    <rect x="280" y="72" width="288" height="232" rx="36" fill="#1C1C1C" stroke="#343434" stroke-width="1.25"/>
+  </g>
+  <rect x="300" y="92" width="132" height="24" rx="12" fill="#202020" stroke="#2E2E2E"/>
+  <circle cx="314" cy="104" r="4" fill="url(#gGreen)"/>
+  <text x="326" y="108" fill="#EDEDED" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11">SELF-HOSTED</text>
+  <rect x="300" y="128" width="248" height="32" rx="8" fill="#202020" stroke="#2E2E2E"/>
+  <circle cx="318" cy="144" r="4" fill="#3ECF8E"/>
+  <text x="334" y="148" fill="#EDEDED" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Database</text>
+  <rect x="470" y="140" width="60" height="8" rx="4" fill="#282828"/>
+  <rect x="470" y="140" width="52" height="8" rx="4" fill="#3ECF8E"/>
+  <rect x="300" y="168" width="248" height="32" rx="8" fill="#202020" stroke="#2E2E2E"/>
+  <circle cx="318" cy="184" r="4" fill="#3ECF8E"/>
+  <text x="334" y="188" fill="#EDEDED" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Auth</text>
+  <rect x="470" y="180" width="60" height="8" rx="4" fill="#282828"/>
+  <rect x="470" y="180" width="46" height="8" rx="4" fill="#3ECF8E"/>
+  <rect x="300" y="208" width="248" height="32" rx="8" fill="#202020" stroke="#2E2E2E"/>
+  <circle cx="318" cy="224" r="4" fill="#3ECF8E"/>
+  <text x="334" y="228" fill="#EDEDED" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Storage</text>
+  <rect x="470" y="220" width="60" height="8" rx="4" fill="#282828"/>
+  <rect x="470" y="220" width="40" height="8" rx="4" fill="#3ECF8E"/>
+  <rect x="300" y="248" width="248" height="32" rx="8" fill="#202020" stroke="#2E2E2E"/>
+  <circle cx="318" cy="264" r="4" fill="#3ECF8E"/>
+  <text x="334" y="268" fill="#EDEDED" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Realtime</text>
+  <rect x="470" y="260" width="60" height="8" rx="4" fill="#282828"/>
+  <rect x="470" y="260" width="48" height="8" rx="4" fill="#3ECF8E"/>
+</svg>

--- a/apps/docs/public/img/self-hosting/self-hosting-hero-light.svg
+++ b/apps/docs/public/img/self-hosting/self-hosting-hero-light.svg
@@ -1,0 +1,57 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="669" height="360" fill="none" viewBox="0 0 669 360">
+  <defs>
+    <linearGradient id="gGreen" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#3ECF8E"/>
+      <stop offset="100%" stop-color="#249361"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="16" flood-color="#000" flood-opacity="0.08"/>
+    </filter>
+    <radialGradient id="glow" cx="72%" cy="42%" r="48%">
+      <stop offset="0%" stop-color="#3ECF8E" stop-opacity="0.08"/>
+      <stop offset="100%" stop-color="#3ECF8E" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="669" height="360" fill="url(#glow)"/>
+
+  <g filter="url(#shadow)">
+    <rect x="72" y="88" width="160" height="184" rx="28" fill="#FFFFFF" stroke="#E6E6E6" stroke-width="1.1"/>
+  </g>
+  <line x1="92" y1="96" x2="92" y2="264" stroke="#E8E8E8" stroke-width="0.75"/><line x1="112" y1="96" x2="112" y2="264" stroke="#E8E8E8" stroke-width="0.75"/><line x1="132" y1="96" x2="132" y2="264" stroke="#E8E8E8" stroke-width="0.75"/><line x1="152" y1="96" x2="152" y2="264" stroke="#E8E8E8" stroke-width="0.75"/><line x1="172" y1="96" x2="172" y2="264" stroke="#E8E8E8" stroke-width="0.75"/><line x1="192" y1="96" x2="192" y2="264" stroke="#E8E8E8" stroke-width="0.75"/><line x1="212" y1="96" x2="212" y2="264" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="116" x2="226" y2="116" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="136" x2="226" y2="136" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="156" x2="226" y2="156" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="176" x2="226" y2="176" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="196" x2="226" y2="196" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="216" x2="226" y2="216" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="236" x2="226" y2="236" stroke="#E8E8E8" stroke-width="0.75"/><line x1="78" y1="256" x2="226" y2="256" stroke="#E8E8E8" stroke-width="0.75"/>
+  <rect x="108" y="140" width="88" height="88" rx="14" fill="none" stroke="#7E7E7E" stroke-width="1.2" stroke-dasharray="4 4"/>
+  <rect x="124" y="156" width="56" height="14" rx="3" fill="#B5B5B5" fill-opacity="0.35"/>
+  <rect x="124" y="178" width="56" height="14" rx="3" fill="#B5B5B5" fill-opacity="0.35"/>
+  <rect x="124" y="200" width="56" height="14" rx="3" fill="#3ECF8E" fill-opacity="0.55"/>
+  <text x="152" y="254" text-anchor="middle" fill="#7E7E7E" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10">YOUR INFRA</text>
+
+  <path d="M232 120 H256 V52 H424 V72" stroke="#B5B5B5" stroke-width="1.25" fill="none"/>
+  <circle cx="232" cy="120" r="3" fill="#B5B5B5"/>
+  <circle cx="424" cy="72" r="4.5" fill="#1C1C1C"/>
+
+  <g filter="url(#shadow)">
+    <rect x="280" y="72" width="288" height="232" rx="36" fill="#FFFFFF" stroke="#E6E6E6" stroke-width="1.25"/>
+  </g>
+  <rect x="300" y="92" width="132" height="24" rx="12" fill="#F3F3F3" stroke="#DDDDDD"/>
+  <circle cx="314" cy="104" r="4" fill="url(#gGreen)"/>
+  <text x="326" y="108" fill="#1C1C1C" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11">SELF-HOSTED</text>
+  <rect x="300" y="128" width="248" height="32" rx="8" fill="#F3F3F3" stroke="#DDDDDD"/>
+  <circle cx="318" cy="144" r="4" fill="#3ECF8E"/>
+  <text x="334" y="148" fill="#1C1C1C" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Database</text>
+  <rect x="470" y="140" width="60" height="8" rx="4" fill="#E8E8E8"/>
+  <rect x="470" y="140" width="52" height="8" rx="4" fill="#3ECF8E"/>
+  <rect x="300" y="168" width="248" height="32" rx="8" fill="#F3F3F3" stroke="#DDDDDD"/>
+  <circle cx="318" cy="184" r="4" fill="#3ECF8E"/>
+  <text x="334" y="188" fill="#1C1C1C" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Auth</text>
+  <rect x="470" y="180" width="60" height="8" rx="4" fill="#E8E8E8"/>
+  <rect x="470" y="180" width="46" height="8" rx="4" fill="#3ECF8E"/>
+  <rect x="300" y="208" width="248" height="32" rx="8" fill="#F3F3F3" stroke="#DDDDDD"/>
+  <circle cx="318" cy="224" r="4" fill="#3ECF8E"/>
+  <text x="334" y="228" fill="#1C1C1C" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Storage</text>
+  <rect x="470" y="220" width="60" height="8" rx="4" fill="#E8E8E8"/>
+  <rect x="470" y="220" width="40" height="8" rx="4" fill="#3ECF8E"/>
+  <rect x="300" y="248" width="248" height="32" rx="8" fill="#F3F3F3" stroke="#DDDDDD"/>
+  <circle cx="318" cy="264" r="4" fill="#3ECF8E"/>
+  <text x="334" y="268" fill="#1C1C1C" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="12">Realtime</text>
+  <rect x="470" y="260" width="60" height="8" rx="4" fill="#E8E8E8"/>
+  <rect x="470" y="260" width="48" height="8" rx="4" fill="#3ECF8E"/>
+</svg>


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This is an exploratory redesign prototype for the self-hosting overview page.

Closes DOCS-1251 (exploratory — meant to be shown to Design before deciding whether to pursue this direction; see companion PR for the more conservative "inform" pass).

## What is the current behavior?

- Linear item: Explore two PR approaches for the self-hosting page
- The self-hosting overview page (`/guides/self-hosting`) is the top search hit for "supabase self-hosting," but only informs — it has no visual hook, no feature highlight, and the getting-started CTA is buried as a small card partway down a text-heavy page.

## What is the new behavior?

- Hero-style opening: title/subtitle, intro copy left of a draft self-hosting illustration (dark/light SVG), no top CTA row above the hero.
- **Draft hero illustration** showing your infra connected to a self-hosted Database/Auth/Storage/Realtime stack.
- **Redesigned "Everything you get, self-hosted" section**, replacing the previous boxed `IconPanel` grid: an eyebrow label ("Full platform"), a muted heading with a highlighted phrase, and a borderless 4-item icon grid (Auth, Database, Storage, Realtime) with a thin accent rule under each icon — modeled on SupaSquad's `FeaturesSection` layout. Kept the existing colored `/docs/img/icons/menu/*.svg` assets as plain icons (zero shared-component/registry changes) rather than switching to monochrome `lucide-react` icons, since that would require registering new icons in the shared MDX component list used by every guide page.
- Added a closing CTA section ("Ready to self-host Supabase?" + Get started button) before the existing `ContentListings` grids, matching SupaSquad's structure.
- **Simplified "Support and community"** (same change as the companion PR): merged the three separate `ContentListings` groups into a single 5-card grid, folding each group's lead-in line into its card description.
- Same "Get started" / "Community-driven projects" `ContentListings` grids and same collapsed "More about self-hosting" `Accordion` as before.

## Additional context

- Worktree: `~/GitHub/supabase/supabase-worktrees/nikrichers/docs-1251-self-hosting-design`
- Companion PR: a more conservative "inform" pass on the same page/ticket that skips the hero/feature-grid layer.
- Known constraint: `docker.mdx`'s `tocVideo` frontmatter can't be surfaced on this page as an "excite" element, because the TOC/video rail only renders when `hideToc` is false, and this page keeps `hideToc: true` in both directions — flagging this as a follow-up idea, not something this PR attempts.
- Verification:

| Check                                           | Result                                                        |
| ----------------------------------------------- | ------------------------------------------------------------- |
| `pnpm lint:mdx content/guides/self-hosting.mdx` | Pass — no errors/warnings on this file                        |
| Vercel docs preview                             | Pass — full-page screenshots captured from the preview deploy |

### Proof: hero + feature grid render at desktop and mobile widths

**Verified:** `pnpm lint:mdx content/guides/self-hosting.mdx` (pass) · Vercel docs preview (pass)

### Before & After

| [Before (production)](https://supabase.com/docs/guides/self-hosting)                                                                                         | [After (PR preview)](https://docs-git-nikrichers-docs-1251-self-hosting-design-supabase.vercel.app/docs/guides/self-hosting)                               |
| ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
| ![Before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48416/self-hosting-design-before-full-d5e6f7a8.png) | ![After](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48416/self-hosting-design-after-full-c9d0e1f2.png) |

### Test plan

- [ ] Visit the preview link once available and sanity-check the hero, illustration, and feature grid at desktop and mobile widths
- [ ] Confirm the 4 feature-grid links (Auth/Database/Storage/Realtime) resolve correctly
- [ ] Confirm "Support and community" renders as a single 5-card grid with no floating lead-in text
- [ ] Expand each accordion item and confirm no content was lost from the current production page
- [ ] Get Design's read on the hero/grid direction (and the draft illustration) before deciding whether to pursue further
