### PR TITLE
docs(security): add GDPR, ISO 27001, and DDoS coverage to security guide

### DIFF
--- a/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
+++ b/apps/docs/components/Navigation/NavigationMenu/NavigationMenu.constants.ts
@@ -2616,6 +2616,7 @@ export const security: NavMenuConstant = {
       items: [
         { name: 'SOC 2', url: '/guides/security/soc-2-compliance' },
         { name: 'HIPAA', url: '/guides/security/hipaa-compliance' },
+        { name: 'GDPR', url: '/guides/security/gdpr-compliance' },
       ],
     },
     {

--- a/apps/docs/content/guides/platform/regions.mdx
+++ b/apps/docs/content/guides/platform/regions.mdx
@@ -6,7 +6,7 @@ Each Supabase project is deployed to one primary region. Choose the location clo
 
 ## Data residency
 
-The region you choose also determines where your primary project data is stored. If your data residency requirements call for data to stay within a specific jurisdiction, choose a [specific region](#specific-regions) rather than a general region grouping. 
+The region you choose also determines where your primary project data is stored. If your data residency requirements call for data to stay within a specific jurisdiction, choose a [specific region](#specific-regions) rather than a general region grouping.
 
 General regions deploy to _an_ available AWS region within that broader area, which may not match a specific jurisdiction. For example, the "Europe" general region includes London and Zurich, which are not EU member states. Region selection is a data-location control, not proof of regulatory compliance. For GDPR considerations, see the [GDPR compliance guide](/docs/guides/security/gdpr-compliance).
 

--- a/apps/docs/content/guides/platform/regions.mdx
+++ b/apps/docs/content/guides/platform/regions.mdx
@@ -6,7 +6,9 @@ Each Supabase project is deployed to one primary region. Choose the location clo
 
 ## Data residency
 
-The region you choose also determines where your data is stored. If you have regulatory requirements — for example, GDPR — that require your data to stay within a specific jurisdiction, choose a [specific region](#specific-regions) rather than a general region grouping. General regions deploy to _an_ available AWS region within that broader area, which may not match a specific jurisdiction (for example, the "Europe" general region includes London and Zurich, which are not EU member states).
+The region you choose also determines where your primary project data is stored. If your data residency requirements call for data to stay within a specific jurisdiction, choose a [specific region](#specific-regions) rather than a general region grouping. 
+
+General regions deploy to _an_ available AWS region within that broader area, which may not match a specific jurisdiction. For example, the "Europe" general region includes London and Zurich, which are not EU member states. Region selection is a data-location control, not proof of regulatory compliance. For GDPR considerations, see the [GDPR compliance guide](/docs/guides/security/gdpr-compliance).
 
 ## General regions
 

--- a/apps/docs/content/guides/platform/regions.mdx
+++ b/apps/docs/content/guides/platform/regions.mdx
@@ -4,6 +4,10 @@ title: Available regions
 
 Each Supabase project is deployed to one primary region. Choose the location closest to your users for the best performance.
 
+## Data residency
+
+The region you choose also determines where your data is stored. If you have regulatory requirements — for example, GDPR — that require your data to stay within a specific jurisdiction, choose a [specific region](#specific-regions) rather than a general region grouping. General regions deploy to _an_ available AWS region within that broader area, which may not match a specific jurisdiction (for example, the "Europe" general region includes London and Zurich, which are not EU member states).
+
 ## General regions
 
 For most projects, we recommend choosing a general region. Supabase will deploy your project to an available AWS region within that area based on current infrastructure capacity.

--- a/apps/docs/content/guides/security.mdx
+++ b/apps/docs/content/guides/security.mdx
@@ -15,11 +15,17 @@ The [SOC 2 Compliance Guide](/docs/guides/security/soc-2-compliance) explains Su
 
 The [HIPAA Compliance Guide](/docs/guides/security/hipaa-compliance) explains Supabase's HIPAA responsibilities. Additional [security and compliance controls](/docs/guides/deployment/shared-responsibility-model#managing-healthcare-data) for projects that deal with electronic Protected Health Information (ePHI) and require HIPAA compliance are available through the HIPAA add-on.
 
+Supabase is ISO 27001 certified. ISO 27001 is an internationally recognized standard for information security management systems (ISMS), confirming that we maintain rigorous controls to protect customer data. Enterprise and Team customers can access our ISO 27001 certificate [on the dashboard](/dashboard/org/_/documents).
+
+Supabase supports GDPR-compliant deployments, including EU-region hosting for data residency and a Data Processing Agreement (DPA) for customers who need one. The [GDPR compliance guide](/docs/guides/security/gdpr-compliance) explains this in more detail.
+
 ## Platform configuration
 
 As a hosted platform, Supabase provides additional security controls to further enhance the security posture depending on organizations' own requirements or obligations.
 
 These can be found under the [dedicated security page](/dashboard/org/_/security) under organization settings. And are described in greater detail [here](/docs/guides/security/platform-security).
+
+In addition to protection at the CDN level via Cloudflare, Supabase employs fail2ban to block malicious IP addresses at the infrastructure layer, protecting the platform against Distributed Denial of Service (DDoS) attacks.
 
 ## Product configuration
 

--- a/apps/docs/content/guides/security.mdx
+++ b/apps/docs/content/guides/security.mdx
@@ -17,7 +17,7 @@ The [HIPAA Compliance Guide](/docs/guides/security/hipaa-compliance) explains Su
 
 Supabase is ISO 27001 certified. ISO 27001 is an internationally recognized standard for information security management systems (ISMS), confirming that we maintain rigorous controls to protect customer data. Enterprise and Team customers can access our ISO 27001 certificate [on the dashboard](/dashboard/org/_/documents).
 
-Supabase supports GDPR-compliant deployments, including EU-region hosting for data residency and a Data Processing Agreement (DPA) for customers who need one. The [GDPR compliance guide](/docs/guides/security/gdpr-compliance) explains this in more detail.
+Supabase supports GDPR-related requirements with EU-region hosting for data residency and a Data Processing Agreement (DPA) for customers who need one. The [GDPR compliance guide](/docs/guides/security/gdpr-compliance) covers shared responsibility, residency scope, and the DPA.
 
 ## Platform configuration
 
@@ -25,7 +25,7 @@ As a hosted platform, Supabase provides additional security controls to further 
 
 These can be found under the [dedicated security page](/dashboard/org/_/security) under organization settings. And are described in greater detail [here](/docs/guides/security/platform-security).
 
-In addition to protection at the CDN level via Cloudflare, Supabase employs fail2ban to block malicious IP addresses at the infrastructure layer, protecting the platform against Distributed Denial of Service (DDoS) attacks.
+Supabase protects against Distributed Denial of Service (DDoS) attacks at the edge via Cloudflare. At the infrastructure layer, fail2ban blocks IP addresses after repeated log-detected abuse, such as failed authentication attempts.
 
 ## Product configuration
 

--- a/apps/docs/content/guides/security/gdpr-compliance.mdx
+++ b/apps/docs/content/guides/security/gdpr-compliance.mdx
@@ -1,0 +1,15 @@
+---
+id: 'gdpr-compliance'
+title: 'GDPR compliance and Supabase'
+description: 'How Supabase supports GDPR-compliant deployments, including data residency and the Data Processing Agreement (DPA).'
+---
+
+Supabase supports building GDPR-compliant applications. Building a compliant application is a [shared responsibility](/docs/guides/deployment/shared-responsibility-model): Supabase secures the underlying infrastructure, while you're responsible for your application's data processing activities, consent flows, and access controls.
+
+## Data residency
+
+Each Supabase project is deployed to a single primary region, and your project's primary Postgres database, Auth service, and Storage objects are hosted in that region. Choosing a [specific region](/docs/guides/platform/regions#specific-regions) within the EU pins your data to that exact AWS region. Note that the "Europe" general region grouping also includes London (UK) and Zurich (Switzerland) — both have GDPR-adequacy data protection regimes, but neither is an EU member state. If your compliance requirements call for data to stay within the EU specifically, choose a specific EU region rather than the general Europe grouping. See [available regions](/docs/guides/platform/regions) for the full list.
+
+## Data processing agreement (DPA)
+
+If you need a formal data processing contract under GDPR, Supabase provides a Data Processing Agreement (DPA). [Request or view the DPA](/legal/dpa).

--- a/apps/docs/content/guides/security/gdpr-compliance.mdx
+++ b/apps/docs/content/guides/security/gdpr-compliance.mdx
@@ -8,7 +8,11 @@ Supabase supports building GDPR-compliant applications. Building a compliant app
 
 ## Data residency
 
-Each Supabase project is deployed to a single primary region, and your project's primary Postgres database, Auth service, and Storage objects are hosted in that region. Choosing a [specific region](/docs/guides/platform/regions#specific-regions) within the EU pins your data to that exact AWS region. Note that the "Europe" general region grouping also includes London (UK) and Zurich (Switzerland) — both have GDPR-adequacy data protection regimes, but neither is an EU member state. If your compliance requirements call for data to stay within the EU specifically, choose a specific EU region rather than the general Europe grouping. See [available regions](/docs/guides/platform/regions) for the full list.
+Each Supabase project is deployed to a single primary region, and your project's primary Postgres database, Auth service, and Storage objects are hosted in that region. Choosing a [specific region](/docs/guides/platform/regions#specific-regions) within the EU pins these services to that exact AWS region. 
+
+Note that the "Europe" general region grouping also includes London (UK) and Zurich (Switzerland) — both have GDPR-adequacy data protection regimes, but neither is an EU member state. If your compliance requirements call for data to stay within the EU specifically, choose a specific EU region rather than the general Europe grouping. See [available regions](/docs/guides/platform/regions) for the full list.
+
+Choosing a region is a data-location control and does not make your application GDPR compliant on its own. Backups, logs, data exported to external systems, Edge Function execution, and subprocessors can affect your data residency and international transfer analysis.
 
 ## Data processing agreement (DPA)
 

--- a/apps/docs/content/guides/security/gdpr-compliance.mdx
+++ b/apps/docs/content/guides/security/gdpr-compliance.mdx
@@ -8,11 +8,11 @@ Supabase supports building GDPR-compliant applications. Building a compliant app
 
 ## Data residency
 
-Each Supabase project is deployed to a single primary region, and your project's primary Postgres database, Auth service, and Storage objects are hosted in that region. Choosing a [specific region](/docs/guides/platform/regions#specific-regions) within the EU pins these services to that exact AWS region. 
+Each Supabase project is deployed to a single primary region, and your project's primary Postgres database, Auth service, and Storage objects are hosted in that region. Choosing a [specific region](/docs/guides/platform/regions#specific-regions) within the EU pins these services to that exact AWS region.
 
 Note that the "Europe" general region grouping also includes London (UK) and Zurich (Switzerland) — both have GDPR-adequacy data protection regimes, but neither is an EU member state. If your compliance requirements call for data to stay within the EU specifically, choose a specific EU region rather than the general Europe grouping. See [available regions](/docs/guides/platform/regions) for the full list.
 
-Choosing a region is a data-location control and does not make your application GDPR compliant on its own. Backups, logs, data exported to external systems, Edge Function execution, and subprocessors can affect your data residency and international transfer analysis.
+Choosing a region is a data-location control and does not make your application GDPR compliant on its own. Backups, logs, data exported to external systems, Edge Function execution, and sub-processors can affect your data residency and international transfer analysis.
 
 ## Data processing agreement (DPA)
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

This is a docs-only content update to the `/docs/guides/security` landing page and its neighboring guides. It adds a dedicated GDPR compliance guide, and surfaces ISO 27001 and DDoS protection coverage that Supabase already provides but wasn't listed anywhere in the docs security guide.

Closes DOCS-354.

## What is the current behavior?

- In `/docs/guides/security`, there is no mention of GDPR, ISO 27001 or DPA request potential, despite Supabase docs covering these partially in one place or another.
- Confirmed by auditing `apps/docs/content/`: zero mentions of GDPR/data residency, zero DPA content or link to `/legal/dpa`, zero ISO 27001 mentions, and only incidental/wrong-audience mentions of DDoS protection (a pen-testing exclusion, a Storage CDN aside, a fail2ban troubleshooting article for banned users).
- `regions.mdx` only frames region choice as a performance decision, with no data-residency/compliance angle.
- This is a parallel docs-side counterpart to #48403 (marketing `/security` page content additions), which is adding the same GDPR/Data Residency/DPA/DDoS topics on `apps/www`. This PR does not modify `apps/www` — see that PR for the marketing-page changes.

## What is the new behavior?

- New guide: `apps/docs/content/guides/security/gdpr-compliance.mdx` covering data residency (including the nuance that the "Europe" general region grouping includes non-EU jurisdictions UK and Switzerland) and the Data Processing Agreement (DPA), linked to `/legal/dpa`.
- Added to the sidebar nav under Security → Compliance, alongside SOC 2 and HIPAA.
- `apps/docs/content/guides/security.mdx`: added an ISO 27001 paragraph (dashboard certificate link, matching the existing SOC 2/HIPAA pattern) and a GDPR pointer paragraph to `## Compliance`; added a DDoS protection paragraph (Cloudflare CDN + fail2ban) to `## Platform configuration`.
- `apps/docs/content/guides/platform/regions.mdx`: added a "Data residency" section clarifying that general region groupings may span non-matching jurisdictions, and specific regions should be used when strict jurisdictional residency is required.

## Additional context

- Worktree: `~/GitHub/supabase/supabase-worktrees/nikrichers/docs-354-security-landing-page`
- Note: Supabase's subprocessor list was considered for the GDPR guide but omitted — both candidate links (`/legal/customer-resources/subprocessor-list` and `/legal/privacy#subprocessors`) are not yet publishable/live. Follow up once Legal publishes that page.

**Verification:**

| Check                                | Result                                                                                                |
| ------------------------------------ | ----------------------------------------------------------------------------------------------------- |
| `pnpm lint:mdx` on changed/new files | Pass (0 errors, 0 warnings on touched files)                                                          |
| `pnpm build:guides-markdown`         | Fails on `master` too (unrelated missing `ai-skills.json` generated file) — not caused by this change |
| Local render (`pnpm dev:docs`)       | All three pages return 200; new copy, nav entry, and all links/anchors verified to resolve            |

### Proof:

Reviewers should believe: the security landing page and regions guide now list GDPR/ISO 27001/DDoS coverage that was previously missing, and the new GDPR guide renders correctly with working links, where before it 404'd.

### Before & After

**`/docs/guides/security`** — ISO 27001, GDPR, and DDoS paragraphs now present:

| [Before (production)](https://supabase.com/docs/guides/security)                                                                                      | [After (PR preview)](https://docs-git-nikrichers-docs-354-security-landing-page-supabase.vercel.app/docs/guides/security)                           |
| ----------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
| ![security-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48449/security-before-5fd638c1.png) | ![security-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48449/security-after-2f89b1b0.png) |

**`/docs/guides/platform/regions`** — new "Data residency" section:

| [Before (production)](https://supabase.com/docs/guides/platform/regions)                                                                            | [After (PR preview)](https://docs-git-nikrichers-docs-354-security-landing-page-supabase.vercel.app/docs/guides/platform/regions)                 |
| --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
| ![regions-before](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48449/regions-before-e824c680.png) | ![regions-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48449/regions-after-c119e50d.png) |

**`/docs/guides/security/gdpr-compliance`** — net-new page, no production URL exists yet (404 before this PR):

| Before (production) | [After (PR preview)](https://docs-git-nikrichers-docs-354-security-landing-page-supabase.vercel.app/docs/guides/security/gdpr-compliance)   |
| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
|                     | ![gdpr-after](https://moijyfpvgnmgoxvwcikq.supabase.co/storage/v1/object/public/pr-proof/supabase/supabase/pr48449/gdpr-after-e42cf263.png) |

### Test plan

```text
- [ ] Visit /docs/guides/security — confirm ISO 27001, GDPR, and DDoS paragraphs render under the right headings
- [ ] Visit /docs/guides/security/gdpr-compliance — confirm it renders and appears in the sidebar under Compliance (next to SOC 2, HIPAA)
- [ ] Visit /docs/guides/platform/regions — confirm the new "Data residency" section renders before "General regions"
- [ ] Confirm links resolve: /docs/guides/security/gdpr-compliance, /docs/guides/platform/regions#specific-regions, /legal/dpa, /dashboard/org/_/documents
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Documentation
- Added a GDPR Compliance entry to the Compliance navigation.
- Updated security documentation with ISO 27001 certification details, clearer GDPR guidance, and expanded protection information.
- Clarified regional data residency guidance, including primary project data and GDPR considerations.
- Made minor wording and formatting improvements to the GDPR compliance guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
