### PR TITLE
chore(claude): hoist static form references in RHF skill example

### DIFF
--- a/.claude/skills/react-hook-form/SKILL.md
+++ b/.claude/skills/react-hook-form/SKILL.md
@@ -100,6 +100,9 @@ and the demos in `apps/design-system/registry/default/example/`
 before inventing structure.
 
 ```tsx
+// Module level — static references, not recreated on every render
+const FORM_ID = 'pool-config-form'
+
 const FormSchema = z.object({
   name: z.string().min(1, 'Name is required'),
   maxConnections: z
@@ -108,13 +111,16 @@ const FormSchema = z.object({
 })
 type FormValues = z.infer<typeof FormSchema>
 
+const defaultValues: FormValues = { name: '', maxConnections: '' }
+
+// Inside the component
 const form = useForm<FormValues>({
   resolver: zodResolver(FormSchema),
-  defaultValues: { name: '', maxConnections: '' },
+  defaultValues,
 })
 
 <Form {...form}>
-  <form id={formId} onSubmit={form.handleSubmit(onSubmit)}>
+  <form id={FORM_ID} onSubmit={form.handleSubmit(onSubmit)}>
     <FormField
       control={form.control}
       name="name"
@@ -130,8 +136,16 @@ const form = useForm<FormValues>({
 </Form>
 ```
 
-Submit buttons living outside the `<form>` (sheet/dialog footers) use a stable
-`formId` and `form={formId}` on the button.
+Define the schema, `type`, static `defaultValues`, and the form's id at module
+level, outside the component. Rebuilding them per render is wasted work and
+unstable references — RHF reads `defaultValues` only on the first render, but
+anything else comparing against these objects sees a fresh identity each time.
+When they genuinely depend on runtime data, build the schema with `useMemo` and
+feed server-driven defaults through the `values` option (next section) instead
+of hoisting.
+
+Submit buttons living outside the `<form>` (sheet/dialog footers) use the same
+module-level `FORM_ID` via `form={FORM_ID}` on the button.
 
 ## defaultValues, server data, and reset
 

--- a/.claude/skills/react-hook-form/SKILL.md
+++ b/.claude/skills/react-hook-form/SKILL.md
@@ -145,7 +145,11 @@ feed server-driven defaults through the `values` option (next section) instead
 of hoisting.
 
 Submit buttons living outside the `<form>` (sheet/dialog footers) use the same
-module-level `FORM_ID` via `form={FORM_ID}` on the button.
+module-level `FORM_ID` via `form={FORM_ID}` on the button. A module-level id is
+only safe for singleton forms — if the component can mount more than once at a
+time, duplicate ids make external buttons submit the first matching form, so
+mint a per-instance id with `useId()` and share it between the `<form>` and its
+buttons.
 
 ## defaultValues, server data, and reset
 


### PR DESCRIPTION
Quick follow-up to #48431 addressing Ivan's post-merge feedback: the canonical form example now defines `FORM_ID`, the zod schema, and static `defaultValues` at module level so they're stable references rather than being recreated on every render, with a note to use `useMemo` (runtime-dependent schemas) or the `values:` option (server-driven defaults) when hoisting isn't possible.

## To test

- Skim the diff — docs-only change to `.claude/skills/react-hook-form/SKILL.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the React Hook Form guidance with a canonical example using stable, module-level form configuration.
  * Clarified that schemas, inferred types, default values, and form identifiers should be defined outside the component.
  * Documented how submit buttons outside the form should reference the shared form identifier (and cautioned to use per-instance IDs when the component may mount multiple times).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->