### PR TITLE
fix(pg-meta): honour useSpace when opening a grouped list

### DIFF
--- a/packages/pg-meta/src/pg-format/index.ts
+++ b/packages/pg-meta/src/pg-format/index.ts
@@ -79,7 +79,7 @@ function arrayToList<ElementType = unknown>(
 ): SafeSqlFragment {
   let sql = safeSql``
 
-  sql = useSpace ? safeSql`${sql} (` : safeSql`${sql} (`
+  sql = useSpace ? safeSql`${sql} (` : safeSql`${sql}(`
   for (const [index, element] of array.entries()) {
     sql = safeSql`${sql}${index === 0 ? safeSql`` : safeSql`, `}${formatter(element)}`
   }

--- a/packages/pg-meta/test/pg-format.test.ts
+++ b/packages/pg-meta/test/pg-format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, expectTypeOf, test } from 'vitest'
 
-import { ident, keyword, literal, safeSql } from '../src/pg-format'
+import { ident, keyword, literal, safeSql, string } from '../src/pg-format'
 
 describe('pg-format', () => {
   describe('ident', () => {
@@ -129,6 +129,19 @@ describe('pg-format', () => {
       expect(literal(['a', 'b', 'c'])).toBe("'a','b','c'")
     })
 
+    test('should convert nested arrays to grouped lists', () => {
+      // a leading nested array must not be prefixed with a space
+      expect(literal([['a', 'b']])).toBe("('a', 'b')")
+      expect(
+        literal([
+          ['a', 'b'],
+          ['c', 'd'],
+        ])
+      ).toBe("('a', 'b'), ('c', 'd')")
+      // only groups that follow another element are separated by one
+      expect(literal(['a', ['b', 'c']])).toBe("'a', ('b', 'c')")
+    })
+
     test('should handle objects as JSON', () => {
       expect(literal({ name: 'test' })).toBe('\'{"name":"test"}\'::jsonb')
       expect(literal({ id: 1, name: 'test' })).toBe('\'{"id":1,"name":"test"}\'::jsonb')
@@ -137,6 +150,21 @@ describe('pg-format', () => {
     test('should handle strings with backslashes', () => {
       expect(literal('path\\to\\file')).toBe("E'path\\\\to\\\\file'")
       expect(literal('C:\\Users\\test')).toBe("E'C:\\\\Users\\\\test'")
+    })
+  })
+
+  describe('string', () => {
+    test('should convert nested arrays to grouped lists', () => {
+      // a leading nested array must not be prefixed with a space
+      expect(string([[1, 2]])).toBe('(1, 2)')
+      expect(
+        string([
+          [1, 2],
+          [3, 4],
+        ])
+      ).toBe('(1, 2), (3, 4)')
+      // only groups that follow another element are separated by one
+      expect(string([1, [2, 3]])).toBe('1, (2, 3)')
     })
   })
 


### PR DESCRIPTION
## I have read the [CONTRIBUTING.md](https://github.com/supabase/supabase/blob/master/CONTRIBUTING.md) file.

YES

## What kind of change does this PR introduce?

Bug fix (+ test coverage for a previously untested path)

## What is the current behavior?

Fixes #48460

`arrayToList` in `packages/pg-meta/src/pg-format/index.ts` takes a `useSpace` flag to choose between opening a group with `(` or ` (`, but both branches of the ternary are identical, so the flag is dead:

```ts
sql = useSpace ? safeSql`${sql} (` : safeSql`${sql} (`
```

`literal()` and `string()` call it as `arrayToList(index !== 0, element, …)` — "separate a group from the element before it" — so a nested array in the **first** position picks up a leading space it shouldn't have.

`packages/pg-meta/src/pg-format` is a port of the [`pg-format`](https://www.npmjs.com/package/pg-format) package, so this is a divergence from it. Measured against `pg-format` directly:

| input | `string()` before | `pg-format` `%s` |
| --- | --- | --- |
| `[[1, 2]]` | `" (1, 2)"` | `"(1, 2)"` |
| `[[1, 2], [3, 4]]` | `" (1, 2), (3, 4)"` | `"(1, 2), (3, 4)"` |
| `[1, [2, 3]]` | `"1, (2, 3)"` | `"1, (2, 3)"` ✅ |

Only the leading-group case differed — precisely where `useSpace` is `false`.

## What is the new behavior?

`useSpace === false` now opens the group with `(`. After the change, all four nested-array cases I compared produce byte-identical output to upstream `pg-format` for `string()`, and `literal()` matches for string arrays (`('a', 'b'), ('c', 'd')`).

The generated SQL was still valid before this — Postgres ignores the leading whitespace — so this is a correctness/consistency fix rather than a runtime failure, and it removes a branch that was unreachable.

`literal()` keeps its intentional divergence from upstream on numbers (`literal([1, 2, 3]) === '1,2,3'`, asserted by the existing test, where upstream `%L` gives `'1','2','3'`). That is untouched.

## Additional context

Nested arrays were untested for `literal()`, and `string()` had no tests at all — the existing suite only covered flat arrays — which is how the dead branch survived. This adds coverage for both.

Verification, run from `packages/pg-meta`:

```console
$ npx vitest run test/pg-format.test.ts test/query/query.test.ts
 ✓ test/pg-format.test.ts (54 tests)
 ✓ test/query/query.test.ts (88 tests)
 Tests  142 passed (142)
```

Baseline on an unmodified checkout is `52 + 88 = 140`; the two extra passes are the new tests. Reverting only the `src/pg-format/index.ts` change makes them fail, which is what pins the behaviour:

```
AssertionError: expected ' (\'a\', \'b\')' to be '(\'a\', \'b\')'
AssertionError: expected ' (1, 2)' to be '(1, 2)'
```

Also checked:

* `tsc --noEmit -p tsconfig.json` — no errors in the files touched.
* `prettier --config prettier.config.mjs --check` — clean on both files.

Two notes on what I could **not** run locally: `test/query/advanced-query.test.ts` and `test/query/table-row-query.test.ts` need the Dockerised Postgres from `test/run-tests.sh`, and Docker isn't available in my environment, so those 43 tests are untouched-but-unverified by me. I also didn't run a full monorepo `npm run build`, since the change is confined to `packages/pg-meta` and I worked from a sparse checkout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected SQL list formatting to remove unwanted spaces before opening parentheses.
  * Improved grouping and spacing when formatting nested arrays into SQL tuples.

* **Tests**
  * Added coverage for nested array formatting with literal and string values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->