### PR TITLE
fix(design-system): small chart and metric card fixes

### DIFF
--- a/apps/design-system/registry/default/block/chart-composed-actions.tsx
+++ b/apps/design-system/registry/default/block/chart-composed-actions.tsx
@@ -80,7 +80,7 @@ export default function ChartComposedActions() {
                   showYAxis={true}
                   YAxisProps={{
                     tickFormatter: (value) => `${value}k`,
-                    width: 80,
+                    width: 36,
                   }}
                   isFullHeight={true}
                 />
@@ -92,7 +92,7 @@ export default function ChartComposedActions() {
                   showYAxis={true}
                   YAxisProps={{
                     tickFormatter: (value) => `${value}k`,
-                    width: 80,
+                    width: 36,
                   }}
                   isFullHeight={true}
                 />

--- a/apps/design-system/registry/default/block/chart-composed-basic.tsx
+++ b/apps/design-system/registry/default/block/chart-composed-basic.tsx
@@ -93,7 +93,7 @@ export default function ComposedChartBasic() {
                 showYAxis={true}
                 YAxisProps={{
                   tickFormatter: (value) => `${value}k`,
-                  width: 80,
+                  width: 36,
                 }}
                 isFullHeight={true}
               />
@@ -129,7 +129,7 @@ export default function ComposedChartBasic() {
                 showYAxis={true}
                 YAxisProps={{
                   tickFormatter: (value) => `${value}k`,
-                  width: 80,
+                  width: 36,
                 }}
                 isFullHeight={true}
               />

--- a/apps/design-system/registry/default/block/chart-composed-table.tsx
+++ b/apps/design-system/registry/default/block/chart-composed-table.tsx
@@ -73,7 +73,7 @@ export default function ChartComposedTable() {
                 showYAxis={true}
                 YAxisProps={{
                   tickFormatter: (value) => `${value}k`,
-                  width: 80,
+                  width: 36,
                 }}
                 isFullHeight={true}
               />

--- a/apps/studio/styles/globals.css
+++ b/apps/studio/styles/globals.css
@@ -208,13 +208,24 @@ body,
   box-sizing: border-box;
 }
 
+@layer base {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-heading;
+  }
+}
+
 h1,
 h2,
 h3,
 h4,
 h5,
 h6 {
-  @apply font-heading font-semibold;
+  @apply font-semibold;
 }
 
 .form-group .form-text,

--- a/packages/ui-patterns/src/LogsBarChart/index.tsx
+++ b/packages/ui-patterns/src/LogsBarChart/index.tsx
@@ -13,8 +13,8 @@ const CHART_COLORS = {
   GREEN_2: 'hsl(var(--brand-500))',
   RED_1: 'hsl(var(--destructive-default))',
   RED_2: 'hsl(var(--destructive-500))',
-  YELLOW_1: 'var(--chart-warning)',
-  YELLOW_2: 'var(--chart-warning-muted)',
+  YELLOW_1: 'var(--chart-warning, hsl(var(--warning-default)))',
+  YELLOW_2: 'var(--chart-warning-muted, hsl(var(--warning-500)))',
 }
 
 type LogsBarChartDatum = {

--- a/packages/ui/src/lib/utils/cn.ts
+++ b/packages/ui/src/lib/utils/cn.ts
@@ -1,5 +1,13 @@
 import { ClassValue, clsx } from 'clsx'
-import { twMerge } from 'tailwind-merge'
+import { extendTailwindMerge } from 'tailwind-merge'
+
+const twMerge = extendTailwindMerge({
+  extend: {
+    theme: {
+      spacing: ['card', 'content'],
+    },
+  },
+})
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This fixes the following:

- Our `<MetricCard />` and `<LogsBarChart />` which use `<ChartTitle />` were rendering the wrong font style for the title. The `font-mono` class being overwritten by recent changes, this helps sort cascade so it renders correct.
- In our design system, the warning variable for charts was rendering black, this should be fixed to be our warning yellow.
- There was an odd padding on `<MetricsCard />` content area, meaning our line chart wasn't flush to the edges, this required a small extension to `twMerge` so it could resolve. 

Please have a look around studio in places we have charts to double check nothing is broken. Also compare live design system vs. this branch by checking Logs Bar Chart, Charts and Metrics Card pages.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined heading typography for more consistent font and weight styling.
  * Improved class merging for custom spacing utilities.

* **Bug Fixes**
  * Adjusted composed chart Y-axis sizing for clearer layouts.
  * Improved warning color fallbacks in log bar charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->