### PR TITLE
docs(pgvector): fix duplicate heading and code block formatting

### DIFF
--- a/apps/docs/content/guides/database/extensions/pgvector.mdx
+++ b/apps/docs/content/guides/database/extensions/pgvector.mdx
@@ -45,7 +45,7 @@ This is particularly useful if you're building AI applications with large langua
 <TabPanel id="sql" label="SQL">
 
 ```sql
- -- Example: enable the "vector" extension.
+-- Example: enable the "vector" extension.
 create extension vector
 with
   schema extensions;
@@ -61,7 +61,7 @@ To disable an extension, call `drop extension`.
 </TabPanel>
 </Tabs>
 
-## Usage
+## Storing vectors
 
 ### Create a table to store vectors
 
@@ -76,7 +76,7 @@ create table posts (
 
 ### Storing a vector / embedding
 
-In this example we'll generate a vector using Transformer.js, then store it in the database using the Supabase client.
+In this example we'll generate a vector using Transformers.js, then store it in the database using the Supabase client.
 
 ```js
 import { pipeline } from '@xenova/transformers'
@@ -110,8 +110,8 @@ If you use an IVFFlat or HNSW index and naively filter the results based on the 
 
 For example, the following query may return fewer than 5 rows, even if 5 corresponding rows exist in the database. This is because the embedding index may not return 5 rows matching the filter.
 
-```
-SELECT * FROM items WHERE category_id = 123 ORDER BY embedding <-> '[3,1,2]' LIMIT 5;
+```sql
+select * from items where category_id = 123 order by embedding <-> '[3,1,2]' limit 5;
 ```
 
 To get the exact number of requested rows, use [iterative search](https://github.com/pgvector/pgvector/?tab=readme-ov-file#iterative-index-scans) to continue scanning the index until enough results are found.


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Docs update — small structural and formatting fixes to `apps/docs/content/guides/database/extensions/pgvector.mdx`.

## What is the current behavior?

**Duplicate `## Usage` heading.** The guide has `## Usage` at two places — once above "Enable the extension", and again above "Create a table to store vectors". Anchor IDs are generated from heading text, so both render as `#usage`. The table of contents shows two identical "Usage" entries, and clicking the second one scrolls to the first section.

**Untagged code fence.** The iterative-search example uses a bare ``` fence, so it gets no syntax highlighting, unlike every other block on the page. Its SQL is also uppercase, while the rest of the guide (and the docs style guide) uses lowercase keywords.

**Stray leading space** before `-- Example: enable the "vector" extension.` inside the enable-extension SQL block.

**Typo:** the prose says "Transformer.js"; the library is Transformers.js (the code comment two lines below already spells it correctly).

## What is the new behavior?

- Second `## Usage` renamed to `## Storing vectors`, which describes the two subsections it introduces ("Create a table to store vectors" and "Storing a vector / embedding"). The TOC now has unique entries and unique anchors.
- Iterative-search fence tagged ` ```sql ` and its keywords lowercased.
- Stray leading space removed.
- "Transformer.js" → "Transformers.js".

Content-only; no components, navigation, or generated output touched.

## Additional context

Before renaming the heading I checked for anything linking to the old anchor:

```
grep -rn "#usage" apps/docs/content
```

No in-page or cross-file link targets `pgvector#usage` — the hits are unrelated pages and external URLs — so the rename doesn't break any links.

Verified locally against the repo's own tooling:

- `supa-mdx-lint` with `supa-mdx-lint.config.toml` → no errors or warnings (the new heading is sentence case, per `Rule001HeadingCase`).
- Prettier 3.8.1 with `prettier.config.mjs` and `prettier-plugin-sql-cst` → already formatted, including the newly tagged `sql` block.

One thing I deliberately left alone: the JS sample still imports `@xenova/transformers`, which has since been superseded by `@huggingface/transformers`. That's a behavioral change rather than a formatting one, so it felt out of scope here — happy to open a separate PR if you'd like it updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected pgvector SQL examples and formatting.
  * Renamed the “Usage” section to “Storing vectors.”
  * Fixed the Transformers.js library name and updated the filtering query example for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->