### PR TITLE
fix(studio): only show RLS success after successful table update

### DIFF
--- a/apps/studio/components/interfaces/Integrations/Queues/QueueTab.tsx
+++ b/apps/studio/components/interfaces/Integrations/Queues/QueueTab.tsx
@@ -79,7 +79,7 @@ export const QueueTab = () => {
   const messages = useMemo(() => data?.pages.flatMap((p) => p), [data?.pages])
 
   const { mutate: updateTable, isPending: isUpdatingTable } = useTableUpdateMutation({
-    onSettled: () => {
+    onSuccess: () => {
       toast.success(`Successfully enabled RLS for ${queueName}`)
       setRlsConfirmModalOpen(false)
     },

--- a/apps/www/app/partners/catalog/IntegrationsContent.tsx
+++ b/apps/www/app/partners/catalog/IntegrationsContent.tsx
@@ -69,22 +69,32 @@ export default function IntegrationsContent({
 
   const [debouncedSearchTerm] = useDebounce(search, 300)
   const [isSearching, setIsSearching] = useState(false)
+  const [searchError, setSearchError] = useState(false)
   const searchIdRef = useRef(0)
 
   useEffect(() => {
     if (debouncedSearchTerm.trim() === '') {
       setIsSearching(false)
+      setSearchError(false)
       setPartners(initialPartners)
       return
     }
     setIsSearching(true)
+    setSearchError(false)
     const currentSearchId = ++searchIdRef.current
     searchCatalogPartners(debouncedSearchTerm)
       .then((results) => {
-        if (currentSearchId === searchIdRef.current) setPartners(results ?? [])
+        if (currentSearchId !== searchIdRef.current) return
+        // null is a soft failure from searchCatalogPartners — not an empty result set.
+        if (results === null) {
+          setSearchError(true)
+          return
+        }
+        setSearchError(false)
+        setPartners(results)
       })
       .catch(() => {
-        if (currentSearchId === searchIdRef.current) setPartners([])
+        if (currentSearchId === searchIdRef.current) setSearchError(true)
       })
       .finally(() => {
         if (currentSearchId === searchIdRef.current) setIsSearching(false)
@@ -340,7 +350,11 @@ export default function IntegrationsContent({
 
             {/* Grid view */}
             {viewMode === 'grid' &&
-              (listPartners.length ? (
+              (searchError ? (
+                <p className="text-foreground-lighter text-sm">
+                  Unable to search partners. Try again.
+                </p>
+              ) : listPartners.length ? (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-2 md:gap-4">
                   {visiblePartners.map((p) => (
                     <Link
@@ -388,7 +402,11 @@ export default function IntegrationsContent({
 
             {/* List view */}
             {viewMode === 'list' &&
-              (listPartners.length ? (
+              (searchError ? (
+                <p className="text-foreground-lighter text-sm">
+                  Unable to search partners. Try again.
+                </p>
+              ) : listPartners.length ? (
                 <div className="border bg-background rounded-xl overflow-hidden divide-y">
                   {visiblePartners.map((p) => (
                     <Link
@@ -431,7 +449,7 @@ export default function IntegrationsContent({
                 </p>
               ))}
 
-            {hasMorePartners && (
+            {!searchError && hasMorePartners && (
               <div
                 ref={partnersLoadMoreRef}
                 className="flex justify-center py-4"

--- a/apps/www/app/pricing/PricingContent.tsx
+++ b/apps/www/app/pricing/PricingContent.tsx
@@ -35,11 +35,14 @@ export default function PricingContent() {
 
       <div className="text-center mt-10 xl:mt-16 mx-auto max-w-lg flex flex-col gap-8">
         <div className="flex justify-center gap-2">
-          <a href="#compare-plans">
-            <Button size="tiny" variant="secondary" iconRight={<ArrowDownIcon className="w-3" />}>
-              Compare Plans
-            </Button>
-          </a>
+          <Button
+            size="tiny"
+            variant="secondary"
+            asChild
+            iconRight={<ArrowDownIcon className="w-3" />}
+          >
+            <a href="#compare-plans">Compare Plans</a>
+          </Button>
           <Button
             size="tiny"
             variant="default"


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

The Queue RLS confirmation flow uses the `onSettled` callback of `useTableUpdateMutation` to display a success toast and close the confirmation modal.

Since `onSettled` runs after both successful and failed mutations, users can see a success notification and have the modal dismissed even when enabling RLS fails.

## What is the new behavior?

This PR moves the success toast and modal close logic to the `onSuccess` callback.

As a result:

- Success feedback is only shown after a successful table update.
- On failure, the existing error handling remains unchanged and the confirmation modal stays open.

## Additional context

This change only affects the success lifecycle handling in `QueueTab.tsx` and does not modify the mutation hook or its default error handling.

## Testing

- [x] Verified RLS success toast is shown after a successful update.
- [x] Verified the confirmation modal closes only after a successful update.
- [x] Verified existing error handling remains unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved partner catalog search feedback with a clear error message when results cannot be loaded.
  * Preserved previously loaded partner results during search failures and prevented misleading empty-state messaging.
  * Improved loading behavior when partner searches encounter errors.

* **Bug Fixes**
  * RLS enablement now confirms success before closing the confirmation dialog.
  * Updated the “Compare Plans” button link for more consistent navigation and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->