### PR TITLE
docs: point dashboard links at the Infrastructure settings page

### DIFF
--- a/apps/docs/content/_partials/migration_warnings.mdx
+++ b/apps/docs/content/_partials/migration_warnings.mdx
@@ -1,6 +1,6 @@
 <Admonition type="caution">
 
-- If you're planning to migrate a database larger than 6 GB, we recommend [upgrading to at least a Large compute add-on](/docs/guides/platform/compute-add-ons). This will ensure you have the necessary resources to handle the migration efficiently.
+- If you're planning to migrate a database larger than 6 GB, we recommend [upgrading to at least a Large compute add-on](/docs/guides/platform/compute-and-disk). This will ensure you have the necessary resources to handle the migration efficiently.
 
 - We strongly advise you to pre-provision the disk space you will need for your migration. On paid projects, you can do this by navigating to the [Infrastructure settings](/dashboard/project/_/settings/infrastructure) page. For more information on disk scaling and disk limits, check out our [disk settings](/docs/guides/platform/compute-and-disk#disk) documentation.
 

--- a/apps/docs/content/_partials/migration_warnings.mdx
+++ b/apps/docs/content/_partials/migration_warnings.mdx
@@ -2,6 +2,6 @@
 
 - If you're planning to migrate a database larger than 6 GB, we recommend [upgrading to at least a Large compute add-on](/docs/guides/platform/compute-add-ons). This will ensure you have the necessary resources to handle the migration efficiently.
 
-- We strongly advise you to pre-provision the disk space you will need for your migration. On paid projects, you can do this by navigating to the [Compute and Disk Settings](/dashboard/project/_/settings/compute-and-disk) page. For more information on disk scaling and disk limits, check out our [disk settings](/docs/guides/platform/compute-and-disk#disk) documentation.
+- We strongly advise you to pre-provision the disk space you will need for your migration. On paid projects, you can do this by navigating to the [Infrastructure settings](/dashboard/project/_/settings/infrastructure) page. For more information on disk scaling and disk limits, check out our [disk settings](/docs/guides/platform/compute-and-disk#disk) documentation.
 
 </Admonition>

--- a/apps/docs/content/guides/database/inspect.mdx
+++ b/apps/docs/content/guides/database/inspect.mdx
@@ -240,7 +240,7 @@ from pg_statio_user_tables;
 
 This shows the ratio of data blocks fetched from the Postgres [shared_buffers](https://www.postgresql.org/docs/15/runtime-config-resource.html#RUNTIME-CONFIG-RESOURCE-MEMORY) cache against the data blocks that were read from disk/OS cache.
 
-If either of your index or table hit rate are < 99% then this can indicate your compute plan is too small for your current workload and you would benefit from more memory. [Upgrading your compute](/docs/guides/platform/compute-and-disk#compute) is easy and can be done from your [project dashboard](/dashboard/project/_/settings/infrastructure).
+If either of your index or table hit rate are < 99% then this can indicate your compute plan is too small for your current workload and you would benefit from more memory. [Upgrading your compute](/docs/guides/platform/compute-and-disk#compute) can be done from your [project dashboard](/dashboard/project/_/settings/infrastructure).
 
 ### Optimizing poor performing queries
 

--- a/apps/docs/content/guides/database/inspect.mdx
+++ b/apps/docs/content/guides/database/inspect.mdx
@@ -19,7 +19,7 @@ You can examine your database and queries for these issues using either the [Sup
 
 The Supabase CLI comes with a range of tools to help inspect your Postgres instances for potential issues. The CLI gets the information from <a href="https://www.postgresql.org/docs/current/internals.html" target="_blank">Postgres internals</a>. Therefore, most tools provided are compatible with any Postgres databases regardless if they are a Supabase project or not.
 
-You can find installation instructions for the Supabase CLI <a href="/docs/guides/cli" target="_blank">here</a>.
+You can find installation instructions for the Supabase CLI <a href="/docs/guides/local-development" target="_blank">here</a>.
 
 ### The `inspect db` command
 

--- a/apps/docs/content/guides/database/inspect.mdx
+++ b/apps/docs/content/guides/database/inspect.mdx
@@ -240,7 +240,7 @@ from pg_statio_user_tables;
 
 This shows the ratio of data blocks fetched from the Postgres [shared_buffers](https://www.postgresql.org/docs/15/runtime-config-resource.html#RUNTIME-CONFIG-RESOURCE-MEMORY) cache against the data blocks that were read from disk/OS cache.
 
-If either of your index or table hit rate are < 99% then this can indicate your compute plan is too small for your current workload and you would benefit from more memory. [Upgrading your compute](/docs/guides/platform/compute-and-disk#compute) is easy and can be done from your [project dashboard](/dashboard/project/_/settings/compute-and-disk).
+If either of your index or table hit rate are < 99% then this can indicate your compute plan is too small for your current workload and you would benefit from more memory. [Upgrading your compute](/docs/guides/platform/compute-and-disk#compute) is easy and can be done from your [project dashboard](/dashboard/project/_/settings/infrastructure).
 
 ### Optimizing poor performing queries
 

--- a/apps/docs/content/guides/platform/compute-and-disk.mdx
+++ b/apps/docs/content/guides/platform/compute-and-disk.mdx
@@ -33,7 +33,7 @@ In paid organizations, Nano Compute are billed at the same price as Micro Comput
 
 [^1]: Database max connections are recommended values and can be [customized via `max_connections`](/docs/guides/database/custom-postgres-config) depending on your use case. Be aware of [these considerations](/docs/guides/troubleshooting/how-to-change-max-database-connections-_BQ8P5) before modifying.
 
-[^2]: Database size for each compute instance is the default recommendation but the actual performance of your database has many contributing factors, including resources available to it and the size of the data contained within it. See the [shared responsibility model](/docs/guides/platform/shared-responsibility-model) for more information.
+[^2]: Database size for each compute instance is the default recommendation but the actual performance of your database has many contributing factors, including resources available to it and the size of the data contained within it. See the [shared responsibility model](/docs/guides/deployment/shared-responsibility-model) for more information.
 
 [^3]: Compute resources on the Free plan are subject to change.
 

--- a/apps/docs/content/guides/platform/compute-and-disk.mdx
+++ b/apps/docs/content/guides/platform/compute-and-disk.mdx
@@ -37,7 +37,7 @@ In paid organizations, Nano Compute are billed at the same price as Micro Comput
 
 [^3]: Compute resources on the Free plan are subject to change.
 
-Compute sizes can be changed by first selecting your project in the dashboard [here](/dashboard/project/_/settings/compute-and-disk) and the upgrade process will [incur downtime](/docs/guides/platform/compute-and-disk#upgrades).
+Compute sizes can be changed by first selecting your project in the dashboard [here](/dashboard/project/_/settings/infrastructure) and the upgrade process will [incur downtime](/docs/guides/platform/compute-and-disk#upgrades).
 
 <Image
   alt="Compute Size Selection"
@@ -102,7 +102,7 @@ If you need consistent disk performance, choose the 4XL or larger compute instan
 
 ### Provisioned disk throughput and IOPS
 
-The default disk type is gp3, which comes with a baseline throughput of 125 MB/s and a default IOPS of 3,000. You can provision additional IOPS and throughput from the [Database Settings](/dashboard/project/_/settings/compute-and-disk) page, but keep in mind that the effective IOPS and throughput will be limited by the compute instance size. This requires Large compute size or above.
+The default disk type is gp3, which comes with a baseline throughput of 125 MB/s and a default IOPS of 3,000. You can provision additional IOPS and throughput from the [Infrastructure settings](/dashboard/project/_/settings/infrastructure) page, but keep in mind that the effective IOPS and throughput will be limited by the compute instance size. This requires Large compute size or above.
 
 <Admonition type="caution">
 

--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -42,7 +42,7 @@ select pg_size_pretty(sum(size)) as wal_size from pg_ls_waldir();
 
 ### Vacuum operations
 
-Postgres does not immediately reclaim the physical space used by dead tuples (i.e., deleted rows) in the DB. They are marked as "removed" until a [vacuum operation](https://www.postgresql.org/docs/current/routine-vacuuming.html) is executed. As a result, deleting data from your database may not immediately reduce the reported disk usage. You can use the [Supabase CLI](/docs/guides/cli/getting-started) `inspect db bloat` command to view all dead tuples in your database. Alternatively, you can run the [query](https://github.com/supabase/cli/blob/c9cce58025fded16b4c332747f819a44f45c3b83/internal/inspect/bloat/bloat.go#L17) found in the CLI's GitHub repo in the [SQL Editor](/dashboard/project/_/sql/)
+Postgres does not immediately reclaim the physical space used by dead tuples (i.e., deleted rows) in the DB. They are marked as "removed" until a [vacuum operation](https://www.postgresql.org/docs/current/routine-vacuuming.html) is executed. As a result, deleting data from your database may not immediately reduce the reported disk usage. You can use the [Supabase CLI](/docs/guides/local-development/cli/getting-started) `inspect db bloat` command to view all dead tuples in your database. Alternatively, you can run the [query](https://github.com/supabase/cli/blob/c9cce58025fded16b4c332747f819a44f45c3b83/internal/inspect/bloat/bloat.go#L17) found in the CLI's GitHub repo in the [SQL Editor](/dashboard/project/_/sql/)
 
 ```bash
 # Login to the CLI

--- a/apps/docs/content/guides/platform/database-size.mdx
+++ b/apps/docs/content/guides/platform/database-size.mdx
@@ -152,7 +152,7 @@ set default_transaction_read_only = 'off';
 
 ### Disk size distribution
 
-You can check the distribution of your disk size on your [project's compute and disk page](/dashboard/project/_/settings/compute-and-disk).
+You can check the distribution of your disk size on your [project's Infrastructure page](/dashboard/project/_/settings/infrastructure).
 
 ![Disk Size Distribution](/docs/img/guides/platform/database-size/disk-size-distribution.png)
 

--- a/apps/docs/content/guides/platform/performance.mdx
+++ b/apps/docs/content/guides/platform/performance.mdx
@@ -12,7 +12,7 @@ Unoptimized queries are a major cause of poor database performance. To analyze t
 
 ## Optimizing the number of connections
 
-The default connection limits for Postgres and Supavisor is based on your compute size. See the default connection numbers in the [Compute Add-ons](/docs/guides/platform/compute-add-ons) section.
+The default connection limits for Postgres and Supavisor is based on your compute size. See the default connection numbers in the [Compute Add-ons](/docs/guides/platform/compute-and-disk) section.
 
 If the number of connections is insufficient, you will receive the following error upon connecting to the DB:
 
@@ -35,7 +35,7 @@ Depending on the clients involved, you might be able to configure them to work w
 
 ### Allowing higher number of connections
 
-You can configure Postgres connection limit among other parameters by using [Custom Postgres Config](/docs/guides/platform/custom-postgres-config#custom-postgres-config).
+You can configure Postgres connection limit among other parameters by using [Custom Postgres Config](/docs/guides/database/custom-postgres-config).
 
 ### Enterprise
 

--- a/apps/docs/content/guides/platform/performance.mdx
+++ b/apps/docs/content/guides/platform/performance.mdx
@@ -23,7 +23,7 @@ FATAL: remaining connection slots are reserved for non-replication superuser con
 
 In such a scenario, you can consider:
 
-- [upgrading to a larger compute add-on](/dashboard/project/_/settings/compute-and-disk)
+- [upgrading to a larger compute add-on](/dashboard/project/_/settings/infrastructure)
 - configuring your clients to use fewer connections
 - manually configuring the database for a higher number of connections
 

--- a/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
@@ -7,9 +7,9 @@ database_id = "4844905d-1456-44a1-858e-7a4995e5054c"
 
 ## Understanding disk IO and disk IO budget
 
-Disk IO refers to two metrics: throughput in Megabytes per second (MB/s) and IOPS which are Input/Output Operations per Second. Throughput measures how much data you can move each second, while IOPS measures how many read/write operations you can perform each second. Depending on the compute add-on of your instance you will have [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size).
+Disk IO refers to two metrics: throughput in Megabytes per second (MB/s) and IOPS which are Input/Output Operations per Second. Throughput measures how much data you can move each second, while IOPS measures how many read/write operations you can perform each second. Depending on the compute add-on of your instance you will have [different baseline performances](/docs/guides/platform/compute-and-disk#compute-size).
 
-Smaller compute instances can burst and exceed their baseline performance for a short period of time every day. This is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. Learn more about [choosing the right compute instance for consistent disk performance](/docs/guides/platform/compute-add-ons#choosing-the-right-compute-instance-for-consistent-disk-performance).
+Smaller compute instances can burst and exceed their baseline performance for a short period of time every day. This is represented as your Disk IO Budget and once your Disk IO Budget is consumed, your instance reverts back to its baseline performance. Learn more about [choosing the right compute instance for consistent disk performance](/docs/guides/platform/compute-and-disk#choosing-the-right-compute-instance-for-consistent-disk-performance).
 
 ## Depleting your disk IO budget
 
@@ -38,5 +38,5 @@ Most operations on your Supabase project require disk IO in some form. Hence, th
 
 ## How to fix
 
-1. **Upgrade your compute:** You can get a Compute Add-on for your project. Larger compute options (4XL and above) have more consistent disk performance. See your [upgrade options](/dashboard/project/_/settings/infrastructure) by selecting your project. Do reference the [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size) that come with larger Compute Add-ons.
-2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).
+1. **Upgrade your compute:** You can get a Compute Add-on for your project. Larger compute options (4XL and above) have more consistent disk performance. See your [upgrade options](/dashboard/project/_/settings/infrastructure) by selecting your project. Do reference the [different baseline performances](/docs/guides/platform/compute-and-disk#compute-size) that come with larger Compute Add-ons.
+2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/deployment/going-into-prod#performance).

--- a/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-disk-io.mdx
@@ -38,5 +38,5 @@ Most operations on your Supabase project require disk IO in some form. Hence, th
 
 ## How to fix
 
-1. **Upgrade your compute:** You can get a Compute Add-on for your project. Larger compute options (4XL and above) have more consistent disk performance. See your [upgrade options](/dashboard/project/_/settings/compute-and-disk) by selecting your project. Do reference the [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size) that come with larger Compute Add-ons.
+1. **Upgrade your compute:** You can get a Compute Add-on for your project. Larger compute options (4XL and above) have more consistent disk performance. See your [upgrade options](/dashboard/project/_/settings/infrastructure) by selecting your project. Do reference the [different baseline performances](/docs/guides/platform/compute-add-ons#compute-size) that come with larger Compute Add-ons.
 2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).

--- a/apps/docs/content/troubleshooting/exhaust-ram.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-ram.mdx
@@ -17,7 +17,7 @@ You may observe elevated memory usage even when your database has little to no l
 
 ## Issues with high memory usage
 
-Every Supabase project runs in its own dedicated virtual machine. Your instance will have a different set of hardware provisioned depending on your [compute add-on](/docs/guides/platform/compute-add-ons). Depending on your workload, your compute hardware may not be suitable and can result in high RAM usage.
+Every Supabase project runs in its own dedicated virtual machine. Your instance will have a different set of hardware provisioned depending on your [compute add-on](/docs/guides/platform/compute-and-disk). Depending on your workload, your compute hardware may not be suitable and can result in high RAM usage.
 
 A good proxy for unhealthy memory usage is swap usage. If you run out of RAM, your system will offload memory to your disk's much slower swap partition. If your swap is above 70%, chances are high that your compute hardware is not suitable for your workload. Head over to your project's [Database Health](/dashboard/project/_/observability/database) to see your swap usage.
 
@@ -38,10 +38,10 @@ It is also possible to monitor your resources and set up alerts using Prometheus
 Everything you do with your Supabase project requires memory in some form. Hence, there can be many reasons for high RAM usage. Here are some common ones:
 
 - **Query performance:** Queries that take a long time to complete (>1 second) could be using your RAM inefficiently. Check our guide on [examining query performance](/docs/guides/platform/performance#examining-query-performance).
-- **Too many connections:** Every connection to your database consumes memory. You can check the number of active connections under [Database Roles](/dashboard/project/_/database/roles) after you select your project. Read our guide on [too many open connections](/docs/guides/platform/troubleshooting#too-many-open-connections).
+- **Too many connections:** Every connection to your database consumes memory. You can check the number of active connections under [Database Roles](/dashboard/project/_/database/roles) after you select your project. Read our guide on [too many open connections](/docs/guides/troubleshooting/http-api-issues#too-many-open-connections).
 - **Extensions:** Some extensions such as `timescaledb` or `pg_cron` can use a lot of memory. It can also add up when you have too many extensions running. You can manage your database extensions in the dashboard under [Extensions](/dashboard/project/_/database/extensions).
 
 ## How to fix your memory issues
 
 1. **Upgrade your compute:** You can get a Compute Add-on for your project. See your [upgrade options](/dashboard/project/_/settings/infrastructure) by selecting your project.
-2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).
+2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/deployment/going-into-prod#performance).

--- a/apps/docs/content/troubleshooting/exhaust-ram.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-ram.mdx
@@ -43,5 +43,5 @@ Everything you do with your Supabase project requires memory in some form. Hence
 
 ## How to fix your memory issues
 
-1. **Upgrade your compute:** You can get a Compute Add-on for your project. See your [upgrade options](/dashboard/project/_/settings/compute-and-disk) by selecting your project.
+1. **Upgrade your compute:** You can get a Compute Add-on for your project. See your [upgrade options](/dashboard/project/_/settings/infrastructure) by selecting your project.
 2. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).

--- a/apps/docs/content/troubleshooting/exhaust-swap.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-swap.mdx
@@ -59,5 +59,5 @@ Everything you do with your Supabase project requires compute. Hence, there can 
 If you find that your RAM and Swap usage are high, you have three options:
 
 1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. See the [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).
-2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](/dashboard/project/_/settings/compute-and-disk) and select your project to see your upgrade options.
+2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](/dashboard/project/_/settings/infrastructure) and select your project to see your upgrade options.
 3. **Read Replicas:** You can spread the load on your Supabase project by creating a Read Replica. See [the read replicas guide](/docs/guides/platform/read-replicas) for more information.

--- a/apps/docs/content/troubleshooting/exhaust-swap.mdx
+++ b/apps/docs/content/troubleshooting/exhaust-swap.mdx
@@ -15,7 +15,7 @@ High Swap is usually not a problem unless other resources (such as RAM) are cons
 
 </Admonition>
 
-Every Supabase project runs on its own dedicated virtual machine. The machine's underlying specs and hardware depend on your [compute add-on](/docs/guides/platform/compute-add-ons). If your hardware isn't suitable for your workload, you might experience high Swap usage.
+Every Supabase project runs on its own dedicated virtual machine. The machine's underlying specs and hardware depend on your [compute add-on](/docs/guides/platform/compute-and-disk). If your hardware isn't suitable for your workload, you might experience high Swap usage.
 
 Swap is a portion of your instance's disk that is reserved for the operating system to use when the available RAM is used. As it uses the disk, Swap is slower to access and is generally used as a last resort.
 
@@ -58,6 +58,6 @@ Everything you do with your Supabase project requires compute. Hence, there can 
 
 If you find that your RAM and Swap usage are high, you have three options:
 
-1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. See the [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).
+1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. See the [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/deployment/going-into-prod#performance).
 2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](/dashboard/project/_/settings/infrastructure) and select your project to see your upgrade options.
 3. **Read Replicas:** You can spread the load on your Supabase project by creating a Read Replica. See [the read replicas guide](/docs/guides/platform/read-replicas) for more information.

--- a/apps/docs/content/troubleshooting/failed-to-retrieve-tables.mdx
+++ b/apps/docs/content/troubleshooting/failed-to-retrieve-tables.mdx
@@ -41,6 +41,6 @@ Once you are confident there will not be a crash loop, you can review the follow
 - If it was unintentional, double check for any recursive calls in your application code, edge functions or database functions.
 - Consider your table and your query structure - if your tables are very "wide" (lots of columns) or have complicated data types within them, it may be worth revisiting your architecture.
 - Continue to monitor your project's [query performance tab](/dashboard/project/_/observability/query-performance) and [enable index advisor](/docs/guides/database/extensions/index_advisor) if you haven't already - especially if there are a lot of select queries.
-- If after monitoring your changes you still do not notice improvements, consider upgrading compute if you think this level of activity is going to be regular. It will give you more memory overhead to process tasks like this. You can view all compute offerings [here](/dashboard/project/_/settings/compute-and-disk).
+- If after monitoring your changes you still do not notice improvements, consider upgrading compute if you think this level of activity is going to be regular. It will give you more memory overhead to process tasks like this. You can view all compute offerings [here](/dashboard/project/_/settings/infrastructure).
 
 If you want to effectively monitor your project's performance minute by minute, you can use the [Metrics API](/docs/guides/telemetry/metrics).

--- a/apps/docs/content/troubleshooting/failed-to-run-sql-query-connection-terminated-due-to-connection-timeout.mdx
+++ b/apps/docs/content/troubleshooting/failed-to-run-sql-query-connection-terminated-due-to-connection-timeout.mdx
@@ -12,7 +12,7 @@ message = "Error: Failed to run sql query: Connection terminated due to connecti
 This error typically happens when the database is overloaded and causing an outage. As the database does not respond in a timely manner there can be a variety of symptoms such as tables not loading, error messages related to retrieving data and the dashboard seems to be unresponsive.
 
 - Check your database health in [Database reports](/dashboard/project/_/observability/database).
-- If needed, increase resources in [Compute and Disk](/dashboard/project/_/settings/compute-and-disk).
+- If needed, increase resources in [Infrastructure](/dashboard/project/_/settings/infrastructure).
 - Alternatively, you can restart the database in [Project Settings](/dashboard/project/_/settings/general) but this may be only a temporary fix if the project is undersized / unoptimized.
 
 Review the appropriate guides based on your scenario:

--- a/apps/docs/content/troubleshooting/high-cpu-usage.mdx
+++ b/apps/docs/content/troubleshooting/high-cpu-usage.mdx
@@ -40,4 +40,4 @@ Everything you do with your Supabase project requires compute. Hence, there can 
 There are two ways to solve high CPU:
 
 1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).
-2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](/dashboard/project/_/settings/compute-and-disk) and select your project to see your upgrade options.
+2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](/dashboard/project/_/settings/infrastructure) and select your project to see your upgrade options.

--- a/apps/docs/content/troubleshooting/high-cpu-usage.mdx
+++ b/apps/docs/content/troubleshooting/high-cpu-usage.mdx
@@ -9,7 +9,7 @@ Learn what high CPU usage could mean for your Supabase instance and what could h
 
 ## The danger of high CPU usage
 
-Every Supabase project runs in its dedicated virtual machine. Your instance will have a different set of hardware provisioned depending on your [compute add-on](/docs/guides/platform/compute-add-ons). Your hardware may not be suitable for the intended workload and may experience high CPU usage.
+Every Supabase project runs in its dedicated virtual machine. Your instance will have a different set of hardware provisioned depending on your [compute add-on](/docs/guides/platform/compute-and-disk). Your hardware may not be suitable for the intended workload and may experience high CPU usage.
 
 High CPU usage could come with a range of issues:
 
@@ -39,5 +39,5 @@ Everything you do with your Supabase project requires compute. Hence, there can 
 
 There are two ways to solve high CPU:
 
-1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/platform/going-into-prod#performance).
+1. **Optimize performance:** Get more out of your instance's resources by optimizing your usage. Have a look at our [performance tuning guide](/docs/guides/platform/performance#examining-query-performance) and our [production readiness guide](/docs/guides/deployment/going-into-prod#performance).
 2. **Upgrade your compute:** You can get a Compute Add-on for your project. Follow [this link](/dashboard/project/_/settings/infrastructure) and select your project to see your upgrade options.

--- a/apps/docs/content/troubleshooting/http-api-issues.mdx
+++ b/apps/docs/content/troubleshooting/http-api-issues.mdx
@@ -21,20 +21,20 @@ Symptoms of HTTP API issues include:
 
 The most common class of issues that causes HTTP timeouts and 5xx response codes is the under-provisioning of resources for your project. This can cause your project to be unable to service the traffic it is receiving.
 
-Each Supabase project is provisioned with [segregated compute resources](../platform/compute-add-ons). This allows the project to serve unlimited requests, as long as they can be handled using the resources that have been provisioned. Complex queries, or queries that process larger amounts of data, will require higher amounts of resources. As such, the amount of resources that can handle a high volume of basic queries (or queries involving small amounts of data), will likely be unable to handle a similar volume of complex queries.
+Each Supabase project is provisioned with [segregated compute resources](../platform/compute-and-disk). This allows the project to serve unlimited requests, as long as they can be handled using the resources that have been provisioned. Complex queries, or queries that process larger amounts of data, will require higher amounts of resources. As such, the amount of resources that can handle a high volume of basic queries (or queries involving small amounts of data), will likely be unable to handle a similar volume of complex queries.
 
 You can view the resource utilization of your Supabase Project using the [reports in the Dashboard](/dashboard/project/_/observability/database).
 
 Some common solutions for this issue are:
 
-- [Upgrading](/dashboard/project/_/settings/infrastructure) to a [larger compute add-on](../platform/compute-add-ons) in order to serve higher volumes of traffic.
+- [Upgrading](/dashboard/project/_/settings/infrastructure) to a [larger compute add-on](../platform/compute-and-disk) in order to serve higher volumes of traffic.
 - [Optimizing the queries](../platform/performance#examining-query-performance) being executed.
 - [Using fewer Postgres connections](../platform/performance#configuring-clients-to-use-fewer-connections) can reduce the amount of resources needed on the project.
 - [Restarting](/dashboard/project/_/settings/general) the project. This only temporarily solves the issue by terminating any ongoing workloads that might be tying up your compute resources.
   - All databases of the project, including [Read replicas](/docs/guides/platform/read-replicas), will be restarted.
   - If you only want to restart a specific Read Replica, you can do so from the [Infrastructure Settings page](/dashboard/project/_/settings/infrastructure).
 
-If your [Disk IO budget](../platform/compute-add-ons#disk-io) has been drained, you will need to either wait for it to be replenished the next day, or upgrade to a larger compute add-on to increase the budget available to your project.
+If your [Disk IO budget](../platform/compute-and-disk#disk) has been drained, you will need to either wait for it to be replenished the next day, or upgrade to a larger compute add-on to increase the budget available to your project.
 
 ## Unable to connect to your Supabase project
 
@@ -46,7 +46,7 @@ Errors about too many open connections can be _temporarily_ resolved by [restart
 
 - If you're receiving a `No more connections allowed (max_client_conn)` error:
   - Configure your applications and services to [use fewer connections](../platform/performance#configuring-clients-to-use-fewer-connections).
-  - [Upgrade](/dashboard/project/_/settings/infrastructure) to a [larger compute add-on](../platform/compute-add-ons) to increase the number of available connections.
+  - [Upgrade](/dashboard/project/_/settings/infrastructure) to a [larger compute add-on](../platform/compute-and-disk) to increase the number of available connections.
 - If you're receiving a `sorry, too many clients already` or `remaining connection slots are reserved for non-replication superuser connections` error message in addition to the above suggestions, switch to using the [connection pooler](/docs/guides/database/connecting-to-postgres#connection-pool) instead.
 
 ### Connection refused

--- a/apps/docs/content/troubleshooting/http-api-issues.mdx
+++ b/apps/docs/content/troubleshooting/http-api-issues.mdx
@@ -27,7 +27,7 @@ You can view the resource utilization of your Supabase Project using the [report
 
 Some common solutions for this issue are:
 
-- [Upgrading](/dashboard/project/_/settings/compute-and-disk) to a [larger compute add-on](../platform/compute-add-ons) in order to serve higher volumes of traffic.
+- [Upgrading](/dashboard/project/_/settings/infrastructure) to a [larger compute add-on](../platform/compute-add-ons) in order to serve higher volumes of traffic.
 - [Optimizing the queries](../platform/performance#examining-query-performance) being executed.
 - [Using fewer Postgres connections](../platform/performance#configuring-clients-to-use-fewer-connections) can reduce the amount of resources needed on the project.
 - [Restarting](/dashboard/project/_/settings/general) the project. This only temporarily solves the issue by terminating any ongoing workloads that might be tying up your compute resources.
@@ -46,7 +46,7 @@ Errors about too many open connections can be _temporarily_ resolved by [restart
 
 - If you're receiving a `No more connections allowed (max_client_conn)` error:
   - Configure your applications and services to [use fewer connections](../platform/performance#configuring-clients-to-use-fewer-connections).
-  - [Upgrade](/dashboard/project/_/settings/compute-and-disk) to a [larger compute add-on](../platform/compute-add-ons) to increase the number of available connections.
+  - [Upgrade](/dashboard/project/_/settings/infrastructure) to a [larger compute add-on](../platform/compute-add-ons) to increase the number of available connections.
 - If you're receiving a `sorry, too many clients already` or `remaining connection slots are reserved for non-replication superuser connections` error message in addition to the above suggestions, switch to using the [connection pooler](/docs/guides/database/connecting-to-postgres#connection-pool) instead.
 
 ### Connection refused

--- a/apps/docs/content/troubleshooting/increase-vector-lookup-speeds-by-applying-an-hsnw-index-ohLHUM.mdx
+++ b/apps/docs/content/troubleshooting/increase-vector-lookup-speeds-by-applying-an-hsnw-index-ohLHUM.mdx
@@ -105,7 +105,7 @@ If your task is particularly long, you can speed it up by boosting your computin
 **7. Consider increasing disk size (optional)**
 
 HSNW indexes can produce temporary files during their construction that may consume a few GBs worth of disk.
-Consider increasing the disk size in the [Compute and Disk settings](/dashboard/project/_/settings/compute-and-disk) to accommodate for short-term disk stress.
+Consider increasing the disk size in the [Infrastructure settings](/dashboard/project/_/settings/infrastructure) to accommodate for short-term disk stress.
 
 <img
   width="947"

--- a/apps/docs/content/troubleshooting/increase-vector-lookup-speeds-by-applying-an-hsnw-index-ohLHUM.mdx
+++ b/apps/docs/content/troubleshooting/increase-vector-lookup-speeds-by-applying-an-hsnw-index-ohLHUM.mdx
@@ -72,7 +72,7 @@ show maintenance_work_mem;
 
 **4. Increase cores for index creation (optional)**
 
-The `max_parallel_maintenance_workers` variable limits the amount of cores that can be used by maintenance operations, including indexing tables. In your session, you should try to set it to a value roughly 1/2 to 2/3s of your [compute core amount](/docs/guides/platform/compute-add-ons):
+The `max_parallel_maintenance_workers` variable limits the amount of cores that can be used by maintenance operations, including indexing tables. In your session, you should try to set it to a value roughly 1/2 to 2/3s of your [compute core amount](/docs/guides/platform/compute-and-disk):
 
 ```sql
 set max_parallel_maintenance_workers to <integer>;
@@ -100,7 +100,7 @@ show statement_timeout;
 
 **6. Consider temporarily upgrading your compute size (optional)**
 
-If your task is particularly long, you can speed it up by boosting your computing power temporarily. Compute size is charged by the hour, so you can increase it for an hour or two to finish your task faster, then scale it back afterwards. Here is a list of [compute add-ons](/docs/guides/platform/compute-add-ons). If you want to temporarily upgrade, you can find the add-ons for your project in your [Dashboard's Add-ons Settings.](https://supabase.green/dashboard/project/_/settings/addons)
+If your task is particularly long, you can speed it up by boosting your computing power temporarily. Compute size is charged by the hour, so you can increase it for an hour or two to finish your task faster, then scale it back afterwards. Here is a list of [compute add-ons](/docs/guides/platform/compute-and-disk). If you want to temporarily upgrade, you can find the add-ons for your project in your [Dashboard's Add-ons Settings.](https://supabase.green/dashboard/project/_/settings/addons)
 
 **7. Consider increasing disk size (optional)**
 

--- a/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
+++ b/apps/docs/content/troubleshooting/interpreting-supabase-grafana-io-charts-MUynDR.mdx
@@ -52,7 +52,7 @@ If a database exhibited some of these metrics for prolonged periods, then there 
 - Scale the database to get more IO if possible
 - Optimize queries/tables or refactor database/app to reduce IO
 - Spin-up a [read-replica](/dashboard/project/_/settings/infrastructure)
-- Modify IO configs in the [Compute and Disk settings](/dashboard/project/_/settings/compute-and-disk)
+- Modify IO configs in the [Infrastructure settings](/dashboard/project/_/settings/infrastructure)
 - [Partitions](/docs/guides/database/partitions): Generally should be used on very large tables to minimize data pulled from disk
 
 Other useful Supabase Grafana guides:

--- a/apps/docs/content/troubleshooting/project-status-reports-unhealthy-services.mdx
+++ b/apps/docs/content/troubleshooting/project-status-reports-unhealthy-services.mdx
@@ -16,7 +16,7 @@ Services rely on the backend database. Unhealthy services can indicate a databas
 Possible resolutions:
 
 - Restart the database in [Project Settings](/dashboard/project/_/settings/general) (this may be only a temporary fix if the project is undersized / unoptimized).
-- Increase project resources in [Compute and Disk](/dashboard/project/_/settings/compute-and-disk).
+- Increase project resources in [Infrastructure](/dashboard/project/_/settings/infrastructure).
 - [Performance Tune](/docs/guides/platform/performance) the database.
 
 The "Edge Functions Unhealthy" indicator is based on a platform-level health check, not the project's own functions. Confirm the actual functions work by invoking them directly. If functions are working fine, this is likely a false positive.


### PR DESCRIPTION
Follow-up to #48370, which merged the Compute and Disk settings page into Infrastructure and made `/settings/compute-and-disk` a permanent redirect.

**Changed:**

- Retargeted all 17 dashboard links from `/dashboard/project/_/settings/compute-and-disk` to `/dashboard/project/_/settings/infrastructure` (15 files across guides, troubleshooting entries, and the `migration_warnings` partial)
- Updated link text that named the old page ("Compute and Disk settings" → "Infrastructure settings", plus one stale "Database Settings" label in the compute-and-disk guide)

Links to the `/docs/guides/platform/compute-and-disk` docs guide are untouched — that page still exists; only dashboard deep links changed.

> [!NOTE]
> Best merged after #48370 — until then the Infrastructure page doesn't host the compute and disk config (the old URL keeps working either way via the redirect).

## To test

- Spot-check a few changed pages on the preview (e.g. `/guides/platform/database-size`, `/guides/troubleshooting/high-cpu-usage`) and confirm the dashboard links land on the Infrastructure settings page
- Confirm the compute-and-disk guide page itself still renders and its docs-internal links are unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated migration and troubleshooting guidance to direct users to the **Infrastructure** settings page, replacing outdated **Compute and Disk** links.
  - Refreshed platform/database/performance links for resizing, disk throughput/IOPS, upgrade steps, and related troubleshooting to use the updated **Infrastructure** routes and anchors.
  - Adjusted “Using the CLI” to point to the current local development getting-started page, and refined wording in the “Hit rate” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->