### PR TITLE
[FE-4019] fix(studio): direct-only connection strings with SSL params for Multigres

### DIFF
--- a/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
@@ -54,8 +54,15 @@ function useConnectionStringPooler(deploymentMode: DeploymentMode): ConnectionSt
   const isHighAvailability = useIsHighAvailability()
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
-  const { data: pgbouncerConfig } = usePgbouncerConfigQuery({ projectRef })
-  const { data: supavisorConfig } = useSupavisorConfigurationQuery({ projectRef })
+  // Multigres has no pooler, so the pooler config endpoints don't apply
+  const { data: pgbouncerConfig } = usePgbouncerConfigQuery(
+    { projectRef },
+    { enabled: !isHighAvailability }
+  )
+  const { data: supavisorConfig } = useSupavisorConfigurationQuery(
+    { projectRef },
+    { enabled: !isHighAvailability }
+  )
   const { data: addons } = useProjectAddonsQuery({ projectRef })
   const { ipv4: ipv4Addon } = getAddons(addons?.selected_addons ?? [])
 

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectStepsSection.tsx
@@ -35,6 +35,7 @@ import { useProjectAddonsQuery } from '@/data/subscriptions/project-addons-query
 import { useCheckEntitlements } from '@/hooks/misc/useCheckEntitlements'
 import { useDeploymentMode } from '@/hooks/misc/useDeploymentMode'
 import { useIsDataApiEnabled } from '@/hooks/misc/useIsDataApiEnabled'
+import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 import { DOCS_URL } from '@/lib/constants'
 import { pluckObjectFields } from '@/lib/helpers'
 
@@ -50,6 +51,7 @@ interface ConnectStepsSectionProps {
 function useConnectionStringPooler(deploymentMode: DeploymentMode): ConnectionStringPooler {
   const { ref: projectRef } = useParams()
   const { hasAccess: allowPgBouncerSelection } = useCheckEntitlements('dedicated_pooler')
+  const isHighAvailability = useIsHighAvailability()
 
   const { data: settings } = useProjectSettingsV2Query({ projectRef })
   const { data: pgbouncerConfig } = usePgbouncerConfigQuery({ projectRef })
@@ -113,8 +115,16 @@ function useConnectionStringPooler(deploymentMode: DeploymentMode): ConnectionSt
         connectionStringsShared,
         connectionStringsDedicated,
         ipv4Addon: !!ipv4Addon,
+        isHighAvailability,
       }),
-    [deploymentMode, connectionInfo, connectionStringsShared, connectionStringsDedicated, ipv4Addon]
+    [
+      deploymentMode,
+      connectionInfo,
+      connectionStringsShared,
+      connectionStringsDedicated,
+      ipv4Addon,
+      isHighAvailability,
+    ]
   )
 }
 

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectionString.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectionString.utils.ts
@@ -4,6 +4,10 @@ import type { ConnectionStringPooler } from './Connect.types'
 export const DEFAULT_PORT = '5432'
 export const PASSWORD_PLACEHOLDER = '[YOUR-PASSWORD]'
 
+/** Appends query params to a connection string, joining with `?` or `&` as needed */
+export const appendConnectionStringParams = (uri: string, params: string) =>
+  !uri || !params ? uri : `${uri}${uri.includes('?') ? '&' : '?'}${params}`
+
 export type ConnectionParams = {
   host: string
   port: string

--- a/apps/studio/components/interfaces/ConnectSheet/ConnectionString.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/ConnectionString.utils.ts
@@ -9,6 +9,8 @@ export type ConnectionParams = {
   port: string
   user: string
   database: string
+  /** Raw query string including the leading `?`, or '' when the URI has none */
+  search: string
 }
 
 export const resolveConnectionString = ({
@@ -44,6 +46,7 @@ export const parseConnectionParams = (connectionString: string): ConnectionParam
       port: DEFAULT_PORT,
       user: 'hidden',
       database: 'hidden',
+      search: '',
     }
   }
 
@@ -64,6 +67,7 @@ export const parseConnectionParams = (connectionString: string): ConnectionParam
       port: parsed.port || DEFAULT_PORT,
       user: parsed.username ? decode(parsed.username) : 'hidden',
       database: parsed.pathname?.replace(/^\//, '') || 'hidden',
+      search: parsed.search,
     }
   } catch (error) {
     return {
@@ -71,6 +75,7 @@ export const parseConnectionParams = (connectionString: string): ConnectionParam
       port: DEFAULT_PORT,
       user: 'hidden',
       database: 'hidden',
+      search: '',
     }
   }
 }
@@ -81,15 +86,22 @@ export const buildSafeConnectionString = (
 ): string => {
   if (!connectionString) return ''
 
-  const search = (() => {
-    try {
-      return new URL(connectionString).search
-    } catch (error) {
-      return ''
-    }
-  })()
+  return `postgresql://${params.user}:${PASSWORD_PLACEHOLDER}@${params.host}:${params.port}/${params.database}${params.search}`
+}
 
-  return `postgresql://${params.user}:${PASSWORD_PLACEHOLDER}@${params.host}:${params.port}/${params.database}${search}`
+export const buildPsqlCommand = (params: ConnectionParams) =>
+  params.search
+    ? // Query params (e.g. sslmode) can't be expressed as psql flags, so fall
+      // back to the URI form — psql prompts for the password.
+      `psql "postgresql://${params.user}@${params.host}:${params.port}/${params.database}${params.search}"`
+    : `psql -h ${params.host} -p ${params.port} -d ${params.database} -U ${params.user}`
+
+export const buildJdbcString = (params: ConnectionParams) => {
+  // pgJDBC (42.7.4+) spells libpq's `sslnegotiation` as `sslNegotiation`
+  const extraParams = params.search
+    ? `&${params.search.slice(1).replace('sslnegotiation=', 'sslNegotiation=')}`
+    : ''
+  return `jdbc:postgresql://${params.host}:${params.port}/${params.database}?user=${params.user}&password=${PASSWORD_PLACEHOLDER}${extraParams}`
 }
 
 export const buildConnectionStringWithPassword = (

--- a/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
@@ -1,5 +1,15 @@
 import type { ConnectionStringPooler, DeploymentMode } from './Connect.types'
 
+/**
+ * Multigres (high-availability) projects only accept TLS connections with
+ * direct SSL negotiation — without these params clients fail with
+ * "server closed the connection unexpectedly".
+ */
+export const HIGH_AVAILABILITY_SSL_PARAMS = 'sslmode=require&sslnegotiation=direct'
+
+export const appendHighAvailabilitySslParams = (uri: string) =>
+  !uri ? uri : `${uri}${uri.includes('?') ? '&' : '?'}${HIGH_AVAILABILITY_SSL_PARAMS}`
+
 type ConnectionStrings = {
   psql: string
   uri: string
@@ -228,12 +238,14 @@ export const buildConnectionStringPooler = ({
   connectionStringsShared,
   connectionStringsDedicated,
   ipv4Addon,
+  isHighAvailability,
 }: {
   deploymentMode: DeploymentMode
   connectionInfo: { db_host: string; db_port: number | string }
   connectionStringsShared: { direct: ConnectionStrings; pooler: ConnectionStrings }
   connectionStringsDedicated?: { direct: ConnectionStrings; pooler: ConnectionStrings }
   ipv4Addon: boolean
+  isHighAvailability: boolean
 }): ConnectionStringPooler => {
   if (deploymentMode.isSelfHosted) {
     const dbHost = connectionInfo.db_host
@@ -274,6 +286,8 @@ export const buildConnectionStringPooler = ({
     transactionDedicated: connectionStringsDedicated?.pooler.uri,
     sessionDedicated: connectionStringsDedicated?.pooler.uri.replace('6543', '5432'),
     ipv4SupportedForDedicatedPooler: ipv4Addon,
-    direct: connectionStringsShared.direct.uri,
+    direct: isHighAvailability
+      ? appendHighAvailabilitySslParams(connectionStringsShared.direct.uri)
+      : connectionStringsShared.direct.uri,
   }
 }

--- a/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
@@ -1,4 +1,5 @@
 import type { ConnectionStringPooler, DeploymentMode } from './Connect.types'
+import { appendConnectionStringParams } from './ConnectionString.utils'
 
 /**
  * Multigres (high-availability) projects only accept TLS connections with
@@ -7,8 +8,14 @@ import type { ConnectionStringPooler, DeploymentMode } from './Connect.types'
  */
 export const HIGH_AVAILABILITY_SSL_PARAMS = 'sslmode=require&sslnegotiation=direct'
 
+/**
+ * No-op when the URI already carries `sslnegotiation` — API-provided pooler
+ * connection strings may already include the SSL params.
+ */
 export const appendHighAvailabilitySslParams = (uri: string) =>
-  !uri ? uri : `${uri}${uri.includes('?') ? '&' : '?'}${HIGH_AVAILABILITY_SSL_PARAMS}`
+  uri.includes('sslnegotiation=')
+    ? uri
+    : appendConnectionStringParams(uri, HIGH_AVAILABILITY_SSL_PARAMS)
 
 type ConnectionStrings = {
   psql: string
@@ -280,14 +287,18 @@ export const buildConnectionStringPooler = ({
   // Port-swap 6543→5432 derives session from transaction. For shared this is a
   // real Supavisor session connection; for dedicated it lands on direct Postgres
   // (PgBouncer has no session mode).
+  const withSslParams = (uri: string) =>
+    isHighAvailability ? appendHighAvailabilitySslParams(uri) : uri
+  const transactionDedicated = connectionStringsDedicated?.pooler.uri
+  const sessionDedicated = connectionStringsDedicated?.pooler.uri.replace('6543', '5432')
+
   return {
-    transactionShared: connectionStringsShared.pooler.uri,
-    sessionShared: connectionStringsShared.pooler.uri.replace('6543', '5432'),
-    transactionDedicated: connectionStringsDedicated?.pooler.uri,
-    sessionDedicated: connectionStringsDedicated?.pooler.uri.replace('6543', '5432'),
+    transactionShared: withSslParams(connectionStringsShared.pooler.uri),
+    sessionShared: withSslParams(connectionStringsShared.pooler.uri.replace('6543', '5432')),
+    transactionDedicated:
+      transactionDedicated === undefined ? undefined : withSslParams(transactionDedicated),
+    sessionDedicated: sessionDedicated === undefined ? undefined : withSslParams(sessionDedicated),
     ipv4SupportedForDedicatedPooler: ipv4Addon,
-    direct: isHighAvailability
-      ? appendHighAvailabilitySslParams(connectionStringsShared.direct.uri)
-      : connectionStringsShared.direct.uri,
+    direct: withSslParams(connectionStringsShared.direct.uri),
   }
 }

--- a/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/DatabaseSettings.utils.ts
@@ -9,8 +9,8 @@ import { appendConnectionStringParams } from './ConnectionString.utils'
 export const HIGH_AVAILABILITY_SSL_PARAMS = 'sslmode=require&sslnegotiation=direct'
 
 /**
- * No-op when the URI already carries `sslnegotiation` — API-provided pooler
- * connection strings may already include the SSL params.
+ * No-op when the URI already carries `sslnegotiation`, so the params are never
+ * double-appended.
  */
 export const appendHighAvailabilitySslParams = (uri: string) =>
   uri.includes('sslnegotiation=')
@@ -284,21 +284,29 @@ export const buildConnectionStringPooler = ({
     }
   }
 
+  if (isHighAvailability) {
+    // Multigres has no pooler (neither Supavisor nor PgBouncer), so every slot
+    // falls back to the direct connection.
+    const directUri = appendHighAvailabilitySslParams(connectionStringsShared.direct.uri)
+    return {
+      transactionShared: directUri,
+      sessionShared: directUri,
+      transactionDedicated: undefined,
+      sessionDedicated: undefined,
+      ipv4SupportedForDedicatedPooler: false,
+      direct: directUri,
+    }
+  }
+
   // Port-swap 6543→5432 derives session from transaction. For shared this is a
   // real Supavisor session connection; for dedicated it lands on direct Postgres
   // (PgBouncer has no session mode).
-  const withSslParams = (uri: string) =>
-    isHighAvailability ? appendHighAvailabilitySslParams(uri) : uri
-  const transactionDedicated = connectionStringsDedicated?.pooler.uri
-  const sessionDedicated = connectionStringsDedicated?.pooler.uri.replace('6543', '5432')
-
   return {
-    transactionShared: withSslParams(connectionStringsShared.pooler.uri),
-    sessionShared: withSslParams(connectionStringsShared.pooler.uri.replace('6543', '5432')),
-    transactionDedicated:
-      transactionDedicated === undefined ? undefined : withSslParams(transactionDedicated),
-    sessionDedicated: sessionDedicated === undefined ? undefined : withSslParams(sessionDedicated),
+    transactionShared: connectionStringsShared.pooler.uri,
+    sessionShared: connectionStringsShared.pooler.uri.replace('6543', '5432'),
+    transactionDedicated: connectionStringsDedicated?.pooler.uri,
+    sessionDedicated: connectionStringsDedicated?.pooler.uri.replace('6543', '5432'),
     ipv4SupportedForDedicatedPooler: ipv4Addon,
-    direct: withSslParams(connectionStringsShared.direct.uri),
+    direct: connectionStringsShared.direct.uri,
   }
 }

--- a/apps/studio/components/interfaces/ConnectSheet/OrmConnection.utils.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/OrmConnection.utils.ts
@@ -1,0 +1,39 @@
+import type {
+  ConnectionStringPooler,
+  DeploymentMode,
+} from '@/components/interfaces/ConnectSheet/Connect.types'
+
+export type OrmConnectionScenario =
+  | 'cli'
+  | 'self-hosted'
+  | 'high-availability'
+  | 'dedicated-pooler'
+  | 'shared-pooler-with-dedicated-alternative'
+  | 'shared-pooler'
+
+/**
+ * Resolves which connection setup an ORM env template should render.
+ * Shared by the ORM step contents (Prisma, Drizzle) so they only differ in
+ * formatting, not in how the scenario is picked.
+ */
+export const resolveOrmConnectionScenario = ({
+  connectionStringPooler,
+  deploymentMode,
+  isHighAvailability,
+}: {
+  connectionStringPooler: ConnectionStringPooler
+  deploymentMode: DeploymentMode
+  isHighAvailability: boolean
+}): OrmConnectionScenario => {
+  if (deploymentMode.isCli) return 'cli'
+  if (deploymentMode.isSelfHosted) return 'self-hosted'
+  if (isHighAvailability) return 'high-availability'
+
+  if (connectionStringPooler.transactionDedicated) {
+    return connectionStringPooler.ipv4SupportedForDedicatedPooler
+      ? 'dedicated-pooler'
+      : 'shared-pooler-with-dedicated-alternative'
+  }
+
+  return 'shared-pooler'
+}

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  appendConnectionStringParams,
   buildConnectionParameters,
   buildConnectionStringWithPassword,
   buildJdbcString,
@@ -167,6 +168,27 @@ describe('resolveConnectionString', () => {
         connectionStringPooler: { ...pooler, transactionDedicated: undefined },
       })
     ).toBe('tx-shared')
+  })
+})
+
+describe('appendConnectionStringParams', () => {
+  test('joins with ? when the URI has no query string', () => {
+    expect(appendConnectionStringParams('postgresql://u@h:5432/db', 'pgbouncer=true')).toBe(
+      'postgresql://u@h:5432/db?pgbouncer=true'
+    )
+  })
+
+  test('joins with & when the URI already has a query string', () => {
+    expect(
+      appendConnectionStringParams('postgresql://u@h:5432/db?sslmode=require', 'pgbouncer=true')
+    ).toBe('postgresql://u@h:5432/db?sslmode=require&pgbouncer=true')
+  })
+
+  test('returns the URI unchanged for empty inputs', () => {
+    expect(appendConnectionStringParams('', 'pgbouncer=true')).toBe('')
+    expect(appendConnectionStringParams('postgresql://u@h:5432/db', '')).toBe(
+      'postgresql://u@h:5432/db'
+    )
   })
 })
 

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/ConnectionString.utils.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from 'vitest'
 import {
   buildConnectionParameters,
   buildConnectionStringWithPassword,
+  buildJdbcString,
+  buildPsqlCommand,
   buildSafeConnectionString,
   DEFAULT_PORT,
   parseConnectionParams,
@@ -17,6 +19,7 @@ describe('parseConnectionParams', () => {
       port: DEFAULT_PORT,
       user: 'hidden',
       database: 'hidden',
+      search: '',
     })
   })
 
@@ -26,6 +29,7 @@ describe('parseConnectionParams', () => {
       port: DEFAULT_PORT,
       user: 'hidden',
       database: 'hidden',
+      search: '',
     })
   })
 
@@ -37,7 +41,14 @@ describe('parseConnectionParams', () => {
       port: '6543',
       user: 'postgres.projref',
       database: 'postgres',
+      search: '',
     })
+  })
+
+  test('keeps the query string in search', () => {
+    const uri =
+      'postgresql://postgres:[YOUR-PASSWORD]@db.proj.supabase.co:5432/postgres?sslmode=require&sslnegotiation=direct'
+    expect(parseConnectionParams(uri).search).toBe('?sslmode=require&sslnegotiation=direct')
   })
 
   test('decodes percent-encoded bracket placeholders in the user info', () => {
@@ -159,6 +170,50 @@ describe('resolveConnectionString', () => {
   })
 })
 
+describe('buildPsqlCommand', () => {
+  const params = {
+    host: 'db.proj.supabase.co',
+    port: '5432',
+    user: 'postgres',
+    database: 'postgres',
+    search: '',
+  }
+
+  test('uses flag form when there is no query string', () => {
+    expect(buildPsqlCommand(params)).toBe(
+      'psql -h db.proj.supabase.co -p 5432 -d postgres -U postgres'
+    )
+  })
+
+  test('falls back to the URI form when the query string must be carried', () => {
+    expect(buildPsqlCommand({ ...params, search: '?sslmode=require&sslnegotiation=direct' })).toBe(
+      'psql "postgresql://postgres@db.proj.supabase.co:5432/postgres?sslmode=require&sslnegotiation=direct"'
+    )
+  })
+})
+
+describe('buildJdbcString', () => {
+  const params = {
+    host: 'db.proj.supabase.co',
+    port: '5432',
+    user: 'postgres',
+    database: 'postgres',
+    search: '',
+  }
+
+  test('builds the base string without extra params', () => {
+    expect(buildJdbcString(params)).toBe(
+      `jdbc:postgresql://db.proj.supabase.co:5432/postgres?user=postgres&password=${PASSWORD_PLACEHOLDER}`
+    )
+  })
+
+  test('appends the query string using pgJDBC casing for sslnegotiation', () => {
+    expect(buildJdbcString({ ...params, search: '?sslmode=require&sslnegotiation=direct' })).toBe(
+      `jdbc:postgresql://db.proj.supabase.co:5432/postgres?user=postgres&password=${PASSWORD_PLACEHOLDER}&sslmode=require&sslNegotiation=direct`
+    )
+  })
+})
+
 describe('buildConnectionParameters', () => {
   test('produces host/port/database/user rows in display order', () => {
     expect(
@@ -167,6 +222,7 @@ describe('buildConnectionParameters', () => {
         port: '5432',
         user: 'u',
         database: 'd',
+        search: '',
       })
     ).toEqual([
       { key: 'host', value: 'h' },

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
@@ -179,7 +179,7 @@ describe('buildConnectionStringPooler', () => {
     expect(result.direct).toContain(':5432/postgres')
   })
 
-  test('platform high availability: appends SSL params to the direct URI only', () => {
+  test('platform high availability: appends SSL params to every URI in the bag', () => {
     const result = buildConnectionStringPooler({
       deploymentMode: platform,
       connectionInfo,
@@ -190,9 +190,48 @@ describe('buildConnectionStringPooler', () => {
     })
 
     expect(result.direct).toBe(`${sharedPlatform.direct.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`)
-    expect(result.transactionShared).toBe(sharedPlatform.pooler.uri)
-    expect(result.sessionShared).toBe(sharedPlatform.pooler.uri.replace('6543', '5432'))
-    expect(result.transactionDedicated).toBe(dedicatedPlatform.pooler.uri)
+    expect(result.transactionShared).toBe(
+      `${sharedPlatform.pooler.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`
+    )
+    expect(result.sessionShared).toBe(
+      `${sharedPlatform.pooler.uri.replace('6543', '5432')}?${HIGH_AVAILABILITY_SSL_PARAMS}`
+    )
+    expect(result.transactionDedicated).toBe(
+      `${dedicatedPlatform.pooler.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`
+    )
+    expect(result.sessionDedicated).toBe(
+      `${dedicatedPlatform.pooler.uri.replace('6543', '5432')}?${HIGH_AVAILABILITY_SSL_PARAMS}`
+    )
+  })
+
+  test('platform high availability: leaves API-provided URIs that already carry the params untouched', () => {
+    const withParams = makeStrings(
+      `postgresql://postgres.proj:[YOUR-PASSWORD]@pooler.supabase.com:6543/postgres?${HIGH_AVAILABILITY_SSL_PARAMS}`,
+      'postgresql://postgres:[YOUR-PASSWORD]@db.proj.supabase.co:5432/postgres'
+    )
+    const result = buildConnectionStringPooler({
+      deploymentMode: platform,
+      connectionInfo,
+      connectionStringsShared: withParams,
+      ipv4Addon: false,
+      isHighAvailability: true,
+    })
+
+    expect(result.transactionShared).toBe(withParams.pooler.uri)
+    expect(result.direct).toBe(`${withParams.direct.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`)
+  })
+
+  test('platform high availability: dedicated slots stay undefined without a dedicated pooler', () => {
+    const result = buildConnectionStringPooler({
+      deploymentMode: platform,
+      connectionInfo,
+      connectionStringsShared: sharedPlatform,
+      ipv4Addon: false,
+      isHighAvailability: true,
+    })
+
+    expect(result.transactionDedicated).toBeUndefined()
+    expect(result.sessionDedicated).toBeUndefined()
   })
 })
 
@@ -207,6 +246,11 @@ describe('appendHighAvailabilitySslParams', () => {
     expect(appendHighAvailabilitySslParams('postgresql://u:p@host:5432/db?options=x')).toBe(
       `postgresql://u:p@host:5432/db?options=x&${HIGH_AVAILABILITY_SSL_PARAMS}`
     )
+  })
+
+  test('does not double-append when sslnegotiation is already present', () => {
+    const uri = `postgresql://u:p@host:5432/db?${HIGH_AVAILABILITY_SSL_PARAMS}`
+    expect(appendHighAvailabilitySslParams(uri)).toBe(uri)
   })
 
   test('leaves an empty string untouched', () => {

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from 'vitest'
 
 import {
+  appendHighAvailabilitySslParams,
   buildConnectionStringPooler,
   getSelfHostedDirectStrings,
   getSelfHostedPoolerStrings,
+  HIGH_AVAILABILITY_SSL_PARAMS,
 } from '../DatabaseSettings.utils'
 import type { DeploymentMode } from '@/hooks/misc/useDeploymentMode'
 
@@ -99,6 +101,7 @@ describe('buildConnectionStringPooler', () => {
       connectionStringsShared: sharedPlatform,
       connectionStringsDedicated: dedicatedPlatform,
       ipv4Addon: true,
+      isHighAvailability: false,
     })
 
     expect(result.transactionShared).toBe(sharedPlatform.pooler.uri)
@@ -115,6 +118,7 @@ describe('buildConnectionStringPooler', () => {
       connectionInfo,
       connectionStringsShared: sharedPlatform,
       ipv4Addon: false,
+      isHighAvailability: false,
     })
     expect(result.ipv4SupportedForDedicatedPooler).toBe(false)
     expect(result.transactionDedicated).toBeUndefined()
@@ -128,6 +132,7 @@ describe('buildConnectionStringPooler', () => {
       connectionInfo,
       connectionStringsShared: sharedPlatform,
       ipv4Addon: false,
+      isHighAvailability: false,
     })
 
     expect(result.direct).toBe(directUri)
@@ -144,6 +149,7 @@ describe('buildConnectionStringPooler', () => {
       connectionInfo: { db_host: 'supabase.example.com', db_port: 5432 },
       connectionStringsShared: sharedPlatform,
       ipv4Addon: true,
+      isHighAvailability: false,
     })
 
     expect(result.transactionShared).toBe(
@@ -167,8 +173,43 @@ describe('buildConnectionStringPooler', () => {
       connectionInfo: { db_host: 'supabase.example.com', db_port: 0 },
       connectionStringsShared: sharedPlatform,
       ipv4Addon: false,
+      isHighAvailability: false,
     })
     expect(result.sessionShared).toContain(':5432/postgres')
     expect(result.direct).toContain(':5432/postgres')
+  })
+
+  test('platform high availability: appends SSL params to the direct URI only', () => {
+    const result = buildConnectionStringPooler({
+      deploymentMode: platform,
+      connectionInfo,
+      connectionStringsShared: sharedPlatform,
+      connectionStringsDedicated: dedicatedPlatform,
+      ipv4Addon: true,
+      isHighAvailability: true,
+    })
+
+    expect(result.direct).toBe(`${sharedPlatform.direct.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`)
+    expect(result.transactionShared).toBe(sharedPlatform.pooler.uri)
+    expect(result.sessionShared).toBe(sharedPlatform.pooler.uri.replace('6543', '5432'))
+    expect(result.transactionDedicated).toBe(dedicatedPlatform.pooler.uri)
+  })
+})
+
+describe('appendHighAvailabilitySslParams', () => {
+  test('appends with ? when the URI has no query string', () => {
+    expect(appendHighAvailabilitySslParams('postgresql://u:p@host:5432/db')).toBe(
+      `postgresql://u:p@host:5432/db?${HIGH_AVAILABILITY_SSL_PARAMS}`
+    )
+  })
+
+  test('appends with & when the URI already has a query string', () => {
+    expect(appendHighAvailabilitySslParams('postgresql://u:p@host:5432/db?options=x')).toBe(
+      `postgresql://u:p@host:5432/db?options=x&${HIGH_AVAILABILITY_SSL_PARAMS}`
+    )
+  })
+
+  test('leaves an empty string untouched', () => {
+    expect(appendHighAvailabilitySslParams('')).toBe('')
   })
 })

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/DatabaseSettings.utils.test.ts
@@ -179,7 +179,8 @@ describe('buildConnectionStringPooler', () => {
     expect(result.direct).toContain(':5432/postgres')
   })
 
-  test('platform high availability: appends SSL params to every URI in the bag', () => {
+  test('platform high availability: collapses every slot to the direct URI with SSL params', () => {
+    const directUri = `${sharedPlatform.direct.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`
     const result = buildConnectionStringPooler({
       deploymentMode: platform,
       connectionInfo,
@@ -189,49 +190,30 @@ describe('buildConnectionStringPooler', () => {
       isHighAvailability: true,
     })
 
-    expect(result.direct).toBe(`${sharedPlatform.direct.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`)
-    expect(result.transactionShared).toBe(
-      `${sharedPlatform.pooler.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`
-    )
-    expect(result.sessionShared).toBe(
-      `${sharedPlatform.pooler.uri.replace('6543', '5432')}?${HIGH_AVAILABILITY_SSL_PARAMS}`
-    )
-    expect(result.transactionDedicated).toBe(
-      `${dedicatedPlatform.pooler.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`
-    )
-    expect(result.sessionDedicated).toBe(
-      `${dedicatedPlatform.pooler.uri.replace('6543', '5432')}?${HIGH_AVAILABILITY_SSL_PARAMS}`
-    )
+    expect(result.direct).toBe(directUri)
+    expect(result.transactionShared).toBe(directUri)
+    expect(result.sessionShared).toBe(directUri)
+    // No pooler on Multigres: dedicated slots stay empty and the IPv4 flag is
+    // off even when a dedicated pooler config and the addon were passed in
+    expect(result.transactionDedicated).toBeUndefined()
+    expect(result.sessionDedicated).toBeUndefined()
+    expect(result.ipv4SupportedForDedicatedPooler).toBe(false)
   })
 
-  test('platform high availability: leaves API-provided URIs that already carry the params untouched', () => {
-    const withParams = makeStrings(
-      `postgresql://postgres.proj:[YOUR-PASSWORD]@pooler.supabase.com:6543/postgres?${HIGH_AVAILABILITY_SSL_PARAMS}`,
-      'postgresql://postgres:[YOUR-PASSWORD]@db.proj.supabase.co:5432/postgres'
-    )
-    const result = buildConnectionStringPooler({
-      deploymentMode: platform,
-      connectionInfo,
-      connectionStringsShared: withParams,
-      ipv4Addon: false,
-      isHighAvailability: true,
-    })
-
-    expect(result.transactionShared).toBe(withParams.pooler.uri)
-    expect(result.direct).toBe(`${withParams.direct.uri}?${HIGH_AVAILABILITY_SSL_PARAMS}`)
-  })
-
-  test('platform high availability: dedicated slots stay undefined without a dedicated pooler', () => {
+  test('platform without high availability appends no SSL params', () => {
     const result = buildConnectionStringPooler({
       deploymentMode: platform,
       connectionInfo,
       connectionStringsShared: sharedPlatform,
-      ipv4Addon: false,
-      isHighAvailability: true,
+      connectionStringsDedicated: dedicatedPlatform,
+      ipv4Addon: true,
+      isHighAvailability: false,
     })
 
-    expect(result.transactionDedicated).toBeUndefined()
-    expect(result.sessionDedicated).toBeUndefined()
+    expect(result.direct).toBe(sharedPlatform.direct.uri)
+    expect(result.transactionShared).toBe(sharedPlatform.pooler.uri)
+    expect(result.direct).not.toContain('sslnegotiation')
+    expect(result.transactionShared).not.toContain('sslnegotiation')
   })
 })
 

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/OrmConnection.utils.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/OrmConnection.utils.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from 'vitest'
+
+import type { ConnectionStringPooler } from '../Connect.types'
+import { resolveOrmConnectionScenario } from '../OrmConnection.utils'
+import type { DeploymentMode } from '@/hooks/misc/useDeploymentMode'
+
+const platform: DeploymentMode = { isPlatform: true, isCli: false, isSelfHosted: false }
+const cli: DeploymentMode = { isPlatform: false, isCli: true, isSelfHosted: false }
+const selfHosted: DeploymentMode = { isPlatform: false, isCli: false, isSelfHosted: true }
+
+const makePooler = (overrides: Partial<ConnectionStringPooler> = {}): ConnectionStringPooler => ({
+  transactionShared: 'postgresql://shared:6543/postgres',
+  sessionShared: 'postgresql://shared:5432/postgres',
+  ipv4SupportedForDedicatedPooler: false,
+  direct: 'postgresql://direct:5432/postgres',
+  ...overrides,
+})
+
+describe('resolveOrmConnectionScenario', () => {
+  test('resolves cli for CLI deployments', () => {
+    const scenario = resolveOrmConnectionScenario({
+      connectionStringPooler: makePooler(),
+      deploymentMode: cli,
+      isHighAvailability: false,
+    })
+    expect(scenario).toBe('cli')
+  })
+
+  test('resolves self-hosted for self-hosted deployments', () => {
+    const scenario = resolveOrmConnectionScenario({
+      connectionStringPooler: makePooler(),
+      deploymentMode: selfHosted,
+      isHighAvailability: false,
+    })
+    expect(scenario).toBe('self-hosted')
+  })
+
+  test('resolves high-availability for HA projects on platform', () => {
+    const scenario = resolveOrmConnectionScenario({
+      connectionStringPooler: makePooler(),
+      deploymentMode: platform,
+      isHighAvailability: true,
+    })
+    expect(scenario).toBe('high-availability')
+  })
+
+  test('cli wins over the HA flag', () => {
+    const scenario = resolveOrmConnectionScenario({
+      connectionStringPooler: makePooler(),
+      deploymentMode: cli,
+      isHighAvailability: true,
+    })
+    expect(scenario).toBe('cli')
+  })
+
+  test('resolves dedicated-pooler when the dedicated pooler exists and IPv4 is supported', () => {
+    const scenario = resolveOrmConnectionScenario({
+      connectionStringPooler: makePooler({
+        transactionDedicated: 'postgresql://dedicated:6543/postgres',
+        sessionDedicated: 'postgresql://dedicated:5432/postgres',
+        ipv4SupportedForDedicatedPooler: true,
+      }),
+      deploymentMode: platform,
+      isHighAvailability: false,
+    })
+    expect(scenario).toBe('dedicated-pooler')
+  })
+
+  test('resolves shared-pooler-with-dedicated-alternative when the dedicated pooler exists without IPv4 support', () => {
+    const scenario = resolveOrmConnectionScenario({
+      connectionStringPooler: makePooler({
+        transactionDedicated: 'postgresql://dedicated:6543/postgres',
+        sessionDedicated: 'postgresql://dedicated:5432/postgres',
+        ipv4SupportedForDedicatedPooler: false,
+      }),
+      deploymentMode: platform,
+      isHighAvailability: false,
+    })
+    expect(scenario).toBe('shared-pooler-with-dedicated-alternative')
+  })
+
+  test('falls back to shared-pooler when there is no dedicated pooler', () => {
+    const scenario = resolveOrmConnectionScenario({
+      connectionStringPooler: makePooler(),
+      deploymentMode: platform,
+      isHighAvailability: false,
+    })
+    expect(scenario).toBe('shared-pooler')
+  })
+})

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/useConnectState.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/useConnectState.test.ts
@@ -530,6 +530,34 @@ describe('useConnectState', () => {
       expect(connectionTypeField?.label).toBe('Connection Type')
     })
 
+    test('should coerce pooler-flavored initial state to the direct method for HA projects', async () => {
+      const { useIsHighAvailability } = await import('@/hooks/misc/useSelectedProject')
+      vi.mocked(useIsHighAvailability).mockReturnValue(true)
+
+      // Simulates pooler selections restored from the URL or localStorage
+      const { result } = renderHook(() =>
+        useConnectState({ mode: 'direct', connectionMethod: 'transaction', useSharedPooler: true })
+      )
+
+      expect(result.current.state.connectionMethod).toBe('direct')
+      expect(result.current.state.useSharedPooler).toBe(false)
+    })
+
+    test('should coerce connectionMethod updates to the direct method for HA projects', async () => {
+      const { useIsHighAvailability } = await import('@/hooks/misc/useSelectedProject')
+      vi.mocked(useIsHighAvailability).mockReturnValue(true)
+
+      const { result } = renderHook(() => useConnectState({ mode: 'direct' }))
+
+      act(() => {
+        result.current.updateField('connectionMethod', 'session')
+        result.current.updateField('useSharedPooler', true)
+      })
+
+      expect(result.current.state.connectionMethod).toBe('direct')
+      expect(result.current.state.useSharedPooler).toBe(false)
+    })
+
     test('should not affect non-HA projects', async () => {
       const { useIsHighAvailability } = await import('@/hooks/misc/useSelectedProject')
       vi.mocked(useIsHighAvailability).mockReturnValue(false)

--- a/apps/studio/components/interfaces/ConnectSheet/__tests__/useConnectState.test.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/__tests__/useConnectState.test.ts
@@ -498,6 +498,11 @@ describe('useConnectState', () => {
   // ============================================================================
 
   describe('high availability projects', () => {
+    afterEach(async () => {
+      const { useIsHighAvailability } = await import('@/hooks/misc/useSelectedProject')
+      vi.mocked(useIsHighAvailability).mockReturnValue(false)
+    })
+
     test('should hide connectionMethod field for HA projects', async () => {
       const { useIsHighAvailability } = await import('@/hooks/misc/useSelectedProject')
       vi.mocked(useIsHighAvailability).mockReturnValue(true)

--- a/apps/studio/components/interfaces/ConnectSheet/content/drizzle/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/drizzle/content.tsx
@@ -1,37 +1,74 @@
 import { MultipleCodeBlock } from 'ui-patterns/MultipleCodeBlock'
 
-import type { StepContentProps } from '@/components/interfaces/ConnectSheet/Connect.types'
+import type {
+  ConnectionStringPooler,
+  DeploymentMode,
+  StepContentProps,
+} from '@/components/interfaces/ConnectSheet/Connect.types'
+import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 
-const ContentFile = ({ connectionStringPooler, deploymentMode }: StepContentProps) => {
-  const envCode = deploymentMode.isCli
-    ? `
+function getEnvCode({
+  connectionStringPooler,
+  deploymentMode,
+  isHighAvailability,
+}: {
+  connectionStringPooler: ConnectionStringPooler
+  deploymentMode: DeploymentMode
+  isHighAvailability: boolean
+}): string {
+  if (deploymentMode.isCli) {
+    return `
 # Connect to Postgres via the direct connection
 DATABASE_URL="${connectionStringPooler.direct}"
 `
-    : deploymentMode.isSelfHosted
-      ? `
+  }
+
+  if (deploymentMode.isSelfHosted) {
+    return `
 # Connect to Postgres via the self-hosted transaction-mode pooler
 DATABASE_URL="${connectionStringPooler.transactionShared}"
 `
-      : connectionStringPooler.transactionDedicated &&
-          connectionStringPooler.ipv4SupportedForDedicatedPooler
-        ? `
+  }
+
+  if (isHighAvailability) {
+    return `
+# Multigres does not support connection pooling — connect to Postgres directly
+DATABASE_URL="${connectionStringPooler.direct}"
+`
+  }
+
+  if (
+    connectionStringPooler.transactionDedicated &&
+    connectionStringPooler.ipv4SupportedForDedicatedPooler
+  ) {
+    return `
 # Connect to Postgres via the dedicated transaction-mode pooler (IPv4-only)
 DATABASE_URL="${connectionStringPooler.transactionDedicated}"
         `
-        : connectionStringPooler.transactionDedicated &&
-            !connectionStringPooler.ipv4SupportedForDedicatedPooler
-          ? `
+  }
+
+  if (
+    connectionStringPooler.transactionDedicated &&
+    !connectionStringPooler.ipv4SupportedForDedicatedPooler
+  ) {
+    return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${connectionStringPooler.transactionShared}"
 
 # For paid projects, if your network supports IPv6, or you purchased the IPv4 add-on, use the dedicated transaction-mode pooler as an alternative
 # DATABASE_URL="${connectionStringPooler.transactionDedicated}"
         `
-          : `
+  }
+
+  return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${connectionStringPooler.transactionShared}"
 `
+}
+
+const ContentFile = ({ connectionStringPooler, deploymentMode }: StepContentProps) => {
+  const isHighAvailability = useIsHighAvailability()
+  const envCode = getEnvCode({ connectionStringPooler, deploymentMode, isHighAvailability })
 
   const files = [
     {

--- a/apps/studio/components/interfaces/ConnectSheet/content/drizzle/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/drizzle/content.tsx
@@ -5,6 +5,7 @@ import type {
   DeploymentMode,
   StepContentProps,
 } from '@/components/interfaces/ConnectSheet/Connect.types'
+import { resolveOrmConnectionScenario } from '@/components/interfaces/ConnectSheet/OrmConnection.utils'
 import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 
 function getEnvCode({
@@ -16,54 +17,47 @@ function getEnvCode({
   deploymentMode: DeploymentMode
   isHighAvailability: boolean
 }): string {
-  if (deploymentMode.isCli) {
-    return `
+  const scenario = resolveOrmConnectionScenario({
+    connectionStringPooler,
+    deploymentMode,
+    isHighAvailability,
+  })
+
+  switch (scenario) {
+    case 'cli':
+      return `
 # Connect to Postgres via the direct connection
 DATABASE_URL="${connectionStringPooler.direct}"
 `
-  }
-
-  if (deploymentMode.isSelfHosted) {
-    return `
+    case 'self-hosted':
+      return `
 # Connect to Postgres via the self-hosted transaction-mode pooler
 DATABASE_URL="${connectionStringPooler.transactionShared}"
 `
-  }
-
-  if (isHighAvailability) {
-    return `
+    case 'high-availability':
+      return `
 # Multigres does not support connection pooling — connect to Postgres directly
 DATABASE_URL="${connectionStringPooler.direct}"
 `
-  }
-
-  if (
-    connectionStringPooler.transactionDedicated &&
-    connectionStringPooler.ipv4SupportedForDedicatedPooler
-  ) {
-    return `
+    case 'dedicated-pooler':
+      return `
 # Connect to Postgres via the dedicated transaction-mode pooler (IPv4-only)
 DATABASE_URL="${connectionStringPooler.transactionDedicated}"
         `
-  }
-
-  if (
-    connectionStringPooler.transactionDedicated &&
-    !connectionStringPooler.ipv4SupportedForDedicatedPooler
-  ) {
-    return `
+    case 'shared-pooler-with-dedicated-alternative':
+      return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${connectionStringPooler.transactionShared}"
 
 # For paid projects, if your network supports IPv6, or you purchased the IPv4 add-on, use the dedicated transaction-mode pooler as an alternative
 # DATABASE_URL="${connectionStringPooler.transactionDedicated}"
         `
-  }
-
-  return `
+    case 'shared-pooler':
+      return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${connectionStringPooler.transactionShared}"
 `
+  }
 }
 
 const ContentFile = ({ connectionStringPooler, deploymentMode }: StepContentProps) => {

--- a/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
@@ -6,6 +6,7 @@ import type {
   StepContentProps,
 } from '@/components/interfaces/ConnectSheet/Connect.types'
 import { appendConnectionStringParams } from '@/components/interfaces/ConnectSheet/ConnectionString.utils'
+import { resolveOrmConnectionScenario } from '@/components/interfaces/ConnectSheet/OrmConnection.utils'
 import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 
 const withPgbouncerParam = (uri: string | undefined) =>
@@ -20,54 +21,47 @@ function getEnvCode({
   deploymentMode: DeploymentMode
   isHighAvailability: boolean
 }): string {
-  if (deploymentMode.isCli) {
-    return `
+  const scenario = resolveOrmConnectionScenario({
+    connectionStringPooler,
+    deploymentMode,
+    isHighAvailability,
+  })
+
+  switch (scenario) {
+    case 'cli':
+      return `
 # Connect to Postgres via the direct connection
 DATABASE_URL="${connectionStringPooler.direct}"
 
 # Used for migrations
 DIRECT_URL="${connectionStringPooler.direct}"
 `
-  }
-
-  if (deploymentMode.isSelfHosted) {
-    return `
+    case 'self-hosted':
+      return `
 # Connect to Postgres via the self-hosted transaction-mode pooler
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
 # Connect to Postgres via the self-hosted session-mode pooler (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionShared}"
 `
-  }
-
-  if (isHighAvailability) {
-    return `
+    case 'high-availability':
+      return `
 # Multigres does not support connection pooling — connect to Postgres directly
 DATABASE_URL="${connectionStringPooler.direct}"
 
 # Used for migrations
 DIRECT_URL="${connectionStringPooler.direct}"
 `
-  }
-
-  if (
-    connectionStringPooler.transactionDedicated &&
-    connectionStringPooler.ipv4SupportedForDedicatedPooler
-  ) {
-    return `
+    case 'dedicated-pooler':
+      return `
 # Connect to Postgres via the dedicated transaction-mode pooler (IPv4-only)
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionDedicated)}"
 
 # Connect to Postgres directly (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionDedicated}"
         `
-  }
-
-  if (
-    connectionStringPooler.transactionDedicated &&
-    !connectionStringPooler.ipv4SupportedForDedicatedPooler
-  ) {
-    return `
+    case 'shared-pooler-with-dedicated-alternative':
+      return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
@@ -78,15 +72,15 @@ DIRECT_URL="${connectionStringPooler.sessionShared}"
 # DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionDedicated)}"
 # DIRECT_URL="${connectionStringPooler.sessionDedicated}"
  `
-  }
-
-  return `
+    case 'shared-pooler':
+      return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
 # Connect to Postgres via the shared session-mode pooler (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionShared}"
 `
+  }
 }
 
 const ContentFile = ({ connectionStringPooler, deploymentMode }: StepContentProps) => {

--- a/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
@@ -1,39 +1,73 @@
 import { MultipleCodeBlock } from 'ui-patterns/MultipleCodeBlock'
 
-import type { StepContentProps } from '@/components/interfaces/ConnectSheet/Connect.types'
+import type {
+  ConnectionStringPooler,
+  DeploymentMode,
+  StepContentProps,
+} from '@/components/interfaces/ConnectSheet/Connect.types'
 import { appendConnectionStringParams } from '@/components/interfaces/ConnectSheet/ConnectionString.utils'
+import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 
-const ContentFile = ({ connectionStringPooler, deploymentMode }: StepContentProps) => {
-  const withPgbouncerParam = (uri: string | undefined) =>
-    appendConnectionStringParams(uri ?? '', 'pgbouncer=true')
-  const envCode = deploymentMode.isCli
-    ? `
+const withPgbouncerParam = (uri: string | undefined) =>
+  appendConnectionStringParams(uri ?? '', 'pgbouncer=true')
+
+function getEnvCode({
+  connectionStringPooler,
+  deploymentMode,
+  isHighAvailability,
+}: {
+  connectionStringPooler: ConnectionStringPooler
+  deploymentMode: DeploymentMode
+  isHighAvailability: boolean
+}): string {
+  if (deploymentMode.isCli) {
+    return `
 # Connect to Postgres via the direct connection
 DATABASE_URL="${connectionStringPooler.direct}"
 
 # Used for migrations
 DIRECT_URL="${connectionStringPooler.direct}"
 `
-    : deploymentMode.isSelfHosted
-      ? `
+  }
+
+  if (deploymentMode.isSelfHosted) {
+    return `
 # Connect to Postgres via the self-hosted transaction-mode pooler
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
 # Connect to Postgres via the self-hosted session-mode pooler (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionShared}"
 `
-      : connectionStringPooler.transactionDedicated &&
-          connectionStringPooler.ipv4SupportedForDedicatedPooler
-        ? `
+  }
+
+  if (isHighAvailability) {
+    return `
+# Multigres does not support connection pooling — connect to Postgres directly
+DATABASE_URL="${connectionStringPooler.direct}"
+
+# Used for migrations
+DIRECT_URL="${connectionStringPooler.direct}"
+`
+  }
+
+  if (
+    connectionStringPooler.transactionDedicated &&
+    connectionStringPooler.ipv4SupportedForDedicatedPooler
+  ) {
+    return `
 # Connect to Postgres via the dedicated transaction-mode pooler (IPv4-only)
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionDedicated)}"
 
 # Connect to Postgres directly (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionDedicated}"
         `
-        : connectionStringPooler.transactionDedicated &&
-            !connectionStringPooler.ipv4SupportedForDedicatedPooler
-          ? `
+  }
+
+  if (
+    connectionStringPooler.transactionDedicated &&
+    !connectionStringPooler.ipv4SupportedForDedicatedPooler
+  ) {
+    return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
@@ -44,13 +78,20 @@ DIRECT_URL="${connectionStringPooler.sessionShared}"
 # DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionDedicated)}"
 # DIRECT_URL="${connectionStringPooler.sessionDedicated}"
  `
-          : `
+  }
+
+  return `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
 DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
 # Connect to Postgres via the shared session-mode pooler (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionShared}"
 `
+}
+
+const ContentFile = ({ connectionStringPooler, deploymentMode }: StepContentProps) => {
+  const isHighAvailability = useIsHighAvailability()
+  const envCode = getEnvCode({ connectionStringPooler, deploymentMode, isHighAvailability })
 
   const files = [
     {

--- a/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/prisma/content.tsx
@@ -1,8 +1,11 @@
 import { MultipleCodeBlock } from 'ui-patterns/MultipleCodeBlock'
 
 import type { StepContentProps } from '@/components/interfaces/ConnectSheet/Connect.types'
+import { appendConnectionStringParams } from '@/components/interfaces/ConnectSheet/ConnectionString.utils'
 
 const ContentFile = ({ connectionStringPooler, deploymentMode }: StepContentProps) => {
+  const withPgbouncerParam = (uri: string | undefined) =>
+    appendConnectionStringParams(uri ?? '', 'pgbouncer=true')
   const envCode = deploymentMode.isCli
     ? `
 # Connect to Postgres via the direct connection
@@ -14,7 +17,7 @@ DIRECT_URL="${connectionStringPooler.direct}"
     : deploymentMode.isSelfHosted
       ? `
 # Connect to Postgres via the self-hosted transaction-mode pooler
-DATABASE_URL="${connectionStringPooler.transactionShared}?pgbouncer=true"
+DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
 # Connect to Postgres via the self-hosted session-mode pooler (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionShared}"
@@ -23,7 +26,7 @@ DIRECT_URL="${connectionStringPooler.sessionShared}"
           connectionStringPooler.ipv4SupportedForDedicatedPooler
         ? `
 # Connect to Postgres via the dedicated transaction-mode pooler (IPv4-only)
-DATABASE_URL="${connectionStringPooler.transactionDedicated}?pgbouncer=true"
+DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionDedicated)}"
 
 # Connect to Postgres directly (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionDedicated}"
@@ -32,18 +35,18 @@ DIRECT_URL="${connectionStringPooler.sessionDedicated}"
             !connectionStringPooler.ipv4SupportedForDedicatedPooler
           ? `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
-DATABASE_URL="${connectionStringPooler.transactionShared}?pgbouncer=true"
+DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
 # Connect to Postgres via the shared session-mode pooler (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionShared}"
 
 # For paid projects, if your network supports IPv6, or you purchased the IPv4 add-on, use the dedicated transaction-mode pooler with a direct connection to Postgres for migrations as an alternative
-# DATABASE_URL="${connectionStringPooler.transactionDedicated}?pgbouncer=true"
+# DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionDedicated)}"
 # DIRECT_URL="${connectionStringPooler.sessionDedicated}"
  `
           : `
 # Connect to Postgres via the shared transaction-mode pooler (IPv4-only)
-DATABASE_URL="${connectionStringPooler.transactionShared}?pgbouncer=true"
+DATABASE_URL="${withPgbouncerParam(connectionStringPooler.transactionShared)}"
 
 # Connect to Postgres via the shared session-mode pooler (used for migrations)
 DIRECT_URL="${connectionStringPooler.sessionShared}"

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -20,6 +20,8 @@ import { ConnectionParameters } from '@/components/interfaces/ConnectSheet/Conne
 import {
   buildConnectionParameters,
   buildConnectionStringWithPassword,
+  buildJdbcString,
+  buildPsqlCommand,
   buildSafeConnectionString,
   parseConnectionParams,
   PASSWORD_PLACEHOLDER,
@@ -38,12 +40,6 @@ import { DOCS_URL } from '@/lib/constants'
 import { pluckObjectFields } from '@/lib/helpers'
 import { useTrack } from '@/lib/telemetry/track'
 
-const buildPsqlCommand = (params: { host: string; port: string; database: string; user: string }) =>
-  `psql -h ${params.host} -p ${params.port} -d ${params.database} -U ${params.user}`
-
-const buildJdbcString = (params: { host: string; port: string; database: string; user: string }) =>
-  `jdbc:postgresql://${params.host}:${params.port}/${params.database}?user=${params.user}&password=${PASSWORD_PLACEHOLDER}`
-
 /**
  * [Joshen] ConnectStepsSection does something similar but since only this page needs to consider connection strings
  * from all databases (including read replicas), am opting to separate the logic for retrieving connection strings here
@@ -54,6 +50,7 @@ const buildJdbcString = (params: { host: string; port: string; database: string;
 const useConnectionStringDatabases = (deploymentMode: DeploymentMode) => {
   const { ref: projectRef } = useParams()
   const { hasAccess: allowPgBouncerSelection } = useCheckEntitlements('dedicated_pooler')
+  const isHighAvailability = useIsHighAvailability()
 
   const { data: databases = [] } = useReadReplicasQuery({ projectRef })
   const { data: pgbouncerConfig } = usePgbouncerConfigQuery({ projectRef })
@@ -115,6 +112,7 @@ const useConnectionStringDatabases = (deploymentMode: DeploymentMode) => {
             connectionStringsShared,
             connectionStringsDedicated,
             ipv4Addon: !!ipv4Addon,
+            isHighAvailability,
           }),
         ]
       })
@@ -127,6 +125,7 @@ const useConnectionStringDatabases = (deploymentMode: DeploymentMode) => {
     ipv4Addon,
     projectRef,
     deploymentMode,
+    isHighAvailability,
   ])
 }
 

--- a/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
+++ b/apps/studio/components/interfaces/ConnectSheet/content/steps/direct-connection/content.tsx
@@ -53,8 +53,15 @@ const useConnectionStringDatabases = (deploymentMode: DeploymentMode) => {
   const isHighAvailability = useIsHighAvailability()
 
   const { data: databases = [] } = useReadReplicasQuery({ projectRef })
-  const { data: pgbouncerConfig } = usePgbouncerConfigQuery({ projectRef })
-  const { data: supavisorConfig } = useSupavisorConfigurationQuery({ projectRef })
+  // Multigres has no pooler, so the pooler config endpoints don't apply
+  const { data: pgbouncerConfig } = usePgbouncerConfigQuery(
+    { projectRef },
+    { enabled: !isHighAvailability }
+  )
+  const { data: supavisorConfig } = useSupavisorConfigurationQuery(
+    { projectRef },
+    { enabled: !isHighAvailability }
+  )
   const { data: addons } = useProjectAddonsQuery({ projectRef })
   const { ipv4: ipv4Addon } = getAddons(addons?.selected_addons ?? [])
 

--- a/apps/studio/components/interfaces/ConnectSheet/useConnectState.ts
+++ b/apps/studio/components/interfaces/ConnectSheet/useConnectState.ts
@@ -359,8 +359,17 @@ export function useConnectState(initialState?: Partial<ConnectState>): UseConnec
     [projectRef, deploymentMode.isSelfHosted, deploymentMode.isPlatform]
   )
 
+  // Multigres has no pooler, so pooler-flavored selections restored from the
+  // URL or localStorage (shared across projects) must never leak into an HA
+  // project — every consumer sees the direct connection method.
+  const resolvedState = useMemo(
+    () =>
+      isHighAvailability ? { ...state, connectionMethod: 'direct', useSharedPooler: false } : state,
+    [state, isHighAvailability]
+  )
+
   const activeFields = useMemo(() => {
-    let fields = getActiveFields(connectSchema, state)
+    let fields = getActiveFields(connectSchema, resolvedState)
     if (!hasDedicatedPooler || !deploymentMode.isPlatform) {
       // useSharedPooler is a platform-only toggle (CLI has no pooler; self-hosted
       // already uses Supavisor shared)
@@ -372,21 +381,26 @@ export function useConnectState(initialState?: Partial<ConnectState>): UseConnec
         .map((f) => (f.id === 'connectionType' ? { ...f, label: 'Connection Type' } : f))
     }
     return fields
-  }, [state, hasDedicatedPooler, isHighAvailability, deploymentMode.isPlatform])
+  }, [resolvedState, hasDedicatedPooler, isHighAvailability, deploymentMode.isPlatform])
 
-  const resolvedSteps = useMemo(() => resolveSteps(connectSchema, state), [state])
+  const resolvedSteps = useMemo(() => resolveSteps(connectSchema, resolvedState), [resolvedState])
 
   const getFieldOptions = useCallback(
     (fieldId: string): FieldOption[] => {
       const field = activeFields.find((f) => f.id === fieldId)
       if (!field) return []
-      return resolveFieldOptionsWithSource({ field, state, databases, deploymentMode })
+      return resolveFieldOptionsWithSource({
+        field,
+        state: resolvedState,
+        databases,
+        deploymentMode,
+      })
     },
-    [activeFields, state, databases, deploymentMode]
+    [activeFields, resolvedState, databases, deploymentMode]
   )
 
   return {
-    state,
+    state: resolvedState,
     updateField,
     setMode,
     activeFields,

--- a/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
+++ b/apps/studio/components/interfaces/ProjectHome/ProjectConnectionPopover.tsx
@@ -15,10 +15,12 @@ import {
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { getConnectionStrings } from '@/components/interfaces/Connect/DatabaseSettings.utils'
+import { appendHighAvailabilitySslParams } from '@/components/interfaces/ConnectSheet/DatabaseSettings.utils'
 import { useAPIKeys } from '@/data/api-keys/api-keys-query'
 import { useProjectApiUrl } from '@/data/config/project-endpoint-query'
 import { useReadReplicasQuery } from '@/data/read-replicas/replicas-query'
 import { useAsyncCheckPermissions } from '@/hooks/misc/useCheckPermissions'
+import { useIsHighAvailability } from '@/hooks/misc/useSelectedProject'
 import { IS_PLATFORM } from '@/lib/constants'
 import { pluckObjectFields } from '@/lib/helpers'
 
@@ -57,6 +59,7 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
     { enabled: IS_PLATFORM && open && !!projectRef }
   )
   const primaryDatabase = databases?.find((db) => db.identifier === projectRef)
+  const isHighAvailability = useIsHighAvailability()
 
   const directConnectionString = useMemo(() => {
     if (
@@ -68,11 +71,12 @@ export const ProjectConnectionPopover = ({ projectRef }: ProjectConnectionPopove
       return ''
     }
     const connectionInfo = pluckObjectFields(primaryDatabase, [...DB_FIELDS])
-    return getConnectionStrings({
+    const uri = getConnectionStrings({
       connectionInfo: { ...EMPTY_CONNECTION_INFO, ...connectionInfo },
       metadata: { projectRef },
     }).direct.uri
-  }, [primaryDatabase, projectRef])
+    return isHighAvailability ? appendHighAvailabilitySslParams(uri) : uri
+  }, [primaryDatabase, projectRef, isHighAvailability])
 
   const cliCommands = useMemo(
     () =>


### PR DESCRIPTION
Multigres (high-availability) projects only accept TLS connections with direct SSL negotiation, and they don't support connection pooling at all — neither Supavisor nor the dedicated PgBouncer pooler exists for them. Studio previously showed pooler connection strings that would fail with "server closed the connection unexpectedly". This PR makes every connection-string surface direct-only for HA projects and appends `?sslmode=require&sslnegotiation=direct` to the examples. Non-HA projects are unchanged.

Addresses [FE-4019](https://linear.app/supabase/issue/FE-4019/append-ssl-params-to-multigres-connection-string-examples-in-ui)

**Changed:**

- `buildConnectionStringPooler` gets an HA branch that collapses every slot in the bag to the direct connection string with the SSL params appended (mirroring the existing CLI branch, which also has no pooler) — dedicated slots come back `undefined` and `ipv4SupportedForDedicatedPooler` is forced off. Since HA never reaches the pooler layout anymore, the earlier per-URI SSL-append logic on pooler strings is removed
- `useConnectState` coerces `connectionMethod` to `direct` and `useSharedPooler` to `false` for HA projects. The Connect sheet restores the last-used method from localStorage shared across projects, so a "Transaction pooler" selection made on a regular project could otherwise leak pooler-flavored notices, badges, and telemetry into an HA project
- Prisma and Drizzle ORM tabs get an HA branch: `DATABASE_URL`/`DIRECT_URL` both use the direct connection, no `?pgbouncer=true` appended, with a comment explaining Multigres doesn't support pooling. The 5-arm nested ternaries in both files are flattened into `getEnvCode` helpers that switch on a shared `resolveOrmConnectionScenario` helper (`OrmConnection.utils.ts`), so the deployment-mode/HA branching lives in one tested place and each file keeps only its own formatting
- The PgBouncer and Supavisor config queries are disabled (`enabled: !isHighAvailability`) in the Connect sheet — those endpoints serve pooler config that doesn't exist on Multigres
- `parseConnectionParams` keeps the URI's query string in a new `search` field so formats rebuilt from parsed parts can carry it
- psql switches from the `-h/-p/-d/-U` flag form to the quoted-URI form when query params are present (flags can't express them; psql still prompts for the password)
- JDBC appends the params using pgJDBC's casing (`sslNegotiation`, supported since 42.7.4)
- Prisma's `?pgbouncer=true` appends are query-aware (join with `&` when the URI already has a query string) via a new `appendConnectionStringParams` helper
- The project home "Direct connection string" copy item also appends the params for HA projects

**Added:**

- Unit tests for the HA collapse behavior (all slots direct, dedicated config and IPv4 add-on ignored, no SSL params on non-HA output), the `useConnectState` coercion, the psql/JDBC builders (moved from `content.tsx` into `ConnectionString.utils.ts` so they're testable), and `resolveOrmConnectionScenario` (every deployment-mode/HA/pooler branch)

**Known gaps (left out deliberately):**

- The grid ExportDialog psql/pg_dump commands, the .NET `appsettings.json` (Npgsql only supports direct negotiation from v9 via `SSL Negotiation=Direct`), and the SQLAlchemy keyword-style `.env` are flag/keyword forms that can't carry the URI params — these would still fail against Multigres and need a follow-up
- Settings > Database's Connection Pooling section and the pooler logs page have no HA gating yet — they'd still render pooler config UI for a Multigres project and should be hidden in a follow-up

## To test

On a **Multigres (HA) project** (staging only supports `us-east-1` for Multigres):

- Open the Connect sheet → Direct tab: there's no connection-method picker, and the connection string is the direct one ending with `?sslmode=require&sslnegotiation=direct` for the URI, PHP, and psql (quoted-URI form) types; JDBC includes `&sslmode=require&sslNegotiation=direct`
- ORM tab → Prisma: both `DATABASE_URL` and `DIRECT_URL` are the direct connection string with the SSL params, no `pgbouncer=true`, with a "Multigres does not support connection pooling" comment. Drizzle likewise shows the direct string only
- Framework tabs (e.g. Next.js): every `DATABASE_URL` carries the direct string with the params exactly once
- Open the network tab: no requests to `/config/pgbouncer` or `/config/supavisor` while using the Connect sheet
- To check the localStorage coercion: on a **regular** project pick "Transaction pooler" in the Connect sheet, then open the sheet on the Multigres project — no pooler badge/notices, string is still direct
- Copy the URI, substitute your password, and `psql "<string>"` — it should connect
- Project home → Copy dropdown → "Direct connection string" includes the params

On a **regular (non-Multigres) project** — confirm nothing changed:

- Connect sheet: direct/session/transaction strings for all connection types (URI, psql flag form, JDBC, PHP) look the same as before, no SSL params appended
- Prisma/Drizzle tabs render identically (`?pgbouncer=true` still appended with `?`, dedicated-pooler alternatives still shown per IPv4 add-on state)
- Project home copy dropdown is unchanged


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced connection-string generation for high-availability projects, including required SSL settings for direct connections.
  * Preserved URI query parameters in PostgreSQL, `psql`, JDBC, and generated environment configurations.
  * Improved ORM environment templates with clearer handling for pooler and high-availability connection scenarios.

* **Bug Fixes**
  * High-availability projects now consistently use direct connections instead of pooler options.
  * Connection strings and generated templates update correctly when availability settings change.

* **Tests**
  * Expanded coverage for query parameters, high-availability behavior, and connection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
