### PR TITLE
chore(ui): Remove 'tip' from Admonition

### DIFF
--- a/apps/docs/CONTRIBUTING.md
+++ b/apps/docs/CONTRIBUTING.md
@@ -191,8 +191,7 @@ Choose the appropriate `type` for your admonition:
 - `danger`: Warn about actions or conditions that could cause data loss, expose sensitive data, or create another severe and difficult-to-reverse outcome. State the consequence first, and then explain how to avoid it.
 - `deprecation`: Identify a deprecated feature or behavior. State how the change affects the reader, and then provide the supported alternative or migration path.
 - `caution`: Warn about behavior that could cause bugs, failed operations, unexpected results, or serious inconvenience but doesn't rise to the severity of `danger`.
-- `tip`: Share an optional shortcut, optimization, or best practice that helps the reader complete the task more effectively. The main procedure must still work without it.
-- `note`: Highlight an important prerequisite, constraint, or clarification that doesn't represent a risk. If the information is essential to completing a step, include it in the procedure instead.
+- `note`: Highlight an important prerequisite, constraint, clarification, or optional shortcut that doesn't represent a risk. If the information is essential to completing a step, include it in the procedure instead.
 
 ```
 <Admonition type="note" title="Optional title">

--- a/apps/docs/app/contributing/content.mdx
+++ b/apps/docs/app/contributing/content.mdx
@@ -75,7 +75,7 @@ For content that requires progressive disclosure:
 
 ### Admonition
 
-For extra information that doesn't fit into the main flow. There are 4 supported types of admonitions:
+For extra information that doesn't fit into the main flow, you can use the following types of admonitions:
 
 - `danger` to warn the user about any missteps that could cause data loss or data leaks
 - `deprecation` to notify the user about features that are (or will soon be) deprecated

--- a/apps/docs/app/contributing/content.mdx
+++ b/apps/docs/app/contributing/content.mdx
@@ -75,12 +75,11 @@ For content that requires progressive disclosure:
 
 ### Admonition
 
-For extra information that doesn't fit into the main flow. There are 5 supported types of admonitions:
+For extra information that doesn't fit into the main flow. There are 4 supported types of admonitions:
 
 - `danger` to warn the user about any missteps that could cause data loss or data leaks
 - `deprecation` to notify the user about features that are (or will soon be) deprecated
 - `caution` to warn about anything that could cause a bug or serious user inconvenience
-- `tip` to point out helpful but optional actions
 - `note` for anything else
 
 Leave a blank line between the admonition tag and the contained content. This will prevent Prettier from trying to break the lines within the content.
@@ -104,15 +103,9 @@ You should make sure you don't set this up wrong.
 
 </Admonition>
 
-<Admonition type="tip">
-
-In certain cases, you may want to do this.
-
-</Admonition>
-
 <Admonition type="note">
 
-Additional helpful information.
+In certain cases, you may want to do this.
 
 </Admonition>
 ```
@@ -135,15 +128,9 @@ You should make sure you don't set this up wrong.
 
 </Admonition>
 
-<Admonition type="tip">
-
-In certain cases, you may want to do this.
-
-</Admonition>
-
 <Admonition type="note">
 
-Additional helpful information.
+In certain cases, you may want to do this.
 
 </Admonition>
 

--- a/apps/docs/components/WrapperDashboardIntegration.tsx
+++ b/apps/docs/components/WrapperDashboardIntegration.tsx
@@ -4,7 +4,7 @@ import { Admonition } from 'ui-patterns/Admonition'
 
 export function WrapperDashboardIntegration({ title, path }: { title: string; path: string }) {
   return (
-    <Admonition type="tip" className="mb-4">
+    <Admonition type="note" className="mb-4">
       <p>You can enable the {title} wrapper right from the Supabase dashboard.</p>
 
       <Button asChild>

--- a/apps/docs/content/_partials/api_settings.mdx
+++ b/apps/docs/content/_partials/api_settings.mdx
@@ -5,7 +5,7 @@ To interact with data in database tables, you use the client libraries that wrap
 <ProjectConfigVariables variable="url" />
 <ProjectConfigVariables variable="publishable" />
 
-<Admonition type="tip">
+<Admonition type="note">
 
 [Read the API keys docs](/docs/guides/getting-started/api-keys) for a full explanation of all key types, their uses, and where to find them.
 

--- a/apps/docs/content/_partials/cost_warning.mdx
+++ b/apps/docs/content/_partials/cost_warning.mdx
@@ -1,6 +1,6 @@
 <Admonition type="caution">
 
-To keep SMS sending costs under control, make sure you adjust your project's rate limits and [configure CAPTCHA](/docs/guides/auth/auth-captcha). See the [Production Checklist](/docs/guides/platform/going-into-prod) to learn more.
+To keep SMS sending costs under control, make sure you adjust your project's rate limits and [configure CAPTCHA](/docs/guides/auth/auth-captcha). See the [Production Checklist](/docs/guides/deployment/going-into-prod) to learn more.
 
 Some countries have special regulations for services that send SMS messages to users, (e.g India's TRAI DLT regulations). Remember to look up and follow the regulations of countries where you operate.
 

--- a/apps/docs/content/_partials/create_client_snippet.mdx
+++ b/apps/docs/content/_partials/create_client_snippet.mdx
@@ -1,4 +1,4 @@
-<Admonition type="tip">
+<Admonition type="note">
 
 Make sure you're using the right `supabase` client in the following code.
 

--- a/apps/docs/content/_partials/postgres_installation.mdx
+++ b/apps/docs/content/_partials/postgres_installation.mdx
@@ -47,7 +47,7 @@
     psql --version
     ```
 
-    <Admonition type="tip">
+    <Admonition type="note">
 
     If you get an error that psql is not available or cannot be found, check that you have correctly added the binary to your system PATH. Also try restarting your terminal.
 

--- a/apps/docs/content/_partials/providers.mdx
+++ b/apps/docs/content/_partials/providers.mdx
@@ -6,7 +6,7 @@ Supabase Auth works with many popular Auth methods, including Social and Phone A
 
 <AuthProviders type="social" />
 
-<Admonition type="tip">
+<Admonition type="note">
 
 You can also add any OAuth2 or OIDC-compatible identity provider using [Custom OAuth/OIDC Providers](/docs/guides/auth/custom-oauth-providers).
 

--- a/apps/docs/content/_partials/quickstart_db_setup.mdx
+++ b/apps/docs/content/_partials/quickstart_db_setup.mdx
@@ -29,7 +29,7 @@ To start, you need a Supabase project.
 
 Create a new Supabase project from [the Dashboard of any organization](/dashboard/new/_) you belong to.
 
-<Admonition type="tip" title="Want to create a project programmatically?">
+<Admonition type="note" title="Want to create a project programmatically?">
 
 Use [the Management API](/docs/reference/api/v1-create-a-project) or ask [the MCP server](/docs/guides/ai-tools/mcp#account-management) to create a new Supabase project.
 
@@ -41,13 +41,13 @@ When your Supabase project is up and running, create an `instruments` table with
 
 Do these steps within your project's dashboard by copying and running the snippet in your project's [SQL Editor](/dashboard/project/_/sql/new).
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Save some steps by <a href={`/dashboard/project/_/sql/new?content=${encodeURIComponent(sqlSetup)}`}>clicking here to prefill the SQL</a> in the SQL Editor, and then clicking **Run**.
 
 </Admonition>
 
-<Admonition type="tip" title="Want to setup the database programmatically?">
+<Admonition type="note" title="Want to setup the database programmatically?">
 
 You can use [the Management API](/docs/reference/api/v1-run-a-query) or ask [the MCP server](/docs/guides/ai-tools/mcp#database) to execute SQL queries.
 

--- a/apps/docs/content/_partials/uiLibCta.mdx
+++ b/apps/docs/content/_partials/uiLibCta.mdx
@@ -1,4 +1,4 @@
-<Admonition type="tip" title="Explore drop-in UI components for your Supabase app.">
+<Admonition type="note" title="Explore drop-in UI components for your Supabase app.">
 
 UI components built on shadcn/ui that connect to Supabase via a single command.
 

--- a/apps/docs/content/guides/ai-tools/byo-mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/byo-mcp.mdx
@@ -49,7 +49,7 @@ Create a new Edge Function for your MCP server:
 supabase functions new mcp
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 This tutorial uses the [official MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk) with the `WebStandardStreamableHTTPServerTransport`, but you can use any MCP framework that's compatible with the [Edge Runtime](/docs/guides/functions), such as [mcp-lite](https://github.com/fiberplane/mcp-lite) or [mcp-handler](https://github.com/vercel/mcp-handler).
 

--- a/apps/docs/content/guides/ai-tools/mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/mcp.mdx
@@ -118,7 +118,7 @@ Parameters can be combined: <code><CustomContent data="mcp:servers">remote</Cust
 
 <Admonition type="note">
 
-When using [Supabase CLI](/docs/guides/cli) for local development, the MCP server is available at <code><CustomContent data="mcp:servers">local</CustomContent></code>.
+When using [Supabase CLI](/docs/guides/local-development) for local development, the MCP server is available at <code><CustomContent data="mcp:servers">local</CustomContent></code>.
 
 </Admonition>
 

--- a/apps/docs/content/guides/ai-tools/mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/mcp.mdx
@@ -116,7 +116,7 @@ The [configuration panel above](#configure-your-ai-tool) can set these options f
 
 Parameters can be combined: <code><CustomContent data="mcp:servers">remote</CustomContent>?project_ref=abc123&read_only=true</code>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 When using [Supabase CLI](/docs/guides/cli) for local development, the MCP server is available at <code><CustomContent data="mcp:servers">local</CustomContent></code>.
 

--- a/apps/docs/content/guides/ai-tools/mcp.mdx
+++ b/apps/docs/content/guides/ai-tools/mcp.mdx
@@ -32,13 +32,13 @@ To verify the client has access to the MCP server tools, try asking it to query 
 
 <$Show if="docs:prompts">
 
-For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/docs/guides/getting-started/ai-prompts) collection.
+For curated, ready-to-use prompts that work well with IDEs and AI agents, see our [AI Prompts](/docs/guides/ai-tools/ai-prompts) collection.
 
 </$Show>
 
 <$Show if="docs:agent_skills">
 
-Additionally, you can install Supabase agent skills alongside the MCP server, use the [Supabase Plugin for AI Coding Agents](/docs/guides/getting-started/plugins) for a combined one-step setup.
+Additionally, you can install Supabase agent skills alongside the MCP server, use the [Supabase Plugin for AI Coding Agents](/docs/guides/ai-tools/plugins) for a combined one-step setup.
 
 </$Show>
 

--- a/apps/docs/content/guides/ai/python-clients.mdx
+++ b/apps/docs/content/guides/ai/python-clients.mdx
@@ -9,7 +9,7 @@ As described in [Structured & Unstructured Embeddings](/docs/guides/ai/structure
 
 For data science or ephemeral workloads, the [Supabase Vecs](https://supabase.github.io/vecs/) client gets you started. You need a connection string and vecs handles setting up your database to store and query vectors with associated metadata.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Click [**Connect**](/dashboard/project/_/?showConnect=true) at the top of any project page to get your connection string.
 

--- a/apps/docs/content/guides/ai/rag-with-permissions.mdx
+++ b/apps/docs/content/guides/ai/rag-with-permissions.mdx
@@ -53,7 +53,7 @@ on document_sections for select to authenticated using (
 );
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 In this example, the current user is determined using the built-in `auth.uid()` function when the query is executed through your project's auto-generated [REST API](/docs/guides/api). If you are connecting to your Supabase database through a direct Postgres connection, see [Direct Postgres Connection](#direct-postgres-connection) below for directions on how to achieve the same access control.
 
@@ -120,7 +120,7 @@ RLS is latency-sensitive, so extra caution should be taken before implementing t
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 For data sources other than Postgres, see [Foreign Data Wrappers](/docs/guides/database/extensions/wrappers/overview) for a list of external sources supported today. If your data lives in a source not provided in the list, contact [support](/dashboard/support/new) and we'll be happy to discuss your use case.
 
@@ -164,7 +164,7 @@ import foreign schema public limit to (users, documents)
   from server foreign_server into external;
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 This example maps the `authenticated` role in Supabase to the `postgres` user in the external DB. In production, it's best to create a custom user on the external DB that has the minimum permissions necessary to access the information you need.
 

--- a/apps/docs/content/guides/ai/vector-columns.mdx
+++ b/apps/docs/content/guides/ai/vector-columns.mdx
@@ -61,7 +61,7 @@ create table documents (
 
 In the SQL snippet above, we create a `documents` table with an `embedding` column. This is a standard Postgres column, so you can name it anything you like. The `embedding` column uses the `vector` data type with 384 dimensions. Change this number to match the dimensions your embedding model produces. For example, if you're [generating embeddings](/docs/guides/ai/quickstarts/generate-text-embeddings) using the open source [`gte-small`](https://huggingface.co/Supabase/gte-small) model, set this to 384.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 In general, embeddings with fewer dimensions perform best. See our [analysis on fewer dimensions in pgvector](/blog/fewer-dimensions-are-better-pgvector).
 
@@ -156,13 +156,13 @@ const { data: documents } = await supabaseClient.rpc('match_documents', {
 
 In this example `embedding` would be another embedding you wish to compare against your table of pre-generated embedding documents. For example if you were building a search engine, every time the user submits their query you would first generate an embedding on the search query itself, then pass it into the above `rpc()` function to match.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 To filter your vector search by another column from the JS client, extend the function above with an extra parameter and `where` clause. See [Filtering vector search by metadata](/docs/guides/ai/semantic-search#filtering-vector-search-by-metadata) for a worked example.
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Be sure to use embeddings produced from the same embedding model when calculating distance. Comparing embeddings from two different models will produce no meaningful result.
 

--- a/apps/docs/content/guides/api.mdx
+++ b/apps/docs/content/guides/api.mdx
@@ -12,7 +12,7 @@ The API is auto-generated from your database and is designed to get you building
 
 You can use them directly from the browser (two-tier architecture), or as a complement to your own API server (three-tier architecture).
 
-<Admonition type="tip" title="Looking for your Data API URL and Keys?">
+<Admonition type="note" title="Looking for your Data API URL and Keys?">
 
 - You can find the API URL in the [**Integrations > Data API**](/dashboard/project/_/integrations/data_api/overview) section of the Dashboard.
 - You can find the API Keys in the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard.

--- a/apps/docs/content/guides/api/handling-errors-in-supabase-js.mdx
+++ b/apps/docs/content/guides/api/handling-errors-in-supabase-js.mdx
@@ -19,7 +19,7 @@ The `message` exposes the error reason, and `hint` gives you the literal SQL sta
 
 The same pattern shows up across many Postgres errors — missing column? `hint` suggests the column name you probably meant. Type mismatch? `hint` shows the expected type. Whenever Postgres knows the fix, it puts it in `hint`.
 
-<Admonition type="tip">Log the full `error` object, not only `error.message`.</Admonition>
+<Admonition type="note">Log the full `error` object, not only `error.message`.</Admonition>
 
 ## The recommended pattern
 

--- a/apps/docs/content/guides/auth/audit-logs.mdx
+++ b/apps/docs/content/guides/auth/audit-logs.mdx
@@ -32,7 +32,7 @@ You can disable Postgres storage to reduce database storage costs while keeping 
 3. Find the **Audit Logs** under **Configuration** section
 4. Toggle on "Disable writing auth audit logs to project database" to disable database storage
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Disabling Postgres storage reduces your database storage costs. Audit logs will still be available through the dashboard.
 

--- a/apps/docs/content/guides/auth/auth-mfa.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa.mdx
@@ -261,7 +261,7 @@ create policy "Policy name."
 
 ### Server-Side Rendering
 
-<Admonition type="tip">
+<Admonition type="note">
 
 When using the Supabase JavaScript library in a server-side rendering context, make sure you always create a new object for each request! This will prevent you from accidentally rendering and serving content belonging to different users.
 

--- a/apps/docs/content/guides/auth/auth-mfa/totp.mdx
+++ b/apps/docs/content/guides/auth/auth-mfa/totp.mdx
@@ -36,7 +36,7 @@ In the **setup flow**, a session already at AAL1 calls the Enroll API, which ret
 
 In the **login flow**, the user signs in (upgrading the session to AAL1) and the List Factors API is called. If the user has one or more factors, they open their authenticator and enter a code, which follows the same Challenge and Verify path to reach AAL2. If they have no factors enrolled, they are sent through the setup flow first.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 [TOTP MFA API](/docs/reference/javascript/auth-mfa-api) is free to use and is enabled on all Supabase projects by default.
 

--- a/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
+++ b/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
@@ -23,7 +23,7 @@ If you're having issues with identity provider software not on this list, [open 
 
 ## Prerequisites
 
-This guide requires the use of the [Supabase CLI](/docs/guides/cli). Make sure you're using version v1.46.4 or higher. You can use `supabase -v` to see the currently installed version.
+This guide requires the use of the [Supabase CLI](/docs/guides/local-development). Make sure you're using version v1.46.4 or higher. You can use `supabase -v` to see the currently installed version.
 You can use the `supabase sso` [subcommands](/docs/reference/cli/supabase-sso) to manage your project's configuration.
 
 SAML 2.0 support is disabled by default on Supabase projects. You can configure this on the [Auth Providers](/dashboard/project/_/auth/providers) page on your project.
@@ -279,7 +279,7 @@ For example, the following JSON structure configures attribute mapping for the `
 }
 ```
 
-When creating or updating an identity provider with the [Supabase CLI](/docs/guides/cli) you can include this JSON as a file with the `--attribute-mapping-file /path/to/attribute/mapping.json` flag.
+When creating or updating an identity provider with the [Supabase CLI](/docs/guides/local-development) you can include this JSON as a file with the `--attribute-mapping-file /path/to/attribute/mapping.json` flag.
 
 For example, to change the attribute mappings to an existing provider you can use:
 

--- a/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
+++ b/apps/docs/content/guides/auth/enterprise-sso/auth-sso-saml.mdx
@@ -5,7 +5,7 @@ description: 'Use Single Sign-On (SSO) authentication on your project with SAML 
 video: 'https://www.youtube.com/v/em1cpOAXknM'
 ---
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Looking for guides on how to use Single Sign-On with the Supabase dashboard? Head on over to [Enable SSO for Your Organization](/docs/guides/platform/sso).
 

--- a/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
@@ -115,7 +115,7 @@ This ensures that JWTs issued by your local instance use the correct issuer clai
 </TabPanel>
 </Tabs>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Use asymmetric JWT signing keys for better security**
 

--- a/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/getting-started.mdx
@@ -12,7 +12,7 @@ Before you begin, make sure you have:
 
 - A Supabase project (create one at [supabase.com](https://supabase.com))
 - Admin access to your project
-- (Optional) [Supabase CLI](/docs/guides/cli) v2.54.11 or higher for local development
+- (Optional) [Supabase CLI](/docs/guides/local-development) v2.54.11 or higher for local development
 
 ## Overview
 

--- a/apps/docs/content/guides/auth/oauth-server/mcp-authentication.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/mcp-authentication.mdx
@@ -75,7 +75,7 @@ Dynamic registration allows any MCP client to register with your project. Consid
 
 When building your own MCP server, integrate with Supabase Auth to authenticate AI agents as your existing users and leverage your RLS policies.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Looking for an easier way to build MCP servers?**
 

--- a/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
+++ b/apps/docs/content/guides/auth/oauth-server/oauth-flows.mdx
@@ -645,7 +645,7 @@ This enables automatic integration with OIDC-compliant libraries and tools.
 
 Third-party clients should validate access tokens to ensure they're authentic and not tampered with.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Recommended: Use asymmetric JWT signing keys**
 
@@ -841,7 +841,7 @@ After revoking access:
 - All refresh tokens for that client are deleted
 - The user will need to re-authorize the application to grant access again
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Build a settings page for your users**
 

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -15,7 +15,7 @@ Email authentication is enabled by default.
 
 You can configure whether users need to verify their email to sign in. On hosted Supabase projects, this is true by default. On self-hosted projects or in local development, this is false by default.
 
-Change this setting on the [Auth Providers page](/dashboard/project/_/auth/providers) for hosted projects, or in the [configuration file](/docs/guides/cli/config#auth.email.enable_confirmations) for self-hosted projects.
+Change this setting on the [Auth Providers page](/dashboard/project/_/auth/providers) for hosted projects, or in the [configuration file](/docs/guides/local-development/cli/config#auth.email.enable_confirmations) for self-hosted projects.
 
 ### Signing up with an email and password
 
@@ -50,7 +50,7 @@ The implicit flow only works for client-only apps. Your site directly receives t
 
 To sign up the user, call [signUp()](/docs/reference/javascript/auth-signup) with their email address and password.
 
-You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/cli/config#auth.additional_redirect_urls) for self-hosted projects.
+You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/local-development/cli/config#auth.additional_redirect_urls) for self-hosted projects.
 
 If you don't specify a redirect URL, the user is automatically redirected to your site URL. This defaults to `localhost:3000`, but you can also configure this.
 
@@ -93,7 +93,7 @@ Future<void> signUpNewUser() async {
 
 To sign up the user, call [signUp()](/docs/reference/swift/auth-signup) with their email address and password.
 
-You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/cli/config#auth.additional_redirect_urls) for self-hosted projects.
+You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/local-development/cli/config#auth.additional_redirect_urls) for self-hosted projects.
 
 If you don't specify a redirect URL, the user is automatically redirected to your site URL. This defaults to `localhost:3000`, but you can also configure this.
 
@@ -128,7 +128,7 @@ suspend fun signUpNewUser() {
 
 To sign up the user, call [signUp()](/docs/reference/python/auth-signup) with their email address and password.
 
-You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/cli/config#auth.additional_redirect_urls) for self-hosted projects.
+You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/local-development/cli/config#auth.additional_redirect_urls) for self-hosted projects.
 
 If you don't specify a redirect URL, the user is automatically redirected to your site URL. This defaults to `localhost:3000`, but you can also configure this.
 
@@ -396,7 +396,7 @@ app.get("/auth/confirm", async function (req, res) {
 
 To sign up the user, call [signUp()](/docs/reference/javascript/auth-signup) with their email address and password:
 
-You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/cli/config#auth.additional_redirect_urls) for self-hosted projects.
+You can optionally specify a URL to redirect to after the user clicks the confirmation link. This URL must be configured as a [Redirect URL](/docs/guides/auth/redirect-urls), which you can do in the [dashboard](/dashboard/project/_/auth/url-configuration) for hosted projects, or in the [configuration file](/docs/guides/local-development/cli/config#auth.additional_redirect_urls) for self-hosted projects.
 
 If you don't specify a redirect URL, the user is automatically redirected to your site URL. This defaults to `localhost:3000`, but you can also configure this.
 
@@ -1104,7 +1104,7 @@ Protect users who use a phone number as a password-based auth identifier by enab
 
 Enable phone authentication on the [Auth Providers page](/dashboard/project/_/auth/providers) for hosted Supabase projects.
 
-For self-hosted projects or local development, use the [configuration file](/docs/guides/cli/config#auth.sms.enable_signup). See the configuration variables namespaced under `auth.sms`.
+For self-hosted projects or local development, use the [configuration file](/docs/guides/local-development/cli/config#auth.sms.enable_signup). See the configuration variables namespaced under `auth.sms`.
 
 If you want users to confirm their phone number on signup, you need to set up an SMS provider. Each provider has its own configuration. Supported providers include MessageBird, Twilio, Vonage, and TextLocal (community-supported).
 

--- a/apps/docs/content/guides/auth/passwords.mdx
+++ b/apps/docs/content/guides/auth/passwords.mdx
@@ -1074,7 +1074,7 @@ The signup confirmation and password reset flows require an SMTP server to send 
 
 The Supabase platform comes with a default email-sending service for you to try out. The service has a rate limit of <SharedData data="config">auth.rate_limits.email.inbuilt_smtp_per_hour.value</SharedData> emails per hour, and availability is on a best-effort basis. For production use, you should consider configuring a custom SMTP server.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Consider configuring a custom SMTP server for production.
 

--- a/apps/docs/content/guides/auth/server-side.mdx
+++ b/apps/docs/content/guides/auth/server-side.mdx
@@ -7,7 +7,7 @@ SSR frameworks move rendering and data fetches to the server, to reduce client b
 
 Supabase Auth is fully compatible with SSR. You need to make a few changes to the configuration of your Supabase client, to store the user session in cookies instead of local storage. After setting up your Supabase client, follow the instructions for any flow in the How-To guides.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Make sure to use the PKCE flow instructions where those differ from the implicit flow instructions. If no difference is mentioned, don't worry about this.
 

--- a/apps/docs/content/guides/auth/server-side/advanced-guide.mdx
+++ b/apps/docs/content/guides/auth/server-side/advanced-guide.mdx
@@ -12,7 +12,7 @@ The default behavior if you're not using SSR is to store this information in loc
 
 If you're not using SSR, you might also be using the [implicit flow](/docs/guides/auth/sessions/implicit-flow) to get the access and refresh tokens. The server can't access the tokens in this flow, so for SSR, you should change to the [PKCE flow](/docs/guides/auth/sessions/pkce-flow). You can change the flow type when initiating your Supabase client if your client library provides this option.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 In the `@supabase/ssr` package, Supabase clients are initiated to use the PKCE flow by default. They are also automatically configured to handle the saving and retrieval of session information in cookies.
 

--- a/apps/docs/content/guides/auth/social-login.mdx
+++ b/apps/docs/content/guides/auth/social-login.mdx
@@ -45,7 +45,7 @@ Supabase supports a suite of social providers. Follow these guides to configure 
   </NavData>
 </div>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Need to integrate with a provider not listed here? You can add any OAuth2 or OIDC-compatible provider using [Custom OAuth/OIDC Providers](/docs/guides/auth/custom-oauth-providers).
 

--- a/apps/docs/content/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-apple.mdx
@@ -140,7 +140,7 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
   }'
 ```
 
-    <Admonition type="tip">
+    <Admonition type="note">
 
     Use this tool to generate a new Apple client secret. No keys leave your browser! Be aware that this tool does not currently work in Safari, so use Firefox or a Chrome-based browser instead.
 
@@ -510,7 +510,7 @@ curl -X PATCH "https://api.supabase.com/v1/projects/$PROJECT_REF/config/auth" \
     6. Create a signing **Key** in the [Keys](https://developer.apple.com/account/resources/authkeys/list) section of the Apple Developer Console. You can use this key to generate a secret key using the tool below, which is added to your Supabase project's Auth configuration. Make sure you safely store the `AuthKey_XXXXXXXXXX.p8` file. If you ever lose access to it, or make it public accidentally, revoke it from the Apple Developer Console and create a new one immediately. You will have to generate a new secret key using this file every 6 months, so make sure you schedule a recurring reminder in your calendar!
     7. Finally, add the information you configured above to the [Apple provider configuration in the Supabase dashboard](/dashboard/project/_/auth/providers). If your app also uses native Sign in with Apple (on iOS or macOS), list this Services ID as the **first** entry in the _Client IDs_ field. Supabase uses the first client ID in the list for the web `signInWithOAuth` flow, while the native `signInWithIdToken` flow accepts any client ID in the list as a valid token audience, regardless of order. If a native App ID comes before the Services ID, native sign-in keeps working but web sign-in is rejected by Apple.
 
-    <Admonition type="tip">
+    <Admonition type="note">
 
     Use this tool to generate a new Apple client secret. No keys leave your browser! Be aware that this tool does not currently work in Safari, so use Firefox or a Chrome-based browser instead.
 

--- a/apps/docs/content/guides/auth/social-login/auth-azure.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-azure.mdx
@@ -142,7 +142,7 @@ Configure this by storing a value under _Azure Tenant URL_ in the Supabase Auth 
 
 ## Add login code to your client app
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Supabase Auth requires that Azure returns a valid email address. Therefore you must request the `email` scope in the `signInWithOAuth` method.
 

--- a/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-facebook.mdx
@@ -41,7 +41,7 @@ From the `Add Products to your App` screen:
 - Enter your callback URI under **Valid OAuth Redirect URIs** on the **Facebook Login Settings** page
 - Click **Save Changes** at the bottom right
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Your callback URI follows this pattern: `https://<project-ref>.supabase.co/auth/v1/callback`
 
@@ -64,7 +64,7 @@ You must configure the email permission in your Facebook app's Use Cases:
 3. Verify that both `public_profile` and `email` show status **Ready for testing**
 4. If `email` is not listed, click the **Add** button next to it
 
-<Admonition type="tip">
+<Admonition type="note">
 
 You can verify the permissions are set correctly by checking that both `public_profile` and `email` appear with a green check mark or "Ready for testing" status.
 
@@ -161,7 +161,7 @@ dependencies:
   flutter_facebook_auth: ^7.0.0
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Check [pub.dev](https://pub.dev/packages/flutter_facebook_auth) for the latest version of `flutter_facebook_auth`.
 
@@ -348,7 +348,7 @@ To add test users:
 3. Add users as Testers, Developers, or Administrators
 4. Users must accept the invitation from their Facebook notification settings
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Development mode is sufficient for local development and testing. You only need to submit for App Review when you're ready to allow any Facebook user to authenticate with your app.
 

--- a/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-kakao.mdx
@@ -75,7 +75,7 @@ If you don't need an email address (or `account_email` isn't available for your 
 
 ![Kakao consent items configuration](/docs/img/guides/auth-kakao/kakao-developers-consent-items-set.png)
 
-<Admonition type="tip">
+<Admonition type="note">
 
 In the Kakao Developers Portal, the "account_email" consent item is only available for apps that are registered as "Biz App". To convert your app to a "Biz App", go to **App Settings** > **App** > **General**, and complete the required fields in the **Business Information** section.
 

--- a/apps/docs/content/guides/auth/social-login/auth-workos.mdx
+++ b/apps/docs/content/guides/auth/social-login/auth-workos.mdx
@@ -20,7 +20,7 @@ Visit the getting started page of the [WorkOS Dashboard](https://dashboard.worko
 - `WORKOS_CLIENT_ID`
 - `WORKOS_API_KEY`
 
-<Admonition type="tip">
+<Admonition type="note">
 
 You must be signed in to see these values.
 
@@ -94,7 +94,7 @@ async function signInWithWorkOS() {
 }
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 You can find your `connection_id` in the WorkOS dashboard under the Organizations tab. Select your organization and then click View connection.
 

--- a/apps/docs/content/guides/database/custom-postgres-config.mdx
+++ b/apps/docs/content/guides/database/custom-postgres-config.mdx
@@ -105,7 +105,7 @@ In order to overwrite the default settings, you must have `Owner` or `Administra
 
 #### CLI supported parameters
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If a setting you need is not yet configurable, [share your use case with us](/dashboard/support/new)! Let us know what setting you'd like to control, and we'll consider adding support in future updates.
 

--- a/apps/docs/content/guides/database/import-data.mdx
+++ b/apps/docs/content/guides/database/import-data.mdx
@@ -16,7 +16,7 @@ You have multiple options for importing your data into Supabase:
 3. [Using the Postgres `COPY` command](#option-3-using-postgres-copy-command)
 4. [Using the Supabase API](#option-4-using-the-supabase-api)
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you're importing a large dataset or importing data into production, plan ahead and [prepare your database](#preparing-to-import-data).
 

--- a/apps/docs/content/guides/database/postgres/data-deletion.mdx
+++ b/apps/docs/content/guides/database/postgres/data-deletion.mdx
@@ -89,7 +89,7 @@ create view active_orders as
   select * from orders where deleted_at is null;
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Combine soft deletes with a scheduled hard-delete job (using [pg_cron](/docs/guides/database/extensions/pg_cron)) to permanently remove old soft-deleted rows in batches during low-traffic periods.
 
@@ -147,7 +147,7 @@ Dropping a regular index takes an `ACCESS EXCLUSIVE` lock on the index but **not
 drop index if exists idx_users_legacy_field;
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 The `inspect` command in the [Supabase CLI](/docs/reference/cli/supabase-inspect-db-index-stats) can help you identify unused indexes:
 

--- a/apps/docs/content/guides/database/postgres/indexes.mdx
+++ b/apps/docs/content/guides/database/postgres/indexes.mdx
@@ -26,7 +26,7 @@ create table persons (
 );
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 All the queries in this guide can be run using the [SQL Editor](/dashboard/project/_/sql) in the Supabase Dashboard, or via `psql` if you're [connecting directly to the database](/docs/guides/database/connecting-to-postgres#direct-connections).
 

--- a/apps/docs/content/guides/database/postgres/setup-replication-external.mdx
+++ b/apps/docs/content/guides/database/postgres/setup-replication-external.mdx
@@ -42,7 +42,7 @@ PUBLICATION example_pub
 WITH (copy_data = true, create_slot=false, slot_name=example_slot);
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 For projects running Postgres 17+, it is possible to subscribe to a [Read
 Replica](/docs/guides/platform/read-replicas) by using your Read Replica's connection string.

--- a/apps/docs/content/guides/database/postgres/timeouts.mdx
+++ b/apps/docs/content/guides/database/postgres/timeouts.mdx
@@ -70,7 +70,7 @@ Run the following query to change a role's timeout:
 alter role example_role set statement_timeout = '10min'; -- could also use seconds '10s'
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you are changing the timeout for the Supabase Client API calls, you will need to reload PostgREST to reflect the timeout changes by running the following script:
 

--- a/apps/docs/content/guides/database/prisma.mdx
+++ b/apps/docs/content/guides/database/prisma.mdx
@@ -325,7 +325,7 @@ If you plan to solely use Prisma instead of the Supabase Data API (PostgREST), t
               --to-schema prisma/schema.prisma \
               --script > prisma/migrations/0_init_supabase/migration.sql
             ```
-            <Admonition type="tip" title="conflict management">
+            <Admonition type="note" title="conflict management">
 
               If there are any conflicts, reference [Prisma's official doc](https://www.prisma.io/docs/orm/prisma-migrate/getting-started#work-around-features-not-supported-by-prisma-schema-language) or the [trouble shooting guide](/docs/guides/database/prisma/prisma-troubleshooting) for more details
 

--- a/apps/docs/content/guides/database/replication/pipelines.mdx
+++ b/apps/docs/content/guides/database/replication/pipelines.mdx
@@ -27,7 +27,7 @@ For billing examples and optimization guidance, see [Manage Pipelines usage](/do
 
 Pipelines requires two main components: a **Postgres publication** (defines what to replicate) and a **destination** (where data is sent). Supabase runs the managed pipeline that reads from the publication and writes to the destination. Follow these steps to set up your replication pipeline.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you already have a Postgres publication set up, you can skip to [Step 2: Enable Pipelines](#step-2-enable-pipelines).
 

--- a/apps/docs/content/guides/database/tables.mdx
+++ b/apps/docs/content/guides/database/tables.mdx
@@ -452,7 +452,7 @@ create table private.salaries (
 );
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you want to access a custom schema through the Supabase Data API, you need to expose it and grant the appropriate permissions. See [Using Custom Schemas](/docs/guides/api/using-custom-schemas) for detailed steps. For security best practices around schema exposure, see [Securing your API](/docs/guides/api/securing-your-api).
 

--- a/apps/docs/content/guides/deployment.mdx
+++ b/apps/docs/content/guides/deployment.mdx
@@ -67,7 +67,7 @@ Branching creates isolated preview environments for each pull request, so you ca
 
 Branching gives each pull request its own isolated Supabase environment with a full copy of your database schema (without any production data), so you can validate migrations and test your app end-to-end before merging to `main`.
 
-<Admonition type="tip" title="Self-hosting">
+<Admonition type="note" title="Self-hosting">
 
 Read the [self-hosting guides](/docs/guides/self-hosting) for instructions on hosting your own Supabase stack.
 

--- a/apps/docs/content/guides/deployment/branching/configuration.mdx
+++ b/apps/docs/content/guides/deployment/branching/configuration.mdx
@@ -35,7 +35,7 @@ supabase --experimental branches create --persistent
 # Do you want to create a branch named develop? [Y/n]
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 To retrieve the project ID for an existing branch, use the `branches list` command:
 
@@ -250,7 +250,7 @@ max_rows = 500
 pool_size = 25
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 To retrieve the project ID for an existing branch, use the `branches list` command:
 
@@ -277,7 +277,7 @@ client_id = "env(GOOGLE_CLIENT_ID)"
 secret = "env(GOOGLE_CLIENT_SECRET)"
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 To retrieve the project ID for an existing branch, use the `branches list` command:
 

--- a/apps/docs/content/guides/deployment/database-migrations.mdx
+++ b/apps/docs/content/guides/deployment/database-migrations.mdx
@@ -15,7 +15,7 @@ For this guide, we'll create a table called `employees` and see how we can make 
 
 You will need to [install](/docs/guides/local-development#quickstart) the Supabase CLI and start the local development stack.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If a lock timeout error occurs, in your migration file, consider increasing your [`lock_timeout`](https://postgresqlco.nf/doc/en/param/lock_timeout/) setting.
 
@@ -437,7 +437,7 @@ supabase db push
 
 </StepHikeCompact>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 For a more automated deployment approach, consider using [Supabase Branching](/docs/guides/deployment/branching) or a CI/CD pipeline that runs `supabase db push` on merge to your main branch.
 

--- a/apps/docs/content/guides/deployment/going-into-prod.mdx
+++ b/apps/docs/content/guides/deployment/going-into-prod.mdx
@@ -12,7 +12,7 @@ After developing your project and deciding it's production ready, you should run
 
 ## Security
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Check and review issues in your database using [Security Advisor](/dashboard/project/_/database/security-advisor).
 
@@ -43,7 +43,7 @@ Check and review issues in your database using [Security Advisor](/dashboard/pro
 
 ## Performance
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Check and review issues in your database using [Performance Advisor](/dashboard/project/_/database/performance-advisor).
 

--- a/apps/docs/content/guides/deployment/managing-environments.mdx
+++ b/apps/docs/content/guides/deployment/managing-environments.mdx
@@ -92,7 +92,7 @@ supabase db reset
 
 This command recreates your local database from scratch and applies all migration scripts under `supabase/migrations` directory. Now your local database is up to date.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 The new migration command also supports stdin as input. This allows you to pipe in an existing script from another file or stdout:
 
@@ -146,7 +146,7 @@ This is because the default schema diff tool does not account for default privil
 
 Commit the new migration script to git and you are ready to deploy.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Alternatively, you may pass in the `--use-migra` experimental flag to generate a more concise migration using [`migra`](https://github.com/djrobstep/migra).
 

--- a/apps/docs/content/guides/functions/ai-models.mdx
+++ b/apps/docs/content/guides/functions/ai-models.mdx
@@ -26,7 +26,7 @@ Create a new inference session:
 const model = new Supabase.ai.Session('model-name')
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 To get type hints and checks for the API, import types from `functions-js`:
 

--- a/apps/docs/content/guides/functions/auth-legacy-jwt.mdx
+++ b/apps/docs/content/guides/functions/auth-legacy-jwt.mdx
@@ -37,7 +37,7 @@ Deno.serve(async (req: Request) => {
 })
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 This context setting happens in the `Deno.serve()` callback argument, so that the `Authorization` header is set for each individual request scope.
 

--- a/apps/docs/content/guides/functions/cors.mdx
+++ b/apps/docs/content/guides/functions/cors.mdx
@@ -25,7 +25,7 @@ export default {
 
 If your function doesn't use `withSupabase`, add the headers yourself. See the [example on GitHub](https://github.com/supabase/supabase/blob/master/examples/edge-functions/supabase/functions/browser-with-cors/index.ts).
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **For `@supabase/supabase-js` v2.95.0 and later:** Import CORS headers directly from the SDK to ensure they stay synchronized with any new headers added to the client libraries.
 

--- a/apps/docs/content/guides/functions/deploy.mdx
+++ b/apps/docs/content/guides/functions/deploy.mdx
@@ -34,7 +34,7 @@ Get the project ID associated with your function:
 supabase projects list
 ```
 
-<Admonition type="tip" title="Need a new project?">
+<Admonition type="note" title="Need a new project?">
 
 If you haven't yet created a Supabase project, you can do so by visiting [database.new](https://database.new).
 

--- a/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-generate-speech-stream.mdx
@@ -8,7 +8,7 @@ tocVideo: '4Roog4PAmZ8'
 
 In this tutorial you will learn how to build an edge API to generate, stream, store, and cache speech using Supabase Edge Functions, Supabase Storage, and [ElevenLabs text to speech API](https://elevenlabs.io/text-to-speech).
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Find the [example project on GitHub](https://github.com/elevenlabs/elevenlabs-examples/tree/main/examples/text-to-speech/supabase/stream-and-cache-storage).
 
@@ -43,7 +43,7 @@ allowed_mime_types = ["audio/mp3"]
 objects_path = "./audio"
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Upon running `supabase start` this will create a new storage bucket in your local Supabase project. Should you want to push this to your hosted Supabase project, you can run `supabase seed buckets --linked`.
 
@@ -58,7 +58,7 @@ To use background tasks in Supabase Edge Functions when developing locally, you 
 policy = "per_worker"
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 When running with `per_worker` policy, Function won't auto-reload on edits. You will need to manually restart it by running `supabase functions serve`.
 

--- a/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
+++ b/apps/docs/content/guides/functions/examples/elevenlabs-transcribe-speech.mdx
@@ -10,7 +10,7 @@ In this tutorial you will learn how to build a Telegram bot that transcribes aud
 
 To check out what the end result will look like, you can test out the [t.me/ElevenLabsScribeBot](https://t.me/ElevenLabsScribeBot)
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Find the [example project on GitHub](https://github.com/elevenlabs/elevenlabs-examples/tree/main/examples/speech-to-text/telegram-transcription-bot).
 

--- a/apps/docs/content/guides/functions/quickstart-dashboard.mdx
+++ b/apps/docs/content/guides/functions/quickstart-dashboard.mdx
@@ -9,7 +9,7 @@ Supabase allows you to create Supabase Edge Functions directly from the Supabase
 
 This guide will walk you through creating, testing, and deploying your first Edge Function using the Supabase Dashboard. You'll have a working function running globally in under 10 minutes.
 
-<Admonition type="tip" title="Prefer using the CLI?">
+<Admonition type="note" title="Prefer using the CLI?">
 
 You can also create and deploy functions using the Supabase CLI. Check out our [CLI Quickstart guide](/docs/guides/functions/quickstart).
 

--- a/apps/docs/content/guides/functions/quickstart.mdx
+++ b/apps/docs/content/guides/functions/quickstart.mdx
@@ -9,7 +9,7 @@ This guide walks you through creating, testing locally, deploying, and invoking 
 
 You can also create and deploy functions directly from the Supabase Dashboard. Read [the Dashboard Quickstart guide](/docs/guides/functions/quickstart-dashboard) for more information.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Supabase Edge Functions **only** supports creating functions in TypeScript with [the Deno runtime](https://deno.com/). This is because Deno was designed with extensibility in mind and its Rust codebase offers a modern developer experience, memory safety, and other features ideal for running edge functions.
 
@@ -53,7 +53,7 @@ supabase functions new hello-world
 
 {/* TODO: Link to parameter documentation */}
 
-<Admonition type="tip" title="Secure your function with Supabase Auth">
+<Admonition type="note" title="Secure your function with Supabase Auth">
 
 When an HTTP request is sent to Edge Functions, you can use Supabase Auth to secure endpoints. By default, the `supabase functions new` command adds handling a valid publishable or secret key to the basic template. However, you can change this behavior with the `--auth` flag when creating a new function.
 
@@ -132,7 +132,7 @@ After this step, you should have successfully tested your Edge Function locally 
 
 To deploy your function globally, you need to connect your local project to a Supabase project.
 
-<Admonition type="tip" title="Need to create a new Supabase project?">
+<Admonition type="note" title="Need to create a new Supabase project?">
 
 Create one at [database.new](https://database.new/).
 

--- a/apps/docs/content/guides/getting-started/api-keys.mdx
+++ b/apps/docs/content/guides/getting-started/api-keys.mdx
@@ -6,7 +6,7 @@ description: "First-layer protection for your project's data"
 
 Supabase gives you fine-grained control over which application components are allowed to access your project through API keys.
 
-<Admonition type="tip" title="Looking for your API Keys?">
+<Admonition type="note" title="Looking for your API Keys?">
 
 In most cases, you can get the correct key from [the Project's **Connect** dialog](/dashboard/project/_?showConnect=true), but if you want a specific key, you can find all keys in the [**Settings > API Keys**](/dashboard/project/_/settings/api-keys/) section of the Dashboard:
 

--- a/apps/docs/content/guides/getting-started/quickstarts/kotlin.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/kotlin.mdx
@@ -28,7 +28,7 @@ Open `build.gradle.kts` (app) file and add the serialization plugin, Ktor client
 
 Replace the version placeholders `$kotlin_version` with the Kotlin version of the project, and `$supabase_version` and `$ktor_version` with the respective latest versions.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 You can find the latest supabase-kt version [on GitHub](https://github.com/supabase-community/supabase-kt/releases) and Ktor [in the Ktor documentation](https://ktor.io/docs/welcome.html).
 

--- a/apps/docs/content/guides/getting-started/quickstarts/nuxtjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/nuxtjs.mdx
@@ -105,7 +105,7 @@ Start the app, navigate to http://localhost:3000 in the browser, and you should 
 npm run dev
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 The community-maintained [@nuxtjs/supabase](https://supabase.nuxtjs.org/) module provides an alternate DX for working with Supabase in Nuxt.
 

--- a/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/redwoodjs.mdx
@@ -10,7 +10,7 @@ breadcrumb: 'Framework Quickstarts'
 
 [Create a new project](/dashboard) in the Supabase Dashboard.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Be sure to make note of the Database Password you used as you will need this later to connect to your database.
 
@@ -28,7 +28,7 @@ To get the Session mode connection pooler string, change the port of the connect
 
 You will need the Transaction mode connection string and the Session mode connection string to set up environment variables in Step 6.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 You can copy and paste these connection strings from the Supabase Dashboard when needed in later steps.
 
@@ -140,7 +140,7 @@ export default async () => {
 
 Run the seed database command to populate the `Instrument` table with the instruments you created.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 The reset database command `yarn rw prisma db reset` recreates the tables and also runs the seed script.
 

--- a/apps/docs/content/guides/getting-started/quickstarts/refine.mdx
+++ b/apps/docs/content/guides/getting-started/quickstarts/refine.mdx
@@ -82,7 +82,7 @@ npm run refine create-resource instruments
 
 Add routes for the `list`, `create`, `show`, and `edit` pages.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Remove the `index` route for the Welcome page presented with the `<Welcome />` component.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-angular.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-angular.mdx
@@ -58,7 +58,7 @@ Optionally, update `src/styles.css` to style the app. You can find the full cont
 
 You need an Angular component to manage logins and sign ups. The component uses [Magic Links](/docs/guides/auth/auth-email-passwordless#with-magic-link), so users can sign in with their email without using passwords.
 
-<Admonition type="tip" title="Did you know?">
+<Admonition type="note" title="Did you know?">
 
 You can customize other emails sent out to new users, including the email's looks, content, and query parameters from [the **Authentication > Email**](/dashboard/project/_/auth/templates) section of the Dashboard.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-nextjs.mdx
@@ -182,7 +182,7 @@ Before proceeding, change the email template to support a server-side authentica
 - Select the **Confirm signup** template.
 - Change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email`.
 
-<Admonition type="tip" title="Did you know?">
+<Admonition type="note" title="Did you know?">
 
 You can customize other emails sent out to new users, including the email's looks, content, and query parameters from [the **Authentication > Email**](/dashboard/project/_/auth/templates) section of the Dashboard.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-react.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-react.mdx
@@ -62,7 +62,7 @@ You can find the full contents of this file [in the example repository](https://
 
 You need a React component to manage logins and sign-ups. It uses [Magic Links](/docs/guides/auth/auth-email-passwordless#with-magic-link), so users can sign in with their email without using passwords.
 
-<Admonition type="tip" title="Did you know?">
+<Admonition type="note" title="Did you know?">
 
 You can customize other emails sent out to new users, including the email's looks, content, and query parameters from [the **Authentication > Email**](/dashboard/project/_/auth/templates) section of the Dashboard.
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-svelte.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-svelte.mdx
@@ -120,7 +120,7 @@ npm run dev
 
 And then open the browser to [localhost:5173](http://localhost:5173) and you should see the completed app.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Svelte uses Vite and the default port is `5173`, Supabase uses `port 3000`. To change the redirection port for Supabase go to: **Authentication > URL Configuration** and change the **Site URL** to `http://localhost:5173/`
 

--- a/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
+++ b/apps/docs/content/guides/getting-started/tutorials/with-sveltekit.mdx
@@ -102,7 +102,7 @@ meta="name=src/routes/+layout.server.ts"
 
 </$CodeTabs>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Start the dev server (`npm run dev`) to generate the `./$types` files we are referencing in our project.
 
@@ -169,7 +169,7 @@ Before proceeding, change the email template to support sending a token hash:
 - Change `{{ .ConfirmationURL }}` to `{{ .SiteURL }}/auth/confirm?token_hash={{ .TokenHash }}&type=email`.
 - Repeat the previous step for **Magic link** template.
 
-<Admonition type="tip" title="Did you know?">
+<Admonition type="note" title="Did you know?">
 
 You can also customize emails sent out to new users, including the email's looks, content, and query parameters. Check out the [settings of your project](/dashboard/project/_/auth/templates).
 

--- a/apps/docs/content/guides/integrations/partner-integration-guide.mdx
+++ b/apps/docs/content/guides/integrations/partner-integration-guide.mdx
@@ -263,7 +263,7 @@ When a user arrives at this endpoint:
 3. Optionally, walk the user through any setup required on your side — for example, signing up, signing in, or configuring your system so the integration will work.
 4. Redirect the user to the [Supabase authorization URL](/docs/guides/integrations/build-a-supabase-oauth-integration#redirecting-to-the-authorize-url) to start the OAuth flow.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you need the user to perform setup steps on your site, design the experience as a wizard that ends by redirecting to the Supabase authorization URL. This minimizes the chance of users getting distracted, navigating elsewhere on your site, and abandoning the OAuth flow.
 

--- a/apps/docs/content/guides/local-development/cli-workflows.mdx
+++ b/apps/docs/content/guides/local-development/cli-workflows.mdx
@@ -29,7 +29,7 @@ Every example in this guide is written as `supabase <command>`. Translate it to 
 
 </Admonition>
 
-<Admonition type="tip" label="Starting from a template">
+<Admonition type="note" label="Starting from a template">
 
 If you want a working project to explore rather than an empty one, `supabase bootstrap` scaffolds a starter application (Next.js, Flutter, and more) with schema, migrations, and config already wired up. It's an alternative entry point to `supabase init` when starting a new project from scratch.
 
@@ -107,7 +107,7 @@ This initial migration is your baseline. It represents the current state of your
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you also use Supabase Auth or Storage and have customized their schemas, pull them separately:
 

--- a/apps/docs/content/guides/local-development/cli/getting-started.mdx
+++ b/apps/docs/content/guides/local-development/cli/getting-started.mdx
@@ -230,7 +230,7 @@ npm update supabase@beta --save-dev
 
 If you have any Supabase containers running locally, stop them and delete their data volumes before proceeding with the upgrade. This ensures that Supabase managed services can apply new migrations on a clean state of the local database.
 
-<Admonition type="tip" title="Backup and stop running containers">
+<Admonition type="note" title="Backup and stop running containers">
 
 Remember to save any local schema and data changes before stopping because the `--no-backup` flag will delete them.
 

--- a/apps/docs/content/guides/local-development/database-migrations.mdx
+++ b/apps/docs/content/guides/local-development/database-migrations.mdx
@@ -13,7 +13,7 @@ Develop locally using the CLI to run a local Supabase stack. You can use the int
 
 Alternatively, if you're comfortable with migration files and SQL, you can write your own migrations and push them to the local database for testing before sharing your changes.
 
-<Admonition type="tip" label="Looking for the full end-to-end workflow?">
+<Admonition type="note" label="Looking for the full end-to-end workflow?">
 
 This page is a focused tutorial on migrations. If you want to move an existing platform project to local development, or set up a reproducible project from scratch and take it all the way to a remote deploy, see the [Local development workflow](/docs/guides/local-development/cli-workflows) guide. It covers both starting points, the daily development loop, pushing to production, cleaning up generated migrations, and troubleshooting.
 

--- a/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
+++ b/apps/docs/content/guides/local-development/declarative-database-schemas.mdx
@@ -123,7 +123,7 @@ create table "employees" (
   </StepHikeCompact.Step>
 </StepHikeCompact>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Some entities like views and enums expect columns to be declared in a specific order. To avoid messy diffs, always append new columns to the end of the table.
 

--- a/apps/docs/content/guides/local-development/seeding-your-database.mdx
+++ b/apps/docs/content/guides/local-development/seeding-your-database.mdx
@@ -46,7 +46,7 @@ enabled = true
 sql_paths = ['./seeds/*.sql']
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 The CLI processes seed files in the order they are declared in the `sql_paths` array. If a glob pattern is used and matches multiple files, those files are sorted in lexicographic order to ensure consistent execution. Additionally:
 
@@ -66,7 +66,7 @@ Snaplet wound down as a company in 2024 and open-sourced its tooling. `@snaplet/
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 To use Snaplet, you need to have Node.js and npm installed. You can add Node.js to your project by running `npm init -y` in your project directory.
 
@@ -80,7 +80,7 @@ npx @snaplet/seed init
 
 This command will analyze your database and its structure, and then generate a JavaScript client which can be used to define exactly how your data should be generated using code. The `init` command generates a configuration file, `seed.config.ts` and an example script, `seed.ts`, as a starting point.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 During `init` if you are not using an Object Relational Mapper (ORM) or your ORM is not in the supported list, choose `node-postgres`.
 

--- a/apps/docs/content/guides/platform/migrating-to-supabase/postgres.mdx
+++ b/apps/docs/content/guides/platform/migrating-to-supabase/postgres.mdx
@@ -82,7 +82,7 @@ CREATE EXTENSION IF NOT EXISTS extension_name;
 
 ### Step 1: Set up migration VM
 
-<Admonition type="tip">
+<Admonition type="note">
 
 For optimal performance, run the migration from a cloud VM, not your local machine. The VM should be in the same region as either your source or target database to optimize network performance. See the Resource Requirements table in Step 2 for VM sizing recommendations.
 

--- a/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
+++ b/apps/docs/content/guides/platform/read-replicas/getting-started.mdx
@@ -127,7 +127,7 @@ There is no single threshold to indicate when you should address replication lag
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you are already ingesting your [project's metrics](/docs/guides/telemetry/metrics) into your own environment, you can also keep track of replication lag and set alarms with the `physical_replication_lag_physical_replica_lag_seconds` metric.
 
@@ -142,7 +142,7 @@ Some common sources of high replication lag include:
 3. **Long-running transactions on the Primary**: Transactions that run for a long-time on the primary can also result in high replication lag. You can use the `pg_stat_activity` view to identify and terminate such transactions if needed. `pg_stat_activity` is a live view, and does not offer historical data on transactions that might have been active for a long time in the past.
    High replication lag can result in stale data returned for queries executed against the affected read replicas.
 
-<Admonition type="tip" >
+<Admonition type="note" >
 
 You can find additional resources on replication lag in [the Google documentation](https://cloud.google.com/sql/docs/postgres/replication/replication-lag), [the AWS documentation](https://repost.aws/knowledge-center/rds-postgresql-replication-lag), and [the several nines blog](https://severalnines.com/blog/what-look-if-your-postgresql-replication-lagging/).
 

--- a/apps/docs/content/guides/platform/sso.mdx
+++ b/apps/docs/content/guides/platform/sso.mdx
@@ -3,7 +3,7 @@ title: 'Enable SSO for Your Organization'
 description: 'General information about enabling single sign-on (SSO) for your organization'
 ---
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Looking for docs on how to add Single Sign-On support in your Supabase project? Head on over to [Single Sign-On with SAML 2.0 for Projects](/docs/guides/auth/enterprise-sso/auth-sso-saml).
 
@@ -29,7 +29,7 @@ Once configured, you can update your settings anytime from [the **SSO** section]
 
 ![SSO Example](/docs/img/sso-dashboard-enabled-idp.png)
 
-<Admonition type="tip" title="Testing your SSO configuration">
+<Admonition type="note" title="Testing your SSO configuration">
 
 After configuring your SSO provider, thorough testing is essential. See our [SSO Testing and Best Practices](/docs/guides/platform/sso/testing-best-practices) guide for:
 

--- a/apps/docs/content/guides/platform/sso/azure.mdx
+++ b/apps/docs/content/guides/platform/sso/azure.mdx
@@ -9,7 +9,7 @@ This feature is only available on the [Team and Enterprise Plans](/pricing). If 
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Looking for docs on how to add Single Sign-On support in your Supabase project? Head on over to [Single Sign-On with SAML 2.0 for Projects](/docs/guides/auth/enterprise-sso/auth-sso-saml).
 

--- a/apps/docs/content/guides/platform/sso/choosing-login-flow.mdx
+++ b/apps/docs/content/guides/platform/sso/choosing-login-flow.mdx
@@ -5,7 +5,7 @@ description: 'Quick reference guide to help you choose between IdP-initiated, SP
 
 Not sure which single sign-on (SSO) login flow to enable? This guide maps common enterprise scenarios to the recommended configuration.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Start with identity provider (IdP)-initiated, the default behavior. It requires no domain configuration, and works for most enterprise use cases. You can enable SP-initiated later if needed.
 
@@ -306,7 +306,7 @@ If you're uncertain which configuration to use:
 4. Enable SP-initiated if users request it
 5. Monitor usage to see which flow is preferred
 
-<Admonition type="tip" title="Support available">
+<Admonition type="note" title="Support available">
 
 If you need help choosing the right configuration for your organization, contact Supabase support with details about your use case. We're happy to provide personalized recommendations.
 

--- a/apps/docs/content/guides/platform/sso/gsuite.mdx
+++ b/apps/docs/content/guides/platform/sso/gsuite.mdx
@@ -9,7 +9,7 @@ This feature is only available on the [Team and Enterprise Plans](/pricing). If 
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Looking for docs on how to add Single Sign-On support in your Supabase project? Head on over to [Single Sign-On with SAML 2.0 for Projects](/docs/guides/auth/enterprise-sso/auth-sso-saml).
 
@@ -134,7 +134,7 @@ If you did not customize your settings you may save some time by clicking the **
 
 ## Step 12: Join organization on signup (optional) [#dashboard-configure-autojoin]
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Recommended workflow:** Start with auto-join **disabled** to test your SSO configuration. Once SSO login is working correctly, enable auto-join if desired.
 
@@ -164,7 +164,7 @@ Visit [access-control](/docs/guides/platform/access-control) documentation for d
 
 When you click **Save changes**, your new SSO configuration is applied immediately. From that moment, any user with an email address matching one of your configured domains who visits your organization's sign-in URL will be routed through the SSO flow.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Next step: Test your SSO configuration**
 

--- a/apps/docs/content/guides/platform/sso/login-flows.mdx
+++ b/apps/docs/content/guides/platform/sso/login-flows.mdx
@@ -5,7 +5,7 @@ description: 'Learn about IdP-initiated and SP-initiated SSO login flows and whe
 
 When configuring SSO for your organization, you can choose between two different login flows: **identity provider (IdP)-initiated** and **service provider (SP)-initiated**. Understanding the difference helps you provide the best experience for your users.
 
-<Admonition type="tip" title="Quick decision guide">
+<Admonition type="note" title="Quick decision guide">
 
 Most enterprises use IdP-initiated flow for its simplicity and better user experience. Enable SP-initiated only if you need users to start their login journey at supabase.com.
 
@@ -214,7 +214,7 @@ This is often impractical since all employees use `company.com` email addresses.
 
 Users click the appropriate tile for the environment they need.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 This is the recommended approach for enterprises with multiple environments. Configure each environment as IdP-initiated only (no domains needed).
 

--- a/apps/docs/content/guides/platform/sso/multiple-providers.mdx
+++ b/apps/docs/content/guides/platform/sso/multiple-providers.mdx
@@ -21,7 +21,7 @@ The traditional challenge with multiple SAML apps is domain conflicts. With SP-i
 
 **Solution:** Use identity provider (IdP)-initiated flow, which doesn't require domain configuration. You can create unlimited SAML apps under the same domain.
 
-<Admonition type="tip" title="Recommended pattern">
+<Admonition type="note" title="Recommended pattern">
 
 Configure each environment as IdP-initiated only (no domains). Users access each environment through different app tiles in your identity provider.
 

--- a/apps/docs/content/guides/platform/sso/okta.mdx
+++ b/apps/docs/content/guides/platform/sso/okta.mdx
@@ -9,7 +9,7 @@ This feature is only available on the [Team and Enterprise Plans](/pricing). If 
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Looking for docs on how to add Single Sign-On support in your Supabase project? Head on over to [Single Sign-On with SAML 2.0 for Projects](/docs/guides/auth/enterprise-sso/auth-sso-saml).
 
@@ -120,7 +120,7 @@ If you did not customize your settings you may save some time by clicking the **
 
 ## Step 11: Join organization on signup (optional) [#dashboard-configure-autojoin]
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Recommended workflow:** Start with auto-join **disabled** to test your SSO configuration. Once SSO login is working correctly, enable auto-join if desired.
 
@@ -150,7 +150,7 @@ Visit [access-control](/docs/guides/platform/access-control) documentation for d
 
 When you click **Save changes**, your new SSO configuration is applied immediately. From that moment, any user with an email address matching one of your configured domains who visits your organization's sign-in URL will be routed through the SSO flow.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Next step: Test your SSO configuration**
 

--- a/apps/docs/content/guides/platform/sso/testing-best-practices.mdx
+++ b/apps/docs/content/guides/platform/sso/testing-best-practices.mdx
@@ -129,7 +129,7 @@ You've configured SSO with:
 - ✅ Multiple environments accessible via different tiles
 - ✅ No domain conflicts between environments
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **Multiple environments:** If you're setting up Dev/Staging/Prod, this domainless pattern is recommended. See [Multiple SSO Providers](/docs/guides/platform/sso/multiple-providers) for detailed configuration guidance.
 

--- a/apps/docs/content/guides/platform/upgrading.mdx
+++ b/apps/docs/content/guides/platform/upgrading.mdx
@@ -142,7 +142,7 @@ In projects using Postgres 17, the following extensions are deprecated:
 
 Projects planning to upgrade from Postgres 15 to Postgres 17 need to first disable these extensions in the [Supabase Dashboard](/dashboard/project/_/database/extensions).
 
-<Admonition type="tip">
+<Admonition type="note">
 
 `pgjwt` was enabled by default on every Supabase project up until Postgres 17. If you weren't explicitly using `pgjwt` in your project, it's most likely safe to disable.
 

--- a/apps/docs/content/guides/queues/quickstart.mdx
+++ b/apps/docs/content/guides/queues/quickstart.mdx
@@ -51,7 +51,7 @@ On the [Queues page](/dashboard/project/_/integrations/queues/queues):
 
 - Name your queue
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Queue names can only be lowercase and hyphens and underscores are permitted.
 
@@ -73,7 +73,7 @@ width={1456}
 height={1420}
 />
 
-<Admonition type="tip" title="What happens when you create a queue?">
+<Admonition type="note" title="What happens when you create a queue?">
 
 Every new Queue creates two tables in the `pgmq` schema. These tables are `pgmq.q_<queue_name>` to store and process active messages and `pgmq.a_<queue_name>` to store any archived messages.
 

--- a/apps/docs/content/guides/realtime/limits.mdx
+++ b/apps/docs/content/guides/realtime/limits.mdx
@@ -38,7 +38,7 @@ When you exceed a limit, errors will appear in the backend logs and client-side 
 - **Logs**: check the [Realtime logs](/dashboard/project/_/database/realtime-logs) inside your project Dashboard.
 - **WebSocket errors**: Use your browser's developer tools to find the WebSocket initiation request and view individual messages.
 
-<Admonition type="tip" title="Realtime Inspector">
+<Admonition type="note" title="Realtime Inspector">
 
 You can use the [Realtime Inspector](https://realtime.supabase.com/inspector/new) to reproduce an error and share those connection details with Supabase support.
 

--- a/apps/docs/content/guides/realtime/postgres-changes.mdx
+++ b/apps/docs/content/guides/realtime/postgres-changes.mdx
@@ -1064,7 +1064,7 @@ You can also [negate any operator](#negating-a-filter-not) with `not.` and [comb
 
 <$Show if="sdk:js">
 
-<Admonition type="tip">
+<Admonition type="note">
 
 In JavaScript you can pass a raw filter string, or build one with the type-safe `postgresChangesFilter()` helper, which handles operator names, negation, `AND` composition, and escaping for you:
 
@@ -3256,7 +3256,7 @@ Use the estimator below to gauge the maximum throughput for your instance, and r
 
 <RealtimeLimitsEstimator />
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you expect more than ~3,000 concurrent subscribers on the same changes, use [Broadcast to stream database changes](/docs/guides/realtime/subscribing-to-database-changes#using-broadcast) instead. Broadcast sends each change once and fans it out to all subscribers, so it scales to far higher connection counts than per-subscriber authorization allows.
 

--- a/apps/docs/content/guides/realtime/reports.mdx
+++ b/apps/docs/content/guides/realtime/reports.mdx
@@ -14,7 +14,7 @@ These reports help you:
 - Troubleshoot errors and connection issues
 - Plan capacity upgrades based on usage trends
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Access Realtime reports from **[Project Settings > Product Reports > Realtime](/dashboard/project/_/observability/realtime)** in your project dashboard.
 

--- a/apps/docs/content/guides/security/npm-security.mdx
+++ b/apps/docs/content/guides/security/npm-security.mdx
@@ -6,7 +6,7 @@ description: 'Consumer-side guide to hardening your npm installs of Supabase pac
 
 A practical guide for anyone installing Supabase packages from npm — the JavaScript client libraries (`@supabase/supabase-js` and friends), the `supabase` CLI, or any other dependency in your tree — on defending against supply-chain attacks. Most of it applies to any npm package, not only Supabase's.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Looking to **report** a vulnerability in Supabase itself? See the [Supabase security policy](https://github.com/supabase/supabase-js/security) instead. This guide is about hardening your install of Supabase (and other) packages on your machines and in your CI.
 

--- a/apps/docs/content/guides/self-hosting/copy-from-platform-s3.mdx
+++ b/apps/docs/content/guides/self-hosting/copy-from-platform-s3.mdx
@@ -41,7 +41,7 @@ For better performance with large files, use the direct storage hostname: `https
 
 Buckets must exist on the destination before you can copy objects into them. You can create them through the dashboard UI, or with the **SQL Editor**.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you already restored your platform database to self-hosted using the [restore guide](/docs/guides/self-hosting/restore-from-platform), your bucket definitions are already present. You can skip this step.
 

--- a/apps/docs/content/guides/self-hosting/custom-email-templates.mdx
+++ b/apps/docs/content/guides/self-hosting/custom-email-templates.mdx
@@ -20,7 +20,7 @@ To provide templates to Supabase Auth, you need a service that serves static HTM
 
 This guide uses [Caddy](https://github.com/caddyserver/caddy) for serving templates.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If Supabase Auth cannot fetch the template or if the fetched template is invalid, it falls back to the default template.
 

--- a/apps/docs/content/guides/self-hosting/docker.mdx
+++ b/apps/docs/content/guides/self-hosting/docker.mdx
@@ -54,7 +54,7 @@ Minimum requirements for running all Supabase components, suitable for developme
 
 If you don't need specific services, such as Realtime, Storage, imgproxy, or Edge Runtime (`functions`), you can remove the corresponding sections and dependencies from `docker-compose.yml` to reduce resource requirements.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 The default configuration does not include [Logs & Analytics](/features/logs-analytics). You can [enable](#enabling-analytics) Logflare (Analytics), Vector (log collection), and the Log Explorer in Studio by using an optional docker-compose override file. Note that enabling these services will increase resource requirements.
 
@@ -184,7 +184,7 @@ docker compose pull
 
 </Tabs>
 
-<Admonition type="tip">
+<Admonition type="note">
 
   If you are using rootless Docker, edit `.env` and set `DOCKER_SOCKET_LOCATION` to your docker socket location. For example: `/run/user/1000/docker.sock`. Otherwise, you will see an error like `container supabase-vector exited (0)`.
 

--- a/apps/docs/content/guides/self-hosting/remove-superuser-access.mdx
+++ b/apps/docs/content/guides/self-hosting/remove-superuser-access.mdx
@@ -29,7 +29,7 @@ Use the provided script to reassign ownership of database objects in the `public
 sh utils/reassign-owner.sh
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 This script only updates ownership for database objects in the `public` schema. Supabase-managed and custom schemas are not affected.
 
@@ -53,7 +53,7 @@ This script only updates ownership for database objects in the `public` schema. 
       PG_META_DB_USER: postgres
   ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Studio uses its own credentials to access Postgres via `postgres-meta`, so this change is only needed for backward compatibility and consistency.
 

--- a/apps/docs/content/guides/self-hosting/restore-from-platform.mdx
+++ b/apps/docs/content/guides/self-hosting/restore-from-platform.mdx
@@ -121,7 +121,7 @@ Your `auth.users` table and related data are included in the database dump, so u
 
 Managed Supabase may run a newer Postgres version (Postgres 17) than the self-hosted Docker image (currently it's Postgres 15 by default). The `supabase db dump` command produces plain SQL files that work across major Postgres versions.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If your managed project runs Postgres 17, consider starting your self-hosted deployment with Postgres 17 as well. See the [Postgres 17 guide](/docs/guides/self-hosting/postgres-upgrade-17) for setup instructions.
 

--- a/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-proxy-https.mdx
@@ -20,7 +20,7 @@ You need:
 
 Below are two options for adding a reverse proxy with automatic HTTPS in front of your self-hosted Supabase: **Caddy** (simpler, zero-config TLS) and **Nginx + Let's Encrypt** (more control over proxy settings). Both sit in front of the API gateway and terminate TLS, so internal traffic stays on HTTP.
 
-<Admonition type="tip" title="Using a different reverse proxy?">
+<Admonition type="note" title="Using a different reverse proxy?">
 
 If you already run [HAProxy](https://www.haproxy.com/), [Traefik](https://traefik.io/), [Nginx Proxy Manager](https://nginxproxymanager.com/), or another reverse proxy for your infrastructure, you can use it instead of Caddy or Nginx above. The key requirements are:
 

--- a/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
+++ b/apps/docs/content/guides/self-hosting/self-hosted-saml-sso.mdx
@@ -65,7 +65,7 @@ Keep this key secret. Anyone with the private key can forge SAML requests on beh
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 For a production deployment, consider using a 4096-bit key by adding `-pkeyopt rsa_keygen_bits:4096` to the `openssl genpkey` command above.
 
@@ -136,7 +136,7 @@ curl http://<your-domain>/auth/v1/sso/saml/metadata
 
 This returns an XML document containing your SP entity ID, ACS endpoint URL, and signing certificate. You will need to provide this to your IdP.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 {/* supa-mdx-lint-disable-next-line Rule003Spelling */}
 Add `?download=true` to the request URL to get the metadata as a downloadable XML file with a 5-year validity period - this is useful for IdPs that require a file upload instead of a URL.

--- a/apps/docs/content/guides/storage/debugging/logs.mdx
+++ b/apps/docs/content/guides/storage/debugging/logs.mdx
@@ -9,7 +9,7 @@ The [Storage Logs](/dashboard/project/_/logs/storage-logs) provide a convenient 
 
 For more advanced filtering needs, use the [Logs Explorer](/dashboard/project/_/logs/explorer) to query the Storage logs dataset directly. The Logs Explorer is separate from the SQL Editor and uses a subset of the BigQuery SQL syntax rather than traditional SQL.
 
-<Admonition type="tip">
+<Admonition type="note">
   
 For more details on filtering the log tables, see [Advanced Log Filtering](/docs/guides/telemetry/advanced-log-filtering)
 

--- a/apps/docs/content/guides/storage/management/download-objects.mdx
+++ b/apps/docs/content/guides/storage/management/download-objects.mdx
@@ -30,7 +30,7 @@ To connect:
 
 See the [S3 authentication doc](/docs/guides/storage/s3/authentication) for full connection details.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 For downloading a large number of objects, using an S3-compatible tool like rclone or Cyberduck is significantly more efficient than downloading files individually.
 

--- a/apps/docs/content/guides/storage/vector/querying-vectors.mdx
+++ b/apps/docs/content/guides/storage/vector/querying-vectors.mdx
@@ -11,7 +11,7 @@ Expect rapid changes, limited features, and possible breaking updates. [Share fe
 
 Vector similarity search finds vectors most similar to a query vector using distance metrics. You can query vectors using the JavaScript SDK or directly from Postgres using SQL.
 
-<Admonition type="tip" title="Comparison to pgvector">
+<Admonition type="note" title="Comparison to pgvector">
 
 Vector buckets and any [Foreign Data Wrappers (FDW)](/docs/guides/database/extensions/wrappers/overview) they use only support one similarity search algorithm, the `<===>` distance operator.
 

--- a/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
+++ b/apps/docs/content/guides/telemetry/metrics/grafana-self-hosted.mdx
@@ -40,7 +40,7 @@ scrape_configs:
           project: '<project-ref>'
 ```
 
-<Admonition type="tip">
+<Admonition type="note">
 
 - Keep the scrape interval at 60 seconds to match Supabase’s refresh cadence.
 - If you run Prometheus behind a proxy, make sure it can establish outbound HTTPS connections to `*.supabase.co`.

--- a/apps/docs/content/troubleshooting/avoiding-timeouts-in-long-running-queries-6nmbdN.mdx
+++ b/apps/docs/content/troubleshooting/avoiding-timeouts-in-long-running-queries-6nmbdN.mdx
@@ -7,7 +7,7 @@ keywords = [ "timeout", "query", "database", "psql", "compute" ]
 database_id = "8bb130d5-d298-49c7-8cfb-dd7a3f231154"
 ---
 
-<Admonition type="tip">
+<Admonition type="note">
 
 This page covers long-running queries via the Dashboard or external interfaces. For Supabase Client API timeout errors, check this [guide](https://github.com/orgs/supabase/discussions/14256) instead.
 
@@ -35,7 +35,7 @@ sudo apt-get install postgresql-client
 
 Once installed, you can find your PSQL string on the dashboard by clicking [connect](/dashboard/project/_?showConnect=true). Make sure if you are using the pooler connection that it is the [Session pooler](/dashboard/project/_?showConnect=true&method=session) (port 5432).
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If you are working in an [IPv6 environment](https://github.com/orgs/supabase/discussions/27034) or have the IPv4 Add-On, it is preferable to use the direct connection.
 

--- a/apps/docs/content/troubleshooting/edge-function-404-error-response.mdx
+++ b/apps/docs/content/troubleshooting/edge-function-404-error-response.mdx
@@ -53,7 +53,7 @@ When an edge function fails due to a platform 404 error, it will return the erro
 
 ### Inspecting the logs
 
-<Admonition type='tip'>
+<Admonition type='note'>
 
 Always configure an appropriate time frame when using the log explorer
 

--- a/apps/docs/content/troubleshooting/exhaust-swap.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-swap.mdx
@@ -9,7 +9,7 @@ Learn what high Swap usage means, what can cause it, and how to solve it.
 
 ## What is swap for?
 
-<Admonition type="tip">
+<Admonition type="note">
 
 High Swap is usually not a problem unless other resources (such as RAM) are constrained.
 

--- a/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
+++ b/apps/docs/content/troubleshooting/rotating-anon-service-and-jwt-secrets-1Jq6yd.mdx
@@ -13,7 +13,7 @@ This troubleshooting guide is about rotating **Legacy anon, service_role API key
 
 </Admonition>
 
-<Admonition type="tip">
+<Admonition type="note">
 
 Once the JWT secret is regenerated, all current API secrets will be immediately invalidated, and all connections using them will be severed. You will need to deploy the new secrets for connections to begin working again. You can avoid downtime by migrating to new API Keys.
 

--- a/apps/docs/content/troubleshooting/unable-to-call-edge-function.mdx
+++ b/apps/docs/content/troubleshooting/unable-to-call-edge-function.mdx
@@ -19,7 +19,7 @@ Make sure your function handles OPTIONS preflight requests.
 
 ### Recommended (v2.95.0+)
 
-<Admonition type="tip">
+<Admonition type="note">
 
 **For `@supabase/supabase-js` v2.95.0 and later:** Import CORS headers directly from the SDK to ensure they stay synchronized with any new headers added to the client libraries.
 

--- a/apps/docs/lib/mdx/plugins/remarkAdmonition.ts
+++ b/apps/docs/lib/mdx/plugins/remarkAdmonition.ts
@@ -116,9 +116,8 @@ function mapAdmonitionType(type: string): AdmonitionProps['type'] {
     case 'quote':
     case 'example':
     case 'note':
-      return 'note'
     case 'tip':
-      return 'tip'
+      return 'note'
     case 'warning':
       return 'caution'
     case 'failure':

--- a/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenNewBanner/AccessTokenNewBanner.tsx
+++ b/apps/studio/components/interfaces/Account/AccessTokens/AccessTokenNewBanner/AccessTokenNewBanner.tsx
@@ -29,7 +29,7 @@ export const AccessTokenNewBanner = <T,>({
 
   return (
     <Admonition
-      type="tip"
+      type="note"
       title={title}
       className="mb-6 relative"
       actions={

--- a/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
+++ b/apps/studio/components/interfaces/Auth/OAuthApps/OAuthServerSettingsForm.tsx
@@ -285,7 +285,7 @@ export const OAuthServerSettingsForm = () => {
 
                         return (
                           <Admonition
-                            type="tip"
+                            type="note"
                             title="Make sure this path is implemented in your application."
                             description={
                               <>

--- a/apps/studio/components/interfaces/Integrations/Queues/CreateQueueSheet/PgPartmanCallout.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/CreateQueueSheet/PgPartmanCallout.tsx
@@ -14,7 +14,7 @@ export function PgPartmanCallout() {
   return (
     <div className="mx-5 my-2">
       <Admonition
-        type="tip"
+        type="note"
         title="pg_partman is now available"
         description="Unlock partitioned queues for automatic data retention, lower storage costs, and faster performance at scale."
       >

--- a/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
+++ b/apps/studio/components/interfaces/SQLEditor/UtilityPanel/ChartConfig.tsx
@@ -189,7 +189,7 @@ export const ChartConfig = ({
         </div>
 
         {!acknowledged && (
-          <Admonition showIcon={false} type="tip" className="p-2 relative group">
+          <Admonition showIcon={false} type="note" className="p-2 relative group">
             <Tooltip>
               <TooltipTrigger
                 onClick={() => setAcknowledged(true)}

--- a/apps/studio/components/ui/AlphaNotice.tsx
+++ b/apps/studio/components/ui/AlphaNotice.tsx
@@ -21,7 +21,7 @@ export const AlphaNotice = ({
   return (
     <Admonition
       showIcon={false}
-      type="tip"
+      type="note"
       layout="horizontal"
       actions={
         <Button

--- a/apps/studio/pages/partners/stripe/projects/login.tsx
+++ b/apps/studio/pages/partners/stripe/projects/login.tsx
@@ -140,7 +140,7 @@ const StripeProjectsLoginPage: NextPageWithLayout = () => {
           {showAuthorizationState && emailMatches && linkedOrg && (
             <div className="flex flex-col gap-3">
               <Admonition
-                type="tip"
+                type="note"
                 description={
                   <>
                     <span className="font-medium text-foreground">{linkedOrg.name}</span> is already

--- a/apps/www/_blog/2024-01-31-nosql-mongodb-compatibility-with-ferretdb-and-flydotio.mdx
+++ b/apps/www/_blog/2024-01-31-nosql-mongodb-compatibility-with-ferretdb-and-flydotio.mdx
@@ -45,7 +45,7 @@ FerretDB only requires the Postgres database URI to be provided as the `FERRETDB
 
 Make sure **Use connection pooling** is checked and **Session mode** is selected. Then copy the URI. Replace the password placeholder with your saved database password.
 
-<Admonition type="tip">
+<Admonition type="note">
 
 If your network supports IPv6 connections, you can also use the direct connection string. Uncheck **Use connection pooling** and copy the new URI.
 

--- a/apps/www/_blog/2024-12-04-cli-v2-config-as-code.mdx
+++ b/apps/www/_blog/2024-12-04-cli-v2-config-as-code.mdx
@@ -41,7 +41,7 @@ You can make deployments consistent and repeatable by promoting Edge Functions, 
 
 To demonstrate this workflow, let’s use the `supabase.com` website as an example. It’s hosted on Vercel with [Supabase Branching](/docs/guides/deployment/branching) enabled for development. If you are not using Branching, a similar setup can be achieved using GitHub Actions.
 
-<Admonition type="tip" title="Detecting config drift">
+<Admonition type="note" title="Detecting config drift">
 
 Before changing any project configuration, it’s a good idea to verify that your remote config has not drifted.
 
@@ -75,7 +75,7 @@ verify_jwt = false
 
 If you are using a monorepo (like the [@supabase/supabase](https://github.com/supabase/supabase) GitHub repository), you may also want to customize the paths to your function’s entrypoint and import map files. This is especially useful for code sharing between your frontend application and Edge Functions.
 
-<Admonition type="tip" title="Setting Edge Function secrets">
+<Admonition type="note" title="Setting Edge Function secrets">
 
 Edge Function secrets must be manually added to branches as of this release. We plan to support setting Function secrets at deploy time in the near future.
 

--- a/packages/ui-patterns/src/Admonition/Admonition.constants.ts
+++ b/packages/ui-patterns/src/Admonition/Admonition.constants.ts
@@ -2,7 +2,6 @@ import type { AdmonitionType } from './Admonition.types'
 
 export const TYPE_TO_VARIANT = {
   note: 'default',
-  tip: 'default',
   caution: 'warning',
   danger: 'destructive',
   deprecation: 'warning',
@@ -14,7 +13,6 @@ export const TYPE_TO_VARIANT = {
 
 export const TYPE_LABEL = {
   note: 'Note',
-  tip: 'Tip',
   caution: 'Caution',
   danger: 'Danger',
   deprecation: 'Deprecated',

--- a/packages/ui-patterns/src/Admonition/Admonition.test.tsx
+++ b/packages/ui-patterns/src/Admonition/Admonition.test.tsx
@@ -110,7 +110,6 @@ describe('Admonition', () => {
   })
 
   it.each([
-    ['tip', 'Tip'],
     ['danger', 'Danger'],
     ['deprecation', 'Deprecated'],
   ] as const)('exposes %s via aria-label as %s', (type, name) => {

--- a/packages/ui-patterns/src/Admonition/Admonition.types.ts
+++ b/packages/ui-patterns/src/Admonition/Admonition.types.ts
@@ -2,7 +2,6 @@ import type { HTMLAttributes, ReactNode } from 'react'
 
 export type AdmonitionType =
   | 'note'
-  | 'tip'
   | 'caution'
   | 'danger'
   | 'deprecation'

--- a/supa-mdx-lint.config.toml
+++ b/supa-mdx-lint.config.toml
@@ -9,7 +9,7 @@ Rule003Spelling = "include('supa-mdx-lint/Rule003Spelling.toml')"
 
 [Rule002AdmonitionTypes]
 # Allowed admonition types are:
-admonition_types = ["note", "tip", "caution", "deprecation", "danger"]
+admonition_types = ["note", "caution", "deprecation", "danger"]
 
 [Rule004ExcludeWords]
 rules.filler = "include('supa-mdx-lint/Rule004ExcludeWords/filler.toml')"


### PR DESCRIPTION
Closes FE-3966

## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## Problem

- The admonition uses both 'tip' and 'note', but the visual distinction has long-ago collapsed.
- 'Note' is used far more frequently than 'tip'
- The two are very similar and it is confusing to know which one to use when they are visually identical

## Solution

Collapse 'tip' and 'note' into one by removing all places where there is 'tip' and updating all references to 'tip' into 'note'.

**Note:** This PR also resolves new broken links flagged by the E2E docs checker. It may move to another PR since E2Es keep erroring.

### Specific changes

See below for an AI-generated list of changes:

- **Type system** — removed `'tip'` from `AdmonitionType`, its `TYPE_TO_VARIANT`/`TYPE_LABEL` entries, and the test case in [`packages/ui-patterns/src/Admonition/](packages/ui-patterns/src/Admonition/)
- **Remark plugin** — [remarkAdmonition.ts](apps/docs/lib/mdx/plugins/remarkAdmonition.ts) now maps mkdocs `tip` → `note`
- **Lint allowlist** — `tip` dropped from `supa-mdx-lint.config.toml`
- **Content migration** — all 109 files with `type="tip"` (across `apps/docs`, `apps/www`, `apps/studio`) converted to `type="note"`; zero remaining hits confirmed by repo-wide grep
- **Style guide** — `CONTRIBUTING.md` and `contributing/content.mdx` updated to describe 4 admonition types instead of 5

### Usage before implementation

See the usage table that points toward 'note' as being dominant across all apps:

Here's the usage table:

| Location | `note` | `tip` |
|---|---|---|
| apps/docs | ~480 | ~143 |
| apps/studio | 34 | 6 |
| apps/www (blog) | 19 | 3 |
| packages/ui-patterns (tests) | 3 | 1 (parametrized) |
| design-system / ui-library / packages/ui / packages/common | 0–1 (test fixture only) | 0 |

## Preview links


| App | Page | Search text (Ctrl+F) | Verify |
|---|---|---|---|
| docs | [/docs/guides/ai-tools/byo-mcp](https://docs-git-admonition-collapse-note-tip-supabase.vercel.app/docs/guides/ai-tools/byo-mcp) | official MCP TypeScript SDK | callout's aria-label="Note" |
| docs | [/docs/guides/ai-tools/mcp](https://docs-git-admonition-collapse-note-tip-supabase.vercel.app/docs/guides/ai-tools/mcp) | MCP server is available at | callout's aria-label="Note" |
| docs | [/docs/guides/ai/python-clients](https://docs-git-admonition-collapse-note-tip-supabase.vercel.app/docs/guides/ai/python-clients) | Click Connect at the top of any project page | callout's aria-label="Note" |
| docs | [/docs/guides/auth/audit-logs](https://docs-git-admonition-collapse-note-tip-supabase.vercel.app/docs/guides/auth/audit-logs) | Disabling Postgres storage reduces your database storage costs | callout's aria-label="Note" |
| docs | [/docs/guides/database/tables](https://docs-git-admonition-collapse-note-tip-supabase.vercel.app/docs/guides/database/tables) | access a custom schema through the Supabase Data API | callout's aria-label="Note" |
| docs | [/docs/guides/troubleshooting/edge-function-404-error-response](https://docs-git-admonition-collapse-note-tip-supabase.vercel.app/docs/guides/troubleshooting/edge-function-404-error-response) | Always configure an appropriate time frame | callout's aria-label="Note" (was single-quoted type='tip') |
| www | [blog: cli-v2-config-as-code](https://zone-www-dot-com-git-admonition-collapse-note-tip-supabase.vercel.app/blog/cli-v2-config-as-code) | Detecting config drift | callout's aria-label="Note" |
| www | [blog: cli-v2-config-as-code](https://zone-www-dot-com-git-admonition-collapse-note-tip-supabase.vercel.app/blog/cli-v2-config-as-code) | Setting Edge Function secrets | callout's aria-label="Note" |
| www | [blog: nosql-mongodb-compatibility-with-ferretdb-and-flydotio](https://zone-www-dot-com-git-admonition-collapse-note-tip-supabase.vercel.app/blog/nosql-mongodb-compatibility-with-ferretdb-and-flydotio) | If your network supports IPv6 connections | callout's aria-label="Note" |

Note: the `www` rows use the `zone-www-dot-com` preview host, not the `docs` one you gave — since blog pages are served from the www app, not docs.


## Manual testing

1. Open preview links for affected pages.
2. Inspect. Open console.
3. Paste the following in and see there is no 'Tip' on the page:
```
document.querySelectorAll('[role="alert"]').forEach(el => console.log(el.getAttribute('aria-label'), el.textContent.slice(0,60)))
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardized informational callouts across docs and tutorials from **“Tip”** to **“Note”**, updating multiple examples and guidance blocks.
  * Updated a few related doc references/links and conditional “Next steps” content.
* **UI Updates**
  * Switched various in-app banners and notices to the **“Note”** style variant.
* **Bug Fixes / Improvements**
  * Removed support for the retired **“Tip”** callout type and aligned docs linting, component behavior, and aria labeling to the remaining admonition types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->