### PR TITLE
Joshen/fe 4027 telemetry for database connections

### DIFF
--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -152,7 +152,7 @@ export const Activity = ({ live }: ActivityProps) => {
     })
 
   const onResetFilters = () => {
-    track('database_connections_filter_applied', { type: 'reset' })
+    track('database_connections_filter_updated', { type: 'reset' })
     setQueryStates({
       search: '',
       states: [],
@@ -179,7 +179,8 @@ export const Activity = ({ live }: ActivityProps) => {
           options={stateOptions}
           value={statesFilter ?? []}
           onChange={(states) => {
-            track('database_connections_filter_applied', { type: 'state' })
+            if (isEqual(states, statesFilter)) return
+            track('database_connections_filter_updated', { type: 'state' })
             setQueryStates({ states })
           }}
           isLoading={isPending}
@@ -191,7 +192,8 @@ export const Activity = ({ live }: ActivityProps) => {
           options={roleOptions}
           value={rolesFilter ?? []}
           onChange={(roles) => {
-            track('database_connections_filter_applied', { type: 'roles' })
+            if (isEqual(roles, rolesFilter)) return
+            track('database_connections_filter_updated', { type: 'roles' })
             setQueryStates({ roles })
           }}
           isLoading={isPending}
@@ -203,7 +205,8 @@ export const Activity = ({ live }: ActivityProps) => {
           options={applicationOptions}
           value={applicationsFilter ?? []}
           onChange={(applications) => {
-            track('database_connections_filter_applied', { type: 'application' })
+            if (isEqual(applications, applicationsFilter)) return
+            track('database_connections_filter_updated', { type: 'application' })
             setQueryStates({ applications })
           }}
           isLoading={isPending}
@@ -213,7 +216,9 @@ export const Activity = ({ live }: ActivityProps) => {
           variant={viewFilter === 'blockers' ? 'default' : 'dashed'}
           iconRight={rootBlockers.length > 0 ? <span>{rootBlockers.length}</span> : null}
           onClick={() => {
-            track('database_connections_filter_applied', { type: 'blockers' })
+            track('database_connections_blocker_view_clicked', {
+              newState: viewFilter === 'blockers' ? 'disabled' : 'enabled',
+            })
             setQueryStates({ view: viewFilter === 'blockers' ? '' : 'blockers' })
           }}
           tooltip={{

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Activity.tsx
@@ -11,6 +11,7 @@ import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useDatabaseRolesQuery } from '@/data/database-roles/database-roles-query'
 import { useDatabaseActivityQuery } from '@/data/database/activity-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useTrack } from '@/lib/telemetry/track'
 
 const DEFAULT_ROLES_FILTER = ['anon', 'authenticated', 'postgres']
 
@@ -19,6 +20,7 @@ interface ActivityProps {
 }
 
 export const Activity = ({ live }: ActivityProps) => {
+  const track = useTrack()
   const { data: project } = useSelectedProjectQuery()
 
   const [
@@ -150,6 +152,7 @@ export const Activity = ({ live }: ActivityProps) => {
     })
 
   const onResetFilters = () => {
+    track('database_connections_filter_applied', { type: 'reset' })
     setQueryStates({
       search: '',
       states: [],
@@ -175,7 +178,10 @@ export const Activity = ({ live }: ActivityProps) => {
           label="State"
           options={stateOptions}
           value={statesFilter ?? []}
-          onChange={(states) => setQueryStates({ states })}
+          onChange={(states) => {
+            track('database_connections_filter_applied', { type: 'state' })
+            setQueryStates({ states })
+          }}
           isLoading={isPending}
           popoverClassName="w-60"
         />
@@ -184,7 +190,10 @@ export const Activity = ({ live }: ActivityProps) => {
           label="Roles"
           options={roleOptions}
           value={rolesFilter ?? []}
-          onChange={(roles) => setQueryStates({ roles })}
+          onChange={(roles) => {
+            track('database_connections_filter_applied', { type: 'roles' })
+            setQueryStates({ roles })
+          }}
           isLoading={isPending}
           popoverClassName="w-72"
         />
@@ -193,14 +202,20 @@ export const Activity = ({ live }: ActivityProps) => {
           label="Application"
           options={applicationOptions}
           value={applicationsFilter ?? []}
-          onChange={(applications) => setQueryStates({ applications })}
+          onChange={(applications) => {
+            track('database_connections_filter_applied', { type: 'application' })
+            setQueryStates({ applications })
+          }}
           isLoading={isPending}
           popoverClassName="w-60"
         />
         <ButtonTooltip
           variant={viewFilter === 'blockers' ? 'default' : 'dashed'}
           iconRight={rootBlockers.length > 0 ? <span>{rootBlockers.length}</span> : null}
-          onClick={() => setQueryStates({ view: viewFilter === 'blockers' ? '' : 'blockers' })}
+          onClick={() => {
+            track('database_connections_filter_applied', { type: 'blockers' })
+            setQueryStates({ view: viewFilter === 'blockers' ? '' : 'blockers' })
+          }}
           tooltip={{
             content: {
               side: 'bottom',

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
@@ -396,9 +396,7 @@ export const ActivityRow = ({
                 className="gap-x-2"
                 disabled={superuserRoles?.includes(activity.role_name)}
                 onClick={() => {
-                  const isBlocking = (data ?? []).some((x) =>
-                    x.blocked_by.includes(activity.pid)
-                  )
+                  const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
                   track('session_terminate_button_clicked', {
                     activityState: activity.state,
                     isBlocking,

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
@@ -48,6 +48,7 @@ import { useDatabaseActivityQuery, type DatabaseActivity } from '@/data/database
 import { useQueryAbortMutation } from '@/data/sql/abort-query-mutation'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { formatSql } from '@/lib/formatSql'
+import { useTrack } from '@/lib/telemetry/track'
 
 export const GroupedActivityRow = ({ activity }: { activity: DatabaseActivity }) => {
   const { data: project } = useSelectedProjectQuery()
@@ -103,6 +104,7 @@ export const ActivityRow = ({
   isLast?: boolean
   onExpand?: () => void
 }) => {
+  const track = useTrack()
   const { data: project } = useSelectedProjectQuery()
   const [showTerminateConfirmDialog, setShowTerminateConfirmDialog] = useState(false)
   const [selectedPid, setSelectedPid] = useQueryState('pid', parseAsInteger)
@@ -126,6 +128,7 @@ export const ActivityRow = ({
 
   const durationSeconds = getDuration(activity)
   const badgeVariant = getBadgeVariant(activity)
+  const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
 
   /**
    * Queries in "active state": 30s threshold is long enough (most CRUD queries should be quick)
@@ -139,6 +142,7 @@ export const ActivityRow = ({
         durationSeconds >= WARN_DURATION_IDLE_TXN))
 
   const onConfirmTerminate = async () => {
+    track('session_termination_submitted', { activityState: activity.state, isBlocking })
     try {
       await abortQuery({
         pid: activity.pid,
@@ -391,7 +395,13 @@ export const ActivityRow = ({
               <DropdownMenuItemTooltip
                 className="gap-x-2"
                 disabled={superuserRoles?.includes(activity.role_name)}
-                onClick={() => setShowTerminateConfirmDialog(true)}
+                onClick={() => {
+                  track('session_terminate_button_clicked', {
+                    activityState: activity.state,
+                    isBlocking,
+                  })
+                  setShowTerminateConfirmDialog(true)
+                }}
                 tooltip={{
                   content: {
                     side: 'left',

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/ActivityRow.tsx
@@ -128,7 +128,6 @@ export const ActivityRow = ({
 
   const durationSeconds = getDuration(activity)
   const badgeVariant = getBadgeVariant(activity)
-  const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
 
   /**
    * Queries in "active state": 30s threshold is long enough (most CRUD queries should be quick)
@@ -142,7 +141,8 @@ export const ActivityRow = ({
         durationSeconds >= WARN_DURATION_IDLE_TXN))
 
   const onConfirmTerminate = async () => {
-    track('session_termination_submitted', { activityState: activity.state, isBlocking })
+    const isBlocking = (data ?? []).some((x) => x.blocked_by.includes(activity.pid))
+    track('session_terminate_submitted', { activityState: activity.state, isBlocking })
     try {
       await abortQuery({
         pid: activity.pid,
@@ -396,6 +396,9 @@ export const ActivityRow = ({
                 className="gap-x-2"
                 disabled={superuserRoles?.includes(activity.role_name)}
                 onClick={() => {
+                  const isBlocking = (data ?? []).some((x) =>
+                    x.blocked_by.includes(activity.pid)
+                  )
                   track('session_terminate_button_clicked', {
                     activityState: activity.state,
                     isBlocking,

--- a/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
+++ b/apps/studio/components/interfaces/Observability/DatabaseConnections/Overview.tsx
@@ -14,12 +14,14 @@ import { useDatabaseRolesQuery } from '@/data/database-roles/database-roles-quer
 import { useDatabaseActivityQuery } from '@/data/database/activity-query'
 import { useMaxConnectionsQuery } from '@/data/database/max-connections-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useTrack } from '@/lib/telemetry/track'
 
 interface OverviewProps {
   live?: boolean
 }
 
 export const Overview = ({ live }: OverviewProps) => {
+  const track = useTrack()
   const { data: project } = useSelectedProjectQuery()
   const [, setSelectedPid] = useQueryState('pid', parseAsInteger)
 
@@ -69,6 +71,24 @@ export const Overview = ({ live }: OverviewProps) => {
   const onSelectPid = (pid: number) => {
     setSelectedPid(pid)
     document.getElementById(pid.toString())?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
+
+  const onSelectLongestBlocked = () => {
+    if (!longestBlockedQuery) return
+    track('database_connections_overview_metric_card_clicked', { type: 'longest_blocked' })
+    onSelectPid(longestBlockedQuery.activity.pid)
+  }
+
+  const onSelectTopBlocker = () => {
+    if (!queryBlockingTheMostQueries) return
+    track('database_connections_overview_metric_card_clicked', { type: 'top_blocker' })
+    onSelectPid(queryBlockingTheMostQueries.activity.pid)
+  }
+
+  const onSelectLongestRunning = () => {
+    if (!longestRunningQuery) return
+    track('database_connections_overview_metric_card_clicked', { type: 'longest_running' })
+    onSelectPid(longestRunningQuery.activity.pid)
   }
 
   return (
@@ -193,11 +213,11 @@ export const Overview = ({ live }: OverviewProps) => {
                         'hover:text-foreground hover:underline',
                         'focus:text-foreground focus:underline'
                       )}
-                      onClick={() => onSelectPid(longestBlockedQuery.activity.pid)}
+                      onClick={() => onSelectLongestBlocked()}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
-                          onSelectPid(longestBlockedQuery.activity.pid)
+                          onSelectLongestBlocked()
                         }
                       }}
                     >
@@ -243,11 +263,11 @@ export const Overview = ({ live }: OverviewProps) => {
                       role="button"
                       tabIndex={0}
                       className="normal-nums cursor-pointer hover:underline focus:underline"
-                      onClick={() => onSelectPid(queryBlockingTheMostQueries.activity.pid)}
+                      onClick={() => onSelectTopBlocker()}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
-                          onSelectPid(queryBlockingTheMostQueries.activity.pid)
+                          onSelectTopBlocker()
                         }
                       }}
                     >
@@ -300,11 +320,11 @@ export const Overview = ({ live }: OverviewProps) => {
                       role="button"
                       tabIndex={0}
                       className="normal-nums hover:underline focus:underline cursor-pointer"
-                      onClick={() => onSelectPid(longestRunningQuery.activity.pid)}
+                      onClick={() => onSelectLongestRunning()}
                       onKeyDown={(e) => {
                         if (e.key === 'Enter' || e.key === ' ') {
                           e.preventDefault()
-                          onSelectPid(longestRunningQuery.activity.pid)
+                          onSelectLongestRunning()
                         }
                       }}
                     >

--- a/apps/studio/components/ui/AiAssistantDropdown.tsx
+++ b/apps/studio/components/ui/AiAssistantDropdown.tsx
@@ -142,6 +142,7 @@ export function AiAssistantDropdown({
       <DropdownMenu open={isOpen} onOpenChange={setIsOpen}>
         <DropdownMenuTrigger asChild>
           <Button
+            aria-label="More actions"
             variant={variant}
             size={size}
             disabled={disabled}

--- a/apps/studio/pages/project/[ref]/observability/connections.tsx
+++ b/apps/studio/pages/project/[ref]/observability/connections.tsx
@@ -112,8 +112,7 @@ export const DatabaseConnections: NextPageWithLayout = () => {
             buildPrompt={buildPrompt}
             onOpenAssistant={handleSummarizeActivity}
             disabled={isLoadingActivity}
-            isLoading={isLoadingActivity}
-            // @ts-ignore [Joshen] To add proper telemetry source in subsequent PR
+            loading={isLoadingActivity}
             telemetrySource="database_connections"
             size="tiny"
             variant="default"

--- a/apps/studio/pages/project/[ref]/observability/connections.tsx
+++ b/apps/studio/pages/project/[ref]/observability/connections.tsx
@@ -14,6 +14,7 @@ import { AiAssistantDropdown } from '@/components/ui/AiAssistantDropdown'
 import { ShortcutTooltip } from '@/components/ui/ShortcutTooltip'
 import { useDatabaseActivityQuery } from '@/data/database/activity-query'
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
+import { useTrack } from '@/lib/telemetry/track'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
 import { SHORTCUT_IDS } from '@/state/shortcuts/registry'
 import { useShortcut } from '@/state/shortcuts/useShortcut'
@@ -21,6 +22,7 @@ import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 import type { NextPageWithLayout } from '@/types'
 
 export const DatabaseConnections: NextPageWithLayout = () => {
+  const track = useTrack()
   const { data: project } = useSelectedProjectQuery()
   const { openSidebar } = useSidebarManagerSnapshot()
   const aiSnap = useAiAssistantStateSnapshot()
@@ -46,6 +48,11 @@ export const DatabaseConnections: NextPageWithLayout = () => {
 
   function handleToggleLive() {
     const nextLive = !live
+
+    track('database_connections_live_mode_clicked', {
+      newState: nextLive ? 'enabled' : 'disabled',
+    })
+
     setLive(nextLive)
     if (nextLive) {
       setNow(dayjs.utc())

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1479,6 +1479,21 @@ export interface IndexAdvisorTabClickedEvent {
   groups: TelemetryGroups
 }
 
+/**
+ * User toggled live mode on the Database Connections observability page.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/connections
+ */
+export interface DatabaseConnectionsLiveModeClickedEvent {
+  action: 'database_connections_live_mode_clicked'
+  properties: {
+    newState: 'enabled' | 'disabled'
+  }
+  groups: TelemetryGroups
+}
+
 type DatabaseActivityState =
   | 'idle'
   | 'active'
@@ -3713,6 +3728,7 @@ export type TelemetryEvent =
   | IndexAdvisorEnableButtonClickedEvent
   | IndexAdvisorBannerDismissButtonClickedEvent
   | IndexAdvisorTabClickedEvent
+  | DatabaseConnectionsLiveModeClickedEvent
   | SessionTerminateButtonClickedEvent
   | SessionTerminationSubmittedEvent
   | IndexAdvisorCreateIndexesButtonClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -5,7 +5,7 @@
  *
  * ## Naming conventions
  * Event names and actions should use standardized past-tense verbs for data quality and consistency.
- * Only use verbs already established in this file or in https://github.com/supabase/infrastructure/blob/develop/packages/api-core/src/shared/telemetry.ts
+ * Only use verbs already established in this file or in https://github.com/supabase/platform/blob/develop/packages/api-core/src/shared/telemetry.ts
  * Adding new verbs requires @growth-eng review to prevent data pollution.
  *
  * @module telemetry-frontend
@@ -1510,16 +1510,31 @@ export interface DatabaseConnectionsOverviewMetricCardClickedEvent {
 }
 
 /**
- * User applied a filter on the Sessions table of the Database Connections observability page.
+ * User updated a filter on the Sessions table of the Database Connections observability page.
  *
  * @group Events
  * @source studio
  * @page /dashboard/project/{ref}/observability/connections
  */
-export interface DatabaseConnectionsFilterAppliedEvent {
-  action: 'database_connections_filter_applied'
+export interface DatabaseConnectionsFilterUpdatedEvent {
+  action: 'database_connections_filter_updated'
   properties: {
-    type: 'state' | 'roles' | 'application' | 'blockers' | 'reset'
+    type: 'state' | 'roles' | 'application' | 'reset'
+  }
+  groups: TelemetryGroups
+}
+
+/**
+ * User clicked the Root blockers filter button on the Database Connections activity table.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/connections
+ */
+export interface DatabaseConnectionsBlockerViewClickedEvent {
+  action: 'database_connections_blocker_view_clicked'
+  properties: {
+    newState: 'enabled' | 'disabled'
   }
   groups: TelemetryGroups
 }
@@ -1559,8 +1574,8 @@ export interface SessionTerminateButtonClickedEvent {
  * @source studio
  * @page /dashboard/project/{ref}/observability/connections
  */
-export interface SessionTerminationSubmittedEvent {
-  action: 'session_termination_submitted'
+export interface SessionTerminateSubmittedEvent {
+  action: 'session_terminate_submitted'
   properties: {
     activityState: DatabaseActivityState
     /**
@@ -3760,9 +3775,10 @@ export type TelemetryEvent =
   | IndexAdvisorTabClickedEvent
   | DatabaseConnectionsLiveModeClickedEvent
   | DatabaseConnectionsOverviewMetricCardClickedEvent
-  | DatabaseConnectionsFilterAppliedEvent
+  | DatabaseConnectionsFilterUpdatedEvent
+  | DatabaseConnectionsBlockerViewClickedEvent
   | SessionTerminateButtonClickedEvent
-  | SessionTerminationSubmittedEvent
+  | SessionTerminateSubmittedEvent
   | IndexAdvisorCreateIndexesButtonClickedEvent
   | EdgeFunctionDeployButtonClickedEvent
   | EdgeFunctionDeployUpdatesConfirmClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -1494,6 +1494,36 @@ export interface DatabaseConnectionsLiveModeClickedEvent {
   groups: TelemetryGroups
 }
 
+/**
+ * User clicked a metric card PID in the Overview panel of the Database Connections observability page, selecting it in the activity table below.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/connections
+ */
+export interface DatabaseConnectionsOverviewMetricCardClickedEvent {
+  action: 'database_connections_overview_metric_card_clicked'
+  properties: {
+    type: 'longest_blocked' | 'top_blocker' | 'longest_running'
+  }
+  groups: TelemetryGroups
+}
+
+/**
+ * User applied a filter on the Sessions table of the Database Connections observability page.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/connections
+ */
+export interface DatabaseConnectionsFilterAppliedEvent {
+  action: 'database_connections_filter_applied'
+  properties: {
+    type: 'state' | 'roles' | 'application' | 'blockers' | 'reset'
+  }
+  groups: TelemetryGroups
+}
+
 type DatabaseActivityState =
   | 'idle'
   | 'active'
@@ -3729,6 +3759,8 @@ export type TelemetryEvent =
   | IndexAdvisorBannerDismissButtonClickedEvent
   | IndexAdvisorTabClickedEvent
   | DatabaseConnectionsLiveModeClickedEvent
+  | DatabaseConnectionsOverviewMetricCardClickedEvent
+  | DatabaseConnectionsFilterAppliedEvent
   | SessionTerminateButtonClickedEvent
   | SessionTerminationSubmittedEvent
   | IndexAdvisorCreateIndexesButtonClickedEvent

--- a/packages/common/telemetry-constants.ts
+++ b/packages/common/telemetry-constants.ts
@@ -5,7 +5,7 @@
  *
  * ## Naming conventions
  * Event names and actions should use standardized past-tense verbs for data quality and consistency.
- * Only use verbs already established in this file or in https://github.com/supabase/platform/blob/develop/shared/src/telemetry.ts
+ * Only use verbs already established in this file or in https://github.com/supabase/infrastructure/blob/develop/packages/api-core/src/shared/telemetry.ts
  * Adding new verbs requires @growth-eng review to prevent data pollution.
  *
  * @module telemetry-frontend
@@ -1479,6 +1479,53 @@ export interface IndexAdvisorTabClickedEvent {
   groups: TelemetryGroups
 }
 
+type DatabaseActivityState =
+  | 'idle'
+  | 'active'
+  | 'idle in transaction'
+  | 'idle in transaction (aborted)'
+  | 'fastpath function call'
+  | 'disabled'
+  | null
+
+/**
+ * User clicked the Terminate menu item for a database session in the Database Connections activity table, opening the confirmation dialog.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/connections
+ */
+export interface SessionTerminateButtonClickedEvent {
+  action: 'session_terminate_button_clicked'
+  properties: {
+    activityState: DatabaseActivityState
+    /**
+     * Whether the session being terminated was itself blocking one or more other sessions.
+     */
+    isBlocking: boolean
+  }
+  groups: TelemetryGroups
+}
+
+/**
+ * User confirmed terminating a database session in the Database Connections activity table.
+ *
+ * @group Events
+ * @source studio
+ * @page /dashboard/project/{ref}/observability/connections
+ */
+export interface SessionTerminationSubmittedEvent {
+  action: 'session_termination_submitted'
+  properties: {
+    activityState: DatabaseActivityState
+    /**
+     * Whether the terminated session was itself blocking one or more other sessions.
+     */
+    isBlocking: boolean
+  }
+  groups: TelemetryGroups
+}
+
 /**
  * Index Advisor create indexes button clicked event.
  *
@@ -2859,6 +2906,7 @@ export type AiAssistantSource =
   | 'log_explorer'
   | 'error_code'
   | 'advisor_signal_detail'
+  | 'database_connections'
 
 /**
  * User copied an AI prompt to clipboard instead of using the built-in assistant.
@@ -3665,6 +3713,8 @@ export type TelemetryEvent =
   | IndexAdvisorEnableButtonClickedEvent
   | IndexAdvisorBannerDismissButtonClickedEvent
   | IndexAdvisorTabClickedEvent
+  | SessionTerminateButtonClickedEvent
+  | SessionTerminationSubmittedEvent
   | IndexAdvisorCreateIndexesButtonClickedEvent
   | EdgeFunctionDeployButtonClickedEvent
   | EdgeFunctionDeployUpdatesConfirmClickedEvent


### PR DESCRIPTION
## Context

Adding telemetry for the following actions on the database connections page

- Toggling of live mode
- Applying the various filters
- Clicking on the overview metric cards
- Clicking of terminate CTA + Confirm terminate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Added a descriptive label to the AI Assistant actions menu trigger for improved screen-reader support.

- **Observability**
  - Added tracking for database connections interactions: live-mode toggles, session filter updates, blocker-view toggles, clicks on observability metric cards, and the session termination flow (both the terminate action and confirmation submission).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->