### PR TITLE
fix(studio): harden ProfileImage against non-string src to prevent AI Assistant crash on self-hosted

### DIFF
--- a/apps/studio/components/ui/ProfileImage.tsx
+++ b/apps/studio/components/ui/ProfileImage.tsx
@@ -13,7 +13,7 @@ interface ProfileImageProps {
 export const ProfileImage = ({ alt, src, placeholder, className }: ProfileImageProps) => {
   const [hasInvalidImg, setHasInvalidImg] = useState(false)
 
-  return !!src && !hasInvalidImg ? (
+  return typeof src === 'string' && !hasInvalidImg ? (
     <Image
       alt={alt ?? ''}
       src={src}

--- a/apps/studio/lib/github.ts
+++ b/apps/studio/lib/github.ts
@@ -88,6 +88,7 @@ export function openInstallGitHubIntegrationWindow(
   }
 }
 
-export const getGitHubProfileImgUrl = (username: string) => {
+export const getGitHubProfileImgUrl = (username: string | undefined) => {
+  if (!username) return undefined
   return `https://github.com/${username}.png?size=96`
 }


### PR DESCRIPTION
## Problem

The AI Assistant on self-hosted Supabase crashes with:
```
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at ProfileImage
```

Closes #39654

## Root cause

`ProfileImage` used `!!src` to guard against undefined src before passing to `next/image`. However, `next/image` internally calls `src.startsWith()` to check for data URIs, protocol-relative URLs, etc. When a truthy non-string value reached `next/image`, it threw since `startsWith` doesn't exist on non-strings.

Additionally, `getGitHubProfileImgUrl(undefined)` returned `"https://github.com/undefined.png?size=96"` — a valid string URL pointing to a non-existent image, causing unnecessary 404s.

## Changes

- **ProfileImage.tsx**: Use `typeof src === 'string'` instead of `!!src` — only pass string values to `next/image`
- **github.ts**: `getGitHubProfileImgUrl` now accepts `string | undefined` and returns `undefined` for falsy usernames

## Testing

- `tsc --noEmit` passes
- `vitest run lib/github.test.ts` passes (2/2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved profile image handling when an image source is unavailable or invalid.
  - Prevented incorrect GitHub avatar URLs from being generated when no username is provided.
  - Profile images now reliably fall back to the placeholder when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->