### PR TITLE
show Vercel connection errors inline

### DIFF
--- a/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/ProjectLinker.tsx
@@ -8,6 +8,7 @@ import {
   SupabaseProjectSelector,
 } from './ProjectLinkerComponents'
 import { Project, ProjectLinkerProps } from './VercelGithub.types'
+import { InterstitialActionError } from '@/components/layouts/InterstitialLayout'
 import ShimmerLine from '@/components/ui/ShimmerLine'
 import { useOrgProjectsInfiniteQuery } from '@/data/projects/org-projects-infinite-query'
 import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganization'
@@ -31,6 +32,8 @@ export const ProjectLinker = ({
   defaultForeignProjectId,
   mode,
   variant = 'default',
+  actionError,
+  onSelectionChange,
 }: ProjectLinkerProps) => {
   const [openProjectsDropdown, setOpenProjectsDropdown] = useState(false)
   const [openForeignProjectsComboBox, setOpenForeignProjectsComboBox] = useState(false)
@@ -38,6 +41,7 @@ export const ProjectLinker = ({
     defaultForeignProjectId
   )
   const [selectedSupabaseProject, setSelectedSupabaseProject] = useState<Project>()
+  const [validationError, setValidationError] = useState<string>()
 
   const { data: selectedOrganization } = useSelectedOrganizationQuery()
   const { data: orgProjects, isPending: loadingSupabaseProjects } = useOrgProjectsInfiniteQuery({
@@ -60,11 +64,15 @@ export const ProjectLinker = ({
 
     const alreadyInstalled = flatInstalledConnectionsIds.has(foreignProjectId ?? '')
     if (alreadyInstalled) {
-      return toast.error(
-        `Unable to connect to ${selectedForeignProject.name}: Selected repository already has an installed connection to a project`
-      )
+      const message = `Unable to connect to ${selectedForeignProject.name}: Selected repository already has an installed connection to a project`
+      if (variant === 'interstitial') {
+        setValidationError(message)
+        return
+      }
+      return toast.error(message)
     }
 
+    setValidationError(undefined)
     _onCreateConnections({
       organizationIntegrationId: organizationIntegrationId!,
       connection: {
@@ -95,6 +103,17 @@ export const ProjectLinker = ({
     isLoading ||
     !selectedSupabaseProject ||
     !selectedForeignProject
+  const displayedActionError = actionError ?? validationError
+  const setForeignProjectSelection: typeof setForeignProjectId = (value) => {
+    setForeignProjectId(value)
+    setValidationError(undefined)
+    onSelectionChange?.()
+  }
+  const setSupabaseProjectSelection: typeof setSelectedSupabaseProject = (value) => {
+    setSelectedSupabaseProject(value)
+    setValidationError(undefined)
+    onSelectionChange?.()
+  }
 
   useEffect(() => {
     if (defaultSupabaseProject !== undefined && selectedSupabaseProject === undefined)
@@ -134,7 +153,7 @@ export const ProjectLinker = ({
                 selectedSupabaseProject={selectedSupabaseProject}
                 loadingSupabaseProjects={loadingSupabaseProjects}
                 setOpen={setOpenProjectsDropdown}
-                setSelectedSupabaseProject={setSelectedSupabaseProject}
+                setSelectedSupabaseProject={setSupabaseProjectSelection}
               />
             </section>
 
@@ -151,7 +170,7 @@ export const ProjectLinker = ({
                 loadingForeignProjects={loadingForeignProjects}
                 foreignProjects={foreignProjects}
                 integrationIcon={integrationIcon}
-                setForeignProjectId={setForeignProjectId}
+                setForeignProjectId={setForeignProjectSelection}
                 onOpenChange={setOpenForeignProjectsComboBox}
                 getForeignProjectIcon={getForeignProjectIcon}
               />
@@ -159,17 +178,20 @@ export const ProjectLinker = ({
           </>
         )}
 
-        <ActionButtons
-          slug={slug}
-          mode={mode}
-          variant={variant}
-          showCreateProject={showNoEntitiesState && noSupabaseProjects}
-          connectDisabled={connectDisabled}
-          foreignProjectId={foreignProjectId}
-          isLoading={isLoading}
-          onCreateConnections={onCreateConnections}
-          onSkip={onSkip}
-        />
+        <div className="flex flex-col gap-2">
+          <ActionButtons
+            slug={slug}
+            mode={mode}
+            variant={variant}
+            showCreateProject={showNoEntitiesState && noSupabaseProjects}
+            connectDisabled={connectDisabled}
+            foreignProjectId={foreignProjectId}
+            isLoading={isLoading}
+            onCreateConnections={onCreateConnections}
+            onSkip={onSkip}
+          />
+          <InterstitialActionError error={displayedActionError} />
+        </div>
       </div>
     )
   }
@@ -216,7 +238,7 @@ export const ProjectLinker = ({
                 selectedSupabaseProject={selectedSupabaseProject}
                 loadingSupabaseProjects={loadingSupabaseProjects}
                 setOpen={setOpenProjectsDropdown}
-                setSelectedSupabaseProject={setSelectedSupabaseProject}
+                setSelectedSupabaseProject={setSupabaseProjectSelection}
               />
             </Panel>
 
@@ -236,7 +258,7 @@ export const ProjectLinker = ({
                 loadingForeignProjects={loadingForeignProjects}
                 foreignProjects={foreignProjects}
                 integrationIcon={integrationIcon}
-                setForeignProjectId={setForeignProjectId}
+                setForeignProjectId={setForeignProjectSelection}
                 onOpenChange={setOpenForeignProjectsComboBox}
                 getForeignProjectIcon={getForeignProjectIcon}
               />

--- a/apps/studio/components/interfaces/Integrations/VercelGithub/VercelGithub.types.ts
+++ b/apps/studio/components/interfaces/Integrations/VercelGithub/VercelGithub.types.ts
@@ -33,4 +33,6 @@ export interface ProjectLinkerProps {
   defaultForeignProjectId?: string
   mode: 'Vercel' | 'GitHub'
   variant?: 'default' | 'interstitial'
+  actionError?: string
+  onSelectionChange?: () => void
 }

--- a/apps/studio/components/interfaces/Organization/IntegrationSettings/SidePanelVercelProjectLinker.tsx
+++ b/apps/studio/components/interfaces/Organization/IntegrationSettings/SidePanelVercelProjectLinker.tsx
@@ -16,6 +16,7 @@ import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { BASE_PATH } from '@/lib/constants'
 import { EMPTY_ARR } from '@/lib/void'
 import { useSidePanelsStateSnapshot } from '@/state/side-panels'
+import type { ResponseError } from '@/types'
 
 const VERCEL_ICON = (
   <svg xmlns="http://www.w3.org/2000/svg" fill="white" viewBox="0 0 512 512" className="w-6">
@@ -81,6 +82,9 @@ export const SidePanelVercelProjectLinker = () => {
         }
 
         sidePanelStateSnapshot.setVercelConnectionsOpen(false)
+      },
+      onError(error: ResponseError) {
+        toast.error(`Failed to create connection: ${error.message}`)
       },
     })
 

--- a/apps/studio/data/integrations/integrations-vercel-connections-create-mutation.ts
+++ b/apps/studio/data/integrations/integrations-vercel-connections-create-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import type { IntegrationConnectionsCreateVariables } from './integrations.types'
 import { integrationKeys } from './keys'
@@ -67,11 +66,7 @@ export const useIntegrationVercelConnectionsCreateMutation = ({
     },
     async onError(data, variables, context) {
       snapshot.setLoading(false)
-      if (onError === undefined) {
-        toast.error(`Failed to create connection: ${data.message}`)
-      } else {
-        onError(data, variables, context)
-      }
+      await onError?.(data, variables, context)
     },
     ...options,
   })

--- a/apps/studio/data/integrations/vercel-integration-create-mutation.ts
+++ b/apps/studio/data/integrations/vercel-integration-create-mutation.ts
@@ -1,5 +1,4 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
-import { toast } from 'sonner'
 
 import { integrationKeys } from './keys'
 import { handleError, post } from '@/data/fetchers'
@@ -69,11 +68,7 @@ export const useVercelIntegrationCreateMutation = ({
       await onSuccess?.(data, variables, context)
     },
     async onError(data, variables, context) {
-      if (onError === undefined) {
-        toast.error(`Failed to create Vercel integration: ${data.message}`)
-      } else {
-        onError(data, variables, context)
-      }
+      await onError?.(data, variables, context)
     },
     ...options,
   })

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -1,6 +1,7 @@
 import { useParams } from 'common'
 import Head from 'next/head'
 import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
 
 import { isVercelUrl } from '@/components/interfaces/Integrations/Vercel/VercelIntegration.utils'
 import {
@@ -54,7 +55,11 @@ const VercelIntegration: NextPageWithLayout = () => {
     }
   )
 
-  const { mutateAsync: createConnections } = useIntegrationVercelConnectionsCreateMutation()
+  const { mutateAsync: createConnections } = useIntegrationVercelConnectionsCreateMutation({
+    onError(error) {
+      toast.error(`Failed to create connection: ${error.message}`)
+    },
+  })
 
   useEffect(() => {
     if (!isSuccess) return

--- a/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
@@ -115,9 +115,6 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
     onMutate() {
       snapshot.setLoading(true)
     },
-    onError() {
-      snapshot.setLoading(false)
-    },
   })
   const actionError = createConnectionsError
     ? `Creating connection failed: ${createConnectionsError.message}`

--- a/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/marketplace/choose-project.tsx
@@ -2,7 +2,6 @@ import { useParams } from 'common'
 import { keyBy } from 'lodash'
 import Head from 'next/head'
 import { useCallback, useMemo } from 'react'
-import { toast } from 'sonner'
 import { Card, CardContent } from 'ui'
 import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
@@ -101,25 +100,32 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
 
   const snapshot = useIntegrationInstallationSnapshot()
 
-  const { mutate: createConnections, isPending: isCreatingConnection } =
-    useIntegrationVercelConnectionsCreateMutation({
-      onSuccess() {
-        if (next && isVercelUrl(next)) {
-          snapshot.setLoading(false)
-          window.location.href = next
-        }
-      },
-      onMutate() {
-        snapshot.setLoading(true)
-      },
-      onError(error) {
+  const {
+    mutate: createConnections,
+    isPending: isCreatingConnection,
+    error: createConnectionsError,
+    reset: resetCreateConnectionsError,
+  } = useIntegrationVercelConnectionsCreateMutation({
+    onSuccess() {
+      if (next && isVercelUrl(next)) {
         snapshot.setLoading(false)
-        toast.error(`Creating connection failed: ${error.message}`)
-      },
-    })
+        window.location.href = next
+      }
+    },
+    onMutate() {
+      snapshot.setLoading(true)
+    },
+    onError() {
+      snapshot.setLoading(false)
+    },
+  })
+  const actionError = createConnectionsError
+    ? `Creating connection failed: ${createConnectionsError.message}`
+    : undefined
 
   const onCreateConnections = useCallback(
     (vars: Parameters<typeof createConnections>[0]) => {
+      resetCreateConnectionsError()
       createConnections({
         ...vars,
         connection: {
@@ -135,7 +141,7 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
         },
       })
     },
-    [createConnections]
+    [createConnections, resetCreateConnectionsError]
   )
 
   const showLoadingState =
@@ -212,6 +218,8 @@ const VercelChooseProjectPage: NextPageWithLayout = () => {
                 }
                 loadingForeignProjects={isLoadingVercelProjectsData}
                 mode="Vercel"
+                actionError={actionError}
+                onSelectionChange={resetCreateConnectionsError}
               />
             </div>
           )}

--- a/apps/studio/pages/integrations/vercel/install.tsx
+++ b/apps/studio/pages/integrations/vercel/install.tsx
@@ -3,7 +3,6 @@ import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useEffect, useMemo, useState } from 'react'
-import { toast } from 'sonner'
 import {
   Badge,
   Button,
@@ -24,7 +23,11 @@ import {
   VercelIntegrationLogo,
 } from '@/components/interfaces/Integrations/Vercel/VercelIntegrationInterstitial'
 import { getHasInstalledObject } from '@/components/layouts/IntegrationsLayout/Integrations.utils'
-import { InterstitialAccountRow, InterstitialLayout } from '@/components/layouts/InterstitialLayout'
+import {
+  InterstitialAccountRow,
+  InterstitialActionError,
+  InterstitialLayout,
+} from '@/components/layouts/InterstitialLayout'
 import { useIntegrationsQuery } from '@/data/integrations/integrations-query'
 import { useVercelIntegrationCreateMutation } from '@/data/integrations/vercel-integration-create-mutation'
 import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
@@ -62,6 +65,7 @@ const VercelIntegration: NextPageWithLayout = () => {
   const { code, configurationId, currentProjectId, externalId, next, teamId, source } = useParams()
 
   const [selectedOrg, setSelectedOrg] = useState<Organization | null>(null)
+  const [validationError, setValidationError] = useState<string>()
 
   const { username, primaryEmail, avatarUrl } = useProfileNameAndPicture()
   const displayName = primaryEmail ?? username ?? ''
@@ -146,46 +150,56 @@ const VercelIntegration: NextPageWithLayout = () => {
         break
       }
       default:
-        toast.error(
+        setValidationError(
           `Unsupported Vercel installation source: ${source}. Please contact support if this error persists.`
         )
     }
   }
 
-  const { mutate, isPending: isLoadingVercelIntegrationCreateMutation } =
-    useVercelIntegrationCreateMutation({
-      onMutate() {
-        snapshot.setLoading(true)
-      },
-      onSuccess() {
-        handleRouteChange()
-        snapshot.setLoading(false)
-      },
-      onError(error) {
-        snapshot.setLoading(false)
-        toast.error(`Creating Vercel integration failed: ${error.message}`)
-      },
-    })
+  const {
+    mutate,
+    isPending: isLoadingVercelIntegrationCreateMutation,
+    error: createIntegrationError,
+    reset: resetCreateIntegrationError,
+  } = useVercelIntegrationCreateMutation({
+    onMutate() {
+      snapshot.setLoading(true)
+    },
+    onSuccess() {
+      handleRouteChange()
+      snapshot.setLoading(false)
+    },
+    onError() {
+      snapshot.setLoading(false)
+    },
+  })
+  const actionError =
+    validationError ??
+    (createIntegrationError
+      ? `Creating Vercel integration failed: ${createIntegrationError.message}`
+      : undefined)
 
   function onInstall() {
+    setValidationError(undefined)
+    resetCreateIntegrationError()
     const orgSlug = selectedOrg?.slug
 
     const isIntegrationInstalled = orgSlug ? installed[orgSlug] : false
 
     if (!orgSlug) {
-      return toast.error('Please select an organization')
+      return setValidationError('Please select an organization')
     }
 
     if (!code) {
-      return toast.error('Vercel code missing')
+      return setValidationError('Vercel code missing')
     }
 
     if (!configurationId) {
-      return toast.error('Vercel Configuration ID missing')
+      return setValidationError('Vercel configuration ID missing')
     }
 
     if (!source) {
-      return toast.error('Vercel Configuration source missing')
+      return setValidationError('Vercel configuration source missing')
     }
 
     /**
@@ -271,7 +285,11 @@ const VercelIntegration: NextPageWithLayout = () => {
                 selectedOrg={selectedOrg}
                 disabled={noOrganizations || dataLoading}
                 installed={installed}
-                onSelectedOrgChange={setSelectedOrg}
+                onSelectedOrgChange={(organization) => {
+                  setSelectedOrg(organization)
+                  setValidationError(undefined)
+                  resetCreateIntegrationError()
+                }}
               />
 
               {missingParams.length > 0 && (
@@ -311,6 +329,7 @@ const VercelIntegration: NextPageWithLayout = () => {
                 >
                   {selectedOrg && installed[selectedOrg.slug] ? 'Continue' : 'Install integration'}
                 </Button>
+                <InterstitialActionError error={actionError} />
               </div>
             </div>
           )}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

Vercel install and project-link failures use transient toasts.

## What is the new behavior?

Failures remain visible below the relevant action and clear when the user retries or changes a selection.

The Vercel mutation hooks expose errors without choosing their presentation. Interstitial callers render them inline, while existing non-interstitial callers explicitly retain their toasts.

| Before | After |
| --- | --- |
| <img width="1024" height="759" alt="Install Vercel Integration  Supabase" src="https://github.com/user-attachments/assets/6348cdd2-220a-4ad8-89f9-7fc51de36a3c" /> | <img width="1024" height="759" alt="Install Vercel Integration  Supabase" src="https://github.com/user-attachments/assets/ecc50c4e-daab-4f6d-bf86-7282e2aff92c" /> |

## To test

1. Switch to `dnywh/inline-vercel-errors` (this branch).
2. Open `apps/studio/pages/integrations/vercel/install.tsx`.
3. Find the `actionError` assignment immediately below `useVercelIntegrationCreateMutation` and replace the whole assignment with:
   ```tsx
   const actionError = 'Creating Vercel integration failed: Test error'
   ```
4. With local Studio running and while signed in, open `http://localhost:8082/integrations/vercel/install?code=test&configurationId=test&source=marketplace`
5. Confirm the error remains visible below **Install integration**. No Vercel installation or real authorisation code is required.
6. Revert the temporary edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved error handling across Vercel project connection and installation flows.
* Validation, duplicate-connection, and connection failures now appear inline in the relevant setup steps.
* Errors clear automatically when the selected project or organization changes.
* Notifications remain available in supported flows, including new project creation and side-panel setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->