### PR TITLE
fix(studio): use redirect({ to }) for internal TanStack redirects

### DIFF
--- a/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
+++ b/apps/studio/components/interfaces/OrganizationInvite/OrganizationInvite.tsx
@@ -194,7 +194,7 @@ export const OrganizationInvite = () => {
           Accept invite
         </Button>
         <Button asChild variant="text" block>
-          <Link href="/projects">Decline</Link>
+          <Link href="/organizations">Decline</Link>
         </Button>
       </div>
     </div>

--- a/apps/studio/routes/__root.tsx
+++ b/apps/studio/routes/__root.tsx
@@ -30,6 +30,7 @@ import {
   Outlet,
   redirect,
   Scripts,
+  type AnyRouter,
 } from '@tanstack/react-router'
 import { TanStackRouterDevtoolsPanel } from '@tanstack/react-router-devtools'
 import {
@@ -76,6 +77,7 @@ import { AuthProvider } from '@/lib/auth'
 import { configureMonacoLoader } from '@/lib/configure-monaco-loader'
 import { API_URL, BASE_PATH, IS_PLATFORM, useDefaultProvider } from '@/lib/constants'
 import { TimezoneProvider, useTimezone } from '@/lib/datetime'
+import { splitInternalUrl } from '@/lib/internal-url'
 // Custom adapter instead of `nuqs/adapters/tanstack-router` — the stock one
 // injects a trailing slash before the query on every nuqs write (see module).
 import { NuqsAdapter } from '@/lib/nuqs-tanstack-adapter'
@@ -330,8 +332,21 @@ export const Route = createRootRouteWithContext<RouterContext>()({
       hash: location.hash,
     })
     if (!match) return
-    const href = BASE_PATH ? `${BASE_PATH}${match.destination}` : match.destination
-    throw redirect({ href, statusCode: match.permanent ? 308 : 307 })
+    // `to`/`search`/`hash`, never `href`: the router treats `href` as an
+    // opaque (external) target, and preloading a Link whose beforeLoad
+    // throws `redirect({ href })` recurses forever — the preload retry
+    // rebuilds the origin location and re-runs this beforeLoad
+    // (https://github.com/TanStack/router/issues/7141). `to` is also
+    // basepath-relative, so no manual BASE_PATH prefix. The explicit
+    // `search`/`hash` fallbacks clear the incoming values rather than
+    // inherit them — `preserveQueryAndHash` already merged what carries over.
+    const { to, search, hash } = splitInternalUrl(match.destination)
+    throw redirect<AnyRouter, string>({
+      to,
+      search: search ?? {},
+      hash: hash ?? '',
+      statusCode: match.permanent ? 308 : 307,
+    })
   },
   component: RootComponent,
   shellComponent: RootDocument,

--- a/apps/studio/routes/index.tsx
+++ b/apps/studio/routes/index.tsx
@@ -16,7 +16,7 @@ export const Route = createFileRoute('/')({
     // keep `projectName`. Only the consumed `next` param is dropped (and only
     // when it matched); everything else passes through.
     const carried = (shouldConsumeNext: boolean) => {
-      const carriedSearch = { ...location.search } as Record<string, unknown>
+      const carriedSearch: Record<string, unknown> = { ...location.search }
       if (shouldConsumeNext) delete carriedSearch.next
       return carriedSearch
     }

--- a/apps/studio/routes/index.tsx
+++ b/apps/studio/routes/index.tsx
@@ -1,7 +1,6 @@
-import { createFileRoute, redirect } from '@tanstack/react-router'
+import { createFileRoute, redirect, type AnyRouter } from '@tanstack/react-router'
 
 import { IS_PLATFORM } from '@/lib/constants'
-import { stringifySearch } from '@/lib/router-search-params'
 
 // `/` is never rendered — it always redirects. Mirrors the Next.js
 // `redirects()` rules in next.config.ts: platform sends users to `/org`
@@ -16,21 +15,30 @@ export const Route = createFileRoute('/')({
     // destination — deep links like `/?next=new-project&projectName=x` must
     // keep `projectName`. Only the consumed `next` param is dropped (and only
     // when it matched); everything else passes through.
-    const suffix = (shouldConsumeNext: boolean) => {
-      const carried = { ...location.search } as Record<string, unknown>
-      if (shouldConsumeNext) delete carried.next
-      return `${stringifySearch(carried)}${location.hash ? `#${location.hash}` : ''}`
+    const carried = (shouldConsumeNext: boolean) => {
+      const carriedSearch = { ...location.search } as Record<string, unknown>
+      if (shouldConsumeNext) delete carriedSearch.next
+      return carriedSearch
     }
-    // `href` instead of `to` because these targets aren't in the TanStack
-    // routeTree yet — they're still on the Next.js pages side during the
-    // migration. Swap to `to` once `/org`, `/new/new-project`, and
-    // `/project/default` are migrated.
+    // `to`, never `href`: preloading a Link whose beforeLoad throws
+    // `redirect({ href })` recurses forever
+    // (https://github.com/TanStack/router/issues/7141). The `<AnyRouter,
+    // string>` type arguments opt out of the registered route tree's strict
+    // typing so the carried free-form search record is accepted.
     if (IS_PLATFORM) {
       if (search.next === 'new-project') {
-        throw redirect({ href: `/new/new-project${suffix(true)}` })
+        throw redirect<AnyRouter, string>({
+          to: '/new/new-project',
+          search: carried(true),
+          hash: location.hash,
+        })
       }
-      throw redirect({ href: `/org${suffix(false)}` })
+      throw redirect<AnyRouter, string>({ to: '/org', search: carried(false), hash: location.hash })
     }
-    throw redirect({ href: `/project/default${suffix(false)}` })
+    throw redirect<AnyRouter, string>({
+      to: '/project/default',
+      search: carried(false),
+      hash: location.hash,
+    })
   },
 })

--- a/apps/studio/tests/components/OrganizationInvite.test.tsx
+++ b/apps/studio/tests/components/OrganizationInvite.test.tsx
@@ -156,7 +156,7 @@ describe('OrganizationInvite', () => {
     expect(screen.getByText('Signed in as')).toBeInTheDocument()
     expect(screen.getByText('jane@acmecorp.io')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Accept invite' })).toBeInTheDocument()
-    expect(screen.getByRole('link', { name: 'Decline' })).toHaveAttribute('href', '/projects')
+    expect(screen.getByRole('link', { name: 'Decline' })).toHaveAttribute('href', '/organizations')
   })
 
   test('accepts an invite with the current slug and token', async () => {


### PR DESCRIPTION
Hover-preloading any link that points at a redirecting path (e.g. the org invite "Decline" link to `/projects`) hung the tab under the TanStack runtime: `redirect({ href })` is treated as an opaque external target, and the router's preload retry ignores `href` when rebuilding the location, so it re-runs the same `beforeLoad`, throws the same redirect, and recurses forever (TanStack/router#7141 — internal targets must use `to`).

**Changed:**

- `routes/__root.tsx` — the redirect-table `beforeLoad` splits the destination with `splitInternalUrl()` and throws `redirect({ to, search, hash, statusCode })` instead of `redirect({ href })`. `to` is basepath-relative, so the manual `BASE_PATH` prefix goes away too.
- `routes/index.tsx` — same `href` → `to`/`search`/`hash` switch for the `/` redirects; the "targets aren't in the routeTree yet" comment was stale (all three destinations resolve to real routes now).
- `OrganizationInvite.tsx` — "Decline" links straight to `/organizations`, skipping the `/projects` redirect hop entirely.

## To test

- On the TanStack runtime, hover (don't click) a link to a redirecting path — e.g. the auth overview's "Go to observability" link (`/project/:ref/reports/auth`) or the 404 page's `/projects` link. The page must stay responsive (this hung before).
- `/projects` → `/organizations` (307), `/project/:ref/database` → `/database/tables` (308), `/` → `/org`.
- Query/hash semantics still hold: `/?next=new-project&projectName=x` → `/new/new-project?projectName=x`; `/project/:ref/database/wrappers?foo=bar` → `/integrations?category=wrapper&foo=bar`; `/org/:slug/invoices#other` → `/org/:slug/billing#invoices`.
- Chained redirects stay bounded: `/project/:ref/database/linter` → `/advisors/security` in two hops.

All of the above verified locally via Playwright against the TanStack dev server; `redirects.shared` / `internal-url` / compat-router unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the invitation “Decline” action to route users to the Organizations page instead of the Projects page.
  - Improved Studio redirect/navigation handling by correctly preserving URL search parameters and hash fragments and routing to the intended destination.
- **Tests**
  - Updated Organization Invite test expectations to reflect the corrected “Decline” link destination.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->