### PR TITLE
fix: open integrated support form from Feedback → Issue → Contact sup…

### DIFF
--- a/apps/studio/components/layouts/Navigation/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
+++ b/apps/studio/components/layouts/Navigation/LayoutHeader/FeedbackDropdown/FeedbackDropdown.tsx
@@ -13,6 +13,7 @@ import { useSelectedOrganizationQuery } from '@/hooks/misc/useSelectedOrganizati
 import { useSelectedProjectQuery } from '@/hooks/misc/useSelectedProject'
 import { useTrack } from '@/lib/telemetry/track'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { helpPanelState } from '@/state/help-panel-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 export const FeedbackDropdown = ({ className }: { className?: string }) => {
@@ -98,7 +99,12 @@ export const FeedbackDropdown = ({ className }: { className?: string }) => {
                   snap.newChat(ASSISTANT_SUGGESTIONS)
                   setIsOpen(false)
                 }}
-                onSupportClick={() => setIsOpen(false)}
+                onSupportClick={() => {
+                  helpPanelState.requestedView = 'support'
+                  setIsOpen(false)
+                  openSidebar(SIDEBAR_KEYS.HELP_PANEL)
+                  return false
+                }}
               />
             </div>
             <PopoverSeparator />

--- a/apps/studio/components/ui/HelpPanel/HelpPanel.tsx
+++ b/apps/studio/components/ui/HelpPanel/HelpPanel.tsx
@@ -2,9 +2,10 @@ import { IS_PLATFORM } from 'common'
 import { ChevronLeft, X } from 'lucide-react'
 import Image from 'next/image'
 import { useRouter } from 'next/router'
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import SVG from 'react-inlinesvg'
 import { Button } from 'ui'
+import { useSnapshot } from 'valtio'
 
 import { ASSISTANT_SUGGESTIONS } from './HelpPanel.constants'
 import { HelpSection } from './HelpSection'
@@ -16,6 +17,7 @@ import {
 import { SIDEBAR_KEYS } from '@/components/layouts/ProjectLayout/LayoutSidebar/LayoutSidebarProvider'
 import { ButtonTooltip } from '@/components/ui/ButtonTooltip'
 import { useAiAssistantStateSnapshot } from '@/state/ai-assistant-state'
+import { helpPanelState } from '@/state/help-panel-state'
 import { useSidebarManagerSnapshot } from '@/state/sidebar-manager-state'
 
 export const HelpPanel = ({
@@ -30,7 +32,16 @@ export const HelpPanel = ({
   const snap = useAiAssistantStateSnapshot()
   const { openSidebar, closeSidebar } = useSidebarManagerSnapshot()
   const router = useRouter()
-  const [view, setView] = useState<'home' | 'support'>('home')
+  const helpSnap = useSnapshot(helpPanelState)
+  const [view, setView] = useState<'home' | 'support'>(() => helpPanelState.requestedView)
+
+  useEffect(() => {
+    if (helpSnap.requestedView !== 'home') {
+      setView(helpSnap.requestedView)
+      helpPanelState.requestedView = 'home'
+    }
+  }, [helpSnap.requestedView])
+
   const isSupportView = view === 'support'
   const openAssistant = () => {
     onClose()

--- a/apps/studio/state/help-panel-state.ts
+++ b/apps/studio/state/help-panel-state.ts
@@ -1,0 +1,7 @@
+import { proxy } from 'valtio'
+
+export const helpPanelState = proxy<{
+  requestedView: 'home' | 'support'
+}>({
+  requestedView: 'home',
+})


### PR DESCRIPTION
Fixes FE-4132. 

PR description:

## Summary

- Clicking Feedback → Issue → Contact support was navigating to `/support/new` (the old full-page form) instead of opening the integrated sidebar support form
- Fixed by setting a `helpPanelState.requestedView` signal before opening the Help sidebar, so it opens directly at the support form view
- Added a small valtio store (`state/help-panel-state.ts`) to communicate the desired view between `FeedbackDropdown` and `HelpPanel`

## Test plan

- [ ] Feedback → Issue → Contact support opens the Help sidebar at the support form (not `/support/new`)
- [ ] Help button → Contact support still works as before
- [ ] Closing and reopening the Help sidebar via the Help button opens at the home view

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Selecting **Support** from the Help menu now opens the Help Panel directly to the Support view.
  * The Help Panel automatically updates to the requested section when opened.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->