### PR TITLE
fix(docs): give wide tables their own scroll container

### DIFF
--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -69,10 +69,17 @@ const Pre = (props: any) => {
 /**
  * Give a wide table its own scroll container, the way `pre` gets one from `CodeBlock`.
  * Without it the overflow propagates up and scrolls the whole page. `tabIndex` keeps the
- * scroll region reachable without a pointer (WCAG 2.1.1).
+ * scroll region reachable without a pointer (WCAG 2.1.1), and the role names that stop.
+ * `group` rather than `region` so a page of tables doesn't fill the landmark menu, matching
+ * how `CodeBlock` labels its own scroll container.
  */
 const Table = (props: ComponentPropsWithoutRef<'table'>) => (
-  <div tabIndex={0} className="table-scroll w-full overflow-x-auto">
+  <div
+    tabIndex={0}
+    role="group"
+    aria-roledescription="scrollable table"
+    className="table-scroll w-full overflow-x-auto"
+  >
     <table {...props} />
   </div>
 )

--- a/apps/docs/features/docs/MdxBase.shared.tsx
+++ b/apps/docs/features/docs/MdxBase.shared.tsx
@@ -66,6 +66,17 @@ const Pre = (props: any) => {
   return <CodeBlock {...props} />
 }
 
+/**
+ * Give a wide table its own scroll container, the way `pre` gets one from `CodeBlock`.
+ * Without it the overflow propagates up and scrolls the whole page. `tabIndex` keeps the
+ * scroll region reachable without a pointer (WCAG 2.1.1).
+ */
+const Table = (props: ComponentPropsWithoutRef<'table'>) => (
+  <div tabIndex={0} className="table-scroll w-full overflow-x-auto">
+    <table {...props} />
+  </div>
+)
+
 const components = {
   Accordion,
   AccordionItem,
@@ -138,6 +149,7 @@ const components = {
    * plus having a more resilient highlighting strategy.
    */
   code: (props: any) => <code {...props}>{props.children}</code>,
+  table: Table,
   Price,
 }
 

--- a/apps/docs/styles/globals.css
+++ b/apps/docs/styles/globals.css
@@ -393,6 +393,25 @@ th code {
   width: 30%;
 }
 
+/*
+ * The scroll container is a block formatting context, so the table's margins can no longer
+ * collapse with its neighbours. Move the vertical rhythm onto the container to keep spacing
+ * unchanged, in rem because the table renders at a smaller font size than the container.
+ */
+.prose :where(.table-scroll) {
+  margin-top: 1.75rem;
+  margin-bottom: 1.75rem;
+}
+
+.prose :where(.table-scroll) > table {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.prose :where(h2 + .table-scroll, h3 + .table-scroll, h4 + .table-scroll, hr + .table-scroll) {
+  margin-top: 0;
+}
+
 /* Zoomable image */
 
 [data-rmiz-modal]:focus,


### PR DESCRIPTION

<img width="1588" height="1438" alt="pr-comparison" src="https://github.com/user-attachments/assets/149389b9-13d0-4104-9091-8680c9a5e303" />


## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Wide tables have no scroll container, so on a phone they scroll the whole page sideways
instead of scrolling themselves. At 375px the row level security guide lays out 500px wide
and the Management API introduction 581px.

## What is the new behavior?

Tables scroll inside their own container, the same way `pre` already gets one from
`CodeBlock`.

Worth knowing where this came from: it regressed in the App Router migration. #27322 fixed
it in 2024 by adding `apps/docs/components/Table.tsx` and mapping it to `table` in
`apps/docs/components/index.tsx`. That file went away and the mapping wasn't carried into
`features/docs/MdxBase.shared.tsx`, so tables have had no scroll container since.

I didn't re-map that component, for three reasons:

- It uses `useEffect`, so it needs `'use client'`. That ships a client component and a
  hydration step to every guide page with a table, for something CSS does on its own.
- Its gradient overlay has no `pointer-events-none`, so it puts a 20px dead strip down the
  right edge of every table on mobile. `opacity-0` doesn't disable hit testing, so the strip
  is there even when the hint is hidden.
- `showShadow` starts as `true` and only updates on `scroll`, so a table that fits never
  fires the event and shows a hint it can never clear.

Either way, `apps/docs/components/Table.tsx` is currently unused. I've left it alone rather
than widen this PR, but flagging it since it's been dead since the migration.

The CSS is there because the scroll container is a block formatting context, so the table's
margins would stop collapsing with its neighbours and every table would sit about 28px
looser. Moving the vertical rhythm onto the container keeps spacing identical: on the row
level security guide the document height is 21314 and the "Benchmarks" heading sits at
y=14567, before and after.

## Additional context

- Components that render their own `<table>` (`ComputeDiskLimitsTable`,
  `TerraformProviderSchema`, `RealtimeLimitsEstimator`) don't go through the MDX map, so
  they still overflow. Happy to pick those up in a follow-up.
- Ran `next build` locally: 801 routes prerendered. The full `pnpm --filter docs build` needs
  `DOCS_GITHUB_APP_PRIVATE_KEY` for `build:federated-content`, so it can only run inside Supabase.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Documentation tables now support horizontal scrolling on smaller screens.
  * Scrollable table areas are keyboard-accessible to improve navigation.

* **Style**
  * Updated table spacing to prevent layout issues near headings and separators, including refined margins within the scroll container.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
