### PR TITLE
recover failed Vercel deploy connections

### DIFF
--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -410,7 +410,7 @@ export const ProjectCreationForm = ({
 
     if (customPostgresVersion && !customPostgresVersion.match(/1[2-9]\..*/)) {
       const message =
-        'Invalid Postgres version. It should start with a number between 12–19, a dot, and additional characters, for example 15.2 or 15.2.0-3.'
+        'Invalid Postgres version, should start with a number between 12-19, a dot and additional characters, i.e. 15.2 or 15.2.0-3'
       if (isVercelIntegrationFlow) {
         setProjectCreationError(message)
         return
@@ -419,7 +419,7 @@ export const ProjectCreationForm = ({
     }
 
     if (useOrioleDb && !availableOrioleVersion) {
-      const message = 'No available OrioleDB image found. Only Postgres is available.'
+      const message = 'No available OrioleDB image found, only Postgres is available'
       if (isVercelIntegrationFlow) {
         setProjectCreationError(message)
         trackFunnelError(

--- a/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
+++ b/apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx
@@ -150,6 +150,7 @@ export const ProjectCreationForm = ({
   const [allProjects, setAllProjects] = useState<OrgProject[] | undefined>(undefined)
   const [isComputeCostsConfirmationModalVisible, setIsComputeCostsConfirmationModalVisible] =
     useState(false)
+  const [projectCreationError, setProjectCreationError] = useState<string>()
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
@@ -327,6 +328,7 @@ export const ProjectCreationForm = ({
     isSuccess: isSuccessNewProject,
   } = useProjectCreateMutation({
     onSuccess: (res) => {
+      setProjectCreationError(undefined)
       track(
         'project_creation_simple_version_submitted',
         {
@@ -349,6 +351,11 @@ export const ProjectCreationForm = ({
       if (surface === 'main') router.push(`/project/${res.ref}`)
     },
     onError: (error) => {
+      if (isVercelIntegrationFlow) {
+        setProjectCreationError(`Failed to create new project: ${error.message}`)
+        trackFunnelError('project_creation', classifyApiError('project_creation', error), 'form')
+        return
+      }
       const toastId = toast.error(`Failed to create new project: ${error.message}`)
       trackFunnelError(
         'project_creation',
@@ -376,6 +383,7 @@ export const ProjectCreationForm = ({
 
   const onSubmit = async (values: z.infer<typeof FormSchema>) => {
     if (!currentOrg) return console.error('Unable to retrieve current organization')
+    setProjectCreationError(undefined)
 
     const {
       cloudProvider,
@@ -401,13 +409,27 @@ export const ProjectCreationForm = ({
     const customPostgresVersion = highAvailability ? undefined : postgresVersion
 
     if (customPostgresVersion && !customPostgresVersion.match(/1[2-9]\..*/)) {
-      return toast.error(
-        `Invalid Postgres version, should start with a number between 12-19, a dot and additional characters, i.e. 15.2 or 15.2.0-3`
-      )
+      const message =
+        'Invalid Postgres version. It should start with a number between 12–19, a dot, and additional characters, for example 15.2 or 15.2.0-3.'
+      if (isVercelIntegrationFlow) {
+        setProjectCreationError(message)
+        return
+      }
+      return toast.error(message)
     }
 
     if (useOrioleDb && !availableOrioleVersion) {
-      const toastId = toast.error('No available OrioleDB image found, only Postgres is available')
+      const message = 'No available OrioleDB image found. Only Postgres is available.'
+      if (isVercelIntegrationFlow) {
+        setProjectCreationError(message)
+        trackFunnelError(
+          'project_creation',
+          { errorCategory: 'validation', errorReason: 'oriole_unavailable' },
+          'form'
+        )
+        return
+      }
+      const toastId = toast.error(message)
       trackFunnelError(
         'project_creation',
         { errorCategory: 'validation', errorReason: 'oriole_unavailable' },
@@ -753,6 +775,13 @@ export const ProjectCreationForm = ({
                   </Panel.Content>
                 ) : null}
               </div>
+            )}
+            {projectCreationError && (
+              <Panel.Content>
+                <p role="alert" className="text-sm text-destructive">
+                  {projectCreationError}
+                </p>
+              </Panel.Content>
             )}
           </>
         </Panel>

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -121,6 +121,64 @@ const VercelIntegration: NextPageWithLayout = () => {
     }
   }, [connectProject, connectionError, isConnecting, isConnectionComplete, isSuccess])
 
+  const renderContent = () => {
+    if (newProjectRef === undefined) {
+      return <ProjectCreationForm isVercelIntegrationFlow onCreateSuccess={setNewProjectRef} />
+    }
+
+    if (isProjectSettingsError) {
+      return (
+        <VercelConnectionError
+          projectRef={newProjectRef}
+          message={
+            projectSettingsError?.message ?? 'Unable to check whether the project is ready.'
+          }
+          onRetry={() => void refetchProjectSettings()}
+        />
+      )
+    }
+
+    if (connectionError) {
+      return (
+        <VercelConnectionError
+          projectRef={newProjectRef}
+          message={connectionError}
+          onRetry={() => void connectProject()}
+        />
+      )
+    }
+
+    if (isConnectionComplete) {
+      return (
+        <div className="px-6 pb-6">
+          <div className="flex flex-col gap-3">
+            <Admonition
+              type="success"
+              title="Project connected"
+              description="Your Supabase project is connected to Vercel."
+            />
+            <Button asChild variant="primary" block>
+              <Link href={`/project/${newProjectRef}`}>Open project</Link>
+            </Button>
+          </div>
+        </div>
+      )
+    }
+
+    return (
+      <div className="px-6 pb-6">
+        <div className="space-y-3" role="status">
+          <p className="text-sm text-foreground-light">
+            {isConnecting
+              ? 'Connecting your project to Vercel'
+              : 'Waiting for your project to be ready'}
+          </p>
+          <ShimmeringLoader className="h-2 w-full rounded-full py-0" />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <>
       <Head>
@@ -134,47 +192,7 @@ const VercelIntegration: NextPageWithLayout = () => {
         footer={<VercelIntegrationFooter />}
         widthClassName="max-w-2xl"
       >
-        {newProjectRef === undefined ? (
-          <ProjectCreationForm isVercelIntegrationFlow onCreateSuccess={setNewProjectRef} />
-        ) : isProjectSettingsError ? (
-          <VercelConnectionError
-            projectRef={newProjectRef}
-            message={
-              projectSettingsError?.message ?? 'Unable to check whether the project is ready.'
-            }
-            onRetry={() => void refetchProjectSettings()}
-          />
-        ) : connectionError ? (
-          <VercelConnectionError
-            projectRef={newProjectRef}
-            message={connectionError}
-            onRetry={() => void connectProject()}
-          />
-        ) : (
-          <div className="px-6 pb-6">
-            {isConnectionComplete ? (
-              <div className="flex flex-col gap-3">
-                <Admonition
-                  type="success"
-                  title="Project connected"
-                  description="Your Supabase project is connected to Vercel."
-                />
-                <Button asChild variant="primary" block>
-                  <Link href={`/project/${newProjectRef}`}>Open project</Link>
-                </Button>
-              </div>
-            ) : (
-              <div className="space-y-3" role="status">
-                <p className="text-sm text-foreground-light">
-                  {isConnecting
-                    ? 'Connecting your project to Vercel'
-                    : 'Waiting for your project to be ready'}
-                </p>
-                <ShimmeringLoader className="h-2 w-full rounded-full py-0" />
-              </div>
-            )}
-          </div>
-        )}
+        {renderContent()}
       </InterstitialLayout>
     </>
   )

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -130,9 +130,7 @@ const VercelIntegration: NextPageWithLayout = () => {
       return (
         <VercelConnectionError
           projectRef={newProjectRef}
-          message={
-            projectSettingsError?.message ?? 'Unable to check whether the project is ready.'
-          }
+          message={projectSettingsError?.message ?? 'Unable to check whether the project is ready.'}
           onRetry={() => void refetchProjectSettings()}
         />
       )

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -140,23 +140,23 @@ const VercelIntegration: NextPageWithLayout = () => {
       >
         {newProjectRef === undefined ? (
           <ProjectCreationForm isVercelIntegrationFlow onCreateSuccess={setNewProjectRef} />
+        ) : isProjectSettingsError ? (
+          <VercelConnectionError
+            projectRef={newProjectRef}
+            message={
+              projectSettingsError?.message ?? 'Unable to check whether the project is ready.'
+            }
+            onRetry={() => void refetchProjectSettings()}
+          />
+        ) : connectionError ? (
+          <VercelConnectionError
+            projectRef={newProjectRef}
+            message={connectionError}
+            onRetry={() => void connectProject()}
+          />
         ) : (
           <div className="px-6 pb-6">
-            {isProjectSettingsError ? (
-              <VercelConnectionError
-                projectRef={newProjectRef}
-                message={
-                  projectSettingsError?.message ?? 'Unable to check whether the project is ready.'
-                }
-                onRetry={() => void refetchProjectSettings()}
-              />
-            ) : connectionError ? (
-              <VercelConnectionError
-                projectRef={newProjectRef}
-                message={connectionError}
-                onRetry={() => void connectProject()}
-              />
-            ) : isConnectionComplete ? (
+            {isConnectionComplete ? (
               <div className="flex flex-col gap-3">
                 <Admonition
                   type="success"
@@ -194,18 +194,20 @@ export function VercelConnectionError({
   onRetry: () => void
 }) {
   return (
-    <div className="flex flex-col gap-3">
-      <Admonition
-        type="danger"
-        title="Supabase project created but Vercel connection failed"
-        description={`Error: ${message}`}
-      />
-      <Button variant="primary" block onClick={onRetry}>
-        Retry connection
-      </Button>
-      <Button asChild variant="text" block>
-        <Link href={`/project/${projectRef}`}>Open project</Link>
-      </Button>
+    <div>
+      <div className="px-6 pb-6">
+        <Admonition
+          type="danger"
+          title="Unable to connect to Vercel"
+          description={`Your Supabase project was created. Error: ${message}`}
+        />
+      </div>
+      <div className="flex h-12 items-center justify-end gap-x-2 border-t border-default bg-surface-100 px-card">
+        <Button asChild variant="default">
+          <Link href={`/project/${projectRef}`}>Open project</Link>
+        </Button>
+        <Button onClick={onRetry}>Retry connection</Button>
+      </div>
     </div>
   )
 }

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -199,7 +199,7 @@ export function VercelConnectionError({
         <Admonition
           type="danger"
           title="Unable to connect to Vercel"
-          description={`Your Supabase project was created. Error: ${message}`}
+          description={`Your Supabase project was still created. Error: ${message}`}
         />
       </div>
       <div className="flex h-12 items-center justify-end gap-x-2 border-t border-default bg-surface-100 px-card">

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -1,7 +1,10 @@
 import { useParams } from 'common'
 import Head from 'next/head'
-import { useEffect, useState } from 'react'
-import { toast } from 'sonner'
+import Link from 'next/link'
+import { useCallback, useEffect, useState } from 'react'
+import { Button } from 'ui'
+import { Admonition } from 'ui-patterns/Admonition'
+import { ShimmeringLoader } from 'ui-patterns/ShimmeringLoader'
 
 import { isVercelUrl } from '@/components/interfaces/Integrations/Vercel/VercelIntegration.utils'
 import {
@@ -30,6 +33,9 @@ const VercelIntegration: NextPageWithLayout = () => {
   const snapshot = useIntegrationInstallationSnapshot()
 
   const [newProjectRef, setNewProjectRef] = useState<string>()
+  const [connectionError, setConnectionError] = useState<string>()
+  const [isConnecting, setIsConnecting] = useState(false)
+  const [isConnectionComplete, setIsConnectionComplete] = useState(false)
 
   const { data: integrationData } = useIntegrationsQuery()
   const organizationIntegration = integrationData?.find((x) => x.organization.slug === slug)
@@ -43,7 +49,13 @@ const VercelIntegration: NextPageWithLayout = () => {
   )
 
   // Wait for the new project to be created before creating the connection
-  const { data, isSuccess } = useProjectSettingsV2Query(
+  const {
+    data,
+    isSuccess,
+    isError: isProjectSettingsError,
+    error: projectSettingsError,
+    refetch: refetchProjectSettings,
+  } = useProjectSettingsV2Query(
     { projectRef: newProjectRef },
     {
       enabled: newProjectRef !== undefined,
@@ -55,55 +67,63 @@ const VercelIntegration: NextPageWithLayout = () => {
     }
   )
 
-  const { mutateAsync: createConnections } = useIntegrationVercelConnectionsCreateMutation({
-    onError(error) {
-      toast.error(`Failed to create connection: ${error.message}`)
-    },
-  })
+  const { mutateAsync: createConnections } = useIntegrationVercelConnectionsCreateMutation()
 
-  useEffect(() => {
-    if (!isSuccess) return
+  const connectProject = useCallback(async () => {
+    const isReady = (data?.service_api_keys ?? []).length > 0
 
-    const onSuccessFunc = async () => {
-      const isReady = (data.service_api_keys ?? []).length > 0
+    if (!isReady || !organizationIntegration || !foreignProjectId || !newProjectRef) {
+      return
+    }
 
-      if (!isReady || !organizationIntegration || !foreignProjectId || !newProjectRef) {
-        return
-      }
+    const projectDetails = vercelProjects?.find((x) => x.id === foreignProjectId)
+    setConnectionError(undefined)
+    setIsConnecting(true)
 
-      const projectDetails = vercelProjects?.find((x) => x.id === foreignProjectId)
-
-      try {
-        await createConnections({
-          organizationIntegrationId: organizationIntegration?.id,
-          connection: {
-            foreign_project_id: foreignProjectId,
-            supabase_project_ref: newProjectRef,
-            integration_id: '0',
-            metadata: {
-              ...projectDetails,
-              supabaseConfig: {
-                projectEnvVars: {
-                  write: true,
-                },
+    try {
+      await createConnections({
+        organizationIntegrationId: organizationIntegration.id,
+        connection: {
+          foreign_project_id: foreignProjectId,
+          supabase_project_ref: newProjectRef,
+          integration_id: '0',
+          metadata: {
+            ...projectDetails,
+            supabaseConfig: {
+              projectEnvVars: {
+                write: true,
               },
             },
           },
-          orgSlug: organization?.slug,
-        })
-      } catch (error) {
-        console.error('An error occurred during createConnections:', error)
-        return
-      }
-
+        },
+        orgSlug: organization?.slug,
+      })
       snapshot.setLoading(false)
-
+      setIsConnectionComplete(true)
       if (next && isVercelUrl(next)) window.location.href = next
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'An unknown error occurred'
+      setConnectionError(message)
+    } finally {
+      setIsConnecting(false)
     }
+  }, [
+    createConnections,
+    data?.service_api_keys,
+    foreignProjectId,
+    newProjectRef,
+    next,
+    organization?.slug,
+    organizationIntegration,
+    snapshot,
+    vercelProjects,
+  ])
 
-    onSuccessFunc()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, isSuccess])
+  useEffect(() => {
+    if (isSuccess && !connectionError && !isConnecting && !isConnectionComplete) {
+      void connectProject()
+    }
+  }, [connectProject, connectionError, isConnecting, isConnectionComplete, isSuccess])
 
   return (
     <>
@@ -118,9 +138,80 @@ const VercelIntegration: NextPageWithLayout = () => {
         footer={<VercelIntegrationFooter />}
         widthClassName="max-w-2xl"
       >
-        <ProjectCreationForm isVercelIntegrationFlow onCreateSuccess={setNewProjectRef} />
+        {newProjectRef === undefined ? (
+          <ProjectCreationForm isVercelIntegrationFlow onCreateSuccess={setNewProjectRef} />
+        ) : (
+          <div className="px-6 pb-6">
+            {isProjectSettingsError ? (
+              <VercelConnectionError
+                projectRef={newProjectRef}
+                message={
+                  projectSettingsError?.message ?? 'Unable to check whether the project is ready.'
+                }
+                onRetry={() => void refetchProjectSettings()}
+              />
+            ) : connectionError ? (
+              <VercelConnectionError
+                projectRef={newProjectRef}
+                message={connectionError}
+                onRetry={() => void connectProject()}
+              />
+            ) : isConnectionComplete ? (
+              <div className="flex flex-col gap-3">
+                <Admonition
+                  type="success"
+                  title="Project connected"
+                  description="Your Supabase project is connected to Vercel."
+                />
+                <Button asChild variant="primary" block>
+                  <Link href={`/project/${newProjectRef}`}>Open project</Link>
+                </Button>
+              </div>
+            ) : (
+              <div className="space-y-3" role="status">
+                <p className="text-sm text-foreground-light">
+                  {isConnecting
+                    ? 'Connecting your project to Vercel'
+                    : 'Waiting for your project to be ready'}
+                </p>
+                <ShimmeringLoader className="h-2 w-full rounded-full py-0" />
+              </div>
+            )}
+          </div>
+        )}
       </InterstitialLayout>
     </>
+  )
+}
+
+export function VercelConnectionError({
+  projectRef,
+  message,
+  onRetry,
+}: {
+  projectRef: string
+  message: string
+  onRetry: () => void
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <Admonition
+        type="danger"
+        title="Project created, connection failed"
+        description={
+          <>
+            Your Supabase project was created, but it could not be connected to Vercel.
+            <span className="mt-1 block text-foreground-lighter">Error: {message}</span>
+          </>
+        }
+      />
+      <Button variant="primary" block onClick={onRetry}>
+        Retry connection
+      </Button>
+      <Button asChild variant="text" block>
+        <Link href={`/project/${projectRef}`}>Open project</Link>
+      </Button>
+    </div>
   )
 }
 

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -17,7 +17,6 @@ import { useProjectSettingsV2Query } from '@/data/config/project-settings-v2-que
 import { useIntegrationsQuery } from '@/data/integrations/integrations-query'
 import { useIntegrationVercelConnectionsCreateMutation } from '@/data/integrations/integrations-vercel-connections-create-mutation'
 import { useVercelProjectsQuery } from '@/data/integrations/integrations-vercel-projects-query'
-import { useOrganizationsQuery } from '@/data/organizations/organizations-query'
 import { withAuth } from '@/hooks/misc/withAuth'
 import { buildStudioPageTitle } from '@/lib/page-title'
 import { useIntegrationInstallationSnapshot } from '@/state/integration-installation'
@@ -39,9 +38,6 @@ const VercelIntegration: NextPageWithLayout = () => {
 
   const { data: integrationData } = useIntegrationsQuery()
   const organizationIntegration = integrationData?.find((x) => x.organization.slug === slug)
-
-  const { data: organizationData } = useOrganizationsQuery()
-  const organization = organizationData?.find((x) => x.slug === slug)
 
   const { data: vercelProjects } = useVercelProjectsQuery(
     { organization_integration_id: organizationIntegration?.id },
@@ -96,7 +92,7 @@ const VercelIntegration: NextPageWithLayout = () => {
             },
           },
         },
-        orgSlug: organization?.slug,
+        orgSlug: slug,
       })
       snapshot.setLoading(false)
       setIsConnectionComplete(true)
@@ -113,9 +109,9 @@ const VercelIntegration: NextPageWithLayout = () => {
     foreignProjectId,
     newProjectRef,
     next,
-    organization?.slug,
     organizationIntegration,
     snapshot,
+    slug,
     vercelProjects,
   ])
 

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -198,12 +198,7 @@ export function VercelConnectionError({
       <Admonition
         type="danger"
         title="Supabase project created but Vercel connection failed"
-        description={
-          <>
-            Your Supabase project was created, but it could not be connected to Vercel.
-            <span className="mt-1 block text-foreground-lighter">Error: {message}</span>
-          </>
-        }
+        description={`Error: ${message}`}
       />
       <Button variant="primary" block onClick={onRetry}>
         Retry connection

--- a/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
+++ b/apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx
@@ -197,7 +197,7 @@ export function VercelConnectionError({
     <div className="flex flex-col gap-3">
       <Admonition
         type="danger"
-        title="Project created, connection failed"
+        title="Supabase project created but Vercel connection failed"
         description={
           <>
             Your Supabase project was created, but it could not be connected to Vercel.

--- a/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
+++ b/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
@@ -1,0 +1,29 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { expect, test, vi } from 'vitest'
+
+import { VercelConnectionError } from '@/pages/integrations/vercel/[slug]/deploy-button/new-project'
+import { customRender } from '@/tests/lib/custom-render'
+
+test('shows a recoverable partial-success state without recreating the project', async () => {
+  const user = userEvent.setup()
+  const retry = vi.fn()
+
+  customRender(
+    <VercelConnectionError
+      projectRef="project-ref"
+      message="Connection request failed"
+      onRetry={retry}
+    />
+  )
+
+  expect(screen.getByRole('alert')).toHaveTextContent('Project created, connection failed')
+  expect(screen.getByRole('alert')).toHaveTextContent('Connection request failed')
+  expect(screen.getByRole('link', { name: 'Open project' })).toHaveAttribute(
+    'href',
+    '/project/project-ref'
+  )
+
+  await user.click(screen.getByRole('button', { name: 'Retry connection' }))
+  expect(retry).toHaveBeenCalledOnce()
+})

--- a/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
+++ b/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
@@ -18,9 +18,10 @@ test('shows a recoverable partial-success state without recreating the project',
   )
 
   const alert = screen.getByRole('alert')
-  expect(alert).toHaveTextContent('Supabase project created but Vercel connection failed')
-  expect(alert).toHaveTextContent('Error: Connection request failed')
-  expect(alert).not.toHaveTextContent('Your Supabase project was created')
+  expect(alert).toHaveTextContent('Unable to connect to Vercel')
+  expect(alert).toHaveTextContent(
+    'Your Supabase project was created. Error: Connection request failed'
+  )
   expect(screen.getByRole('link', { name: 'Open project' })).toHaveAttribute(
     'href',
     '/project/project-ref'

--- a/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
+++ b/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
@@ -17,10 +17,10 @@ test('shows a recoverable partial-success state without recreating the project',
     />
   )
 
-  expect(screen.getByRole('alert')).toHaveTextContent(
-    'Supabase project created but Vercel connection failed'
-  )
-  expect(screen.getByRole('alert')).toHaveTextContent('Connection request failed')
+  const alert = screen.getByRole('alert')
+  expect(alert).toHaveTextContent('Supabase project created but Vercel connection failed')
+  expect(alert).toHaveTextContent('Error: Connection request failed')
+  expect(alert).not.toHaveTextContent('Your Supabase project was created')
   expect(screen.getByRole('link', { name: 'Open project' })).toHaveAttribute(
     'href',
     '/project/project-ref'

--- a/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
+++ b/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
@@ -17,7 +17,9 @@ test('shows a recoverable partial-success state without recreating the project',
     />
   )
 
-  expect(screen.getByRole('alert')).toHaveTextContent('Project created, connection failed')
+  expect(screen.getByRole('alert')).toHaveTextContent(
+    'Supabase project created but Vercel connection failed'
+  )
   expect(screen.getByRole('alert')).toHaveTextContent('Connection request failed')
   expect(screen.getByRole('link', { name: 'Open project' })).toHaveAttribute(
     'href',

--- a/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
+++ b/apps/studio/tests/pages/vercel-deploy-button-new-project.test.tsx
@@ -20,7 +20,7 @@ test('shows a recoverable partial-success state without recreating the project',
   const alert = screen.getByRole('alert')
   expect(alert).toHaveTextContent('Unable to connect to Vercel')
   expect(alert).toHaveTextContent(
-    'Your Supabase project was created. Error: Connection request failed'
+    'Your Supabase project was still created. Error: Connection request failed'
   )
   expect(screen.getByRole('link', { name: 'Open project' })).toHaveAttribute(
     'href',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

A failed Vercel connection after project creation is only logged, leaving the project-creation screen in its loading state.

## What is the new behavior?

The flow preserves the created project and shows the connection error with retry and open-project actions in the standard project-creation footer.

Project-creation failures remain ordinary inline form errors. Connection failures are owned by this flow without a duplicate toast or a no-op error handler.

| Before | After |
| --- | --- |
| ![Create Vercel Project  Supabase](https://github.com/user-attachments/assets/18dfb6d1-614a-4298-bf28-8399d86c7bca) | <img width="1024" height="563" alt="Create Vercel Project  Supabase" src="https://github.com/user-attachments/assets/b7d3fdca-d7a0-4b50-9231-3cf7dc371a87" /> |

## To test

### Before on master

1. Switch to `master`.
2. With local Studio running and while signed in, open an organisation you can access. Copy its slug from `http://localhost:8082/org/<YOUR_ORG_SLUG>`.
3. Open `apps/studio/components/interfaces/ProjectCreation/ProjectCreationForm.tsx`.
4. Find `isSuccessNewProject={isSuccessNewProject}` in the `ProjectCreationFooter` props and temporarily change it to:
   ```tsx
   isSuccessNewProject={true}
   ```
5. Replace `<YOUR_ORG_SLUG>` in this URL with the slug from step 2, then open it: `http://localhost:8082/integrations/vercel/<YOUR_ORG_SLUG>/deploy-button/new-project`.
6. Confirm **Create new project** remains in its loading state and there is no error, retry action, or route to the created project. This represents the current stuck state.
7. Revert the temporary edit before switching branches.

### After on this branch

1. Switch to `dnywh/vercel-deploy-recovery`.
2. With local Studio running and while signed in, open an organisation you can access. Copy its slug from `http://localhost:8082/org/<YOUR_ORG_SLUG>`.
3. Open `apps/studio/pages/integrations/vercel/[slug]/deploy-button/new-project.tsx`.
4. Find the conditional beginning with `newProjectRef === undefined` inside `InterstitialLayout`.
5. Replace that whole conditional with:
   ```tsx
   <VercelConnectionError
     projectRef="abcdefghijklmnopqrst"
     message="Connection request failed"
     onRetry={() => undefined}
   />
   ```
6. Replace `<YOUR_ORG_SLUG>` in this URL with the slug from step 2, then open it: `http://localhost:8082/integrations/vercel/<YOUR_ORG_SLUG>/deploy-button/new-project`.
7. Confirm the admonition says **Unable to connect to Vercel** and **Your Supabase project was still created. Error: Connection request failed**.
8. Confirm **Open project** and **Retry connection** appear as compact, right-aligned footer buttons. The retry action is intentionally inert in this visual-only mock, and no project or Vercel connection is created.
9. Revert the temporary edit.

## Additional context

Follows #48473. The consistency follow-up #48640 is stacked on this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added inline error messages to project creation forms for integration, API, and validation failures.
  - Added clear Vercel connection states, including waiting, connecting, success, and error screens.
  - Added retry actions and links to open successfully created projects.

- **Bug Fixes**
  - Improved error handling so Vercel connection issues remain visible in context instead of appearing only as notifications.

- **Tests**
  - Added coverage for partial-success messaging, project links, and retry behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->