### PR TITLE
chore: update lite-studio to Node 22

### DIFF
--- a/apps/lite-studio/Dockerfile
+++ b/apps/lite-studio/Dockerfile
@@ -1,20 +1,20 @@
-FROM node:20-alpine AS development-dependencies-env
+FROM node:22-alpine AS development-dependencies-env
 COPY . /app
 WORKDIR /app
 RUN npm ci
 
-FROM node:20-alpine AS production-dependencies-env
+FROM node:22-alpine AS production-dependencies-env
 COPY ./package.json package-lock.json /app/
 WORKDIR /app
 RUN npm ci --omit=dev
 
-FROM node:20-alpine AS build-env
+FROM node:22-alpine AS build-env
 COPY . /app/
 COPY --from=development-dependencies-env /app/node_modules /app/node_modules
 WORKDIR /app
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:22-alpine
 COPY ./package.json package-lock.json /app/
 COPY --from=production-dependencies-env /app/node_modules /app/node_modules
 COPY --from=build-env /app/build /app/build


### PR DESCRIPTION
## What changed

- update every `apps/lite-studio/Dockerfile` stage from `node:20-alpine` to `node:22-alpine`
- align the development, dependency, build, and production stages with the repository's Node 22 requirement

## Why

Node 20 is end-of-life, while this repository requires Node `>=22.13` and uses Node 22 in `.nvmrc`. Keeping every stage on the same supported line also prevents build/runtime version drift.

## Validation

- `docker build --check -f apps/lite-studio/Dockerfile apps/lite-studio`
- `docker run --rm node:22-alpine node --version` → `v22.23.1`
- verified all four `FROM` instructions use `node:22-alpine`
- `git diff --check`

A full image build reaches the Node 22 base image, then stops at the existing `COPY package-lock.json` instruction because `apps/lite-studio/package-lock.json` is absent on the current default branch. This PR does not expand into that separate problem.

Closes #48444
